### PR TITLE
Refactor CI matrix to reusable build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test-matrix-entry.yml
+++ b/.github/workflows/build-and-test-matrix-entry.yml
@@ -79,15 +79,25 @@ jobs:
         if: steps.build-project.outputs.has-project == 'true'
         run: dotnet build ${{ steps.build-project.outputs.project }} --configuration ${{ inputs.configuration }} /bl ${{ inputs.additional_arguments }}
 
+      - id: pack-build-output
+        name: Archive build outputs
+        if: steps.build-project.outputs.has-project == 'true'
+        run: |
+          $ArchivePath = Join-Path $env:RUNNER_TEMP "build-output.tar"
+          if (Test-Path $ArchivePath) {
+            Remove-Item $ArchivePath -Force
+          }
+
+          tar -cf $ArchivePath artifacts/bin artifacts/obj
+          "archive-path=$ArchivePath" >> $env:GITHUB_OUTPUT
+
       - uses: actions/upload-artifact@v7
         if: always() && steps.build-project.outputs.has-project == 'true'
         with:
           name: ${{ steps.compute-artifact-name.outputs.artifact-name }}
           if-no-files-found: ${{ case(steps.build-project.outputs.project == 'eng/delta.proj', 'warn', 'error') }}
           retention-days: 3
-          path: |
-            **/bin/**/*
-            **/obj/**/*
+          path: ${{ steps.pack-build-output.outputs.archive-path }}
 
   test:
     runs-on: ${{ inputs.runs_on }}
@@ -136,7 +146,11 @@ jobs:
         if: steps.build-project.outputs.has-project == 'true'
         with:
           name: ${{ steps.compute-artifact-name.outputs.build-artifact-name }}
-          path: ${{ github.workspace }}
+          path: ${{ runner.temp }}/build-output
+
+      - name: Extract build outputs
+        if: steps.build-project.outputs.has-project == 'true'
+        run: tar -xf "${{ runner.temp }}/build-output/build-output.tar" -C ${{ github.workspace }}
 
       - name: List environment variables
         if: steps.build-project.outputs.has-project == 'true'

