### PR TITLE
Remove redundant Nullable from child Directory.Build.props files

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <IsSampleProject>True</IsSampleProject>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <EnableCodeCoverage>false</EnableCodeCoverage>
-    <Nullable>enable</Nullable>
     <OutputType Condition="'$(OutputType)' == ''">Exe</OutputType>
     <IncludeDefaultTestReferences Condition="'$(IncludeDefaultTestReferences)' == ''">true</IncludeDefaultTestReferences>
     <DefineConstants Condition="'$(GITHUB_ACTIONS)' == 'true'">$(DefineConstants);GITHUB_ACTIONS</DefineConstants>


### PR DESCRIPTION
## Why
`Meziantouj.NET.Sdk` already enables nullable, so keeping explicit `<Nullable>enable</Nullable>` in child `Directory.Build.props` files is redundant and adds config noise.

## What changed
- Removed `<Nullable>enable</Nullable>` from:
  - `tests/Directory.Build.props`
  - `samples/Directory.Build.props`

This keeps nullable configuration implicit through the SDK instead of repeating it in child props files.

## Notes
- No behavioral change is expected; this is a configuration cleanup.