### PR TITLE
Fix ReplayGain parsing and FLAC duration detection

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacReader.cs
@@ -106,11 +106,12 @@ internal sealed class FlacReader : IMediaTagReader
 
         stream.Position = 0;
         var id3v2TagSize = Id3v2.Id3v2Reader.GetTagSize(stream);
-        if (id3v2TagSize <= 0 || stream.Length < id3v2TagSize + 4)
+        if (id3v2TagSize <= 0)
             return false;
 
-        stream.Position = id3v2TagSize;
-        return TryReadFlacMagic(stream);
+        return TryReadFlacMagicAtOffset(stream, id3v2TagSize)
+            || TryReadFlacMagicAtOffset(stream, id3v2TagSize + 10)
+            || TryReadFlacMagicAtOffset(stream, id3v2TagSize - 10);
     }
 
     private static bool TryReadFlacMagic(Stream stream)
@@ -118,5 +119,14 @@ internal sealed class FlacReader : IMediaTagReader
         Span<byte> magic = stackalloc byte[4];
         return stream.ReadAtLeast(magic, magic.Length, throwOnEndOfStream: false) == magic.Length
             && magic is [(byte)'f', (byte)'L', (byte)'a', (byte)'C'];
+    }
+
+    private static bool TryReadFlacMagicAtOffset(Stream stream, long offset)
+    {
+        if (offset < 0 || stream.Length < offset + 4)
+            return false;
+
+        stream.Position = offset;
+        return TryReadFlacMagic(stream);
     }
 }

--- a/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Reader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Reader.cs
@@ -226,15 +226,13 @@ internal sealed class Mp4Reader : IMediaTagReader
             return;
 
         // mean and name atoms have 4-byte version/flags prefix
-        var mean = meanAtom.Data.Length > 4 ? Encoding.UTF8.GetString(meanAtom.Data.AsSpan(4)) : "";
-        var name = nameAtom.Data.Length > 4 ? Encoding.UTF8.GetString(nameAtom.Data.AsSpan(4)) : "";
-
-        if (dataAtom.Data.Length < 8)
+        var mean = ReadFreeformText(meanAtom.Data);
+        var name = ReadFreeformText(nameAtom.Data);
+        var value = ReadFreeformDataValue(dataAtom.Data);
+        if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(value))
             return;
 
-        var value = Encoding.UTF8.GetString(dataAtom.Data.AsSpan(8));
-
-        if (mean == "com.apple.iTunes")
+        if (string.Equals(mean, "com.apple.iTunes", StringComparison.OrdinalIgnoreCase))
         {
             if (string.Equals(name, "MusicBrainz Track Id", StringComparison.OrdinalIgnoreCase))
                 tags.MusicBrainzTrackId ??= value;
@@ -253,7 +251,7 @@ internal sealed class Mp4Reader : IMediaTagReader
             }
             else if (string.Equals(name, "REPLAYGAIN_TRACK_PEAK", StringComparison.OrdinalIgnoreCase))
             {
-                if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var peak))
+                if (TryParseFloatingPointValue(value, out var peak))
                     tags.ReplayGain = (tags.ReplayGain ?? default) with { TrackPeak = peak };
             }
             else if (string.Equals(name, "REPLAYGAIN_ALBUM_GAIN", StringComparison.OrdinalIgnoreCase))
@@ -263,7 +261,7 @@ internal sealed class Mp4Reader : IMediaTagReader
             }
             else if (string.Equals(name, "REPLAYGAIN_ALBUM_PEAK", StringComparison.OrdinalIgnoreCase))
             {
-                if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var peak))
+                if (TryParseFloatingPointValue(value, out var peak))
                     tags.ReplayGain = (tags.ReplayGain ?? default) with { AlbumPeak = peak };
             }
             else
@@ -277,13 +275,49 @@ internal sealed class Mp4Reader : IMediaTagReader
         }
     }
 
-    private static string ReadUtf8Value(ReadOnlySpan<byte> data) => Encoding.UTF8.GetString(data);
+    private static string ReadUtf8Value(ReadOnlySpan<byte> data) => TrimTrailingNullCharacters(Encoding.UTF8.GetString(data));
+
+    private static string ReadFreeformText(byte[] atomData)
+    {
+        if (atomData.Length <= 4)
+            return "";
+
+        return TrimTrailingNullCharacters(Encoding.UTF8.GetString(atomData.AsSpan(4)));
+    }
+
+    private static string ReadFreeformDataValue(byte[] atomData)
+    {
+        if (atomData.Length < 8)
+            return "";
+
+        var typeIndicator = BinaryPrimitives.ReadUInt32BigEndian(atomData);
+        var valueData = atomData.AsSpan(8);
+        var text = typeIndicator switch
+        {
+            2 => Encoding.BigEndianUnicode.GetString(valueData),
+            _ => Encoding.UTF8.GetString(valueData),
+        };
+
+        return TrimTrailingNullCharacters(text);
+    }
 
     private static bool TryParseReplayGainValue(string value, out double result)
     {
         var trimmed = value.AsSpan().Trim();
         if (trimmed.EndsWith(" dB", StringComparison.OrdinalIgnoreCase))
             trimmed = trimmed[..^3].Trim();
-        return double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+
+        return TryParseFloatingPointValue(trimmed, out result);
     }
