### PR TITLE
Normalize MSBuild path separators to forward slashes

### DIFF
--- a/benchmarks/DependencyScanningBenchmarks/DependencyScanningBenchmarks.csproj
+++ b/benchmarks/DependencyScanningBenchmarks/DependencyScanningBenchmarks.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.DependencyScanning\Meziantou.Framework.DependencyScanning.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.DependencyScanning/Meziantou.Framework.DependencyScanning.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
   </ItemGroup>
 
 </Project>

--- a/benchmarks/GlobbingBenchmarks/GlobbingBenchmarks.csproj
+++ b/benchmarks/GlobbingBenchmarks/GlobbingBenchmarks.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Globbing\Meziantou.Framework.Globbing.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/BlazorAppSample/BlazorAppSample.csproj
+++ b/samples/BlazorAppSample/BlazorAppSample.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.AspNetCore.Components.LogViewer\Meziantou.AspNetCore.Components.LogViewer.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.AspNetCore.Components.WebAssembly\Meziantou.AspNetCore.Components.WebAssembly.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.AspNetCore.Components\Meziantou.AspNetCore.Components.csproj" />
+    <ProjectReference Include="../../src/Meziantou.AspNetCore.Components.LogViewer/Meziantou.AspNetCore.Components.LogViewer.csproj" />
+    <ProjectReference Include="../../src/Meziantou.AspNetCore.Components.WebAssembly/Meziantou.AspNetCore.Components.WebAssembly.csproj" />
+    <ProjectReference Include="../../src/Meziantou.AspNetCore.Components/Meziantou.AspNetCore.Components.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/DependencyScannerSample/DependencyScannerSample.csproj
+++ b/samples/DependencyScannerSample/DependencyScannerSample.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.DependencyScanning\Meziantou.Framework.DependencyScanning.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.DependencyScanning/Meziantou.Framework.DependencyScanning.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Properties\" />
+    <Folder Include="Properties/" />
   </ItemGroup>
 
 </Project>

