### PR TITLE
Fix FLAC detection for files with leading ID3v2 tags

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacReader.cs
@@ -6,15 +6,15 @@ internal sealed class FlacReader : IMediaTagReader
     {
         try
         {
-            stream.Position = 0;
+            if (!TrySeekAfterFlacMagic(stream))
+            {
+                stream.Position = 0;
+                Span<byte> magic = stackalloc byte[4];
+                if (stream.ReadAtLeast(magic, magic.Length, throwOnEndOfStream: false) < magic.Length)
+                    return MediaTagResult<MediaTagInfo>.Failure(MediaTagError.CorruptFile, "File too small for FLAC.");
 
-            // Verify "fLaC" magic
-            Span<byte> magic = stackalloc byte[4];
-            if (stream.ReadAtLeast(magic, 4, throwOnEndOfStream: false) < 4)
-                return MediaTagResult<MediaTagInfo>.Failure(MediaTagError.CorruptFile, "File too small for FLAC.");
-
-            if (magic[0] != 'f' || magic[1] != 'L' || magic[2] != 'a' || magic[3] != 'C')
                 return MediaTagResult<MediaTagInfo>.Failure(MediaTagError.UnsupportedFormat, "Not a FLAC file.");
+            }
 
             var tags = new MediaTagInfo();
             Span<byte> blockHeader = stackalloc byte[4];
@@ -85,5 +85,38 @@ internal sealed class FlacReader : IMediaTagReader
         {
             return MediaTagResult<MediaTagInfo>.Failure(MediaTagError.CorruptFile, ex.Message);
         }
+    }
+
+    private static bool TrySeekAfterFlacMagic(Stream stream)
+    {
+        if (!stream.CanSeek)
+            return false;
+
+        stream.Position = 0;
+        if (TryReadFlacMagic(stream))
+            return true;
+
+        stream.Position = 0;
+        Span<byte> id3Header = stackalloc byte[3];
+        if (stream.ReadAtLeast(id3Header, id3Header.Length, throwOnEndOfStream: false) < id3Header.Length)
+            return false;
+
+        if (id3Header is not [(byte)'I', (byte)'D', (byte)'3'])
+            return false;
+
+        stream.Position = 0;
+        var id3v2TagSize = Id3v2.Id3v2Reader.GetTagSize(stream);
+        if (id3v2TagSize <= 0 || stream.Length < id3v2TagSize + 4)
+            return false;
+
+        stream.Position = id3v2TagSize;
+        return TryReadFlacMagic(stream);
+    }
+
+    private static bool TryReadFlacMagic(Stream stream)
+    {
+        Span<byte> magic = stackalloc byte[4];
+        return stream.ReadAtLeast(magic, magic.Length, throwOnEndOfStream: false) == magic.Length
+            && magic is [(byte)'f', (byte)'L', (byte)'a', (byte)'C'];
     }
 }

--- a/src/Meziantou.Framework.MediaTags/MediaFile.cs
+++ b/src/Meziantou.Framework.MediaTags/MediaFile.cs
@@ -151,14 +151,33 @@ public static class MediaFile
         var originalPosition = stream.Position;
         try
         {
-            Span<byte> header = stackalloc byte[FormatDetector.MinHeaderSize];
-            var bytesRead = stream.ReadAtLeast(header, FormatDetector.MinHeaderSize, throwOnEndOfStream: false);
-            return FormatDetector.DetectFromHeader(header[..bytesRead]);
+            var format = DetectFormatFromCurrentPosition(stream);
+            if (format == MediaFormat.Mp3 && stream.Length >= originalPosition + 10)
+            {
+                stream.Position = originalPosition;
+                var id3v2Size = Id3v2Reader.GetTagSize(stream);
+                if (id3v2Size > 0 && stream.Length >= originalPosition + id3v2Size + 4)
+                {
+                    stream.Position = originalPosition + id3v2Size;
+                    var nestedFormat = DetectFormatFromCurrentPosition(stream);
+                    if (nestedFormat is not null and not MediaFormat.Mp3)
+                        return nestedFormat;
+                }
+            }
+
+            return format;
         }
         finally
         {
             stream.Position = originalPosition;
         }
+    }
+
+    private static MediaFormat? DetectFormatFromCurrentPosition(Stream stream)
+    {
+        Span<byte> header = stackalloc byte[FormatDetector.MinHeaderSize];
+        var bytesRead = stream.ReadAtLeast(header, FormatDetector.MinHeaderSize, throwOnEndOfStream: false);
+        return FormatDetector.DetectFromHeader(header[..bytesRead]);
     }
 
     private static MediaTagResult<MediaTagInfo> ReadTagsCore(Stream stream, MediaFormat format)

--- a/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
+++ b/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>1.1.3</Version>
+    <Version>1.1.4</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>A library for reading and writing metadata tags in media files (MP3, OGG, FLAC, MP4/M4A, WAV, AIFF)</Description>
   </PropertyGroup>

--- a/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
@@ -193,6 +193,33 @@ public sealed class FlacTests
     }
 
     [Fact]
+    public void ReadTags_WithLeadingId3Tag_UsesFlacReader()
+    {
+        var tempFile = Path.GetTempFileName() + ".flac";
+        try
+        {
+            using (var output = File.Create(tempFile))
+            {
+                output.Write("ID3"u8);
+                output.Write([0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+                using var input = File.OpenRead(GetTestFilePath("basic.flac"));
+                input.CopyTo(output);
+            }
+
+            var result = MediaFile.ReadTags(tempFile);
+            Assert.True(result.IsSuccess);
+            Assert.Equal(MediaFormat.Flac, result.Value.Format);
+            Assert.NotNull(result.Value.Duration);
+            Assert.True(result.Value.Duration!.Value.TotalSeconds is > 0.9 and < 1.1);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
     public void ReadTags_InvalidFile_ReturnsError()
     {
         using var stream = new MemoryStream([0x00, 0x01, 0x02, 0x03]);


### PR DESCRIPTION
Some FLAC files can contain an ID3v2 tag before the FLAC payload. In that case we were detecting the file as MP3, so FLAC metadata parsing never ran and `Duration` remained unset.

## What changed
- Updated `MediaFile.DetectFormat(Stream)` to perform a second format detection pass after a valid leading ID3v2 tag and prefer a nested non-MP3 format (such as FLAC).
- Updated `FlacReader` to support FLAC files that include a leading ID3v2 tag by seeking to the `fLaC` marker before reading metadata blocks.
- Added a regression test (`ReadTags_WithLeadingId3Tag_UsesFlacReader`) that prefixes `basic.flac` with an ID3v2 header and verifies FLAC detection and duration extraction.

## Notes
- This keeps existing MP3 detection behavior for real MP3 files while handling ID3-prefixed FLAC files correctly.
- Full MediaTags test runs are functionally passing for this change; this repository currently reports the known Blame data collector message during `dotnet test`.