### PR TITLE
Remove obsolete NuGet audit suppressions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,9 +41,4 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-7jgj-8wvc-jh57" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-cmhx-cq75-c4mj" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-447r-wph3-92pm" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
NuGet audit suppressions were masking advisories that no longer appear during restore. This removes the suppressions so only currently relevant vulnerabilities are reported.

- Removed 3 `NuGetAuditSuppress` entries from `Directory.Build.props`.
- No NU190x/vulnerability warnings were reported for those advisory IDs after removal.

## Notes
- Full test runs in this macOS environment still hit existing Win32 AMSI-related failures/aborts that are unrelated to this config-only change.