--- a/samples/Meziantou.Framework.Http.HstsSample/Meziantou.Framework.Http.HstsSample.csproj
+++ b/samples/Meziantou.Framework.Http.HstsSample/Meziantou.Framework.Http.HstsSample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Http.Hsts\Meziantou.Framework.Http.Hsts.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Http.Hsts/Meziantou.Framework.Http.Hsts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Meziantou.Framework.InlineSnapshotTesting.Samples/Meziantou.Framework.InlineSnapshotTesting.Samples.csproj
+++ b/samples/Meziantou.Framework.InlineSnapshotTesting.Samples/Meziantou.Framework.InlineSnapshotTesting.Samples.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.InlineSnapshotTesting\Meziantou.Framework.InlineSnapshotTesting.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Meziantou.Framework.Scheduling.RecurrenceRuleSample/Meziantou.Framework.Scheduling.RecurrenceRuleSample.csproj
+++ b/samples/Meziantou.Framework.Scheduling.RecurrenceRuleSample/Meziantou.Framework.Scheduling.RecurrenceRuleSample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Scheduling\Meziantou.Framework.Scheduling.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Scheduling/Meziantou.Framework.Scheduling.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Meziantou.Framework.WPF.CollectionSamples/Meziantou.Framework.WPF.CollectionSamples.csproj
+++ b/samples/Meziantou.Framework.WPF.CollectionSamples/Meziantou.Framework.WPF.CollectionSamples.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.WPF\Meziantou.Framework.WPF.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.WPF/Meziantou.Framework.WPF.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Meziantou.Framework.WPF.EnumComboBox/Meziantou.Framework.WPF.EnumComboBox.csproj
+++ b/samples/Meziantou.Framework.WPF.EnumComboBox/Meziantou.Framework.WPF.EnumComboBox.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.WPF\Meziantou.Framework.WPF.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.WPF/Meziantou.Framework.WPF.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Meziantou.Framework.Win32.AccessTokenConsole/Meziantou.Framework.Win32.AccessTokenConsole.csproj
+++ b/samples/Meziantou.Framework.Win32.AccessTokenConsole/Meziantou.Framework.Win32.AccessTokenConsole.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.AccessToken\Meziantou.Framework.Win32.AccessToken.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.AccessToken/Meziantou.Framework.Win32.AccessToken.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Meziantou.Framework.Win32.ChangeJournal.Sample/Meziantou.Framework.Win32.ChangeJournal.Sample.csproj
+++ b/samples/Meziantou.Framework.Win32.ChangeJournal.Sample/Meziantou.Framework.Win32.ChangeJournal.Sample.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.ByteSize\Meziantou.Framework.ByteSize.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.ChangeJournal\Meziantou.Framework.Win32.ChangeJournal.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.ByteSize/Meziantou.Framework.ByteSize.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.ChangeJournal/Meziantou.Framework.Win32.ChangeJournal.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Meziantou.Framework.Win32.CredentialManagerConsole/Meziantou.Framework.Win32.CredentialManagerConsole.csproj
+++ b/samples/Meziantou.Framework.Win32.CredentialManagerConsole/Meziantou.Framework.Win32.CredentialManagerConsole.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.CredentialManager\Meziantou.Framework.Win32.CredentialManager.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.CredentialManager/Meziantou.Framework.Win32.CredentialManager.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Meziantou.Framework.Win32.DialogsSamples/Meziantou.Framework.Win32.DialogsSamples.csproj
+++ b/samples/Meziantou.Framework.Win32.DialogsSamples/Meziantou.Framework.Win32.DialogsSamples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.Dialogs\Meziantou.Framework.Win32.Dialogs.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.Dialogs/Meziantou.Framework.Win32.Dialogs.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Meziantou.Framework.Win32.RecentDocumentsConsole/Meziantou.Framework.Win32.RecentDocumentsConsole.csproj
+++ b/samples/Meziantou.Framework.Win32.RecentDocumentsConsole/Meziantou.Framework.Win32.RecentDocumentsConsole.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.RecentDocuments\Meziantou.Framework.Win32.RecentDocuments.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.RecentDocuments/Meziantou.Framework.Win32.RecentDocuments.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/SingleInstanceConsoleAppSample/SingleInstanceConsoleAppSample.csproj
+++ b/samples/SingleInstanceConsoleAppSample/SingleInstanceConsoleAppSample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.SingleInstance\Meziantou.Framework.SingleInstance.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.SingleInstance/Meziantou.Framework.SingleInstance.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.AspNetCore.ServiceDefaults.AutoRegister/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.csproj
+++ b/src/Meziantou.AspNetCore.ServiceDefaults.AutoRegister/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <None Include="Meziantou.AspNetCore.ServiceDefaults.AutoRegister.targets" Pack="true" PackagePath="build/" />
-    <None Include="$(OutputPath)\..\$(Configuration.ToLowerInvariant())_netstandard2.0\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)/../$(Configuration.ToLowerInvariant())_netstandard2.0/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.DnsProxy/Meziantou.DnsProxy.csproj
+++ b/src/Meziantou.DnsProxy/Meziantou.DnsProxy.csproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.DnsClient\Meziantou.Framework.DnsClient.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.DnsServer\Meziantou.Framework.DnsServer.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.DnsFilter\Meziantou.Framework.DnsFilter.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.DnsClient/Meziantou.Framework.DnsClient.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.DnsServer/Meziantou.Framework.DnsServer.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.DnsFilter/Meziantou.Framework.DnsFilter.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Extensions.Logging.InMemory/Meziantou.Extensions.Logging.InMemory.csproj
+++ b/src/Meziantou.Extensions.Logging.InMemory/Meziantou.Extensions.Logging.InMemory.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\common\TypeNameHelper.cs" Link="TypeNameHelper.cs" />
+    <Compile Include="../../common/TypeNameHelper.cs" Link="TypeNameHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\common\TypeNameHelper.cs" Link="TypeNameHelper.cs" />
+    <Compile Include="../../common/TypeNameHelper.cs" Link="TypeNameHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Extensions.Logging.Xunit/Meziantou.Extensions.Logging.Xunit.csproj
+++ b/src/Meziantou.Extensions.Logging.Xunit/Meziantou.Extensions.Logging.Xunit.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\common\TypeNameHelper.cs" Link="TypeNameHelper.cs" />
+    <Compile Include="../../common/TypeNameHelper.cs" Link="TypeNameHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Meziantou.Framework.DependencyScanning.Tool.csproj
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Meziantou.Framework.DependencyScanning.Tool.csproj
@@ -14,12 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework\Meziantou.Framework.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.DependencyScanning\Meziantou.Framework.DependencyScanning.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.Globbing\Meziantou.Framework.Globbing.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.ProcessWrapper\Meziantou.Framework.ProcessWrapper.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.Versioning\Meziantou.Framework.Versioning.csproj" />
+    <ProjectReference Include="../Meziantou.Framework/Meziantou.Framework.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.DependencyScanning/Meziantou.Framework.DependencyScanning.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.DependencyScanning/Meziantou.Framework.DependencyScanning.csproj
+++ b/src/Meziantou.Framework.DependencyScanning/Meziantou.Framework.DependencyScanning.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.Globbing\Meziantou.Framework.Globbing.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.FastEnumToStringGenerator/Meziantou.Framework.FastEnumToStringGenerator.csproj
+++ b/src/Meziantou.Framework.FastEnumToStringGenerator/Meziantou.Framework.FastEnumToStringGenerator.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <None Include="Meziantou.Framework.FastEnumToStringGenerator.targets" Pack="true" PackagePath="build/" />
-    <None Include="$(OutputPath)\..\$(Configuration.ToLowerInvariant())_netstandard2.0\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)/../$(Configuration.ToLowerInvariant())_netstandard2.0/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/Meziantou.Framework.FixedStringBuilder.Generator.csproj
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/Meziantou.Framework.FixedStringBuilder.Generator.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)\..\$(Configuration.ToLowerInvariant())_netstandard2.0\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)/../$(Configuration.ToLowerInvariant())_netstandard2.0/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.FixedStringBuilder/Meziantou.Framework.FixedStringBuilder.csproj
+++ b/src/Meziantou.Framework.FixedStringBuilder/Meziantou.Framework.FixedStringBuilder.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.FixedStringBuilder.Generator\Meziantou.Framework.FixedStringBuilder.Generator.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <ProjectReference Include="../Meziantou.Framework.FixedStringBuilder.Generator/Meziantou.Framework.FixedStringBuilder.Generator.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj
+++ b/src/Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Meziantou.Framework\StringExtensions.SplitLines.cs" Link="Internals\StringExtensions.SplitLines.cs" />
-    <Compile Include="..\Meziantou.Framework.ValueStringBuilder\ValueStringBuilder.cs" Link="Internals\ValueStringBuilder\ValueStringBuilder.cs" />
+    <Compile Include="../Meziantou.Framework/StringExtensions.SplitLines.cs" Link="Internals/StringExtensions.SplitLines.cs" />
+    <Compile Include="../Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs" Link="Internals/ValueStringBuilder/ValueStringBuilder.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/Meziantou.Framework.Html.Tool/Meziantou.Framework.Html.Tool.csproj
+++ b/src/Meziantou.Framework.Html.Tool/Meziantou.Framework.Html.Tool.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.Globbing\Meziantou.Framework.Globbing.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.Html\Meziantou.Framework.Html.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.Html/Meziantou.Framework.Html.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Http.Caching.InMemory/Meziantou.Framework.Http.Caching.InMemory.csproj
+++ b/src/Meziantou.Framework.Http.Caching.InMemory/Meziantou.Framework.Http.Caching.InMemory.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.Http.Caching\Meziantou.Framework.Http.Caching.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.Http.Caching/Meziantou.Framework.Http.Caching.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Http.Caching.Redis/Meziantou.Framework.Http.Caching.Redis.csproj
+++ b/src/Meziantou.Framework.Http.Caching.Redis/Meziantou.Framework.Http.Caching.Redis.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.Http.Caching\Meziantou.Framework.Http.Caching.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.Http.Caching/Meziantou.Framework.Http.Caching.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Http.Caching.Sqlite/Meziantou.Framework.Http.Caching.Sqlite.csproj
+++ b/src/Meziantou.Framework.Http.Caching.Sqlite/Meziantou.Framework.Http.Caching.Sqlite.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.Http.Caching\Meziantou.Framework.Http.Caching.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.Http.Caching/Meziantou.Framework.Http.Caching.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Http.Htpasswd/Meziantou.Framework.Http.Htpasswd.csproj
+++ b/src/Meziantou.Framework.Http.Htpasswd/Meziantou.Framework.Http.Htpasswd.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.Bcrypt\Meziantou.Framework.Bcrypt.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.Bcrypt/Meziantou.Framework.Bcrypt.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Http.Recording/Meziantou.Framework.Http.Recording.csproj
+++ b/src/Meziantou.Framework.Http.Recording/Meziantou.Framework.Http.Recording.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.HttpArchive\Meziantou.Framework.HttpArchive.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.HttpArchive/Meziantou.Framework.HttpArchive.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.InlineSnapshotTesting.Serializers.Argon/Meziantou.Framework.InlineSnapshotTesting.Serializers.Argon.csproj
+++ b/src/Meziantou.Framework.InlineSnapshotTesting.Serializers.Argon/Meziantou.Framework.InlineSnapshotTesting.Serializers.Argon.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.InlineSnapshotTesting\Meziantou.Framework.InlineSnapshotTesting.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Meziantou.Framework.HumanReadableSerializer\Utils\StringUtils.cs" Link="Utils\StringUtils.cs" />
-    <Compile Include="..\Meziantou.Framework\ExecutableFinder.cs" Link="Utils\ExecutableFinder.cs" />
+    <Compile Include="../Meziantou.Framework.HumanReadableSerializer/Utils/StringUtils.cs" Link="Utils/StringUtils.cs" />
+    <Compile Include="../Meziantou.Framework/ExecutableFinder.cs" Link="Utils/ExecutableFinder.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,11 +20,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.SnapshotTesting.Common\Meziantou.Framework.SnapshotTesting.Common.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.HumanReadableSerializer\Meziantou.Framework.HumanReadableSerializer.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.JsonPath\Meziantou.Framework.JsonPath.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.TextDiff\Meziantou.Framework.TextDiff.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.SnapshotTesting.Common/Meziantou.Framework.SnapshotTesting.Common.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.NuGetPackageValidation.Tool/Meziantou.Framework.NuGetPackageValidation.Tool.csproj
+++ b/src/Meziantou.Framework.NuGetPackageValidation.Tool/Meziantou.Framework.NuGetPackageValidation.Tool.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.NuGetPackageValidation\Meziantou.Framework.NuGetPackageValidation.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.NuGetPackageValidation/Meziantou.Framework.NuGetPackageValidation.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.NuGetPackageValidation/Meziantou.Framework.NuGetPackageValidation.csproj
+++ b/src/Meziantou.Framework.NuGetPackageValidation/Meziantou.Framework.NuGetPackageValidation.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\common\SharedHttpClient.cs" Link="SharedHttpClient.cs" />
+    <Compile Include="../../common/SharedHttpClient.cs" Link="SharedHttpClient.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.OpenTelemetryCollector.InMemory/Meziantou.Framework.OpenTelemetryCollector.InMemory.csproj
+++ b/src/Meziantou.Framework.OpenTelemetryCollector.InMemory/Meziantou.Framework.OpenTelemetryCollector.InMemory.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Meziantou.Framework\Collections\AppendOnlyCollection.cs" Link="Collections/AppendOnlyCollection.cs" />
-    <Compile Include="..\Meziantou.Framework\Collections\AppendOnlyCollectionSegment.cs" Link="Collections/AppendOnlyCollectionSegment.cs" />
-    <Compile Include="..\Meziantou.Framework\Collections\CircularBuffer.cs" Link="Collections/CircularBuffer.cs" />
-    <Compile Include="..\Meziantou.Framework\Collections\ThrowHelper.cs" Link="Collections/ThrowHelper.cs" />
+    <Compile Include="../Meziantou.Framework/Collections/AppendOnlyCollection.cs" Link="Collections/AppendOnlyCollection.cs" />
+    <Compile Include="../Meziantou.Framework/Collections/AppendOnlyCollectionSegment.cs" Link="Collections/AppendOnlyCollectionSegment.cs" />
+    <Compile Include="../Meziantou.Framework/Collections/CircularBuffer.cs" Link="Collections/CircularBuffer.cs" />
+    <Compile Include="../Meziantou.Framework/Collections/ThrowHelper.cs" Link="Collections/ThrowHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.OpenTelemetryCollector\Meziantou.Framework.OpenTelemetryCollector.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.OpenTelemetryCollector/Meziantou.Framework.OpenTelemetryCollector.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.OpenTelemetryCollector/Meziantou.Framework.OpenTelemetryCollector.csproj
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/Meziantou.Framework.OpenTelemetryCollector.csproj
@@ -15,14 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Protobuf Include="Otlp\Protos\opentelemetry\proto\common\v1\common.proto" ProtoRoot="Otlp\Protos" GrpcServices="None" />
-    <Protobuf Include="Otlp\Protos\opentelemetry\proto\resource\v1\resource.proto" ProtoRoot="Otlp\Protos" GrpcServices="None" />
-    <Protobuf Include="Otlp\Protos\opentelemetry\proto\logs\v1\logs.proto" ProtoRoot="Otlp\Protos" GrpcServices="None" />
-    <Protobuf Include="Otlp\Protos\opentelemetry\proto\trace\v1\trace.proto" ProtoRoot="Otlp\Protos" GrpcServices="None" />
-    <Protobuf Include="Otlp\Protos\opentelemetry\proto\metrics\v1\metrics.proto" ProtoRoot="Otlp\Protos" GrpcServices="None" />
-    <Protobuf Include="Otlp\Protos\opentelemetry\proto\collector\logs\v1\logs_service.proto" ProtoRoot="Otlp\Protos" GrpcServices="Both" />
-    <Protobuf Include="Otlp\Protos\opentelemetry\proto\collector\trace\v1\trace_service.proto" ProtoRoot="Otlp\Protos" GrpcServices="Both" />
-    <Protobuf Include="Otlp\Protos\opentelemetry\proto\collector\metrics\v1\metrics_service.proto" ProtoRoot="Otlp\Protos" GrpcServices="Both" />
+    <Protobuf Include="Otlp/Protos/opentelemetry/proto/common/v1/common.proto" ProtoRoot="Otlp/Protos" GrpcServices="None" />
+    <Protobuf Include="Otlp/Protos/opentelemetry/proto/resource/v1/resource.proto" ProtoRoot="Otlp/Protos" GrpcServices="None" />
+    <Protobuf Include="Otlp/Protos/opentelemetry/proto/logs/v1/logs.proto" ProtoRoot="Otlp/Protos" GrpcServices="None" />
+    <Protobuf Include="Otlp/Protos/opentelemetry/proto/trace/v1/trace.proto" ProtoRoot="Otlp/Protos" GrpcServices="None" />
+    <Protobuf Include="Otlp/Protos/opentelemetry/proto/metrics/v1/metrics.proto" ProtoRoot="Otlp/Protos" GrpcServices="None" />
+    <Protobuf Include="Otlp/Protos/opentelemetry/proto/collector/logs/v1/logs_service.proto" ProtoRoot="Otlp/Protos" GrpcServices="Both" />
+    <Protobuf Include="Otlp/Protos/opentelemetry/proto/collector/trace/v1/trace_service.proto" ProtoRoot="Otlp/Protos" GrpcServices="Both" />
+    <Protobuf Include="Otlp/Protos/opentelemetry/proto/collector/metrics/v1/metrics_service.proto" ProtoRoot="Otlp/Protos" GrpcServices="Both" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
+++ b/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Meziantou.Framework\ExecutableFinder.cs" Link="Utils\ExecutableFinder.cs" />
+    <Compile Include="../Meziantou.Framework/ExecutableFinder.cs" Link="Utils/ExecutableFinder.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.Unix.ControlGroups\Meziantou.Framework.Unix.ControlGroups.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.Win32.Jobs\Meziantou.Framework.Win32.Jobs.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.ResxSourceGenerator/Meziantou.Framework.ResxSourceGenerator.csproj
+++ b/src/Meziantou.Framework.ResxSourceGenerator/Meziantou.Framework.ResxSourceGenerator.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)\..\$(Configuration.ToLowerInvariant())_netstandard2.0\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)/../$(Configuration.ToLowerInvariant())_netstandard2.0/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="build/**/*.props" Pack="true" PackagePath="build" />
     <None Include="buildMultiTargeting/**/*.props" Pack="true" PackagePath="buildMultiTargeting" />
   </ItemGroup>

