### PR TITLE
docs: use dotnet package add in package readmes

### DIFF
--- a/src/Meziantou.Framework.Globbing/readme.md
+++ b/src/Meziantou.Framework.Globbing/readme.md
@@ -15,8 +15,8 @@
 
 Install the NuGet package `Meziantou.Framework.Globbing` ([NuGet](https://www.nuget.org/packages/Meziantou.Framework.Globbing/))
 
-````xml
-<PackageReference Include="Meziantou.Framework.Globbing" Version="1.0.4" />
+````bash
+dotnet package add Meziantou.Framework.Globbing
 ````
 
 - `IsMatch` tests whether a file matches the glob pattern

--- a/src/Meziantou.Framework.ResxSourceGenerator/readme.md
+++ b/src/Meziantou.Framework.ResxSourceGenerator/readme.md
@@ -21,6 +21,12 @@ The generator also supports binary resources and expose them as `byte[]`.
 
 ## How to configure the source generator
 
+Install the NuGet package `Meziantou.Framework.ResxSourceGenerator` ([NuGet](https://www.nuget.org/packages/Meziantou.Framework.ResxSourceGenerator/))
+
+````bash
+dotnet package add Meziantou.Framework.ResxSourceGenerator
+````
+
 ````xml
 <Project Sdk="Microsoft.NET.Sdk">
 
@@ -34,9 +40,6 @@ The generator also supports binary resources and expose them as `byte[]`.
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Reference the source generator -->
-    <PackageReference Include="Meziantou.Framework.ResxSourceGenerator" Version="1.0.0" />
-
     <!-- Enable the source generator for all resx files in the project -->
     <AdditionalFiles Include="**/*.resx" />
 

--- a/src/Meziantou.Framework.TextDiff/readme.md
+++ b/src/Meziantou.Framework.TextDiff/readme.md
@@ -4,8 +4,8 @@ Compute text differences at line, word, or character level with configurable com
 
 Install the NuGet package `Meziantou.Framework.TextDiff` ([NuGet](https://www.nuget.org/packages/Meziantou.Framework.TextDiff/))
 
-````xml
-<PackageReference Include="Meziantou.Framework.TextDiff" Version="1.0.0" />
+````bash
+dotnet package add Meziantou.Framework.TextDiff
 ````
 
 ## Basic usage


### PR DESCRIPTION
## Why
Some package readmes documented installation with hardcoded `<PackageReference ... Version=...>` snippets. That guidance is easy to copy with stale versions and does not reflect the preferred dynamic install flow.

## What changed
This updates package installation guidance in affected `src/**/readme.md` files to use `dotnet package add <PackageName>` without specifying a version.

- Replaced install snippets in `Meziantou.Framework.TextDiff` and `Meziantou.Framework.Globbing` readmes.
- Updated `Meziantou.Framework.ResxSourceGenerator` readme to present install as a separate CLI step and removed the pinned `PackageReference` install line from the configuration sample.

## Notes
This is a documentation-only change intended to keep install instructions version-agnostic and aligned across package readmes.