### PR TITLE
Enable nullable reference types in selected test projects

### DIFF
--- a/tests/Meziantou.Framework.ChromiumTracing.Tests/Meziantou.Framework.ChromiumTracing.Tests.csproj
+++ b/tests/Meziantou.Framework.ChromiumTracing.Tests/Meziantou.Framework.ChromiumTracing.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.ChromiumTracing.Tests/WriterTests.cs
+++ b/tests/Meziantou.Framework.ChromiumTracing.Tests/WriterTests.cs
@@ -12,7 +12,8 @@ public sealed partial class WriterTests
         var eventTypes = typeof(ChromiumTracingWriter).Assembly.GetTypes().Where(t => !t.IsAbstract && t.IsAssignableTo(typeof(ChromiumTracingEvent)));
         foreach (var eventType in eventTypes)
         {
-            var instance = (ChromiumTracingEvent)Activator.CreateInstance(eventType);
+            var instance = Activator.CreateInstance(eventType) as ChromiumTracingEvent;
+            Assert.NotNull(instance);
             await writer.WriteEventAsync(instance);
         }
 
@@ -29,7 +30,7 @@ public sealed partial class WriterTests
             ProcessId = 1,
             ThreadId = 2,
             ColorName = "yellow",
-            Arguments = new Dictionary<string, object>(StringComparer.Ordinal) { ["step"] = "sample" },
+            Arguments = new Dictionary<string, object?>(StringComparer.Ordinal) { ["step"] = "sample" },
         });
 
         // Custom writes
@@ -53,7 +54,7 @@ public sealed partial class WriterTests
         {
             Name = "Sample",
             Timestamp = DateTimeOffset.UtcNow,
-            Arguments = new Dictionary<string, object>(StringComparer.Ordinal)
+            Arguments = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
                 ["value"] = 123L,
             },
@@ -69,7 +70,7 @@ public sealed partial class WriterTests
         {
             Name = "Sample",
             Timestamp = DateTimeOffset.UtcNow,
-            Arguments = new Dictionary<string, object>(StringComparer.Ordinal)
+            Arguments = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
                 ["payload"] = new CustomPayload(42),
             },

--- a/tests/Meziantou.Framework.CodeDom.Tests/AwaitExpressionTests.cs
+++ b/tests/Meziantou.Framework.CodeDom.Tests/AwaitExpressionTests.cs
@@ -8,7 +8,8 @@ public class AwaitExpressionTests
         var expression = new AwaitExpression(new SnippetExpression("test"));
         var configuredExpression = expression.ConfigureAwait(continueOnCapturedContext: true);
         Assert.Equal(expression, configuredExpression);
-        Assert.Equal(true, configuredExpression.Expression.As<MethodInvokeExpression>().Arguments[0].As<LiteralExpression>().Value);
+        var configureAwaitExpression = configuredExpression.Expression!.As<MethodInvokeExpression>();
+        Assert.Equal(true, configureAwaitExpression.Arguments[0].As<LiteralExpression>().Value);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.CodeDom.Tests/Meziantou.Framework.CodeDom.Tests.csproj
+++ b/tests/Meziantou.Framework.CodeDom.Tests/Meziantou.Framework.CodeDom.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.CodeDom.Tests/VisitorTests.cs
+++ b/tests/Meziantou.Framework.CodeDom.Tests/VisitorTests.cs
@@ -19,7 +19,8 @@ public class VisitorTests
 
     private static void VisitType(Type type)
     {
-        var instance = (CodeObject)Activator.CreateInstance(type);
+        var instance = Activator.CreateInstance(type) as CodeObject;
+        Assert.NotNull(instance);
         var generator = new Visitor();
         generator.Visit(instance);
     }

--- a/tests/Meziantou.Framework.CodeOwners.Tests/Meziantou.Framework.CodeOwners.Tests.csproj
+++ b/tests/Meziantou.Framework.CodeOwners.Tests/Meziantou.Framework.CodeOwners.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.CommandLineTests/ArgumentPrinterClassFixture.cs
+++ b/tests/Meziantou.Framework.CommandLineTests/ArgumentPrinterClassFixture.cs
@@ -18,7 +18,7 @@ public sealed class ArgumentPrinterClassFixture
     {
         var rootPath = FullPath.CurrentDirectory().FindRequiredGitRepositoryRoot();
         _projectPath = rootPath / "tests" / "ArgumentsPrinter" / "ArgumentsPrinter.csproj";
-        _dotnetPath = ExecutableFinder.GetFullExecutablePath("dotnet");
+        _dotnetPath = ExecutableFinder.GetFullExecutablePath("dotnet") ?? throw new XunitException("Cannot find dotnet executable");
     }
 
     public async ValueTask<string[]> RoundtripArguments(string arguments)

