### PR TITLE
Use ProcessExitCode value object in ProcessWrapper

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NpmPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NpmPackageUpdater.cs
@@ -81,7 +81,7 @@ internal sealed class NpmPackageUpdater : PackageUpdater
                     .WithValidation(ProcessValidationMode.None)
                     .ExecuteBufferedAsync(cancellationToken);
 
-                if (result.ExitCode is not 0)
+                if (!result.ExitCode.IsSuccess)
                 {
                     Console.WriteLine($"Unable to update lock file '{lockFile}':\n{result.Output}");
                 }

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NuGetPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NuGetPackageUpdater.cs
@@ -76,7 +76,7 @@ internal sealed class NuGetPackageUpdater : PackageUpdater
                     .WithValidation(ProcessValidationMode.None)
                     .ExecuteBufferedAsync(cancellationToken);
 
-                if (result.ExitCode is not 0)
+                if (!result.ExitCode.IsSuccess)
                 {
                     Console.WriteLine($"Unable to update lock file '{lockFile}':\n{result.Output}");
                 }

--- a/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
@@ -42,7 +42,7 @@ public sealed class BufferedProcessInstance : ProcessInstance
         }
     }
 
-    private protected override ProcessResult CreateProcessResult(int exitCode, DateTimeOffset exitDate)
+    private protected override ProcessResult CreateProcessResult(ProcessExitCode exitCode, DateTimeOffset exitDate)
     {
         return new BufferedProcessResult(processId: ProcessId, exitCode: exitCode, startDate: StartDate, exitDate: exitDate, output: _output);
     }

--- a/src/Meziantou.Framework.ProcessWrapper/BufferedProcessResult.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/BufferedProcessResult.cs
@@ -3,7 +3,7 @@ namespace Meziantou.Framework;
 /// <summary>Represents a completed buffered process execution.</summary>
 public sealed class BufferedProcessResult : ProcessResult
 {
-    internal BufferedProcessResult(int processId, int exitCode, DateTimeOffset startDate, DateTimeOffset exitDate, ProcessOutputCollection output)
+    internal BufferedProcessResult(int processId, ProcessExitCode exitCode, DateTimeOffset startDate, DateTimeOffset exitDate, ProcessOutputCollection output)
         : base(processId, exitCode, startDate, exitDate)
     {
         Output = output;

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessExecutionException.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessExecutionException.cs
@@ -22,12 +22,12 @@ public sealed class ProcessExecutionException : Exception
     }
 
     /// <summary>Initializes a new instance of <see cref="ProcessExecutionException"/> with the specified exit code.</summary>
-    public ProcessExecutionException(int exitCode)
+    public ProcessExecutionException(ProcessExitCode exitCode)
         : base($"Process exited with code {exitCode}.")
     {
         ExitCode = exitCode;
     }
 
     /// <summary>Gets the exit code of the process.</summary>
-    public int ExitCode { get; }
+    public ProcessExitCode ExitCode { get; }
 }

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessExitCode.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessExitCode.cs
@@ -1,0 +1,43 @@
+using System.Runtime.InteropServices;
+
+namespace Meziantou.Framework;
+
+/// <summary>Represents a process exit code.</summary>
+[StructLayout(LayoutKind.Auto)]
+public readonly struct ProcessExitCode : IEquatable<ProcessExitCode>
+{
+    public ProcessExitCode(int value)
+    {
+        Value = value;
+    }
+
+    /// <summary>Gets the numeric exit code value.</summary>
+    public int Value { get; }
+
+    /// <summary>Gets a value indicating whether the process exited successfully.</summary>
+    public bool IsSuccess => Value == 0;
+
+    public bool Equals(ProcessExitCode other)
+    {
+        return Value == other.Value;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is ProcessExitCode other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return Value.GetHashCode();
+    }
+
+    public override string ToString()
+    {
+        return Value.ToString();
+    }
+
+    public static implicit operator int(ProcessExitCode exitCode) => exitCode.Value;
+    public static bool operator ==(ProcessExitCode left, ProcessExitCode right) => left.Equals(right);
+    public static bool operator !=(ProcessExitCode left, ProcessExitCode right) => !(left == right);
+}

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessExitCode.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessExitCode.cs
@@ -1,42 +1,31 @@
+using System.Globalization;
 using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework;
 
 /// <summary>Represents a process exit code.</summary>
 [StructLayout(LayoutKind.Auto)]
