### PR TITLE
Disable Renovate Microsoft.Build updates for MSBuild generator

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,11 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": [ "/^Microsoft\\.Build\\..*/" ],
+      "matchFileNames": [ "src/Meziantou.Framework.PublicApiGenerator.MSBuild/Meziantou.Framework.PublicApiGenerator.MSBuild.csproj" ],
+      "enabled": false
+    },
+    {
       "matchPackageNames": [ "Microsoft.CodeAnalysis", "Microsoft.CodeAnalysis.CSharp", "Microsoft.CodeAnalysis.CSharp.Workspaces" ],
       "matchFileNames": [
         "src/Meziantou.AspNetCore.ServiceDefaults.AutoRegister/Meziantou.AspNetCore.ServiceDefaults.AutoRegister.csproj",


### PR DESCRIPTION
## Why
Renovate should not propose `Microsoft.Build.*` dependency updates for `Meziantou.Framework.PublicApiGenerator.MSBuild`, where these updates are intentionally managed outside normal dependency update flow.

## What changed
Added a dedicated `packageRules` entry in `renovate.json5` that:
- matches packages with `/^Microsoft\.Build\..*/`
- applies only to `src/Meziantou.Framework.PublicApiGenerator.MSBuild/Meziantou.Framework.PublicApiGenerator.MSBuild.csproj`
- disables updates with `"enabled": false`

## Notes
This is narrowly scoped to one project file and does not change existing rules for other package groups.