### PR TITLE
Enable nullable reference types in selected test projects

### DIFF
--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
@@ -158,6 +158,6 @@ public sealed class ExpressionQueryBuilderTests
     {
         public int Int32Value { get; set; }
         public long Int64Value { get; set; }
-        public string StringValue { get; set; }
+        public string StringValue { get; set; } = "";
     }
 }

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
@@ -158,6 +158,6 @@ public sealed class ExpressionQueryBuilderTests
     {
         public int Int32Value { get; set; }
         public long Int64Value { get; set; }
-        public string StringValue { get; set; } = "";
+        public string? StringValue { get; set; }
     }
 }

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/Meziantou.Framework.SimpleQueryLanguage.Tests.csproj
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/Meziantou.Framework.SimpleQueryLanguage.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
@@ -863,6 +863,6 @@ public sealed class QueryBuilderTests
         public DateTime DateTimeValue { get; set; }
         public DateTimeOffset DateTimeOffsetValue { get; set; }
         public DayOfWeek DayOfWeekValue { get; set; }
-        public string StringValue { get; set; } = "";
+        public string? StringValue { get; set; }
     }
 }

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
@@ -863,6 +863,6 @@ public sealed class QueryBuilderTests
         public DateTime DateTimeValue { get; set; }
         public DateTimeOffset DateTimeOffsetValue { get; set; }
         public DayOfWeek DayOfWeekValue { get; set; }
-        public string StringValue { get; set; }
+        public string StringValue { get; set; } = "";
     }
 }

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ValueParserTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ValueParserTests.cs
@@ -86,7 +86,7 @@ public class ValueParserTests
 
     private sealed class CustomTypeWithTryParse
     {
-        public static bool TryParse(string value, out CustomTypeWithTryParse result)
+        public static bool TryParse(string value, out CustomTypeWithTryParse? result)
         {
             if (string.IsNullOrEmpty(value))
             {

--- a/tests/Meziantou.Framework.SingleInstance.Tests/Meziantou.Framework.SingleInstance.Tests.csproj
+++ b/tests/Meziantou.Framework.SingleInstance.Tests/Meziantou.Framework.SingleInstance.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
+++ b/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
@@ -33,7 +33,7 @@ public sealed class SingleInstanceTests
         Assert.Equal(["123"], orderedEvents[0].Arguments);
         Assert.Equal(["a", "b", "c"], orderedEvents[1].Arguments);
 
-        void SingleInstance_NewInstance(object sender, SingleInstanceEventArgs e)
+        void SingleInstance_NewInstance(object? sender, SingleInstanceEventArgs e)
         {
             Assert.Equal(singleInstance, sender);
             lock (events)

--- a/tests/Meziantou.Framework.Slug.Tests/Meziantou.Framework.Slug.Tests.csproj
+++ b/tests/Meziantou.Framework.Slug.Tests/Meziantou.Framework.Slug.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <Import Project="../../src/Meziantou.Framework.SnapshotTesting/build/Meziantou.Framework.SnapshotTesting.props" />

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/Meziantou.Framework.StronglyTypedId.Tests.csproj
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/Meziantou.Framework.StronglyTypedId.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
@@ -53,7 +53,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
 
     private static ISourceGenerator InstantiateGenerator() => new StronglyTypedIdSourceGenerator().AsSourceGenerator();
 
-    private static async Task<(GeneratorDriverRunResult GeneratorResult, Compilation OutputCompilation, byte[] Assembly, byte[] Symbols)> GenerateFiles(string sourceText, bool mustCompile = true)
+    private static async Task<(GeneratorDriverRunResult GeneratorResult, Compilation OutputCompilation, byte[]? Assembly, byte[] Symbols)> GenerateFiles(string sourceText, bool mustCompile = true)
     {
         var compilation = await CreateCompilation(sourceText,
         [
@@ -84,7 +84,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
             Assert.True(result.Success);
         }
 
-        return (runResult, outputCompilation, result.Success ? outputStream.ToArray() : null!, pdbStream.ToArray());
+        return (runResult, outputCompilation, result.Success ? outputStream.ToArray() : null, pdbStream.ToArray());
     }
 
     private static async Task<ImmutableArray<Diagnostic>> Analyze(string sourceText)

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
@@ -84,7 +84,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
             Assert.True(result.Success);
         }
 
-        return (runResult, outputCompilation, result.Success ? outputStream.ToArray() : null, pdbStream.ToArray());
+        return (runResult, outputCompilation, result.Success ? outputStream.ToArray() : null!, pdbStream.ToArray());
     }
 
     private static async Task<ImmutableArray<Diagnostic>> Analyze(string sourceText)
@@ -308,6 +308,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
             {
                 var from = (MethodInfo)type.GetMember("FromInt32").Single();
                 var instance = from.Invoke(null, [-42]);
+                Assert.NotNull(instance);
                 var str = instance.ToString();
                 Assert.Equal("Test { Value = -42 }", str);
             });
@@ -335,6 +336,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
         {
             var from = type.GetMember("TryParse").OfType<MethodInfo>().Single(m => m.GetParameters()[0].ParameterType == typeof(string));
             var parsed = from.Invoke(null, ["0", null]);
+            Assert.NotNull(parsed);
             Assert.False((bool)parsed);
         });
     }
