### PR TITLE
Change InlineSnapshot default strategy to Disallow

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
@@ -5,7 +5,7 @@
     <Description>Enables verification of objects using inline snapshots</Description>
     <DefineConstants Condition="'$(IsOfficialBuild)' != 'true'">$(DefineConstants);DEBUG_TaskDialogPrompt</DefineConstants>
 
-    <Version>3.3.43</Version>
+    <Version>4.0.0</Version>
     <NoWarn>$(NoWarn);NU5100</NoWarn>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.InlineSnapshotTesting/SnapshotUpdateStrategy.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/SnapshotUpdateStrategy.cs
@@ -31,7 +31,7 @@ public abstract class SnapshotUpdateStrategy
     {
         get
         {
-            return MergeTool;
+            return Disallow;
         }
     }
 

--- a/src/Meziantou.Framework.InlineSnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/readme.md
@@ -24,8 +24,19 @@ var data = new
 InlineSnapshot.Validate(data);
 ````
 
-Then, run the tests. It will show you a diff tool where you can compare the expected value and the new value.
-Once you accept the change, the source code is updated:
+Then, run the tests. By default, snapshot updates are disabled and the test fails when the snapshot doesn't match.
+This default is better for AI-assisted flows where automatic source updates can be unexpected.
+
+If you want to restore the previous behavior (open a merge tool and update snapshots), configure `SnapshotUpdateStrategy.MergeTool`:
+
+````c#
+InlineSnapshotSettings.Default = InlineSnapshotSettings.Default with
+{
+    SnapshotUpdateStrategy = SnapshotUpdateStrategy.MergeTool,
+};
+````
+
+Once the snapshot is updated, the source code is changed:
 
 ````c#
 var data = new
@@ -196,6 +207,8 @@ The HumanReadableSerializer has many options to make the snapshot deterministic 
     ````
 
 ## Diff tool
+
+To restore the old default behavior (before v4), set the snapshot update strategy to `SnapshotUpdateStrategy.MergeTool`.
 
 When a snapshot is updated, a diff tool is used to compare the expected value and the new value. By default, it uses one of the following tools
 - The diff tool configured by the `DiffEngine_Tool` environment variable


### PR DESCRIPTION
## Why
Inline snapshot auto-update via merge tools is convenient locally, but it can be disruptive in AI-assisted development flows where automatic source edits are not always expected. This change makes the package behavior safer and more explicit by default.

## What changed
- Changed `SnapshotUpdateStrategy.Default` from `MergeTool` to `Disallow` in `Meziantou.Framework.InlineSnapshotTesting`
- Bumped `Meziantou.Framework.InlineSnapshotTesting` package version from `3.3.43` to `4.0.0`
- Updated the package README to:
  - describe the new default behavior
  - explain how to restore the previous behavior with `SnapshotUpdateStrategy.MergeTool`

## Notes for reviewers
This is a breaking behavioral change, which is why the package major version was increased.

In this environment, `dotnet` was not available, so I could not run project tests or the required `eng/*.cs` maintenance scripts here.