### PR TITLE
Stabilize localhost NTP round-trip delay test

### DIFF
--- a/tests/Meziantou.Framework.NtpServer.Tests/NtpServerTests.cs
+++ b/tests/Meziantou.Framework.NtpServer.Tests/NtpServerTests.cs
@@ -66,13 +66,14 @@ public sealed class NtpServerTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Query_RoundTripDelay_IsSmall()
+    public async Task Query_RoundTripDelay_IsReasonable()
     {
         using var client = new NtpClient("127.0.0.1", new NtpClientOptions { Port = _server.Port });
         var response = await client.QueryAsync(XunitCancellationToken);
 
-        // Round-trip to localhost should be very fast
-        Assert.True(response.RoundTripDelay < TimeSpan.FromSeconds(1), $"Round-trip delay was {response.RoundTripDelay}");
+        // Localhost should stay reasonably low, but CI runners can be noisy
+        Assert.True(response.RoundTripDelay >= TimeSpan.Zero);
+        Assert.True(response.RoundTripDelay < TimeSpan.FromSeconds(5), $"Round-trip delay was {response.RoundTripDelay}");
     }
 
     [Fact]


### PR DESCRIPTION
## Why
The NTP localhost timing test was flaky in CI because it assumed round-trip delay was always below 1 second. Hosted runners can exceed that threshold due to scheduler and VM jitter, causing intermittent failures unrelated to product correctness.

## What changed
- Renamed `Query_RoundTripDelay_IsSmall` to `Query_RoundTripDelay_IsReasonable` to reflect intent.
- Replaced the strict `< 1s` assertion with a more robust invariant:
  - delay is non-negative
  - delay stays below 5 seconds
- Updated the test comment to document CI noise tolerance.

## Notes
This keeps the test meaningful for localhost behavior while removing an overly strict real-time expectation that was causing false negatives in CI.