### PR TITLE
Enable nullable reference types for selected test projects

### DIFF
--- a/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/EnumToStringSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/EnumToStringSourceGeneratorTests.cs
@@ -9,7 +9,7 @@ namespace Meziantou.Framework.FastEnumToStringGenerator.Tests;
 
 public sealed class EnumToStringSourceGeneratorTests
 {
-    private static async Task<(GeneratorDriverRunResult GeneratorResult, Compilation OutputCompilation, byte[] Assembly)> GenerateFiles(string file, bool mustCompile = true, string[] assemblyLocations = null)
+    private static async Task<(GeneratorDriverRunResult GeneratorResult, Compilation OutputCompilation, byte[]? Assembly)> GenerateFiles(string file, bool mustCompile = true, string[]? assemblyLocations = null)
     {
         var netcoreRef = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "8.0.0", "ref/net8.0/");
         assemblyLocations ??= [];
@@ -70,6 +70,7 @@ public sealed class EnumToStringSourceGeneratorTests
             }
             """;
         var (generatorResult, _, assembly) = await GenerateFiles(sourceCode);
+        Assert.NotNull(assembly);
         Assert.Empty(generatorResult.Diagnostics);
         Assert.Equal(3, generatorResult.GeneratedTrees.Length);
         Assert.Contains(generatorResult.GeneratedTrees, static tree => tree.FilePath.EndsWith("FastEnumToStringExtensions.g.cs", StringComparison.Ordinal));
@@ -78,7 +79,9 @@ public sealed class EnumToStringSourceGeneratorTests
 
         var asm = Assembly.Load(assembly);
         var type = asm.GetType("A.B.C");
+        Assert.NotNull(type);
         var method = type.GetMethod("Sample", BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(method);
         Assert.Equal("Value2", method.Invoke(null, [1]));
         Assert.Equal("999", method.Invoke(null, [999]));
 
@@ -112,6 +115,7 @@ public sealed class EnumToStringSourceGeneratorTests
             }
             """;
         var (generatorResult, _, assembly) = await GenerateFiles(sourceCode);
+        Assert.NotNull(assembly);
         Assert.Empty(generatorResult.Diagnostics);
         Assert.Equal(3, generatorResult.GeneratedTrees.Length);
         Assert.Contains(generatorResult.GeneratedTrees, static tree => tree.FilePath.EndsWith("FastEnumToStringExtensions.g.cs", StringComparison.Ordinal));
@@ -120,6 +124,7 @@ public sealed class EnumToStringSourceGeneratorTests
 
         var asm = Assembly.Load(assembly);
         var ns1Type = asm.GetType("SampleNs1.FastEnumToStringExtensions");
+        Assert.NotNull(ns1Type);
         var methods1 = ns1Type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             .Where(m => m.Name == "ToStringFast")
             .OrderBy(m => m.GetParameters()[0].ParameterType.FullName, StringComparer.Ordinal);
@@ -130,6 +135,7 @@ public sealed class EnumToStringSourceGeneratorTests
             m => Assert.False(m.IsPublic));
 
         var ns3Type = asm.GetType("SampleNs3.FastEnumToStringExtensions");
+        Assert.NotNull(ns3Type);
         var methods3 = ns3Type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             .Where(m => string.Equals(m.Name, "ToStringFast", StringComparison.Ordinal))
             .OrderBy(m => m.GetParameters()[0].ParameterType.FullName, StringComparer.Ordinal);
@@ -137,6 +143,7 @@ public sealed class EnumToStringSourceGeneratorTests
         Assert.False(ns3Type.IsPublic);
 
         var ns4Type = asm.GetType("SampleNs4.FastEnumToStringExtensions");
+        Assert.NotNull(ns4Type);
         var methods4 = ns4Type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             .Where(m => m.Name == "ToStringFast")
             .OrderBy(m => m.GetParameters()[0].ParameterType.FullName, StringComparer.Ordinal);

--- a/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/Meziantou.Framework.FastEnumToStringGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/Meziantou.Framework.FastEnumToStringGenerator.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.FixedStringBuilder.Tests/Meziantou.Framework.FixedStringBuilder.Tests.csproj
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Tests/Meziantou.Framework.FixedStringBuilder.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.FullPath.Tests/Meziantou.Framework.FullPath.Tests.csproj
+++ b/tests/Meziantou.Framework.FullPath.Tests/Meziantou.Framework.FullPath.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
@@ -29,9 +29,9 @@ public class GlobParserTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void InvalidPatterns(string content)
+    public void InvalidPatterns(string? content)
     {
-        Assert.Throws<ArgumentException>(() => Glob.Parse(content, GlobOptions.None));
+        Assert.Throws<ArgumentException>(() => Glob.Parse(content!, GlobOptions.None));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
@@ -170,13 +170,13 @@ public class GlobTests
         Assert.True(glob.IsMatch(directoryName, fileName, itemType));
         Assert.True(globi.IsMatch(path));
         Assert.True(globi.IsMatch(directoryName, fileName, itemType));
-        Assert.True(glob.IsPartialMatch(directoryName));
-        Assert.True(globi.IsPartialMatch(directoryName));
+        Assert.True(glob.IsPartialMatch(directoryName!));
+        Assert.True(globi.IsPartialMatch(directoryName!));
 
         if (OperatingSystem.IsWindows())
         {
             Assert.True(glob.IsMatch(path.Replace('/', '\\')));
-            Assert.True(glob.IsMatch(directoryName.Replace('/', '\\'), fileName, itemType));
+            Assert.True(glob.IsMatch(directoryName!.Replace('/', '\\'), fileName, itemType));
         }
     }
 
