### PR TITLE
Add request-context query root filtering in TDS query engine

### DIFF
--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryAuthorizationException.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryAuthorizationException.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Meziantou.Framework.Tds.QueryEngine;
+
+[SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "Internal exception used only to carry query-engine authorization errors to TDS error responses.")]
+[SuppressMessage("Design", "CA1064:Exceptions should be public", Justification = "Internal exception used only within the query engine.")]
+internal sealed class TdsQueryAuthorizationException : Exception
+{
+    public TdsQueryAuthorizationException(TdsQueryEngineResourceKind resourceKind, string resourceName)
+        : base($"Not authorized to access {resourceKind} '{resourceName}'.")
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
+
+        ResourceKind = resourceKind;
+        ResourceName = resourceName;
+    }
+
+    public TdsQueryEngineResourceKind ResourceKind { get; }
+
+    public string ResourceName { get; }
+}

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryContextExtensions.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryContextExtensions.cs
@@ -1,0 +1,15 @@
+using Meziantou.Framework.Tds.Handler;
+
+namespace Meziantou.Framework.Tds.QueryEngine;
+
+internal static class TdsQueryContextExtensions
+{
+    internal static IQueryable ResolveQuery(this TdsQueryContext context, TdsQueryRoot queryRoot)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(queryRoot);
+
+        var query = queryRoot.GetQuery(context);
+        return query ?? throw new InvalidOperationException($"The query root '{queryRoot.Name}' returned null.");
+    }
+}

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineAuthorizationHandler.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineAuthorizationHandler.cs
@@ -1,0 +1,12 @@
+using Meziantou.Framework.Tds.Handler;
+
+namespace Meziantou.Framework.Tds.QueryEngine;
+
+/// <summary>
+/// Evaluates whether the current query request can access a query-engine resource.
+/// </summary>
+/// <param name="context">The current query request context.</param>
+/// <param name="resourceKind">The resource kind being accessed.</param>
+/// <param name="resourceName">The resource name being accessed.</param>
+/// <returns><see langword="true"/> when access is allowed; otherwise, <see langword="false"/>.</returns>
+public delegate bool TdsQueryEngineAuthorizationHandler(TdsQueryContext context, TdsQueryEngineResourceKind resourceKind, string resourceName);

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
@@ -17,6 +17,22 @@ namespace Meziantou.Framework.Tds.QueryEngine;
 [SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance", Justification = "Query translation helpers intentionally use abstract return types for flexibility.")]
 internal sealed class TdsQueryEngineExecutor
 {
+    private sealed class QueryExecutionContext
+    {
+        public QueryExecutionContext(TdsQueryContext queryContext, IReadOnlyDictionary<string, TdsQueryRoot> queryRoots)
+        {
+            ArgumentNullException.ThrowIfNull(queryContext);
+            ArgumentNullException.ThrowIfNull(queryRoots);
+
+            QueryContext = queryContext;
+            QueryRoots = queryRoots;
+        }
+
+        public TdsQueryContext QueryContext { get; }
+
+        public IReadOnlyDictionary<string, TdsQueryRoot> QueryRoots { get; }
+    }
+
     private readonly TdsQueryEngineOptions _options;
 
     public TdsQueryEngineExecutor(TdsQueryEngineOptions options)
@@ -30,6 +46,7 @@ internal sealed class TdsQueryEngineExecutor
     {
         ArgumentNullException.ThrowIfNull(context);
 
+        var queryExecutionContext = CreateQueryExecutionContext(context);
         try
         {
             if (context.RequestType == TdsQueryRequestType.Rpc && !string.Equals(context.ProcedureName, "sp_executesql", StringComparison.OrdinalIgnoreCase))
@@ -39,7 +56,7 @@ internal sealed class TdsQueryEngineExecutor
 
             var commandText = GetCommandText(context);
             var parameters = GetSqlParameters(context);
-            return await ExecuteTextQueryAsync(commandText, parameters, cancellationToken).ConfigureAwait(false);
+            return await ExecuteTextQueryAsync(commandText, parameters, queryExecutionContext, cancellationToken).ConfigureAwait(false);
         }
         catch (TdsQueryEngineException ex)
         {
@@ -51,6 +68,22 @@ internal sealed class TdsQueryEngineExecutor
                 Message = ex.Message,
             });
         }
+    }
+
+    private QueryExecutionContext CreateQueryExecutionContext(TdsQueryContext queryContext)
+    {
+        var result = new Dictionary<string, TdsQueryRoot>(StringComparer.OrdinalIgnoreCase);
+        foreach (var queryRoot in _options.QueryRoots)
+        {
+            if (result.ContainsKey(queryRoot.Name))
+            {
+                continue;
+            }
+
+            result.Add(queryRoot.Name, new TdsQueryRoot(queryRoot.Name, queryContext.ResolveQuery(queryRoot)));
+        }
+
+        return new QueryExecutionContext(queryContext, result);
     }
 
     private async ValueTask<TdsQueryResult> ExecuteStoredProcedureAsync(TdsQueryContext context, CancellationToken cancellationToken)
@@ -131,14 +164,14 @@ internal sealed class TdsQueryEngineExecutor
         return result;
     }
 
-    private async ValueTask<TdsQueryResult> ExecuteTextQueryAsync(string commandText, IReadOnlyDictionary<string, TdsQueryParameter> parameters, CancellationToken cancellationToken)
+    private async ValueTask<TdsQueryResult> ExecuteTextQueryAsync(string commandText, IReadOnlyDictionary<string, TdsQueryParameter> parameters, QueryExecutionContext queryExecutionContext, CancellationToken cancellationToken)
     {
-        var translatedQuery = TranslateQuery(commandText, parameters);
+        var translatedQuery = TranslateQuery(commandText, parameters, queryExecutionContext);
         var rows = await _options.MaterializeAsync(translatedQuery, cancellationToken).ConfigureAwait(false);
         return TdsQueryResultBuilder.FromRows(rows, translatedQuery.ElementType);
     }
 
-    private IQueryable TranslateQuery(string commandText, IReadOnlyDictionary<string, TdsQueryParameter> parameters)
+    private IQueryable TranslateQuery(string commandText, IReadOnlyDictionary<string, TdsQueryParameter> parameters, QueryExecutionContext queryExecutionContext)
     {
         var parseResult = SqlParser.Parse(commandText, new SqlParserParseOptions(), out _);
         if (parseResult.Errors.Any() || parseResult.ParseErrors.Any())
@@ -158,15 +191,15 @@ internal sealed class TdsQueryEngineExecutor
             throw new TdsQueryEngineException("The SQL query uses a SELECT feature that is not supported.");
         }
 
