### PR TITLE
Add lax/strict evaluation modes to JsonPath

### DIFF
--- a/src/Meziantou.Framework.JsonPath/Internals/JsonPathEvaluator.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/JsonPathEvaluator.cs
@@ -9,6 +9,11 @@ internal static class JsonPathEvaluator
 {
     public static JsonPathResult Evaluate(JsonPathExpression expression, JsonNode? root)
     {
+        return Evaluate(expression, root, JsonPathEvaluationMode.Lax);
+    }
+
+    public static JsonPathResult Evaluate(JsonPathExpression expression, JsonNode? root, JsonPathEvaluationMode mode)
+    {
         // Start with the root node
         var currentNodes = new List<(JsonNode? Node, List<PathComponent> Path)>
         {
@@ -18,7 +23,7 @@ internal static class JsonPathEvaluator
         // Apply each segment in sequence
         foreach (var segment in expression.Segments)
         {
-            currentNodes = ApplySegment(segment, currentNodes, root);
+            currentNodes = ApplySegment(segment, currentNodes, root, mode);
         }
 
         // Build results
@@ -34,7 +39,8 @@ internal static class JsonPathEvaluator
     private static List<(JsonNode? Node, List<PathComponent> Path)> ApplySegment(
         Segment segment,
         List<(JsonNode? Node, List<PathComponent> Path)> inputNodes,
-        JsonNode? root)
+        JsonNode? root,
+        JsonPathEvaluationMode mode)
     {
         var result = new List<(JsonNode? Node, List<PathComponent> Path)>();
 
@@ -42,11 +48,11 @@ internal static class JsonPathEvaluator
         {
             if (segment.Kind is SegmentKind.Child)
             {
-                ApplyChildSegment(segment.Selectors, node, path, root, result);
+                ApplyChildSegment(segment.Selectors, node, path, root, mode, result, strictFailure: true);
             }
             else
             {
-                ApplyDescendantSegment(segment.Selectors, node, path, root, result);
+                ApplyDescendantSegment(segment.Selectors, node, path, root, mode, result);
             }
         }
 
@@ -58,11 +64,13 @@ internal static class JsonPathEvaluator
         JsonNode? node,
         List<PathComponent> path,
         JsonNode? root,
-        List<(JsonNode? Node, List<PathComponent> Path)> result)
+        JsonPathEvaluationMode mode,
+        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        bool strictFailure)
     {
         foreach (var selector in selectors)
         {
-            ApplySelector(selector, node, path, root, result);
+            ApplySelector(selector, node, path, root, mode, result, strictFailure);
         }
     }
 
@@ -71,11 +79,12 @@ internal static class JsonPathEvaluator
         JsonNode? node,
         List<PathComponent> path,
         JsonNode? root,
+        JsonPathEvaluationMode mode,
         List<(JsonNode? Node, List<PathComponent> Path)> result)
     {
         // Visit nodes in pre-order: node first, then descendants
         // For each visited node, apply the selectors as a child segment
-        VisitDescendants(node, path, selectors, root, result);
+        VisitDescendants(node, path, selectors, root, mode, result);
     }
 
     private static void VisitDescendants(
@@ -83,10 +92,11 @@ internal static class JsonPathEvaluator
         List<PathComponent> path,
         Selector[] selectors,
         JsonNode? root,
+        JsonPathEvaluationMode mode,
         List<(JsonNode? Node, List<PathComponent> Path)> result)
     {
         // Apply selectors to current node
-        ApplyChildSegment(selectors, node, path, root, result);
+        ApplyChildSegment(selectors, node, path, root, mode, result, strictFailure: false);
 
         // Recurse into children
         switch (node)
@@ -98,7 +108,7 @@ internal static class JsonPathEvaluator
                     {
                         PathComponent.FromName(property.Key),
                     };
-                    VisitDescendants(property.Value, childPath, selectors, root, result);
+                    VisitDescendants(property.Value, childPath, selectors, root, mode, result);
                 }
 
                 break;
@@ -109,7 +119,7 @@ internal static class JsonPathEvaluator
                     {
                         PathComponent.FromIndex(i),
                     };
-                    VisitDescendants(array[i], childPath, selectors, root, result);
+                    VisitDescendants(array[i], childPath, selectors, root, mode, result);
                 }
 
                 break;
