### PR TITLE
Use TimeProvider in SimpleQueryLanguage range parsing

### DIFF
--- a/src/Meziantou.Framework.SimpleQueryLanguage/ExpressionQueryBuilder.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/ExpressionQueryBuilder.cs
@@ -240,7 +240,7 @@ public sealed class ExpressionQueryBuilder<T>
         var parser = tryParseValue ?? ValueConverter.TryParseValue;
 
         // Try to parse as range
-        var range = RangeSyntax.TryParse(value, parser);
+        var range = RangeSyntax.TryParse(value, parser, TimeProvider.System);
         if (range is BinaryRangeSyntax<TValue> binary)
         {
             var lowerExpression = CreateComparisonExpressionCore(

--- a/src/Meziantou.Framework.SimpleQueryLanguage/QueryBuilder.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/QueryBuilder.cs
@@ -22,9 +22,23 @@ public sealed class QueryBuilder<T>
     private static readonly Predicate<T> AlwaysFalsePredicate = _ => false;
     private static readonly Predicate<T> AlwaysTruePredicate = _ => true;
 
+    private readonly TimeProvider _timeProvider;
     private readonly Dictionary<FilterKeyValue, Func<T, KeyValueOperator, string, bool>> _filters = [];
     private Func<T, string, bool>? _freeTextFilter;
     private UnhandledPropertyDelegate<T>? _unhandledPropertyFilter;
+
+    /// <summary>Initializes a new instance of <see cref="QueryBuilder{T}"/> using the system time provider.</summary>
+    public QueryBuilder()
+        : this(timeProvider: null)
+    {
+    }
+
+    /// <summary>Initializes a new instance of <see cref="QueryBuilder{T}"/> with a specific time provider for date-related range keywords.</summary>
+    /// <param name="timeProvider">The time provider to use, or <see langword="null"/> to use <see cref="TimeProvider.System"/>.</param>
+    public QueryBuilder(TimeProvider? timeProvider)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
 
     private void AddHandler(string key, string? value, Func<T, KeyValueOperator, string, bool> handler)
     {
@@ -147,19 +161,19 @@ public sealed class QueryBuilder<T>
     }
 
     // Ranges
-    private static bool ConvertRangePredicate<TValue>(T obj, KeyValueOperator op, string value, Func<T, RangeSyntax<TValue>, bool> predicate, ScalarParser<TValue> tryParseValue)
+    private bool ConvertRangePredicate<TValue>(T obj, KeyValueOperator op, string value, Func<T, RangeSyntax<TValue>, bool> predicate, ScalarParser<TValue> tryParseValue)
     {
         // field:1..10
         // field=1..10
         if (op == KeyValueOperator.EqualTo)
         {
-            var range = RangeSyntax.TryParse(value, tryParseValue);
+            var range = RangeSyntax.TryParse(value, tryParseValue, _timeProvider);
             if (range is not null)
                 return predicate(obj, range);
         }
         else if (op == KeyValueOperator.NotEqualTo)
         {
-            var range = RangeSyntax.TryParse(value, tryParseValue);
+            var range = RangeSyntax.TryParse(value, tryParseValue, _timeProvider);
             if (range is not null)
                 return !predicate(obj, range);
         }

--- a/src/Meziantou.Framework.SimpleQueryLanguage/Ranges/RangeSyntax.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/Ranges/RangeSyntax.cs
@@ -2,13 +2,6 @@ namespace Meziantou.Framework.SimpleQueryLanguage.Ranges;
 
 internal static class RangeSyntax
 {
-    internal static DateTime UtcNow { get; set; }
-
-    private static DateTime GetUtcNow()
-    {
-        return UtcNow == default ? DateTime.UtcNow : UtcNow;
-    }
-
     public static RangeSyntax<T>? Parse<T>(string? text, ScalarParser<T> scalarParser)
     {
         if (text is null)
@@ -31,20 +24,23 @@ internal static class RangeSyntax
         return null;
     }
 
-    public static RangeSyntax<T>? TryParse<T>(string text, ScalarParser<T> tryParse)
+    public static RangeSyntax<T>? TryParse<T>(string text, ScalarParser<T> tryParse, TimeProvider timeProvider)
     {
-        if (TryExpandRangeVariables<T>(text, out var result))
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        if (TryExpandRangeVariables<T>(text, timeProvider, out var result))
             return result;
 
         return Parse(text, tryParse);
     }
 
-    private static bool TryExpandRangeVariables<T>(string text, [MaybeNullWhen(false)] out RangeSyntax<T> value)
+    private static bool TryExpandRangeVariables<T>(string text, TimeProvider timeProvider, [MaybeNullWhen(false)] out RangeSyntax<T> value)
     {
         var span = text.AsSpan().Trim();
+        var utcNow = timeProvider.GetUtcNow();
         if (span.Equals("today", StringComparison.OrdinalIgnoreCase))
         {
-            var now = GetUtcNow();
+            var now = utcNow.UtcDateTime;
             var start = new DateTime(now.Year, now.Month, now.Day);
             var end = start.AddDays(1);
             value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);
@@ -53,7 +49,7 @@ internal static class RangeSyntax
         }
         else if (span.Equals("yesterday", StringComparison.OrdinalIgnoreCase))
         {
-            var now = GetUtcNow();
+            var now = utcNow.UtcDateTime;
             var end = new DateTime(now.Year, now.Month, now.Day);
             var start = end.AddDays(-1);
             value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);
@@ -61,7 +57,7 @@ internal static class RangeSyntax
         }
         else if (span.Trim().Equals("this week", StringComparison.OrdinalIgnoreCase))
         {
-            var now = new DateTimeOffset(GetUtcNow());
+            var now = utcNow;
             var start = StartOfWeek(now);
             var end = start.AddDays(7);
             value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);
@@ -69,7 +65,7 @@ internal static class RangeSyntax
         }
         else if (span.Trim().Equals("this month", StringComparison.OrdinalIgnoreCase))
         {
-            var now = GetUtcNow();
+            var now = utcNow.UtcDateTime;
             var start = new DateTime(now.Year, now.Month, 1);
             var end = start.AddMonths(1);
             value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);
@@ -77,7 +73,7 @@ internal static class RangeSyntax
         }
         else if (span.Trim().Equals("last month", StringComparison.OrdinalIgnoreCase))
         {
-            var now = GetUtcNow();
+            var now = utcNow.UtcDateTime;
             var end = new DateTime(now.Year, now.Month, 1);
             var start = end.AddMonths(-1);
             value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);
@@ -85,7 +81,7 @@ internal static class RangeSyntax
         }
         else if (span.Trim().Equals("this year", StringComparison.OrdinalIgnoreCase))
         {
-            var now = GetUtcNow();
+            var now = utcNow.UtcDateTime;
             var start = new DateTime(now.Year, 1, 1);
             var end = new DateTime(now.Year + 1, 1, 1);
             value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);
