### PR TITLE
Remove explicit FSharp.Core override in F# test projects

### DIFF
--- a/tests/Meziantou.Framework.HumanReadableSerializer.FSharp.Tests/Meziantou.Framework.HumanReadableSerializer.FSharp.Tests.fsproj
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.FSharp.Tests/Meziantou.Framework.HumanReadableSerializer.FSharp.Tests.fsproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <Compile Include="Library.fs" />
-    <PackageReference Update="FSharp.Core" Version="11.0.100-preview1.26104.118" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.ObjectMethodExecutor.FSharpTests/Meziantou.Framework.ObjectMethodExecutor.FSharpTests.fsproj
+++ b/tests/Meziantou.Framework.ObjectMethodExecutor.FSharpTests/Meziantou.Framework.ObjectMethodExecutor.FSharpTests.fsproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <Compile Include="Library.fs" />
-    <PackageReference Update="FSharp.Core" Version="11.0.100-preview1.26104.118" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Why
The F# test projects explicitly overrode `FSharp.Core` with a preview package version. This override is unnecessary and adds avoidable maintenance overhead.

## What changed
This removes the explicit `PackageReference Update="FSharp.Core"` entries from the two F# test project files so they rely on the SDK/default resolution instead:

- `tests/Meziantou.Framework.ObjectMethodExecutor.FSharpTests/Meziantou.Framework.ObjectMethodExecutor.FSharpTests.fsproj`
- `tests/Meziantou.Framework.HumanReadableSerializer.FSharp.Tests/Meziantou.Framework.HumanReadableSerializer.FSharp.Tests.fsproj`

## Notes
Required repo maintenance scripts were run as part of this change. Related tests pass on `net10.0` in this environment; `net8.0`/`net9.0` execution is not available here because those runtimes are missing.