-        var cteRoots = BuildCteRoots(selectStatement.QueryWithClause, parameters);
+        var cteRoots = BuildCteRoots(selectStatement.QueryWithClause, parameters, queryExecutionContext);
         IQueryable query;
         if (selectStatement.SelectSpecification.QueryExpression is SqlQuerySpecification querySpecification)
         {
-            query = TranslateQuerySpecification(querySpecification, selectStatement.SelectSpecification.OrderByClause, parameters, cteRoots);
+            query = TranslateQuerySpecification(querySpecification, selectStatement.SelectSpecification.OrderByClause, parameters, cteRoots, queryExecutionContext);
         }
         else
         {
-            query = TranslateQueryExpression(selectStatement.SelectSpecification.QueryExpression, parameters, cteRoots);
+            query = TranslateQueryExpression(selectStatement.SelectSpecification.QueryExpression, parameters, cteRoots, queryExecutionContext);
             if (selectStatement.SelectSpecification.OrderByClause is not null)
             {
                 query = ApplyOrderBy(CreateProjectionSource(query), selectStatement.SelectSpecification.OrderByClause, parameters).Query;
@@ -183,7 +216,7 @@ internal sealed class TdsQueryEngineExecutor
         return expression is null ? query : query.Provider.CreateQuery(expression);
     }
 
-    private IReadOnlyDictionary<string, TdsQueryRoot> BuildCteRoots(SqlQueryWithClause? withClause, IReadOnlyDictionary<string, TdsQueryParameter> parameters)
+    private IReadOnlyDictionary<string, TdsQueryRoot> BuildCteRoots(SqlQueryWithClause? withClause, IReadOnlyDictionary<string, TdsQueryParameter> parameters, QueryExecutionContext queryExecutionContext)
     {
         var result = new Dictionary<string, TdsQueryRoot>(StringComparer.OrdinalIgnoreCase);
         if (withClause is null)
@@ -194,7 +227,7 @@ internal sealed class TdsQueryEngineExecutor
         foreach (var cte in withClause.CommonTableExpressions)
         {
             var cteName = cte.Name.Value;
-            var query = TranslateQueryExpression(cte.QueryExpression, parameters, result);
+            var query = TranslateQueryExpression(cte.QueryExpression, parameters, result, queryExecutionContext);
             if (cte.ColumnList is not null && cte.ColumnList.Count > 0)
             {
                 query = ApplyColumnList(query, cte.ColumnList, scopeName: "CTE");
@@ -246,20 +279,20 @@ internal sealed class TdsQueryEngineExecutor
         return query.Provider.CreateQuery(call);
     }
 
-    private IQueryable TranslateQueryExpression(SqlQueryExpression queryExpression, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots)
+    private IQueryable TranslateQueryExpression(SqlQueryExpression queryExpression, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext queryExecutionContext)
     {
         return queryExpression switch
         {
-            SqlQuerySpecification querySpecification => TranslateQuerySpecification(querySpecification, orderByOverride: null, parameters, cteRoots),
-            SqlBinaryQueryExpression binaryQueryExpression => TranslateBinaryQueryExpression(binaryQueryExpression, parameters, cteRoots),
+            SqlQuerySpecification querySpecification => TranslateQuerySpecification(querySpecification, orderByOverride: null, parameters, cteRoots, queryExecutionContext),
+            SqlBinaryQueryExpression binaryQueryExpression => TranslateBinaryQueryExpression(binaryQueryExpression, parameters, cteRoots, queryExecutionContext),
             _ => throw new TdsQueryEngineException("Only query specifications and UNION query expressions are supported."),
         };
     }
 
-    private IQueryable TranslateBinaryQueryExpression(SqlBinaryQueryExpression queryExpression, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots)
+    private IQueryable TranslateBinaryQueryExpression(SqlBinaryQueryExpression queryExpression, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext queryExecutionContext)
     {
-        var left = TranslateQueryExpression(queryExpression.Left, parameters, cteRoots);
-        var right = TranslateQueryExpression(queryExpression.Right, parameters, cteRoots);
+        var left = TranslateQueryExpression(queryExpression.Left, parameters, cteRoots, queryExecutionContext);
+        var right = TranslateQueryExpression(queryExpression.Right, parameters, cteRoots, queryExecutionContext);
         if (left.ElementType != right.ElementType)
         {
             throw new TdsQueryEngineException("UNION query expressions must project the same columns and types.");
@@ -281,7 +314,7 @@ internal sealed class TdsQueryEngineExecutor
         return left.Provider.CreateQuery(call);
     }
 
-    private IQueryable TranslateQuerySpecification(SqlQuerySpecification querySpecification, SqlOrderByClause? orderByOverride, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots)
+    private IQueryable TranslateQuerySpecification(SqlQuerySpecification querySpecification, SqlOrderByClause? orderByOverride, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext queryExecutionContext)
     {
         if (querySpecification.IntoClause is not null ||
             querySpecification.WindowClause is not null ||
@@ -290,10 +323,10 @@ internal sealed class TdsQueryEngineExecutor
             throw new TdsQueryEngineException("The SQL query uses a SELECT feature that is not supported.");
         }
 
-        var source = BuildSource(querySpecification.FromClause, cteRoots, parameters);
+        var source = BuildSource(querySpecification.FromClause, cteRoots, parameters, queryExecutionContext);
         if (querySpecification.WhereClause?.Expression is not null)
         {
-            source = ApplyWhere(source, querySpecification.WhereClause.Expression, parameters, cteRoots);
+            source = ApplyWhere(source, querySpecification.WhereClause.Expression, parameters, cteRoots, queryExecutionContext);
         }
 
         var orderByClause = orderByOverride ?? querySpecification.OrderByClause;
@@ -349,70 +382,71 @@ internal sealed class TdsQueryEngineExecutor
         return query;
     }
 
-    private QuerySource BuildSource(SqlFromClause? fromClause, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, IReadOnlyDictionary<string, TdsQueryParameter> parameters)
+    private QuerySource BuildSource(SqlFromClause? fromClause, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, IReadOnlyDictionary<string, TdsQueryParameter> parameters, QueryExecutionContext queryExecutionContext)
     {
         if (fromClause is null || fromClause.TableExpressions.Count != 1)
         {
             throw new TdsQueryEngineException("The SQL query must contain exactly one FROM table expression.");
         }
 
-        return BuildSource(fromClause.TableExpressions[0], cteRoots, parameters);
+        return BuildSource(fromClause.TableExpressions[0], cteRoots, parameters, queryExecutionContext);
     }
 
-    private QuerySource BuildSource(SqlTableExpression tableExpression, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, IReadOnlyDictionary<string, TdsQueryParameter> parameters)
+    private QuerySource BuildSource(SqlTableExpression tableExpression, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, IReadOnlyDictionary<string, TdsQueryParameter> parameters, QueryExecutionContext queryExecutionContext)
     {
         if (tableExpression is SqlTableRefExpression tableRefExpression)
         {
-            return BuildTableSource(tableRefExpression, cteRoots);
+            return BuildTableSource(tableRefExpression, cteRoots, queryExecutionContext);
         }
 
         if (tableExpression is SqlDerivedTableExpression derivedTableExpression)
         {
-            return BuildDerivedTableSource(derivedTableExpression, cteRoots, parameters);
+            return BuildDerivedTableSource(derivedTableExpression, cteRoots, parameters, queryExecutionContext);
         }
 
         if (tableExpression is SqlQualifiedJoinTableExpression joinExpression)
         {
-            return BuildJoinSource(joinExpression, cteRoots, parameters);
+            return BuildJoinSource(joinExpression, cteRoots, parameters, queryExecutionContext);
         }
 
         if (tableExpression is SqlUnqualifiedJoinTableExpression unqualifiedJoinExpression)
         {
-            return BuildUnqualifiedJoinSource(unqualifiedJoinExpression, cteRoots, parameters);
+            return BuildUnqualifiedJoinSource(unqualifiedJoinExpression, cteRoots, parameters, queryExecutionContext);
         }
 
         throw new TdsQueryEngineException("Only table references, derived tables, INNER JOIN/LEFT JOIN/RIGHT JOIN table expressions, and CROSS APPLY table expressions are supported.");
     }
 
-    private QuerySource BuildTableSource(SqlTableRefExpression tableExpression, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots)
+    private QuerySource BuildTableSource(SqlTableRefExpression tableExpression, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext queryExecutionContext)
     {
         var tableName = tableExpression.ObjectIdentifier.ObjectName.Value;
         var root = cteRoots.TryGetValue(tableName, out var cteRoot)
             ? cteRoot
-            : _options.QueryRoots.FirstOrDefault(candidate => string.Equals(candidate.Name, tableName, StringComparison.OrdinalIgnoreCase));
+            : queryExecutionContext.QueryRoots.TryGetValue(tableName, out var queryRoot) ? queryRoot : null;
         if (root is null)
         {
             throw new TdsQueryEngineException($"Unknown query root '{tableName}'.");
         }
 
+        var query = queryExecutionContext.QueryContext.ResolveQuery(root);
         var alias = tableExpression.Alias?.Value ?? tableName;
         return new QuerySource(
-            root.Query,
-            root.ElementType,
+            query,
+            query.ElementType,
             new Dictionary<string, AliasBinding>(StringComparer.OrdinalIgnoreCase)
             {
-                [alias] = new AliasBinding(root.ElementType, expression => expression),
+                [alias] = new AliasBinding(query.ElementType, expression => expression),
             });
     }
 
-    private QuerySource BuildDerivedTableSource(SqlDerivedTableExpression tableExpression, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, IReadOnlyDictionary<string, TdsQueryParameter> parameters)
+    private QuerySource BuildDerivedTableSource(SqlDerivedTableExpression tableExpression, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, IReadOnlyDictionary<string, TdsQueryParameter> parameters, QueryExecutionContext queryExecutionContext)
     {
         if (tableExpression.Alias is null)
         {
             throw new TdsQueryEngineException("Derived tables must have an alias.");
         }
 
-        var query = TranslateQueryExpression(tableExpression.QueryExpression, parameters, cteRoots);
+        var query = TranslateQueryExpression(tableExpression.QueryExpression, parameters, cteRoots, queryExecutionContext);
         if (tableExpression.ColumnList is not null && tableExpression.ColumnList.Count > 0)
         {
             query = ApplyColumnList(query, tableExpression.ColumnList, scopeName: "Derived table");
@@ -428,7 +462,7 @@ internal sealed class TdsQueryEngineExecutor
             });
     }
 
-    private QuerySource BuildJoinSource(SqlQualifiedJoinTableExpression joinExpression, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, IReadOnlyDictionary<string, TdsQueryParameter> parameters)
+    private QuerySource BuildJoinSource(SqlQualifiedJoinTableExpression joinExpression, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, IReadOnlyDictionary<string, TdsQueryParameter> parameters, QueryExecutionContext queryExecutionContext)
     {
         var isLeftJoin = joinExpression.JoinOperator == SqlJoinOperatorType.LeftOuterJoin;
         var isRightJoin = joinExpression.JoinOperator == SqlJoinOperatorType.RightOuterJoin;
@@ -444,8 +478,8 @@ internal sealed class TdsQueryEngineExecutor
         }
 #endif
 
-        var left = BuildSource(joinExpression.Left, cteRoots, parameters);
-        var right = BuildSource(joinExpression.Right, cteRoots, parameters);
+        var left = BuildSource(joinExpression.Left, cteRoots, parameters, queryExecutionContext);
+        var right = BuildSource(joinExpression.Right, cteRoots, parameters, queryExecutionContext);
         if (joinExpression.OnClause?.Expression is not SqlComparisonBooleanExpression { ComparisonOperator: SqlComparisonBooleanExpressionType.Equals } comparison)
         {
             var joinName = isLeftJoin ? "LEFT JOIN" : isRightJoin ? "RIGHT JOIN" : "INNER JOIN";
@@ -552,14 +586,14 @@ internal sealed class TdsQueryEngineExecutor
 #endif
     }
 
-    private QuerySource BuildUnqualifiedJoinSource(SqlUnqualifiedJoinTableExpression joinExpression, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, IReadOnlyDictionary<string, TdsQueryParameter> parameters)
+    private QuerySource BuildUnqualifiedJoinSource(SqlUnqualifiedJoinTableExpression joinExpression, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, IReadOnlyDictionary<string, TdsQueryParameter> parameters, QueryExecutionContext queryExecutionContext)
     {
         if (joinExpression.JoinOperator != SqlJoinOperatorType.CrossApply)
         {
             throw new TdsQueryEngineException("Only CROSS APPLY is supported for unqualified joins.");
         }
 
-        var left = BuildSource(joinExpression.Left, cteRoots, parameters);
+        var left = BuildSource(joinExpression.Left, cteRoots, parameters, queryExecutionContext);
         if (joinExpression.Right is not SqlTableValuedFunctionRefExpression tableValuedFunction)
         {
             throw new TdsQueryEngineException("CROSS APPLY currently supports only table-valued function expressions.");
@@ -645,10 +679,10 @@ internal sealed class TdsQueryEngineExecutor
         return new QuerySource(left.Query.Provider.CreateQuery(call), carrierType, aliases);
     }
 
-    private QuerySource ApplyWhere(QuerySource source, SqlBooleanExpression expression, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots)
+    private QuerySource ApplyWhere(QuerySource source, SqlBooleanExpression expression, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext queryExecutionContext)
     {
         var parameter = Expression.Parameter(source.RowType, "row");
-        var predicate = BuildBoolean(expression, source.Aliases, parameter, parameters, cteRoots);
+        var predicate = BuildBoolean(expression, source.Aliases, parameter, parameters, cteRoots, queryExecutionContext);
         var call = Expression.Call(
             typeof(Queryable),
             nameof(Queryable.Where),
@@ -915,21 +949,21 @@ internal sealed class TdsQueryEngineExecutor
         return source.Query.Provider.CreateQuery(call);
     }
 
-    private Expression BuildBoolean(SqlBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots)
+    private Expression BuildBoolean(SqlBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext)
     {
         return expression switch
         {
             SqlComparisonBooleanExpression comparison => BuildComparison(comparison, aliases, parameter, parameters),
-            SqlInBooleanExpression inExpression => BuildInBoolean(inExpression, aliases, parameter, parameters, cteRoots),
+            SqlInBooleanExpression inExpression => BuildInBoolean(inExpression, aliases, parameter, parameters, cteRoots, queryExecutionContext),
             SqlIsNullBooleanExpression isNullExpression => BuildIsNullBoolean(isNullExpression, aliases, parameter, parameters),
-            SqlExistsBooleanExpression existsExpression => BuildExistsBoolean(existsExpression, aliases, parameter, parameters, cteRoots),
-            SqlNotBooleanExpression notExpression => Expression.Not(BuildBoolean(notExpression.Expression, aliases, parameter, parameters, cteRoots)),
+            SqlExistsBooleanExpression existsExpression => BuildExistsBoolean(existsExpression, aliases, parameter, parameters, cteRoots, queryExecutionContext),
+            SqlNotBooleanExpression notExpression => Expression.Not(BuildBoolean(notExpression.Expression, aliases, parameter, parameters, cteRoots, queryExecutionContext)),
             SqlBinaryBooleanExpression { Operator: SqlBooleanOperatorType.And } binary => Expression.AndAlso(
-                BuildBoolean(binary.Left, aliases, parameter, parameters, cteRoots),
-                BuildBoolean(binary.Right, aliases, parameter, parameters, cteRoots)),
+                BuildBoolean(binary.Left, aliases, parameter, parameters, cteRoots, queryExecutionContext),
+                BuildBoolean(binary.Right, aliases, parameter, parameters, cteRoots, queryExecutionContext)),
             SqlBinaryBooleanExpression { Operator: SqlBooleanOperatorType.Or } orBinary => Expression.OrElse(
-                BuildBoolean(orBinary.Left, aliases, parameter, parameters, cteRoots),
-                BuildBoolean(orBinary.Right, aliases, parameter, parameters, cteRoots)),
+                BuildBoolean(orBinary.Left, aliases, parameter, parameters, cteRoots, queryExecutionContext),
+                BuildBoolean(orBinary.Right, aliases, parameter, parameters, cteRoots, queryExecutionContext)),
             _ => throw new TdsQueryEngineException("Only comparison, IN, EXISTS, and IS NULL predicates combined with AND/OR/NOT are supported."),
         };
     }
@@ -956,13 +990,13 @@ internal sealed class TdsQueryEngineExecutor
         };
     }
 
-    private Expression BuildInBoolean(SqlInBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots)
+    private Expression BuildInBoolean(SqlInBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext)
     {
         var inExpression = BuildScalar(expression.InExpression, aliases, parameter, parameters);
         Expression containsExpression = expression.ComparisonValue switch
         {
             SqlInBooleanExpressionCollectionValue collectionValue => BuildInCollectionExpression(collectionValue, inExpression, aliases, parameter, parameters),
-            SqlInBooleanExpressionQueryValue queryValue => BuildInSubqueryExpression(queryValue, inExpression, aliases, parameter, parameters, cteRoots),
+            SqlInBooleanExpressionQueryValue queryValue => BuildInSubqueryExpression(queryValue, inExpression, aliases, parameter, parameters, cteRoots, queryExecutionContext),
             _ => throw new TdsQueryEngineException("Only IN collections and simple IN subqueries are supported."),
         };
 
@@ -984,9 +1018,9 @@ internal sealed class TdsQueryEngineExecutor
             inExpression);
     }
 