--- a/src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.SnapshotTesting\Meziantou.Framework.SnapshotTesting.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Meziantou.Framework\ExecutableFinder.cs" Link="Utils\ExecutableFinder.cs" />
+    <Compile Include="../Meziantou.Framework/ExecutableFinder.cs" Link="Utils/ExecutableFinder.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,9 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.SnapshotTesting.Common\Meziantou.Framework.SnapshotTesting.Common.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.HumanReadableSerializer\Meziantou.Framework.HumanReadableSerializer.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.SnapshotTesting.Common/Meziantou.Framework.SnapshotTesting.Common.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.SnapshotTesting/build/Meziantou.Framework.SnapshotTesting.props
+++ b/src/Meziantou.Framework.SnapshotTesting/build/Meziantou.Framework.SnapshotTesting.props
@@ -23,13 +23,13 @@
     <!--
       Collect top-level SourceRoot items that have a MappedPath, mirroring the filter used by
       _SetPathMapFromSourceRoots (NestedRoot == '' excludes sub-roots such as NuGet package roots
-      that are already covered by their parent). Normalize backslashes in Identity so the generated
+      that are already covered by their parent). Normalize path separators in Identity so the generated
       string literal is always valid on Windows.
     -->
     <ItemGroup>
       <_SnapshotTestingSourceRoot Include="@(SourceRoot)"
           Condition="'%(SourceRoot.NestedRoot)' == '' and '%(SourceRoot.MappedPath)' != ''">
