### PR TITLE
Configure VS Code default solution

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "dotnet.defaultSolution": "Meziantou.Framework.slnx"
+}


### PR DESCRIPTION
## Why
This repository contains many solution files, so VS Code may not open the intended one by default. This change sets a deterministic default solution for C# tooling.

## What changed
- Added `.vscode/settings.json`.
- Set `dotnet.defaultSolution` to `Meziantou.Framework.slnx`.

## Notes
- `dotnet.defaultSolution` is the current C# extension setting for selecting the default solution when multiple solutions are present.
- During local validation, `eng/validate-testprojects-configuration.cs` reported existing target-framework mismatches in test projects unrelated to this workspace setting change.