### PR TITLE
Enable nullable reference types in DNS test projects

### DIFF
--- a/tests/Meziantou.Framework.DnsClient.Tests/Meziantou.Framework.DnsClient.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsClient.Tests/Meziantou.Framework.DnsClient.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.DnsFilter.Tests/DnsFilterListReaderTests.cs
+++ b/tests/Meziantou.Framework.DnsFilter.Tests/DnsFilterListReaderTests.cs
@@ -184,7 +184,7 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].AllowedDnsTypes);
-        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].AllowedDnsTypes);
+        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].AllowedDnsTypes!);
     }
 
     [Fact]
@@ -196,7 +196,7 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].ExcludedDnsTypes);
-        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].ExcludedDnsTypes);
+        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].ExcludedDnsTypes!);
     }
 
     [Fact]
@@ -208,9 +208,9 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].AllowedDnsTypes);
-        Assert.Equal(2, rules[0].AllowedDnsTypes.Count);
-        Assert.Contains(DnsFilterQueryType.A, rules[0].AllowedDnsTypes);
-        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].AllowedDnsTypes);
+        Assert.Equal(2, rules[0].AllowedDnsTypes!.Count);
+        Assert.Contains(DnsFilterQueryType.A, rules[0].AllowedDnsTypes!);
+        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].AllowedDnsTypes!);
     }
 
     [Fact]
@@ -222,7 +222,7 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].DenyAllowDomains);
-        Assert.Equal(2, rules[0].DenyAllowDomains.Count);
+        Assert.Equal(2, rules[0].DenyAllowDomains!.Count);
     }
 
     [Fact]
@@ -234,9 +234,9 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].Rewrite);
-        Assert.Equal(DnsFilterRewriteResponseCode.NoError, rules[0].Rewrite.ResponseCode);
-        Assert.Equal(DnsFilterQueryType.A, rules[0].Rewrite.RecordType);
-        Assert.Equal("1.2.3.4", rules[0].Rewrite.Value);
+        Assert.Equal(DnsFilterRewriteResponseCode.NoError, rules[0].Rewrite!.ResponseCode);
+        Assert.Equal(DnsFilterQueryType.A, rules[0].Rewrite!.RecordType);
+        Assert.Equal("1.2.3.4", rules[0].Rewrite!.Value);
     }
 
     [Fact]
@@ -248,7 +248,7 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].Rewrite);
-        Assert.Equal(DnsFilterQueryType.AAAA, rules[0].Rewrite.RecordType);
+        Assert.Equal(DnsFilterQueryType.AAAA, rules[0].Rewrite!.RecordType);
     }
 
     [Fact]
@@ -260,7 +260,7 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].Rewrite);
-        Assert.Equal(DnsFilterRewriteResponseCode.NameError, rules[0].Rewrite.ResponseCode);
+        Assert.Equal(DnsFilterRewriteResponseCode.NameError, rules[0].Rewrite!.ResponseCode);
     }
 
     [Fact]
@@ -272,7 +272,7 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].Rewrite);
-        Assert.Equal(DnsFilterRewriteResponseCode.Refused, rules[0].Rewrite.ResponseCode);
+        Assert.Equal(DnsFilterRewriteResponseCode.Refused, rules[0].Rewrite!.ResponseCode);
     }
 
     [Fact]
@@ -284,9 +284,9 @@ public sealed class DnsFilterListReaderTests
 
         Assert.Single(rules);
         Assert.NotNull(rules[0].Rewrite);
-        Assert.Equal(DnsFilterRewriteResponseCode.NoError, rules[0].Rewrite.ResponseCode);
-        Assert.Equal(DnsFilterQueryType.A, rules[0].Rewrite.RecordType);
-        Assert.Equal("1.2.3.4", rules[0].Rewrite.Value);
+        Assert.Equal(DnsFilterRewriteResponseCode.NoError, rules[0].Rewrite!.ResponseCode);
+        Assert.Equal(DnsFilterQueryType.A, rules[0].Rewrite!.RecordType);
+        Assert.Equal("1.2.3.4", rules[0].Rewrite!.Value);
     }
 
     [Fact]
@@ -398,9 +398,9 @@ public sealed class DnsFilterListReaderTests
         Assert.Single(rules);
         Assert.True(rules[0].IsImportant);
         Assert.NotNull(rules[0].AllowedDnsTypes);
-        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].AllowedDnsTypes);
+        Assert.Contains(DnsFilterQueryType.AAAA, rules[0].AllowedDnsTypes!);
         Assert.NotNull(rules[0].Rewrite);
-        Assert.Equal(DnsFilterRewriteResponseCode.Refused, rules[0].Rewrite.ResponseCode);
+        Assert.Equal(DnsFilterRewriteResponseCode.Refused, rules[0].Rewrite!.ResponseCode);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.DnsFilter.Tests/Meziantou.Framework.DnsFilter.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsFilter.Tests/Meziantou.Framework.DnsFilter.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsServer.Tests/DnsServerIntegrationTests.cs
@@ -614,7 +614,7 @@ public sealed class DnsServerIntegrationTests
         using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
         socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
 
-        return ((IPEndPoint)socket.LocalEndPoint).Port;
+        return ((IPEndPoint)socket.LocalEndPoint!).Port;
     }
 
     private sealed record AllProtocolsServer(WebApplication App, int UdpPort, int TcpPort, int TlsPort, int? QuicPort);

--- a/tests/Meziantou.Framework.DnsServer.Tests/Meziantou.Framework.DnsServer.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsServer.Tests/Meziantou.Framework.DnsServer.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This updates the DNS test projects to participate in nullable reference type analysis, so nullability issues in tests are surfaced and handled consistently with the rest of the codebase.

## What changed
- Removed `<Nullable>disable</Nullable>` from:
  - `Meziantou.Framework.DnsClient.Tests`
  - `Meziantou.Framework.DnsFilter.Tests`
  - `Meziantou.Framework.DnsProxy.Tests`
  - `Meziantou.Framework.DnsServer.Tests`
- Fixed resulting nullable diagnostics in tests without changing test behavior, using null-forgiving where nearby assertions already guarantee non-null values.

## Notes
- This PR intentionally avoids test logic changes and only addresses nullability annotations/flow warnings.

## Validation
- Ran targeted tests for all four updated projects:
  - `Meziantou.Framework.DnsClient.Tests`
  - `Meziantou.Framework.DnsFilter.Tests`
  - `Meziantou.Framework.DnsProxy.Tests`
  - `Meziantou.Framework.DnsServer.Tests`
- Ran required repository scripts:
  - `dotnet run ./eng/update-trimmable.cs` succeeded
  - `dotnet run ./eng/update-bom.cs`, `dotnet run ./eng/update-readme.cs`, `dotnet run ./eng/update-project-slnx.cs`, and `dotnet run ./eng/validate-testprojects-configuration.cs` fail in this worktree due to pre-existing unrelated test-project target-framework mismatch errors.