### PR TITLE
Replace LoremNET with in-repo lorem generator

### DIFF
--- a/samples/BlazorAppSample/BlazorAppSample.csproj
+++ b/samples/BlazorAppSample/BlazorAppSample.csproj
@@ -8,13 +8,13 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.7" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
-    <PackageReference Include="LoremNET" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../../src/Meziantou.AspNetCore.Components.LogViewer/Meziantou.AspNetCore.Components.LogViewer.csproj" />
     <ProjectReference Include="../../src/Meziantou.AspNetCore.Components.WebAssembly/Meziantou.AspNetCore.Components.WebAssembly.csproj" />
     <ProjectReference Include="../../src/Meziantou.AspNetCore.Components/Meziantou.AspNetCore.Components.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework/Meziantou.Framework.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/BlazorAppSample/Pages/AnchorNavigationDemo.razor
+++ b/samples/BlazorAppSample/Pages/AnchorNavigationDemo.razor
@@ -12,7 +12,7 @@
 @for (int i = 0; i < 10; i++)
 {
     <h1 id="@GetId(i)">Header @i</h1>
-    <p>@LoremNET.Lorem.Paragraph(wordCount: 30, sentenceCount: 10)</p>
+    <p>@Meziantou.Framework.LoremIpsumGenerator.Paragraph(wordCount: 30, sentenceCount: 10)</p>
 }
 
 <AnchorNavigation />

--- a/src/Meziantou.Framework/LoremIpsumGenerator.cs
+++ b/src/Meziantou.Framework/LoremIpsumGenerator.cs
@@ -1,0 +1,48 @@
+#pragma warning disable CA5394 // Random is insecure
+namespace Meziantou.Framework;
+
+public static class LoremIpsumGenerator
+{
+    private static readonly string[] Words =
+    [
+        "lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit",
+        "sed", "do", "eiusmod", "tempor", "incididunt", "ut", "labore", "et", "dolore",
+        "magna", "aliqua", "enim", "ad", "minim", "veniam", "quis", "nostrud",
+        "exercitation", "ullamco", "laboris", "nisi", "aliquip", "ex", "ea", "commodo",
+        "consequat", "duis", "aute", "irure", "in", "reprehenderit", "voluptate",
+        "velit", "esse", "cillum", "fugiat", "nulla", "pariatur", "excepteur", "sint",
+        "occaecat", "cupidatat", "non", "proident", "sunt", "culpa", "qui", "officia",
+        "deserunt", "mollit", "anim", "id", "est", "laborum",
+    ];
+
+    public static IEnumerable<string> Paragraphs(int wordsPerSentence, int sentencesPerParagraph, int paragraphCount)
+    {
+        for (var i = 0; i < paragraphCount; i++)
+        {
+            yield return Paragraph(wordsPerSentence, sentencesPerParagraph);
+        }
+    }
+
+    public static string Paragraph(int wordCount, int sentenceCount)
+    {
+        var sentences = new List<string>(sentenceCount);
+        for (var i = 0; i < sentenceCount; i++)
+        {
+            sentences.Add(Sentence(wordCount));
+        }
+
+        return string.Join(' ', sentences);
+    }
+
+    public static string Sentence(int wordCount)
+    {
+        var words = new List<string>(wordCount);
+        for (var i = 0; i < wordCount; i++)
+        {
+            var word = Words[Random.Shared.Next(Words.Length)];
+            words.Add(i is 0 ? char.ToUpperInvariant(word[0]) + word[1..] : word);
+        }
+
+        return string.Join(' ', words) + ".";
+    }
+}

--- a/tests/Meziantou.Framework.Tests/LoremIpsumGeneratorTests.cs
+++ b/tests/Meziantou.Framework.Tests/LoremIpsumGeneratorTests.cs
@@ -1,0 +1,40 @@
+namespace Meziantou.Framework.Tests;
+
+public class LoremIpsumGeneratorTests
+{
+    [Fact]
+    public void Sentence_ShouldHaveExpectedShape()
+    {
+        var sentence = LoremIpsumGenerator.Sentence(wordCount: 4);
+
+        Assert.EndsWith(".", sentence, StringComparison.Ordinal);
+        var content = sentence[..^1];
+        Assert.True(char.IsUpper(content[0]));
+        Assert.Equal(4, content.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length);
+    }
+
+    [Fact]
+    public void Paragraph_ShouldHaveExpectedSentenceAndWordCount()
+    {
+        var paragraph = LoremIpsumGenerator.Paragraph(wordCount: 5, sentenceCount: 3);
+
+        Assert.EndsWith(".", paragraph, StringComparison.Ordinal);
+        var sentences = paragraph.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Equal(3, sentences.Length);
+
+        foreach (var sentence in sentences)
+        {
+            Assert.True(char.IsUpper(sentence[0]));
+            Assert.Equal(5, sentence.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length);
+        }
+    }
+
+    [Fact]
+    public void Paragraphs_ShouldReturnRequestedCount()
+    {
+        var paragraphs = LoremIpsumGenerator.Paragraphs(wordsPerSentence: 3, sentencesPerParagraph: 2, paragraphCount: 4).ToArray();
+
+        Assert.Equal(4, paragraphs.Length);
+        Assert.All(paragraphs, Assert.NotEmpty);
+    }
+}


### PR DESCRIPTION
This change removes the `LoremNET` dependency from the Blazor sample to reduce external dependencies while keeping the same lorem ipsum feature available.

## What changed
- Added `Meziantou.Framework.LoremIpsumGenerator` (ported from `Meziantou.OnlineTools`) with `Sentence`, `Paragraph`, and `Paragraphs` helpers.
- Updated `BlazorAppSample` to remove the `LoremNET` package reference.
- Added a project reference to `Meziantou.Framework` and switched the Razor page to call `LoremIpsumGenerator.Paragraph(...)`.
- Added unit tests covering sentence shape, paragraph structure, and paragraph count behavior.

## Notes for reviewers
- Generator output is intentionally random; tests validate structural guarantees (capitalization, punctuation, counts) rather than exact text.