### PR TITLE
fix boolean mistake in ToString of nullable idType

### DIFF
--- a/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.Members.cs
+++ b/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.Members.cs
@@ -76,11 +76,11 @@ public partial class StronglyTypedIdSourceGenerator
                 {
                     using (writer.BeginBlock($"if ({PropertyName} == null)"))
                     {
-                        writer.WriteLine($$"""return "{{context.TypeName}} { Value = " + {{PropertyAsStringName}} + " }";""");
+                        writer.WriteLine($$"""return "{{context.TypeName}} { Value = <null> }";""");
                     }
                     using (writer.BeginBlock("else"))
                     {
-                        writer.WriteLine($$"""return "{{context.TypeName}} { Value = <null> }";""");
+                        writer.WriteLine($$"""return "{{context.TypeName}} { Value = " + {{PropertyAsStringName}} + " }";""");
                     }
                 }
                 else


### PR DESCRIPTION
`someIdType.ToString()` returns `SomeIdType { Value = <null> }` when actually a value is not null