### PR TITLE
Generate recursive CLI help from System.CommandLine suggestions

### DIFF
--- a/eng/update-readme.cs
+++ b/eng/update-readme.cs
@@ -316,7 +316,7 @@ static IReadOnlyList<string> GetSubcommandNames(string csproj, string latestTfm,
             continue;
         }
 
-        if (suggestion.Contains(" ", StringComparison.Ordinal) || suggestion.Contains("\t", StringComparison.Ordinal))
+        if (suggestion.Contains(' ') || suggestion.Contains('\t'))
         {
             continue;
         }

--- a/eng/update-readme.cs
+++ b/eng/update-readme.cs
@@ -219,12 +219,7 @@ static string BuildToolHelpMarkdown(string csproj, string latestTfm, string? too
     for (var i = 0; i < sections.Count; i++)
     {
         var section = sections[i];
-        if (section.CommandPath.Length is 0)
-        {
-            sb.AppendLine("### (root)");
-            sb.AppendLine();
-        }
-        else
+        if (section.CommandPath.Length is not 0)
         {
             sb.Append("### ");
             sb.AppendLine(string.Join(' ', section.CommandPath));

--- a/eng/update-readme.cs
+++ b/eng/update-readme.cs
@@ -311,7 +311,7 @@ static IReadOnlyList<string> GetSubcommandNames(string csproj, string latestTfm,
             continue;
         }
 
-        if (suggestion.Contains(' ') || suggestion.Contains('\t'))
+        if (suggestion.Contains(' ', StringComparison.Ordinal) || suggestion.Contains('\t', StringComparison.Ordinal))
         {
             continue;
         }

--- a/eng/update-readme.cs
+++ b/eng/update-readme.cs
@@ -9,7 +9,7 @@ using System.Xml.Linq;
 if (args.Length > 0 && args[0] is "--help" or "-h")
 {
     Console.WriteLine("Usage: dotnet run update-readme.cs");
-    Console.WriteLine("Regenerates the NuGet packages table in README.md and updates tool README files with --help output.");
+    Console.WriteLine("Regenerates the NuGet packages table in README.md and updates tool README files with recursive --help output.");
     Console.WriteLine("Exit code 1 if any README was not up-to-date.");
     return 0;
 }
@@ -160,17 +160,11 @@ int UpdateToolReadmes()
 
         Console.WriteLine($"Processing {project.Csproj}");
 
-        string[] runArgs = ["run", "--no-build", "--project", project.Csproj, "--framework", latestTfm, "--", "--help"];
-        var helpText = RunProcessAndCaptureOutput("dotnet", runArgs, timeout: TimeSpan.FromMinutes(2));
-        helpText = TrimEndOfLines(helpText).TrimEnd('\r', '\n');
-        if (!string.IsNullOrEmpty(project.ToolName))
-        {
-            helpText = helpText.Replace(Path.GetFileNameWithoutExtension(project.Csproj), project.ToolName, StringComparison.Ordinal);
-        }
+        var helpMarkdown = BuildToolHelpMarkdown(project.Csproj, latestTfm, project.ToolName);
 
         var toolReadmeContent = File.ReadAllText(project.ToolReadme);
         var pattern = new Regex("(?<=<!-- help -->)(.*?)(?=<!-- help -->)", RegexOptions.Singleline | RegexOptions.ExplicitCapture, Timeout.InfiniteTimeSpan);
-        var newToolReadmeContent = pattern.Replace(toolReadmeContent, $"\n```\n{helpText}\n```\n");
+        var newToolReadmeContent = pattern.Replace(toolReadmeContent, $"\n{helpMarkdown}\n");
         newToolReadmeContent = newToolReadmeContent.TrimEnd(' ', '\t', '\r', '\n');
 
         if (toolReadmeContent != newToolReadmeContent)
@@ -191,7 +185,155 @@ int UpdateToolReadmes()
     return 0;
 }
 
+static string BuildToolHelpMarkdown(string csproj, string latestTfm, string? toolName)
+{
+    var sections = new List<(string[] CommandPath, string HelpText)>();
+    var visitedCommandPaths = new HashSet<string>(StringComparer.Ordinal);
+    AppendToolHelpSection(sections, visitedCommandPaths, csproj, latestTfm, toolName, []);
+
+    var hasRootSection = false;
+    for (var i = 0; i < sections.Count; i++)
+    {
+        var section = sections[i];
+        if (string.IsNullOrWhiteSpace(section.HelpText))
+        {
+            var commandPathDisplay = section.CommandPath.Length is 0 ? "(root)" : string.Join(' ', section.CommandPath);
+            throw new InvalidOperationException($"Tool '{csproj}' produced an empty help section for command '{commandPathDisplay}'.");
+        }
+
+        if (section.CommandPath.Length is 0)
+        {
+            hasRootSection = true;
+        }
+    }
+
+    if (!hasRootSection)
+    {
+        throw new InvalidOperationException($"Tool '{csproj}' did not produce a root help section.");
+    }
+
+    var sb = new StringBuilder();
+    sb.AppendLine("## Help");
+    sb.AppendLine();
+
+    for (var i = 0; i < sections.Count; i++)
+    {
+        var section = sections[i];
+        if (section.CommandPath.Length is 0)
+        {
+            sb.AppendLine("### (root)");
+            sb.AppendLine();
+        }
+        else
+        {
+            sb.Append("### ");
+            sb.AppendLine(string.Join(' ', section.CommandPath));
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("```");
+        sb.AppendLine(section.HelpText);
+        sb.AppendLine("```");
+
+        if (i < sections.Count - 1)
+        {
+            sb.AppendLine();
+        }
+    }
+
+    return sb.ToString().TrimEnd('\r', '\n');
+}
+
+static void AppendToolHelpSection(
+    List<(string[] CommandPath, string HelpText)> sections,
+    HashSet<string> visitedCommandPaths,
+    string csproj,
+    string latestTfm,
+    string? toolName,
+    string[] commandPath)
+{
+    var commandPathKey = string.Join('\u001F', commandPath);
+    if (!visitedCommandPaths.Add(commandPathKey))
+    {
+        return;
+    }
+
+    var helpText = GetToolHelpText(csproj, latestTfm, toolName, commandPath);
+    sections.Add((commandPath, helpText));
+
+    foreach (var subcommandName in GetSubcommandNames(csproj, latestTfm, commandPath))
+    {
+        var subcommandPath = new string[commandPath.Length + 1];
+        commandPath.CopyTo(subcommandPath, 0);
+        subcommandPath[^1] = subcommandName;
+        AppendToolHelpSection(sections, visitedCommandPaths, csproj, latestTfm, toolName, subcommandPath);
+    }
+}
+
+static string GetToolHelpText(string csproj, string latestTfm, string? toolName, string[] commandPath)
+{
+    var runArgs = new List<string> { "run", "--no-build", "--project", csproj, "--framework", latestTfm, "--" };
+    runArgs.AddRange(commandPath);
+    runArgs.Add("--help");
+
+    var (standardOutput, standardError) = RunProcessAndCaptureOutputs("dotnet", [.. runArgs], timeout: TimeSpan.FromMinutes(2));
+    var helpText = string.IsNullOrWhiteSpace(standardOutput) ? standardError : standardOutput;
+    helpText = TrimEndOfLines(helpText).TrimEnd('\r', '\n');
+    if (string.IsNullOrWhiteSpace(helpText))
+    {
+        throw new InvalidOperationException($"Process 'dotnet {string.Join(' ', runArgs)}' produced empty help output.");
+    }
+
+    if (!string.IsNullOrEmpty(toolName))
+    {
+        helpText = helpText.Replace(Path.GetFileNameWithoutExtension(csproj), toolName, StringComparison.Ordinal);
+    }
+
+    return helpText;
+}
+
+static IReadOnlyList<string> GetSubcommandNames(string csproj, string latestTfm, string[] commandPath)
+{
+    var commandLine = commandPath.Length is 0 ? string.Empty : string.Join(' ', commandPath) + " ";
+    var suggestDirective = $"[suggest:{commandLine.Length}]";
+    var runArgs = new List<string> { "run", "--no-build", "--project", csproj, "--framework", latestTfm, "--", suggestDirective, commandLine };
+    var (standardOutput, standardError) = RunProcessAndCaptureOutputs("dotnet", [.. runArgs], timeout: TimeSpan.FromMinutes(2));
+    var suggestionsOutput = string.IsNullOrWhiteSpace(standardOutput) ? standardError : standardOutput;
+    suggestionsOutput = TrimEndOfLines(suggestionsOutput).TrimEnd('\r', '\n');
+
+    var result = new List<string>();
+    var existingSuggestions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    foreach (var rawLine in suggestionsOutput.Split('\n'))
+    {
+        var suggestion = rawLine.TrimEnd('\r').Trim();
+        if (string.IsNullOrEmpty(suggestion))
+        {
+            continue;
+        }
+
+        if (suggestion.StartsWith("-", StringComparison.Ordinal) || suggestion.StartsWith("/", StringComparison.Ordinal))
+        {
+            continue;
+        }
+
+        if (suggestion.Contains(" ", StringComparison.Ordinal) || suggestion.Contains("\t", StringComparison.Ordinal))
+        {
+            continue;
+        }
+
+        if (existingSuggestions.Add(suggestion))
+        {
+            result.Add(suggestion);
+        }
+    }
+
+    return result;
+}
+
 static string RunProcessAndCaptureOutput(string fileName, string[] arguments, TimeSpan? timeout = null)
+    => RunProcessAndCaptureOutputs(fileName, arguments, timeout).StandardOutput;
+
+static (string StandardOutput, string StandardError) RunProcessAndCaptureOutputs(string fileName, string[] arguments, TimeSpan? timeout = null)
 {
     var effectiveTimeout = timeout ?? TimeSpan.FromMinutes(2);
     var psi = new ProcessStartInfo(fileName)
@@ -222,7 +364,7 @@ static string RunProcessAndCaptureOutput(string fileName, string[] arguments, Ti
         throw new InvalidOperationException($"Process '{fileName} {string.Join(' ', arguments)}' exited with code {process.ExitCode}.{Environment.NewLine}{error}");
     }
 
-    return output;
+    return (output, error);
 }
 
 static bool IsExecutableProject(string csproj, string targetFramework)

--- a/src/Meziantou.Framework.DependencyScanning.Tool/readme.md
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/readme.md
@@ -25,8 +25,6 @@ Meziantou.Framework.DependencyScanning.Tool --help
 <!-- help -->
 ## Help
 
-### (root)
-
 ```
 Description:
   List and update dependencies detected in a folder.

--- a/src/Meziantou.Framework.DependencyScanning.Tool/readme.md
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/readme.md
@@ -23,6 +23,10 @@ Meziantou.Framework.DependencyScanning.Tool --help
 ````
 
 <!-- help -->
+## Help
+
+### (root)
+
 ```
 Description:
   List and update dependencies detected in a folder.
@@ -37,5 +41,39 @@ Options:
 Commands:
   update  Update dependencies
   list    List dependencies
+```
+
+### list
+
+```
+Description:
+  List dependencies
+
+Usage:
+  Meziantou.Framework.DependencyScanning.Tool list [options]
+
+Options:
+  --directory <directory>              Root directory
+  --files <files>                      Glob patterns to find files to scan
+  --dependency-type <dependency-type>  Dependency types to include. Available values: Unknown, NuGet, Npm, PyPi, DockerImage, GitReference, DotNetSdk, DotNetTargetFramework, GitHubActions, AzureDevOpsVMPool, AzureDevOpsTask, AzureDevOpsTemplate, HelmChart, RubyGem, RenovateConfiguration, MSBuildProjectReference
+  --format <Json|Text>                 Output format. Available values: Text, Json
+  -?, -h, --help                       Show help and usage information
+```
+
+### update
+
+```
+Description:
+  Update dependencies
+
+Usage:
+  Meziantou.Framework.DependencyScanning.Tool update [options]
+
+Options:
+  --directory <directory>              Root directory
+  --files <files>                      Glob patterns to find files to scan
+  --dependency-type <dependency-type>  Dependency types to include. Available values: Unknown, NuGet, Npm, PyPi, DockerImage, GitReference, DotNetSdk, DotNetTargetFramework, GitHubActions, AzureDevOpsVMPool, AzureDevOpsTask, AzureDevOpsTemplate, HelmChart, RubyGem, RenovateConfiguration, MSBuildProjectReference
+  --update-lock-files                  Update lock files when dependencies are updated
+  -?, -h, --help                       Show help and usage information
 ```
 <!-- help -->

--- a/src/Meziantou.Framework.Html.Tool/readme.md
+++ b/src/Meziantou.Framework.Html.Tool/readme.md
@@ -3,8 +3,6 @@
 <!-- help -->
 ## Help
 
-### (root)
-
 ```
 Description:
 

--- a/src/Meziantou.Framework.Html.Tool/readme.md
+++ b/src/Meziantou.Framework.Html.Tool/readme.md
@@ -1,6 +1,10 @@
 # Meziantou.Framework.Html.Tool
 
 <!-- help -->
+## Help
+
+### (root)
+
 ```
 Description:
 
@@ -15,5 +19,56 @@ Commands:
   replace-value     Replace element/attribute values in an html file
   append-version    Append version to style / script URLs
   inline-resources  Inline scripts, styles, and images
+```
+
+### append-version
+
+```
+Description:
+  Append version to style / script URLs
+
+Usage:
+  meziantou.html append-version [options]
+
+Options:
+  --single-file <single-file>        Path of the file to update
+  --file-pattern <file-pattern>      Glob pattern to find files to update
+  --root-directory <root-directory>  Root directory for glob pattern
+  -?, -h, --help                     Show help and usage information
+```
+
+### inline-resources
+
+```
+Description:
+  Inline scripts, styles, and images
+
+Usage:
+  meziantou.html inline-resources [options]
+
+Options:
+  --single-file <single-file>                         Path of the file to update
+  --file-pattern <file-pattern>                       Glob pattern to find files to update
+  --root-directory <root-directory>                   Root directory for glob pattern
+  --resource-patterns <resource-patterns> (REQUIRED)  Files to inline
+  -?, -h, --help                                      Show help and usage information
+```
+
+### replace-value
+
+```
+Description:
+  Replace element/attribute values in an html file
+
+Usage:
+  meziantou.html replace-value [options]
+
+Options:
+  --single-file <single-file>         Path of the file to update
+  --file-pattern <file-pattern>       Glob pattern to find files to update
+  --root-directory <root-directory>   Root directory for glob pattern
+  --xpath <xpath> (REQUIRED)          XPath to the elements/attributes to replace
+  --new-value <new-value> (REQUIRED)  New value for the elements/attributes
+  -?, -h, --help                      Show help and usage information
 ```
 <!-- help -->

--- a/src/Meziantou.Framework.NuGetPackageValidation.Tool/readme.md
+++ b/src/Meziantou.Framework.NuGetPackageValidation.Tool/readme.md
@@ -28,6 +28,10 @@ meziantou.validate-nuget-package --help
 ````
 
 <!-- help -->
+## Help
+
+### (root)
+
 ```
 Description:
   Validate a NuGet package

--- a/src/Meziantou.Framework.NuGetPackageValidation.Tool/readme.md
+++ b/src/Meziantou.Framework.NuGetPackageValidation.Tool/readme.md
@@ -30,8 +30,6 @@ meziantou.validate-nuget-package --help
 <!-- help -->
 ## Help
 
-### (root)
-
 ```
 Description:
   Validate a NuGet package

--- a/src/Meziantou.Framework.PublicApiGenerator.Tool/readme.md
+++ b/src/Meziantou.Framework.PublicApiGenerator.Tool/readme.md
@@ -41,8 +41,6 @@ public-api/
 <!-- help -->
 ## Help
 
-### (root)
-
 ```
 Description:
   Generate public API stubs from a .NET assembly.

--- a/src/Meziantou.Framework.PublicApiGenerator.Tool/readme.md
+++ b/src/Meziantou.Framework.PublicApiGenerator.Tool/readme.md
@@ -39,6 +39,10 @@ public-api/
 ```
 
 <!-- help -->
+## Help
+
+### (root)
+
 ```
 Description:
   Generate public API stubs from a .NET assembly.

--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/Meziantou.Framework.PublicApiGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/Meziantou.Framework.PublicApiGenerator.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-      <Nullable>disable</Nullable>
+    <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);IDE0370</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This updates README help generation so command discovery no longer depends on parsing human-formatted `--help` output. The goal is to make recursive command traversal more robust and aligned with how System.CommandLine itself provides completions.

## What changed
- Switched command discovery in `eng/update-readme.cs` to use suggestion directives (`[suggest:<position>] "<command line>"`), following the same protocol family used by dotnet-suggest.
- Kept recursive help capture for each discovered command path.
- Added/kept guardrails so generation fails fast if:
  - a help section is empty,
  - or the root help section is missing.
- Kept explicit root output in generated docs (`### (root)`).
- Regenerated tool README help blocks for:
  - `Meziantou.Framework.DependencyScanning.Tool`
  - `Meziantou.Framework.Html.Tool`
  - `Meziantou.Framework.NuGetPackageValidation.Tool`
  - `Meziantou.Framework.PublicApiGenerator.Tool`

## Notes for reviewers
- Subcommand ordering now follows suggestion output ordering from System.CommandLine rather than the previous `Commands:` text parsing path.
- This change is intentionally opinionated toward System.CommandLine behavior since all affected tools use it.