@@ -93,7 +89,7 @@ internal static class RangeSyntax
         }
         else if (span.Trim().Equals("last year", StringComparison.OrdinalIgnoreCase))
         {
-            var now = GetUtcNow();
+            var now = utcNow.UtcDateTime;
             var end = new DateTime(now.Year, 1, 1);
             var start = new DateTime(now.Year - 1, 1, 1);
             value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/Meziantou.Framework.SimpleQueryLanguage.Tests.csproj
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/Meziantou.Framework.SimpleQueryLanguage.Tests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../../src/Meziantou.Framework.SimpleQueryLanguage/Meziantou.Framework.SimpleQueryLanguage.csproj" />
   </ItemGroup>
 

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
@@ -1,11 +1,10 @@
 using System.Numerics;
 using Meziantou.Framework.SimpleQueryLanguage.Ranges;
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace Meziantou.Framework.SimpleQueryLanguage.Tests;
 
-// Prevent parallelization because of RangeSyntax.UtcNow
-[Collection("QueryBuilderTests")]
 public sealed class QueryBuilderTests
 {
     [Fact]
@@ -204,11 +203,9 @@ public sealed class QueryBuilderTests
     [Fact]
     public void FieldEquals_DateTime_Today()
     {
-        var queryBuilder = new QueryBuilder<Sample>();
-        queryBuilder.AddRangeHandler<DateTimeOffset>("date", (obj, range) => range.IsInRange(obj.DateTimeOffsetValue));
+        var queryBuilder = CreateDateTimeOffsetRangeQueryBuilder(new DateTimeOffset(2022, 1, 1, 10, 0, 0, TimeSpan.Zero));
         var query = queryBuilder.Build("date:today");
 
-        RangeSyntax.UtcNow = new DateTime(2022, 1, 1, 10, 0, 0);
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero) }));
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 1, 1, 23, 59, 59, TimeSpan.Zero) }));
         Assert.False(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2021, 12, 31, 23, 59, 59, TimeSpan.Zero) }));
