### PR TITLE
Enable nullable reference types in six test projects

### DIFF
--- a/tests/Meziantou.Framework.Threading.Tests/Meziantou.Framework.Threading.Tests.csproj
+++ b/tests/Meziantou.Framework.Threading.Tests/Meziantou.Framework.Threading.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_ByteArrayTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_ByteArrayTo.cs
@@ -9,7 +9,7 @@ public class DefaultConverterTests_ByteArrayTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(new byte[] { 1, 2, 3, 4 }, cultureInfo, out string value);
+        var converted = converter.TryChangeType(new byte[] { 1, 2, 3, 4 }, cultureInfo, out string? value);
         Assert.True(converted);
         Assert.Equal("AQIDBA==", value);
     }
@@ -22,7 +22,7 @@ public class DefaultConverterTests_ByteArrayTo
             ByteArrayToStringFormat = ByteArrayToStringFormat.Base16Prefixed,
         };
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(new byte[] { 1, 2, 3, 4 }, cultureInfo, out string value);
+        var converted = converter.TryChangeType(new byte[] { 1, 2, 3, 4 }, cultureInfo, out string? value);
         Assert.True(converted);
         Assert.Equal("0x01020304", value);
     }
@@ -35,7 +35,7 @@ public class DefaultConverterTests_ByteArrayTo
             ByteArrayToStringFormat = ByteArrayToStringFormat.Base16,
         };
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(new byte[] { 1, 2, 3, 4 }, cultureInfo, out string value);
+        var converted = converter.TryChangeType(new byte[] { 1, 2, 3, 4 }, cultureInfo, out string? value);
         Assert.True(converted);
         Assert.Equal("01020304", value);
     }

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_CultureInfoTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_CultureInfoTo.cs
@@ -8,7 +8,7 @@ public class DefaultConverterTests_CultureInfoTo
     public void TryConvert_CultureInfoToString_UsingInvariantCulture()
     {
         var converter = new DefaultConverter();
-        var value = converter.ChangeType<string>(CultureInfo.GetCultureInfo("en"), defaultValue: null, CultureInfo.InvariantCulture);
+        var value = converter.ChangeType<string?>(CultureInfo.GetCultureInfo("en"), defaultValue: null, CultureInfo.InvariantCulture);
         Assert.Equal("en", value);
     }
 
@@ -16,7 +16,7 @@ public class DefaultConverterTests_CultureInfoTo
     public void TryConvert_CultureInfoToString_UsingSpecificCulture()
     {
         var converter = new DefaultConverter();
-        var value = converter.ChangeType<string>(CultureInfo.GetCultureInfo("en"), defaultValue: null, CultureInfo.GetCultureInfo("en-US"));
+        var value = converter.ChangeType<string?>(CultureInfo.GetCultureInfo("en"), defaultValue: null, CultureInfo.GetCultureInfo("en-US"));
         Assert.Equal("en", value);
     }
 }

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_DbNullTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_DbNullTo.cs
@@ -28,7 +28,7 @@ public class DefaultConverterTests_DbNullTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(DBNull.Value, cultureInfo, out string value);
+        var converted = converter.TryChangeType(DBNull.Value, cultureInfo, out string? value);
         Assert.True(converted);
         Assert.Null(value);
     }

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_Int32To.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_Int32To.cs
@@ -10,11 +10,12 @@ public class DefaultConverterTests_Int32To
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(1033, cultureInfo, out CultureInfo value);
+        var converted = converter.TryChangeType(1033, cultureInfo, out CultureInfo? value);
 
         if (OperatingSystem.IsWindows())
         {
             Assert.True(converted);
+            Assert.NotNull(value);
             Assert.Equal("en-US", value.Name);
         }
         else
@@ -58,8 +59,9 @@ public class DefaultConverterTests_Int32To
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(0x12345678, cultureInfo, out byte[] value);
+        var converted = converter.TryChangeType(0x12345678, cultureInfo, out byte[]? value);
         Assert.True(converted);