@@ -387,7 +389,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
         {
             var interfaces = type.GetInterfaces();
             Assert.Contains(interfaces, x => x.FullName == "Meziantou.Framework.IStronglyTypedId");
-            Assert.Contains(interfaces, x => x.FullName.StartsWith("Meziantou.Framework.IStronglyTypedId`1", StringComparison.Ordinal));
+            Assert.Contains(interfaces, x => x.FullName is not null && x.FullName.StartsWith("Meziantou.Framework.IStronglyTypedId`1", StringComparison.Ordinal));
         });
     }
 
@@ -459,14 +461,14 @@ public sealed class StronglyTypedIdSourceGeneratorTests
 
         // Replace struct with record struct
         compilation = compilation.ReplaceSyntaxTree(compilation.SyntaxTrees.First(), CSharpSyntaxTree.ParseText("[Meziantou.Framework.Annotations.StronglyTypedId(typeof(int))] public partial record struct Test { }"));
-        result = RunGenerator(validate: (_, symbol) => Assert.Equal((true, true), (symbol.IsRecord, symbol.IsValueType)));
+        result = RunGenerator(validate: (_, symbol) => Assert.Equal((true, true), (symbol!.IsRecord, symbol.IsValueType)));
         AssertSyntaxStepIsNotCached(result);
         AssertOutputIsNotCached(result);
 
         // Update references
         var newReferences = await NuGetHelpers.GetNuGetReferences("Newtonsoft.Json", "12.0.3", "lib/netstandard2.0/");
         compilation = compilation.AddReferences(newReferences.Select(path => MetadataReference.CreateFromFile(path)));
-        result = RunGenerator(validate: (_, symbol) => Assert.NotEmpty(symbol.GetTypeMembers("TestNewtonsoftJsonConverter")));
+        result = RunGenerator(validate: (_, symbol) => Assert.NotEmpty(symbol!.GetTypeMembers("TestNewtonsoftJsonConverter")));
         AssertOutputIsNotCached(result);
 
         // Update syntax
@@ -498,7 +500,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
             Assert.DoesNotContain(IncrementalStepRunReason.Cached, result.TrackedSteps["Syntax"].SelectMany(step => step.Outputs).Select(output => output.Reason));
         }
 
-        GeneratorRunResult RunGenerator(bool shouldGenerateFiles = true, Action<Compilation, INamedTypeSymbol> validate = null)
+        GeneratorRunResult RunGenerator(bool shouldGenerateFiles = true, Action<Compilation, INamedTypeSymbol?>? validate = null)
         {
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics, XunitCancellationToken);
             Assert.Empty(diagnostics);
@@ -655,7 +657,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
         return TestGeneratedAssembly(sourceCode, typeName: null, assert);
     }
 
-    private static async Task TestGeneratedAssembly([StringSyntax("c#-test")] string sourceCode, string typeName, Action<Type> assert, bool mustGenerateTrees = true)
+    private static async Task TestGeneratedAssembly([StringSyntax("c#-test")] string sourceCode, string? typeName, Action<Type> assert, bool mustGenerateTrees = true)
     {
         var result = await GenerateFiles(sourceCode);
         Assert.Empty(result.GeneratorResult.Diagnostics);
@@ -675,6 +677,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
         {
             var assembly = alc.LoadFromStream(new MemoryStream(result.Assembly), new MemoryStream(result.Symbols));
             var type = assembly.GetType(typeName ?? "Test");
+            Assert.NotNull(type);
 
             assert(type);
         }

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
@@ -675,6 +675,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
         var alc = new AssemblyLoadContext("test", isCollectible: true);
         try
         {
+            Assert.NotNull(result.Assembly);
             var assembly = alc.LoadFromStream(new MemoryStream(result.Assembly), new MemoryStream(result.Symbols));
             var type = assembly.GetType(typeName ?? "Test");
             Assert.NotNull(type);


### PR DESCRIPTION
## Why
These test projects had nullable reference types explicitly disabled, which hides potential nullability issues in tests and makes diagnostics less consistent with the rest of the repo.

## What changed
- Removed `<Nullable>disable</Nullable>` from:
  - `Meziantou.Framework.SimpleQueryLanguage.Tests`
  - `Meziantou.Framework.SingleInstance.Tests`
  - `Meziantou.Framework.Slug.Tests`
  - `Meziantou.Framework.SnapshotTesting.Tests`
  - `Meziantou.Framework.StronglyTypedId.Tests`
- Updated `StronglyTypedIdSourceGeneratorTests` to satisfy nullable analysis without changing test behavior by using nullability annotations, `Assert.NotNull(...)`, and null-forgiving where appropriate.

## Notes
- `Meziantou.Framework.StronglyTypedId.GeneratorTests` did not contain `<Nullable>disable</Nullable>` in its csproj, so no csproj change was needed there.
- The `<Nullable>disable</Nullable>` text inside `SnapshotEndToEndTests.cs` is part of test source content and was intentionally left unchanged.

## Validation
- Built all 6 requested test projects.
- Ran tests for all 6 requested test projects.
- Ran required scripts:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`