### PR TITLE
Always log Public API generator command on build

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -70,10 +70,7 @@
       <_PublicApiGeneratorCommand>dotnet &quot;$(_PublicApiGeneratorToolAssemblyPath)&quot; @(_PublicApiGeneratorAssembly->'--input &quot;%(TargetFramework)=%(Identity)&quot;', ' ') --output-file &quot;$(_PublicApiGeneratorResolvedOutputPath)&quot; --file-layout $(PublicApiGeneratorFileLayout) $(_PublicApiGeneratorIncludeCommentArg) $(_PublicApiGeneratorVerifyNoChangeArg)</_PublicApiGeneratorCommand>
     </PropertyGroup>
 
-    <Message Importance="High"
-             Condition="'$(PublicApiGeneratorVerifyNoChangeOnBuild)' == 'true'"
-             Text="Public API verify command: $(_PublicApiGeneratorCommand)" />
-
+    <Message Importance="High" Text="Public API verify command: $(_PublicApiGeneratorCommand)" />
     <Exec Command="$(_PublicApiGeneratorCommand)" />
   </Target>
 
@@ -91,10 +88,7 @@
       <_PublicApiGeneratorCommand>dotnet &quot;$(_PublicApiGeneratorToolAssemblyPath)&quot; @(_PublicApiGeneratorAssembly->'--input &quot;%(TargetFramework)=%(Identity)&quot;', ' ') --output-file &quot;$(_PublicApiGeneratorResolvedOutputPath)&quot; --file-layout $(PublicApiGeneratorFileLayout) $(_PublicApiGeneratorIncludeCommentArg) $(_PublicApiGeneratorVerifyNoChangeArg)</_PublicApiGeneratorCommand>
     </PropertyGroup>
 
-    <Message Importance="High"
-             Condition="'$(PublicApiGeneratorVerifyNoChangeOnBuild)' == 'true'"
-             Text="Public API verify command: $(_PublicApiGeneratorCommand)" />
-
+    <Message Importance="High" Text="Public API verify command: $(_PublicApiGeneratorCommand)" />
     <Exec Command="$(_PublicApiGeneratorCommand)" />
   </Target>
 </Project>


### PR DESCRIPTION
Build output currently only prints the Public API generator command in verify mode, which makes local debugging harder when running generation mode builds.

This change removes the verify-only condition from the `Message` task in both single-targeting and cross-targeting targets in `src/Directory.Build.targets`, so the command line is always visible before the `Exec` task runs.

This keeps behavior unchanged for generation/verification execution itself and only improves observability of the invoked command.