### PR TITLE
Install .NET agent skill plugins in Copilot setup workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,5 +32,16 @@ jobs:
             8.0.x
             9.0.x
 
+      - name: Install .NET agent skills
+        continue-on-error: true
+        run: |
+          copilot plugin marketplace add dotnet/skills || true
+          copilot plugin install dotnet@dotnet-agent-skills || true
+          copilot plugin install dotnet-diag@dotnet-agent-skills || true
+          copilot plugin install dotnet-msbuild@dotnet-agent-skills || true
+          copilot plugin install dotnet-nuget@dotnet-agent-skills || true
+          copilot plugin install dotnet-test@dotnet-agent-skills || true
+          copilot plugin list || true
+
       - name: Restore solution
         run: dotnet restore


### PR DESCRIPTION
Copilot cloud agent sessions need .NET skill plugins preinstalled so plugin commands are available consistently. This updates the Copilot setup workflow to install the dotnet skill marketplace and key plugins before `dotnet restore`.

## What changed
- Added an `Install .NET agent skills` step to `.github/workflows/copilot-setup-steps.yml`
- Installs `dotnet`, `dotnet-diag`, `dotnet-msbuild`, `dotnet-nuget`, and `dotnet-test` from `dotnet-agent-skills`
- Uses `continue-on-error: true` and `|| true` so setup does not fail if plugin marketplace operations are transiently unavailable