### PR TITLE
Add ASP.NET Core middleware pipeline diagnostics

### DIFF
--- a/Meziantou.Framework.slnx
+++ b/Meziantou.Framework.slnx
@@ -27,6 +27,7 @@
     <Project Path="src/Meziantou.AspNetCore.Mvc/Meziantou.AspNetCore.Mvc.csproj" />
     <Project Path="src/Meziantou.AspNetCore.ServiceDefaults.AutoRegister/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.csproj" Id="997b1066-b521-4738-977a-b60cc01f15ed" />
     <Project Path="src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj" Id="75c124f1-5f21-47f5-b05b-7e1334290074" />
+    <Project Path="src/Meziantou.AspNetCore/Meziantou.AspNetCore.csproj" />
     <Project Path="src/Meziantou.DnsProxy/Meziantou.DnsProxy.csproj" />
     <Project Path="src/Meziantou.Extensions.Logging.FileLogger/Meziantou.Extensions.Logging.FileLogger.csproj" />
     <Project Path="src/Meziantou.Extensions.Logging.InMemory/Meziantou.Extensions.Logging.InMemory.csproj" />
@@ -127,6 +128,7 @@
     <Project Path="tests/Meziantou.AspNetCore.Components.LogViewer.Tests/Meziantou.AspNetCore.Components.LogViewer.Tests.csproj" />
     <Project Path="tests/Meziantou.AspNetCore.Components.Tests/Meziantou.AspNetCore.Components.Tests.csproj" />
     <Project Path="tests/Meziantou.AspNetCore.ServiceDefaults.Tests/Meziantou.AspNetCore.ServiceDefaults.Tests.csproj" Id="a1514aa2-f75e-4dcc-bf6b-1860a8c44fcb" />
+    <Project Path="tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj" />
     <Project Path="tests/Meziantou.Extensions.Logging.FileLogger.Tests/Meziantou.Extensions.Logging.FileLogger.Tests.csproj" />
     <Project Path="tests/Meziantou.Extensions.Logging.InMemory.Tests/Meziantou.Extensions.Logging.InMemory.Tests.csproj" />
     <Project Path="tests/Meziantou.Extensions.Logging.Xunit.Tests/Meziantou.Extensions.Logging.Xunit.Tests.csproj" />

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 | Name | Version | Readme |
 | :--- | :---: | :---: |
+| Meziantou.AspNetCore | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore/) | |
 | Meziantou.AspNetCore.Authentication.HttpBasic | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.Authentication.HttpBasic.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore.Authentication.HttpBasic/) | [readme](src/Meziantou.AspNetCore.Authentication.HttpBasic/readme.md) |
 | Meziantou.AspNetCore.Components | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.Components.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore.Components/) | |
 | Meziantou.AspNetCore.Components.LogViewer | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.Components.LogViewer.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore.Components.LogViewer/) | [readme](src/Meziantou.AspNetCore.Components.LogViewer/readme.md) |

--- a/renovate.json5
+++ b/renovate.json5
@@ -32,6 +32,7 @@
         "src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj",
         "src/Meziantou.Framework.HttpClientMock/Meziantou.Framework.HttpClientMock.csproj",
         "tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests.csproj",
+        "tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj",
         "tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj",
         "tests/Meziantou.Framework.HttpClientMock.Tests/Meziantou.Framework.HttpClientMock.Tests.csproj",
         "tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj",

--- a/slnx/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.slnx
+++ b/slnx/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="../src/Meziantou.AspNetCore.ServiceDefaults.AutoRegister/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.csproj" />
     <Project Path="../src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj" />
+    <Project Path="../src/Meziantou.AspNetCore/Meziantou.AspNetCore.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/TestUtilities/TestUtilities.csproj" />

--- a/slnx/Meziantou.AspNetCore.ServiceDefaults.slnx
+++ b/slnx/Meziantou.AspNetCore.ServiceDefaults.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="../src/Meziantou.AspNetCore.ServiceDefaults.AutoRegister/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.csproj" />
     <Project Path="../src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj" />
+    <Project Path="../src/Meziantou.AspNetCore/Meziantou.AspNetCore.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.AspNetCore.ServiceDefaults.Tests/Meziantou.AspNetCore.ServiceDefaults.Tests.csproj" />

--- a/slnx/Meziantou.AspNetCore.slnx
+++ b/slnx/Meziantou.AspNetCore.slnx
@@ -1,0 +1,14 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="../src/Meziantou.AspNetCore/Meziantou.AspNetCore.csproj" />
+    <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
+    <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
+    <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.SnapshotTesting.Common/Meziantou.Framework.SnapshotTesting.Common.csproj" />
+    <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="../tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj" />
+  </Folder>
+</Solution>

--- a/slnx/Meziantou.Framework.InlineSnapshotTesting.slnx
+++ b/slnx/Meziantou.Framework.InlineSnapshotTesting.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/src/">
+    <Project Path="../src/Meziantou.AspNetCore/Meziantou.AspNetCore.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
     <Project Path="../src/Meziantou.Framework.Http.Caching.InMemory/Meziantou.Framework.Http.Caching.InMemory.csproj" />
     <Project Path="../src/Meziantou.Framework.Http.Caching.Redis/Meziantou.Framework.Http.Caching.Redis.csproj" />
