### PR TITLE
Add FastEnum per-method analyzers and code fixes

### DIFF
--- a/benchmarks/FastEnumGeneratorBenchmarks/FastEnumGeneratorBenchmarks.csproj
+++ b/benchmarks/FastEnumGeneratorBenchmarks/FastEnumGeneratorBenchmarks.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(LatestTargetFramework)</TargetFramework>
+    <NoWarn>$(NoWarn);MFEG0002;MFEG0003;MFEG0004;MFEG0005;MFEG0006;MFEG0007;MFEG0008</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.FastEnumGenerator/FastEnumAnalyzer.cs
+++ b/src/Meziantou.Framework.FastEnumGenerator/FastEnumAnalyzer.cs
@@ -16,7 +16,63 @@ public sealed class FastEnumAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(InvalidEnumType);
+    internal static readonly DiagnosticDescriptor UseFastEnumParse = new(
+        id: "MFEG0002",
+        title: "Use FastEnum Parse",
+        messageFormat: "Use '{0}.Parse(...)' instead of 'Enum.Parse(...)'",
+        category: "FastEnumGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor UseFastEnumTryParse = new(
+        id: "MFEG0003",
+        title: "Use FastEnum TryParse",
+        messageFormat: "Use '{0}.TryParse(...)' instead of 'Enum.TryParse(...)'",
+        category: "FastEnumGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor UseFastEnumGetNames = new(
+        id: "MFEG0004",
+        title: "Use FastEnum GetNames",
+        messageFormat: "Use '{0}.GetNames(useMetadata: false)' instead of 'Enum.GetNames(...)'",
+        category: "FastEnumGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor UseFastEnumGetValues = new(
+        id: "MFEG0005",
+        title: "Use FastEnum GetValues",
+        messageFormat: "Use '{0}.GetValues()' instead of 'Enum.GetValues(...)'",
+        category: "FastEnumGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor UseFastEnumGetName = new(
+        id: "MFEG0006",
+        title: "Use FastEnum GetName",
+        messageFormat: "Use '{0}.GetName()' instead of 'Enum.GetName(...)'",
+        category: "FastEnumGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor UseFastEnumIsDefined = new(
+        id: "MFEG0007",
+        title: "Use FastEnum IsDefined",
+        messageFormat: "Use '{0}.IsDefined(...)' instead of 'Enum.IsDefined(...)'",
+        category: "FastEnumGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor UseFastEnumToStringFast = new(
+        id: "MFEG0008",
+        title: "Use FastEnum ToStringFast",
+        messageFormat: "Use 'ToStringFast()' instead of '{0}.ToString()'",
+        category: "FastEnumGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [InvalidEnumType, UseFastEnumParse, UseFastEnumTryParse, UseFastEnumGetNames, UseFastEnumGetValues, UseFastEnumGetName, UseFastEnumIsDefined, UseFastEnumToStringFast];
 
     public override void Initialize(AnalysisContext context)
     {
@@ -24,11 +80,18 @@ public sealed class FastEnumAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
         context.RegisterCompilationStartAction(context =>
         {
-            var fastEnumAttribute = context.Compilation.GetTypeByMetadataName("Meziantou.Framework.Annotations.FastEnumAttribute");
+            var fastEnumAttribute = context.Compilation.GetTypeByMetadataName(FastEnumAnalyzerCommon.FastEnumAttributeMetadataName);
             if (fastEnumAttribute is null)
                 return;
 
             context.RegisterOperationAction(context => AnalyzeAttributeOperation(context, fastEnumAttribute), OperationKind.Attribute);
+
+            var enumType = context.Compilation.GetSpecialType(SpecialType.System_Enum);
+            var fastEnumTypes = FastEnumAnalyzerCommon.GetFastEnumTypes(context.Compilation, fastEnumAttribute);
+            if (fastEnumTypes.Count == 0)
+                return;
+
+            context.RegisterOperationAction(context => AnalyzeInvocationOperation(context, enumType, fastEnumTypes), OperationKind.Invocation);
         });
     }
 
@@ -63,5 +126,30 @@ public sealed class FastEnumAnalyzer : DiagnosticAnalyzer
             return;
 
         context.ReportDiagnostic(Diagnostic.Create(InvalidEnumType, location, typeOfOperation.TypeOperand.ToDisplayString()));
+    }
+
+    private static void AnalyzeInvocationOperation(OperationAnalysisContext context, INamedTypeSymbol enumType, ImmutableHashSet<INamedTypeSymbol> fastEnumTypes)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        if (!FastEnumAnalyzerCommon.TryGetFastEnumInvocationMatch(invocationOperation, enumType, fastEnumTypes, out var match))
+            return;
+
+        var diagnostic = Diagnostic.Create(GetDiagnosticDescriptor(match.MethodKind), invocationOperation.Syntax.GetLocation(), match.EnumType.ToDisplayString());
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    private static DiagnosticDescriptor GetDiagnosticDescriptor(FastEnumMethodKind methodKind)
+    {
+        return methodKind switch
+        {
+            FastEnumMethodKind.Parse => UseFastEnumParse,
+            FastEnumMethodKind.TryParse => UseFastEnumTryParse,
+            FastEnumMethodKind.GetNames => UseFastEnumGetNames,
+            FastEnumMethodKind.GetValues => UseFastEnumGetValues,
+            FastEnumMethodKind.GetName => UseFastEnumGetName,
+            FastEnumMethodKind.IsDefined => UseFastEnumIsDefined,
+            FastEnumMethodKind.ToString => UseFastEnumToStringFast,
+            _ => InvalidEnumType,
+        };
     }
 }

