### PR TITLE
Fix context sensitive tests

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/SnapshotUpdateStrategies/ProcessInfo.Get.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/SnapshotUpdateStrategies/ProcessInfo.Get.cs
@@ -26,14 +26,13 @@ internal sealed partial record ProcessInfo
             if (contextProcess != null)
             {
                 var startTime = new DateTimeOffset(contextProcess.StartTime);
-                startTime = new DateTimeOffset(startTime.Ticks % TimeSpan.TicksPerMillisecond, startTime.Offset);
+                // Trim milliseconds to avoid some comparison issues
+                startTime = new DateTimeOffset(startTime.Ticks - startTime.Ticks % TimeSpan.TicksPerMillisecond, startTime.Offset);
 
                 return new ProcessInfo
                 {
                     ProcessId = contextProcess.Id,
                     ProcessName = contextProcess.ProcessName,
-
-                    // Trim milliseconds to avoid some comparison issues
                     ProcessStartedAt = startTime,
                 };
             }

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -1092,8 +1092,9 @@ public sealed partial class SerializerTests : SerializerTestsBase
     [Fact]
     public void DateTime_Local()
     {
-        var currentUtcOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow);
-        AssertSerialization(new DateTime(2123, 4, 5, 6, 7, 8, DateTimeKind.Local), "2123-04-05T06:07:08" + (currentUtcOffset < TimeSpan.Zero ? "-" : "+") + currentUtcOffset.ToString(@"hh\:mm", CultureInfo.InvariantCulture));
+        var dateTime = new DateTime(2123, 4, 5, 6, 7, 8, DateTimeKind.Local);
+        var utcOffset = TimeZoneInfo.Local.GetUtcOffset(dateTime);
+        AssertSerialization(dateTime, "2123-04-05T06:07:08" + (utcOffset < TimeSpan.Zero ? "-" : "+") + utcOffset.ToString(@"hh\:mm", CultureInfo.InvariantCulture));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_DateTimeTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_DateTimeTo.cs
@@ -10,7 +10,7 @@ public class DefaultConverterTests_DateTimeTo
     public void TryConvert_DateTimeToDateTimeOffset()
     {
         var converter = new DefaultConverter();
-        var cultureInfo = CultureInfo.CurrentCulture;
+        var cultureInfo = new CultureInfo("en-US");
         var converted = converter.TryChangeType("6/12/2018 12:00:00 AM -05:00", cultureInfo, out DateTimeOffset value);
 
         converted.Should().BeTrue();

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_DateTimeTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_DateTimeTo.cs
@@ -10,7 +10,7 @@ public class DefaultConverterTests_DateTimeTo
     public void TryConvert_DateTimeToDateTimeOffset()
     {
         var converter = new DefaultConverter();
-        var cultureInfo = new CultureInfo("en-US");
+        var cultureInfo = CultureInfo.GetCultureInfo("en-US");
         var converted = converter.TryChangeType("6/12/2018 12:00:00 AM -05:00", cultureInfo, out DateTimeOffset value);
 
         converted.Should().BeTrue();


### PR DESCRIPTION
#### Fix TypeConverter TryConvert_DateTimeToDateTimeOffset test

It would fail with the following error when the current culture has a sensible day / month / year ordering.

> Expected value to represent the same point in time as `2018-06-12 -5h`, but `2018-12-06 -5h` does not.

#### Fix HumanReadableSerializer DateTime_Local test

Get the offset from the actual date, not from the current date since the offset might change when adjusted for daylight saving time.

Today, the test would fail with the following error.

```
Assert.Equal() Failure: Strings differ
                                ↓ (pos 21)
Expected: "2123-04-05T06:07:08+01:00"
Actual:   "2123-04-05T06:07:08+02:00"
                                ↑ (pos 21)
```

### Fix InlineSnapshotTesting prompt test

Trimming the milliseconds was not actually trimming the milliseconds but taking only the ticks per milliseconds part. The test would fail with the following error.

> The UTC time represented when the offset is applied must be between year 0 and 10,000.
> Parameter name: offset
>    at System.DateTimeOffset.ValidateDate(DateTime dateTime, TimeSpan offset)
>    at System.DateTimeOffset..ctor(Int64 ticks, TimeSpan offset)
>    at Meziantou.Framework.InlineSnapshotTesting.SnapshotUpdateStrategies.ProcessInfo.GetContextProcess() in Meziantou.Framework\src\Meziantou.Framework.InlineSnapshotTesting\SnapshotUpdateStrategies\ProcessInfo.Get.cs:line 31
