### PR TITLE
Remove unused 'target' parameter from PromptForCredentials()

### DIFF
--- a/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
+++ b/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
@@ -237,7 +237,7 @@ namespace Meziantou.Framework.Win32
             }
         }
 
-        public static CredentialResult PromptForCredentials(string target, IntPtr owner = default, string messageText = null, string captionText = null, string userName = null, CredentialSaveOption saveCredential = CredentialSaveOption.Unselected)
+        public static CredentialResult PromptForCredentials(IntPtr owner = default, string messageText = null, string captionText = null, string userName = null, CredentialSaveOption saveCredential = CredentialSaveOption.Unselected)
         {
             var credUI = new CredentialUIInfo
             {


### PR DESCRIPTION
It looks like `target` isn't used within `PromptForCredentials()` so it seems like a good idea to remove it unless it's there for a reason I've missed?