### PR TITLE
Add README for Meziantou.Xunit package

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@
 | Meziantou.Framework.Win32.RecentDocuments | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.Win32.RecentDocuments.svg)](https://www.nuget.org/packages/Meziantou.Framework.Win32.RecentDocuments/) | [readme](src/Meziantou.Framework.Win32.RecentDocuments/readme.md) |
 | Meziantou.Framework.Win32.RestartManager | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.Win32.RestartManager.svg)](https://www.nuget.org/packages/Meziantou.Framework.Win32.RestartManager/) | [readme](src/Meziantou.Framework.Win32.RestartManager/readme.md) |
 | Meziantou.Framework.WPF | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.WPF.svg)](https://www.nuget.org/packages/Meziantou.Framework.WPF/) | |
-| Meziantou.Xunit | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Xunit.svg)](https://www.nuget.org/packages/Meziantou.Xunit/) | |
+| Meziantou.Xunit | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Xunit.svg)](https://www.nuget.org/packages/Meziantou.Xunit/) | [readme](src/Meziantou.Xunit/readme.md) |
 
 # How to contribute
 

--- a/src/Meziantou.Xunit/readme.md
+++ b/src/Meziantou.Xunit/readme.md
@@ -1,0 +1,54 @@
+# Meziantou.Xunit
+
+`Meziantou.Xunit` provides xUnit.v3 attributes to run or skip tests depending on the current environment.
+
+## Installation
+
+```bash
+dotnet add package Meziantou.Xunit
+```
+
+## Usage
+
+```c#
+using Meziantou.Xunit;
+using Xunit;
+
+public sealed class SampleTests
+{
+    [Fact]
+    [RunIf(TestOperatingSystems.Windows | TestOperatingSystems.Linux)]
+    public void Runs_on_windows_or_linux()
+    {
+    }
+
+    [Fact]
+    [RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    public void Runs_only_when_invariant_globalization_is_disabled()
+    {
+    }
+
+    [Fact]
+    [SkipIf(WindowsGroups.Administrator)]
+    public void Skipped_when_running_as_administrator()
+    {
+    }
+
+    [Fact]
+    [RunIf(ContinuousIntegration = ContinuousIntegrationEnvironments.GitHubActions)]
+    public void Runs_only_on_github_actions()
+    {
+    }
+}
+```
+
+`RunIf` executes the test only when all specified conditions match. `SkipIf` skips the test when all specified conditions match.
+
+## Supported conditions
+
+| Condition | Type | Values |
+| :--- | :--- | :--- |
+| `OperatingSystem` | `TestOperatingSystems` | `Windows`, `Linux`, `MacOS` (`Flags`) |
+| `GlobalizationMode` | `TestGlobalizationMode` | `Any`, `Enabled` (invariant mode), `Disabled` (non-invariant mode) |
+| `ContinuousIntegration` | `ContinuousIntegrationEnvironments` | `GitHubActions` |
+| `WindowsGroup` | `WindowsGroups` | `Any`, `User`, `Administrator` |


### PR DESCRIPTION
## Why
`Meziantou.Xunit` did not have a package README, which made it harder to discover how to use its conditional test attributes from NuGet and the repository package index.

## What changed
- Added `src/Meziantou.Xunit/readme.md` with:
  - package purpose
  - installation command
  - practical `RunIf` and `SkipIf` examples
  - a summary table of supported conditions (`OperatingSystem`, `GlobalizationMode`, `ContinuousIntegration`, `WindowsGroup`)
- Updated the root `README.md` NuGet table entry for `Meziantou.Xunit` to link to the new package README.