### PR TITLE
Increase build_and_test timeout to 90 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
 
   build_and_test:
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       TestResultsDirectory: ${{ github.workspace}}/TestResults
     strategy:


### PR DESCRIPTION
Windows `build_and_test` jobs on `main` have been timing out and getting canceled around the 60-minute cap, which prevents the matrix from completing even when tests are still progressing.

This PR applies a low-risk stabilization change by increasing `build_and_test.timeout-minutes` in `.github/workflows/ci.yml` from `60` to `90`.

This is intended as the first mitigation step to stop timeout-driven cancellations while we evaluate follow-up runtime reductions (matrix scoping and test-cost tuning).