### PR TITLE
Improve URL log highlighting with URI validation

### DIFF
--- a/src/Meziantou.AspNetCore.Components.LogViewer/LogHighlighters/UrlLogHighlighter.cs
+++ b/src/Meziantou.AspNetCore.Components.LogViewer/LogHighlighters/UrlLogHighlighter.cs
@@ -13,10 +13,43 @@ public partial class UrlLogHighlighter : ILogHighlighter
         var matches = UrlRegex().Matches(text);
         foreach (Match match in matches)
         {
-            yield return new LogHighlighterResult(match.Index, match.Length, Priority: 0) { Link = match.Value };
+            if (!TryGetHttpUrl(match.Value, out var url))
+                continue;
+
+            yield return new LogHighlighterResult(match.Index, url.Length, Priority: 0) { Link = url };
         }
     }
 
-    [GeneratedRegex(@"(http|https)://([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant, matchTimeoutMilliseconds: 2000)]
+    private static bool TryGetHttpUrl(string value, out string url)
+    {
+        url = value;
+        while (url.Length > 0)
+        {
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && IsHttpScheme(uri.Scheme))
+            {
+                return true;
+            }
+
+            if (!ShouldTrimTrailingCharacter(url[^1]))
+                break;
+
+            url = url[..^1];
+        }
+
+        url = string.Empty;
+        return false;
+    }
+
+    private static bool IsHttpScheme(string scheme)
+    {
+        return scheme == Uri.UriSchemeHttp || scheme == Uri.UriSchemeHttps;
+    }
+
+    private static bool ShouldTrimTrailingCharacter(char c)
+    {
+        return c is '.' or ',' or ';' or ':' or ')' or ']' or '}' or '!';
+    }
+
+    [GeneratedRegex(@"https?://[^\s""'<>]+", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.NonBacktracking, matchTimeoutMilliseconds: 5000)]
     private static partial Regex UrlRegex();
 }

--- a/tests/Meziantou.AspNetCore.Components.LogViewer.Tests/LogHighlighterTests.cs
+++ b/tests/Meziantou.AspNetCore.Components.LogViewer.Tests/LogHighlighterTests.cs
@@ -36,4 +36,37 @@ public class LogHighlighterTests
         var result = Highlight("a http://test.com 'sample' b", new UrlLogHighlighter(), new QuoteLogHighlighter());
         Assert.Equal("a <a scope class='log-message-match-link' target='_blank' href='http://test.com'>http://test.com</a> &#x27;<span scope class='log-message-match'>sample</span>&#x27; b", result);
     }
+
+    [Fact]
+    public void MatchLocalhostUrl()
+    {
+        var result = Highlight("a http://localhost:5000/path b", new UrlLogHighlighter());
+        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' href='http://localhost:5000/path'>http://localhost:5000/path</a> b", result);
+    }
+
+    [Fact]
+    public void MatchUrlWithTrailingPunctuation()
+    {
+        var result = Highlight("a http://test.com, b", new UrlLogHighlighter());
+        Assert.Equal("a <a scope class='log-message-match-link' target='_blank' href='http://test.com'>http://test.com</a>, b", result);
+    }
+
+    [Fact]
+    public void LongInvalidUrlDoesNotTimeout()
+    {
+        var input = "http://test.com:" + new string('9', 200_000);
+        var highlighter = new UrlLogHighlighter();
+        var count = 0;
+
+        var exception = Record.Exception(() =>
+        {
+            foreach (var _ in highlighter.Process(input))
+            {
+                count++;
+            }
+        });
+
+        Assert.Null(exception);
+        Assert.Equal(0, count);
+    }
 }


### PR DESCRIPTION
## Why
The URL highlighter regex could still hit timeout-related edge cases and did not reliably handle valid URLs like localhost or URLs followed by punctuation.

## What changed
- Switched URL detection to a hybrid approach:
  - Use a fast non-backtracking regex to extract URL candidates.
  - Validate each candidate with `Uri.TryCreate` and only accept `http`/`https` schemes.
- Increased regex timeout to 5000 ms.
- Added trailing punctuation trimming (`. , ; : ) ] } !`) before final URI validation so surrounding punctuation is not included in links.

## Tests
- Updated `LogHighlighterTests` with:
  - `MatchLocalhostUrl`
  - `MatchUrlWithTrailingPunctuation`
  - `LongInvalidUrlDoesNotTimeout` (adapted for the hybrid matcher)
- Ran required repository scripts and the LogViewer test project.