### PR TITLE
Fix MP3 duration parsing in MediaTags

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2FrameId.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2FrameId.cs
@@ -16,6 +16,7 @@ internal static class Id3v2FrameId
     public const string Conductor = "TPE3";
     public const string Copyright = "TCOP";
     public const string Bpm = "TBPM";
+    public const string Duration = "TLEN";
     public const string Compilation = "TCMP";  // iTunes non-standard
     public const string Isrc = "TSRC";
 
@@ -38,6 +39,7 @@ internal static class Id3v2FrameId
     public const string ConductorV22 = "TP3";
     public const string CopyrightV22 = "TCR";
     public const string BpmV22 = "TBP";
+    public const string DurationV22 = "TLE";
     public const string IsrcV22 = "TRC";
     public const string CommentV22 = "COM";
     public const string LyricsV22 = "ULT";

--- a/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2Reader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2Reader.cs
@@ -221,6 +221,11 @@ internal static class Id3v2Reader
                 }
                 break;
 
+            case Id3v2FrameId.Duration:
+                if (tags.Duration is null)
+                    ParseDuration(ReadTextFrame(data), tags);
+                break;
+
             case Id3v2FrameId.Isrc:
                 tags.Isrc ??= ReadTextFrame(data);
                 break;
@@ -429,6 +434,12 @@ internal static class Id3v2Reader
         return double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
     }
 
+    private static void ParseDuration(string value, MediaTagInfo tags)
+    {
+        if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var milliseconds) && milliseconds >= 0)
+            tags.Duration = TimeSpan.FromMilliseconds(milliseconds);
+    }
+
     private static string ParseGenre(string genre)
     {
         // ID3v2 genre can be "(12)" for index, "(12)Rock" for index+text, or just text
@@ -496,6 +507,7 @@ internal static class Id3v2Reader
         Id3v2FrameId.ConductorV22 => Id3v2FrameId.Conductor,
         Id3v2FrameId.CopyrightV22 => Id3v2FrameId.Copyright,
         Id3v2FrameId.BpmV22 => Id3v2FrameId.Bpm,
+        Id3v2FrameId.DurationV22 => Id3v2FrameId.Duration,
         Id3v2FrameId.IsrcV22 => Id3v2FrameId.Isrc,
         Id3v2FrameId.CommentV22 => Id3v2FrameId.Comment,
         Id3v2FrameId.LyricsV22 => Id3v2FrameId.Lyrics,

--- a/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Mp3TagReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Mp3TagReader.cs
@@ -2,6 +2,33 @@ namespace Meziantou.Framework.MediaTags.Formats.Id3v2;
 
 internal sealed class Mp3TagReader : IMediaTagReader
 {
+    private const int MaxResyncBytes = 64 * 1024;
+
+    private static readonly int[] Mpeg1Layer1BitRates =
+    [
+        32_000, 64_000, 96_000, 128_000, 160_000, 192_000, 224_000, 256_000, 288_000, 320_000, 352_000, 384_000, 416_000, 448_000,
+    ];
+
+    private static readonly int[] Mpeg1Layer2BitRates =
+    [
+        32_000, 48_000, 56_000, 64_000, 80_000, 96_000, 112_000, 128_000, 160_000, 192_000, 224_000, 256_000, 320_000, 384_000,
+    ];
+
+    private static readonly int[] Mpeg1Layer3BitRates =
+    [
+        32_000, 40_000, 48_000, 56_000, 64_000, 80_000, 96_000, 112_000, 128_000, 160_000, 192_000, 224_000, 256_000, 320_000,
+    ];
+
+    private static readonly int[] Mpeg2Layer1BitRates =
+    [
+        32_000, 48_000, 56_000, 64_000, 80_000, 96_000, 112_000, 128_000, 144_000, 160_000, 176_000, 192_000, 224_000, 256_000,
+    ];
+
+    private static readonly int[] Mpeg2Layer2Or3BitRates =
+    [
+        8_000, 16_000, 24_000, 32_000, 40_000, 48_000, 56_000, 64_000, 80_000, 96_000, 112_000, 128_000, 144_000, 160_000,
+    ];
+
     public MediaTagResult<MediaTagInfo> ReadTags(Stream stream)
     {
         try
@@ -14,6 +41,7 @@ internal sealed class Mp3TagReader : IMediaTagReader
 
             // Then try ID3v1 (at end of file) — ID3v2 values take priority (already set via ??=)
             Id3v1.Id3v1Reader.TryReadTag(stream, tags);
+            tags.Duration ??= TryReadDuration(stream);
 
             return MediaTagResult<MediaTagInfo>.Success(tags);
         }
@@ -22,4 +50,170 @@ internal sealed class Mp3TagReader : IMediaTagReader
             return MediaTagResult<MediaTagInfo>.Failure(MediaTagError.CorruptFile, ex.Message);
         }
     }