+
+    private static bool TryParseFloatingPointValue(ReadOnlySpan<char> value, out double result)
+    {
+        var trimmed = value.Trim();
+        if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out result))
+            return true;
+
+        return double.TryParse(trimmed.ToString().Replace(',', '.'), NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+    }
+
+    private static string TrimTrailingNullCharacters(string value) => value.TrimEnd('\0');
 }

--- a/src/Meziantou.Framework.MediaTags/MediaFile.cs
+++ b/src/Meziantou.Framework.MediaTags/MediaFile.cs
@@ -156,12 +156,14 @@ public static class MediaFile
             {
                 stream.Position = originalPosition;
                 var id3v2Size = Id3v2Reader.GetTagSize(stream);
-                if (id3v2Size > 0 && stream.Length >= originalPosition + id3v2Size + 4)
+                if (id3v2Size > 0)
                 {
-                    stream.Position = originalPosition + id3v2Size;
-                    var nestedFormat = DetectFormatFromCurrentPosition(stream);
-                    if (nestedFormat is not null and not MediaFormat.Mp3)
+                    if (TryDetectNestedFormatAtOffset(stream, originalPosition + id3v2Size, out var nestedFormat)
+                        || TryDetectNestedFormatAtOffset(stream, originalPosition + id3v2Size + 10, out nestedFormat)
+                        || TryDetectNestedFormatAtOffset(stream, originalPosition + id3v2Size - 10, out nestedFormat))
+                    {
                         return nestedFormat;
+                    }
                 }
             }
 
@@ -178,6 +180,24 @@ public static class MediaFile
         Span<byte> header = stackalloc byte[FormatDetector.MinHeaderSize];
         var bytesRead = stream.ReadAtLeast(header, FormatDetector.MinHeaderSize, throwOnEndOfStream: false);
         return FormatDetector.DetectFromHeader(header[..bytesRead]);
+    }
+
+    private static bool TryDetectNestedFormatAtOffset(Stream stream, long offset, out MediaFormat nestedFormat)
+    {
+        nestedFormat = default;
+
+        if (offset < 0 || stream.Length < offset + 4)
+            return false;
+
+        stream.Position = offset;
+        var detectedFormat = DetectFormatFromCurrentPosition(stream);
+        if (detectedFormat is not null and not MediaFormat.Mp3)
+        {
+            nestedFormat = detectedFormat.Value;
+            return true;
+        }
+
+        return false;
     }
 
     private static MediaTagResult<MediaTagInfo> ReadTagsCore(Stream stream, MediaFormat format)

--- a/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
+++ b/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>1.1.4</Version>
+    <Version>1.1.6</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>A library for reading and writing metadata tags in media files (MP3, OGG, FLAC, MP4/M4A, WAV, AIFF)</Description>
   </PropertyGroup>

--- a/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
@@ -220,6 +220,36 @@ public sealed class FlacTests
     }
 
     [Fact]
