### PR TITLE
Update ImageSharp to 4.0.0 and add SixLabors license file

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.0" />
     <PackageReference Include="System.Numerics.Tensors" Version="10.0.7" />
   </ItemGroup>
 

--- a/src/Meziantou.Framework.SnapshotTesting.ImageSharp/sixlabors.lic
+++ b/src/Meziantou.Framework.SnapshotTesting.ImageSharp/sixlabors.lic
@@ -1,0 +1,1 @@
+Id=ctm_01krfgmb5deyg30c12hcyvm6p3;Kind=Community;ExpiryDateUtc=2026-08-11T01:53:41.1678711Z;Key=6oFq9sz8pseP1wkXEW/V/lhnJbn/LkqsBEvNHVycl3lTewTk0m//vy9AoNgKNSR+YUmqgCuYnPHViSJ6Dgj2hw==


### PR DESCRIPTION
ImageSharp 4.0.0 requires a valid Six Labors license during build. This updates the SnapshotTesting.ImageSharp package dependency and adds the provided license file so the project builds with the new version.

## Changes
- Bump `SixLabors.ImageSharp` from `3.1.12` to `4.0.0` in `Meziantou.Framework.SnapshotTesting.ImageSharp.csproj`
- Add `sixlabors.lic` in `src/Meziantou.Framework.SnapshotTesting.ImageSharp/` so the default project-directory license discovery picks it up

## Notes
- This PR only changes dependency/licensing setup for the SnapshotTesting.ImageSharp project; runtime behavior is unchanged.