--- a/src/Meziantou.Framework.FastEnumGenerator/FastEnumAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.FastEnumGenerator/FastEnumAnalyzerCommon.cs
@@ -1,0 +1,131 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.FastEnumGenerator;
+
+internal static class FastEnumAnalyzerCommon
+{
+    internal const string FastEnumAttributeMetadataName = "Meziantou.Framework.Annotations.FastEnumAttribute";
+
+    internal static ImmutableHashSet<INamedTypeSymbol> GetFastEnumTypes(Compilation compilation, INamedTypeSymbol fastEnumAttribute)
+    {
+        var result = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        foreach (var attribute in compilation.Assembly.GetAttributes())
+        {
+            if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, fastEnumAttribute))
+                continue;
+
+            if (attribute.ConstructorArguments.Length != 1 || attribute.ConstructorArguments[0].Value is not INamedTypeSymbol { TypeKind: TypeKind.Enum } enumType)
+                continue;
+
+            _ = result.Add(enumType);
+        }
+
+        return result.ToImmutable();
+    }
+
+    internal static bool TryGetFastEnumInvocationMatch(IInvocationOperation invocationOperation, INamedTypeSymbol enumType, ImmutableHashSet<INamedTypeSymbol> fastEnumTypes, out FastEnumInvocationMatch match)
+    {
+        if (TryGetEnumToStringInvocationMatch(invocationOperation, fastEnumTypes, out match))
+            return true;
+
+        if (!TryGetSystemEnumMethodKind(invocationOperation.TargetMethod, enumType, out var methodKind))
+        {
+            match = default;
+            return false;
+        }
+
+        if (!TryGetTargetEnumType(invocationOperation, out var targetEnumType))
+        {
+            match = default;
+            return false;
+        }
+
+        if (!fastEnumTypes.Contains(targetEnumType))
+        {
+            match = default;
+            return false;
+        }
+
+        match = new FastEnumInvocationMatch(methodKind, targetEnumType);
+        return true;
+    }
+
+    private static bool TryGetEnumToStringInvocationMatch(IInvocationOperation invocationOperation, ImmutableHashSet<INamedTypeSymbol> fastEnumTypes, out FastEnumInvocationMatch match)
+    {
+        if (invocationOperation is
+            {
+                TargetMethod.Name: nameof(object.ToString),
+                TargetMethod.IsStatic: false,
+                Arguments.Length: 0,
+                Instance.Type: INamedTypeSymbol { TypeKind: TypeKind.Enum } enumType,
+            } &&
+            fastEnumTypes.Contains(enumType))
+        {
+            match = new FastEnumInvocationMatch(FastEnumMethodKind.ToString, enumType);
+            return true;
+        }
+
+        match = default;
+        return false;
+    }
+
+    private static bool TryGetSystemEnumMethodKind(IMethodSymbol method, INamedTypeSymbol enumType, out FastEnumMethodKind methodKind)
+    {
+        if (!method.IsStatic || !SymbolEqualityComparer.Default.Equals(method.ContainingType, enumType))
+        {
+            methodKind = default;
+            return false;
+        }
+
+        methodKind = method.Name switch
+        {
+            nameof(Enum.Parse) => FastEnumMethodKind.Parse,
+            nameof(Enum.TryParse) => FastEnumMethodKind.TryParse,
+            nameof(Enum.GetNames) => FastEnumMethodKind.GetNames,
+            nameof(Enum.GetValues) => FastEnumMethodKind.GetValues,
+            nameof(Enum.GetName) => FastEnumMethodKind.GetName,
+            nameof(Enum.IsDefined) => FastEnumMethodKind.IsDefined,
+            _ => default,
+        };
+
+        return methodKind is FastEnumMethodKind.Parse or FastEnumMethodKind.TryParse or FastEnumMethodKind.GetNames or FastEnumMethodKind.GetValues or FastEnumMethodKind.GetName or FastEnumMethodKind.IsDefined;
+    }
+
+    private static bool TryGetTargetEnumType(IInvocationOperation invocationOperation, out INamedTypeSymbol targetEnumType)
+    {
+        if (invocationOperation.TargetMethod.IsGenericMethod &&
+            invocationOperation.TargetMethod.TypeArguments.Length >= 1 &&
+            invocationOperation.TargetMethod.TypeArguments[0] is INamedTypeSymbol { TypeKind: TypeKind.Enum } typeArgument)
+        {
+            targetEnumType = typeArgument;
+            return true;
+        }
+
+        if (invocationOperation.Arguments.Length > 0 &&
+            UnwrapConversion(invocationOperation.Arguments[0].Value) is ITypeOfOperation { TypeOperand: INamedTypeSymbol { TypeKind: TypeKind.Enum } typeOfOperation })
+        {
+            targetEnumType = typeOfOperation;
+            return true;
+        }
+
+        targetEnumType = null!;
+        return false;
+    }
+
+    internal static bool HasTypeOfFirstArgument(IInvocationOperation invocationOperation)
+    {
+        return invocationOperation.Arguments.Length > 0 && UnwrapConversion(invocationOperation.Arguments[0].Value) is ITypeOfOperation;
+    }
+
+    private static IOperation UnwrapConversion(IOperation operation)
+    {
+        while (operation is IConversionOperation conversionOperation)
+        {
+            operation = conversionOperation.Operand;
+        }
+
+        return operation;
+    }
+}

