### PR TITLE
Add tracing Activity to ProcessWrapper execution

### DIFF
--- a/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
@@ -9,8 +9,8 @@ public sealed class BufferedProcessInstance : ProcessInstance
     private readonly ProcessOutputCollection _output;
     private Task<BufferedProcessResult>? _waitTask;
 
-    internal BufferedProcessInstance(Process process, Task inputTask, Task outputTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, CancellationToken cancellationToken)
-        : base(process, inputTask, outputTask, cancellationRegistration, processLimiter, validationMode, hasStandardErrorOutput, cancellationToken)
+    internal BufferedProcessInstance(Process process, Task inputTask, Task outputTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, Activity? activity, CancellationToken cancellationToken)
+        : base(process, inputTask, outputTask, cancellationRegistration, processLimiter, validationMode, hasStandardErrorOutput, activity, cancellationToken)
     {
         _output = output;
     }

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
@@ -20,11 +20,12 @@ public class ProcessInstance
     private readonly ProcessValidationMode _validationMode;
     private readonly CancellationToken _cancellationToken;
     private readonly Func<bool> _hasStandardErrorOutput;
+    private readonly Activity? _activity;
     private readonly Task<ProcessCompletion> _processCompletionTask;
     private protected readonly Lock WaitTaskLock = new();
     private Task<ProcessResult>? _waitTask;
 
-    internal ProcessInstance(Process process, Task inputStreamTask, Task outputStreamTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, CancellationToken cancellationToken)
+    internal ProcessInstance(Process process, Task inputStreamTask, Task outputStreamTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, Activity? activity, CancellationToken cancellationToken)
     {
         _process = process;
         _inputStreamTask = inputStreamTask;
@@ -34,6 +35,7 @@ public class ProcessInstance
         _validationMode = validationMode;
         _cancellationToken = cancellationToken;
         _hasStandardErrorOutput = hasStandardErrorOutput;
+        _activity = activity;
 
         ProcessId = process.Id;
         StartDate = DateTimeOffset.UtcNow;
@@ -140,18 +142,29 @@ public class ProcessInstance
 
             _cancellationToken.ThrowIfCancellationRequested();
 
-            if ((_validationMode & ProcessValidationMode.FailIfNonZeroExitCode) == ProcessValidationMode.FailIfNonZeroExitCode && processCompletion.ExitCode != 0)
+            var validationException = GetValidationException(processCompletion.ExitCode);
+            if (validationException is not null)
             {
-                throw new ProcessExecutionException(processCompletion.ExitCode);
-            }
-
-            if ((_validationMode & ProcessValidationMode.FailIfStdError) == ProcessValidationMode.FailIfStdError && _hasStandardErrorOutput())
-            {
-                throw new ProcessExecutionException("Process wrote to standard error.");
+                throw validationException;
             }
 
             return CreateProcessResult(processCompletion.ExitCode, processCompletion.ExitDate);
         }
+    }
+
+    private ProcessExecutionException? GetValidationException(int exitCode)
+    {
+        if ((_validationMode & ProcessValidationMode.FailIfNonZeroExitCode) == ProcessValidationMode.FailIfNonZeroExitCode && exitCode != 0)
+        {
+            return new ProcessExecutionException(exitCode);
+        }
+
+        if ((_validationMode & ProcessValidationMode.FailIfStdError) == ProcessValidationMode.FailIfStdError && _hasStandardErrorOutput())
+        {
+            return new ProcessExecutionException("Process wrote to standard error.");
+        }
+
+        return null;
     }
 
     // Wait for process exit and dispose all resources (do not wait for user to await the instance)
@@ -161,6 +174,7 @@ public class ProcessInstance
         Exception? outputStreamException = null;
         var exitCode = default(int);
         var exitDate = default(DateTimeOffset);
