### PR TITLE
Add Lyrics and ISRC support to MediaTags

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Aiff/AiffReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Aiff/AiffReader.cs
@@ -68,6 +68,12 @@ internal sealed class AiffReader : IMediaTagReader
                     if (stream.ReadAtLeast(data, chunkSize, throwOnEndOfStream: false) >= chunkSize)
                         tags.Copyright ??= ReadAiffString(data);
                 }
+                else if (chunkId == "ISRC")
+                {
+                    var data = new byte[chunkSize];
+                    if (stream.ReadAtLeast(data, chunkSize, throwOnEndOfStream: false) >= chunkSize)
+                        tags.Isrc ??= ReadAiffString(data);
+                }
 
                 // Skip to next chunk (big-endian sizes, pad to even boundary)
                 var nextPos = chunkDataStart + chunkSize;

--- a/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2FrameId.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2FrameId.cs
@@ -17,9 +17,11 @@ internal static class Id3v2FrameId
     public const string Copyright = "TCOP";
     public const string Bpm = "TBPM";
     public const string Compilation = "TCMP";  // iTunes non-standard
+    public const string Isrc = "TSRC";
 
     // Other frames
     public const string Comment = "COMM";
+    public const string Lyrics = "USLT";
     public const string Picture = "APIC";
     public const string UserDefinedText = "TXXX";
 
@@ -36,7 +38,9 @@ internal static class Id3v2FrameId
     public const string ConductorV22 = "TP3";
     public const string CopyrightV22 = "TCR";
     public const string BpmV22 = "TBP";
+    public const string IsrcV22 = "TRC";
     public const string CommentV22 = "COM";
+    public const string LyricsV22 = "ULT";
     public const string PictureV22 = "PIC";
     public const string UserDefinedTextV22 = "TXX";
 }

--- a/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2Reader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2Reader.cs
@@ -221,6 +221,10 @@ internal static class Id3v2Reader
                 }
                 break;
 