--- a/src/Meziantou.Framework.FastEnumGenerator/FastEnumCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FastEnumGenerator/FastEnumCodeFixProvider.cs
@@ -1,0 +1,281 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Operations;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Meziantou.Framework.FastEnumGenerator;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(FastEnumCodeFixProvider))]
+public sealed class FastEnumCodeFixProvider : CodeFixProvider
+{
+    private static readonly ImmutableArray<string> SupportedDiagnosticIds = [FastEnumAnalyzer.UseFastEnumParse.Id, FastEnumAnalyzer.UseFastEnumTryParse.Id, FastEnumAnalyzer.UseFastEnumGetNames.Id, FastEnumAnalyzer.UseFastEnumGetValues.Id, FastEnumAnalyzer.UseFastEnumGetName.Id, FastEnumAnalyzer.UseFastEnumIsDefined.Id, FastEnumAnalyzer.UseFastEnumToStringFast.Id];
+
+    public override ImmutableArray<string> FixableDiagnosticIds => SupportedDiagnosticIds;
+
+    public override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var invocationSyntax = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true).FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (invocationSyntax is null || semanticModel.GetOperation(invocationSyntax, context.CancellationToken) is not IInvocationOperation invocationOperation)
+                continue;
+
+            if (!TryCreateReplacementInvocation(invocationOperation, invocationSyntax, out _))
+                continue;
+
+            var title = diagnostic.Id switch
+            {
+                "MFEG0002" => "Use FastEnum Parse",
+                "MFEG0003" => "Use FastEnum TryParse",
+                "MFEG0004" => "Use FastEnum GetNames",
+                "MFEG0005" => "Use FastEnum GetValues",
+                "MFEG0006" => "Use FastEnum GetName",
+                "MFEG0007" => "Use FastEnum IsDefined",
+                "MFEG0008" => "Use FastEnum ToStringFast",
+                _ => "Use FastEnum API",
+            };
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title,
+                    cancellationToken => ApplyFixAsync(context.Document, invocationSyntax, cancellationToken),
+                    equivalenceKey: diagnostic.Id),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocationSyntax, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null || semanticModel.GetOperation(invocationSyntax, cancellationToken) is not IInvocationOperation invocationOperation)
+            return document;
+
+        if (!TryCreateReplacementInvocation(invocationOperation, invocationSyntax, out var replacement))
+            return document;
+
+        replacement = replacement.WithTriviaFrom(invocationSyntax).WithAdditionalAnnotations(Formatter.Annotation);
+        var newRoot = root.ReplaceNode(invocationSyntax, replacement);
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static bool TryCreateReplacementInvocation(IInvocationOperation invocationOperation, InvocationExpressionSyntax invocationSyntax, out InvocationExpressionSyntax replacement)
+    {
+        if (invocationOperation.SemanticModel is null)
+        {
+            replacement = null!;
+            return false;
+        }
+
+        var compilation = invocationOperation.SemanticModel.Compilation;
+        var fastEnumAttribute = compilation.GetTypeByMetadataName(FastEnumAnalyzerCommon.FastEnumAttributeMetadataName);
+        if (fastEnumAttribute is null)
+        {
+            replacement = null!;
+            return false;
+        }
+
+        var enumType = compilation.GetSpecialType(SpecialType.System_Enum);
+        var fastEnumTypes = FastEnumAnalyzerCommon.GetFastEnumTypes(compilation, fastEnumAttribute);
+        if (!FastEnumAnalyzerCommon.TryGetFastEnumInvocationMatch(invocationOperation, enumType, fastEnumTypes, out var match))
+        {
+            replacement = null!;
+            return false;
+        }
+
+        return match.MethodKind switch
+        {
+            FastEnumMethodKind.Parse => TryCreateParseReplacement(invocationOperation, invocationSyntax, match.EnumType, out replacement),
+            FastEnumMethodKind.TryParse => TryCreateTryParseReplacement(invocationOperation, invocationSyntax, match.EnumType, out replacement),
+            FastEnumMethodKind.GetNames => TryCreateGetNamesReplacement(invocationOperation, invocationSyntax, match.EnumType, out replacement),
+            FastEnumMethodKind.GetValues => TryCreateGetValuesReplacement(invocationOperation, invocationSyntax, match.EnumType, out replacement),
+            FastEnumMethodKind.GetName => TryCreateGetNameReplacement(invocationOperation, invocationSyntax, match.EnumType, out replacement),
+            FastEnumMethodKind.IsDefined => TryCreateIsDefinedReplacement(invocationOperation, invocationSyntax, match.EnumType, out replacement),
+            FastEnumMethodKind.ToString => TryCreateToStringReplacement(invocationSyntax, out replacement),
+            _ => TryReturnNoReplacement(out replacement),
+        };
+    }
+
+    private static bool TryCreateParseReplacement(IInvocationOperation invocationOperation, InvocationExpressionSyntax invocationSyntax, INamedTypeSymbol enumType, out InvocationExpressionSyntax replacement)
+    {
+        if (!TryGetArgumentsWithoutTypeOf(invocationOperation, invocationSyntax, out var arguments, out _))
+            return TryReturnNoReplacement(out replacement);
+
+        if (arguments.Count == 1)
+        {
+            arguments = arguments.Add(CreateNamedBooleanArgument("ignoreCase", value: false));
+        }
+        else if (arguments.Count != 2)
+        {
+            return TryReturnNoReplacement(out replacement);
+        }
+
+        replacement = CreateStaticInvocation(enumType, nameof(Enum.Parse), arguments);
+        return true;
+    }
+
+    private static bool TryCreateTryParseReplacement(IInvocationOperation invocationOperation, InvocationExpressionSyntax invocationSyntax, INamedTypeSymbol enumType, out InvocationExpressionSyntax replacement)
+    {
+        if (!TryGetArgumentsWithoutTypeOf(invocationOperation, invocationSyntax, out var arguments, out var operationArguments))
+            return TryReturnNoReplacement(out replacement);
+
+        if (operationArguments.Length is < 2 or > 3)
+            return TryReturnNoReplacement(out replacement);
+
+        if (operationArguments[^1].Parameter?.RefKind != RefKind.Out)
+            return TryReturnNoReplacement(out replacement);
+
+        if (!CanUseOutArgument(operationArguments[^1].Value, enumType))
+            return TryReturnNoReplacement(out replacement);
+
+        if (arguments.Count == 2)
+        {
+            arguments = arguments.Insert(1, CreateNamedBooleanArgument("ignoreCase", value: false));
+        }
+        else if (arguments.Count != 3)
+        {
+            return TryReturnNoReplacement(out replacement);
+        }
+
+        replacement = CreateStaticInvocation(enumType, nameof(Enum.TryParse), arguments);
+        return true;
+    }
+
+    private static bool TryCreateGetNamesReplacement(IInvocationOperation invocationOperation, InvocationExpressionSyntax invocationSyntax, INamedTypeSymbol enumType, out InvocationExpressionSyntax replacement)
+    {
+        if (!TryGetArgumentsWithoutTypeOf(invocationOperation, invocationSyntax, out var arguments, out var operationArguments) || arguments.Count != 0 || operationArguments.Length != 0)
+            return TryReturnNoReplacement(out replacement);
+
+        arguments = arguments.Add(CreateNamedBooleanArgument("useMetadata", value: false));
+        replacement = CreateStaticInvocation(enumType, nameof(Enum.GetNames), arguments);
+        return true;
+    }
+
+    private static bool TryCreateGetValuesReplacement(IInvocationOperation invocationOperation, InvocationExpressionSyntax invocationSyntax, INamedTypeSymbol enumType, out InvocationExpressionSyntax replacement)
+    {
+        if (!TryGetArgumentsWithoutTypeOf(invocationOperation, invocationSyntax, out var arguments, out var operationArguments) || arguments.Count != 0 || operationArguments.Length != 0)
+            return TryReturnNoReplacement(out replacement);
+
+        replacement = CreateStaticInvocation(enumType, nameof(Enum.GetValues), arguments);
+        return true;
+    }
+
+    private static bool TryCreateGetNameReplacement(IInvocationOperation invocationOperation, InvocationExpressionSyntax invocationSyntax, INamedTypeSymbol enumType, out InvocationExpressionSyntax replacement)
+    {
+        if (!TryGetArgumentsWithoutTypeOf(invocationOperation, invocationSyntax, out var arguments, out var operationArguments) || arguments.Count != 1 || operationArguments.Length != 1)
+            return TryReturnNoReplacement(out replacement);
+
+        var valueExpression = GetValueExpression(arguments[0].Expression, operationArguments[0].Value, enumType);
+        replacement = InvocationExpression(
+            MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                valueExpression,
+                IdentifierName("GetName")));
+        return true;
+    }
+
+    private static bool TryCreateIsDefinedReplacement(IInvocationOperation invocationOperation, InvocationExpressionSyntax invocationSyntax, INamedTypeSymbol enumType, out InvocationExpressionSyntax replacement)
+    {
+        if (!TryGetArgumentsWithoutTypeOf(invocationOperation, invocationSyntax, out var arguments, out var operationArguments) || arguments.Count != 1 || operationArguments.Length != 1)
+            return TryReturnNoReplacement(out replacement);
+
+        var valueExpression = GetValueExpression(arguments[0].Expression, operationArguments[0].Value, enumType);
+        replacement = CreateStaticInvocation(enumType, nameof(Enum.IsDefined), [Argument(valueExpression)]);
+        return true;
+    }
+
+    private static bool TryCreateToStringReplacement(InvocationExpressionSyntax invocationSyntax, out InvocationExpressionSyntax replacement)
+    {
+        if (invocationSyntax is not { ArgumentList.Arguments.Count: 0, Expression: MemberAccessExpressionSyntax memberAccessExpression })
+            return TryReturnNoReplacement(out replacement);
+
+        replacement = invocationSyntax.WithExpression(memberAccessExpression.WithName(IdentifierName("ToStringFast")));
+        return true;
+    }
+
+    private static bool TryGetArgumentsWithoutTypeOf(IInvocationOperation invocationOperation, InvocationExpressionSyntax invocationSyntax, out SeparatedSyntaxList<ArgumentSyntax> syntaxArguments, out ImmutableArray<IArgumentOperation> operationArguments)
+    {
+        syntaxArguments = invocationSyntax.ArgumentList.Arguments;
+        operationArguments = invocationOperation.Arguments;
+        if (FastEnumAnalyzerCommon.HasTypeOfFirstArgument(invocationOperation))
+        {
+            if (syntaxArguments.Count == 0 || operationArguments.Length == 0)
+                return false;
+
+            syntaxArguments = syntaxArguments.RemoveAt(0);
+            operationArguments = [.. operationArguments.Skip(1)];
+        }
+
+        return true;
+    }
+
+    private static bool CanUseOutArgument(IOperation argumentValue, INamedTypeSymbol enumType)
+    {
+        if (argumentValue is IDiscardOperation)
+            return true;
+
+        if (argumentValue is IDeclarationExpressionOperation declarationExpressionOperation)
+        {
+            if (declarationExpressionOperation.Type is null)
+                return true;
+
+            return SymbolEqualityComparer.Default.Equals(declarationExpressionOperation.Type, enumType);
+        }
+
+        return SymbolEqualityComparer.Default.Equals(argumentValue.Type, enumType);
+    }
+
+    private static InvocationExpressionSyntax CreateStaticInvocation(INamedTypeSymbol enumType, string methodName, SeparatedSyntaxList<ArgumentSyntax> arguments)
+    {
+        var enumTypeSyntax = ParseName(enumType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        return InvocationExpression(
+            MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                enumTypeSyntax,
+                IdentifierName(methodName)),
+            ArgumentList(arguments));
+    }
+
+    private static ArgumentSyntax CreateNamedBooleanArgument(string name, bool value)
+    {
+        return Argument(LiteralExpression(value ? SyntaxKind.TrueLiteralExpression : SyntaxKind.FalseLiteralExpression))
+            .WithNameColon(NameColon(IdentifierName(name)));
+    }
+
+    private static ExpressionSyntax GetValueExpression(ExpressionSyntax expression, IOperation valueOperation, INamedTypeSymbol enumType)
+    {
+        if (SymbolEqualityComparer.Default.Equals(valueOperation.Type, enumType))
+            return expression;
+
+        var enumTypeSyntax = ParseTypeName(enumType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        return ParenthesizedExpression(CastExpression(enumTypeSyntax, ParenthesizedExpression(expression)));
+    }
+
+    private static bool TryReturnNoReplacement(out InvocationExpressionSyntax replacement)
+    {
+        replacement = null!;
+        return false;
+    }
+}