@@ -17,6 +18,7 @@
     <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="../tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.InlineSnapshotTesting.Tests/Meziantou.Framework.InlineSnapshotTesting.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.QRCode.Tests/Meziantou.Framework.QRCode.Tests.csproj" />

--- a/src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj
+++ b/src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\Meziantou.AspNetCore\Meziantou.AspNetCore.csproj" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />

--- a/src/Meziantou.AspNetCore.ServiceDefaults/MeziantouServiceDefaults.cs
+++ b/src/Meziantou.AspNetCore.ServiceDefaults/MeziantouServiceDefaults.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Meziantou.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewareDescriptor.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewareDescriptor.cs
@@ -1,0 +1,12 @@
+namespace Meziantou.AspNetCore.Diagnostics;
+
+internal sealed class MiddlewareDescriptor
+{
+    public required string Name { get; init; }
+
+    public required string DelegateType { get; init; }
+
+    public required string DelegateMethod { get; init; }
+
+    public List<MiddlewarePipelineDescriptor> Branches { get; } = [];
+}

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureApplicationBuilder.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureApplicationBuilder.cs
@@ -1,0 +1,186 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace Meziantou.AspNetCore.Diagnostics;
+
+internal sealed class MiddlewarePipelineCaptureApplicationBuilder : IApplicationBuilder
+{
+    private const string NextMiddlewareNamePropertyName = "analysis.NextMiddlewareName";
+
+    private readonly IApplicationBuilder _innerBuilder;
+    private readonly MiddlewarePipelineDescriptor _pipeline;
+    private readonly Queue<MiddlewarePipelineDescriptor> _pendingBranches = new();
+
+    public MiddlewarePipelineCaptureApplicationBuilder(IApplicationBuilder innerBuilder, MiddlewarePipelineDescriptor pipeline)
+    {
+        _innerBuilder = innerBuilder;
+        _pipeline = pipeline;
+    }
+
+    public IServiceProvider ApplicationServices
+    {
+        get => _innerBuilder.ApplicationServices;
+        set => _innerBuilder.ApplicationServices = value;
+    }
+
+    public IDictionary<string, object?> Properties => _innerBuilder.Properties;
+
+    public IFeatureCollection ServerFeatures => _innerBuilder.ServerFeatures;
+
+    public RequestDelegate Build() => _innerBuilder.Build();
+
+    public IApplicationBuilder New()
+    {
+        var branch = new MiddlewarePipelineDescriptor();
+        _pendingBranches.Enqueue(branch);
+
+        return new MiddlewarePipelineCaptureApplicationBuilder(_innerBuilder.New(), branch);
+    }
+
+    public IApplicationBuilder Use(Func<RequestDelegate, RequestDelegate> middleware)
+    {
+        ArgumentNullException.ThrowIfNull(middleware);
+
+        var descriptor = new MiddlewareDescriptor
+        {
+            Name = GetMiddlewareName(Properties, middleware),
+            DelegateType = middleware.GetType().FullName ?? middleware.GetType().Name,
+            DelegateMethod = middleware.Method.Name,
+        };
+
+        while (_pendingBranches.TryDequeue(out var branch))
+        {
+            descriptor.Branches.Add(branch);
+        }
+
+        _pipeline.Middlewares.Add(descriptor);
+        _innerBuilder.Use(middleware);
+
+        return this;
+    }
+
+    private static string GetMiddlewareName(IDictionary<string, object?> properties, Func<RequestDelegate, RequestDelegate> middleware)
+    {
+        if (properties.TryGetValue(NextMiddlewareNamePropertyName, out var middlewareName))
+        {
+            properties.Remove(NextMiddlewareNamePropertyName);
+
+            var middlewareNameString = middlewareName?.ToString();
+            if (!string.IsNullOrWhiteSpace(middlewareNameString))
+            {
+                return middlewareNameString;
+            }
+        }
+
+        if (TryGetMiddlewareTypeName(middleware.Target, out var middlewareTypeName))
+        {
+            return middlewareTypeName;
+        }
+
+        var declaringType = middleware.Method.DeclaringType?.FullName;
+        if (declaringType is null)
+            return middleware.Method.Name;
+
+        return $"{declaringType}.{middleware.Method.Name}";
+    }
+
+    private static bool TryGetMiddlewareTypeName(object? middlewareTarget, [NotNullWhen(true)] out string? middlewareTypeName)
+    {
+        if (middlewareTarget is null)
+        {
+            middlewareTypeName = null;
+            return false;
+        }
+
+        if (TryGetMiddlewareType(middlewareTarget, new HashSet<object>(ReferenceEqualityComparer.Instance), maxDepth: 6, out var middlewareType))
+        {
+            middlewareTypeName = middlewareType.FullName ?? middlewareType.Name;
+            return true;
+        }
+
+        middlewareTypeName = null;
+        return false;
+    }
+
+    private static bool TryGetMiddlewareType(object value, HashSet<object> visited, int maxDepth, [NotNullWhen(true)] out Type? middlewareType)
+    {
+        if (maxDepth < 0)
+        {
+            middlewareType = null;
+            return false;
+        }
+
+        if (!visited.Add(value))
+        {
+            middlewareType = null;
+            return false;
+        }
+
+        if (value is Delegate { Target: not null } delegateValue && TryGetMiddlewareType(delegateValue.Target, visited, maxDepth - 1, out middlewareType))
+            return true;
+
+        var valueType = value.GetType();
+        if (value is IEnumerable enumerable and not string)
+        {
+            foreach (var item in enumerable)
+            {
+                if (item is not string && item is not null && !item.GetType().IsValueType && TryGetMiddlewareType(item, visited, maxDepth - 1, out middlewareType))
+                    return true;
+            }
+        }
+
+        if (!ShouldInspectObject(valueType))
+        {
+            middlewareType = null;
+            return false;
+        }
+
+        var middlewareField = valueType.GetField("_middleware", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+        if (middlewareField?.FieldType == typeof(Type) && middlewareField.GetValue(value) is Type explicitMiddlewareType && IsMiddlewareType(explicitMiddlewareType))
+        {
+            middlewareType = explicitMiddlewareType;
+            return true;
+        }
+
+        foreach (var field in valueType.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
+        {
+            if (field.GetValue(value) is not { } fieldValue)
+                continue;
+
+            if (fieldValue is Type fieldTypeValue && IsMiddlewareType(fieldTypeValue))
+            {
+                middlewareType = fieldTypeValue;
+                return true;
+            }
+
+            if (fieldValue is not string && !fieldValue.GetType().IsValueType && TryGetMiddlewareType(fieldValue, visited, maxDepth - 1, out middlewareType))
+                return true;
+        }
+
+        middlewareType = null;
+        return false;
+    }
+
+    private static bool IsMiddlewareType(Type type)
+    {
+        if (type == typeof(RequestDelegate))
+            return false;
+
+        return type.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) is not null ||
+               type.GetMethod("InvokeAsync", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) is not null;
+    }
+
+    private static bool ShouldInspectObject(Type type)
+    {
+        var @namespace = type.Namespace;
+        if (@namespace is null)
+            return false;
+
+        return @namespace.StartsWith("Microsoft.AspNetCore", StringComparison.Ordinal) ||
+               @namespace.StartsWith("Meziantou", StringComparison.Ordinal);
+    }
+}

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureApplicationBuilder.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureApplicationBuilder.cs
@@ -106,6 +106,7 @@ internal sealed class MiddlewarePipelineCaptureApplicationBuilder : IApplication
         return false;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Middleware diagnostics uses reflective best-effort discovery over ASP.NET internals.")]
     private static bool TryGetMiddlewareType(object value, HashSet<object> visited, int maxDepth, [NotNullWhen(true)] out Type? middlewareType)
     {
         if (maxDepth < 0)
@@ -165,6 +166,7 @@ internal sealed class MiddlewarePipelineCaptureApplicationBuilder : IApplication
         return false;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Middleware diagnostics inspects middleware invoke methods by reflection.")]
     private static bool IsMiddlewareType(Type type)
     {
         if (type == typeof(RequestDelegate))

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureStartupFilter.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureStartupFilter.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Meziantou.AspNetCore.Diagnostics;
+
+internal sealed class MiddlewarePipelineCaptureStartupFilter(MiddlewarePipelineCaptureState captureState) : IStartupFilter
+{
+    private readonly MiddlewarePipelineCaptureState _captureState = captureState;
+
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+    {
+        ArgumentNullException.ThrowIfNull(next);
+
+        return app =>
+        {
+            _captureState.Reset();
+            next(new MiddlewarePipelineCaptureApplicationBuilder(app, _captureState.Root));
+        };
+    }
+}

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureState.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineCaptureState.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Meziantou.AspNetCore.Diagnostics;
+
+internal sealed class MiddlewarePipelineCaptureState
+{
+    public MiddlewarePipelineDescriptor Root { get; } = new();
+
+    public void Reset()
+    {
+        Root.Middlewares.Clear();
+    }
+
+    public MiddlewarePipelineDebugSnapshot CreateSnapshot(IEnumerable<EndpointDataSource> endpointDataSources)
+    {
+        ArgumentNullException.ThrowIfNull(endpointDataSources);
+
+        var endpoints = endpointDataSources
+            .SelectMany(static dataSource => dataSource.Endpoints)
+            .Select(static endpoint => CreateEndpoint(endpoint))
+            .OrderBy(static endpoint => endpoint.RoutePattern, StringComparer.Ordinal)
+            .ThenBy(static endpoint => endpoint.DisplayName, StringComparer.Ordinal)
+            .ToArray();
+
+        return new MiddlewarePipelineDebugSnapshot
+        {
+            Pipeline = CreatePipeline(Root),
+            Endpoints = endpoints,
+        };
+    }
+
+    private static MiddlewarePipelineDebugPipeline CreatePipeline(MiddlewarePipelineDescriptor pipeline)
+    {
+        return new MiddlewarePipelineDebugPipeline
+        {
+            Middlewares = pipeline.Middlewares.Select(static middleware => CreateMiddleware(middleware)).ToArray(),
+        };
+    }
+
+    private static MiddlewarePipelineDebugMiddleware CreateMiddleware(MiddlewareDescriptor middleware)
+    {
+        return new MiddlewarePipelineDebugMiddleware
+        {
+            Name = middleware.Name,
+            DelegateType = middleware.DelegateType,
+            DelegateMethod = middleware.DelegateMethod,
+            Branches = middleware.Branches.Select(static branch => CreatePipeline(branch)).ToArray(),
+        };
+    }
+
+    private static MiddlewarePipelineDebugEndpoint CreateEndpoint(Endpoint endpoint)
+    {
+        var routeEndpoint = endpoint as RouteEndpoint;
+        var methods = endpoint.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods?.ToArray() ?? [];
+
+        return new MiddlewarePipelineDebugEndpoint
+        {
+            Endpoint = endpoint,
+            DisplayName = endpoint.DisplayName,
+            EndpointType = endpoint.GetType().FullName ?? endpoint.GetType().Name,
+            HttpMethods = methods,
+            Order = routeEndpoint?.Order,
+            RoutePattern = routeEndpoint?.RoutePattern.RawText,
+        };
+    }
+}

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugEndpoint.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugEndpoint.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Http;
+
+namespace Meziantou.AspNetCore.Diagnostics;
+
+/// <summary>Represents one endpoint in the endpoint data source collection.</summary>
+public sealed record MiddlewarePipelineDebugEndpoint
+{
+    /// <summary>Gets the underlying endpoint instance.</summary>
+    [JsonIgnore]
+    public Endpoint Endpoint { get; init; } = default!;
+
+    /// <summary>Gets the endpoint display name.</summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>Gets the endpoint implementation type.</summary>
+    public required string EndpointType { get; init; }
+
+    /// <summary>Gets the route pattern if this endpoint is a <see cref="Microsoft.AspNetCore.Routing.RouteEndpoint"/>.</summary>
+    public string? RoutePattern { get; init; }
+
+    /// <summary>Gets the route order if this endpoint is a <see cref="Microsoft.AspNetCore.Routing.RouteEndpoint"/>.</summary>
+    public int? Order { get; init; }
+
+    /// <summary>Gets the allowed HTTP methods for the endpoint.</summary>
+    public required IReadOnlyList<string> HttpMethods { get; init; }
+}

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugInfoProvider.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugInfoProvider.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Meziantou.AspNetCore.Diagnostics;
+
+/// <summary>Provides a snapshot of the middleware pipeline and endpoint list.</summary>
+public sealed class MiddlewarePipelineDebugInfoProvider(IServiceProvider serviceProvider)
+{
+    private readonly IServiceProvider _serviceProvider = serviceProvider;
+
+    /// <summary>Creates a middleware pipeline and endpoint snapshot.</summary>
+    public MiddlewarePipelineDebugSnapshot GetSnapshot()
+    {
+        var captureState = _serviceProvider.GetRequiredService<MiddlewarePipelineCaptureState>();
+        var endpointDataSources = _serviceProvider.GetServices<EndpointDataSource>();
+
+        return captureState.CreateSnapshot(endpointDataSources);
+    }
+}

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugMiddleware.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugMiddleware.cs
@@ -1,0 +1,17 @@
+namespace Meziantou.AspNetCore.Diagnostics;
+
+/// <summary>Represents one middleware registration and its child branches.</summary>
+public sealed record MiddlewarePipelineDebugMiddleware
+{
+    /// <summary>Gets the middleware name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Gets the delegate type used to register the middleware.</summary>
+    public required string DelegateType { get; init; }
+
+    /// <summary>Gets the delegate method used to register the middleware.</summary>
+    public required string DelegateMethod { get; init; }
+
+    /// <summary>Gets the branch pipelines associated with this middleware.</summary>
+    public required IReadOnlyList<MiddlewarePipelineDebugPipeline> Branches { get; init; }
+}

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugPipeline.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugPipeline.cs
@@ -1,0 +1,8 @@
+namespace Meziantou.AspNetCore.Diagnostics;
+
+/// <summary>Represents a middleware pipeline.</summary>
+public sealed record MiddlewarePipelineDebugPipeline
+{
+    /// <summary>Gets the middlewares registered in this pipeline.</summary>
+    public required IReadOnlyList<MiddlewarePipelineDebugMiddleware> Middlewares { get; init; }
+}

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugSnapshot.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebugSnapshot.cs
@@ -1,0 +1,92 @@
+using System.Globalization;
+using System.Text;
+
+namespace Meziantou.AspNetCore.Diagnostics;
+
+/// <summary>Represents a snapshot of the ASP.NET Core middleware pipeline and endpoint list.</summary>
+public sealed record MiddlewarePipelineDebugSnapshot
+{
+    /// <summary>Gets the middleware pipeline tree.</summary>
+    public required MiddlewarePipelineDebugPipeline Pipeline { get; init; }
+
+    /// <summary>Gets the list of endpoints registered in the application.</summary>
+    public required IReadOnlyList<MiddlewarePipelineDebugEndpoint> Endpoints { get; init; }
+
+    /// <summary>Renders the middleware pipeline tree and endpoint list as text.</summary>
+    /// <returns>A text representation of the snapshot.</returns>
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Pipeline:");
+        AppendPipeline(sb, Pipeline, indentationLevel: 1);
+        sb.AppendLine();
+        sb.AppendLine("Endpoints:");
+        AppendEndpoints(sb, Endpoints);
+        return sb.ToString();
+    }
+
+    private static void AppendPipeline(StringBuilder sb, MiddlewarePipelineDebugPipeline pipeline, int indentationLevel)
+    {
+        if (pipeline.Middlewares.Count == 0)
+        {
+            AppendIndentation(sb, indentationLevel);
+            sb.AppendLine("(none)");
+            return;
+        }
+
+        foreach (var middleware in pipeline.Middlewares)
+        {
+            AppendIndentation(sb, indentationLevel);
+            sb.Append("- ");
+            sb.Append(middleware.Name);
+            sb.Append(" [");
+            sb.Append(middleware.DelegateType);
+            sb.Append("::");
+            sb.Append(middleware.DelegateMethod);
+            sb.AppendLine("]");
+
+            for (var branchIndex = 0; branchIndex < middleware.Branches.Count; branchIndex++)
+            {
+                AppendIndentation(sb, indentationLevel + 1);
+                sb.Append("Branch ");
+                sb.Append(branchIndex + 1);
+                sb.AppendLine(":");
+                AppendPipeline(sb, middleware.Branches[branchIndex], indentationLevel + 2);
+            }
+        }
+    }
+
+    private static void AppendEndpoints(StringBuilder sb, IReadOnlyList<MiddlewarePipelineDebugEndpoint> endpoints)
+    {
+        if (endpoints.Count == 0)
+        {
+            sb.AppendLine("  (none)");
+            return;
+        }
+
+        foreach (var endpoint in endpoints)
+        {
+            var methods = endpoint.HttpMethods.Count == 0 ? "*" : string.Join(",", endpoint.HttpMethods);
+            var routePattern = endpoint.RoutePattern ?? "(no route pattern)";
+            var displayName = endpoint.DisplayName ?? "(no display name)";
+            var order = endpoint.Order?.ToString(CultureInfo.InvariantCulture) ?? "-";
+
+            sb.Append("  - [");
+            sb.Append(methods);
+            sb.Append("] ");
+            sb.Append(routePattern);
+            sb.Append(" (Order: ");
+            sb.Append(order);
+            sb.Append(") ");
+            sb.Append(displayName);
+            sb.Append(" [");
+            sb.Append(endpoint.EndpointType);
+            sb.AppendLine("]");
+        }
+    }
+
+    private static void AppendIndentation(StringBuilder sb, int indentationLevel)
+    {
+        _ = sb.Append(' ', indentationLevel * 2);
+    }
+}

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebuggingServiceCollectionExtensions.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebuggingServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Meziantou.AspNetCore.Diagnostics;
+
+/// <summary>Extension methods to register middleware pipeline debugging services.</summary>
+public static class MiddlewarePipelineDebuggingServiceCollectionExtensions
+{
+    /// <summary>Adds services required to capture and expose the middleware pipeline tree.</summary>
+    public static IServiceCollection AddMiddlewarePipelineDebugging(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<MiddlewarePipelineCaptureState>();
+        services.TryAddSingleton<MiddlewarePipelineDebugInfoProvider>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IStartupFilter, MiddlewarePipelineCaptureStartupFilter>());
+
+        return services;
+    }
+}

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebuggingWebApplicationExtensions.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDebuggingWebApplicationExtensions.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Meziantou.AspNetCore.Diagnostics;
+
+/// <summary>Extension methods to map middleware pipeline debugging endpoints.</summary>
+public static class MiddlewarePipelineDebuggingWebApplicationExtensions
+{
+    /// <summary>Gets a middleware pipeline snapshot from code without using the debug route.</summary>
+    /// <param name="app">The web application.</param>
+    /// <returns>The middleware pipeline snapshot.</returns>
+    public static MiddlewarePipelineDebugSnapshot GetMiddlewarePipelineDebugSnapshot(this WebApplication app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        return GetDebugInfoProvider(app.Services).GetSnapshot();
+    }
+
+    /// <summary>
+    /// Maps a JSON endpoint that returns the middleware tree and endpoint list.
+    /// By default, the endpoint is only mapped in Development.
+    /// </summary>
+    /// <param name="app">The web application.</param>
+    /// <param name="pattern">The route pattern used for the debug endpoint.</param>
+    /// <param name="developmentOnly">Indicates whether the endpoint should only be mapped in Development.</param>
+    /// <returns>The mapped route builder, or <see langword="null"/> if not mapped because of environment filtering.</returns>
+    [RequiresUnreferencedCode("This method maps a delegate endpoint, which may use reflection and is not trim-safe.")]
+    public static RouteHandlerBuilder? MapMiddlewarePipelineDebugEndpoint(this WebApplication app, string pattern = "/_debug/pipeline", bool developmentOnly = true)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentException.ThrowIfNullOrEmpty(pattern);
+
+        if (developmentOnly && !app.Environment.IsDevelopment())
+            return null;
+
+        _ = GetDebugInfoProvider(app.Services);
+
+        return app.MapGet(pattern, static (MiddlewarePipelineDebugInfoProvider debugInfoProvider) =>
+        {
+            return TypedResults.Ok(debugInfoProvider.GetSnapshot());
+        });
+    }
+
+    private static MiddlewarePipelineDebugInfoProvider GetDebugInfoProvider(IServiceProvider serviceProvider)
+    {
+        if (serviceProvider.GetService<MiddlewarePipelineDebugInfoProvider>() is MiddlewarePipelineDebugInfoProvider debugInfoProvider)
+            return debugInfoProvider;
+
+        throw new InvalidOperationException($"Middleware pipeline debugging services are not registered. Call {nameof(MiddlewarePipelineDebuggingServiceCollectionExtensions)}.{nameof(MiddlewarePipelineDebuggingServiceCollectionExtensions.AddMiddlewarePipelineDebugging)}(...) before building the application.");
+    }
+}

