### PR TITLE
Add binary stream handlers and encoding options to ProcessWrapper

### DIFF
--- a/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
@@ -9,8 +9,8 @@ public sealed class BufferedProcessInstance : ProcessInstance
     private readonly ProcessOutputCollection _output;
     private Task<BufferedProcessResult>? _waitTask;
 
-    internal BufferedProcessInstance(Process process, Task inputTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, CancellationToken cancellationToken)
-        : base(process, inputTask, cancellationRegistration, processLimiter, validationMode, hasStandardErrorOutput, cancellationToken)
+    internal BufferedProcessInstance(Process process, Task inputTask, Task outputTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, CancellationToken cancellationToken)
+        : base(process, inputTask, outputTask, cancellationRegistration, processLimiter, validationMode, hasStandardErrorOutput, cancellationToken)
     {
         _output = output;
     }

--- a/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
+++ b/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework</RootNamespace>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Fluent API for wrapping System.Diagnostics.Process</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
@@ -14,6 +14,7 @@ public class ProcessInstance
 {
     private Process? _process;
     private readonly Task _inputStreamTask;
+    private readonly Task _outputStreamTask;
     private readonly CancellationTokenRegistration _cancellationRegistration;
     private readonly IDisposable? _processLimiter;
     private readonly ProcessValidationMode _validationMode;
@@ -23,10 +24,11 @@ public class ProcessInstance
     private protected readonly Lock WaitTaskLock = new();
     private Task<ProcessResult>? _waitTask;
 
-    internal ProcessInstance(Process process, Task inputStreamTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, CancellationToken cancellationToken)
+    internal ProcessInstance(Process process, Task inputStreamTask, Task outputStreamTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, CancellationToken cancellationToken)
     {
         _process = process;
         _inputStreamTask = inputStreamTask;
+        _outputStreamTask = outputStreamTask;
         _cancellationRegistration = cancellationRegistration;
         _processLimiter = processLimiter;
         _validationMode = validationMode;
@@ -111,6 +113,11 @@ public class ProcessInstance
                 ExceptionDispatchInfo.Capture(processCompletion.InputStreamException).Throw();
             }
 
+            if (processCompletion.OutputStreamException is not null)
+            {
+                ExceptionDispatchInfo.Capture(processCompletion.OutputStreamException).Throw();
+            }
+
             _cancellationToken.ThrowIfCancellationRequested();
 
             if ((_validationMode & ProcessValidationMode.FailIfNonZeroExitCode) == ProcessValidationMode.FailIfNonZeroExitCode && processCompletion.ExitCode != 0)
@@ -131,6 +138,7 @@ public class ProcessInstance
     private async Task<ProcessCompletion> WaitForProcessExitAsync(Process process)
     {
         Exception? inputStreamException = null;
+        Exception? outputStreamException = null;
         var exitCode = default(int);
         var exitDate = default(DateTimeOffset);
 
@@ -145,6 +153,15 @@ public class ProcessInstance
             catch (Exception ex)
             {
                 inputStreamException = ex;
+            }
+
+            try
+            {
+                await _outputStreamTask.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                outputStreamException = ex;
             }
 
             exitCode = process.ExitCode;
@@ -162,7 +179,7 @@ public class ProcessInstance
             }
         }
 
-        return new ProcessCompletion(exitCode, exitDate, inputStreamException);
+        return new ProcessCompletion(exitCode, exitDate, inputStreamException, outputStreamException);
     }
 
     private protected virtual ProcessResult CreateProcessResult(int exitCode, DateTimeOffset exitDate)
@@ -172,11 +189,12 @@ public class ProcessInstance
 
     private sealed class ProcessCompletion
     {
-        public ProcessCompletion(int exitCode, DateTimeOffset exitDate, Exception? inputStreamException)
+        public ProcessCompletion(int exitCode, DateTimeOffset exitDate, Exception? inputStreamException, Exception? outputStreamException)
         {
             ExitCode = exitCode;
             ExitDate = exitDate;
             InputStreamException = inputStreamException;
+            OutputStreamException = outputStreamException;
         }
 
         public int ExitCode { get; }
@@ -184,5 +202,7 @@ public class ProcessInstance
         public DateTimeOffset ExitDate { get; }
 
         public Exception? InputStreamException { get; }
+
+        public Exception? OutputStreamException { get; }
     }
 }

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -13,8 +13,8 @@ namespace Meziantou.Framework;
 
 /// <summary>
 /// Fluent builder for configuring and running processes.
-/// Every <c>With*</c> method mutates the current instance.
-/// Handler-related <c>With*</c> methods accumulate with previous calls.
+/// Every <c>With*</c> method mutates the current instance with the replaced value.
+/// Every <c>Add*</c> method mutates the current instance with the appended value.
 /// </summary>
 public sealed class ProcessWrapper
 {
@@ -168,60 +168,120 @@ public sealed class ProcessWrapper
         return this;
     }
 
-    /// <summary>Adds an output stream handler.</summary>
-    public ProcessWrapper WithOutputStream(Action<string> handler)
+    /// <summary>Replaces all output stream handlers with the specified handlers.</summary>
+    public ProcessWrapper WithOutputStream(params ReadOnlySpan<Action<string>> handlers)
     {
-        ArgumentNullException.ThrowIfNull(handler);
-        _outputHandlers = _outputHandlers.Add(handler);
+        _outputHandlers = CreateImmutableArray(handlers, nameof(handlers));
+        _outputBinaryHandlers = [];
         return this;
     }
 
-    /// <summary>Adds a binary output stream handler that writes to the specified <see cref="Stream"/>.</summary>
-    public ProcessWrapper WithOutputStream(Stream stream)
+    /// <summary>Replaces all binary output stream handlers with the specified streams.</summary>
+    public ProcessWrapper WithOutputStream(params ReadOnlySpan<Stream> streams)
     {
-        ArgumentNullException.ThrowIfNull(stream);
-        _outputBinaryHandlers = _outputBinaryHandlers.Add(stream);
+        _outputHandlers = [];
+        _outputBinaryHandlers = CreateImmutableArray(streams, nameof(streams));
         return this;
     }
 
-    /// <summary>Adds an output stream handler that appends to the specified <see cref="StringBuilder"/>.</summary>
+    /// <summary>Replaces all output stream handlers with one that appends to the specified <see cref="StringBuilder"/>.</summary>
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Output stream handlers are managed for the process lifetime.")]
     public ProcessWrapper WithOutputStream(StringBuilder stringBuilder)
     {
         return WithOutputStream(CreateStringBuilderOutputStream(stringBuilder));
     }
 
