### PR TITLE
Add ProcessWrapper resource limits via JobObject and cgroup

### DIFF
--- a/slnx/Meziantou.Framework.DependencyScanning.Tool.slnx
+++ b/slnx/Meziantou.Framework.DependencyScanning.Tool.slnx
@@ -6,7 +6,9 @@
     <Project Path="../src/Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj" />
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
     <Project Path="../src/Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj" />
+    <Project Path="../src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj" />
     <Project Path="../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/slnx/Meziantou.Framework.DependencyScanning.slnx
+++ b/slnx/Meziantou.Framework.DependencyScanning.slnx
@@ -5,7 +5,9 @@
     <Project Path="../src/Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj" />
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
     <Project Path="../src/Meziantou.Framework.ValueStopwatch/Meziantou.Framework.ValueStopwatch.csproj" />
+    <Project Path="../src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj" />
     <Project Path="../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/slnx/Meziantou.Framework.ProcessWrapper.slnx
+++ b/slnx/Meziantou.Framework.ProcessWrapper.slnx
@@ -5,7 +5,9 @@
     <Project Path="../src/Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj" />
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
     <Project Path="../src/Meziantou.Framework.ValueStopwatch/Meziantou.Framework.ValueStopwatch.csproj" />
+    <Project Path="../src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj" />
     <Project Path="../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/slnx/Meziantou.Framework.TemporaryDirectory.slnx
+++ b/slnx/Meziantou.Framework.TemporaryDirectory.slnx
@@ -14,8 +14,10 @@
     <Project Path="../src/Meziantou.Framework.NuGetPackageValidation/Meziantou.Framework.NuGetPackageValidation.csproj" />
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
     <Project Path="../src/Meziantou.Framework.ValueStopwatch/Meziantou.Framework.ValueStopwatch.csproj" />
     <Project Path="../src/Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj" />
+    <Project Path="../src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj" />
     <Project Path="../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/slnx/Meziantou.Framework.ValueStopwatch.slnx
+++ b/slnx/Meziantou.Framework.ValueStopwatch.slnx
@@ -5,7 +5,9 @@
     <Project Path="../src/Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj" />
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
     <Project Path="../src/Meziantou.Framework.ValueStopwatch/Meziantou.Framework.ValueStopwatch.csproj" />
+    <Project Path="../src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj" />
     <Project Path="../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/slnx/Meziantou.Framework.slnx
+++ b/slnx/Meziantou.Framework.slnx
@@ -10,7 +10,9 @@
     <Project Path="../src/Meziantou.Framework.StronglyTypedId.Annotations/Meziantou.Framework.StronglyTypedId.Annotations.csproj" />
     <Project Path="../src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
     <Project Path="../src/Meziantou.Framework.ValueStopwatch/Meziantou.Framework.ValueStopwatch.csproj" />
+    <Project Path="../src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj" />
     <Project Path="../src/Meziantou.Framework.Win32.ProjectedFileSystem/Meziantou.Framework.Win32.ProjectedFileSystem.csproj" />
     <Project Path="../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </Folder>

--- a/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
@@ -9,8 +9,8 @@ public sealed class BufferedProcessInstance : ProcessInstance
     private readonly ProcessOutputCollection _output;
     private Task<BufferedProcessResult>? _waitTask;
 
-    internal BufferedProcessInstance(Process process, Task inputTask, CancellationTokenRegistration cancellationRegistration, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, CancellationToken cancellationToken)
-        : base(process, inputTask, cancellationRegistration, validationMode, hasStandardErrorOutput, cancellationToken)
+    internal BufferedProcessInstance(Process process, Task inputTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, CancellationToken cancellationToken)
+        : base(process, inputTask, cancellationRegistration, processLimiter, validationMode, hasStandardErrorOutput, cancellationToken)
     {
         _output = output;
     }

