### PR TITLE
Add v4 migration guide to InlineSnapshotTesting README

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/readme.md
@@ -449,3 +449,19 @@ InlineSnapshotSettings.Default = InlineSnapshotSettings.Default with
 - [Scrub lines matching a predicate](https://github.com/meziantou/Meziantou.Framework/blob/main/samples/Meziantou.Framework.InlineSnapshotTesting.Samples/Scrub_lines_matching_a_predicate.cs)
 - [Scrub lines matching a regex](https://github.com/meziantou/Meziantou.Framework/blob/main/samples/Meziantou.Framework.InlineSnapshotTesting.Samples/Scrub_lines_matching_a_regex.cs)
 - [Scrub lines with rewriting](https://github.com/meziantou/Meziantou.Framework/blob/main/samples/Meziantou.Framework.InlineSnapshotTesting.Samples/Srub_replace_line_content.cs)
+
+# Migration guide
+
+## Migrate from v3 to v4
+
+In v4, snapshot updates are disabled by default (`SnapshotUpdateStrategy.Disallow`).
+If you want to keep the v3 behavior (open a merge tool and let it update snapshots), explicitly set the update strategy:
+
+````c#
+InlineSnapshotSettings.Default = InlineSnapshotSettings.Default with
+{
+    SnapshotUpdateStrategy = SnapshotUpdateStrategy.MergeTool,
+};
+````
+
+If you prefer waiting for the merge tool to close before continuing, use `SnapshotUpdateStrategy.MergeToolSync`.


### PR DESCRIPTION
## Why
InlineSnapshotTesting v4 introduced a breaking default behavior change, and while the README already mentioned it, users need a dedicated migration section that is easy to find when upgrading.

## What changed
This PR adds a `Migration guide` section at the end of the InlineSnapshotTesting README with a focused `Migrate from v3 to v4` subsection. It documents that v4 defaults to `SnapshotUpdateStrategy.Disallow` and shows how to restore v3-style behavior with `SnapshotUpdateStrategy.MergeTool`, with `MergeToolSync` called out as an alternative.

## Notes
This is a documentation-only change in a single file.