### PR TITLE
Enable nullable defaults in tests with explicit opt-outs

### DIFF
--- a/tests/ArgumentsPrinter/ArgumentsPrinter.csproj
+++ b/tests/ArgumentsPrinter/ArgumentsPrinter.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(LatestTargetFramework)</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <IncludeDefaultTestReferences>false</IncludeDefaultTestReferences>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <EnableCodeCoverage>false</EnableCodeCoverage>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
     <OutputType Condition="'$(OutputType)' == ''">Exe</OutputType>
     <IncludeDefaultTestReferences Condition="'$(IncludeDefaultTestReferences)' == ''">true</IncludeDefaultTestReferences>
     <DefineConstants Condition="'$(GITHUB_ACTIONS)' == 'true'">$(DefineConstants);GITHUB_ACTIONS</DefineConstants>

--- a/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.AspNetCore.Components.LogViewer.Tests/Meziantou.AspNetCore.Components.LogViewer.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Components.LogViewer.Tests/Meziantou.AspNetCore.Components.LogViewer.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.AspNetCore.Components.Tests/Meziantou.AspNetCore.Components.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Components.Tests/Meziantou.AspNetCore.Components.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.GeneratorTests/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.GeneratorTests.csproj
+++ b/tests/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.GeneratorTests/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.GeneratorTests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFramework);net9.0</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)/GeneratedFiles</CompilerGeneratedFilesOutputPath>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.AspNetCore.ServiceDefaults.Tests/Meziantou.AspNetCore.ServiceDefaults.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.ServiceDefaults.Tests/Meziantou.AspNetCore.ServiceDefaults.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFramework);net9.0</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/Meziantou.Extensions.Logging.FileLogger.Tests.csproj
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/Meziantou.Extensions.Logging.FileLogger.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/Meziantou.Extensions.Logging.InMemory.Tests.csproj
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/Meziantou.Extensions.Logging.InMemory.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Extensions.Logging.Xunit.Tests/Meziantou.Extensions.Logging.Xunit.Tests.csproj
+++ b/tests/Meziantou.Extensions.Logging.Xunit.Tests/Meziantou.Extensions.Logging.Xunit.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <IncludeDefaultTestReferences>false</IncludeDefaultTestReferences>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/Meziantou.Extensions.Logging.Xunit.v3.Tests.csproj
+++ b/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/Meziantou.Extensions.Logging.Xunit.v3.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <IncludeDefaultTestReferences>false</IncludeDefaultTestReferences>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Avatar.Tests/Meziantou.Framework.Avatar.Tests.csproj
+++ b/tests/Meziantou.Framework.Avatar.Tests/Meziantou.Framework.Avatar.Tests.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Bcrypt.Tests/Meziantou.Framework.Bcrypt.Tests.csproj
+++ b/tests/Meziantou.Framework.Bcrypt.Tests/Meziantou.Framework.Bcrypt.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.ByteSize.Tests/Meziantou.Framework.ByteSize.Tests.csproj
+++ b/tests/Meziantou.Framework.ByteSize.Tests/Meziantou.Framework.ByteSize.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.ChromiumTracing.Tests/Meziantou.Framework.ChromiumTracing.Tests.csproj
+++ b/tests/Meziantou.Framework.ChromiumTracing.Tests/Meziantou.Framework.ChromiumTracing.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.CodeDom.Tests/Meziantou.Framework.CodeDom.Tests.csproj
+++ b/tests/Meziantou.Framework.CodeDom.Tests/Meziantou.Framework.CodeDom.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.CodeOwners.Tests/Meziantou.Framework.CodeOwners.Tests.csproj
+++ b/tests/Meziantou.Framework.CodeOwners.Tests/Meziantou.Framework.CodeOwners.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj
+++ b/tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Csv.Tests/Meziantou.Framework.Csv.Tests.csproj
+++ b/tests/Meziantou.Framework.Csv.Tests/Meziantou.Framework.Csv.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/Meziantou.Framework.DependencyScanning.Tests.csproj
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/Meziantou.Framework.DependencyScanning.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/Meziantou.Framework.DependencyScanning.Tool.Tests.csproj
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/Meziantou.Framework.DependencyScanning.Tool.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests.csproj
+++ b/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.DnsClient.Tests/Meziantou.Framework.DnsClient.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsClient.Tests/Meziantou.Framework.DnsClient.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.DnsFilter.Tests/Meziantou.Framework.DnsFilter.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsFilter.Tests/Meziantou.Framework.DnsFilter.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.DnsServer.Tests/Meziantou.Framework.DnsServer.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsServer.Tests/Meziantou.Framework.DnsServer.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/Meziantou.Framework.FastEnumToStringGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/Meziantou.Framework.FastEnumToStringGenerator.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests.csproj
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.FixedStringBuilder.Tests/Meziantou.Framework.FixedStringBuilder.Tests.csproj
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Tests/Meziantou.Framework.FixedStringBuilder.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.FullPath.Tests/Meziantou.Framework.FullPath.Tests.csproj
+++ b/tests/Meziantou.Framework.FullPath.Tests/Meziantou.Framework.FullPath.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Globbing.Tests/Meziantou.Framework.Globbing.Tests.csproj
+++ b/tests/Meziantou.Framework.Globbing.Tests/Meziantou.Framework.Globbing.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Html.Tests/Meziantou.Framework.Html.Tests.csproj
+++ b/tests/Meziantou.Framework.Html.Tests/Meziantou.Framework.Html.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Html.Tool.Tests/Meziantou.Framework.Html.Tool.Tests.csproj
+++ b/tests/Meziantou.Framework.Html.Tool.Tests/Meziantou.Framework.Html.Tool.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.HtmlSanitizer.Tests/Meziantou.Framework.HtmlSanitizer.Tests.csproj
+++ b/tests/Meziantou.Framework.HtmlSanitizer.Tests/Meziantou.Framework.HtmlSanitizer.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/Meziantou.Framework.HtmlToMarkdown.Tests.csproj
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/Meziantou.Framework.HtmlToMarkdown.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.HtmlToMarkdownTests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/Meziantou.Framework.Http.Hsts.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/Meziantou.Framework.Http.Hsts.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/Meziantou.Framework.Http.Htpasswd.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/Meziantou.Framework.Http.Htpasswd.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Http.Recording.Tests/Meziantou.Framework.Http.Recording.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/Meziantou.Framework.Http.Recording.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Http.Tests/Meziantou.Framework.Http.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Tests/Meziantou.Framework.Http.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.HttpArchive.Tests/Meziantou.Framework.HttpArchive.Tests.csproj
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/Meziantou.Framework.HttpArchive.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.HttpClientMock.Tests/Meziantou.Framework.HttpClientMock.Tests.csproj
+++ b/tests/Meziantou.Framework.HttpClientMock.Tests/Meziantou.Framework.HttpClientMock.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/Meziantou.Framework.HumanReadableSerializer.Tests.csproj
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/Meziantou.Framework.HumanReadableSerializer.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.HumanReadable.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/Meziantou.Framework.InlineSnapshotTesting.Tests.csproj
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/Meziantou.Framework.InlineSnapshotTesting.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472;net48</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.JsonPath.Tests/Meziantou.Framework.JsonPath.Tests.csproj
+++ b/tests/Meziantou.Framework.JsonPath.Tests/Meziantou.Framework.JsonPath.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.JsonPathTests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.MediaTags.Tests/Meziantou.Framework.MediaTags.Tests.csproj
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Meziantou.Framework.MediaTags.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.NtpClient.Tests/Meziantou.Framework.NtpClient.Tests.csproj
+++ b/tests/Meziantou.Framework.NtpClient.Tests/Meziantou.Framework.NtpClient.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.NtpServer.Tests/Meziantou.Framework.NtpServer.Tests.csproj
+++ b/tests/Meziantou.Framework.NtpServer.Tests/Meziantou.Framework.NtpServer.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tests/Meziantou.Framework.NuGetPackageValidation.Tests.csproj
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tests/Meziantou.Framework.NuGetPackageValidation.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests.csproj
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/Meziantou.Framework.ObjectMethodExecutor.Tests.csproj
+++ b/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/Meziantou.Framework.ObjectMethodExecutor.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.OpenTelemetry.Tests/Meziantou.Framework.OpenTelemetry.Tests.csproj
+++ b/tests/Meziantou.Framework.OpenTelemetry.Tests/Meziantou.Framework.OpenTelemetry.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/Meziantou.Framework.ProcessWrapper.Tests.csproj
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/Meziantou.Framework.ProcessWrapper.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/Meziantou.Framework.PublicApiGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/Meziantou.Framework.PublicApiGenerator.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.QRCode.Tests/Meziantou.Framework.QRCode.Tests.csproj
+++ b/tests/Meziantou.Framework.QRCode.Tests/Meziantou.Framework.QRCode.Tests.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.RelativeDate.Tests/Meziantou.Framework.RelativeDate.Tests.csproj
+++ b/tests/Meziantou.Framework.RelativeDate.Tests/Meziantou.Framework.RelativeDate.Tests.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests.csproj
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)/GeneratedFiles</CompilerGeneratedFilesOutputPath>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/Meziantou.Framework.ResxSourceGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/Meziantou.Framework.ResxSourceGenerator.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Scheduling.Tests/Meziantou.Framework.Scheduling.Tests.csproj
+++ b/tests/Meziantou.Framework.Scheduling.Tests/Meziantou.Framework.Scheduling.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.SensitiveData.Tests/Meziantou.Framework.SensitiveData.Tests.csproj
+++ b/tests/Meziantou.Framework.SensitiveData.Tests/Meziantou.Framework.SensitiveData.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/Meziantou.Framework.SimpleQueryLanguage.Tests.csproj
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/Meziantou.Framework.SimpleQueryLanguage.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.SingleInstance.Tests/Meziantou.Framework.SingleInstance.Tests.csproj
+++ b/tests/Meziantou.Framework.SingleInstance.Tests/Meziantou.Framework.SingleInstance.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Slug.Tests/Meziantou.Framework.Slug.Tests.csproj
+++ b/tests/Meziantou.Framework.Slug.Tests/Meziantou.Framework.Slug.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <Import Project="../../src/Meziantou.Framework.SnapshotTesting/build/Meziantou.Framework.SnapshotTesting.props" />

