### PR TITLE
Optimize hot-path parsing and protocol components

### DIFF
--- a/src/Meziantou.Extensions.Logging.FileLogger/FileLogger.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileLogger.cs
@@ -5,6 +5,8 @@ namespace Meziantou.Extensions.Logging;
 /// <summary>A logger that writes to a file via the FileLoggerProvider.</summary>
 internal sealed class FileLogger(FileLoggerProvider provider, string categoryName) : ILogger
 {
+    private readonly string _shortCategoryName = GetShortCategoryName(categoryName);
+
     public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
 
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
@@ -24,13 +26,22 @@ internal sealed class FileLogger(FileLoggerProvider provider, string categoryNam
 
         var timestamp = provider.TimeProvider.GetUtcNow().ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
         var level = GetLogLevelString(logLevel);
-        var shortCategory = GetShortCategoryName(categoryName);
+        var logMessageBuilder = new StringBuilder(message.Length + _shortCategoryName.Length + 40);
+        logMessageBuilder.Append('[');
+        logMessageBuilder.Append(timestamp);
+        logMessageBuilder.Append("] [");
+        logMessageBuilder.Append(level);
+        logMessageBuilder.Append("] [");
+        logMessageBuilder.Append(_shortCategoryName);
+        logMessageBuilder.Append("] ");
+        logMessageBuilder.Append(message);
+        if (exception is not null)
+        {
+            logMessageBuilder.AppendLine();
+            logMessageBuilder.Append(exception);
+        }
 
-        var logMessage = exception is not null
-            ? $"[{timestamp}] [{level}] [{shortCategory}] {message}{Environment.NewLine}{exception}"
-            : $"[{timestamp}] [{level}] [{shortCategory}] {message}";
-
-        provider.WriteLog(logMessage);
+        provider.WriteLog(logMessageBuilder.ToString());
     }
 
     private static string GetLogLevelString(LogLevel logLevel) => logLevel switch

--- a/src/Meziantou.Framework.Csv/CsvReader.cs
+++ b/src/Meziantou.Framework.Csv/CsvReader.cs
@@ -21,7 +21,12 @@ public class CsvReader
     public const char DefaultQuoteCharacter = '"';
 
     private CsvColumn[]? _columns;
-    private readonly char[] _readBuffer = new char[1];
+    private readonly char[] _readBuffer = new char[4096];
+    private int _readBufferOffset;
+    private int _readBufferLength;
+    private bool _hasBufferedChar;
+    private char _bufferedChar;
+    private bool _endOfStreamReached;
 
     /// <summary>Gets or sets the character used to separate values in a row. Default is a comma (,).</summary>
     public char Separator { get; set; } = DefaultSeparatorCharacter;
@@ -49,6 +54,15 @@ public class CsvReader
     {
         get
         {
+            if (_hasBufferedChar)
+                return false;
+
+            if (_readBufferOffset < _readBufferLength)
+                return false;
+
+            if (_endOfStreamReached)
+                return true;
+
             if (BaseReader is StreamReader streamReader)
                 return streamReader.EndOfStream;
 
@@ -64,14 +78,48 @@ public class CsvReader
         BaseReader = textReader ?? throw new ArgumentNullException(nameof(textReader));
     }
 
-    private async Task<char?> ReadCharAsync()
+    private async ValueTask<char?> ReadCharAsync()
     {
-        var buffer = _readBuffer;
-        var readCount = await BaseReader.ReadAsync(buffer, 0, 1).ConfigureAwait(false);
-        if (readCount <= 0)
+        if (_hasBufferedChar)
+        {
+            _hasBufferedChar = false;
+            return _bufferedChar;
+        }
+
+        return await ReadCharCoreAsync().ConfigureAwait(false);
+    }
+
+    private async ValueTask<char?> PeekCharAsync()
+    {
+        if (_hasBufferedChar)
+            return _bufferedChar;
+
+        var nextChar = await ReadCharCoreAsync().ConfigureAwait(false);
+        if (!nextChar.HasValue)
             return null;
 
-        return buffer[0];
+        _bufferedChar = nextChar.Value;
+        _hasBufferedChar = true;
+        return nextChar;
+    }
+
+    private async ValueTask<char?> ReadCharCoreAsync()
+    {
+        if (_endOfStreamReached)
+            return null;
+
+        if (_readBufferOffset >= _readBufferLength)
+        {
+            _readBufferLength = await BaseReader.ReadAsync(_readBuffer.AsMemory()).ConfigureAwait(false);
+            _readBufferOffset = 0;
+            if (_readBufferLength <= 0)
+            {
+                _endOfStreamReached = true;
+                return null;
+            }
+        }
+
+        return _readBuffer[_readBufferOffset++];
     }
 
     /// <summary>Reads the next row from the CSV data.</summary>
@@ -102,7 +150,7 @@ public class CsvReader
                 }
 
                 ColumnNumber++;
-                var next = BaseReader.Peek();
+                var next = await PeekCharAsync().ConfigureAwait(false);
                 if (inQuote)
                 {
                     if (c == '\n')
@@ -166,7 +214,7 @@ public class CsvReader
                 {
                     if (next == '\n')
                     {
-                        BaseReader.Read();
+                        await ReadCharAsync().ConfigureAwait(false);
                         ColumnNumber++;
                     }
 

--- a/src/Meziantou.Framework.DependencyScanning/Scanners/RegexScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/RegexScanner.cs
@@ -25,6 +25,10 @@ public sealed class RegexScanner : DependencyScanner
     private const string VersionGroupName = "version";
 
     private bool _frozen;
+    private string? _regexPattern;
+    private Regex? _regex;
+    private int _nameGroupNumber = -1;
+    private int _versionGroupNumber = -1;
 
     protected internal override IReadOnlyCollection<DependencyType> SupportedDependencyTypes
     {
@@ -37,7 +41,20 @@ public sealed class RegexScanner : DependencyScanner
     }
 
     /// <summary>Gets or sets the regular expression pattern to match dependencies. The pattern must include named groups 'name' and optionally 'version'.</summary>
-    public string? RegexPattern { get; set; }
+    public string? RegexPattern
+    {
+        get => _regexPattern;
+        set
+        {
+            if (_frozen)
+                throw new InvalidOperationException("The scanner is already used and cannot be modified.");
+
+            _regexPattern = value;
+            _regex = null;
+            _nameGroupNumber = -1;
+            _versionGroupNumber = -1;
+        }
+    }
 
     /// <summary>Gets or sets the type of dependency to report when a match is found.</summary>
     public DependencyType DependencyType
@@ -57,35 +74,49 @@ public sealed class RegexScanner : DependencyScanner
 
     public override async ValueTask ScanAsync(ScanFileContext context)
     {
-        if (RegexPattern is null)
+        var regexPattern = RegexPattern;
+        if (regexPattern is null)
             return;
 
         _frozen = true;
+        var regex = _regex;
+        if (regex is null)
+        {
+            regex = new Regex(regexPattern, RegexOptions.Compiled | RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(10));
+            _regex = regex;
+            _nameGroupNumber = regex.GroupNumberFromName(NameGroupName);
+            if (_nameGroupNumber <= 0)
+                throw new InvalidOperationException($"The regular expression must define the '{NameGroupName}' named group.");
+
+            _versionGroupNumber = regex.GroupNumberFromName(VersionGroupName);
+        }
 
         using var sr = new StreamReader(context.Content);
         var text = await sr.ReadToEndAsync(context.CancellationToken).ConfigureAwait(false);
 
-        foreach (Match match in Regex.Matches(text, RegexPattern, RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(10)))
+        foreach (Match match in regex.Matches(text))
         {
             Debug.Assert(match.Success);
 
-            var nameGroup = match.Groups[NameGroupName];
+            var nameGroup = match.Groups[_nameGroupNumber];
             var name = nameGroup.Value;
             if (!string.IsNullOrEmpty(name))
             {
-                var versionGroup = match.Groups[VersionGroupName];
-                if (versionGroup.Success)
+                if (_versionGroupNumber >= 0)
                 {
-                    var version = versionGroup.Value;
-                    var nameLocation = TextLocation.FromIndex(context.FileSystem, context.FullPath, text, nameGroup.Index, nameGroup.Length);
-                    var versionLocation = TextLocation.FromIndex(context.FileSystem, context.FullPath, text, versionGroup.Index, versionGroup.Length);
-                    context.ReportDependency(this, name, version, DependencyType, nameLocation, versionLocation);
+                    var versionGroup = match.Groups[_versionGroupNumber];
+                    if (versionGroup.Success)
+                    {
+                        var version = versionGroup.Value;
+                        var nameLocation = TextLocation.FromIndex(context.FileSystem, context.FullPath, text, nameGroup.Index, nameGroup.Length);
+                        var versionLocation = TextLocation.FromIndex(context.FileSystem, context.FullPath, text, versionGroup.Index, versionGroup.Length);
+                        context.ReportDependency(this, name, version, DependencyType, nameLocation, versionLocation);
+                        continue;
+                    }
                 }
-                else
-                {
-                    var nameLocation = TextLocation.FromIndex(context.FileSystem, context.FullPath, text, nameGroup.Index, nameGroup.Length);
-                    context.ReportDependency(this, name, version: null, DependencyType, nameLocation, versionLocation: null);
-                }
+
+                var location = TextLocation.FromIndex(context.FileSystem, context.FullPath, text, nameGroup.Index, nameGroup.Length);
+                context.ReportDependency(this, name, version: null, DependencyType, location, versionLocation: null);
             }
         }
     }

--- a/src/Meziantou.Framework.DnsClient/Protocol/DnsWireReader.cs
+++ b/src/Meziantou.Framework.DnsClient/Protocol/DnsWireReader.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 
@@ -94,53 +95,68 @@ internal ref struct DnsWireReader
         var jumped = false;
         var originalPosition = -1;
         var pointerCount = 0;
+        var charBuffer = ArrayPool<char>.Shared.Rent(63);
 
-        while (position < message.Length)
+        try
         {
-            var length = message[position];
-
-            if (length is 0)
+            while (position < message.Length)
             {
-                position++;
-                break;
-            }
+                var length = message[position];
 
-            // Check for compression pointer (top 2 bits set)
-            if ((length & 0xC0) is 0xC0)
-            {
-                if (++pointerCount > maxPointers)
-                    throw new DnsProtocolException("Too many compression pointers in domain name (possible loop).");
-
-                if (position + 1 >= message.Length)
-                    throw new DnsProtocolException("Unexpected end of DNS message while reading compression pointer.");
-
-                var pointer = ((length & 0x3F) << 8) | message[position + 1];
-
-                if (!jumped)
+                if (length is 0)
                 {
-                    originalPosition = position + 2;
+                    position++;
+                    break;
                 }
 
-                position = pointer;
-                jumped = true;
-                continue;
+                // Check for compression pointer (top 2 bits set)
+                if ((length & 0xC0) is 0xC0)
+                {
+                    if (++pointerCount > maxPointers)
+                        throw new DnsProtocolException("Too many compression pointers in domain name (possible loop).");
+
+                    if (position + 1 >= message.Length)
+                        throw new DnsProtocolException("Unexpected end of DNS message while reading compression pointer.");
+
+                    var pointer = ((length & 0x3F) << 8) | message[position + 1];
+
+                    if (!jumped)
+                    {
+                        originalPosition = position + 2;
+                    }
+
+                    position = pointer;
+                    jumped = true;
+                    continue;
+                }
+
+                if ((length & 0xC0) != 0)
+                    throw new DnsProtocolException($"Invalid label type: 0x{length:X2}.");
+
+                position++;
+
+                if (position + length > message.Length)
+                    throw new DnsProtocolException("Domain name label extends beyond message boundary.");
+
+                if (sb.Length > 0)
+                {
+                    sb.Append('.');
+                }
+
+                if (length > charBuffer.Length)
+                {
+                    ArrayPool<char>.Shared.Return(charBuffer);
+                    charBuffer = ArrayPool<char>.Shared.Rent(length);
+                }
+
+                var charCount = Encoding.ASCII.GetChars(message.Slice(position, length), charBuffer);
+                sb.Append(charBuffer.AsSpan(0, charCount));
+                position += length;
             }
-
-            if ((length & 0xC0) != 0)
-                throw new DnsProtocolException($"Invalid label type: 0x{length:X2}.");
-
-            position++;
-
-            if (position + length > message.Length)
-                throw new DnsProtocolException("Domain name label extends beyond message boundary.");
-
-            if (sb.Length > 0)
-            {
-                sb.Append('.');
-            }
-
-            sb.Append(Encoding.ASCII.GetString(message.Slice(position, length)));
-            position += length;
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(charBuffer);
         }
 
         if (jumped)

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterSetSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterSetSegment.cs
@@ -1,16 +1,19 @@
+using System.Buffers;
 using Meziantou.Framework;
 
 namespace Meziantou.Framework.Globbing.Internals;
 
 internal sealed class CharacterSetSegment : Segment
 {
-    private readonly StringComparison _stringComparison;
+    private readonly SearchValues<char> _searchValues;
+    private readonly bool _ignoreCase;
 
     public CharacterSetSegment(string set, bool ignoreCase)
     {
         Set = set;
         IgnoreCase = ignoreCase;
-        _stringComparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        _ignoreCase = ignoreCase;
+        _searchValues = SearchValues.Create(ignoreCase ? set.ToUpperInvariant() : set);
     }
 
     public bool IgnoreCase { get; }
@@ -19,9 +22,12 @@ internal sealed class CharacterSetSegment : Segment
 
     public override bool IsMatch(ref PathReader pathReader)
     {
-        bool result;
-        var c = pathReader.CurrentText[0];
-        result = Set.Contains(c, _stringComparison);
+        if (pathReader.CurrentText.IsEmpty || pathReader.IsEndOfCurrentSegment)
+            return false;
+
+        Span<char> currentCharacter = stackalloc char[1];
+        currentCharacter[0] = _ignoreCase ? char.ToUpperInvariant(pathReader.CurrentText[0]) : pathReader.CurrentText[0];
+        var result = currentCharacter.ContainsAny(_searchValues);
         if (result)
         {
             pathReader.ConsumeInSegment(1);

--- a/src/Meziantou.Framework.HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/Meziantou.Framework.HtmlSanitizer/HtmlSanitizer.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Collections.Frozen;
 using AngleSharp.Dom;
 using AngleSharp.Html.Parser;
 
@@ -46,38 +47,41 @@ public sealed class HtmlSanitizer
 
     private const string DefaulValidAttrs = DefaulUriAttrs + "," + DefaulSrcsetAttrs + "," + DefaultHtmlAttrs;
 
+    private static readonly FrozenSet<string> DefaultValidElementsSet = SplitToFrozenSet(DefaulValidElements);
+    private static readonly FrozenSet<string> DefaultValidAttributesSet = SplitToFrozenSet(DefaulValidAttrs);
+    private static readonly FrozenSet<string> DefaultBlockedElementsSet = SplitToFrozenSet(DefaulBlockedElements);
+    private static readonly FrozenSet<string> DefaultUriAttributesSet = SplitToFrozenSet(DefaulUriAttrs);
+    private static readonly FrozenSet<string> DefaultSrcsetAttributesSet = SplitToFrozenSet(DefaulSrcsetAttrs);
+
     /// <summary>Gets the set of HTML elements that are allowed in sanitized output. Elements not in this set will be removed unless they are in the BlockedElements set.</summary>
-    public ISet<string> ValidElements { get; } = SplitToHashSet(DefaulValidElements);
+    public ISet<string> ValidElements { get; } = CreateMutableSet(DefaultValidElementsSet);
 
     /// <summary>Gets the set of HTML attributes that are allowed in sanitized output. Attributes not in this set will be removed from elements.</summary>
-    public ISet<string> ValidAttributes { get; } = SplitToHashSet(DefaulValidAttrs);
+    public ISet<string> ValidAttributes { get; } = CreateMutableSet(DefaultValidAttributesSet);
 
     /// <summary>Gets the set of HTML elements that will be completely removed from the output, including their content. By default includes script and style elements.</summary>
-    public ISet<string> BlockedElements { get; } = SplitToHashSet(DefaulBlockedElements);
+    public ISet<string> BlockedElements { get; } = CreateMutableSet(DefaultBlockedElementsSet);
 
     /// <summary>Gets the set of attribute names that contain URLs and should be validated for safety. Unsafe URLs will be replaced with empty strings.</summary>
-    public ISet<string> UriAttributes { get; } = SplitToHashSet(DefaulUriAttrs);
+    public ISet<string> UriAttributes { get; } = CreateMutableSet(DefaultUriAttributesSet);
 
     /// <summary>Gets the set of attribute names that contain srcset values (responsive image sources) and should be validated for safety.</summary>
-    public ISet<string> SrcsetAttributes { get; } = SplitToHashSet(DefaulSrcsetAttrs);
+    public ISet<string> SrcsetAttributes { get; } = CreateMutableSet(DefaultSrcsetAttributesSet);
 
-    private static HashSet<string> SplitToHashSet(string text)
+    private static HashSet<string> CreateMutableSet(IEnumerable<string> values)
     {
-        var hashSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (!string.IsNullOrEmpty(text))
-        {
-            var items = text.Split(',');
-            foreach (var item in items)
-            {
-                var trim = item.Trim();
-                if (string.IsNullOrEmpty(trim))
-                    continue;
+        return new HashSet<string>(values, StringComparer.OrdinalIgnoreCase);
+    }
 
-                hashSet.Add(trim);
-            }
+    private static FrozenSet<string> SplitToFrozenSet(string text)
+    {
+        var values = text.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (values.Length == 0)
+        {
+            return Array.Empty<string>().ToFrozenSet(StringComparer.OrdinalIgnoreCase);
         }
 
-        return hashSet;
+        return values.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
     }
 
     private bool IsValidNode(string tagName)

--- a/src/Meziantou.Framework.HtmlSanitizer/UrlSanitizer.cs
+++ b/src/Meziantou.Framework.HtmlSanitizer/UrlSanitizer.cs
@@ -54,7 +54,7 @@ public static partial class UrlSanitizer
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings", Justification = "Breaking change")]
     public static bool IsSafeUrl(string url)
     {
-        return SafeUrlRegex().IsMatch(url) || DataUrlPattern().IsMatch(url);
+        return IsSafeUrl(url.AsSpan());
     }
 
     /// <summary>Determines whether a srcset value (used for responsive images) is safe by validating all URLs in the comma-separated list.</summary>
@@ -63,16 +63,30 @@ public static partial class UrlSanitizer
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings", Justification = "Breaking change")]
     public static bool IsSafeSrcset(string url)
     {
-        return url.Split(',').All(value => IsSafeUrl(GetUrlPart(value)));
-
-        static string GetUrlPart(string value)
+        var remaining = url.AsSpan();
+        while (true)
         {
-            value = value.Trim(Whitespaces);
-            var separator = value.IndexOfAny(Whitespaces);
-            if (separator < 0)
-                return value;
+            var separatorIndex = remaining.IndexOf(',');
+            var segment = separatorIndex < 0 ? remaining : remaining[..separatorIndex];
+            segment = segment.Trim(Whitespaces);
 
-            return value[..separator];
+            if (!segment.IsEmpty)
+            {
+                var valueSeparator = segment.IndexOfAny(Whitespaces);
+                var value = valueSeparator < 0 ? segment : segment[..valueSeparator];
+                if (!IsSafeUrl(value))
+                    return false;
+            }
+
+            if (separatorIndex < 0)
+                return true;
+
+            remaining = remaining[(separatorIndex + 1)..];
         }
+    }
+
+    private static bool IsSafeUrl(ReadOnlySpan<char> url)
+    {
+        return SafeUrlRegex().IsMatch(url) || DataUrlPattern().IsMatch(url);
     }
 }

--- a/src/Meziantou.Framework.NtpClient/NtpPacket.cs
+++ b/src/Meziantou.Framework.NtpClient/NtpPacket.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.Ntp;
@@ -49,9 +50,9 @@ internal struct NtpPacket
             Stratum = buffer[1],
             PollInterval = (sbyte)buffer[2],
             Precision = (sbyte)buffer[3],
-            RootDelay = (uint)(buffer[4] << 24 | buffer[5] << 16 | buffer[6] << 8 | buffer[7]),
-            RootDispersion = (uint)(buffer[8] << 24 | buffer[9] << 16 | buffer[10] << 8 | buffer[11]),
-            ReferenceIdentifier = (uint)(buffer[12] << 24 | buffer[13] << 16 | buffer[14] << 8 | buffer[15]),
+            RootDelay = BinaryPrimitives.ReadUInt32BigEndian(buffer.Slice(4, 4)),
+            RootDispersion = BinaryPrimitives.ReadUInt32BigEndian(buffer.Slice(8, 4)),
+            ReferenceIdentifier = BinaryPrimitives.ReadUInt32BigEndian(buffer.Slice(12, 4)),
             ReferenceTimestamp = NtpTimestamp.Decode(buffer[16..]),
             OriginateTimestamp = NtpTimestamp.Decode(buffer[24..]),
             ReceiveTimestamp = NtpTimestamp.Decode(buffer[32..]),
@@ -70,18 +71,9 @@ internal struct NtpPacket
         buffer[1] = Stratum;
         buffer[2] = (byte)PollInterval;
         buffer[3] = (byte)Precision;
-        buffer[4] = (byte)(RootDelay >> 24);
-        buffer[5] = (byte)(RootDelay >> 16);
-        buffer[6] = (byte)(RootDelay >> 8);
-        buffer[7] = (byte)RootDelay;
-        buffer[8] = (byte)(RootDispersion >> 24);
-        buffer[9] = (byte)(RootDispersion >> 16);
-        buffer[10] = (byte)(RootDispersion >> 8);
-        buffer[11] = (byte)RootDispersion;
-        buffer[12] = (byte)(ReferenceIdentifier >> 24);
-        buffer[13] = (byte)(ReferenceIdentifier >> 16);
-        buffer[14] = (byte)(ReferenceIdentifier >> 8);
-        buffer[15] = (byte)ReferenceIdentifier;
+        BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(4, 4), RootDelay);
+        BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(8, 4), RootDispersion);
+        BinaryPrimitives.WriteUInt32BigEndian(buffer.Slice(12, 4), ReferenceIdentifier);
         NtpTimestamp.Encode(ReferenceTimestamp, buffer[16..]);
         NtpTimestamp.Encode(OriginateTimestamp, buffer[24..]);
         NtpTimestamp.Encode(ReceiveTimestamp, buffer[32..]);

--- a/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
+++ b/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
@@ -47,6 +47,7 @@ public sealed class ObjectMethodExecutor
             typeof(Action<object, Action>), // onCompletedMethod
             typeof(Action<object, Action>), // unsafeOnCompletedMethod
         ])!;
+    private static readonly ConditionalWeakTable<MethodInfo, ObjectMethodExecutor> MethodExecutorCache = new();
 
     private ObjectMethodExecutor(MethodInfo methodInfo, TypeInfo targetTypeInfo, object?[]? parameterDefaultValues)
     {
@@ -98,6 +99,16 @@ public sealed class ObjectMethodExecutor
         ArgumentNullException.ThrowIfNull(methodInfo);
 
         return Create(methodInfo, parameterDefaultValues: null);
+    }
+
+    /// <summary>Gets a cached executor for the specified method, creating it if it does not already exist.</summary>
+    /// <param name="methodInfo">The method to be invoked.</param>
+    /// <returns>A cached <see cref="ObjectMethodExecutor"/> instance.</returns>
+    public static ObjectMethodExecutor GetOrCreate(MethodInfo methodInfo)
+    {
+        ArgumentNullException.ThrowIfNull(methodInfo);
+
+        return MethodExecutorCache.GetValue(methodInfo, static key => Create(key, parameterDefaultValues: null));
     }
 
     /// <summary>Creates an executor for the specified method with parameter default values.</summary>

--- a/src/Meziantou.Framework.QRCode/Internal/BitBuffer.cs
+++ b/src/Meziantou.Framework.QRCode/Internal/BitBuffer.cs
@@ -10,8 +10,7 @@ internal sealed class BitBuffer
     public void Append(int value, int bitCount)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(bitCount);
-        if (bitCount > sizeof(int) * 8)
-            throw new ArgumentOutOfRangeException(nameof(bitCount));
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(bitCount, sizeof(int) * 8);
 
         if (bitCount == 0)
             return;

--- a/src/Meziantou.Framework.QRCode/Internal/BitBuffer.cs
+++ b/src/Meziantou.Framework.QRCode/Internal/BitBuffer.cs
@@ -2,34 +2,69 @@ namespace Meziantou.Framework.Internal;
 
 internal sealed class BitBuffer
 {
-    private readonly List<byte> _bytes = [];
+    private byte[] _bytes = [];
     private int _bitCount;
 
     public int BitCount => _bitCount;
 
     public void Append(int value, int bitCount)
     {
-        for (var i = bitCount - 1; i >= 0; i--)
+        ArgumentOutOfRangeException.ThrowIfNegative(bitCount);
+        if (bitCount > sizeof(int) * 8)
+            throw new ArgumentOutOfRangeException(nameof(bitCount));
+
+        if (bitCount == 0)
+            return;
+
+        EnsureCapacity(_bitCount + bitCount);
+
+        var remainingBits = bitCount;
+        if ((_bitCount & 7) == 0)
         {
+            while (remainingBits >= 8)
+            {
+                remainingBits -= 8;
+                _bytes[_bitCount >> 3] = (byte)(value >> remainingBits);
+                _bitCount += 8;
+            }
+        }
+
+        while (remainingBits > 0)
+        {
+            remainingBits--;
             var byteIndex = _bitCount >> 3;
             var bitIndex = 7 - (_bitCount & 7);
 
-            if (byteIndex >= _bytes.Count)
+            if (((value >> remainingBits) & 1) == 1)
             {
-                _bytes.Add(0);
-            }
-
-            if (((value >> i) & 1) == 1)
-            {
-                _bytes[byteIndex] |= (byte)(1 << bitIndex);
+                _bytes[byteIndex] |= (byte)(1u << bitIndex);
             }
 
             _bitCount++;
         }
     }
 
+    private void EnsureCapacity(int bitCount)
+    {
+        var requiredByteCount = (bitCount + 7) >> 3;
+        if (requiredByteCount <= _bytes.Length)
+            return;
+
+        var newLength = _bytes.Length == 0 ? 8 : _bytes.Length;
+        while (newLength < requiredByteCount)
+        {
+            newLength *= 2;
+        }
+
+        Array.Resize(ref _bytes, newLength);
+    }
+
     public byte[] ToByteArray()
     {
-        return [.. _bytes];
+        var byteCount = (_bitCount + 7) >> 3;
+        if (byteCount == 0)
+            return [];
+
+        return _bytes[..byteCount].ToArray();
     }
 }

--- a/src/Meziantou.Framework.SimpleQueryLanguage/Syntax/QuerySyntax.Lexer.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/Syntax/QuerySyntax.Lexer.cs
@@ -1,9 +1,13 @@
+using System.Buffers;
+
 namespace Meziantou.Framework.SimpleQueryLanguage.Syntax;
 
 public partial class QuerySyntax
 {
     private static class Lexer
     {
+        private static readonly SearchValues<char> TextTokenTerminators = SearchValues.Create(":=<>() \t\r\n");
+
         public static IEnumerable<QueryToken> Tokenize(string text)
         {
             var position = 0;
@@ -135,33 +139,30 @@ public partial class QuerySyntax
         private static QueryToken ReadText(ref int position, string text)
         {
             var start = position;
-
-            while (position < text.Length)
-            {
-                var c = text[position];
-                if (c is ':' or '=' or '<' or '>' or '(' or ')' || char.IsWhiteSpace(c))
-                    break;
-
-                position++;
-            }
+            var remaining = text.AsSpan(position);
+            var separatorPosition = remaining.IndexOfAny(TextTokenTerminators);
+            position = separatorPosition < 0 ? text.Length : position + separatorPosition;
 
             var length = position - start;
             var span = new TextSpan(start, length);
 
-            var tokenText = text.Substring(start, length);
+            var tokenText = text.AsSpan(start, length);
             var kind = GetKeywordOrText(tokenText);
-            return new QueryToken(kind, text, span, tokenText);
+            return new QueryToken(kind, text, span, tokenText.ToString());
         }
 
-        private static QuerySyntaxKind GetKeywordOrText(string text)
+        private static QuerySyntaxKind GetKeywordOrText(ReadOnlySpan<char> text)
         {
-            return text.ToLowerInvariant() switch
-            {
-                "not" => QuerySyntaxKind.NotKeyword,
-                "or" => QuerySyntaxKind.OrKeyword,
-                "and" => QuerySyntaxKind.AndKeyword,
-                _ => QuerySyntaxKind.TextToken,
-            };
+            if (text.Equals("not", StringComparison.OrdinalIgnoreCase))
+                return QuerySyntaxKind.NotKeyword;
+
+            if (text.Equals("or", StringComparison.OrdinalIgnoreCase))
+                return QuerySyntaxKind.OrKeyword;
+
+            if (text.Equals("and", StringComparison.OrdinalIgnoreCase))
+                return QuerySyntaxKind.AndKeyword;
+
+            return QuerySyntaxKind.TextToken;
         }
     }
 }

--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsPacketReader.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsPacketReader.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Buffers.Binary;
 
 namespace Meziantou.Framework.Tds.Protocol;
@@ -9,54 +10,83 @@ internal static class TdsPacketReader
         ArgumentNullException.ThrowIfNull(stream);
 
         TdsPacketType? messageType = null;
-        using var payload = new MemoryStream();
+        byte[]? payload = null;
+        var payloadLength = 0;
+        var header = ArrayPool<byte>.Shared.Rent(8);
 
-        while (true)
+        try
         {
-            var header = new byte[8];
-            if (!await TryReadExactlyAsync(stream, header, cancellationToken).ConfigureAwait(false))
+            while (true)
             {
-                if (payload.Length == 0)
+                if (!await TryReadExactlyAsync(stream, header.AsMemory(0, 8), cancellationToken).ConfigureAwait(false))
                 {
-                    return null;
+                    if (payloadLength == 0)
+                    {
+                        return null;
+                    }
+
+                    throw new InvalidDataException("Unexpected end of stream while reading TDS packet header.");
                 }
 
-                throw new InvalidDataException("Unexpected end of stream while reading TDS packet header.");
+                var packetType = (TdsPacketType)header[0];
+                var status = (TdsPacketStatus)header[1];
+                var packetLength = BinaryPrimitives.ReadUInt16BigEndian(header.AsSpan(2, 2));
+                if (packetLength < 8)
+                {
+                    throw new InvalidDataException("Invalid TDS packet length.");
+                }
+
+                messageType ??= packetType;
+                if (messageType != packetType)
+                {
+                    throw new InvalidDataException("TDS message packets must share the same packet type.");
+                }
+
+                var currentPayloadLength = packetLength - 8;
+                if (currentPayloadLength > 0)
+                {
+                    EnsurePayloadCapacity(ref payload, payloadLength + currentPayloadLength, payloadLength);
+                    await stream.ReadExactlyAsync(payload.AsMemory(payloadLength, currentPayloadLength), cancellationToken).ConfigureAwait(false);
+                    payloadLength += currentPayloadLength;
+                }
+
+                if ((status & TdsPacketStatus.EndOfMessage) == TdsPacketStatus.EndOfMessage)
+                {
+                    break;
+                }
             }
 
-            var packetType = (TdsPacketType)header[0];
-            var status = (TdsPacketStatus)header[1];
-            var packetLength = BinaryPrimitives.ReadUInt16BigEndian(header.AsSpan(2, 2));
-            if (packetLength < 8)
+            return new TdsPacket
             {
-                throw new InvalidDataException("Invalid TDS packet length.");
-            }
-
-            messageType ??= packetType;
-            if (messageType != packetType)
+                Type = messageType ?? TdsPacketType.TabularResult,
+                Payload = payloadLength == 0 ? [] : payload![..payloadLength].ToArray(),
+            };
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(header);
+            if (payload is not null)
             {
-                throw new InvalidDataException("TDS message packets must share the same packet type.");
-            }
-
-            var currentPayloadLength = packetLength - 8;
-            if (currentPayloadLength > 0)
-            {
-                var buffer = new byte[currentPayloadLength];
-                await stream.ReadExactlyAsync(buffer, cancellationToken).ConfigureAwait(false);
-                payload.Write(buffer, 0, buffer.Length);
-            }
-
-            if ((status & TdsPacketStatus.EndOfMessage) == TdsPacketStatus.EndOfMessage)
-            {
-                break;
+                ArrayPool<byte>.Shared.Return(payload);
             }
         }
+    }
 
-        return new TdsPacket
+    private static void EnsurePayloadCapacity(ref byte[]? payload, int requiredLength, int existingLength)
+    {
+        if (payload is null)
         {
-            Type = messageType ?? TdsPacketType.TabularResult,
-            Payload = payload.ToArray(),
-        };
+            payload = ArrayPool<byte>.Shared.Rent(requiredLength);
+            return;
+        }
+
+        if (payload.Length >= requiredLength)
+            return;
+
+        var newPayload = ArrayPool<byte>.Shared.Rent(requiredLength);
+        payload.AsSpan(0, existingLength).CopyTo(newPayload);
+        ArrayPool<byte>.Shared.Return(payload);
+        payload = newPayload;
     }
 
     private static async ValueTask<bool> TryReadExactlyAsync(Stream stream, Memory<byte> destination, CancellationToken cancellationToken)

