### PR TITLE
Split FastEnum code fixes from analyzer/generator assembly

### DIFF
--- a/Meziantou.Framework.slnx
+++ b/Meziantou.Framework.slnx
@@ -47,6 +47,7 @@
     <Project Path="src/Meziantou.Framework.DnsClient/Meziantou.Framework.DnsClient.csproj" />
     <Project Path="src/Meziantou.Framework.DnsFilter/Meziantou.Framework.DnsFilter.csproj" />
     <Project Path="src/Meziantou.Framework.DnsServer/Meziantou.Framework.DnsServer.csproj" />
+    <Project Path="src/Meziantou.Framework.FastEnumGenerator.CodeFixes/Meziantou.Framework.FastEnumGenerator.CodeFixes.csproj" />
     <Project Path="src/Meziantou.Framework.FastEnumGenerator/Meziantou.Framework.FastEnumGenerator.csproj" />
     <Project Path="src/Meziantou.Framework.FixedStringBuilder.Generator/Meziantou.Framework.FixedStringBuilder.Generator.csproj" />
     <Project Path="src/Meziantou.Framework.FixedStringBuilder/Meziantou.Framework.FixedStringBuilder.csproj" />

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,7 @@
       "matchFileNames": [
         "src/Meziantou.AspNetCore.ServiceDefaults.AutoRegister/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.csproj",
         "src/Meziantou.Framework.FastEnumGenerator/Meziantou.Framework.FastEnumGenerator.csproj",
+        "src/Meziantou.Framework.FastEnumGenerator.CodeFixes/Meziantou.Framework.FastEnumGenerator.CodeFixes.csproj",
         "src/Meziantou.Framework.FixedStringBuilder.Generator/Meziantou.Framework.FixedStringBuilder.Generator.csproj",
         "src/Meziantou.Framework.ResxSourceGenerator/Meziantou.Framework.ResxSourceGenerator.csproj",
         "src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj"

--- a/slnx/Meziantou.Framework.FastEnumGenerator.CodeFixes.slnx
+++ b/slnx/Meziantou.Framework.FastEnumGenerator.CodeFixes.slnx
@@ -8,7 +8,4 @@
     <Project Path="../tests/Meziantou.Framework.FastEnumGenerator.Tests/Meziantou.Framework.FastEnumGenerator.Tests.csproj" />
     <Project Path="../tests/TestUtilities/TestUtilities.csproj" />
   </Folder>
-  <Folder Name="/tests/SourceGenerators/">
-    <Project Path="../tests/Meziantou.Framework.FastEnumGenerator.GeneratorTests/Meziantou.Framework.FastEnumGenerator.GeneratorTests.csproj" />
-  </Folder>
 </Solution>

--- a/src/Meziantou.Framework.FastEnumGenerator.CodeFixes/FastEnumCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FastEnumGenerator.CodeFixes/FastEnumCodeFixProvider.cs
@@ -14,7 +14,15 @@ namespace Meziantou.Framework.FastEnumGenerator;
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(FastEnumCodeFixProvider))]
 public sealed class FastEnumCodeFixProvider : CodeFixProvider
 {
-    private static readonly ImmutableArray<string> SupportedDiagnosticIds = [FastEnumAnalyzer.UseFastEnumParse.Id, FastEnumAnalyzer.UseFastEnumTryParse.Id, FastEnumAnalyzer.UseFastEnumGetNames.Id, FastEnumAnalyzer.UseFastEnumGetValues.Id, FastEnumAnalyzer.UseFastEnumGetName.Id, FastEnumAnalyzer.UseFastEnumIsDefined.Id, FastEnumAnalyzer.UseFastEnumToStringFast.Id];
+    private const string UseFastEnumParseDiagnosticId = "MFEG0002";
+    private const string UseFastEnumTryParseDiagnosticId = "MFEG0003";
+    private const string UseFastEnumGetNamesDiagnosticId = "MFEG0004";
+    private const string UseFastEnumGetValuesDiagnosticId = "MFEG0005";
+    private const string UseFastEnumGetNameDiagnosticId = "MFEG0006";
+    private const string UseFastEnumIsDefinedDiagnosticId = "MFEG0007";
+    private const string UseFastEnumToStringFastDiagnosticId = "MFEG0008";
+
+    private static readonly ImmutableArray<string> SupportedDiagnosticIds = [UseFastEnumParseDiagnosticId, UseFastEnumTryParseDiagnosticId, UseFastEnumGetNamesDiagnosticId, UseFastEnumGetValuesDiagnosticId, UseFastEnumGetNameDiagnosticId, UseFastEnumIsDefinedDiagnosticId, UseFastEnumToStringFastDiagnosticId];
 
     public override ImmutableArray<string> FixableDiagnosticIds => SupportedDiagnosticIds;
 
@@ -44,13 +52,13 @@ public sealed class FastEnumCodeFixProvider : CodeFixProvider
 
             var title = diagnostic.Id switch
             {
-                "MFEG0002" => "Use FastEnum Parse",
-                "MFEG0003" => "Use FastEnum TryParse",
-                "MFEG0004" => "Use FastEnum GetNames",
-                "MFEG0005" => "Use FastEnum GetValues",
-                "MFEG0006" => "Use FastEnum GetName",
-                "MFEG0007" => "Use FastEnum IsDefined",
-                "MFEG0008" => "Use FastEnum ToStringFast",
+                UseFastEnumParseDiagnosticId => "Use FastEnum Parse",
+                UseFastEnumTryParseDiagnosticId => "Use FastEnum TryParse",
+                UseFastEnumGetNamesDiagnosticId => "Use FastEnum GetNames",
+                UseFastEnumGetValuesDiagnosticId => "Use FastEnum GetValues",
+                UseFastEnumGetNameDiagnosticId => "Use FastEnum GetName",
+                UseFastEnumIsDefinedDiagnosticId => "Use FastEnum IsDefined",
+                UseFastEnumToStringFastDiagnosticId => "Use FastEnum ToStringFast",
                 _ => "Use FastEnum API",
             };
 

--- a/src/Meziantou.Framework.FastEnumGenerator.CodeFixes/Meziantou.Framework.FastEnumGenerator.CodeFixes.csproj
+++ b/src/Meziantou.Framework.FastEnumGenerator.CodeFixes/Meziantou.Framework.FastEnumGenerator.CodeFixes.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Meziantou.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <NoWarn>$(NoWarn);RS1041</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../Meziantou.Framework.FastEnumGenerator/FastEnumAnalyzerCommon.cs" Link="FastEnumAnalyzerCommon.cs" />
+    <Compile Include="../Meziantou.Framework.FastEnumGenerator/FastEnumInvocationMatch.cs" Link="FastEnumInvocationMatch.cs" />
+    <Compile Include="../Meziantou.Framework.FastEnumGenerator/FastEnumMethodKind.cs" Link="FastEnumMethodKind.cs" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/src/Meziantou.Framework.FastEnumGenerator/Meziantou.Framework.FastEnumGenerator.csproj
+++ b/src/Meziantou.Framework.FastEnumGenerator/Meziantou.Framework.FastEnumGenerator.csproj
@@ -14,10 +14,14 @@
   <ItemGroup>
     <None Include="Meziantou.Framework.FastEnumGenerator.targets" Pack="true" PackagePath="build/" />
     <None Include="$(OutputPath)/../$(Configuration.ToLowerInvariant())_netstandard2.0/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)/../../Meziantou.Framework.FastEnumGenerator.CodeFixes/$(Configuration.ToLowerInvariant())_netstandard2.0/Meziantou.Framework.FastEnumGenerator.CodeFixes.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Meziantou.Framework.FastEnumGenerator.CodeFixes/Meziantou.Framework.FastEnumGenerator.CodeFixes.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/tests/Meziantou.Framework.FastEnumGenerator.Tests/Meziantou.Framework.FastEnumGenerator.Tests.csproj
+++ b/tests/Meziantou.Framework.FastEnumGenerator.Tests/Meziantou.Framework.FastEnumGenerator.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/Meziantou.Framework.FastEnumGenerator/Meziantou.Framework.FastEnumGenerator.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.FastEnumGenerator.CodeFixes/Meziantou.Framework.FastEnumGenerator.CodeFixes.csproj" />
     <ProjectReference Include="../TestUtilities/TestUtilities.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />


### PR DESCRIPTION
The FastEnum analyzer/source-generator project referenced `Microsoft.CodeAnalysis.CSharp.Workspaces` because it also hosted the code fix provider. This change separates code fixes into their own assembly so the analyzer/source-generator assembly depends only on `Microsoft.CodeAnalysis.CSharp`.

## What changed
- Added a new `Meziantou.Framework.FastEnumGenerator.CodeFixes` project for `FastEnumCodeFixProvider`.
- Moved `FastEnumCodeFixProvider` into that new project.
- Updated `Meziantou.Framework.FastEnumGenerator.csproj` to:
  - remove `Microsoft.CodeAnalysis.CSharp.Workspaces`
  - reference the new code-fix project as a build dependency
  - pack the code-fix DLL alongside the main analyzer/generator DLL in `analyzers/dotnet/cs`
- Updated FastEnum test project references to include the new code-fix project.
- Regenerated solution entries to include the new project.

## Notes
- The code-fix project is `IsPackable=false`; it is distributed through the existing `Meziantou.Framework.FastEnumGenerator` package.