### PR TITLE
Fix final CI status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,10 +400,9 @@ jobs:
         env:
           NEEDS_JSON: ${{ toJson(needs) }}
         run: |
+          $needs = $env:NEEDS_JSON | ConvertFrom-Json -AsHashtable
           $failedJobs = @(
-            $env:NEEDS_JSON
-            | ConvertFrom-Json -AsHashtable
-            | GetEnumerator
+            $needs.GetEnumerator()
             | Where-Object { $_.Value.result -notin @('success', 'skipped') }
           )
 


### PR DESCRIPTION
The CI run was failing in `final_status_check` even when all dependency jobs succeeded. The workflow parsed `needs` into a hashtable, then tried to pipe into `GetEnumerator` as if it were a PowerShell command, which causes the final step to fail.

This updates the step to store the parsed JSON in `$needs` and call `$needs.GetEnumerator()` before filtering unsuccessful jobs. That keeps the existing behavior, but makes the PowerShell expression valid so the final status check reflects the actual job results.