### PR TITLE
Remove FullPath dependency from PublicApiGenerator tool and MSBuild

### DIFF
--- a/src/Meziantou.Framework.PublicApiGenerator.MSBuild/GeneratePublicApiTask.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator.MSBuild/GeneratePublicApiTask.cs
@@ -39,7 +39,7 @@ public sealed class GeneratePublicApiTask : Microsoft.Build.Utilities.Task
             .OrderBy(item => item.GetMetadata("TargetFramework"), StringComparer.Ordinal)
             .ThenBy(item => item.ItemSpec, StringComparer.Ordinal))
         {
-            var assemblyPath = FullPath.FromPath(assembly.ItemSpec);
+            var assemblyPath = Path.GetFullPath(assembly.ItemSpec);
             if (!File.Exists(assemblyPath))
             {
                 Log.LogError("The assembly '{0}' does not exist.", assemblyPath);
@@ -65,19 +65,19 @@ public sealed class GeneratePublicApiTask : Microsoft.Build.Utilities.Task
                 return false;
             }
 
-            var outputFilePath = FullPath.FromPath(OutputPath);
+            var outputFilePath = Path.GetFullPath(OutputPath);
             if (VerifyNoChange)
             {
                 LogValidationErrors(ValidateSingleFile(files[0], outputFilePath));
                 return !Log.HasLoggedErrors;
             }
 
-            outputFilePath.CreateParentDirectory();
+            CreateParentDirectory(outputFilePath);
             File.WriteAllText(outputFilePath, files[0].Content);
             return !Log.HasLoggedErrors;
         }
 
-        var outputDirectoryPath = FullPath.FromPath(OutputPath);
+        var outputDirectoryPath = Path.GetFullPath(OutputPath);
         if (VerifyNoChange)
         {
             var files = PublicApi.Generate(assemblySources, options);
@@ -98,7 +98,7 @@ public sealed class GeneratePublicApiTask : Microsoft.Build.Utilities.Task
         }
     }
 
-    private static List<string> ValidateSingleFile(PublicApiFile expectedFile, FullPath outputFilePath)
+    private static List<string> ValidateSingleFile(PublicApiFile expectedFile, string outputFilePath)
     {
         var errors = new List<string>();
         if (!File.Exists(outputFilePath))
@@ -116,17 +116,17 @@ public sealed class GeneratePublicApiTask : Microsoft.Build.Utilities.Task
         return errors;
     }
 