--- a/src/Meziantou.Framework.FastEnumGenerator/FastEnumInvocationMatch.cs
+++ b/src/Meziantou.Framework.FastEnumGenerator/FastEnumInvocationMatch.cs
@@ -1,0 +1,5 @@
+using Microsoft.CodeAnalysis;
+
+namespace Meziantou.Framework.FastEnumGenerator;
+
+internal readonly record struct FastEnumInvocationMatch(FastEnumMethodKind MethodKind, INamedTypeSymbol EnumType);

--- a/src/Meziantou.Framework.FastEnumGenerator/FastEnumMethodKind.cs
+++ b/src/Meziantou.Framework.FastEnumGenerator/FastEnumMethodKind.cs
@@ -1,0 +1,12 @@
+namespace Meziantou.Framework.FastEnumGenerator;
+
+internal enum FastEnumMethodKind
+{
+    Parse,
+    TryParse,
+    GetNames,
+    GetValues,
+    GetName,
+    IsDefined,
+    ToString,
+}

--- a/src/Meziantou.Framework.FastEnumGenerator/Meziantou.Framework.FastEnumGenerator.csproj
+++ b/src/Meziantou.Framework.FastEnumGenerator/Meziantou.Framework.FastEnumGenerator.csproj
@@ -8,7 +8,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-    <NoWarn>$(NoWarn);RS1041</NoWarn>
+    <NoWarn>$(NoWarn);RS1038;RS1041</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,5 +18,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Meziantou.Framework.FastEnumGenerator/readme.md
+++ b/src/Meziantou.Framework.FastEnumGenerator/readme.md
@@ -46,6 +46,19 @@ When the target project supports C# 14 extension members, the generator also emi
 - `ReadOnlySpan<string> GetNames(bool useMetadata)`
 - `ReadOnlySpan<TEnum> GetValues()`
 