-    /// <summary>Adds an output stream handler that adds to the specified <see cref="ProcessOutputCollection"/>.</summary>
+    /// <summary>Replaces all output stream handlers with one that adds to the specified <see cref="ProcessOutputCollection"/>.</summary>
     public ProcessWrapper WithOutputStream(ProcessOutputCollection collection)
     {
+        ArgumentNullException.ThrowIfNull(collection);
         return WithOutputStream(line => collection.Add(ProcessOutputType.StandardOutput, line));
     }
 
-    /// <summary>Adds an error stream handler.</summary>
-    public ProcessWrapper WithErrorStream(Action<string> handler)
+    /// <summary>Adds additional output stream handlers.</summary>
+    public ProcessWrapper AddOutputStream(params ReadOnlySpan<Action<string>> handlers)
     {
-        ArgumentNullException.ThrowIfNull(handler);
-        _errorHandlers = _errorHandlers.Add(handler);
+        _outputHandlers = AddToImmutableArray(_outputHandlers, handlers, nameof(handlers));
         return this;
     }
 
-    /// <summary>Adds a binary error stream handler that writes to the specified <see cref="Stream"/>.</summary>
-    public ProcessWrapper WithErrorStream(Stream stream)
+    /// <summary>Adds additional binary output stream handlers.</summary>
+    public ProcessWrapper AddOutputStream(params ReadOnlySpan<Stream> streams)
     {
-        ArgumentNullException.ThrowIfNull(stream);
-        _errorBinaryHandlers = _errorBinaryHandlers.Add(stream);
+        _outputBinaryHandlers = AddToImmutableArray(_outputBinaryHandlers, streams, nameof(streams));
         return this;
     }
 
-    /// <summary>Adds an error stream handler that appends to the specified <see cref="StringBuilder"/>.</summary>
+    /// <summary>Adds an additional output stream handler that appends to the specified <see cref="StringBuilder"/>.</summary>
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Output stream handlers are managed for the process lifetime.")]
+    public ProcessWrapper AddOutputStream(StringBuilder stringBuilder)
+    {
+        return AddOutputStream(CreateStringBuilderOutputStream(stringBuilder));
+    }
+
+    /// <summary>Adds an additional output stream handler that adds to the specified <see cref="ProcessOutputCollection"/>.</summary>
+    public ProcessWrapper AddOutputStream(ProcessOutputCollection collection)
+    {
+        ArgumentNullException.ThrowIfNull(collection);
+        return AddOutputStream(line => collection.Add(ProcessOutputType.StandardOutput, line));
+    }
+
+    /// <summary>Replaces all error stream handlers with the specified handlers.</summary>
+    public ProcessWrapper WithErrorStream(params ReadOnlySpan<Action<string>> handlers)
+    {
+        _errorHandlers = CreateImmutableArray(handlers, nameof(handlers));
+        _errorBinaryHandlers = [];
+        return this;
+    }
+
+    /// <summary>Replaces all binary error stream handlers with the specified streams.</summary>
+    public ProcessWrapper WithErrorStream(params ReadOnlySpan<Stream> streams)
+    {
+        _errorHandlers = [];
+        _errorBinaryHandlers = CreateImmutableArray(streams, nameof(streams));
+        return this;
+    }
+
+    /// <summary>Replaces all error stream handlers with one that appends to the specified <see cref="StringBuilder"/>.</summary>
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Output stream handlers are managed for the process lifetime.")]
     public ProcessWrapper WithErrorStream(StringBuilder stringBuilder)
     {
         return WithErrorStream(CreateStringBuilderOutputStream(stringBuilder));
     }
 
-    /// <summary>Adds an error stream handler that adds to the specified <see cref="ProcessOutputCollection"/>.</summary>
+    /// <summary>Replaces all error stream handlers with one that adds to the specified <see cref="ProcessOutputCollection"/>.</summary>
     public ProcessWrapper WithErrorStream(ProcessOutputCollection collection)
     {
+        ArgumentNullException.ThrowIfNull(collection);
         return WithErrorStream(line => collection.Add(ProcessOutputType.StandardError, line));
+    }
+
+    /// <summary>Adds additional error stream handlers.</summary>
+    public ProcessWrapper AddErrorStream(params ReadOnlySpan<Action<string>> handlers)
+    {
+        _errorHandlers = AddToImmutableArray(_errorHandlers, handlers, nameof(handlers));
+        return this;
+    }
+
+    /// <summary>Adds additional binary error stream handlers.</summary>
+    public ProcessWrapper AddErrorStream(params ReadOnlySpan<Stream> streams)
+    {
+        _errorBinaryHandlers = AddToImmutableArray(_errorBinaryHandlers, streams, nameof(streams));
+        return this;
+    }
+
+    /// <summary>Adds an additional error stream handler that appends to the specified <see cref="StringBuilder"/>.</summary>
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Output stream handlers are managed for the process lifetime.")]
+    public ProcessWrapper AddErrorStream(StringBuilder stringBuilder)
+    {
+        return AddErrorStream(CreateStringBuilderOutputStream(stringBuilder));
+    }
+
+    /// <summary>Adds an additional error stream handler that adds to the specified <see cref="ProcessOutputCollection"/>.</summary>
+    public ProcessWrapper AddErrorStream(ProcessOutputCollection collection)
+    {
+        ArgumentNullException.ThrowIfNull(collection);
+        return AddErrorStream(line => collection.Add(ProcessOutputType.StandardError, line));
     }
 
     /// <summary>Sets the input stream to the specified <see cref="Stream"/>.</summary>
