### PR TITLE
Enable nullable in additional test projects

### DIFF
--- a/tests/Meziantou.Framework.ValueStringBuilder.Tests/Meziantou.Framework.ValueStringBuilder.Tests.csproj
+++ b/tests/Meziantou.Framework.ValueStringBuilder.Tests/Meziantou.Framework.ValueStringBuilder.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Versioning.Tests/Meziantou.Framework.Versioning.Tests.csproj
+++ b/tests/Meziantou.Framework.Versioning.Tests/Meziantou.Framework.Versioning.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
@@ -45,16 +45,13 @@ public class SemanticVersionTests
     [Fact]
     public void TryParse_ShouldNotParseNullVersion()
     {
-        Assert.False(SemanticVersion.TryParse((string)null, out _));
-#pragma warning restore IDE0004
+        Assert.False(SemanticVersion.TryParse((string?)null, out _));
     }
 
     [Fact]
     public void Parse_ShouldNotParseNullVersion()
     {
-#pragma warning disable IDE0004 // Remove Unnecessary Cast
-        Assert.Throws<ArgumentNullException>(() => SemanticVersion.Parse((string)null));
-#pragma warning restore IDE0004
+        Assert.Throws<ArgumentNullException>(() => SemanticVersion.Parse((string)null!));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.WPF.Tests/BooleanToValueConverterTests.cs
+++ b/tests/Meziantou.Framework.WPF.Tests/BooleanToValueConverterTests.cs
@@ -11,7 +11,7 @@ public sealed class BooleanToValueConverterTests
         NullValue = "null",
     };
 
-    private object Convert(object value)
+    private object? Convert(object? value)
     {
         return _converter.Convert(value, typeof(object), parameter: null, culture: null);
     }
@@ -28,7 +28,7 @@ public sealed class BooleanToValueConverterTests
     [InlineData(null, null)]
     [InlineData(null, "")]
     [InlineData(null, "abc")]
-    public void Test(bool? expectedValue, object value)
+    public void Test(bool? expectedValue, object? value)
     {
         var expected = expectedValue switch
         {

--- a/tests/Meziantou.Framework.WPF.Tests/Meziantou.Framework.WPF.Tests.csproj
+++ b/tests/Meziantou.Framework.WPF.Tests/Meziantou.Framework.WPF.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <UseWpf>true</UseWpf>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472' ">

--- a/tests/Meziantou.Framework.Win32.AccessToken.Tests/Meziantou.Framework.Win32.AccessToken.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.AccessToken.Tests/Meziantou.Framework.Win32.AccessToken.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Win32.AmsiTests/Meziantou.Framework.Win32.AmsiTests.csproj
+++ b/tests/Meziantou.Framework.Win32.AmsiTests/Meziantou.Framework.Win32.AmsiTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworksWindows)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This extends nullable reference type coverage to a set of test projects that were still opting out, so new nullability regressions are surfaced earlier in those test assemblies.

### What changed
- Removed `<Nullable>disable</Nullable>` from these test projects:
  - `Meziantou.Framework.ValueStringBuilder.Tests`
  - `Meziantou.Framework.Versioning.Tests`
  - `Meziantou.Framework.WPF.Tests`
  - `Meziantou.Framework.Win32.AccessToken.Tests`
  - `Meziantou.Framework.Win32.AmsiTests`
- Updated the null-input assertion in `SemanticVersionTests` to use `(string?)null` instead of a null-forgiving cast, keeping behavior unchanged while satisfying nullable analysis.

### Notes
- Test logic was not changed; only nullability configuration and nullability annotations/casts in tests were adjusted.