### PR TITLE
Fix flaky UDP server failure integration test

### DIFF
--- a/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
@@ -253,7 +253,7 @@ public sealed class DnsServerIntegrationTests
         try
         {
             using var client = new ClientDns.DnsClient($"127.0.0.1:{port}", ClientDns.DnsClientProtocol.Udp);
-            var response = await client.QueryAsync("test.example.com", ClientDns.Query.DnsQueryType.A);
+            var response = await XUnitStaticHelpers.Retry(() => client.QueryAsync("test.example.com", ClientDns.Query.DnsQueryType.A, XUnitStaticHelpers.XunitCancellationToken));
 
             Assert.True(response.Header.IsResponse);
             Assert.Equal(ClientDns.Response.DnsResponseCode.ServerFailure, response.Header.ResponseCode);


### PR DESCRIPTION
## Why
The CI run for this branch failed intermittently in `DnsServerIntegrationTests.Udp_ServerFailure_WhenNoHandlerConfigured` with `OperationCanceledException` from the UDP receive path. The test can race listener readiness and fail before the server responds.

## What changed
- Updated `Udp_ServerFailure_WhenNoHandlerConfigured` to issue the UDP query through `XUnitStaticHelpers.Retry(...)`.
- Used `XUnitStaticHelpers.XunitCancellationToken` for the retried query, matching the existing pattern used by other UDP integration tests in the same file.

## Notes
- The change is intentionally minimal: expected response assertions are unchanged.
- This only adds resilience to transient startup timing in CI.