### PR TITLE
Handle FLAC detection after leading ID3 tags deterministically

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacReader.cs
@@ -1,3 +1,5 @@
+using Meziantou.Framework.MediaTags.Formats.Id3v2;
+
 namespace Meziantou.Framework.MediaTags.Formats.Flac;
 
 internal sealed class FlacReader : IMediaTagReader
@@ -104,14 +106,11 @@ internal sealed class FlacReader : IMediaTagReader
         if (id3Header is not [(byte)'I', (byte)'D', (byte)'3'])
             return false;
 
-        stream.Position = 0;
-        var id3v2TagSize = Id3v2.Id3v2Reader.GetTagSize(stream);
-        if (id3v2TagSize <= 0)
+        if (!Id3v2TagLocator.TryGetAudioDataOffsets(stream, 0, out var primaryOffset, out var secondaryOffset))
             return false;
 
-        return TryReadFlacMagicAtOffset(stream, id3v2TagSize)
-            || TryReadFlacMagicAtOffset(stream, id3v2TagSize + 10)
-            || TryReadFlacMagicAtOffset(stream, id3v2TagSize - 10);
+        return TryReadFlacMagicAtOffset(stream, primaryOffset)
+            || (secondaryOffset >= 0 && TryReadFlacMagicAtOffset(stream, secondaryOffset));
     }
 
     private static bool TryReadFlacMagic(Stream stream)

--- a/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2TagLocator.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2TagLocator.cs
@@ -1,0 +1,92 @@
+using Meziantou.Framework.MediaTags.Internals;
+
+namespace Meziantou.Framework.MediaTags.Formats.Id3v2;
+
+internal static class Id3v2TagLocator
+{
+    public static bool TryGetAudioDataOffsets(Stream stream, long tagStartOffset, out long primaryOffset, out long secondaryOffset)
+    {
+        primaryOffset = -1;
+        secondaryOffset = -1;
+
+        if (!stream.CanSeek || tagStartOffset < 0 || stream.Length < tagStartOffset + 10)
+            return false;
+
+        var originalPosition = stream.Position;
+        try
+        {
+            stream.Position = tagStartOffset;
+            Span<byte> headerBytes = stackalloc byte[10];
+            if (stream.ReadAtLeast(headerBytes, headerBytes.Length, throwOnEndOfStream: false) < headerBytes.Length)
+                return false;
+
+            if (!Id3v2Header.TryParse(headerBytes, out var header))
+                return false;
+
+            var contentEndOffset = tagStartOffset + 10L + header.TagSize;
+            if (contentEndOffset > stream.Length)
+                return false;
+
+            if (header.FooterPresent)
+            {
+                primaryOffset = contentEndOffset + 10;
+                secondaryOffset = contentEndOffset;
+            }
+            else
+            {
+                primaryOffset = contentEndOffset;
+                if (HasMatchingFooterAt(stream, contentEndOffset, header))
+                {
+                    secondaryOffset = contentEndOffset + 10;
+                }
+            }
+
+            return true;
+        }
+        finally
+        {
+            stream.Position = originalPosition;
+        }
+    }
+
+    private static bool HasMatchingFooterAt(Stream stream, long offset, Id3v2Header header)
+    {
+        if (stream.Length < offset + 10)
+            return false;
+
+        stream.Position = offset;
+        Span<byte> footerBytes = stackalloc byte[10];
+        if (stream.ReadAtLeast(footerBytes, footerBytes.Length, throwOnEndOfStream: false) < footerBytes.Length)
+            return false;
+
+        if (footerBytes is not [(byte)'3', (byte)'D', (byte)'I', ..])
+            return false;
+
+        if (footerBytes[3] != header.MajorVersion || footerBytes[4] != header.MinorVersion)
+            return false;
+
+        if (footerBytes[5] != GetFlags(header))
+            return false;
+
+        var footerTagSize = SynchsafeInteger.Decode(footerBytes[6..]);
+        return footerTagSize == header.TagSize;
+    }
+
+    private static byte GetFlags(Id3v2Header header)
+    {
+        byte flags = 0;
+        if (header.Unsynchronisation)
+            flags |= 0x80;
+
+        if (header.ExtendedHeader)
+            flags |= 0x40;
+
+        if (header.ExperimentalIndicator)
+            flags |= 0x20;
+
+        if (header.FooterPresent)
+            flags |= 0x10;
+
+        return flags;
+    }
+}