@@ -218,11 +215,9 @@ public sealed class QueryBuilderTests
     [Fact]
     public void FieldEquals_DateTime_Yesterday()
     {
-        var queryBuilder = new QueryBuilder<Sample>();
-        queryBuilder.AddRangeHandler<DateTimeOffset>("date", (obj, range) => range.IsInRange(obj.DateTimeOffsetValue));
+        var queryBuilder = CreateDateTimeOffsetRangeQueryBuilder(new DateTimeOffset(2022, 1, 2, 10, 0, 0, TimeSpan.Zero));
         var query = queryBuilder.Build("date:Yesterday");
 
-        RangeSyntax.UtcNow = new DateTime(2022, 1, 2, 10, 0, 0);
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero) }));
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 1, 1, 23, 59, 59, TimeSpan.Zero) }));
         Assert.False(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2021, 12, 31, 23, 59, 59, TimeSpan.Zero) }));
@@ -232,11 +227,9 @@ public sealed class QueryBuilderTests
     [Fact]
     public void FieldEquals_DateTime_ThisWeek()
     {
-        var queryBuilder = new QueryBuilder<Sample>();
-        queryBuilder.AddRangeHandler<DateTimeOffset>("date", (obj, range) => range.IsInRange(obj.DateTimeOffsetValue));
+        var queryBuilder = CreateDateTimeOffsetRangeQueryBuilder(new DateTimeOffset(2022, 1, 2, 10, 0, 0, TimeSpan.Zero));
         var query = queryBuilder.Build("date:\"this week\"");
 
-        RangeSyntax.UtcNow = new DateTime(2022, 1, 2, 10, 0, 0);
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2021, 12, 27, 0, 0, 0, TimeSpan.Zero) }));
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 1, 2, 23, 59, 59, TimeSpan.Zero) }));
         Assert.False(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2021, 12, 26, 23, 59, 59, TimeSpan.Zero) }));
@@ -246,11 +239,9 @@ public sealed class QueryBuilderTests
     [Fact]
     public void FieldEquals_DateTime_ThisMonth()
     {
-        var queryBuilder = new QueryBuilder<Sample>();
-        queryBuilder.AddRangeHandler<DateTimeOffset>("date", (obj, range) => range.IsInRange(obj.DateTimeOffsetValue));
+        var queryBuilder = CreateDateTimeOffsetRangeQueryBuilder(new DateTimeOffset(2022, 1, 2, 10, 0, 0, TimeSpan.Zero));
         var query = queryBuilder.Build("date:\"this month\"");
 
-        RangeSyntax.UtcNow = new DateTime(2022, 1, 2, 10, 0, 0);
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero) }));
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 1, 31, 23, 59, 59, TimeSpan.Zero) }));
         Assert.False(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2021, 12, 31, 23, 59, 59, TimeSpan.Zero) }));
@@ -260,11 +251,9 @@ public sealed class QueryBuilderTests
     [Fact]
     public void FieldEquals_DateTime_ThisMonth_LeapYear()
     {
-        var queryBuilder = new QueryBuilder<Sample>();
-        queryBuilder.AddRangeHandler<DateTimeOffset>("date", (obj, range) => range.IsInRange(obj.DateTimeOffsetValue));
+        var queryBuilder = CreateDateTimeOffsetRangeQueryBuilder(new DateTimeOffset(2020, 2, 2, 10, 0, 0, TimeSpan.Zero));
         var query = queryBuilder.Build("date:\"this month\"");
 
-        RangeSyntax.UtcNow = new DateTime(2020, 2, 2, 10, 0, 0);
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2020, 2, 1, 0, 0, 0, TimeSpan.Zero) }));
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2020, 2, 29, 23, 59, 59, TimeSpan.Zero) }));
         Assert.False(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2020, 1, 31, 23, 59, 59, TimeSpan.Zero) }));
@@ -274,11 +263,9 @@ public sealed class QueryBuilderTests
     [Fact]
     public void FieldEquals_DateTime_ThisMonth_NonLeapYear()
     {
-        var queryBuilder = new QueryBuilder<Sample>();
-        queryBuilder.AddRangeHandler<DateTimeOffset>("date", (obj, range) => range.IsInRange(obj.DateTimeOffsetValue));
+        var queryBuilder = CreateDateTimeOffsetRangeQueryBuilder(new DateTimeOffset(2022, 2, 2, 10, 0, 0, TimeSpan.Zero));
         var query = queryBuilder.Build("date:\"this month\"");
 
-        RangeSyntax.UtcNow = new DateTime(2022, 2, 2, 10, 0, 0);
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 2, 1, 0, 0, 0, TimeSpan.Zero) }));
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 2, 28, 23, 59, 59, TimeSpan.Zero) }));
         Assert.False(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 1, 31, 23, 59, 59, TimeSpan.Zero) }));