-        <NormalizedIdentity>$([System.String]::Copy('%(Identity)').Replace('\', '/'))</NormalizedIdentity>
+        <NormalizedIdentity>$([System.String]::Copy('%(Identity)').Replace($([System.IO.Path]::DirectorySeparatorChar), '/'))</NormalizedIdentity>
       </_SnapshotTestingSourceRoot>
     </ItemGroup>
 

--- a/src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj
+++ b/src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj
@@ -11,19 +11,19 @@
 
   <ItemGroup>
     <None Include="Meziantou.Framework.StronglyTypedId.targets" Pack="true" PackagePath="build/" />
-    <None Include="$(OutputPath)\..\$(Configuration.ToLowerInvariant())_netstandard2.0\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)/../$(Configuration.ToLowerInvariant())_netstandard2.0/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <Target Name="AddAnnotationsToPackage">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)\..\..\Meziantou.Framework.StronglyTypedId.Annotations\$(Configuration.ToLowerInvariant())_$(TargetFramework)\*">
+      <TfmSpecificPackageFile Include="$(OutputPath)/../../Meziantou.Framework.StronglyTypedId.Annotations/$(Configuration.ToLowerInvariant())_$(TargetFramework)/*">
         <PackagePath>lib/$(TargetFramework)</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.StronglyTypedId.Annotations\Meziantou.Framework.StronglyTypedId.Annotations.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <ProjectReference Include="../Meziantou.Framework.StronglyTypedId.Annotations/Meziantou.Framework.StronglyTypedId.Annotations.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Meziantou.Framework.Templating.Html/Meziantou.Framework.Templating.Html.csproj
+++ b/src/Meziantou.Framework.Templating.Html/Meziantou.Framework.Templating.Html.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.Templating\Meziantou.Framework.Templating.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.Templating/Meziantou.Framework.Templating.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj
+++ b/src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Meziantou.Framework\IOUtilities.Delete.cs" Link="IOUtilities.Delete.cs" />
+    <Compile Include="../Meziantou.Framework/IOUtilities.Delete.cs" Link="IOUtilities.Delete.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net472'">

--- a/src/Meziantou.Framework.Threading/Meziantou.Framework.Threading.csproj
+++ b/src/Meziantou.Framework.Threading/Meziantou.Framework.Threading.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="Threading\Tasks\TaskExtensions.WhenAll.tt">
+    <None Update="Threading/Tasks/TaskExtensions.WhenAll.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>TaskExtensions.WhenAll.cs</LastGenOutput>
     </None>
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="Threading\Tasks\TaskExtensions.WhenAll.cs">
+    <Compile Update="Threading/Tasks/TaskExtensions.WhenAll.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>TaskExtensions.WhenAll.tt</DependentUpon>

--- a/src/Meziantou.Framework.TypeConverter/Meziantou.Framework.TypeConverter.csproj
+++ b/src/Meziantou.Framework.TypeConverter/Meziantou.Framework.TypeConverter.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Meziantou.Framework\ReflectionUtilities.cs" Link="ReflectionUtilities.cs" />
+    <Compile Include="../Meziantou.Framework/ReflectionUtilities.cs" Link="ReflectionUtilities.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Unicode/Meziantou.Framework.Unicode.csproj
+++ b/src/Meziantou.Framework.Unicode/Meziantou.Framework.Unicode.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Resources\UnicodeData.bin.gz">
+    <EmbeddedResource Include="Resources/UnicodeData.bin.gz">
       <LogicalName>Meziantou.Framework.Resources.UnicodeData.bin.gz</LogicalName>
       <WithCulture>false</WithCulture>
     </EmbeddedResource>

--- a/src/Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj
+++ b/src/Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\common\CultureInsensitiveTypeAttribute.cs" />
+    <Compile Include="../../common/CultureInsensitiveTypeAttribute.cs" />
   </ItemGroup>
 </Project>

--- a/src/Meziantou.Framework.Win32.AccessToken/Meziantou.Framework.Win32.AccessToken.csproj
+++ b/src/Meziantou.Framework.Win32.AccessToken/Meziantou.Framework.Win32.AccessToken.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Meziantou.Framework\SafeHandleValue.cs" Link="SafeHandleValue.cs" />
+    <Compile Include="../Meziantou.Framework/SafeHandleValue.cs" Link="SafeHandleValue.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Win32.ChangeJournal/Meziantou.Framework.Win32.ChangeJournal.csproj
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/Meziantou.Framework.Win32.ChangeJournal.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Meziantou.Framework\SafeHandleValue.cs" Link="SafeHandleValue.cs" />
+    <Compile Include="../Meziantou.Framework/SafeHandleValue.cs" Link="SafeHandleValue.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj
+++ b/src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Meziantou.Framework\SafeHandleValue.cs" Link="SafeHandleValue.cs" />
+    <Compile Include="../Meziantou.Framework/SafeHandleValue.cs" Link="SafeHandleValue.cs" />
   </ItemGroup>
   
   <ItemGroup>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) != 'netstandard2.0' AND '$(IncludeDefaultTestReferences)' == 'true'">
-    <Compile Include="$(MSBuildThisFileDirectory)..\common\XUnitStaticHelpers.cs" Link="XUnitStaticHelpers.cs" Condition="'$(MSBuildProjectExtension)' == '.csproj'" Visible="false" />
+    <Compile Include="$(MSBuildThisFileDirectory)../common/XUnitStaticHelpers.cs" Link="XUnitStaticHelpers.cs" Condition="'$(MSBuildProjectExtension)' == '.csproj'" Visible="false" />
 
     <Using Include="Xunit.TestContext" Alias="TestContext" />
     <Using Include="TestUtilities.XUnitStaticHelpers" Static="true" />

--- a/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <ProjectReference Include="..\..\src\Meziantou.AspNetCore.Authentication.HttpBasic\Meziantou.AspNetCore.Authentication.HttpBasic.csproj" />
+    <ProjectReference Include="../../src/Meziantou.AspNetCore.Authentication.HttpBasic/Meziantou.AspNetCore.Authentication.HttpBasic.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/tests/Meziantou.AspNetCore.Components.LogViewer.Tests/Meziantou.AspNetCore.Components.LogViewer.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Components.LogViewer.Tests/Meziantou.AspNetCore.Components.LogViewer.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.AspNetCore.Components.LogViewer\Meziantou.AspNetCore.Components.LogViewer.csproj" />
+    <ProjectReference Include="../../src/Meziantou.AspNetCore.Components.LogViewer/Meziantou.AspNetCore.Components.LogViewer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.AspNetCore.Components.Tests/Meziantou.AspNetCore.Components.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Components.Tests/Meziantou.AspNetCore.Components.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.AspNetCore.Components\Meziantou.AspNetCore.Components.csproj" />
+    <ProjectReference Include="../../src/Meziantou.AspNetCore.Components/Meziantou.AspNetCore.Components.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.GeneratorTests/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.GeneratorTests.csproj
+++ b/tests/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.GeneratorTests/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.GeneratorTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFramework);net9.0</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
+    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)/GeneratedFiles</CompilerGeneratedFilesOutputPath>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -12,11 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.AspNetCore.ServiceDefaults.AutoRegister\Meziantou.AspNetCore.ServiceDefaults.AutoRegister.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />
-    <ProjectReference Include="..\..\src\Meziantou.AspNetCore.ServiceDefaults\Meziantou.AspNetCore.ServiceDefaults.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.AspNetCore.ServiceDefaults.AutoRegister/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />
+    <ProjectReference Include="../../src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
-  <Import Project="..\..\src\Meziantou.AspNetCore.ServiceDefaults.AutoRegister\Meziantou.AspNetCore.ServiceDefaults.AutoRegister.targets" />
+  <Import Project="../../src/Meziantou.AspNetCore.ServiceDefaults.AutoRegister/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.targets" />
 
 </Project>

