### PR TITLE
Enable nullable reference types in HTML-related test projects

### DIFF
--- a/tests/Meziantou.Framework.Html.Tests/EditDocumentTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/EditDocumentTests.cs
@@ -8,7 +8,8 @@ public class EditDocumentTests
         var document = new HtmlDocument();
         document.LoadHtml("<div><p>sample1</p><p>sample2</p></div>");
         var node = document.SelectSingleNode("/div/p[1]/text()", HtmlNodeNavigatorOptions.LowercasedAll);
-        node.Value = "edited";
+        Assert.NotNull(node);
+        node!.Value = "edited";
         Assert.Equal("<div><p>edited</p><p>sample2</p></div>", document.OuterHtml);
     }
 
@@ -21,7 +22,8 @@ public class EditDocumentTests
         var anchorElement = document.CreateElement("a");
         anchorElement.SetAttribute("href", "sample.txt");
         anchorElement.InnerText = "sample";
-        node.AppendChild(anchorElement);
+        Assert.NotNull(node);
+        node!.AppendChild(anchorElement);
         Assert.Equal("<div><p>sample1<a href=\"sample.txt\">sample</a></p><p>sample2</p></div>", document.OuterHtml);
     }
 }

--- a/tests/Meziantou.Framework.Html.Tests/HtmlNodeTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/HtmlNodeTests.cs
@@ -23,7 +23,9 @@ public class HtmlNodeTests
     {
         var doc = new HtmlDocument();
         doc.LoadHtml("<p>def</p>");
-        Assert.Null(doc.SelectSingleNode("/p").ParentElement);
+        var node = doc.SelectSingleNode("/p");
+        Assert.NotNull(node);
+        Assert.Null(node!.ParentElement);
     }
 
     [Fact]
@@ -31,6 +33,8 @@ public class HtmlNodeTests
     {
         var doc = new HtmlDocument();
         doc.LoadHtml("<p>def</p>");
-        Assert.Equal("p", doc.SelectSingleNode("/p/node()").ParentElement.Name);
+        var node = doc.SelectSingleNode("/p/node()");
+        Assert.NotNull(node);
+        Assert.Equal("p", node!.ParentElement!.Name);
     }
 }

--- a/tests/Meziantou.Framework.Html.Tests/HtmlParserTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/HtmlParserTests.cs
@@ -27,8 +27,10 @@ public class HtmlParserTests
     {
         var document = new HtmlDocument();
         document.LoadHtml("<script type='text/javascript'>my script</script>");
-        Assert.Equal("my script", document.SelectSingleNode("//script").InnerHtml);
-        Assert.Equal("text/javascript", document.SelectSingleNode("//script").GetAttributeValue("type"));
+        var scriptNode = document.SelectSingleNode("//script");
+        Assert.NotNull(scriptNode);
+        Assert.Equal("my script", scriptNode!.InnerHtml);
+        Assert.Equal("text/javascript", scriptNode.GetAttributeValue("type"));
     }
 
     [Fact]
@@ -80,7 +82,8 @@ public class HtmlParserTests
     {
         var document = new HtmlDocument();
         document.LoadHtml("<!--Test-->");
-        Assert.Equal(HtmlNodeType.Comment, document.FirstChild.NodeType);
+        Assert.NotNull(document.FirstChild);
+        Assert.Equal(HtmlNodeType.Comment, document.FirstChild!.NodeType);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Html.Tests/Internals/HtmlXsltContext.cs
+++ b/tests/Meziantou.Framework.Html.Tests/Internals/HtmlXsltContext.cs
@@ -59,7 +59,7 @@ internal sealed class HtmlXsltContext : XsltContext
         var prefix = base.LookupPrefix(uri);
         if (prefix is null && Resolver is not null)
         {
-            prefix = Resolver.LookupPrefix(prefix);
+            prefix = Resolver.LookupPrefix(uri);
         }
 
         return prefix ?? "";

--- a/tests/Meziantou.Framework.Html.Tests/Internals/HtmlXsltFunction.cs
+++ b/tests/Meziantou.Framework.Html.Tests/Internals/HtmlXsltFunction.cs
@@ -6,16 +6,16 @@ namespace Meziantou.Framework.Html.Tests;
 
 internal abstract class HtmlXsltFunction : IXsltContextFunction
 {
-    protected HtmlXsltFunction(HtmlXsltContext context, string prefix, string name, XPathResultType[] argTypes)
+    protected HtmlXsltFunction(HtmlXsltContext context, string? prefix, string name, XPathResultType[]? argTypes)
     {
         Context = context;
         Prefix = prefix;
         Name = name;
-        ArgTypes = argTypes;
+        ArgTypes = argTypes ?? [];
     }
 
     public HtmlXsltContext Context { get; }
-    public string Prefix { get; }
+    public string? Prefix { get; }
     public string Name { get; }
     public XPathResultType[] ArgTypes { get; }
 
@@ -62,7 +62,7 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
         return defaultValue;
     }
 
-    public static string ConvertToString(object argument, bool outer, string separator)
+    public static string? ConvertToString(object? argument, bool outer, string? separator)
     {
         if (argument is null)
             return null;
@@ -102,7 +102,7 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
 
         if (argument is IEnumerable enumerable)
         {
-            StringBuilder sb = null;
+            StringBuilder? sb = null;
             foreach (var arg in enumerable)
             {
                 sb ??= new StringBuilder();
@@ -124,7 +124,7 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
         return string.Format(CultureInfo.InvariantCulture, "{0}", argument);
     }
 
-    internal static bool IsNull(object arg)
+    internal static bool IsNull(object? arg)
     {
         if (arg is null || Convert.IsDBNull(arg))
             return true;
@@ -138,7 +138,7 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
             if (!it.MoveNext())
                 return true;
 
-            object current = it.Current;
+            object? current = it.Current;
             return IsNull(current);
         }
 
@@ -164,13 +164,13 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
 
         public string Lowercase(object obj)
         {
-            return (string)new Lowercase(Context, "Lowercase").Invoke(xsltContext: null, [obj], docContext: null);
+            return (string)new Lowercase(Context, "Lowercase").Invoke(xsltContext: null!, [obj], docContext: null!);
         }
 
         // add methods as needed
     }
 
-    public static IXsltContextFunction GetBuiltIn(HtmlXsltContext context, string prefix, string name, XPathResultType[] argTypes)
+    public static IXsltContextFunction? GetBuiltIn(HtmlXsltContext context, string prefix, string name, XPathResultType[] argTypes)
     {
         _ = prefix;
         _ = argTypes;
@@ -190,7 +190,7 @@ internal abstract class HtmlXsltFunction : IXsltContextFunction
         [SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "By design")]
         public override object Invoke(XsltContext xsltContext, object[] args, XPathNavigator docContext)
         {
-            return ConvertToString(args, outer: false, separator: null)?.ToLowerInvariant();
+            return ConvertToString(args, outer: false, separator: null)?.ToLowerInvariant()!;
         }
     }
 }

