### PR TITLE
Enable nullable in selected test projects

### DIFF
--- a/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/Meziantou.Framework.ObjectMethodExecutor.Tests.csproj
+++ b/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/Meziantou.Framework.ObjectMethodExecutor.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
+++ b/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
@@ -9,7 +9,7 @@ public sealed class ObjectMethodExecutorTests
     public void StaticSyncVoidTest()
     {
         var validator = new Validator();
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("StaticSyncVoid"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("StaticSyncVoid")!);
         var result = executor.Execute(target: null, [validator]);
 
         Assert.Null(result);
@@ -20,7 +20,7 @@ public sealed class ObjectMethodExecutorTests
     public void SyncVoidTest()
     {
         var validator = new Validator();
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncVoid"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncVoid")!);
         var result = executor.Execute(new Test(), [validator]);
 
         Assert.Null(result);
@@ -30,7 +30,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public void SyncInt32Test()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32")!);
         var result = executor.Execute(new Test(), []);
         Assert.Equal(1, result);
     }
@@ -38,7 +38,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public void SyncInt32WithParamTest()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32WithParam"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32WithParam")!);
         var result = executor.Execute(new Test(), [12]);
         Assert.Equal(12, result);
     }
@@ -47,7 +47,7 @@ public sealed class ObjectMethodExecutorTests
     public async Task StaticAsyncTaskTests()
     {
         var validator = new Validator();
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("StaticAsyncTask"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("StaticAsyncTask")!);
         var result = await executor.ExecuteAsync(null, [validator]);
 
         Assert.Null(result);
@@ -58,7 +58,7 @@ public sealed class ObjectMethodExecutorTests
     public async Task AsyncTaskTests()
     {
         var validator = new Validator();
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTask"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTask")!);
         var result = await executor.ExecuteAsync(new Test(), [validator]);
 
         Assert.Null(result);
@@ -68,7 +68,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public async Task AsyncTaskInt32Tests()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32")!);
         var result = await executor.ExecuteAsync(new Test(), []);
         Assert.Equal(1, result);
     }
@@ -76,7 +76,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public async Task ValueTaskInt32Tests()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("ValueTaskInt32"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("ValueTaskInt32")!);
         var result = await executor.ExecuteAsync(new Test(), []);
         Assert.Equal(1, result);
     }
@@ -84,7 +84,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public async Task AsyncTaskInt32WithParamTests()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32WithParam"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32WithParam")!);
         var result = await executor.ExecuteAsync(new Test(), [12]);
         Assert.Equal(12, result);
     }
@@ -92,7 +92,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public async Task AsyncCustomAwaiter()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncCustomAwaiter"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncCustomAwaiter")!);
         var result = await executor.ExecuteAsync(new Test(), []);
         Assert.Null(result);
     }
@@ -101,7 +101,7 @@ public sealed class ObjectMethodExecutorTests
     public async Task AsyncValueTaskTests()
     {
         var validator = new Validator();
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncValueTask"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncValueTask")!);
         var result = await executor.ExecuteAsync(new Test(), [validator]);
 
         Assert.Null(result);
@@ -112,7 +112,7 @@ public sealed class ObjectMethodExecutorTests
     public async Task SyncVoidCalledAsyncTest()
     {
         var validator = new Validator();
-        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncVoid"));
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncVoid")!);
         var result = await executor.ExecuteAsync(new Test(), [validator]);
 
         Assert.Null(result);
@@ -122,7 +122,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public async Task FSharpAsync()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(FSharpTests.Say).GetMethod("get_int32"));
+        var executor = ObjectMethodExecutor.Create(typeof(FSharpTests.Say).GetMethod("get_int32")!);
         var result = await executor.ExecuteAsync(new FSharpTests.Say(), []);
         Assert.Equal(42, result);
     }
@@ -130,7 +130,7 @@ public sealed class ObjectMethodExecutorTests
     [Fact]
     public async Task FSharpAsync_Unit()
     {
-        var executor = ObjectMethodExecutor.Create(typeof(FSharpTests.Say).GetMethod("get_dummyUnit"));
+        var executor = ObjectMethodExecutor.Create(typeof(FSharpTests.Say).GetMethod("get_dummyUnit")!);
         var result = await executor.ExecuteAsync(new FSharpTests.Say(), []);
         Assert.Null(result);
     }