+
+    private static TimeSpan? TryReadDuration(Stream stream)
+    {
+        if (!stream.CanSeek || !stream.CanRead)
+            return null;
+
+        var originalPosition = stream.Position;
+        try
+        {
+            var audioStart = GetAudioStartOffset(stream);
+            var audioEnd = GetAudioEndOffset(stream);
+            if (audioEnd - audioStart < 4)
+                return null;
+
+            var currentOffset = audioStart;
+            var totalSeconds = 0d;
+            var hasFrame = false;
+            var resyncBytes = 0;
+
+            Span<byte> headerBuffer = stackalloc byte[4];
+            while (currentOffset + 4 <= audioEnd)
+            {
+                stream.Position = currentOffset;
+                if (stream.ReadAtLeast(headerBuffer, 4, throwOnEndOfStream: false) < 4)
+                    break;
+
+                if (TryParseFrameHeader(headerBuffer, out var frameLength, out var samplesPerFrame, out var sampleRate) && currentOffset + frameLength <= audioEnd)
+                {
+                    totalSeconds += (double)samplesPerFrame / sampleRate;
+                    currentOffset += frameLength;
+                    hasFrame = true;
+                    resyncBytes = 0;
+                    continue;
+                }
+
+                currentOffset++;
+                resyncBytes++;
+
+                if (hasFrame && resyncBytes >= MaxResyncBytes)
+                    break;
+            }
+
+            return hasFrame ? TimeSpan.FromSeconds(totalSeconds) : null;
+        }
+        finally
+        {
+            stream.Position = originalPosition;
+        }
+    }
+
+    private static long GetAudioStartOffset(Stream stream)
+    {
+        stream.Position = 0;
+        return Id3v2Reader.GetTagSize(stream);
+    }
+
+    private static long GetAudioEndOffset(Stream stream)
+    {
+        var audioEnd = stream.Length;
+        if (audioEnd < 128)
+            return audioEnd;
+
+        stream.Position = audioEnd - 128;
+        Span<byte> id3v1Header = stackalloc byte[3];
+        if (stream.ReadAtLeast(id3v1Header, id3v1Header.Length, throwOnEndOfStream: false) < id3v1Header.Length)
+            return audioEnd;
+
+        return id3v1Header is [(byte)'T', (byte)'A', (byte)'G'] ? audioEnd - 128 : audioEnd;
+    }
+
+    private static bool TryParseFrameHeader(ReadOnlySpan<byte> header, out int frameLength, out int samplesPerFrame, out int sampleRate)
+    {
+        frameLength = 0;
+        samplesPerFrame = 0;
+        sampleRate = 0;
+        if (header.Length < 4)
+            return false;
+
+        var headerValue = ((uint)header[0] << 24) | ((uint)header[1] << 16) | ((uint)header[2] << 8) | header[3];
+
+        // Sync word: first 11 bits must be set.
+        if ((headerValue & 0xFFE00000) != 0xFFE00000)
+            return false;
+
+        var versionBits = (int)((headerValue >> 19) & 0b11);
+        var layerBits = (int)((headerValue >> 17) & 0b11);
+        var bitrateIndex = (int)((headerValue >> 12) & 0b1111);
+        var sampleRateIndex = (int)((headerValue >> 10) & 0b11);
+        var padding = (int)((headerValue >> 9) & 0b1);
+
+        if (versionBits is 0b01 || layerBits is 0b00 || bitrateIndex is 0b0000 or 0b1111 || sampleRateIndex is 0b11)
+            return false;
+
+        sampleRate = GetSampleRate(versionBits, sampleRateIndex);
+        if (sampleRate <= 0)
+            return false;
+
+        var layer = 4 - layerBits;
+        var isMpeg1 = versionBits == 0b11;
+        var bitrate = GetBitrate(layer, isMpeg1, bitrateIndex);
+        if (bitrate <= 0)
+            return false;
+
+        switch (layer)
+        {
+            case 1:
+                samplesPerFrame = 384;
+                frameLength = (((12 * bitrate) / sampleRate) + padding) * 4;
+                break;
+
+            case 2:
+                samplesPerFrame = 1152;
+                frameLength = ((144 * bitrate) / sampleRate) + padding;
+                break;
+
+            case 3:
+                samplesPerFrame = isMpeg1 ? 1152 : 576;
+                frameLength = (((isMpeg1 ? 144 : 72) * bitrate) / sampleRate) + padding;
+                break;
+
+            default:
+                return false;
+        }
+
+        if (frameLength <= 4)
+            return false;
+
+        return true;
+    }
+
+    private static int GetSampleRate(int versionBits, int sampleRateIndex)
+    {
+        var sampleRate = sampleRateIndex switch
+        {
+            0 => 44_100,
+            1 => 48_000,
+            2 => 32_000,
+            _ => 0,
+        };
+
+        return versionBits switch
+        {
+            0b11 => sampleRate,      // MPEG 1
+            0b10 => sampleRate / 2,  // MPEG 2
+            0b00 => sampleRate / 4,  // MPEG 2.5
+            _ => 0,
+        };
+    }
+
+    private static int GetBitrate(int layer, bool isMpeg1, int bitrateIndex)
+    {
+        if (bitrateIndex < 1 || bitrateIndex > 14)
+            return 0;
+
+        var tableIndex = bitrateIndex - 1;
+        return (isMpeg1, layer) switch
+        {
+            (true, 1) => Mpeg1Layer1BitRates[tableIndex],
+            (true, 2) => Mpeg1Layer2BitRates[tableIndex],
+            (true, 3) => Mpeg1Layer3BitRates[tableIndex],
+            (false, 1) => Mpeg2Layer1BitRates[tableIndex],
+            (false, 2) or (false, 3) => Mpeg2Layer2Or3BitRates[tableIndex],
+            _ => 0,
+        };
+    }
+
 }