--- a/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
+++ b/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
@@ -12,4 +12,9 @@
     <Compile Include="..\Meziantou.Framework\ExecutableFinder.cs" Link="Utils\ExecutableFinder.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Meziantou.Framework.Unix.ControlGroups\Meziantou.Framework.Unix.ControlGroups.csproj" />
+    <ProjectReference Include="..\Meziantou.Framework.Win32.Jobs\Meziantou.Framework.Win32.Jobs.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
@@ -15,6 +15,7 @@ public class ProcessInstance
     private Process? _process;
     private readonly Task _inputStreamTask;
     private readonly CancellationTokenRegistration _cancellationRegistration;
+    private readonly IDisposable? _processLimiter;
     private readonly ProcessValidationMode _validationMode;
     private readonly CancellationToken _cancellationToken;
     private readonly Func<bool> _hasStandardErrorOutput;
@@ -22,11 +23,12 @@ public class ProcessInstance
     private protected readonly Lock WaitTaskLock = new();
     private Task<ProcessResult>? _waitTask;
 
-    internal ProcessInstance(Process process, Task inputStreamTask, CancellationTokenRegistration cancellationRegistration, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, CancellationToken cancellationToken)
+    internal ProcessInstance(Process process, Task inputStreamTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, CancellationToken cancellationToken)
     {
         _process = process;
         _inputStreamTask = inputStreamTask;
         _cancellationRegistration = cancellationRegistration;
+        _processLimiter = processLimiter;
         _validationMode = validationMode;
         _cancellationToken = cancellationToken;
         _hasStandardErrorOutput = hasStandardErrorOutput;
@@ -152,6 +154,7 @@ public class ProcessInstance
         {
             _cancellationRegistration.Dispose();
             process.Dispose();
+            _processLimiter?.Dispose();
 
             if (ReferenceEquals(_process, process))
             {

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessLimits.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessLimits.cs
@@ -1,0 +1,16 @@
+namespace Meziantou.Framework;
+
+/// <summary>Represents the cross-platform process limits that can be applied by <see cref="ProcessWrapper"/>.</summary>
+public sealed class ProcessLimits
+{
+    /// <summary>Gets or sets the maximum CPU usage in percentage between 1 and 100.</summary>
+    public int? CpuPercentage { get; set; }
+
+    /// <summary>Gets or sets the maximum memory usage in bytes.</summary>
+    public long? MemoryLimitInBytes { get; set; }
+
+    /// <summary>Gets or sets the maximum number of processes allowed in the process group.</summary>
+    public int? ProcessCountLimit { get; set; }
+
+    internal bool HasAnyLimitConfigured => CpuPercentage is not null || MemoryLimitInBytes is not null || ProcessCountLimit is not null;
+}

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -1,7 +1,12 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Text;
+using Meziantou.Framework.Unix.ControlGroups;
+using Meziantou.Framework.Win32;
 
 namespace Meziantou.Framework;
 
@@ -17,6 +22,9 @@ public sealed class ProcessWrapper
     private ImmutableArray<Action<string>> _outputHandlers;
     private ImmutableArray<Action<string>> _errorHandlers;
     private ProcessInputStream? _inputStream;
+    private ProcessLimits? _limits;
+    private Action<JobObject>? _windowsJobObjectConfiguration;
+    private Action<CGroup2>? _linuxControlGroupConfiguration;
 
     private ProcessWrapper(string fileName)
     {
@@ -102,6 +110,40 @@ public sealed class ProcessWrapper
     public ProcessWrapper WithValidation(ProcessValidationMode mode)
     {
         _validationMode = mode;
+        return this;
+    }
+
+    /// <summary>Sets the process limits, replacing previously configured limits.</summary>
+    public ProcessWrapper WithLimits(ProcessLimits limits)
+    {
+        ArgumentNullException.ThrowIfNull(limits);
+        _limits = limits;
+        return this;
+    }
+
+    /// <summary>Configures process limits. Accumulates with previous calls.</summary>
+    public ProcessWrapper WithLimits(Action<ProcessLimits> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        _limits ??= new ProcessLimits();
+        configure(_limits);
+        return this;
+    }
+
+    /// <summary>Configures the Windows Job Object used to apply process limits.</summary>
+    public ProcessWrapper WithWindowsJobObject(Action<JobObject> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        _windowsJobObjectConfiguration = configure;
+        return this;
+    }
+
+    /// <summary>Configures the Linux cgroup used to apply process limits.</summary>
+    public ProcessWrapper WithLinuxControlGroup(Action<CGroup2> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        _linuxControlGroupConfiguration = configure;
         return this;
     }
 
@@ -234,7 +276,7 @@ public sealed class ProcessWrapper
     public ProcessInstance ExecuteAsync(CancellationToken cancellationToken = default)
     {
         return StartProcess(_outputHandlers, _errorHandlers,
-            (process, inputTask, registration, hasStandardErrorOutput, ct) => new ProcessInstance(process, inputTask, registration, _validationMode, hasStandardErrorOutput, ct),
+            (process, inputTask, registration, limiter, hasStandardErrorOutput, ct) => new ProcessInstance(process, inputTask, registration, limiter, _validationMode, hasStandardErrorOutput, ct),
             cancellationToken);
     }
 
@@ -251,12 +293,12 @@ public sealed class ProcessWrapper
         var errorHandlers = _errorHandlers.Add(line => output.Add(ProcessOutputType.StandardError, line));
 
         return StartProcess(outputHandlers, errorHandlers,
-            (process, inputTask, registration, hasStandardErrorOutput, ct) => new BufferedProcessInstance(process, inputTask, registration, _validationMode, output, hasStandardErrorOutput, ct),
+            (process, inputTask, registration, limiter, hasStandardErrorOutput, ct) => new BufferedProcessInstance(process, inputTask, registration, limiter, _validationMode, output, hasStandardErrorOutput, ct),
             cancellationToken);
     }
 
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "ProcessInstance will dispose it")]
-    private T StartProcess<T>(ImmutableArray<Action<string>> outputHandlers, ImmutableArray<Action<string>> errorHandlers, Func<Process, Task, CancellationTokenRegistration, Func<bool>, CancellationToken, T> factory, CancellationToken cancellationToken)
+    private T StartProcess<T>(ImmutableArray<Action<string>> outputHandlers, ImmutableArray<Action<string>> errorHandlers, Func<Process, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, CancellationToken, T> factory, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -273,6 +315,7 @@ public sealed class ProcessWrapper
         _startInfo.FileName = ResolveFileName(configuredFileName, _startInfo.WorkingDirectory);
 
         var process = new Process { StartInfo = _startInfo };
+        var processLimiter = CreateProcessLimiter();
 
         if (hasOutputHandlers)
         {
@@ -303,16 +346,35 @@ public sealed class ProcessWrapper
             };
         }
 
+        var processStarted = false;
         try
         {
-            if (!process.Start())
+            try
             {
-                throw new Win32Exception("Cannot start the process");
+                if (!process.Start())
+                {
+                    throw new Win32Exception("Cannot start the process");
+                }
+
+                processStarted = true;
             }
+            finally
+            {
+                _startInfo.FileName = configuredFileName;
+            }
+
+            processLimiter?.Apply(process);
         }
-        finally
+        catch
         {
-            _startInfo.FileName = configuredFileName;
+            if (processStarted)
+            {
+                ProcessInstance.KillProcess(process, entireProcessTree: true);
+            }
+
+            process.Dispose();
+            processLimiter?.Dispose();
+            throw;
         }
 
         if (hasOutputHandlers)
@@ -352,7 +414,216 @@ public sealed class ProcessWrapper
             registration = cancellationToken.Register(() => ProcessInstance.KillProcess(process, entireProcessTree: true));
         }
 
