### PR TITLE
Parallelize CI tests per TFM

### DIFF
--- a/.github/workflows/build-and-test-matrix-entry.yml
+++ b/.github/workflows/build-and-test-matrix-entry.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Restore test dependencies
         if: steps.build-project.outputs.has-project == 'true'
-        run: dotnet restore ${{ steps.build-project.outputs.project }} --configuration ${{ inputs.configuration }} --framework ${{ matrix.target_framework }} ${{ inputs.additional_arguments }}
+        run: dotnet restore ${{ steps.build-project.outputs.project }} ${{ inputs.additional_arguments }}
 
       - name: Run tests
         if: steps.build-project.outputs.has-project == 'true'

--- a/.github/workflows/build-and-test-matrix-entry.yml
+++ b/.github/workflows/build-and-test-matrix-entry.yml
@@ -18,6 +18,9 @@ on:
         required: false
         type: boolean
         default: false
+      test_target_frameworks:
+        required: true
+        type: string
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -58,6 +61,7 @@ jobs:
             .github/workflows/ci.yml
             .github/workflows/build-and-test-matrix-entry.yml
             eng/**/*.proj
+            eng/test-target-frameworks.json
 
       - name: PATH
         if: steps.build-project.outputs.has-project == 'true'
@@ -103,6 +107,10 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: 90
     needs: [build]
+    strategy:
+      matrix:
+        target_framework: ${{ fromJSON(inputs.test_target_frameworks) }}
+      fail-fast: false
     env:
       RUNS_ON: ${{ inputs.runs_on }}
       TestResultsDirectory: ${{ github.workspace}}/TestResults
@@ -111,9 +119,10 @@ jobs:
       - id: compute-artifact-name
         name: Compute artifact name
         run: |
-          $SanitizedName = "${{ inputs.runs_on }}-${{ inputs.configuration }}-${{inputs.additional_arguments}}".Replace(":", "_").Replace("/", "_")
+          $SanitizedName = "${{ inputs.runs_on }}-${{ inputs.configuration }}-${{inputs.additional_arguments}}-${{ matrix.target_framework }}".Replace(":", "_").Replace("/", "_")
           "artifact-name=test-results-$SanitizedName" >> $env:GITHUB_OUTPUT
-          "build-artifact-name=build-output-$SanitizedName" >> $env:GITHUB_OUTPUT
+          $BuildArtifactName = "build-output-${{ inputs.runs_on }}-${{ inputs.configuration }}-${{inputs.additional_arguments}}".Replace(":", "_").Replace("/", "_")
+          "build-artifact-name=$BuildArtifactName" >> $env:GITHUB_OUTPUT
       - uses: actions/checkout@v6
         with:
           fetch-depth: ${{ case(inputs.is_pull_request, 0, 1) }}
@@ -133,6 +142,7 @@ jobs:
             .github/workflows/ci.yml
             .github/workflows/build-and-test-matrix-entry.yml
             eng/**/*.proj
+            eng/test-target-frameworks.json
 
       - name: Enable ProjFS
         if: startsWith(inputs.runs_on, 'windows') && steps.build-project.outputs.has-project == 'true'
@@ -158,7 +168,7 @@ jobs:
 
       - name: Run tests
         if: steps.build-project.outputs.has-project == 'true'
-        run: dotnet test ${{ steps.build-project.outputs.project }} --configuration ${{ inputs.configuration }} --no-build --results-directory "${{ env.TestResultsDirectory }}" /p:EnableCodeCoverage=${{ env.EnableCodeCoverage }} ${{ inputs.additional_arguments }}
+        run: dotnet test ${{ steps.build-project.outputs.project }} --configuration ${{ inputs.configuration }} --framework ${{ matrix.target_framework }} --no-build --results-directory "${{ env.TestResultsDirectory }}" /p:EnableCodeCoverage=${{ env.EnableCodeCoverage }} ${{ inputs.additional_arguments }}
 
       - uses: actions/upload-artifact@v7
         if: always() && steps.build-project.outputs.has-project == 'true'

--- a/.github/workflows/build-and-test-matrix-entry.yml
+++ b/.github/workflows/build-and-test-matrix-entry.yml
@@ -63,22 +63,6 @@ jobs:
             eng/**/*.proj
             eng/test-target-frameworks.json
 