+            case Id3v2FrameId.Isrc:
+                tags.Isrc ??= ReadTextFrame(data);
+                break;
+
             case Id3v2FrameId.Compilation:
                 if (tags.IsCompilation is null)
                 {
@@ -231,6 +235,10 @@ internal static class Id3v2Reader
 
             case Id3v2FrameId.Comment:
                 tags.Comment ??= ReadCommentFrame(data);
+                break;
+
+            case Id3v2FrameId.Lyrics:
+                tags.Lyrics ??= ReadUnsynchronizedLyricsFrame(data);
                 break;
 
             case Id3v2FrameId.Picture:
@@ -263,6 +271,28 @@ internal static class Id3v2Reader
         var remaining = data[4..];
 
         // Find null terminator for short description
+        var nullPos = Id3v2TextEncoding.FindNullTerminator(remaining, encoding, 0);
+        if (nullPos < 0)
+            return Id3v2TextEncoding.DecodeString(encoding, remaining);
+
+        var textStart = nullPos + Id3v2TextEncoding.NullTerminatorSize(encoding);
+        if (textStart >= remaining.Length)
+            return string.Empty;
+
+        return Id3v2TextEncoding.DecodeString(encoding, remaining[textStart..]);
+    }
+
+    private static string? ReadUnsynchronizedLyricsFrame(ReadOnlySpan<byte> data)
+    {
+        // USLT frame: encoding(1) + language(3) + content descriptor(null-terminated) + lyrics text
+        if (data.Length < 4)
+            return null;
+
+        var encoding = data[0];
+        // Skip language (3 bytes)
+        var remaining = data[4..];
+
+        // Find null terminator for descriptor
         var nullPos = Id3v2TextEncoding.FindNullTerminator(remaining, encoding, 0);
         if (nullPos < 0)
             return Id3v2TextEncoding.DecodeString(encoding, remaining);
@@ -466,7 +496,9 @@ internal static class Id3v2Reader
         Id3v2FrameId.ConductorV22 => Id3v2FrameId.Conductor,
         Id3v2FrameId.CopyrightV22 => Id3v2FrameId.Copyright,
         Id3v2FrameId.BpmV22 => Id3v2FrameId.Bpm,
+        Id3v2FrameId.IsrcV22 => Id3v2FrameId.Isrc,
         Id3v2FrameId.CommentV22 => Id3v2FrameId.Comment,
+        Id3v2FrameId.LyricsV22 => Id3v2FrameId.Lyrics,
         Id3v2FrameId.PictureV22 => Id3v2FrameId.Picture,
         Id3v2FrameId.UserDefinedTextV22 => Id3v2FrameId.UserDefinedText,
         _ => v22Id,

--- a/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2Writer.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2Writer.cs
@@ -47,11 +47,16 @@ internal static class Id3v2Writer
         if (tags.Bpm is not null)
             AddTextFrame(frames, Id3v2FrameId.Bpm, tags.Bpm.Value.ToString(CultureInfo.InvariantCulture));
 
+        AddTextFrame(frames, Id3v2FrameId.Isrc, tags.Isrc);
+
         if (tags.IsCompilation is not null)
             AddTextFrame(frames, Id3v2FrameId.Compilation, tags.IsCompilation.Value ? "1" : "0");
 
         if (tags.Comment is not null)
             AddCommentFrame(frames, tags.Comment);
+
+        if (tags.Lyrics is not null)
+            AddUnsynchronizedLyricsFrame(frames, tags.Lyrics);
 
         foreach (var picture in tags.Pictures)
         {
@@ -141,6 +146,20 @@ internal static class Id3v2Writer
         frameData[4] = 0; // Empty description null terminator
         textBytes.CopyTo(frameData, 5);
         frames.Add(BuildFrame(Id3v2FrameId.Comment, frameData));
+    }
+
+    private static void AddUnsynchronizedLyricsFrame(List<byte[]> frames, string value)
+    {
+        // USLT frame: encoding(1) + language(3) + content descriptor(null-terminated) + lyrics text
+        var textBytes = Encoding.UTF8.GetBytes(value);
+        var frameData = new byte[1 + 3 + 1 + textBytes.Length]; // encoding + "eng" + null descriptor + text
+        frameData[0] = Id3v2TextEncoding.Utf8;
+        frameData[1] = (byte)'e';
+        frameData[2] = (byte)'n';
+        frameData[3] = (byte)'g';
+        frameData[4] = 0; // Empty descriptor null terminator
+        textBytes.CopyTo(frameData, 5);
+        frames.Add(BuildFrame(Id3v2FrameId.Lyrics, frameData));
     }
 
     private static void AddPictureFrame(List<byte[]> frames, MediaPicture picture)

--- a/src/Meziantou.Framework.MediaTags/Formats/Mp4/ItunesAtomNames.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Mp4/ItunesAtomNames.cs
@@ -15,6 +15,7 @@ internal static class ItunesAtomNames
     public const string DiscNumber = "disk";
     public const string Composer = "\u00A9wrt";
     public const string Comment = "\u00A9cmt";
+    public const string Lyrics = "\u00A9lyr";
     public const string Copyright = "cprt";
     public const string Bpm = "tmpo";
     public const string Compilation = "cpil";

--- a/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Atom.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Atom.cs
@@ -121,7 +121,7 @@ internal sealed class Mp4Atom
             or ItunesAtomNames.Title or ItunesAtomNames.Artist or ItunesAtomNames.Album
             or ItunesAtomNames.AlbumArtist or ItunesAtomNames.Genre or ItunesAtomNames.Year
             or ItunesAtomNames.TrackNumber or ItunesAtomNames.DiscNumber or ItunesAtomNames.Composer
-            or ItunesAtomNames.Comment or ItunesAtomNames.Copyright or ItunesAtomNames.Bpm
+            or ItunesAtomNames.Comment or ItunesAtomNames.Lyrics or ItunesAtomNames.Copyright or ItunesAtomNames.Bpm
             or ItunesAtomNames.Compilation or ItunesAtomNames.CoverArt or ItunesAtomNames.Freeform
             or "aART";
     }

