### PR TITLE
Stabilize flaky SqlClient large-payload test

### DIFF
--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -166,7 +166,9 @@ public sealed class TdsServerProtocolTests
         await server.StartAsync();
         var port = Assert.Single(server.Ports);
 
-        await using var connection = new SqlConnection(CreateConnectionString(port) + ";Packet Size=512");
+        await WaitForServerReadyAsync(port, TimeSpan.FromSeconds(30));
+
+        await using var connection = new SqlConnection(CreateConnectionString(port, connectTimeout: 30) + ";Packet Size=512");
         await connection.OpenAsync();
 
         await using var command = connection.CreateCommand();
@@ -885,7 +887,8 @@ public sealed class TdsServerProtocolTests
 
         var hasTimeout = exception.Message.Contains("Connection Timeout Expired", StringComparison.OrdinalIgnoreCase);
         var hasPreLogin = exception.Message.Contains("pre-login", StringComparison.OrdinalIgnoreCase);
-        return hasTimeout && hasPreLogin;
+        var hasPostLogin = exception.Message.Contains("post-login", StringComparison.OrdinalIgnoreCase);
+        return hasTimeout && (hasPreLogin || hasPostLogin);
     }
 
     private static async Task WaitForServerReadyAsync(int port, TimeSpan timeout)


### PR DESCRIPTION
## Why
The `SqlClient_TextQuery_LargePayload_UsesMultiplePackets` integration test is flaky in CI because it can open the SQL connection before the test server is fully ready, leading to intermittent timeout failures during login.

## What changed
- Hardened `SqlClient_TextQuery_LargePayload_UsesMultiplePackets` to use the same startup pattern as other resilient SQL tests:
  - wait for server readiness with `WaitForServerReadyAsync(port, TimeSpan.FromSeconds(30))`
  - increase connection timeout for this test to `connectTimeout: 30` while keeping `Packet Size=512`
- Broadened transient SQL open-failure detection in `IsTransientSqlOpenFailure` to treat both `pre-login` and `post-login` timeout phases as transient when `SqlException.Number == -2` and the message indicates connection timeout.

## Notes
- This is scoped to TDS server test hardening only.
- No Public API generator behavior was changed.