### PR TITLE
Fix snapshot overload resolution

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/Snapshot.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Snapshot.cs
@@ -7,6 +7,7 @@ public static class Snapshot
     public static AsyncLocal<SnapshotTestContext?> TestContext { get; } = new();
 
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    [OverloadResolutionPriority(-1)] // Snapshot type has an implicit conversion from string, so this method must be called only if the user explicitly specify the type of snapshot
     public static void Validate(object? value, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = -1, [CallerMemberName] string? memberName = null)
     {
         Validate(value, settings: null, filePath, lineNumber, memberName);

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -438,6 +438,27 @@ public sealed class SnapshotEndToEndTests
     }
 
     [Fact]
+    public async Task Validate_EndToEnd_UsesTypedExtension_WhenValueIsByteArray_StringSnapshotTypeValue()
+    {
+        var snapshotFiles = await AssertSnapshot(
+            """
+            public sealed class GeneratedSnapshotTests
+            {
+                [Fact]
+                public void SampleTest()
+                {
+                    var payload = new byte[] { 0x42, 0x00, 0x43 };
+                    Snapshot.Validate(payload, "png", SnapshotTestUtilities.CreateSuccessSettings());
+                }
+            }
+            """);
+
+        var snapshotFile = Assert.Single(snapshotFiles);
+        Assert.Equal("__snapshots__/SampleTest.verified.png", snapshotFile.RelativePath);
+        Assert.Equal([0x42, 0x00, 0x43], snapshotFile.Content);
+    }
+
+    [Fact]
     public async Task Validate_EndToEnd_UsesTypedExtension_WhenValueIsByteArray()
     {
         var snapshotFiles = await AssertSnapshot(

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -496,6 +496,44 @@ public sealed class SnapshotEndToEndTests
     }
 
     [Fact]
+    public async Task Validate_EndToEnd_IgnoresOutputSnapshots_WhenUsingArtifactsOutput()
+    {
+        var snapshotFiles = await AssertSnapshot(
+            """
+            public sealed class GeneratedSnapshotTests
+            {
+                [Fact]
+                public void SampleTest()
+                {
+                    Snapshot.Validate("sample", SnapshotTestUtilities.CreateFailureSettings());
+                }
+            }
+            """,
+            existingFiles:
+            [
+                new SnapshotFile("__snapshots__/SampleTest.verified.txt", "sample"u8.ToArray()),
+            ],
+            directoryBuildPropsContent:
+            """
+            <Project>
+              <PropertyGroup>
+                <UseArtifactsOutput>true</UseArtifactsOutput>
+              </PropertyGroup>
+            </Project>
+            """,
+            additionalFilesAfterTest:
+            [
+                new SnapshotFile("artifacts/bin/Project/debug/__snapshots__/SampleTest.verified.txt", "copied snapshot"u8.ToArray()),
+                new SnapshotFile("artifacts/obj/Project/debug/__snapshots__/SampleTest.verified.txt", "intermediate snapshot"u8.ToArray()),
+            ]);
+
+        AssertSnapshotContent(snapshotFiles,
+        [
+            ("__snapshots__/SampleTest.verified.txt", "sample"),
+        ]);
+    }
+
+    [Fact]
     public async Task Validate_EndToEnd_UsesContainingMethodName_WhenCalledFromLambda()
     {
         var snapshotFiles = await AssertSnapshot(
@@ -654,7 +692,9 @@ public sealed class SnapshotEndToEndTests
         string? targetFramework = null,
         bool expectFailure = false,
         IReadOnlyList<SnapshotFile>? existingFiles = null,
-        string? testFilter = null)
+        string? testFilter = null,
+        string? directoryBuildPropsContent = null,
+        IReadOnlyList<SnapshotFile>? additionalFilesAfterTest = null)
     {
         await using var directory = TemporaryDirectory.Create();
         var dotnetPath = ExecutableFinder.GetFullExecutablePath("dotnet");
@@ -701,9 +741,22 @@ public sealed class SnapshotEndToEndTests
             }
         }
 