--- a/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Reader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Reader.cs
@@ -95,6 +95,9 @@ internal sealed class Mp4Reader : IMediaTagReader
             case ItunesAtomNames.Comment:
                 tags.Comment ??= ReadUtf8Value(valueData);
                 break;
+            case ItunesAtomNames.Lyrics:
+                tags.Lyrics ??= ReadUtf8Value(valueData);
+                break;
             case ItunesAtomNames.Copyright:
                 tags.Copyright ??= ReadUtf8Value(valueData);
                 break;
@@ -159,6 +162,8 @@ internal sealed class Mp4Reader : IMediaTagReader
                 tags.MusicBrainzAlbumId ??= value;
             else if (string.Equals(name, "MusicBrainz Release Group Id", StringComparison.OrdinalIgnoreCase))
                 tags.MusicBrainzReleaseGroupId ??= value;
+            else if (string.Equals(name, "ISRC", StringComparison.OrdinalIgnoreCase))
+                tags.Isrc ??= value;
             else if (string.Equals(name, "REPLAYGAIN_TRACK_GAIN", StringComparison.OrdinalIgnoreCase))
             {
                 if (TryParseReplayGainValue(value, out var gain))

--- a/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Writer.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Writer.cs
@@ -127,7 +127,9 @@ internal sealed class Mp4Writer : IMediaTagWriter
 
         WriteTextAtom(ms, ItunesAtomNames.Composer, tags.Composer);
         WriteTextAtom(ms, ItunesAtomNames.Comment, tags.Comment);
+        WriteTextAtom(ms, ItunesAtomNames.Lyrics, tags.Lyrics);
         WriteTextAtom(ms, ItunesAtomNames.Copyright, tags.Copyright);
+        WriteFreeformTextAtom(ms, "com.apple.iTunes", "ISRC", tags.Isrc);
 
         if (tags.Bpm is not null)
             WriteUInt16Atom(ms, ItunesAtomNames.Bpm, (ushort)tags.Bpm.Value);
@@ -191,6 +193,35 @@ internal sealed class Mp4Writer : IMediaTagWriter
         Encoding.Latin1.GetBytes(atomType, itemHeader[4..]);
         ms.Write(itemHeader);
         ms.Write(dataAtom);
+    }
+
+    private static void WriteFreeformTextAtom(MemoryStream ms, string mean, string name, string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return;
+
+        var meanBytes = Encoding.UTF8.GetBytes(mean);
+        var meanData = new byte[4 + meanBytes.Length]; // version/flags + value
+        meanBytes.CopyTo(meanData, 4);
+        var meanAtom = BuildAtom("mean", meanData);
+
+        var nameBytes = Encoding.UTF8.GetBytes(name);
+        var nameData = new byte[4 + nameBytes.Length]; // version/flags + value
+        nameBytes.CopyTo(nameData, 4);
+        var nameAtom = BuildAtom("name", nameData);
+
+        var valueBytes = Encoding.UTF8.GetBytes(value);
+        var dataPayload = new byte[8 + valueBytes.Length]; // type + locale + value
+        BinaryPrimitives.WriteUInt32BigEndian(dataPayload, 1); // UTF-8 text
+        valueBytes.CopyTo(dataPayload, 8);
+        var dataAtom = BuildAtom("data", dataPayload);
+
+        var freeformData = new byte[meanAtom.Length + nameAtom.Length + dataAtom.Length];
+        meanAtom.CopyTo(freeformData, 0);
+        nameAtom.CopyTo(freeformData, meanAtom.Length);
+        dataAtom.CopyTo(freeformData, meanAtom.Length + nameAtom.Length);
+
+        ms.Write(BuildAtom(ItunesAtomNames.Freeform, freeformData));
     }
 
     private static byte[] BuildAtom(string type, byte[] data)

--- a/src/Meziantou.Framework.MediaTags/Formats/VorbisComment/VorbisCommentFieldNames.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/VorbisComment/VorbisCommentFieldNames.cs
@@ -14,6 +14,9 @@ internal static class VorbisCommentFieldNames
     public const string DiscTotal = "DISCTOTAL";
     public const string Comment = "COMMENT";
     public const string Description = "DESCRIPTION";