-        return factory(process, inputStreamTask, registration, () => Volatile.Read(ref hasStandardErrorOutput) != 0, cancellationToken);
+        return factory(process, inputStreamTask, registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, cancellationToken);
+    }
+
+    private IProcessLimiter? CreateProcessLimiter()
+    {
+        var hasWindowsConfiguration = _windowsJobObjectConfiguration is not null;
+        var hasLinuxConfiguration = _linuxControlGroupConfiguration is not null;
+        var hasCommonLimits = _limits?.HasAnyLimitConfigured == true;
+
+        if (!hasWindowsConfiguration && !hasLinuxConfiguration && !hasCommonLimits)
+            return null;
+
+        if (hasCommonLimits)
+        {
+            ValidateLimits(_limits!);
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            if (hasLinuxConfiguration)
+                throw new PlatformNotSupportedException("Linux control group configuration can be used only on Linux.");
+
+            return new WindowsProcessLimiter(_limits, _windowsJobObjectConfiguration);
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            if (hasWindowsConfiguration)
+                throw new PlatformNotSupportedException("Windows job object configuration can be used only on Windows.");
+
+            return new LinuxProcessLimiter(_limits, _linuxControlGroupConfiguration);
+        }
+
+        throw new PlatformNotSupportedException("Process limits are supported only on Windows and Linux.");
+    }
+
+    private static void ValidateLimits(ProcessLimits limits)
+    {
+        if (limits.CpuPercentage is < 1 or > 100)
+            throw new ArgumentOutOfRangeException(nameof(limits.CpuPercentage), "CPU percentage must be between 1 and 100.");
+
+        if (limits.MemoryLimitInBytes is <= 0)
+            throw new ArgumentOutOfRangeException(nameof(limits.MemoryLimitInBytes), "Memory limit must be greater than 0.");
+
+        if (limits.ProcessCountLimit is <= 0)
+            throw new ArgumentOutOfRangeException(nameof(limits.ProcessCountLimit), "Process count limit must be greater than 0.");
+    }
+
+    private interface IProcessLimiter : IDisposable
+    {
+        void Apply(Process process);
+    }
+
+    private sealed class WindowsProcessLimiter : IProcessLimiter
+    {
+        private readonly JobObject _jobObject;
+
+        public WindowsProcessLimiter(ProcessLimits? limits, Action<JobObject>? configure)
+        {
+            _jobObject = new JobObject();
+
+            if (limits?.MemoryLimitInBytes is not null || limits?.ProcessCountLimit is not null)
+            {
+                var jobLimits = new JobObjectLimits();
+
+                if (limits.MemoryLimitInBytes is not null)
+                {
+                    jobLimits.JobMemoryLimit = checked((nuint)limits.MemoryLimitInBytes.Value);
+                }
+
+                if (limits.ProcessCountLimit is not null)
+                {
+                    jobLimits.ActiveProcessLimit = checked((uint)limits.ProcessCountLimit.Value);
+                }
+
+                _jobObject.SetLimits(jobLimits);
+            }
+
+            if (limits?.CpuPercentage is not null)
+            {
+                _jobObject.SetCpuRateHardCap(limits.CpuPercentage.Value * 100);
+            }
+
+            configure?.Invoke(_jobObject);
+        }
+
+        public void Apply(Process process)
+        {
+            ArgumentNullException.ThrowIfNull(process);
+            _jobObject.AssignProcess(process);
+        }
+
+        public void Dispose()
+        {
+            _jobObject.Dispose();
+        }
+    }
+
+    private sealed class LinuxProcessLimiter : IProcessLimiter
+    {
+        private readonly ProcessLimits? _limits;
+        private readonly Action<CGroup2>? _configure;
+        private CGroup2? _parentControlGroup;
+        private CGroup2? _controlGroup;
+
+        public LinuxProcessLimiter(ProcessLimits? limits, Action<CGroup2>? configure)
+        {
+            _limits = limits;
+            _configure = configure;
+        }
+
+        public void Apply(Process process)
+        {
+            ArgumentNullException.ThrowIfNull(process);
+
+            _parentControlGroup = CGroup2.Root.CreateOrGetChild($"process-wrapper-{Environment.ProcessId}-{Guid.NewGuid():N}");
+            var availableControllers = _parentControlGroup.GetAvailableControllers().ToHashSet(StringComparer.Ordinal);
+            var controllersToEnable = new HashSet<string>(StringComparer.Ordinal);
+
+            if (_limits?.CpuPercentage is not null)
+            {
+                EnsureControllerIsAvailable(availableControllers, "cpu");
+                controllersToEnable.Add("cpu");
+            }
+
+            if (_limits?.MemoryLimitInBytes is not null)
+            {
+                EnsureControllerIsAvailable(availableControllers, "memory");
+                controllersToEnable.Add("memory");
+            }
+
+            if (_limits?.ProcessCountLimit is not null)
+            {
+                EnsureControllerIsAvailable(availableControllers, "pids");
+                controllersToEnable.Add("pids");
+            }
+
+            if (_configure is not null)
+            {
+                foreach (var controller in availableControllers)
+                {
+                    controllersToEnable.Add(controller);
+                }
+            }
+
+            if (controllersToEnable.Count > 0)
+            {
+                _parentControlGroup.SetControllers(controllersToEnable.ToArray());
+            }
+
+            _controlGroup = _parentControlGroup.CreateOrGetChild($"process-{Guid.NewGuid():N}");
+
+            if (_limits?.CpuPercentage is not null)
+            {
+                const long periodMicroseconds = 100000;
+                var maxMicroseconds = (long)Math.Ceiling(_limits.CpuPercentage.Value * periodMicroseconds / 100d);
+                _controlGroup.SetCpuMax(maxMicroseconds, periodMicroseconds);
+            }
+
+            if (_limits?.MemoryLimitInBytes is not null)
+            {
+                _controlGroup.SetMemoryMax(_limits.MemoryLimitInBytes.Value);
+            }
+
+            if (_limits?.ProcessCountLimit is not null)
+            {
+                _controlGroup.SetPidsMax(_limits.ProcessCountLimit.Value);
+            }
+
+            _configure?.Invoke(_controlGroup);
+            _controlGroup.AssociateProcess(process);
+        }
+
+        public void Dispose()
+        {
+            var controlGroup = Interlocked.Exchange(ref _controlGroup, null);
+            TryDeleteControlGroup(controlGroup);
+
+            var parentControlGroup = Interlocked.Exchange(ref _parentControlGroup, null);
+            TryDeleteControlGroup(parentControlGroup);
+        }
+
+        private static void EnsureControllerIsAvailable(HashSet<string> availableControllers, string controllerName)
+        {
+            if (!availableControllers.Contains(controllerName))
+                throw new NotSupportedException($"The '{controllerName}' cgroup controller is not available.");
+        }
+
+        private static void TryDeleteControlGroup(CGroup2? controlGroup)
+        {
+            if (controlGroup is null)
+                return;
+
+            try
+            {
+                if (controlGroup.Exists())
+                {
+                    controlGroup.Delete();
+                }
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
     }
 
     private static string ResolveFileName(string fileName, string? workingDirectory)

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Text;
 using Meziantou.Framework.Unix.ControlGroups;
 using Meziantou.Framework.Win32;
@@ -431,12 +432,17 @@ public sealed class ProcessWrapper
             ValidateLimits(_limits!);
         }
 
-        if (OperatingSystem.IsWindows())
+        if (OperatingSystem.IsWindowsVersionAtLeast(5, 1, 2600))
         {
             if (hasLinuxConfiguration)
                 throw new PlatformNotSupportedException("Linux control group configuration can be used only on Linux.");
 
             return new WindowsProcessLimiter(_limits, _windowsJobObjectConfiguration);
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            throw new PlatformNotSupportedException("Windows process limits are supported only on Windows 5.1.2600 and later.");
         }
 
         if (OperatingSystem.IsLinux())
@@ -453,13 +459,13 @@ public sealed class ProcessWrapper
     private static void ValidateLimits(ProcessLimits limits)
     {
         if (limits.CpuPercentage is < 1 or > 100)
-            throw new ArgumentOutOfRangeException(nameof(limits.CpuPercentage), "CPU percentage must be between 1 and 100.");
+            throw new ArgumentOutOfRangeException(nameof(limits), limits.CpuPercentage, $"{nameof(ProcessLimits.CpuPercentage)} must be between 1 and 100.");
 
         if (limits.MemoryLimitInBytes is <= 0)
-            throw new ArgumentOutOfRangeException(nameof(limits.MemoryLimitInBytes), "Memory limit must be greater than 0.");
+            throw new ArgumentOutOfRangeException(nameof(limits), limits.MemoryLimitInBytes, $"{nameof(ProcessLimits.MemoryLimitInBytes)} must be greater than 0.");
 
         if (limits.ProcessCountLimit is <= 0)
-            throw new ArgumentOutOfRangeException(nameof(limits.ProcessCountLimit), "Process count limit must be greater than 0.");
+            throw new ArgumentOutOfRangeException(nameof(limits), limits.ProcessCountLimit, $"{nameof(ProcessLimits.ProcessCountLimit)} must be greater than 0.");
     }
 
     private interface IProcessLimiter : IDisposable
@@ -467,6 +473,7 @@ public sealed class ProcessWrapper
         void Apply(Process process);
     }
 
