### PR TITLE
Add canonical path resolution API to FullPath

### DIFF
--- a/src/Meziantou.Framework.FullPath/CanonicalPath.cs
+++ b/src/Meziantou.Framework.FullPath/CanonicalPath.cs
@@ -1,0 +1,124 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Meziantou.Framework;
+
+internal static class CanonicalPath
+{
+    public static bool TryGetCanonicalPath(string path, [NotNullWhen(true)] out string? canonicalPath)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return WindowsCanonicalPath.TryGetCanonicalPath(path, out canonicalPath);
+        }
+
+#if NETCOREAPP3_1_OR_GREATER
+        return UnixCanonicalPath.TryGetCanonicalPath(path, out canonicalPath);
+#elif NET472
+        throw new PlatformNotSupportedException();
+#else
+#error Platform not supported
+#endif
+    }
+
+    private static class WindowsCanonicalPath
+    {
+        public static bool TryGetCanonicalPath(string path, [NotNullWhen(true)] out string? canonicalPath)
+        {
+            using var handle = Interop.Kernel32.CreateFile(
+                path,
+                dwDesiredAccess: 0,
+                dwShareMode: FileShare.ReadWrite | FileShare.Delete,
+                dwCreationDisposition: FileMode.Open,
+                dwFlagsAndAttributes: Interop.Kernel32.FileOperations.FILE_FLAG_BACKUP_SEMANTICS);
+            if (handle.IsInvalid)
+            {
+                canonicalPath = null;
+                return false;
+            }
+
+            var bufferSize = Interop.Kernel32.MAX_PATH;
+            while (true)
+            {
+                var buffer = new char[bufferSize];
+                var result = Interop.Kernel32.GetFinalPathNameByHandle(handle, buffer, (uint)buffer.Length, dwFlags: 0);
+                if (result == 0)
+                {
+                    canonicalPath = null;
+                    return false;
+                }
+
+                if (result >= buffer.Length)
+                {
+                    bufferSize = checked((int)result + 1);
+                    continue;
+                }
+
+                canonicalPath = NormalizePath(new string(buffer, 0, (int)result));
+                return true;
+            }
+        }
+
+        private static string NormalizePath(string path)
+        {
+            if (path.StartsWith(PathInternal.UncExtendedPathPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Concat(PathInternal.UncPathPrefix, path.AsSpan(PathInternal.UncExtendedPathPrefix.Length));
+            }
+
+            if (PathInternal.IsExtended(path))
+            {
+                return path[PathInternal.DevicePrefixLength..];
+            }
+
+            return path;
+        }
+    }
+
+#if NETCOREAPP3_1_OR_GREATER
+    private static class UnixCanonicalPath
+    {
+        public static bool TryGetCanonicalPath(string path, [NotNullWhen(true)] out string? canonicalPath)
+        {
+            var utf8Path = Encoding.UTF8.GetBytes(path + '\0');
+            var pointer = Interop.RealPath(utf8Path, IntPtr.Zero);
+            if (pointer == IntPtr.Zero)
+            {
+                canonicalPath = null;
+                return false;
+            }
+
+            try
+            {
+                canonicalPath = Marshal.PtrToStringUTF8(pointer);
+                return canonicalPath is not null;
+            }
+            finally
+            {
+                Interop.Free(pointer);
+            }
+        }
+
+        private static class Interop
+        {
+            [DllImport("libc", EntryPoint = "realpath", SetLastError = true, ExactSpelling = true)]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+            private static extern IntPtr RealPathCore(byte[] path, IntPtr resolvedPath);
+
+            [DllImport("libc", EntryPoint = "free", SetLastError = false, ExactSpelling = true)]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+            private static extern void FreeCore(IntPtr pointer);
+
+            internal static IntPtr RealPath(byte[] path, IntPtr resolvedPath)
+            {
+                return RealPathCore(path, resolvedPath);
+            }
+
+            internal static void Free(IntPtr pointer)
+            {
+                FreeCore(pointer);
+            }
+        }
+    }
+#endif
+}

--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -436,6 +436,25 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         return Symlink.IsSymbolicLink(_value);
     }
 
