### PR TITLE
Enable nullable reference types in Meziantou.AspNetCore tests

### DIFF
--- a/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
+++ b/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
@@ -215,10 +215,10 @@ public sealed class HttpBasicAuthenticationTests
             return SendAndAssert(url, null, null, assert);
         }
 
-        public async Task SendAndAssert(string url, string username, string password, Func<HttpResponseMessage, Task> assert)
+        public async Task SendAndAssert(string url, string? username, string? password, Func<HttpResponseMessage, Task> assert)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            if (username != null && password != null)
+            if (username is not null && password is not null)
             {
                 request.Headers.Authorization = CreateAuthorizationHeader(username, password);
             }

--- a/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.AspNetCore.Components.LogViewer.Tests/Meziantou.AspNetCore.Components.LogViewer.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Components.LogViewer.Tests/Meziantou.AspNetCore.Components.LogViewer.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.AspNetCore.Components.Tests/Meziantou.AspNetCore.Components.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Components.Tests/Meziantou.AspNetCore.Components.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.AspNetCore.ServiceDefaults.Tests/Meziantou.AspNetCore.ServiceDefaults.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.ServiceDefaults.Tests/Meziantou.AspNetCore.ServiceDefaults.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFramework);net9.0</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.AspNetCore.ServiceDefaults.Tests/ServiceDefaultTests.cs
+++ b/tests/Meziantou.AspNetCore.ServiceDefaults.Tests/ServiceDefaultTests.cs
@@ -22,7 +22,7 @@ public sealed class ServiceDefaultTests
         app.MapGet("/", () => TypedResults.Ok(new { Sample = Sample.Value1 }));
         var t = app.RunAsync();
 
-        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>().Addresses.First();
+        var address = GetServerAddress(app);
         using var httpClient = new HttpClient() { BaseAddress = new Uri(address) };
         Assert.Equal("Healthy", await httpClient.GetStringAsync("health", XunitCancellationToken));
         Assert.Equal("Healthy", await httpClient.GetStringAsync("alive", XunitCancellationToken));
@@ -43,7 +43,7 @@ public sealed class ServiceDefaultTests
         app.MapGet("/", () => TypedResults.Ok(new { Sample = Sample.Value1 }));
         var t = app.RunAsync();
 
-        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>().Addresses.First();
+        var address = GetServerAddress(app);
         using var httpClient = new HttpClient() { BaseAddress = new Uri(address) };
         Assert.Equal("Healthy", await httpClient.GetStringAsync("health", XunitCancellationToken));
         Assert.Equal("Healthy", await httpClient.GetStringAsync("alive", XunitCancellationToken));
@@ -84,7 +84,7 @@ public sealed class ServiceDefaultTests
         app.MapGet("/test", () => TypedResults.Ok(new { Value = "test" }));
         var t = app.RunAsync();
 
-        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>().Addresses.First();
+        var address = GetServerAddress(app);
         using var httpClient = new HttpClient() { BaseAddress = new Uri(address) };
         using var response = await httpClient.GetAsync("/test", XunitCancellationToken);
 
@@ -110,7 +110,7 @@ public sealed class ServiceDefaultTests
         });
         var t = app.RunAsync();
 
-        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>().Addresses.First();
+        var address = GetServerAddress(app);
         using var httpClient = new HttpClient() { BaseAddress = new Uri(address) };
         using var response = await httpClient.GetAsync("/test", XunitCancellationToken);
 
@@ -135,7 +135,7 @@ public sealed class ServiceDefaultTests
         app.MapGet("/test", () => TypedResults.Ok(new { Value = "test" }));
         var t = app.RunAsync();
 
-        var address = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>().Addresses.First();
+        var address = GetServerAddress(app);
         using var httpClient = new HttpClient() { BaseAddress = new Uri(address) };
         using var response = await httpClient.GetAsync("/test", XunitCancellationToken);
 
@@ -146,6 +146,14 @@ public sealed class ServiceDefaultTests
     {
         Value1,
         Value2,
+    }
+
+    private static string GetServerAddress(WebApplication app)
+    {
+        var addressesFeature = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>();
+        Assert.NotNull(addressesFeature);
+
+        return addressesFeature.Addresses.First();
     }
 
     private sealed class FooService(BarService bar) { public BarService Bar { get; } = bar; }

--- a/tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj
+++ b/tests/Meziantou.AspNetCore.Tests/Meziantou.AspNetCore.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Enable nullable reference type analysis in the ASP.NET Core test projects so these tests follow the same null-safety defaults as the rest of the repository.

## Summary
- Removed `<Nullable>disable</Nullable>` from `tests/Meziantou.AspNetCore.*` test project files.
- Updated test helper signatures in `HttpBasicAuthenticationTests` to accept nullable credentials where `null` is intentionally passed.
- Added an `Assert.NotNull` guard in `ServiceDefaultTests` before using `IServerAddressesFeature` to satisfy nullable analysis without changing behavior.

## Notes
- Test logic and assertions were preserved; changes are limited to nullability annotations/guards and project configuration.