### PR TITLE
Optimize TextDiff hot paths and dictionary-heavy loops

### DIFF
--- a/src/Meziantou.Framework.TextDiff/DiffAlgorithmHelpers.cs
+++ b/src/Meziantou.Framework.TextDiff/DiffAlgorithmHelpers.cs
@@ -4,15 +4,8 @@ internal static class DiffAlgorithmHelpers
 {
     internal static void ApplySubDiff(DiffComputationResult subDiff, bool[] leftModified, int leftOffset, bool[] rightModified, int rightOffset)
     {
-        for (var i = 0; i < subDiff.LeftLength; i++)
-        {
-            leftModified[leftOffset + i] = subDiff.LeftModified[i];
-        }
-
-        for (var i = 0; i < subDiff.RightLength; i++)
-        {
-            rightModified[rightOffset + i] = subDiff.RightModified[i];
-        }
+        Array.Copy(subDiff.LeftModified, 0, leftModified, leftOffset, subDiff.LeftLength);
+        Array.Copy(subDiff.RightModified, 0, rightModified, rightOffset, subDiff.RightLength);
     }
 
     internal static int LowerBound(List<int> values, int value)

--- a/src/Meziantou.Framework.TextDiff/HistogramDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/HistogramDiff.cs
@@ -88,12 +88,14 @@ internal static class HistogramDiff
         var bestScore = int.MaxValue;
         for (var leftIndex = leftStart; leftIndex < leftEnd; leftIndex++)
         {
-            if (!rightPositions.TryGetValue(left[leftIndex], out var positions))
+            var token = left[leftIndex];
+            if (!rightPositions.TryGetValue(token, out var positions))
                 continue;
 
-            foreach (var rightIndex in positions)
+            var score = leftFrequency[token] + rightFrequency[token];
+            for (var i = 0; i < positions.Count; i++)
             {
-                var score = leftFrequency[left[leftIndex]] + rightFrequency[left[leftIndex]];
+                var rightIndex = positions[i];
                 if (best is null || score < bestScore || (score == bestScore && IsBetterTieBreak(leftIndex, rightIndex, best.Value)))
                 {
                     best = new Anchor(leftIndex, rightIndex);
@@ -118,8 +120,8 @@ internal static class HistogramDiff
         var result = new Dictionary<string, int>(comparer);
         for (var i = start; i < end; i++)
         {
-            result.TryGetValue(values[i], out var count);
-            result[values[i]] = count + 1;
+            ref var count = ref CollectionsMarshal.GetValueRefOrAddDefault(result, values[i], out var exists);
+            count = exists ? count + 1 : 1;
         }
 
         return result;
@@ -130,11 +132,8 @@ internal static class HistogramDiff
         var result = new Dictionary<string, List<int>>(comparer);
         for (var i = start; i < end; i++)
         {
-            if (!result.TryGetValue(values[i], out var positions))
-            {
-                positions = new List<int>();
-                result.Add(values[i], positions);
-            }
+            ref var positions = ref CollectionsMarshal.GetValueRefOrAddDefault(result, values[i], out _);
+            positions ??= new List<int>();
 
             positions.Add(i);
         }

--- a/src/Meziantou.Framework.TextDiff/HuntSzymanskiDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/HuntSzymanskiDiff.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Meziantou.Framework;
 
 internal static class HuntSzymanskiDiff
@@ -28,11 +30,8 @@ internal static class HuntSzymanskiDiff
         var positionsByToken = new Dictionary<string, List<int>>(comparer);
         for (var i = 0; i < right.Length; i++)
         {
-            if (!positionsByToken.TryGetValue(right[i], out var positions))
-            {
-                positions = new List<int>();
-                positionsByToken.Add(right[i], positions);
-            }
+            ref var positions = ref CollectionsMarshal.GetValueRefOrAddDefault(positionsByToken, right[i], out _);
+            positions ??= new List<int>();
 
             positions.Add(i);
         }

--- a/src/Meziantou.Framework.TextDiff/MyersDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/MyersDiff.cs
@@ -51,17 +51,14 @@ internal static class MyersDiff
 
         for (var i = 0; i < chunks.Length; i++)
         {
-            var s = chunks[i];
-            if (!h.TryGetValue(s, out var value))
+            ref var value = ref CollectionsMarshal.GetValueRefOrAddDefault(h, chunks[i], out var exists);
+            if (!exists)
             {
                 lastUsedCode++;
-                h[s] = lastUsedCode;
-                codes[i] = lastUsedCode;
+                value = lastUsedCode;
             }
-            else
-            {
-                codes[i] = value;
-            }
+
+            codes[i] = value;
         }
     }
 

--- a/src/Meziantou.Framework.TextDiff/PatienceDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/PatienceDiff.cs
@@ -114,15 +114,8 @@ internal static class PatienceDiff
         var result = new Dictionary<string, int>(comparer);
         for (var i = start; i < end; i++)
         {
-            var current = values[i];
-            if (result.TryGetValue(current, out _))
-            {
-                result[current] = Duplicate;
-            }
-            else
-            {
-                result[current] = i;
-            }
+            ref var position = ref CollectionsMarshal.GetValueRefOrAddDefault(result, values[i], out var exists);
+            position = exists ? Duplicate : i;
         }
 
         return result;

--- a/src/Meziantou.Framework.TextDiff/TextDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiff.cs
@@ -2,6 +2,9 @@ namespace Meziantou.Framework;
 
 public static class TextDiff
 {
+    private static readonly IEqualityComparer<string> OrdinalWhitespaceComparer = new WhitespaceTrimmingComparer(StringComparer.Ordinal);
+    private static readonly IEqualityComparer<string> OrdinalIgnoreCaseWhitespaceComparer = new WhitespaceTrimmingComparer(StringComparer.OrdinalIgnoreCase);
+
     public static TextDiffResult ComputeDiff(string oldText, string newText, TextDiffOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(oldText);
@@ -24,46 +27,51 @@ public static class TextDiff
 
     private static IEqualityComparer<string> BuildComparer(TextDiffOptions options)
     {
-        var inner = options.IgnoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
-
         if (!options.IgnoreWhitespace)
-            return inner;
+            return options.IgnoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
-        return new WhitespaceTrimmingComparer(inner);
+        return options.IgnoreCase ? OrdinalIgnoreCaseWhitespaceComparer : OrdinalWhitespaceComparer;
     }
 
     private static TextDiffResult BuildResult(string[] oldChunks, string[] newChunks, DiffComputationResult diff)
     {
-        var entries = new List<TextDiffEntry>();
+        var leftModified = diff.LeftModified;
+        var rightModified = diff.RightModified;
+        var leftLength = leftModified.Length;
+        var rightLength = rightModified.Length;
+        var entries = new List<TextDiffEntry>(leftLength + rightLength);
         var hasDifferences = false;
 
         var lineLeft = 0;
         var lineRight = 0;
 
-        while (lineLeft < diff.LeftLength || lineRight < diff.RightLength)
+        while (lineLeft < leftLength || lineRight < rightLength)
         {
-            if (lineLeft < diff.LeftLength && !diff.LeftModified[lineLeft]
-                && lineRight < diff.RightLength && !diff.RightModified[lineRight])
+            while (lineLeft < leftLength
+                && lineRight < rightLength
+                && !leftModified[lineLeft]
+                && !rightModified[lineRight])
             {
                 entries.Add(new TextDiffEntry(TextDiffOperation.Equal, oldChunks[lineLeft]));
                 lineLeft++;
                 lineRight++;
             }
-            else
-            {
-                while (lineLeft < diff.LeftLength && (lineRight >= diff.RightLength || diff.LeftModified[lineLeft]))
-                {
-                    entries.Add(new TextDiffEntry(TextDiffOperation.Delete, oldChunks[lineLeft]));
-                    lineLeft++;
-                    hasDifferences = true;
-                }
 
-                while (lineRight < diff.RightLength && (lineLeft >= diff.LeftLength || diff.RightModified[lineRight]))
-                {
-                    entries.Add(new TextDiffEntry(TextDiffOperation.Insert, newChunks[lineRight]));
-                    lineRight++;
-                    hasDifferences = true;
-                }
+            if (lineLeft >= leftLength && lineRight >= rightLength)
+                break;
+
+            hasDifferences = true;
+
+            while (lineLeft < leftLength && (lineRight >= rightLength || leftModified[lineLeft]))
+            {
+                entries.Add(new TextDiffEntry(TextDiffOperation.Delete, oldChunks[lineLeft]));
+                lineLeft++;
+            }
+
+            while (lineRight < rightLength && (lineLeft >= leftLength || rightModified[lineRight]))
+            {
+                entries.Add(new TextDiffEntry(TextDiffOperation.Insert, newChunks[lineRight]));
+                lineRight++;
             }
         }
 
@@ -98,31 +106,14 @@ public static class TextDiff
             if (y is null)
                 return false;
 
-            return Trim(x.AsSpan()).Equals(Trim(y.AsSpan()), _comparison);
+            return x.AsSpan().Trim().Equals(y.AsSpan().Trim(), _comparison);
         }
 
         public int GetHashCode(string obj)
         {
             ArgumentNullException.ThrowIfNull(obj);
-            var trimmed = Trim(obj.AsSpan());
+            var trimmed = obj.AsSpan().Trim();
             return string.GetHashCode(trimmed, _comparison);
-        }
-
-        private static ReadOnlySpan<char> Trim(ReadOnlySpan<char> value)
-        {
-            var start = 0;
-            while (start < value.Length && char.IsWhiteSpace(value[start]))
-            {
-                start++;
-            }
-
-            var end = value.Length - 1;
-            while (end >= start && char.IsWhiteSpace(value[end]))
-            {
-                end--;
-            }
-
-            return value[start..(end + 1)];
         }
     }
 }


### PR DESCRIPTION
## Why
The TextDiff implementation was already correct, but several hot paths still did extra allocations and repeated dictionary work. This change reduces those constant costs so frequent diffs are cheaper without changing behavior.

## What changed
- Optimized `TextDiff` comparer and result-building internals:
  - Reused whitespace comparer instances instead of allocating per call.
  - Tightened the `BuildResult` loop and pre-sized the entries list.
  - Inlined span trimming in `WhitespaceTrimmingComparer` and removed the helper method.
- Replaced element-by-element sub-diff bool copies with `Array.Copy` in `DiffAlgorithmHelpers`.
- Optimized dictionary-heavy paths in algorithms using `CollectionsMarshal.GetValueRefOrAddDefault`:
  - `MyersDiff.DiffCodes`
  - `PatienceDiff.FindUniquePositions`
  - `HistogramDiff.CountOccurrences` and `BuildPositions`
  - `HuntSzymanskiDiff.BuildRightPositions`
- Reduced repeated lookup work in `HistogramDiff.FindBestAnchor` by caching token/score per left index.

## Notes
- This PR is focused on low-risk internal optimizations only; no public API or semantic behavior changes were intended.
- Validation was run with the existing TextDiff test suite and required repository maintenance scripts.