### PR TITLE
Parse MP4 duration metadata in MediaTags

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Reader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Reader.cs
@@ -14,6 +14,7 @@ internal sealed class Mp4Reader : IMediaTagReader
             var tags = new MediaTagInfo();
 
             var atoms = Mp4Atom.ReadAtoms(stream, stream.Length);
+            tags.Duration = TryReadDuration(atoms);
 
             // Navigate to moov.udta.meta.ilst
             var ilst = Mp4Atom.FindPath(atoms, "moov", "udta", "meta", "ilst");
@@ -31,6 +32,87 @@ internal sealed class Mp4Reader : IMediaTagReader
         {
             return MediaTagResult<MediaTagInfo>.Failure(MediaTagError.CorruptFile, ex.Message);
         }
+    }
+
+    private static TimeSpan? TryReadDuration(List<Mp4Atom> atoms)
+    {
+        var moovAtom = Mp4Atom.FindPath(atoms, "moov");
+        if (moovAtom is null)
+            return null;
+
+        foreach (var atom in moovAtom.Children)
+        {
+            if (atom.Type != "trak")
+                continue;
+
+            var trackDuration = TryReadAudioTrackDuration(atom);
+            if (trackDuration is not null)
+                return trackDuration;
+        }
+
+        return TryReadDurationFromFullBox(moovAtom.FindChild("mvhd")?.Data);
+    }
+
+    private static TimeSpan? TryReadAudioTrackDuration(Mp4Atom trackAtom)
+    {
+        var mediaAtom = trackAtom.FindChild("mdia");
+        if (mediaAtom is null)
+            return null;
+
+        if (!IsSoundTrack(mediaAtom.FindChild("hdlr")?.Data))
+            return null;
+
+        return TryReadDurationFromFullBox(mediaAtom.FindChild("mdhd")?.Data);
+    }
+
+    private static bool IsSoundTrack(byte[]? handlerData)
+    {
+        if (handlerData is null || handlerData.Length < 12)
+            return false;
+
+        return handlerData[8] == 's' && handlerData[9] == 'o' && handlerData[10] == 'u' && handlerData[11] == 'n';
+    }
+
+    private static TimeSpan? TryReadDurationFromFullBox(byte[]? data)
+    {
+        if (data is null || data.Length < 20)
+            return null;
+
+        var version = data[0];
+        return version switch
+        {
+            0 => TryReadVersion0Duration(data),
+            1 => TryReadVersion1Duration(data),
+            _ => null,
+        };
+    }
+
+    private static TimeSpan? TryReadVersion0Duration(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < 20)
+            return null;
+
+        var timeScale = BinaryPrimitives.ReadUInt32BigEndian(data[12..]);
+        var duration = BinaryPrimitives.ReadUInt32BigEndian(data[16..]);
+
+        if (timeScale == 0 || duration == 0 || duration == uint.MaxValue)
+            return null;
+
+        return TimeSpan.FromSeconds(duration / (double)timeScale);
+    }
+
+    private static TimeSpan? TryReadVersion1Duration(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < 32)
+            return null;
+
+        var timeScale = BinaryPrimitives.ReadUInt32BigEndian(data[20..]);
+        var duration = BinaryPrimitives.ReadUInt64BigEndian(data[24..]);
+
+        if (timeScale == 0 || duration == 0 || duration == ulong.MaxValue)
+            return null;
+
+        return TimeSpan.FromSeconds(duration / (double)timeScale);
     }
 
     private static void ProcessIlstItem(Mp4Atom item, MediaTagInfo tags)

--- a/src/Meziantou.Framework.MediaTags/MediaTagInfo.cs
+++ b/src/Meziantou.Framework.MediaTags/MediaTagInfo.cs
@@ -58,6 +58,9 @@ public sealed class MediaTagInfo
     /// <summary>Gets or sets the beats per minute.</summary>
     public int? Bpm { get; set; }
 
+    /// <summary>Gets or sets the media duration.</summary>
+    public TimeSpan? Duration { get; set; }
+
     /// <summary>Gets or sets whether this track is part of a compilation.</summary>
     public bool? IsCompilation { get; set; }
 

--- a/src/Meziantou.Framework.MediaTags/readme.md
+++ b/src/Meziantou.Framework.MediaTags/readme.md
@@ -26,6 +26,7 @@ if (!result.IsSuccess)
 
 var tags = result.Value;
 Console.WriteLine($"Format: {tags.Format}");
+Console.WriteLine($"Duration: {tags.Duration}");
 Console.WriteLine($"Title: {tags.Title}");
 Console.WriteLine($"Artist: {tags.Artist}");
 ```

--- a/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
@@ -20,6 +20,30 @@ public sealed class Mp4Tests
         Assert.Equal(2024, tags.Year);
         Assert.Equal("Rock", tags.Genre);
         Assert.Equal(3, tags.TrackNumber);
+        Assert.NotNull(tags.Duration);
+        Assert.InRange(tags.Duration.Value.TotalSeconds, 0.9, 1.2);
+    }
+
+    [Fact]
+    public void ReadTags_M4aWithFlacExtension_UsesMagicBytesAndParsesDuration()
+    {
+        var tempFile = Path.GetTempFileName() + ".flac";
+        try
+        {
+            File.Copy(GetTestFilePath("basic.m4a"), tempFile, overwrite: true);
+
+            var result = MediaFile.ReadTags(tempFile);
+            Assert.True(result.IsSuccess);
+
+            var tags = result.Value;
+            Assert.Equal(MediaFormat.Mp4, tags.Format);
+            Assert.NotNull(tags.Duration);
+            Assert.InRange(tags.Duration.Value.TotalSeconds, 0.9, 1.2);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Why
A user reported an audio file with a `.flac` extension whose duration was not parsed correctly. Investigation showed the file is actually MP4/M4A content (`ftypM4A`) with a mismatched extension. `MediaFile` already detected MP4 from magic bytes, but `Mp4Reader` did not extract duration at all.

## What changed
- Added `MediaTagInfo.Duration` (`TimeSpan?`) to expose parsed media duration.
- Implemented MP4 duration parsing in `Mp4Reader`:
  - Prefer audio track duration from `moov/trak/mdia/mdhd` when the track handler is `soun`.
  - Fallback to movie duration from `moov/mvhd` when needed.
  - Handle version 0 and version 1 full box layouts.
- Added regression coverage in `Mp4Tests`:
  - Assert duration is populated for `basic.m4a`.
  - Assert a file with MP4 content renamed to `.flac` is still detected as MP4 and has duration.
- Updated `src/Meziantou.Framework.MediaTags/readme.md` usage snippet to show `Duration`.

## Notes for reviewers
The key behavior choice is unchanged format detection by magic bytes (not extension). This fix focuses on missing MP4 duration extraction, which is the actual root cause for the reported case.