### PR TITLE
Use RUNS_ON env instead of IsLinuxArm64 workflow switch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 90
     env:
+      RUNS_ON: ${{ matrix.runs-on }}
       TestResultsDirectory: ${{ github.workspace}}/TestResults
     strategy:
       matrix:
@@ -203,7 +204,7 @@ jobs:
 
       - name: Build
         if: steps.build-project.outputs.has-project == 'true'
-        run: dotnet build ${{ steps.build-project.outputs.project }} --configuration ${{ matrix.configuration }} /bl /p:IsLinuxArm64=${{ matrix.runs-on == 'ubuntu-24.04-arm' }} ${{ matrix.additionalArguments }}
+        run: dotnet build ${{ steps.build-project.outputs.project }} --configuration ${{ matrix.configuration }} /bl ${{ matrix.additionalArguments }}
 
       - name: List environment variables
         if: steps.build-project.outputs.has-project == 'true'
@@ -211,7 +212,7 @@ jobs:
 
       - name: Run tests
         if: steps.build-project.outputs.has-project == 'true'
-        run: dotnet test ${{ steps.build-project.outputs.project }} --configuration ${{ matrix.configuration }} --no-build --results-directory "${{ env.TestResultsDirectory }}" /p:IsLinuxArm64=${{ matrix.runs-on == 'ubuntu-24.04-arm' }} ${{ matrix.additionalArguments }}
+        run: dotnet test ${{ steps.build-project.outputs.project }} --configuration ${{ matrix.configuration }} --no-build --results-directory "${{ env.TestResultsDirectory }}" ${{ matrix.additionalArguments }}
 
       - uses: actions/upload-artifact@v7
         if: always() && steps.build-project.outputs.has-project == 'true'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Build
         if: matrix.build-mode == 'manual' && steps.build-project.outputs.has-project == 'true'
-        run: dotnet build ${{ steps.build-project.outputs.project }} --configuration Release /p:IsLinuxArm64=false
+        run: dotnet build ${{ steps.build-project.outputs.project }} --configuration Release
 
       - name: Perform CodeQL Analysis
         if: matrix.language != 'csharp' || steps.build-project.outputs.has-project == 'true'

--- a/eng/build.platform-exclusions.proj
+++ b/eng/build.platform-exclusions.proj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <!-- GRPC tooling doesn't support Linux Arm64 (https://github.com/grpc/grpc/issues/38538) -->
-  <ItemGroup Condition="'$(IsLinuxArm64)' == 'true'">
+  <ItemGroup Condition="'$(RUNS_ON)' == 'ubuntu-24.04-arm'">
     <ProjectReference Remove="../src/Meziantou.Framework.OpenTelemetryCollector/Meziantou.Framework.OpenTelemetryCollector.csproj" />
     <ProjectReference Remove="../src/Meziantou.Framework.OpenTelemetryCollector.InMemory/Meziantou.Framework.OpenTelemetryCollector.InMemory.csproj" />
     <ProjectReference Remove="../tests/Meziantou.Framework.OpenTelemetry.Tests/Meziantou.Framework.OpenTelemetry.Tests.csproj" />


### PR DESCRIPTION
## Why
The workflow passed `/p:IsLinuxArm64=...` explicitly, but this was configuration-specific and duplicated runner knowledge in command lines. This change makes the condition implicit by exposing the runner label as an environment variable that MSBuild can read directly.

## What changed
- In `ci.yml`, exposed `RUNS_ON: ${{ matrix.runs-on }}` for the `build_and_test` job.
- Removed explicit `/p:IsLinuxArm64=...` from `dotnet build` and `dotnet test` in CI.
- In `eng/build.platform-exclusions.proj`, replaced the Linux Arm64 condition with `$(RUNS_ON) == 'ubuntu-24.04-arm'`.
- In `codeql.yml`, removed the explicit `/p:IsLinuxArm64=false` override so behavior is consistent with the env-driven approach.

## Notes
- The temporary `RUNS_ON` env block that had been added to CodeQL was removed as unnecessary during review.