+    public void ReadTags_WithLeadingId3TagAndExtraFooterBytes_UsesFlacReader()
+    {
+        var tempFile = Path.GetTempFileName() + ".flac";
+        try
+        {
+            using (var output = File.Create(tempFile))
+            {
+                output.Write("ID3"u8);
+                output.Write([0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+                // Some files contain extra 10 bytes after the declared ID3 tag size.
+                output.Write(new byte[10]);
+
+                using var input = File.OpenRead(GetTestFilePath("basic.flac"));
+                input.CopyTo(output);
+            }
+
+            var result = MediaFile.ReadTags(tempFile);
+            Assert.True(result.IsSuccess);
+            Assert.Equal(MediaFormat.Flac, result.Value.Format);
+            Assert.NotNull(result.Value.Duration);
+            Assert.True(result.Value.Duration!.Value.TotalSeconds is > 0.9 and < 1.1);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
     public void ReadTags_InvalidFile_ReturnsError()
     {
         using var stream = new MemoryStream([0x00, 0x01, 0x02, 0x03]);

--- a/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
@@ -1,3 +1,5 @@
+using System.Buffers.Binary;
+using System.Text;
 using Meziantou.Framework.MediaTags;
 
 namespace Meziantou.Framework.MediaTags.Tests;
@@ -165,5 +167,86 @@ public sealed class Mp4Tests
         var result = MediaFile.ReadTags(stream, MediaFormat.Mp4);
         // Very short ftyp, should succeed with empty tags or handle gracefully
         Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public void ReadTags_FreeformReplayGain_NullTerminatedText()
+    {
+        using var stream = new MemoryStream(CreateMp4WithFreeformTags([
+            ("com.apple.iTunes\0", "REPLAYGAIN_TRACK_GAIN\0", "-6.25 dB\0", 1u),
+            ("com.apple.iTunes", "REPLAYGAIN_ALBUM_PEAK", "0.987654\0", 1u),
+        ]));
+
+        var result = MediaFile.ReadTags(stream, MediaFormat.Mp4);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value.ReplayGain);
+        Assert.Equal(-6.25, result.Value.ReplayGain.Value.TrackGain);
+        Assert.Equal(0.987654, result.Value.ReplayGain.Value.AlbumPeak);
+    }
+
+    [Fact]
+    public void ReadTags_FreeformReplayGain_Utf16Text()
+    {
+        using var stream = new MemoryStream(CreateMp4WithFreeformTags([
+            ("com.apple.iTunes", "REPLAYGAIN_TRACK_GAIN", "-7.50 dB", 2u),
+            ("com.apple.iTunes", "REPLAYGAIN_TRACK_PEAK", "0.998877", 2u),
+        ]));
+
+        var result = MediaFile.ReadTags(stream, MediaFormat.Mp4);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value.ReplayGain);
+        Assert.Equal(-7.5, result.Value.ReplayGain.Value.TrackGain);
+        Assert.Equal(0.998877, result.Value.ReplayGain.Value.TrackPeak);
+    }
+
+    private static byte[] CreateMp4WithFreeformTags((string Mean, string Name, string Value, uint DataType)[] freeformTags)
+    {
+        using var ilstPayload = new MemoryStream();
+        foreach (var (mean, name, value, dataType) in freeformTags)
+        {
+            ilstPayload.Write(CreateFreeformAtom(mean, name, value, dataType));
+        }
+
+        var ilstAtom = CreateAtom("ilst", ilstPayload.ToArray());
+        var metaPayload = new byte[4 + ilstAtom.Length];
+        ilstAtom.CopyTo(metaPayload, 4); // Full box version/flags
+        var metaAtom = CreateAtom("meta", metaPayload);
+        var udtaAtom = CreateAtom("udta", metaAtom);
+        return CreateAtom("moov", udtaAtom);
+    }
+
+    private static byte[] CreateFreeformAtom(string mean, string name, string value, uint dataType)
+    {
+        var meanAtom = CreateTextAtom("mean", mean);
+        var nameAtom = CreateTextAtom("name", name);
+
+        var valueBytes = dataType == 2 ? Encoding.BigEndianUnicode.GetBytes(value) : Encoding.UTF8.GetBytes(value);
+        var dataPayload = new byte[8 + valueBytes.Length];
+        BinaryPrimitives.WriteUInt32BigEndian(dataPayload, dataType);
+        valueBytes.CopyTo(dataPayload, 8);
+        var dataAtom = CreateAtom("data", dataPayload);
+
+        var freeformPayload = new byte[meanAtom.Length + nameAtom.Length + dataAtom.Length];
+        meanAtom.CopyTo(freeformPayload, 0);
+        nameAtom.CopyTo(freeformPayload, meanAtom.Length);
+        dataAtom.CopyTo(freeformPayload, meanAtom.Length + nameAtom.Length);
+        return CreateAtom("----", freeformPayload);
+    }
+
+    private static byte[] CreateTextAtom(string atomType, string value)
+    {
+        var valueBytes = Encoding.UTF8.GetBytes(value);
+        var payload = new byte[4 + valueBytes.Length]; // Full box version/flags + UTF-8 data
+        valueBytes.CopyTo(payload, 4);
+        return CreateAtom(atomType, payload);
+    }
+
+    private static byte[] CreateAtom(string atomType, byte[] payload)
+    {
+        var atom = new byte[8 + payload.Length];
+        BinaryPrimitives.WriteUInt32BigEndian(atom, (uint)atom.Length);
+        Encoding.Latin1.GetBytes(atomType, atom.AsSpan(4, 4));
+        payload.CopyTo(atom, 8);
+        return atom;
     }
 }


### PR DESCRIPTION
Some media files were parsed incompletely because metadata parsing was too strict around container edge cases. In practice this caused ReplayGain fields to be missed in MP4 freeform atoms and could cause FLAC files with leading ID3 padding/footer bytes to be treated as MP3, which left duration unset.

## What changed
- Hardened MP4 freeform parsing in `Mp4Reader`:
  - trims trailing null terminators from `mean`, `name`, and `data` values
  - supports UTF-16 freeform `data` payloads (in addition to UTF-8)
  - makes floating-point parsing more tolerant for ReplayGain peak/gain values
- Improved nested format detection in `MediaFile.DetectFormat(Stream)` when an ID3v2 header is present by probing nearby offsets (`id3End`, `id3End + 10`, `id3End - 10`) instead of a single strict location.
- Applied the same tolerant offset probing in `FlacReader` when locating `fLaC` after a leading ID3 block.
- Added regression tests:
  - MP4 ReplayGain freeform with null-terminated fields
  - MP4 ReplayGain freeform with UTF-16 data
  - FLAC with leading ID3 plus extra 10 bytes still detected as FLAC and returns duration

## Notes for reviewers
- The `+/- 10` probe is intentional to handle real-world files where ID3 metadata boundaries include extra footer/padding bytes.
- Package version was updated to `1.1.5` in `Meziantou.Framework.MediaTags.csproj` as part of the update scripts.