### PR TITLE
Fix TaskEx.WhenAll formatting

### DIFF
--- a/src/Meziantou.Framework/TaskEx.WhenAll.cs
+++ b/src/Meziantou.Framework/TaskEx.WhenAll.cs
@@ -20,11 +20,8 @@ public static partial class TaskEx
 {
     public static async Task<(T1, T2)> WhenAll<T1, T2>(Task<T1> task1, Task<T2> task2)
     {
-        
         ArgumentNullException.ThrowIfNull(task1);
-        
         ArgumentNullException.ThrowIfNull(task2);
-        
         await Task.WhenAll(task1, task2).ConfigureAwait(false);
         return (task1.Result, task2.Result);
     }
@@ -33,15 +30,12 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2).GetAwaiter();
     }
+
     public static async Task<(T1, T2, T3)> WhenAll<T1, T2, T3>(Task<T1> task1, Task<T2> task2, Task<T3> task3)
     {
-        
         ArgumentNullException.ThrowIfNull(task1);
-        
         ArgumentNullException.ThrowIfNull(task2);
-        
         ArgumentNullException.ThrowIfNull(task3);
-        
         await Task.WhenAll(task1, task2, task3).ConfigureAwait(false);
         return (task1.Result, task2.Result, task3.Result);
     }
@@ -50,17 +44,13 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2, tasks.Item3).GetAwaiter();
     }
+
     public static async Task<(T1, T2, T3, T4)> WhenAll<T1, T2, T3, T4>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4)
     {
-        
         ArgumentNullException.ThrowIfNull(task1);
-        
         ArgumentNullException.ThrowIfNull(task2);
-        
         ArgumentNullException.ThrowIfNull(task3);
-        
         ArgumentNullException.ThrowIfNull(task4);
-        
         await Task.WhenAll(task1, task2, task3, task4).ConfigureAwait(false);
         return (task1.Result, task2.Result, task3.Result, task4.Result);
     }
@@ -69,19 +59,14 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4).GetAwaiter();
     }
+
     public static async Task<(T1, T2, T3, T4, T5)> WhenAll<T1, T2, T3, T4, T5>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5)
     {
-        
         ArgumentNullException.ThrowIfNull(task1);
-        
         ArgumentNullException.ThrowIfNull(task2);
-        
         ArgumentNullException.ThrowIfNull(task3);
-        
         ArgumentNullException.ThrowIfNull(task4);
-        
         ArgumentNullException.ThrowIfNull(task5);
-        
         await Task.WhenAll(task1, task2, task3, task4, task5).ConfigureAwait(false);
         return (task1.Result, task2.Result, task3.Result, task4.Result, task5.Result);
     }
@@ -90,21 +75,15 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5).GetAwaiter();
     }
+
     public static async Task<(T1, T2, T3, T4, T5, T6)> WhenAll<T1, T2, T3, T4, T5, T6>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5, Task<T6> task6)
     {
-        
         ArgumentNullException.ThrowIfNull(task1);
-        
         ArgumentNullException.ThrowIfNull(task2);
-        
         ArgumentNullException.ThrowIfNull(task3);
-        
         ArgumentNullException.ThrowIfNull(task4);
-        
         ArgumentNullException.ThrowIfNull(task5);
-        
         ArgumentNullException.ThrowIfNull(task6);
-        
         await Task.WhenAll(task1, task2, task3, task4, task5, task6).ConfigureAwait(false);
         return (task1.Result, task2.Result, task3.Result, task4.Result, task5.Result, task6.Result);
     }
@@ -113,23 +92,16 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6).GetAwaiter();
     }
