### PR TITLE
CodeOwners inline comment fix

### DIFF
--- a/src/Meziantou.Framework.CodeOwners/CodeOwnersParser.cs
+++ b/src/Meziantou.Framework.CodeOwners/CodeOwnersParser.cs
@@ -154,6 +154,14 @@ public static class CodeOwnersParser
                 var sb = StringBuilderPool.Get();
 
                 var c = _lexer.Consume();
+
+                // Inline comment
+                if (c == '#')
+                {
+                    _lexer.ConsumeUntil('\n');
+                    return;
+                }
+
                 var isMember = c == '@';
                 if (!isMember)
                 {

--- a/tests/Meziantou.Framework.CodeOwners.Tests/CodeOwnersParserTests.cs
+++ b/tests/Meziantou.Framework.CodeOwners.Tests/CodeOwnersParserTests.cs
@@ -57,7 +57,7 @@ public sealed class CodeOwnersParserTests
                                "# precedence. When someone opens a pull request that only\n" +
                                "# modifies JS files, only @js-owner and not the global\n" +
                                "# owner(s) will be requested for a review.\n" +
-                               "*.js    @js-owner\n" +
+                               "*.js    @js-owner #This is an inline comment.\n" +
                                "\n" +
                                "# You can also use email addresses if you prefer. They'll be\n" +
                                "# used to look up users just like we do for commit author\n" +


### PR DESCRIPTION
When I parsed GitHub's example (https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file) it didn't ignore the inline comment. It instead treated each word in the comment as a member.

This example
```
# Order is important; the last matching pattern takes the most
# precedence. When someone opens a pull request that only
# modifies JS files, only @js-owner and not the global
# owner(s) will be requested for a review.
*.js    @js-owner #This is an inline comment.
```
Resulted in 6 owners ("js-owner", "#This", "is", "an", "inline", "comment.").

With this change, it should now kick out of `ParseMembers` when it comes across a # character.
