### PR TITLE
Fix duration parsing for Opus and WAV

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggOpusReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Ogg/OggOpusReader.cs
@@ -1,8 +1,13 @@
+using System.Buffers.Binary;
+
 namespace Meziantou.Framework.MediaTags.Formats.Ogg;
 
 internal sealed class OggOpusReader : IMediaTagReader
 {
+    private const int OpusSampleRate = 48_000;
+    private const int OpusHeadPreSkipOffset = 10;
     private static readonly byte[] OpusTagsPrefix = "OpusTags"u8.ToArray();
+    private static readonly byte[] OpusHeadPrefix = "OpusHead"u8.ToArray();
 
     public MediaTagResult<MediaTagInfo> ReadTags(Stream stream)
     {
@@ -22,11 +27,50 @@ internal sealed class OggOpusReader : IMediaTagReader
                 }
             }
 
+            tags.Duration ??= TryReadDuration(pages, packets);
+
             return MediaTagResult<MediaTagInfo>.Success(tags);
         }
         catch (Exception ex)
         {
             return MediaTagResult<MediaTagInfo>.Failure(MediaTagError.CorruptFile, ex.Message);
         }
+    }
+
+    private static TimeSpan? TryReadDuration(List<OggPage> pages, List<OggPacketInfo> packets)
+    {
+        OggPacketInfo? opusHeadPacket = null;
+        foreach (var packet in packets)
+        {
+            if (packet.Data.AsSpan().StartsWith(OpusHeadPrefix))
+            {
+                opusHeadPacket = packet;
+                break;
+            }
+        }
+
+        if (opusHeadPacket is null || opusHeadPacket.Data.Length < OpusHeadPreSkipOffset + 2)
+            return null;
+
+        var preSkip = BinaryPrimitives.ReadUInt16LittleEndian(opusHeadPacket.Data.AsSpan(OpusHeadPreSkipOffset));
+        if (opusHeadPacket.StartPageIndex < 0 || opusHeadPacket.StartPageIndex >= pages.Count)
+            return null;
+
+        var streamSerialNumber = pages[opusHeadPacket.StartPageIndex].SerialNumber;
+        long? lastGranulePosition = null;
+        for (var i = pages.Count - 1; i >= 0; i--)
+        {
+            var page = pages[i];
+            if (page.SerialNumber != streamSerialNumber || page.GranulePosition < 0)
+                continue;
+
+            lastGranulePosition = page.GranulePosition;
+            break;
+        }
+
+        if (lastGranulePosition is null || lastGranulePosition <= preSkip)
+            return null;
+
+        return TimeSpan.FromSeconds((lastGranulePosition.Value - preSkip) / (double)OpusSampleRate);
     }
 }

--- a/src/Meziantou.Framework.MediaTags/Formats/Wav/WavReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Wav/WavReader.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Text;
 
 namespace Meziantou.Framework.MediaTags.Formats.Wav;
@@ -42,12 +43,65 @@ internal sealed class WavReader : IMediaTagReader
                 }
             }
 
+            tags.Duration ??= TryReadDuration(chunks);
             return MediaTagResult<MediaTagInfo>.Success(tags);
         }
         catch (Exception ex)
         {
             return MediaTagResult<MediaTagInfo>.Failure(MediaTagError.CorruptFile, ex.Message);
         }
+    }
+
+    private static TimeSpan? TryReadDuration(List<RiffChunk> chunks)
+    {
+        RiffChunk? formatChunk = null;
+        RiffChunk? dataChunk = null;
+        RiffChunk? factChunk = null;
+
+        foreach (var chunk in chunks)
+        {
+            switch (chunk.Id)
+            {
+                case "fmt ":
+                    formatChunk = chunk;
+                    break;
+
+                case "data":
+                    dataChunk = chunk;
+                    break;
+
+                case "fact":
+                    factChunk = chunk;
+                    break;
+            }
+        }
+
+        if (formatChunk?.Data is not { Length: >= 16 } formatData)
+            return null;
+
+        var sampleRate = BinaryPrimitives.ReadUInt32LittleEndian(formatData.AsSpan(4));
+        var byteRate = BinaryPrimitives.ReadUInt32LittleEndian(formatData.AsSpan(8));
+        var blockAlign = BinaryPrimitives.ReadUInt16LittleEndian(formatData.AsSpan(12));
+        if (sampleRate == 0)
+            return null;
+
+        if (factChunk?.Data is { Length: >= 4 } factData)
+        {
+            var sampleCount = BinaryPrimitives.ReadUInt32LittleEndian(factData);
+            if (sampleCount > 0)
+                return TimeSpan.FromSeconds(sampleCount / (double)sampleRate);
+        }
+
+        if (dataChunk is null || dataChunk.Size <= 0)
+            return null;
+
+        if (byteRate > 0)
+            return TimeSpan.FromSeconds(dataChunk.Size / (double)byteRate);
+
+        if (blockAlign > 0)
+            return TimeSpan.FromSeconds(dataChunk.Size / (double)(sampleRate * blockAlign));
+
+        return null;
     }
 
     private static void ReadInfoChunks(List<RiffChunk> chunks, MediaTagInfo tags)

--- a/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
+++ b/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>1.1.7</Version>
+    <Version>1.1.8</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>A library for reading and writing metadata tags in media files (MP3, OGG, FLAC, MP4/M4A, WAV, AIFF)</Description>
   </PropertyGroup>

--- a/tests/Meziantou.Framework.MediaTags.Tests/OggOpusTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/OggOpusTests.cs
@@ -19,6 +19,8 @@ public sealed class OggOpusTests
         Assert.Equal("Test Artist", tags.Artist);
         Assert.Equal("Test Album", tags.Album);
         Assert.Equal(2024, tags.Year);
+        Assert.NotNull(tags.Duration);
+        Assert.InRange(tags.Duration.Value.TotalSeconds, 0.95, 1.1);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.MediaTags.Tests/WavTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/WavTests.cs
@@ -14,6 +14,8 @@ public sealed class WavTests
 
         var tags = result.Value;
         Assert.Equal(MediaFormat.Wav, tags.Format);
+        Assert.NotNull(tags.Duration);
+        Assert.InRange(tags.Duration.Value.TotalSeconds, 0.95, 1.05);
         // WAV metadata support varies by ffmpeg version; check at least title
         if (tags.Title is not null)
             Assert.Equal("Test Title", tags.Title);


### PR DESCRIPTION
Duration was not populated for some real-world `.opus` and `.wav` files, which made `MediaFile.ReadTags` return incomplete metadata.

## What changed
- Added Opus duration parsing in `OggOpusReader` by:
  - reading `OpusHead` pre-skip
  - using the final granule position for the stream serial
  - computing duration as `(lastGranule - preSkip) / 48000`
- Added WAV duration parsing in `WavReader` by:
  - reading `fmt ` data (`sampleRate`, `byteRate`, `blockAlign`)
  - preferring `fact` sample count when present
  - otherwise deriving duration from `data` chunk size
- Extended existing tests to assert duration is populated for `basic.opus` and `basic.wav`.
- Updated package version from `1.1.7` to `1.1.8` (from required update scripts).

## Validation
- `dotnet build src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj -c Release`
- `dotnet test tests/Meziantou.Framework.MediaTags.Tests/Meziantou.Framework.MediaTags.Tests.csproj -c Release` (tests pass; environment reports known `Blame` collector errors)
- Verified the targeted local files now return non-null durations.