### PR TITLE
Enable nullable in test projects and remove file-level directives

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <EnableCodeCoverage>false</EnableCodeCoverage>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);nullable</NoWarn>
     <OutputType Condition="'$(OutputType)' == ''">Exe</OutputType>
     <IncludeDefaultTestReferences Condition="'$(IncludeDefaultTestReferences)' == ''">true</IncludeDefaultTestReferences>
     <DefineConstants Condition="'$(GITHUB_ACTIONS)' == 'true'">$(DefineConstants);GITHUB_ACTIONS</DefineConstants>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,7 +3,8 @@
 
   <PropertyGroup>
     <EnableCodeCoverage>false</EnableCodeCoverage>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);nullable</NoWarn>
     <OutputType Condition="'$(OutputType)' == ''">Exe</OutputType>
     <IncludeDefaultTestReferences Condition="'$(IncludeDefaultTestReferences)' == ''">true</IncludeDefaultTestReferences>
     <DefineConstants Condition="'$(GITHUB_ACTIONS)' == 'true'">$(DefineConstants);GITHUB_ACTIONS</DefineConstants>

--- a/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
+++ b/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
@@ -215,7 +215,7 @@ public sealed class HttpBasicAuthenticationTests
             return SendAndAssert(url, null, null, assert);
         }
 
-        public async Task SendAndAssert(string url, string username, string password, Func<HttpResponseMessage, Task> assert)
+        public async Task SendAndAssert(string url, string? username, string? password, Func<HttpResponseMessage, Task> assert)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
             if (username != null && password != null)

--- a/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
+++ b/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
@@ -240,7 +240,6 @@ public sealed class HttpBasicAuthenticationTests
         }
     }
 
-#nullable enable
     private sealed class InMemoryIdentityUserStore : IUserPasswordStore<IdentityUser>
     {
         private readonly List<IdentityUser> _users;
@@ -339,5 +338,4 @@ public sealed class HttpBasicAuthenticationTests
             return Task.FromResult(IdentityResult.Success);
         }
     }
-    #nullable restore
 }

--- a/tests/Meziantou.AspNetCore.ServiceDefaults.Tests/ServiceDefaultTests.cs
+++ b/tests/Meziantou.AspNetCore.ServiceDefaults.Tests/ServiceDefaultTests.cs
@@ -22,7 +22,7 @@ public sealed class ServiceDefaultTests
         app.MapGet("/", () => TypedResults.Ok(new { Sample = Sample.Value1 }));
         var t = app.RunAsync();
 
-        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>().Addresses.First();
+        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>()!.Addresses.First();
         using var httpClient = new HttpClient() { BaseAddress = new Uri(address) };
         Assert.Equal("Healthy", await httpClient.GetStringAsync("health", XunitCancellationToken));
         Assert.Equal("Healthy", await httpClient.GetStringAsync("alive", XunitCancellationToken));
@@ -43,7 +43,7 @@ public sealed class ServiceDefaultTests
         app.MapGet("/", () => TypedResults.Ok(new { Sample = Sample.Value1 }));
         var t = app.RunAsync();
 
-        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>().Addresses.First();
+        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>()!.Addresses.First();
         using var httpClient = new HttpClient() { BaseAddress = new Uri(address) };
         Assert.Equal("Healthy", await httpClient.GetStringAsync("health", XunitCancellationToken));
         Assert.Equal("Healthy", await httpClient.GetStringAsync("alive", XunitCancellationToken));
@@ -84,7 +84,7 @@ public sealed class ServiceDefaultTests
         app.MapGet("/test", () => TypedResults.Ok(new { Value = "test" }));
         var t = app.RunAsync();
 
-        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>().Addresses.First();
+        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>()!.Addresses.First();
         using var httpClient = new HttpClient() { BaseAddress = new Uri(address) };
         using var response = await httpClient.GetAsync("/test", XunitCancellationToken);
 
@@ -110,7 +110,7 @@ public sealed class ServiceDefaultTests
         });
         var t = app.RunAsync();
 
-        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>().Addresses.First();
+        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>()!.Addresses.First();
         using var httpClient = new HttpClient() { BaseAddress = new Uri(address) };
         using var response = await httpClient.GetAsync("/test", XunitCancellationToken);
 
@@ -135,7 +135,7 @@ public sealed class ServiceDefaultTests
         app.MapGet("/test", () => TypedResults.Ok(new { Value = "test" }));
         var t = app.RunAsync();
 
-        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>().Addresses.First();
+        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>()!.Addresses.First();
         using var httpClient = new HttpClient() { BaseAddress = new Uri(address) };
         using var response = await httpClient.GetAsync("/test", XunitCancellationToken);
 

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
@@ -101,7 +101,7 @@ public sealed partial class InMemoryLoggerTests
         using (logger.BeginScope(new { Name = "test" }))
         using (logger.BeginScope(new { Age = 52, Name = "John" }))
         {
-            SampleMessage(logger, 1, null);
+            SampleMessage(logger, 1, null!);
         }
 
         var log = provider.Logs.Informations.Single();

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
@@ -6,7 +6,7 @@ namespace Meziantou.Extensions.Logging.InMemory.Tests;
 
 public sealed partial class InMemoryLoggerTests
 {
-    private static readonly Action<ILogger, int, Exception> SampleMessage = LoggerMessage.Define<int>(LogLevel.Information, new EventId(1, "Sample Event Id"), "Test {Number}");
+    private static readonly Action<ILogger, int, Exception?> SampleMessage = LoggerMessage.Define<int>(LogLevel.Information, new EventId(1, "Sample Event Id"), "Test {Number}");
 
     [Fact]
     public void CreateLogger()
@@ -101,7 +101,7 @@ public sealed partial class InMemoryLoggerTests
         using (logger.BeginScope(new { Name = "test" }))
         using (logger.BeginScope(new { Age = 52, Name = "John" }))
         {
-            SampleMessage(logger, 1, null!);
+            SampleMessage(logger, 1, null);
         }
 
         var log = provider.Logs.Informations.Single();

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/NullExternalScopeProvider.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/NullExternalScopeProvider.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
 namespace Meziantou.Extensions.Logging.InMemory.Tests;
 internal sealed class NullExternalScopeProvider : IExternalScopeProvider

--- a/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/InMemoryTestOutputHelper.cs
+++ b/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/InMemoryTestOutputHelper.cs
@@ -8,7 +8,6 @@ internal sealed class InMemoryTestOutputHelper : ITestOutputHelper
     private readonly List<string> _logs = new();
 
     public IEnumerable<string> Logs => _logs;
-
     public string Output => string.Concat(_logs);
 
     public void Write(string message)

--- a/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/InMemoryTestOutputHelper.cs
+++ b/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/InMemoryTestOutputHelper.cs
@@ -9,7 +9,7 @@ internal sealed class InMemoryTestOutputHelper : ITestOutputHelper
 
     public IEnumerable<string> Logs => _logs;
 
-    public string Output { get; }
+    public string Output => string.Concat(_logs);
 
     public void Write(string message)
     {

--- a/tests/Meziantou.Framework.Avatar.Tests/AvatarGeneratorTests.cs
+++ b/tests/Meziantou.Framework.Avatar.Tests/AvatarGeneratorTests.cs
@@ -122,7 +122,7 @@ public class AvatarGeneratorTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    public void CreateSvg_ThrowsWhenNameIsInvalid(string name)
+    public void CreateSvg_ThrowsWhenNameIsInvalid(string? name)
     {
         Assert.ThrowsAny<ArgumentException>(() => AvatarGenerator.CreateSvg(name!, new AvatarOptions()));
     }

--- a/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
+++ b/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
@@ -19,7 +19,7 @@ public sealed class ByteSizeTests
     [InlineData(1_510_000L, "f1", "1.5MB")]
     [InlineData(1_510_000L, "", "1.51MB")]
     [InlineData(1_510_000L, "f2", "1.51MB")]
-    public void ToString_Test(long length, string format, string expectedValue)
+    public void ToString_Test(long length, string? format, string expectedValue)
     {
         var byteSize = new ByteSize(length);
         var formattedValue = byteSize.ToString(format, CultureInfo.InvariantCulture);
@@ -92,7 +92,7 @@ public sealed class ByteSizeTests
     [InlineData(1_510_000L, "f1", "1.5MB")]
     [InlineData(1_510_000L, "", "1.51MB")]
     [InlineData(1_510_000L, "f2", "1.51MB")]
-    public void TryFormat_Test(long length, string format, string expectedValue)
+    public void TryFormat_Test(long length, string? format, string expectedValue)
     {
         var byteSize = new ByteSize(length);
         Span<char> destination = stackalloc char[100];
@@ -162,7 +162,7 @@ public sealed class ByteSizeTests
     [InlineData(1_510_000L, "f1", "1.5MB")]
     [InlineData(1_510_000L, "", "1.51MB")]
     [InlineData(1_510_000L, "f2", "1.51MB")]
-    public void TryFormat_Utf8_Test(long length, string format, string expectedValue)
+    public void TryFormat_Utf8_Test(long length, string? format, string expectedValue)
     {
         var byteSize = new ByteSize(length);
         Span<byte> destination = stackalloc byte[100];

--- a/tests/Meziantou.Framework.ChromiumTracing.Tests/WriterTests.cs
+++ b/tests/Meziantou.Framework.ChromiumTracing.Tests/WriterTests.cs
@@ -12,7 +12,7 @@ public sealed partial class WriterTests
         var eventTypes = typeof(ChromiumTracingWriter).Assembly.GetTypes().Where(t => !t.IsAbstract && t.IsAssignableTo(typeof(ChromiumTracingEvent)));
         foreach (var eventType in eventTypes)
         {
-            var instance = (ChromiumTracingEvent)Activator.CreateInstance(eventType);
+            var instance = (ChromiumTracingEvent)Activator.CreateInstance(eventType)!;
             await writer.WriteEventAsync(instance);
         }
 
@@ -29,7 +29,7 @@ public sealed partial class WriterTests
             ProcessId = 1,
             ThreadId = 2,
             ColorName = "yellow",
-            Arguments = new Dictionary<string, object>(StringComparer.Ordinal) { ["step"] = "sample" },
+            Arguments = new Dictionary<string, object?>(StringComparer.Ordinal) { ["step"] = "sample" },
         });
 
         // Custom writes
@@ -53,7 +53,7 @@ public sealed partial class WriterTests
         {
             Name = "Sample",
             Timestamp = DateTimeOffset.UtcNow,
-            Arguments = new Dictionary<string, object>(StringComparer.Ordinal)
+            Arguments = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
                 ["value"] = 123L,
             },
@@ -69,7 +69,7 @@ public sealed partial class WriterTests
         {
             Name = "Sample",
             Timestamp = DateTimeOffset.UtcNow,
-            Arguments = new Dictionary<string, object>(StringComparer.Ordinal)
+            Arguments = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
                 ["payload"] = new CustomPayload(42),
             },

--- a/tests/Meziantou.Framework.CodeDom.Tests/AwaitExpressionTests.cs
+++ b/tests/Meziantou.Framework.CodeDom.Tests/AwaitExpressionTests.cs
@@ -8,7 +8,7 @@ public class AwaitExpressionTests
         var expression = new AwaitExpression(new SnippetExpression("test"));
         var configuredExpression = expression.ConfigureAwait(continueOnCapturedContext: true);
         Assert.Equal(expression, configuredExpression);
-        Assert.Equal(true, configuredExpression.Expression.As<MethodInvokeExpression>().Arguments[0].As<LiteralExpression>().Value);
+        Assert.Equal(true, configuredExpression.Expression!.As<MethodInvokeExpression>().Arguments[0].As<LiteralExpression>().Value);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.CodeDom.Tests/VisitorTests.cs
+++ b/tests/Meziantou.Framework.CodeDom.Tests/VisitorTests.cs
@@ -19,7 +19,7 @@ public class VisitorTests
 
     private static void VisitType(Type type)
     {
-        var instance = (CodeObject)Activator.CreateInstance(type);
+        var instance = (CodeObject)Activator.CreateInstance(type)!;
         var generator = new Visitor();
         generator.Visit(instance);
     }

--- a/tests/Meziantou.Framework.CommandLineTests/ArgumentPrinterClassFixture.cs
+++ b/tests/Meziantou.Framework.CommandLineTests/ArgumentPrinterClassFixture.cs
@@ -18,7 +18,7 @@ public sealed class ArgumentPrinterClassFixture
     {
         var rootPath = FullPath.CurrentDirectory().FindRequiredGitRepositoryRoot();
         _projectPath = rootPath / "tests" / "ArgumentsPrinter" / "ArgumentsPrinter.csproj";
-        _dotnetPath = ExecutableFinder.GetFullExecutablePath("dotnet");
+        _dotnetPath = ExecutableFinder.GetFullExecutablePath("dotnet") ?? throw new XunitException("Cannot find dotnet executable");
     }
 
     public async ValueTask<string[]> RoundtripArguments(string arguments)

--- a/tests/Meziantou.Framework.Csv.Tests/CsvReaderTests.cs
+++ b/tests/Meziantou.Framework.Csv.Tests/CsvReaderTests.cs
@@ -21,10 +21,10 @@ public class CsvReaderTests
         var row2 = await reader.ReadRowAsync();
         var row3 = await reader.ReadRowAsync();
 
-        Assert.Equal("value1.1", row1[0]);
+        Assert.Equal("value1.1", row1![0]);
         Assert.Equal("value1.2", row1[1]);
         Assert.Equal("value1.3", row1[2]);
-        Assert.Equal("value2.1", row2[0]);
+        Assert.Equal("value2.1", row2![0]);
         Assert.Equal("value2.2", row2[1]);
         Assert.Equal("value2.3", row2[2]);
         Assert.Null(row3);
@@ -47,10 +47,10 @@ public class CsvReaderTests
         var row2 = await reader.ReadRowAsync();
         var row3 = await reader.ReadRowAsync();
 
-        Assert.Equal("value1.1", row1["column1"]);
+        Assert.Equal("value1.1", row1!["column1"]);
         Assert.Equal("value1.2", row1["column2"]);
         Assert.Equal("value1.3", row1["column3"]);
-        Assert.Equal("value2.1", row2["column1"]);
+        Assert.Equal("value2.1", row2!["column1"]);
         Assert.Equal("value2.2", row2["column2"]);
         Assert.Equal("value2.3", row2["column3"]);
 
@@ -74,10 +74,10 @@ public class CsvReaderTests
         var row2 = await reader.ReadRowAsync();
         var row3 = await reader.ReadRowAsync();
 
-        Assert.Equal("value1.1", row1["column1"]);
+        Assert.Equal("value1.1", row1!["column1"]);
         Assert.Equal("value1.2\r\nline2", row1["column2"]);
         Assert.Equal("value1.3", row1["column3"]);
-        Assert.Equal("value2.1", row2["column1"]);
+        Assert.Equal("value2.1", row2!["column1"]);
         Assert.Equal("value2.2", row2["column2"]);
         Assert.Equal("value2.3", row2["column3"]);
 
@@ -93,7 +93,7 @@ public class CsvReaderTests
         using var sr = new StringReader(sb.ToString());
         var reader = new CsvReader(sr);
         var row1 = await reader.ReadRowAsync();
-        Assert.Equal("a\"c", row1[0]);
+        Assert.Equal("a\"c", row1![0]);
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class CsvReaderTests
         using var sr = new StringReader(sb.ToString());
         var reader = new CsvReader(sr);
         var row1 = await reader.ReadRowAsync();
-        Assert.Equal("\"bc", row1[0]);
+        Assert.Equal("\"bc", row1![0]);
     }
 
     [Fact]
@@ -117,7 +117,7 @@ public class CsvReaderTests
         using var sr = new StringReader(sb.ToString());
         var reader = new CsvReader(sr);
         var row1 = await reader.ReadRowAsync();
-        Assert.Equal("ab\"", row1[0]);
+        Assert.Equal("ab\"", row1![0]);
     }
 
     [Fact]
@@ -133,7 +133,7 @@ public class CsvReaderTests
             Separator = '\t',
         };
         var row1 = await reader.ReadRowAsync();
-        Assert.Equal("ab", row1[0]);
+        Assert.Equal("ab", row1![0]);
         Assert.Equal("cd", row1[1]);
     }
 

--- a/tests/Meziantou.Framework.Csv.Tests/CsvWriterTests.cs
+++ b/tests/Meziantou.Framework.Csv.Tests/CsvWriterTests.cs
@@ -88,7 +88,7 @@ public class CsvWriterTests
         var reader = new CsvReader(sr);
 
         var rowIndex = -1;
-        CsvRow csvRow;
+        CsvRow? csvRow;
         while ((csvRow = await reader.ReadRowAsync()) is not null)
         {
             rowIndex++;

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
@@ -121,7 +121,7 @@ public sealed class DependencyScannerTests
             ],
         };
         var result = await DependencyScanner.ScanDirectoryAsync(directory.FullPath, options, XunitCancellationToken);
