### PR TITLE
Add parsing new section headings in CODEOWNERS files

### DIFF
--- a/src/Meziantou.Framework.CodeOwners/CodeOwnersSection.cs
+++ b/src/Meziantou.Framework.CodeOwners/CodeOwnersSection.cs
@@ -5,14 +5,21 @@ namespace Meziantou.Framework.CodeOwners;
 [StructLayout(LayoutKind.Auto)]
 public readonly struct CodeOwnersSection : IEquatable<CodeOwnersSection>
 {
-    public CodeOwnersSection(string name, bool isOptional)
+    public CodeOwnersSection(string name, int requiredReviewerCount = 1, IReadOnlyCollection<string> defaultOwners = null)
     {
         Name = name;
-        IsOptional = isOptional;
+        RequiredReviewerCount = requiredReviewerCount;
+        DefaultOwners = defaultOwners ?? new List<string>();
     }
 
     public string Name { get; }
-    public bool IsOptional { get; }
+
+    public int RequiredReviewerCount { get; }
+    public bool IsOptional => RequiredReviewerCount == 0;
+    public bool IsMandatory => !IsOptional;
+
+    public IReadOnlyCollection<string> DefaultOwners { get; }
+    public bool HasDefaultOwners => DefaultOwners is not null && DefaultOwners.Count > 0;
 
     public override bool Equals(object? obj)
     {
@@ -22,14 +29,16 @@ public readonly struct CodeOwnersSection : IEquatable<CodeOwnersSection>
     public bool Equals(CodeOwnersSection other)
     {
         return Name == other.Name &&
-               IsOptional == other.IsOptional;
+               RequiredReviewerCount == other.RequiredReviewerCount &&
+               DefaultOwners.SequenceEqual(other.DefaultOwners, StringComparer.Ordinal);
     }
 
     public override int GetHashCode()
     {
         var hashCode = 1707150943;
-        hashCode = hashCode * -1521134295 + IsOptional.GetHashCode();
         hashCode = hashCode * -1521134295 + StringComparer.Ordinal.GetHashCode(Name);
+        hashCode = hashCode * -1521134295 + RequiredReviewerCount.GetHashCode();
+        hashCode = hashCode * -1521134295 + DefaultOwners.GetHashCode();
         return hashCode;
     }
 

--- a/src/Meziantou.Framework.CodeOwners/CodeOwnersSection.cs
+++ b/src/Meziantou.Framework.CodeOwners/CodeOwnersSection.cs
@@ -5,7 +5,7 @@ namespace Meziantou.Framework.CodeOwners;
 [StructLayout(LayoutKind.Auto)]
 public readonly struct CodeOwnersSection : IEquatable<CodeOwnersSection>
 {
-    public CodeOwnersSection(string name, int requiredReviewerCount = 1, IReadOnlyCollection<string> defaultOwners = null)
+    internal CodeOwnersSection(string name, int requiredReviewerCount = 1, IReadOnlyCollection<string> defaultOwners = null)
     {
         Name = name;
         RequiredReviewerCount = requiredReviewerCount;

--- a/src/Meziantou.Framework.CodeOwners/Meziantou.Framework.CodeOwners.csproj
+++ b/src/Meziantou.Framework.CodeOwners/Meziantou.Framework.CodeOwners.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks);netstandard2.0</TargetFrameworks>
     <Description>CODEOWNERS file parser</Description>
-    <Version>2.0.2</Version>
+    <Version>3.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/tests/Meziantou.Framework.CodeOwners.Tests/CodeOwnersParserTests.cs
+++ b/tests/Meziantou.Framework.CodeOwners.Tests/CodeOwnersParserTests.cs
@@ -313,7 +313,8 @@ public sealed class CodeOwnersParserTests
 
         var expected = new CodeOwnersEntry[]
         {
-            CodeOwnersEntry.FromUsername(0, "*", "defaultOwner", section: new CodeOwnersSection("Test", 1, ["@defaultOwner1", "defaultOwner2"])),
+            CodeOwnersEntry.FromUsername(0, "*", "defaultOwner1", section: new CodeOwnersSection("Test", 1, ["@defaultOwner1", "defaultOwner2"])),
+            CodeOwnersEntry.FromUsername(0, "*", "defaultOwner2", section: new CodeOwnersSection("Test", 1, ["@defaultOwner1", "defaultOwner2"])),
         };
 
         actual.Should().Equal(expected);
@@ -326,7 +327,8 @@ public sealed class CodeOwnersParserTests
 
         var expected = new CodeOwnersEntry[]
         {
-            CodeOwnersEntry.FromUsername(0, "*", "defaultOwner", section: new CodeOwnersSection("Test", 2, ["@defaultOwner1, defaultOwner2"])),
+            CodeOwnersEntry.FromUsername(0, "*", "defaultOwner1", section: new CodeOwnersSection("Test", 2, ["@defaultOwner1, defaultOwner2"])),
+            CodeOwnersEntry.FromUsername(0, "*", "defaultOwner2", section: new CodeOwnersSection("Test", 2, ["@defaultOwner1, defaultOwner2"])),
         };
 
         actual.Should().Equal(expected);

--- a/tests/Meziantou.Framework.CodeOwners.Tests/CodeOwnersParserTests.cs
+++ b/tests/Meziantou.Framework.CodeOwners.Tests/CodeOwnersParserTests.cs
@@ -238,6 +238,101 @@ public sealed class CodeOwnersParserTests
     }
 
     [Fact]
+    public void OptionalOverridesRequiredReviewerCount()
+    {
+        var actual = CodeOwnersParser.Parse("^[Test][2]\n* @user").ToArray();
+
+        var expected = new CodeOwnersEntry[]
+        {
+            CodeOwnersEntry.FromUsername(0, "*", "user", section: new CodeOwnersSection("Test", 0)),
+        };
+
+        actual.Should().Equal(expected);
+    }
+
+    [Fact]
+    public void RequiredRewiewerCountIgnoredIfSpaceBefore()
+    {
+        var actual = CodeOwnersParser.Parse("[Test] [2]\n* @user").ToArray();
+
+        var expected = new CodeOwnersEntry[]
+        {
+            CodeOwnersEntry.FromUsername(0, "*", "user", section: new CodeOwnersSection("Test", 1)),
+        };
+
+        actual.Should().Equal(expected);
+    }
+
+    [Fact]
+    public void RequiredRewiewerCountIgnoredIfHashTagBefore()
+    {
+        var actual = CodeOwnersParser.Parse("[Test]#[2]\n* @user").ToArray();
+
+        var expected = new CodeOwnersEntry[]
+        {
+            CodeOwnersEntry.FromUsername(0, "*", "user", section: new CodeOwnersSection("Test", 1)),
+        };
+
+        actual.Should().Equal(expected);
+    }
+
+    [Fact]
+    public void DefaultOwnersIgnoredIfJuxtaposedToSectionName()
+    {
+        var actual = CodeOwnersParser.Parse("[Test]@defaultOwner\n*").ToArray();
+
+        var expected = Array.Empty<CodeOwnersEntry>();
+
+        actual.Should().Equal(expected);
+    }
+
+    [Fact]
+    public void DefaultOwnersIgnoredIfJuxtaposedToRequiredReviewerCount()
+    {
+        var actual = CodeOwnersParser.Parse("[Test][2]@defaultOwner\n*").ToArray();
+
+        var expected = Array.Empty<CodeOwnersEntry>();
+
+        actual.Should().Equal(expected);
+    }
+
+    [Fact]
+    public void RequiredReviewerCountAndDefaultOwnerIgnoredIfSpaceBefore()
+    {
+        var actual = CodeOwnersParser.Parse("[Test] [2] @defaultOwner\n*").ToArray();
+
+        var expected = Array.Empty<CodeOwnersEntry>();
+
+        actual.Should().Equal(expected);
+    }
+
+    [Fact]
+    public void DefaultOwnersIgnoresExtraSpaces()
+    {
+        var actual = CodeOwnersParser.Parse("[Test]  @defaultOwner1    @defaultOwner2\n*").ToArray();
+
+        var expected = new CodeOwnersEntry[]
+        {
+            CodeOwnersEntry.FromUsername(0, "*", "defaultOwner", section: new CodeOwnersSection("Test", 1, ["@defaultOwner1", "defaultOwner2"])),
+        };
+
+        actual.Should().Equal(expected);
+    }
+
+    [Fact]
+    public void DefaultOwnersIgnoresExtraSpacesWithRequiredReviewerCount()
+    {
+        var actual = CodeOwnersParser.Parse("[Test][2]  @defaultOwner1    @defaultOwner2\n*").ToArray();
+
+        var expected = new CodeOwnersEntry[]
+        {
+            CodeOwnersEntry.FromUsername(0, "*", "defaultOwner", section: new CodeOwnersSection("Test", 2, ["@defaultOwner1, defaultOwner2"])),
+        };
+
+        actual.Should().Equal(expected);
+    }
+
+    [Fact]
     public void ParseSectionWithCRLFLineEndings()
     {
         const string Content = "\r\n" +

--- a/tests/Meziantou.Framework.CodeOwners.Tests/CodeOwnersParserTests.cs
+++ b/tests/Meziantou.Framework.CodeOwners.Tests/CodeOwnersParserTests.cs
@@ -240,11 +240,24 @@ public sealed class CodeOwnersParserTests
     [Fact]
     public void ParseSectionWithCRLFLineEndings()
     {
-        var actual = CodeOwnersParser.Parse("[Section]\r\n* @owner1\r\n").ToArray();
+        const string Content = "\r\n" +
+                               "[Test1]\r\n" +
+                               "* @user1\r\n" +
+                               "\r\n" +
+                               "[Test2][2]\r\n" +
+                               "* @user2\r\n" +
+                               "\r\n" +
+                               "[Test3] @defaultOwner\r\n" +
+                               "* @user3\r\n" +
+                               " ";
+
+        var actual = CodeOwnersParser.Parse(Content).ToArray();
 
         var expected = new CodeOwnersEntry[]
         {
-            CodeOwnersEntry.FromUsername(0, "*", "owner1", section: new CodeOwnersSection("Section")),
+            CodeOwnersEntry.FromUsername(0, "*", "user1", section: new CodeOwnersSection("Test1")),
+            CodeOwnersEntry.FromUsername(1, "*", "user2", section: new CodeOwnersSection("Test2", 2)),
+            CodeOwnersEntry.FromUsername(2, "*", "user3", section: new CodeOwnersSection("Test3", 1, ["@defaultOwner"])),
         };
 
         actual.Should().Equal(expected);


### PR DESCRIPTION
Hi! My team would like to be able to parse new section headings in CODEOWNERS files, namely the required reviewer count and the default owners (https://docs.gitlab.com/ee/user/project/codeowners/reference.html#section-headings).

This change improves the parsing of section lines, and adds a few tests for section heading parsing as well as a test for files with lines ending with CRLF.

Please note there is a breaking change as the CodeOwnersSection constructor now takes an int instead of bool, since we can now deduce IsOptional from RequiredReviewerCount.
I couldn't find a breaking change guidelines for this project, but if we don't want one right now I suggest keeping both constructors, set the RequiredReviewerCount at 1 if isOptional is false in the old one, and ideally mark it as deprecated.

Thanks ⁠😊
Thomas