### PR TITLE
Enable 2-way DeltaBuild test sharding in CI

### DIFF
--- a/.github/actions/deltabuild/action.yml
+++ b/.github/actions/deltabuild/action.yml
@@ -22,6 +22,18 @@ inputs:
     description: Whether to run DeltaBuild generation
     required: false
     default: "true"
+  test-projects-only:
+    description: Whether to include only test projects
+    required: false
+    default: "false"
+  shard:
+    description: Optional shard number to pass to DeltaBuild
+    required: false
+    default: ""
+  total-shards:
+    description: Optional total shard count to pass to DeltaBuild
+    required: false
+    default: ""
 
 outputs:
   project:
@@ -48,6 +60,9 @@ runs:
         OUTPUT_PROJECT: ${{ inputs.output-project }}
         TRAVERSAL_AFTER_IMPORT: ${{ inputs.traversal-after-import }}
         FULL_REBUILD_TRIGGERS: ${{ inputs.full-rebuild-triggers }}
+        TEST_PROJECTS_ONLY: ${{ inputs.test-projects-only }}
+        SHARD: ${{ inputs.shard }}
+        TOTAL_SHARDS: ${{ inputs.total-shards }}
       run: |
         $arguments = @(
           "generate"
@@ -56,6 +71,18 @@ runs:
           "--traversal-after-import", $env:TRAVERSAL_AFTER_IMPORT
           "--no-output-if-empty"
         )
+
+        if ($env:TEST_PROJECTS_ONLY -eq "true") {
+          $arguments += "--test-projects-only"
+        }
+
+        if ($env:SHARD) {
+          $arguments += @("--shard", $env:SHARD)
+        }
+
+        if ($env:TOTAL_SHARDS) {
+          $arguments += @("--total-shards", $env:TOTAL_SHARDS)
+        }
 
         $env:FULL_REBUILD_TRIGGERS -split "`n" | ForEach-Object {
           $trigger = $_.Trim()

--- a/.github/workflows/build-and-test-matrix-entry.yml
+++ b/.github/workflows/build-and-test-matrix-entry.yml
@@ -103,6 +103,10 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: 90
     needs: [build]
+    strategy:
+      matrix:
+        shard: [1, 2]
+      fail-fast: false
     env:
       RUNS_ON: ${{ inputs.runs_on }}
       TestResultsDirectory: ${{ github.workspace}}/TestResults
@@ -112,7 +116,7 @@ jobs:
         name: Compute artifact name
         run: |
           $SanitizedName = "${{ inputs.runs_on }}-${{ inputs.configuration }}-${{inputs.additional_arguments}}".Replace(":", "_").Replace("/", "_")
-          "artifact-name=test-results-$SanitizedName" >> $env:GITHUB_OUTPUT
+          "artifact-name=test-results-$SanitizedName-shard-${{ matrix.shard }}" >> $env:GITHUB_OUTPUT
           "build-artifact-name=build-output-$SanitizedName" >> $env:GITHUB_OUTPUT
       - uses: actions/checkout@v6
         with:
@@ -129,6 +133,9 @@ jobs:
           input-project: eng/build.proj
           output-project: eng/delta.proj
           run-generate: ${{ case(inputs.is_pull_request, 'true', 'false') }}
+          test-projects-only: "true"
+          shard: ${{ matrix.shard }}
+          total-shards: 2
           full-rebuild-triggers: |
             .github/workflows/ci.yml
             .github/workflows/build-and-test-matrix-entry.yml


### PR DESCRIPTION
CI test execution currently uses a single delta traversal project, which misses the new DeltaBuild sharding support for test workloads. This updates CI to split test project selection into 2 shards while keeping build behavior stable.

The DeltaBuild composite action now accepts optional test-sharding inputs and maps them to `generate` flags (`--test-projects-only`, `--shard`, `--total-shards`). The reusable `build-and-test-matrix-entry` workflow applies those inputs only in the `test` job with a `shard: [1, 2]` matrix.

Artifact naming now includes the shard id so uploads from parallel test shards cannot collide. The build job remains unsharded, so build outputs are still produced once and reused by both test shards.