### PR TITLE
Trim trailing whitespace from generated --help output

### DIFF
--- a/eng/update-readme.cs
+++ b/eng/update-readme.cs
@@ -162,7 +162,7 @@ int UpdateToolReadmes()
 
         string[] runArgs = ["run", "--no-build", "--project", project.Csproj, "--framework", latestTfm, "--", "--help"];
         var helpText = RunProcessAndCaptureOutput("dotnet", runArgs, timeout: TimeSpan.FromMinutes(2));
-        helpText = helpText.TrimEnd(' ', '\t', '\r', '\n');
+        helpText = TrimEndOfLines(helpText).TrimEnd('\r', '\n');
         if (!string.IsNullOrEmpty(project.ToolName))
         {
             helpText = helpText.Replace(Path.GetFileNameWithoutExtension(project.Csproj), project.ToolName, StringComparison.Ordinal);
@@ -246,6 +246,9 @@ static string? ExtractMsBuildPropertyValue(string output, string propertyName)
     var match = Regex.Match(output, $"\"{Regex.Escape(propertyName)}\"\\s*:\\s*\"(?<value>[^\"]*)\"", RegexOptions.CultureInvariant, Timeout.InfiniteTimeSpan);
     return match.Success ? match.Groups["value"].Value : null;
 }
+
+static string TrimEndOfLines(string text) =>
+    Regex.Replace(text, "[ \\t]+(?=\\r?\\n|$)", string.Empty, RegexOptions.CultureInvariant, Timeout.InfiniteTimeSpan);
 
 static void RunProcess(string fileName, string[] arguments)
 {


### PR DESCRIPTION
## Why
`eng/update-readme.cs` captures tool `--help` output and embeds it in tool README files. Some help text lines include trailing spaces, which leads to unnecessary README diffs.

## What changed
This updates the help-text normalization step to trim trailing whitespace at the end of every line before injecting the text into markdown code blocks.

- Replaced end-only trimming with per-line end trimming (`TrimEndOfLines`)
- Kept final newline trimming so code block formatting remains stable
- Applied the normalization in `UpdateToolReadmes`

## Notes
`dotnet run ./eng/validate-testprojects-configuration.cs` reports existing target-framework mismatch errors in this branch that are unrelated to this change.