### PR TITLE
Enable nullable in Win32 test projects

### DIFF
--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/Meziantou.Framework.Win32.ChangeJournal.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/Meziantou.Framework.Win32.ChangeJournal.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
@@ -122,7 +122,7 @@ public sealed class CredentialManagerTests : IDisposable
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Framework/issues/263")]
     [InlineData(null)]
     [InlineData("*")]
-    public void CredentialManager_EnumerateCredential_FilterNull(string filter)
+    public void CredentialManager_EnumerateCredential_FilterNull(string? filter)
     {
         _mutex.WaitOne();
         try

--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/Meziantou.Framework.Win32.CredentialManager.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/Meziantou.Framework.Win32.CredentialManager.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Win32.Jobs.Tests/Meziantou.Framework.Win32.Jobs.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.Jobs.Tests/Meziantou.Framework.Win32.Jobs.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Win32.Lsa.Tests/Meziantou.Framework.Win32.Lsa.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.Lsa.Tests/Meziantou.Framework.Win32.Lsa.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why
These four Win32 test projects had nullable reference types explicitly disabled. Enabling nullable keeps them aligned with the repository defaults and prevents nullable issues from being hidden in test code.

## What changed
- Removed `<Nullable>disable</Nullable>` from:
  - `Meziantou.Framework.Win32.ChangeJournal.Tests`
  - `Meziantou.Framework.Win32.CredentialManager.Tests`
  - `Meziantou.Framework.Win32.Jobs.Tests`
  - `Meziantou.Framework.Win32.Lsa.Tests`
- Updated `CredentialManager_EnumerateCredential_FilterNull` parameter from `string` to `string?` to match `[InlineData(null)]` and satisfy analyzer warnings without changing test behavior.

## Notes
- Test logic is unchanged.
- Required update scripts currently report existing repository-wide target framework mismatch errors unrelated to this change set.