### PR TITLE
Add UTC DateTimeOffset extensions for X509Certificate2

### DIFF
--- a/src/Meziantou.Framework/X509CertificateExtensions.cs
+++ b/src/Meziantou.Framework/X509CertificateExtensions.cs
@@ -1,0 +1,18 @@
+using System.Security.Cryptography.X509Certificates;
+
+namespace Meziantou.Framework;
+
+/// <summary>
+/// Provides extension methods for <see cref="X509Certificate2"/>.
+/// </summary>
+public static class X509CertificateExtensions
+{
+    extension(X509Certificate2 certificate)
+    {
+        /// <summary>Gets the certificate validity end date in UTC.</summary>
+        public DateTimeOffset NotAfterUtc => new(certificate.NotAfter.ToUniversalTime());
+
+        /// <summary>Gets the certificate validity start date in UTC.</summary>
+        public DateTimeOffset NotBeforeUtc => new(certificate.NotBefore.ToUniversalTime());
+    }
+}

--- a/tests/Meziantou.Framework.Tests/X509CertificateExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/X509CertificateExtensionsTests.cs
@@ -1,0 +1,19 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class X509CertificateExtensionsTests
+{
+    [Fact]
+    public void NotBeforeUtc_And_NotAfterUtc()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=localhost", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(new DateTimeOffset(2025, 03, 01, 08, 00, 00, TimeSpan.Zero), new DateTimeOffset(2027, 03, 01, 08, 00, 00, TimeSpan.Zero));
+
+        Assert.Equal(new DateTimeOffset(certificate.NotBefore.ToUniversalTime()), certificate.NotBeforeUtc);
+        Assert.Equal(new DateTimeOffset(certificate.NotAfter.ToUniversalTime()), certificate.NotAfterUtc);
+        Assert.NotEqual(certificate.NotBeforeUtc, certificate.NotAfterUtc);
+    }
+}


### PR DESCRIPTION
`X509Certificate2` exposes `NotBefore` and `NotAfter` as local `DateTime` values, which makes it easy to lose offset semantics when consuming certificate validity periods. This change adds explicit UTC helpers returning `DateTimeOffset` for safer handling.

## What changed
- Added `X509CertificateExtensions` with:
  - `NotBeforeUtc`
  - `NotAfterUtc`
- Both properties convert certificate dates to UTC and expose them as `DateTimeOffset`.
- Added `X509CertificateExtensionsTests` to validate both properties and ensure they return distinct validity boundaries.

## Notes
- The API intentionally uses `DateTimeOffset` (instead of `DateTime`) to keep UTC offset information explicit for callers.