+        var processExited = false;
 
         try
         {
@@ -186,6 +200,7 @@ public class ProcessInstance
 
             exitCode = process.ExitCode;
             exitDate = DateTimeOffset.UtcNow;
+            processExited = true;
         }
         finally
         {
@@ -196,6 +211,27 @@ public class ProcessInstance
             if (ReferenceEquals(_process, process))
             {
                 _process = null;
+            }
+
+            var activity = _activity;
+            if (activity is not null)
+            {
+                if (processExited)
+                {
+                    activity.SetTag("process.exit.code", exitCode);
+
+                    if (!_cancellationToken.IsCancellationRequested)
+                    {
+                        var validationException = GetValidationException(exitCode);
+                        if (validationException is not null)
+                        {
+                            activity.SetStatus(ActivityStatusCode.Error, validationException.Message);
+                        }
+                    }
+                }
+
+                activity.Stop();
+                activity.Dispose();
             }
         }
 

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -210,7 +210,7 @@ public sealed class ProcessWrapper
     public ProcessInstance ExecuteAsync(CancellationToken cancellationToken = default)
     {
         return StartProcess(_outputTargets, _errorTargets,
-            (process, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, ct) => new ProcessInstance(process, inputTask, outputTask, registration, limiter, _validationMode, hasStandardErrorOutput, ct),
+            (process, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, ct) => new ProcessInstance(process, inputTask, outputTask, registration, limiter, _validationMode, hasStandardErrorOutput, activity, ct),
             cancellationToken);
     }
 
@@ -227,12 +227,12 @@ public sealed class ProcessWrapper
         var errorTargets = _errorTargets.Add(OutputTarget.ToProcessOutputCollection(output).ForOutputType(ProcessOutputType.StandardError));
 
         return StartProcess(outputTargets, errorTargets,
-            (process, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, ct) => new BufferedProcessInstance(process, inputTask, outputTask, registration, limiter, _validationMode, output, hasStandardErrorOutput, ct),
+            (process, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, ct) => new BufferedProcessInstance(process, inputTask, outputTask, registration, limiter, _validationMode, output, hasStandardErrorOutput, activity, ct),
             cancellationToken);
     }
 
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "ProcessInstance will dispose it")]
-    private T StartProcess<T>(ImmutableArray<OutputTarget> outputTargets, ImmutableArray<OutputTarget> errorTargets, Func<Process, Task, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, CancellationToken, T> factory, CancellationToken cancellationToken)
+    private T StartProcess<T>(ImmutableArray<OutputTarget> outputTargets, ImmutableArray<OutputTarget> errorTargets, Func<Process, Task, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, Activity?, CancellationToken, T> factory, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -243,10 +243,11 @@ public sealed class ProcessWrapper
         var hasStandardErrorOutput = 0;
 
         var configuredFileName = _startInfo.FileName;
+        var resolvedFileName = ResolveFileName(configuredFileName, _startInfo.WorkingDirectory);
         _startInfo.RedirectStandardOutput = hasOutputHandlers;
         _startInfo.RedirectStandardError = hasErrorHandlers;
         _startInfo.RedirectStandardInput = hasInputStream;
-        _startInfo.FileName = ResolveFileName(configuredFileName, _startInfo.WorkingDirectory);
+        _startInfo.FileName = resolvedFileName;
 
         var process = new Process { StartInfo = _startInfo };
         var processLimiter = CreateProcessLimiter();
@@ -330,7 +331,10 @@ public sealed class ProcessWrapper
             registration = cancellationToken.Register(() => ProcessInstance.KillProcess(process, entireProcessTree: true));
         }
 