--- a/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
+++ b/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
@@ -6,6 +6,16 @@ namespace Meziantou.Framework.Tests;
 public sealed class ObjectMethodExecutorTests
 {
     [Fact]
+    public void GetOrCreate_ReturnsSameExecutorForTheSameMethod()
+    {
+        var method = typeof(Test).GetMethod(nameof(Test.SyncInt32))!;
+        var first = ObjectMethodExecutor.GetOrCreate(method);
+        var second = ObjectMethodExecutor.GetOrCreate(method);
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
     public void StaticSyncVoidTest()
     {
         var validator = new Validator();


### PR DESCRIPTION
This PR implements a set of planned performance optimizations across parser and protocol hot paths to reduce allocations and per-call overhead while keeping behavior unchanged.

## What changed

- `CsvReader` now uses buffered async reads with internal lookahead instead of single-char async reads.
- `BitBuffer` now uses a growable `byte[]` with a byte-aligned append fast path.
- `HtmlSanitizer` default allow/block sets are precomputed as `FrozenSet`; `UrlSanitizer.IsSafeSrcset` now uses span-based parsing.
- `CharacterSetSegment` now uses precomputed `SearchValues<char>` matching.
- `RegexScanner` now caches a compiled `Regex` instance and resolved group indices.
- `TdsPacketReader` and `DnsWireReader` now use pooled buffers to cut packet/name decoding allocations.
- `NtpPacket` switched manual endian bit-shifts to `BinaryPrimitives` read/write helpers.
- `SimpleQuery` lexer now uses `SearchValues<char>` token boundary detection and span-based keyword matching.
- `FileLogger` now caches the short category name and builds each line through one builder path.
- `ObjectMethodExecutor` now exposes `GetOrCreate(MethodInfo)` backed by a weak cache, with test coverage.

## Notes for review

- This is a behavior-preserving refactor set focused on throughput and GC pressure.
- `RegexScanner` now fails fast if the configured pattern does not define the required `name` group.