+        Assert.NotNull(value);
         Assert.Equal([0x78, 0x56, 0x34, 0x12], value);
     }
 }

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_StringTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_StringTo.cs
@@ -98,8 +98,9 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("fr-FR", cultureInfo, out CultureInfo value);
+        var converted = converter.TryChangeType("fr-FR", cultureInfo, out CultureInfo? value);
         Assert.True(converted);
+        Assert.NotNull(value);
         Assert.Equal("fr-FR", value.Name);
     }
 
@@ -108,8 +109,9 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("es", cultureInfo, out CultureInfo value);
+        var converted = converter.TryChangeType("es", cultureInfo, out CultureInfo? value);
         Assert.True(converted);
+        Assert.NotNull(value);
         Assert.Equal("es", value.Name);
     }
 
@@ -118,11 +120,12 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("1033", cultureInfo, out CultureInfo value);
+        var converted = converter.TryChangeType("1033", cultureInfo, out CultureInfo? value);
 
         if (OperatingSystem.IsWindows())
         {
             Assert.True(converted);
+            Assert.NotNull(value);
             Assert.Equal("en-US", value.Name);
         }
         else
@@ -136,7 +139,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("dfgnksdfklgfg", cultureInfo, out CultureInfo _);
+        var converted = converter.TryChangeType("dfgnksdfklgfg", cultureInfo, out CultureInfo? _);
         Assert.False(converted);
     }
 
@@ -145,7 +148,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("", cultureInfo, out CultureInfo value);
+        var converted = converter.TryChangeType("", cultureInfo, out CultureInfo? value);
         Assert.True(converted);
         Assert.Equal(CultureInfo.InvariantCulture, value);
     }
@@ -155,7 +158,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        string inputValue = null;
+        string? inputValue = null;
         var converted = converter.TryChangeType<CultureInfo>(inputValue, cultureInfo, out var value);
         Assert.True(converted);
         Assert.Null(value);
@@ -166,7 +169,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("", cultureInfo, out Uri value);
+        var converted = converter.TryChangeType("", cultureInfo, out Uri? value);
         Assert.True(converted);
         Assert.Null(value);
     }
@@ -176,7 +179,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("test.png", cultureInfo, out Uri value);
+        var converted = converter.TryChangeType("test.png", cultureInfo, out Uri? value);
         Assert.True(converted);
         Assert.Equal(new Uri("test.png", UriKind.Relative), value);
     }
@@ -186,7 +189,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("https://meziantou.net", cultureInfo, out Uri value);
+        var converted = converter.TryChangeType("https://meziantou.net", cultureInfo, out Uri? value);
         Assert.True(converted);
         Assert.Equal(new Uri("https://meziantou.net", UriKind.Absolute), value);
     }
@@ -226,8 +229,9 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("0x0AFF", cultureInfo, out byte[] value);
+        var converted = converter.TryChangeType("0x0AFF", cultureInfo, out byte[]? value);
         Assert.True(converted);
+        Assert.NotNull(value);
         Assert.Equal([0x0A, 0xFF], value);
     }
 
@@ -236,8 +240,9 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("AQIDBA==", cultureInfo, out byte[] value);
+        var converted = converter.TryChangeType("AQIDBA==", cultureInfo, out byte[]? value);
         Assert.True(converted);
+        Assert.NotNull(value);
         Assert.Equal([1, 2, 3, 4], value);
     }
 
@@ -246,7 +251,7 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("AQIDBA=", cultureInfo, out byte[] _);
+        var converted = converter.TryChangeType("AQIDBA=", cultureInfo, out byte[]? _);
         Assert.False(converted);
     }
 
@@ -275,8 +280,9 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("0d0102", cultureInfo, out byte[] value);
+        var converted = converter.TryChangeType("0d0102", cultureInfo, out byte[]? value);
         Assert.True(converted);
+        Assert.NotNull(value);
         Assert.Equal([0x0d, 0x01, 0x02], value);
     }
 
@@ -285,8 +291,9 @@ public class DefaultConverterTests_StringTo
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType("0x0d01", cultureInfo, out byte[] value);
+        var converted = converter.TryChangeType("0x0d01", cultureInfo, out byte[]? value);
         Assert.True(converted);
