### PR TITLE
Defer CallerContext creation for valid inline snapshots

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshot.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshot.cs
@@ -89,11 +89,10 @@ public static class InlineSnapshot
     public static void Validate(object? subject, InlineSnapshotSettings? settings, string? expected, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = -1)
     {
         settings ??= InlineSnapshotSettings.Default;
-        var context = CallerContext.Get(settings, filePath, lineNumber);
-        ShouldMatchInlineSnapshot(subject, context, settings, expected);
+        ShouldMatchInlineSnapshot(subject, settings, expected, filePath, lineNumber);
     }
 
-    internal static void ShouldMatchInlineSnapshot(object? subject, CallerContext context, InlineSnapshotSettings settings, string? expected)
+    internal static void ShouldMatchInlineSnapshot(object? subject, InlineSnapshotSettings settings, string? expected, string? filePath, int lineNumber)
     {
         var actual = settings.SnapshotSerializer.Serialize(subject);
         if (actual is not null)
@@ -109,8 +108,12 @@ public static class InlineSnapshot
 
         var normalizedActual = settings.SnapshotComparer.NormalizeValue(actual);
         var normalizedExpected = settings.SnapshotComparer.NormalizeValue(expected);
+        CallerContext? callerContext = null;
+        CallerContext GetCallerContext() => callerContext ??= CallerContext.Get(settings, filePath, lineNumber);
+
         if (!settings.SnapshotComparer.AreEqual(normalizedActual, normalizedExpected))
         {
+            var context = GetCallerContext();
             if (settings.SnapshotUpdateStrategy.CanUpdateSnapshotInternal(settings, context.FilePath, expected, actual))
             {
                 FileEditor.UpdateFile(context, settings, expected, actual);
@@ -127,6 +130,7 @@ public static class InlineSnapshot
         }
         else if (settings.ForceUpdateSnapshots)
         {
+            var context = GetCallerContext();
             FileEditor.UpdateFile(context, settings, expected, actual);
         }
     }

--- a/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshot.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshot.cs
@@ -108,8 +108,7 @@ public static class InlineSnapshot
 
         var normalizedActual = settings.SnapshotComparer.NormalizeValue(actual);
         var normalizedExpected = settings.SnapshotComparer.NormalizeValue(expected);
-        CallerContext? callerContext = null;
-        CallerContext GetCallerContext() => callerContext ??= CallerContext.Get(settings, filePath, lineNumber);
+        CallerContext GetCallerContext() => CallerContext.Get(settings, filePath, lineNumber);
 
         if (!settings.SnapshotComparer.AreEqual(normalizedActual, normalizedExpected))
         {

--- a/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotBuilder.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotBuilder.cs
@@ -74,7 +74,6 @@ public readonly struct InlineSnapshotBuilder
     public void Validate(object? subject, string? expected = null, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = -1)
     {
         var settings = _settings;
-        var context = CallerContext.Get(settings, filePath, lineNumber);
-        InlineSnapshot.ShouldMatchInlineSnapshot(subject, context, settings, expected);
+        InlineSnapshot.ShouldMatchInlineSnapshot(subject, settings, expected, filePath, lineNumber);
     }
 }

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -59,6 +59,19 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public void Validate_DoesNotComputeCallerContextWhenSnapshotMatches()
+    {
+        var exception = Record.Exception(() => InlineSnapshot.Validate(new object(), InlineSnapshotSettings.Default, "{}", "invalid\0path", 1));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Validate_ComputesCallerContextWhenSnapshotDiffers()
+    {
+        Assert.Throws<ArgumentException>(() => InlineSnapshot.Validate(new object(), InlineSnapshotSettings.Default, "invalid snapshot", "invalid\0path", 1));
+    }
+
+    [Fact]
     public async Task UpdateSnapshotUsingQuotedString_WithSettings()
     {
         await AssertSnapshot(


### PR DESCRIPTION
## Why
Inline snapshot validation was always building `CallerContext` up front, which walks the stack and reads PDB-related data even when the snapshot already matches. This adds avoidable overhead on the common success path.

## What changed
- Refactored `InlineSnapshot.Validate` and `InlineSnapshotBuilder.Validate` to pass caller inputs into `ShouldMatchInlineSnapshot`.
- Updated `ShouldMatchInlineSnapshot` to create `CallerContext` lazily, only when snapshot update/error paths actually need it (mismatch or `ForceUpdateSnapshots`).
- Kept mismatch/update behavior intact by reusing the same `CallerContext.Get(...)` logic once context is required.
- Added regression tests proving:
  - matching snapshots no longer require eager caller-context computation,
  - differing snapshots still compute caller context.

## Notes
This intentionally defers PDB/file/line validation to the paths that edit/report snapshots instead of running it for already-valid snapshots.

## Validation
- `DiffEngine_Disabled=true dotnet test tests/Meziantou.Framework.InlineSnapshotTesting.Tests/Meziantou.Framework.InlineSnapshotTesting.Tests.csproj`
- `dotnet run ./eng/update-bom.cs`
- `dotnet run ./eng/update-readme.cs`
- `dotnet run ./eng/update-project-slnx.cs`
- `dotnet run ./eng/validate-testprojects-configuration.cs`
- `dotnet run ./eng/update-trimmable.cs`