@@ -288,11 +275,9 @@ public sealed class QueryBuilderTests
     [Fact]
     public void FieldEquals_DateTime_LastMonth()
     {
-        var queryBuilder = new QueryBuilder<Sample>();
-        queryBuilder.AddRangeHandler<DateTimeOffset>("date", (obj, range) => range.IsInRange(obj.DateTimeOffsetValue));
+        var queryBuilder = CreateDateTimeOffsetRangeQueryBuilder(new DateTimeOffset(2022, 2, 2, 10, 0, 0, TimeSpan.Zero));
         var query = queryBuilder.Build("date:\"last month\"");
 
-        RangeSyntax.UtcNow = new DateTime(2022, 2, 2, 10, 0, 0);
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero) }));
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 1, 31, 23, 59, 59, TimeSpan.Zero) }));
         Assert.False(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2021, 12, 31, 23, 59, 59, TimeSpan.Zero) }));
@@ -302,11 +287,9 @@ public sealed class QueryBuilderTests
     [Fact]
     public void FieldEquals_DateTime_LastMonth_LeapYear()
     {
-        var queryBuilder = new QueryBuilder<Sample>();
-        queryBuilder.AddRangeHandler<DateTimeOffset>("date", (obj, range) => range.IsInRange(obj.DateTimeOffsetValue));
+        var queryBuilder = CreateDateTimeOffsetRangeQueryBuilder(new DateTimeOffset(2020, 3, 2, 10, 0, 0, TimeSpan.Zero));
         var query = queryBuilder.Build("date:\"last month\"");
 
-        RangeSyntax.UtcNow = new DateTime(2020, 3, 2, 10, 0, 0);
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2020, 2, 1, 0, 0, 0, TimeSpan.Zero) }));
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2020, 2, 29, 23, 59, 59, TimeSpan.Zero) }));
         Assert.False(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2020, 1, 31, 23, 59, 59, TimeSpan.Zero) }));
@@ -316,11 +299,9 @@ public sealed class QueryBuilderTests
     [Fact]
     public void FieldEquals_DateTime_LastMonth_NonLeapYear()
     {
-        var queryBuilder = new QueryBuilder<Sample>();
-        queryBuilder.AddRangeHandler<DateTimeOffset>("date", (obj, range) => range.IsInRange(obj.DateTimeOffsetValue));
+        var queryBuilder = CreateDateTimeOffsetRangeQueryBuilder(new DateTimeOffset(2022, 3, 2, 10, 0, 0, TimeSpan.Zero));
         var query = queryBuilder.Build("date:\"last month\"");
 
-        RangeSyntax.UtcNow = new DateTime(2022, 3, 2, 10, 0, 0);
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 2, 1, 0, 0, 0, TimeSpan.Zero) }));
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 2, 28, 23, 59, 59, TimeSpan.Zero) }));
         Assert.False(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 1, 31, 23, 59, 59, TimeSpan.Zero) }));
@@ -330,11 +311,9 @@ public sealed class QueryBuilderTests
     [Fact]
     public void FieldEquals_DateTime_ThisYear()
     {
-        var queryBuilder = new QueryBuilder<Sample>();
-        queryBuilder.AddRangeHandler<DateTimeOffset>("date", (obj, range) => range.IsInRange(obj.DateTimeOffsetValue));
+        var queryBuilder = CreateDateTimeOffsetRangeQueryBuilder(new DateTimeOffset(2022, 2, 2, 10, 0, 0, TimeSpan.Zero));
         var query = queryBuilder.Build("date:\"This Year\"");
 
-        RangeSyntax.UtcNow = new DateTime(2022, 2, 2, 10, 0, 0);
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero) }));
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 12, 31, 23, 59, 59, TimeSpan.Zero) }));
         Assert.False(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2021, 12, 31, 23, 59, 59, TimeSpan.Zero) }));