+
     public static async Task<(T1, T2, T3, T4, T5, T6, T7)> WhenAll<T1, T2, T3, T4, T5, T6, T7>(Task<T1> task1, Task<T2> task2, Task<T3> task3, Task<T4> task4, Task<T5> task5, Task<T6> task6, Task<T7> task7)
     {
-        
         ArgumentNullException.ThrowIfNull(task1);
-        
         ArgumentNullException.ThrowIfNull(task2);
-        
         ArgumentNullException.ThrowIfNull(task3);
-        
         ArgumentNullException.ThrowIfNull(task4);
-        
         ArgumentNullException.ThrowIfNull(task5);
-        
         ArgumentNullException.ThrowIfNull(task6);
-        
         ArgumentNullException.ThrowIfNull(task7);
-        
         await Task.WhenAll(task1, task2, task3, task4, task5, task6, task7).ConfigureAwait(false);
         return (task1.Result, task2.Result, task3.Result, task4.Result, task5.Result, task6.Result, task7.Result);
     }
@@ -143,22 +115,27 @@ public static partial class TaskEx
     {
         return Task.WhenAll(tasks.Item1, tasks.Item2).GetAwaiter();
     }
+
     public static TaskAwaiter GetAwaiter(this (Task, Task, Task) tasks)
     {
         return Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3).GetAwaiter();
     }
+
     public static TaskAwaiter GetAwaiter(this (Task, Task, Task, Task) tasks)
     {
         return Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4).GetAwaiter();
     }
+
     public static TaskAwaiter GetAwaiter(this (Task, Task, Task, Task, Task) tasks)
     {
         return Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5).GetAwaiter();
     }
+
     public static TaskAwaiter GetAwaiter(this (Task, Task, Task, Task, Task, Task) tasks)
     {
         return Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6).GetAwaiter();
     }
+
     public static TaskAwaiter GetAwaiter(this (Task, Task, Task, Task, Task, Task, Task) tasks)
     {
         return Task.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7).GetAwaiter();
@@ -167,7 +144,7 @@ public static partial class TaskEx
     public static async ValueTask<(T1, T2)> WhenAll<T1, T2>(ValueTask<T1> task1, ValueTask<T2> task2)
     {
         List<Exception>? observedExceptions = null;
-                T1 result1;        
+        T1 result1;
         try
         {
             result1 = await task1.ConfigureAwait(false);
@@ -178,7 +155,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result1);
         }
-                T2 result2;        
+        T2 result2;
         try
         {
             result2 = await task2.ConfigureAwait(false);
@@ -202,10 +179,11 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2).GetAwaiter();
     }
+
     public static async ValueTask<(T1, T2, T3)> WhenAll<T1, T2, T3>(ValueTask<T1> task1, ValueTask<T2> task2, ValueTask<T3> task3)
     {
         List<Exception>? observedExceptions = null;
-                T1 result1;        
+        T1 result1;
         try
         {
             result1 = await task1.ConfigureAwait(false);
@@ -216,7 +194,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result1);
         }
-                T2 result2;        
+        T2 result2;
         try
         {
             result2 = await task2.ConfigureAwait(false);
@@ -227,7 +205,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result2);
         }
-                T3 result3;        
+        T3 result3;
         try
         {
             result3 = await task3.ConfigureAwait(false);
@@ -251,10 +229,11 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2, tasks.Item3).GetAwaiter();
     }
+
     public static async ValueTask<(T1, T2, T3, T4)> WhenAll<T1, T2, T3, T4>(ValueTask<T1> task1, ValueTask<T2> task2, ValueTask<T3> task3, ValueTask<T4> task4)
     {
         List<Exception>? observedExceptions = null;
-                T1 result1;        
+        T1 result1;
         try
         {
             result1 = await task1.ConfigureAwait(false);
@@ -265,7 +244,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result1);
         }
-                T2 result2;        
+        T2 result2;
         try
         {
             result2 = await task2.ConfigureAwait(false);
@@ -276,7 +255,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result2);
         }
-                T3 result3;        
+        T3 result3;
         try
         {
             result3 = await task3.ConfigureAwait(false);
@@ -287,7 +266,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result3);
         }