--- a/tests/Meziantou.AspNetCore.ServiceDefaults.Tests/Meziantou.AspNetCore.ServiceDefaults.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.ServiceDefaults.Tests/Meziantou.AspNetCore.ServiceDefaults.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.AspNetCore.ServiceDefaults\Meziantou.AspNetCore.ServiceDefaults.csproj" />
+    <ProjectReference Include="../../src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/Meziantou.Extensions.Logging.FileLogger.Tests.csproj
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/Meziantou.Extensions.Logging.FileLogger.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Extensions.Logging.FileLogger\Meziantou.Extensions.Logging.FileLogger.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TemporaryDirectory\Meziantou.Framework.TemporaryDirectory.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Extensions.Logging.FileLogger/Meziantou.Extensions.Logging.FileLogger.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/Meziantou.Extensions.Logging.InMemory.Tests.csproj
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/Meziantou.Extensions.Logging.InMemory.Tests.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Extensions.Logging.InMemory\Meziantou.Extensions.Logging.InMemory.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Extensions.Logging.Xunit.v3\Meziantou.Extensions.Logging.Xunit.v3.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Extensions.Logging.InMemory/Meziantou.Extensions.Logging.InMemory.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Meziantou.Extensions.Logging.Xunit.Tests/Meziantou.Extensions.Logging.Xunit.Tests.csproj
+++ b/tests/Meziantou.Extensions.Logging.Xunit.Tests/Meziantou.Extensions.Logging.Xunit.Tests.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Extensions.Logging.Xunit\Meziantou.Extensions.Logging.Xunit.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Extensions.Logging.Xunit/Meziantou.Extensions.Logging.Xunit.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/Meziantou.Extensions.Logging.Xunit.v3.Tests.csproj
+++ b/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/Meziantou.Extensions.Logging.Xunit.v3.Tests.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Extensions.Logging.Xunit.v3\Meziantou.Extensions.Logging.Xunit.v3.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Meziantou.Framework.Avatar.Tests/Meziantou.Framework.Avatar.Tests.csproj
+++ b/tests/Meziantou.Framework.Avatar.Tests/Meziantou.Framework.Avatar.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Avatar\Meziantou.Framework.Avatar.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.SnapshotTesting\Meziantou.Framework.SnapshotTesting.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Avatar/Meziantou.Framework.Avatar.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Bcrypt.Tests/Meziantou.Framework.Bcrypt.Tests.csproj
+++ b/tests/Meziantou.Framework.Bcrypt.Tests/Meziantou.Framework.Bcrypt.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Bcrypt\Meziantou.Framework.Bcrypt.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Bcrypt/Meziantou.Framework.Bcrypt.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.ByteSize.Tests/Meziantou.Framework.ByteSize.Tests.csproj
+++ b/tests/Meziantou.Framework.ByteSize.Tests/Meziantou.Framework.ByteSize.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.ByteSize\Meziantou.Framework.ByteSize.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.ByteSize/Meziantou.Framework.ByteSize.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.ChromiumTracing.Tests/Meziantou.Framework.ChromiumTracing.Tests.csproj
+++ b/tests/Meziantou.Framework.ChromiumTracing.Tests/Meziantou.Framework.ChromiumTracing.Tests.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.ChromiumTracing\Meziantou.Framework.ChromiumTracing.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.ChromiumTracing/Meziantou.Framework.ChromiumTracing.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Meziantou.Framework.CodeDom.Tests/Meziantou.Framework.CodeDom.Tests.csproj
+++ b/tests/Meziantou.Framework.CodeDom.Tests/Meziantou.Framework.CodeDom.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.CodeDom\Meziantou.Framework.CodeDom.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework\Meziantou.Framework.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.CodeDom/Meziantou.Framework.CodeDom.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework/Meziantou.Framework.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Meziantou.Framework.CodeOwners.Tests/Meziantou.Framework.CodeOwners.Tests.csproj
+++ b/tests/Meziantou.Framework.CodeOwners.Tests/Meziantou.Framework.CodeOwners.Tests.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.CodeOwners\Meziantou.Framework.CodeOwners.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.CodeOwners/Meziantou.Framework.CodeOwners.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj
+++ b/tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.CommandLine\Meziantou.Framework.CommandLine.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework\Meziantou.Framework.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.CommandLine/Meziantou.Framework.CommandLine.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework/Meziantou.Framework.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Csv.Tests/Meziantou.Framework.Csv.Tests.csproj
+++ b/tests/Meziantou.Framework.Csv.Tests/Meziantou.Framework.Csv.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Csv\Meziantou.Framework.Csv.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TypeConverter\Meziantou.Framework.TypeConverter.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Csv/Meziantou.Framework.Csv.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TypeConverter/Meziantou.Framework.TypeConverter.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/Meziantou.Framework.DependencyScanning.Tests.csproj
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/Meziantou.Framework.DependencyScanning.Tests.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.DependencyScanning\Meziantou.Framework.DependencyScanning.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.ProcessWrapper\Meziantou.Framework.ProcessWrapper.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TemporaryDirectory\Meziantou.Framework.TemporaryDirectory.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.ValueStopwatch\Meziantou.Framework.ValueStopwatch.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework\Meziantou.Framework.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.DependencyScanning/Meziantou.Framework.DependencyScanning.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.ValueStopwatch/Meziantou.Framework.ValueStopwatch.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework/Meziantou.Framework.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/Meziantou.Framework.DependencyScanning.Tool.Tests.csproj
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/Meziantou.Framework.DependencyScanning.Tool.Tests.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\common\ConsoleHelper.cs" Link="ConsoleHelper.cs" />
+    <Compile Include="../../common/ConsoleHelper.cs" Link="ConsoleHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.DependencyScanning.Tool\Meziantou.Framework.DependencyScanning.Tool.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TemporaryDirectory\Meziantou.Framework.TemporaryDirectory.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.DependencyScanning.Tool/Meziantou.Framework.DependencyScanning.Tool.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests.csproj
+++ b/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Diagnostics.ContextSnapshot\Meziantou.Framework.Diagnostics.ContextSnapshot.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Diagnostics.ContextSnapshot/Meziantou.Framework.Diagnostics.ContextSnapshot.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.DnsClient.Tests/Meziantou.Framework.DnsClient.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsClient.Tests/Meziantou.Framework.DnsClient.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.DnsClient\Meziantou.Framework.DnsClient.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.DnsClient/Meziantou.Framework.DnsClient.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.DnsFilter.Tests/Meziantou.Framework.DnsFilter.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsFilter.Tests/Meziantou.Framework.DnsFilter.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.DnsFilter\Meziantou.Framework.DnsFilter.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.DnsFilter/Meziantou.Framework.DnsFilter.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.DnsProxy\Meziantou.DnsProxy.csproj" />
+    <ProjectReference Include="../../src/Meziantou.DnsProxy/Meziantou.DnsProxy.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/tests/Meziantou.Framework.DnsServer.Tests/Meziantou.Framework.DnsServer.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsServer.Tests/Meziantou.Framework.DnsServer.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.DnsClient\Meziantou.Framework.DnsClient.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.DnsServer\Meziantou.Framework.DnsServer.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.DnsClient/Meziantou.Framework.DnsClient.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.DnsServer/Meziantou.Framework.DnsServer.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/Meziantou.Framework.FastEnumToStringGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/Meziantou.Framework.FastEnumToStringGenerator.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.FastEnumToStringGenerator\Meziantou.Framework.FastEnumToStringGenerator.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.FastEnumToStringGenerator/Meziantou.Framework.FastEnumToStringGenerator.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
   </ItemGroup>
 

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests.csproj
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.FixedStringBuilder.Generator\Meziantou.Framework.FixedStringBuilder.Generator.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.FixedStringBuilder.Generator/Meziantou.Framework.FixedStringBuilder.Generator.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
   </ItemGroup>
 