-public readonly struct ProcessExitCode : IEquatable<ProcessExitCode>
+public readonly struct ProcessExitCode(int value) : IEquatable<ProcessExitCode>
 {
-    public ProcessExitCode(int value)
-    {
-        Value = value;
-    }
-
     /// <summary>Gets the numeric exit code value.</summary>
-    public int Value { get; }
+    public int Value { get; } = value;
 
     /// <summary>Gets a value indicating whether the process exited successfully.</summary>
     public bool IsSuccess => Value == 0;
 
-    public bool Equals(ProcessExitCode other)
-    {
-        return Value == other.Value;
-    }
+    /// <inheritdoc />
+    public bool Equals(ProcessExitCode other) => Value == other.Value;
 
-    public override bool Equals(object? obj)
-    {
-        return obj is ProcessExitCode other && Equals(other);
-    }
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is ProcessExitCode other && Equals(other);
 
-    public override int GetHashCode()
-    {
-        return Value.GetHashCode();
-    }
+    /// <inheritdoc />
+    public override int GetHashCode() => Value.GetHashCode();
 
-    public override string ToString()
-    {
-        return Value.ToString();
-    }
+    /// <inheritdoc />
+    public override string ToString() => Value.ToString(CultureInfo.InvariantCulture);
 
+    public static explicit operator ProcessExitCode(int value) => new(value);
     public static implicit operator int(ProcessExitCode exitCode) => exitCode.Value;
     public static bool operator ==(ProcessExitCode left, ProcessExitCode right) => left.Equals(right);
     public static bool operator !=(ProcessExitCode left, ProcessExitCode right) => !(left == right);

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
@@ -152,9 +152,9 @@ public class ProcessInstance
         }
     }
 
-    private ProcessExecutionException? GetValidationException(int exitCode)
+    private ProcessExecutionException? GetValidationException(ProcessExitCode exitCode)
     {
-        if ((_validationMode & ProcessValidationMode.FailIfNonZeroExitCode) == ProcessValidationMode.FailIfNonZeroExitCode && exitCode != 0)
+        if ((_validationMode & ProcessValidationMode.FailIfNonZeroExitCode) == ProcessValidationMode.FailIfNonZeroExitCode && !exitCode.IsSuccess)
         {
             return new ProcessExecutionException(exitCode);
         }
@@ -172,7 +172,7 @@ public class ProcessInstance
     {
         Exception? inputStreamException = null;
         Exception? outputStreamException = null;
-        var exitCode = default(int);
+        var exitCode = default(ProcessExitCode);
         var exitDate = default(DateTimeOffset);
         var processExited = false;
 
@@ -198,7 +198,7 @@ public class ProcessInstance
                 outputStreamException = ex;
             }
 
-            exitCode = process.ExitCode;
+            exitCode = new ProcessExitCode(process.ExitCode);
             exitDate = DateTimeOffset.UtcNow;
             processExited = true;
         }