+## Analyzer rules
+
+The package also ships analyzers and code fixes for enums configured with `FastEnumAttribute`.
+
+- `MFEG0001`: invalid `FastEnumAttribute` enum type
+- `MFEG0002`: use `TEnum.Parse(...)` instead of `Enum.Parse(...)`
+- `MFEG0003`: use `TEnum.TryParse(...)` instead of `Enum.TryParse(...)`
+- `MFEG0004`: use `TEnum.GetNames(useMetadata: false)` instead of `Enum.GetNames(...)`
+- `MFEG0005`: use `TEnum.GetValues()` instead of `Enum.GetValues(...)`
+- `MFEG0006`: use `value.GetName()` instead of `Enum.GetName(...)`
+- `MFEG0007`: use `TEnum.IsDefined(...)` instead of `Enum.IsDefined(...)`
+- `MFEG0008`: use `value.ToStringFast()` instead of `value.ToString()`
+
 ### Metadata names
 
 `useMetadata` uses names from:

--- a/tests/Meziantou.Framework.FastEnumGenerator.GeneratorTests/Meziantou.Framework.FastEnumGenerator.GeneratorTests.csproj
+++ b/tests/Meziantou.Framework.FastEnumGenerator.GeneratorTests/Meziantou.Framework.FastEnumGenerator.GeneratorTests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)/GeneratedFiles/$(TargetFramework)</CompilerGeneratedFilesOutputPath>
+    <NoWarn>$(NoWarn);MFEG0002;MFEG0003;MFEG0004;MFEG0005;MFEG0006;MFEG0007;MFEG0008</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.FastEnumGenerator.Tests/FastEnumSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FastEnumGenerator.Tests/FastEnumSourceGeneratorTests.cs
@@ -1,8 +1,11 @@
 #pragma warning disable MA0101 // String contains an implicit end of line character
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 using Meziantou.Framework.FastEnumGenerator;
 using TestUtilities;
 using Xunit;