--- a/tests/Meziantou.Framework.FixedStringBuilder.Tests/Meziantou.Framework.FixedStringBuilder.Tests.csproj
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Tests/Meziantou.Framework.FixedStringBuilder.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.FixedStringBuilder\Meziantou.Framework.FixedStringBuilder.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.FixedStringBuilder/Meziantou.Framework.FixedStringBuilder.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.FullPath.Tests/Meziantou.Framework.FullPath.Tests.csproj
+++ b/tests/Meziantou.Framework.FullPath.Tests/Meziantou.Framework.FullPath.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TemporaryDirectory\Meziantou.Framework.TemporaryDirectory.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Globbing.Tests/Meziantou.Framework.Globbing.Tests.csproj
+++ b/tests/Meziantou.Framework.Globbing.Tests/Meziantou.Framework.Globbing.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Globbing\Meziantou.Framework.Globbing.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TemporaryDirectory\Meziantou.Framework.TemporaryDirectory.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Html.Tests/Meziantou.Framework.Html.Tests.csproj
+++ b/tests/Meziantou.Framework.Html.Tests/Meziantou.Framework.Html.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Html\Meziantou.Framework.Html.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Html/Meziantou.Framework.Html.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Html.Tool.Tests/Meziantou.Framework.Html.Tool.Tests.csproj
+++ b/tests/Meziantou.Framework.Html.Tool.Tests/Meziantou.Framework.Html.Tool.Tests.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\common\ConsoleHelper.cs" Link="ConsoleHelper.cs" />
+    <Compile Include="../../common/ConsoleHelper.cs" Link="ConsoleHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Html.Tool\Meziantou.Framework.Html.Tool.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TemporaryDirectory\Meziantou.Framework.TemporaryDirectory.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Html.Tool/Meziantou.Framework.Html.Tool.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.HtmlSanitizer.Tests/Meziantou.Framework.HtmlSanitizer.Tests.csproj
+++ b/tests/Meziantou.Framework.HtmlSanitizer.Tests/Meziantou.Framework.HtmlSanitizer.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.HtmlSanitizer\Meziantou.Framework.HtmlSanitizer.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.HtmlSanitizer/Meziantou.Framework.HtmlSanitizer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/Meziantou.Framework.HtmlToMarkdown.Tests.csproj
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/Meziantou.Framework.HtmlToMarkdown.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.HtmlToMarkdown\Meziantou.Framework.HtmlToMarkdown.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.HtmlToMarkdown/Meziantou.Framework.HtmlToMarkdown.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="TestData\**\*" />
+    <EmbeddedResource Include="TestData/**/*" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj
@@ -26,12 +26,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Http.Caching\Meziantou.Framework.Http.Caching.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Http.Caching.InMemory\Meziantou.Framework.Http.Caching.InMemory.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Http.Caching.Redis\Meziantou.Framework.Http.Caching.Redis.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Http.Caching.Sqlite\Meziantou.Framework.Http.Caching.Sqlite.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.InlineSnapshotTesting\Meziantou.Framework.InlineSnapshotTesting.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Http.Caching/Meziantou.Framework.Http.Caching.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Http.Caching.InMemory/Meziantou.Framework.Http.Caching.InMemory.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Http.Caching.Redis/Meziantou.Framework.Http.Caching.Redis.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Http.Caching.Sqlite/Meziantou.Framework.Http.Caching.Sqlite.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/Meziantou.Framework.Http.Hsts.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/Meziantou.Framework.Http.Hsts.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Http.Hsts\Meziantou.Framework.Http.Hsts.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Http.Hsts/Meziantou.Framework.Http.Hsts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/Meziantou.Framework.Http.Htpasswd.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/Meziantou.Framework.Http.Htpasswd.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Http.Htpasswd\Meziantou.Framework.Http.Htpasswd.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Http.Htpasswd/Meziantou.Framework.Http.Htpasswd.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Http.Recording.Tests/Meziantou.Framework.Http.Recording.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/Meziantou.Framework.Http.Recording.Tests.csproj
@@ -9,8 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Http.Recording\Meziantou.Framework.Http.Recording.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TemporaryDirectory\Meziantou.Framework.TemporaryDirectory.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Http.Recording/Meziantou.Framework.Http.Recording.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Http.Tests/Meziantou.Framework.Http.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Tests/Meziantou.Framework.Http.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Http\Meziantou.Framework.Http.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Http/Meziantou.Framework.Http.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.HttpArchive.Tests/Meziantou.Framework.HttpArchive.Tests.csproj
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/Meziantou.Framework.HttpArchive.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.HttpArchive\Meziantou.Framework.HttpArchive.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.HttpArchive/Meziantou.Framework.HttpArchive.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.HttpClientMock.Tests/Meziantou.Framework.HttpClientMock.Tests.csproj
+++ b/tests/Meziantou.Framework.HttpClientMock.Tests/Meziantou.Framework.HttpClientMock.Tests.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Extensions.Logging.InMemory\Meziantou.Extensions.Logging.InMemory.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Extensions.Logging.Xunit.v3\Meziantou.Extensions.Logging.Xunit.v3.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.HttpClientMock\Meziantou.Framework.HttpClientMock.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Extensions.Logging.InMemory/Meziantou.Extensions.Logging.InMemory.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.HttpClientMock/Meziantou.Framework.HttpClientMock.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/Meziantou.Framework.HumanReadableSerializer.Tests.csproj
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/Meziantou.Framework.HumanReadableSerializer.Tests.csproj
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.HumanReadableSerializer\Meziantou.Framework.HumanReadableSerializer.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.HumanReadableSerializer.FSharp.Tests\Meziantou.Framework.HumanReadableSerializer.FSharp.Tests.fsproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.HumanReadableSerializer.FSharp.Tests/Meziantou.Framework.HumanReadableSerializer.FSharp.Tests.fsproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/Meziantou.Framework.InlineSnapshotTesting.Tests.csproj
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/Meziantou.Framework.InlineSnapshotTesting.Tests.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.InlineSnapshotTesting.Serializers.Argon\Meziantou.Framework.InlineSnapshotTesting.Serializers.Argon.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.InlineSnapshotTesting\Meziantou.Framework.InlineSnapshotTesting.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TemporaryDirectory\Meziantou.Framework.TemporaryDirectory.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.InlineSnapshotTesting.Serializers.Argon/Meziantou.Framework.InlineSnapshotTesting.Serializers.Argon.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48'">
@@ -17,6 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="..\..\src\Meziantou.Framework.InlineSnapshotTesting\Meziantou.Framework.InlineSnapshotTesting.csproj" Visible="False" />
+    <EmbeddedResource Include="../../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" Visible="False" />
   </ItemGroup>
 </Project>

--- a/tests/Meziantou.Framework.JsonPath.Tests/Meziantou.Framework.JsonPath.Tests.csproj
+++ b/tests/Meziantou.Framework.JsonPath.Tests/Meziantou.Framework.JsonPath.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.JsonPath\Meziantou.Framework.JsonPath.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.MediaTags.Tests/Meziantou.Framework.MediaTags.Tests.csproj
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Meziantou.Framework.MediaTags.Tests.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.MediaTags\Meziantou.Framework.MediaTags.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="TestFiles\**" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestFiles/**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.NtpClient.Tests/Meziantou.Framework.NtpClient.Tests.csproj
+++ b/tests/Meziantou.Framework.NtpClient.Tests/Meziantou.Framework.NtpClient.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.NtpClient\Meziantou.Framework.NtpClient.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.NtpClient/Meziantou.Framework.NtpClient.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.NtpServer.Tests/Meziantou.Framework.NtpServer.Tests.csproj
+++ b/tests/Meziantou.Framework.NtpServer.Tests/Meziantou.Framework.NtpServer.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.NtpClient\Meziantou.Framework.NtpClient.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.NtpServer\Meziantou.Framework.NtpServer.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.NtpClient/Meziantou.Framework.NtpClient.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.NtpServer/Meziantou.Framework.NtpServer.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tests/Meziantou.Framework.NuGetPackageValidation.Tests.csproj
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tests/Meziantou.Framework.NuGetPackageValidation.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.NuGetPackageValidation\Meziantou.Framework.NuGetPackageValidation.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TemporaryDirectory\Meziantou.Framework.TemporaryDirectory.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework\Meziantou.Framework.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.NuGetPackageValidation/Meziantou.Framework.NuGetPackageValidation.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests.csproj
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.NuGetPackageValidation.Tool\Meziantou.Framework.NuGetPackageValidation.Tool.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.NuGetPackageValidation.Tool/Meziantou.Framework.NuGetPackageValidation.Tool.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\common\ConsoleHelper.cs" Link="ConsoleHelper.cs" />
+    <Compile Include="../../common/ConsoleHelper.cs" Link="ConsoleHelper.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/Meziantou.Framework.ObjectMethodExecutor.Tests.csproj
+++ b/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/Meziantou.Framework.ObjectMethodExecutor.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.ObjectMethodExecutor\Meziantou.Framework.ObjectMethodExecutor.csproj" />
-    <ProjectReference Include="..\Meziantou.Framework.ObjectMethodExecutor.FSharpTests\Meziantou.Framework.ObjectMethodExecutor.FSharpTests.fsproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.ObjectMethodExecutor/Meziantou.Framework.ObjectMethodExecutor.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.ObjectMethodExecutor.FSharpTests/Meziantou.Framework.ObjectMethodExecutor.FSharpTests.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.OpenTelemetry.Tests/Meziantou.Framework.OpenTelemetry.Tests.csproj
+++ b/tests/Meziantou.Framework.OpenTelemetry.Tests/Meziantou.Framework.OpenTelemetry.Tests.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.OpenTelemetryCollector\Meziantou.Framework.OpenTelemetryCollector.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.OpenTelemetryCollector.InMemory\Meziantou.Framework.OpenTelemetryCollector.InMemory.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.OpenTelemetryCollector/Meziantou.Framework.OpenTelemetryCollector.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.OpenTelemetryCollector.InMemory/Meziantou.Framework.OpenTelemetryCollector.InMemory.csproj" />
     <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
   </ItemGroup>
 

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/Meziantou.Framework.ProcessWrapper.Tests.csproj
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/Meziantou.Framework.ProcessWrapper.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.ProcessWrapper\Meziantou.Framework.ProcessWrapper.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TemporaryDirectory\Meziantou.Framework.TemporaryDirectory.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.QRCode.Tests/Meziantou.Framework.QRCode.Tests.csproj
+++ b/tests/Meziantou.Framework.QRCode.Tests/Meziantou.Framework.QRCode.Tests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.QRCode\Meziantou.Framework.QRCode.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.InlineSnapshotTesting\Meziantou.Framework.InlineSnapshotTesting.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.SnapshotTesting\Meziantou.Framework.SnapshotTesting.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.SnapshotTesting.ImageSharp\Meziantou.Framework.SnapshotTesting.ImageSharp.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.QRCode/Meziantou.Framework.QRCode.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.RelativeDate.Tests/Meziantou.Framework.RelativeDate.Tests.csproj
+++ b/tests/Meziantou.Framework.RelativeDate.Tests/Meziantou.Framework.RelativeDate.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.RelativeDate\Meziantou.Framework.RelativeDate.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.RelativeDate/Meziantou.Framework.RelativeDate.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests.csproj
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests.csproj
@@ -3,13 +3,13 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
+    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)/GeneratedFiles</CompilerGeneratedFilesOutputPath>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.ResxSourceGenerator\Meziantou.Framework.ResxSourceGenerator.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.ResxSourceGenerator/Meziantou.Framework.ResxSourceGenerator.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
     <AdditionalFiles Include="**/*.resx" />
   </ItemGroup>
 

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/Meziantou.Framework.ResxSourceGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/Meziantou.Framework.ResxSourceGenerator.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.ResxSourceGenerator\Meziantou.Framework.ResxSourceGenerator.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.ResxSourceGenerator/Meziantou.Framework.ResxSourceGenerator.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
   </ItemGroup>
 

