### PR TITLE
Retry HTTP request with delay hint (on 429)

### DIFF
--- a/src/Meziantou.Framework.NuGetPackageValidation/Internal/SharedHttpClient.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/Internal/SharedHttpClient.cs
@@ -26,13 +26,26 @@ internal static class SharedHttpClient
             const int MaxRetries = 5;
             for (var i = 1; ; i++)
             {
+                TimeSpan? delay = null;
                 HttpResponseMessage? result = null;
+
                 try
                 {
                     result = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
-                    if (!IsLastAttempt(i) && ((int)result.StatusCode >= 500 || result.StatusCode is System.Net.HttpStatusCode.RequestTimeout))
+                    if (!IsLastAttempt(i) && ((int)result.StatusCode >= 500 || result.StatusCode is System.Net.HttpStatusCode.RequestTimeout or System.Net.HttpStatusCode.TooManyRequests))
                     {
                         result.Dispose();
+
+                        // Use "Retry-After" value, if available. Typically, this is sent with
+                        // either a 503 (Service Unavailable) or 429 (Too Many Requests):
+                        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
+
+                        delay = result.Headers.RetryAfter switch
+                        {
+                            { Date : { } date  } => date - DateTimeOffset.UtcNow,
+                            { Delta: { } delta } => delta,
+                            _ => null,
+                        };
                     }
                     else
                     {
@@ -46,7 +59,7 @@ internal static class SharedHttpClient
                         throw;
                 }
 
-                await Task.Delay(100 * i, cancellationToken).ConfigureAwait(false);
+                await Task.Delay(delay is { } someDelay && someDelay > TimeSpan.Zero ? someDelay : TimeSpan.FromMicroseconds(100 * i), cancellationToken).ConfigureAwait(false);
 
                 static bool IsLastAttempt(int i) => i >= MaxRetries;
             }

--- a/src/Meziantou.Framework.NuGetPackageValidation/Internal/SharedHttpClient.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/Internal/SharedHttpClient.cs
@@ -34,8 +34,6 @@ internal static class SharedHttpClient
                     result = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
                     if (!IsLastAttempt(i) && ((int)result.StatusCode >= 500 || result.StatusCode is System.Net.HttpStatusCode.RequestTimeout or System.Net.HttpStatusCode.TooManyRequests))
                     {
-                        result.Dispose();
-
                         // Use "Retry-After" value, if available. Typically, this is sent with
                         // either a 503 (Service Unavailable) or 429 (Too Many Requests):
                         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
@@ -46,6 +44,8 @@ internal static class SharedHttpClient
                             { Delta: { } delta } => delta,
                             _ => null,
                         };
+
+                        result.Dispose();
                     }
                     else
                     {

--- a/src/Meziantou.Framework.NuGetPackageValidation/Internal/SharedHttpClient.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/Internal/SharedHttpClient.cs
@@ -59,7 +59,7 @@ internal static class SharedHttpClient
                         throw;
                 }
 
-                await Task.Delay(delay is { } someDelay && someDelay > TimeSpan.Zero ? someDelay : TimeSpan.FromMicroseconds(100 * i), cancellationToken).ConfigureAwait(false);
+                await Task.Delay(delay is { } someDelay && someDelay > TimeSpan.Zero ? someDelay : TimeSpan.FromMicroseconds(200 * i), cancellationToken).ConfigureAwait(false);
 
                 static bool IsLastAttempt(int i) => i >= MaxRetries;
             }

--- a/src/Meziantou.Framework.NuGetPackageValidation/Rules/SymbolsValidationRule.cs
+++ b/src/Meziantou.Framework.NuGetPackageValidation/Rules/SymbolsValidationRule.cs
@@ -249,7 +249,8 @@ internal sealed partial class SymbolsValidationRule : NuGetPackageValidationRule
                                     using var response = await context.SendHttpRequestAsync(request, context.CancellationToken).ConfigureAwait(false);
                                     if (!response.IsSuccessStatusCode)
                                     {
-                                        context.ReportError(ErrorCodes.UrlIsNotAccessible, $"Source file '{url}' is not accessible", fileName: item);
+                                        var message = string.Create(CultureInfo.InvariantCulture, $"Source file '{url}' is not accessible (HTTP status code = {(int)response.StatusCode})");
+                                        context.ReportError(ErrorCodes.UrlIsNotAccessible, message, fileName: item);
                                     }
                                     else
                                     {


### PR DESCRIPTION
@meziantou [said](https://github.com/meziantou/Meziantou.Framework/issues/539#issuecomment-1609928285):

>  I think it could be improved by handling correctly the status code 429 (I would accept a PR).

This PR contributes to and potentially closes #539.

The value of the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header is used as long as it's present and we're retrying. In the even that there's no retry duration hint, it uses the default like before. If you think the default could revised to be less aggressive then I can make that change in a follow-up commit. My suggestion would be starting with a second and doubling on each attempt.

Let me know if anything needs to be adapted to the project's coding style although I tried to respect what I could see from going through a few of sources.