--- a/tests/Meziantou.Framework.OpenTelemetry.Tests/Meziantou.Framework.OpenTelemetry.Tests.csproj
+++ b/tests/Meziantou.Framework.OpenTelemetry.Tests/Meziantou.Framework.OpenTelemetry.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.OpenTelemetry.Tests/OpenTelemetryReceiverTests.cs
+++ b/tests/Meziantou.Framework.OpenTelemetry.Tests/OpenTelemetryReceiverTests.cs
@@ -223,7 +223,7 @@ public sealed class OpenTelemetryReceiverTests
 
         public InMemoryOpenTelemetryHandler Receiver { get; } = receiver;
 
-        public static async Task<TestApplication> CreateAsync(InMemoryOpenTelemetryHandlerOptions options = null, Action<IServiceCollection> configureServices = null)
+        public static async Task<TestApplication> CreateAsync(InMemoryOpenTelemetryHandlerOptions? options = null, Action<IServiceCollection>? configureServices = null)
         {
             var builder = WebApplication.CreateBuilder();
             builder.WebHost.UseTestServer();

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/Meziantou.Framework.ProcessWrapper.Tests.csproj
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/Meziantou.Framework.ProcessWrapper.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/Meziantou.Framework.PublicApiGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/Meziantou.Framework.PublicApiGenerator.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
@@ -1670,7 +1670,7 @@ public sealed class PublicApiGeneratorTests
 #endif
 
     [InlineSnapshotAssertion(nameof(expected))]
-    private static async Task Validate(string source, string expected, PublicApiOptions options = null, CompilerOptions compilerOptions = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int lineNumber = -1)
+    private static async Task Validate(string source, string expected, PublicApiOptions? options = null, CompilerOptions? compilerOptions = null, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = -1)
     {
         await using var temporaryDirectory = TemporaryDirectory.Create();
         compilerOptions ??= new CompilerOptions();
@@ -1708,7 +1708,7 @@ public sealed class PublicApiGeneratorTests
         var reflectionContent = SerializeFiles(reflectionFiles);
         var metadataContent = SerializeFiles(metadataFiles);
         Assert.Equal(reflectionContent, metadataContent);
-        InlineSnapshot.Validate(reflectionContent, expected, filePath, lineNumber);
+        InlineSnapshot.Validate(reflectionContent, expected, filePath!, lineNumber);
 
         // Ensure the generated files are compilable
         var generatedDirectory = temporaryDirectory / "generated";
@@ -1740,7 +1740,7 @@ public sealed class PublicApiGeneratorTests
         }
     }
 
-    private static async Task<IReadOnlyList<PublicApiFile>> BuildFiles(string source, PublicApiOptions options, CompilerOptions compilerOptions = null)
+    private static async Task<IReadOnlyList<PublicApiFile>> BuildFiles(string source, PublicApiOptions options, CompilerOptions? compilerOptions = null)
     {
         await using var temporaryDirectory = TemporaryDirectory.Create();
         compilerOptions ??= new CompilerOptions();


### PR DESCRIPTION
## Why
These test projects still had nullable reference types disabled, which hides nullability issues and makes test code less consistent with the rest of the repository.

## What changed
- Removed `<Nullable>disable</Nullable>` from:
  - `Meziantou.Framework.ObjectMethodExecutor.Tests`
  - `Meziantou.Framework.OpenTelemetry.Tests`
  - `Meziantou.Framework.ProcessWrapper.Tests`
  - `Meziantou.Framework.PublicApiGenerator.Tests`
- `Meziantou.Framework.PostgreSqlServer.Tests` already had nullable enabled, so no csproj change was needed there.
- Fixed resulting nullable diagnostics in test sources without changing test behavior:
  - Added null-forgiving operators for reflection-based `GetMethod(...)` calls in `ObjectMethodExecutorTests`.
  - Marked optional parameters as nullable in `OpenTelemetryReceiverTests.CreateAsync`.
  - Updated helper signatures in `PublicApiGeneratorTests` to use nullable annotations and null-forgiving where required by APIs.

## Notes for reviewers
- The intent is strictly nullability cleanup for the requested test projects; no test logic changes were introduced.
- Required repository scripts were executed; `eng/validate-testprojects-configuration.cs` reports pre-existing cross-project target framework mismatches unrelated to this change.

## Validation
- Built all 5 target test projects after the nullable updates.
- Ran tests for all 5 target projects on `net10.0`:
  - ObjectMethodExecutor: 14 tests
  - OpenTelemetry: 9 tests
  - PostgreSqlServer: 10 tests
  - ProcessWrapper: 62 tests
  - PublicApiGenerator: 68 tests