-        Assert.Collection(result, dep => Assert.Equal(file1, dep.VersionLocation.FilePath));
+        Assert.Collection(result, dep => Assert.Equal(file1, dep.VersionLocation!.FilePath));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -599,7 +599,7 @@ public sealed class ScannerTests(ITestOutputHelper testOutputHelper) : IDisposab
         var result = await GetDependencies<GitSubmoduleDependencyScanner>();
         AssertContainDependency(result, (DependencyType.GitReference, remote.FullPath, head, 0, 0));
 
-        Assert.All(result, item => Assert.False(item.VersionLocation.IsUpdatable));
+        Assert.All(result, item => Assert.False(item.VersionLocation?.IsUpdatable ?? false));
 
         async Task ExecuteProcess(string process, string args, string workingDirectory)
         {
@@ -1253,11 +1253,11 @@ jobs:
         async Task<Dependency[]> Scan(ScannerOptions options)
         {
             var items = await DependencyScanner.ScanDirectoryAsync(_directory.FullPath, options);
-            return items.Where(d => d.Tags.Contains(typeof(T).FullName)).ToArray();
+            return items.Where(d => d.Tags.Contains(typeof(T).FullName!)).ToArray();
         }
     }
 
-    private sealed record DetectedDependency(Dependency Dependency, Location Location, Func<Task> UpdateText);
+    private sealed record DetectedDependency(Dependency Dependency, Location? Location, Func<Task> UpdateText);
 
     private static async Task UpdateDependencies(IEnumerable<Dependency> dependencies, string newName, string newVersion)
     {
@@ -1273,11 +1273,11 @@ jobs:
             .Where(item => item.Location is not null);
 
         // Group by file location and order by position desc
-        foreach (var locationsByFile in allLocations.Where(item => item.Location.IsUpdatable).GroupBy(item => item.Location.FilePath, StringComparer.Ordinal))
+        foreach (var locationsByFile in allLocations.Where(item => item.Location!.IsUpdatable).GroupBy(item => item.Location!.FilePath, StringComparer.Ordinal))
         {
             var locationsWithLineInfo = locationsByFile
                 .Where(item => item.Location is ILocationLineInfo)
-                .OrderByDescending(item => (((ILocationLineInfo)item.Location).LineNumber, ((ILocationLineInfo)item.Location).LinePosition))
+                .OrderByDescending(item => (((ILocationLineInfo)item.Location!).LineNumber, ((ILocationLineInfo)item.Location!).LinePosition))
                 .ToArray();
 
             var locationWithoutLineInfo = locationsByFile.Where(item => item.Location is not ILocationLineInfo).ToArray();
@@ -1306,7 +1306,7 @@ jobs:
         File.WriteAllBytes(fullPath, content);
     }
 
-    private static void AssertContainDependency(IEnumerable<Dependency> dependencies, params (DependencyType Type, string Name, string Version, int VersionLine, int VersionColumn)[] expectedDependencies)
+    private static void AssertContainDependency(IEnumerable<Dependency> dependencies, params (DependencyType Type, string? Name, string? Version, int VersionLine, int VersionColumn)[] expectedDependencies)
     {
         foreach (var expected in expectedDependencies)
         {
@@ -1314,8 +1314,8 @@ jobs:
                 d.Type == expected.Type &&
                 d.Name == expected.Name &&
                 d.Version == expected.Version &&
-                (expected.VersionLine == 0 || ((ILocationLineInfo)d.VersionLocation).LineNumber == expected.VersionLine) &&
-                (expected.VersionColumn == 0 || ((ILocationLineInfo)d.VersionLocation).LinePosition == expected.VersionColumn));
+                (expected.VersionLine == 0 || d.VersionLocation is ILocationLineInfo lineInfo1 && lineInfo1.LineNumber == expected.VersionLine) &&
+                (expected.VersionColumn == 0 || d.VersionLocation is ILocationLineInfo lineInfo2 && lineInfo2.LinePosition == expected.VersionColumn));
         }
     }
 

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -1314,8 +1314,8 @@ jobs:
                 d.Type == expected.Type &&
                 d.Name == expected.Name &&
                 d.Version == expected.Version &&
-                (expected.VersionLine == 0 || d.VersionLocation is ILocationLineInfo lineInfo1 && lineInfo1.LineNumber == expected.VersionLine) &&
-                (expected.VersionColumn == 0 || d.VersionLocation is ILocationLineInfo lineInfo2 && lineInfo2.LinePosition == expected.VersionColumn));
+                (expected.VersionLine == 0 || ((ILocationLineInfo)d.VersionLocation!).LineNumber == expected.VersionLine) &&
+                (expected.VersionColumn == 0 || ((ILocationLineInfo)d.VersionLocation!).LinePosition == expected.VersionColumn));
         }
     }
 

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
@@ -562,6 +562,6 @@ public sealed class FunctionalTests
     private static async Task<IReadOnlyList<Dependency>> ScanDependencies(TemporaryDirectory temporaryDirectory)
     {
         var deps = (await DependencyScanner.ScanDirectoryAsync(temporaryDirectory.FullPath, options: null, XunitCancellationToken)).ToList();
-        return deps.OrderBy(dep => dep.VersionLocation.FilePath, System.StringComparer.Ordinal).ToArray();
+        return deps.OrderBy(dep => dep.VersionLocation?.FilePath, System.StringComparer.Ordinal).ToArray();
     }
 }

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
@@ -562,6 +562,6 @@ public sealed class FunctionalTests
     private static async Task<IReadOnlyList<Dependency>> ScanDependencies(TemporaryDirectory temporaryDirectory)
     {
         var deps = (await DependencyScanner.ScanDirectoryAsync(temporaryDirectory.FullPath, options: null, XunitCancellationToken)).ToList();
-        return deps.OrderBy(dep => dep.VersionLocation?.FilePath, System.StringComparer.Ordinal).ToArray();
+        return deps.OrderBy(dep => dep.VersionLocation!.FilePath, System.StringComparer.Ordinal).ToArray();
     }
 }

--- a/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
@@ -41,7 +41,7 @@ public sealed class SnapshotTests(ITestOutputHelper testOutputHelper)
         foreach (var folder in Enum.GetNames<Environment.SpecialFolder>())
         {
             var expectedValue = Environment.GetFolderPath(Enum.Parse<Environment.SpecialFolder>(folder, ignoreCase: false));
-            var actualValue = typeof(SpecialFolderSnapshot).GetProperty(folder).GetValue(snapshot);
+            var actualValue = typeof(SpecialFolderSnapshot).GetProperty(folder)!.GetValue(snapshot);
 
             Assert.Equal(expectedValue, actualValue);
         }

--- a/tests/Meziantou.Framework.DnsFilter.Tests/DnsFilterListReaderTests.cs
+++ b/tests/Meziantou.Framework.DnsFilter.Tests/DnsFilterListReaderTests.cs
@@ -184,7 +184,7 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].AllowedDnsTypes);
-        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].AllowedDnsTypes);
+        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].AllowedDnsTypes!);
     }
 
     [Fact]
@@ -196,7 +196,7 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].ExcludedDnsTypes);
-        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].ExcludedDnsTypes);
+        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].ExcludedDnsTypes!);
     }
 
     [Fact]
@@ -208,9 +208,9 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].AllowedDnsTypes);
-        Assert.Equal(2, rules[0].AllowedDnsTypes.Count);
-        Assert.Contains(DnsFilterQueryType.A, rules[0].AllowedDnsTypes);
-        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].AllowedDnsTypes);
+        Assert.Equal(2, rules[0].AllowedDnsTypes!.Count);
+        Assert.Contains(DnsFilterQueryType.A, rules[0].AllowedDnsTypes!);
+        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].AllowedDnsTypes!);
     }
 
     [Fact]
@@ -222,7 +222,7 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].DenyAllowDomains);
-        Assert.Equal(2, rules[0].DenyAllowDomains.Count);
+        Assert.Equal(2, rules[0].DenyAllowDomains!.Count);
     }
 
     [Fact]
@@ -234,9 +234,9 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].Rewrite);
-        Assert.Equal(DnsFilterRewriteResponseCode.NoError, rules[0].Rewrite.ResponseCode);
-        Assert.Equal(DnsFilterQueryType.A, rules[0].Rewrite.RecordType);
-        Assert.Equal("1.2.3.4", rules[0].Rewrite.Value);
+        Assert.Equal(DnsFilterRewriteResponseCode.NoError, rules[0].Rewrite!.ResponseCode);
+        Assert.Equal(DnsFilterQueryType.A, rules[0].Rewrite!.RecordType);
+        Assert.Equal("1.2.3.4", rules[0].Rewrite!.Value);
     }
 
     [Fact]
@@ -248,7 +248,7 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].Rewrite);
-        Assert.Equal(DnsFilterQueryType.AAAA, rules[0].Rewrite.RecordType);
+        Assert.Equal(DnsFilterQueryType.AAAA, rules[0].Rewrite!.RecordType);
     }
 
     [Fact]
@@ -260,7 +260,7 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].Rewrite);
-        Assert.Equal(DnsFilterRewriteResponseCode.NameError, rules[0].Rewrite.ResponseCode);
+        Assert.Equal(DnsFilterRewriteResponseCode.NameError, rules[0].Rewrite!.ResponseCode);
     }
 
     [Fact]
@@ -272,7 +272,7 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].Rewrite);
-        Assert.Equal(DnsFilterRewriteResponseCode.Refused, rules[0].Rewrite.ResponseCode);
+        Assert.Equal(DnsFilterRewriteResponseCode.Refused, rules[0].Rewrite!.ResponseCode);
     }
 
     [Fact]
@@ -284,9 +284,9 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].Rewrite);
-        Assert.Equal(DnsFilterRewriteResponseCode.NoError, rules[0].Rewrite.ResponseCode);
-        Assert.Equal(DnsFilterQueryType.A, rules[0].Rewrite.RecordType);
-        Assert.Equal("1.2.3.4", rules[0].Rewrite.Value);
+        Assert.Equal(DnsFilterRewriteResponseCode.NoError, rules[0].Rewrite!.ResponseCode);
+        Assert.Equal(DnsFilterQueryType.A, rules[0].Rewrite!.RecordType);
+        Assert.Equal("1.2.3.4", rules[0].Rewrite!.Value);
     }
 
     [Fact]
@@ -398,9 +398,9 @@ public sealed class DnsFilterListReaderTests
         Assert.Single(rules);
         Assert.True(rules[0].IsImportant);
         Assert.NotNull(rules[0].AllowedDnsTypes);
-        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].AllowedDnsTypes);
+        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].AllowedDnsTypes!);
         Assert.NotNull(rules[0].Rewrite);
-        Assert.Equal(DnsFilterRewriteResponseCode.Refused, rules[0].Rewrite.ResponseCode);
+        Assert.Equal(DnsFilterRewriteResponseCode.Refused, rules[0].Rewrite!.ResponseCode);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
@@ -614,7 +614,7 @@ public sealed class DnsServerIntegrationTests
         using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
         socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
 
-        return ((IPEndPoint)socket.LocalEndPoint).Port;
+        return ((IPEndPoint)socket.LocalEndPoint!).Port;
     }
 
     private sealed record AllProtocolsServer(WebApplication App, int UdpPort, int TcpPort, int TlsPort, int? QuicPort);

--- a/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/EnumToStringSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/EnumToStringSourceGeneratorTests.cs
@@ -9,7 +9,7 @@ namespace Meziantou.Framework.FastEnumToStringGenerator.Tests;
 
 public sealed class EnumToStringSourceGeneratorTests
 {
-    private static async Task<(GeneratorDriverRunResult GeneratorResult, Compilation OutputCompilation, byte[] Assembly)> GenerateFiles(string file, bool mustCompile = true, string[]? assemblyLocations = null)
+    private static async Task<(GeneratorDriverRunResult GeneratorResult, Compilation OutputCompilation, byte[]? Assembly)> GenerateFiles(string file, bool mustCompile = true, string[]? assemblyLocations = null)
     {
         var netcoreRef = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "8.0.0", "ref/net8.0/");
         assemblyLocations ??= [];
@@ -44,7 +44,7 @@ public sealed class EnumToStringSourceGeneratorTests
             Assert.Empty(result.Diagnostics);
         }
 
-        return (runResult, outputCompilation, result.Success ? ms.ToArray() : []);
+        return (runResult, outputCompilation, result.Success ? ms.ToArray() : null);
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public sealed class EnumToStringSourceGeneratorTests
         Assert.Contains(generatorResult.GeneratedTrees, static tree => tree.FilePath.EndsWith("Microsoft.CodeAnalysis.EmbeddedAttribute.g.cs", StringComparison.Ordinal));
         Assert.Contains(generatorResult.GeneratedTrees, static tree => tree.FilePath.EndsWith("Meziantou.Framework.Annotations.FastEnumToStringAttribute.g.cs", StringComparison.Ordinal));
 
-        var asm = Assembly.Load(assembly);
+        var asm = Assembly.Load(Assert.IsType<byte[]>(assembly));
         var type = asm.GetType("A.B.C");
         var method = type!.GetMethod("Sample", BindingFlags.Public | BindingFlags.Static);
         Assert.Equal("Value2", method!.Invoke(null, [1]));
@@ -118,7 +118,7 @@ public sealed class EnumToStringSourceGeneratorTests
         Assert.Contains(generatorResult.GeneratedTrees, static tree => tree.FilePath.EndsWith("Microsoft.CodeAnalysis.EmbeddedAttribute.g.cs", StringComparison.Ordinal));
         Assert.Contains(generatorResult.GeneratedTrees, static tree => tree.FilePath.EndsWith("Meziantou.Framework.Annotations.FastEnumToStringAttribute.g.cs", StringComparison.Ordinal));
 
-        var asm = Assembly.Load(assembly);
+        var asm = Assembly.Load(Assert.IsType<byte[]>(assembly));
         var ns1Type = asm.GetType("SampleNs1.FastEnumToStringExtensions");
         var methods1 = ns1Type!.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             .Where(m => m.Name == "ToStringFast")

--- a/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/EnumToStringSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/EnumToStringSourceGeneratorTests.cs
@@ -9,7 +9,7 @@ namespace Meziantou.Framework.FastEnumToStringGenerator.Tests;
 
 public sealed class EnumToStringSourceGeneratorTests
 {
-    private static async Task<(GeneratorDriverRunResult GeneratorResult, Compilation OutputCompilation, byte[] Assembly)> GenerateFiles(string file, bool mustCompile = true, string[] assemblyLocations = null)
+    private static async Task<(GeneratorDriverRunResult GeneratorResult, Compilation OutputCompilation, byte[] Assembly)> GenerateFiles(string file, bool mustCompile = true, string[]? assemblyLocations = null)
     {
         var netcoreRef = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "8.0.0", "ref/net8.0/");
         assemblyLocations ??= [];
@@ -44,7 +44,7 @@ public sealed class EnumToStringSourceGeneratorTests
             Assert.Empty(result.Diagnostics);
         }
 
-        return (runResult, outputCompilation, result.Success ? ms.ToArray() : null);
+        return (runResult, outputCompilation, result.Success ? ms.ToArray() : []);
     }
 
     [Fact]
@@ -78,8 +78,8 @@ public sealed class EnumToStringSourceGeneratorTests
 
         var asm = Assembly.Load(assembly);
         var type = asm.GetType("A.B.C");
-        var method = type.GetMethod("Sample", BindingFlags.Public | BindingFlags.Static);
-        Assert.Equal("Value2", method.Invoke(null, [1]));
+        var method = type!.GetMethod("Sample", BindingFlags.Public | BindingFlags.Static);
+        Assert.Equal("Value2", method!.Invoke(null, [1]));
         Assert.Equal("999", method.Invoke(null, [999]));
 
     }
@@ -120,7 +120,7 @@ public sealed class EnumToStringSourceGeneratorTests
 
         var asm = Assembly.Load(assembly);
         var ns1Type = asm.GetType("SampleNs1.FastEnumToStringExtensions");
-        var methods1 = ns1Type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+        var methods1 = ns1Type!.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             .Where(m => m.Name == "ToStringFast")
             .OrderBy(m => m.GetParameters()[0].ParameterType.FullName, StringComparer.Ordinal);
 
@@ -130,14 +130,14 @@ public sealed class EnumToStringSourceGeneratorTests
             m => Assert.False(m.IsPublic));
 
         var ns3Type = asm.GetType("SampleNs3.FastEnumToStringExtensions");
-        var methods3 = ns3Type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+        var methods3 = ns3Type!.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             .Where(m => string.Equals(m.Name, "ToStringFast", StringComparison.Ordinal))
             .OrderBy(m => m.GetParameters()[0].ParameterType.FullName, StringComparer.Ordinal);
 
         Assert.False(ns3Type.IsPublic);
 
         var ns4Type = asm.GetType("SampleNs4.FastEnumToStringExtensions");
