### PR TITLE
Enable nullable in selected serializer-related test projects

### DIFF
--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HttpJsonSerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HttpJsonSerializerTests.cs
@@ -176,7 +176,7 @@ public sealed class HttpJsonSerializerTests : SerializerTestsBase
 
     private sealed class CustomStringConverter : HumanReadableConverter<string>
     {
-        protected override void WriteValue(HumanReadableTextWriter writer, string value, HumanReadableSerializerOptions options)
+        protected override void WriteValue(HumanReadableTextWriter writer, string? value, HumanReadableSerializerOptions options)
         {
             writer.WriteValue("custom-" + value);
         }

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HumanReadableSerializerOptionsTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HumanReadableSerializerOptionsTests.cs
@@ -21,6 +21,6 @@ public sealed class HumanReadableSerializerOptionsTests
     private sealed class DummyConverter : HumanReadableConverter
     {
         public override bool CanConvert(Type type) => false;
-        public override void WriteValue(HumanReadableTextWriter writer, object value, Type valueType, HumanReadableSerializerOptions options) { }
+        public override void WriteValue(HumanReadableTextWriter writer, object? value, Type valueType, HumanReadableSerializerOptions options) { }
     }
 }

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/Meziantou.Framework.HumanReadableSerializer.Tests.csproj
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/Meziantou.Framework.HumanReadableSerializer.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.HumanReadable.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -68,7 +68,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     public void SerializeObject_Null() => AssertSerialization(null, "<null>");
 
     [Fact]
-    public void SerializeObject_Null_Nested() => AssertSerialization(new { Obj = (object)null }, "Obj: <null>");
+    public void SerializeObject_Null_Nested() => AssertSerialization(new { Obj = (object?)null }, "Obj: <null>");
 
     [Fact]
     public void SerializeArray_Empty()
@@ -1030,61 +1030,61 @@ public sealed partial class SerializerTests : SerializerTestsBase
     public void Type_AnonymType() => AssertSerialization(new { }.GetType(), "<>f__AnonymousType4, Meziantou.Framework.HumanReadableSerializer.Tests");
 
     [Fact]
-    public void MethodInfo() => AssertSerialization(typeof(object).GetMethod("ToString"), "System.Object.ToString()");
+    public void MethodInfo() => AssertSerialization(typeof(object).GetMethod("ToString")!, "System.Object.ToString()");
 
     [Fact]
-    public void MethodInfo_dynamic_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.Dynamic)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.Dynamic(dynamic value)");
+    public void MethodInfo_dynamic_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.Dynamic))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.Dynamic(dynamic value)");
 
     [Fact]
-    public void MethodInfo_dynamic_ValueTuple_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.ValueTupleDynamic)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.ValueTupleDynamic((dynamic, System.Int32) value)");
+    public void MethodInfo_dynamic_ValueTuple_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.ValueTupleDynamic))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.ValueTupleDynamic((dynamic, System.Int32) value)");
 
     [Fact]
-    public void MethodInfo_dynamic_Nested_ValueTuple_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.ValueTupleNestedDynamic)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.ValueTupleNestedDynamic((dynamic A, (System.Int32 B, dynamic C) D) value)");
+    public void MethodInfo_dynamic_Nested_ValueTuple_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.ValueTupleNestedDynamic))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.ValueTupleNestedDynamic((dynamic A, (System.Int32 B, dynamic C) D) value)");
 
     [Fact]
-    public void MethodInfo_ValueTuple_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.NotNamed)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.NotNamed((System.Int32, System.String) a)");
+    public void MethodInfo_ValueTuple_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.NotNamed))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.NotNamed((System.Int32, System.String) a)");
 
     [Fact]
-    public void MethodInfo_ValueTuple_Named_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.Named)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.Named((System.Int32 A, System.String B) a)");
+    public void MethodInfo_ValueTuple_Named_Parameter() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.Named))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.Named((System.Int32 A, System.String B) a)");
 
     [Fact]
-    public void MethodInfo_ValueTuple_Named_ReturnType() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.NamedResult)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.NamedResult()");
+    public void MethodInfo_ValueTuple_Named_ReturnType() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.NamedResult))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.NamedResult()");
 
     [Fact]
