### PR TITLE
Improve OGG Opus/Vorbis tag packet continuation handling

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggOpusReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggOpusReader.cs
@@ -2,6 +2,8 @@ namespace Meziantou.Framework.MediaTags.Formats.Ogg;
 
 internal sealed class OggOpusReader : IMediaTagReader
 {
+    private static readonly byte[] OpusTagsPrefix = "OpusTags"u8.ToArray();
+
     public MediaTagResult<MediaTagInfo> ReadTags(Stream stream)
     {
         try
@@ -9,32 +11,15 @@ internal sealed class OggOpusReader : IMediaTagReader
             stream.Position = 0;
             var tags = new MediaTagInfo();
 
-            // Read pages until we find the OpusTags header
-            // Page 0: OpusHead identification header
-            // Page 1: OpusTags comment header
-            var pageIndex = 0;
-            while (true)
+            var pages = OggPacketUtilities.ReadAllPages(stream);
+            var packets = OggPacketUtilities.ReadPackets(pages);
+            foreach (var packet in packets)
             {
-                var page = OggPage.Read(stream);
-                if (page is null)
-                    break;
-
-                if (pageIndex == 1 || IsOpusTagsPage(page))
+                if (packet.Data.AsSpan().StartsWith(OpusTagsPrefix))
                 {
-                    // Extract comment data: skip "OpusTags" (8 bytes) prefix
-                    var data = page.Data;
-                    if (data.Length > 8
-                        && data[0] == 'O' && data[1] == 'p' && data[2] == 'u' && data[3] == 's'
-                        && data[4] == 'T' && data[5] == 'a' && data[6] == 'g' && data[7] == 's')
-                    {
-                        VorbisComment.VorbisCommentReader.TryParse(data.AsSpan(8), tags);
-                    }
+                    VorbisComment.VorbisCommentReader.TryParse(packet.Data.AsSpan(OpusTagsPrefix.Length), tags);
                     break;
                 }
-
-                pageIndex++;
-                if (pageIndex > 10)
-                    break;
             }
 
             return MediaTagResult<MediaTagInfo>.Success(tags);
@@ -43,12 +28,5 @@ internal sealed class OggOpusReader : IMediaTagReader
         {
             return MediaTagResult<MediaTagInfo>.Failure(MediaTagError.CorruptFile, ex.Message);
         }
-    }
-
-    private static bool IsOpusTagsPage(OggPage page)
-    {
-        return page.Data.Length > 8
-            && page.Data[0] == 'O' && page.Data[1] == 'p' && page.Data[2] == 'u' && page.Data[3] == 's'
-            && page.Data[4] == 'T' && page.Data[5] == 'a' && page.Data[6] == 'g' && page.Data[7] == 's';
     }
 }