-        var methods4 = ns4Type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+        var methods4 = ns4Type!.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             .Where(m => m.Name == "ToStringFast")
             .OrderBy(m => m.GetParameters()[0].ParameterType.FullName, StringComparer.Ordinal);
 

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
@@ -31,7 +31,7 @@ public class GlobParserTests
     [InlineData("")]
     public void InvalidPatterns(string? content)
     {
-        Assert.Throws<ArgumentException>(() => Glob.Parse(content, GlobOptions.None));
+        Assert.Throws<ArgumentException>(() => Glob.Parse(content!, GlobOptions.None));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
@@ -29,7 +29,7 @@ public class GlobParserTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void InvalidPatterns(string content)
+    public void InvalidPatterns(string? content)
     {
         Assert.Throws<ArgumentException>(() => Glob.Parse(content, GlobOptions.None));
     }

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
@@ -160,7 +160,7 @@ public class GlobTests
     {
         var isDirectory = path.EndsWith('/');
         var pathWithoutEndingSlash = isDirectory ? path.TrimEnd('/') : path;
-        var directoryName = Path.GetDirectoryName(pathWithoutEndingSlash);
+        var directoryName = Path.GetDirectoryName(pathWithoutEndingSlash) ?? "";
         var fileName = Path.GetFileName(pathWithoutEndingSlash);
         var itemType = isDirectory ? PathItemType.Directory : PathItemType.File;
 
@@ -230,7 +230,7 @@ public class GlobTests
     {
         var glob = Glob.Parse(pattern, GlobOptions.IgnoreCase);
         Assert.True(glob.IsMatch(path));
-        Assert.True(glob.IsMatch(Path.GetDirectoryName(path), Path.GetFileName(path)));
+        Assert.True(glob.IsMatch(Path.GetDirectoryName(path) ?? "", Path.GetFileName(path)));
     }
 
     [Theory]
@@ -283,7 +283,7 @@ public class GlobTests
     {
         var isDirectory = path.EndsWith('/');
         var pathWithoutEndingSlash = isDirectory ? path.TrimEnd('/') : path;
-        var directoryName = Path.GetDirectoryName(pathWithoutEndingSlash);
+        var directoryName = Path.GetDirectoryName(pathWithoutEndingSlash) ?? "";
         var fileName = Path.GetFileName(pathWithoutEndingSlash);
         var itemType = isDirectory ? PathItemType.Directory : PathItemType.File;
 
@@ -312,7 +312,7 @@ public class GlobTests
     {
         var isDirectory = path.EndsWith('/');
         var pathWithoutEndingSlash = isDirectory ? path.TrimEnd('/') : path;
-        var directoryName = Path.GetDirectoryName(pathWithoutEndingSlash);
+        var directoryName = Path.GetDirectoryName(pathWithoutEndingSlash) ?? "";
         var fileName = Path.GetFileName(pathWithoutEndingSlash);
         var itemType = isDirectory ? PathItemType.Directory : PathItemType.File;
 
@@ -340,7 +340,7 @@ public class GlobTests
     {
         var isDirectory = path.EndsWith('/');
         var pathWithoutEndingSlash = isDirectory ? path.TrimEnd('/') : path;
-        var directoryName = Path.GetDirectoryName(pathWithoutEndingSlash);
+        var directoryName = Path.GetDirectoryName(pathWithoutEndingSlash) ?? "";
         var fileName = Path.GetFileName(pathWithoutEndingSlash);
         var itemType = isDirectory ? PathItemType.Directory : PathItemType.File;
 
@@ -362,7 +362,7 @@ public class GlobTests
     {
         var glob = Glob.Parse(pattern, GlobOptions.None);
         Assert.False(glob.IsMatch(path));
-        Assert.False(glob.IsMatch(Path.GetDirectoryName(path), Path.GetFileName(path)));
+        Assert.False(glob.IsMatch(Path.GetDirectoryName(path) ?? "", Path.GetFileName(path)));
     }
 
     [Theory]
@@ -535,16 +535,16 @@ public class GlobTests
         var glob = Glob.Parse(pattern, GlobOptions.Git);
         var globi = Glob.Parse(pattern, GlobOptions.IgnoreCase | GlobOptions.Git);
         Assert.True(glob.IsMatch(path));
-        Assert.True(glob.IsMatch(Path.GetDirectoryName(path), Path.GetFileName(path)));
+        Assert.True(glob.IsMatch(Path.GetDirectoryName(path) ?? "", Path.GetFileName(path)));
         Assert.True(globi.IsMatch(path));
-        Assert.True(globi.IsMatch(Path.GetDirectoryName(path), Path.GetFileName(path)));
-        Assert.True(glob.IsPartialMatch(Path.GetDirectoryName(path)));
-        Assert.True(globi.IsPartialMatch(Path.GetDirectoryName(path)));
+        Assert.True(globi.IsMatch(Path.GetDirectoryName(path) ?? "", Path.GetFileName(path)));
+        Assert.True(glob.IsPartialMatch(Path.GetDirectoryName(path) ?? ""));
+        Assert.True(globi.IsPartialMatch(Path.GetDirectoryName(path) ?? ""));
 
         if (OperatingSystem.IsWindows())
         {
             Assert.True(glob.IsMatch(path.Replace('/', '\\')));
-            Assert.True(glob.IsMatch(Path.GetDirectoryName(path).Replace('/', '\\'), Path.GetFileName(path)));
+            Assert.True(glob.IsMatch((Path.GetDirectoryName(path) ?? "").Replace('/', '\\'), Path.GetFileName(path)));
         }
     }
 
@@ -561,9 +561,9 @@ public class GlobTests
         var glob = Glob.Parse(pattern, GlobOptions.Git);
         var globi = Glob.Parse(pattern, GlobOptions.IgnoreCase | GlobOptions.Git);
         Assert.False(glob.IsMatch(path));
-        Assert.False(glob.IsMatch(Path.GetDirectoryName(path), Path.GetFileName(path)));
+        Assert.False(glob.IsMatch(Path.GetDirectoryName(path) ?? "", Path.GetFileName(path)));
         Assert.False(globi.IsMatch(path));
-        Assert.False(globi.IsMatch(Path.GetDirectoryName(path), Path.GetFileName(path)));
+        Assert.False(globi.IsMatch(Path.GetDirectoryName(path) ?? "", Path.GetFileName(path)));
     }
 
     // Corpus source: https://raw.githubusercontent.com/git/git/master/Documentation/gitignore.adoc
@@ -580,7 +580,7 @@ public class GlobTests
     {
         var isDirectory = path.EndsWith('/');
         var pathWithoutEndingSlash = isDirectory ? path.TrimEnd('/') : path;
-        var directoryName = Path.GetDirectoryName(pathWithoutEndingSlash);
+        var directoryName = Path.GetDirectoryName(pathWithoutEndingSlash) ?? "";
         var fileName = Path.GetFileName(pathWithoutEndingSlash);
         var itemType = isDirectory ? PathItemType.Directory : PathItemType.File;
 
@@ -601,7 +601,7 @@ public class GlobTests
     {
         var isDirectory = path.EndsWith('/');
         var pathWithoutEndingSlash = isDirectory ? path.TrimEnd('/') : path;
-        var directoryName = Path.GetDirectoryName(pathWithoutEndingSlash);
+        var directoryName = Path.GetDirectoryName(pathWithoutEndingSlash) ?? "";
         var fileName = Path.GetFileName(pathWithoutEndingSlash);
         var itemType = isDirectory ? PathItemType.Directory : PathItemType.File;
 

--- a/tests/Meziantou.Framework.Html.Tests/EditDocumentTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/EditDocumentTests.cs
@@ -8,7 +8,7 @@ public class EditDocumentTests
         var document = new HtmlDocument();
         document.LoadHtml("<div><p>sample1</p><p>sample2</p></div>");
         var node = document.SelectSingleNode("/div/p[1]/text()", HtmlNodeNavigatorOptions.LowercasedAll);
-        node.Value = "edited";
+        node!.Value = "edited";
         Assert.Equal("<div><p>edited</p><p>sample2</p></div>", document.OuterHtml);
     }
 
@@ -21,7 +21,7 @@ public class EditDocumentTests
         var anchorElement = document.CreateElement("a");
         anchorElement.SetAttribute("href", "sample.txt");
         anchorElement.InnerText = "sample";
-        node.AppendChild(anchorElement);
+        node!.AppendChild(anchorElement);
         Assert.Equal("<div><p>sample1<a href=\"sample.txt\">sample</a></p><p>sample2</p></div>", document.OuterHtml);
     }
 }

--- a/tests/Meziantou.Framework.Html.Tests/HtmlNodeTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/HtmlNodeTests.cs
@@ -23,7 +23,7 @@ public class HtmlNodeTests
     {
         var doc = new HtmlDocument();
         doc.LoadHtml("<p>def</p>");
-        Assert.Null(doc.SelectSingleNode("/p").ParentElement);
+        Assert.Null(doc.SelectSingleNode("/p")!.ParentElement);
     }
 
     [Fact]
@@ -31,6 +31,6 @@ public class HtmlNodeTests
     {
         var doc = new HtmlDocument();
         doc.LoadHtml("<p>def</p>");
-        Assert.Equal("p", doc.SelectSingleNode("/p/node()").ParentElement.Name);
+        Assert.Equal("p", doc.SelectSingleNode("/p/node()")!.ParentElement!.Name);
     }
 }

--- a/tests/Meziantou.Framework.Html.Tests/HtmlParserTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/HtmlParserTests.cs
@@ -27,8 +27,8 @@ public class HtmlParserTests
     {
         var document = new HtmlDocument();
         document.LoadHtml("<script type='text/javascript'>my script</script>");
-        Assert.Equal("my script", document.SelectSingleNode("//script").InnerHtml);
-        Assert.Equal("text/javascript", document.SelectSingleNode("//script").GetAttributeValue("type"));
+        Assert.Equal("my script", document.SelectSingleNode("//script")!.InnerHtml);
+        Assert.Equal("text/javascript", document.SelectSingleNode("//script")!.GetAttributeValue("type"));
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public class HtmlParserTests
     {
         var document = new HtmlDocument();
         document.LoadHtml("<!--Test-->");
-        Assert.Equal(HtmlNodeType.Comment, document.FirstChild.NodeType);
+        Assert.Equal(HtmlNodeType.Comment, document.FirstChild!.NodeType);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Html.Tests/Internals/HtmlXsltContext.cs
+++ b/tests/Meziantou.Framework.Html.Tests/Internals/HtmlXsltContext.cs
@@ -59,7 +59,7 @@ internal sealed class HtmlXsltContext : XsltContext
         var prefix = base.LookupPrefix(uri);
         if (prefix is null && Resolver is not null)
         {
-            prefix = Resolver.LookupPrefix(prefix);
+            prefix = Resolver.LookupPrefix(uri);
         }
 
         return prefix ?? "";

--- a/tests/Meziantou.Framework.Html.Tests/Internals/HtmlXsltFunction.cs
+++ b/tests/Meziantou.Framework.Html.Tests/Internals/HtmlXsltFunction.cs
@@ -6,16 +6,16 @@ namespace Meziantou.Framework.Html.Tests;
 
 internal abstract class HtmlXsltFunction : IXsltContextFunction
 {
-    protected HtmlXsltFunction(HtmlXsltContext context, string prefix, string name, XPathResultType[] argTypes)
+    protected HtmlXsltFunction(HtmlXsltContext context, string? prefix, string name, XPathResultType[]? argTypes)
     {
         Context = context;
         Prefix = prefix;
         Name = name;
-        ArgTypes = argTypes;
+        ArgTypes = argTypes ?? [];
     }
 
     public HtmlXsltContext Context { get; }
-    public string Prefix { get; }
+    public string? Prefix { get; }
     public string Name { get; }
     public XPathResultType[] ArgTypes { get; }
 
@@ -62,7 +62,7 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
         return defaultValue;
     }
 
-    public static string ConvertToString(object argument, bool outer, string separator)
+    public static string? ConvertToString(object? argument, bool outer, string? separator)
     {
         if (argument is null)
             return null;
@@ -102,7 +102,7 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
 
         if (argument is IEnumerable enumerable)
         {
-            StringBuilder sb = null;
+            StringBuilder? sb = null;
             foreach (var arg in enumerable)
             {
                 sb ??= new StringBuilder();
@@ -124,7 +124,7 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
         return string.Format(CultureInfo.InvariantCulture, "{0}", argument);
     }
 
-    internal static bool IsNull(object arg)
+    internal static bool IsNull(object? arg)
     {
         if (arg is null || Convert.IsDBNull(arg))
             return true;
@@ -138,7 +138,7 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
             if (!it.MoveNext())
                 return true;
 
-            object current = it.Current;
+            object? current = it.Current;
             return IsNull(current);
         }
 
@@ -162,15 +162,15 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
 
         public HtmlXsltContext Context { get; }
 
-        public string Lowercase(object obj)
+        public string? Lowercase(object obj)
         {
-            return (string)new Lowercase(Context, "Lowercase").Invoke(xsltContext: null, [obj], docContext: null);
+            return (string?)new Lowercase(Context, "Lowercase").Invoke(xsltContext: null!, [obj], docContext: null!);
         }
 
         // add methods as needed
     }
 
-    public static IXsltContextFunction GetBuiltIn(HtmlXsltContext context, string prefix, string name, XPathResultType[] argTypes)
+    public static IXsltContextFunction? GetBuiltIn(HtmlXsltContext context, string prefix, string name, XPathResultType[] argTypes)
     {
         _ = prefix;
         _ = argTypes;
@@ -190,7 +190,7 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
         [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "By design")]
         public override object Invoke(XsltContext xsltContext, object[] args, XPathNavigator docContext)
         {
-            return ConvertToString(args, outer: false, separator: null)?.ToLowerInvariant();
+            return ConvertToString(args, outer: false, separator: null)?.ToLowerInvariant()!;
         }
     }
 }

--- a/tests/Meziantou.Framework.Html.Tests/Internals/HtmlXsltFunction.cs
+++ b/tests/Meziantou.Framework.Html.Tests/Internals/HtmlXsltFunction.cs
@@ -21,7 +21,12 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
 
     public static object CreateXsltArgument(HtmlXsltContext context) => new XsltArgument(context);
 
-    public abstract object Invoke(XsltContext xsltContext, object[] args, XPathNavigator docContext);
+    object IXsltContextFunction.Invoke(XsltContext xsltContext, object[] args, XPathNavigator docContext)
+    {
+        return InvokeCore(xsltContext, args, docContext)!;
+    }
+
+    protected abstract object? InvokeCore(XsltContext? xsltContext, object[] args, XPathNavigator? docContext);
 
     public virtual int Maxargs => Minargs;
 
@@ -164,7 +169,7 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
 
         public string? Lowercase(object obj)
         {
-            return (string?)new Lowercase(Context, "Lowercase").Invoke(xsltContext: null!, [obj], docContext: null!);
+            return (string?)new Lowercase(Context, "Lowercase").InvokeCore(xsltContext: null, [obj], docContext: null);
         }
 
         // add methods as needed
@@ -188,9 +193,9 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
         }
 
         [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "By design")]
-        public override object Invoke(XsltContext xsltContext, object[] args, XPathNavigator docContext)
+        protected override object? InvokeCore(XsltContext? xsltContext, object[] args, XPathNavigator? docContext)
         {
-            return ConvertToString(args, outer: false, separator: null)?.ToLowerInvariant()!;
+            return ConvertToString(args, outer: false, separator: null)?.ToLowerInvariant();
         }
     }
 }

--- a/tests/Meziantou.Framework.Html.Tests/XpathQueryTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/XpathQueryTests.cs
@@ -19,6 +19,6 @@ public class XpathQueryTests
         var context = new HtmlXsltContext(document.ParentNamespaceResolver);
 
         var node = document.SelectSingleNode("//p[lowercase(@class)='abc']", context);
-        Assert.Equal("Sample1", node.InnerText);
+        Assert.Equal("Sample1", node!.InnerText);
     }
 }

--- a/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
+++ b/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
@@ -46,14 +46,14 @@ public class HtmlSanitizerTests
         }
         else
         {
-            Assert.Equal(expectedDocument.Body.InnerHtml, actualDocument.Body.InnerHtml);
+            Assert.Equal(expectedDocument.Body!.InnerHtml, actualDocument.Body!.InnerHtml);
         }
     }
 
     private static string FormatDocument(IHtmlDocument document)
     {
         using var sw = new StringWriter();
-        document.Body.ToHtml(sw, new PrettyMarkupFormatter());
+        document.Body!.ToHtml(sw, new PrettyMarkupFormatter());
         return sw.ToString();
     }
 }

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/CommonMarkSpecTests.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/CommonMarkSpecTests.cs
@@ -18,7 +18,7 @@ public sealed class CommonMarkSpecTests
             throw new InvalidOperationException("Could not find embedded resource 'commonmark-spec-0.31.2.json'");
         }
 
