### PR TITLE
Prefer OTEL_SERVICE_NAME for OpenTelemetry service name

### DIFF
--- a/src/Meziantou.AspNetCore.ServiceDefaults/MeziantouServiceDefaults.cs
+++ b/src/Meziantou.AspNetCore.ServiceDefaults/MeziantouServiceDefaults.cs
@@ -107,7 +107,12 @@ public static class MeziantouServiceDefaults
         builder.Services.AddOpenTelemetry()
             .ConfigureResource(x =>
             {
-                var name = builder.Environment.ApplicationName;
+                var name = Environment.GetEnvironmentVariable("OTEL_SERVICE_NAME");
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    name = builder.Environment.ApplicationName;
+                }
+
                 var version = Assembly.GetEntryAssembly()?.GetName().Version?.ToString() ?? "unknown";
                 x.AddService(name, serviceVersion: version);
             })


### PR DESCRIPTION
## Why
When `OTEL_SERVICE_NAME` is set, it should define the OpenTelemetry service name. The current behavior always uses `builder.Environment.ApplicationName`, which can override that explicit telemetry configuration.

## What changed
`ConfigureResource` in `MeziantouServiceDefaults` now reads `OTEL_SERVICE_NAME` first. If the variable is missing or empty, it falls back to `builder.Environment.ApplicationName`.

## Notes
- Service version behavior is unchanged.
- Scope is intentionally limited to the resource service-name resolution path.