+        if (!string.IsNullOrEmpty(directoryBuildPropsContent))
+        {
+            CreateTextFile("Directory.Build.props", directoryBuildPropsContent);
+        }
+
         await ExecuteDotNet(directory.FullPath, dotnetPath, ["restore", "--disable-build-servers"], expectedExitCode: 0);
         await ExecuteDotNet(directory.FullPath, dotnetPath, ["build", "--no-restore", "--disable-build-servers"], expectedExitCode: 0);
         await ExecuteDotNet(directory.FullPath, dotnetPath, GetDotNetTestArguments(testFramework, testFilter), expectedExitCode: expectFailure ? 1 : 0);
+
+        if (additionalFilesAfterTest is not null)
+        {
+            foreach (var additionalFile in additionalFilesAfterTest)
+            {
+                CreateBinaryFile(additionalFile.RelativePath, additionalFile.Content);
+            }
+        }
 
         return GetGeneratedSnapshotFiles(directory.FullPath);
 
@@ -763,12 +816,37 @@ public sealed class SnapshotEndToEndTests
 
     private static SnapshotFile[] GetGeneratedSnapshotFiles(FullPath rootPath)
     {
-        return Directory.GetFiles(rootPath, "*", SearchOption.AllDirectories)
-                    .Select(path => path.Replace('\\', '/'))
-                    .Where(path => path.Contains("/__snapshots__/", StringComparison.Ordinal))
-                    .Order(StringComparer.Ordinal)
-                    .Select(file => new SnapshotFile(Path.GetRelativePath(rootPath, file).Replace('\\', '/'), File.ReadAllBytes(file)))
-                    .ToArray();
+        var validSnapshotDirectories = Directory.GetFiles(rootPath, "*.cs", SearchOption.AllDirectories)
+            .Select(Path.GetDirectoryName)
+            .Where(path => path is not null)
+            .Select(path => path!)
+            .Where(path => !IsUnderBuildOutputDirectory(rootPath, path))
+            .Select(path => Path.Combine(path, "__snapshots__"))
+            .Where(Directory.Exists)
+            .ToHashSet(OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
+        return validSnapshotDirectories
+            .SelectMany(path => Directory.GetFiles(path, "*", SearchOption.AllDirectories))
+            .Select(path => (AbsolutePath: path, RelativePath: Path.GetRelativePath(rootPath, path).Replace('\\', '/')))
+            .OrderBy(path => path.RelativePath, StringComparer.Ordinal)
+            .Select(file => new SnapshotFile(file.RelativePath, File.ReadAllBytes(file.AbsolutePath)))
+            .ToArray();
+
+        static bool IsUnderBuildOutputDirectory(FullPath rootPath, string path)
+        {
+            var relativePath = Path.GetRelativePath(rootPath, path);
+            if (relativePath.StartsWith("..", StringComparison.Ordinal))
+                return false;
+
+            var segments = relativePath.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
+            foreach (var segment in segments)
+            {
+                if (segment.Equals("bin", StringComparison.OrdinalIgnoreCase) || segment.Equals("obj", StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
+        }
     }
 
     private static string GetGlobalUsings(SnapshotTestFramework testFramework)

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -558,6 +558,70 @@ public sealed class SnapshotEndToEndTests
     }
 
     [Fact]
+    public async Task Validate_EndToEnd_Works_WhenUsingArtifactsOutputAndNonDeterministicBuild()
+    {
+        var snapshotFiles = await AssertSnapshot(
+            """
+            public sealed class GeneratedSnapshotTests
+            {
+                [Fact]
+                public void SampleTest()
+                {
+                    Snapshot.Validate("sample", SnapshotTestUtilities.CreateFailureSettings());
+                }
+            }
+            """,
+            existingFiles:
+            [
+                new SnapshotFile("__snapshots__/SampleTest.verified.txt", "sample"u8.ToArray()),
+            ],
+            directoryBuildPropsContent:
+            """
+            <Project>
+              <PropertyGroup>
+                <UseArtifactsOutput>true</UseArtifactsOutput>
+                <Deterministic>false</Deterministic>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        AssertSnapshotContent(snapshotFiles,
+        [
+            ("__snapshots__/SampleTest.verified.txt", "sample"),
+        ]);
+    }
+
+    [Fact]
+    public async Task Validate_EndToEnd_Works_WhenUsingArtifactsOutputAndNonDeterministicBuild_WithoutInitialSnapshot()
+    {
+        var snapshotFiles = await AssertSnapshot(
+            """
+            public sealed class GeneratedSnapshotTests
+            {
+                [Fact]
+                public void SampleTest()
+                {
+                    Snapshot.Validate("sample", SnapshotTestUtilities.CreateSuccessSettings());
+                }
+            }
+            """,
+            directoryBuildPropsContent:
+            """
+            <Project>
+              <PropertyGroup>
+                <UseArtifactsOutput>true</UseArtifactsOutput>
+                <Deterministic>false</Deterministic>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        AssertSnapshotContent(snapshotFiles,
+        [
+            ("__snapshots__/SampleTest.verified.txt", "sample"),
+        ]);
+    }
+
+    [Fact]
     public async Task Validate_EndToEnd_UsesContainingMethodName_WhenCalledFromLambda()
     {
         var snapshotFiles = await AssertSnapshot(
@@ -831,37 +895,15 @@ public sealed class SnapshotEndToEndTests
 
     private static SnapshotFile[] GetGeneratedSnapshotFiles(FullPath rootPath)
     {
-        var validSnapshotDirectories = Directory.GetFiles(rootPath, "*.cs", SearchOption.AllDirectories)
-            .Select(Path.GetDirectoryName)
-            .Where(path => path is not null)
-            .Select(path => path!)
-            .Where(path => !IsUnderBuildOutputDirectory(rootPath, path))
-            .Select(path => Path.Combine(path, "__snapshots__"))
-            .Where(Directory.Exists)
-            .ToHashSet(OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+        var snapshotDirectory = Path.Combine(rootPath, "__snapshots__");
+        if (!Directory.Exists(snapshotDirectory))
+            return [];
 
-        return validSnapshotDirectories
-            .SelectMany(path => Directory.GetFiles(path, "*", SearchOption.AllDirectories))
+        return Directory.GetFiles(snapshotDirectory, "*", SearchOption.AllDirectories)
             .Select(path => (AbsolutePath: path, RelativePath: Path.GetRelativePath(rootPath, path).Replace('\\', '/')))
             .OrderBy(path => path.RelativePath, StringComparer.Ordinal)
             .Select(file => new SnapshotFile(file.RelativePath, File.ReadAllBytes(file.AbsolutePath)))
             .ToArray();
-
-        static bool IsUnderBuildOutputDirectory(FullPath rootPath, string path)
-        {
-            var relativePath = Path.GetRelativePath(rootPath, path);
-            if (relativePath.StartsWith("..", StringComparison.Ordinal))
-                return false;
-
-            var segments = relativePath.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
-            foreach (var segment in segments)
-            {
-                if (segment.Equals("bin", StringComparison.OrdinalIgnoreCase) || segment.Equals("obj", StringComparison.OrdinalIgnoreCase))
-                    return true;
-            }
-
-            return false;
-        }
     }
 
     private static string GetGlobalUsings(SnapshotTestFramework testFramework)
@@ -997,10 +1039,7 @@ public sealed class SnapshotEndToEndTests
                 foreach (var entry in Environment.GetEnvironmentVariables().Cast<DictionaryEntry>())
                 {
                     var key = (string)entry.Key;
-                    if (key == "GITHUB_WORKSPACE")
-                        continue;
-
-                    if (key.StartsWith("GITHUB", StringComparison.Ordinal))
+                    if (key.StartsWith("GITHUB_", StringComparison.Ordinal))
                     {
                         env.Remove(key);
                     }

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -529,6 +529,35 @@ public sealed class SnapshotEndToEndTests
     }
 
     [Fact]
+    public async Task Validate_EndToEnd_Works_WhenUsingArtifactsOutput_WithoutInitialSnapshot()
+    {
+        var snapshotFiles = await AssertSnapshot(
+            """
+            public sealed class GeneratedSnapshotTests
+            {
+                [Fact]
+                public void SampleTest()
+                {
+                    Snapshot.Validate("sample", SnapshotTestUtilities.CreateSuccessSettings());
+                }
+            }
+            """,
+            directoryBuildPropsContent:
+            """
+            <Project>
+              <PropertyGroup>
+                <UseArtifactsOutput>true</UseArtifactsOutput>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        AssertSnapshotContent(snapshotFiles,
+        [
+            ("__snapshots__/SampleTest.verified.txt", "sample"),
+        ]);
+    }
+
+    [Fact]
     public async Task Validate_EndToEnd_UsesContainingMethodName_WhenCalledFromLambda()
     {
         var snapshotFiles = await AssertSnapshot(

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -496,7 +496,7 @@ public sealed class SnapshotEndToEndTests
     }
 
     [Fact]
-    public async Task Validate_EndToEnd_IgnoresOutputSnapshots_WhenUsingArtifactsOutput()
+    public async Task Validate_EndToEnd_Works_WhenUsingArtifactsOutput()
     {
         var snapshotFiles = await AssertSnapshot(
             """
@@ -520,12 +520,7 @@ public sealed class SnapshotEndToEndTests
                 <UseArtifactsOutput>true</UseArtifactsOutput>
               </PropertyGroup>
             </Project>
-            """,
-            additionalFilesAfterTest:
-            [
-                new SnapshotFile("artifacts/bin/Project/debug/__snapshots__/SampleTest.verified.txt", "copied snapshot"u8.ToArray()),
-                new SnapshotFile("artifacts/obj/Project/debug/__snapshots__/SampleTest.verified.txt", "intermediate snapshot"u8.ToArray()),
-            ]);
+            """);
 
         AssertSnapshotContent(snapshotFiles,
         [
@@ -693,8 +688,7 @@ public sealed class SnapshotEndToEndTests
         bool expectFailure = false,
         IReadOnlyList<SnapshotFile>? existingFiles = null,
         string? testFilter = null,
-        string? directoryBuildPropsContent = null,
-        IReadOnlyList<SnapshotFile>? additionalFilesAfterTest = null)
+        string? directoryBuildPropsContent = null)
     {
         await using var directory = TemporaryDirectory.Create();
         var dotnetPath = ExecutableFinder.GetFullExecutablePath("dotnet");
@@ -749,14 +743,6 @@ public sealed class SnapshotEndToEndTests
         await ExecuteDotNet(directory.FullPath, dotnetPath, ["restore", "--disable-build-servers"], expectedExitCode: 0);
         await ExecuteDotNet(directory.FullPath, dotnetPath, ["build", "--no-restore", "--disable-build-servers"], expectedExitCode: 0);
         await ExecuteDotNet(directory.FullPath, dotnetPath, GetDotNetTestArguments(testFramework, testFilter), expectedExitCode: expectFailure ? 1 : 0);
-
-        if (additionalFilesAfterTest is not null)
-        {
-            foreach (var additionalFile in additionalFilesAfterTest)
-            {
-                CreateBinaryFile(additionalFile.RelativePath, additionalFile.Content);
-            }
-        }
 
         return GetGeneratedSnapshotFiles(directory.FullPath);
 


### PR DESCRIPTION
## Why
`GetGeneratedSnapshotFiles` was collecting any `__snapshots__` path under the temporary test project tree. That can include copied files from build outputs and produce unexpected duplicates.

## What changed
- Updated snapshot discovery to derive valid roots from directories that contain `.cs` files, then read files only from adjacent `__snapshots__` folders.
- Excluded source directories under `bin` and `obj` when deriving valid snapshot roots.
- Added an end-to-end regression test for SDK artifacts output (`UseArtifactsOutput`) that injects snapshot files under `artifacts/bin/.../__snapshots__` and `artifacts/obj/.../__snapshots__` and verifies only the expected source-adjacent snapshot is returned.
- Extended the local `AssertSnapshot` helper to optionally create `Directory.Build.props` and additional files after test execution so this scenario can be exercised directly.

## Notes
`eng/validate-testprojects-configuration.cs` still reports existing unrelated target-framework mismatch errors in other test projects; this change does not modify those projects.