-    private MethodCallExpression BuildInSubqueryExpression(SqlInBooleanExpressionQueryValue queryValue, Expression inExpression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots)
+    private MethodCallExpression BuildInSubqueryExpression(SqlInBooleanExpressionQueryValue queryValue, Expression inExpression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext)
     {
-        var subquery = TranslateInSubquery(queryValue.Value, inExpression.Type, aliases, parameter, parameters, cteRoots);
+        var subquery = TranslateInSubquery(queryValue.Value, inExpression.Type, aliases, parameter, parameters, cteRoots, queryExecutionContext);
         return Expression.Call(
             typeof(Queryable),
             nameof(Queryable.Contains),
@@ -995,9 +1029,9 @@ internal sealed class TdsQueryEngineExecutor
             inExpression);
     }
 
-    private MethodCallExpression BuildExistsBoolean(SqlExistsBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots)
+    private MethodCallExpression BuildExistsBoolean(SqlExistsBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext)
     {
-        var subquery = TranslateExistsSubquery(expression.QueryExpression, aliases, parameter, parameters, cteRoots);
+        var subquery = TranslateExistsSubquery(expression.QueryExpression, aliases, parameter, parameters, cteRoots, queryExecutionContext);
         return Expression.Call(
             typeof(Queryable),
             nameof(Queryable.Any),
@@ -1018,8 +1052,10 @@ internal sealed class TdsQueryEngineExecutor
         return expression.HasNot ? Expression.Not(isNullExpression) : isNullExpression;
     }
 
-    private IQueryable TranslateInSubquery(SqlQueryExpression queryExpression, Type targetType, IReadOnlyDictionary<string, AliasBinding> outerAliases, ParameterExpression outerParameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots)
+    private IQueryable TranslateInSubquery(SqlQueryExpression queryExpression, Type targetType, IReadOnlyDictionary<string, AliasBinding> outerAliases, ParameterExpression outerParameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext)
     {
+        ArgumentNullException.ThrowIfNull(queryExecutionContext);
+
         if (queryExpression is not SqlQuerySpecification querySpecification)
         {
             throw new TdsQueryEngineException("Only simple query specifications are supported in IN subqueries.");
@@ -1043,12 +1079,12 @@ internal sealed class TdsQueryEngineExecutor
             throw new TdsQueryEngineException("The IN subquery must select exactly one scalar expression.");
         }
 
-        var source = BuildSource(querySpecification.FromClause, cteRoots, parameters);
+        var source = BuildSource(querySpecification.FromClause, cteRoots, parameters, queryExecutionContext);
         var parameter = Expression.Parameter(source.RowType, GetUniqueParameterName(GetTypeParameterName(source.RowType), outerParameter.Name));
         var scopedAliases = CreateScopedAliases(source.Aliases, outerAliases, outerParameter);
         if (querySpecification.WhereClause?.Expression is not null)
         {
-            var predicate = BuildBoolean(querySpecification.WhereClause.Expression, scopedAliases, parameter, parameters, cteRoots);
+            var predicate = BuildBoolean(querySpecification.WhereClause.Expression, scopedAliases, parameter, parameters, cteRoots, queryExecutionContext);
             var whereCall = Expression.Call(
                 typeof(Queryable),
                 nameof(Queryable.Where),
@@ -1075,8 +1111,10 @@ internal sealed class TdsQueryEngineExecutor
         return source.Query.Provider.CreateQuery(call);
     }
 
-    private IQueryable TranslateExistsSubquery(SqlQueryExpression queryExpression, IReadOnlyDictionary<string, AliasBinding> outerAliases, ParameterExpression outerParameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots)
+    private IQueryable TranslateExistsSubquery(SqlQueryExpression queryExpression, IReadOnlyDictionary<string, AliasBinding> outerAliases, ParameterExpression outerParameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext)
     {
+        ArgumentNullException.ThrowIfNull(queryExecutionContext);
+
         if (queryExpression is not SqlQuerySpecification querySpecification)
         {
             throw new TdsQueryEngineException("Only simple query specifications are supported in EXISTS subqueries.");
@@ -1091,12 +1129,12 @@ internal sealed class TdsQueryEngineExecutor
             throw new TdsQueryEngineException("The EXISTS subquery uses a SELECT feature that is not supported.");
         }
 
-        var source = BuildSource(querySpecification.FromClause, cteRoots, parameters);
+        var source = BuildSource(querySpecification.FromClause, cteRoots, parameters, queryExecutionContext);
         var parameter = Expression.Parameter(source.RowType, GetUniqueParameterName(GetTypeParameterName(source.RowType), outerParameter.Name));
         var scopedAliases = CreateScopedAliases(source.Aliases, outerAliases, outerParameter);
         if (querySpecification.WhereClause?.Expression is not null)
         {
-            var predicate = BuildBoolean(querySpecification.WhereClause.Expression, scopedAliases, parameter, parameters, cteRoots);
+            var predicate = BuildBoolean(querySpecification.WhereClause.Expression, scopedAliases, parameter, parameters, cteRoots, queryExecutionContext);
             var whereCall = Expression.Call(
                 typeof(Queryable),
                 nameof(Queryable.Where),
@@ -1658,7 +1696,8 @@ internal sealed class TdsQueryEngineExecutor
             aliases,
             parameter,
             parameters ?? new Dictionary<string, TdsQueryParameter>(StringComparer.OrdinalIgnoreCase),
-            cteRoots: new Dictionary<string, TdsQueryRoot>(StringComparer.OrdinalIgnoreCase));
+            cteRoots: new Dictionary<string, TdsQueryRoot>(StringComparer.OrdinalIgnoreCase),
+            queryExecutionContext: null);
         var ifTrue = BuildScalar(ParseScalarExpression(argumentTexts[1]), aliases, parameter, parameters);
         var ifFalse = BuildScalar(ParseScalarExpression(argumentTexts[2]), aliases, parameter, parameters, ifTrue.Type);
         if (ifTrue.Type != ifFalse.Type)

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
@@ -26,11 +26,14 @@ internal sealed class TdsQueryEngineExecutor
 
             QueryContext = queryContext;
             QueryRoots = queryRoots;
+            ResolvedQueryRoots = new Dictionary<string, IQueryable>(StringComparer.OrdinalIgnoreCase);
         }
 
         public TdsQueryContext QueryContext { get; }
 
         public IReadOnlyDictionary<string, TdsQueryRoot> QueryRoots { get; }
+
+        public IDictionary<string, IQueryable> ResolvedQueryRoots { get; }
     }
 
     private readonly TdsQueryEngineOptions _options;
@@ -58,6 +61,12 @@ internal sealed class TdsQueryEngineExecutor
             var parameters = GetSqlParameters(context);
             return await ExecuteTextQueryAsync(commandText, parameters, queryExecutionContext, cancellationToken).ConfigureAwait(false);
         }
+        catch (TdsQueryAuthorizationException ex)
+        {
+            var error = _options.NotAuthorizedErrorFactory(context, ex.ResourceKind, ex.ResourceName)
+                ?? throw new InvalidOperationException("The not-authorized error factory returned null.");
+            return TdsQueryResult.FromError(error);
+        }
         catch (TdsQueryEngineException ex)
         {
             return TdsQueryResult.FromError(new TdsQueryError
@@ -80,7 +89,7 @@ internal sealed class TdsQueryEngineExecutor
                 continue;
             }
 
-            result.Add(queryRoot.Name, new TdsQueryRoot(queryRoot.Name, queryContext.ResolveQuery(queryRoot)));
+            result.Add(queryRoot.Name, queryRoot);
         }
 
         return new QueryExecutionContext(queryContext, result);
@@ -98,8 +107,20 @@ internal sealed class TdsQueryEngineExecutor
             throw new TdsQueryEngineException($"Unknown stored procedure '{context.ProcedureName}'.");
         }
 
