### PR TITLE
Add inline snapshot resolution guidance

### DIFF
--- a/slnx/Meziantou.Framework.Http.Caching.InMemory.slnx
+++ b/slnx/Meziantou.Framework.Http.Caching.InMemory.slnx
@@ -9,6 +9,7 @@
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.Common/Meziantou.Framework.SnapshotTesting.Common.csproj" />
+    <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj" />

--- a/slnx/Meziantou.Framework.Http.Caching.Redis.slnx
+++ b/slnx/Meziantou.Framework.Http.Caching.Redis.slnx
@@ -9,6 +9,7 @@
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.Common/Meziantou.Framework.SnapshotTesting.Common.csproj" />
+    <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj" />

--- a/slnx/Meziantou.Framework.Http.Caching.Sqlite.slnx
+++ b/slnx/Meziantou.Framework.Http.Caching.Sqlite.slnx
@@ -9,6 +9,7 @@
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.Common/Meziantou.Framework.SnapshotTesting.Common.csproj" />
+    <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj" />

--- a/slnx/Meziantou.Framework.Http.Caching.slnx
+++ b/slnx/Meziantou.Framework.Http.Caching.slnx
@@ -9,6 +9,7 @@
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.Common/Meziantou.Framework.SnapshotTesting.Common.csproj" />
+    <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj" />

--- a/slnx/Meziantou.Framework.InlineSnapshotTesting.Serializers.Argon.slnx
+++ b/slnx/Meziantou.Framework.InlineSnapshotTesting.Serializers.Argon.slnx
@@ -7,6 +7,7 @@
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.Common/Meziantou.Framework.SnapshotTesting.Common.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Framework.InlineSnapshotTesting.Tests/Meziantou.Framework.InlineSnapshotTesting.Tests.csproj" />

--- a/slnx/Meziantou.Framework.InlineSnapshotTesting.slnx
+++ b/slnx/Meziantou.Framework.InlineSnapshotTesting.slnx
@@ -14,6 +14,7 @@
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj" />

--- a/slnx/Meziantou.Framework.QRCode.slnx
+++ b/slnx/Meziantou.Framework.QRCode.slnx
@@ -8,6 +8,7 @@
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.Common/Meziantou.Framework.SnapshotTesting.Common.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
+    <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Framework.QRCode.Tests/Meziantou.Framework.QRCode.Tests.csproj" />

--- a/slnx/Meziantou.Framework.SnapshotTesting.ImageSharp.slnx
+++ b/slnx/Meziantou.Framework.SnapshotTesting.ImageSharp.slnx
@@ -8,6 +8,7 @@
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.Common/Meziantou.Framework.SnapshotTesting.Common.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
+    <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Framework.QRCode.Tests/Meziantou.Framework.QRCode.Tests.csproj" />

--- a/slnx/Meziantou.Framework.SnapshotTesting.slnx
+++ b/slnx/Meziantou.Framework.SnapshotTesting.slnx
@@ -11,6 +11,7 @@
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
     <Project Path="../src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
     <Project Path="../src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj" />
   </Folder>

--- a/slnx/Meziantou.Framework.TemporaryDirectory.slnx
+++ b/slnx/Meziantou.Framework.TemporaryDirectory.slnx
@@ -18,6 +18,7 @@
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.Common/Meziantou.Framework.SnapshotTesting.Common.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
     <Project Path="../src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
     <Project Path="../src/Meziantou.Framework.ValueStopwatch/Meziantou.Framework.ValueStopwatch.csproj" />
     <Project Path="../src/Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj" />

--- a/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettings.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettings.cs
@@ -182,7 +182,20 @@ public sealed record InlineSnapshotSettings
     [DoesNotReturn]
     internal void AssertSnapshot(string? expected, string? actual)
     {
-        var errorMessage = "Snapshots do not match:\n" + ErrorMessageFormatter.FormatMessage(expected, actual);
+        var errorMessage =
+            "Snapshots do not match:\n" +
+            ErrorMessageFormatter.FormatMessage(expected, actual) +
+            "\n\n" +
+            GetResolutionGuidanceMessage();
         throw AssertionExceptionCreator.CreateException(errorMessage);
     }
+
+    private static string GetResolutionGuidanceMessage() =>
+        """
+        Resolution guidance:
+          - Compare the expected snapshot and received value shown above.
+          - If the new behavior is correct, update the inline snapshot.
+          - If the old behavior is correct, fix the test or production code so the output matches the snapshot.
+          - Re-run the test.
+        """;
 }

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
@@ -42,4 +42,16 @@ public sealed class InlineSnapshotSettingsTests
         Assert.Equal(settings.Scrubbers, clone.Scrubbers);
         Assert.NotSame(settings.Scrubbers, clone.Scrubbers);
     }
+
+    [Fact]
+    public void AssertSnapshot_ShouldContainResolutionGuidance()
+    {
+        var settings = new InlineSnapshotSettings();
+
+        var exception = Assert.ThrowsAny<Exception>(() => settings.AssertSnapshot("old", "new"));
+        Assert.StartsWith("Snapshots do not match:\n", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Resolution guidance:", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("- If the new behavior is correct, update the inline snapshot.", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("- Re-run the test.", exception.Message, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
Inline snapshot failures currently show the diff but do not clearly explain how to resolve a mismatch. This change adds explicit guidance so developers can quickly decide whether to update snapshots or fix behavior.

## Summary
- Appends a `Resolution guidance` section to inline snapshot assertion messages in `InlineSnapshotSettings.AssertSnapshot`.
- Keeps the existing diff output intact and adds actionable next steps after it.
- Adds a unit test to ensure the guidance text is included in thrown assertion messages.
- Regenerates affected `.slnx` files after rebasing on `main`.

## Notes
- Guidance wording is aligned with the SnapshotTesting project style, adapted for inline snapshots.