--- a/tests/Meziantou.Framework.MediaTags.Tests/Mp3Id3v2Tests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Mp3Id3v2Tests.cs
@@ -211,4 +211,100 @@ public sealed class Mp3Id3v2Tests
         // Should succeed with empty tags (no valid ID3 found)
         Assert.True(result.IsSuccess);
     }
+
+    [Fact]
+    public void ReadTags_Mp3Frames_ComputesDuration()
+    {
+        const int FrameCount = 100;
+        using var stream = new MemoryStream(CreateSyntheticMp3(FrameCount, includeId3v2Tag: true));
+
+        var result = MediaFile.ReadTags(stream, MediaFormat.Mp3);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value.Duration);
+
+        var expectedSeconds = FrameCount * (1152d / 44_100);
+        Assert.InRange(result.Value.Duration.Value.TotalSeconds, expectedSeconds - 0.01, expectedSeconds + 0.01);
+    }
+
+    [Fact]
+    public void ReadTags_Id3v2Tlen_ComputesDuration()
+    {
+        using var stream = new MemoryStream(CreateId3v24WithTextFrame("TLEN", "123456"));
+
+        var result = MediaFile.ReadTags(stream, MediaFormat.Mp3);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value.Duration);
+        Assert.Equal(TimeSpan.FromMilliseconds(123456), result.Value.Duration.Value);
+    }
+
+    private static byte[] CreateSyntheticMp3(int frameCount, bool includeId3v2Tag)
+    {
+        const int Mpeg1Layer3FrameLength = 417;
+        var id3v2HeaderLength = includeId3v2Tag ? 10 : 0;
+        var data = new byte[id3v2HeaderLength + (frameCount * Mpeg1Layer3FrameLength)];
+
+        if (includeId3v2Tag)
+        {
+            data[0] = (byte)'I';
+            data[1] = (byte)'D';
+            data[2] = (byte)'3';
+            data[3] = 4; // ID3v2.4
+            data[4] = 0; // Revision
+            data[5] = 0; // Flags
+            // Tag size is 0, so bytes 6..9 are already 0.
+        }
+
+        var offset = id3v2HeaderLength;
+        for (var i = 0; i < frameCount; i++)
+        {
+            data[offset + 0] = 0xFF;
+            data[offset + 1] = 0xFB;
+            data[offset + 2] = 0x90;
+            data[offset + 3] = 0x00;
+            offset += Mpeg1Layer3FrameLength;
+        }
+
+        return data;
+    }
+
+    private static byte[] CreateId3v24WithTextFrame(string frameId, string value)
+    {
+        var textBytes = System.Text.Encoding.ASCII.GetBytes(value);
+        var frameDataLength = 1 + textBytes.Length;
+        var frameLength = 10 + frameDataLength;
+        var tagLength = 10 + frameLength;
+        var result = new byte[tagLength];
+
+        // Tag header
+        result[0] = (byte)'I';
+        result[1] = (byte)'D';
+        result[2] = (byte)'3';
+        result[3] = 4; // Version 2.4
+        result[4] = 0;
+        result[5] = 0;
+        WriteSynchsafeInteger(result.AsSpan(6, 4), frameLength);
+
+        // Frame header
+        result[10] = (byte)frameId[0];
+        result[11] = (byte)frameId[1];
+        result[12] = (byte)frameId[2];
+        result[13] = (byte)frameId[3];
+        WriteSynchsafeInteger(result.AsSpan(14, 4), frameDataLength);
+        result[18] = 0; // Frame flags
+        result[19] = 0;
+
+        // Frame payload
+        result[20] = 0; // ISO-8859-1 encoding
+        textBytes.CopyTo(result.AsSpan(21));
+
+        return result;
+    }
+
+    private static void WriteSynchsafeInteger(Span<byte> destination, int value)
+    {
+        destination[0] = (byte)((value >> 21) & 0x7F);
+        destination[1] = (byte)((value >> 14) & 0x7F);
+        destination[2] = (byte)((value >> 7) & 0x7F);
+        destination[3] = (byte)(value & 0x7F);
+    }
 }


### PR DESCRIPTION
## Why
MP3 duration was not populated in `MediaFile.ReadTags` because the MP3 reader only parsed ID3 metadata and never computed audio duration. This made valid MP3 files return `Duration = null`.

## What changed
- Added support for ID3 duration frames (`TLEN` in v2.3/v2.4 and `TLE` in v2.2) and mapped them to `MediaTagInfo.Duration`.
- Added an MP3 frame-based fallback in `Mp3TagReader` to estimate duration when `TLEN` is absent by:
  - skipping the ID3v2 tag at the start,
  - parsing MPEG frame headers across the audio payload,
  - ignoring an optional ID3v1 trailer,
  - summing frame durations (`samplesPerFrame / sampleRate`).
- Kept tag precedence: frame scanning only runs when `Duration` is still null.
- Added regression tests for both `TLEN` parsing and frame-based duration calculation.

## Notes
- The fallback is robust to occasional invalid bytes via bounded resynchronization.
- Changes are limited to MediaTags MP3 parsing and related tests.