@@ -344,11 +323,9 @@ public sealed class QueryBuilderTests
     [Fact]
     public void FieldEquals_DateTime_LastYear()
     {
-        var queryBuilder = new QueryBuilder<Sample>();
-        queryBuilder.AddRangeHandler<DateTimeOffset>("date", (obj, range) => range.IsInRange(obj.DateTimeOffsetValue));
+        var queryBuilder = CreateDateTimeOffsetRangeQueryBuilder(new DateTimeOffset(2023, 2, 2, 10, 0, 0, TimeSpan.Zero));
         var query = queryBuilder.Build("date:\"last Year\"");
 
-        RangeSyntax.UtcNow = new DateTime(2023, 2, 2, 10, 0, 0);
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero) }));
         Assert.True(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2022, 12, 31, 23, 59, 59, TimeSpan.Zero) }));
         Assert.False(query.Evaluate(new() { DateTimeOffsetValue = new DateTimeOffset(2021, 12, 31, 23, 59, 59, TimeSpan.Zero) }));
@@ -358,11 +335,9 @@ public sealed class QueryBuilderTests
     [Fact]
     public void FieldEquals_DateOnly_LastYear()
     {
-        var queryBuilder = new QueryBuilder<Sample>();
-        queryBuilder.AddRangeHandler<DateOnly>("date", (obj, range) => range.IsInRange(obj.DateOnlyValue));
+        var queryBuilder = CreateDateOnlyRangeQueryBuilder(new DateTimeOffset(2023, 2, 2, 10, 0, 0, TimeSpan.Zero));
         var query = queryBuilder.Build("date:\"last Year\"");
 
-        RangeSyntax.UtcNow = new DateTime(2023, 2, 2, 10, 0, 0);
         Assert.True(query.Evaluate(new() { DateOnlyValue = DateOnly.FromDateTime(new DateTime(2022, 1, 1, 0, 0, 0)) }));
         Assert.True(query.Evaluate(new() { DateOnlyValue = DateOnly.FromDateTime(new DateTime(2022, 12, 31, 23, 59, 59)) }));
         Assert.False(query.Evaluate(new() { DateOnlyValue = DateOnly.FromDateTime(new DateTime(2021, 12, 31, 23, 59, 59)) }));
@@ -838,6 +813,26 @@ public sealed class QueryBuilderTests
         Assert.False(query.Evaluate(new Sample { Int32Value = 1, StringValue = "sample" }));
         Assert.True(query.Evaluate(new Sample { Int32Value = 1, StringValue = "no" }));
         Assert.False(query.Evaluate(new Sample { Int32Value = 2, StringValue = "sample" }));
+    }
+
+    private static QueryBuilder<Sample> CreateDateTimeOffsetRangeQueryBuilder(DateTimeOffset utcNow)
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(utcNow);
+
+        var queryBuilder = new QueryBuilder<Sample>(timeProvider);
+        queryBuilder.AddRangeHandler<DateTimeOffset>("date", (obj, range) => range.IsInRange(obj.DateTimeOffsetValue));
+        return queryBuilder;
+    }
+
+    private static QueryBuilder<Sample> CreateDateOnlyRangeQueryBuilder(DateTimeOffset utcNow)
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(utcNow);
+
+        var queryBuilder = new QueryBuilder<Sample>(timeProvider);
+        queryBuilder.AddRangeHandler<DateOnly>("date", (obj, range) => range.IsInRange(obj.DateOnlyValue));
+        return queryBuilder;
     }
 
     private sealed class Sample


### PR DESCRIPTION
Date keyword range tests in `QueryBuilderTests` relied on shared mutable state (`RangeSyntax.UtcNow`), which forced a test collection lock and prevented parallel execution. This change moves clock usage to `TimeProvider` so each test can control time independently.

## Summary
- Add optional `TimeProvider` support to `QueryBuilder<T>` (`TimeProvider.System` by default).
- Route range parsing in `QueryBuilder` through the builder time provider.
- Refactor `Ranges/RangeSyntax` to remove static `UtcNow` and resolve relative date keywords from `timeProvider.GetUtcNow()`.
- Update `ExpressionQueryBuilder` call site to the new `RangeSyntax.TryParse` signature.
- Migrate `QueryBuilderTests` to `FakeTimeProvider`, remove the `[Collection("QueryBuilderTests")]` attribute, and keep tests isolated for parallel runs.
- Add `Microsoft.Extensions.TimeProvider.Testing` to the SimpleQueryLanguage test project.

## Validation
- `dotnet run ./eng/update-bom.cs`
- `dotnet run ./eng/update-readme.cs`
- `dotnet run ./eng/update-project-slnx.cs`
- `dotnet run ./eng/validate-testprojects-configuration.cs`
- `dotnet run ./eng/update-trimmable.cs`
- `DiffEngine_Disabled=true dotnet test tests/Meziantou.Framework.SimpleQueryLanguage.Tests/Meziantou.Framework.SimpleQueryLanguage.Tests.csproj`