### PR TITLE
Possible fix for show-if tag helper display evaluation

### DIFF
--- a/src/Meziantou.AspNetCore.Mvc/TagHelpers/ShowIfTagHelper.cs
+++ b/src/Meziantou.AspNetCore.Mvc/TagHelpers/ShowIfTagHelper.cs
@@ -10,7 +10,7 @@ public sealed class ShowIfTagHelper : TagHelper
 
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
-        if (Value)
+        if (!Value)
         {
             output.SuppressOutput();
             return;


### PR DESCRIPTION
Not sure if this was the intended behavior, but the show-if tag helper was missing a ! when evaluating the Value and suppressing output.