### PR TITLE
Enable nullable reference types in Meziantou.Framework.Tests

### DIFF
--- a/src/Meziantou.Framework/Collections/ImmutableEquatableArray.cs
+++ b/src/Meziantou.Framework/Collections/ImmutableEquatableArray.cs
@@ -34,7 +34,7 @@ public sealed class ImmutableEquatableArray<T> : IEquatable<ImmutableEquatableAr
 
     public Enumerator GetEnumerator() => new(_values);
 
-    public static bool operator ==(ImmutableEquatableArray<T> left, ImmutableEquatableArray<T> right)
+    public static bool operator ==(ImmutableEquatableArray<T>? left, ImmutableEquatableArray<T>? right)
     {
         if (ReferenceEquals(left, right))
             return true;
@@ -43,7 +43,7 @@ public sealed class ImmutableEquatableArray<T> : IEquatable<ImmutableEquatableAr
         return left.Equals(right);
     }
 
-    public static bool operator !=(ImmutableEquatableArray<T> left, ImmutableEquatableArray<T> right)
+    public static bool operator !=(ImmutableEquatableArray<T>? left, ImmutableEquatableArray<T>? right)
     {
         if (ReferenceEquals(left, right))
             return false;

--- a/src/Meziantou.Framework/Collections/ImmutableEquatableDictionary.cs
+++ b/src/Meziantou.Framework/Collections/ImmutableEquatableDictionary.cs
@@ -52,7 +52,7 @@ public sealed class ImmutableEquatableDictionary<TKey, TValue> : IEquatable<Immu
 
     public override int GetHashCode() => _values.Count;
 
-    public static bool operator ==(ImmutableEquatableDictionary<TKey, TValue> left, ImmutableEquatableDictionary<TKey, TValue> right)
+    public static bool operator ==(ImmutableEquatableDictionary<TKey, TValue>? left, ImmutableEquatableDictionary<TKey, TValue>? right)
     {
         if (ReferenceEquals(left, right))
             return true;
@@ -61,7 +61,7 @@ public sealed class ImmutableEquatableDictionary<TKey, TValue> : IEquatable<Immu
         return left.Equals(right);
     }
 
-    public static bool operator !=(ImmutableEquatableDictionary<TKey, TValue> left, ImmutableEquatableDictionary<TKey, TValue> right)
+    public static bool operator !=(ImmutableEquatableDictionary<TKey, TValue>? left, ImmutableEquatableDictionary<TKey, TValue>? right)
     {
         if (ReferenceEquals(left, right))
             return false;

--- a/src/Meziantou.Framework/Collections/ImmutableEquatableSet.cs
+++ b/src/Meziantou.Framework/Collections/ImmutableEquatableSet.cs
@@ -51,7 +51,7 @@ public sealed class ImmutableEquatableSet<T> : IEquatable<ImmutableEquatableSet<
     public override bool Equals(object? obj) => obj is ImmutableEquatableSet<T> other && Equals(other);
     public override int GetHashCode() => _values.Count;
 
-    public static bool operator ==(ImmutableEquatableSet<T> left, ImmutableEquatableSet<T> right)
+    public static bool operator ==(ImmutableEquatableSet<T>? left, ImmutableEquatableSet<T>? right)
     {
         if (ReferenceEquals(left, right))
             return true;
@@ -60,7 +60,7 @@ public sealed class ImmutableEquatableSet<T> : IEquatable<ImmutableEquatableSet<
         return left.Equals(right);
     }
 
-    public static bool operator !=(ImmutableEquatableSet<T> left, ImmutableEquatableSet<T> right)
+    public static bool operator !=(ImmutableEquatableSet<T>? left, ImmutableEquatableSet<T>? right)
     {
         if (ReferenceEquals(left, right))
             return false;

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableDictionaryTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableDictionaryTests.cs
@@ -183,14 +183,14 @@ public sealed class ImmutableEquatableDictionaryTests
         Assert.False(null == dict);
         Assert.True(dict != null);
         Assert.True(null != dict);
-        Assert.False(dict.Equals((object)null));
+        Assert.False(dict.Equals((object?)null));
     }
 
     [Fact]
     public void Equals_BothNull_ShouldReturnTrue()
     {
-        ImmutableEquatableDictionary<string, int> dict1 = null;
-        ImmutableEquatableDictionary<string, int> dict2 = null;
+        ImmutableEquatableDictionary<string, int>? dict1 = null;
+        ImmutableEquatableDictionary<string, int>? dict2 = null;
 
         Assert.True(dict1 == dict2);
         Assert.False(dict1 != dict2);

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
@@ -35,7 +35,7 @@ public sealed class ImmutableEquatableSetTests
         Assert.Contains("b", set);
         Assert.Contains("c", set);
         Assert.DoesNotContain("d", set);
-        Assert.DoesNotContain(null, set);
+        Assert.DoesNotContain(set, item => item is null);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Tests/EnumerableTests.cs
+++ b/tests/Meziantou.Framework.Tests/EnumerableTests.cs
@@ -110,7 +110,7 @@ public class EnumerableTests
     [Fact]
     public void EmptyIfNull_Null()
     {
-        IEnumerable<string> items = null;
+        IEnumerable<string>? items = null;
         Assert.Equal([], items.EmptyIfNull());
     }
 

--- a/tests/Meziantou.Framework.Tests/Meziantou.Framework.Tests.csproj
+++ b/tests/Meziantou.Framework.Tests/Meziantou.Framework.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Tests/ObjectGraphVisitorTests.cs
+++ b/tests/Meziantou.Framework.Tests/ObjectGraphVisitorTests.cs
@@ -37,7 +37,7 @@ public sealed class ObjectGraphVisitorTests
         Assert.Empty(visitor.VisitedProperties);
     }
 
-    private sealed record Recursive(object Value, Recursive Parent);
+    private sealed record Recursive(object Value, Recursive? Parent);
 
     private sealed class Indexer
     {
@@ -49,7 +49,7 @@ public sealed class ObjectGraphVisitorTests
         public List<PropertyInfo> VisitedProperties { get; } = [];
         public List<object> VisitedValues { get; } = [];
 
-        protected override void VisitProperty(object parentInstance, PropertyInfo property, object value)
+        protected override void VisitProperty(object parentInstance, PropertyInfo property, object? value)
         {
             VisitedProperties.Add(property);
         }

--- a/tests/Meziantou.Framework.Tests/ProcessExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/ProcessExtensionsTests.cs
@@ -191,6 +191,7 @@ public class ProcessExtensionsTests
     {
         var current = Process.GetCurrentProcess();
         var parent = current.GetParentProcess();
+        Assert.NotNull(parent);
         var grandParent = parent.GetParentProcess();
 
         Assert.NotNull(grandParent);

--- a/tests/Meziantou.Framework.Tests/ReflectionDynamicObjectTests.cs
+++ b/tests/Meziantou.Framework.Tests/ReflectionDynamicObjectTests.cs
@@ -120,7 +120,7 @@ public class ReflectionDynamicObjectTests
         private int this[int i] => i;
         private int this[int i, int j] => i + j;
 
-        private string _indexer;
+        private string? _indexer;
 
         private string this[string str]
         {

--- a/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
@@ -18,7 +18,7 @@ public class StringExtensionsTests
     [InlineData("abc", "abc", true)]
     [InlineData("abc", "aBc", true)]
     [InlineData("aabc", "abc", false)]
-    public void EqualsIgnoreCase(string left, string right, bool expectedResult)
+    public void EqualsIgnoreCase(string? left, string? right, bool expectedResult)
     {
         Assert.Equal(expectedResult, left.EqualsIgnoreCase(right));
     }


### PR DESCRIPTION
Enabling nullable reference types in `Meziantou.Framework.Tests` helps align this test project with the rest of the repository and removes nullable suppressions from tests.

## What changed
- Removed `<Nullable>disable</Nullable>` from `tests/Meziantou.Framework.Tests/Meziantou.Framework.Tests.csproj`.
- Updated nullable annotations in tests where null is intentional (for example `string?`, nullable record/property parameters, and nullable locals).
- Added an explicit `Assert.NotNull(parent);` before dereferencing `parent` in `ProcessExtensionsTests`.
- Updated `ImmutableEquatableArray`, `ImmutableEquatableSet`, and `ImmutableEquatableDictionary` equality operators (`==`/`!=`) to accept nullable operands. This keeps null-comparison test logic unchanged while avoiding `null!` in assertions.
- Adjusted null-related assertions in immutable collection tests to use plain null comparisons.

## Notes for reviewers
- Test intent and behavior are preserved; changes are focused on nullability annotations/operators and safe dereference assertions.
- No PR template was found under `.github/`, so this description is provided in freeform.

## Validation
- `DiffEngine_Disabled=true dotnet test tests/Meziantou.Framework.Tests/Meziantou.Framework.Tests.csproj -v minimal`
- `dotnet run ./eng/update-bom.cs`
- `dotnet run ./eng/update-readme.cs`
- `dotnet run ./eng/update-project-slnx.cs`
- `dotnet run ./eng/validate-testprojects-configuration.cs`
- `dotnet run ./eng/update-trimmable.cs`