### PR TITLE
Fix FlacReader not reading duration from STREAMINFO block

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacReader.cs
@@ -29,7 +29,31 @@ internal sealed class FlacReader : IMediaTagReader
                 var blockType = (byte)(blockHeader[0] & 0x7F);
                 var blockSize = (blockHeader[1] << 16) | (blockHeader[2] << 8) | blockHeader[3];
 
-                if (blockType == FlacMetadataBlock.VorbisCommentType)
+                if (blockType == FlacMetadataBlock.StreamInfo)
+                {
+                    // STREAMINFO is always 34 bytes
+                    var blockData = new byte[blockSize];
+                    if (stream.ReadAtLeast(blockData, blockSize, throwOnEndOfStream: false) < blockSize)
+                        break;
+
+                    if (blockSize >= 18)
+                    {
+                        // Sample rate: bits 80-99 (20 bits starting at byte 10)
+                        var sampleRate = (blockData[10] << 12) | (blockData[11] << 4) | ((blockData[12] & 0xF0) >> 4);
+                        // Total samples: bits 108-143 (36 bits starting at nibble in byte 13)
+                        var totalSamples = ((long)(blockData[13] & 0x0F) << 32)
+                            | ((long)blockData[14] << 24)
+                            | ((long)blockData[15] << 16)
+                            | ((long)blockData[16] << 8)
+                            | blockData[17];
+
+                        if (sampleRate > 0 && totalSamples > 0)
+                        {
+                            tags.Duration = TimeSpan.FromSeconds((double)totalSamples / sampleRate);
+                        }
+                    }
+                }
+                else if (blockType == FlacMetadataBlock.VorbisCommentType)
                 {
                     var blockData = new byte[blockSize];
                     if (stream.ReadAtLeast(blockData, blockSize, throwOnEndOfStream: false) < blockSize)

--- a/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
@@ -184,6 +184,15 @@ public sealed class FlacTests
     }
 
     [Fact]
+    public void ReadTags_Duration_IsPopulated()
+    {
+        var result = MediaFile.ReadTags(GetTestFilePath("basic.flac"));
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value.Duration);
+        Assert.True(result.Value.Duration!.Value.TotalSeconds is > 0.9 and < 1.1);
+    }
+
+    [Fact]
     public void ReadTags_InvalidFile_ReturnsError()
     {
         using var stream = new MemoryStream([0x00, 0x01, 0x02, 0x03]);


### PR DESCRIPTION
## Problem

`MediaFile.ReadTags` returned `null` for `Duration` on all FLAC files. The `FlacReader` parsed VorbisComment and Picture metadata blocks but silently skipped the STREAMINFO block (type `0`), which is the mandatory first block in every FLAC file and the only place where duration information lives.

## Solution

`FlacReader` now parses the STREAMINFO block. The FLAC spec packs two fields into that block's 34 bytes using non-byte-aligned bit fields:

- **Sample rate** -- 20 bits starting at byte offset 10
- **Total samples** -- 36 bits starting at the low nibble of byte 13

`Duration` is then set as `TimeSpan.FromSeconds((double)totalSamples / sampleRate)`.

## Tests

Added `ReadTags_Duration_IsPopulated` to `FlacTests` to assert that reading `basic.flac` (a 1-second sine-wave fixture) produces a non-null `Duration` in the expected range. All 10 FLAC tests pass.