+        EnsureAuthorized(context, TdsQueryEngineResourceKind.StoredProcedure, context.ProcedureName);
         var value = await InvokeStoredProcedureAsync(storedProcedure, context.Parameters, cancellationToken).ConfigureAwait(false);
         return TdsQueryResultBuilder.FromValue(value);
+    }
+
+    private void EnsureAuthorized(TdsQueryContext context, TdsQueryEngineResourceKind resourceKind, string resourceName)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
+
+        if (!_options.IsAuthorized(context, resourceKind, resourceName))
+        {
+            throw new TdsQueryAuthorizationException(resourceKind, resourceName);
+        }
     }
 
     private static async ValueTask<object?> InvokeStoredProcedureAsync(Delegate storedProcedure, IReadOnlyList<TdsQueryParameter> parameters, CancellationToken cancellationToken)
@@ -420,15 +441,25 @@ internal sealed class TdsQueryEngineExecutor
     private QuerySource BuildTableSource(SqlTableRefExpression tableExpression, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext queryExecutionContext)
     {
         var tableName = tableExpression.ObjectIdentifier.ObjectName.Value;
-        var root = cteRoots.TryGetValue(tableName, out var cteRoot)
-            ? cteRoot
-            : queryExecutionContext.QueryRoots.TryGetValue(tableName, out var queryRoot) ? queryRoot : null;
-        if (root is null)
+        if (cteRoots.TryGetValue(tableName, out var cteRoot))
+        {
+            var cteQuery = queryExecutionContext.QueryContext.ResolveQuery(cteRoot);
+            var cteAlias = tableExpression.Alias?.Value ?? tableName;
+            return new QuerySource(
+                cteQuery,
+                cteQuery.ElementType,
+                new Dictionary<string, AliasBinding>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [cteAlias] = new AliasBinding(cteQuery.ElementType, expression => expression),
+                });
+        }
+
+        if (!queryExecutionContext.QueryRoots.TryGetValue(tableName, out var queryRoot))
         {
             throw new TdsQueryEngineException($"Unknown query root '{tableName}'.");
         }
 