-                T4 result4;        
+        T4 result4;
         try
         {
             result4 = await task4.ConfigureAwait(false);
@@ -311,10 +290,11 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4).GetAwaiter();
     }
+
     public static async ValueTask<(T1, T2, T3, T4, T5)> WhenAll<T1, T2, T3, T4, T5>(ValueTask<T1> task1, ValueTask<T2> task2, ValueTask<T3> task3, ValueTask<T4> task4, ValueTask<T5> task5)
     {
         List<Exception>? observedExceptions = null;
-                T1 result1;        
+        T1 result1;
         try
         {
             result1 = await task1.ConfigureAwait(false);
@@ -325,7 +305,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result1);
         }
-                T2 result2;        
+        T2 result2;
         try
         {
             result2 = await task2.ConfigureAwait(false);
@@ -336,7 +316,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result2);
         }
-                T3 result3;        
+        T3 result3;
         try
         {
             result3 = await task3.ConfigureAwait(false);
@@ -347,7 +327,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result3);
         }
-                T4 result4;        
+        T4 result4;
         try
         {
             result4 = await task4.ConfigureAwait(false);
@@ -358,7 +338,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result4);
         }
-                T5 result5;        
+        T5 result5;
         try
         {
             result5 = await task5.ConfigureAwait(false);
@@ -382,10 +362,11 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5).GetAwaiter();
     }
+
     public static async ValueTask<(T1, T2, T3, T4, T5, T6)> WhenAll<T1, T2, T3, T4, T5, T6>(ValueTask<T1> task1, ValueTask<T2> task2, ValueTask<T3> task3, ValueTask<T4> task4, ValueTask<T5> task5, ValueTask<T6> task6)
     {
         List<Exception>? observedExceptions = null;
-                T1 result1;        
+        T1 result1;
         try
         {
             result1 = await task1.ConfigureAwait(false);
@@ -396,7 +377,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result1);
         }
-                T2 result2;        
+        T2 result2;
         try
         {
             result2 = await task2.ConfigureAwait(false);
@@ -407,7 +388,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result2);
         }
-                T3 result3;        
+        T3 result3;
         try
         {
             result3 = await task3.ConfigureAwait(false);
@@ -418,7 +399,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result3);
         }
-                T4 result4;        
+        T4 result4;
         try
         {
             result4 = await task4.ConfigureAwait(false);
@@ -429,7 +410,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result4);
         }
-                T5 result5;        
+        T5 result5;
         try
         {
             result5 = await task5.ConfigureAwait(false);
@@ -440,7 +421,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result5);
         }
-                T6 result6;        
+        T6 result6;
         try
         {
             result6 = await task6.ConfigureAwait(false);
@@ -464,10 +445,11 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6).GetAwaiter();
     }
+
     public static async ValueTask<(T1, T2, T3, T4, T5, T6, T7)> WhenAll<T1, T2, T3, T4, T5, T6, T7>(ValueTask<T1> task1, ValueTask<T2> task2, ValueTask<T3> task3, ValueTask<T4> task4, ValueTask<T5> task5, ValueTask<T6> task6, ValueTask<T7> task7)
     {
         List<Exception>? observedExceptions = null;
-                T1 result1;        
+        T1 result1;
         try
         {
             result1 = await task1.ConfigureAwait(false);
@@ -478,7 +460,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result1);
         }
-                T2 result2;        
+        T2 result2;
         try
         {
             result2 = await task2.ConfigureAwait(false);
@@ -489,7 +471,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result2);
         }
-                T3 result3;        
+        T3 result3;
         try
         {
             result3 = await task3.ConfigureAwait(false);
@@ -500,7 +482,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result3);
         }
-                T4 result4;        
+        T4 result4;
         try
         {
             result4 = await task4.ConfigureAwait(false);
@@ -511,7 +493,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result4);
         }
-                T5 result5;        
+        T5 result5;
         try
         {
             result5 = await task5.ConfigureAwait(false);
@@ -522,7 +504,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result5);
         }