@@ -121,24 +131,26 @@ internal static class JsonPathEvaluator
         JsonNode? node,
         List<PathComponent> path,
         JsonNode? root,
-        List<(JsonNode? Node, List<PathComponent> Path)> result)
+        JsonPathEvaluationMode mode,
+        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        bool strictFailure)
     {
         switch (selector)
         {
             case NameSelector nameSelector:
-                ApplyNameSelector(nameSelector, node, path, result);
+                ApplyNameSelector(nameSelector, node, path, mode, result, strictFailure);
                 break;
             case WildcardSelector:
-                ApplyWildcardSelector(node, path, result);
+                ApplyWildcardSelector(node, path, mode, result, strictFailure);
                 break;
             case IndexSelector indexSelector:
-                ApplyIndexSelector(indexSelector, node, path, result);
+                ApplyIndexSelector(indexSelector, node, path, mode, result, strictFailure);
                 break;
             case SliceSelector sliceSelector:
-                ApplySliceSelector(sliceSelector, node, path, result);
+                ApplySliceSelector(sliceSelector, node, path, mode, result, strictFailure);
                 break;
             case FilterSelector filterSelector:
-                ApplyFilterSelector(filterSelector, node, path, root, result);
+                ApplyFilterSelector(filterSelector, node, path, root, mode, result, strictFailure);
                 break;
         }
     }
@@ -147,22 +159,35 @@ internal static class JsonPathEvaluator
         NameSelector selector,
         JsonNode? node,
         List<PathComponent> path,
-        List<(JsonNode? Node, List<PathComponent> Path)> result)
+        JsonPathEvaluationMode mode,
+        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        bool strictFailure)
     {
-        if (node is JsonObject obj && obj.TryGetPropertyValue(selector.Name, out var value))
+        if (node is JsonObject obj)
         {
+            if (!obj.TryGetPropertyValue(selector.Name, out var value))
+            {
+                ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, $"Object member '{selector.Name}' does not exist");
+                return;
+            }
+
             var newPath = new List<PathComponent>(path)
             {
                 PathComponent.FromName(selector.Name),
             };
             result.Add((value, newPath));
+            return;
         }
+
+        ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, $"Name selector '{selector.Name}' requires an object");
     }
 
     private static void ApplyWildcardSelector(
         JsonNode? node,
         List<PathComponent> path,
-        List<(JsonNode? Node, List<PathComponent> Path)> result)
+        JsonPathEvaluationMode mode,
+        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        bool strictFailure)
     {
         switch (node)
         {
@@ -188,6 +213,9 @@ internal static class JsonPathEvaluator
                 }
 
                 break;
+            default:
+                ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, "Wildcard selector requires an object or an array");
+                break;
         }
     }
 
@@ -195,10 +223,13 @@ internal static class JsonPathEvaluator
         IndexSelector selector,
         JsonNode? node,
         List<PathComponent> path,
-        List<(JsonNode? Node, List<PathComponent> Path)> result)
+        JsonPathEvaluationMode mode,
+        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        bool strictFailure)
     {
         if (node is not JsonArray array)
         {
+            ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, $"Index selector [{selector.Index}] requires an array");
             return;
         }
 
@@ -210,17 +241,23 @@ internal static class JsonPathEvaluator
                 PathComponent.FromIndex(index),
             };
             result.Add((array[(int)index], newPath));
+            return;
         }
+
+        ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, $"Array index [{selector.Index}] is out of range");
     }
 
     private static void ApplySliceSelector(
         SliceSelector selector,
         JsonNode? node,
         List<PathComponent> path,
-        List<(JsonNode? Node, List<PathComponent> Path)> result)
+        JsonPathEvaluationMode mode,
+        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        bool strictFailure)
     {
         if (node is not JsonArray array)
         {
+            ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, "Slice selector requires an array");
             return;
         }
 
@@ -279,7 +316,9 @@ internal static class JsonPathEvaluator
         JsonNode? node,
         List<PathComponent> path,
         JsonNode? root,
-        List<(JsonNode? Node, List<PathComponent> Path)> result)
+        JsonPathEvaluationMode mode,
+        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        bool strictFailure)
     {
         switch (node)
         {
@@ -311,7 +350,20 @@ internal static class JsonPathEvaluator
                 }
 
                 break;
+            default:
+                ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, "Filter selector requires an object or an array");
+                break;
         }