+    [SupportedOSPlatform("windows5.1.2600")]
     private sealed class WindowsProcessLimiter : IProcessLimiter
     {
         private readonly JobObject _jobObject;
@@ -512,6 +519,7 @@ public sealed class ProcessWrapper
         }
     }
 
+    [SupportedOSPlatform("linux")]
     private sealed class LinuxProcessLimiter : IProcessLimiter
     {
         private readonly ProcessLimits? _limits;
@@ -568,9 +576,9 @@ public sealed class ProcessWrapper
 
             if (_limits?.CpuPercentage is not null)
             {
-                const long periodMicroseconds = 100000;
-                var maxMicroseconds = (long)Math.Ceiling(_limits.CpuPercentage.Value * periodMicroseconds / 100d);
-                _controlGroup.SetCpuMax(maxMicroseconds, periodMicroseconds);
+                const long PeriodMicroseconds = 100000;
+                var maxMicroseconds = (long)Math.Ceiling(_limits.CpuPercentage.Value * PeriodMicroseconds / 100d);
+                _controlGroup.SetCpuMax(maxMicroseconds, PeriodMicroseconds);
             }
 
             if (_limits?.MemoryLimitInBytes is not null)

--- a/src/Meziantou.Framework.ProcessWrapper/readme.md
+++ b/src/Meziantou.Framework.ProcessWrapper/readme.md
@@ -59,6 +59,46 @@ await ProcessWrapper.Create("my-app")
     .ExecuteAsync();
 ````
 
+## Resource limits
+
+````c#
+var result = await ProcessWrapper.Create("my-app")
+    .WithLimits(new ProcessLimits
+    {
+        CpuPercentage = 50,            // 50% max CPU
+        MemoryLimitInBytes = 512L * 1024 * 1024, // 512 MB
+        ProcessCountLimit = 20,
+    })
+    .ExecuteAsync();
+````
+
+Common limits are mapped to Windows Job Objects or Linux cgroups v2 depending on the current OS.
+If a configured limit cannot be applied on the current platform, execution throws.
+
+### Advanced platform-specific configuration
+
+````c#
+var result = await ProcessWrapper.Create("my-app")
+    .WithLimits(limits => limits.MemoryLimitInBytes = 512L * 1024 * 1024)
+    .WithWindowsJobObject(job =>
+    {
+        job.SetLimits(new JobObjectLimits
+        {
+            Flags = JobObjectLimitFlags.KillOnJobClose,
+        });
+    })
+    .ExecuteAsync();
+````
+
+````c#
+var result = await ProcessWrapper.Create("my-app")
+    .WithLinuxControlGroup(cgroup =>
+    {
+        cgroup.SetMemoryHigh(256L * 1024 * 1024);
+    })
+    .ExecuteAsync();
+````
+
 ## Output handling
 
 ````c#
@@ -147,4 +187,3 @@ var process = ProcessWrapper.Create("long-running-process")
 process.Kill(); // or process.Kill(entireProcessTree: false)
 await process;
 ````
-

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -460,6 +460,78 @@ public class ProcessWrapperTests
         Assert.Same(command, command.WithErrorStream(_ => { }));
         Assert.Same(command, command.AddErrorStream(_ => { }));
         Assert.Same(command, command.WithInputStream("stdin"));
+        Assert.Same(command, command.WithLimits(new ProcessLimits()));
+        Assert.Same(command, command.WithLimits(limits => limits.CpuPercentage = 50));
+        Assert.Same(command, command.WithWindowsJobObject(_ => { }));
+        Assert.Same(command, command.WithLinuxControlGroup(_ => { }));
+    }
+
+    [Fact]
+    public void ExecuteAsync_WithInvalidCpuLimit_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            _ = CreateEchoCommand("test")
+                .WithLimits(new ProcessLimits { CpuPercentage = 0 })
+                .ExecuteAsync();
+        });
+    }
+
+    [Fact]
+    public void ExecuteAsync_WithInvalidMemoryLimit_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            _ = CreateEchoCommand("test")
+                .WithLimits(new ProcessLimits { MemoryLimitInBytes = -1 })
+                .ExecuteAsync();
+        });
+    }
+
+    [Fact]
+    public void ExecuteAsync_WithInvalidProcessCountLimit_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            _ = CreateEchoCommand("test")
+                .WithLimits(new ProcessLimits { ProcessCountLimit = 0 })
+                .ExecuteAsync();
+        });
+    }
+
+    [Fact]
+    public void ExecuteAsync_WithUnsupportedPlatformSpecificConfiguration_Throws()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Throws<PlatformNotSupportedException>(() =>
+            {
+                _ = CreateEchoCommand("test")
+                    .WithLinuxControlGroup(_ => { })
+                    .ExecuteAsync();
+            });
+
+            return;
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            Assert.Throws<PlatformNotSupportedException>(() =>
+            {
+                _ = CreateEchoCommand("test")
+                    .WithWindowsJobObject(_ => { })
+                    .ExecuteAsync();
+            });
+
+            return;
+        }
+
+        Assert.Throws<PlatformNotSupportedException>(() =>
+        {
+            _ = CreateEchoCommand("test")
+                .WithLimits(new ProcessLimits { CpuPercentage = 10 })
+                .ExecuteAsync();
+        });
     }
 
     [Fact]


### PR DESCRIPTION
## Why
ProcessWrapper needed a first-class way to apply resource limits to started processes using the existing platform libraries in this repo. This adds a unified API for common limits while still allowing advanced platform-specific configuration.

## What changed
- Added a new cross-platform limits type: `ProcessLimits` (CPU %, memory bytes, process count).
- Extended `ProcessWrapper` with:
  - `WithLimits(ProcessLimits)`
  - `WithLimits(Action<ProcessLimits>)`
  - `WithWindowsJobObject(Action<JobObject>)`
  - `WithLinuxControlGroup(Action<CGroup2>)`
- Wired limit application into process startup:
  - Windows: creates/configures a `JobObject`, then assigns the started process.
  - Linux: creates/configures a cgroup v2 hierarchy, then associates the started process.
- Kept limiter resources alive for the process lifetime and dispose/cleanup on process completion.
- Added fail-fast behavior for unsupported platform-specific configuration and invalid limit values.
- Updated `ProcessWrapper` docs and tests for fluent API behavior and validation/error scenarios.

## Notes for reviewers
- The unified API intentionally covers only common limits; advanced knobs remain available through platform callbacks.
- `update-project-slnx` refreshed generated `slnx/*` files as part of required maintenance scripts.