--- a/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/Meziantou.Framework.StronglyTypedId.GeneratorTests.csproj
+++ b/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/Meziantou.Framework.StronglyTypedId.GeneratorTests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)/GeneratedFiles/$(TargetFramework)</CompilerGeneratedFilesOutputPath>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/Meziantou.Framework.StronglyTypedId.Tests.csproj
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/Meziantou.Framework.StronglyTypedId.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.TdsServer.Tests/Meziantou.Framework.TdsServer.Tests.csproj
+++ b/tests/Meziantou.Framework.TdsServer.Tests/Meziantou.Framework.TdsServer.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Templating.Html.Tests/Meziantou.Framework.Templating.Html.Tests.csproj
+++ b/tests/Meziantou.Framework.Templating.Html.Tests/Meziantou.Framework.Templating.Html.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Templating.Tests/Meziantou.Framework.Templating.Tests.csproj
+++ b/tests/Meziantou.Framework.Templating.Tests/Meziantou.Framework.Templating.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.TemporaryDirectory.Tests/Meziantou.Framework.TemporaryDirectory.Tests.csproj
+++ b/tests/Meziantou.Framework.TemporaryDirectory.Tests/Meziantou.Framework.TemporaryDirectory.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Tests/Meziantou.Framework.Tests.csproj
+++ b/tests/Meziantou.Framework.Tests/Meziantou.Framework.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.TextDiff.Tests/Meziantou.Framework.TextDiff.Tests.csproj
+++ b/tests/Meziantou.Framework.TextDiff.Tests/Meziantou.Framework.TextDiff.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472;net48</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Threading.Tests/Meziantou.Framework.Threading.Tests.csproj
+++ b/tests/Meziantou.Framework.Threading.Tests/Meziantou.Framework.Threading.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.TypeConverter.Tests/Meziantou.Framework.TypeConverter.Tests.csproj
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/Meziantou.Framework.TypeConverter.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Unicode.Tests/Meziantou.Framework.Unicode.Tests.csproj
+++ b/tests/Meziantou.Framework.Unicode.Tests/Meziantou.Framework.Unicode.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Unix.ControlGroups.Tests/Meziantou.Framework.Unix.ControlGroups.Tests.csproj
+++ b/tests/Meziantou.Framework.Unix.ControlGroups.Tests/Meziantou.Framework.Unix.ControlGroups.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Uri.Tests/Meziantou.Framework.Uri.Tests.csproj
+++ b/tests/Meziantou.Framework.Uri.Tests/Meziantou.Framework.Uri.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.ValueStopwatch.Tests/Meziantou.Framework.ValueStopwatch.Tests.csproj
+++ b/tests/Meziantou.Framework.ValueStopwatch.Tests/Meziantou.Framework.ValueStopwatch.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.ValueStringBuilder.Tests/Meziantou.Framework.ValueStringBuilder.Tests.csproj
+++ b/tests/Meziantou.Framework.ValueStringBuilder.Tests/Meziantou.Framework.ValueStringBuilder.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Versioning.Tests/Meziantou.Framework.Versioning.Tests.csproj
+++ b/tests/Meziantou.Framework.Versioning.Tests/Meziantou.Framework.Versioning.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.WPF.Tests/Meziantou.Framework.WPF.Tests.csproj
+++ b/tests/Meziantou.Framework.WPF.Tests/Meziantou.Framework.WPF.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <UseWpf>true</UseWpf>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472' ">

