### PR TITLE
Add ConfigureAwaitOptions support to ProcessWrapper awaitables

### DIFF
--- a/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
@@ -17,6 +17,12 @@ public sealed class BufferedProcessInstance : ProcessInstance
 
     public new TaskAwaiter<BufferedProcessResult> GetAwaiter() => WaitForExitBufferedCoreAsync().GetAwaiter();
 
+    /// <summary>Configures whether to marshal continuations back to the captured context.</summary>
+    public new ConfiguredTaskAwaitable<BufferedProcessResult> ConfigureAwait(bool continueOnCapturedContext) => WaitForExitBufferedCoreAsync().ConfigureAwait(continueOnCapturedContext);
+
+    /// <summary>Configures how awaits on this instance are performed.</summary>
+    public new ConfiguredTaskAwaitable<BufferedProcessResult> ConfigureAwait(ConfigureAwaitOptions options) => WaitForExitBufferedCoreAsync().ConfigureAwait(options);
+
     private Task<BufferedProcessResult> WaitForExitBufferedCoreAsync()
     {
         if (_waitTask is not null)

--- a/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
+++ b/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework</RootNamespace>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Fluent API for wrapping System.Diagnostics.Process</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
@@ -52,6 +52,12 @@ public class ProcessInstance
     /// <summary>Gets an awaiter that waits for the process to exit and returns the process result.</summary>
     public TaskAwaiter<ProcessResult> GetAwaiter() => GetAwaiterTask().GetAwaiter();
 
+    /// <summary>Configures whether to marshal continuations back to the captured context.</summary>
+    public ConfiguredTaskAwaitable<ProcessResult> ConfigureAwait(bool continueOnCapturedContext) => GetAwaiterTask().ConfigureAwait(continueOnCapturedContext);
+
+    /// <summary>Configures how awaits on this instance are performed.</summary>
+    public ConfiguredTaskAwaitable<ProcessResult> ConfigureAwait(ConfigureAwaitOptions options) => GetAwaiterTask().ConfigureAwait(options);
+
     /// <summary>Kills the process.</summary>
     public void Kill(bool entireProcessTree = true)
     {

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -21,6 +21,30 @@ public class ProcessWrapperTests
     }
 
     [Fact]
+    public async Task ExecuteBufferedAsync_SupportsConfigureAwait()
+    {
+        var processResult = await CreateEchoCommand("test")
+            .ExecuteBufferedAsync()
+            .ConfigureAwait(false);
+
+        Assert.Equal(0, processResult.ExitCode);
+        Assert.Single(processResult.Output.StandardOutput);
+        Assert.Equal("test", processResult.Output.StandardOutput.First().Text);
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_SupportsConfigureAwaitOptions()
+    {
+        var processResult = await CreateEchoCommand("test")
+            .ExecuteBufferedAsync()
+            .ConfigureAwait(ConfigureAwaitOptions.None);
+
+        Assert.Equal(0, processResult.ExitCode);
+        Assert.Single(processResult.Output.StandardOutput);
+        Assert.Equal("test", processResult.Output.StandardOutput.First().Text);
+    }
+
+    [Fact]
     public async Task ExecuteBufferedAsync_CapturesStdErr()
     {
         ProcessWrapper command;
@@ -80,6 +104,26 @@ public class ProcessWrapperTests
 
         Assert.Single(lines);
         Assert.Equal("test", lines[0]);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SupportsConfigureAwait()
+    {
+        var processResult = await CreateEchoCommand("test")
+            .ExecuteAsync()
+            .ConfigureAwait(false);
+
+        Assert.Equal(0, processResult.ExitCode);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SupportsConfigureAwaitOptions()
+    {
+        var processResult = await CreateEchoCommand("test")
+            .ExecuteAsync()
+            .ConfigureAwait(ConfigureAwaitOptions.None);
+
+        Assert.Equal(0, processResult.ExitCode);
     }
 
     [Fact]


### PR DESCRIPTION
## Why
ProcessWrapper returns custom awaitable types from `ExecuteAsync` and `ExecuteBufferedAsync`. They could be awaited directly, but they did not expose the same `ConfigureAwait` API surface as `Task`, so callers could not use `ConfigureAwait(false)` or newer `ConfigureAwaitOptions` values.

## What changed
- Added `ConfigureAwait(bool continueOnCapturedContext)` and `ConfigureAwait(ConfigureAwaitOptions options)` to `ProcessInstance`.
- Added matching overloads to `BufferedProcessInstance`.
- Added test coverage for both overload families on buffered and non-buffered execution paths.

## Notes
This aligns ProcessWrapper awaitables with modern .NET continuation configuration patterns while preserving existing behavior.