### PR TITLE
Add configurable FullPath.CreateTempFile overloads

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -297,10 +297,53 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
     public static FullPath GetTempPath() => FromPath(Path.GetTempPath());
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static FullPath GetTempFileName() => FromPath(Path.GetTempFileName());
+    public static FullPath GetTempFileName() => CreateTempFile();
 
     /// <summary>Creates a uniquely named, zero-byte temporary file and returns its full path.</summary>
-    public static FullPath CreateTempFile() => FromPath(Path.GetTempFileName());
+    public static FullPath CreateTempFile() => CreateTempFile(prefix: null);
+
+    /// <summary>Creates a uniquely named, zero-byte temporary file and returns its full path.</summary>
+    /// <param name="prefix">A prefix to prepend to the generated file name.</param>
+    /// <param name="suffix">A suffix to append to the generated file name. Defaults to <c>.tmp</c>.</param>
+    /// <exception cref="IOException">Thrown when a unique file could not be created after 10 attempts.</exception>
+    public static FullPath CreateTempFile(string? prefix, string? suffix = ".tmp") => CreateTempFile(folder: null, prefix: prefix, suffix: suffix);
+
+    /// <summary>Creates a uniquely named, zero-byte temporary file and returns its full path.</summary>
+    /// <param name="folder">The destination folder. If <see langword="null"/> or empty, the system temporary folder is used.</param>
+    /// <param name="prefix">A prefix to prepend to the generated file name.</param>
+    /// <param name="suffix">A suffix to append to the generated file name. Defaults to <c>.tmp</c>.</param>
+    /// <exception cref="IOException">Thrown when a unique file could not be created after 10 attempts.</exception>
+    public static FullPath CreateTempFile(FullPath? folder, string? prefix, string? suffix = ".tmp")
+    {
+        var destinationFolder = folder.GetValueOrDefault();
+        if (destinationFolder.IsEmpty)
+        {
+            destinationFolder = GetTempPath();
+        }
+
+        Directory.CreateDirectory(destinationFolder.Value);
+
+        prefix ??= string.Empty;
+        suffix ??= string.Empty;
+
+        IOException? lastException = null;
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            var filePath = destinationFolder / (prefix + Guid.NewGuid().ToString("N") + suffix);
+
+            try
+            {
+                using var stream = File.Open(filePath.Value, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
+                return filePath;
+            }
+            catch (IOException ex)
+            {
+                lastException = ex;
+            }
+        }
+
+        throw new IOException("Could not create a unique temporary file after 10 attempts.", lastException);
+    }
 
     /// <summary>Gets the path to the system special folder identified by the specified enumeration.</summary>
     public static FullPath GetFolderPath(Environment.SpecialFolder folder) => FromPath(Environment.GetFolderPath(folder));

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -353,7 +353,7 @@ public sealed class FullPathTests
         {
             Assert.Equal(".txt", path.Extension);
             Assert.Equal(folder, path.Parent);
-            Assert.StartsWith("prefix-", path.Name);
+            Assert.StartsWith("prefix-", path.Name, StringComparison.Ordinal);
             Assert.True(File.Exists(path.Value));
             Assert.True(Directory.Exists(folder.Value));
         }
@@ -370,7 +370,7 @@ public sealed class FullPathTests
         try
         {
             Assert.Equal(string.Empty, path.Extension);
-            Assert.StartsWith("prefix-", path.Name);
+            Assert.StartsWith("prefix-", path.Name, StringComparison.Ordinal);
             Assert.True(File.Exists(path.Value));
         }
         finally
@@ -385,7 +385,7 @@ public sealed class FullPathTests
         var folder = FullPath.GetTempPath();
         var invalidSuffix = $"{Path.DirectorySeparatorChar}invalid";
         var exception = Assert.Throws<IOException>(() => FullPath.CreateTempFile(folder, prefix: null, suffix: invalidSuffix));
-        Assert.Contains("10 attempts", exception.Message);
+        Assert.Contains("10 attempts", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -326,6 +326,69 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public void CreateTempFile_Default()
+    {
+        var path = FullPath.CreateTempFile(prefix: null);
+        try
+        {
+            Assert.Equal(".tmp", path.Extension);
+            Assert.True(File.Exists(path.Value));
+        }
+        finally
+        {
+            File.Delete(path.Value);
+        }
+    }
+
+    [Fact]
+    public void CreateTempFile_WithFolderPrefixSuffix()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var folder = tempDirectory.FullPath / Guid.NewGuid().ToString("N");
+        Assert.False(Directory.Exists(folder.Value));
+
+        var path = FullPath.CreateTempFile(folder, "prefix-", ".txt");
+
+        try
+        {
+            Assert.Equal(".txt", path.Extension);
+            Assert.Equal(folder, path.Parent);
+            Assert.StartsWith("prefix-", path.Name);
+            Assert.True(File.Exists(path.Value));
+            Assert.True(Directory.Exists(folder.Value));
+        }
+        finally
+        {
+            File.Delete(path.Value);
+        }
+    }
+
+    [Fact]
+    public void CreateTempFile_WithNullSuffix()
+    {
+        var path = FullPath.CreateTempFile(prefix: "prefix-", suffix: null);
+        try
+        {
+            Assert.Equal(string.Empty, path.Extension);
+            Assert.StartsWith("prefix-", path.Name);
+            Assert.True(File.Exists(path.Value));
+        }
+        finally
+        {
+            File.Delete(path.Value);
+        }
+    }
+
+    [Fact]
+    public void CreateTempFile_ThrowsAfterMaxAttempts()
+    {
+        var folder = FullPath.GetTempPath();
+        var invalidSuffix = $"{Path.DirectorySeparatorChar}invalid";
+        var exception = Assert.Throws<IOException>(() => FullPath.CreateTempFile(folder, prefix: null, suffix: invalidSuffix));
+        Assert.Contains("10 attempts", exception.Message);
+    }
+
+    [Fact]
     public async Task TryFindFirstAncestorOrSelf()
     {
         await using var tempDir = TemporaryDirectory.Create();


### PR DESCRIPTION
## Why
`FullPath` temp file creation only exposed a fixed behavior. The new overloads allow callers to control filename prefix/suffix and optionally the destination folder while still guaranteeing unique, atomically-created temp files.

## What changed
- Added `CreateTempFile(string? prefix, string? suffix = ".tmp")`.
- Added `CreateTempFile(FullPath? folder, string? prefix, string? suffix = ".tmp")`.
- Updated `CreateTempFile()` and hidden `GetTempFileName()` to delegate to the new implementation.
- Implemented temp file creation using GUID-based names and `FileMode.CreateNew` with retry logic (10 attempts).
- Ensured the destination folder exists before attempting file creation.
- Added tests for:
  - default behavior,
  - custom folder/prefix/suffix,
  - null suffix,
  - retry exhaustion path.

## Notes for reviewers
- The retry loop catches `IOException` from create-new collisions/path creation failures and throws after 10 attempts with a clear error message.
- I ran the FullPath test project locally and the updated tests pass.
- The required `eng/validate-testprojects-configuration.cs` script still reports existing target-framework mismatch issues in this worktree (pre-existing, unrelated to this PR).