+    /// <summary>Attempts to resolve this path to its canonical final existing path.</summary>
+    /// <param name="result">The canonical final path if successful; otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if canonical resolution succeeds; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// <para>The canonical path resolves symbolic links and reparse points to the final target.</para>
+    /// <para>This method returns <see langword="false"/> when the path does not exist or cannot be resolved.</para>
+    /// </remarks>
+    public bool TryGetCanonicalPath([NotNullWhen(true)] out FullPath? result)
+    {
+        if (!IsEmpty && CanonicalPath.TryGetCanonicalPath(_value, out var path))
+        {
+            result = FromPath(path);
+            return true;
+        }
+
+        result = null;
+        return false;
+    }
+
     /// <summary>Finds the first ancestor path or self that matches the specified predicate.</summary>
     /// <param name="predicate">A function to test each path.</param>
     /// <param name="result">The first matching path, or default if not found.</param>

--- a/src/Meziantou.Framework.FullPath/Interop/Windows.cs
+++ b/src/Meziantou.Framework.FullPath/Interop/Windows.cs
@@ -152,6 +152,14 @@ namespace Meziantou.Framework
                 IntPtr overlapped
             );
 
+            [DllImport(Kernel32Name, EntryPoint = "GetFinalPathNameByHandleW", CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            internal static extern uint GetFinalPathNameByHandle(
+                SafeFileHandle hFile,
+                [Out] char[] lpszFilePath,
+                uint cchFilePath,
+                uint dwFlags);
+
             internal const int MAX_PATH = 260;
 
             [StructLayout(LayoutKind.Sequential)]

--- a/src/Meziantou.Framework.FullPath/readme.md
+++ b/src/Meziantou.Framework.FullPath/readme.md
@@ -30,6 +30,12 @@ string relativePath = filePath.MakeRelativeTo(rootPath); // temp\meziantou.txt
 // Check if a path is under another path
 bool isChildOf = filePath.IsChildOf(rootPath);
 
+// Resolve to canonical final path (follows symbolic links/reparse points)
+if (filePath.TryGetCanonicalPath(out var canonicalPath))
+{
+    Console.WriteLine(canonicalPath);
+}
+
 // FullPath is implicitly converted to string, so it works well with File/Directory methods
 System.IO.File.WriteAllText(filePath, content);
 ````

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -254,6 +254,38 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public async Task TryGetCanonicalPath_File()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var file = temp.CreateEmptyFile("a.txt");
+
+        Assert.True(file.TryGetCanonicalPath(out var canonicalPath));
+        Assert.True(File.Exists(canonicalPath));
+    }
+
+    [Fact]
+    public async Task TryGetCanonicalPath_SymbolicLink()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var target = temp.CreateEmptyFile("a.txt");
+        var symlink = temp.GetFullPath("b.txt");
+        CreateSymlink(symlink, "a.txt", SymbolicLink.File | SymbolicLink.AllowUnpriviledgedCreate);
+
+        Assert.True(target.TryGetCanonicalPath(out var expected));
+        Assert.True(symlink.TryGetCanonicalPath(out var actual));
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public async Task TryGetCanonicalPath_MissingPath()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var missingPath = temp.GetFullPath("missing.txt");
+
+        Assert.False(missingPath.TryGetCanonicalPath(out _));
+    }
+
+    [Fact]
     public void ChangeExtension()
     {
         var actual = FullPath.FromPath("test.a.txt").ChangeExtension(".avi");


### PR DESCRIPTION
## Why
`FullPath` normalized input paths, but it did not expose a way to get the canonical filesystem path of an existing entry. This change adds a cross-platform canonical-name capability that resolves to the final existing target.

## What changed
- Added `FullPath.TryGetCanonicalPath(out FullPath? result)`.
- Added OS-specific canonical resolution in `CanonicalPath`:
  - Windows: `GetFinalPathNameByHandleW` via file/directory handle.
  - Unix: `realpath` from `libc`.
- Normalized Windows extended path outputs (`\\?\` and `\\?\UNC\...`) back to regular path forms before creating `FullPath`.
- Added coverage for canonical resolution on:
  - existing file path,
  - symbolic link path,
  - missing path.
- Updated `Meziantou.Framework.FullPath/readme.md` with canonical path usage.

## Notes for reviewers
- The API intentionally succeeds only for existing paths and returns `false` when canonical resolution cannot be performed.
- This behavior matches the intended "final existing target" semantics discussed for this feature.