+    }
+
+    private static void ThrowPathEvaluationErrorIfStrict(JsonPathEvaluationMode mode, bool strictFailure, List<PathComponent> path, string error)
+    {
+        if (mode is not JsonPathEvaluationMode.Strict || !strictFailure)
+        {
+            return;
+        }
+
+        throw new JsonPathEvaluationException($"Path error at {NormalizedPathBuilder.Build(path)}: {error}");
     }
 
     // ---- Filter Expression Evaluation ----
@@ -658,7 +710,7 @@ internal static class JsonPathEvaluator
 
         foreach (var segment in query.Segments)
         {
-            nodes = ApplySegment(segment, nodes, root);
+            nodes = ApplySegment(segment, nodes, root, JsonPathEvaluationMode.Lax);
         }
 
         var result = new List<JsonNode?>(nodes.Count);

--- a/src/Meziantou.Framework.JsonPath/JsonPath.cs
+++ b/src/Meziantou.Framework.JsonPath/JsonPath.cs
@@ -72,13 +72,33 @@ public sealed class JsonPath
     /// <returns>A <see cref="JsonPathResult"/> containing all matched nodes.</returns>
     public JsonPathResult Evaluate(JsonNode? root)
     {
-        return JsonPathEvaluator.Evaluate(_ast, root);
+        return Evaluate(root, JsonPathEvaluationMode.Lax);
+    }
+
+    /// <summary>Evaluates this JSONPath expression against a JSON value.</summary>
+    /// <param name="root">The root JSON value to query. May be <see langword="null"/>.</param>
+    /// <param name="mode">The evaluation mode.</param>
+    /// <returns>A <see cref="JsonPathResult"/> containing all matched nodes.</returns>
+    /// <exception cref="JsonPathEvaluationException">The path cannot be evaluated in <see cref="JsonPathEvaluationMode.Strict"/> mode.</exception>
+    public JsonPathResult Evaluate(JsonNode? root, JsonPathEvaluationMode mode)
+    {
+        return JsonPathEvaluator.Evaluate(_ast, root, mode);
     }
 
     /// <summary>Evaluates this JSONPath expression against a JSON document.</summary>
     /// <param name="root">The root JSON document to query. May be <see langword="null"/>.</param>
     /// <returns>A <see cref="JsonPathResult"/> containing all matched nodes.</returns>
     public JsonPathResult Evaluate(JsonDocument? root)
+    {
+        return Evaluate(root, JsonPathEvaluationMode.Lax);
+    }
+
+    /// <summary>Evaluates this JSONPath expression against a JSON document.</summary>
+    /// <param name="root">The root JSON document to query. May be <see langword="null"/>.</param>
+    /// <param name="mode">The evaluation mode.</param>
+    /// <returns>A <see cref="JsonPathResult"/> containing all matched nodes.</returns>
+    /// <exception cref="JsonPathEvaluationException">The path cannot be evaluated in <see cref="JsonPathEvaluationMode.Strict"/> mode.</exception>
+    public JsonPathResult Evaluate(JsonDocument? root, JsonPathEvaluationMode mode)
     {
         JsonNode? node = null;
         if (root is not null)
@@ -87,7 +107,53 @@ public sealed class JsonPath
             node = JsonNode.Parse(json);
         }
 
