### PR TITLE
Enable nullable references in Avatar/Bcrypt/ByteSize tests

### DIFF
--- a/tests/Meziantou.Framework.Avatar.Tests/AvatarGeneratorTests.cs
+++ b/tests/Meziantou.Framework.Avatar.Tests/AvatarGeneratorTests.cs
@@ -122,7 +122,7 @@ public class AvatarGeneratorTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    public void CreateSvg_ThrowsWhenNameIsInvalid(string name)
+    public void CreateSvg_ThrowsWhenNameIsInvalid(string? name)
     {
         Assert.ThrowsAny<ArgumentException>(() => AvatarGenerator.CreateSvg(name!, new AvatarOptions()));
     }

--- a/tests/Meziantou.Framework.Avatar.Tests/Meziantou.Framework.Avatar.Tests.csproj
+++ b/tests/Meziantou.Framework.Avatar.Tests/Meziantou.Framework.Avatar.Tests.csproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Bcrypt.Tests/Meziantou.Framework.Bcrypt.Tests.csproj
+++ b/tests/Meziantou.Framework.Bcrypt.Tests/Meziantou.Framework.Bcrypt.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
+++ b/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
@@ -19,7 +19,7 @@ public sealed class ByteSizeTests
     [InlineData(1_510_000L, "f1", "1.5MB")]
     [InlineData(1_510_000L, "", "1.51MB")]
     [InlineData(1_510_000L, "f2", "1.51MB")]
-    public void ToString_Test(long length, string format, string expectedValue)
+    public void ToString_Test(long length, string? format, string expectedValue)
     {
         var byteSize = new ByteSize(length);
         var formattedValue = byteSize.ToString(format, CultureInfo.InvariantCulture);
@@ -92,7 +92,7 @@ public sealed class ByteSizeTests
     [InlineData(1_510_000L, "f1", "1.5MB")]
     [InlineData(1_510_000L, "", "1.51MB")]
     [InlineData(1_510_000L, "f2", "1.51MB")]
-    public void TryFormat_Test(long length, string format, string expectedValue)
+    public void TryFormat_Test(long length, string? format, string expectedValue)
     {
         var byteSize = new ByteSize(length);
         Span<char> destination = stackalloc char[100];
@@ -162,7 +162,7 @@ public sealed class ByteSizeTests
     [InlineData(1_510_000L, "f1", "1.5MB")]
     [InlineData(1_510_000L, "", "1.51MB")]
     [InlineData(1_510_000L, "f2", "1.51MB")]
-    public void TryFormat_Utf8_Test(long length, string format, string expectedValue)
+    public void TryFormat_Utf8_Test(long length, string? format, string expectedValue)
     {
         var byteSize = new ByteSize(length);
         Span<byte> destination = stackalloc byte[100];

--- a/tests/Meziantou.Framework.ByteSize.Tests/Meziantou.Framework.ByteSize.Tests.csproj
+++ b/tests/Meziantou.Framework.ByteSize.Tests/Meziantou.Framework.ByteSize.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This updates three test projects to participate in nullable reference type analysis instead of opting out. The goal is to keep nullability checks consistent across the test suite while preserving existing test behavior.

## What changed
- Removed `<Nullable>disable</Nullable>` from:
  - `tests/Meziantou.Framework.Avatar.Tests/Meziantou.Framework.Avatar.Tests.csproj`
  - `tests/Meziantou.Framework.Bcrypt.Tests/Meziantou.Framework.Bcrypt.Tests.csproj`
  - `tests/Meziantou.Framework.ByteSize.Tests/Meziantou.Framework.ByteSize.Tests.csproj`
- Adjusted test method parameter annotations where `[InlineData(null)]` is intentionally used:
  - `CreateSvg_ThrowsWhenNameIsInvalid(string? name)`
  - `ToString_Test(..., string? format, ...)`
  - `TryFormat_Test(..., string? format, ...)`
  - `TryFormat_Utf8_Test(..., string? format, ...)`
- Kept test logic unchanged; only nullability/analyzer-facing signatures were updated.