--- a/src/Meziantou.Framework.MediaTags/MediaFile.cs
+++ b/src/Meziantou.Framework.MediaTags/MediaFile.cs
@@ -154,16 +154,11 @@ public static class MediaFile
             var format = DetectFormatFromCurrentPosition(stream);
             if (format == MediaFormat.Mp3 && stream.Length >= originalPosition + 10)
             {
-                stream.Position = originalPosition;
-                var id3v2Size = Id3v2Reader.GetTagSize(stream);
-                if (id3v2Size > 0)
+                if (Id3v2TagLocator.TryGetAudioDataOffsets(stream, originalPosition, out var primaryOffset, out var secondaryOffset)
+                    && (TryDetectNestedFormatAtOffset(stream, primaryOffset, out var nestedFormat)
+                        || (secondaryOffset >= 0 && TryDetectNestedFormatAtOffset(stream, secondaryOffset, out nestedFormat))))
                 {
-                    if (TryDetectNestedFormatAtOffset(stream, originalPosition + id3v2Size, out var nestedFormat)
-                        || TryDetectNestedFormatAtOffset(stream, originalPosition + id3v2Size + 10, out nestedFormat)
-                        || TryDetectNestedFormatAtOffset(stream, originalPosition + id3v2Size - 10, out nestedFormat))
-                    {
-                        return nestedFormat;
-                    }
+                    return nestedFormat;
                 }
             }
 

--- a/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
+++ b/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>1.1.6</Version>
+    <Version>1.1.7</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>A library for reading and writing metadata tags in media files (MP3, OGG, FLAC, MP4/M4A, WAV, AIFF)</Description>
   </PropertyGroup>

--- a/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
@@ -220,7 +220,7 @@ public sealed class FlacTests
     }
 
     [Fact]
-    public void ReadTags_WithLeadingId3TagAndExtraFooterBytes_UsesFlacReader()
+    public void ReadTags_WithLeadingId3TagAndFooter_UsesFlacReader()
     {
         var tempFile = Path.GetTempFileName() + ".flac";
         try
@@ -230,8 +230,7 @@ public sealed class FlacTests
                 output.Write("ID3"u8);
                 output.Write([0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
 
-                // Some files contain extra 10 bytes after the declared ID3 tag size.
-                output.Write(new byte[10]);
+                output.Write([(byte)'3', (byte)'D', (byte)'I', 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
 
                 using var input = File.OpenRead(GetTestFilePath("basic.flac"));
                 input.CopyTo(output);

--- a/tests/Meziantou.Framework.MediaTags.Tests/MediaFileDetectionTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/MediaFileDetectionTests.cs
@@ -71,4 +71,28 @@ public sealed class MediaFileDetectionTests
         var format = MediaFile.DetectFormat(stream);
         Assert.Null(format);
     }
+
+    [Fact]
+    public void DetectFormat_FlacWithLeadingId3AndFooter_DetectsFlac()
+    {
+        var tempFile = Path.GetTempFileName() + ".flac";
+        try
+        {
+            using (var output = File.Create(tempFile))
+            {
+                output.Write("ID3"u8);
+                output.Write([0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+                output.Write([(byte)'3', (byte)'D', (byte)'I', 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+                using var input = File.OpenRead(GetTestFilePath("basic.flac"));
+                input.CopyTo(output);
+            }
+
+            var format = MediaFile.DetectFormat(tempFile);
+            Assert.Equal(MediaFormat.Flac, format);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
 }


### PR DESCRIPTION
Some FLAC files with a prepended ID3v2 tag were being handled via heuristic offset probing, which made the behavior look non-deterministic and could prevent FLAC parsing (and duration extraction) in edge cases.

This change makes ID3-wrapped format detection and FLAC parsing deterministic by following ID3v2 boundaries:

- Added `Id3v2TagLocator` to compute audio data offsets from the ID3v2 header size and optional footer rules.
- Updated `MediaFile.DetectFormat(Stream)` to use those computed offsets instead of broad nearby probing.
- Updated `FlacReader` to seek `fLaC` at deterministic offsets derived from ID3v2 layout.
- Updated regression tests to cover leading ID3v2 plus footer scenarios for both format detection and FLAC tag reading/duration.

The main tradeoff is stricter adherence to ID3 structure instead of permissive scanning, which is intentional to keep behavior predictable and spec-aligned.