+    public const string Lyrics = "LYRICS";
+    public const string UnsyncedLyrics = "UNSYNCEDLYRICS";
+    public const string Isrc = "ISRC";
     public const string Composer = "COMPOSER";
     public const string Conductor = "CONDUCTOR";
     public const string Copyright = "COPYRIGHT";

--- a/src/Meziantou.Framework.MediaTags/Formats/VorbisComment/VorbisCommentReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/VorbisComment/VorbisCommentReader.cs
@@ -98,6 +98,11 @@ internal static class VorbisCommentReader
         else if (string.Equals(fieldName, VorbisCommentFieldNames.Comment, StringComparison.OrdinalIgnoreCase)
               || string.Equals(fieldName, VorbisCommentFieldNames.Description, StringComparison.OrdinalIgnoreCase))
             tags.Comment ??= value;
+        else if (string.Equals(fieldName, VorbisCommentFieldNames.Lyrics, StringComparison.OrdinalIgnoreCase)
+              || string.Equals(fieldName, VorbisCommentFieldNames.UnsyncedLyrics, StringComparison.OrdinalIgnoreCase))
+            tags.Lyrics ??= value;
+        else if (string.Equals(fieldName, VorbisCommentFieldNames.Isrc, StringComparison.OrdinalIgnoreCase))
+            tags.Isrc ??= value;
         else if (string.Equals(fieldName, VorbisCommentFieldNames.Composer, StringComparison.OrdinalIgnoreCase))
             tags.Composer ??= value;
         else if (string.Equals(fieldName, VorbisCommentFieldNames.Conductor, StringComparison.OrdinalIgnoreCase))

--- a/src/Meziantou.Framework.MediaTags/Formats/VorbisComment/VorbisCommentWriter.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/VorbisComment/VorbisCommentWriter.cs
@@ -31,6 +31,8 @@ internal static class VorbisCommentWriter
             AddField(comments, VorbisCommentFieldNames.DiscTotal, tags.DiscTotal.Value.ToString(CultureInfo.InvariantCulture));
 
         AddField(comments, VorbisCommentFieldNames.Comment, tags.Comment);
+        AddField(comments, VorbisCommentFieldNames.Lyrics, tags.Lyrics);
+        AddField(comments, VorbisCommentFieldNames.Isrc, tags.Isrc);
         AddField(comments, VorbisCommentFieldNames.Composer, tags.Composer);
         AddField(comments, VorbisCommentFieldNames.Conductor, tags.Conductor);
         AddField(comments, VorbisCommentFieldNames.Copyright, tags.Copyright);

--- a/src/Meziantou.Framework.MediaTags/Formats/Wav/WavReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Wav/WavReader.cs
@@ -76,6 +76,8 @@ internal sealed class WavReader : IMediaTagReader
                         tags.TrackNumber = track;
                     break;
                 case "ICMT": tags.Comment ??= value; break;
+                case "ILYR": tags.Lyrics ??= value; break;
+                case "ISRC": tags.Isrc ??= value; break;
                 case "ICOP": tags.Copyright ??= value; break;
                 case "IENG": tags.Composer ??= value; break;
                 default:

--- a/src/Meziantou.Framework.MediaTags/MediaTagInfo.cs
+++ b/src/Meziantou.Framework.MediaTags/MediaTagInfo.cs
@@ -40,6 +40,12 @@ public sealed class MediaTagInfo
     /// <summary>Gets or sets a comment or description.</summary>
     public string? Comment { get; set; }
 
+    /// <summary>Gets or sets the track lyrics.</summary>
+    public string? Lyrics { get; set; }
+
+    /// <summary>Gets or sets the ISRC (International Standard Recording Code).</summary>
+    public string? Isrc { get; set; }
+
     /// <summary>Gets or sets the composer.</summary>
     public string? Composer { get; set; }
 

--- a/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
+++ b/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>A library for reading and writing metadata tags in media files (MP3, OGG, FLAC, MP4/M4A, WAV, AIFF)</Description>
   </PropertyGroup>

