### PR TITLE
Fix IDE0370 CI failure in PublicApiGenerator tests

### DIFF
--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
@@ -1708,7 +1708,7 @@ public sealed class PublicApiGeneratorTests
         var reflectionContent = SerializeFiles(reflectionFiles);
         var metadataContent = SerializeFiles(metadataFiles);
         Assert.Equal(reflectionContent, metadataContent);
-        InlineSnapshot.Validate(reflectionContent, expected, filePath!, lineNumber);
+        InlineSnapshot.Validate(reflectionContent, expected, filePath, lineNumber);
 
         // Ensure the generated files are compilable
         var generatedDirectory = temporaryDirectory / "generated";


### PR DESCRIPTION
Main CI is currently red because all `build_and_test` jobs fail on analyzer error `IDE0370` in `PublicApiGeneratorTests`.

This change removes an unnecessary null-forgiving operator in the `InlineSnapshot.Validate` call:

- `filePath!` -> `filePath`

`filePath` is provided via `[CallerFilePath]`, so behavior is unchanged; this only removes an unnecessary suppression so analyzer checks pass again on `main`.

## Validation
- `dotnet build eng/build.proj --configuration Debug /bl /p:IsLinuxArm64=false`
- `DiffEngine_Disabled=true dotnet test tests/Meziantou.Framework.PublicApiGenerator.Tests/Meziantou.Framework.PublicApiGenerator.Tests.csproj -c Debug -f net10.0`