### PR TITLE
Clarify inline snapshot diff guidance in assertion errors

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettings.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettings.cs
@@ -194,7 +194,9 @@ public sealed record InlineSnapshotSettings
         """
         Resolution guidance:
           - Compare the expected snapshot and received value shown above.
-          - If the new behavior is correct, update the inline snapshot.
+          - If the new behavior is correct, update the inline snapshot in source code:
+            - remove lines starting with '-' from the snapshot
+            - add lines starting with '+' to the snapshot
           - If the old behavior is correct, fix the test or production code so the output matches the snapshot.
           - Re-run the test.
         """;

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
@@ -51,7 +51,9 @@ public sealed class InlineSnapshotSettingsTests
         var exception = Assert.ThrowsAny<Exception>(() => settings.AssertSnapshot("old", "new"));
         Assert.StartsWith("Snapshots do not match:\n", exception.Message, StringComparison.Ordinal);
         Assert.Contains("Resolution guidance:", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("- If the new behavior is correct, update the inline snapshot.", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("- If the new behavior is correct, update the inline snapshot in source code:", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("  - remove lines starting with '-' from the snapshot", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("  - add lines starting with '+' to the snapshot", exception.Message, StringComparison.Ordinal);
         Assert.Contains("- Re-run the test.", exception.Message, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## Why
The inline snapshot failure message said to "update the inline snapshot" but did not explain how to apply the `-` and `+` diff lines shown above it. This could make manual snapshot updates less clear.

## What changed
The inline snapshot resolution guidance now explicitly explains how to apply diff markers in source code:
- lines starting with `-` should be removed from the inline snapshot
- lines starting with `+` should be added to the inline snapshot

The corresponding assertion test was updated to validate the new guidance text.

## Notes
This is a diagnostics wording improvement only. Snapshot comparison behavior is unchanged.