--- a/tests/Meziantou.Framework.Win32.AccessToken.Tests/Meziantou.Framework.Win32.AccessToken.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.AccessToken.Tests/Meziantou.Framework.Win32.AccessToken.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Win32.AmsiTests/Meziantou.Framework.Win32.AmsiTests.csproj
+++ b/tests/Meziantou.Framework.Win32.AmsiTests/Meziantou.Framework.Win32.AmsiTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/Meziantou.Framework.Win32.ChangeJournal.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/Meziantou.Framework.Win32.ChangeJournal.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/Meziantou.Framework.Win32.CredentialManager.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/Meziantou.Framework.Win32.CredentialManager.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Win32.Jobs.Tests/Meziantou.Framework.Win32.Jobs.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.Jobs.Tests/Meziantou.Framework.Win32.Jobs.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Win32.Lsa.Tests/Meziantou.Framework.Win32.Lsa.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.Lsa.Tests/Meziantou.Framework.Win32.Lsa.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Win32.PerceivedType.Tests/Meziantou.Framework.Win32.PerceivedType.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.PerceivedType.Tests/Meziantou.Framework.Win32.PerceivedType.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Win32.RestartManager.Tests/Meziantou.Framework.Win32.RestartManager.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.RestartManager.Tests/Meziantou.Framework.Win32.RestartManager.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/TestUtilities/TestUtilities.csproj
+++ b/tests/TestUtilities/TestUtilities.csproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Trimmable.Wpf/Trimmable.Wpf.csproj
+++ b/tests/Trimmable.Wpf/Trimmable.Wpf.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>$(LatestTargetFramework)-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IncludeDefaultTestReferences>false</IncludeDefaultTestReferences>
-    <Nullable>enable</Nullable>
 
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <PublishTrimmed>true</PublishTrimmed>