@@ -185,6 +188,55 @@ public sealed class FastEnumSourceGeneratorTests
         Assert.Empty(diagnostics);
     }
 
+    public static TheoryData<string, string> AnalyzerRuleCases { get; } = new()
+    {
+        { "_ = Enum.Parse<Sample.Color>(\"Blue\", false);", "MFEG0002" },
+        { "_ = Enum.TryParse<Sample.Color>(\"Blue\", out var parsed);", "MFEG0003" },
+        { "_ = Enum.GetNames<Sample.Color>();", "MFEG0004" },
+        { "_ = Enum.GetValues<Sample.Color>();", "MFEG0005" },
+        { "_ = Enum.GetName(Sample.Color.Blue);", "MFEG0006" },
+        { "_ = Enum.IsDefined(Sample.Color.Blue);", "MFEG0007" },
+        { "_ = Sample.Color.Blue.ToString();", "MFEG0008" },
+    };
+
+    [Theory]
+    [MemberData(nameof(AnalyzerRuleCases))]
+    public async Task AnalyzerReportsFastEnumApis(string invocation, string expectedDiagnosticId)
+    {
+        var sourceCode = CreateAnalyzerSource(invocation, useFastEnumAttribute: true);
+        var diagnostics = await AnalyzeFiles(sourceCode);
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(expectedDiagnosticId, diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task AnalyzerDoesNotReportEnumApisForNonFastEnum()
+    {
+        var sourceCode = CreateAnalyzerSource("_ = Enum.Parse<Sample.Color>(\"Blue\", false);", useFastEnumAttribute: false);
+        var diagnostics = await AnalyzeFiles(sourceCode);
+        Assert.Empty(diagnostics);
+    }
+
+    public static TheoryData<string, string, string> CodeFixCases { get; } = new()
+    {
+        { "_ = Enum.Parse<Sample.Color>(\"Blue\", false);", "MFEG0002", "global::Sample.Color.Parse(\"Blue\", false)" },
+        { "_ = Enum.TryParse<Sample.Color>(\"Blue\", out var parsed);", "MFEG0003", "global::Sample.Color.TryParse(\"Blue\", ignoreCase: false, out var parsed)" },
+        { "_ = Enum.GetNames<Sample.Color>();", "MFEG0004", "global::Sample.Color.GetNames(useMetadata: false)" },
+        { "_ = Enum.GetValues<Sample.Color>();", "MFEG0005", "global::Sample.Color.GetValues()" },
+        { "_ = Enum.GetName(Sample.Color.Blue);", "MFEG0006", "Sample.Color.Blue.GetName()" },
+        { "_ = Enum.IsDefined(Sample.Color.Blue);", "MFEG0007", "global::Sample.Color.IsDefined(Sample.Color.Blue)" },
+        { "_ = Sample.Color.Blue.ToString();", "MFEG0008", "Sample.Color.Blue.ToStringFast()" },
+    };
+
+    [Theory]
+    [MemberData(nameof(CodeFixCases))]
+    public async Task CodeFixRewritesFastEnumApis(string invocation, string expectedDiagnosticId, string expectedInvocation)
+    {
+        var sourceCode = CreateCodeFixSource(invocation);
+        var fixedSource = await ApplyCodeFixAsync(sourceCode, expectedDiagnosticId);
+        Assert.Contains(expectedInvocation, fixedSource, StringComparison.Ordinal);
+    }
+
     private static async Task<string> GenerateCode(string sourceCode, LanguageVersion languageVersion = LanguageVersion.Preview)
     {
         var (runResult, _) = await GenerateFiles(sourceCode, languageVersion);
@@ -225,5 +277,106 @@ public sealed class FastEnumSourceGeneratorTests
         var emitResult = outputCompilation.Emit(stream);
         Assert.True(emitResult.Success, string.Join('\n', emitResult.Diagnostics));
         return (driver.GetRunResult(), outputCompilation);
+    }
+
+    private static string CreateAnalyzerSource(string invocation, bool useFastEnumAttribute)
+    {
+        return $$"""
+            using System;
+
+            {{(useFastEnumAttribute ? "[assembly: Meziantou.Framework.Annotations.FastEnumAttribute(typeof(Sample.Color))]" : "")}}
+
+            namespace Sample
+            {
+                public enum Color
+                {
+                    Blue,
+                    Red,
+                }
+
+                public static class TestClass
+                {
+                    public static void M()
+                    {
+                        {{invocation}}
+                    }
+                }
+            }
+            """;
+    }
+
+    private static string CreateCodeFixSource(string invocation)
+    {
+        return $$"""
+            using System;
+
+            [assembly: Meziantou.Framework.Annotations.FastEnumAttribute(typeof(Sample.Color))]
+
+            namespace Meziantou.Framework.Annotations
+            {
+                [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+                internal sealed class FastEnumAttribute : Attribute
+                {
+                    public FastEnumAttribute(Type enumType)
+                    {
+                    }
+                }
+            }
+
+            namespace Sample
+            {
+                public enum Color
+                {
+                    Blue,
+                    Red,
+                }
+
+                public static class TestClass
+                {
+                    public static void M()
+                    {
+                        {{invocation}}
+                    }
+                }
+            }
+            """;
+    }
+
+    private static async Task<string> ApplyCodeFixAsync(string sourceCode, string diagnosticId)
+    {
+        using var workspace = new AdhocWorkspace();
+        var projectId = ProjectId.CreateNewId();
+        var documentId = DocumentId.CreateNewId(projectId);
+        var netcoreReferences = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "8.0.0", "ref/net8.0/");
+        var metadataReferences = netcoreReferences.Select(static location => MetadataReference.CreateFromFile(location)).ToArray();
+
+        var solution = workspace.CurrentSolution
+            .AddProject(projectId, "Project", "Project", LanguageNames.CSharp)
+            .WithProjectParseOptions(projectId, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview))
+            .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable))
+            .AddDocument(documentId, "Test.cs", SourceText.From(sourceCode, Encoding.UTF8));
+
+        foreach (var metadataReference in metadataReferences)
+        {
+            solution = solution.AddMetadataReference(projectId, metadataReference);
+        }
+
+        var project = solution.GetProject(projectId) ?? throw new InvalidOperationException("Project should be available.");
+        var document = project.GetDocument(documentId) ?? throw new InvalidOperationException("Document should be available.");
+        var compilation = await project.GetCompilationAsync() ?? throw new InvalidOperationException("Compilation should be available.");
+
+        var diagnostics = await compilation
+            .WithAnalyzers([new FastEnumAnalyzer()])
+            .GetAnalyzerDiagnosticsAsync();
+
+        var diagnostic = Assert.Single(diagnostics, diag => diag.Id == diagnosticId);
+        var codeFixProvider = new FastEnumCodeFixProvider();
+        var codeActions = new List<CodeAction>();
+        var codeFixContext = new CodeFixContext(document, diagnostic, (action, _) => codeActions.Add(action), CancellationToken.None);
+        await codeFixProvider.RegisterCodeFixesAsync(codeFixContext);
+        var codeAction = Assert.Single(codeActions);
+        var operation = Assert.Single((await codeAction.GetOperationsAsync(CancellationToken.None)).OfType<ApplyChangesOperation>());
+        var changedDocument = operation.ChangedSolution.GetDocument(documentId) ?? throw new InvalidOperationException("Changed document should be available.");
+        return (await changedDocument.GetTextAsync()).ToString();
     }
 }

