### PR TITLE
Fail fast on QR payload capacity overflow

### DIFF
--- a/src/Meziantou.Framework.QRCode/Internal/ErrorCorrectionEncoder.cs
+++ b/src/Meziantou.Framework.QRCode/Internal/ErrorCorrectionEncoder.cs
@@ -32,6 +32,11 @@ internal static class ErrorCorrectionEncoder
             dataIndex += group2DataCW;
         }
 
+        if (dataIndex != dataCodewords.Length)
+        {
+            throw new InvalidOperationException("The data is too long to be encoded in a QR code.");
+        }
+
         // Compute EC for each block
         for (var i = 0; i < totalBlocks; i++)
         {
@@ -50,6 +55,11 @@ internal static class ErrorCorrectionEncoder
             {
                 if (col < dataBlocks[block].Length)
                 {
+                    if (resultIndex >= result.Length)
+                    {
+                        throw new InvalidOperationException("The data is too long to be encoded in a QR code.");
+                    }
+
                     result[resultIndex++] = dataBlocks[block][col];
                 }
             }
@@ -60,8 +70,18 @@ internal static class ErrorCorrectionEncoder
         {
             for (var block = 0; block < totalBlocks; block++)
             {
+                if (resultIndex >= result.Length)
+                {
+                    throw new InvalidOperationException("The data is too long to be encoded in a QR code.");
+                }
+
                 result[resultIndex++] = ecBlocks[block][col];
             }
+        }
+
+        if (resultIndex != result.Length)
+        {
+            throw new InvalidOperationException("The data is too long to be encoded in a QR code.");
         }
 
         return result;

--- a/src/Meziantou.Framework.QRCode/Meziantou.Framework.QRCode.csproj
+++ b/src/Meziantou.Framework.QRCode/Meziantou.Framework.QRCode.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework</RootNamespace>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>QR Code generation with SVG and console renderers</Description>
     <NoWarn>$(NoWarn);CA1814</NoWarn>

--- a/tests/Meziantou.Framework.QRCode.Tests/QRCodeTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/QRCodeTests.cs
@@ -986,6 +986,14 @@ public class QRCodeTests
         Assert.Throws<InvalidOperationException>(() => QRCode.Create(longData, ErrorCorrectionLevel.L));
     }
 
+    [Fact]
+    public void Create_AlphanumericDataTooLong_ThrowsInvalidOperationException()
+    {
+        var longData = new string('A', 660);
+
+        Assert.Throws<InvalidOperationException>(() => QRCode.Create(longData, ErrorCorrectionLevel.Q));
+    }
+
     // ───── Determinism ─────
 
     [Fact]


### PR DESCRIPTION
The QR generator could accept payloads that pass initial version selection but still overrun the effective codeword layout during EC/data interleaving, which can lead to malformed output instead of a clear failure.

This change adds defensive capacity validation in `ErrorCorrectionEncoder.AddErrorCorrection` so we now throw `InvalidOperationException` as soon as we detect inconsistent/overflow conditions:

- verify all input data codewords are consumed by block splitting,
- prevent writes past the expected total codeword buffer while interleaving,
- verify the final interleaved length matches the QR version total.

A regression test was added in `QRCodeTests` for a long alphanumeric payload (`new string('A', 660)` with `ErrorCorrectionLevel.Q`) to ensure this path throws.

`Meziantou.Framework.QRCode.csproj` version was also updated to `1.0.4` by the repository maintenance scripts run as part of this change.