--- a/tests/Meziantou.Framework.Scheduling.Tests/Meziantou.Framework.Scheduling.Tests.csproj
+++ b/tests/Meziantou.Framework.Scheduling.Tests/Meziantou.Framework.Scheduling.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Scheduling\Meziantou.Framework.Scheduling.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Scheduling/Meziantou.Framework.Scheduling.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.SensitiveData.Tests/Meziantou.Framework.SensitiveData.Tests.csproj
+++ b/tests/Meziantou.Framework.SensitiveData.Tests/Meziantou.Framework.SensitiveData.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.SensitiveData\Meziantou.Framework.SensitiveData.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.SensitiveData/Meziantou.Framework.SensitiveData.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/Meziantou.Framework.SimpleQueryLanguage.Tests.csproj
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/Meziantou.Framework.SimpleQueryLanguage.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.SimpleQueryLanguage\Meziantou.Framework.SimpleQueryLanguage.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.SimpleQueryLanguage/Meziantou.Framework.SimpleQueryLanguage.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.SingleInstance.Tests/Meziantou.Framework.SingleInstance.Tests.csproj
+++ b/tests/Meziantou.Framework.SingleInstance.Tests/Meziantou.Framework.SingleInstance.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.SingleInstance\Meziantou.Framework.SingleInstance.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.SingleInstance/Meziantou.Framework.SingleInstance.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Slug.Tests/Meziantou.Framework.Slug.Tests.csproj
+++ b/tests/Meziantou.Framework.Slug.Tests/Meziantou.Framework.Slug.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Slug\Meziantou.Framework.Slug.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Slug/Meziantou.Framework.Slug.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj
@@ -7,8 +7,8 @@
   <Import Project="../../src/Meziantou.Framework.SnapshotTesting/build/Meziantou.Framework.SnapshotTesting.props" />
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.ProcessWrapper\Meziantou.Framework.ProcessWrapper.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.SnapshotTesting\Meziantou.Framework.SnapshotTesting.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TemporaryDirectory\Meziantou.Framework.TemporaryDirectory.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/Meziantou.Framework.StronglyTypedId.GeneratorTests.csproj
+++ b/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/Meziantou.Framework.StronglyTypedId.GeneratorTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles\$(TargetFramework)</CompilerGeneratedFilesOutputPath>
+    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)/GeneratedFiles/$(TargetFramework)</CompilerGeneratedFilesOutputPath>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.StronglyTypedId.Annotations\Meziantou.Framework.StronglyTypedId.Annotations.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.StronglyTypedId.Interfaces\Meziantou.Framework.StronglyTypedId.Interfaces.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.StronglyTypedId\Meziantou.Framework.StronglyTypedId.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <ProjectReference Include="../../src/Meziantou.Framework.StronglyTypedId.Annotations/Meziantou.Framework.StronglyTypedId.Annotations.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.StronglyTypedId.Interfaces/Meziantou.Framework.StronglyTypedId.Interfaces.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/Meziantou.Framework.StronglyTypedId.Tests.csproj
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/Meziantou.Framework.StronglyTypedId.Tests.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.StronglyTypedId.Annotations\Meziantou.Framework.StronglyTypedId.Annotations.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.StronglyTypedId\Meziantou.Framework.StronglyTypedId.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework\Meziantou.Framework.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.StronglyTypedId.Annotations/Meziantou.Framework.StronglyTypedId.Annotations.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework/Meziantou.Framework.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Templating.Html.Tests/Meziantou.Framework.Templating.Html.Tests.csproj
+++ b/tests/Meziantou.Framework.Templating.Html.Tests/Meziantou.Framework.Templating.Html.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Templating.Html\Meziantou.Framework.Templating.Html.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Templating.Html/Meziantou.Framework.Templating.Html.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Templating.Tests/Meziantou.Framework.Templating.Tests.csproj
+++ b/tests/Meziantou.Framework.Templating.Tests/Meziantou.Framework.Templating.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Templating\Meziantou.Framework.Templating.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Templating/Meziantou.Framework.Templating.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.TemporaryDirectory.Tests/Meziantou.Framework.TemporaryDirectory.Tests.csproj
+++ b/tests/Meziantou.Framework.TemporaryDirectory.Tests/Meziantou.Framework.TemporaryDirectory.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TemporaryDirectory\Meziantou.Framework.TemporaryDirectory.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Tests/Meziantou.Framework.Tests.csproj
+++ b/tests/Meziantou.Framework.Tests/Meziantou.Framework.Tests.csproj
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework\Meziantou.Framework.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.ProcessWrapper\Meziantou.Framework.ProcessWrapper.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework/Meziantou.Framework.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.TextDiff.Tests/Meziantou.Framework.TextDiff.Tests.csproj
+++ b/tests/Meziantou.Framework.TextDiff.Tests/Meziantou.Framework.TextDiff.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TextDiff\Meziantou.Framework.TextDiff.csproj">
+    <ProjectReference Include="../../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj">
       <Aliases>TextDiffLib</Aliases>
     </ProjectReference>
   </ItemGroup>