--- a/tests/Trimmable/Trimmable.csproj
+++ b/tests/Trimmable/Trimmable.csproj
@@ -10,7 +10,6 @@
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>full</TrimMode>
     <ExcludeFromGeneratedSlnx>true</ExcludeFromGeneratedSlnx>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Trimmable/Trimmable.csproj
+++ b/tests/Trimmable/Trimmable.csproj
@@ -10,6 +10,7 @@
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>full</TrimMode>
     <ExcludeFromGeneratedSlnx>true</ExcludeFromGeneratedSlnx>
+      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why
We want nullable reference types enabled at the test-level configuration, while keeping most existing test projects on their current nullability behavior.

## What changed
- Switched `tests/Directory.Build.props` from `<Nullable>disable</Nullable>` to `<Nullable>enable</Nullable>`.
- Added `<Nullable>disable</Nullable>` explicitly to test `.csproj` files under `tests/` so they do not change behavior when the shared default flipped.
- Left 5 projects without the explicit disable based on review feedback so they inherit enabled/default nullable behavior:
  - `Meziantou.AspNetCore.ServiceDefaults.AutoRegister.GeneratorTests`
  - `Meziantou.Framework.FixedStringBuilder.Generator.Tests`
  - `Meziantou.Framework.ResxSourceGenerator.GeneratorTests`
  - `Meziantou.Framework.StronglyTypedId.GeneratorTests`
  - `Trimmable.Wpf`

## Notes for reviewers
This is primarily a configuration sweep: one shared default change plus explicit per-project overrides to preserve existing behavior for the rest of the test projects.