### PR TITLE
Add InlineSnapshot.Validate overload for InlineSnapshotSettings

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshot.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshot.cs
@@ -72,7 +72,23 @@ public static class InlineSnapshot
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
     public static void Validate(object? subject, string? expected = null, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = -1)
     {
-        var settings = InlineSnapshotSettings.Default;
+        Validate(subject, InlineSnapshotSettings.Default, expected, filePath, lineNumber);
+    }
+
+    /// <summary>
+    /// Validates that the serialized representation of the subject matches the expected snapshot using the provided settings.
+    /// If the snapshot doesn't match, the source file is updated with the actual value based on the configured update strategy.
+    /// </summary>
+    /// <param name="subject">The object to validate.</param>
+    /// <param name="settings">The settings to use for validation. If null, <see cref="InlineSnapshotSettings.Default"/> is used.</param>
+    /// <param name="expected">The expected snapshot value. This parameter will be automatically updated when the snapshot changes.</param>
+    /// <param name="filePath">The source file path. Automatically populated by the compiler.</param>
+    /// <param name="lineNumber">The line number in the source file. Automatically populated by the compiler.</param>
+    [InlineSnapshotAssertion(nameof(expected))]
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    public static void Validate(object? subject, InlineSnapshotSettings? settings, string? expected, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = -1)
+    {
+        settings ??= InlineSnapshotSettings.Default;
         var context = CallerContext.Get(settings, filePath, lineNumber);
         ShouldMatchInlineSnapshot(subject, context, settings, expected);
     }

--- a/src/Meziantou.Framework.InlineSnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/readme.md
@@ -72,12 +72,18 @@ var settings = InlineSnapshotSettings.Default with
     SnapshotUpdateStrategy = SnapshotUpdateStrategy.Overwrite,
 };
 
+InlineSnapshot.Validate(data, settings, "");
+````
+
+If you prefer, you can use the builder syntax:
+
+````c#
 InlineSnapshot.CreateBuilder()
     .WithSettings(settings)
     .Validate(data, "");
 ````
 
-If you prefer, you can use the alternative syntax:
+Or configure settings inline:
 
 ````c#
 InlineSnapshot.CreateBuilder()

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -53,6 +53,40 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public void Validate_WithSettings()
+    {
+        InlineSnapshot.Validate(new object(), InlineSnapshotSettings.Default, "{}");
+    }
+
+    [Fact]
+    public async Task UpdateSnapshotUsingQuotedString_WithSettings()
+    {
+        await AssertSnapshot(
+            """
+            var settings = InlineSnapshotSettings.Default;
+            InlineSnapshot.Validate(new object(), settings, "");
+            """,
+            """
+            var settings = InlineSnapshotSettings.Default;
+            InlineSnapshot.Validate(new object(), settings, "{}");
+            """);
+    }
+
+    [Fact]
+    public async Task UpdateSnapshotWhenExpectedIsNull_WithSettings()
+    {
+        await AssertSnapshot(
+            """
+            var settings = InlineSnapshotSettings.Default;
+            InlineSnapshot.Validate(new object(), settings, expected: null);
+            """,
+            """
+            var settings = InlineSnapshotSettings.Default;
+            InlineSnapshot.Validate(new object(), settings, expected: "{}");
+            """);
+    }
+
+    [Fact]
     public async Task UpdateSnapshotUsingQuotedString()
     {
         await AssertSnapshot(
@@ -1189,13 +1223,13 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
                 }
             }
 
-            psi.EnvironmentVariables.Add("DiffEngine_Disabled", "true");
-            psi.EnvironmentVariables.Add("MF_CurrentDirectory", Environment.CurrentDirectory);
+            psi.EnvironmentVariables["DiffEngine_Disabled"] = "true";
+            psi.EnvironmentVariables["MF_CurrentDirectory"] = Environment.CurrentDirectory;
             if (environmentVariables is not null)
             {
                 foreach (var variable in environmentVariables)
                 {
-                    psi.EnvironmentVariables.Add(variable.Key, variable.Value);
+                    psi.EnvironmentVariables[variable.Key] = variable.Value;
                 }
             }
 


### PR DESCRIPTION
## Why
`InlineSnapshot.Validate` supported default settings or builder-based configuration, but not a direct call shape that passes a settings instance inline. This adds the requested API form so callers can use `InlineSnapshot.Validate(subject, settings, expected)` without switching to the builder.

## What changed
- Added a new overload in `InlineSnapshot`:
  - `Validate(object? subject, InlineSnapshotSettings? settings, string? expected, ...)`
- Kept behavior consistent by routing through existing caller-context and snapshot comparison/update logic.
- Updated the existing overload to delegate to the new one.
- Documented direct settings usage in the InlineSnapshotTesting README.
- Added tests covering the new overload, including snapshot update behavior.
- Updated test process environment variable assignment to overwrite existing keys instead of adding duplicates, avoiding duplicate-key failures when `DiffEngine_Disabled` is already set by the test host.

## Notes for reviewers
This is an additive API change only; existing call sites continue to work unchanged.