--- a/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggOpusWriter.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggOpusWriter.cs
@@ -2,22 +2,15 @@ namespace Meziantou.Framework.MediaTags.Formats.Ogg;
 
 internal sealed class OggOpusWriter : IMediaTagWriter
 {
+    private static readonly byte[] OpusTagsPrefix = "OpusTags"u8.ToArray();
+
     public MediaTagResult WriteTags(Stream inputStream, Stream outputStream, MediaTagInfo tags)
     {
         try
         {
             inputStream.Position = 0;
 
-            // Read all pages
-            var pages = new List<OggPage>();
-            while (true)
-            {
-                var page = OggPage.Read(inputStream);
-                if (page is null)
-                    break;
-                pages.Add(page);
-            }
-
+            var pages = OggPacketUtilities.ReadAllPages(inputStream);
             if (pages.Count < 2)
                 return MediaTagResult.Failure(MediaTagError.CorruptFile, "OGG file has fewer than 2 pages.");
 
@@ -36,28 +29,10 @@ internal sealed class OggOpusWriter : IMediaTagWriter
             newCommentPacket[7] = (byte)'s';
             commentData.CopyTo(newCommentPacket, 8);
 
-            // Write page 0 (identification header) unchanged
-            pages[0].Write(outputStream);
-
-            // Write page 1 with new comment data
-            var commentPage = new OggPage
+            var outputPages = OggPacketUtilities.ReplacePacket(pages, OpusTagsPrefix, newCommentPacket);
+            for (var i = 0; i < outputPages.Count; i++)
             {
-                Version = pages[1].Version,
-                HeaderType = pages[1].HeaderType,
-                GranulePosition = pages[1].GranulePosition,
-                SerialNumber = pages[1].SerialNumber,
-                PageSequenceNumber = pages[1].PageSequenceNumber,
-                SegmentTable = OggPage.BuildSegmentTable(newCommentPacket.Length),
-                Data = newCommentPacket,
-            };
-            commentPage.Write(outputStream);
-
-            // Write remaining pages
-            var seqDelta = commentPage.PageSequenceNumber + 1 - (pages.Count > 2 ? pages[2].PageSequenceNumber : 0);
-            for (var i = 2; i < pages.Count; i++)
-            {
-                pages[i].PageSequenceNumber = (uint)(pages[i].PageSequenceNumber + seqDelta);
-                pages[i].Write(outputStream);
+                outputPages[i].Write(outputStream);
             }
 
             return MediaTagResult.Success();

--- a/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggPacketInfo.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggPacketInfo.cs
@@ -1,0 +1,11 @@
+namespace Meziantou.Framework.MediaTags.Formats.Ogg;
+
+internal sealed class OggPacketInfo
+{
+    public required byte[] Data { get; init; }
+    public required int StartPageIndex { get; init; }
+    public required int EndPageIndex { get; init; }
+    public required bool StartsAtPageStart { get; init; }
+    public required bool EndsAtPageEnd { get; init; }
+    public required long FinalPageGranulePosition { get; init; }
+}

--- a/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggPacketUtilities.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggPacketUtilities.cs
@@ -1,15 +1,5 @@
 namespace Meziantou.Framework.MediaTags.Formats.Ogg;
 
-internal sealed class OggPacketInfo
-{
-    public required byte[] Data { get; init; }
-    public required int StartPageIndex { get; init; }
-    public required int EndPageIndex { get; init; }
-    public required bool StartsAtPageStart { get; init; }
-    public required bool EndsAtPageEnd { get; init; }
-    public required long FinalPageGranulePosition { get; init; }
-}
-
 internal static class OggPacketUtilities
 {
     public static List<OggPage> ReadAllPages(Stream stream)
@@ -252,7 +242,7 @@ internal static class OggPacketUtilities
         return lacingValues;
     }
 
-    private static int FindPacketIndex(IReadOnlyList<OggPacketInfo> packets, ReadOnlySpan<byte> prefix)
+    private static int FindPacketIndex(List<OggPacketInfo> packets, ReadOnlySpan<byte> prefix)
     {
         for (var i = 0; i < packets.Count; i++)
         {

--- a/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggPacketUtilities.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggPacketUtilities.cs
@@ -1,0 +1,265 @@
+namespace Meziantou.Framework.MediaTags.Formats.Ogg;
+
+internal sealed class OggPacketInfo
+{
+    public required byte[] Data { get; init; }
+    public required int StartPageIndex { get; init; }
+    public required int EndPageIndex { get; init; }
+    public required bool StartsAtPageStart { get; init; }
+    public required bool EndsAtPageEnd { get; init; }
+    public required long FinalPageGranulePosition { get; init; }
+}
+
+internal static class OggPacketUtilities
+{
+    public static List<OggPage> ReadAllPages(Stream stream)
+    {
+        var pages = new List<OggPage>();
+        while (true)
+        {
+            var page = OggPage.Read(stream);
+            if (page is null)
+                break;
+
+            pages.Add(page);
+        }
+
+        return pages;
+    }
+
+    public static List<OggPacketInfo> ReadPackets(IReadOnlyList<OggPage> pages)
+    {
+        var packets = new List<OggPacketInfo>();
+        using var currentPacket = new MemoryStream();
+
+        var hasCurrentPacket = false;
+        var packetStartPageIndex = 0;
+        var packetStartsAtPageStart = false;
+
+        for (var pageIndex = 0; pageIndex < pages.Count; pageIndex++)
+        {
+            var page = pages[pageIndex];
+            var dataOffset = 0;
+
+            for (var segmentIndex = 0; segmentIndex < page.SegmentTable.Length; segmentIndex++)
+            {
+                var segmentLength = page.SegmentTable[segmentIndex];
+                if (!hasCurrentPacket)
+                {
+                    hasCurrentPacket = true;
+                    packetStartPageIndex = pageIndex;
+                    packetStartsAtPageStart = segmentIndex == 0 && (page.HeaderType & OggPage.HeaderTypeContinued) == 0;
+                }
+
+                if (segmentLength > 0)
+                {
+                    currentPacket.Write(page.Data, dataOffset, segmentLength);
+                }
+
+                dataOffset += segmentLength;
+
+                if (segmentLength < 255)
+                {
+                    packets.Add(new OggPacketInfo
+                    {
+                        Data = currentPacket.ToArray(),
+                        StartPageIndex = packetStartPageIndex,
+                        EndPageIndex = pageIndex,
+                        StartsAtPageStart = packetStartsAtPageStart,
+                        EndsAtPageEnd = segmentIndex == page.SegmentTable.Length - 1,
+                        FinalPageGranulePosition = page.GranulePosition,
+                    });
+
+                    currentPacket.SetLength(0);
+                    hasCurrentPacket = false;
+                }
+            }
+        }
+
+        if (hasCurrentPacket)
+            throw new InvalidOperationException("Invalid OGG stream: unterminated packet.");
+
+        return packets;
+    }
+
+    public static List<OggPage> ReplacePacket(
+        IReadOnlyList<OggPage> pages,
+        ReadOnlySpan<byte> packetPrefix,
+        byte[] replacementPacketData)
+    {
+        var packets = ReadPackets(pages);
+        var packetIndexToReplace = FindPacketIndex(packets, packetPrefix);
+        if (packetIndexToReplace < 0)
+            throw new InvalidOperationException("Target OGG packet not found.");
+
+        var rewriteStartPacketIndex = packetIndexToReplace;
+        while (rewriteStartPacketIndex > 0 && !packets[rewriteStartPacketIndex].StartsAtPageStart)
+        {
+            rewriteStartPacketIndex--;
+        }
+
+        var rewriteEndPacketIndex = packets.Count;
+        for (var i = packetIndexToReplace + 1; i < packets.Count; i++)
+        {
+            if (packets[i].StartsAtPageStart)
+            {
+                rewriteEndPacketIndex = i;
+                break;
+            }
+        }
+
+        var rewriteStartPageIndex = packets[rewriteStartPacketIndex].StartPageIndex;
+        var appendStartPageIndex = rewriteEndPacketIndex < packets.Count ? packets[rewriteEndPacketIndex].StartPageIndex : pages.Count;
+
+        var packetsToRewrite = new List<(byte[] Data, long GranulePosition)>(rewriteEndPacketIndex - rewriteStartPacketIndex);
+        for (var i = rewriteStartPacketIndex; i < rewriteEndPacketIndex; i++)
+        {
+            var packet = packets[i];
+            var data = i == packetIndexToReplace ? replacementPacketData : packet.Data;
+            var granulePosition = packet.EndsAtPageEnd ? packet.FinalPageGranulePosition : -1;
+            packetsToRewrite.Add((data, granulePosition));
+        }
+
+        var templatePage = pages[rewriteStartPageIndex];
+        var includeBeginOfStream = rewriteStartPageIndex == 0 && (pages[0].HeaderType & OggPage.HeaderTypeBeginOfStream) != 0;
+        var includeEndOfStream = appendStartPageIndex == pages.Count && (pages[^1].HeaderType & OggPage.HeaderTypeEndOfStream) != 0;
+        var rebuiltPages = BuildPagesFromPackets(
+            packetsToRewrite,
+            templatePage.Version,
+            templatePage.SerialNumber,
+            templatePage.PageSequenceNumber,
+            includeBeginOfStream,
+            includeEndOfStream);
+
+        var outputPages = new List<OggPage>(rewriteStartPageIndex + rebuiltPages.Count + pages.Count - appendStartPageIndex);
+        for (var i = 0; i < rewriteStartPageIndex; i++)
+        {
+            outputPages.Add(pages[i].Clone());
+        }
+
+        outputPages.AddRange(rebuiltPages);
+
+        var replacedPageCount = appendStartPageIndex - rewriteStartPageIndex;
+        var sequenceDelta = rebuiltPages.Count - replacedPageCount;
+        for (var i = appendStartPageIndex; i < pages.Count; i++)
+        {
+            var page = pages[i].Clone();
+            var newSequence = (long)page.PageSequenceNumber + sequenceDelta;
+            if (newSequence is < 0 or > uint.MaxValue)
+                throw new InvalidOperationException("Invalid OGG sequence number after packet rewrite.");
+
+            page.PageSequenceNumber = (uint)newSequence;
+            outputPages.Add(page);
+        }
+
+        return outputPages;
+    }
+
+    private static List<OggPage> BuildPagesFromPackets(
+        IReadOnlyList<(byte[] Data, long GranulePosition)> packets,
+        byte version,
+        uint serialNumber,
+        uint firstSequenceNumber,
+        bool includeBeginOfStreamOnFirstPage,
+        bool includeEndOfStreamOnLastPage)
+    {
+        var outputPages = new List<OggPage>();
+        var sequenceNumber = firstSequenceNumber;
+        var isFirstOutputPage = true;
+
+        foreach (var packet in packets)
+        {
+            var lacingValues = BuildLacingValues(packet.Data.Length);
+            var lacingOffset = 0;
+            var dataOffset = 0;
+            var isFirstChunkOfPacket = true;
+
+            while (lacingOffset < lacingValues.Count)
+            {
+                var lacingCount = Math.Min(255, lacingValues.Count - lacingOffset);
+                var segmentTable = new byte[lacingCount];
+                lacingValues.CopyTo(lacingOffset, segmentTable, 0, lacingCount);
+
+                var pageDataLength = 0;
+                for (var i = 0; i < segmentTable.Length; i++)
+                {
+                    pageDataLength += segmentTable[i];
+                }
+
+                var pageData = new byte[pageDataLength];
+                if (pageDataLength > 0)
+                {
+                    Array.Copy(packet.Data, dataOffset, pageData, 0, pageDataLength);
+                }
+
+                dataOffset += pageDataLength;
+                lacingOffset += lacingCount;
+
+                var isLastChunkOfPacket = lacingOffset >= lacingValues.Count;
+
+                var headerType = 0;
+                if (isFirstOutputPage && includeBeginOfStreamOnFirstPage)
+                {
+                    headerType |= OggPage.HeaderTypeBeginOfStream;
+                }
+
+                if (!isFirstChunkOfPacket)
+                {
+                    headerType |= OggPage.HeaderTypeContinued;
+                }
+
+                outputPages.Add(new OggPage
+                {
+                    Version = version,
+                    HeaderType = (byte)headerType,
+                    GranulePosition = isLastChunkOfPacket ? packet.GranulePosition : -1,
+                    SerialNumber = serialNumber,
+                    PageSequenceNumber = sequenceNumber++,
+                    SegmentTable = segmentTable,
+                    Data = pageData,
+                });
+
+                isFirstOutputPage = false;
+                isFirstChunkOfPacket = false;
+            }
+        }
+
+        if (includeEndOfStreamOnLastPage && outputPages.Count > 0)
+        {
+            outputPages[^1].HeaderType |= OggPage.HeaderTypeEndOfStream;
+        }
+
+        return outputPages;
+    }
+
+    private static List<byte> BuildLacingValues(int dataLength)
+    {
+        var lacingValues = new List<byte>();
+        if (dataLength == 0)
+        {
+            lacingValues.Add(0);
+            return lacingValues;
+        }
+
+        var remaining = dataLength;
+        while (remaining >= 255)
+        {
+            lacingValues.Add(255);
+            remaining -= 255;
+        }
+
+        lacingValues.Add((byte)remaining);
+        return lacingValues;
+    }
+
+    private static int FindPacketIndex(IReadOnlyList<OggPacketInfo> packets, ReadOnlySpan<byte> prefix)
+    {
+        for (var i = 0; i < packets.Count; i++)
+        {
+            if (packets[i].Data.AsSpan().StartsWith(prefix))
+                return i;
+        }
+
+        return -1;
+    }
+}

--- a/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggPage.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggPage.cs
@@ -92,6 +92,20 @@ internal sealed class OggPage
         return result;
     }
 
+    public OggPage Clone()
+    {
+        return new OggPage
+        {
+            Version = Version,
+            HeaderType = HeaderType,
+            GranulePosition = GranulePosition,
+            SerialNumber = SerialNumber,
+            PageSequenceNumber = PageSequenceNumber,
+            SegmentTable = (byte[])SegmentTable.Clone(),
+            Data = (byte[])Data.Clone(),
+        };
+    }
+
     /// <summary>
     /// Builds the segment table for a given data size.
     /// </summary>

--- a/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggVorbisReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggVorbisReader.cs
@@ -2,6 +2,8 @@ namespace Meziantou.Framework.MediaTags.Formats.Ogg;
 
 internal sealed class OggVorbisReader : IMediaTagReader
 {
+    private static readonly byte[] VorbisCommentPrefix = [0x03, (byte)'v', (byte)'o', (byte)'r', (byte)'b', (byte)'i', (byte)'s'];
+
     public MediaTagResult<MediaTagInfo> ReadTags(Stream stream)
     {
         try
@@ -9,32 +11,15 @@ internal sealed class OggVorbisReader : IMediaTagReader
             stream.Position = 0;
             var tags = new MediaTagInfo();
 
-            // Read pages until we find the Vorbis comment header
-            // Page 0: identification header (\x01vorbis)
-            // Page 1: comment header (\x03vorbis)
-            var pageIndex = 0;
-            while (true)
+            var pages = OggPacketUtilities.ReadAllPages(stream);
+            var packets = OggPacketUtilities.ReadPackets(pages);
+            foreach (var packet in packets)
             {
-                var page = OggPage.Read(stream);
-                if (page is null)
-                    break;
-
-                if (pageIndex == 1 || IsVorbisCommentPage(page))
+                if (packet.Data.AsSpan().StartsWith(VorbisCommentPrefix))
                 {
-                    // Extract comment data: skip "\x03vorbis" (7 bytes) prefix
-                    var data = page.Data;
-                    if (data.Length > 7 && data[0] == 0x03
-                        && data[1] == 'v' && data[2] == 'o' && data[3] == 'r'
-                        && data[4] == 'b' && data[5] == 'i' && data[6] == 's')
-                    {
-                        VorbisComment.VorbisCommentReader.TryParse(data.AsSpan(7), tags);
-                    }
+                    VorbisComment.VorbisCommentReader.TryParse(packet.Data.AsSpan(VorbisCommentPrefix.Length), tags);
                     break;
                 }
-
-                pageIndex++;
-                if (pageIndex > 10)
-                    break; // Safety limit
             }
 
             return MediaTagResult<MediaTagInfo>.Success(tags);
@@ -43,13 +28,5 @@ internal sealed class OggVorbisReader : IMediaTagReader
         {
             return MediaTagResult<MediaTagInfo>.Failure(MediaTagError.CorruptFile, ex.Message);
         }
-    }
-
-    private static bool IsVorbisCommentPage(OggPage page)
-    {
-        return page.Data.Length > 7
-            && page.Data[0] == 0x03
-            && page.Data[1] == 'v' && page.Data[2] == 'o' && page.Data[3] == 'r'
-            && page.Data[4] == 'b' && page.Data[5] == 'i' && page.Data[6] == 's';
     }
 }

--- a/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggVorbisWriter.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggVorbisWriter.cs
@@ -2,22 +2,15 @@ namespace Meziantou.Framework.MediaTags.Formats.Ogg;
 
 internal sealed class OggVorbisWriter : IMediaTagWriter
 {
+    private static readonly byte[] VorbisCommentPrefix = [0x03, (byte)'v', (byte)'o', (byte)'r', (byte)'b', (byte)'i', (byte)'s'];
+
     public MediaTagResult WriteTags(Stream inputStream, Stream outputStream, MediaTagInfo tags)
     {
         try
         {
             inputStream.Position = 0;
 
-            // Read all pages
-            var pages = new List<OggPage>();
-            while (true)
-            {
-                var page = OggPage.Read(inputStream);
-                if (page is null)
-                    break;
-                pages.Add(page);
-            }
-
+            var pages = OggPacketUtilities.ReadAllPages(inputStream);
             if (pages.Count < 2)
                 return MediaTagResult.Failure(MediaTagError.CorruptFile, "OGG file has fewer than 2 pages.");
 
@@ -35,28 +28,10 @@ internal sealed class OggVorbisWriter : IMediaTagWriter
             newCommentPacket[6] = (byte)'s';
             commentData.CopyTo(newCommentPacket, 7);
 
-            // Write page 0 (identification header) unchanged
-            pages[0].Write(outputStream);
-
-            // Write page 1 with new comment data
-            var commentPage = new OggPage
+            var outputPages = OggPacketUtilities.ReplacePacket(pages, VorbisCommentPrefix, newCommentPacket);
+            for (var i = 0; i < outputPages.Count; i++)
             {
-                Version = pages[1].Version,
-                HeaderType = pages[1].HeaderType,
-                GranulePosition = pages[1].GranulePosition,
-                SerialNumber = pages[1].SerialNumber,
-                PageSequenceNumber = pages[1].PageSequenceNumber,
-                SegmentTable = OggPage.BuildSegmentTable(newCommentPacket.Length),
-                Data = newCommentPacket,
-            };
-            commentPage.Write(outputStream);
-
-            // Write remaining pages with updated sequence numbers
-            var seqDelta = commentPage.PageSequenceNumber + 1 - (pages.Count > 2 ? pages[2].PageSequenceNumber : 0);
-            for (var i = 2; i < pages.Count; i++)
-            {
-                pages[i].PageSequenceNumber = (uint)(pages[i].PageSequenceNumber + seqDelta);
-                pages[i].Write(outputStream);
+                outputPages[i].Write(outputStream);
             }
 
             return MediaTagResult.Success();

--- a/tests/Meziantou.Framework.MediaTags.Tests/OggOpusTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/OggOpusTests.cs
@@ -1,4 +1,5 @@
 using Meziantou.Framework.MediaTags;
+using Meziantou.Framework.MediaTags.Formats.Ogg;
 
 namespace Meziantou.Framework.MediaTags.Tests;
 
@@ -50,6 +51,51 @@ public sealed class OggOpusTests
         finally
         {
             File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void WriteTags_LargeCommentPacket_RoundTrip()
+    {
+        var tempFile = Path.GetTempFileName() + ".opus";
+        try
+        {
+            File.Copy(GetTestFilePath("basic.opus"), tempFile, overwrite: true);
+
+            var largeLyrics = new string('a', 80000);
+            var newTags = new MediaTagInfo
+            {
+                Title = "Large Opus Title",
+                Lyrics = largeLyrics,
+            };
+
+            var writeResult = MediaFile.WriteTags(tempFile, newTags);
+            Assert.True(writeResult.IsSuccess);
+
+            var readResult = MediaFile.ReadTags(tempFile);
+            Assert.True(readResult.IsSuccess);
+
+            Assert.Equal("Large Opus Title", readResult.Value.Title);
+            Assert.Equal(largeLyrics, readResult.Value.Lyrics);
+            Assert.True(ContainsContinuedPage(tempFile));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    private static bool ContainsContinuedPage(string filePath)
+    {
+        using var stream = File.OpenRead(filePath);
+        while (true)
+        {
+            var page = OggPage.Read(stream);
+            if (page is null)
+                return false;
+
+            if ((page.HeaderType & OggPage.HeaderTypeContinued) != 0)
+                return true;
         }
     }
 }

--- a/tests/Meziantou.Framework.MediaTags.Tests/OggVorbisTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/OggVorbisTests.cs
@@ -1,4 +1,5 @@
 using Meziantou.Framework.MediaTags;
+using Meziantou.Framework.MediaTags.Formats.Ogg;
 
 namespace Meziantou.Framework.MediaTags.Tests;
 
@@ -123,6 +124,51 @@ public sealed class OggVorbisTests
         finally
         {
             File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void WriteTags_LargeCommentPacket_RoundTrip()
+    {
+        var tempFile = Path.GetTempFileName() + ".ogg";
+        try
+        {
+            File.Copy(GetTestFilePath("basic.ogg"), tempFile, overwrite: true);
+
+            var largeLyrics = new string('a', 80000);
+            var tags = new MediaTagInfo
+            {
+                Title = "Large OGG Title",
+                Lyrics = largeLyrics,
+            };
+
+            var writeResult = MediaFile.WriteTags(tempFile, tags);
+            Assert.True(writeResult.IsSuccess);
+
+            var readResult = MediaFile.ReadTags(tempFile);
+            Assert.True(readResult.IsSuccess);
+
+            Assert.Equal("Large OGG Title", readResult.Value.Title);
+            Assert.Equal(largeLyrics, readResult.Value.Lyrics);
+            Assert.True(ContainsContinuedPage(tempFile));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    private static bool ContainsContinuedPage(string filePath)
+    {
+        using var stream = File.OpenRead(filePath);
+        while (true)
+        {
+            var page = OggPage.Read(stream);
+            if (page is null)
+                return false;
+
+            if ((page.HeaderType & OggPage.HeaderTypeContinued) != 0)
+                return true;
         }
     }
 }


### PR DESCRIPTION
## Why
Large Opus or Vorbis comment payloads can span multiple lacing segments/pages, but the previous implementation assumed single-page comment packets. That made tag read/write logic fragile for real-world files with bigger metadata blocks.

## What changed
- Added shared OGG packet utilities to:
  - read packet boundaries across continued pages
  - replace a target packet and rebuild affected pages with correct lacing, sequence numbers, and BOS/EOS flags
- Updated Ogg Opus and Ogg Vorbis readers to parse comment headers from full packet data (`OpusTags` and `\x03vorbis`) instead of page-local assumptions.
- Updated Ogg Opus and Ogg Vorbis writers to rewrite comment packets via packet-aware repagination logic.
- Added `OggPage.Clone()` to safely rebuild output page sets.
- Added large-comment round-trip tests for both Opus and Vorbis that assert continued-page scenarios.

## Notes for reviewers
- The change is intentionally shared between Opus and Vorbis to keep OGG behavior consistent and avoid fixing the same packet-boundary bug twice.
- FLAC support was already present and remains unchanged.