### PR TITLE
Optimize span-based decoding in DnsWireReader.ReadDomainNameCore

### DIFF
--- a/src/Meziantou.Framework.DnsClient/Protocol/DnsWireReader.cs
+++ b/src/Meziantou.Framework.DnsClient/Protocol/DnsWireReader.cs
@@ -94,10 +94,12 @@ internal ref struct DnsWireReader
         var jumped = false;
         var originalPosition = -1;
         var pointerCount = 0;
+        Span<char> labelBuffer = stackalloc char[63];
 
         while (position < message.Length)
         {
             var length = message[position];
+            var labelType = length & 0xC0;
 
             if (length is 0)
             {
@@ -106,7 +108,7 @@ internal ref struct DnsWireReader
             }
 
             // Check for compression pointer (top 2 bits set)
-            if ((length & 0xC0) is 0xC0)
+            if (labelType is 0xC0)
             {
                 if (++pointerCount > maxPointers)
                     throw new DnsProtocolException("Too many compression pointers in domain name (possible loop).");
@@ -126,7 +128,7 @@ internal ref struct DnsWireReader
                 continue;
             }
 
-            if ((length & 0xC0) != 0)
+            if (labelType != 0)
                 throw new DnsProtocolException($"Invalid label type: 0x{length:X2}.");
 
             position++;
@@ -139,7 +141,8 @@ internal ref struct DnsWireReader
                 sb.Append('.');
             }
 
-            sb.Append(Encoding.ASCII.GetString(message.Slice(position, length)));
+            var charCount = Encoding.ASCII.GetChars(message.Slice(position, length), labelBuffer);
+            sb.Append(labelBuffer[..charCount]);
             position += length;
         }
 


### PR DESCRIPTION
## Why
`ReadDomainNameCore` decoded each DNS label with `Encoding.ASCII.GetString(...)`, which allocates a temporary string per label. This parser is used heavily while decoding responses, so reducing per-label allocations improves efficiency.

## What changed
The method now uses a stack-allocated label buffer (`stackalloc char[63]`, the DNS label max length) and span-based decoding:
- decode bytes with `Encoding.ASCII.GetChars(...)` into the stack buffer
- append the decoded char span directly to `StringBuilder`

The existing parsing behavior is preserved, including compression pointer handling, pointer loop guard, invalid label checks, bounds checks, and root-domain handling.

## Notes
This PR intentionally scopes the optimization to the DNS client reader (`src/Meziantou.Framework.DnsClient/Protocol/DnsWireReader.cs`).