--- a/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
@@ -126,6 +126,8 @@ public sealed class FlacTests
                 DiscNumber = 1,
                 DiscTotal = 2,
                 Comment = "FLAC Comment",
+                Lyrics = "FLAC Lyrics",
+                Isrc = "USRC17607839",
             };
 
             var writeResult = MediaFile.WriteTags(tempFile, newTags);
@@ -145,6 +147,8 @@ public sealed class FlacTests
             Assert.Equal(1, tags.DiscNumber);
             Assert.Equal(2, tags.DiscTotal);
             Assert.Equal("FLAC Comment", tags.Comment);
+            Assert.Equal("FLAC Lyrics", tags.Lyrics);
+            Assert.Equal("USRC17607839", tags.Isrc);
         }
         finally
         {

--- a/tests/Meziantou.Framework.MediaTags.Tests/Mp3Id3v2Tests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Mp3Id3v2Tests.cs
@@ -96,6 +96,8 @@ public sealed class Mp3Id3v2Tests
                 TrackNumber = 7,
                 TrackTotal = 15,
                 Comment = "New Comment",
+                Lyrics = "New Lyrics",
+                Isrc = "USRC17607839",
             };
 
             var writeResult = MediaFile.WriteTags(tempFile, newTags);
@@ -113,6 +115,8 @@ public sealed class Mp3Id3v2Tests
             Assert.Equal(7, tags.TrackNumber);
             Assert.Equal(15, tags.TrackTotal);
             Assert.Equal("New Comment", tags.Comment);
+            Assert.Equal("New Lyrics", tags.Lyrics);
+            Assert.Equal("USRC17607839", tags.Isrc);
         }
         finally
         {

--- a/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
@@ -109,6 +109,8 @@ public sealed class Mp4Tests
                 Year = 2025,
                 TrackNumber = 2,
                 TrackTotal = 8,
+                Lyrics = "New MP4 Lyrics",
+                Isrc = "USRC17607839",
             };
 
             var writeResult = MediaFile.WriteTags(tempFile, newTags);
@@ -123,6 +125,8 @@ public sealed class Mp4Tests
             Assert.Equal(2025, readResult.Value.Year);
             Assert.Equal(2, readResult.Value.TrackNumber);
             Assert.Equal(8, readResult.Value.TrackTotal);
+            Assert.Equal("New MP4 Lyrics", readResult.Value.Lyrics);
+            Assert.Equal("USRC17607839", readResult.Value.Isrc);
         }
         finally
         {

--- a/tests/Meziantou.Framework.MediaTags.Tests/OggOpusTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/OggOpusTests.cs
@@ -32,6 +32,8 @@ public sealed class OggOpusTests
             {
                 Title = "New Opus Title",
                 Artist = "New Opus Artist",
+                Lyrics = "New Opus Lyrics",
+                Isrc = "USRC17607839",
             };
 
             var writeResult = MediaFile.WriteTags(tempFile, newTags);
@@ -42,6 +44,8 @@ public sealed class OggOpusTests
 
             Assert.Equal("New Opus Title", readResult.Value.Title);
             Assert.Equal("New Opus Artist", readResult.Value.Artist);
+            Assert.Equal("New Opus Lyrics", readResult.Value.Lyrics);
+            Assert.Equal("USRC17607839", readResult.Value.Isrc);
         }
         finally
         {

--- a/tests/Meziantou.Framework.MediaTags.Tests/OggVorbisTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/OggVorbisTests.cs
@@ -77,6 +77,8 @@ public sealed class OggVorbisTests
                 Artist = "New OGG Artist",
                 Year = 2025,
                 TrackNumber = 4,
+                Lyrics = "New OGG Lyrics",
+                Isrc = "USRC17607839",
             };
 
             var writeResult = MediaFile.WriteTags(tempFile, newTags);
@@ -89,6 +91,8 @@ public sealed class OggVorbisTests
             Assert.Equal("New OGG Artist", readResult.Value.Artist);
             Assert.Equal(2025, readResult.Value.Year);
             Assert.Equal(4, readResult.Value.TrackNumber);
