### PR TITLE
Add XML comments to NoCacheMiddleware

### DIFF
--- a/src/Meziantou.AspNetCore/NoCacheMiddleware.cs
+++ b/src/Meziantou.AspNetCore/NoCacheMiddleware.cs
@@ -2,8 +2,17 @@ using Microsoft.AspNetCore.Http;
 
 namespace Meziantou.AspNetCore;
 
+/// <summary>
+/// Ensures responses are marked as non-cacheable when no Cache-Control header is already set.
+/// </summary>
+/// <param name="next">The next middleware in the pipeline.</param>
 public sealed class NoCacheMiddleware(RequestDelegate next)
 {
+    /// <summary>
+    /// Processes the request and adds a default non-cacheable Cache-Control header to the response when none is set.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <returns>A task that completes when the middleware has finished processing.</returns>
     public async Task InvokeAsync(HttpContext context)
     {
         context.Response.OnStarting(() =>


### PR DESCRIPTION
NoCacheMiddleware did not have XML documentation, which made its intent and API surface less clear in generated docs and IDE tooltips.

This change adds XML comments to `NoCacheMiddleware` and `InvokeAsync(HttpContext)` including parameter and return documentation. The middleware behavior is unchanged.