### PR TITLE
Enable nullable in ArgumentsPrinter and TestUtilities

### DIFF
--- a/tests/ArgumentsPrinter/ArgumentsPrinter.csproj
+++ b/tests/ArgumentsPrinter/ArgumentsPrinter.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(LatestTargetFramework)</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <IncludeDefaultTestReferences>false</IncludeDefaultTestReferences>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/tests/TestUtilities/NuGetHelpers.cs
+++ b/tests/TestUtilities/NuGetHelpers.cs
@@ -53,7 +53,8 @@ public static class NuGetHelpers
 
                 try
                 {
-                    Directory.CreateDirectory(Path.GetDirectoryName(cacheFolder));
+                    var cacheDirectory = Path.GetDirectoryName(cacheFolder) ?? throw new InvalidOperationException("Cannot determine cache directory path");
+                    Directory.CreateDirectory(cacheDirectory);
                     Directory.Move(tempFolder, cacheFolder);
                 }
                 catch (Exception ex)

--- a/tests/TestUtilities/RunIfAttribute.cs
+++ b/tests/TestUtilities/RunIfAttribute.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Reflection;
 using Xunit.v3;
 

--- a/tests/TestUtilities/TestUtilities.csproj
+++ b/tests/TestUtilities/TestUtilities.csproj
@@ -5,7 +5,6 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This enables nullable reference type analysis in the `tests/ArgumentsPrinter` and `tests/TestUtilities` projects so these test helpers follow the repository default nullable configuration.

### What changed
- Removed explicit `<Nullable>disable</Nullable>` from both test project files so they inherit the parent `Directory.Build.props` setting.
- Removed the redundant `#nullable enable` directive from `RunIfAttribute.cs`.
- Fixed the nullable warning in `NuGetHelpers` by validating `Path.GetDirectoryName(cacheFolder)` before passing it to `Directory.CreateDirectory`.

### Notes
- The change is intentionally limited to these two test projects and their immediate nullable warning fallout.