+            Assert.Equal("New OGG Lyrics", readResult.Value.Lyrics);
+            Assert.Equal("USRC17607839", readResult.Value.Isrc);
         }
         finally
         {

--- a/tests/Meziantou.Framework.MediaTags.Tests/VorbisCommentTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/VorbisCommentTests.cs
@@ -65,6 +65,30 @@ public sealed class VorbisCommentTests
     }
 
     [Fact]
+    public void TryParse_LyricsFieldVariants()
+    {
+        var lyricsData = BuildVorbisComment("Vendor", ["LYRICS=Lyrics from LYRICS"]);
+        var lyricsTags = new MediaTagInfo();
+        VorbisCommentReader.TryParse(lyricsData, lyricsTags);
+        Assert.Equal("Lyrics from LYRICS", lyricsTags.Lyrics);
+
+        var unsyncedLyricsData = BuildVorbisComment("Vendor", ["UNSYNCEDLYRICS=Lyrics from UNSYNCEDLYRICS"]);
+        var unsyncedLyricsTags = new MediaTagInfo();
+        VorbisCommentReader.TryParse(unsyncedLyricsData, unsyncedLyricsTags);
+        Assert.Equal("Lyrics from UNSYNCEDLYRICS", unsyncedLyricsTags.Lyrics);
+    }
+
+    [Fact]
+    public void TryParse_IsrcField()
+    {
+        var data = BuildVorbisComment("Vendor", ["ISRC=USRC17607839"]);
+        var tags = new MediaTagInfo();
+        VorbisCommentReader.TryParse(data, tags);
+
+        Assert.Equal("USRC17607839", tags.Isrc);
+    }
+
+    [Fact]
     public void TryParse_EmptyData_ReturnsFalse()
     {
         var tags = new MediaTagInfo();
@@ -91,6 +115,8 @@ public sealed class VorbisCommentTests
             TrackTotal = 10,
             Genre = "Pop",
             Comment = "A comment",
+            Lyrics = "Some lyrics",
+            Isrc = "USRC17607839",
         };
 
         var data = VorbisCommentWriter.Build(originalTags);
@@ -106,6 +132,8 @@ public sealed class VorbisCommentTests
         Assert.Equal(10, readTags.TrackTotal);
         Assert.Equal("Pop", readTags.Genre);
         Assert.Equal("A comment", readTags.Comment);
+        Assert.Equal("Some lyrics", readTags.Lyrics);
+        Assert.Equal("USRC17607839", readTags.Isrc);
     }
 
     [Fact]


### PR DESCRIPTION
## Why
MediaTags exposed common metadata like comment and composer, but it did not expose lyrics or ISRC as first-class properties. This makes it hard to read and write these widely-used fields consistently across formats.

## What changed
- Added `Lyrics` and `Isrc` properties to `MediaTagInfo`.
- Added lyrics field support for the requested tags:
  - Vorbis: `LYRICS`, `UNSYNCEDLYRICS`
  - ID3v2: `USLT` (plus ID3v2.2 `ULT` mapping)
  - MP4: `\u00A9lyr`
- Added ISRC support:
  - Vorbis: `ISRC`
  - ID3v2: `TSRC` (plus ID3v2.2 `TRC` mapping)
  - MP4 freeform atom (`----`) with `mean=com.apple.iTunes` and `name=ISRC`
  - WAV/AIFF readers: `ISRC`
- Updated MP4 atom container recognition so `\u00A9lyr` is parsed as an ilst item.
- Bumped `Meziantou.Framework.MediaTags` version from `1.0.1` to `1.1.0`.

## Tests
- Expanded existing round-trip tests for MP3, FLAC, OGG Vorbis, OGG Opus, and MP4 to assert `Lyrics` and `Isrc`.
- Added Vorbis parser tests specifically for `LYRICS`, `UNSYNCEDLYRICS`, and `ISRC`.

## Notes for reviewers
MP4 ISRC is intentionally written/read via iTunes freeform metadata instead of a dedicated standard atom, because that is the interoperable path used by common tagging tools.