### PR TITLE
Fix exception in GitTool

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/MergeTools/GitTool.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/MergeTools/GitTool.cs
@@ -45,6 +45,7 @@ internal abstract class GitTool : MergeTool
             RedirectStandardOutput = true,
             WorkingDirectory = workingDirectory,
             CreateNoWindow = true,
+            UseShellExecute = false,
         };
 
         using var process = Process.Start(psi);


### PR DESCRIPTION
While running `net472` tests from Rider:  

```
System.InvalidOperationException : L'objet Process doit avoir la propriété UseShellExecute définie à la valeur false afin de rediriger les flux d'E/S.
   à System.Diagnostics.Process.StartWithShellExecuteEx(ProcessStartInfo startInfo)
   à System.Diagnostics.Process.Start(ProcessStartInfo startInfo)
   à Meziantou.Framework.InlineSnapshotTesting.MergeTools.GitTool.GetGitConfiguration(String workingDirectory, String key) dans /_/src/Meziantou.Framework.InlineSnapshotTesting/MergeTools/GitTool.cs:ligne 41
   à Meziantou.Framework.InlineSnapshotTesting.MergeTools.GitMergeTool.Start(String currentFilePath, String newFilePath) dans /_/src/Meziantou.Framework.InlineSnapshotTesting/MergeTools/GitMergeTool.cs:ligne 10
   à Meziantou.Framework.InlineSnapshotTesting.MergeTool.Launch(IEnumerable`1 mergeTools, String currentFilePath, String newFilePath) dans /_/src/Meziantou.Framework.InlineSnapshotTesting/MergeTool.cs:ligne 61
   à Meziantou.Framework.InlineSnapshotTesting.SnapshotUpdateStrategies.MergeToolStrategyBase.LaunchMergeTool(InlineSnapshotSettings settings, String currentFilePath, String newFilePath) dans /_/src/Meziantou.Framework.InlineSnapshotTesting/SnapshotUpdateStrategies/MergeToolStrategyBase.cs:ligne 10
   à Meziantou.Framework.InlineSnapshotTesting.FileEditor.UpdateFile(CallerContext context, InlineSnapshotSettings settings, String existingValue, String newValue, CancellationToken cancellationToken) dans /_/src/Meziantou.Framework.InlineSnapshotTesting/FileEditor.cs:ligne 157
   à Meziantou.Framework.InlineSnapshotTesting.InlineSnapshot.ShouldMatchInlineSnapshot(Object subject, CallerContext context, InlineSnapshotSettings settings, String expected) dans /_/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshot.cs:ligne 49
   à Meziantou.Framework.InlineSnapshotTesting.InlineSnapshotBuilder.Validate(Object subject, String expected, String filePath, Int32 lineNumber) dans /_/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotBuilder.cs:ligne 20
```