@@ -389,7 +449,7 @@ public sealed class ProcessWrapper
         var buffer = new byte[4096];
         while (true)
         {
-            var bytesRead = await stream.ReadAsync(buffer.AsMemory()).ConfigureAwait(false);
+            var bytesRead = await ReadBufferAsync(stream, buffer.AsMemory()).ConfigureAwait(false);
             if (bytesRead == 0)
             {
                 break;
@@ -419,7 +479,7 @@ public sealed class ProcessWrapper
 
         while (true)
         {
-            var bytesRead = await stream.ReadAsync(buffer.AsMemory()).ConfigureAwait(false);
+            var bytesRead = await ReadBufferAsync(stream, buffer.AsMemory()).ConfigureAwait(false);
             if (bytesRead == 0)
             {
                 break;
@@ -447,6 +507,23 @@ public sealed class ProcessWrapper
         foreach (var binaryHandler in binaryHandlers)
         {
             await binaryHandler.FlushAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static async ValueTask<int> ReadBufferAsync(Stream stream, Memory<byte> buffer)
+    {
+        try
+        {
+            return await stream.ReadAsync(buffer).ConfigureAwait(false);
+        }
+        catch (IOException)
+        {
+            // Match Process.AsyncStreamReader behavior and treat cancellation-related read failures as EOF.
+            return 0;
+        }
+        catch (OperationCanceledException)
+        {
+            return 0;
         }
     }
 
@@ -505,6 +582,38 @@ public sealed class ProcessWrapper
     {
         ArgumentNullException.ThrowIfNull(stringBuilder);
         return new StringBuilderOutputStream(stringBuilder);
+    }
+
+    private static ImmutableArray<T> CreateImmutableArray<T>(ReadOnlySpan<T> values, string parameterName)
+        where T : class
+    {
+        if (values.IsEmpty)
+            return [];
+
+        var builder = ImmutableArray.CreateBuilder<T>(values.Length);
+        foreach (var value in values)
+        {
+            ArgumentNullException.ThrowIfNull(value, parameterName);
+            builder.Add(value);
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static ImmutableArray<T> AddToImmutableArray<T>(ImmutableArray<T> existingValues, ReadOnlySpan<T> values, string parameterName)
+        where T : class
+    {
+        if (values.IsEmpty)
+            return existingValues;
+
+        var builder = existingValues.ToBuilder();
+        foreach (var value in values)
+        {
+            ArgumentNullException.ThrowIfNull(value, parameterName);
+            builder.Add(value);
+        }
+
+        return builder.ToImmutable();
     }
 
     private IProcessLimiter? CreateProcessLimiter()

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -13,15 +13,17 @@ namespace Meziantou.Framework;
 
 /// <summary>
 /// Fluent builder for configuring and running processes.
-/// Every <c>With*</c> method mutates the current instance with the replaced value.
-/// Every <c>Add*</c> method mutates the current instance with the appended value.
+/// Every <c>With*</c> method mutates the current instance.
+/// Handler-related <c>With*</c> methods accumulate with previous calls.
 /// </summary>
 public sealed class ProcessWrapper
 {
     private readonly ProcessStartInfo _startInfo;
     private ProcessValidationMode _validationMode;
     private ImmutableArray<Action<string>> _outputHandlers;
+    private ImmutableArray<Stream> _outputBinaryHandlers;
     private ImmutableArray<Action<string>> _errorHandlers;
+    private ImmutableArray<Stream> _errorBinaryHandlers;
     private ProcessInputStream? _inputStream;
     private ProcessLimits? _limits;
     private Action<JobObject>? _windowsJobObjectConfiguration;
@@ -33,7 +35,9 @@ public sealed class ProcessWrapper
         _startInfo = CreateStartInfo(fileName);
         _validationMode = ProcessValidationMode.FailIfNonZeroExitCode;
         _outputHandlers = [];
+        _outputBinaryHandlers = [];
         _errorHandlers = [];
+        _errorBinaryHandlers = [];
     }
 
     private static ProcessStartInfo CreateStartInfo(string fileName)
@@ -114,6 +118,22 @@ public sealed class ProcessWrapper
         return this;
     }
 
+    /// <summary>Sets the encoding used to decode standard output.</summary>
+    public ProcessWrapper WithOutputEncoding(Encoding encoding)
+    {
+        ArgumentNullException.ThrowIfNull(encoding);
+        _startInfo.StandardOutputEncoding = encoding;
+        return this;
+    }
+
+    /// <summary>Sets the encoding used to decode standard error.</summary>
+    public ProcessWrapper WithErrorEncoding(Encoding encoding)
+    {
+        ArgumentNullException.ThrowIfNull(encoding);
+        _startInfo.StandardErrorEncoding = encoding;
+        return this;
+    }
+
     /// <summary>Sets the process limits, replacing previously configured limits.</summary>
     public ProcessWrapper WithLimits(ProcessLimits limits)
     {
@@ -148,104 +168,60 @@ public sealed class ProcessWrapper
         return this;
     }
 
-    /// <summary>Replaces all output stream handlers with the specified handler.</summary>
+    /// <summary>Adds an output stream handler.</summary>
     public ProcessWrapper WithOutputStream(Action<string> handler)
     {
-        _outputHandlers = [handler];
+        ArgumentNullException.ThrowIfNull(handler);
+        _outputHandlers = _outputHandlers.Add(handler);
         return this;
     }
 
-    /// <summary>Replaces all output stream handlers with one that appends to the specified <see cref="StringBuilder"/>.</summary>
-    public ProcessWrapper WithOutputStream(StringBuilder stringBuilder)
+    /// <summary>Adds a binary output stream handler that writes to the specified <see cref="Stream"/>.</summary>
+    public ProcessWrapper WithOutputStream(Stream stream)
     {
-        return WithOutputStream(line =>
-        {
-            lock (stringBuilder)
-            {
-                stringBuilder.AppendLine(line);
-            }
-        });
+        ArgumentNullException.ThrowIfNull(stream);
+        _outputBinaryHandlers = _outputBinaryHandlers.Add(stream);
+        return this;
     }
 
-    /// <summary>Replaces all output stream handlers with one that adds to the specified <see cref="ProcessOutputCollection"/>.</summary>
+    /// <summary>Adds an output stream handler that appends to the specified <see cref="StringBuilder"/>.</summary>
+    public ProcessWrapper WithOutputStream(StringBuilder stringBuilder)
+    {
+        return WithOutputStream(CreateStringBuilderOutputStream(stringBuilder));
+    }
+
+    /// <summary>Adds an output stream handler that adds to the specified <see cref="ProcessOutputCollection"/>.</summary>
     public ProcessWrapper WithOutputStream(ProcessOutputCollection collection)
     {
         return WithOutputStream(line => collection.Add(ProcessOutputType.StandardOutput, line));
     }
 
-    /// <summary>Adds an additional output stream handler.</summary>
-    public ProcessWrapper AddOutputStream(Action<string> handler)
-    {
-        _outputHandlers = _outputHandlers.Add(handler);
-        return this;
-    }
-
-    /// <summary>Adds an additional output stream handler that appends to the specified <see cref="StringBuilder"/>.</summary>
-    public ProcessWrapper AddOutputStream(StringBuilder stringBuilder)
-    {
-        return AddOutputStream(line =>
-        {
-            lock (stringBuilder)
-            {
-                stringBuilder.AppendLine(line);
-            }
-        });
-    }
-
-    /// <summary>Adds an additional output stream handler that adds to the specified <see cref="ProcessOutputCollection"/>.</summary>
-    public ProcessWrapper AddOutputStream(ProcessOutputCollection collection)
-    {
-        return AddOutputStream(line => collection.Add(ProcessOutputType.StandardOutput, line));
-    }
-
-    /// <summary>Replaces all error stream handlers with the specified handler.</summary>
+    /// <summary>Adds an error stream handler.</summary>
     public ProcessWrapper WithErrorStream(Action<string> handler)
     {
-        _errorHandlers = [handler];
-        return this;
-    }
-
-    /// <summary>Replaces all error stream handlers with one that appends to the specified <see cref="StringBuilder"/>.</summary>
-    public ProcessWrapper WithErrorStream(StringBuilder stringBuilder)
-    {
-        return WithErrorStream(line =>
-        {
-            lock (stringBuilder)
-            {
-                stringBuilder.AppendLine(line);
-            }
-        });
-    }
-
-    /// <summary>Replaces all error stream handlers with one that adds to the specified <see cref="ProcessOutputCollection"/>.</summary>
-    public ProcessWrapper WithErrorStream(ProcessOutputCollection collection)
-    {
-        return WithErrorStream(line => collection.Add(ProcessOutputType.StandardError, line));
-    }
-
-    /// <summary>Adds an additional error stream handler.</summary>
-    public ProcessWrapper AddErrorStream(Action<string> handler)
-    {
+        ArgumentNullException.ThrowIfNull(handler);
         _errorHandlers = _errorHandlers.Add(handler);
         return this;
     }
 
-    /// <summary>Adds an additional error stream handler that appends to the specified <see cref="StringBuilder"/>.</summary>
-    public ProcessWrapper AddErrorStream(StringBuilder stringBuilder)
+    /// <summary>Adds a binary error stream handler that writes to the specified <see cref="Stream"/>.</summary>
+    public ProcessWrapper WithErrorStream(Stream stream)
     {
-        return AddErrorStream(line =>
-        {
-            lock (stringBuilder)
-            {
-                stringBuilder.AppendLine(line);
-            }
-        });
+        ArgumentNullException.ThrowIfNull(stream);
+        _errorBinaryHandlers = _errorBinaryHandlers.Add(stream);
+        return this;
     }
 
-    /// <summary>Adds an additional error stream handler that adds to the specified <see cref="ProcessOutputCollection"/>.</summary>
-    public ProcessWrapper AddErrorStream(ProcessOutputCollection collection)
+    /// <summary>Adds an error stream handler that appends to the specified <see cref="StringBuilder"/>.</summary>
+    public ProcessWrapper WithErrorStream(StringBuilder stringBuilder)
     {
-        return AddErrorStream(line => collection.Add(ProcessOutputType.StandardError, line));
+        return WithErrorStream(CreateStringBuilderOutputStream(stringBuilder));
+    }
+
+    /// <summary>Adds an error stream handler that adds to the specified <see cref="ProcessOutputCollection"/>.</summary>
+    public ProcessWrapper WithErrorStream(ProcessOutputCollection collection)
+    {
+        return WithErrorStream(line => collection.Add(ProcessOutputType.StandardError, line));
     }
 
     /// <summary>Sets the input stream to the specified <see cref="Stream"/>.</summary>
@@ -276,8 +252,8 @@ public sealed class ProcessWrapper
     /// </summary>
     public ProcessInstance ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        return StartProcess(_outputHandlers, _errorHandlers,
-            (process, inputTask, registration, limiter, hasStandardErrorOutput, ct) => new ProcessInstance(process, inputTask, registration, limiter, _validationMode, hasStandardErrorOutput, ct),
+        return StartProcess(_outputHandlers, _errorHandlers, _outputBinaryHandlers, _errorBinaryHandlers,
+            (process, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, ct) => new ProcessInstance(process, inputTask, outputTask, registration, limiter, _validationMode, hasStandardErrorOutput, ct),
             cancellationToken);
     }
 
@@ -293,19 +269,23 @@ public sealed class ProcessWrapper
         var outputHandlers = _outputHandlers.Add(line => output.Add(ProcessOutputType.StandardOutput, line));
         var errorHandlers = _errorHandlers.Add(line => output.Add(ProcessOutputType.StandardError, line));
 
-        return StartProcess(outputHandlers, errorHandlers,
-            (process, inputTask, registration, limiter, hasStandardErrorOutput, ct) => new BufferedProcessInstance(process, inputTask, registration, limiter, _validationMode, output, hasStandardErrorOutput, ct),
+        return StartProcess(outputHandlers, errorHandlers, _outputBinaryHandlers, _errorBinaryHandlers,
+            (process, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, ct) => new BufferedProcessInstance(process, inputTask, outputTask, registration, limiter, _validationMode, output, hasStandardErrorOutput, ct),
             cancellationToken);
     }
 
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "ProcessInstance will dispose it")]
-    private T StartProcess<T>(ImmutableArray<Action<string>> outputHandlers, ImmutableArray<Action<string>> errorHandlers, Func<Process, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, CancellationToken, T> factory, CancellationToken cancellationToken)
+    private T StartProcess<T>(ImmutableArray<Action<string>> outputHandlers, ImmutableArray<Action<string>> errorHandlers, ImmutableArray<Stream> outputBinaryHandlers, ImmutableArray<Stream> errorBinaryHandlers, Func<Process, Task, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, CancellationToken, T> factory, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var hasOutputHandlers = !outputHandlers.IsEmpty;
+        var hasOutputTextHandlers = !outputHandlers.IsEmpty;
+        var hasOutputBinaryHandlers = !outputBinaryHandlers.IsEmpty;
+        var hasOutputHandlers = hasOutputTextHandlers || hasOutputBinaryHandlers;
         var shouldValidateErrorOutput = (_validationMode & ProcessValidationMode.FailIfStdError) == ProcessValidationMode.FailIfStdError;
-        var hasErrorHandlers = !errorHandlers.IsEmpty || shouldValidateErrorOutput;
+        var hasErrorTextHandlers = !errorHandlers.IsEmpty;
+        var hasErrorBinaryHandlers = !errorBinaryHandlers.IsEmpty;
+        var hasErrorHandlers = hasErrorTextHandlers || hasErrorBinaryHandlers || shouldValidateErrorOutput;
         var hasInputStream = _inputStream is not null;
         var hasStandardErrorOutput = 0;
 
@@ -317,35 +297,6 @@ public sealed class ProcessWrapper
 
         var process = new Process { StartInfo = _startInfo };
         var processLimiter = CreateProcessLimiter();
-
-        if (hasOutputHandlers)
-        {
-            process.OutputDataReceived += (_, e) =>
-            {
-                if (e.Data is not null)
-                {
-                    foreach (var handler in outputHandlers)
-                    {
-                        handler(e.Data);
-                    }
-                }
-            };
-        }
-
-        if (hasErrorHandlers)
-        {
-            process.ErrorDataReceived += (_, e) =>
-            {
-                if (e.Data is not null)
-                {
-                    Interlocked.Exchange(ref hasStandardErrorOutput, 1);
-                    foreach (var handler in errorHandlers)
-                    {
-                        handler(e.Data);
-                    }
-                }
-            };
-        }
 
         var processStarted = false;
         try
@@ -378,14 +329,16 @@ public sealed class ProcessWrapper
             throw;
         }
 
+        var outputStreamTask = Task.CompletedTask;
         if (hasOutputHandlers)
         {
-            process.BeginOutputReadLine();
+            outputStreamTask = PumpStreamAsync(process.StandardOutput.BaseStream, process.StandardOutput.CurrentEncoding, outputHandlers, outputBinaryHandlers, onDataRead: null);
         }
 
+        var errorStreamTask = Task.CompletedTask;
         if (hasErrorHandlers)
         {
-            process.BeginErrorReadLine();
+            errorStreamTask = PumpStreamAsync(process.StandardError.BaseStream, process.StandardError.CurrentEncoding, errorHandlers, errorBinaryHandlers, onDataRead: () => Interlocked.Exchange(ref hasStandardErrorOutput, 1));
         }
 
         var inputStreamTask = Task.CompletedTask;
@@ -415,7 +368,143 @@ public sealed class ProcessWrapper
             registration = cancellationToken.Register(() => ProcessInstance.KillProcess(process, entireProcessTree: true));
         }
 
-        return factory(process, inputStreamTask, registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, cancellationToken);
+        return factory(process, inputStreamTask, Task.WhenAll(outputStreamTask, errorStreamTask), registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, cancellationToken);
+    }
+
+    private static async Task PumpStreamAsync(Stream stream, Encoding encoding, ImmutableArray<Action<string>> lineHandlers, ImmutableArray<Stream> binaryHandlers, Action? onDataRead)
+    {
+        InitializeBinaryHandlers(binaryHandlers, encoding);
+
+        if (lineHandlers.IsEmpty)
+        {
+            await CopyStreamToBinaryHandlersAsync(stream, binaryHandlers, onDataRead).ConfigureAwait(false);
+            return;
+        }
+
+        await PumpMixedTextAndBinaryStreamAsync(stream, encoding, lineHandlers, binaryHandlers, onDataRead).ConfigureAwait(false);
+    }
+
+    private static async Task CopyStreamToBinaryHandlersAsync(Stream stream, ImmutableArray<Stream> binaryHandlers, Action? onDataRead)
+    {
+        var buffer = new byte[4096];
+        while (true)
+        {
+            var bytesRead = await stream.ReadAsync(buffer.AsMemory()).ConfigureAwait(false);
+            if (bytesRead == 0)
+            {
+                break;
+            }
+
+            onDataRead?.Invoke();
+            var data = buffer.AsMemory(0, bytesRead);
+            foreach (var binaryHandler in binaryHandlers)
+            {
+                await binaryHandler.WriteAsync(data).ConfigureAwait(false);
+            }
+        }
+
+        foreach (var binaryHandler in binaryHandlers)
+        {
+            await binaryHandler.FlushAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static async Task PumpMixedTextAndBinaryStreamAsync(Stream stream, Encoding encoding, ImmutableArray<Action<string>> lineHandlers, ImmutableArray<Stream> binaryHandlers, Action? onDataRead)
+    {
+        var decoder = encoding.GetDecoder();
+        var buffer = new byte[4096];
+        var chars = new char[encoding.GetMaxCharCount(buffer.Length)];
+        var lineBuilder = new StringBuilder();
+        var lastCharacterWasCarriageReturn = false;
+
+        while (true)
+        {
+            var bytesRead = await stream.ReadAsync(buffer.AsMemory()).ConfigureAwait(false);
+            if (bytesRead == 0)
+            {
+                break;
+            }
+
+            onDataRead?.Invoke();
+            var data = buffer.AsMemory(0, bytesRead);
+            foreach (var binaryHandler in binaryHandlers)
+            {
+                await binaryHandler.WriteAsync(data).ConfigureAwait(false);
+            }
+
+            var charsRead = decoder.GetChars(buffer, 0, bytesRead, chars, 0, flush: false);
+            DispatchLines(chars.AsSpan(0, charsRead), lineHandlers, lineBuilder, ref lastCharacterWasCarriageReturn);
+        }
+
+        var finalCharsRead = decoder.GetChars(Array.Empty<byte>(), 0, 0, chars, 0, flush: true);
+        DispatchLines(chars.AsSpan(0, finalCharsRead), lineHandlers, lineBuilder, ref lastCharacterWasCarriageReturn);
+
+        if (lastCharacterWasCarriageReturn || lineBuilder.Length > 0)
+        {
+            DispatchLine(lineHandlers, lineBuilder);
+        }
+
+        foreach (var binaryHandler in binaryHandlers)
+        {
+            await binaryHandler.FlushAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static void DispatchLines(ReadOnlySpan<char> chars, ImmutableArray<Action<string>> lineHandlers, StringBuilder lineBuilder, ref bool lastCharacterWasCarriageReturn)
+    {
+        foreach (var character in chars)
+        {
+            if (lastCharacterWasCarriageReturn)
+            {
+                lastCharacterWasCarriageReturn = false;
+                if (character == '\n')
+                {
+                    continue;
+                }
+            }
+
+            if (character == '\r')
+            {
+                DispatchLine(lineHandlers, lineBuilder);
+                lastCharacterWasCarriageReturn = true;
+                continue;
+            }
+
+            if (character == '\n')
+            {
+                DispatchLine(lineHandlers, lineBuilder);
+                continue;
+            }
+
+            lineBuilder.Append(character);
+        }
+    }
+
+    private static void DispatchLine(ImmutableArray<Action<string>> lineHandlers, StringBuilder lineBuilder)
+    {
+        var line = lineBuilder.ToString();
+        lineBuilder.Clear();
+        foreach (var lineHandler in lineHandlers)
+        {
+            lineHandler(line);
+        }
+    }
+
+    private static void InitializeBinaryHandlers(ImmutableArray<Stream> binaryHandlers, Encoding encoding)
+    {
+        foreach (var binaryHandler in binaryHandlers)
+        {
+            if (binaryHandler is StringBuilderOutputStream stringBuilderOutputStream)
+            {
+                stringBuilderOutputStream.SetEncoding(encoding);
+            }
+        }
+    }
+
+    private static StringBuilderOutputStream CreateStringBuilderOutputStream(StringBuilder stringBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(stringBuilder);
+        return new StringBuilderOutputStream(stringBuilder);
     }
 
     private IProcessLimiter? CreateProcessLimiter()

--- a/src/Meziantou.Framework.ProcessWrapper/StringBuilderOutputStream.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/StringBuilderOutputStream.cs
@@ -1,0 +1,122 @@
+using System.Text;
+
+namespace Meziantou.Framework;
+
+internal sealed class StringBuilderOutputStream : Stream
+{
+    private readonly StringBuilder _stringBuilder;
+    private Decoder? _decoder;
+
+    public StringBuilderOutputStream(StringBuilder stringBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(stringBuilder);
+        _stringBuilder = stringBuilder;
+    }
+
+    public override bool CanRead => false;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => true;
+
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    internal void SetEncoding(Encoding encoding)
+    {
+        _decoder = encoding.GetDecoder();
+    }
+
+    public override void Flush()
+    {
+        FlushDecoder();
+    }
+
+    public override Task FlushAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        FlushDecoder();
+        return Task.CompletedTask;
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        Write(buffer.AsSpan(offset, count));
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        WriteCore(buffer);
+    }
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        WriteCore(buffer.AsSpan(offset, count));
+        return Task.CompletedTask;
+    }
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        WriteCore(buffer.Span);
+        return ValueTask.CompletedTask;
+    }
+
+    private void WriteCore(ReadOnlySpan<byte> buffer)
+    {
+        var decoder = _decoder ??= Encoding.UTF8.GetDecoder();
+        Span<char> chars = stackalloc char[1024];
+
+        while (!buffer.IsEmpty)
+        {
+            decoder.Convert(buffer, chars, flush: false, out var bytesUsed, out var charsUsed, out _);
+            if (charsUsed > 0)
+            {
+                lock (_stringBuilder)
+                {
+                    _stringBuilder.Append(chars[..charsUsed]);
+                }
+            }
+
+            buffer = buffer[bytesUsed..];
+        }
+    }
+
+    private void FlushDecoder()
+    {
+        if (_decoder is null)
+        {
+            return;
+        }
+
+        Span<char> chars = stackalloc char[1024];
+        while (true)
+        {
+            _decoder.Convert(ReadOnlySpan<byte>.Empty, chars, flush: true, out _, out var charsUsed, out var completed);
+            if (charsUsed > 0)
+            {
+                lock (_stringBuilder)
+                {
+                    _stringBuilder.Append(chars[..charsUsed]);
+                }
+            }
+
+            if (completed)
+            {
+                break;
+            }
+        }
+    }
+}

--- a/src/Meziantou.Framework.ProcessWrapper/readme.md
+++ b/src/Meziantou.Framework.ProcessWrapper/readme.md
@@ -105,8 +105,8 @@ var result = await ProcessWrapper.Create("my-app")
 // Stream output line by line
 await ProcessWrapper.Create("dotnet")
     .WithArguments("build")
-    .AddOutputStream(line => Console.WriteLine($"[OUT] {line}"))
-    .AddErrorStream(line => Console.Error.WriteLine($"[ERR] {line}"))
+    .WithOutputStream(line => Console.WriteLine($"[OUT] {line}"))
+    .WithErrorStream(line => Console.Error.WriteLine($"[ERR] {line}"))
     .ExecuteAsync();
 
 // Collect output into a StringBuilder
@@ -122,14 +122,39 @@ Console.WriteLine(sb.ToString());
 var output = new ProcessOutputCollection();
 await ProcessWrapper.Create("dotnet")
     .WithArguments("build")
-    .AddOutputStream(output)
-    .AddErrorStream(output)
+    .WithOutputStream(output)
+    .WithErrorStream(output)
     .ExecuteAsync();
 
 foreach (var line in output.StandardError)
 {
     Console.Error.WriteLine(line.Text);
 }
+
+// Capture raw bytes from stdout/stderr
+await using var stdout = File.Create("stdout.bin");
+await using var stderr = File.Create("stderr.bin");
+
+await ProcessWrapper.Create("my-command")
+    .WithOutputStream(stdout)
+    .WithErrorStream(stderr)
+    .ExecuteAsync();
+
+// Text and binary handlers can be combined on the same stream
+await using var rawOutput = File.Create("raw-output.bin");
+await ProcessWrapper.Create("dotnet")
+    .WithArguments("--version")
+    .WithOutputStream(rawOutput)
+    .WithOutputStream(line => Console.WriteLine($"Version line: {line}"))
+    .ExecuteAsync();
+
+// Override stdout/stderr decoding when process output is not UTF-8
+await ProcessWrapper.Create("my-command")
+    .WithOutputEncoding(Encoding.Latin1)
+    .WithErrorEncoding(Encoding.Latin1)
+    .WithOutputStream(line => Console.WriteLine(line))
+    .WithErrorStream(line => Console.Error.WriteLine(line))
+    .ExecuteAsync();
 ````
 
 ## Input stream

--- a/src/Meziantou.Framework.ProcessWrapper/readme.md
+++ b/src/Meziantou.Framework.ProcessWrapper/readme.md
@@ -101,6 +101,8 @@ var result = await ProcessWrapper.Create("my-app")
 
 ## Output handling
 
+Use `With*` methods to replace handlers, and `Add*` methods to append additional handlers.
+
 ````c#
 // Stream output line by line
 await ProcessWrapper.Create("dotnet")
@@ -145,7 +147,7 @@ await using var rawOutput = File.Create("raw-output.bin");
 await ProcessWrapper.Create("dotnet")
     .WithArguments("--version")
     .WithOutputStream(rawOutput)
-    .WithOutputStream(line => Console.WriteLine($"Version line: {line}"))
+    .AddOutputStream(line => Console.WriteLine($"Version line: {line}"))
     .ExecuteAsync();
 
 // Override stdout/stderr decoding when process output is not UTF-8

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -97,6 +97,35 @@ public class ProcessWrapperTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithOutputStream_StringBuilder_PreservesOutputWithoutTrailingNewline()
+    {
+        var sb = new StringBuilder();
+
+        var process = CreateNoNewlineOutputCommand("test")
+            .WithOutputStream(sb)
+            .ExecuteAsync();
+
+        await process;
+
+        Assert.Equal("test", sb.ToString());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithOutputEncoding_UsesConfiguredEncoding()
+    {
+        var sb = new StringBuilder();
+
+        var process = CreateSingleByteOutputCommand(0xE9)
+            .WithOutputEncoding(Encoding.Latin1)
+            .WithOutputStream(sb)
+            .ExecuteAsync();
+
+        await process;
+
+        Assert.Equal("é", sb.ToString());
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WithOutputStream_ProcessOutputCollection()
     {
         var output = new ProcessOutputCollection();
@@ -112,14 +141,68 @@ public class ProcessWrapperTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_AddOutputStream_AccumulatesHandlers()
+    public async Task ExecuteAsync_WithOutputStream_Stream()
+    {
+        using var output = new MemoryStream();
+        var process = CreateEchoCommand("test")
+            .WithOutputStream(output)
+            .ExecuteAsync();
+
+        await process;
+
+        var capturedText = Encoding.UTF8.GetString(output.ToArray());
+        Assert.Contains("test", capturedText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithOutputStream_Stream_AndTextHandler()
+    {
+        using var output = new MemoryStream();
+        var lines = new List<string>();
+
+        var process = CreateEchoCommand("test")
+            .WithOutputStream(output)
+            .WithOutputStream(line => { lock (lines) { lines.Add(line); } })
+            .ExecuteAsync();
+
+        await process;
+
+        Assert.Single(lines);
+        Assert.Equal("test", lines[0]);
+
+        var capturedText = Encoding.UTF8.GetString(output.ToArray());
+        Assert.Contains("test", capturedText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WithOutputStream_Stream_DoesNotReplaceTextHandlers()
+    {
+        using var output = new MemoryStream();
+        var lines = new List<string>();
+
+        var process = CreateEchoCommand("test")
+            .WithOutputStream(line => { lock (lines) { lines.Add(line); } })
+            .WithOutputStream(output)
+            .ExecuteAsync();
+
+        await process;
+
+        Assert.Single(lines);
+        Assert.Equal("test", lines[0]);
+
+        var capturedText = Encoding.UTF8.GetString(output.ToArray());
+        Assert.Contains("test", capturedText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithOutputStream_AccumulatesHandlers()
     {
         var list1 = new List<string>();
         var list2 = new List<string>();
 
         var process = CreateEchoCommand("test")
-            .AddOutputStream(line => { lock (list1) { list1.Add(line); } })
-            .AddOutputStream(line => { lock (list2) { list2.Add(line); } })
+            .WithOutputStream(line => { lock (list1) { list1.Add(line); } })
+            .WithOutputStream(line => { lock (list2) { list2.Add(line); } })
             .ExecuteAsync();
 
         await process;
@@ -131,19 +214,19 @@ public class ProcessWrapperTests
     }
 
     [Fact]
-    public async Task WithOutputStream_ReplacesAllHandlers()
+    public async Task WithOutputStream_DoesNotReplaceExistingHandlers()
     {
         var list1 = new List<string>();
         var list2 = new List<string>();
 
         var process = CreateEchoCommand("test")
-            .AddOutputStream(line => { lock (list1) { list1.Add(line); } })
+            .WithOutputStream(line => { lock (list1) { list1.Add(line); } })
             .WithOutputStream(line => { lock (list2) { list2.Add(line); } })
             .ExecuteAsync();
 
         await process;
 
-        Assert.Empty(list1);
+        Assert.Single(list1);
         Assert.Single(list2);
     }
 
@@ -354,6 +437,72 @@ public class ProcessWrapperTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithErrorStream_Stream()
+    {
+        ProcessWrapper command;
+        if (OperatingSystem.IsWindows())
+        {
+            command = ProcessWrapper.Create("cmd.exe")
+                .WithArguments("/C", "echo error>&2");
+        }
+        else
+        {
+            command = ProcessWrapper.Create("sh")
+                .WithArguments("-c", "echo error >&2");
+        }
+
+        using var error = new MemoryStream();
+        var process = command
+            .WithErrorStream(error)
+            .WithValidation(ProcessValidationMode.None)
+            .ExecuteAsync();
+
+        await process;
+
+        var capturedText = Encoding.UTF8.GetString(error.ToArray());
+        Assert.Contains("error", capturedText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithErrorEncoding_UsesConfiguredEncoding()
+    {
+        var sb = new StringBuilder();
+        var process = CreateSingleByteOutputCommand(0xE9, standardError: true)
+            .WithValidation(ProcessValidationMode.None)
+            .WithErrorEncoding(Encoding.Latin1)
+            .WithErrorStream(sb)
+            .ExecuteAsync();
+
+        await process;
+
+        Assert.Equal("é", sb.ToString());
+    }
+
+    [Fact]
+    public async Task Validation_FailIfStdError_WithBinaryHandler_Throws()
+    {
+        ProcessWrapper command;
+        if (OperatingSystem.IsWindows())
+        {
+            command = ProcessWrapper.Create("cmd.exe")
+                .WithArguments("/C", "echo error>&2");
+        }
+        else
+        {
+            command = ProcessWrapper.Create("sh")
+                .WithArguments("-c", "echo error >&2");
+        }
+
+        using var error = new MemoryStream();
+        var process = command
+            .WithErrorStream(error)
+            .WithValidation(ProcessValidationMode.FailIfStdError)
+            .ExecuteAsync();
+
+        await Assert.ThrowsAsync<ProcessExecutionException>(async () => await process);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_Cancel()
     {
         using var cts = new CancellationTokenSource();
@@ -449,16 +598,19 @@ public class ProcessWrapperTests
     public void FluentMethods_ReturnCurrentInstance()
     {
         var command = ProcessWrapper.Create("dotnet");
+        using var stream = new MemoryStream();
 
         Assert.Same(command, command.WithArguments("--version"));
         Assert.Same(command, command.WithWorkingDirectory(Path.GetTempPath()));
         Assert.Same(command, command.WithEnvironmentVariables(env => env.Set("TEST_VAR_45", "value")));
         Assert.Same(command, command.WithEnvironmentVariables(new Dictionary<string, string?>(StringComparer.Ordinal) { ["TEST_VAR_45"] = "updated" }));
         Assert.Same(command, command.WithValidation(ProcessValidationMode.None));
+        Assert.Same(command, command.WithOutputEncoding(Encoding.UTF8));
+        Assert.Same(command, command.WithErrorEncoding(Encoding.UTF8));
         Assert.Same(command, command.WithOutputStream(_ => { }));
-        Assert.Same(command, command.AddOutputStream(_ => { }));
+        Assert.Same(command, command.WithOutputStream(stream));
         Assert.Same(command, command.WithErrorStream(_ => { }));
-        Assert.Same(command, command.AddErrorStream(_ => { }));
+        Assert.Same(command, command.WithErrorStream(stream));
         Assert.Same(command, command.WithInputStream("stdin"));
         Assert.Same(command, command.WithLimits(new ProcessLimits()));
         Assert.Same(command, command.WithLimits(limits => limits.CpuPercentage = 50));
@@ -640,6 +792,39 @@ public class ProcessWrapperTests
 
         return ProcessWrapper.Create("echo")
             .WithArguments(text);
+    }
+
+    private static ProcessWrapper CreateNoNewlineOutputCommand(string text)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return ProcessWrapper.Create("cmd.exe")
+                .WithArguments("/C", $"set /p ={text}<nul&exit /b 0");
+        }
+
+        return ProcessWrapper.Create("sh")
+            .WithArguments("-c", $"printf '%s' \"{text}\"");
+    }
+
+    private static ProcessWrapper CreateSingleByteOutputCommand(byte value, bool standardError = false)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var streamAccessor = standardError ? "StandardError" : "StandardOutput";
+            return ProcessWrapper.Create("powershell.exe")
+                .WithArguments(
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command",
+                    $"[Console]::Open{streamAccessor}().Write([byte[]]({value}), 0, 1)");
+        }
+
+        var octalValue = Convert.ToString(value, 8).PadLeft(3, '0');
+        var redirection = standardError ? " >&2" : "";
+        return ProcessWrapper.Create("sh")
+            .WithArguments("-c", $"printf '\\{octalValue}'{redirection}");
     }
 
     private static string[] GetEchoArguments(string text)

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -162,7 +162,7 @@ public class ProcessWrapperTests
 
         var process = CreateEchoCommand("test")
             .WithOutputStream(output)
-            .WithOutputStream(line => { lock (lines) { lines.Add(line); } })
+            .AddOutputStream(line => { lock (lines) { lines.Add(line); } })
             .ExecuteAsync();
 
         await process;
@@ -175,34 +175,32 @@ public class ProcessWrapperTests
     }
 
     [Fact]
-    public async Task WithOutputStream_Stream_DoesNotReplaceTextHandlers()
+    public async Task WithOutputStream_Stream_ReplacesTextHandlers()
     {
         using var output = new MemoryStream();
         var lines = new List<string>();
 
         var process = CreateEchoCommand("test")
-            .WithOutputStream(line => { lock (lines) { lines.Add(line); } })
+            .AddOutputStream(line => { lock (lines) { lines.Add(line); } })
             .WithOutputStream(output)
             .ExecuteAsync();
 
         await process;
 
-        Assert.Single(lines);
-        Assert.Equal("test", lines[0]);
+        Assert.Empty(lines);
 
         var capturedText = Encoding.UTF8.GetString(output.ToArray());
         Assert.Contains("test", capturedText, StringComparison.Ordinal);
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithOutputStream_AccumulatesHandlers()
+    public async Task ExecuteAsync_AddOutputStream_AccumulatesHandlers()
     {
         var list1 = new List<string>();
         var list2 = new List<string>();
 
         var process = CreateEchoCommand("test")
-            .WithOutputStream(line => { lock (list1) { list1.Add(line); } })
-            .WithOutputStream(line => { lock (list2) { list2.Add(line); } })
+            .AddOutputStream(line => { lock (list1) { list1.Add(line); } }, line => { lock (list2) { list2.Add(line); } })
             .ExecuteAsync();
 
         await process;
@@ -214,20 +212,41 @@ public class ProcessWrapperTests
     }
 
     [Fact]
-    public async Task WithOutputStream_DoesNotReplaceExistingHandlers()
+    public async Task WithOutputStream_ReplacesAllHandlers()
     {
         var list1 = new List<string>();
         var list2 = new List<string>();
 
         var process = CreateEchoCommand("test")
-            .WithOutputStream(line => { lock (list1) { list1.Add(line); } })
+            .AddOutputStream(line => { lock (list1) { list1.Add(line); } })
             .WithOutputStream(line => { lock (list2) { list2.Add(line); } })
             .ExecuteAsync();
 
         await process;
 
-        Assert.Single(list1);
+        Assert.Empty(list1);
         Assert.Single(list2);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithOutputStream_MultipleHandlers_ReplacesWithAllProvidedHandlers()
+    {
+        var list1 = new List<string>();
+        var list2 = new List<string>();
+        var list3 = new List<string>();
+
+        var process = CreateEchoCommand("test")
+            .AddOutputStream(line => { lock (list1) { list1.Add(line); } })
+            .WithOutputStream(
+                line => { lock (list2) { list2.Add(line); } },
+                line => { lock (list3) { list3.Add(line); } })
+            .ExecuteAsync();
+
+        await process;
+
+        Assert.Empty(list1);
+        Assert.Single(list2);
+        Assert.Single(list3);
     }
 
     [Fact]
@@ -599,6 +618,7 @@ public class ProcessWrapperTests
     {
         var command = ProcessWrapper.Create("dotnet");
         using var stream = new MemoryStream();
+        using var stream2 = new MemoryStream();
 
         Assert.Same(command, command.WithArguments("--version"));
         Assert.Same(command, command.WithWorkingDirectory(Path.GetTempPath()));
@@ -608,9 +628,21 @@ public class ProcessWrapperTests
         Assert.Same(command, command.WithOutputEncoding(Encoding.UTF8));
         Assert.Same(command, command.WithErrorEncoding(Encoding.UTF8));
         Assert.Same(command, command.WithOutputStream(_ => { }));
+        Assert.Same(command, command.WithOutputStream(_ => { }, _ => { }));
         Assert.Same(command, command.WithOutputStream(stream));
+        Assert.Same(command, command.WithOutputStream(stream, stream2));
+        Assert.Same(command, command.AddOutputStream(_ => { }));
+        Assert.Same(command, command.AddOutputStream(_ => { }, _ => { }));
+        Assert.Same(command, command.AddOutputStream(stream));
+        Assert.Same(command, command.AddOutputStream(stream, stream2));
         Assert.Same(command, command.WithErrorStream(_ => { }));
+        Assert.Same(command, command.WithErrorStream(_ => { }, _ => { }));
         Assert.Same(command, command.WithErrorStream(stream));
+        Assert.Same(command, command.WithErrorStream(stream, stream2));
+        Assert.Same(command, command.AddErrorStream(_ => { }));
+        Assert.Same(command, command.AddErrorStream(_ => { }, _ => { }));
+        Assert.Same(command, command.AddErrorStream(stream));
+        Assert.Same(command, command.AddErrorStream(stream, stream2));
         Assert.Same(command, command.WithInputStream("stdin"));
         Assert.Same(command, command.WithLimits(new ProcessLimits()));
         Assert.Same(command, command.WithLimits(limits => limits.CpuPercentage = 50));


### PR DESCRIPTION
## Why
ProcessWrapper needed first-class access to raw stdout/stderr bytes while preserving correct text capture behavior (including newline fidelity). We also needed a straightforward API to configure decoding when a process does not emit UTF-8.

## What changed
- Added binary handler support for stdout/stderr using `WithOutputStream(Stream)` and `WithErrorStream(Stream)`.
- Unified redirected output processing on a single binary read path, with text line handlers derived from decoded bytes.
- Extracted stream-to-`StringBuilder` decoding into a dedicated `StringBuilderOutputStream` class.
- Simplified handler API semantics: removed `AddOutputStream`/`AddErrorStream` and made `WithOutputStream`/`WithErrorStream` additive.
- Added encoding configuration APIs:
  - `WithOutputEncoding(Encoding encoding)`
  - `WithErrorEncoding(Encoding encoding)`
- Updated docs and tests for binary handlers, additive `With*` behavior, newline fidelity, and custom encoding decoding.
- Bumped `Meziantou.Framework.ProcessWrapper` package version from `1.0.1` to `1.0.2`.

## Notes for reviewers
- The key behavioral shift is the With-only additive model for output/error handlers.
- Text and binary handlers can now be chained consistently on the same stream.
- ProcessWrapper internals now route all redirected output through the binary pump path to keep behavior consistent across handlers.