-        return JsonPathEvaluator.Evaluate(_ast, node);
+        return JsonPathEvaluator.Evaluate(_ast, node, mode);
+    }
+
+    /// <summary>
+    /// Evaluates this JSONPath expression and returns the first matched value, or <see langword="null"/> when there is no match.
+    /// </summary>
+    /// <param name="root">The root JSON value to query. May be <see langword="null"/>.</param>
+    /// <returns>The first matched value, or <see langword="null"/> when there is no match.</returns>
+    public JsonNode? EvaluateValue(JsonNode? root)
+    {
+        return EvaluateValue(root, JsonPathEvaluationMode.Lax);
+    }
+
+    /// <summary>
+    /// Evaluates this JSONPath expression and returns the first matched value, or <see langword="null"/> when there is no match.
+    /// </summary>
+    /// <param name="root">The root JSON value to query. May be <see langword="null"/>.</param>
+    /// <param name="mode">The evaluation mode.</param>
+    /// <returns>The first matched value, or <see langword="null"/> when there is no match.</returns>
+    /// <exception cref="JsonPathEvaluationException">The path cannot be evaluated in <see cref="JsonPathEvaluationMode.Strict"/> mode.</exception>
+    public JsonNode? EvaluateValue(JsonNode? root, JsonPathEvaluationMode mode)
+    {
+        var result = Evaluate(root, mode);
+        return result.Count > 0 ? result[0].Value : null;
+    }
+
+    /// <summary>
+    /// Evaluates this JSONPath expression and returns the first matched value, or <see langword="null"/> when there is no match.
+    /// </summary>
+    /// <param name="root">The root JSON document to query. May be <see langword="null"/>.</param>
+    /// <returns>The first matched value, or <see langword="null"/> when there is no match.</returns>
+    public JsonNode? EvaluateValue(JsonDocument? root)
+    {
+        return EvaluateValue(root, JsonPathEvaluationMode.Lax);
+    }
+
+    /// <summary>
+    /// Evaluates this JSONPath expression and returns the first matched value, or <see langword="null"/> when there is no match.
+    /// </summary>
+    /// <param name="root">The root JSON document to query. May be <see langword="null"/>.</param>
+    /// <param name="mode">The evaluation mode.</param>
+    /// <returns>The first matched value, or <see langword="null"/> when there is no match.</returns>
+    /// <exception cref="JsonPathEvaluationException">The path cannot be evaluated in <see cref="JsonPathEvaluationMode.Strict"/> mode.</exception>
+    public JsonNode? EvaluateValue(JsonDocument? root, JsonPathEvaluationMode mode)
+    {
+        var result = Evaluate(root, mode);
+        return result.Count > 0 ? result[0].Value : null;
     }
 
     /// <summary>Returns the original JSONPath expression string.</summary>