-        var query = queryExecutionContext.QueryContext.ResolveQuery(root);
+        var query = ResolveConfiguredQueryRoot(queryExecutionContext, tableName, queryRoot);
         var alias = tableExpression.Alias?.Value ?? tableName;
         return new QuerySource(
             query,
@@ -437,6 +468,19 @@ internal sealed class TdsQueryEngineExecutor
             {
                 [alias] = new AliasBinding(query.ElementType, expression => expression),
             });
+    }
+
+    private IQueryable ResolveConfiguredQueryRoot(QueryExecutionContext queryExecutionContext, string queryRootName, TdsQueryRoot queryRoot)
+    {
+        if (queryExecutionContext.ResolvedQueryRoots.TryGetValue(queryRootName, out var query))
+        {
+            return query;
+        }
+
+        EnsureAuthorized(queryExecutionContext.QueryContext, TdsQueryEngineResourceKind.QueryRoot, queryRootName);
+        query = queryExecutionContext.QueryContext.ResolveQuery(queryRoot);
+        queryExecutionContext.ResolvedQueryRoots.Add(queryRootName, query);
+        return query;
     }
 
     private QuerySource BuildDerivedTableSource(SqlDerivedTableExpression tableExpression, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, IReadOnlyDictionary<string, TdsQueryParameter> parameters, QueryExecutionContext queryExecutionContext)

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineOptions.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineOptions.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Xml;
 using System.Xml.Schema;
+using Meziantou.Framework.Tds.Handler;
 
 namespace Meziantou.Framework.Tds.QueryEngine;
 
@@ -23,19 +24,20 @@ public sealed class TdsQueryEngineOptions
     /// <summary>Gets the XML schema collections available to typed XML casts.</summary>
     public IDictionary<string, XmlSchemaSet> XmlSchemaCollections { get; } = new Dictionary<string, XmlSchemaSet>(StringComparer.OrdinalIgnoreCase);
 
