### PR TITLE
Stabilize flaky TDS stored procedure RPC test

### DIFF
--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -2,6 +2,7 @@ using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
+using System.Net.Sockets;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -483,7 +484,9 @@ public sealed class TdsServerProtocolTests
         await server.StartAsync();
         var port = Assert.Single(server.Ports);
 
-        await using var connection = new SqlConnection(CreateConnectionString(port));
+        await WaitForServerReadyAsync(port, TimeSpan.FromSeconds(30));
+
+        await using var connection = new SqlConnection(CreateConnectionString(port, connectTimeout: 30));
         await connection.OpenAsync();
 
         await using var command = connection.CreateCommand();
@@ -862,9 +865,39 @@ public sealed class TdsServerProtocolTests
         return Convert.ToInt32(value, CultureInfo.InvariantCulture);
     }
 
-    private static string CreateConnectionString(int port, string userName = "sa", string password = "Password123!", string encrypt = "Optional", bool trustServerCertificate = true)
+    private static async Task WaitForServerReadyAsync(int port, TimeSpan timeout)
     {
-        return $"Server={IPAddress.Loopback},{port};User ID={userName};Password={password};Database=master;Encrypt={encrypt};TrustServerCertificate={(trustServerCertificate ? "True" : "False")};Pooling=False;Connect Timeout=5";
+        var deadline = DateTime.UtcNow + timeout;
+        Exception? lastException = null;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            using var client = new TcpClient();
+
+            try
+            {
+                using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+                await client.ConnectAsync(IPAddress.Loopback, port, cancellationTokenSource.Token);
+                return;
+            }
+            catch (OperationCanceledException ex)
+            {
+                lastException = ex;
+            }
+            catch (SocketException ex)
+            {
+                lastException = ex;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(200));
+        }
+
+        throw new TimeoutException($"The test server on {IPAddress.Loopback}:{port} was not ready within {timeout}.", lastException);
+    }
+
+    private static string CreateConnectionString(int port, string userName = "sa", string password = "Password123!", string encrypt = "Optional", bool trustServerCertificate = true, int connectTimeout = 5)
+    {
+        return $"Server={IPAddress.Loopback},{port};User ID={userName};Password={password};Database=master;Encrypt={encrypt};TrustServerCertificate={(trustServerCertificate ? "True" : "False")};Pooling=False;Connect Timeout={connectTimeout}";
     }
 
     private static TlsCertificateFiles CreateTlsCertificateFiles()


### PR DESCRIPTION
## Why
`SqlClient_StoredProcedure_WithParameters_UsesRpc` was flaky in Windows CI with `Connection Timeout Expired` during the pre-login handshake. The issue is a startup timing race in the test path, not a build failure.

## What changed
- Added `WaitForServerReadyAsync(int port, TimeSpan timeout)` in `TdsServerProtocolTests` to probe loopback TCP readiness with bounded retries.
- Updated `SqlClient_StoredProcedure_WithParameters_UsesRpc` to wait for server readiness before opening `SqlConnection`.
- Extended `CreateConnectionString(...)` with an optional `connectTimeout` parameter (default remains `5`) and set this flaky test to `30` seconds.

## Notes
- Scope is intentionally limited to the failing integration test so behavior of other tests remains unchanged.