### PR TITLE
Enable nullable reference types in HTTP-related test projects

### DIFF
--- a/tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/Meziantou.Framework.Http.Caching.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Http.Caching.Tests/PersistenceProvidersTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/PersistenceProvidersTests.cs
@@ -490,7 +490,7 @@ public class PersistenceProvidersTests
         DateTimeOffset now,
         TimeSpan maxAge,
         bool mustRevalidate,
-        string eTag = null)
+        string? eTag = null)
     {
         var requestTime = now - TimeSpan.FromMinutes(3);
         var responseTime = now - TimeSpan.FromMinutes(2);

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/HstsClientHandlerTests.cs
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/HstsClientHandlerTests.cs
@@ -38,7 +38,7 @@ public sealed class HstsClientHandlerTests
         Assert.Equal(Uri.UriSchemeHttps, response2.RequestMessage!.RequestUri!.Scheme);
     }
 
-    private sealed class MockHttpMessageHandler(string headerResponse) : HttpMessageHandler
+    private sealed class MockHttpMessageHandler(string? headerResponse) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/Meziantou.Framework.Http.Hsts.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/Meziantou.Framework.Http.Hsts.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/Meziantou.Framework.Http.Htpasswd.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/Meziantou.Framework.Http.Htpasswd.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Http.Recording.Tests/HarHttpRecordingStoreTests.cs
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/HarHttpRecordingStoreTests.cs
@@ -61,7 +61,7 @@ public sealed class HarHttpRecordingStoreTests
         Assert.Equal("https://example.com/api/data", loaded[0].RequestUri);
         Assert.Equal(200, loaded[0].StatusCode);
         Assert.NotNull(loaded[0].ResponseBody);
-        Assert.Equal("{\"id\":1}", System.Text.Encoding.UTF8.GetString(loaded[0].ResponseBody));
+        Assert.Equal("{\"id\":1}", System.Text.Encoding.UTF8.GetString(loaded[0].ResponseBody!));
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public sealed class HarHttpRecordingStoreTests
         Assert.Equal("POST", loaded[0].Method);
         Assert.Equal(201, loaded[0].StatusCode);
         Assert.NotNull(loaded[0].RequestHeaders);
-        Assert.True(loaded[0].RequestHeaders.ContainsKey("Content-Type"));
+        Assert.True(loaded[0].RequestHeaders!.ContainsKey("Content-Type"));
         Assert.NotNull(loaded[0].RequestBody);
     }
 

--- a/tests/Meziantou.Framework.Http.Recording.Tests/HttpRecordingHandlerTests.cs
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/HttpRecordingHandlerTests.cs
@@ -12,7 +12,7 @@ public sealed class HttpRecordingHandlerTests
     private static HttpRecordingHandler CreateHandler(
         HttpMessageHandler innerHandler,
         IHttpRecordingStore store,
-        HttpRecordingOptions options = null)
+        HttpRecordingOptions? options = null)
     {
         return new HttpRecordingHandler(innerHandler, store, options);
     }

--- a/tests/Meziantou.Framework.Http.Recording.Tests/JsonHttpRecordingStoreTests.cs
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/JsonHttpRecordingStoreTests.cs
@@ -73,7 +73,7 @@ public sealed class JsonHttpRecordingStoreTests : IDisposable
         Assert.Equal("https://example.com/api/test", loaded[0].RequestUri);
         Assert.Equal(200, loaded[0].StatusCode);
         Assert.NotNull(loaded[0].ResponseBody);
-        Assert.Equal("hello", System.Text.Encoding.UTF8.GetString(loaded[0].ResponseBody));
+        Assert.Equal("hello", System.Text.Encoding.UTF8.GetString(loaded[0].ResponseBody!));
 
         Assert.Equal("POST", loaded[1].Method);
         Assert.Equal(201, loaded[1].StatusCode);

--- a/tests/Meziantou.Framework.Http.Recording.Tests/Meziantou.Framework.Http.Recording.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/Meziantou.Framework.Http.Recording.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Http.Tests/LinkHeaderValueTests.cs
+++ b/tests/Meziantou.Framework.Http.Tests/LinkHeaderValueTests.cs
@@ -21,7 +21,9 @@ public sealed class LinkHeaderValueTests
                 Assert.Equal("plop", item.Url);
                 Assert.Equal("d\"e;f,", item.Rel);
                 Assert.Equal("test title", item.GetParameterValue("title"));
-                Assert.Empty(item.GetParameterValue("abc"));
+                var abcValue = item.GetParameterValue("abc");
+                Assert.NotNull(abcValue);
+                Assert.Empty(abcValue);
                 Assert.Null(item.GetParameterValue("unknown"));
             });
     }

--- a/tests/Meziantou.Framework.Http.Tests/Meziantou.Framework.Http.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Tests/Meziantou.Framework.Http.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.HttpArchive.Tests/Meziantou.Framework.HttpArchive.Tests.csproj
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/Meziantou.Framework.HttpArchive.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.HttpClientMock.Tests/Meziantou.Framework.HttpClientMock.Tests.csproj
+++ b/tests/Meziantou.Framework.HttpClientMock.Tests/Meziantou.Framework.HttpClientMock.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.HttpClientMock.Tests/MockTests.cs
+++ b/tests/Meziantou.Framework.HttpClientMock.Tests/MockTests.cs
@@ -101,6 +101,7 @@ public sealed class MockTests(ITestOutputHelper testOutputHelper)
 
         using var client = mock.CreateHttpClient();
         var data = await client.GetFromJsonAsync<Dictionary<string, object>>("/", XunitCancellationToken);
+        Assert.NotNull(data);
         Assert.True(data.ContainsKey("id"));
     }
 
@@ -114,6 +115,7 @@ public sealed class MockTests(ITestOutputHelper testOutputHelper)
         using var response = await client.GetAsync("/", XunitCancellationToken);
         Assert.Equal(400, (int)response.StatusCode);
         var data = await response.Content.ReadFromJsonAsync<Dictionary<string, object>>(XunitCancellationToken);
+        Assert.NotNull(data);
         Assert.True(data.ContainsKey("id"));
     }
 


### PR DESCRIPTION
## Why
These test projects still explicitly disabled nullable reference types, which hides nullability issues and makes them inconsistent with current project standards.

## What changed
- Removed `<Nullable>disable</Nullable>` from seven HTTP-related test project files.
- Added targeted null assertions in existing tests where nullable values are expected by the analyzer:
  - `LinkHeaderValueTests` now asserts the `abc` parameter value is not null before `Assert.Empty`.
  - `MockTests` now asserts JSON dictionaries are not null before `ContainsKey`.

## Notes
- Test logic and expected behavior are unchanged; the added assertions only satisfy nullable flow analysis.