### PR TITLE
Stabilize transient SQL handshake timeouts in TDS tests

### DIFF
--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -2897,20 +2897,26 @@ public sealed class TdsQueryEngineTests
         await server.StartAsync();
         var port = Assert.Single(server.Ports);
 
-        await using var connection = new SqlConnection(CreateConnectionString(port));
-        await connection.OpenAsync();
+        var payload = await ExecuteWithTransientSqlRetry(async () =>
+        {
+            await using var connection = new SqlConnection(CreateConnectionString(port));
+            await connection.OpenAsync();
 
-        await using var selectCommand = connection.CreateCommand();
-        selectCommand.CommandText = """
-            SELECT CAST(Payload AS XML(dbo.BasicXml)) AS PayloadXml
-            FROM xml_docs
-            WHERE Id = 1
-            """;
-        await using var reader = await selectCommand.ExecuteReaderAsync();
+            await using var selectCommand = connection.CreateCommand();
+            selectCommand.CommandText = """
+                SELECT CAST(Payload AS XML(dbo.BasicXml)) AS PayloadXml
+                FROM xml_docs
+                WHERE Id = 1
+                """;
+            await using var reader = await selectCommand.ExecuteReaderAsync();
 
-        Assert.True(await reader.ReadAsync());
-        Assert.Equal("<root><item id=\"1\">Alpha</item><item id=\"2\">Beta</item></root>", reader.GetString(0));
-        Assert.False(await reader.ReadAsync());
+            Assert.True(await reader.ReadAsync());
+            var value = reader.GetString(0);
+            Assert.False(await reader.ReadAsync());
+            return value;
+        });
+
+        Assert.Equal("<root><item id=\"1\">Alpha</item><item id=\"2\">Beta</item></root>", payload);
     }
 
     [Fact]
@@ -3043,17 +3049,21 @@ public sealed class TdsQueryEngineTests
         await server.StartAsync();
         var port = Assert.Single(server.Ports);
 
-        await using var connection = new SqlConnection(CreateConnectionString(port));
-        await connection.OpenAsync();
+        var exception = await ExecuteWithTransientSqlRetry(async () =>
+        {
+            await using var connection = new SqlConnection(CreateConnectionString(port));
+            await connection.OpenAsync();
 
-        await using var command = connection.CreateCommand();
-        command.CommandText = """
-            SELECT Id
-            FROM customers
-            WHERE Id =
-            """;
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                SELECT Id
+                FROM customers
+                WHERE Id =
+                """;
 
-        var exception = await Assert.ThrowsAsync<SqlException>(() => command.ExecuteReaderAsync());
+            return await Assert.ThrowsAsync<SqlException>(() => command.ExecuteReaderAsync());
+        });
+
         Assert.Equal(50004, exception.Number);
         Assert.True(await invalidQueryTask.Task.WaitAsync(TimeSpan.FromSeconds(5)));
     }

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -525,14 +525,9 @@ public sealed class TdsServerProtocolTests
         await server.StartAsync();
         var port = Assert.Single(server.Ports);
 
-        await using var connection = new SqlConnection(CreateConnectionString(port, encrypt: "True"));
-        await connection.OpenAsync();
+        var value = await ExecuteScalarWithTransientSqlRetryAsync(port, encrypt: "True");
 
-        await using var command = connection.CreateCommand();
-        command.CommandText = "SELECT 1";
-        var value = await command.ExecuteScalarAsync();
-
-        Assert.Equal(1, Convert.ToInt32(value, CultureInfo.InvariantCulture));
+        Assert.Equal(1, value);
     }
 
     [Fact]
@@ -555,14 +550,9 @@ public sealed class TdsServerProtocolTests
         await server.StartAsync();
         var port = Assert.Single(server.Ports);
 
-        await using var connection = new SqlConnection(CreateConnectionString(port, encrypt: "True"));
-        await connection.OpenAsync();
+        var value = await ExecuteScalarWithTransientSqlRetryAsync(port, encrypt: "True");
 
-        await using var command = connection.CreateCommand();
-        command.CommandText = "SELECT 1";
-        var value = await command.ExecuteScalarAsync();
-
-        Assert.Equal(1, Convert.ToInt32(value, CultureInfo.InvariantCulture));
+        Assert.Equal(1, value);
     }
 
     [Fact]
@@ -586,7 +576,7 @@ public sealed class TdsServerProtocolTests
         var port = Assert.Single(server.Ports);
 
         var optionalResult = await ExecuteScalarAsync(port, encrypt: "Optional");
-        var encryptedResult = await ExecuteScalarAsync(port, encrypt: "True");
+        var encryptedResult = await ExecuteScalarWithTransientSqlRetryAsync(port, encrypt: "True");
 
         Assert.Equal(1, optionalResult);
         Assert.Equal(1, encryptedResult);
@@ -854,15 +844,48 @@ public sealed class TdsServerProtocolTests
         return new ClaimsPrincipal(identity);
     }
 
-    private static async Task<int> ExecuteScalarAsync(int port, string encrypt)
+    private static async Task<int> ExecuteScalarAsync(int port, string encrypt, int connectTimeout = 5)
     {
-        await using var connection = new SqlConnection(CreateConnectionString(port, encrypt: encrypt));
+        await using var connection = new SqlConnection(CreateConnectionString(port, encrypt: encrypt, connectTimeout: connectTimeout));
         await connection.OpenAsync();
 
         await using var command = connection.CreateCommand();
         command.CommandText = "SELECT 1";
         var value = await command.ExecuteScalarAsync();
         return Convert.ToInt32(value, CultureInfo.InvariantCulture);
+    }
+
+    private static Task<int> ExecuteScalarWithTransientSqlRetryAsync(int port, string encrypt, int connectTimeout = 15)
+    {
+        return ExecuteWithTransientSqlRetry(() => ExecuteScalarAsync(port, encrypt: encrypt, connectTimeout: connectTimeout));
+    }
+
+    private static async Task<T> ExecuteWithTransientSqlRetry<T>(Func<Task<T>> action)
+    {
+        const int MaxAttempts = 3;
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return await action();
+            }
+            catch (SqlException ex) when (attempt < MaxAttempts && IsTransientSqlOpenFailure(ex))
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(200 * attempt));
+            }
+        }
+    }
+
+    private static bool IsTransientSqlOpenFailure(SqlException exception)
+    {
+        if (exception.Number != -2)
+        {
+            return false;
+        }
+
+        var hasTimeout = exception.Message.Contains("Connection Timeout Expired", StringComparison.OrdinalIgnoreCase);
+        var hasPreLogin = exception.Message.Contains("pre-login", StringComparison.OrdinalIgnoreCase);
+        return hasTimeout && hasPreLogin;
     }
 
     private static async Task WaitForServerReadyAsync(int port, TimeSpan timeout)


### PR DESCRIPTION
Connection setup in a few TDS integration tests can intermittently time out during SQL pre-login/TLS handshake on CI. This makes otherwise-correct test runs flaky.

This change standardizes transient `SqlConnection.OpenAsync()` retry handling where handshake/connect timeouts can occur:

- In `TdsServerProtocolTests`, encrypted connection tests now use a shared retry path with a longer connect timeout for retry attempts.
- The `Encrypt=True` path in `SqlClient_EncryptOptional_AndEncryptTrue_WorkOnSameEndpoint` now uses the same retry-aware helper.
- In `TdsQueryEngineTests`, the two remaining direct-open tests that bypassed existing retry helpers are now wrapped in the same transient retry flow used elsewhere in that file.

The retry filter remains narrow (`SqlException` timeout + pre-login signature), so non-transient failures still fail fast and preserve test signal.