--- a/src/Meziantou.Framework.JsonPath/JsonPathEvaluationException.cs
+++ b/src/Meziantou.Framework.JsonPath/JsonPathEvaluationException.cs
@@ -5,8 +5,17 @@ namespace Meziantou.Framework.Json;
 /// </summary>
 public sealed class JsonPathEvaluationException : InvalidOperationException
 {
+    public JsonPathEvaluationException()
+    {
+    }
+
     public JsonPathEvaluationException(string message)
         : base(message)
+    {
+    }
+
+    public JsonPathEvaluationException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Meziantou.Framework.JsonPath/JsonPathEvaluationException.cs
+++ b/src/Meziantou.Framework.JsonPath/JsonPathEvaluationException.cs
@@ -1,0 +1,12 @@
+namespace Meziantou.Framework.Json;
+
+/// <summary>
+/// The exception that is thrown when JSONPath evaluation fails in <see cref="JsonPathEvaluationMode.Strict"/> mode.
+/// </summary>
+public sealed class JsonPathEvaluationException : InvalidOperationException
+{
+    public JsonPathEvaluationException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Meziantou.Framework.JsonPath/JsonPathEvaluationMode.cs
+++ b/src/Meziantou.Framework.JsonPath/JsonPathEvaluationMode.cs
@@ -1,0 +1,15 @@
+namespace Meziantou.Framework.Json;
+
+/// <summary>Controls how JSONPath evaluation handles path errors.</summary>
+public enum JsonPathEvaluationMode
+{
+    /// <summary>
+    /// Tolerant evaluation. Path errors (such as missing members or invalid indexes) produce no match.
+    /// </summary>
+    Lax,
+
+    /// <summary>
+    /// Strict evaluation. Path errors raise a <see cref="JsonPathEvaluationException"/>.
+    /// </summary>
+    Strict,
+}

--- a/src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj
+++ b/src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks);netstandard2.0</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Json</RootNamespace>
     <Description>An implementation of JSONPath (RFC 9535) for System.Text.Json.</Description>
-    <Version>1.0.2</Version>
+    <Version>1.1.0</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.JsonPath/readme.md
+++ b/src/Meziantou.Framework.JsonPath/readme.md
@@ -23,6 +23,22 @@ foreach (var match in result)
 }
 ```
 
+## Evaluation modes
+
+`Evaluate` supports two modes:
+
+- `JsonPathEvaluationMode.Lax` (default): path evaluation errors produce no match.
+- `JsonPathEvaluationMode.Strict`: path evaluation errors throw `JsonPathEvaluationException`.
+
+```csharp
+var doc = JsonNode.Parse("""{"a": 1}""");
+var path = JsonPath.Parse("$.name");
+
+var laxValue = path.EvaluateValue(doc, JsonPathEvaluationMode.Lax); // null
+
+var strictValue = path.EvaluateValue(doc, JsonPathEvaluationMode.Strict); // throws JsonPathEvaluationException
+```
+
 ## Supported Features
 
 Full RFC 9535 compliance:

--- a/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
@@ -46,6 +46,24 @@ public sealed class JsonPathEvaluateTests
     }
 
     [Fact]
+    public void Evaluate_NameSelector_MissingMember_LaxMode()
+    {
+        var doc = JsonNode.Parse("""{"a": 1}""");
+        var path = JsonPath.Parse("$.b");
+        var result = path.Evaluate(doc, JsonPathEvaluationMode.Lax);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Evaluate_NameSelector_MissingMember_StrictMode()
+    {
+        var doc = JsonNode.Parse("""{"a": 1}""");
+        var path = JsonPath.Parse("$.b");
+        var exception = Assert.Throws<JsonPathEvaluationException>(() => path.Evaluate(doc, JsonPathEvaluationMode.Strict));
+        Assert.Contains("$", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Evaluate_WildcardSelector_Array()
     {
         var doc = JsonNode.Parse("""[1, 2, 3]""");
@@ -86,6 +104,39 @@ public sealed class JsonPathEvaluateTests
         var path = JsonPath.Parse("$[5]");
         var result = path.Evaluate(doc);
         Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Evaluate_IndexSelector_OutOfRange_StrictMode()
+    {
+        var doc = JsonNode.Parse("""["a"]""");
+        var path = JsonPath.Parse("$[5]");
+        Assert.Throws<JsonPathEvaluationException>(() => path.Evaluate(doc, JsonPathEvaluationMode.Strict));
+    }
+
+    [Fact]
+    public void Evaluate_NameSelector_RequiresObject_StrictMode()
+    {
+        var doc = JsonNode.Parse("""["a"]""");
+        var path = JsonPath.Parse("$.a");
+        Assert.Throws<JsonPathEvaluationException>(() => path.Evaluate(doc, JsonPathEvaluationMode.Strict));
+    }
+
+    [Fact]
+    public void EvaluateValue_NameSelector_MissingMember_LaxMode()
+    {
+        var doc = JsonNode.Parse("""{"a": 1}""");
+        var path = JsonPath.Parse("$.b");
+        var result = path.EvaluateValue(doc, JsonPathEvaluationMode.Lax);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void EvaluateValue_NameSelector_MissingMember_StrictMode()
+    {
+        var doc = JsonNode.Parse("""{"a": 1}""");
+        var path = JsonPath.Parse("$.b");
+        Assert.Throws<JsonPathEvaluationException>(() => path.EvaluateValue(doc, JsonPathEvaluationMode.Strict));
     }
 
     [Fact]


### PR DESCRIPTION
## Why
JSONPath consumers need control over error handling during evaluation. For missing members or invalid path operations, some scenarios require tolerant behavior (null/no match), while others require a hard failure.

## What changed
- Added `JsonPathEvaluationMode` with `Lax` and `Strict` modes.
- Added `JsonPathEvaluationException` for strict-mode evaluation failures.
- Extended `JsonPath.Evaluate(...)` overloads to accept a mode for both `JsonNode` and `JsonDocument`.
- Added `JsonPath.EvaluateValue(...)` overloads to return the first match as a single value and support mode selection.
- Kept existing `Evaluate(...)` overload behavior backward-compatible by defaulting to `Lax`.
- Updated evaluator internals to raise strict-mode errors for child-segment path failures (missing members, wrong container type, out-of-range index), while preserving lax behavior.
- Added unit tests for lax vs strict behavior and updated package README usage.
- Updated JsonPath package version to `1.1.0`.

## Notes
- Descendant traversal keeps tolerant behavior per visited node to avoid breaking expected recursive query semantics.

## Validation
- Ran required update/validation scripts:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`
- Built JsonPath project and test project.
- Ran JsonPath test suite with `DiffEngine_Disabled=true`.