### PR TITLE
Centralize Roslyn target framework and simplify generator tests

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
   <!-- Build options -->
   <PropertyGroup>
     <LatestTargetFramework>net10.0</LatestTargetFramework>
+    <LatestTargetFramework_Roslyn>netstandard2.0;$(LatestTargetFramework)</LatestTargetFramework_Roslyn>
 
     <LatestTargetFrameworks>net10.0;net9.0;net8.0</LatestTargetFrameworks>
     <LatestTargetFrameworksWindows>net10.0-windows;net9.0-windows;net8.0-windows</LatestTargetFrameworksWindows>

--- a/src/Meziantou.AspNetCore.ServiceDefaults.AutoRegister/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.csproj
+++ b/src/Meziantou.AspNetCore.ServiceDefaults.AutoRegister/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFramework_Roslyn)</TargetFrameworks>
     <Version>1.0.3</Version>
     <Description>Auto register services and map routes</Description>
 

--- a/src/Meziantou.Framework.FastEnumToStringGenerator/Meziantou.Framework.FastEnumToStringGenerator.csproj
+++ b/src/Meziantou.Framework.FastEnumToStringGenerator/Meziantou.Framework.FastEnumToStringGenerator.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFramework_Roslyn)</TargetFrameworks>
     <Version>2.0.6</Version>
     <Description>Generate a faster ToString method for enumerations</Description>
 

--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/Meziantou.Framework.FixedStringBuilder.Generator.csproj
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/Meziantou.Framework.FixedStringBuilder.Generator.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFramework_Roslyn)</TargetFrameworks>
     <Version>1.0.1</Version>
     <Description>Roslyn source generator and analyzer for custom fixed-length string structs</Description>
 

--- a/src/Meziantou.Framework.ResxSourceGenerator/Meziantou.Framework.ResxSourceGenerator.csproj
+++ b/src/Meziantou.Framework.ResxSourceGenerator/Meziantou.Framework.ResxSourceGenerator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFramework_Roslyn)</TargetFrameworks>
     <Version>1.0.18</Version>
 
     <developmentDependency>true</developmentDependency>

--- a/src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj
+++ b/src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFrameworks);netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFramework_Roslyn)</TargetFrameworks>
     <Version>2.3.13</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/tests/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.GeneratorTests/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.GeneratorTests.csproj
+++ b/tests/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.GeneratorTests/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.GeneratorTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk.Test">
 
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFramework);net9.0</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFramework)</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)/GeneratedFiles</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>

--- a/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/Meziantou.Framework.FastEnumToStringGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.FastEnumToStringGenerator.Tests/Meziantou.Framework.FastEnumToStringGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk.Test">
 
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests.csproj
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk.Test">
 
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests.csproj
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk.Test">
 
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFramework)</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)/GeneratedFiles</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/Meziantou.Framework.ResxSourceGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/Meziantou.Framework.ResxSourceGenerator.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk.Test">
 
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/Meziantou.Framework.StronglyTypedId.GeneratorTests.csproj
+++ b/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/Meziantou.Framework.StronglyTypedId.GeneratorTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk.Test">
 
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFramework)</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)/GeneratedFiles/$(TargetFramework)</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/Meziantou.Framework.StronglyTypedId.Tests.csproj
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/Meziantou.Framework.StronglyTypedId.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk.Test">
 
   <PropertyGroup>
-    <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(LatestTargetFramework)</TargetFrameworks>
     <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
   </PropertyGroup>
 


### PR DESCRIPTION
## Why
Roslyn source generator projects were repeating their target framework list, and their related test projects were still running across multiple TFMs even though these checks mainly validate generator behavior. This makes TFM updates harder and increases test matrix cost.

## What changed
- Added a shared `LatestTargetFramework_Roslyn` property in `Directory.Build.props` with `netstandard2.0;$(LatestTargetFramework)`.
- Updated all Roslyn source generator projects to use `$(LatestTargetFramework_Roslyn)` for `TargetFrameworks`.
- Reduced related generator test projects to `$(LatestTargetFramework)` only, so they run once on the latest TFM.

## Notes for reviewers
- Packaging behavior remains the same, including analyzer packing from the `netstandard2.0` output.
- `Meziantou.Framework.StronglyTypedId` now follows the same Roslyn-targeting property as the other generators for consistency.