### PR TITLE
Detect Docker image dependencies in COPY --from

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Scanners/DockerfileDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/DockerfileDependencyScanner.cs
@@ -3,7 +3,7 @@ using Meziantou.Framework.DependencyScanning.Internals;
 
 namespace Meziantou.Framework.DependencyScanning.Scanners;
 
-/// <summary>Scans Dockerfile and Containerfile for Docker image dependencies in FROM instructions.</summary>
+/// <summary>Scans Dockerfile and Containerfile for Docker image dependencies in FROM and COPY --from instructions.</summary>
 public sealed partial class DockerfileDependencyScanner : DependencyScanner
 {
     protected internal override IReadOnlyCollection<DependencyType> SupportedDependencyTypes { get; } = [DependencyType.DockerImage];
@@ -18,10 +18,17 @@ public sealed partial class DockerfileDependencyScanner : DependencyScanner
             lineNo++;
             var match = FromRegex().Match(line);
             if (!match.Success)
-                continue;
+            {
+                match = CopyFromRegex().Match(line);
+                if (!match.Success)
+                    continue;
+            }
 
             var packageNameGroup = match.Groups["ImageName"];
             var packageName = packageNameGroup.Value;
+            if (packageName.Contains('@', StringComparison.Ordinal))
+                continue;
+
             var versionGroup = match.Groups["Version"];
             var version = versionGroup.Value;
             context.ReportDependency(this, packageName, version, DependencyType.DockerImage,
@@ -37,4 +44,7 @@ public sealed partial class DockerfileDependencyScanner : DependencyScanner
 
     [GeneratedRegex(@"^FROM\s*(?<ImageName>[^\s]+):(?<Version>[^\s]+)(\s+AS\s+\w+)?\s*$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 10000)]
     private static partial Regex FromRegex();
+
+    [GeneratedRegex(@"^\s*COPY\b.*?\s--from(?:=|\s+)(?<ImageName>[^\s]+):(?<Version>[^\s]+)(?:\s|$)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 10000)]
+    private static partial Regex CopyFromRegex();
 }

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -496,11 +496,17 @@ public sealed class ScannerTests(ITestOutputHelper testOutputHelper) : IDisposab
         const string Original = """
             FROM a.com/b:1.2.2
             FROM a.com/c:1.2.3 AS base
+            COPY --from a.com/d:4.5.6 /tool /tool
+            COPY --chown=app:app --from=a.com/e:7.8.9 /src /dest
+            COPY --from=base /output /output
             CMD  /code/run-app
             """;
         const string Expected = """
             FROM dummy1:2.0.0
             FROM dummy2:2.0.0 AS base
+            COPY --from dummy3:2.0.0 /tool /tool
+            COPY --chown=app:app --from=dummy4:2.0.0 /src /dest
+            COPY --from=base /output /output
             CMD  /code/run-app
             """;
 
@@ -508,7 +514,9 @@ public sealed class ScannerTests(ITestOutputHelper testOutputHelper) : IDisposab
         var result = await GetDependencies<DockerfileDependencyScanner>();
         AssertContainDependency(result,
             (DependencyType.DockerImage, "a.com/b", "1.2.2", 1, 14),
-            (DependencyType.DockerImage, "a.com/c", "1.2.3", 2, 14));
+            (DependencyType.DockerImage, "a.com/c", "1.2.3", 2, 14),
+            (DependencyType.DockerImage, "a.com/d", "4.5.6", 3, 21),
+            (DependencyType.DockerImage, "a.com/e", "7.8.9", 4, 37));
 
         await UpdateDependencies(result, "dummy", "2.0.0");
         AssertFileContentEqual("Dockerfile", Expected, ignoreNewLines: false);


### PR DESCRIPTION
## Why
Dockerfile dependencies were only detected from `FROM image:tag` instructions. This missed external image dependencies referenced in multi-stage copy instructions such as `COPY --from image:tag ...`.

## What changed
- Extended `DockerfileDependencyScanner` to detect Docker image dependencies from `COPY --from` instructions.
- Added support for both syntaxes:
  - `COPY --from image:tag ...`
  - `COPY --from=image:tag ...`
- Kept existing `FROM` detection behavior.
- Added tests in `ScannerTests.DockerfileFromDependencies` to cover both COPY forms, verify version locations, and verify update behavior.

## Notes
- Stage aliases such as `COPY --from=base ...` are intentionally ignored.
- Digest references are not treated as tag-based updatable versions in this change.