--- a/tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj
+++ b/tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Csv.Tests/CsvReaderTests.cs
+++ b/tests/Meziantou.Framework.Csv.Tests/CsvReaderTests.cs
@@ -21,6 +21,8 @@ public class CsvReaderTests
         var row2 = await reader.ReadRowAsync();
         var row3 = await reader.ReadRowAsync();
 
+        Assert.NotNull(row1);
+        Assert.NotNull(row2);
         Assert.Equal("value1.1", row1[0]);
         Assert.Equal("value1.2", row1[1]);
         Assert.Equal("value1.3", row1[2]);
@@ -47,6 +49,8 @@ public class CsvReaderTests
         var row2 = await reader.ReadRowAsync();
         var row3 = await reader.ReadRowAsync();
 
+        Assert.NotNull(row1);
+        Assert.NotNull(row2);
         Assert.Equal("value1.1", row1["column1"]);
         Assert.Equal("value1.2", row1["column2"]);
         Assert.Equal("value1.3", row1["column3"]);
@@ -74,6 +78,8 @@ public class CsvReaderTests
         var row2 = await reader.ReadRowAsync();
         var row3 = await reader.ReadRowAsync();
 
+        Assert.NotNull(row1);
+        Assert.NotNull(row2);
         Assert.Equal("value1.1", row1["column1"]);
         Assert.Equal("value1.2\r\nline2", row1["column2"]);
         Assert.Equal("value1.3", row1["column3"]);
@@ -93,6 +99,7 @@ public class CsvReaderTests
         using var sr = new StringReader(sb.ToString());
         var reader = new CsvReader(sr);
         var row1 = await reader.ReadRowAsync();
+        Assert.NotNull(row1);
         Assert.Equal("a\"c", row1[0]);
     }
 
@@ -105,6 +112,7 @@ public class CsvReaderTests
         using var sr = new StringReader(sb.ToString());
         var reader = new CsvReader(sr);
         var row1 = await reader.ReadRowAsync();
+        Assert.NotNull(row1);
         Assert.Equal("\"bc", row1[0]);
     }
 
@@ -117,6 +125,7 @@ public class CsvReaderTests
         using var sr = new StringReader(sb.ToString());
         var reader = new CsvReader(sr);
         var row1 = await reader.ReadRowAsync();
+        Assert.NotNull(row1);
         Assert.Equal("ab\"", row1[0]);
     }
 
@@ -133,6 +142,7 @@ public class CsvReaderTests
             Separator = '\t',
         };
         var row1 = await reader.ReadRowAsync();
+        Assert.NotNull(row1);
         Assert.Equal("ab", row1[0]);
         Assert.Equal("cd", row1[1]);
     }

--- a/tests/Meziantou.Framework.Csv.Tests/CsvWriterTests.cs
+++ b/tests/Meziantou.Framework.Csv.Tests/CsvWriterTests.cs
@@ -88,7 +88,7 @@ public class CsvWriterTests
         var reader = new CsvReader(sr);
 
         var rowIndex = -1;
-        CsvRow csvRow;
+        CsvRow? csvRow;
         while ((csvRow = await reader.ReadRowAsync()) is not null)
         {
             rowIndex++;

--- a/tests/Meziantou.Framework.Csv.Tests/Meziantou.Framework.Csv.Tests.csproj
+++ b/tests/Meziantou.Framework.Csv.Tests/Meziantou.Framework.Csv.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why
These test projects were still opting out of nullable reference types. Enabling nullable analysis here improves static safety and keeps these test suites aligned with the rest of the codebase.

## What changed
- Removed `<Nullable>disable</Nullable>` from:
  - `Meziantou.Framework.ChromiumTracing.Tests`
  - `Meziantou.Framework.CodeDom.Tests`
  - `Meziantou.Framework.CodeOwners.Tests`
  - `Meziantou.Framework.CommandLineTests`
  - `Meziantou.Framework.Csv.Tests`
- Addressed nullable diagnostics in the affected tests without changing test behavior:
  - added targeted `Assert.NotNull(...)` checks before dereferences,
  - used nullable-aware type adjustments where needed,
  - used a null-safe executable path initialization in the command line fixture.

## Notes for reviewers
- The intent was to keep test logic unchanged while making nullability explicit and warning-free in the targeted projects.
- Required repository scripts were executed. `validate-testprojects-configuration.cs` reports pre-existing cross-targeting mismatches in unrelated test projects.