### PR TITLE
Fix snapshot caller resolution for lambda invocations

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
@@ -12,7 +12,8 @@ internal sealed record SnapshotCallerContext(FullPath SourceFilePath, string Met
     /// Newer Roslyn versions use the format "&lt;callerName&gt;g__functionName|x_y".
     /// Older versions use "&lt;callerName&gt;g__functionNamex_y".
     /// </summary>
-    private static readonly Regex LocalFunctionNameRegex = new(@"^<(.*)>g__(?<name>[^\|]*)\|{0,1}[0-9]+(_[0-9]+)?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture, matchTimeout: Timeout.InfiniteTimeSpan);
+    /// <see href="https://github.com/dotnet/roslyn/blob/aecd49800750d64e08767836e2678ffa62a4647f/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNames.cs#L109" />
+    private static readonly Regex FunctionNameRegex = new(@"^<(.*)>g__(?<name>[^\|]*)\|{0,1}[0-9]+(_[0-9]+)?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture, matchTimeout: Timeout.InfiniteTimeSpan);
     private static readonly Regex LambdaContainingMethodNameRegex = new(@"^<(?<name>[^>]+)>b__[0-9]+(_[0-9]+)?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture, matchTimeout: Timeout.InfiniteTimeSpan);
 
     private static readonly HashSet<string> TestAttributeNames = new(StringComparer.Ordinal)
@@ -243,7 +244,7 @@ internal sealed record SnapshotCallerContext(FullPath SourceFilePath, string Met
         if (TryGetLambdaContainingMethodName(name, out var lambdaContainingMethodName))
             return lambdaContainingMethodName;
 
-        if (TryGetLocalFunctionName(name, out var localFunctionName))
+        if (ParseLocalFunctionName(name, out var localFunctionName))
             return localFunctionName;
 
         return name;
@@ -263,17 +264,14 @@ internal sealed record SnapshotCallerContext(FullPath SourceFilePath, string Met
         return !string.IsNullOrEmpty(containingMethodName);
     }
 
-    private static bool TryGetLocalFunctionName(string name, [NotNullWhen(true)] out string? functionName)
+    internal static bool ParseLocalFunctionName(string name, [NotNullWhen(true)] out string? functionName)
     {
         functionName = null;
         if (string.IsNullOrWhiteSpace(name))
             return false;
 
-        var match = LocalFunctionNameRegex.Match(name);
-        if (!match.Success)
-            return false;
-
+        var match = FunctionNameRegex.Match(name);
         functionName = match.Groups["name"].Value;
-        return !string.IsNullOrEmpty(functionName);
+        return match.Success;
     }
 }

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
@@ -1,10 +1,20 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 
 namespace Meziantou.Framework.SnapshotTesting;
 
 internal sealed record SnapshotCallerContext(FullPath SourceFilePath, string MethodName, string? MemberName, int LineNumber)
 {
+    /// <summary>
+    /// Newer Roslyn versions use the format "&lt;callerName&gt;g__functionName|x_y".
+    /// Older versions use "&lt;callerName&gt;g__functionNamex_y".
+    /// </summary>
+    private static readonly Regex LocalFunctionNameRegex = new(@"^<(.*)>g__(?<name>[^\|]*)\|{0,1}[0-9]+(_[0-9]+)?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture, matchTimeout: Timeout.InfiniteTimeSpan);
+    private static readonly Regex LambdaContainingMethodNameRegex = new(@"^<(?<name>[^>]+)>b__[0-9]+(_[0-9]+)?$", RegexOptions.Compiled | RegexOptions.ExplicitCapture, matchTimeout: Timeout.InfiniteTimeSpan);
+
     private static readonly HashSet<string> TestAttributeNames = new(StringComparer.Ordinal)
     {
         "FactAttribute",
@@ -57,17 +67,18 @@ internal sealed record SnapshotCallerContext(FullPath SourceFilePath, string Met
             if (method is null)
                 continue;
 
+            method = GetActualMethod(method);
             var declaringType = method.DeclaringType;
             if (declaringType?.Namespace?.StartsWith("Meziantou.Framework.SnapshotTesting", StringComparison.Ordinal) == true)
                 continue;
 
             if (HasTestAttribute(method))
             {
-                discoveredMethodName = method.Name;
+                discoveredMethodName = NormalizeMethodName(method.Name);
                 break;
             }
 
-            discoveredMethodName ??= method.Name;
+            discoveredMethodName ??= NormalizeMethodName(method.Name);
         }
 
         var sourceFilePath = filePath;
@@ -195,5 +206,74 @@ internal sealed record SnapshotCallerContext(FullPath SourceFilePath, string Met
         }
 
         return false;
+    }
+
+    private static MethodBase GetActualMethod(MethodBase method)
+    {
+        if (method.DeclaringType is null || !method.DeclaringType.IsAssignableTo(typeof(IAsyncStateMachine)))
+            return method;
+
+        var parentType = method.DeclaringType.DeclaringType;
+        if (parentType is null)
+            return method;
+
+        static MethodInfo[] GetDeclaredMethods(Type type) => type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+        var methods = GetDeclaredMethods(parentType);
+        if (methods is null)
+            return method;
+
+        foreach (var candidateMethod in methods)
+        {
+            var attributes = candidateMethod.GetCustomAttributes<StateMachineAttribute>(inherit: false);
+            if (attributes is null)
+                continue;
+
+            foreach (var stateMachineAttribute in attributes)
+            {
+                if (stateMachineAttribute.StateMachineType == method.DeclaringType)
+                    return candidateMethod;
+            }
+        }
+
+        return method;
+    }
+
+    private static string NormalizeMethodName(string name)
+    {
+        if (TryGetLambdaContainingMethodName(name, out var lambdaContainingMethodName))
+            return lambdaContainingMethodName;
+
+        if (TryGetLocalFunctionName(name, out var localFunctionName))
+            return localFunctionName;
+
+        return name;
+    }
+
+    private static bool TryGetLambdaContainingMethodName(string name, [NotNullWhen(true)] out string? containingMethodName)
+    {
+        containingMethodName = null;
+        if (string.IsNullOrWhiteSpace(name))
+            return false;
+
+        var match = LambdaContainingMethodNameRegex.Match(name);
+        if (!match.Success)
+            return false;
+
+        containingMethodName = match.Groups["name"].Value;
+        return !string.IsNullOrEmpty(containingMethodName);
+    }
+
+    private static bool TryGetLocalFunctionName(string name, [NotNullWhen(true)] out string? functionName)
+    {
+        functionName = null;
+        if (string.IsNullOrWhiteSpace(name))
+            return false;
+
+        var match = LocalFunctionNameRegex.Match(name);
+        if (!match.Success)
+            return false;
+
+        functionName = match.Groups["name"].Value;
+        return !string.IsNullOrEmpty(functionName);
     }
 }

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -495,6 +495,58 @@ public sealed class SnapshotEndToEndTests
         ]);
     }
 
+    [Fact]
+    public async Task Validate_EndToEnd_UsesContainingMethodName_WhenCalledFromLambda()
+    {
+        var snapshotFiles = await AssertSnapshot(
+            """
+            using System.Threading.Tasks;
+
+            public sealed class GeneratedSnapshotTests
+            {
+                [Fact]
+                public async Task SampleTest()
+                {
+                    await Task.Run(() => Snapshot.Validate("sample", SnapshotTestUtilities.CreateSuccessSettings()));
+                }
+            }
+            """,
+            testFramework: SnapshotTestFramework.Xunit);
+
+        AssertSnapshotContent(snapshotFiles,
+        [
+            ("__snapshots__/SampleTest.verified.txt", "sample"),
+        ]);
+    }
+
+    [Fact]
+    public async Task Validate_EndToEnd_UsesContainingMethodName_WhenCalledFromAsyncLambda()
+    {
+        var snapshotFiles = await AssertSnapshot(
+            """
+            using System.Threading.Tasks;
+
+            public sealed class GeneratedSnapshotTests
+            {
+                [Fact]
+                public async Task SampleTest()
+                {
+                    await Task.Run(async () =>
+                    {
+                        Snapshot.Validate("sample", SnapshotTestUtilities.CreateSuccessSettings());
+                        await Task.CompletedTask;
+                    });
+                }
+            }
+            """,
+            testFramework: SnapshotTestFramework.Xunit);
+
+        AssertSnapshotContent(snapshotFiles,
+        [
+            ("__snapshots__/SampleTest.verified.txt", "sample"),
+        ]);
+    }
+
     private static string GetFrameworkSmokeSource(SnapshotTestFramework framework)
     {
         return framework switch


### PR DESCRIPTION
## Why

`Snapshot.Validate` calls inside `Task.Run` lambdas were producing snapshot names from compiler-generated methods (for example `SampleTest_b__0_0` and `MoveNext`) instead of the containing test method. That makes snapshot file names noisy and unstable.

## What changed

- Added end-to-end regression coverage in `SnapshotEndToEndTests` for:
  - `await Task.Run(() => Snapshot.Validate(...))`
  - `await Task.Run(async () => { Snapshot.Validate(...); ... })`
- Updated `SnapshotCallerContext` to normalize call-site method detection by:
  - resolving async state-machine frames back to their original methods via `StateMachineAttribute`
  - mapping compiler-generated lambda method names (`<Method>b__...`) to their containing method names
  - preserving local-function name normalization behavior

## Notes for reviewers

- This change is intentionally narrow to caller-name extraction used for snapshot path generation.
- `tests/Meziantou.Framework.SnapshotTesting.Tests` passes with these changes.
- Required repository scripts were run; `eng/validate-testprojects-configuration.cs` still reports existing target-framework mismatch errors unrelated to this PR.