### PR TITLE
Optimize TDS packet reader memory usage

### DIFF
--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsPacketReader.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsPacketReader.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Buffers.Binary;
 
 namespace Meziantou.Framework.Tds.Protocol;
@@ -9,54 +10,89 @@ internal static class TdsPacketReader
         ArgumentNullException.ThrowIfNull(stream);
 
         TdsPacketType? messageType = null;
-        using var payload = new MemoryStream();
+        byte[]? payload = null;
+        var payloadLength = 0;
+        var header = ArrayPool<byte>.Shared.Rent(8);
 
-        while (true)
+        try
         {
-            var header = new byte[8];
-            if (!await TryReadExactlyAsync(stream, header, cancellationToken).ConfigureAwait(false))
+            while (true)
             {
-                if (payload.Length == 0)
+                if (!await TryReadExactlyAsync(stream, header.AsMemory(0, 8), cancellationToken).ConfigureAwait(false))
                 {
-                    return null;
+                    if (payloadLength == 0)
+                    {
+                        return null;
+                    }
+
+                    throw new InvalidDataException("Unexpected end of stream while reading TDS packet header.");
                 }
 
-                throw new InvalidDataException("Unexpected end of stream while reading TDS packet header.");
+                var packetType = (TdsPacketType)header[0];
+                var status = (TdsPacketStatus)header[1];
+                var packetLength = BinaryPrimitives.ReadUInt16BigEndian(header.AsSpan(2, 2));
+                if (packetLength < 8)
+                {
+                    throw new InvalidDataException("Invalid TDS packet length.");
+                }
+
+                messageType ??= packetType;
+                if (messageType != packetType)
+                {
+                    throw new InvalidDataException("TDS message packets must share the same packet type.");
+                }
+
+                var currentPayloadLength = packetLength - 8;
+                if (currentPayloadLength > 0)
+                {
+                    EnsurePayloadCapacity(ref payload, payloadLength + currentPayloadLength, payloadLength);
+                    await stream.ReadExactlyAsync(payload.AsMemory(payloadLength, currentPayloadLength), cancellationToken).ConfigureAwait(false);
+                    payloadLength += currentPayloadLength;
+                }
+
+                if ((status & TdsPacketStatus.EndOfMessage) == TdsPacketStatus.EndOfMessage)
+                {
+                    break;
+                }
             }
 
-            var packetType = (TdsPacketType)header[0];
-            var status = (TdsPacketStatus)header[1];
-            var packetLength = BinaryPrimitives.ReadUInt16BigEndian(header.AsSpan(2, 2));
-            if (packetLength < 8)
+            return new TdsPacket
             {
-                throw new InvalidDataException("Invalid TDS packet length.");
-            }
-
-            messageType ??= packetType;
-            if (messageType != packetType)
+                Type = messageType ?? TdsPacketType.TabularResult,
+                Payload = payloadLength == 0 ? [] : payload![..payloadLength].ToArray(),
+            };
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(header);
+            if (payload is not null)
             {
-                throw new InvalidDataException("TDS message packets must share the same packet type.");
-            }
-
-            var currentPayloadLength = packetLength - 8;
-            if (currentPayloadLength > 0)
-            {
-                var buffer = new byte[currentPayloadLength];
-                await stream.ReadExactlyAsync(buffer, cancellationToken).ConfigureAwait(false);
-                payload.Write(buffer, 0, buffer.Length);
-            }
-
-            if ((status & TdsPacketStatus.EndOfMessage) == TdsPacketStatus.EndOfMessage)
-            {
-                break;
+                ArrayPool<byte>.Shared.Return(payload);
             }
         }
+    }
 