-      - name: PATH
-        if: steps.build-project.outputs.has-project == 'true'
-        run: echo $env:PATH
-
-      - name: .NET info
-        if: steps.build-project.outputs.has-project == 'true'
-        run: dotnet --info
-
-      - name: Enable ProjFS
-        if: startsWith(inputs.runs_on, 'windows') && steps.build-project.outputs.has-project == 'true'
-        run: |
-          $feature = Get-WindowsOptionalFeature -Online -FeatureName Client-ProjFS
-          if ($feature.State -ne 'Enabled') {
-            Enable-WindowsOptionalFeature -Online -FeatureName Client-ProjFS -NoRestart
-          }
-
       - name: Build
         if: steps.build-project.outputs.has-project == 'true'
         run: dotnet build ${{ steps.build-project.outputs.project }} --configuration ${{ inputs.configuration }} /bl ${{ inputs.additional_arguments }}

--- a/.github/workflows/build-and-test-matrix-entry.yml
+++ b/.github/workflows/build-and-test-matrix-entry.yml
@@ -166,6 +166,10 @@ jobs:
         if: steps.build-project.outputs.has-project == 'true'
         run: "Get-ChildItem env: | Sort-Object Name"
 
+      - name: Restore test dependencies
+        if: steps.build-project.outputs.has-project == 'true'
+        run: dotnet restore ${{ steps.build-project.outputs.project }} --configuration ${{ inputs.configuration }} --framework ${{ matrix.target_framework }} ${{ inputs.additional_arguments }}
+
       - name: Run tests
         if: steps.build-project.outputs.has-project == 'true'
         run: dotnet test ${{ steps.build-project.outputs.project }} --configuration ${{ inputs.configuration }} --framework ${{ matrix.target_framework }} --no-build --results-directory "${{ env.TestResultsDirectory }}" /p:EnableCodeCoverage=${{ env.EnableCodeCoverage }} ${{ inputs.additional_arguments }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,39 @@ jobs:
       - name: Validate
         run: dotnet run ./eng/validate-testprojects-configuration.cs
 
+  load_test_target_frameworks:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      linux_tfms: ${{ steps.load.outputs.linux_tfms }}
+      mac_tfms: ${{ steps.load.outputs.mac_tfms }}
+      windows_tfms: ${{ steps.load.outputs.windows_tfms }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Load test target frameworks
+        id: load
+        run: |
+          $manifestPath = Join-Path $env:GITHUB_WORKSPACE "eng/test-target-frameworks.json"
+          $manifest = Get-Content -Raw $manifestPath | ConvertFrom-Json -AsHashtable
+
+          if (-not $manifest.ContainsKey("linux")) { throw "Missing 'linux' key in $manifestPath" }
+          if (-not $manifest.ContainsKey("mac")) { throw "Missing 'mac' key in $manifestPath" }
+          if (-not $manifest.ContainsKey("windows")) { throw "Missing 'windows' key in $manifestPath" }
+
+          "linux_tfms=$($manifest.linux | ConvertTo-Json -Compress)" >> $env:GITHUB_OUTPUT
+          "mac_tfms=$($manifest.mac | ConvertTo-Json -Compress)" >> $env:GITHUB_OUTPUT
+          "windows_tfms=$($manifest.windows | ConvertTo-Json -Compress)" >> $env:GITHUB_OUTPUT
+
+  validate_test_target_frameworks:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet
+      - name: Validate
+        run: dotnet run ./eng/validate-test-target-frameworks.cs
+
   validate_trimmable_projects:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -155,6 +188,7 @@ jobs:
           NUGET_VALIDATION_IS_DELTA: ${{ case(github.event_name == 'pull_request' && needs.create_nuget.outputs.has-project == 'true', 'true', 'false') }}
 
   build_and_test:
+    needs: [load_test_target_frameworks]
     strategy:
       matrix:
         # x64, arm64
@@ -169,6 +203,7 @@ jobs:
       additional_arguments: ${{ matrix.additionalArguments }}
       is_pull_request: ${{ github.event_name == 'pull_request' }}
       enable_code_coverage: ${{ github.event_name == 'workflow_dispatch' && inputs.enable_code_coverage }}
+      test_target_frameworks: ${{ case(startsWith(matrix.runs-on, 'windows'), needs.load_test_target_frameworks.outputs.windows_tfms, case(startsWith(matrix.runs-on, 'macos'), needs.load_test_target_frameworks.outputs.mac_tfms, needs.load_test_target_frameworks.outputs.linux_tfms)) }}
     secrets: inherit
 
   test_trimming:
@@ -232,7 +267,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-24.04
-    needs: [ build_eng_scripts, validate_bom, validate_readme, validate_test_projects, validate_trimmable_projects, validate_nuget, build_and_test, test_trimming, test_trimming_wpf ]
+    needs: [ build_eng_scripts, validate_bom, validate_readme, validate_test_projects, validate_test_target_frameworks, validate_trimmable_projects, validate_nuget, build_and_test, test_trimming, test_trimming_wpf ]
     permissions:
       contents: read
       id-token: write
@@ -333,7 +368,7 @@ jobs:
   final_status_check:
     runs-on: ubuntu-24.04
     if: always()
-    needs: [ build_eng_scripts, validate_bom, validate_readme, validate_test_projects, validate_trimmable_projects, create_nuget, validate_nuget, build_and_test, test_trimming, test_trimming_wpf, merge_coverage, deploy ]
+    needs: [ build_eng_scripts, validate_bom, validate_readme, validate_test_projects, load_test_target_frameworks, validate_test_target_frameworks, validate_trimmable_projects, create_nuget, validate_nuget, build_and_test, test_trimming, test_trimming_wpf, merge_coverage, deploy ]
     steps:
       - name: Check previous jobs status
         env:

--- a/eng/test-target-frameworks.json
+++ b/eng/test-target-frameworks.json
@@ -1,0 +1,20 @@
+{
+  "linux": [
+    "net8.0",
+    "net9.0",
+    "net10.0"
+  ],
+  "mac": [
+    "net8.0",
+    "net9.0",
+    "net10.0"
+  ],
+  "windows": [
+    "net8.0",
+    "net9.0",
+    "net10.0",
+    "net8.0-windows",
+    "net9.0-windows",
+    "net10.0-windows"
+  ]
+}

--- a/eng/validate-test-target-frameworks.cs
+++ b/eng/validate-test-target-frameworks.cs
@@ -1,0 +1,192 @@
+#:sdk Meziantou.NET.Sdk
+#:project ../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using Meziantou.Framework;
+
+if (args.Length > 0 && args[0] is "--help" or "-h")
+{
+    Console.WriteLine("Usage: dotnet run validate-test-target-frameworks.cs");
+    Console.WriteLine("Validates that eng/test-target-frameworks.json matches TFMs found in tests/**/*.csproj.");
+    return 0;
+}
+
+var rootPath = GetRepositoryRoot();
+var manifestPath = rootPath / "eng" / "test-target-frameworks.json";
+var testsRootPath = rootPath / "tests";
+
+if (!File.Exists(manifestPath))
+{
+    Console.Error.WriteLine($"ERROR: Cannot find manifest file: {manifestPath}");
+    return 1;
+}
+
+var manifest = LoadManifest(manifestPath);
+
+var testProjects = Directory.GetFiles(testsRootPath, "*.csproj", SearchOption.AllDirectories)
+    .Select(FullPath.FromPath)
+    .ToList();
+
+var tfms = new ConcurrentDictionary<string, bool>(StringComparer.Ordinal);
+Parallel.ForEach(testProjects, new ParallelOptions { MaxDegreeOfParallelism = 5 }, projectPath =>
+{
+    foreach (var tfm in GetProjectTargetFrameworksWithRetry(projectPath))
+    {
+        tfms.TryAdd(tfm, true);
+    }
+});
+
+var allTfms = tfms.Keys.OrderBy(static tfm => tfm, StringComparer.Ordinal).ToArray();
+var nonWindowsTfms = allTfms.Where(static tfm => !tfm.Contains("-windows", StringComparison.Ordinal)).ToArray();
+
+var hasErrors = false;
+hasErrors |= !ValidateManifestEntry("linux", manifest.Linux, nonWindowsTfms);
+hasErrors |= !ValidateManifestEntry("mac", manifest.Mac, nonWindowsTfms);
+hasErrors |= !ValidateManifestEntry("windows", manifest.Windows, allTfms);
+
+if (hasErrors)
+{
+    return 1;
+}
+
+Console.WriteLine("Test target framework manifest is valid.");
+return 0;
+
+static bool ValidateManifestEntry(string os, IEnumerable<string> expectedValues, IEnumerable<string> actualValues)
+{
+    var expected = expectedValues
+        .Where(static value => !string.IsNullOrWhiteSpace(value))
+        .Distinct(StringComparer.Ordinal)
+        .OrderBy(static value => value, StringComparer.Ordinal)
+        .ToArray();
+
+    var actual = actualValues
+        .Where(static value => !string.IsNullOrWhiteSpace(value))
+        .Distinct(StringComparer.Ordinal)
+        .OrderBy(static value => value, StringComparer.Ordinal)
+        .ToArray();
+
+    var missingFromManifest = actual.Except(expected, StringComparer.Ordinal).OrderBy(static value => value, StringComparer.Ordinal).ToArray();
+    var extraInManifest = expected.Except(actual, StringComparer.Ordinal).OrderBy(static value => value, StringComparer.Ordinal).ToArray();
+
+    if (missingFromManifest.Length == 0 && extraInManifest.Length == 0)
+    {
+        Console.WriteLine($"[{os}] OK ({string.Join(", ", expected)})");
+        return true;
+    }
+
+    Console.Error.WriteLine($"ERROR: Mismatch for '{os}' TFMs in eng/test-target-frameworks.json.");
+    if (missingFromManifest.Length > 0)
+    {
+        Console.Error.WriteLine($"  Missing in manifest: {string.Join(", ", missingFromManifest)}");
+    }
+
+    if (extraInManifest.Length > 0)
+    {
+        Console.Error.WriteLine($"  Extra in manifest: {string.Join(", ", extraInManifest)}");
+    }
+
+    Console.Error.WriteLine($"  Manifest value: {string.Join(", ", expected)}");
+    Console.Error.WriteLine($"  Actual value:   {string.Join(", ", actual)}");
+    return false;
+}
+
+static string[] GetProjectTargetFrameworksWithRetry(FullPath projectPath)
+{
+    var value = DotNetBuildGetPropertyWithRetry(projectPath, "TargetFrameworks");
+    if (string.IsNullOrWhiteSpace(value))
+    {
+        value = DotNetBuildGetPropertyWithRetry(projectPath, "TargetFramework");
+    }
+
+    return value
+        .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        .Distinct(StringComparer.Ordinal)
+        .OrderBy(static tfm => tfm, StringComparer.Ordinal)
+        .ToArray();
+}
+
+static string DotNetBuildGetPropertyWithRetry(FullPath projectPath, string propertyName, int maxAttempts = 3, int delaySeconds = 2)
+{
+    for (var attempt = 1; attempt <= maxAttempts; attempt++)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("build");
+        psi.ArgumentList.Add("--no-restore");
+        psi.ArgumentList.Add("--nologo");
+        psi.ArgumentList.Add("-v:q");
+        psi.ArgumentList.Add("--getProperty:" + propertyName);
+        psi.ArgumentList.Add(projectPath);
+
+        using var process = Process.Start(psi)!;
+        var output = process.StandardOutput.ReadToEnd().Trim();
+        var error = process.StandardError.ReadToEnd().Trim();
+        process.WaitForExit();
+
+        if (process.ExitCode == 0)
+        {
+            return output;
+        }
+
+        if (attempt < maxAttempts)
+        {
+            Console.WriteLine($"WARNING: Attempt {attempt} failed for {projectPath} ({propertyName}). Retrying in {delaySeconds} seconds...");
+            Thread.Sleep(delaySeconds * 1000);
+        }
+        else
+        {
+            throw new InvalidOperationException($"Failed to get {propertyName} for {projectPath} after {maxAttempts} attempts. {error}");
+        }
+    }
+
+    return ""; // unreachable
+}
+
+static FullPath GetRepositoryRoot() => FullPath.CurrentDirectory().FindRequiredGitRepositoryRoot();
+
+static TestTargetFrameworkManifest LoadManifest(FullPath manifestPath)
+{
+    using var document = JsonDocument.Parse(File.ReadAllText(manifestPath));
+    var root = document.RootElement;
+    if (root.ValueKind != JsonValueKind.Object)
+    {
+        throw new InvalidOperationException($"Invalid JSON in {manifestPath}. Expected an object.");
+    }
+
+    return new TestTargetFrameworkManifest(
+        Linux: GetRequiredStringArray(root, "linux", manifestPath),
+        Mac: GetRequiredStringArray(root, "mac", manifestPath),
+        Windows: GetRequiredStringArray(root, "windows", manifestPath));
+}
+
+static string[] GetRequiredStringArray(JsonElement root, string propertyName, FullPath manifestPath)
+{
+    if (!root.TryGetProperty(propertyName, out var property))
+    {
+        throw new InvalidOperationException($"Missing '{propertyName}' property in {manifestPath}.");
+    }
+
+    if (property.ValueKind != JsonValueKind.Array)
+    {
+        throw new InvalidOperationException($"Property '{propertyName}' in {manifestPath} must be an array.");
+    }
+
+    return property
+        .EnumerateArray()
+        .Select(static value => value.GetString())
+        .Where(static value => !string.IsNullOrWhiteSpace(value))
+        .Select(static value => value!)
+        .ToArray();
+}
+
+readonly record struct TestTargetFrameworkManifest(string[] Linux, string[] Mac, string[] Windows);

--- a/eng/validate-test-target-frameworks.cs
+++ b/eng/validate-test-target-frameworks.cs
@@ -189,4 +189,4 @@ static string[] GetRequiredStringArray(JsonElement root, string propertyName, Fu
         .ToArray();
 }
 
-readonly record struct TestTargetFrameworkManifest(string[] Linux, string[] Mac, string[] Windows);
+internal readonly record struct TestTargetFrameworkManifest(string[] Linux, string[] Mac, string[] Windows);


### PR DESCRIPTION
Add a test target framework manifest and validation script, then split reusable test execution by framework while keeping a single build per matrix entry.