### PR TITLE
Use shard-separate for selected test projects

### DIFF
--- a/.github/actions/deltabuild/action.yml
+++ b/.github/actions/deltabuild/action.yml
@@ -34,6 +34,12 @@ inputs:
     description: Optional total shard count to pass to DeltaBuild
     required: false
     default: ""
+  shard-separate:
+    description: |
+      Newline-separated list of projects.
+      Each entry is passed as --shard-separate.
+    required: false
+    default: ""
 
 outputs:
   project:
@@ -63,6 +69,7 @@ runs:
         TEST_PROJECTS_ONLY: ${{ inputs.test-projects-only }}
         SHARD: ${{ inputs.shard }}
         TOTAL_SHARDS: ${{ inputs.total-shards }}
+        SHARD_SEPARATE: ${{ inputs.shard-separate }}
       run: |
         $arguments = @(
           "generate"
@@ -82,6 +89,13 @@ runs:
 
         if ($env:TOTAL_SHARDS) {
           $arguments += @("--total-shards", $env:TOTAL_SHARDS)
+        }
+
+        $env:SHARD_SEPARATE -split "`n" | ForEach-Object {
+          $project = $_.Trim()
+          if ($project) {
+            $arguments += @("--shard-separate", $project)
+          }
         }
 
         $env:FULL_REBUILD_TRIGGERS -split "`n" | ForEach-Object {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,10 @@ jobs:
           test-projects-only: "true"
           shard: ${{ matrix.shard }}
           total-shards: 2
+          shard-separate: |
+            tests/Meziantou.Framework.InlineSnapshotTesting.Tests
+            tests/Meziantou.Framework.PublicApiGenerator.Tests
+            tests/Meziantou.Framework.SnapshotTesting.Tests/
           full-rebuild-triggers: |
             .github/workflows/ci.yml
             eng/**/*.proj


### PR DESCRIPTION
Test shard computation needs a way to keep a few heavy test projects separated so shard balancing is more predictable. This updates the DeltaBuild workflow wiring to pass repeated `--shard-separate` arguments for the requested projects.

## What changed
- Added an optional `shard-separate` input to `.github/actions/deltabuild/action.yml`.
- Updated the action script to parse newline-separated entries and append one `--shard-separate <project>` argument per entry.
- Updated `.github/workflows/ci.yml` (`build_and_test` -> `Generate delta build file`) to pass these projects in order:
  1. `tests/Meziantou.Framework.InlineSnapshotTesting.Tests`
  2. `tests/Meziantou.Framework.PublicApiGenerator.Tests`
  3. `tests/Meziantou.Framework.SnapshotTesting.Tests/`

This keeps existing shard behavior unchanged for other projects while explicitly separating the three listed test projects.