### PR TITLE
Update SingleInstance to scope the NamedPipeServer per windows SessionId

### DIFF
--- a/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
+++ b/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
@@ -11,12 +11,13 @@ namespace Meziantou.Framework;
 public sealed class SingleInstance(Guid applicationId) : IDisposable
 {
     private const byte NotifyInstanceMessageType = 1;
+    private readonly int _sessionId = Process.GetCurrentProcess().SessionId;
     private NamedPipeServerStream? _server;
     private Mutex? _mutex;
 
     public event EventHandler<SingleInstanceEventArgs>? NewInstance;
 
-    private string PipeName => "Local\\Pipe" + applicationId.ToString();
+    private string PipeName => $"Local\\Pipe_{applicationId}_{_sessionId}";
 
     public bool StartServer { get; set; } = true;
 


### PR DESCRIPTION
Hello, I'm using your SingleInstance project in my .NET 9 app, and I found one specific situation, that leads to an `UnauthorizedAccessException`.

It happens, when two different Windows Users start the app on the same machine.
I managed to reproduce the issue, by using 2 local user accounts on my own machine, but the problem should also happen in Terminal-Servers.

I saw in the SingleInstance code, that you use user-scoped mutexes, which is great!
So I assume, that multiple users should be able to start the app in their own sessions without interfering with each other.

This works for the Mutex, but unfortunately doesn't work for the NamedPipeServerStream.

Even tho you specify `NamedPipeServerStream.MaxAllowedServerInstances`, the second user always gets an `UnauthorizedAccessException: Access to the path is denied` when the `NamedPipeServerStream` is created.

This PR contains a very simple fix, append the current windows `SessionId` to the `PipeName` to make it unique per user.

This way, both users can successfully start the app and subsequent app-launches by these users work with the `NotifyFirstInstance` functionality!