+        Assert.NotNull(value);
         Assert.Equal([0x0d, 0x01], value);
     }
 

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_TypeDescriptor.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_TypeDescriptor.cs
@@ -9,22 +9,22 @@ public sealed class DefaultConverterTests_TypeDescriptor
     {
         public static Dummy Instance { get; } = new Dummy();
 
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             return sourceType == typeof(int);
         }
 
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
         {
             return Instance;
         }
 
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
         {
             return destinationType == typeof(int);
         }
 
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
         {
             return 10;
         }
@@ -50,7 +50,7 @@ public sealed class DefaultConverterTests_TypeDescriptor
     {
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
-        var converted = converter.TryChangeType(1, cultureInfo, out Dummy value);
+        var converted = converter.TryChangeType(1, cultureInfo, out Dummy? value);
         Assert.True(converted);
         Assert.Equal(CustomTypeConverter.Instance, value);
     }
@@ -61,7 +61,7 @@ public sealed class DefaultConverterTests_TypeDescriptor
         var converter = new DefaultConverter();
         var cultureInfo = CultureInfo.InvariantCulture;
 
-        var converted = converter.TryChangeType("", cultureInfo, out Dummy _);
+        var converted = converter.TryChangeType("", cultureInfo, out Dummy? _);
         Assert.False(converted);
     }
 }

--- a/tests/Meziantou.Framework.TypeConverter.Tests/Meziantou.Framework.TypeConverter.Tests.csproj
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/Meziantou.Framework.TypeConverter.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Unicode.Tests/Meziantou.Framework.Unicode.Tests.csproj
+++ b/tests/Meziantou.Framework.Unicode.Tests/Meziantou.Framework.Unicode.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Unix.ControlGroups.Tests/Meziantou.Framework.Unix.ControlGroups.Tests.csproj
+++ b/tests/Meziantou.Framework.Unix.ControlGroups.Tests/Meziantou.Framework.Unix.ControlGroups.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Uri.Tests/Meziantou.Framework.Uri.Tests.csproj
+++ b/tests/Meziantou.Framework.Uri.Tests/Meziantou.Framework.Uri.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
+++ b/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
@@ -1159,10 +1159,11 @@ public sealed class UrlPatternTests
 
         Assert.NotNull(result);
         Assert.Single(result.Inputs);
-        Assert.NotNull(result.Inputs[0].Init);
-        Assert.Equal("https", result.Inputs[0].Init.Protocol);
-        Assert.Equal("example.com", result.Inputs[0].Init.Hostname);
-        Assert.Equal("/books/123", result.Inputs[0].Init.Pathname);
+        var inputInit = result.Inputs[0].Init;
+        Assert.NotNull(inputInit);
+        Assert.Equal("https", inputInit.Protocol);
+        Assert.Equal("example.com", inputInit.Hostname);
+        Assert.Equal("/books/123", inputInit.Pathname);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.ValueStopwatch.Tests/Meziantou.Framework.ValueStopwatch.Tests.csproj
+++ b/tests/Meziantou.Framework.ValueStopwatch.Tests/Meziantou.Framework.ValueStopwatch.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change enables nullable reference types in a set of test projects that were still explicitly opting out. The goal is to align these tests with the repository nullable defaults without changing test behavior.

### What changed
- Removed `<Nullable>disable</Nullable>` from:
  - `Meziantou.Framework.Threading.Tests`
  - `Meziantou.Framework.TypeConverter.Tests`
  - `Meziantou.Framework.Unicode.Tests`
  - `Meziantou.Framework.Unix.ControlGroups.Tests`
  - `Meziantou.Framework.Uri.Tests`
  - `Meziantou.Framework.ValueStopwatch.Tests`

### Notes
- No test logic was changed.
- These projects compiled and their test suites passed after enabling nullable.
- Required maintenance scripts were run; `validate-testprojects-configuration` reports pre-existing unrelated target-framework mismatches in other test projects.