-                T6 result6;        
+        T6 result6;
         try
         {
             result6 = await task6.ConfigureAwait(false);
@@ -533,7 +515,7 @@ public static partial class TaskEx
             observedExceptions.Add(ex);
             Unsafe.SkipInit(out result6);
         }
-                T7 result7;        
+        T7 result7;
         try
         {
             result7 = await task7.ConfigureAwait(false);
@@ -561,7 +543,7 @@ public static partial class TaskEx
     public static async ValueTask WhenAll(ValueTask task1, ValueTask task2)
     {
         List<Exception>? observedExceptions = null;
-                try
+        try
         {
             await task1.ConfigureAwait(false);
         }
@@ -570,7 +552,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task2.ConfigureAwait(false);
         }
@@ -590,10 +572,11 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2).GetAwaiter();
     }
+
     public static async ValueTask WhenAll(ValueTask task1, ValueTask task2, ValueTask task3)
     {
         List<Exception>? observedExceptions = null;
-                try
+        try
         {
             await task1.ConfigureAwait(false);
         }
@@ -602,7 +585,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task2.ConfigureAwait(false);
         }
@@ -611,7 +594,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task3.ConfigureAwait(false);
         }
@@ -631,10 +614,11 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2, tasks.Item3).GetAwaiter();
     }
+
     public static async ValueTask WhenAll(ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4)
     {
         List<Exception>? observedExceptions = null;
-                try
+        try
         {
             await task1.ConfigureAwait(false);
         }
@@ -643,7 +627,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task2.ConfigureAwait(false);
         }
@@ -652,7 +636,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task3.ConfigureAwait(false);
         }
@@ -661,7 +645,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task4.ConfigureAwait(false);
         }
@@ -681,10 +665,11 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4).GetAwaiter();
     }
+
     public static async ValueTask WhenAll(ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5)
     {
         List<Exception>? observedExceptions = null;
-                try
+        try
         {
             await task1.ConfigureAwait(false);
         }
@@ -693,7 +678,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task2.ConfigureAwait(false);
         }
@@ -702,7 +687,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task3.ConfigureAwait(false);
         }
@@ -711,7 +696,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task4.ConfigureAwait(false);
         }
@@ -720,7 +705,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task5.ConfigureAwait(false);
         }
@@ -740,10 +725,11 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5).GetAwaiter();
     }
+
     public static async ValueTask WhenAll(ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6)
     {
         List<Exception>? observedExceptions = null;
-                try
+        try
         {
             await task1.ConfigureAwait(false);
         }
@@ -752,7 +738,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task2.ConfigureAwait(false);
         }
@@ -761,7 +747,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task3.ConfigureAwait(false);
         }
@@ -770,7 +756,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task4.ConfigureAwait(false);
         }
@@ -779,7 +765,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task5.ConfigureAwait(false);
         }
@@ -788,7 +774,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task6.ConfigureAwait(false);
         }
@@ -808,10 +794,11 @@ public static partial class TaskEx
     {
         return WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6).GetAwaiter();
     }
+
     public static async ValueTask WhenAll(ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7)
     {
         List<Exception>? observedExceptions = null;
-                try
+        try
         {
             await task1.ConfigureAwait(false);
         }
@@ -820,7 +807,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task2.ConfigureAwait(false);
         }
@@ -829,7 +816,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task3.ConfigureAwait(false);
         }
@@ -838,7 +825,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task4.ConfigureAwait(false);
         }
@@ -847,7 +834,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task5.ConfigureAwait(false);
         }
@@ -856,7 +843,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task6.ConfigureAwait(false);
         }
@@ -865,7 +852,7 @@ public static partial class TaskEx
             observedExceptions ??= new();
             observedExceptions.Add(ex);
         }
-                try
+        try
         {
             await task7.ConfigureAwait(false);
         }

