### PR TITLE
Remove unnecessary Tool collection attributes in tests

### DIFF
--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
@@ -8,7 +8,6 @@ using NuGet.Versioning;
 
 namespace Meziantou.Framework.DependencyScanning.Tool.Tests;
 
-[Collection("Tool")] // Ensure tests run sequentially
 public sealed class FunctionalTests
 {
     private readonly ITestOutputHelper _testOutputHelper;

--- a/tests/Meziantou.Framework.Html.Tool.Tests/HtmlToolTests.cs
+++ b/tests/Meziantou.Framework.Html.Tool.Tests/HtmlToolTests.cs
@@ -1,6 +1,5 @@
 namespace Meziantou.Framework.Html.Tool.Tests;
 
-[Collection("Tool")] // Ensure tests run sequentially
 public class HtmlToolTests(ITestOutputHelper testOutputHelper)
 {
     private static async Task ContentEquals(FullPath path, string expectedContent)

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/NugetPackageValidateToolTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/NugetPackageValidateToolTests.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 
 namespace Meziantou.Framework.NuGetPackageValidation.Tool.Tests;
 
-[Collection("Tool")] // Ensure tests run sequentially
 public sealed class NugetPackageValidateToolTests(ITestOutputHelper testOutputHelper)
 {
     private sealed record RunResult(int ExitCode, string StdOutput, string StdError, ValidationResult? ValidationResults, NuGetPackageValidationResult? ValidationResult);

--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
@@ -11,7 +11,6 @@ using Xunit.Sdk;
 
 namespace Meziantou.Framework.PublicApiGenerator.Tests;
 
-//[Collection("Tool")] // Ensure tests run sequentially
 public sealed class PublicApiGeneratorTests
 {
     private const string CompilationCacheVersion = "v1";


### PR DESCRIPTION
## Summary
- removed [Collection("Tool")] from tool test classes that already use ConsoleHelper
- removed the stale commented //[Collection("Tool")] line from PublicApiGeneratorTests
- kept test behavior unchanged while allowing normal xUnit isolation

## Validation
- dotnet run ./eng/update-bom.cs
- dotnet run ./eng/update-readme.cs
- dotnet run ./eng/update-project-slnx.cs
- dotnet run ./eng/validate-testprojects-configuration.cs
- dotnet run ./eng/update-trimmable.cs
- DiffEngine_Disabled=true dotnet test tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests.csproj
- DiffEngine_Disabled=true dotnet test tests/Meziantou.Framework.Html.Tool.Tests/Meziantou.Framework.Html.Tool.Tests.csproj
- DiffEngine_Disabled=true dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests/Meziantou.Framework.DependencyScanning.Tool.Tests.csproj
- DiffEngine_Disabled=true dotnet test tests/Meziantou.Framework.PublicApiGenerator.Tests/Meziantou.Framework.PublicApiGenerator.Tests.csproj