### PR TITLE
Fix latest TFM condition for Windows target frameworks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <!-- disable the nullable warnings when compiling for target that haven't annotation -->
-  <PropertyGroup Condition="'$(TargetFramework)' != '$(LatestTargetFramework)'">
+  <PropertyGroup Condition="!$(TargetFramework.StartsWith('$(LatestTargetFramework)'))">
     <NoWarn>$(NoWarn);nullable;IDE0370</NoWarn>
   </PropertyGroup>
 

--- a/samples/Meziantou.Framework.Win32.AccessTokenConsole/Program.cs
+++ b/samples/Meziantou.Framework.Win32.AccessTokenConsole/Program.cs
@@ -18,8 +18,11 @@ internal static class Program
         Console.WriteLine("IsAdministrator " + IsAdministrator());
     }
 
-    private static void PrintToken(AccessToken token)
+    private static void PrintToken(AccessToken? token)
     {
+        if (token is null)
+            return;
+
         Console.WriteLine("Owner: " + token.GetOwner());
         Console.WriteLine("TokenType: " + token.GetTokenType());
         Console.WriteLine("ElevationType: " + token.GetElevationType());
@@ -27,17 +30,17 @@ internal static class Program
         Console.WriteLine("IsRestricted: " + token.IsRestricted());
         Console.WriteLine("MandatoryIntegrityLevel: " + token.GetMandatoryIntegrityLevel()?.Sid);
 
-        foreach (var group in token.EnumerateGroups())
+        foreach (var group in token.EnumerateGroups() ?? [])
         {
             Console.WriteLine($"Group: {group.Sid} ({group.Attributes})");
         }
 
-        foreach (var group in token.EnumerateRestrictedSid())
+        foreach (var group in token.EnumerateRestrictedSid() ?? [])
         {
             Console.WriteLine($"Restricted Group: {group.Sid} ({group.Attributes})");
         }
 
-        foreach (var privilege in token.EnumeratePrivileges())
+        foreach (var privilege in token.EnumeratePrivileges() ?? [])
         {
             Console.WriteLine($"Privilege: {privilege.Name} ({privilege.Attributes})");
         }
@@ -46,6 +49,9 @@ internal static class Program
     public static bool IsAdministrator()
     {
         using var token = AccessToken.OpenCurrentProcessToken(TokenAccessLevels.Query);
+        if (token is null)
+            return false;
+
         if (!IsAdministrator(token) && token.GetElevationType() == TokenElevationType.Limited)
         {
             using var linkedToken = token.GetLinkedToken();
@@ -54,10 +60,13 @@ internal static class Program
 
         return false;
 
-        static bool IsAdministrator(AccessToken accessToken)
+        static bool IsAdministrator(AccessToken? accessToken)
         {
+            if (accessToken is null)
+                return false;
+
             var adminSid = SecurityIdentifier.FromWellKnown(WellKnownSidType.WinBuiltinAdministratorsSid);
-            foreach (var group in accessToken.EnumerateGroups())
+            foreach (var group in accessToken.EnumerateGroups() ?? [])
             {
                 if (group.Attributes.HasFlag(GroupSidAttributes.SE_GROUP_ENABLED) && group.Sid == adminSid)
                     return true;

--- a/samples/Meziantou.Framework.Win32.CredentialManagerConsole/Program.cs
+++ b/samples/Meziantou.Framework.Win32.CredentialManagerConsole/Program.cs
@@ -1,6 +1,6 @@
 using Meziantou.Framework.Win32;
 
-CredentialResult creds;
+CredentialResult? creds;
 
 creds = CredentialManager.PromptForCredentialsConsole(
     target: "test",

--- a/src/Meziantou.Framework.WPF/Collections/Internals/DispatchedObservableCollection.cs
+++ b/src/Meziantou.Framework.WPF/Collections/Internals/DispatchedObservableCollection.cs
@@ -237,7 +237,7 @@ internal sealed class DispatchedObservableCollection<T> : ObservableCollectionBa
                     break;
 
                 case PendingEventType.AddRange:
-                    AddItems(pendingEvent.Items);
+                    AddItems(pendingEvent.Items!);
                     break;
 
                 case PendingEventType.Remove:
@@ -253,7 +253,7 @@ internal sealed class DispatchedObservableCollection<T> : ObservableCollectionBa
                     break;
 
                 case PendingEventType.InsertRange:
-                    InsertItems(pendingEvent.Index, pendingEvent.Items);
+                    InsertItems(pendingEvent.Index, pendingEvent.Items!);
                     break;
 
                 case PendingEventType.RemoveAt:
@@ -265,7 +265,7 @@ internal sealed class DispatchedObservableCollection<T> : ObservableCollectionBa
                     break;
 
                 case PendingEventType.Reset:
-                    Reset(pendingEvent.Items);
+                    Reset(pendingEvent.Items!);
                     break;
             }
         }

--- a/src/Meziantou.Framework.WPF/EnumLocalizationUtilities.cs
+++ b/src/Meziantou.Framework.WPF/EnumLocalizationUtilities.cs
@@ -8,7 +8,7 @@ namespace Meziantou.Framework.WPF;
 internal static class EnumLocalizationUtilities
 {
     private static readonly Dictionary<Type, LocalizedEnumValueCollection> EnumsCache = [];
-    private static readonly Dictionary<Expression, object> PropertiesCache = [];
+    private static readonly Dictionary<Expression, string?> PropertiesCache = [];
 
     public static LocalizedEnumValueCollection GetEnumLocalization<T>()
         where T : struct
@@ -53,22 +53,12 @@ internal static class EnumLocalizationUtilities
         {
             var memberExpression = (MemberExpression)exp.Body;
             var displayAttribute = memberExpression.Member.GetCustomAttribute<DisplayAttribute>();
-            if (displayAttribute is null)
-            {
-                value = memberExpression.Member.Name;
-            }
-            else
-            {
-                value = displayAttribute.GetName();
-            }
+            value = displayAttribute?.GetName() ?? memberExpression.Member.Name;
 
             PropertiesCache.Add(exp, value);
         }
 
-        if (value is DisplayAttribute attribute)
-            return attribute.GetName();
-
-        return value.ToString();
+        return value;
     }
 
     public static string GetEnumMemberLocalization(Enum value)

--- a/src/Meziantou.Framework.WPF/LocalizedEnumValue.cs
+++ b/src/Meziantou.Framework.WPF/LocalizedEnumValue.cs
@@ -38,7 +38,7 @@ public sealed class LocalizedEnumValue
         get
         {
             if (_displayAttribute is not null)
-                return _displayAttribute.GetName();
+                return _displayAttribute.GetName() ?? Value.ToString()!;
 
             return field!;
         }

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
@@ -21,7 +21,7 @@ namespace Meziantou.Framework.Win32.ProjectedFileSystem;
 ///         }
 ///     }
 ///
-///     protected override Stream OpenRead(string path)
+///     protected override Stream? OpenRead(string path)
 ///     {
 ///         if (AreFileNamesEqual(path, "file.txt"))
 ///             return new MemoryStream(Encoding.UTF8.GetBytes("Hello, World!"));
@@ -238,7 +238,7 @@ public abstract class ProjectedFileSystemBase : IDisposable
     /// <summary>When overridden in a derived class, opens a stream to read the content of a file at the specified path.</summary>
     /// <param name="path">The relative path of the file to read.</param>
     /// <returns>A <see cref="Stream"/> to read the file content, or <see langword="null"/> if the file does not exist.</returns>
-    protected abstract Stream OpenRead(string path);
+    protected abstract Stream? OpenRead(string path);
 
     public void Dispose()
     {

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/readme.md
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/readme.md
@@ -42,7 +42,7 @@ public class MyVirtualFileSystem : ProjectedFileSystemBase
     }
 
     // Return a stream to read the file content
-    protected override Stream OpenRead(string path)
+    protected override Stream? OpenRead(string path)
     {
         if (AreFileNamesEqual(path, "file1.txt"))
         {

--- a/tests/Meziantou.Framework.WPF.Tests/Collections/ObservableCollectionTests.cs
+++ b/tests/Meziantou.Framework.WPF.Tests/Collections/ObservableCollectionTests.cs
@@ -267,8 +267,17 @@ public sealed partial class ObservableCollectionTests
 
     private sealed class SampleComparer : IComparer<Sample>
     {
-        public int Compare(Sample x, Sample y)
+        public int Compare(Sample? x, Sample? y)
         {
+            if (ReferenceEquals(x, y))
+                return 0;
+
+            if (x is null)
+                return -1;
+
+            if (y is null)
+                return 1;
+
             return StringComparer.Ordinal.Compare(x.Value, y.Value);
         }
     }
@@ -307,12 +316,12 @@ public sealed partial class ObservableCollectionTests
             }
         }
 
-        private void NotifyCollectionChanged_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void NotifyCollectionChanged_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             CollectionChangedArgs.Add(e);
         }
 
-        private void NotifyPropertyChanged_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void NotifyPropertyChanged_PropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             PropertyChangedArgs.Add(e);
         }
@@ -326,6 +335,7 @@ public sealed partial class ObservableCollectionTests
         {
             Assert.Single(CollectionChangedArgs);
             var args = CollectionChangedArgs.Single(e => e.Action == NotifyCollectionChangedAction.Add);
+            Assert.NotNull(args.NewItems);
             Assert.Equal(obj, args.NewItems[0]);
             Assert.Equal(0, args.NewStartingIndex);
             Assert.Equal(-1, args.OldStartingIndex);
@@ -336,6 +346,7 @@ public sealed partial class ObservableCollectionTests
         {
             Assert.Single(CollectionChangedArgs);
             var args = CollectionChangedArgs.Single(e => e.Action == NotifyCollectionChangedAction.Add);
+            Assert.NotNull(args.NewItems);
             Assert.Equal(obj, args.NewItems.OfType<object>());
             Assert.Equal(startIndex, args.NewStartingIndex);
             Assert.Equal(-1, args.OldStartingIndex);
@@ -346,6 +357,7 @@ public sealed partial class ObservableCollectionTests
         {
             Assert.Single(CollectionChangedArgs);
             var args = CollectionChangedArgs.Single(e => e.Action == NotifyCollectionChangedAction.Remove);
+            Assert.NotNull(args.OldItems);
             Assert.Equal(obj, args.OldItems[0]);
             Assert.Equal(-1, args.NewStartingIndex);
             Assert.Equal(0, args.OldStartingIndex);
@@ -366,6 +378,8 @@ public sealed partial class ObservableCollectionTests
         {
             Assert.Single(CollectionChangedArgs);
             var args = CollectionChangedArgs.Single(e => e.Action == NotifyCollectionChangedAction.Replace);
+            Assert.NotNull(args.NewItems);
+            Assert.NotNull(args.OldItems);
             Assert.Equal(newValue, args.NewItems[0]);
             Assert.Equal(oldValue, args.OldItems[0]);
             Assert.Equal(0, args.NewStartingIndex);

--- a/tests/Meziantou.Framework.WPF.Tests/DispatcherExtensionsTests.cs
+++ b/tests/Meziantou.Framework.WPF.Tests/DispatcherExtensionsTests.cs
@@ -8,7 +8,7 @@ public sealed class DispatcherExtensionsTests
     [Fact(Timeout = 95000)]
     public async Task SwitchToUIThreadTests()
     {
-        Dispatcher dispatcher = null;
+        Dispatcher? dispatcher = null;
         var t = new Thread(() =>
         {
             dispatcher = Dispatcher.CurrentDispatcher;
@@ -19,15 +19,18 @@ public sealed class DispatcherExtensionsTests
         };
         t.Start();
 
-        while ((dispatcher = Volatile.Read(ref dispatcher)) is null)
+        while (Volatile.Read(ref dispatcher) is null)
         {
             await Task.Delay(1);
         }
 
+        var currentDispatcher = Volatile.Read(ref dispatcher);
+        Assert.NotNull(currentDispatcher);
+
         Assert.NotEqual(t.ManagedThreadId, Environment.CurrentManagedThreadId);
-        await dispatcher.SwitchToDispatcherThread();
+        await currentDispatcher.SwitchToDispatcherThread();
         Assert.Equal(t.ManagedThreadId, Environment.CurrentManagedThreadId);
 
-        dispatcher.BeginInvokeShutdown(DispatcherPriority.Background);
+        currentDispatcher.BeginInvokeShutdown(DispatcherPriority.Background);
     }
 }

--- a/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
+++ b/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
@@ -48,25 +48,28 @@ public sealed class AccessTokenTests
         _output.WriteLine("WellKnownSID " + SecurityIdentifier.FromWellKnown(WellKnownSidType.WinLowLabelSid));
     }
 
-    private void PrintToken(AccessToken token)
+    private void PrintToken(AccessToken? token)
     {
+        if (token is null)
+            return;
+
         _output.WriteLine("Owner: " + token.GetOwner());
         _output.WriteLine("TokenType: " + token.GetTokenType());
         _output.WriteLine("ElevationType: " + token.GetElevationType());
         _output.WriteLine("IsElevatedToken: " + token.IsElevated());
         _output.WriteLine("IsRestricted: " + token.IsRestricted());
         _output.WriteLine("MandatoryIntegrityLevel: " + token.GetMandatoryIntegrityLevel()?.Sid);
-        foreach (var group in token.EnumerateGroups())
+        foreach (var group in token.EnumerateGroups() ?? [])
         {
             _output.WriteLine($"Group: {group.Sid} ({group.Attributes})");
         }
 
-        foreach (var group in token.EnumerateRestrictedSid())
+        foreach (var group in token.EnumerateRestrictedSid() ?? [])
         {
             _output.WriteLine($"Restricted Group: {group.Sid} ({group.Attributes})");
         }
 
-        foreach (var privilege in token.EnumeratePrivileges())
+        foreach (var privilege in token.EnumeratePrivileges() ?? [])
         {
             _output.WriteLine($"Privilege: {privilege.Name} ({privilege.Attributes})");
         }
@@ -75,6 +78,9 @@ public sealed class AccessTokenTests
     public static bool IsAdministrator()
     {
         using var token = AccessToken.OpenCurrentProcessToken(TokenAccessLevels.Query);
+        if (token is null)
+            return false;
+
         if (!IsAdministrator(token) && token.GetElevationType() == TokenElevationType.Limited)
         {
             using var linkedToken = token.GetLinkedToken();
@@ -83,10 +89,13 @@ public sealed class AccessTokenTests
 
         return false;
 
-        static bool IsAdministrator(AccessToken accessToken)
+        static bool IsAdministrator(AccessToken? accessToken)
         {
+            if (accessToken is null)
+                return false;
+
             var adminSid = SecurityIdentifier.FromWellKnown(WellKnownSidType.WinBuiltinAdministratorsSid);
-            foreach (var group in accessToken.EnumerateGroups())
+            foreach (var group in accessToken.EnumerateGroups() ?? [])
             {
                 if (group.Attributes.HasFlag(GroupSidAttributes.SE_GROUP_ENABLED) && group.Sid == adminSid)
                     return true;

--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
@@ -12,7 +12,7 @@ public class ChangeJournalTests
         {
             var file = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".tmp");
             var fileName = Path.GetFileName(file);
-            var drive = Path.GetPathRoot(file);
+            var drive = Path.GetPathRoot(file) ?? throw new InvalidOperationException("Cannot determine drive root");
             using var changeJournal = ChangeJournal.Open(new DriveInfo(drive));
             var item = changeJournal.Entries.OfType<ChangeJournalEntryVersion2or3>().FirstOrDefault(entry => string.Equals(entry.Name, fileName, StringComparison.Ordinal));
             Assert.Null(item);
@@ -37,7 +37,7 @@ public class ChangeJournalTests
         {
             var file = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".tmp");
             var fileName = Path.GetFileName(file);
-            var drive = Path.GetPathRoot(file);
+            var drive = Path.GetPathRoot(file) ?? throw new InvalidOperationException("Cannot determine drive root");
             using var changeJournal = ChangeJournal.Open(new DriveInfo(drive));
             var item = changeJournal.Entries.OfType<ChangeJournalEntryVersion2or3>().FirstOrDefault(entry => string.Equals(entry.Name, fileName, StringComparison.Ordinal));
             Assert.Null(item);
@@ -56,7 +56,7 @@ public class ChangeJournalTests
         Retry(() =>
         {
             var file = Path.GetTempFileName();
-            var drive = Path.GetPathRoot(file);
+            var drive = Path.GetPathRoot(file) ?? throw new InvalidOperationException("Cannot determine drive root");
             using var changeJournal = ChangeJournal.Open(new DriveInfo(drive));
             var entries = changeJournal.Entries.ToList();
             Assert.True(entries.Count >= 0);
@@ -69,7 +69,7 @@ public class ChangeJournalTests
         Retry(() =>
         {
             var file = Path.GetTempFileName();
-            var drive = Path.GetPathRoot(file);
+            var drive = Path.GetPathRoot(file) ?? throw new InvalidOperationException("Cannot determine drive root");
             using var changeJournal = ChangeJournal.Open(new DriveInfo(drive), unprivileged: true);
             var entries = changeJournal.GetEntries(ChangeReason.FileCreate, returnOnlyOnClose: false, TimeSpan.FromSeconds(10)).ToList();
             Assert.True(entries.Count >= 0);

--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
@@ -27,6 +27,7 @@ public sealed class CredentialManagerTests : IDisposable
         CredentialManager.WriteCredential(_credentialName1, "John", "Doe", "Test", CredentialPersistence.Session);
 
         var cred = CredentialManager.ReadCredential(_credentialName1);
+        Assert.NotNull(cred);
         Assert.Equal(_credentialName1, cred.ApplicationName);
         Assert.Equal("John", cred.UserName);
         Assert.Equal("Doe", cred.Password);
@@ -61,6 +62,7 @@ public sealed class CredentialManagerTests : IDisposable
         CredentialManager.WriteCredential(_credentialName1, "John", "Doe", comment, CredentialPersistence.Session);
 
         var cred = CredentialManager.ReadCredential(_credentialName1);
+        Assert.NotNull(cred);
         Assert.Equal(_credentialName1, cred.ApplicationName);
         Assert.Equal("John", cred.UserName);
         Assert.Equal("Doe", cred.Password);
@@ -82,6 +84,7 @@ public sealed class CredentialManagerTests : IDisposable
         CredentialManager.WriteCredential(_credentialName1, "John", secret, CredentialPersistence.Session);
 
         var cred = CredentialManager.ReadCredential(_credentialName1);
+        Assert.NotNull(cred);
         Assert.Equal(secret, cred.Password);
 
         CredentialManager.DeleteCredential(_credentialName1);

--- a/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
+++ b/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
@@ -25,6 +25,7 @@ public class JobObjectTests
         };
 
         using var process = Process.Start(psi);
+        Assert.NotNull(process);
         Assert.False(process.WaitForExit(500)); // Ensure process is started
 
         job.AssignProcess(process);
@@ -51,6 +52,7 @@ public class JobObjectTests
         };
 
         using var process = Process.Start(psi);
+        Assert.NotNull(process);
         Assert.False(process.WaitForExit(500)); // Ensure process is started
 
         job.AssignProcess(process);
@@ -100,12 +102,12 @@ public class JobObjectTests
 
             using (new JobObject("JobObjectTests"))
             {
-                JobObject job = JobObject.Open(JobObjectAccessRights.Query, false, "JobObjectTests");
+                using var job = JobObject.Open(JobObjectAccessRights.Query, false, "JobObjectTests");
                 Assert.NotNull(job);
-                job.Dispose();
-                Assert.True(JobObject.TryOpen(JobObjectAccessRights.Query, false, "JobObjectTests", out job));
-                Assert.NotNull(job);
-                job.Dispose();
+
+                Assert.True(JobObject.TryOpen(JobObjectAccessRights.Query, false, "JobObjectTests", out JobObject? openedJob));
+                Assert.NotNull(openedJob);
+                openedJob.Dispose();
             }
         }
         finally

--- a/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
+++ b/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
@@ -23,7 +23,9 @@ public sealed class MarkOfTheWebTests
 
         MarkOfTheWeb.SetFileZone(path, UrlZone.Internet);
 
-        Assert.Equal("[ZoneTransfer]\nZoneId=3\n", MarkOfTheWeb.GetFileZoneContent(path).ReplaceLineEndings("\n"));
+        var zoneContent = MarkOfTheWeb.GetFileZoneContent(path);
+        Assert.NotNull(zoneContent);
+        Assert.Equal("[ZoneTransfer]\nZoneId=3\n", zoneContent.ReplaceLineEndings("\n"));
         Assert.Equal(UrlZone.Internet, MarkOfTheWeb.GetFileZone(path));
         Assert.True(MarkOfTheWeb.IsUntrusted(path));
 
@@ -37,7 +39,9 @@ public sealed class MarkOfTheWebTests
         File.WriteAllBytes(path, []);
 
         MarkOfTheWeb.SetFileZone(path, UrlZone.Internet);
-        Assert.NotEmpty(MarkOfTheWeb.GetFileZoneContent(path));
+        var zoneContent = MarkOfTheWeb.GetFileZoneContent(path);
+        Assert.NotNull(zoneContent);
+        Assert.NotEmpty(zoneContent);
 
         MarkOfTheWeb.RemoveFileZone(path);
         Assert.Null(MarkOfTheWeb.GetFileZoneContent(path));

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemFactAttribute.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemFactAttribute.cs
@@ -5,7 +5,7 @@ namespace Meziantou.Framework.Win32.ProjectedFileSystem;
 [AttributeUsage(AttributeTargets.All)]
 public sealed class ProjectedFileSystemFactAttribute : FactAttribute
 {
-    public ProjectedFileSystemFactAttribute([CallerFilePath] string sourceFilePath = null, [CallerLineNumber] int sourceLineNumber = -1)
+    public ProjectedFileSystemFactAttribute([CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = -1)
         : base(sourceFilePath, sourceLineNumber)
     {
         var guid = Guid.NewGuid();

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/SampleVirtualFileSystem.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/SampleVirtualFileSystem.cs
@@ -22,7 +22,7 @@ internal sealed class SampleVirtualFileSystem : ProjectedFileSystemBase
     }
 
     [SuppressMessage("Style", "IDE0230:Use UTF-8 string literal", Justification = "")]
-    protected override Stream OpenRead(string path)
+    protected override Stream? OpenRead(string path)
     {
         if (AreFileNamesEqual(path, "a"))
         {


### PR DESCRIPTION
The nullable-warning suppression condition in `Directory.Build.props` only matched `net10.0`, so `net10.0-windows` was treated as a non-latest TFM. This caused inconsistent analyzer behavior for latest Windows targets.

This PR switches the condition to a prefix check so both `net10.0` and `net10.0-windows` are treated as latest TFMs, then fixes the nullability issues that surfaced under that stricter behavior.

- Update the build condition to use `TargetFramework.StartsWith(LatestTargetFramework)`.
- Fix nullable flow issues in affected Win32 samples/tests and WPF tests.
- Align `ProjectedFileSystemBase.OpenRead` and related test overrides/docs with nullable return semantics.
- Tighten a few event/test helper signatures and null guards to satisfy current compiler annotations.

This keeps nullable enforcement consistent across latest framework variants while preserving behavior.