@@ -230,7 +230,7 @@ public class GlobTests
     {
         var glob = Glob.Parse(pattern, GlobOptions.IgnoreCase);
         Assert.True(glob.IsMatch(path));
-        Assert.True(glob.IsMatch(Path.GetDirectoryName(path), Path.GetFileName(path)));
+        Assert.True(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
     }
 
     [Theory]
@@ -362,7 +362,7 @@ public class GlobTests
     {
         var glob = Glob.Parse(pattern, GlobOptions.None);
         Assert.False(glob.IsMatch(path));
-        Assert.False(glob.IsMatch(Path.GetDirectoryName(path), Path.GetFileName(path)));
+        Assert.False(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
     }
 
     [Theory]
@@ -535,16 +535,16 @@ public class GlobTests
         var glob = Glob.Parse(pattern, GlobOptions.Git);
         var globi = Glob.Parse(pattern, GlobOptions.IgnoreCase | GlobOptions.Git);
         Assert.True(glob.IsMatch(path));
-        Assert.True(glob.IsMatch(Path.GetDirectoryName(path), Path.GetFileName(path)));
+        Assert.True(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
         Assert.True(globi.IsMatch(path));
-        Assert.True(globi.IsMatch(Path.GetDirectoryName(path), Path.GetFileName(path)));
-        Assert.True(glob.IsPartialMatch(Path.GetDirectoryName(path)));
-        Assert.True(globi.IsPartialMatch(Path.GetDirectoryName(path)));
+        Assert.True(globi.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
+        Assert.True(glob.IsPartialMatch(Path.GetDirectoryName(path)!));
+        Assert.True(globi.IsPartialMatch(Path.GetDirectoryName(path)!));
 
         if (OperatingSystem.IsWindows())
         {
             Assert.True(glob.IsMatch(path.Replace('/', '\\')));
-            Assert.True(glob.IsMatch(Path.GetDirectoryName(path).Replace('/', '\\'), Path.GetFileName(path)));
+            Assert.True(glob.IsMatch(Path.GetDirectoryName(path)!.Replace('/', '\\'), Path.GetFileName(path)));
         }
     }
 
@@ -561,9 +561,9 @@ public class GlobTests
         var glob = Glob.Parse(pattern, GlobOptions.Git);
         var globi = Glob.Parse(pattern, GlobOptions.IgnoreCase | GlobOptions.Git);
         Assert.False(glob.IsMatch(path));
-        Assert.False(glob.IsMatch(Path.GetDirectoryName(path), Path.GetFileName(path)));
+        Assert.False(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
         Assert.False(globi.IsMatch(path));
-        Assert.False(globi.IsMatch(Path.GetDirectoryName(path), Path.GetFileName(path)));
+        Assert.False(globi.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
     }
 
     // Corpus source: https://raw.githubusercontent.com/git/git/master/Documentation/gitignore.adoc

--- a/tests/Meziantou.Framework.Globbing.Tests/Meziantou.Framework.Globbing.Tests.csproj
+++ b/tests/Meziantou.Framework.Globbing.Tests/Meziantou.Framework.Globbing.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why
Several target test projects still explicitly disabled nullable reference types in their csproj files. Removing these overrides aligns them with nullable defaults and keeps test projects consistent.

## What changed
- Removed `<Nullable>disable</Nullable>` from:
  - `tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/Meziantou.Framework.FastEnumToStringGenerator.Tests.csproj`
  - `tests/Meziantou.Framework.FixedStringBuilder.Tests/Meziantou.Framework.FixedStringBuilder.Tests.csproj`
  - `tests/Meziantou.Framework.FullPath.Tests/Meziantou.Framework.FullPath.Tests.csproj`
  - `tests/Meziantou.Framework.Globbing.Tests/Meziantou.Framework.Globbing.Tests.csproj`
- `tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests.csproj` already had nullable enabled, so no csproj change was needed.
- No test logic was changed.

## Notes
- Required repository scripts were run. `eng/validate-testprojects-configuration.cs` reports existing framework mismatch errors in unrelated projects, including pre-existing entries for `FullPath.Tests` and `Globbing.Tests`.