### PR TITLE
Remove redundant top-level #nullable enable directives

### DIFF
--- a/common/ConsoleHelper.cs
+++ b/common/ConsoleHelper.cs
@@ -1,4 +1,3 @@
-#nullable enable
 #pragma warning disable CA1001
 #pragma warning disable CA2213
 #pragma warning disable CA2215

--- a/common/SharedHttpClient.cs
+++ b/common/SharedHttpClient.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Meziantou.Framework;
 
 internal static class SharedHttpClient

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/NullExternalScopeProvider.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/NullExternalScopeProvider.cs
@@ -1,4 +1,3 @@
-﻿#nullable enable
 using Microsoft.Extensions.Logging;
 
 namespace Meziantou.Extensions.Logging.InMemory.Tests;

--- a/tests/Meziantou.Framework.Http.Caching.Tests/Internals/HttpTestContext.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/Internals/HttpTestContext.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Net;
 using System.Net.Http;
 using System.Runtime.CompilerServices;

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Meziantou.Framework.InlineSnapshotTesting.Serialization;
 using Meziantou.Framework.InlineSnapshotTesting.SnapshotUpdateStrategies;
 using TestUtilities;

--- a/tests/Meziantou.Framework.JsonPath.Tests/ComplianceTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/ComplianceTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Xunit.Sdk;

--- a/tests/Meziantou.Framework.NtpClient.Tests/NtpClientTests.cs
+++ b/tests/Meziantou.Framework.NtpClient.Tests/NtpClientTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Net;
 using Meziantou.Framework.Ntp;
 using TestUtilities;

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Diagnostics;
 using System.Text;
 

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Text.RegularExpressions;
 using Meziantou.Framework.SnapshotTesting.MergeTools;
 

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTypeTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTypeTests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Meziantou.Framework.SnapshotTesting.Tests;
 
 public sealed class SnapshotTypeTests

--- a/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
+++ b/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Globalization;
 using System.Text;
 using Xunit;

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Meziantou.Framework.Versioning.Tests;
 
 public class SemanticVersionRangeTests


### PR DESCRIPTION
Nullable is enabled by default for this repository, so file-level `#nullable enable` directives are redundant and add noise.

This PR removes those top-of-file directives from the affected shared helper and test files, while keeping scoped `#nullable` directives that are intentionally used inside tests.

No behavioral changes are intended; this is a cleanup-only change.

## Notes
- Full solution tests on macOS still include known AMSI test failures (`Meziantou.Framework.Win32.AmsiTests`) because `Amsi.dll` is not available on this platform.