--- a/tests/Meziantou.Framework.Html.Tests/Meziantou.Framework.Html.Tests.csproj
+++ b/tests/Meziantou.Framework.Html.Tests/Meziantou.Framework.Html.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Html.Tests/XpathQueryTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/XpathQueryTests.cs
@@ -19,6 +19,7 @@ public class XpathQueryTests
         var context = new HtmlXsltContext(document.ParentNamespaceResolver);
 
         var node = document.SelectSingleNode("//p[lowercase(@class)='abc']", context);
-        Assert.Equal("Sample1", node.InnerText);
+        Assert.NotNull(node);
+        Assert.Equal("Sample1", node!.InnerText);
     }
 }

--- a/tests/Meziantou.Framework.Html.Tool.Tests/Meziantou.Framework.Html.Tool.Tests.csproj
+++ b/tests/Meziantou.Framework.Html.Tool.Tests/Meziantou.Framework.Html.Tool.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
+++ b/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
@@ -48,7 +48,7 @@ public class HtmlSanitizerTests
         {
             Assert.NotNull(expectedDocument.Body);
             Assert.NotNull(actualDocument.Body);
-            Assert.Equal(expectedDocument.Body!.InnerHtml, actualDocument.Body!.InnerHtml);
+            Assert.Equal(expectedDocument.Body.InnerHtml, actualDocument.Body.InnerHtml);
         }
     }
 
@@ -56,7 +56,7 @@ public class HtmlSanitizerTests
     {
         using var sw = new StringWriter();
         Assert.NotNull(document.Body);
-        document.Body!.ToHtml(sw, new PrettyMarkupFormatter());
+        document.Body.ToHtml(sw, new PrettyMarkupFormatter());
         return sw.ToString();
     }
 }

--- a/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
+++ b/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
@@ -46,14 +46,17 @@ public class HtmlSanitizerTests
         }
         else
         {
-            Assert.Equal(expectedDocument.Body.InnerHtml, actualDocument.Body.InnerHtml);
+            Assert.NotNull(expectedDocument.Body);
+            Assert.NotNull(actualDocument.Body);
+            Assert.Equal(expectedDocument.Body!.InnerHtml, actualDocument.Body!.InnerHtml);
         }
     }
 
     private static string FormatDocument(IHtmlDocument document)
     {
         using var sw = new StringWriter();
-        document.Body.ToHtml(sw, new PrettyMarkupFormatter());
+        Assert.NotNull(document.Body);
+        document.Body!.ToHtml(sw, new PrettyMarkupFormatter());
         return sw.ToString();
     }
 }

--- a/tests/Meziantou.Framework.HtmlSanitizer.Tests/Meziantou.Framework.HtmlSanitizer.Tests.csproj
+++ b/tests/Meziantou.Framework.HtmlSanitizer.Tests/Meziantou.Framework.HtmlSanitizer.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/CommonMarkSpecTests.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/CommonMarkSpecTests.cs
@@ -18,7 +18,7 @@ public sealed class CommonMarkSpecTests
             throw new InvalidOperationException("Could not find embedded resource 'commonmark-spec-0.31.2.json'");
         }
 
