### PR TITLE
Add option to present the login failure error on the credentials prompt

### DIFF
--- a/src/Meziantou.Framework.Win32.CredentialManager/CredentialErrorCode.cs
+++ b/src/Meziantou.Framework.Win32.CredentialManager/CredentialErrorCode.cs
@@ -1,0 +1,10 @@
+﻿namespace Meziantou.Framework.Win32;
+
+public enum CredentialErrorCode
+{
+    /// <summary>No error message is displayed.</summary>
+    None,
+
+    /// <summary>Display the error message 'The username or password is incorrect'.</summary>
+    LogonFailure,
+}

--- a/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
+++ b/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
@@ -259,11 +259,17 @@ public static class CredentialManager
     [SupportedOSPlatform("windows6.0.6000")]
     public static unsafe CredentialResult? PromptForCredentials(IntPtr owner, string? messageText, string? captionText, string? userName, CredentialSaveOption saveCredential)
     {
-        return PromptForCredentials(owner, messageText, captionText, userName, password: null, saveCredential);
+        return PromptForCredentials(owner, messageText, captionText, CredentialErrorCode.None, userName, password: null, saveCredential);
     }
 
     [SupportedOSPlatform("windows6.0.6000")]
-    public static unsafe CredentialResult? PromptForCredentials(IntPtr owner = default, string? messageText = null, string? captionText = null, string? userName = null, string? password = null, CredentialSaveOption saveCredential = CredentialSaveOption.Unselected)
+    public static unsafe CredentialResult? PromptForCredentials(IntPtr owner, string? messageText, string? captionText, string? userName, string? password, CredentialSaveOption saveCredential)
+    {
+        return PromptForCredentials(owner, messageText, captionText, CredentialErrorCode.None, userName, password, saveCredential);
+    }
+
+    [SupportedOSPlatform("windows6.0.6000")]
+    public static unsafe CredentialResult? PromptForCredentials(IntPtr owner = default, string? messageText = null, string? captionText = null, CredentialErrorCode error = CredentialErrorCode.None, string? userName = null, string? password = null, CredentialSaveOption saveCredential = CredentialSaveOption.Unselected)
     {
         fixed (char* messageTextPtr = messageText)
         fixed (char* captionTextPtr = captionText)
@@ -280,7 +286,11 @@ public static class CredentialManager
             BOOL save = saveCredential == CredentialSaveOption.Selected;
 
             // Setup the flags and variables
-            var errorcode = 0u;
+            uint errorcode = error switch
+            {
+                CredentialErrorCode.LogonFailure => (uint)WIN32_ERROR.ERROR_LOGON_FAILURE,
+                _ => 0u
+            };
 
             var flags = CREDUIWIN_FLAGS.CREDUIWIN_GENERIC | CREDUIWIN_FLAGS.CREDUIWIN_ENUMERATE_CURRENT_USER;
             if (saveCredential != CredentialSaveOption.Hidden)

--- a/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
+++ b/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
@@ -259,17 +259,17 @@ public static class CredentialManager
     [SupportedOSPlatform("windows6.0.6000")]
     public static unsafe CredentialResult? PromptForCredentials(IntPtr owner, string? messageText, string? captionText, string? userName, CredentialSaveOption saveCredential)
     {
-        return PromptForCredentials(owner, messageText, captionText, CredentialErrorCode.None, userName, password: null, saveCredential);
+        return PromptForCredentials(owner, messageText, captionText, userName, password: null, saveCredential, CredentialErrorCode.None);
     }
 
     [SupportedOSPlatform("windows6.0.6000")]
     public static unsafe CredentialResult? PromptForCredentials(IntPtr owner, string? messageText, string? captionText, string? userName, string? password, CredentialSaveOption saveCredential)
     {
-        return PromptForCredentials(owner, messageText, captionText, CredentialErrorCode.None, userName, password, saveCredential);
+        return PromptForCredentials(owner, messageText, captionText, userName, password, saveCredential, CredentialErrorCode.None);
     }
 
     [SupportedOSPlatform("windows6.0.6000")]
-    public static unsafe CredentialResult? PromptForCredentials(IntPtr owner = default, string? messageText = null, string? captionText = null, CredentialErrorCode error = CredentialErrorCode.None, string? userName = null, string? password = null, CredentialSaveOption saveCredential = CredentialSaveOption.Unselected)
+    public static unsafe CredentialResult? PromptForCredentials(IntPtr owner = default, string? messageText = null, string? captionText = null, string? userName = null, string? password = null, CredentialSaveOption saveCredential = CredentialSaveOption.Unselected, CredentialErrorCode error = CredentialErrorCode.None)
     {
         fixed (char* messageTextPtr = messageText)
         fixed (char* captionTextPtr = captionText)

--- a/src/Meziantou.Framework.Win32.CredentialManager/Meziantou.Framework.Win32.CredentialManager.csproj
+++ b/src/Meziantou.Framework.Win32.CredentialManager/Meziantou.Framework.Win32.CredentialManager.csproj
@@ -5,7 +5,7 @@
     <IsTrimmable>false</IsTrimmable>
     <Description>C# wrapper around CredWrite/CredRead/CredDelete/CredUIPromptForWindowsCredentials/CredUICmdLinePromptForCredentials functions to store and retrieve from Windows Credential Store</Description>
     <RootNamespace>Meziantou.Framework.Win32</RootNamespace>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hopefully this is obvious enough, just adding in minimal support for presenting a login failure error on the credential's prompt (i.e. the user just tried and invalid username/password combination so the prompt is displayed again, this time with the error message). It'll be easy enough to expand to include other errors if that makes sense, but for now it just exposes the single error ERROR_LOGON_FAILURE.