### PR TITLE
Added XML comments on class and method in FastEnumToStringGenerator

### DIFF
--- a/src/Meziantou.Framework.FastEnumToStringGenerator/EnumToStringSourceGenerator.cs
+++ b/src/Meziantou.Framework.FastEnumToStringGenerator/EnumToStringSourceGenerator.cs
@@ -135,7 +135,9 @@ internal sealed class FastEnumToStringAttribute : System.Attribute
 
         foreach (var enumerationGroup in enums.GroupBy(en => en.FullNamespace, StringComparer.Ordinal).OrderBy(g => g.Key, StringComparer.Ordinal))
         {
-            var typeVisibility = enumerationGroup.Any(enumeration => enumeration.IsPublic) ? "public" : "internal";
+            var typeIsPublic = enumerationGroup.Any(enumeration => enumeration.IsPublic);
+            var typeVisibility = typeIsPublic ? "public" : "internal";
+
             foreach (var enumeration in enumerationGroup.OrderBy(e => e.FullCsharpName, StringComparer.Ordinal))
             {
                 var methodVisibility = enumeration.IsPublic ? "public" : "internal";
@@ -146,8 +148,18 @@ internal sealed class FastEnumToStringAttribute : System.Attribute
                     sb.AppendLine("{");
                 }
 
+                if (typeIsPublic)
+                {
+                    sb.AppendLine($"/// <summary>A class with memory-optimized alternative to regular ToString() on enums.</summary>");
+                }
+
                 sb.Append(typeVisibility).AppendLine(" static partial class FastEnumToStringExtensions");
                 sb.AppendLine("{");
+
+                if (enumeration.IsPublic)
+                {
+                    sb.Append("    ").AppendLine($"/// <summary>A memory-optimized alternative to regular ToString() method on {enumeration.FullCsharpName} enum.</summary>");
+                }
 
                 sb.Append("    ").Append(methodVisibility).Append(" static string ToStringFast(this global::").Append(enumeration.FullCsharpName).AppendLine(" value)");
                 sb.AppendLine("    {");

--- a/src/Meziantou.Framework.FastEnumToStringGenerator/EnumToStringSourceGenerator.cs
+++ b/src/Meziantou.Framework.FastEnumToStringGenerator/EnumToStringSourceGenerator.cs
@@ -152,7 +152,7 @@ internal sealed class FastEnumToStringAttribute : System.Attribute
                 sb.Append(typeVisibility).AppendLine(" static partial class FastEnumToStringExtensions");
                 sb.AppendLine("{");
 
-                sb.Append("    ").AppendLine($"/// <summary>A memory-optimized alternative to regular ToString() method on <see cref=\"{enumeration.FullCsharpName}\">{enumeration.FullCsharpName} enum</see>.</summary>");
+                sb.Append("    ").AppendLine($"/// <summary>A memory-optimized alternative to regular ToString() method on <see cref=\"{enumeration.DocumentationId}\">{enumeration.FullCsharpName} enum</see>.</summary>");
                 sb.Append("    ").Append(methodVisibility).Append(" static string ToStringFast(this global::").Append(enumeration.FullCsharpName).AppendLine(" value)");
                 sb.AppendLine("    {");
                 sb.AppendLine("        return value switch");
@@ -197,8 +197,9 @@ internal sealed class FastEnumToStringAttribute : System.Attribute
 
     private sealed record EnumToProcess(ITypeSymbol EnumSymbol, List<EnumMemberToProcess> Members, bool IsPublic, string? Namespace)
     {
-        public string FullCsharpName => EnumSymbol.ToString()!;
-        public string? FullNamespace => Namespace ?? GetNamespace(EnumSymbol);
+        public string FullCsharpName { get; } = EnumSymbol.ToString()!;
+        public string? FullNamespace { get; } = Namespace ?? GetNamespace(EnumSymbol);
+        public string DocumentationId { get; } = DocumentationCommentId.CreateDeclarationId(EnumSymbol);
 
         private static string? GetNamespace(ITypeSymbol symbol)
         {

--- a/src/Meziantou.Framework.FastEnumToStringGenerator/EnumToStringSourceGenerator.cs
+++ b/src/Meziantou.Framework.FastEnumToStringGenerator/EnumToStringSourceGenerator.cs
@@ -148,19 +148,11 @@ internal sealed class FastEnumToStringAttribute : System.Attribute
                     sb.AppendLine("{");
                 }
 
-                if (typeIsPublic)
-                {
-                    sb.AppendLine($"/// <summary>A class with memory-optimized alternative to regular ToString() on enums.</summary>");
-                }
-
+                sb.AppendLine($"/// <summary>A class with memory-optimized alternative to regular ToString() on enums.</summary>");
                 sb.Append(typeVisibility).AppendLine(" static partial class FastEnumToStringExtensions");
                 sb.AppendLine("{");
 
-                if (enumeration.IsPublic)
-                {
-                    sb.Append("    ").AppendLine($"/// <summary>A memory-optimized alternative to regular ToString() method on {enumeration.FullCsharpName} enum.</summary>");
-                }
-
+                sb.Append("    ").AppendLine($"/// <summary>A memory-optimized alternative to regular ToString() method on <see cref=\"{enumeration.FullCsharpName}\">{enumeration.FullCsharpName} enum</see>.</summary>");
                 sb.Append("    ").Append(methodVisibility).Append(" static string ToStringFast(this global::").Append(enumeration.FullCsharpName).AppendLine(" value)");
                 sb.AppendLine("    {");
                 sb.AppendLine("        return value switch");


### PR DESCRIPTION
I came across a situation where I need the generated `ToStringFast()` methods to be public but we have enabled and required XML comments on public members so the project is unable to build. So I am adding a generation for public classes and methods.

Unfortunately, I did not find a proper way on how to unit test generated XML comments so I did not extend existing tests.