### PR TITLE
Add discoverable Clone APIs for snapshot settings

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettingsCloneExtensions.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettingsCloneExtensions.cs
@@ -1,0 +1,9 @@
+namespace Meziantou.Framework.InlineSnapshotTesting;
+
+public static class InlineSnapshotSettingsCloneExtensions
+{
+    extension(InlineSnapshotSettings settings)
+    {
+        public InlineSnapshotSettings Clone() => settings with { };
+    }
+}

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotSettingsCloneExtensions.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotSettingsCloneExtensions.cs
@@ -1,0 +1,9 @@
+namespace Meziantou.Framework.SnapshotTesting;
+
+public static class SnapshotSettingsCloneExtensions
+{
+    extension(SnapshotSettings settings)
+    {
+        public SnapshotSettings Clone() => settings with { };
+    }
+}

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
@@ -29,7 +29,7 @@ public sealed class InlineSnapshotSettingsTests
 
         settings.ScrubLinesContaining(StringComparison.Ordinal, "test");
 
-        var clone = settings with { };
+        var clone = settings.Clone();
 
         Assert.Same(settings.SnapshotSerializer, clone.SnapshotSerializer);
         Assert.Same(settings.AssertionExceptionCreator, clone.AssertionExceptionCreator);

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -58,7 +58,7 @@ public sealed class SnapshotTests
         original.Comparers.Set(SnapshotType.Create("dummy"), ByteArraySnapshotComparer.Instance);
         var originalSerializerCount = original.Serializers.Count;
 
-        var clone = original with { };
+        var clone = original.Clone();
         clone.Serializers.Add(new FixedCountSerializer(count: 2));
 
         Assert.NotSame(original.Serializers, clone.Serializers);


### PR DESCRIPTION
## Why
`SnapshotSettings` and `InlineSnapshotSettings` were cloneable via `with { }`, but that syntax is not very discoverable for users reading the API surface.

## What changed
This PR adds explicit, discoverable `Clone()` APIs for both settings types by introducing extension methods:
- `SnapshotSettings.Clone()` in `SnapshotSettingsCloneExtensions`
- `InlineSnapshotSettings.Clone()` in `InlineSnapshotSettingsCloneExtensions`

The methods delegate to `with { }`, so existing record copy behavior is preserved.

## Notes
Records cannot declare a member named `Clone`, so extension methods were used to provide the API without changing the types from records to classes.

## Tests and checks
- Updated clone-related tests to call `Clone()` in:
  - `SnapshotTests.Settings_WithDeepClone`
  - `InlineSnapshotSettingsTests.Clone`
- Ran required engineering scripts:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`
- Ran targeted tests with diff tool disabled:
  - `DiffEngine_Disabled=true dotnet test tests/Meziantou.Framework.InlineSnapshotTesting.Tests/Meziantou.Framework.InlineSnapshotTesting.Tests.csproj -f net10.0`
  - `DiffEngine_Disabled=true dotnet test tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj -f net10.0`