-        return JsonSerializer.Deserialize<List<CommonMarkSpecTestCase>>(stream);
+        return JsonSerializer.Deserialize<List<CommonMarkSpecTestCase>>(stream) ?? throw new InvalidOperationException("Cannot parse commonmark spec");
     }
 
     public static TheoryData<CommonMarkSpecTestCase> GetTestCases()

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlNormalizer.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlNormalizer.cs
@@ -17,10 +17,10 @@ internal static class HtmlNormalizer
     {
         var parser = new HtmlParser();
         var document = parser.ParseDocument("<body>" + html + "</body>");
-        NormalizeNode(document.Body);
+        NormalizeNode(document.Body!);
 
         using var sw = new StringWriter();
-        foreach (var child in document.Body.ChildNodes)
+        foreach (var child in document.Body!.ChildNodes)
         {
             child.ToHtml(sw, new PrettyMarkupFormatter());
         }

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlToMarkdownConverterTests.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlToMarkdownConverterTests.cs
@@ -2,7 +2,7 @@ namespace Meziantou.Framework.HtmlToMarkdownTests;
 
 public sealed class HtmlToMarkdownConverterTests
 {
-    private static void AssertHtmlToMarkdown(string html, string expectedMarkdown, HtmlToMarkdownOptions options = null)
+    private static void AssertHtmlToMarkdown(string html, string expectedMarkdown, HtmlToMarkdownOptions? options = null)
     {
         var actual = options is null
             ? HtmlToMarkdown.Convert(html)

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/MarkdownRoundTrippingTests.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/MarkdownRoundTrippingTests.cs
@@ -18,7 +18,7 @@ public sealed class MarkdownRoundTrippingTests
             .Where(n => n.StartsWith(prefix, StringComparison.Ordinal) && n.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
             .OrderBy(n => n, StringComparer.Ordinal))
         {
-            using var stream = assembly.GetManifestResourceStream(resourceName);
+            using var stream = assembly.GetManifestResourceStream(resourceName)!;
             using var reader = new StreamReader(stream);
             var content = reader.ReadToEnd();
 
@@ -79,8 +79,11 @@ public sealed class MarkdownRoundTrippingTests
             return true;
         }
 
-        if (SkippedExamples.TryGetValue((testCase.FileName, testCase.Example), out reason))
+        if (SkippedExamples.TryGetValue((testCase.FileName, testCase.Example), out var skippedReason))
+        {
+            reason = skippedReason;
             return true;
+        }
 
         reason = "";
         return false;

--- a/tests/Meziantou.Framework.Http.Caching.Tests/Internals/HttpTestContext.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/Internals/HttpTestContext.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Net;
 using System.Net.Http;
 using System.Runtime.CompilerServices;

--- a/tests/Meziantou.Framework.Http.Caching.Tests/PersistenceProvidersTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/PersistenceProvidersTests.cs
@@ -490,7 +490,7 @@ public class PersistenceProvidersTests
         DateTimeOffset now,
         TimeSpan maxAge,
         bool mustRevalidate,
-        string eTag = null)
+        string? eTag = null)
     {
         var requestTime = now - TimeSpan.FromMinutes(3);
         var responseTime = now - TimeSpan.FromMinutes(2);

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/HstsClientHandlerTests.cs
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/HstsClientHandlerTests.cs
@@ -38,7 +38,7 @@ public sealed class HstsClientHandlerTests
         Assert.Equal(Uri.UriSchemeHttps, response2.RequestMessage!.RequestUri!.Scheme);
     }
 
-    private sealed class MockHttpMessageHandler(string headerResponse) : HttpMessageHandler
+    private sealed class MockHttpMessageHandler(string? headerResponse) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {

--- a/tests/Meziantou.Framework.Http.Recording.Tests/HarHttpRecordingStoreTests.cs
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/HarHttpRecordingStoreTests.cs
@@ -61,7 +61,7 @@ public sealed class HarHttpRecordingStoreTests
         Assert.Equal("https://example.com/api/data", loaded[0].RequestUri);
         Assert.Equal(200, loaded[0].StatusCode);
         Assert.NotNull(loaded[0].ResponseBody);
-        Assert.Equal("{\"id\":1}", System.Text.Encoding.UTF8.GetString(loaded[0].ResponseBody));
+        Assert.Equal("{\"id\":1}", System.Text.Encoding.UTF8.GetString(loaded[0].ResponseBody!));
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public sealed class HarHttpRecordingStoreTests
         Assert.Equal("POST", loaded[0].Method);
         Assert.Equal(201, loaded[0].StatusCode);
         Assert.NotNull(loaded[0].RequestHeaders);
-        Assert.True(loaded[0].RequestHeaders.ContainsKey("Content-Type"));
+        Assert.True(loaded[0].RequestHeaders!.ContainsKey("Content-Type"));
         Assert.NotNull(loaded[0].RequestBody);
     }
 

--- a/tests/Meziantou.Framework.Http.Recording.Tests/HttpRecordingHandlerTests.cs
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/HttpRecordingHandlerTests.cs
@@ -12,7 +12,7 @@ public sealed class HttpRecordingHandlerTests
     private static HttpRecordingHandler CreateHandler(
         HttpMessageHandler innerHandler,
         IHttpRecordingStore store,
-        HttpRecordingOptions options = null)
+        HttpRecordingOptions? options = null)
     {
         return new HttpRecordingHandler(innerHandler, store, options);
     }

--- a/tests/Meziantou.Framework.Http.Recording.Tests/JsonHttpRecordingStoreTests.cs
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/JsonHttpRecordingStoreTests.cs
@@ -73,7 +73,7 @@ public sealed class JsonHttpRecordingStoreTests : IDisposable
         Assert.Equal("https://example.com/api/test", loaded[0].RequestUri);
         Assert.Equal(200, loaded[0].StatusCode);
         Assert.NotNull(loaded[0].ResponseBody);
-        Assert.Equal("hello", System.Text.Encoding.UTF8.GetString(loaded[0].ResponseBody));
+        Assert.Equal("hello", System.Text.Encoding.UTF8.GetString(loaded[0].ResponseBody!));
 
         Assert.Equal("POST", loaded[1].Method);
         Assert.Equal(201, loaded[1].StatusCode);

--- a/tests/Meziantou.Framework.Http.Tests/LinkHeaderValueTests.cs
+++ b/tests/Meziantou.Framework.Http.Tests/LinkHeaderValueTests.cs
@@ -21,7 +21,7 @@ public sealed class LinkHeaderValueTests
                 Assert.Equal("plop", item.Url);
                 Assert.Equal("d\"e;f,", item.Rel);
                 Assert.Equal("test title", item.GetParameterValue("title"));
-                Assert.Empty(item.GetParameterValue("abc") ?? "");
+                Assert.Equal("", item.GetParameterValue("abc"));
                 Assert.Null(item.GetParameterValue("unknown"));
             });
     }

--- a/tests/Meziantou.Framework.Http.Tests/LinkHeaderValueTests.cs
+++ b/tests/Meziantou.Framework.Http.Tests/LinkHeaderValueTests.cs
@@ -21,7 +21,7 @@ public sealed class LinkHeaderValueTests
                 Assert.Equal("plop", item.Url);
                 Assert.Equal("d\"e;f,", item.Rel);
                 Assert.Equal("test title", item.GetParameterValue("title"));
-                Assert.Empty(item.GetParameterValue("abc"));
+                Assert.Empty(item.GetParameterValue("abc") ?? "");
                 Assert.Null(item.GetParameterValue("unknown"));
             });
     }

--- a/tests/Meziantou.Framework.HttpClientMock.Tests/MockTests.cs
+++ b/tests/Meziantou.Framework.HttpClientMock.Tests/MockTests.cs
@@ -101,6 +101,7 @@ public sealed class MockTests(ITestOutputHelper testOutputHelper)
 
         using var client = mock.CreateHttpClient();
         var data = await client.GetFromJsonAsync<Dictionary<string, object>>("/", XunitCancellationToken);
+        Assert.NotNull(data);
         Assert.True(data.ContainsKey("id"));
     }
 
@@ -114,6 +115,7 @@ public sealed class MockTests(ITestOutputHelper testOutputHelper)
         using var response = await client.GetAsync("/", XunitCancellationToken);
         Assert.Equal(400, (int)response.StatusCode);
         var data = await response.Content.ReadFromJsonAsync<Dictionary<string, object>>(XunitCancellationToken);
+        Assert.NotNull(data);
         Assert.True(data.ContainsKey("id"));
     }
 

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HttpJsonSerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HttpJsonSerializerTests.cs
@@ -176,7 +176,7 @@ public sealed class HttpJsonSerializerTests : SerializerTestsBase
 
     private sealed class CustomStringConverter : HumanReadableConverter<string>
     {
-        protected override void WriteValue(HumanReadableTextWriter writer, string value, HumanReadableSerializerOptions options)
+        protected override void WriteValue(HumanReadableTextWriter writer, string? value, HumanReadableSerializerOptions options)
         {
             writer.WriteValue("custom-" + value);
         }

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HumanReadableSerializerOptionsTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HumanReadableSerializerOptionsTests.cs
@@ -21,6 +21,6 @@ public sealed class HumanReadableSerializerOptionsTests
     private sealed class DummyConverter : HumanReadableConverter
     {
         public override bool CanConvert(Type type) => false;
-        public override void WriteValue(HumanReadableTextWriter writer, object value, Type valueType, HumanReadableSerializerOptions options) { }
+        public override void WriteValue(HumanReadableTextWriter writer, object? value, Type valueType, HumanReadableSerializerOptions options) { }
     }
 }

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -68,7 +68,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     public void SerializeObject_Null() => AssertSerialization(null, "<null>");
 
     [Fact]
-    public void SerializeObject_Null_Nested() => AssertSerialization(new { Obj = (object)null }, "Obj: <null>");
+    public void SerializeObject_Null_Nested() => AssertSerialization(new { Obj = (object?)null }, "Obj: <null>");
 
     [Fact]
     public void SerializeArray_Empty()
@@ -1030,61 +1030,61 @@ public sealed partial class SerializerTests : SerializerTestsBase
     public void Type_AnonymType() => AssertSerialization(new { }.GetType(), "<>f__AnonymousType4, Meziantou.Framework.HumanReadableSerializer.Tests");
 
     [Fact]
-    public void MethodInfo() => AssertSerialization(typeof(object).GetMethod("ToString"), "System.Object.ToString()");
+    public void MethodInfo() => AssertSerialization(typeof(object).GetMethod("ToString")!, "System.Object.ToString()");
 
     [Fact]
-    public void MethodInfo_dynamic_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.Dynamic)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.Dynamic(dynamic value)");
+    public void MethodInfo_dynamic_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.Dynamic))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.Dynamic(dynamic value)");
 
     [Fact]
-    public void MethodInfo_dynamic_ValueTuple_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.ValueTupleDynamic)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.ValueTupleDynamic((dynamic, System.Int32) value)");
+    public void MethodInfo_dynamic_ValueTuple_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.ValueTupleDynamic))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.ValueTupleDynamic((dynamic, System.Int32) value)");
 
     [Fact]
-    public void MethodInfo_dynamic_Nested_ValueTuple_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.ValueTupleNestedDynamic)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.ValueTupleNestedDynamic((dynamic A, (System.Int32 B, dynamic C) D) value)");
+    public void MethodInfo_dynamic_Nested_ValueTuple_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.ValueTupleNestedDynamic))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.ValueTupleNestedDynamic((dynamic A, (System.Int32 B, dynamic C) D) value)");
 
     [Fact]
-    public void MethodInfo_ValueTuple_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.NotNamed)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.NotNamed((System.Int32, System.String) a)");
+    public void MethodInfo_ValueTuple_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.NotNamed))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.NotNamed((System.Int32, System.String) a)");
 
     [Fact]
-    public void MethodInfo_ValueTuple_Named_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.Named)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.Named((System.Int32 A, System.String B) a)");
+    public void MethodInfo_ValueTuple_Named_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.Named))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.Named((System.Int32 A, System.String B) a)");
 
     [Fact]
-    public void MethodInfo_ValueTuple_Named_ReturnType() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.NamedResult)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.NamedResult()");
+    public void MethodInfo_ValueTuple_Named_ReturnType() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.NamedResult))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.NamedResult()");
 
     [Fact]
-    public void PropertyInfo_ValueTuple_Named_ReturnType() => AssertSerialization(typeof(Methods).GetProperty(nameof(Methods.NamedProperty)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.NamedProperty");
+    public void PropertyInfo_ValueTuple_Named_ReturnType() => AssertSerialization(typeof(Methods).GetProperty(nameof(Methods.NamedProperty))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.NamedProperty");
 
     [Fact]
-    public void MethodInfo_WithParameters() => AssertSerialization(typeof(Guid).GetMethod("Parse", [typeof(string)]), "static System.Guid.Parse(System.String input)");
+    public void MethodInfo_WithParameters() => AssertSerialization(typeof(Guid).GetMethod("Parse", [typeof(string)])!, "static System.Guid.Parse(System.String input)");
 
     [Fact]
-    public void MethodInfo_Generic() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.GenericMethod)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.GenericMethod<TEnum>(System.String value)");
+    public void MethodInfo_Generic() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.GenericMethod))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.GenericMethod<TEnum>(System.String value)");
 
     [Fact]