-    public void PropertyInfo_ValueTuple_Named_ReturnType() => AssertSerialization(typeof(Methods).GetProperty(nameof(Methods.NamedProperty)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.NamedProperty");
+    public void PropertyInfo_ValueTuple_Named_ReturnType() => AssertSerialization(typeof(Methods).GetProperty(nameof(Methods.NamedProperty))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.NamedProperty");
 
     [Fact]
     public void MethodInfo_WithParameters() => AssertSerialization(typeof(Guid).GetMethod("Parse", [typeof(string)]), "static System.Guid.Parse(System.String input)");
 
     [Fact]
-    public void MethodInfo_Generic() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.GenericMethod)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.GenericMethod<TEnum>(System.String value)");
+    public void MethodInfo_Generic() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.GenericMethod))!, "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.GenericMethod<TEnum>(System.String value)");
 
     [Fact]
-    public void MethodInfo_Generic_Constructed() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.GenericMethod)).MakeGenericMethod(typeof(DayOfWeek)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.GenericMethod<System.DayOfWeek>(System.String value)");
+    public void MethodInfo_Generic_Constructed() => AssertSerialization(typeof(Methods).GetMethod(nameof(Methods.GenericMethod))!.MakeGenericMethod(typeof(DayOfWeek)), "Meziantou.Framework.HumanReadable.Tests.SerializerTests+Methods.GenericMethod<System.DayOfWeek>(System.String value)");
 
     [Fact]
-    public void FieldInfo() => AssertSerialization(typeof(Guid).GetField("_a", BindingFlags.NonPublic | BindingFlags.Instance), "System.Guid._a");
+    public void FieldInfo() => AssertSerialization(typeof(Guid).GetField("_a", BindingFlags.NonPublic | BindingFlags.Instance)!, "System.Guid._a");
 
     [Fact]
-    public void FieldInfo_OpenGenericType() => AssertSerialization(typeof(Nullable<>).GetField("hasValue", BindingFlags.NonPublic | BindingFlags.Instance), "System.Nullable<T>.hasValue");
+    public void FieldInfo_OpenGenericType() => AssertSerialization(typeof(Nullable<>).GetField("hasValue", BindingFlags.NonPublic | BindingFlags.Instance)!, "System.Nullable<T>.hasValue");
 
     [Fact]
-    public void FieldInfo_GenericType() => AssertSerialization(typeof(int?).GetField("hasValue", BindingFlags.NonPublic | BindingFlags.Instance), "System.Nullable<System.Int32>.hasValue");
+    public void FieldInfo_GenericType() => AssertSerialization(typeof(int?).GetField("hasValue", BindingFlags.NonPublic | BindingFlags.Instance)!, "System.Nullable<System.Int32>.hasValue");
 
     [Fact]
-    public void PropertyInfo() => AssertSerialization(typeof(string).GetProperty("Length"), "System.String.Length");
+    public void PropertyInfo() => AssertSerialization(typeof(string).GetProperty("Length")!, "System.String.Length");
 
     [Fact]
-    public void PropertyInfo_Indexer() => AssertSerialization(typeof(string).GetProperty("Chars"), "System.String.Chars[System.Int32 index]");
+    public void PropertyInfo_Indexer() => AssertSerialization(typeof(string).GetProperty("Chars")!, "System.String.Chars[System.Int32 index]");
 
     [Fact]
-    public void ConstructorInfo() => AssertSerialization(typeof(object).GetConstructor([]), "new System.Object()");
+    public void ConstructorInfo() => AssertSerialization(typeof(object).GetConstructor([])!, "new System.Object()");
 
     [Fact]
     public void ConstructorInfo_Static() => AssertSerialization(typeof(ClassWithStaticCtor).GetConstructors(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)[0], "static Meziantou.Framework.HumanReadable.Tests.SerializerTests+ClassWithStaticCtor()");
 
     [Fact]
-    public void ParameterInfo() => AssertSerialization(typeof(Guid).GetMethod("Parse", [typeof(string)]).GetParameters()[0], "System.String input");
+    public void ParameterInfo() => AssertSerialization(typeof(Guid).GetMethod("Parse", [typeof(string)])!.GetParameters()[0], "System.String input");
 
     [Fact]
     public void DateTime_Utc() => AssertSerialization(new DateTime(2123, 4, 5, 6, 7, 8, DateTimeKind.Utc), "2123-04-05T06:07:08Z");
@@ -1789,7 +1789,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         AssertSerialization(new Validation
         {
-            Subject = new { Dummy = "", Object = (object)null, NullableInt32 = (int?)null, DefaultStruct = 0 },
+            Subject = new { Dummy = "", Object = (object?)null, NullableInt32 = (int?)null, DefaultStruct = 0 },
             Options = new HumanReadableSerializerOptions { DefaultIgnoreCondition = HumanReadableIgnoreCondition.Never },
             Expected = """
                 Dummy:
@@ -1805,7 +1805,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         AssertSerialization(new Validation
         {
-            Subject = new { Dummy = "", Object = (object)null, NullableInt32 = (int?)null, DefaultStruct = 0 },
+            Subject = new { Dummy = "", Object = (object?)null, NullableInt32 = (int?)null, DefaultStruct = 0 },
             Options = new HumanReadableSerializerOptions { DefaultIgnoreCondition = HumanReadableIgnoreCondition.WhenWritingNull },
             Expected = """
                 Dummy:
@@ -1819,7 +1819,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         AssertSerialization(new Validation
         {
-            Subject = new { Dummy = "", Object = (object)null, NullableInt32 = (int?)null, DefaultStruct = 0 },
+            Subject = new { Dummy = "", Object = (object?)null, NullableInt32 = (int?)null, DefaultStruct = 0 },
             Options = new HumanReadableSerializerOptions { DefaultIgnoreCondition = HumanReadableIgnoreCondition.WhenWritingDefault },
             Expected = """
                 Dummy:
@@ -1996,7 +1996,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     [Fact]
     public void WhenWritingEmptyCollection_Null()
     {
-        var obj = new { A = (string[])null, B = 2 };
+        var obj = new { A = (string[]?)null, B = 2 };
 
         AssertSerialization(new Validation
         {
@@ -2045,7 +2045,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     [Fact]
     public void WhenWritingDefaultOrEmptyCollection_Null()
     {
-        var obj = new { A = (string[])null, B = 2 };
+        var obj = new { A = (string[]?)null, B = 2 };
 
         AssertSerialization(new Validation
         {
@@ -2143,7 +2143,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         var options = new HumanReadableSerializerOptions();
         options.PropertyOrder = StringComparer.Ordinal;
-        options.IgnoreMember<Exception>(exception => exception.TargetSite);
+        options.IgnoreMember<Exception>(exception => exception.TargetSite!);
 
         AssertSerialization(new Validation
         {
@@ -2166,8 +2166,8 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         var options = new HumanReadableSerializerOptions();
         options.PropertyOrder = StringComparer.Ordinal;
-        options.IgnoreMember<Exception>(exception => exception.TargetSite);
-        options.IgnoreMember<Exception>(exception => exception.InnerException.Message); // Detect Exception.Message
+        options.IgnoreMember<Exception>(exception => exception.TargetSite!);
+        options.IgnoreMember<Exception>(exception => exception.InnerException!.Message); // Detect Exception.Message
 
         AssertSerialization(new Validation
         {
@@ -2246,7 +2246,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         var options = new HumanReadableSerializerOptions();
         options.PropertyOrder = StringComparer.Ordinal;
-        options.AddAttribute<Exception>(e => e.Source, new HumanReadableIgnoreAttribute());
+        options.AddAttribute<Exception>(e => e.Source!, new HumanReadableIgnoreAttribute());
         options.AddAttribute<Exception>(e => new { e.HResult, e.TargetSite, e.Data }, new HumanReadableIgnoreAttribute());
 
         AssertSerialization(new Validation
@@ -2288,11 +2288,11 @@ public sealed partial class SerializerTests : SerializerTestsBase
 
     private sealed class ObjectWithFields
     {
-        private string _privateField;
+        private string _privateField = null!;
 
         [HumanReadableInclude]
-        private string _privateFieldIncluded;
-        public string FieldString;
+        private string _privateFieldIncluded = null!;
+        public string FieldString = null!;
         public int FieldInt32;
 
         public int PropInt32 { get; set; }
@@ -2315,16 +2315,16 @@ public sealed partial class SerializerTests : SerializerTestsBase
         public int PropInt32_Null { get; set; }
 
         [HumanReadableIgnore(Condition = HumanReadableIgnoreCondition.WhenWritingNull)]
-        public object PropObject { get; set; }
+        public object? PropObject { get; set; }
 
         [HumanReadableIgnore(Condition = HumanReadableIgnoreCondition.Never)]
-        public object PropObject2 { get; set; }
+        public object? PropObject2 { get; set; }
 
         [HumanReadableIgnore(Condition = HumanReadableIgnoreCondition.WhenWritingDefault)]
-        public object PropObject3 { get; set; }
+        public object? PropObject3 { get; set; }
 
         [HumanReadableIgnore(Condition = HumanReadableIgnoreCondition.Always)]
-        public object PropObject4 { get; set; }
+        public object? PropObject4 { get; set; }
     }
 
     private sealed class OrderedMember
@@ -2348,31 +2348,31 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         private sealed class CustomTypeConverterImpl : TypeConverter
         {
-            public override bool CanConvertTo(ITypeDescriptorContext context, [NotNullWhen(true)] Type destinationType) => destinationType == typeof(string);
+            public override bool CanConvertTo(ITypeDescriptorContext? context, [NotNullWhen(true)] Type? destinationType) => destinationType == typeof(string);
 
-            public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType) => "converter";
+            public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType) => "converter";
         }
     }
 
     private sealed class CustomConvertible : IConvertible
     {
         public TypeCode GetTypeCode() => throw new NotSupportedException();
-        public bool ToBoolean(IFormatProvider provider) => throw new NotSupportedException();
-        public byte ToByte(IFormatProvider provider) => throw new NotSupportedException();
-        public char ToChar(IFormatProvider provider) => throw new NotSupportedException();
-        public DateTime ToDateTime(IFormatProvider provider) => throw new NotSupportedException();
-        public decimal ToDecimal(IFormatProvider provider) => throw new NotSupportedException();
-        public double ToDouble(IFormatProvider provider) => throw new NotSupportedException();
-        public short ToInt16(IFormatProvider provider) => throw new NotSupportedException();
-        public int ToInt32(IFormatProvider provider) => throw new NotSupportedException();
-        public long ToInt64(IFormatProvider provider) => throw new NotSupportedException();
-        public sbyte ToSByte(IFormatProvider provider) => throw new NotSupportedException();
-        public float ToSingle(IFormatProvider provider) => throw new NotSupportedException();
-        public string ToString(IFormatProvider provider) => "convertible";
-        public object ToType(Type conversionType, IFormatProvider provider) => throw new NotSupportedException();
-        public ushort ToUInt16(IFormatProvider provider) => throw new NotSupportedException();
-        public uint ToUInt32(IFormatProvider provider) => throw new NotSupportedException();
-        public ulong ToUInt64(IFormatProvider provider) => throw new NotSupportedException();
+        public bool ToBoolean(IFormatProvider? provider) => throw new NotSupportedException();
+        public byte ToByte(IFormatProvider? provider) => throw new NotSupportedException();
+        public char ToChar(IFormatProvider? provider) => throw new NotSupportedException();
+        public DateTime ToDateTime(IFormatProvider? provider) => throw new NotSupportedException();
+        public decimal ToDecimal(IFormatProvider? provider) => throw new NotSupportedException();
+        public double ToDouble(IFormatProvider? provider) => throw new NotSupportedException();
+        public short ToInt16(IFormatProvider? provider) => throw new NotSupportedException();
+        public int ToInt32(IFormatProvider? provider) => throw new NotSupportedException();
+        public long ToInt64(IFormatProvider? provider) => throw new NotSupportedException();
+        public sbyte ToSByte(IFormatProvider? provider) => throw new NotSupportedException();
+        public float ToSingle(IFormatProvider? provider) => throw new NotSupportedException();
+        public string ToString(IFormatProvider? provider) => "convertible";
+        public object ToType(Type conversionType, IFormatProvider? provider) => throw new NotSupportedException();
+        public ushort ToUInt16(IFormatProvider? provider) => throw new NotSupportedException();
+        public uint ToUInt32(IFormatProvider? provider) => throw new NotSupportedException();
+        public ulong ToUInt64(IFormatProvider? provider) => throw new NotSupportedException();
     }
 
     private sealed class Recursive
@@ -2389,11 +2389,11 @@ public sealed partial class SerializerTests : SerializerTestsBase
         public int Prop2 { get; set; }
 
         [HumanReadableConverter(typeof(CustomStringConverter))]
-        public string Prop3 { get; set; }
+        public string Prop3 { get; set; } = null!;
 
         private sealed class CustomStringConverter : HumanReadableConverter<string>
         {
-            protected override void WriteValue(HumanReadableTextWriter writer, string value, HumanReadableSerializerOptions options)
+            protected override void WriteValue(HumanReadableTextWriter writer, string? value, HumanReadableSerializerOptions options)
             {
                 writer.WriteValue("Custom");
             }
@@ -2407,7 +2407,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
 
         private sealed class CustomStringConverter : HumanReadableConverter<string>
         {
-            protected override void WriteValue(HumanReadableTextWriter writer, string value, HumanReadableSerializerOptions options)
+            protected override void WriteValue(HumanReadableTextWriter writer, string? value, HumanReadableSerializerOptions options)
             {
                 writer.WriteValue("Custom");
             }
@@ -2423,12 +2423,12 @@ public sealed partial class SerializerTests : SerializerTestsBase
     private sealed class DummyConverter : HumanReadableConverter
     {
         public override bool CanConvert(Type type) => throw new NotSupportedException();
-        public override void WriteValue(HumanReadableTextWriter writer, object value, Type valueType, HumanReadableSerializerOptions options) => throw new NotSupportedException();
+        public override void WriteValue(HumanReadableTextWriter writer, object? value, Type valueType, HumanReadableSerializerOptions options) => throw new NotSupportedException();
     }
 
     private sealed class CustomStringComparer : IEqualityComparer<string>
     {
-        public bool Equals(string x, string y) => x == y;
+        public bool Equals(string? x, string? y) => x == y;
         public int GetHashCode([DisallowNull] string obj) => 0;
     }
 
@@ -2437,7 +2437,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
 
     private sealed class ClassWithCustomConverterConverter : HumanReadableConverter<ClassWithCustomConverter>
     {
-        protected override void WriteValue(HumanReadableTextWriter writer, ClassWithCustomConverter value, HumanReadableSerializerOptions options)
+        protected override void WriteValue(HumanReadableTextWriter writer, ClassWithCustomConverter? value, HumanReadableSerializerOptions options)
         {
             writer.WriteValue("dummy");
         }
@@ -2473,12 +2473,12 @@ public sealed partial class SerializerTests : SerializerTestsBase
 
         public (int A, int B) NamedProperty => default;
 
-        public void GenericMethod<TEnum>(string value) => throw null;
+        public void GenericMethod<TEnum>(string value) => throw new NotSupportedException();
 
-        public void Dynamic(dynamic value) => throw null;
+        public void Dynamic(dynamic value) => throw new NotSupportedException();
 
-        public void ValueTupleDynamic((dynamic, int) value) => throw null;
+        public void ValueTupleDynamic((dynamic, int) value) => throw new NotSupportedException();
 
-        public void ValueTupleNestedDynamic((dynamic A, (int B, dynamic C) D) value) => throw null;
+        public void ValueTupleNestedDynamic((dynamic A, (int B, dynamic C) D) value) => throw new NotSupportedException();
     }
 }

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -2288,11 +2288,11 @@ public sealed partial class SerializerTests : SerializerTestsBase
 
     private sealed class ObjectWithFields
     {
-        private string _privateField = null!;
+        private string? _privateField;
 
         [HumanReadableInclude]
-        private string _privateFieldIncluded = null!;
-        public string FieldString = null!;
+        private string? _privateFieldIncluded;
+        public string? FieldString;
         public int FieldInt32;
 
         public int PropInt32 { get; set; }
@@ -2389,7 +2389,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
         public int Prop2 { get; set; }
 
         [HumanReadableConverter(typeof(CustomStringConverter))]
-        public string Prop3 { get; set; } = null!;
+        public string? Prop3 { get; set; }
 
         private sealed class CustomStringConverter : HumanReadableConverter<string>
         {

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTestsBase.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTestsBase.cs
@@ -5,23 +5,23 @@ public class SerializerTestsBase
 {
     protected sealed record Validation
     {
-        public object Subject { get; init; }
-        public string Expected { get; init; }
-        public Type Type { get; init; }
-        public HumanReadableSerializerOptions Options { get; init; }
+        public object? Subject { get; init; }
+        public string Expected { get; init; } = null!;
+        public Type? Type { get; init; }
+        public HumanReadableSerializerOptions? Options { get; init; }
     }
 
-    protected static void AssertSerialization(object obj, string expected)
+    protected static void AssertSerialization(object? obj, string expected)
     {
         AssertSerialization(obj, options: null, expected);
     }
 
-    protected static void AssertSerialization(object obj, HumanReadableSerializerOptions options, string expected)
+    protected static void AssertSerialization(object? obj, HumanReadableSerializerOptions? options, string expected)
     {
         AssertSerialization(obj, options, type: null, expected);
     }
 
-    protected static void AssertSerialization(object obj, HumanReadableSerializerOptions options, Type type, string expected)
+    protected static void AssertSerialization(object? obj, HumanReadableSerializerOptions? options, Type? type, string expected)
     {
         var text = type == null ? HumanReadableSerializer.Serialize(obj, options) : HumanReadableSerializer.Serialize(obj, type, options);
         Assert.Equal(expected, text, ignoreLineEndingDifferences: true);

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTestsBase.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTestsBase.cs
@@ -6,7 +6,7 @@ public class SerializerTestsBase
     protected sealed record Validation
     {
         public object? Subject { get; init; }
-        public string Expected { get; init; } = null!;
+        public string? Expected { get; init; }
         public Type? Type { get; init; }
         public HumanReadableSerializerOptions? Options { get; init; }
     }
@@ -29,6 +29,7 @@ public class SerializerTestsBase
 
     protected static void AssertSerialization(Validation validation)
     {
-        AssertSerialization(validation.Subject, validation.Options, validation.Type, validation.Expected);
+        var expected = validation.Expected ?? throw new InvalidOperationException("Expected serialization output must be provided.");
+        AssertSerialization(validation.Subject, validation.Options, validation.Type, expected);
     }
 }

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -1066,7 +1066,7 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
 
     [SuppressMessage("Design", "MA0042:Do not use blocking calls in an async method", Justification = "Not supported on .NET Framework")]
     [SuppressMessage("Performance", "CA1849:Call async methods when in an async method", Justification = "Not supported on .NET Framework")]
-    private async Task AssertSnapshot([StringSyntax("c#-test")] string source, [StringSyntax("c#-test")] string expected = null, bool launchDebugger = false, string languageVersion = "11", bool autoDetectCI = false, bool forceUpdateSnapshots = false, IEnumerable<KeyValuePair<string, string>> environmentVariables = null, string[] preprocessorSymbols = null)
+    private async Task AssertSnapshot([StringSyntax("c#-test")] string source, [StringSyntax("c#-test")] string? expected = null, bool launchDebugger = false, string languageVersion = "11", bool autoDetectCI = false, bool forceUpdateSnapshots = false, IEnumerable<KeyValuePair<string, string>>? environmentVariables = null, string[]? preprocessorSymbols = null)
     {
         await using var directory = TemporaryDirectory.Create();
         var projectPath = CreateTextFile("Project.csproj", $$"""
@@ -1189,12 +1189,14 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
         {
             var names = typeof(InlineSnapshotTests).Assembly.GetManifestResourceNames();
             using var stream = typeof(InlineSnapshotTests).Assembly.GetManifestResourceStream("Meziantou.Framework.InlineSnapshotTesting.Tests.Meziantou.Framework.InlineSnapshotTesting.csproj");
+            Assert.NotNull(stream);
             var doc = XDocument.Load(stream);
+            Assert.NotNull(doc.Root);
             var items = doc.Root.Descendants("PackageReference");
 
-            var packages = items.Where(item => item.Parent.Attribute("Condition") is null).ToList();
+            var packages = items.Where(item => item.Parent?.Attribute("Condition") is null).ToList();
 #if NET472 || NET48
-            packages.AddRange(items.Where(item => item.Parent.Attribute("Condition") is not null));
+            packages.AddRange(items.Where(item => item.Parent?.Attribute("Condition") is not null));
 #endif
 
             return string.Join('\n', packages.Select(item => item.ToString()));
@@ -1233,6 +1235,7 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
             }
 
             using var process = Process.Start(psi);
+            Assert.NotNull(process);
             process.OutputDataReceived += (_, e) => testOutputHelper.WriteLine(e.Data ?? "");
             process.ErrorDataReceived += (_, e) => testOutputHelper.WriteLine(e.Data ?? "");
             process.BeginOutputReadLine();

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/Meziantou.Framework.InlineSnapshotTesting.Tests.csproj
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/Meziantou.Framework.InlineSnapshotTesting.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472;net48</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/SnapshotSerializerTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/SnapshotSerializerTests.cs
@@ -300,7 +300,7 @@ public sealed class SnapshotSerializerTests
         public int? NullableInt32_NotNull { get; set; } = 42;
         public int[] Int32Array { get; set; } = [1, 2, 3, 4, 5];
         public int[] EmptyArray { get; set; } = [];
-        public int[] NullArray { get; set; }
+        public int[]? NullArray { get; set; }
         public IEnumerable<int> IEnumerableInt32 { get; set; } = Enumerable.Range(0, 2);
         public IDictionary<int, int> IDictionary { get; set; } = new Dictionary<int, int>() { [1] = 2, [3] = 4 };
         public IReadOnlyDictionary<int, int> IReadOnlyDictionary { get; set; } = new ReadOnlyDictionary<int, int>(new Dictionary<int, int>() { [1] = 2, [3] = 4 });

--- a/tests/Meziantou.Framework.JsonPath.Tests/JsonPathParseTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/JsonPathParseTests.cs
@@ -59,14 +59,14 @@ public sealed class JsonPathParseTests
     [Fact]
     public void TryParse_NullExpression_ReturnsFalse()
     {
-        Assert.False(JsonPath.TryParse((string)null, out var result));
+        Assert.False(JsonPath.TryParse((string)null!, out var result));
         Assert.Null(result);
     }
 
     [Fact]
     public void Parse_NullExpression_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => JsonPath.Parse((string)null));
+        Assert.Throws<ArgumentNullException>(() => JsonPath.Parse((string)null!));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.JsonPath.Tests/JsonPathParseTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/JsonPathParseTests.cs
@@ -59,7 +59,7 @@ public sealed class JsonPathParseTests
     [Fact]
     public void TryParse_NullExpression_ReturnsFalse()
     {
-        Assert.False(JsonPath.TryParse((string)null!, out var result));
+        Assert.False(JsonPath.TryParse((string?)null, out var result));
         Assert.Null(result);
     }
 

--- a/tests/Meziantou.Framework.JsonPath.Tests/Meziantou.Framework.JsonPath.Tests.csproj
+++ b/tests/Meziantou.Framework.JsonPath.Tests/Meziantou.Framework.JsonPath.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.JsonPathTests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
@@ -103,6 +103,7 @@ public sealed class FlacTests
     {
         var result = MediaFile.ReadTags(GetTestFilePath("long_values.flac"));
         Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value.Title);
         Assert.True(result.Value.Title.Length > 100);
     }
 

--- a/tests/Meziantou.Framework.MediaTags.Tests/Meziantou.Framework.MediaTags.Tests.csproj
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Meziantou.Framework.MediaTags.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why
Several targeted test projects explicitly disabled nullable reference type analysis. This change enables nullable in those projects and updates tests to satisfy compiler analysis while keeping the same test behavior.

## What changed
- Removed `<Nullable>disable</Nullable>` from:
  - `Meziantou.Framework.HumanReadableSerializer.Tests`
  - `Meziantou.Framework.InlineSnapshotTesting.Tests`
  - `Meziantou.Framework.JsonPath.Tests`
  - `Meziantou.Framework.MediaTags.Tests`
- Updated shared test helpers (`SerializerTestsBase.Validation` and `AssertSerialization` overloads) to accept nullable inputs.
- Adjusted affected tests and local test-only helper types with nullable annotations, null-forgiving where appropriate, and existing-behavior-preserving assertions.
- Kept test logic and expected snapshots/output unchanged.

## Validation
- `dotnet build` succeeds for the affected projects.
- `dotnet test` succeeds for:
  - `Meziantou.Framework.HumanReadableSerializer.Tests`
  - `Meziantou.Framework.InlineSnapshotTesting.Tests`
  - `Meziantou.Framework.JsonPath.Tests`
  - `Meziantou.Framework.MediaTags.Tests`
- Required scripts were run:
  - Succeeded: `dotnet run ./eng/update-trimmable.cs`
  - Failed due pre-existing repo-wide target framework mismatch checks unrelated to this change: `update-bom.cs`, `update-readme.cs`, `update-project-slnx.cs`, `validate-testprojects-configuration.cs`