--- a/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDescriptor.cs
+++ b/src/Meziantou.AspNetCore/Diagnostics/MiddlewarePipelineDescriptor.cs
@@ -1,0 +1,6 @@
+namespace Meziantou.AspNetCore.Diagnostics;
+
+internal sealed class MiddlewarePipelineDescriptor
+{
+    public List<MiddlewareDescriptor> Middlewares { get; } = [];
+}

--- a/src/Meziantou.AspNetCore/Meziantou.AspNetCore.csproj
+++ b/src/Meziantou.AspNetCore/Meziantou.AspNetCore.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Meziantou.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <Version>1.0.0</Version>
+    <IsTrimmable>true</IsTrimmable>
+    <Description>Helpers for ASP.NET Core middleware diagnostics</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/src/Meziantou.AspNetCore/NoCacheMiddleware.cs
+++ b/src/Meziantou.AspNetCore/NoCacheMiddleware.cs
@@ -1,9 +1,8 @@
 using Microsoft.AspNetCore.Http;
 
-namespace Meziantou.AspNetCore.ServiceDefaults;
+namespace Meziantou.AspNetCore;
 
-[SuppressMessage("Usage", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated dynamically")]
-internal sealed class NoCacheMiddleware(RequestDelegate next)
+public sealed class NoCacheMiddleware(RequestDelegate next)
 {
     public async Task InvokeAsync(HttpContext context)
     {

--- a/tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk.Test">
 
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFramework);net9.0</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFramework);net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +16,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.15" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.26" />
   </ItemGroup>
 
 </Project>

--- a/tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk.Test">
 
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFramework);net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Meziantou.NET.Sdk.Test">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(LatestTargetFramework);net9.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\..\src\Meziantou.Framework.InlineSnapshotTesting\Meziantou.Framework.InlineSnapshotTesting.csproj" />
+    <ProjectReference Include="..\..\src\Meziantou.AspNetCore\Meziantou.AspNetCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.6" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.15" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Meziantou.AspNetCore.Tests/MiddlewarePipelineDebuggingTests.cs
+++ b/tests/Meziantou.AspNetCore.Tests/MiddlewarePipelineDebuggingTests.cs
@@ -1,0 +1,191 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.RegularExpressions;
+using Meziantou.AspNetCore.Diagnostics;
+using Meziantou.Framework.InlineSnapshotTesting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+
+namespace Meziantou.AspNetCore.Tests;
+
+public sealed class MiddlewarePipelineDebuggingTests
+{
+    [Fact]
+    public async Task MapMiddlewarePipelineDebugEndpoint_Development_ReturnsPipelineAndEndpoints()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Development });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddMiddlewarePipelineDebugging();
+
+        await using var app = builder.Build();
+        app.UseRouting();
+        app.Use(static (context, next) => next(context));
+        app.MapGet("/hello", static () => "hello");
+
+        var debugEndpointBuilder = app.MapMiddlewarePipelineDebugEndpoint(developmentOnly: true);
+        Assert.NotNull(debugEndpointBuilder);
+
+        await app.StartAsync(XunitCancellationToken);
+        using var client = app.GetTestClient();
+        var payload = await client.GetFromJsonAsync<MiddlewarePipelineDebugSnapshot>("/_debug/pipeline", cancellationToken: XunitCancellationToken);
+        var snapshot = Assert.IsType<MiddlewarePipelineDebugSnapshot>(payload);
+
+        Assert.NotEmpty(snapshot.Pipeline.Middlewares);
+        Assert.Contains(snapshot.Endpoints, endpoint => string.Equals(endpoint.RoutePattern, "/hello", StringComparison.Ordinal));
+        Assert.Contains(snapshot.Endpoints, endpoint => string.Equals(endpoint.RoutePattern, "/_debug/pipeline", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task MapMiddlewarePipelineDebugEndpoint_NonDevelopment_DoesNotMapByDefault()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddMiddlewarePipelineDebugging();
+
+        await using var app = builder.Build();
+        app.UseRouting();
+        app.Use(static (context, next) => next(context));
+        app.MapGet("/hello", static () => "hello");
+
+        var debugEndpointBuilder = app.MapMiddlewarePipelineDebugEndpoint(developmentOnly: true);
+        Assert.Null(debugEndpointBuilder);
+
+        await app.StartAsync(XunitCancellationToken);
+        using var client = app.GetTestClient();
+        using var response = await client.GetAsync("/_debug/pipeline", XunitCancellationToken);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMiddlewarePipelineDebugSnapshot_NonDevelopment_WithoutRoute_ReturnsSnapshot()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddMiddlewarePipelineDebugging();
+
+        await using var app = builder.Build();
+        app.UseRouting();
+        app.Use(static (context, next) => next(context));
+        app.MapGet("/hello", static () => "hello");
+
+        var debugEndpointBuilder = app.MapMiddlewarePipelineDebugEndpoint(developmentOnly: true);
+        Assert.Null(debugEndpointBuilder);
+
+        await app.StartAsync(XunitCancellationToken);
+        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
+        Assert.NotEmpty(snapshot.Pipeline.Middlewares);
+        Assert.Contains(snapshot.Endpoints, endpoint => string.Equals(endpoint.RoutePattern, "/hello", StringComparison.Ordinal));
+        Assert.DoesNotContain(snapshot.Endpoints, endpoint => string.Equals(endpoint.RoutePattern, "/_debug/pipeline", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetMiddlewarePipelineDebugSnapshot_EndpointEntriesExposeRawEndpoint()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddMiddlewarePipelineDebugging();
+
+        await using var app = builder.Build();
+        app.UseRouting();
+        app.Use(static (context, next) => next(context));
+        app.MapGet("/hello", static () => "hello");
+
+        await app.StartAsync(XunitCancellationToken);
+        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
+        var endpoint = Assert.Single(snapshot.Endpoints, endpoint => string.Equals(endpoint.RoutePattern, "/hello", StringComparison.Ordinal));
+
+        _ = Assert.IsType<RouteEndpoint>(endpoint.Endpoint);
+    }
+
+    [Fact]
+    public async Task GetMiddlewarePipelineDebugSnapshot_ToString_ContainsPipelineAndEndpoints()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddMiddlewarePipelineDebugging();
+
+        await using var app = builder.Build();
+        app.UseRouting();
+        app.Use(static (context, next) => next(context));
+        app.MapGet("/hello", static () => "hello");
+
+        await app.StartAsync(XunitCancellationToken);
+        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
+        var text = snapshot.ToString();
+
+        Assert.Contains("Pipeline:", text, StringComparison.Ordinal);
+        Assert.Contains("Endpoints:", text, StringComparison.Ordinal);
+        Assert.Contains("/hello", text, StringComparison.Ordinal);
+        Assert.Contains("::", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MiddlewarePipelineDebugSnapshot_ToString_ReturnsExpectedFullOutput()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddMiddlewarePipelineDebugging();
+
+        await using var app = builder.Build();
+        app.UseMiddleware<NoCacheMiddleware>();
+        app.MapGet("/hello", static () => "hello");
+
+        await app.StartAsync(XunitCancellationToken);
+        var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
+        var text = snapshot.ToString();
+        InlineSnapshot.WithSettings(static settings =>
+        {
+            settings.ScrubLinesWithReplace(static line =>
+            {
+                var scrubbed = Regex.Replace(line, @"Version=\d+\.\d+\.\d+\.\d+", "Version=*");
+                scrubbed = Regex.Replace(scrubbed, @"PublicKeyToken=[0-9a-f]{16}", "PublicKeyToken=*");
+                return scrubbed;
+            });
+        }).Validate(text, """
+            Pipeline:
+              - Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware [System.Func`2[[Microsoft.AspNetCore.Http.RequestDelegate, Microsoft.AspNetCore.Http.Abstractions, Version=*, Culture=neutral, PublicKeyToken=*],[Microsoft.AspNetCore.Http.RequestDelegate, Microsoft.AspNetCore.Http.Abstractions, Version=*, Culture=neutral, PublicKeyToken=*]]::CreateMiddleware]
+              - Meziantou.AspNetCore.NoCacheMiddleware [System.Func`2[[Microsoft.AspNetCore.Http.RequestDelegate, Microsoft.AspNetCore.Http.Abstractions, Version=*, Culture=neutral, PublicKeyToken=*],[Microsoft.AspNetCore.Http.RequestDelegate, Microsoft.AspNetCore.Http.Abstractions, Version=*, Culture=neutral, PublicKeyToken=*]]::CreateMiddleware]
+              - Microsoft.AspNetCore.Routing.EndpointMiddleware [System.Func`2[[Microsoft.AspNetCore.Http.RequestDelegate, Microsoft.AspNetCore.Http.Abstractions, Version=*, Culture=neutral, PublicKeyToken=*],[Microsoft.AspNetCore.Http.RequestDelegate, Microsoft.AspNetCore.Http.Abstractions, Version=*, Culture=neutral, PublicKeyToken=*]]::CreateMiddleware]
+            
+            Endpoints:
+              - [GET] /hello (Order: 0) HTTP: GET /hello [Microsoft.AspNetCore.Routing.RouteEndpoint]
+            
+            """);
+    }
+
+    [Fact]
+    public async Task MapMiddlewarePipelineDebugEndpoint_NonDevelopment_CanBeMappedExplicitly()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Production });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddMiddlewarePipelineDebugging();
+
+        await using var app = builder.Build();
+        app.UseRouting();
+        app.Use(static (context, next) => next(context));
+        app.MapGet("/hello", static () => "hello");
+
+        var debugEndpointBuilder = app.MapMiddlewarePipelineDebugEndpoint(developmentOnly: false);
+        Assert.NotNull(debugEndpointBuilder);
+
+        await app.StartAsync(XunitCancellationToken);
+        using var client = app.GetTestClient();
+        using var response = await client.GetAsync("/_debug/pipeline", XunitCancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MapMiddlewarePipelineDebugEndpoint_WithoutServiceRegistration_Throws()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = Environments.Development });
+        builder.WebHost.UseTestServer();
+
+        await using var app = builder.Build();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => app.MapMiddlewarePipelineDebugEndpoint(developmentOnly: false));
+        Assert.Contains(nameof(MiddlewarePipelineDebuggingServiceCollectionExtensions.AddMiddlewarePipelineDebugging), exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/Meziantou.AspNetCore.Tests/MiddlewarePipelineDebuggingTests.cs
+++ b/tests/Meziantou.AspNetCore.Tests/MiddlewarePipelineDebuggingTests.cs
@@ -140,8 +140,8 @@ public sealed class MiddlewarePipelineDebuggingTests
         {
             settings.ScrubLinesWithReplace(static line =>
             {
-                var scrubbed = Regex.Replace(line, @"Version=\d+\.\d+\.\d+\.\d+", "Version=*");
-                scrubbed = Regex.Replace(scrubbed, @"PublicKeyToken=[0-9a-f]{16}", "PublicKeyToken=*");
+                var scrubbed = Regex.Replace(line, @"Version=\d+\.\d+\.\d+\.\d+", "Version=*", RegexOptions.None, TimeSpan.FromSeconds(1));
+                scrubbed = Regex.Replace(scrubbed, @"PublicKeyToken=[0-9a-f]{16}", "PublicKeyToken=*", RegexOptions.None, TimeSpan.FromSeconds(1));
                 return scrubbed;
             });
         }).Validate(text, """

--- a/tests/Meziantou.AspNetCore.Tests/NoCacheMiddlewareTests.cs
+++ b/tests/Meziantou.AspNetCore.Tests/NoCacheMiddlewareTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+
+namespace Meziantou.AspNetCore.Tests;
+
+public sealed class NoCacheMiddlewareTests
+{
+    [Fact]
+    public async Task ResponseWithoutCacheControl_AddsNoCacheHeader()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        await using var app = builder.Build();
+        app.UseMiddleware<NoCacheMiddleware>();
+        app.MapGet("/no-cache", static () => "ok");
+
+        await app.StartAsync(XunitCancellationToken);
+        using var client = app.GetTestClient();
+        using var response = await client.GetAsync("/no-cache", XunitCancellationToken);
+
+        var cacheControl = Assert.Single(response.Headers.GetValues("Cache-Control"));
+        var directives = cacheControl.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Contains("no-cache", directives, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("no-store", directives, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("must-revalidate", directives, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ResponseWithCacheControl_DoesNotOverrideHeader()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        await using var app = builder.Build();
+        app.UseMiddleware<NoCacheMiddleware>();
+        app.MapGet("/cache-control", static (HttpContext context) =>
+        {
+            context.Response.Headers.CacheControl = "public,max-age=60";
+            return "ok";
+        });
+
+        await app.StartAsync(XunitCancellationToken);
+        using var client = app.GetTestClient();
+        using var response = await client.GetAsync("/cache-control", XunitCancellationToken);
+
+        var cacheControl = Assert.Single(response.Headers.GetValues("Cache-Control"));
+        Assert.Equal("public,max-age=60", cacheControl.Replace(" ", string.Empty, StringComparison.Ordinal));
+    }
+}

--- a/tests/Trimmable/Trimmable.csproj
+++ b/tests/Trimmable/Trimmable.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Meziantou.AspNetCore\Meziantou.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.AspNetCore.Authentication.HttpBasic\Meziantou.AspNetCore.Authentication.HttpBasic.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.AspNetCore.Mvc\Meziantou.AspNetCore.Mvc.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.Framework\Meziantou.Framework.csproj" />
@@ -60,6 +61,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <TrimmerRootAssembly Include="Meziantou.AspNetCore" />
     <TrimmerRootAssembly Include="Meziantou.AspNetCore.Authentication.HttpBasic" />
     <TrimmerRootAssembly Include="Meziantou.AspNetCore.Mvc" />
     <TrimmerRootAssembly Include="Meziantou.Framework" />


### PR DESCRIPTION
This adds first-class middleware pipeline diagnostics for ASP.NET Core so the pipeline and endpoint map can be inspected both over HTTP and directly from code in tests.

## What changed
- Added a new `Meziantou.AspNetCore` project with diagnostics components under `Diagnostics/`.
- Added service and app extensions to capture and expose pipeline data:
  - `AddMiddlewarePipelineDebugging(...)`
  - `MapMiddlewarePipelineDebugEndpoint(...)`
  - `GetMiddlewarePipelineDebugSnapshot(...)`
- Added snapshot models and text output (`MiddlewarePipelineDebugSnapshot.ToString()`) to render the full pipeline and endpoint list.
- Improved middleware display names so wrapped middleware entries resolve to concrete middleware types when possible (including `UseMiddleware` entries wrapped by `WebApplicationBuilder+WireSourcePipeline`).
- Moved `NoCacheMiddleware` from `Meziantou.AspNetCore.ServiceDefaults` to `Meziantou.AspNetCore` and updated ServiceDefaults to reference/use it.
- Added a dedicated `Meziantou.AspNetCore.Tests` test project with:
  - pipeline/debug endpoint coverage using per-test `WebApplication` + `TestServer`
  - inline snapshot coverage for full text output
  - dedicated `NoCacheMiddleware` behavior tests
- Updated related repo metadata and generated files (`slnx`, `README`, `renovate`, trimmable test project references).

## Notes for reviewers
- The debug snapshot now clearly shows concrete middleware names in the full text output, including `Meziantou.AspNetCore.NoCacheMiddleware`, instead of generic wrapper names in this scenario.