-    public void MethodInfo_Generic_Constructed() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.GenericMethod)).MakeGenericMethod(typeof(DayOfWeek)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.GenericMethod<System.DayOfWeek>(System.String value)");
+    public void MethodInfo_Generic_Constructed() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.GenericMethod))!.MakeGenericMethod(typeof(DayOfWeek)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.GenericMethod<System.DayOfWeek>(System.String value)");
 
     [Fact]
-    public void FieldInfo() => AssertSerialization(typeof(Guid).GetField("_a", BindingFlags.NonPublic | BindingFlags.Instance), "System.Guid._a");
+    public void FieldInfo() => AssertSerialization(typeof(Guid).GetField("_a", BindingFlags.NonPublic | BindingFlags.Instance)!, "System.Guid._a");
 
     [Fact]
-    public void FieldInfo_OpenGenericType() => AssertSerialization(typeof(Nullable<>).GetField("hasValue", BindingFlags.NonPublic | BindingFlags.Instance), "System.Nullable<T>.hasValue");
+    public void FieldInfo_OpenGenericType() => AssertSerialization(typeof(Nullable<>).GetField("hasValue", BindingFlags.NonPublic | BindingFlags.Instance)!, "System.Nullable<T>.hasValue");
 
     [Fact]
-    public void FieldInfo_GenericType() => AssertSerialization(typeof(int?).GetField("hasValue", BindingFlags.NonPublic | BindingFlags.Instance), "System.Nullable<System.Int32>.hasValue");
+    public void FieldInfo_GenericType() => AssertSerialization(typeof(int?).GetField("hasValue", BindingFlags.NonPublic | BindingFlags.Instance)!, "System.Nullable<System.Int32>.hasValue");
 
     [Fact]
-    public void PropertyInfo() => AssertSerialization(typeof(string).GetProperty("Length"), "System.String.Length");
+    public void PropertyInfo() => AssertSerialization(typeof(string).GetProperty("Length")!, "System.String.Length");
 
     [Fact]
-    public void PropertyInfo_Indexer() => AssertSerialization(typeof(string).GetProperty("Chars"), "System.String.Chars[System.Int32 index]");
+    public void PropertyInfo_Indexer() => AssertSerialization(typeof(string).GetProperty("Chars")!, "System.String.Chars[System.Int32 index]");
 
     [Fact]
-    public void ConstructorInfo() => AssertSerialization(typeof(object).GetConstructor([]), "new System.Object()");
+    public void ConstructorInfo() => AssertSerialization(typeof(object).GetConstructor([])!, "new System.Object()");
 
     [Fact]
     public void ConstructorInfo_Static() => AssertSerialization(typeof(ClassWithStaticCtor).GetConstructors(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)[0], "static Meziantou.Framework.HumanReadable.Tests.SerializerTests+ClassWithStaticCtor()");
 
     [Fact]
-    public void ParameterInfo() => AssertSerialization(typeof(Guid).GetMethod("Parse", [typeof(string)]).GetParameters()[0], "System.String input");
+    public void ParameterInfo() => AssertSerialization(typeof(Guid).GetMethod("Parse", [typeof(string)])!.GetParameters()[0], "System.String input");
 
     [Fact]
     public void DateTime_Utc() => AssertSerialization(new DateTime(2123, 4, 5, 6, 7, 8, DateTimeKind.Utc), "2123-04-05T06:07:08Z");
@@ -1789,7 +1789,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         AssertSerialization(new Validation
         {
-            Subject = new { Dummy = "", Object = (object)null, NullableInt32 = (int?)null, DefaultStruct = 0 },
+            Subject = new { Dummy = "", Object = (object?)null, NullableInt32 = (int?)null, DefaultStruct = 0 },
             Options = new HumanReadableSerializerOptions { DefaultIgnoreCondition = HumanReadableIgnoreCondition.Never },
             Expected = """
                 Dummy:
@@ -1805,7 +1805,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         AssertSerialization(new Validation
         {
-            Subject = new { Dummy = "", Object = (object)null, NullableInt32 = (int?)null, DefaultStruct = 0 },
+            Subject = new { Dummy = "", Object = (object?)null, NullableInt32 = (int?)null, DefaultStruct = 0 },
             Options = new HumanReadableSerializerOptions { DefaultIgnoreCondition = HumanReadableIgnoreCondition.WhenWritingNull },
             Expected = """
                 Dummy:
@@ -1819,7 +1819,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         AssertSerialization(new Validation
         {
-            Subject = new { Dummy = "", Object = (object)null, NullableInt32 = (int?)null, DefaultStruct = 0 },
+            Subject = new { Dummy = "", Object = (object?)null, NullableInt32 = (int?)null, DefaultStruct = 0 },
             Options = new HumanReadableSerializerOptions { DefaultIgnoreCondition = HumanReadableIgnoreCondition.WhenWritingDefault },
             Expected = """
                 Dummy:
@@ -1996,7 +1996,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     [Fact]
     public void WhenWritingEmptyCollection_Null()
     {
-        var obj = new { A = (string[])null, B = 2 };
+        var obj = new { A = (string[]?)null, B = 2 };
 
         AssertSerialization(new Validation
         {
@@ -2045,7 +2045,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     [Fact]
     public void WhenWritingDefaultOrEmptyCollection_Null()
     {
-        var obj = new { A = (string[])null, B = 2 };
+        var obj = new { A = (string[]?)null, B = 2 };
 
         AssertSerialization(new Validation
         {
@@ -2143,7 +2143,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         var options = new HumanReadableSerializerOptions();
         options.PropertyOrder = StringComparer.Ordinal;
-        options.IgnoreMember<Exception>(exception => exception.TargetSite);
+        options.IgnoreMember<Exception>(exception => exception.TargetSite!);
 
         AssertSerialization(new Validation
         {
@@ -2166,8 +2166,8 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         var options = new HumanReadableSerializerOptions();
         options.PropertyOrder = StringComparer.Ordinal;
-        options.IgnoreMember<Exception>(exception => exception.TargetSite);
-        options.IgnoreMember<Exception>(exception => exception.InnerException.Message); // Detect Exception.Message
+        options.IgnoreMember<Exception>(exception => exception.TargetSite!);
+        options.IgnoreMember<Exception>(exception => exception.InnerException!.Message); // Detect Exception.Message
 
         AssertSerialization(new Validation
         {
@@ -2246,7 +2246,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         var options = new HumanReadableSerializerOptions();
         options.PropertyOrder = StringComparer.Ordinal;
-        options.AddAttribute<Exception>(e => e.Source, new HumanReadableIgnoreAttribute());
+        options.AddAttribute<Exception>(e => e.Source!, new HumanReadableIgnoreAttribute());
         options.AddAttribute<Exception>(e => new { e.HResult, e.TargetSite, e.Data }, new HumanReadableIgnoreAttribute());
 
         AssertSerialization(new Validation
@@ -2288,11 +2288,11 @@ public sealed partial class SerializerTests : SerializerTestsBase
 
     private sealed class ObjectWithFields
     {
-        private string _privateField;
+        private string? _privateField;
 
         [HumanReadableInclude]
-        private string _privateFieldIncluded;
-        public string FieldString;
+        private string? _privateFieldIncluded;
+        public string? FieldString;
         public int FieldInt32;
 
         public int PropInt32 { get; set; }
@@ -2315,16 +2315,16 @@ public sealed partial class SerializerTests : SerializerTestsBase
         public int PropInt32_Null { get; set; }
 
         [HumanReadableIgnore(Condition = HumanReadableIgnoreCondition.WhenWritingNull)]
-        public object PropObject { get; set; }
+        public object? PropObject { get; set; }
 
         [HumanReadableIgnore(Condition = HumanReadableIgnoreCondition.Never)]
-        public object PropObject2 { get; set; }
+        public object? PropObject2 { get; set; }
 
         [HumanReadableIgnore(Condition = HumanReadableIgnoreCondition.WhenWritingDefault)]
-        public object PropObject3 { get; set; }
+        public object? PropObject3 { get; set; }
 
         [HumanReadableIgnore(Condition = HumanReadableIgnoreCondition.Always)]
-        public object PropObject4 { get; set; }
+        public object? PropObject4 { get; set; }
     }
 
     private sealed class OrderedMember
@@ -2348,31 +2348,31 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         private sealed class CustomTypeConverterImpl : TypeConverter
         {
-            public override bool CanConvertTo(ITypeDescriptorContext context, [NotNullWhen(true)] Type destinationType) => destinationType == typeof(string);
+            public override bool CanConvertTo(ITypeDescriptorContext? context, [NotNullWhen(true)] Type? destinationType) => destinationType == typeof(string);
 
-            public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType) => "converter";
+            public override object ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType) => "converter";
         }
     }
 
     private sealed class CustomConvertible : IConvertible
     {
         public TypeCode GetTypeCode() => throw new NotSupportedException();
-        public bool ToBoolean(IFormatProvider provider) => throw new NotSupportedException();
-        public byte ToByte(IFormatProvider provider) => throw new NotSupportedException();
-        public char ToChar(IFormatProvider provider) => throw new NotSupportedException();
-        public DateTime ToDateTime(IFormatProvider provider) => throw new NotSupportedException();
-        public decimal ToDecimal(IFormatProvider provider) => throw new NotSupportedException();
-        public double ToDouble(IFormatProvider provider) => throw new NotSupportedException();
-        public short ToInt16(IFormatProvider provider) => throw new NotSupportedException();
-        public int ToInt32(IFormatProvider provider) => throw new NotSupportedException();
-        public long ToInt64(IFormatProvider provider) => throw new NotSupportedException();
-        public sbyte ToSByte(IFormatProvider provider) => throw new NotSupportedException();
-        public float ToSingle(IFormatProvider provider) => throw new NotSupportedException();
-        public string ToString(IFormatProvider provider) => "convertible";
-        public object ToType(Type conversionType, IFormatProvider provider) => throw new NotSupportedException();
-        public ushort ToUInt16(IFormatProvider provider) => throw new NotSupportedException();
-        public uint ToUInt32(IFormatProvider provider) => throw new NotSupportedException();
-        public ulong ToUInt64(IFormatProvider provider) => throw new NotSupportedException();
+        public bool ToBoolean(IFormatProvider? provider) => throw new NotSupportedException();
+        public byte ToByte(IFormatProvider? provider) => throw new NotSupportedException();
+        public char ToChar(IFormatProvider? provider) => throw new NotSupportedException();
+        public DateTime ToDateTime(IFormatProvider? provider) => throw new NotSupportedException();
+        public decimal ToDecimal(IFormatProvider? provider) => throw new NotSupportedException();
+        public double ToDouble(IFormatProvider? provider) => throw new NotSupportedException();
+        public short ToInt16(IFormatProvider? provider) => throw new NotSupportedException();
+        public int ToInt32(IFormatProvider? provider) => throw new NotSupportedException();
+        public long ToInt64(IFormatProvider? provider) => throw new NotSupportedException();
+        public sbyte ToSByte(IFormatProvider? provider) => throw new NotSupportedException();
+        public float ToSingle(IFormatProvider? provider) => throw new NotSupportedException();
+        public string ToString(IFormatProvider? provider) => "convertible";
+        public object ToType(Type conversionType, IFormatProvider? provider) => throw new NotSupportedException();
+        public ushort ToUInt16(IFormatProvider? provider) => throw new NotSupportedException();
+        public uint ToUInt32(IFormatProvider? provider) => throw new NotSupportedException();
+        public ulong ToUInt64(IFormatProvider? provider) => throw new NotSupportedException();
     }
 
     private sealed class Recursive
@@ -2389,11 +2389,11 @@ public sealed partial class SerializerTests : SerializerTestsBase
         public int Prop2 { get; set; }
 
         [HumanReadableConverter(typeof(CustomStringConverter))]
-        public string Prop3 { get; set; }
+        public string? Prop3 { get; set; }
 
         private sealed class CustomStringConverter : HumanReadableConverter<string>
         {
-            protected override void WriteValue(HumanReadableTextWriter writer, string value, HumanReadableSerializerOptions options)
+            protected override void WriteValue(HumanReadableTextWriter writer, string? value, HumanReadableSerializerOptions options)
             {
                 writer.WriteValue("Custom");
             }
@@ -2407,7 +2407,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
 
         private sealed class CustomStringConverter : HumanReadableConverter<string>
         {
-            protected override void WriteValue(HumanReadableTextWriter writer, string value, HumanReadableSerializerOptions options)
+            protected override void WriteValue(HumanReadableTextWriter writer, string? value, HumanReadableSerializerOptions options)
             {
                 writer.WriteValue("Custom");
             }
@@ -2423,12 +2423,12 @@ public sealed partial class SerializerTests : SerializerTestsBase
     private sealed class DummyConverter : HumanReadableConverter
     {
         public override bool CanConvert(Type type) => throw new NotSupportedException();
-        public override void WriteValue(HumanReadableTextWriter writer, object value, Type valueType, HumanReadableSerializerOptions options) => throw new NotSupportedException();
+        public override void WriteValue(HumanReadableTextWriter writer, object? value, Type valueType, HumanReadableSerializerOptions options) => throw new NotSupportedException();
     }
 
     private sealed class CustomStringComparer : IEqualityComparer<string>
     {
-        public bool Equals(string x, string y) => x == y;
+        public bool Equals(string? x, string? y) => x == y;
         public int GetHashCode([DisallowNull] string obj) => 0;
     }
 
@@ -2437,7 +2437,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
 
     private sealed class ClassWithCustomConverterConverter : HumanReadableConverter<ClassWithCustomConverter>
     {
-        protected override void WriteValue(HumanReadableTextWriter writer, ClassWithCustomConverter value, HumanReadableSerializerOptions options)
+        protected override void WriteValue(HumanReadableTextWriter writer, ClassWithCustomConverter? value, HumanReadableSerializerOptions options)
         {
             writer.WriteValue("dummy");
         }
@@ -2473,12 +2473,12 @@ public sealed partial class SerializerTests : SerializerTestsBase
 
         public (int A, int B) NamedProperty => default;
 
-        public void GenericMethod<TEnum>(string value) => throw null;
+        public void GenericMethod<TEnum>(string value) => throw new NotSupportedException();
 
-        public void Dynamic(dynamic value) => throw null;
+        public void Dynamic(dynamic value) => throw new NotSupportedException();
 
-        public void ValueTupleDynamic((dynamic, int) value) => throw null;
+        public void ValueTupleDynamic((dynamic, int) value) => throw new NotSupportedException();
 
-        public void ValueTupleNestedDynamic((dynamic A, (int B, dynamic C) D) value) => throw null;
+        public void ValueTupleNestedDynamic((dynamic A, (int B, dynamic C) D) value) => throw new NotSupportedException();
     }
 }

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTestsBase.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTestsBase.cs
@@ -5,23 +5,23 @@ public class SerializerTestsBase
 {
     protected sealed record Validation
     {
-        public object Subject { get; init; }
-        public string Expected { get; init; }
-        public Type Type { get; init; }
-        public HumanReadableSerializerOptions Options { get; init; }
+        public required object? Subject { get; init; }
+        public required string Expected { get; init; }
+        public Type? Type { get; init; }
+        public HumanReadableSerializerOptions? Options { get; init; }
     }
 
-    protected static void AssertSerialization(object obj, string expected)
+    protected static void AssertSerialization(object? obj, string expected)
     {
         AssertSerialization(obj, options: null, expected);
     }
 
-    protected static void AssertSerialization(object obj, HumanReadableSerializerOptions options, string expected)
+    protected static void AssertSerialization(object? obj, HumanReadableSerializerOptions? options, string expected)
     {
         AssertSerialization(obj, options, type: null, expected);
     }
 
-    protected static void AssertSerialization(object obj, HumanReadableSerializerOptions options, Type type, string expected)
+    protected static void AssertSerialization(object? obj, HumanReadableSerializerOptions? options, Type? type, string expected)
     {
         var text = type == null ? HumanReadableSerializer.Serialize(obj, options) : HumanReadableSerializer.Serialize(obj, type, options);
         Assert.Equal(expected, text, ignoreLineEndingDifferences: true);

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Meziantou.Framework.InlineSnapshotTesting.Serialization;
 using Meziantou.Framework.InlineSnapshotTesting.SnapshotUpdateStrategies;
 using TestUtilities;

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -1066,7 +1066,7 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
 
     [SuppressMessage("Design", "MA0042:Do not use blocking calls in an async method", Justification = "Not supported on .NET Framework")]
     [SuppressMessage("Performance", "CA1849:Call async methods when in an async method", Justification = "Not supported on .NET Framework")]
-    private async Task AssertSnapshot([StringSyntax("c#-test")] string source, [StringSyntax("c#-test")] string expected = null, bool launchDebugger = false, string languageVersion = "11", bool autoDetectCI = false, bool forceUpdateSnapshots = false, IEnumerable<KeyValuePair<string, string>> environmentVariables = null, string[] preprocessorSymbols = null)
+    private async Task AssertSnapshot([StringSyntax("c#-test")] string source, [StringSyntax("c#-test")] string? expected = null, bool launchDebugger = false, string languageVersion = "11", bool autoDetectCI = false, bool forceUpdateSnapshots = false, IEnumerable<KeyValuePair<string, string>>? environmentVariables = null, string[]? preprocessorSymbols = null)
     {
         await using var directory = TemporaryDirectory.Create();
         var projectPath = CreateTextFile("Project.csproj", $$"""
@@ -1157,7 +1157,7 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
         expected ??= source;
 
         actual = SnapshotComparer.Default.NormalizeValue(actual);
-        expected = SnapshotComparer.Default.NormalizeValue(expected);
+        expected = SnapshotComparer.Default.NormalizeValue(expected!);
         if (actual != expected)
         {
             Assert.Fail("Snapshots are different\n" + InlineDiffAssertionMessageFormatter.Instance.FormatMessage(expected, actual));
@@ -1189,12 +1189,12 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
         {
             var names = typeof(InlineSnapshotTests).Assembly.GetManifestResourceNames();
             using var stream = typeof(InlineSnapshotTests).Assembly.GetManifestResourceStream("Meziantou.Framework.InlineSnapshotTesting.Tests.Meziantou.Framework.InlineSnapshotTesting.csproj");
-            var doc = XDocument.Load(stream);
-            var items = doc.Root.Descendants("PackageReference");
+            var doc = XDocument.Load(stream!);
+            var items = doc.Root!.Descendants("PackageReference");
 
-            var packages = items.Where(item => item.Parent.Attribute("Condition") is null).ToList();
+            var packages = items.Where(item => item.Parent?.Attribute("Condition") is null).ToList();
 #if NET472 || NET48
-            packages.AddRange(items.Where(item => item.Parent.Attribute("Condition") is not null));
+            packages.AddRange(items.Where(item => item.Parent?.Attribute("Condition") is not null));
 #endif
 
             return string.Join('\n', packages.Select(item => item.ToString()));
@@ -1232,7 +1232,7 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
                 }
             }
 
-            using var process = Process.Start(psi);
+            using var process = Process.Start(psi)!;
             process.OutputDataReceived += (_, e) => testOutputHelper.WriteLine(e.Data ?? "");
             process.ErrorDataReceived += (_, e) => testOutputHelper.WriteLine(e.Data ?? "");
             process.BeginOutputReadLine();

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/SnapshotSerializerTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/SnapshotSerializerTests.cs
@@ -300,7 +300,7 @@ public sealed class SnapshotSerializerTests
         public int? NullableInt32_NotNull { get; set; } = 42;
         public int[] Int32Array { get; set; } = [1, 2, 3, 4, 5];
         public int[] EmptyArray { get; set; } = [];
-        public int[] NullArray { get; set; }
+        public int[]? NullArray { get; set; }
         public IEnumerable<int> IEnumerableInt32 { get; set; } = Enumerable.Range(0, 2);
         public IDictionary<int, int> IDictionary { get; set; } = new Dictionary<int, int>() { [1] = 2, [3] = 4 };
         public IReadOnlyDictionary<int, int> IReadOnlyDictionary { get; set; } = new ReadOnlyDictionary<int, int>(new Dictionary<int, int>() { [1] = 2, [3] = 4 });

--- a/tests/Meziantou.Framework.JsonPath.Tests/ComplianceTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/ComplianceTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Xunit.Sdk;

--- a/tests/Meziantou.Framework.JsonPath.Tests/JsonPathParseTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/JsonPathParseTests.cs
@@ -59,14 +59,14 @@ public sealed class JsonPathParseTests
     [Fact]
     public void TryParse_NullExpression_ReturnsFalse()
     {
-        Assert.False(JsonPath.TryParse((string)null, out var result));
+        Assert.False(JsonPath.TryParse((string?)null, out var result));
         Assert.Null(result);
     }
 
     [Fact]
     public void Parse_NullExpression_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => JsonPath.Parse((string)null));
+        Assert.Throws<ArgumentNullException>(() => JsonPath.Parse((string)null!));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
@@ -103,7 +103,7 @@ public sealed class FlacTests
     {
         var result = MediaFile.ReadTags(GetTestFilePath("long_values.flac"));
         Assert.True(result.IsSuccess);
-        Assert.True(result.Value.Title.Length > 100);
+        Assert.True(result.Value.Title!.Length > 100);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.NtpClient.Tests/NtpClientTests.cs
+++ b/tests/Meziantou.Framework.NtpClient.Tests/NtpClientTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Net;
 using Meziantou.Framework.Ntp;
 using TestUtilities;

--- a/tests/Meziantou.Framework.NtpServer.Tests/NtpServerTests.cs
+++ b/tests/Meziantou.Framework.NtpServer.Tests/NtpServerTests.cs
@@ -4,7 +4,7 @@ namespace Meziantou.Framework.Ntp.Tests;
 
 public sealed class NtpServerTests : IAsyncLifetime
 {
-    private NtpServer _server;
+    private NtpServer? _server;
 
     public async ValueTask InitializeAsync()
     {
@@ -14,14 +14,14 @@ public sealed class NtpServerTests : IAsyncLifetime
 
     public ValueTask DisposeAsync()
     {
-        _server.Dispose();
+        _server?.Dispose();
         return ValueTask.CompletedTask;
     }
 
     [Fact]
     public async Task Query_ReturnsValidResponse()
     {
-        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server.Port });
+        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server!.Port });
         var response = await client.QueryAsync(XunitCancellationToken);
 
         Assert.True(response.Stratum > 0);
@@ -34,7 +34,7 @@ public sealed class NtpServerTests : IAsyncLifetime
     {
         using var client = new NtpClient("127.0.0.1", new NtpClientOptions
         {
-            Port = _server.Port,
+            Port = _server!.Port,
             Version = NtpVersion.V4,
         });
         var response = await client.QueryAsync(XunitCancellationToken);
@@ -47,7 +47,7 @@ public sealed class NtpServerTests : IAsyncLifetime
     {
         using var client = new NtpClient("127.0.0.1", new NtpClientOptions
         {
-            Port = _server.Port,
+            Port = _server!.Port,
             Version = NtpVersion.V3,
         });
         var response = await client.QueryAsync(XunitCancellationToken);
@@ -58,7 +58,7 @@ public sealed class NtpServerTests : IAsyncLifetime
     [Fact]
     public async Task Query_ClockOffset_IsSmall()
     {
-        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server.Port });
+        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server!.Port });
         var response = await client.QueryAsync(XunitCancellationToken);
 
         // Offset to a local server should be very small
@@ -68,7 +68,7 @@ public sealed class NtpServerTests : IAsyncLifetime
     [Fact]
     public async Task Query_RoundTripDelay_IsSmall()
     {
-        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server.Port });
+        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server!.Port });
         var response = await client.QueryAsync(XunitCancellationToken);
 
         // Round-trip to localhost should be very fast
