### PR TITLE
Add strategy env vars and guidance for snapshot updates

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettings.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettings.cs
@@ -197,6 +197,7 @@ public sealed record InlineSnapshotSettings
           - If the new behavior is correct, update the inline snapshot in source code:
             - remove lines starting with '-' from the snapshot
             - add lines starting with '+' to the snapshot
+          - To update snapshots automatically, re-run the test with INLINESNAPSHOTTESTING_STRATEGY=Overwrite (or OverwriteWithoutFailure).
           - If the old behavior is correct, fix the test or production code so the output matches the snapshot.
           - Re-run the test.
         """;

--- a/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
@@ -5,7 +5,7 @@
     <Description>Enables verification of objects using inline snapshots</Description>
     <DefineConstants Condition="'$(IsOfficialBuild)' != 'true'">$(DefineConstants);DEBUG_TaskDialogPrompt</DefineConstants>
 
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
     <NoWarn>$(NoWarn);NU5100</NoWarn>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.InlineSnapshotTesting/SnapshotUpdateStrategy.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/SnapshotUpdateStrategy.cs
@@ -1,11 +1,15 @@
 using Meziantou.Framework.InlineSnapshotTesting.SnapshotUpdateStrategies;
 using Meziantou.Framework.InlineSnapshotTesting.Utils;
 using Meziantou.Framework;
+using System.Reflection;
 
 namespace Meziantou.Framework.InlineSnapshotTesting;
 
 public abstract class SnapshotUpdateStrategy
 {
+    private const string SnapshotUpdateStrategyEnvironmentVariableName = "INLINESNAPSHOTTESTING_STRATEGY";
+    private static readonly IReadOnlyList<PropertyInfo> SnapshotUpdateStrategyProperties = typeof(SnapshotUpdateStrategy).GetProperties(BindingFlags.Public | BindingFlags.Static);
+
     /// <summary>Do not update the snapshots and fail the tests if the snapshots are different.</summary>
     public static SnapshotUpdateStrategy Disallow { get; } = new DisallowStrategy();
 
@@ -31,6 +35,10 @@ public abstract class SnapshotUpdateStrategy
     {
         get
         {
+            var strategyFromEnvironmentVariable = GetStrategyFromEnvironmentVariable();
+            if (strategyFromEnvironmentVariable is not null)
+                return strategyFromEnvironmentVariable;
+
             return Disallow;
         }
     }
@@ -98,5 +106,27 @@ public abstract class SnapshotUpdateStrategy
         }
 
         return name;
+    }
+
+    private static SnapshotUpdateStrategy? GetStrategyFromEnvironmentVariable()
+    {
+        var variable = Environment.GetEnvironmentVariable(SnapshotUpdateStrategyEnvironmentVariableName);
+        if (string.IsNullOrWhiteSpace(variable))
+            return null;
+
+        var strategyName = variable.Trim();
+
+        foreach (var property in SnapshotUpdateStrategyProperties)
+        {
+            if (!typeof(SnapshotUpdateStrategy).IsAssignableFrom(property.PropertyType))
+                continue;
+
+            if (!string.Equals(property.Name, strategyName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            return (SnapshotUpdateStrategy?)property.GetValue(null);
+        }
+
+        return null;
     }
 }

--- a/src/Meziantou.Framework.InlineSnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/readme.md
@@ -425,6 +425,9 @@ InlineSnapshot
 - `SnapshotUpdateStrategy.MergeToolSync`: Use a merge tool to compare the snapshot with the new value and wait for the merge tool to close
 - `SnapshotUpdateStrategy.Disallow`: Do not update the snapshot
 
+You can also set the default strategy using the `INLINESNAPSHOTTESTING_STRATEGY` environment variable.  
+The value is case-insensitive and must match one of the `SnapshotUpdateStrategy` static property names (for example: `DISALLOW`, `MergeTool`, `overwritewithoutfailure`).
+
 ## Recreate the snapshots
 
 You can force the update of all snapshots by setting the `InlineSnapshotSettings.ForceUpdateSnapshots` property to `true` and setting the update strategy to `OverwriteWithoutFailure`.

--- a/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>Enables verification of objects using file-based snapshots</Description>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
@@ -149,6 +149,7 @@ internal static class SnapshotEngine
         sb.AppendLine("Resolution guidance:");
         sb.AppendLine("  - Compare each Verified/Actual pair listed above.");
         sb.AppendLine("  - If the new behavior is correct, copy each .actual file to its .verified file.");
+        sb.AppendLine("  - To update snapshots automatically, re-run the test with SNAPSHOTTESTING_STRATEGY=Overwrite (or OverwriteWithoutFailure).");
         sb.AppendLine("  - If the old behavior is correct, fix the test or production code so output matches the .verified files.");
         sb.AppendLine("  - Remove unexpected .verified files when they are no longer expected.");
         sb.AppendLine("  - Re-run the test.");

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotUpdateStrategy.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotUpdateStrategy.cs
@@ -1,10 +1,14 @@
 using Meziantou.Framework.SnapshotTesting.SnapshotUpdateStrategies;
 using Meziantou.Framework.SnapshotTesting.Utils;
+using System.Reflection;
 
 namespace Meziantou.Framework.SnapshotTesting;
 
 public abstract class SnapshotUpdateStrategy
 {
+    private const string SnapshotUpdateStrategyEnvironmentVariableName = "SNAPSHOTTESTING_STRATEGY";
+    private static readonly IReadOnlyList<PropertyInfo> SnapshotUpdateStrategyProperties = typeof(SnapshotUpdateStrategy).GetProperties(BindingFlags.Public | BindingFlags.Static);
+
     /// <summary>Do not update the snapshots and fail the tests if the snapshots are different.</summary>
     public static SnapshotUpdateStrategy Disallow { get; } = new DisallowStrategy();
 
@@ -30,6 +34,10 @@ public abstract class SnapshotUpdateStrategy
     {
         get
         {
+            var strategyFromEnvironmentVariable = GetStrategyFromEnvironmentVariable();
+            if (strategyFromEnvironmentVariable is not null)
+                return strategyFromEnvironmentVariable;
+
             return Disallow;
         }
     }
@@ -130,5 +138,27 @@ public abstract class SnapshotUpdateStrategy
         }
 
         return name;
+    }
+
+    private static SnapshotUpdateStrategy? GetStrategyFromEnvironmentVariable()
+    {
+        var variable = Environment.GetEnvironmentVariable(SnapshotUpdateStrategyEnvironmentVariableName);
+        if (string.IsNullOrWhiteSpace(variable))
+            return null;
+
+        var strategyName = variable.Trim();
+
+        foreach (var property in SnapshotUpdateStrategyProperties)
+        {
+            if (!typeof(SnapshotUpdateStrategy).IsAssignableFrom(property.PropertyType))
+                continue;
+
+            if (!string.Equals(property.Name, strategyName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            return (SnapshotUpdateStrategy?)property.GetValue(null);
+        }
+
+        return null;
     }
 }

--- a/src/Meziantou.Framework.SnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.SnapshotTesting/readme.md
@@ -62,6 +62,9 @@ Use `SnapshotSettings` to customize behavior:
 - `AssertionExceptionCreator` and `ErrorMessageFormatter`
 - `SnapshotPathStrategy` for full path generation
 
+You can also set the default strategy using the `SNAPSHOTTESTING_STRATEGY` environment variable.
+The value is case-insensitive and must match one of the `SnapshotUpdateStrategy` static property names (for example: `DISALLOW`, `MergeTool`, `overwritewithoutfailure`).
+
 ```csharp
 var settings = SnapshotSettings.Default with
 {

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
@@ -5,6 +5,8 @@ using TestUtilities;
 namespace Meziantou.Framework.InlineSnapshotTesting.Tests;
 public sealed class InlineSnapshotSettingsTests
 {
+    private const string SnapshotUpdateStrategyEnvironmentVariableName = "INLINESNAPSHOTTESTING_STRATEGY";
+
     [Fact]
     public void Clone()
     {
@@ -54,6 +56,75 @@ public sealed class InlineSnapshotSettingsTests
         Assert.Contains("- If the new behavior is correct, update the inline snapshot in source code:", exception.Message, StringComparison.Ordinal);
         Assert.Contains("  - remove lines starting with '-' from the snapshot", exception.Message, StringComparison.Ordinal);
         Assert.Contains("  - add lines starting with '+' to the snapshot", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("  - To update snapshots automatically, re-run the test with INLINESNAPSHOTTESTING_STRATEGY=Overwrite (or OverwriteWithoutFailure).", exception.Message, StringComparison.Ordinal);
         Assert.Contains("- Re-run the test.", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("DISALLOW", nameof(SnapshotUpdateStrategy.Disallow))]
+    [InlineData("overwrite", nameof(SnapshotUpdateStrategy.Overwrite))]
+    [InlineData("mErGeToOlSyNc", nameof(SnapshotUpdateStrategy.MergeToolSync))]
+    [InlineData("OverwriteWithoutFailure", nameof(SnapshotUpdateStrategy.OverwriteWithoutFailure))]
+    public void SnapshotUpdateStrategy_Default_CanBeConfiguredUsingEnvironmentVariable(string value, string expectedStrategyName)
+    {
+        using var _ = new EnvironmentVariableScope(SnapshotUpdateStrategyEnvironmentVariableName, value);
+
+        var settings = new InlineSnapshotSettings();
+
+        Assert.Same(GetSnapshotUpdateStrategy(expectedStrategyName), settings.SnapshotUpdateStrategy);
+    }
+
+    [Fact]
+    public void SnapshotUpdateStrategy_Default_InvalidEnvironmentVariableValue_UsesDisallow()
+    {
+        using var _ = new EnvironmentVariableScope(SnapshotUpdateStrategyEnvironmentVariableName, "invalid");
+
+        var settings = new InlineSnapshotSettings();
+
+        Assert.Same(SnapshotUpdateStrategy.Disallow, settings.SnapshotUpdateStrategy);
+    }
+
+    [Fact]
+    public void SnapshotUpdateStrategy_ExplicitSetting_HasPriorityOverEnvironmentVariable()
+    {
+        using var _ = new EnvironmentVariableScope(SnapshotUpdateStrategyEnvironmentVariableName, nameof(SnapshotUpdateStrategy.Overwrite));
+
+        var settings = new InlineSnapshotSettings()
+        {
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.Disallow,
+        };
+
+        Assert.Same(SnapshotUpdateStrategy.Disallow, settings.SnapshotUpdateStrategy);
+    }
+
+    private static SnapshotUpdateStrategy GetSnapshotUpdateStrategy(string name)
+    {
+        return name switch
+        {
+            nameof(SnapshotUpdateStrategy.Disallow) => SnapshotUpdateStrategy.Disallow,
+            nameof(SnapshotUpdateStrategy.MergeTool) => SnapshotUpdateStrategy.MergeTool,
+            nameof(SnapshotUpdateStrategy.MergeToolSync) => SnapshotUpdateStrategy.MergeToolSync,
+            nameof(SnapshotUpdateStrategy.Overwrite) => SnapshotUpdateStrategy.Overwrite,
+            nameof(SnapshotUpdateStrategy.OverwriteWithoutFailure) => SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            _ => throw new ArgumentOutOfRangeException(nameof(name)),
+        };
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _previousValue;
+
+        public EnvironmentVariableScope(string name, string? value)
+        {
+            _name = name;
+            _previousValue = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(_name, _previousValue);
+        }
     }
 }

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Meziantou.Framework.InlineSnapshotTesting.Serialization;
 using Meziantou.Framework.InlineSnapshotTesting.SnapshotUpdateStrategies;
 using TestUtilities;

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -6,6 +6,8 @@ namespace Meziantou.Framework.SnapshotTesting.Tests;
 
 public sealed class SnapshotTests
 {
+    private const string SnapshotUpdateStrategyEnvironmentVariableName = "SNAPSHOTTESTING_STRATEGY";
+
     [Fact]
     public void Validate_CreateSnapshotFile()
     {
@@ -311,8 +313,46 @@ public sealed class SnapshotTests
         Assert.Contains("Actual:   " + actualPath1.Value, exception.Message, StringComparison.Ordinal);
         Assert.Contains("Resolution guidance:", exception.Message, StringComparison.Ordinal);
         Assert.Contains("If the new behavior is correct, copy each .actual file to its .verified file.", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("To update snapshots automatically, re-run the test with SNAPSHOTTESTING_STRATEGY=Overwrite (or OverwriteWithoutFailure).", exception.Message, StringComparison.Ordinal);
         Assert.True(File.Exists(actualPath0));
         Assert.True(File.Exists(actualPath1));
+    }
+
+    [Theory]
+    [InlineData("DISALLOW", nameof(SnapshotUpdateStrategy.Disallow))]
+    [InlineData("overwrite", nameof(SnapshotUpdateStrategy.Overwrite))]
+    [InlineData("mErGeToOlSyNc", nameof(SnapshotUpdateStrategy.MergeToolSync))]
+    [InlineData("OverwriteWithoutFailure", nameof(SnapshotUpdateStrategy.OverwriteWithoutFailure))]
+    public void SnapshotUpdateStrategy_Default_CanBeConfiguredUsingEnvironmentVariable(string value, string expectedStrategyName)
+    {
+        using var _ = new EnvironmentVariableScope(SnapshotUpdateStrategyEnvironmentVariableName, value);
+
+        var settings = new SnapshotSettings();
+
+        Assert.Same(GetSnapshotUpdateStrategy(expectedStrategyName), settings.SnapshotUpdateStrategy);
+    }
+
+    [Fact]
+    public void SnapshotUpdateStrategy_Default_InvalidEnvironmentVariableValue_UsesDisallow()
+    {
+        using var _ = new EnvironmentVariableScope(SnapshotUpdateStrategyEnvironmentVariableName, "invalid");
+
+        var settings = new SnapshotSettings();
+
+        Assert.Same(SnapshotUpdateStrategy.Disallow, settings.SnapshotUpdateStrategy);
+    }
+
+    [Fact]
+    public void SnapshotUpdateStrategy_ExplicitSetting_HasPriorityOverEnvironmentVariable()
+    {
+        using var _ = new EnvironmentVariableScope(SnapshotUpdateStrategyEnvironmentVariableName, nameof(SnapshotUpdateStrategy.Overwrite));
+
+        var settings = new SnapshotSettings()
+        {
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.Disallow,
+        };
+
+        Assert.Same(SnapshotUpdateStrategy.Disallow, settings.SnapshotUpdateStrategy);
     }
 
     [Fact]
@@ -373,6 +413,19 @@ public sealed class SnapshotTests
         return settings;
     }
 
+    private static SnapshotUpdateStrategy GetSnapshotUpdateStrategy(string name)
+    {
+        return name switch
+        {
+            nameof(SnapshotUpdateStrategy.Disallow) => SnapshotUpdateStrategy.Disallow,
+            nameof(SnapshotUpdateStrategy.MergeTool) => SnapshotUpdateStrategy.MergeTool,
+            nameof(SnapshotUpdateStrategy.MergeToolSync) => SnapshotUpdateStrategy.MergeToolSync,
+            nameof(SnapshotUpdateStrategy.Overwrite) => SnapshotUpdateStrategy.Overwrite,
+            nameof(SnapshotUpdateStrategy.OverwriteWithoutFailure) => SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            _ => throw new ArgumentOutOfRangeException(nameof(name)),
+        };
+    }
+
     private sealed class SnapshotTypeSerializer : ISnapshotSerializer
     {
         public bool CanSerialize(SnapshotType type, object? value) => type == SnapshotType.Png;
@@ -390,6 +443,24 @@ public sealed class SnapshotTests
         public override Exception CreateException(string message)
         {
             return new SnapshotAssertionException(message);
+        }
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _previousValue;
+
+        public EnvironmentVariableScope(string name, string? value)
+        {
+            _name = name;
+            _previousValue = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(_name, _previousValue);
         }
     }
 }


### PR DESCRIPTION
## Why
Updating snapshots during test maintenance should be easy to trigger without changing code. This PR adds environment-variable based strategy overrides for both snapshot libraries and makes the failure guidance explicitly point to the rerun path.

## What changed
- Added default strategy override from environment variables when strategy is not explicitly set in code:
  - `INLINESNAPSHOTTESTING_STRATEGY` for InlineSnapshotTesting
  - `SNAPSHOTTESTING_STRATEGY` for SnapshotTesting
- Parsing is case-insensitive and matches `SnapshotUpdateStrategy` static property names.
- Invalid or empty env var values keep current fallback behavior (`Disallow`).
- Explicit strategy assignments in code still take precedence.
- Updated resolution guidance messages to mention rerunning with:
  - `..._STRATEGY=Overwrite` (or `OverwriteWithoutFailure`)
- Bumped patch versions:
  - `Meziantou.Framework.InlineSnapshotTesting`: `4.0.0` -> `4.0.1`
  - `Meziantou.Framework.SnapshotTesting`: `1.0.0` -> `1.0.1`
- Added/updated tests for:
  - guidance text updates
  - env var mapping (case-insensitive)
  - invalid-value fallback
  - explicit-setting precedence
- Updated SnapshotTesting README with the new env var behavior.

## Validation
- Ran required maintenance scripts:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`
- Ran targeted tests with `DiffEngine_Disabled=true`:
  - `Meziantou.Framework.InlineSnapshotTesting.Tests` (`net10.0`)
  - `Meziantou.Framework.SnapshotTesting.Tests` (`net10.0`)
- Built both modified library projects successfully.