-        return factory(process, inputStreamTask, Task.WhenAll(outputStreamTask, errorStreamTask), registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, cancellationToken);
+        var activity = ProcessWrapperTelemetry.ActivitySource.StartActivity("process.execute");
+        activity?.SetTag("process.executable.path", resolvedFileName);
+
+        return factory(process, inputStreamTask, Task.WhenAll(outputStreamTask, errorStreamTask), registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, activity, cancellationToken);
     }
 
     private static async Task PumpStreamAsync(Stream stream, Encoding encoding, ImmutableArray<OutputTarget> targets, Action? onDataRead)

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapperTelemetry.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapperTelemetry.cs
@@ -1,0 +1,8 @@
+using System.Diagnostics;
+
+namespace Meziantou.Framework;
+
+internal static class ProcessWrapperTelemetry
+{
+    public static readonly ActivitySource ActivitySource = new("Meziantou.Framework.ProcessWrapper");
+}

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -92,6 +92,25 @@ public class ProcessWrapperTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_EmitsActivity_WithProcessPathAndExitCode()
+    {
+        var activityTask = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var listener = CreateProcessWrapperActivityListener(activity => activityTask.TrySetResult(activity));
+        ActivitySource.AddActivityListener(listener);
+
+        var processResult = await CreateEchoCommand("test")
+            .ExecuteAsync();
+
+        var activity = await activityTask.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(0, processResult.ExitCode);
+        Assert.Equal("process.execute", activity.OperationName);
+        Assert.Equal(0, activity.GetTagItem("process.exit.code"));
+        var processPath = Assert.IsType<string>(activity.GetTagItem("process.executable.path"));
+        Assert.False(string.IsNullOrWhiteSpace(processPath));
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WithOutputStream_Action()
     {
         var lines = new List<string>();
@@ -494,6 +513,35 @@ public class ProcessWrapperTests
 
         var ex = await Assert.ThrowsAsync<ProcessExecutionException>(async () => await process);
         Assert.Equal(1, ex.ExitCode);
+    }
+
+    [Fact]
+    public async Task Validation_FailIfNonZeroExitCode_SetsActivityStatusToError()
+    {
+        var activityTask = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var listener = CreateProcessWrapperActivityListener(activity => activityTask.TrySetResult(activity));
+        ActivitySource.AddActivityListener(listener);
+
+        ProcessWrapper command;
+        if (OperatingSystem.IsWindows())
+        {
+            command = ProcessWrapper.Create("cmd.exe")
+                .WithArguments("/C", "exit 1");
+        }
+        else
+        {
+            command = ProcessWrapper.Create("sh")
+                .WithArguments("-c", "exit 1");
+        }
+
+        var process = command.ExecuteAsync();
+
+        await Assert.ThrowsAsync<ProcessExecutionException>(async () => await process);
+
+        var activity = await activityTask.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.Equal("Process exited with code 1.", activity.StatusDescription);
+        Assert.Equal(1, activity.GetTagItem("process.exit.code"));
     }
 
     [Fact]
@@ -1044,6 +1092,17 @@ public class ProcessWrapperTests
 
         var processResult = await process;
         Assert.True(processResult.ProcessId > 0);
+    }
+
+    private static ActivityListener CreateProcessWrapperActivityListener(Action<Activity> activityStopped)
+    {
+        return new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == "Meziantou.Framework.ProcessWrapper",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            SampleUsingParentId = static (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activityStopped,
+        };
     }
 
     private static ProcessWrapper CreateEchoBase()


### PR DESCRIPTION
## Why
`ProcessWrapper` did not emit any tracing activity while a child process was running, so callers could not correlate process duration and validation outcomes in distributed traces.

## What changed
- Added `ProcessWrapperTelemetry.ActivitySource` (`Meziantou.Framework.ProcessWrapper`).
- Started a `process.execute` activity from the shared process startup path used by both `ExecuteAsync` and `ExecuteBufferedAsync`.
- Added `process.executable.path` tag at start.
- Kept the activity alive for the process lifetime, then on exit set `process.exit.code` and stopped/disposed the activity.
- Marked the activity status as `Error` when configured validation fails (non-zero exit code or stderr validation failure), without changing existing exception behavior.
- Extended `ProcessWrapperTests` to cover activity emission, tags, and error status.

## Validation
- Ran required scripts:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`
- Ran `dotnet test ./tests/Meziantou.Framework.ProcessWrapper.Tests/Meziantou.Framework.ProcessWrapper.Tests.csproj` (all target frameworks passed).