### PR TITLE
Throw when Snapshot source path is missing

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
@@ -122,7 +122,7 @@ internal sealed record SnapshotCallerContext(FullPath SourceFilePath, string Met
         // deterministic paths like /_1/foo are not mangled to drive-rooted paths on Windows.
         var relativePath = TryGetPathMappedRelativePath(sourceFilePath);
         if (relativePath is null)
-            return sourcePath;
+            throw new SnapshotException($"Cannot find source file path '{sourceFilePath}'.");
 
         var normalizedRelativePath = relativePath.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
 
@@ -148,7 +148,7 @@ internal sealed record SnapshotCallerContext(FullPath SourceFilePath, string Met
                 return candidatePath;
         }
 
-        return sourcePath;
+        throw new SnapshotException($"Cannot find source file path '{sourceFilePath}'.");
     }
 
     private static string? TryGetPathMappedRelativePath(string path)

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -68,6 +68,15 @@ public sealed class SnapshotTests
     }
 
     [Fact]
+    public void ResolveSourceFilePath_ThrowsWhenSourceFilePathIsNotFound()
+    {
+        var sourceFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "file.cs");
+
+        var exception = Assert.Throws<SnapshotException>(() => SnapshotCallerContext.ResolveSourceFilePath(sourceFilePath));
+        Assert.Contains(sourceFilePath, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SnapshotPathStrategy_UsesIndexPatternForShortName()
     {
         var settings = new SnapshotSettings();


### PR DESCRIPTION
## Why
`SnapshotCallerContext.ResolveSourceFilePath` could return a non-existent path when the caller file path could not be resolved. That delayed the failure to later file operations instead of surfacing a clear SnapshotTesting error at the source-path resolution step.

## What changed
- Updated `SnapshotCallerContext.ResolveSourceFilePath` to throw `SnapshotException` when the source file path cannot be resolved to an existing file.
- Applied this to both failure paths:
  - when the incoming path is not path-mapped and does not exist
  - when a mapped relative path is found but no candidate file exists in registered roots
- Added `ResolveSourceFilePath_ThrowsWhenSourceFilePathIsNotFound` in `SnapshotTests` to lock this behavior and assert the missing path is included in the exception message.

## Notes
This is a behavior-tightening change in SnapshotTesting only: unresolved source paths now fail fast with a targeted exception instead of returning an invalid path.