-    /// <summary>Adds an <see cref="IQueryable{T}"/> query root.</summary>
-    public TdsQueryEngineOptions AddQueryRoot<T>(string name, IQueryable<T> query)
+    /// <summary>Adds a query root factory resolved from the current query request context.</summary>
+    public TdsQueryEngineOptions AddQueryRoot<T>(string name, Func<TdsQueryContext, IQueryable<T>> queryFactory)
     {
-        QueryRoots.Add(new TdsQueryRoot(name, query));
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(queryFactory);
+
+        QueryRoots.Add(new TdsQueryRoot(name, context =>
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            var query = queryFactory(context);
+            return query ?? throw new InvalidOperationException($"The query root '{name}' returned null.");
+        }));
         return this;
-    }
-
-    /// <summary>Adds an in-memory collection query root.</summary>
-    public TdsQueryEngineOptions AddQueryRoot<T>(string name, IEnumerable<T> collection)
-    {
-        ArgumentNullException.ThrowIfNull(collection);
-
-        return AddQueryRoot(name, collection.AsQueryable());
     }
 
     /// <summary>Adds or replaces a scalar SQL function mapping.</summary>

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineOptions.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineOptions.cs
@@ -9,6 +9,14 @@ namespace Meziantou.Framework.Tds.QueryEngine;
 /// <summary>Configures the built-in TDS query engine.</summary>
 public sealed class TdsQueryEngineOptions
 {
+    private static readonly TdsQueryEngineAuthorizationHandler DefaultIsAuthorized = static (context, resourceKind, resourceName) =>
+    {
+        _ = context;
+        _ = resourceKind;
+        _ = resourceName;
+        return true;
+    };
+
     /// <summary>Gets the stored procedures available to RPC requests.</summary>
     public IDictionary<string, Delegate> StoredProcedures { get; } = new Dictionary<string, Delegate>(StringComparer.OrdinalIgnoreCase);
 
@@ -20,6 +28,12 @@ public sealed class TdsQueryEngineOptions
 
     /// <summary>Gets the scalar SQL function mappings used by the query translator.</summary>
     public IDictionary<string, TdsQueryScalarFunction> ScalarFunctions { get; } = SqlFunctions.CreateDefaultScalarFunctions();
+
+    /// <summary>Gets or sets the authorization callback used for stored procedures and query roots.</summary>
+    public TdsQueryEngineAuthorizationHandler IsAuthorized { get; set; } = DefaultIsAuthorized;
+
+    /// <summary>Gets or sets the factory used to build permission-denied errors.</summary>
+    public Func<TdsQueryContext, TdsQueryEngineResourceKind, string, TdsQueryError> NotAuthorizedErrorFactory { get; set; } = DefaultNotAuthorizedErrorFactory;
 
     /// <summary>Gets the XML schema collections available to typed XML casts.</summary>
     public IDictionary<string, XmlSchemaSet> XmlSchemaCollections { get; } = new Dictionary<string, XmlSchemaSet>(StringComparer.OrdinalIgnoreCase);
@@ -95,5 +109,26 @@ public sealed class TdsQueryEngineOptions
     private static void ValidationCallback(object? sender, ValidationEventArgs args)
     {
         throw new TdsQueryEngineException($"Invalid XML schema collection definition: {args.Message}");
+    }
+
+    private static TdsQueryError DefaultNotAuthorizedErrorFactory(TdsQueryContext context, TdsQueryEngineResourceKind resourceKind, string resourceName)
+    {
+        _ = context;
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
+
+        var permission = resourceKind switch
+        {
+            TdsQueryEngineResourceKind.StoredProcedure => "EXECUTE",
+            TdsQueryEngineResourceKind.QueryRoot => "SELECT",
+            _ => throw new InvalidOperationException($"Unsupported resource kind '{resourceKind}'."),
+        };
+
+        return new TdsQueryError
+        {
+            Number = 229,
+            State = 5,
+            Class = 14,
+            Message = $"The {permission} permission was denied on the object '{resourceName}'.",
+        };
     }
 }

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineResourceKind.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineResourceKind.cs
@@ -1,0 +1,11 @@
+namespace Meziantou.Framework.Tds.QueryEngine;
+
+/// <summary>Identifies the query-engine resource being accessed.</summary>
+public enum TdsQueryEngineResourceKind
+{
+    /// <summary>A stored procedure invoked by an RPC request.</summary>
+    StoredProcedure,
+
+    /// <summary>A named query root referenced by a SQL query.</summary>
+    QueryRoot,
+}

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryRoot.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryRoot.cs
@@ -1,23 +1,46 @@
+using Meziantou.Framework.Tds.Handler;
+
 namespace Meziantou.Framework.Tds.QueryEngine;
 
 /// <summary>Represents a named query root exposed to SQL text queries.</summary>
 public sealed class TdsQueryRoot
 {
+    private readonly Func<TdsQueryContext, IQueryable> _queryFactory;
+
     /// <summary>Initializes a new instance of the <see cref="TdsQueryRoot"/> class.</summary>
-    public TdsQueryRoot(string name, IQueryable query)
+    public TdsQueryRoot(string name, Func<TdsQueryContext, IQueryable> queryFactory)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
-        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(queryFactory);
 
         Name = name;
-        Query = query;
+        _queryFactory = queryFactory;
     }
 
     /// <summary>Gets the SQL table name.</summary>
     public string Name { get; }
 
-    /// <summary>Gets the typed query root.</summary>
-    public IQueryable Query { get; }
+    internal TdsQueryRoot(string name, IQueryable query)
+        : this(name, _ => query)
+    {
+    }
 
-    internal Type ElementType => Query.ElementType;
+    internal IQueryable GetQuery(TdsQueryContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return _queryFactory(context);
+    }
+}
+
+internal static class TdsQueryContextExtensions
+{
+    internal static IQueryable ResolveQuery(this TdsQueryContext context, TdsQueryRoot queryRoot)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(queryRoot);
+
+        var query = queryRoot.GetQuery(context);
+        return query ?? throw new InvalidOperationException($"The query root '{queryRoot.Name}' returned null.");
+    }
 }

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryRoot.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryRoot.cs
@@ -32,15 +32,3 @@ public sealed class TdsQueryRoot
         return _queryFactory(context);
     }
 }
-
-internal static class TdsQueryContextExtensions
-{
-    internal static IQueryable ResolveQuery(this TdsQueryContext context, TdsQueryRoot queryRoot)
-    {
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(queryRoot);
-
-        var query = queryRoot.GetQuery(context);
-        return query ?? throw new InvalidOperationException($"The query root '{queryRoot.Name}' returned null.");
-    }
-}

--- a/src/Meziantou.Framework.TdsServer/readme.md
+++ b/src/Meziantou.Framework.TdsServer/readme.md
@@ -93,6 +93,31 @@ app.MapTdsQueryEngine(queryEngineOptions);
 
 Query roots are resolved per request and receive the full query `context`, so you can prefilter data for the authenticated user (or use other request metadata) before SQL translation happens.
 
