### PR TITLE
Add DisplayOrder to GenericForm

### DIFF
--- a/src/Meziantou.AspNetCore.Components/GenericForm.razor
+++ b/src/Meziantou.AspNetCore.Components/GenericForm.razor
@@ -2,7 +2,7 @@
 
 @if (fields != null)
 {
-    foreach (var field in fields)
+    foreach (var field in fields.OrderBy(p => p.DisplayOrder))
     {
         if(FieldTemplate != null)
         {

--- a/src/Meziantou.AspNetCore.Components/GenericForm.razor
+++ b/src/Meziantou.AspNetCore.Components/GenericForm.razor
@@ -2,7 +2,7 @@
 
 @if (fields != null)
 {
-    foreach (var field in fields.OrderBy(p => p.DisplayOrder))
+    foreach (var field in fields.OrderBy(p => p.DisplayOrder)) 
     {
         if(FieldTemplate != null)
         {

--- a/src/Meziantou.AspNetCore.Components/GenericFormField.cs
+++ b/src/Meziantou.AspNetCore.Components/GenericFormField.cs
@@ -74,6 +74,7 @@ namespace Meziantou.AspNetCore.Components
                 return Property.Name;
             }
         }
+
         public int DisplayOrder
         {
             get

--- a/src/Meziantou.AspNetCore.Components/GenericFormField.cs
+++ b/src/Meziantou.AspNetCore.Components/GenericFormField.cs
@@ -74,6 +74,21 @@ namespace Meziantou.AspNetCore.Components
                 return Property.Name;
             }
         }
+        public int DisplayOrder
+        {
+            get
+            {
+                var displayAttribute = Property.GetCustomAttribute<DisplayAttribute>();
+                if (displayAttribute != null)
+                {
+                    var displayOrder = displayAttribute.GetOrder();
+                    if (displayOrder != null)
+                        return (int)displayOrder;
+                }
+                //Undefined DisplayOrder are shown at the end 
+                return int.MaxValue;
+            }
+        }
 
         public string? Description
         {

--- a/src/Meziantou.AspNetCore.Components/GenericFormField.cs
+++ b/src/Meziantou.AspNetCore.Components/GenericFormField.cs
@@ -86,8 +86,12 @@ namespace Meziantou.AspNetCore.Components
                     if (displayOrder != null)
                         return (int)displayOrder;
                 }
-                //Undefined DisplayOrder are shown at the end 
-                return int.MaxValue;
+
+                // https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.displayattribute.getorder?view=net-5.0#remarks
+                // If an order is not specified, presentation layers should consider setting the value 
+                // of the Order property to 10000. This value lets explicitly-ordered fields be displayed 
+                // before and after the fields that do not have a specified order.
+                return 10_000;
             }
         }
 


### PR DESCRIPTION
The [Display]-Annotation has the Property Order:

e.g.
 ```
       [Display(Name = "Lastname", Order = 1)]
        public string Name { get; set; }

        [Display(Name = "Firstname", Order = 2)]
        public string FirstName { get; set; }
```