--- a/.github/workflows/build-and-test-matrix-entry.yml
+++ b/.github/workflows/build-and-test-matrix-entry.yml
@@ -1,0 +1,167 @@
+name: build_and_test_matrix_entry
+on:
+  workflow_call:
+    inputs:
+      runs_on:
+        required: true
+        type: string
+      configuration:
+        required: true
+        type: string
+      additional_arguments:
+        required: true
+        type: string
+      is_pull_request:
+        required: true
+        type: boolean
+      enable_code_coverage:
+        required: false
+        type: boolean
+        default: false
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: 90
+    env:
+      RUNS_ON: ${{ inputs.runs_on }}
+    steps:
+      - id: compute-artifact-name
+        name: Compute artifact name
+        run: |
+          $Name = "build-output-${{ inputs.runs_on }}-${{ inputs.configuration }}-${{inputs.additional_arguments}}".Replace(":", "_").Replace("/", "_")
+          "artifact-name=$Name" >> $env:GITHUB_OUTPUT
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: ${{ case(inputs.is_pull_request, 0, 1) }}
+      - run: git config --global protocol.file.allow always
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet
+
+      - name: Generate delta build file
+        id: build-project
+        uses: ./.github/actions/deltabuild
+        with:
+          input-project: eng/build.proj
+          output-project: eng/delta.proj
+          run-generate: ${{ case(inputs.is_pull_request, 'true', 'false') }}
+          full-rebuild-triggers: |
+            .github/workflows/ci.yml
+            .github/workflows/build-and-test-matrix-entry.yml
+            eng/**/*.proj
+
+      - name: PATH
+        if: steps.build-project.outputs.has-project == 'true'
+        run: echo $env:PATH
+
+      - name: .NET info
+        if: steps.build-project.outputs.has-project == 'true'
+        run: dotnet --info
+
+      - name: Enable ProjFS
+        if: startsWith(inputs.runs_on, 'windows') && steps.build-project.outputs.has-project == 'true'
+        run: |
+          $feature = Get-WindowsOptionalFeature -Online -FeatureName Client-ProjFS
+          if ($feature.State -ne 'Enabled') {
+            Enable-WindowsOptionalFeature -Online -FeatureName Client-ProjFS -NoRestart
+          }
+
+      - name: Build
+        if: steps.build-project.outputs.has-project == 'true'
+        run: dotnet build ${{ steps.build-project.outputs.project }} --configuration ${{ inputs.configuration }} /bl ${{ inputs.additional_arguments }}
+
+      - uses: actions/upload-artifact@v7
+        if: always() && steps.build-project.outputs.has-project == 'true'
+        with:
+          name: ${{ steps.compute-artifact-name.outputs.artifact-name }}
+          if-no-files-found: ${{ case(steps.build-project.outputs.project == 'eng/delta.proj', 'warn', 'error') }}
+          retention-days: 3
+          path: |
+            **/bin/**/*
+            **/obj/**/*
+
+  test:
+    runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: 90
+    needs: [build]
+    env:
+      RUNS_ON: ${{ inputs.runs_on }}
+      TestResultsDirectory: ${{ github.workspace}}/TestResults
+      EnableCodeCoverage: ${{ case(inputs.enable_code_coverage, 'true', 'false') }}
+    steps:
+      - id: compute-artifact-name
+        name: Compute artifact name
+        run: |
+          $SanitizedName = "${{ inputs.runs_on }}-${{ inputs.configuration }}-${{inputs.additional_arguments}}".Replace(":", "_").Replace("/", "_")
+          "artifact-name=test-results-$SanitizedName" >> $env:GITHUB_OUTPUT
+          "build-artifact-name=build-output-$SanitizedName" >> $env:GITHUB_OUTPUT
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: ${{ case(inputs.is_pull_request, 0, 1) }}
+      - run: git config --global protocol.file.allow always
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet
+
+      - name: Generate delta build file
+        id: build-project
+        uses: ./.github/actions/deltabuild
+        with:
+          input-project: eng/build.proj
+          output-project: eng/delta.proj
+          run-generate: ${{ case(inputs.is_pull_request, 'true', 'false') }}
+          full-rebuild-triggers: |
+            .github/workflows/ci.yml
+            .github/workflows/build-and-test-matrix-entry.yml
+            eng/**/*.proj
+
+      - name: Enable ProjFS
+        if: startsWith(inputs.runs_on, 'windows') && steps.build-project.outputs.has-project == 'true'
+        run: |
+          $feature = Get-WindowsOptionalFeature -Online -FeatureName Client-ProjFS
+          if ($feature.State -ne 'Enabled') {
+            Enable-WindowsOptionalFeature -Online -FeatureName Client-ProjFS -NoRestart
+          }
+
+      - uses: actions/download-artifact@v8
+        if: steps.build-project.outputs.has-project == 'true'
+        with:
+          name: ${{ steps.compute-artifact-name.outputs.build-artifact-name }}
+          path: ${{ github.workspace }}
+
+      - name: List environment variables
+        if: steps.build-project.outputs.has-project == 'true'
+        run: "Get-ChildItem env: | Sort-Object Name"
+
+      - name: Run tests
+        if: steps.build-project.outputs.has-project == 'true'
+        run: dotnet test ${{ steps.build-project.outputs.project }} --configuration ${{ inputs.configuration }} --no-build --results-directory "${{ env.TestResultsDirectory }}" /p:EnableCodeCoverage=${{ env.EnableCodeCoverage }} ${{ inputs.additional_arguments }}
+
+      - uses: actions/upload-artifact@v7
+        if: always() && steps.build-project.outputs.has-project == 'true'
+        with:
+          name: ${{ steps.compute-artifact-name.outputs.artifact-name }}
+          if-no-files-found: ${{ case(steps.build-project.outputs.project == 'eng/delta.proj', 'warn', 'error') }}
+          retention-days: 3
+          path: |
+            !**/*.coverage
+            **/*.binlog
+            ${{ env.TestResultsDirectory }}/**/*
+
+      - uses: actions/upload-artifact@v7
+        if: always() && steps.build-project.outputs.has-project == 'true' && env.EnableCodeCoverage == 'true'
+        with:
+          name: ${{ steps.compute-artifact-name.outputs.artifact-name }}-coverage
+          if-no-files-found: ${{ case(steps.build-project.outputs.project == 'eng/delta.proj', 'warn', 'error') }}
+          retention-days: 3
+          path: |
+            **/*.coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,12 +155,6 @@ jobs:
           NUGET_VALIDATION_IS_DELTA: ${{ case(github.event_name == 'pull_request' && needs.create_nuget.outputs.has-project == 'true', 'true', 'false') }}
 
   build_and_test:
-    runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 90
-    env:
-      RUNS_ON: ${{ matrix.runs-on }}
-      TestResultsDirectory: ${{ github.workspace}}/TestResults
-      EnableCodeCoverage: ${{ case(github.event_name == 'workflow_dispatch' && inputs.enable_code_coverage, 'true', 'false') }}
     strategy:
       matrix:
         # x64, arm64
@@ -168,78 +162,14 @@ jobs:
         configuration: [ Debug, Release ]
         additionalArguments: [ "", "/p:InvariantGlobalization=true" ]
       fail-fast: false
-    steps:
-      - id: compute-artifact-name
-        name: Compute artifact name
-        run: |
-          $Name = "test-results-${{ matrix.runs-on }}-${{ matrix.configuration }}-${{matrix.additionalArguments}}".Replace(":", "_").Replace("/", "_")
-          "artifact-name=$Name" >> $env:GITHUB_OUTPUT
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: ${{ case(github.event_name == 'pull_request', 0, 1) }}
-      - run: git config --global protocol.file.allow always
-
-      - name: Setup .NET
-        uses: ./.github/actions/setup-dotnet
-
-      - name: Generate delta build file
-        id: build-project
-        uses: ./.github/actions/deltabuild
-        with:
-          input-project: eng/build.proj
-          output-project: eng/delta.proj
-          run-generate: ${{ case(github.event_name == 'pull_request', 'true', 'false') }}
-          full-rebuild-triggers: |
-            .github/workflows/ci.yml
-            eng/**/*.proj
-
-      - name: PATH
-        if: steps.build-project.outputs.has-project == 'true'
-        run: echo $env:PATH
-
-      - name: .NET info
-        if: steps.build-project.outputs.has-project == 'true'
-        run: dotnet --info
-
-      - name: Enable ProjFS
-        if: startsWith(matrix.runs-on, 'windows') && steps.build-project.outputs.has-project == 'true'
-        run: |
-          $feature = Get-WindowsOptionalFeature -Online -FeatureName Client-ProjFS
-          if ($feature.State -ne 'Enabled') {
-            Enable-WindowsOptionalFeature -Online -FeatureName Client-ProjFS -NoRestart
-          }
-
-      - name: Build
-        if: steps.build-project.outputs.has-project == 'true'
-        run: dotnet build ${{ steps.build-project.outputs.project }} --configuration ${{ matrix.configuration }} /bl ${{ matrix.additionalArguments }}
-
-      - name: List environment variables
-        if: steps.build-project.outputs.has-project == 'true'
-        run: "Get-ChildItem env: | Sort-Object Name"
-
-      - name: Run tests
-        if: steps.build-project.outputs.has-project == 'true'
-        run: dotnet test ${{ steps.build-project.outputs.project }} --configuration ${{ matrix.configuration }} --no-build --results-directory "${{ env.TestResultsDirectory }}" /p:EnableCodeCoverage=${{ env.EnableCodeCoverage }} ${{ matrix.additionalArguments }}
-
-      - uses: actions/upload-artifact@v7
-        if: always() && steps.build-project.outputs.has-project == 'true'
-        with:
-          name: ${{ steps.compute-artifact-name.outputs.artifact-name }}
-          if-no-files-found: ${{ case(steps.build-project.outputs.project == 'eng/delta.proj', 'warn', 'error') }}
-          retention-days: 3
-          path: |
-            !**/*.coverage
-            **/*.binlog
-            ${{ env.TestResultsDirectory }}/**/*
-
-      - uses: actions/upload-artifact@v7
-        if: always() && steps.build-project.outputs.has-project == 'true' && env.EnableCodeCoverage == 'true'
-        with:
-          name: ${{ steps.compute-artifact-name.outputs.artifact-name }}-coverage
-          if-no-files-found: ${{ case(steps.build-project.outputs.project == 'eng/delta.proj', 'warn', 'error') }}
-          retention-days: 3
-          path: |
-            **/*.coverage
+    uses: ./.github/workflows/build-and-test-matrix-entry.yml
+    with:
+      runs_on: ${{ matrix.runs-on }}
+      configuration: ${{ matrix.configuration }}
+      additional_arguments: ${{ matrix.additionalArguments }}
+      is_pull_request: ${{ github.event_name == 'pull_request' }}
+      enable_code_coverage: ${{ github.event_name == 'workflow_dispatch' && inputs.enable_code_coverage }}
+    secrets: inherit
 
   test_trimming:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Running build and test inside one monolithic matrix job makes flaky test retries expensive. This change keeps the matrix in one place while moving execution to a reusable workflow so each matrix entry performs build then test immediately.

## Summary

- Keep the matrix definition in `.github/workflows/ci.yml` and replace inline `build_and_test` steps with a `uses` call.
- Add `.github/workflows/build-and-test-matrix-entry.yml` with two jobs:
  - `build`: runs delta-build logic, builds the selected project, and publishes compiled artifacts.
  - `test`: depends on `build`, downloads the matching artifact, and runs `dotnet test --no-build`.
- Preserve existing delta-build skip behavior (`has-project`), coverage toggling, and artifact publishing for test results and coverage.

## Notes

- This structure avoids duplicating the matrix while enabling targeted reruns of flaky test entries.
- Local required scripts and build completed; local full test run still hit existing AMSI test failures on this machine.