--- a/tests/Meziantou.Framework.FastEnumGenerator.Tests/Meziantou.Framework.FastEnumGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.FastEnumGenerator.Tests/Meziantou.Framework.FastEnumGenerator.Tests.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="../../src/Meziantou.Framework.FastEnumGenerator/Meziantou.Framework.FastEnumGenerator.csproj" />
     <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
FastEnum now generates rich enum APIs, but callers can still use `System.Enum` methods and miss those optimized/generated methods. This change adds targeted analyzer guidance and automatic fixes so FastEnum-enabled enums consistently use the generated API surface.

## What changed

- Added per-method diagnostics for FastEnum-enabled enums listed in `FastEnumAttribute(typeof(...))`:
  - `MFEG0002` Parse
  - `MFEG0003` TryParse
  - `MFEG0004` GetNames
  - `MFEG0005` GetValues
  - `MFEG0006` GetName
  - `MFEG0007` IsDefined
  - `MFEG0008` ToString
- Added shared analyzer matching logic (`FastEnumAnalyzerCommon`, `FastEnumMethodKind`, `FastEnumInvocationMatch`) to resolve target enum types and map invocations consistently.
- Added `FastEnumCodeFixProvider` with one fix per rule, rewriting calls to the generated FastEnum API equivalents.
- Updated FastEnum docs with the new analyzer rules.
- Extended FastEnum analyzer tests with per-rule diagnostics and code-fix rewrite coverage.
- Added Roslyn Workspaces references needed for code-fix support and configured analyzer warnings accordingly.

## Validation

- `dotnet test tests/Meziantou.Framework.FastEnumGenerator.Tests/Meziantou.Framework.FastEnumGenerator.Tests.csproj --nologo -v minimal`
- `dotnet test tests/Meziantou.Framework.FastEnumGenerator.GeneratorTests/Meziantou.Framework.FastEnumGenerator.GeneratorTests.csproj --nologo -v minimal`
- `dotnet run ./eng/update-bom.cs`
- `dotnet run ./eng/update-readme.cs`
- `dotnet run ./eng/update-project-slnx.cs`
- `dotnet run ./eng/validate-testprojects-configuration.cs`
- `dotnet run ./eng/update-trimmable.cs`