### PR TITLE
Add support for domain credential type in Meziantou.Framework.Win32.CredentialManager

### DIFF
--- a/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
+++ b/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
@@ -48,12 +48,12 @@ public static class CredentialManager
         return new Credential((CredentialType)credential->Type, applicationName, userName, secret, comment);
     }
 
-    public static void WriteCredential(string applicationName, string userName, string secret, CredentialPersistence persistence)
+    public static void WriteCredential(string applicationName, string userName, string secret, CredentialPersistence persistence, CredentialType type = CredentialType.Generic)
     {
-        WriteCredential(applicationName, userName, secret, comment: null, persistence);
+        WriteCredential(applicationName, userName, secret, comment: null, persistence, type);
     }
 
-    public static unsafe void WriteCredential(string applicationName, string userName, string secret, string? comment, CredentialPersistence persistence)
+    public static unsafe void WriteCredential(string applicationName, string userName, string secret, string? comment, CredentialPersistence persistence, CredentialType type = CredentialType.Generic)
     {
         if (applicationName is null)
             throw new ArgumentNullException(nameof(applicationName));
@@ -86,6 +86,11 @@ public static class CredentialManager
                 throw new ArgumentOutOfRangeException(nameof(comment), "The comment message has exceeded 256 characters.");
         }
 
+        if (type is not (CredentialType.Generic or CredentialType.DomainPassword))
+        {
+            throw new ArgumentOutOfRangeException(nameof(type), "Only CredentialType.Generic and CredentialType.DomainPassword is supported");
+        }
+
         fixed (char* applicationNamePtr = applicationName)
         fixed (char* userNamePtr = userName)
         fixed (char* commentPtr = comment)
@@ -97,7 +102,7 @@ public static class CredentialManager
                 Attributes = null,
                 Comment = commentPtr,
                 TargetAlias = default,
-                Type = CRED_TYPE.CRED_TYPE_GENERIC,
+                Type = (CRED_TYPE)type,
                 Persist = (CRED_PERSIST)persistence,
                 CredentialBlobSize = (uint)secretLength,
                 TargetName = applicationNamePtr,

--- a/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
+++ b/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
@@ -14,7 +14,12 @@ namespace Meziantou.Framework.Win32;
 [SupportedOSPlatform("windows5.1.2600")]
 public static class CredentialManager
 {
-    public static unsafe Credential? ReadCredential(string applicationName, CredentialType type = CredentialType.Generic)
+    public static Credential? ReadCredential(string applicationName)
+    {
+        return ReadCredential(applicationName, CredentialType.Generic);
+    }
+
+    public static unsafe Credential? ReadCredential(string applicationName, CredentialType type)
     {
         var read = PInvoke.CredRead(applicationName, (CRED_TYPE)type, out var handle);
         if (read)
@@ -48,12 +53,22 @@ public static class CredentialManager
         return new Credential((CredentialType)credential->Type, applicationName, userName, secret, comment);
     }
 
-    public static void WriteCredential(string applicationName, string userName, string secret, CredentialPersistence persistence, CredentialType type = CredentialType.Generic)
+    public static void WriteCredential(string applicationName, string userName, string secret, CredentialPersistence persistence)
+    {
+        WriteCredential(applicationName, userName, secret, comment: null, persistence, CredentialType.Generic);
+    }
+
+    public static void WriteCredential(string applicationName, string userName, string secret, CredentialPersistence persistence, CredentialType type)
     {
         WriteCredential(applicationName, userName, secret, comment: null, persistence, type);
     }
 
-    public static unsafe void WriteCredential(string applicationName, string userName, string secret, string? comment, CredentialPersistence persistence, CredentialType type = CredentialType.Generic)
+    public static void WriteCredential(string applicationName, string userName, string secret, string? comment, CredentialPersistence persistence)
+    {
+        WriteCredential(applicationName, userName, secret, comment, persistence, CredentialType.Generic);
+    }
+
+    public static unsafe void WriteCredential(string applicationName, string userName, string secret, string? comment, CredentialPersistence persistence, CredentialType type)
     {
         if (applicationName is null)
             throw new ArgumentNullException(nameof(applicationName));
@@ -119,7 +134,12 @@ public static class CredentialManager
         }
     }
 
-    public static void DeleteCredential(string applicationName, CredentialType type = CredentialType.Generic)
+    public static void DeleteCredential(string applicationName)
+    {
+        DeleteCredential(applicationName, CredentialType.Generic);
+    }
+
+    public static void DeleteCredential(string applicationName, CredentialType type)
     {
         if (applicationName is null)
             throw new ArgumentNullException(nameof(applicationName));

--- a/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
+++ b/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
@@ -14,9 +14,9 @@ namespace Meziantou.Framework.Win32;
 [SupportedOSPlatform("windows5.1.2600")]
 public static class CredentialManager
 {
-    public static unsafe Credential? ReadCredential(string applicationName)
+    public static unsafe Credential? ReadCredential(string applicationName, CredentialType type = CredentialType.Generic)
     {
-        var read = PInvoke.CredRead(applicationName, CRED_TYPE.CRED_TYPE_GENERIC, out var handle);
+        var read = PInvoke.CredRead(applicationName, (CRED_TYPE)type, out var handle);
         if (read)
         {
             try
@@ -119,12 +119,12 @@ public static class CredentialManager
         }
     }
 
-    public static void DeleteCredential(string applicationName)
+    public static void DeleteCredential(string applicationName, CredentialType type = CredentialType.Generic)
     {
         if (applicationName is null)
             throw new ArgumentNullException(nameof(applicationName));
 
-        var success = PInvoke.CredDelete(applicationName, CRED_TYPE.CRED_TYPE_GENERIC);
+        var success = PInvoke.CredDelete(applicationName, (CRED_TYPE)type);
         if (!success)
         {
             var lastError = Marshal.GetLastWin32Error();

--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
@@ -153,7 +153,7 @@ public sealed class CredentialManagerTests : IDisposable
     }
 
     [RunIfFact(FactOperatingSystem.Windows)]
-    public void CredentialManager_CredentialType_Windows()
+    public void CredentialManager_CredentialType_DomainPassword()
     {
         var credType = CredentialType.DomainPassword;
 
@@ -173,7 +173,7 @@ public sealed class CredentialManagerTests : IDisposable
     }
 
     [RunIfFact(FactOperatingSystem.Windows)]
-    public void CredentialManager_CredentialType_Windows_Enumerate()
+    public void CredentialManager_CredentialType_DomainPassword_Enumerate()
     {
         var credType = CredentialType.DomainPassword;
 


### PR DESCRIPTION
Hello,

I needed the ability to create `CRED_TYPE_DOMAIN_PASSWORD` entries in the credential manager from a c# desktop application.

I found some other credential manager dotnet libs out there that exposes the type. However, Meziantou.Framework.Win32.CredentialManager has a much nicer API so I decided to add support for specifying the CredentialType for the following methods:

ReadCredential
WriteCredential
DeleteCredential

For DeleteCredential I limited it to only CredentialType.Generic and CredentialType.DomainPassword as this is all I have the ability to test etc. `CRED_TYPE_DOMAIN_VISIBLE_PASSWORD` ( `DomainVisiblePassword` ) might be able to be supported but I was wary when I saw `This value is no longer supported` in the docs https://learn.microsoft.com/en-us/windows/win32/api/wincred/ns-wincred-credentiala.

Also added tests.

Please let me know if you have any issues with these changes that you would like me to address. 😄

 
Thanks,
Nick