-        return JsonSerializer.Deserialize<List<CommonMarkSpecTestCase>>(stream);
+        return JsonSerializer.Deserialize<List<CommonMarkSpecTestCase>>(stream)!;
     }
 
     public static TheoryData<CommonMarkSpecTestCase> GetTestCases()

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlNormalizer.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlNormalizer.cs
@@ -18,7 +18,7 @@ internal static class HtmlNormalizer
         var parser = new HtmlParser();
         var document = parser.ParseDocument("<body>" + html + "</body>");
         Assert.NotNull(document.Body);
-        var body = document.Body!;
+        var body = document.Body;
         NormalizeNode(body);
 
         using var sw = new StringWriter();

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlNormalizer.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlNormalizer.cs
@@ -17,10 +17,12 @@ internal static class HtmlNormalizer
     {
         var parser = new HtmlParser();
         var document = parser.ParseDocument("<body>" + html + "</body>");
-        NormalizeNode(document.Body);
+        Assert.NotNull(document.Body);
+        var body = document.Body!;
+        NormalizeNode(body);
 
         using var sw = new StringWriter();
-        foreach (var child in document.Body.ChildNodes)
+        foreach (var child in body.ChildNodes)
         {
             child.ToHtml(sw, new PrettyMarkupFormatter());
         }

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlToMarkdownConverterTests.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlToMarkdownConverterTests.cs
@@ -2,7 +2,7 @@ namespace Meziantou.Framework.HtmlToMarkdownTests;
 
 public sealed class HtmlToMarkdownConverterTests
 {
-    private static void AssertHtmlToMarkdown(string html, string expectedMarkdown, HtmlToMarkdownOptions options = null)
+    private static void AssertHtmlToMarkdown(string html, string expectedMarkdown, HtmlToMarkdownOptions? options = null)
     {
         var actual = options is null
             ? HtmlToMarkdown.Convert(html)

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/MarkdownRoundTrippingTests.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/MarkdownRoundTrippingTests.cs
@@ -19,7 +19,8 @@ public sealed class MarkdownRoundTrippingTests
             .OrderBy(n => n, StringComparer.Ordinal))
         {
             using var stream = assembly.GetManifestResourceStream(resourceName);
-            using var reader = new StreamReader(stream);
+            Assert.NotNull(stream);
+            using var reader = new StreamReader(stream!);
             var content = reader.ReadToEnd();
 
             // Extract filename: e.g., "PipeTableSpecs.md" from full resource name
@@ -79,8 +80,11 @@ public sealed class MarkdownRoundTrippingTests
             return true;
         }
 
-        if (SkippedExamples.TryGetValue((testCase.FileName, testCase.Example), out reason))
+        if (SkippedExamples.TryGetValue((testCase.FileName, testCase.Example), out var skippedReason))
+        {
+            reason = skippedReason!;
             return true;
+        }
 
         reason = "";
         return false;

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/MarkdownRoundTrippingTests.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/MarkdownRoundTrippingTests.cs
@@ -20,7 +20,7 @@ public sealed class MarkdownRoundTrippingTests
         {
             using var stream = assembly.GetManifestResourceStream(resourceName);
             Assert.NotNull(stream);
-            using var reader = new StreamReader(stream!);
+            using var reader = new StreamReader(stream);
             var content = reader.ReadToEnd();
 
             // Extract filename: e.g., "PipeTableSpecs.md" from full resource name
@@ -82,7 +82,7 @@ public sealed class MarkdownRoundTrippingTests
 
         if (SkippedExamples.TryGetValue((testCase.FileName, testCase.Example), out var skippedReason))
         {
-            reason = skippedReason!;
+            reason = skippedReason;
             return true;
         }
 

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/Meziantou.Framework.HtmlToMarkdown.Tests.csproj
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/Meziantou.Framework.HtmlToMarkdown.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.HtmlToMarkdownTests</RootNamespace>
-      <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why
These four HTML-related test projects still had nullable reference types explicitly disabled. Enabling nullable here improves consistency with the rest of the repository and helps catch null-safety issues in test code.

## What changed
- Removed `<Nullable>disable</Nullable>` from:
  - `Meziantou.Framework.Html.Tests`
  - `Meziantou.Framework.Html.Tool.Tests`
  - `Meziantou.Framework.HtmlSanitizer.Tests`
  - `Meziantou.Framework.HtmlToMarkdown.Tests`
- Fixed nullability diagnostics in affected tests by using `Assert.NotNull(...)`, nullable annotations, and null-forgiving operators where appropriate, without changing test behavior.
- Updated the HTML test internals to satisfy nullable contracts (notably `HtmlXsltFunction` signatures/properties and `HtmlXsltContext.LookupPrefix`).

## Notes for reviewers
- The intent is nullability enablement only; test logic was preserved.
- One non-nullability behavior correction is included in `HtmlXsltContext.LookupPrefix`, where the resolver is now called with `uri` instead of a null `prefix` variable.

## Validation
- Built and tested all four updated test projects successfully.
- Ran required repository scripts. `update-trimmable` succeeded; the other required scripts fail in this branch due to pre-existing unrelated test-project target-framework mismatch errors.