--- a/src/Meziantou.Framework/TaskEx.WhenAll.tt
+++ b/src/Meziantou.Framework/TaskEx.WhenAll.tt
@@ -1,4 +1,4 @@
-﻿<#@ template debug="true" hostspecific="false" language="C#" #>
+<#@ template debug="true" hostspecific="false" language="C#" #>
 <#@ output extension=".cs" #>
 <#@ assembly name="System.Linq" #>
 <#@ import namespace="System.Linq" #>
@@ -22,14 +22,12 @@ namespace Meziantou.Framework;
 
 // https://www.meziantou.net/get-the-result-of-multiple-tasks-in-a-valuetuple-and-whenall.htm
 public static partial class TaskEx
-{
-<# for (int i = 2; i <= count; i++) { #>
+{<# for (int i = 2; i <= count; i++) { #>
+
     public static async Task<(<#= GetTemplateString(i) #>)> WhenAll<<#= GetTemplateString(i) #>>(<#= Join(", ", i, i => "Task<T" + i + "> task" + i) #>)
     {
-        <# for (int j = 1; j <= i; j++) { #>
-        ArgumentNullException.ThrowIfNull(task<#= j #>);
-        <# } #>
-        await Task.WhenAll(<#= Join(", ", i, i => "task" + i) #>).ConfigureAwait(false);
+        <# for (int j = 1; j <= i; j++) { #>ArgumentNullException.ThrowIfNull(task<#= j #>);
+        <# } #>await Task.WhenAll(<#= Join(", ", i, i => "task" + i) #>).ConfigureAwait(false);
         return (<#= Join(", ", i, i => "task" + i + ".Result") #>);
     }
 
@@ -38,20 +36,19 @@ public static partial class TaskEx
         return WhenAll(<#= Join(", ", i, i => "tasks.Item" + i) #>).GetAwaiter();
     }
 <# } #>
-
 <# for (int i = 2; i <= count; i++) { #>
+
     public static TaskAwaiter GetAwaiter(this (<#= Join(", ", i, i => "Task") #>) tasks)
     {
         return Task.WhenAll(<#= Join(", ", i, i => "tasks.Item" + i) #>).GetAwaiter();
     }
 <# } #>
-
 <# for (int i = 2; i <= count; i++) { #>
+
     public static async ValueTask<(<#= GetTemplateString(i) #>)> WhenAll<<#= GetTemplateString(i) #>>(<#= Join(", ", i, i => "ValueTask<T" + i + "> task" + i) #>)
     {
         List<Exception>? observedExceptions = null;
-        <# for (int j = 1; j <= i; j++) { #>
-        T<#=j#> result<#=j#>;        
+        <# for (int j = 1; j <= i; j++) { #>T<#=j#> result<#=j#>;
         try
         {
             result<#=j#> = await task<#=j#>.ConfigureAwait(false);
@@ -77,13 +74,12 @@ public static partial class TaskEx
         return WhenAll(<#= Join(", ", i, i => "tasks.Item" + i) #>).GetAwaiter();
     }
 <# } #>
-
 <# for (int i = 2; i <= count; i++) { #>
+
     public static async ValueTask WhenAll(<#= Join(", ", i, i => "ValueTask task" + i) #>)
     {
         List<Exception>? observedExceptions = null;
-        <# for (int j = 1; j <= i; j++) { #>
-        try
+        <# for (int j = 1; j <= i; j++) { #>try
         {
             await task<#=j#>.ConfigureAwait(false);
         }
@@ -111,7 +107,7 @@ public static partial class TaskEx
     {
         return Join(", ", count, i => "T" + i);
     }
-    
+
     string Join(string separator, int count, Func<int, string> selector)
     {
         var str = "";


### PR DESCRIPTION
Nothing fancy, just better alignment of generated code from the T4 text template.

Note that I did it with Rider so it would be worth trying to generate it again with Visual Studio and ensure that there are no differences.