### PR TITLE
Improve reliability of UDP protocol integration test

### DIFF
--- a/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
@@ -290,7 +290,7 @@ public sealed class DnsServerIntegrationTests
         try
         {
             using var client = new ClientDns.DnsClient($"127.0.0.1:{port}", ClientDns.DnsClientProtocol.Udp);
-            await client.QueryAsync("test.example.com", ClientDns.Query.DnsQueryType.A);
+            await XUnitStaticHelpers.Retry(() => client.QueryAsync("test.example.com", ClientDns.Query.DnsQueryType.A, XUnitStaticHelpers.XunitCancellationToken));
 
             Assert.Equal(DnsServerProtocol.Udp, capturedProtocol);
         }


### PR DESCRIPTION
The UDP protocol integration test was intermittently failing in CI with `OperationCanceledException` during a single-shot UDP query. This change makes the test resilient to transient timing/network scheduling issues so it better reflects real behavior instead of random transport jitter.

## What changed
- Updated `DnsServerIntegrationTests.Udp_ProtocolIsUdp` to use `XUnitStaticHelpers.Retry(...)` around the UDP query.
- Passed `XUnitStaticHelpers.XunitCancellationToken` into the query call for consistent test cancellation behavior.

## Notes for reviewers
- This is test-only and scoped to one assertion path.
- The pattern now matches the existing retry strategy already used by other UDP integration tests in the same file.