-        return new TdsPacket
+    private static void EnsurePayloadCapacity(ref byte[]? payload, int requiredLength, int existingLength)
+    {
+        if (payload is null)
         {
-            Type = messageType ?? TdsPacketType.TabularResult,
-            Payload = payload.ToArray(),
-        };
+            payload = ArrayPool<byte>.Shared.Rent(requiredLength);
+            return;
+        }
+
+        if (payload.Length >= requiredLength)
+            return;
+
+        var newPayloadLength = payload.Length;
+        while (newPayloadLength < requiredLength)
+        {
+            newPayloadLength = checked(newPayloadLength * 2);
+        }
+
+        var newPayload = ArrayPool<byte>.Shared.Rent(newPayloadLength);
+        payload.AsSpan(0, existingLength).CopyTo(newPayload);
+        ArrayPool<byte>.Shared.Return(payload);
+        payload = newPayload;
     }
 
     private static async ValueTask<bool> TryReadExactlyAsync(Stream stream, Memory<byte> destination, CancellationToken cancellationToken)

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -137,6 +137,7 @@ public sealed class TdsServerProtocolTests
     }
 
     [Fact]
+    [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "The SQL query is generated within the test and not user-controlled.")]
     public async Task SqlClient_TextQuery_LargePayload_UsesMultiplePackets()
     {
         const string Marker = "LargePayloadMarker";
@@ -176,7 +177,7 @@ public sealed class TdsServerProtocolTests
         Assert.Equal(456, Convert.ToInt32(result, CultureInfo.InvariantCulture));
         Assert.Equal(TdsQueryRequestType.SqlBatch, capturedContext.RequestType);
         Assert.Contains(Marker, capturedContext.CommandText, StringComparison.Ordinal);
-        Assert.True(capturedContext.CommandText.Length > 6000);
+        Assert.True((capturedContext.CommandText?.Length ?? 0) > 6000);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -137,6 +137,49 @@ public sealed class TdsServerProtocolTests
     }
 
     [Fact]
+    public async Task SqlClient_TextQuery_LargePayload_UsesMultiplePackets()
+    {
+        const string Marker = "LargePayloadMarker";
+        var longComment = new string('a', 7000);
+        var query = $"SELECT 1 /* {Marker}{longComment} */";
+        var queryContextTask = new TaskCompletionSource<TdsQueryContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) =>
+            {
+                if (context.CommandText?.Contains(Marker, StringComparison.Ordinal) == true)
+                {
+                    queryContextTask.TrySetResult(context);
+                    return ValueTask.FromResult(CreateScalarResultSet(TdsColumnType.Int32, 456));
+                }
+
+                return ValueTask.FromResult(new TdsQueryResult());
+            });
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port) + ";Packet Size=512");
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = query;
+
+        var result = await command.ExecuteScalarAsync();
+        var capturedContext = await queryContextTask.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(456, Convert.ToInt32(result, CultureInfo.InvariantCulture));
+        Assert.Equal(TdsQueryRequestType.SqlBatch, capturedContext.RequestType);
+        Assert.Contains(Marker, capturedContext.CommandText, StringComparison.Ordinal);
+        Assert.True(capturedContext.CommandText.Length > 6000);
+    }
+
+    [Fact]
     public async Task SqlClient_TextQuery_UserContext_FromAuthentication_IsAvailableInQueryContext()
     {
         const string Marker = "TextQueryUserContextMarker";


### PR DESCRIPTION
## Why
`TdsPacketReader` was allocating per-packet header and payload chunk buffers, which increases allocation pressure for fragmented or large TDS messages. This change restores a pooled-buffer approach and adds a targeted growth optimization to reduce memory churn during packet reassembly.

## What changed
- Switched `TdsPacketReader` back to `ArrayPool<byte>`-based buffering for headers and payload assembly.
- Read packet payload bytes directly into the pooled destination buffer instead of intermediate per-chunk arrays.
- Added capacity growth logic that grows geometrically before renting a new payload buffer, reducing repeated rent/copy cycles on large multi-packet messages.
- Added `SqlClient_TextQuery_LargePayload_UsesMultiplePackets` regression coverage to ensure large SQL batch payloads split across multiple packets are reconstructed correctly.

## Validation
- Ran required maintenance scripts:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`
- Ran tests:
  - `DiffEngine_Disabled=true dotnet test tests/Meziantou.Framework.TdsServer.Tests/Meziantou.Framework.TdsServer.Tests.csproj -v minimal`