@@ -218,7 +218,7 @@ public class ProcessInstance
             {
                 if (processExited)
                 {
-                    activity.SetTag("process.exit.code", exitCode);
+                    activity.SetTag("process.exit.code", (int)exitCode);
 
                     if (!_cancellationToken.IsCancellationRequested)
                     {
@@ -238,14 +238,14 @@ public class ProcessInstance
         return new ProcessCompletion(exitCode, exitDate, inputStreamException, outputStreamException);
     }
 
-    private protected virtual ProcessResult CreateProcessResult(int exitCode, DateTimeOffset exitDate)
+    private protected virtual ProcessResult CreateProcessResult(ProcessExitCode exitCode, DateTimeOffset exitDate)
     {
         return new ProcessResult(processId: ProcessId, exitCode: exitCode, startDate: StartDate, exitDate: exitDate);
     }
 
     private sealed class ProcessCompletion
     {
-        public ProcessCompletion(int exitCode, DateTimeOffset exitDate, Exception? inputStreamException, Exception? outputStreamException)
+        public ProcessCompletion(ProcessExitCode exitCode, DateTimeOffset exitDate, Exception? inputStreamException, Exception? outputStreamException)
         {
             ExitCode = exitCode;
             ExitDate = exitDate;
@@ -253,7 +253,7 @@ public class ProcessInstance
             OutputStreamException = outputStreamException;
         }
 
-        public int ExitCode { get; }
+        public ProcessExitCode ExitCode { get; }
 
         public DateTimeOffset ExitDate { get; }
 

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessResult.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessResult.cs
@@ -3,7 +3,7 @@ namespace Meziantou.Framework;
 /// <summary>Represents a completed process execution.</summary>
 public class ProcessResult
 {
-    internal ProcessResult(int processId, int exitCode, DateTimeOffset startDate, DateTimeOffset exitDate)
+    internal ProcessResult(int processId, ProcessExitCode exitCode, DateTimeOffset startDate, DateTimeOffset exitDate)
     {
         ProcessId = processId;
         ExitCode = exitCode;
@@ -15,7 +15,7 @@ public class ProcessResult
     public int ProcessId { get; }
 
     /// <summary>Gets the process exit code.</summary>
-    public int ExitCode { get; }
+    public ProcessExitCode ExitCode { get; }
 
     /// <summary>Gets the time the process was started.</summary>
     public DateTimeOffset StartDate { get; }

--- a/src/Meziantou.Framework.ProcessWrapper/readme.md
+++ b/src/Meziantou.Framework.ProcessWrapper/readme.md
@@ -10,7 +10,10 @@ var result = await ProcessWrapper.Create("dotnet")
     .WithArguments("--version")
     .ExecuteAsync();
 
-int exitCode = result.ExitCode;
+if (result.ExitCode.IsSuccess)
+{
+    Console.WriteLine("Process succeeded");
+}
 ````
 
 ## Buffered execution
@@ -250,6 +253,7 @@ var result = await ProcessWrapper.Create("false")
     .WithValidation(ProcessValidationMode.None)
     .ExecuteAsync();
 int exitCode = result.ExitCode;
+bool isSuccess = result.ExitCode.IsSuccess;
 
 // Fail on stderr output as well
 await ProcessWrapper.Create("my-command")

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -8,6 +8,47 @@ namespace Meziantou.Framework.Tests;
 public class ProcessWrapperTests
 {
     [Fact]
+    public void ProcessExitCode_IsSuccess_TrueForZero()
+    {
+        var exitCode = new ProcessExitCode(0);
+
+        Assert.True(exitCode.IsSuccess);
+    }
+
+    [Fact]
+    public void ProcessExitCode_IsSuccess_FalseForNonZero()
+    {
+        var exitCode = new ProcessExitCode(42);
+
+        Assert.False(exitCode.IsSuccess);
+    }
+
+    [Fact]
+    public void ProcessExitCode_EqualityMembers()
+    {
+        var exitCodeA = new ProcessExitCode(42);
+        var exitCodeB = new ProcessExitCode(42);
+        var exitCodeC = new ProcessExitCode(1);
+
+        Assert.True(exitCodeA.Equals(exitCodeB));
+        Assert.True(exitCodeA.Equals((object)exitCodeB));
+        Assert.False(exitCodeA.Equals(exitCodeC));
+        Assert.True(exitCodeA == exitCodeB);
+        Assert.True(exitCodeA != exitCodeC);
+        Assert.Equal(exitCodeA.GetHashCode(), exitCodeB.GetHashCode());
+        Assert.Equal("42", exitCodeA.ToString());
+    }
+
+    [Fact]
+    public void ProcessExitCode_ImplicitlyConvertsToInt()
+    {
+        var exitCode = new ProcessExitCode(42);
+
+        int numericExitCode = exitCode;
+        Assert.Equal(42, numericExitCode);
+    }
+
+    [Fact]
     public async Task ExecuteBufferedAsync_CapturesOutput()
     {
         var result = CreateEchoCommand("test")
@@ -16,6 +57,7 @@ public class ProcessWrapperTests
         var processResult = await result;
 
         Assert.Equal(0, processResult.ExitCode);
+        Assert.True(processResult.ExitCode.IsSuccess);
         Assert.Single(processResult.Output.StandardOutput);
         Assert.Equal("test", processResult.Output.StandardOutput.First().Text);
     }


### PR DESCRIPTION
## Why
ProcessWrapper currently exposes raw int exit codes. This makes success checks less discoverable and spreads `== 0` checks across call sites.

## What changed
- Added `ProcessExitCode` as a value type that wraps the numeric code and exposes `IsSuccess`.
- Implemented `IEquatable<ProcessExitCode>`, `Equals`, `GetHashCode`, `ToString`, `==` and `!=`, plus implicit conversion to `int`.
- Switched ProcessWrapper result and exception APIs from `int ExitCode` to `ProcessExitCode`.
- Updated process validation and telemetry flows to use `IsSuccess` while keeping telemetry tags numeric.
- Updated dependent call sites in DependencyScanning.Tool and refreshed ProcessWrapper tests and readme examples.

## Notes
- Success semantics are unchanged: exit code `0` is success.
- Existing consumers can still read an `int` through the implicit conversion.