### PR TITLE
Add command retries to update-readme script

### DIFF
--- a/eng/update-readme.cs
+++ b/eng/update-readme.cs
@@ -395,6 +395,30 @@ static string RunProcessAndCaptureOutput(string fileName, string[] arguments, Ti
 
 static (string StandardOutput, string StandardError) RunProcessAndCaptureOutputs(string fileName, string[] arguments, TimeSpan? timeout = null)
 {
+    TimeSpan[] retryDelays = [TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3)];
+    for (var attempt = 0; ; attempt++)
+    {
+        try
+        {
+            return RunProcessAndCaptureOutputsCore(fileName, arguments, timeout);
+        }
+        catch (TimeoutException) when (attempt < retryDelays.Length)
+        {
+            var retryDelay = retryDelays[attempt];
+            Console.Error.WriteLine($"WARNING: Process '{fileName} {string.Join(' ', arguments)}' timed out on attempt {attempt + 1}/{retryDelays.Length + 1}. Retrying in {retryDelay.TotalSeconds:F0}s...");
+            Thread.Sleep(retryDelay);
+        }
+        catch (InvalidOperationException) when (attempt < retryDelays.Length)
+        {
+            var retryDelay = retryDelays[attempt];
+            Console.Error.WriteLine($"WARNING: Process '{fileName} {string.Join(' ', arguments)}' failed on attempt {attempt + 1}/{retryDelays.Length + 1}. Retrying in {retryDelay.TotalSeconds:F0}s...");
+            Thread.Sleep(retryDelay);
+        }
+    }
+}
+
+static (string StandardOutput, string StandardError) RunProcessAndCaptureOutputsCore(string fileName, string[] arguments, TimeSpan? timeout = null)
+{
     var effectiveTimeout = timeout ?? TimeSpan.FromMinutes(2);
     var psi = new ProcessStartInfo(fileName)
     {


### PR DESCRIPTION
CI can intermittently fail while `eng/update-readme.cs` executes external commands. A single transient timeout or process error causes the README update step to fail.

This updates the process runner to retry all commands, not only `dotnet`, so transient failures are less likely to fail CI.

## What changed
- Added retry logic in `RunProcessAndCaptureOutputs` for every command execution
- Retries on timeout and non-zero exit failures (`TimeoutException` and `InvalidOperationException`)
- Uses short backoff between attempts (1s, then 3s), for 3 attempts total
- Keeps the existing failure behavior when retries are exhausted

## Notes
- The retry policy is centralized in one place, so all command paths in this script (build/help/suggest and others) inherit the same resilience behavior.