### PR TITLE
Update readme.md

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/readme.md
@@ -274,6 +274,32 @@ InlineSnapshot
 ````
 
 ````c#
+var data = JsonNode.Parse("""{ "prop": "value" }""");
+InlineSnapshot
+    .WithSerializer(options => options.ScrubJsonValue("$.prop", node => "[redacted]"))
+    .Validate(data, """
+        {
+          "prop": "[redacted]"
+        }
+        """);
+````
+
+````c#
+var data = XDocument.Parse("""
+                <root>
+                  <item attr="1">test1</item>
+                </root>
+                """);
+InlineSnapshot
+    .WithSerializer(options => options.ScrubXmlAttribute("//item/@attr", attribute => "[redacted]"))
+    .Validate(data, """
+        <root>
+          <item attr="[redacted]">test1</item>
+        </root>
+        """);
+````
+
+````c#
 InlineSnapshot
     .WithSettings(settings => settings.ScrubLines(line => line.Contains("dummy")))
     .Validate("abc\ndummy", "abc");
@@ -295,32 +321,6 @@ InlineSnapshot
 InlineSnapshot
     .WithSettings(settings => settings.ScrubLinesWithReplace(line => line.Replace("abc", "123")))
     .Validate("abcdef", "123def");
-````
-
-````c#
-var data = JsonNode.Parse("""{ "prop": "value" }""");
-InlineSnapshot
-    .WithSettings(settings => settings.ScrubJsonValue("$.prop", node => "[redacted]"))
-    .Validate(data, """
-        {
-          "prop": "[redacted]"
-        }
-        """);
-````
-
-````c#
-var data = XDocument.Parse("""
-                <root>
-                  <item attr="1">test1</item>
-                </root>
-                """);
-InlineSnapshot
-    .WithSettings(settings => settings.ScrubXmlAttribute("//item/@attr", attribute => "[redacted]"))
-    .Validate(data, """
-        <root>
-          <item attr="[redacted]">test1</item>
-        </root>
-        """);
 ````
 
 ## Invisible characters


### PR DESCRIPTION
Changed  scrub xml and scrub json to serializer and moved them up together with the other serializer snippets.

Also a question was trying to play around with this for mvc problem details, got a traceid as part of output. 
I could perhaps do a regex to match a traceid, but would rather not...
I also tried to just manipulate the object like so:
````c#
 var content = await result.Content.ReadFromJsonAsync<ProblemDetails>();

            Assert.NotNull(content);
            content.Extensions["traceId"] = "[any trace...]";

            InlineSnapshot
                .Validate
````

so my solution ended being this

````c#

 var content = await result.Content.ReadFromJsonAsync<ProblemDetails>();
            InlineSnapshot
                .WithSettings(x => x.ScrubLinesWithReplace(
                    x => x.Contains("traceid", StringComparison.OrdinalIgnoreCase) ? "  traceId: [any trace...]" : x
                    ))
                .Validate(content, """
                    Title: Validation Error
                    Status: 400
                    Detail:
                      Validation failed: 
                       -- PageNumber: 'Page Number' must be greater than '0'. Severity: Error
                    Instance: GET /meetinggroupproposals
                    Extensions:
                      traceId: [any trace...]
                      Errors:
                        [
                          {
                            "key": "PageNumber",
                            "value": "'Page Number' must be greater than '0'."
                          }
                        ]
                    """);
        }
                    
````

but maybe there is a better way?