### PR TITLE
Use Verify.Xunit for ResxGenerator tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ bld/
 *.VisualState.xml
 TestResult.xml
 
+# Verify
+*.received.*
+
 # Build Results of an ATL Project
 [Dd]ebugPS/
 [Rr]eleasePS/

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,10 +6,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) != 'netstandard2.0'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/Meziantou.Framework.ResxSourceGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/Meziantou.Framework.ResxSourceGenerator.Tests.csproj
@@ -11,6 +11,14 @@
     <ProjectReference Include="..\..\src\Meziantou.Framework.ResxSourceGenerator\Meziantou.Framework.ResxSourceGenerator.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0" />
+    <PackageReference Include="Verify.Xunit" Version="22.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="**/*.received.cs" />
+    <Compile Remove="**/*.verified.cs" />
+    <None Include="**/*.received.cs" />
+    <None Include="**/*.verified.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.GenerateProperties.verified.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.GenerateProperties.verified.cs
@@ -1,0 +1,247 @@
+﻿
+// Debug info:
+// key: test
+// files: test.resx
+// RootNamespace (metadata): 
+// ProjectDir (metadata): 
+// Namespace / DefaultResourcesNamespace (metadata): test
+// ResourceName (metadata): test
+// ClassName (metadata): 
+// AssemblyName: compilation
+// RootNamespace (computed): compilation
+// ProjectDir (computed): compilation
+// defaultNamespace: 
+// defaultResourceName: 
+// Namespace: test
+// ResourceName: test
+// ClassName: test
+
+#nullable enable
+namespace test
+{
+    internal partial class test
+    {
+        private static global::System.Resources.ResourceManager? resourceMan;
+
+        public test() { }
+
+        /// <summary>
+        ///   Returns the cached ResourceManager instance used by this class.
+        /// </summary>
+        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
+        public static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (resourceMan is null) 
+                {
+                    resourceMan = new global::System.Resources.ResourceManager("test", typeof(test).Assembly);
+                }
+
+                return resourceMan;
+            }
+        }
+
+        /// <summary>
+        ///   Overrides the current thread's CurrentUICulture property for all
+        ///   resource lookups using this strongly typed resource class.
+        /// </summary>
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
+        public static global::System.Globalization.CultureInfo? Culture { get; set; }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static object? GetObject(global::System.Globalization.CultureInfo? culture, string name, object? defaultValue)
+        {
+            culture ??= Culture;
+            object? obj = ResourceManager.GetObject(name, culture);
+            if (obj == null)
+            {
+                return defaultValue;
+            }
+
+            return obj;
+        }
+        
+        public static object? GetObject(global::System.Globalization.CultureInfo? culture, string name)
+        {
+            return GetObject(culture: culture, name: name, defaultValue: null);
+        }
+
+        public static object? GetObject(string name)
+        {
+            return GetObject(culture: null, name: name, defaultValue: null);
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static object? GetObject(string name, object? defaultValue)
+        {
+            return GetObject(culture: null, name: name, defaultValue: defaultValue);
+        }
+
+        public static global::System.IO.Stream? GetStream(string name)
+        {
+            return GetStream(culture: null, name: name);
+        }
+
+        public static global::System.IO.Stream? GetStream(global::System.Globalization.CultureInfo? culture, string name)
+        {
+            culture ??= Culture;
+            return ResourceManager.GetStream(name, culture);
+        }
+
+        public static string? GetString(global::System.Globalization.CultureInfo? culture, string name)
+        {
+            return GetString(culture: culture, name: name, args: null);
+        }
+
+        public static string? GetString(global::System.Globalization.CultureInfo? culture, string name, params object?[]? args)
+        {
+            culture ??= Culture;
+            string? str = ResourceManager.GetString(name, culture);
+            if (str == null)
+            {
+                return null;
+            }
+
+            if (args != null)
+            {
+                return string.Format(culture, str, args);
+            }
+            else
+            {
+                return str;
+            }
+        }
+        
+        public static string? GetString(string name, params object?[]? args)
+        {
+            return GetString(culture: null, name: name, args: args);
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+        
+        public static string? GetString(string name, string? defaultValue)
+        {
+            return GetStringWithDefault(culture: null, name: name, defaultValue: defaultValue, args: null);
+        }
+
+        public static string? GetString(string name)
+        {
+            return GetStringWithDefault(culture: null, name: name, defaultValue: null, args: null);
+        }
+        
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static string? GetStringWithDefault(global::System.Globalization.CultureInfo? culture, string name, string? defaultValue)
+        {
+            return GetStringWithDefault(culture: culture, name: name, defaultValue: defaultValue, args: null);
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static string? GetStringWithDefault(global::System.Globalization.CultureInfo? culture, string name, string? defaultValue, params object?[]? args)
+        {
+            culture ??= Culture;
+            string? str = ResourceManager.GetString(name, culture);
+            if (str == null)
+            {
+                if (defaultValue == null || args == null)
+                {
+                    return defaultValue;
+                }
+                else
+                {
+                    return string.Format(culture, defaultValue, args);
+                }
+            }
+
+            if (args != null)
+            {
+                return string.Format(culture, str, args);
+            }
+            else
+            {
+                return str;
+            }
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static string? GetStringWithDefault(string name, string? defaultValue, params object?[]? args)
+        {
+            return GetStringWithDefault(culture: null, name: name, defaultValue: defaultValue, args: args);
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static string? GetStringWithDefault(string name, string? defaultValue)
+        {
+            return GetStringWithDefault(culture: null, name: name, defaultValue: defaultValue, args: null);
+        }
+
+
+        /// <summary>
+       ///   <para>Looks up a localized string for "HelloWorld".</para>
+       ///   <para>Value: "Hello {0}!".</para>
+       /// </summary>
+        public static string? @HelloWorld
+        {
+            get
+            {
+                return GetString("HelloWorld");
+            }
+        }
+
+
+        /// <summary>
+       ///   <para>Looks up a localized string for "HelloWorld".</para>
+       ///   <para>Value: "Hello {0}!".</para>
+       /// </summary>
+        public static string? FormatHelloWorld(global::System.Globalization.CultureInfo? provider, object? arg0)
+        {
+            return GetString(provider, "HelloWorld", arg0);
+        }
+
+
+        /// <summary>
+       ///   <para>Looks up a localized string for "HelloWorld".</para>
+       ///   <para>Value: "Hello {0}!".</para>
+       /// </summary>
+        public static string? FormatHelloWorld(object? arg0)
+        {
+            return GetString("HelloWorld", arg0);
+        }
+
+
+        public static global::System.Drawing.Bitmap? @Image1
+        {
+            get
+            {
+                return (global::System.Drawing.Bitmap?)GetObject("Image1");
+            }
+        }
+
+
+        /// <summary>
+       ///   <para>Looks up a localized string for "Sample".</para>
+       ///   <para>Value: "Value".</para>
+       /// </summary>
+        public static string? @Sample
+        {
+            get
+            {
+                return GetString("Sample");
+            }
+        }
+
+    }
+
+    internal partial class testNames
+    {
+        public const string @Sample = "Sample";
+        public const string @HelloWorld = "HelloWorld";
+        public const string @Image1 = "Image1";
+    }
+}

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.GeneratePropertiesFromMultipleResx.test.NewResource.verified.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.GeneratePropertiesFromMultipleResx.test.NewResource.verified.cs
@@ -1,0 +1,203 @@
+﻿
+// Debug info:
+// key: {TempPath}test.NewResource
+// files: {TempPath}test.NewResource.fr.resx
+// RootNamespace (metadata): Test
+// ProjectDir (metadata): {TempPath}
+// Namespace / DefaultResourcesNamespace (metadata): 
+// ResourceName (metadata): 
+// ClassName (metadata): 
+// AssemblyName: compilation
+// RootNamespace (computed): Test
+// ProjectDir (computed): {TempPath}
+// defaultNamespace: Test
+// defaultResourceName: Test.test.NewResource
+// Namespace: Test
+// ResourceName: Test.test.NewResource
+// ClassName: test_NewResource
+
+#nullable enable
+namespace Test
+{
+    internal partial class test_NewResource
+    {
+        private static global::System.Resources.ResourceManager? resourceMan;
+
+        public test_NewResource() { }
+
+        /// <summary>
+        ///   Returns the cached ResourceManager instance used by this class.
+        /// </summary>
+        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
+        public static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (resourceMan is null) 
+                {
+                    resourceMan = new global::System.Resources.ResourceManager("Test.test.NewResource", typeof(test_NewResource).Assembly);
+                }
+
+                return resourceMan;
+            }
+        }
+
+        /// <summary>
+        ///   Overrides the current thread's CurrentUICulture property for all
+        ///   resource lookups using this strongly typed resource class.
+        /// </summary>
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
+        public static global::System.Globalization.CultureInfo? Culture { get; set; }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static object? GetObject(global::System.Globalization.CultureInfo? culture, string name, object? defaultValue)
+        {
+            culture ??= Culture;
+            object? obj = ResourceManager.GetObject(name, culture);
+            if (obj == null)
+            {
+                return defaultValue;
+            }
+
+            return obj;
+        }
+        
+        public static object? GetObject(global::System.Globalization.CultureInfo? culture, string name)
+        {
+            return GetObject(culture: culture, name: name, defaultValue: null);
+        }
+
+        public static object? GetObject(string name)
+        {
+            return GetObject(culture: null, name: name, defaultValue: null);
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static object? GetObject(string name, object? defaultValue)
+        {
+            return GetObject(culture: null, name: name, defaultValue: defaultValue);
+        }
+
+        public static global::System.IO.Stream? GetStream(string name)
+        {
+            return GetStream(culture: null, name: name);
+        }
+
+        public static global::System.IO.Stream? GetStream(global::System.Globalization.CultureInfo? culture, string name)
+        {
+            culture ??= Culture;
+            return ResourceManager.GetStream(name, culture);
+        }
+
+        public static string? GetString(global::System.Globalization.CultureInfo? culture, string name)
+        {
+            return GetString(culture: culture, name: name, args: null);
+        }
+
+        public static string? GetString(global::System.Globalization.CultureInfo? culture, string name, params object?[]? args)
+        {
+            culture ??= Culture;
+            string? str = ResourceManager.GetString(name, culture);
+            if (str == null)
+            {
+                return null;
+            }
+
+            if (args != null)
+            {
+                return string.Format(culture, str, args);
+            }
+            else
+            {
+                return str;
+            }
+        }
+        
+        public static string? GetString(string name, params object?[]? args)
+        {
+            return GetString(culture: null, name: name, args: args);
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+        
+        public static string? GetString(string name, string? defaultValue)
+        {
+            return GetStringWithDefault(culture: null, name: name, defaultValue: defaultValue, args: null);
+        }
+
+        public static string? GetString(string name)
+        {
+            return GetStringWithDefault(culture: null, name: name, defaultValue: null, args: null);
+        }
+        
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static string? GetStringWithDefault(global::System.Globalization.CultureInfo? culture, string name, string? defaultValue)
+        {
+            return GetStringWithDefault(culture: culture, name: name, defaultValue: defaultValue, args: null);
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static string? GetStringWithDefault(global::System.Globalization.CultureInfo? culture, string name, string? defaultValue, params object?[]? args)
+        {
+            culture ??= Culture;
+            string? str = ResourceManager.GetString(name, culture);
+            if (str == null)
+            {
+                if (defaultValue == null || args == null)
+                {
+                    return defaultValue;
+                }
+                else
+                {
+                    return string.Format(culture, defaultValue, args);
+                }
+            }
+
+            if (args != null)
+            {
+                return string.Format(culture, str, args);
+            }
+            else
+            {
+                return str;
+            }
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static string? GetStringWithDefault(string name, string? defaultValue, params object?[]? args)
+        {
+            return GetStringWithDefault(culture: null, name: name, defaultValue: defaultValue, args: args);
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static string? GetStringWithDefault(string name, string? defaultValue)
+        {
+            return GetStringWithDefault(culture: null, name: name, defaultValue: defaultValue, args: null);
+        }
+
+
+        /// <summary>
+       ///   <para>Looks up a localized string for "BBB".</para>
+       ///   <para>Value: "Value".</para>
+       /// </summary>
+        public static string? @BBB
+        {
+            get
+            {
+                return GetString("BBB");
+            }
+        }
+
+    }
+
+    internal partial class test_NewResourceNames
+    {
+        public const string @BBB = "BBB";
+    }
+}

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.GeneratePropertiesFromMultipleResx.test.verified.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.GeneratePropertiesFromMultipleResx.test.verified.cs
@@ -1,0 +1,285 @@
+﻿
+// Debug info:
+// key: {TempPath}test
+// files: {TempPath}test.resx, {TempPath}test.en.resx, {TempPath}test.fr-FR.resx
+// RootNamespace (metadata): Test
+// ProjectDir (metadata): {TempPath}
+// Namespace / DefaultResourcesNamespace (metadata): 
+// ResourceName (metadata): 
+// ClassName (metadata): 
+// AssemblyName: compilation
+// RootNamespace (computed): Test
+// ProjectDir (computed): {TempPath}
+// defaultNamespace: Test
+// defaultResourceName: Test.test
+// Namespace: Test
+// ResourceName: Test.test
+// ClassName: test
+
+#nullable enable
+namespace Test
+{
+    internal partial class test
+    {
+        private static global::System.Resources.ResourceManager? resourceMan;
+
+        public test() { }
+
+        /// <summary>
+        ///   Returns the cached ResourceManager instance used by this class.
+        /// </summary>
+        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
+        public static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (resourceMan is null) 
+                {
+                    resourceMan = new global::System.Resources.ResourceManager("Test.test", typeof(test).Assembly);
+                }
+
+                return resourceMan;
+            }
+        }
+
+        /// <summary>
+        ///   Overrides the current thread's CurrentUICulture property for all
+        ///   resource lookups using this strongly typed resource class.
+        /// </summary>
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
+        public static global::System.Globalization.CultureInfo? Culture { get; set; }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static object? GetObject(global::System.Globalization.CultureInfo? culture, string name, object? defaultValue)
+        {
+            culture ??= Culture;
+            object? obj = ResourceManager.GetObject(name, culture);
+            if (obj == null)
+            {
+                return defaultValue;
+            }
+
+            return obj;
+        }
+        
+        public static object? GetObject(global::System.Globalization.CultureInfo? culture, string name)
+        {
+            return GetObject(culture: culture, name: name, defaultValue: null);
+        }
+
+        public static object? GetObject(string name)
+        {
+            return GetObject(culture: null, name: name, defaultValue: null);
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static object? GetObject(string name, object? defaultValue)
+        {
+            return GetObject(culture: null, name: name, defaultValue: defaultValue);
+        }
+
+        public static global::System.IO.Stream? GetStream(string name)
+        {
+            return GetStream(culture: null, name: name);
+        }
+
+        public static global::System.IO.Stream? GetStream(global::System.Globalization.CultureInfo? culture, string name)
+        {
+            culture ??= Culture;
+            return ResourceManager.GetStream(name, culture);
+        }
+
+        public static string? GetString(global::System.Globalization.CultureInfo? culture, string name)
+        {
+            return GetString(culture: culture, name: name, args: null);
+        }
+
+        public static string? GetString(global::System.Globalization.CultureInfo? culture, string name, params object?[]? args)
+        {
+            culture ??= Culture;
+            string? str = ResourceManager.GetString(name, culture);
+            if (str == null)
+            {
+                return null;
+            }
+
+            if (args != null)
+            {
+                return string.Format(culture, str, args);
+            }
+            else
+            {
+                return str;
+            }
+        }
+        
+        public static string? GetString(string name, params object?[]? args)
+        {
+            return GetString(culture: null, name: name, args: args);
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+        
+        public static string? GetString(string name, string? defaultValue)
+        {
+            return GetStringWithDefault(culture: null, name: name, defaultValue: defaultValue, args: null);
+        }
+
+        public static string? GetString(string name)
+        {
+            return GetStringWithDefault(culture: null, name: name, defaultValue: null, args: null);
+        }
+        
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static string? GetStringWithDefault(global::System.Globalization.CultureInfo? culture, string name, string? defaultValue)
+        {
+            return GetStringWithDefault(culture: culture, name: name, defaultValue: defaultValue, args: null);
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static string? GetStringWithDefault(global::System.Globalization.CultureInfo? culture, string name, string? defaultValue, params object?[]? args)
+        {
+            culture ??= Culture;
+            string? str = ResourceManager.GetString(name, culture);
+            if (str == null)
+            {
+                if (defaultValue == null || args == null)
+                {
+                    return defaultValue;
+                }
+                else
+                {
+                    return string.Format(culture, defaultValue, args);
+                }
+            }
+
+            if (args != null)
+            {
+                return string.Format(culture, str, args);
+            }
+            else
+            {
+                return str;
+            }
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static string? GetStringWithDefault(string name, string? defaultValue, params object?[]? args)
+        {
+            return GetStringWithDefault(culture: null, name: name, defaultValue: defaultValue, args: args);
+        }
+
+        [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultValue")]
+
+        public static string? GetStringWithDefault(string name, string? defaultValue)
+        {
+            return GetStringWithDefault(culture: null, name: name, defaultValue: defaultValue, args: null);
+        }
+
+
+        /// <summary>
+       ///   <para>Looks up a localized string for "AAA".</para>
+       ///   <para>Value: "Value".</para>
+       /// </summary>
+        public static string? @AAA
+        {
+            get
+            {
+                return GetString("AAA");
+            }
+        }
+
+
+        /// <summary>
+       ///   <para>Looks up a localized string for "HelloWorld".</para>
+       ///   <para>Value: "Hello {0}!".</para>
+       /// </summary>
+        public static string? @HelloWorld
+        {
+            get
+            {
+                return GetString("HelloWorld");
+            }
+        }
+
+
+        /// <summary>
+       ///   <para>Looks up a localized string for "HelloWorld".</para>
+       ///   <para>Value: "Hello {0}!".</para>
+       /// </summary>
+        public static string? FormatHelloWorld(global::System.Globalization.CultureInfo? provider, object? arg0)
+        {
+            return GetString(provider, "HelloWorld", arg0);
+        }
+
+
+        /// <summary>
+       ///   <para>Looks up a localized string for "HelloWorld".</para>
+       ///   <para>Value: "Hello {0}!".</para>
+       /// </summary>
+        public static string? FormatHelloWorld(object? arg0)
+        {
+            return GetString("HelloWorld", arg0);
+        }
+
+
+        /// <summary>
+       ///   <para>Looks up a localized string for "HelloWorld2".</para>
+       ///   <para>Value: "Hello {0}!".</para>
+       /// </summary>
+        public static string? @HelloWorld2
+        {
+            get
+            {
+                return GetString("HelloWorld2");
+            }
+        }
+
+
+        /// <summary>
+       ///   <para>Looks up a localized string for "HelloWorld2".</para>
+       ///   <para>Value: "Hello {0}!".</para>
+       /// </summary>
+        public static string? FormatHelloWorld2(global::System.Globalization.CultureInfo? provider, object? arg0)
+        {
+            return GetString(provider, "HelloWorld2", arg0);
+        }
+
+
+        /// <summary>
+       ///   <para>Looks up a localized string for "HelloWorld2".</para>
+       ///   <para>Value: "Hello {0}!".</para>
+       /// </summary>
+        public static string? FormatHelloWorld2(object? arg0)
+        {
+            return GetString("HelloWorld2", arg0);
+        }
+
+
+        /// <summary>
+       ///   <para>Looks up a localized string for "Sample".</para>
+       ///   <para>Value: "Value".</para>
+       /// </summary>
+        public static string? @Sample
+        {
+            get
+            {
+                return GetString("Sample");
+            }
+        }
+
+    }
+
+    internal partial class testNames
+    {
+        public const string @Sample = "Sample";
+        public const string @HelloWorld2 = "HelloWorld2";
+        public const string @AAA = "AAA";
+        public const string @HelloWorld = "HelloWorld";
+    }
+}


### PR DESCRIPTION
Comparing the whole generated strongly typed resource class instead of some parts of it will become handy when modifying the Resx source generator in later pull requests.