### PR TITLE
Enable nullable reference types in samples

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <IsSampleProject>True</IsSampleProject>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Why
Sample projects were not consistently opted into nullable reference types, which can hide null-safety issues during development.

## What changed
Added `<Nullable>enable</Nullable>` to `samples/Directory.Build.props` so all projects under `samples/` inherit nullable reference type analysis by default.

## Notes
This keeps the change centralized in one shared props file instead of editing each sample project individually.