### PR TITLE
Make RegexScanner accept Regex instances

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Scanners/RegexScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/RegexScanner.cs
@@ -12,7 +12,7 @@ namespace Meziantou.Framework.DependencyScanning.Scanners;
 /// {
 ///     FilePatterns = [Glob.Parse("**/*.custom", GlobOptions.IgnoreCase)],
 ///     DependencyType = DependencyType.DockerImage,
-///     RegexPattern = @"image:\s*(?<name>[a-z/]+)(:(?<version>[0-9.]+))?"
+///     Regex = new Regex(@"image:\s*(?<name>[a-z/]+)(:(?<version>[0-9.]+))?", RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(10))
 /// };
 /// var options = new ScannerOptions { Scanners = [scanner] };
 /// var dependencies = await DependencyScanner.ScanDirectoryAsync("C:\\MyProject", options, cancellationToken);
@@ -36,8 +36,8 @@ public sealed class RegexScanner : DependencyScanner
         }
     }
 
-    /// <summary>Gets or sets the regular expression pattern to match dependencies. The pattern must include named groups 'name' and optionally 'version'.</summary>
-    public string? RegexPattern { get; set; }
+    /// <summary>Gets or sets the regular expression used to match dependencies. The expression must include named groups 'name' and optionally 'version'.</summary>
+    public Regex? Regex { get; set; }
 
     /// <summary>Gets or sets the type of dependency to report when a match is found.</summary>
     public DependencyType DependencyType
@@ -57,7 +57,8 @@ public sealed class RegexScanner : DependencyScanner
 
     public override async ValueTask ScanAsync(ScanFileContext context)
     {
-        if (RegexPattern is null)
+        var regex = Regex;
+        if (regex is null)
             return;
 
         _frozen = true;
@@ -65,7 +66,7 @@ public sealed class RegexScanner : DependencyScanner
         using var sr = new StreamReader(context.Content);
         var text = await sr.ReadToEndAsync(context.CancellationToken).ConfigureAwait(false);
 
-        foreach (Match match in Regex.Matches(text, RegexPattern, RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(10)))
+        foreach (Match match in regex.Matches(text))
         {
             Debug.Assert(match.Success);
 

--- a/src/Meziantou.Framework.DependencyScanning/readme.md
+++ b/src/Meziantou.Framework.DependencyScanning/readme.md
@@ -164,7 +164,7 @@ var options = new ScannerOptions
         {
             FilePatterns = [Glob.Parse("**/*.custom", GlobOptions.IgnoreCase)],
             DependencyType = DependencyType.DockerImage,
-            RegexPattern = @"image:\s*(?<name>[a-z/]+)(:(?<version>[0-9.]+))?"
+            Regex = new Regex(@"image:\s*(?<name>[a-z/]+)(:(?<version>[0-9.]+))?", RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(10))
         }
     ]
 };

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -1,5 +1,6 @@
 #pragma warning disable MA0101
 using System.Collections.Immutable;
+using System.Text.RegularExpressions;
 using LibGit2Sharp;
 using Meziantou.Framework.DependencyScanning.Scanners;
 using Meziantou.Framework.Globbing;
@@ -756,7 +757,7 @@ jobs:
         {
             FilePatterns = new GlobCollection(Glob.Parse("**/*", GlobOptions.None)),
             DependencyType = DependencyType.DockerImage,
-            RegexPattern = "image: (?<name>[a-z]+):(?<version>[0-9]+)",
+            Regex = new Regex("image: (?<name>[a-z]+):(?<version>[0-9]+)", RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(10)),
         }]);
         AssertContainDependency(result,
             (DependencyType.DockerImage, "node", "10", 2, 15));
@@ -786,7 +787,7 @@ jobs:
         {
             FilePatterns = new GlobCollection(Glob.Parse("**/*", GlobOptions.None)),
             DependencyType = DependencyType.DockerImage,
-            RegexPattern = "image: (?<name>[a-z]+)(:(?<version>[0-9]+))?",
+            Regex = new Regex("image: (?<name>[a-z]+)(:(?<version>[0-9]+))?", RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(10)),
         }]);
         AssertContainDependency(result,
             (DependencyType.DockerImage, "node", null, 0, 0));


### PR DESCRIPTION
`RegexScanner` currently takes a pattern string and internally decides regex options/timeout. This makes customization difficult and hides important runtime behavior. This change switches the scanner API to accept a `Regex` instance directly, as an intentional breaking change.

## What changed
- Replaced `RegexPattern` (`string?`) with `Regex` (`Regex?`) on `RegexScanner`.
- Updated scan logic to use the configured regex instance (`regex.Matches(text)`).
- Updated dependency-scanning tests to pass `new Regex(..., RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(10))`.
- Updated the dependency-scanning README sample to the new API.

## Notes for reviewers
- This PR intentionally changes the public API surface for `RegexScanner`.
- Existing behavior for named capture groups (`name`, optional `version`) is preserved; the caller now controls regex construction details (options/timeout).