@@ -80,7 +80,7 @@ public sealed class NtpServerTests : IAsyncLifetime
     {
         var tasks = Enumerable.Range(0, 10).Select(async _ =>
         {
-            using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server.Port });
+            using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server!.Port });
             return await client.QueryAsync(XunitCancellationToken);
         });
 
@@ -108,7 +108,7 @@ public sealed class NtpServerTests : IAsyncLifetime
     [Fact]
     public async Task Query_OriginateTimestamp_MatchesClientTransmit()
     {
-        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server.Port });
+        using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server!.Port });
         var response = await client.QueryAsync(XunitCancellationToken);
 
         // The originate timestamp in the response should match what the client sent

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tests/NuGetPackageValidatorTests.cs
@@ -4,13 +4,13 @@ namespace Meziantou.Framework.NuGetPackageValidation.Tests;
 
 public sealed class NuGetPackageValidatorTests
 {
-    private static Task<NuGetPackageValidationResult> ValidateAsync(string packageName, int[] excludedRuleIds, params NuGetPackageValidationRule[] rules)
+    private static Task<NuGetPackageValidationResult> ValidateAsync(string packageName, int[]? excludedRuleIds, params NuGetPackageValidationRule[] rules)
     {
         var path = FullPath.FromPath(typeof(NuGetPackageValidatorTests).Assembly.Location).Parent / "Packages" / packageName;
         return ValidateAsync(path, excludedRuleIds, rules);
     }
 
-    private static async Task<NuGetPackageValidationResult> ValidateAsync(FullPath packagePath, int[] excludedRuleIds, params NuGetPackageValidationRule[] rules)
+    private static async Task<NuGetPackageValidationResult> ValidateAsync(FullPath packagePath, int[]? excludedRuleIds, params NuGetPackageValidationRule[] rules)
     {
         var options = new NuGetPackageValidationOptions();
         options.Rules.AddRange(rules);

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/NugetPackageValidateToolTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/NugetPackageValidateToolTests.cs
@@ -5,7 +5,7 @@ namespace Meziantou.Framework.NuGetPackageValidation.Tool.Tests;
 [Collection("Tool")] // Ensure tests run sequentially
 public sealed class NugetPackageValidateToolTests(ITestOutputHelper testOutputHelper)
 {
-    private sealed record RunResult(int ExitCode, string StdOutput, string StdError, ValidationResult ValidationResults, NuGetPackageValidationResult ValidationResult);
+    private sealed record RunResult(int ExitCode, string StdOutput, string StdError, ValidationResult? ValidationResults, NuGetPackageValidationResult? ValidationResult);
 
     private sealed record ValidationResult(bool IsValid, Dictionary<string, NuGetPackageValidationResult> Packages);
 
@@ -16,7 +16,7 @@ public sealed class NugetPackageValidateToolTests(ITestOutputHelper testOutputHe
 
         Assert.True(console.Output.Count(c => c == '\n') > 2); // Check if output is written indented
 
-        ValidationResult deserializedResult = null;
+        ValidationResult? deserializedResult = null;
         try
         {
             deserializedResult = JsonSerializer.Deserialize<ValidationResult>(console.Output);
@@ -41,7 +41,7 @@ public sealed class NugetPackageValidateToolTests(ITestOutputHelper testOutputHe
     {
         var result = await RunValidation("Packages/Debug.1.0.0.nupkg");
         Assert.Equal(1, result.ExitCode);
-        Assert.False(result.ValidationResult.IsValid);
+        Assert.False(result.ValidationResult!.IsValid);
         Assert.Contains(result.ValidationResult.Errors, item => item.ErrorCode == 81);
     }
 
@@ -52,7 +52,7 @@ public sealed class NugetPackageValidateToolTests(ITestOutputHelper testOutputHe
         var path2 = FullPath.FromPath("Packages/Release.1.0.0.nupkg");
         var result = await RunValidation(path1, path2);
         Assert.Equal(1, result.ExitCode);
-        Assert.Equal(2, result.ValidationResults.Packages.Count);
+        Assert.Equal(2, result.ValidationResults!.Packages.Count);
         Assert.False(result.ValidationResults.Packages[path1].IsValid);
         Assert.Contains(result.ValidationResults.Packages[path1].Errors, item => item.ErrorCode == 81);
         Assert.False(result.ValidationResults.Packages[path2].IsValid);
@@ -64,7 +64,7 @@ public sealed class NugetPackageValidateToolTests(ITestOutputHelper testOutputHe
     {
         var result = await RunValidation("Packages/Debug.1.0.0.nupkg", "--excluded-rule-ids", "81,73;101", "--excluded-rule-ids", "75");
         Assert.Equal(1, result.ExitCode);
-        Assert.False(result.ValidationResult.IsValid);
+        Assert.False(result.ValidationResult!.IsValid);
         Assert.DoesNotContain(result.ValidationResult.Errors, item => item.ErrorCode == 73);
         Assert.DoesNotContain(result.ValidationResult.Errors, item => item.ErrorCode == 75);
         Assert.DoesNotContain(result.ValidationResult.Errors, item => item.ErrorCode == 81);
@@ -76,7 +76,7 @@ public sealed class NugetPackageValidateToolTests(ITestOutputHelper testOutputHe
     {
         var result = await RunValidation("Packages/Release_Author.1.0.0.nupkg", "--rules", "AssembliesMustBeOptimized,AuthorMustBeSet");
         Assert.Equal(0, result.ExitCode);
-        Assert.True(result.ValidationResult.IsValid);
+        Assert.True(result.ValidationResult!.IsValid);
         Assert.Empty(result.ValidationResult.Errors);
     }
 
@@ -94,7 +94,7 @@ public sealed class NugetPackageValidateToolTests(ITestOutputHelper testOutputHe
     {
         var result = await RunValidation("Packages/Release_Author.1.0.0.nupkg", "--rules", "AssembliesMustBeOptimized", "--rules", "AuthorMustBeSet");
         Assert.Equal(0, result.ExitCode);
-        Assert.True(result.ValidationResult.IsValid);
+        Assert.True(result.ValidationResult!.IsValid);
         Assert.Empty(result.ValidationResult.Errors);
     }
 }

--- a/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
+++ b/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
@@ -9,7 +9,7 @@ public sealed class ObjectMethodExecutorTests
     public void StaticSyncVoidTest()
     {
         var validator = new Validator();
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("StaticSyncVoid"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("StaticSyncVoid")!);
         var result = executor.Execute(target: null, [validator]);
 
         Assert.Null(result);
@@ -20,7 +20,7 @@ public sealed class ObjectMethodExecutorTests
     public void SyncVoidTest()
     {
         var validator = new Validator();
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncVoid"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncVoid")!);
         var result = executor.Execute(new Test(), [validator]);
 
         Assert.Null(result);
@@ -30,7 +30,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public void SyncInt32Test()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32")!);
         var result = executor.Execute(new Test(), []);
         Assert.Equal(1, result);
     }
@@ -38,7 +38,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public void SyncInt32WithParamTest()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32WithParam"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32WithParam")!);
         var result = executor.Execute(new Test(), [12]);
         Assert.Equal(12, result);
     }
@@ -47,7 +47,7 @@ public sealed class ObjectMethodExecutorTests
     public async Task StaticAsyncTaskTests()
     {
         var validator = new Validator();
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("StaticAsyncTask"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("StaticAsyncTask")!);
         var result = await executor.ExecuteAsync(null, [validator]);
 
         Assert.Null(result);
@@ -58,7 +58,7 @@ public sealed class ObjectMethodExecutorTests
     public async Task AsyncTaskTests()
     {
         var validator = new Validator();
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTask"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTask")!);
         var result = await executor.ExecuteAsync(new Test(), [validator]);
 
         Assert.Null(result);
@@ -68,7 +68,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public async Task AsyncTaskInt32Tests()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32")!);
         var result = await executor.ExecuteAsync(new Test(), []);
         Assert.Equal(1, result);
     }
@@ -76,7 +76,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public async Task ValueTaskInt32Tests()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("ValueTaskInt32"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("ValueTaskInt32")!);
         var result = await executor.ExecuteAsync(new Test(), []);
         Assert.Equal(1, result);
     }
@@ -84,7 +84,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public async Task AsyncTaskInt32WithParamTests()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32WithParam"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32WithParam")!);
         var result = await executor.ExecuteAsync(new Test(), [12]);
         Assert.Equal(12, result);
     }
@@ -92,7 +92,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public async Task AsyncCustomAwaiter()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncCustomAwaiter"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncCustomAwaiter")!);
         var result = await executor.ExecuteAsync(new Test(), []);
         Assert.Null(result);
     }
@@ -101,7 +101,7 @@ public sealed class ObjectMethodExecutorTests
     public async Task AsyncValueTaskTests()
     {
         var validator = new Validator();
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncValueTask"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncValueTask")!);
         var result = await executor.ExecuteAsync(new Test(), [validator]);
 
         Assert.Null(result);
@@ -112,7 +112,7 @@ public sealed class ObjectMethodExecutorTests
     public async Task SyncVoidCalledAsyncTest()
     {
         var validator = new Validator();
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncVoid"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncVoid")!);
         var result = await executor.ExecuteAsync(new Test(), [validator]);
 
         Assert.Null(result);
@@ -122,7 +122,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public async Task FSharpAsync()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(FSharpTests.Say).GetMethod("get_int32"));
+        var executor = ObjectMethodExecutor.Create(typeof(FSharpTests.Say).GetMethod("get_int32")!);
         var result = await executor.ExecuteAsync(new FSharpTests.Say(), []);
         Assert.Equal(42, result);
     }
@@ -130,7 +130,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public async Task FSharpAsync_Unit()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(FSharpTests.Say).GetMethod("get_dummyUnit"));
+        var executor = ObjectMethodExecutor.Create(typeof(FSharpTests.Say).GetMethod("get_dummyUnit")!);
         var result = await executor.ExecuteAsync(new FSharpTests.Say(), []);
         Assert.Null(result);
     }

--- a/tests/Meziantou.Framework.OpenTelemetry.Tests/OpenTelemetryReceiverTests.cs
+++ b/tests/Meziantou.Framework.OpenTelemetry.Tests/OpenTelemetryReceiverTests.cs
@@ -223,7 +223,7 @@ public sealed class OpenTelemetryReceiverTests
 
         public InMemoryOpenTelemetryHandler Receiver { get; } = receiver;
 
-        public static async Task<TestApplication> CreateAsync(InMemoryOpenTelemetryHandlerOptions options = null, Action<IServiceCollection> configureServices = null)
+        public static async Task<TestApplication> CreateAsync(InMemoryOpenTelemetryHandlerOptions? options = null, Action<IServiceCollection>? configureServices = null)
         {
             var builder = WebApplication.CreateBuilder();
             builder.WebHost.UseTestServer();

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Diagnostics;
 using System.Text;
 

--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
@@ -1670,7 +1670,7 @@ public sealed class PublicApiGeneratorTests
 #endif
 
     [InlineSnapshotAssertion(nameof(expected))]
-    private static async Task Validate(string source, string expected, PublicApiOptions options = null, CompilerOptions compilerOptions = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int lineNumber = -1)
+    private static async Task Validate(string source, string expected, PublicApiOptions? options = null, CompilerOptions? compilerOptions = null, [CallerFilePath] string filePath = null!, [CallerLineNumber] int lineNumber = -1)
     {
         await using var temporaryDirectory = TemporaryDirectory.Create();
         compilerOptions ??= new CompilerOptions();
@@ -1740,7 +1740,7 @@ public sealed class PublicApiGeneratorTests
         }
     }
 
