### PR TITLE
Remove EnablePackageValidation from project file

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
@@ -7,9 +7,6 @@
 
     <Version>3.3.20</Version>
     <NoWarn>$(NoWarn);NU5100</NoWarn>
-
-    <!-- Buggy because of netstandard2.0 -->
-    <EnablePackageValidation>false</EnablePackageValidation>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Removed the EnablePackageValidation property due to issues with netstandard2.0.