+You can also deny access to a specific stored procedure or query root:
+
+```csharp
+queryEngineOptions.IsAuthorized = (context, resourceKind, resourceName) =>
+{
+    var userId = context.UserContext?.FindFirstValue(ClaimTypes.NameIdentifier);
+
+    if (resourceKind == TdsQueryEngineResourceKind.StoredProcedure &&
+        string.Equals(resourceName, "AdminOnlyProc", StringComparison.OrdinalIgnoreCase))
+    {
+        return userId == "1";
+    }
+
+    if (resourceKind == TdsQueryEngineResourceKind.QueryRoot &&
+        string.Equals(resourceName, "admin_customers", StringComparison.OrdinalIgnoreCase))
+    {
+        return userId == "1";
+    }
+
+    return true;
+};
+```
+
+When authorization is denied, the built-in query engine returns a permission-denied error (SQL-style error `229`, class `14`). Unknown roots or stored procedures remain distinct errors.
+
 By default, the query engine materializes translated queries by enumerating the `IQueryable`. You can replace `MaterializeAsync` to use an async provider-specific materializer such as Entity Framework Core's `ToListAsync`.
 
 The initial SQL text support is intentionally small: one `SELECT` statement with optional non-recursive CTEs (`WITH ... AS (...)`) including CTE column lists, `FROM` (including derived tables), `INNER JOIN` (including derived tables), and `.NET 10+` `LEFT JOIN` / `RIGHT JOIN` (including derived tables), `CROSS APPLY` for `xml.nodes(...)`, `WHERE` comparisons combined with `AND`/`OR`/`NOT`, `IS NULL`/`IS NOT NULL`, `IN`/`NOT IN` (value lists and simple subqueries, including correlated references), `EXISTS`/`NOT EXISTS` (simple subqueries, including correlated references), SQL parameters, `TOP`, `DISTINCT`, `SELECT *` for single-table queries, selected columns with aliases, `ORDER BY` (including `OFFSET/FETCH`), `UNION`/`UNION ALL`, multi-column `GROUP BY`, `HAVING`, grouped aggregates (`COUNT(*)`, `SUM`, `MIN`, `MAX`, `AVG`), scalar arithmetic operators (`+`, `-`, `*`, `/`, `%`), string concatenation (`+`, `||`, `CONCAT`), and scalar functions (`UPPER`, `LOWER`, `LEN`, `LTRIM`, `RTRIM`, `TRIM`, `LEFT`, `RIGHT`, `SUBSTRING`, `REPLACE`, `TRANSLATE`, `STUFF`, `STRING_ESCAPE`, `FORMAT`, `ISNULL`, `COALESCE`, `NULLIF`, `IIF`, `CHOOSE`, `CAST`, `CONVERT`, `TRY_CAST`, `TRY_CONVERT`, `GETDATE`, `SYSDATETIME`, `DATEADD`, `DATEDIFF`, `EOMONTH`, `YEAR`, `MONTH`, `DAY`, `ABS`, `ROUND`, `CEILING`, `FLOOR`, `POWER`, `SQRT`, `EXP`, `LOG`, `SIN`, `COS`, `TAN`, `ASIN`, `ACOS`, `ATAN`, `ATN2`, `COT`, `ISJSON`, `JSON_VALUE`, `JSON_PATH_EXISTS`, `JSON_QUERY`) with SQL-style `lax`/`strict` path mode support for JSON path arguments, plus XML methods (`.query()`, `.value()`, `.exist()`, `.nodes()`) and typed/untyped XML casts.

--- a/src/Meziantou.Framework.TdsServer/readme.md
+++ b/src/Meziantou.Framework.TdsServer/readme.md
@@ -74,12 +74,24 @@ var customers = new[]
 }.AsQueryable();
 
 var queryEngineOptions = new TdsQueryEngineOptions();