-    private static async Task<IReadOnlyList<PublicApiFile>> BuildFiles(string source, PublicApiOptions options, CompilerOptions compilerOptions = null)
+    private static async Task<IReadOnlyList<PublicApiFile>> BuildFiles(string source, PublicApiOptions options, CompilerOptions? compilerOptions = null)
     {
         await using var temporaryDirectory = TemporaryDirectory.Create();
         compilerOptions ??= new CompilerOptions();

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
@@ -76,7 +76,7 @@ public sealed class ResxGeneratorTest
     [InlineData("")]
     [InlineData("internal")]
     [InlineData("dummy")]
-    public async Task GenerateInternalClasses(string visibility)
+    public async Task GenerateInternalClasses(string? visibility)
     {
         var element = new XElement("root", new XElement("data", new XAttribute("name", "Sample"), new XElement("value", "Value")));
         var result = await GenerateFiles([("test.resx", element.ToString())], new OptionProvider

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
@@ -240,16 +240,16 @@ public sealed class ResxGeneratorTest
 
     private sealed class OptionProvider : AnalyzerConfigOptionsProvider
     {
-        public string ProjectDir { get; set; }
-        public string RootNamespace { get; set; }
-        public string Namespace { get; set; }
-        public string ClassName { get; set; }
-        public string DefaultResourcesNamespace { get; set; }
-        public string ResourceName { get; set; }
-        public string DefaultResourcesVisibility { get; set; }
-        public string Visibility { get; set; }
-        public string GenerateResourcesType { get; set; }
-        public string GenerateKeyNamesType { get; set; }
+        public string? ProjectDir { get; set; }
+        public string? RootNamespace { get; set; }
+        public string? Namespace { get; set; }
+        public string? ClassName { get; set; }
+        public string? DefaultResourcesNamespace { get; set; }
+        public string? ResourceName { get; set; }
+        public string? DefaultResourcesVisibility { get; set; }
+        public string? Visibility { get; set; }
+        public string? GenerateResourcesType { get; set; }
+        public string? GenerateKeyNamesType { get; set; }
         public Dictionary<string, string> PerFileNamespace { get; set; } = new(StringComparer.Ordinal);
 
         public override AnalyzerConfigOptions GlobalOptions => new Options(this);
@@ -261,15 +261,15 @@ public sealed class ResxGeneratorTest
         private sealed class Options : AnalyzerConfigOptions
         {
             private readonly OptionProvider _optionProvider;
-            private readonly string _path;
+            private readonly string? _path;
 
-            public Options(OptionProvider optionProvider, string path = null)
+            public Options(OptionProvider optionProvider, string? path = null)
             {
                 _optionProvider = optionProvider;
                 _path = path;
             }
 
-            public override bool TryGetValue(string key, [NotNullWhen(true)] out string value)
+            public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
             {
                 const string BuildMetadata = "build_metadata.AdditionalFiles.";
                 const string BuildProperties = "build_property.";
@@ -295,7 +295,7 @@ public sealed class ResxGeneratorTest
                 var prop = typeof(OptionProvider).GetProperty(key);
                 if (prop != null)
                 {
-                    var propValue = (string)prop.GetValue(_optionProvider, null);
+                    var propValue = prop.GetValue(_optionProvider, null) as string;
                     if (propValue is not null)
                     {
                         value = propValue;
@@ -318,7 +318,7 @@ public sealed class ResxGeneratorTest
             Path = path;
             _text = text;
         }
-        public TestAdditionalText(string path, string text, Encoding encoding = null)
+        public TestAdditionalText(string path, string text, Encoding? encoding = null)
             : this(path, SourceText.From(text, encoding))
         {
         }

--- a/tests/Meziantou.Framework.Scheduling.Tests/CronExpressionTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/CronExpressionTests.cs
@@ -26,8 +26,8 @@ public sealed class CronExpressionTests
     [Fact]
     public void CronExpression_Parse_NullExpression()
     {
-        Assert.Throws<ArgumentNullException>(() => CronExpression.Parse(null));
-        Assert.False(CronExpression.TryParse(null, out _));
+        Assert.Throws<ArgumentNullException>(() => CronExpression.Parse((string)null!));
+        Assert.False(CronExpression.TryParse((string?)null, out _));
 
         Assert.Throws<FormatException>(() => CronExpression.Parse(ReadOnlySpan<char>.Empty));
         Assert.False(CronExpression.TryParse(ReadOnlySpan<char>.Empty, out _));

--- a/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
+++ b/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
@@ -142,7 +142,7 @@ public sealed class SensitiveDataTests
     [Fact]
     public void CanConvertFromString()
     {
-        using var data = (SensitiveData<char>)TypeDescriptor.GetConverter(typeof(SensitiveData<char>)).ConvertFromString("bar");
+        using var data = (SensitiveData<char>)TypeDescriptor.GetConverter(typeof(SensitiveData<char>)).ConvertFromString("bar")!;
         Assert.Equal("bar", data.RevealToString());
     }
 

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
@@ -158,6 +158,6 @@ public sealed class ExpressionQueryBuilderTests
     {
         public int Int32Value { get; set; }
         public long Int64Value { get; set; }
-        public string StringValue { get; set; }
+        public string? StringValue { get; set; }
     }
 }

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
@@ -863,6 +863,6 @@ public sealed class QueryBuilderTests
         public DateTime DateTimeValue { get; set; }
         public DateTimeOffset DateTimeOffsetValue { get; set; }
         public DayOfWeek DayOfWeekValue { get; set; }
-        public string StringValue { get; set; }
+        public string? StringValue { get; set; }
     }
 }

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ValueParserTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ValueParserTests.cs
@@ -86,7 +86,7 @@ public class ValueParserTests
 
     private sealed class CustomTypeWithTryParse
     {
-        public static bool TryParse(string value, out CustomTypeWithTryParse result)
+        public static bool TryParse(string value, out CustomTypeWithTryParse? result)
         {
             if (string.IsNullOrEmpty(value))
             {

--- a/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
+++ b/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
@@ -33,7 +33,7 @@ public sealed class SingleInstanceTests
         Assert.Equal(["123"], orderedEvents[0].Arguments);
         Assert.Equal(["a", "b", "c"], orderedEvents[1].Arguments);
 
-        void SingleInstance_NewInstance(object sender, SingleInstanceEventArgs e)
+        void SingleInstance_NewInstance(object? sender, SingleInstanceEventArgs e)
         {
             Assert.Equal(singleInstance, sender);
             lock (events)

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Text.RegularExpressions;
 
 namespace Meziantou.Framework.SnapshotTesting.Tests;

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTypeTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTypeTests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Meziantou.Framework.SnapshotTesting.Tests;
 
 public sealed class SnapshotTypeTests

--- a/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
@@ -465,7 +465,6 @@ public sealed partial class StronglyTypedIdTests
         public T? Value { get; set; }
     }
 
-#nullable enable
     [StronglyTypedId(typeof(bool))]
     private partial struct IdBoolean { }
 

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
@@ -53,7 +53,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
 
     private static ISourceGenerator InstantiateGenerator() => new StronglyTypedIdSourceGenerator().AsSourceGenerator();
 
-    private static async Task<(GeneratorDriverRunResult GeneratorResult, Compilation OutputCompilation, byte[] Assembly, byte[] Symbols)> GenerateFiles(string sourceText, bool mustCompile = true)
+    private static async Task<(GeneratorDriverRunResult GeneratorResult, Compilation OutputCompilation, byte[]? Assembly, byte[] Symbols)> GenerateFiles(string sourceText, bool mustCompile = true)
     {
         var compilation = await CreateCompilation(sourceText,
         [
@@ -308,7 +308,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
             {
                 var from = (MethodInfo)type.GetMember("FromInt32").Single();
                 var instance = from.Invoke(null, [-42]);
-                var str = instance.ToString();
+                var str = instance!.ToString();
                 Assert.Equal("Test { Value = -42 }", str);
             });
         });
@@ -335,7 +335,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
         {
             var from = type.GetMember("TryParse").OfType<MethodInfo>().Single(m => m.GetParameters()[0].ParameterType == typeof(string));
             var parsed = from.Invoke(null, ["0", null]);
-            Assert.False((bool)parsed);
+            Assert.False((bool)parsed!);
         });
     }
 
@@ -387,7 +387,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
         {
             var interfaces = type.GetInterfaces();
             Assert.Contains(interfaces, x => x.FullName == "Meziantou.Framework.IStronglyTypedId");
-            Assert.Contains(interfaces, x => x.FullName.StartsWith("Meziantou.Framework.IStronglyTypedId`1", StringComparison.Ordinal));
+            Assert.Contains(interfaces, x => x.FullName?.StartsWith("Meziantou.Framework.IStronglyTypedId`1", StringComparison.Ordinal) == true);
         });
     }
 
@@ -459,14 +459,14 @@ public sealed class StronglyTypedIdSourceGeneratorTests
 
         // Replace struct with record struct
         compilation = compilation.ReplaceSyntaxTree(compilation.SyntaxTrees.First(), CSharpSyntaxTree.ParseText("[Meziantou.Framework.Annotations.StronglyTypedId(typeof(int))] public partial record struct Test { }"));
-        result = RunGenerator(validate: (_, symbol) => Assert.Equal((true, true), (symbol.IsRecord, symbol.IsValueType)));
+        result = RunGenerator(validate: (_, symbol) => Assert.Equal((true, true), (symbol!.IsRecord, symbol.IsValueType)));
         AssertSyntaxStepIsNotCached(result);
         AssertOutputIsNotCached(result);
 
         // Update references
         var newReferences = await NuGetHelpers.GetNuGetReferences("Newtonsoft.Json", "12.0.3", "lib/netstandard2.0/");
         compilation = compilation.AddReferences(newReferences.Select(path => MetadataReference.CreateFromFile(path)));
-        result = RunGenerator(validate: (_, symbol) => Assert.NotEmpty(symbol.GetTypeMembers("TestNewtonsoftJsonConverter")));
+        result = RunGenerator(validate: (_, symbol) => Assert.NotEmpty(symbol!.GetTypeMembers("TestNewtonsoftJsonConverter")));
         AssertOutputIsNotCached(result);
 
         // Update syntax
@@ -498,7 +498,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
             Assert.DoesNotContain(IncrementalStepRunReason.Cached, result.TrackedSteps["Syntax"].SelectMany(step => step.Outputs).Select(output => output.Reason));
         }
 
-        GeneratorRunResult RunGenerator(bool shouldGenerateFiles = true, Action<Compilation, INamedTypeSymbol> validate = null)
+        GeneratorRunResult RunGenerator(bool shouldGenerateFiles = true, Action<Compilation, INamedTypeSymbol?>? validate = null)
         {
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics, XunitCancellationToken);
             Assert.Empty(diagnostics);
@@ -655,7 +655,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
         return TestGeneratedAssembly(sourceCode, typeName: null, assert);
     }
 
-    private static async Task TestGeneratedAssembly([StringSyntax("c#-test")] string sourceCode, string typeName, Action<Type> assert, bool mustGenerateTrees = true)
+    private static async Task TestGeneratedAssembly([StringSyntax("c#-test")] string sourceCode, string? typeName, Action<Type> assert, bool mustGenerateTrees = true)
     {
         var result = await GenerateFiles(sourceCode);
         Assert.Empty(result.GeneratorResult.Diagnostics);
@@ -673,10 +673,10 @@ public sealed class StronglyTypedIdSourceGeneratorTests
         var alc = new AssemblyLoadContext("test", isCollectible: true);
         try
         {
-            var assembly = alc.LoadFromStream(new MemoryStream(result.Assembly), new MemoryStream(result.Symbols));
+            var assembly = alc.LoadFromStream(new MemoryStream(result.Assembly!), new MemoryStream(result.Symbols));
             var type = assembly.GetType(typeName ?? "Test");
 
-            assert(type);
+            assert(type!);
         }
         finally
         {

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -166,7 +166,7 @@ public sealed class TdsServerProtocolTests
             (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
             (context, cancellationToken) =>
             {
-                if (!TryParseCustomerQuery(context.CommandText, out var customerId))
+                if (!TryParseCustomerQuery(context.CommandText!, out var customerId))
                 {
                     parseSucceededTask.TrySetResult(false);
                     return ValueTask.FromResult(TdsQueryResult.FromError(new TdsQueryError
@@ -220,7 +220,7 @@ public sealed class TdsServerProtocolTests
             (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
             (context, cancellationToken) =>
             {
-                if (!TryParseCustomerQuery(context.CommandText, out _))
+                if (!TryParseCustomerQuery(context.CommandText!, out _))
                 {
                     invalidQueryTask.TrySetResult(true);
                     return ValueTask.FromResult(TdsQueryResult.FromError(new TdsQueryError

--- a/tests/Meziantou.Framework.Templating.Html.Tests/EmailTemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Html.Tests/EmailTemplateTest.cs
@@ -12,7 +12,7 @@ public class EmailTemplateTest
         // Act 
         var result = template.Run(out var metadata);
         Assert.Equal("Hello Meziantou!", result);
-        Assert.Null(metadata.Title);
+        Assert.Null(metadata!.Title);
     }
 
     [Fact]
@@ -25,7 +25,7 @@ public class EmailTemplateTest
         // Act 
         var result = template.Run(out var metadata);
         Assert.Equal("Hello Meziantou!", result);
-        Assert.Equal("Meziantou", metadata.Title);
+        Assert.Equal("Meziantou", metadata!.Title);
     }
 
     [Fact]
@@ -86,8 +86,8 @@ public class EmailTemplateTest
         // Act 
         var result = template.Run(out var metadata);
         Assert.Equal("<img src=\"cid:test1.png\" /><img src=\"cid:test2.png\" />", result);
-        Assert.Collection(metadata.ContentIdentifiers,
-             item => Assert.Equal("test1.png", item),
-             item => Assert.Equal("test2.png", item));
+        Assert.Collection(metadata!.ContentIdentifiers!,
+              item => Assert.Equal("test1.png", item),
+              item => Assert.Equal("test2.png", item));
     }
 }

--- a/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
@@ -58,7 +58,7 @@ public class TemplateTest
         // Arrange
         var template = new Template();
         template.Load("Hello <%=Name%>!");
-        var arguments = new Dictionary<string, object>(StringComparer.Ordinal)
+        var arguments = new Dictionary<string, object?>(StringComparer.Ordinal)
         {
             { "Name", "Meziantou" },
         };

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableArrayTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableArrayTests.cs
@@ -91,10 +91,10 @@ public sealed class ImmutableEquatableArrayTests
         var array = ImmutableEquatableArray.Create(new[] { "a" });
 
         Assert.False(array.Equals(null));
-        Assert.False(array == null);
-        Assert.False(null == array);
-        Assert.True(array != null);
-        Assert.True(null != array);
+        Assert.False(array is null);
+        Assert.False(array is null);
+        Assert.True(array is not null);
+        Assert.True(array is not null);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableArrayTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableArrayTests.cs
@@ -91,10 +91,10 @@ public sealed class ImmutableEquatableArrayTests
         var array = ImmutableEquatableArray.Create(new[] { "a" });
 
         Assert.False(array.Equals(null));
-        Assert.False(array is null);
-        Assert.False(array is null);
-        Assert.True(array is not null);
-        Assert.True(array is not null);
+        Assert.False(array == null);
+        Assert.False(null == array);
+        Assert.True(array != null);
+        Assert.True(null != array);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableDictionaryTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableDictionaryTests.cs
@@ -179,21 +179,21 @@ public sealed class ImmutableEquatableDictionaryTests
         var dict = new[] { ("a", 1) }.ToImmutableEquatableDictionary();
 
         Assert.False(dict.Equals(null));
-        Assert.False(dict == null);
-        Assert.False(null == dict);
-        Assert.True(dict != null);
-        Assert.True(null != dict);
-        Assert.False(dict.Equals((object)null));
+        Assert.False(dict is null);
+        Assert.False(dict is null);
+        Assert.True(dict is not null);
+        Assert.True(dict is not null);
+        Assert.False(dict.Equals((object?)null));
     }
 
     [Fact]
     public void Equals_BothNull_ShouldReturnTrue()
     {
-        ImmutableEquatableDictionary<string, int> dict1 = null;
-        ImmutableEquatableDictionary<string, int> dict2 = null;
+        ImmutableEquatableDictionary<string, int>? dict1 = null;
+        ImmutableEquatableDictionary<string, int>? dict2 = null;
 
-        Assert.True(dict1 == dict2);
-        Assert.False(dict1 != dict2);
+        Assert.True(dict1 is null && dict2 is null);
+        Assert.False(dict1 is not null || dict2 is not null);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
@@ -35,7 +35,7 @@ public sealed class ImmutableEquatableSetTests
         Assert.Contains("b", set);
         Assert.Contains("c", set);
         Assert.DoesNotContain("d", set);
-        Assert.DoesNotContain(null, set);
+        Assert.False(set.Contains(null!));
     }
 
     [Fact]
@@ -87,10 +87,10 @@ public sealed class ImmutableEquatableSetTests
         var set = ImmutableEquatableSet.Create(new HashSet<string>(StringComparer.Ordinal) { "a" });
 
         Assert.False(set.Equals(null));
-        Assert.False(set == null);
-        Assert.False(null == set);
-        Assert.True(set != null);
-        Assert.True(null != set);
+        Assert.False(set is null);
+        Assert.False(set is null);
+        Assert.True(set is not null);
+        Assert.True(set is not null);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Tests/EnumerableTests.cs
+++ b/tests/Meziantou.Framework.Tests/EnumerableTests.cs
@@ -110,7 +110,7 @@ public class EnumerableTests
     [Fact]
     public void EmptyIfNull_Null()
     {
-        IEnumerable<string> items = null;
+        IEnumerable<string>? items = null;
         Assert.Equal([], items.EmptyIfNull());
     }
 
@@ -289,7 +289,7 @@ public class EnumerableTests
     [Fact]
     public void ParallelSort_NullArray_Throws()
     {
-        int[] values = null;
+        int[]? values = null;
         Assert.Throws<ArgumentNullException>(() => values!.ParallelSort());
     }
 
@@ -424,7 +424,7 @@ public class EnumerableTests
     [Fact]
     public void ParallelStableSort_NullArray_Throws()
     {
-        int[] values = null;
+        int[]? values = null;
         Assert.Throws<ArgumentNullException>(() => values!.ParallelStableSort());
     }
 
@@ -463,7 +463,7 @@ public class EnumerableTests
         public int Key { get; } = key;
         public int Order { get; } = order;
 
-        public int CompareTo(ComparableReferenceValue other)
+        public int CompareTo(ComparableReferenceValue? other)
         {
             if (other is null)
                 return 1;
@@ -471,7 +471,7 @@ public class EnumerableTests
             return Key.CompareTo(other.Key);
         }
 
-        public bool Equals(ComparableReferenceValue other)
+        public bool Equals(ComparableReferenceValue? other)
         {
             if (other is null)
                 return false;
@@ -479,7 +479,7 @@ public class EnumerableTests
             return Key == other.Key && Order == other.Order;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is ComparableReferenceValue other && Equals(other);
         }

--- a/tests/Meziantou.Framework.Tests/EnumerableTests.cs
+++ b/tests/Meziantou.Framework.Tests/EnumerableTests.cs
@@ -121,7 +121,6 @@ public class EnumerableTests
         Assert.StrictEqual(items, items.EmptyIfNull());
     }
 
-#nullable enable
     [Fact]
     [SuppressMessage("Style", "IDE0007:Use implicit type", Justification = "Need to validate the type is non-nullable")]
     public void WhereNotNull()
@@ -147,8 +146,6 @@ public class EnumerableTests
         List<int> actual = list.WhereNotNull().ToList();
         Assert.Equal([0, 2], actual);
     }
-#nullable disable
-
     [Fact]
     public void ForeachEnumerator()
     {

--- a/tests/Meziantou.Framework.Tests/ObjectGraphVisitorTests.cs
+++ b/tests/Meziantou.Framework.Tests/ObjectGraphVisitorTests.cs
@@ -37,7 +37,7 @@ public sealed class ObjectGraphVisitorTests
         Assert.Empty(visitor.VisitedProperties);
     }
 
-    private sealed record Recursive(object Value, Recursive Parent);
+    private sealed record Recursive(object Value, Recursive? Parent);
 
     private sealed class Indexer
     {
@@ -49,7 +49,7 @@ public sealed class ObjectGraphVisitorTests
         public List<PropertyInfo> VisitedProperties { get; } = [];
         public List<object> VisitedValues { get; } = [];
 
-        protected override void VisitProperty(object parentInstance, PropertyInfo property, object value)
+        protected override void VisitProperty(object parentInstance, PropertyInfo property, object? value)
         {
             VisitedProperties.Add(property);
         }

--- a/tests/Meziantou.Framework.Tests/ProcessExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/ProcessExtensionsTests.cs
@@ -191,12 +191,12 @@ public class ProcessExtensionsTests
     {
         var current = Process.GetCurrentProcess();
         var parent = current.GetParentProcess();
-        var grandParent = parent.GetParentProcess();
+        var grandParent = parent!.GetParentProcess();
 
         Assert.NotNull(grandParent);
 
         var descendants = grandParent.GetDescendantProcesses();
         Assert.Contains(descendants, p => p.Id == current.Id);
-        Assert.Contains(descendants, p => p.Id == parent.Id);
+        Assert.Contains(descendants, p => p.Id == parent!.Id);
     }
 }

--- a/tests/Meziantou.Framework.Tests/ReflectionDynamicObjectTests.cs
+++ b/tests/Meziantou.Framework.Tests/ReflectionDynamicObjectTests.cs
@@ -120,7 +120,7 @@ public class ReflectionDynamicObjectTests
         private int this[int i] => i;
         private int this[int i, int j] => i + j;
 
-        private string _indexer;
+        private string? _indexer;
 
         private string this[string str]
         {

--- a/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
@@ -18,7 +18,7 @@ public class StringExtensionsTests
     [InlineData("abc", "abc", true)]
     [InlineData("abc", "aBc", true)]
     [InlineData("aabc", "abc", false)]
-    public void EqualsIgnoreCase(string left, string right, bool expectedResult)
+    public void EqualsIgnoreCase(string? left, string? right, bool expectedResult)
     {
         Assert.Equal(expectedResult, left.EqualsIgnoreCase(right));
     }

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_ByteArrayTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_ByteArrayTo.cs
@@ -9,7 +9,7 @@ public class DefaultConverterTests_ByteArrayTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(new byte[] { 1, 2, 3, 4 }, cultureInfo, out string value);
+        var converted = converter.TryChangeType(new byte[] { 1, 2, 3, 4 }, cultureInfo, out string? value);
         Assert.True(converted);
         Assert.Equal("AQIDBA==", value);
     }
@@ -22,7 +22,7 @@ public class DefaultConverterTests_ByteArrayTo
             ByteArrayToStringFormat = ByteArrayToStringFormat.Base16Prefixed,
         };
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(new byte[] { 1, 2, 3, 4 }, cultureInfo, out string value);
+        var converted = converter.TryChangeType(new byte[] { 1, 2, 3, 4 }, cultureInfo, out string? value);
         Assert.True(converted);
         Assert.Equal("0x01020304", value);
     }
@@ -35,7 +35,7 @@ public class DefaultConverterTests_ByteArrayTo
             ByteArrayToStringFormat = ByteArrayToStringFormat.Base16,
         };
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(new byte[] { 1, 2, 3, 4 }, cultureInfo, out string value);
+        var converted = converter.TryChangeType(new byte[] { 1, 2, 3, 4 }, cultureInfo, out string? value);
         Assert.True(converted);
         Assert.Equal("01020304", value);
     }

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_CultureInfoTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_CultureInfoTo.cs
@@ -8,7 +8,7 @@ public class DefaultConverterTests_CultureInfoTo
     public void TryConvert_CultureInfoToString_UsingInvariantCulture()
     {
         var converter = new DefaultConverter();
-        var value = converter.ChangeType<string>(CultureInfo.GetCultureInfo("en"), defaultValue: null, CultureInfo.InvariantCulture);
+        var value = converter.ChangeType<string>(CultureInfo.GetCultureInfo("en"), defaultValue: "", CultureInfo.InvariantCulture);
         Assert.Equal("en", value);
     }
 
@@ -16,7 +16,7 @@ public class DefaultConverterTests_CultureInfoTo
     public void TryConvert_CultureInfoToString_UsingSpecificCulture()
     {
         var converter = new DefaultConverter();
-        var value = converter.ChangeType<string>(CultureInfo.GetCultureInfo("en"), defaultValue: null, CultureInfo.GetCultureInfo("en-US"));
+        var value = converter.ChangeType<string>(CultureInfo.GetCultureInfo("en"), defaultValue: "", CultureInfo.GetCultureInfo("en-US"));
         Assert.Equal("en", value);
     }
 }

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_DbNullTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_DbNullTo.cs
@@ -28,7 +28,7 @@ public class DefaultConverterTests_DbNullTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(DBNull.Value, cultureInfo, out string value);
+        var converted = converter.TryChangeType(DBNull.Value, cultureInfo, out string? value);
         Assert.True(converted);
         Assert.Null(value);
     }

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_Int32To.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_Int32To.cs
@@ -10,11 +10,12 @@ public class DefaultConverterTests_Int32To
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(1033, cultureInfo, out CultureInfo value);
+        var converted = converter.TryChangeType(1033, cultureInfo, out CultureInfo? value);
 
         if (OperatingSystem.IsWindows())
         {
             Assert.True(converted);
+            Assert.NotNull(value);
             Assert.Equal("en-US", value.Name);
         }
         else
@@ -58,7 +59,7 @@ public class DefaultConverterTests_Int32To
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(0x12345678, cultureInfo, out byte[] value);
+        var converted = converter.TryChangeType(0x12345678, cultureInfo, out byte[]? value);
         Assert.True(converted);
         Assert.Equal([0x78, 0x56, 0x34, 0x12], value);
     }

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_StringTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_StringTo.cs
@@ -98,8 +98,9 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("fr-FR", cultureInfo, out CultureInfo value);
+        var converted = converter.TryChangeType("fr-FR", cultureInfo, out CultureInfo? value);
         Assert.True(converted);