--- a/tests/Meziantou.Framework.Threading.Tests/Meziantou.Framework.Threading.Tests.csproj
+++ b/tests/Meziantou.Framework.Threading.Tests/Meziantou.Framework.Threading.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Threading\Meziantou.Framework.Threading.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Threading/Meziantou.Framework.Threading.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.TypeConverter.Tests/Meziantou.Framework.TypeConverter.Tests.csproj
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/Meziantou.Framework.TypeConverter.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.TypeConverter\Meziantou.Framework.TypeConverter.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TypeConverter/Meziantou.Framework.TypeConverter.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Unicode.Tests/Meziantou.Framework.Unicode.Tests.csproj
+++ b/tests/Meziantou.Framework.Unicode.Tests/Meziantou.Framework.Unicode.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Unicode\Meziantou.Framework.Unicode.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Unicode/Meziantou.Framework.Unicode.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Unix.ControlGroups.Tests/Meziantou.Framework.Unix.ControlGroups.Tests.csproj
+++ b/tests/Meziantou.Framework.Unix.ControlGroups.Tests/Meziantou.Framework.Unix.ControlGroups.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Unix.ControlGroups\Meziantou.Framework.Unix.ControlGroups.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Unix.ControlGroups/Meziantou.Framework.Unix.ControlGroups.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Uri.Tests/Meziantou.Framework.Uri.Tests.csproj
+++ b/tests/Meziantou.Framework.Uri.Tests/Meziantou.Framework.Uri.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Uri\Meziantou.Framework.Uri.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Uri/Meziantou.Framework.Uri.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.ValueStopwatch.Tests/Meziantou.Framework.ValueStopwatch.Tests.csproj
+++ b/tests/Meziantou.Framework.ValueStopwatch.Tests/Meziantou.Framework.ValueStopwatch.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.ValueStopwatch\Meziantou.Framework.ValueStopwatch.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.ValueStopwatch/Meziantou.Framework.ValueStopwatch.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.ValueStringBuilder.Tests/Meziantou.Framework.ValueStringBuilder.Tests.csproj
+++ b/tests/Meziantou.Framework.ValueStringBuilder.Tests/Meziantou.Framework.ValueStringBuilder.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.ValueStringBuilder\Meziantou.Framework.ValueStringBuilder.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.ValueStringBuilder/Meziantou.Framework.ValueStringBuilder.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Versioning.Tests/Meziantou.Framework.Versioning.Tests.csproj
+++ b/tests/Meziantou.Framework.Versioning.Tests/Meziantou.Framework.Versioning.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Versioning\Meziantou.Framework.Versioning.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.WPF.Tests/Meziantou.Framework.WPF.Tests.csproj
+++ b/tests/Meziantou.Framework.WPF.Tests/Meziantou.Framework.WPF.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.WPF\Meziantou.Framework.WPF.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.WPF/Meziantou.Framework.WPF.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Win32.AccessToken.Tests/Meziantou.Framework.Win32.AccessToken.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.AccessToken.Tests/Meziantou.Framework.Win32.AccessToken.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.AccessToken\Meziantou.Framework.Win32.AccessToken.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.AccessToken/Meziantou.Framework.Win32.AccessToken.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Win32.AmsiTests/Meziantou.Framework.Win32.AmsiTests.csproj
+++ b/tests/Meziantou.Framework.Win32.AmsiTests/Meziantou.Framework.Win32.AmsiTests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.Amsi\Meziantou.Framework.Win32.Amsi.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.Amsi/Meziantou.Framework.Win32.Amsi.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/Meziantou.Framework.Win32.ChangeJournal.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/Meziantou.Framework.Win32.ChangeJournal.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.ChangeJournal\Meziantou.Framework.Win32.ChangeJournal.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.ChangeJournal/Meziantou.Framework.Win32.ChangeJournal.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/Meziantou.Framework.Win32.CredentialManager.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/Meziantou.Framework.Win32.CredentialManager.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.CredentialManager\Meziantou.Framework.Win32.CredentialManager.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.CredentialManager/Meziantou.Framework.Win32.CredentialManager.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Win32.Jobs.Tests/Meziantou.Framework.Win32.Jobs.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.Jobs.Tests/Meziantou.Framework.Win32.Jobs.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.Jobs\Meziantou.Framework.Win32.Jobs.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.Jobs/Meziantou.Framework.Win32.Jobs.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Win32.Lsa.Tests/Meziantou.Framework.Win32.Lsa.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.Lsa.Tests/Meziantou.Framework.Win32.Lsa.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.Lsa\Meziantou.Framework.Win32.Lsa.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.Lsa/Meziantou.Framework.Win32.Lsa.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.MarkOfTheWeb\Meziantou.Framework.Win32.MarkOfTheWeb.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.MarkOfTheWeb/Meziantou.Framework.Win32.MarkOfTheWeb.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Win32.PerceivedType.Tests/Meziantou.Framework.Win32.PerceivedType.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.PerceivedType.Tests/Meziantou.Framework.Win32.PerceivedType.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.PerceivedType\Meziantou.Framework.Win32.PerceivedType.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.PerceivedType/Meziantou.Framework.Win32.PerceivedType.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.ProjectedFileSystem\Meziantou.Framework.Win32.ProjectedFileSystem.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework\Meziantou.Framework.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.ProjectedFileSystem/Meziantou.Framework.Win32.ProjectedFileSystem.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.Framework.Win32.RestartManager.Tests/Meziantou.Framework.Win32.RestartManager.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.RestartManager.Tests/Meziantou.Framework.Win32.RestartManager.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.RestartManager\Meziantou.Framework.Win32.RestartManager.csproj" />
-    <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.RestartManager/Meziantou.Framework.Win32.RestartManager.csproj" />
+    <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/TestUtilities/TestUtilities.csproj
+++ b/tests/TestUtilities/TestUtilities.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\common\SharedHttpClient.cs" Link="SharedHttpClient.cs" />
+    <Compile Include="../../common/SharedHttpClient.cs" Link="SharedHttpClient.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Trimmable.Wpf/Trimmable.Wpf.csproj
+++ b/tests/Trimmable.Wpf/Trimmable.Wpf.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.WPF\Meziantou.Framework.WPF.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.WPF/Meziantou.Framework.WPF.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Meziantou.Framework.HtmlToMarkdown.Emoji.Generator/Meziantou.Framework.HtmlToMarkdown.Emoji.Generator.csproj
+++ b/tools/Meziantou.Framework.HtmlToMarkdown.Emoji.Generator/Meziantou.Framework.HtmlToMarkdown.Emoji.Generator.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\common\SharedHttpClient.cs" Link="SharedHttpClient.cs" />
+    <Compile Include="../../common/SharedHttpClient.cs" Link="SharedHttpClient.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tools/Meziantou.Framework.Http.Hsts.Generator/Meziantou.Framework.Http.Hsts.Generator.csproj
+++ b/tools/Meziantou.Framework.Http.Hsts.Generator/Meziantou.Framework.Http.Hsts.Generator.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\common\SharedHttpClient.cs" Link="SharedHttpClient.cs" />
+    <Compile Include="../../common/SharedHttpClient.cs" Link="SharedHttpClient.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Versioning\Meziantou.Framework.Versioning.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tools/Meziantou.Framework.Unicode.Generator/Meziantou.Framework.Unicode.Generator.csproj
+++ b/tools/Meziantou.Framework.Unicode.Generator/Meziantou.Framework.Unicode.Generator.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\common\SharedHttpClient.cs" Link="SharedHttpClient.cs" />
-    <Compile Include="..\..\src\Meziantou.Framework.Unicode\UnicodeBlock.cs" Link="UnicodeBlock.cs" />
-    <Compile Include="..\..\src\Meziantou.Framework.Unicode\UnicodeRange.cs" Link="UnicodeRange.cs" />
-    <Compile Include="..\..\src\Meziantou.Framework.Unicode\UnicodeBidirectionalCategory.cs" Link="UnicodeBidirectionalCategory.cs" />
+    <Compile Include="../../common/SharedHttpClient.cs" Link="SharedHttpClient.cs" />
+    <Compile Include="../../src/Meziantou.Framework.Unicode/UnicodeBlock.cs" Link="UnicodeBlock.cs" />
+    <Compile Include="../../src/Meziantou.Framework.Unicode/UnicodeRange.cs" Link="UnicodeRange.cs" />
+    <Compile Include="../../src/Meziantou.Framework.Unicode/UnicodeBidirectionalCategory.cs" Link="UnicodeBidirectionalCategory.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
-    <ProjectReference Include="..\..\src\Meziantou.Framework.Versioning\Meziantou.Framework.Versioning.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Why
MSBuild files used mixed path separators, which made the project metadata inconsistent across the repository. Standardizing on forward slashes improves readability and avoids separator drift over time.

## What changed
- Normalized path separators from `\\` to `/` in MSBuild files (`*.props`, `*.targets`, `*.csproj`, `*.fsproj`, `*.vbproj`, `*.proj`).
- Updated 146 files across `src`, `tests`, `samples`, `tools`, and `benchmarks`.
- Kept the SnapshotTesting source-root normalization behavior by using `Path.DirectorySeparatorChar` when rewriting to `/`.

## Notes for reviewers
- This is intended to be a path-format normalization only; no functional behavior change is expected.
- Build succeeds for this branch.
- `eng/validate-testprojects-configuration.cs` reports existing target-framework mismatch errors in this environment.
- Full `dotnet test` reports existing Windows-specific failures (`Meziantou.Framework.Win32.AmsiTests` and `Meziantou.Framework.Win32.ProjectedFileSystem.Tests`) in this environment.