-queryEngineOptions.AddQueryRoot("customers", customers);
+queryEngineOptions.AddQueryRoot(
+    "customers",
+    context =>
+    {
+        if (int.TryParse(context.UserContext?.FindFirstValue(ClaimTypes.NameIdentifier), out var userId))
+        {
+            return customers.Where(customer => customer.Id == userId);
+        }
+
+        return customers;
+    });
 queryEngineOptions.StoredProcedures.Add("GetCustomer", (int id) => customers.Where(customer => customer.Id == id));
 
 app.MapTdsAuthenticationHandler((context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success()));
 app.MapTdsQueryEngine(queryEngineOptions);
 ```
+
+Query roots are resolved per request and receive the full query `context`, so you can prefilter data for the authenticated user (or use other request metadata) before SQL translation happens.
 
 By default, the query engine materializes translated queries by enumerating the `IQueryable`. You can replace `MaterializeAsync` to use an async provider-specific materializer such as Entity Framework Core's `ToListAsync`.
 

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -49,7 +49,7 @@ public sealed class TdsQueryEngineTests
             context =>
             {
                 var userIdClaim = context.UserContext?.FindFirstValue(ClaimTypes.NameIdentifier);
-                if (!int.TryParse(userIdClaim, out var userId))
+                if (!int.TryParse(userIdClaim, NumberStyles.Integer, CultureInfo.InvariantCulture, out var userId))
                 {
                     return Array.Empty<Customer>().AsQueryable();
                 }

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -2961,6 +2961,67 @@ public sealed class TdsQueryEngineTests
     }
 
     [Fact]
+    [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "The stored procedure name is generated within the test and not user-controlled.")]
+    public async Task SqlClient_QueryEngine_StoredProcedure_Unauthorized_ReturnsPermissionDenied()
+    {
+        var procedureName = "query_engine_proc_" + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+        var queryEngineOptions = CreateQueryEngineOptions();
+        queryEngineOptions.StoredProcedures.Add(procedureName, () => GetCustomers());
+        queryEngineOptions.IsAuthorized = (context, resourceKind, resourceName) =>
+            resourceKind != TdsQueryEngineResourceKind.StoredProcedure ||
+            !string.Equals(resourceName, procedureName, StringComparison.OrdinalIgnoreCase);
+
+        await ExecuteQueryExpectingServerError(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandType = CommandType.StoredProcedure;
+                command.CommandText = procedureName;
+            },
+            expectedErrorNumber: 229,
+            expectedMessageContains: "EXECUTE permission was denied");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_QueryRoot_Unauthorized_ReturnsPermissionDenied()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+        queryEngineOptions.IsAuthorized = (context, resourceKind, resourceName) =>
+            resourceKind != TdsQueryEngineResourceKind.QueryRoot ||
+            !string.Equals(resourceName, "customers", StringComparison.OrdinalIgnoreCase);
+
+        await ExecuteQueryExpectingServerError(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id
+                    FROM customers
+                    """;
+            },
+            expectedErrorNumber: 229,
+            expectedMessageContains: "SELECT permission was denied");
+    }
+
+    [Fact]
+    [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "The stored procedure name is generated within the test and not user-controlled.")]
+    public async Task SqlClient_QueryEngine_UnknownStoredProcedure_RemainsNotFoundError()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+        queryEngineOptions.IsAuthorized = (context, resourceKind, resourceName) => false;
+
+        await ExecuteQueryExpectingServerError(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandType = CommandType.StoredProcedure;
+                command.CommandText = "query_engine_missing_proc_" + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+            },
+            expectedErrorNumber: 50004,
+            expectedMessageContains: "Unknown stored procedure");
+    }
+
+    [Fact]
     public async Task SqlClient_QueryEngine_InvalidQuery_ReturnsServerError()
     {
         var invalidQueryTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -3109,14 +3170,14 @@ public sealed class TdsQueryEngineTests
         }
     }
 
-    private static async Task ExecuteQueryExpectingServerError(TdsQueryEngineOptions queryEngineOptions, Action<SqlCommand> configureCommand)
+    private static async Task ExecuteQueryExpectingServerError(TdsQueryEngineOptions queryEngineOptions, Action<SqlCommand> configureCommand, int expectedErrorNumber = 50004, string? expectedMessageContains = null, ClaimsPrincipal? userContext = null)
     {
         var options = new TdsServerOptions();
         options.AddTcpListener(0, IPAddress.Loopback);
 
         using var server = new TdsServer(
             options,
-            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master", userContext)),
             TdsQueryEngine.CreateQueryHandler(queryEngineOptions));
 
         await server.StartAsync();
@@ -3133,7 +3194,11 @@ public sealed class TdsQueryEngineTests
             return await Assert.ThrowsAsync<SqlException>(() => command.ExecuteReaderAsync());
         });
 
-        Assert.Equal(50004, exception.Number);
+        Assert.Equal(expectedErrorNumber, exception.Number);
+        if (!string.IsNullOrEmpty(expectedMessageContains))
+        {
+            Assert.Contains(expectedMessageContains, exception.Message, StringComparison.Ordinal);
+        }
     }
 
     private static async Task<T> ExecuteWithTransientSqlRetry<T>(Func<Task<T>> action)

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Net;
+using System.Security.Claims;
 using System.Text;
 using Meziantou.Framework.Tds;
 using Meziantou.Framework.Tds.Handler;
@@ -37,6 +38,40 @@ public sealed class TdsQueryEngineTests
             4 David
             """,
             expectedMaterializedQueries: "Customer[].Select(customer => new TdsProjection() {Id = customer.Id, Name = customer.Name})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_QueryRootFactory_CanFilterUsingUserContext()
+    {
+        var queryEngineOptions = new TdsQueryEngineOptions();
+        queryEngineOptions.AddQueryRoot(
+            "customers",
+            context =>
+            {
+                var userIdClaim = context.UserContext?.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (!int.TryParse(userIdClaim, out var userId))
+                {
+                    return Array.Empty<Customer>().AsQueryable();
+                }
+
+                return GetCustomers().Where(customer => customer.Id == userId).AsQueryable();
+            });
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id, Name
+                    FROM customers
+                    """;
+            },
+            expected: """
+                Id Name
+                2 Bob
+                """,
+            expectedMaterializedQueries: null,
+            userContext: CreateUserContext("2"));
     }
 
     [Fact]
@@ -2965,12 +3000,22 @@ public sealed class TdsQueryEngineTests
     private static TdsQueryEngineOptions CreateQueryEngineOptions()
     {
         var options = new TdsQueryEngineOptions();
-        options.AddQueryRoot("customers", GetCustomers());
-        options.AddQueryRoot("orders", GetOrders());
-        options.AddQueryRoot("nullable_customers", GetNullableCustomers());
-        options.AddQueryRoot("json_docs", GetJsonDocuments());
-        options.AddQueryRoot("xml_docs", GetXmlDocuments());
+        options.AddQueryRoot("customers", context => GetCustomers().AsQueryable());
+        options.AddQueryRoot("orders", context => GetOrders().AsQueryable());
+        options.AddQueryRoot("nullable_customers", context => GetNullableCustomers().AsQueryable());
+        options.AddQueryRoot("json_docs", context => GetJsonDocuments().AsQueryable());
+        options.AddQueryRoot("xml_docs", context => GetXmlDocuments().AsQueryable());
         return options;
+    }
+
+    private static ClaimsPrincipal CreateUserContext(string userId)
+    {
+        var identity = new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, userId),
+        ],
+        authenticationType: "password");
+        return new ClaimsPrincipal(identity);
     }
 
     private static Customer[] GetCustomers()
@@ -3023,7 +3068,7 @@ public sealed class TdsQueryEngineTests
         ];
     }
 
-    private static async Task ExecuteQuery(TdsQueryEngineOptions queryEngineOptions, Action<SqlCommand> configureCommand, string expected, string expectedMaterializedQueries)
+    private static async Task ExecuteQuery(TdsQueryEngineOptions queryEngineOptions, Action<SqlCommand> configureCommand, string expected, string? expectedMaterializedQueries, ClaimsPrincipal? userContext = null)
     {
         var materializedQueries = new List<string>();
         var materializeAsync = queryEngineOptions.MaterializeAsync;
@@ -3038,7 +3083,7 @@ public sealed class TdsQueryEngineTests
 
         using var server = new TdsServer(
             options,
-            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master", userContext)),
             TdsQueryEngine.CreateQueryHandler(queryEngineOptions));
 
         await server.StartAsync();
@@ -3057,8 +3102,11 @@ public sealed class TdsQueryEngineTests
         });
 
         Assert.Equal(NormalizeMultilineString(expected), actualResult);
-        var actualMaterializedQueries = NormalizeMultilineString(string.Join('\n', materializedQueries));
-        AssertMaterializedQueries(expectedMaterializedQueries, actualMaterializedQueries);
+        if (expectedMaterializedQueries is not null)
+        {
+            var actualMaterializedQueries = NormalizeMultilineString(string.Join('\n', materializedQueries));
+            AssertMaterializedQueries(expectedMaterializedQueries, actualMaterializedQueries);
+        }
     }
 
     private static async Task ExecuteQueryExpectingServerError(TdsQueryEngineOptions queryEngineOptions, Action<SqlCommand> configureCommand)


### PR DESCRIPTION
## Why
The query engine needed a way to prefilter query roots using the full request data for the current execution, not only the authenticated principal.

## What changed
- Changed query-root registration to accept the full request context:
  - `TdsQueryEngineOptions.AddQueryRoot<T>(string, Func<TdsQueryContext, IQueryable<T>>)`
- Refactored query execution to build a per-request `QueryExecutionContext` (resolved roots + request context) and pass it through translation methods.
- Removed request-scoped `AsyncLocal` state and switched to explicit context passing.
- Moved query resolution to a method on `TdsQueryContext` (extension method) and changed null query-factory results to throw `InvalidOperationException`.
- Updated docs and tests to use context-based query-root factories, including coverage for user-context filtering.

## Notes for reviewers
- This is an intentional API change for query-root factories.
- Root factories are resolved once per request, then reused by translation.

## Validation
- `dotnet run ./eng/update-bom.cs`
- `dotnet run ./eng/update-readme.cs`
- `dotnet run ./eng/update-project-slnx.cs`
- `dotnet run ./eng/validate-testprojects-configuration.cs`
- `dotnet run ./eng/update-trimmable.cs`
- `DiffEngine_Disabled=true dotnet test tests/Meziantou.Framework.TdsServer.Tests/Meziantou.Framework.TdsServer.Tests.csproj --filter "FullyQualifiedName~TdsQueryEngine" --nologo`