-    private static List<string> ValidateDirectory(IReadOnlyList<PublicApiFile> expectedFiles, FullPath outputDirectoryPath)
+    private static List<string> ValidateDirectory(IReadOnlyList<PublicApiFile> expectedFiles, string outputDirectoryPath)
     {
         var errors = new List<string>();
         var comparer = GetRelativePathComparer();
         var expectedFilesByRelativePath = expectedFiles
-            .GroupBy(file => file.RelativePath, comparer)
+            .GroupBy(file => NormalizeRelativePath(file.RelativePath), comparer)
             .ToDictionary(group => group.Key, group => group.Last(), comparer);
 
         foreach (var expectedFile in expectedFilesByRelativePath.Values)
         {
-            var outputFilePath = outputDirectoryPath / expectedFile.RelativePath;
+            var outputFilePath = Path.Combine(outputDirectoryPath, expectedFile.RelativePath.Replace('/', Path.DirectorySeparatorChar));
             if (!File.Exists(outputFilePath))
             {
                 errors.Add($"Expected file '{outputFilePath}' does not exist.");
@@ -142,9 +142,9 @@ public sealed class GeneratePublicApiTask : Microsoft.Build.Utilities.Task
 
         if (Directory.Exists(outputDirectoryPath))
         {
-            foreach (var outputFilePath in Directory.EnumerateFiles(outputDirectoryPath, "*", SearchOption.AllDirectories).Select(FullPath.FromPath))
+            foreach (var outputFilePath in Directory.EnumerateFiles(outputDirectoryPath, "*", SearchOption.AllDirectories))
             {
-                var relativePath = outputFilePath.MakePathRelativeTo(outputDirectoryPath);
+                var relativePath = NormalizeRelativePath(Path.GetRelativePath(outputDirectoryPath, outputFilePath));
                 if (!expectedFilesByRelativePath.ContainsKey(relativePath))
                 {
                     errors.Add($"Unexpected file '{outputFilePath}' exists in the output directory.");
@@ -168,5 +168,19 @@ public sealed class GeneratePublicApiTask : Microsoft.Build.Utilities.Task
     private static StringComparer GetRelativePathComparer()
     {
         return OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+    }
+
+    private static void CreateParentDirectory(string path)
+    {
+        var parentDirectory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(parentDirectory))
+        {
+            Directory.CreateDirectory(parentDirectory);
+        }
+    }
+
+    private static string NormalizeRelativePath(string path)
+    {
+        return path.Replace('\\', '/');
     }
 }

--- a/src/Meziantou.Framework.PublicApiGenerator.MSBuild/Meziantou.Framework.PublicApiGenerator.MSBuild.csproj
+++ b/src/Meziantou.Framework.PublicApiGenerator.MSBuild/Meziantou.Framework.PublicApiGenerator.MSBuild.csproj
@@ -14,7 +14,6 @@
     <None Include="build/**" Pack="true" PackagePath="build" />
     <None Include="buildTransitive/**" Pack="true" PackagePath="buildTransitive" />
     <None Include="buildMultiTargeting/**" Pack="true" PackagePath="buildMultiTargeting" />
-    <None Include="$(OutputPath)/../$(Configuration.ToLowerInvariant())_net8.0/Meziantou.Framework.FullPath.dll" Pack="true" PackagePath="tasks/net8.0" Visible="false" />
     <None Include="$(OutputPath)/../$(Configuration.ToLowerInvariant())_net8.0/Meziantou.Framework.PublicApiGenerator.dll" Pack="true" PackagePath="tasks/net8.0" Visible="false" />
     <None Include="$(OutputPath)/../$(Configuration.ToLowerInvariant())_net8.0/Meziantou.Framework.PublicApiGenerator.MSBuild.dll" Pack="true" PackagePath="tasks/net8.0" Visible="false" />
     <None Include="$(OutputPath)/../$(Configuration.ToLowerInvariant())_net8.0/Meziantou.Framework.PublicApiGenerator.MSBuild.deps.json" Pack="true" PackagePath="tasks/net8.0" Visible="false" />
@@ -26,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
     <ProjectReference Include="../Meziantou.Framework.PublicApiGenerator/Meziantou.Framework.PublicApiGenerator.csproj" />
   </ItemGroup>
 

--- a/src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj
+++ b/src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
     <ProjectReference Include="../Meziantou.Framework.PublicApiGenerator/Meziantou.Framework.PublicApiGenerator.csproj" />
   </ItemGroup>
 

--- a/src/Meziantou.Framework.PublicApiGenerator.Tool/Program.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator.Tool/Program.cs
@@ -1,6 +1,5 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using Meziantou.Framework;
 using Meziantou.Framework.PublicApiGenerator;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Meziantou.Framework.PublicApiGenerator.Tests")]
@@ -98,14 +97,14 @@ internal static class Program
                     throw new InvalidOperationException($"Expected a single generated file when using {nameof(PublicApiFileLayout.SingleFile)} layout.");
                 }
 
-                var outputFilePath = FullPath.FromPath(outputFile);
+                var outputFilePath = Path.GetFullPath(outputFile);
                 if (verifyNoChange)
                 {
                     ThrowIfValidationFailed(ValidateSingleFile(files[0], outputFilePath));
                     return;
                 }
 
-                outputFilePath.CreateParentDirectory();
+                CreateParentDirectory(outputFilePath);
                 File.WriteAllText(outputFilePath, files[0].Content);
                 return;
             }
@@ -115,7 +114,7 @@ internal static class Program
                 if (verifyNoChange)
                 {
                     var files = PublicApi.Generate(inputs, options);
-                    var outputDirectoryPath = FullPath.FromPath(outputDirectory);
+                    var outputDirectoryPath = Path.GetFullPath(outputDirectory);
                     ThrowIfValidationFailed(ValidateDirectory(files, outputDirectoryPath));
                     return;
                 }
@@ -140,7 +139,7 @@ internal static class Program
         if (verifyNoChange)
         {
             var files = PublicApi.Generate(inputs, options);
-            var outputDirectoryPath = FullPath.FromPath(outputDirectory);
+            var outputDirectoryPath = Path.GetFullPath(outputDirectory);
             ThrowIfValidationFailed(ValidateDirectory(files, outputDirectoryPath));
             return;
         }
@@ -158,7 +157,7 @@ internal static class Program
         throw new InvalidOperationException("Public API validation failed:\n" + string.Join('\n', errors.Select(error => " - " + error)));
     }
 
-    private static List<string> ValidateSingleFile(PublicApiFile expectedFile, FullPath outputFilePath)
+    private static List<string> ValidateSingleFile(PublicApiFile expectedFile, string outputFilePath)
     {
         var errors = new List<string>();
         if (!File.Exists(outputFilePath))
@@ -176,17 +175,17 @@ internal static class Program
         return errors;
     }
 
-    private static List<string> ValidateDirectory(IReadOnlyList<PublicApiFile> expectedFiles, FullPath outputDirectoryPath)
+    private static List<string> ValidateDirectory(IReadOnlyList<PublicApiFile> expectedFiles, string outputDirectoryPath)
     {
         var errors = new List<string>();
         var comparer = GetRelativePathComparer();
         var expectedFilesByRelativePath = expectedFiles
-            .GroupBy(file => file.RelativePath, comparer)
+            .GroupBy(file => NormalizeRelativePath(file.RelativePath), comparer)
             .ToDictionary(group => group.Key, group => group.Last(), comparer);
 
         foreach (var expectedFile in expectedFilesByRelativePath.Values)
         {
-            var outputFilePath = outputDirectoryPath / expectedFile.RelativePath;
+            var outputFilePath = Path.Combine(outputDirectoryPath, expectedFile.RelativePath.Replace('/', Path.DirectorySeparatorChar));
             if (!File.Exists(outputFilePath))
             {
                 errors.Add($"Expected file '{outputFilePath}' does not exist.");
@@ -202,9 +201,9 @@ internal static class Program
 
         if (Directory.Exists(outputDirectoryPath))
         {
-            foreach (var outputFilePath in Directory.EnumerateFiles(outputDirectoryPath, "*", SearchOption.AllDirectories).Select(FullPath.FromPath))
+            foreach (var outputFilePath in Directory.EnumerateFiles(outputDirectoryPath, "*", SearchOption.AllDirectories))
             {
-                var relativePath = outputFilePath.MakePathRelativeTo(outputDirectoryPath);
+                var relativePath = NormalizeRelativePath(Path.GetRelativePath(outputDirectoryPath, outputFilePath));
                 if (!expectedFilesByRelativePath.ContainsKey(relativePath))
                 {
                     errors.Add($"Unexpected file '{outputFilePath}' exists in the output directory.");
@@ -228,6 +227,20 @@ internal static class Program
     private static StringComparer GetRelativePathComparer()
     {
         return OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+    }
+
+    private static void CreateParentDirectory(string path)
+    {
+        var parentDirectory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(parentDirectory))
+        {
+            Directory.CreateDirectory(parentDirectory);
+        }
+    }
+
+    private static string NormalizeRelativePath(string path)
+    {
+        return path.Replace('\\', '/');
     }
 
     private static List<AssemblySource> ParseInputs(string[] inputValues)


### PR DESCRIPTION
## Why
`Meziantou.Framework.PublicApiGenerator` tooling still depended on `Meziantou.Framework.FullPath` for local path handling. This adds an unnecessary transitive dependency for the CLI tool and MSBuild package.

## What changed
- Replaced `FullPath`-based path handling in the PublicApiGenerator CLI and MSBuild task with `System.IO.Path` APIs.
- Added local helpers to preserve behavior for parent directory creation and relative path normalization during verify mode.
- Removed `Meziantou.Framework.FullPath` project references from:
  - `Meziantou.Framework.PublicApiGenerator.Tool`
  - `Meziantou.Framework.PublicApiGenerator.MSBuild`
- Removed packaging of `Meziantou.Framework.FullPath.dll` from the MSBuild package `tasks/net8.0` output.

## Notes
- Relative path comparison behavior remains OS-aware (case-sensitive on Linux, case-insensitive elsewhere) as before.
- Validation logic still detects missing, outdated, and unexpected generated files with normalized relative paths.