+        Assert.NotNull(value);
         Assert.Equal("fr-FR", value.Name);
     }
 
@@ -108,8 +109,9 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("es", cultureInfo, out CultureInfo value);
+        var converted = converter.TryChangeType("es", cultureInfo, out CultureInfo? value);
         Assert.True(converted);
+        Assert.NotNull(value);
         Assert.Equal("es", value.Name);
     }
 
@@ -118,11 +120,12 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("1033", cultureInfo, out CultureInfo value);
+        var converted = converter.TryChangeType("1033", cultureInfo, out CultureInfo? value);
 
         if (OperatingSystem.IsWindows())
         {
             Assert.True(converted);
+            Assert.NotNull(value);
             Assert.Equal("en-US", value.Name);
         }
         else
@@ -136,7 +139,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("dfgnksdfklgfg", cultureInfo, out CultureInfo _);
+        var converted = converter.TryChangeType("dfgnksdfklgfg", cultureInfo, out CultureInfo? _);
         Assert.False(converted);
     }
 
@@ -145,7 +148,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("", cultureInfo, out CultureInfo value);
+        var converted = converter.TryChangeType("", cultureInfo, out CultureInfo? value);
         Assert.True(converted);
         Assert.Equal(CultureInfo.InvariantCulture, value);
     }
@@ -155,7 +158,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        string inputValue = null;
+        string? inputValue = null;
         var converted = converter.TryChangeType<CultureInfo>(inputValue, cultureInfo, out var value);
         Assert.True(converted);
         Assert.Null(value);
@@ -166,7 +169,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("", cultureInfo, out Uri value);
+        var converted = converter.TryChangeType("", cultureInfo, out Uri? value);
         Assert.True(converted);
         Assert.Null(value);
     }
@@ -176,7 +179,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("test.png", cultureInfo, out Uri value);
+        var converted = converter.TryChangeType("test.png", cultureInfo, out Uri? value);
         Assert.True(converted);
         Assert.Equal(new Uri("test.png", UriKind.Relative), value);
     }
@@ -186,7 +189,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("https://meziantou.net", cultureInfo, out Uri value);
+        var converted = converter.TryChangeType("https://meziantou.net", cultureInfo, out Uri? value);
         Assert.True(converted);
         Assert.Equal(new Uri("https://meziantou.net", UriKind.Absolute), value);
     }
@@ -226,7 +229,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("0x0AFF", cultureInfo, out byte[] value);
+        var converted = converter.TryChangeType("0x0AFF", cultureInfo, out byte[]? value);
         Assert.True(converted);
         Assert.Equal([0x0A, 0xFF], value);
     }
@@ -236,7 +239,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("AQIDBA==", cultureInfo, out byte[] value);
+        var converted = converter.TryChangeType("AQIDBA==", cultureInfo, out byte[]? value);
         Assert.True(converted);
         Assert.Equal([1, 2, 3, 4], value);
     }
@@ -246,7 +249,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("AQIDBA=", cultureInfo, out byte[] _);
+        var converted = converter.TryChangeType("AQIDBA=", cultureInfo, out byte[]? _);
         Assert.False(converted);
     }
 
@@ -275,7 +278,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("0d0102", cultureInfo, out byte[] value);
+        var converted = converter.TryChangeType("0d0102", cultureInfo, out byte[]? value);
         Assert.True(converted);
         Assert.Equal([0x0d, 0x01, 0x02], value);
     }
@@ -285,7 +288,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("0x0d01", cultureInfo, out byte[] value);
+        var converted = converter.TryChangeType("0x0d01", cultureInfo, out byte[]? value);
         Assert.True(converted);
         Assert.Equal([0x0d, 0x01], value);
     }

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_TypeDescriptor.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_TypeDescriptor.cs
@@ -9,22 +9,22 @@ public sealed class DefaultConverterTests_TypeDescriptor
     {
         public static Dummy Instance { get; } = new Dummy();
 
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             return sourceType == typeof(int);
         }
 
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        public override object ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
         {
             return Instance;
         }
 
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
         {
             return destinationType == typeof(int);
         }
 
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        public override object ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
         {
             return 10;
         }
@@ -50,7 +50,7 @@ public sealed class DefaultConverterTests_TypeDescriptor
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(1, cultureInfo, out Dummy value);
+        var converted = converter.TryChangeType(1, cultureInfo, out Dummy? value);
         Assert.True(converted);
         Assert.Equal(CustomTypeConverter.Instance, value);
     }
@@ -61,7 +61,7 @@ public sealed class DefaultConverterTests_TypeDescriptor
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
 
-        var converted = converter.TryChangeType("", cultureInfo, out Dummy _);
+        var converted = converter.TryChangeType("", cultureInfo, out Dummy? _);
         Assert.False(converted);
     }
 }

--- a/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
+++ b/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
@@ -1160,9 +1160,9 @@ public sealed class UrlPatternTests
         Assert.NotNull(result);
         Assert.Single(result.Inputs);
         Assert.NotNull(result.Inputs[0].Init);
-        Assert.Equal("https", result.Inputs[0].Init.Protocol);
-        Assert.Equal("example.com", result.Inputs[0].Init.Hostname);
-        Assert.Equal("/books/123", result.Inputs[0].Init.Pathname);
+        Assert.Equal("https", result.Inputs[0].Init!.Protocol);
+        Assert.Equal("example.com", result.Inputs[0].Init!.Hostname);
+        Assert.Equal("/books/123", result.Inputs[0].Init!.Pathname);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
+++ b/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Globalization;
 using System.Text;
 using Xunit;

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Meziantou.Framework.Versioning.Tests;
 
 public class SemanticVersionRangeTests

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
@@ -45,7 +45,7 @@ public class SemanticVersionTests
     [Fact]
     public void TryParse_ShouldNotParseNullVersion()
     {
-        Assert.False(SemanticVersion.TryParse((string)null, out _));
+        Assert.False(SemanticVersion.TryParse((string?)null, out _));
 #pragma warning restore IDE0004
     }
 
@@ -53,7 +53,7 @@ public class SemanticVersionTests
     public void Parse_ShouldNotParseNullVersion()
     {
 #pragma warning disable IDE0004 // Remove Unnecessary Cast
-        Assert.Throws<ArgumentNullException>(() => SemanticVersion.Parse((string)null));
+        Assert.Throws<ArgumentNullException>(() => SemanticVersion.Parse((string)null!));
 #pragma warning restore IDE0004
     }
 

--- a/tests/Meziantou.Framework.WPF.Tests/BooleanToValueConverterTests.cs
+++ b/tests/Meziantou.Framework.WPF.Tests/BooleanToValueConverterTests.cs
@@ -28,7 +28,7 @@ public sealed class BooleanToValueConverterTests
     [InlineData(null, null)]
     [InlineData(null, "")]
     [InlineData(null, "abc")]
-    public void Test(bool? expectedValue, object value)
+    public void Test(bool? expectedValue, object? value)
     {
         var expected = expectedValue switch
         {

--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
@@ -122,7 +122,7 @@ public sealed class CredentialManagerTests : IDisposable
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Framework/issues/263")]
     [InlineData(null)]
     [InlineData("*")]
-    public void CredentialManager_EnumerateCredential_FilterNull(string filter)
+    public void CredentialManager_EnumerateCredential_FilterNull(string? filter)
     {
         _mutex.WaitOne();
         try

--- a/tests/TestUtilities/NuGetHelpers.cs
+++ b/tests/TestUtilities/NuGetHelpers.cs
@@ -53,7 +53,7 @@ public static class NuGetHelpers
 
                 try
                 {
-                    Directory.CreateDirectory(Path.GetDirectoryName(cacheFolder));
+                    Directory.CreateDirectory(Path.GetDirectoryName(cacheFolder)!);
                     Directory.Move(tempFolder, cacheFolder);
                 }
                 catch (Exception ex)

--- a/tests/TestUtilities/RunIfAttribute.cs
+++ b/tests/TestUtilities/RunIfAttribute.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Reflection;
 using Xunit.v3;
 


### PR DESCRIPTION
## Why
Nullable reference types were disabled for tests at the directory level, which required ad-hoc `#nullable enable` directives in individual files and made nullability behavior inconsistent across test projects.

## What changed
- Enabled nullable context in `tests/Directory.Build.props`.
- Added `NoWarn` for `nullable` in test projects to avoid a large unrelated warning migration in this PR.
- Removed redundant `#nullable enable` directives from affected test files and test utilities.
- Updated test method parameter annotations where `InlineData(null)` is used to satisfy `xUnit1012` under nullable-enabled tests.

## Notes
- `#nullable` text intentionally used inside code-generation expected strings was not changed.
- `dotnet run ./eng/validate-testprojects-configuration.cs` still reports existing target framework mismatch errors that predate this change.

## Validation
- `dotnet build Meziantou.Framework.slnx`
- `dotnet run ./eng/update-bom.cs`
- `dotnet run ./eng/update-readme.cs`
- `dotnet run ./eng/update-project-slnx.cs`
- `dotnet run ./eng/validate-testprojects-configuration.cs` (fails with existing TFM mismatch errors)
- `dotnet run ./eng/update-trimmable.cs`
- Targeted `dotnet test` runs for changed test projects with `DiffEngine_Disabled=true`