### PR TITLE
Restore before delta NuGet build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,8 @@ jobs:
 
       - run: dotnet restore ${{ steps.package-project.outputs.project }} -p:Configuration=Release /p:IsOfficialBuild=true /p:PublicApiGeneratorGenerateOnBuild=false /p:PublicApiGeneratorVerifyNoChangeOnBuild=true -warnaserror
         if: steps.package-project.outputs.has-project == 'true'
+      - run: dotnet build src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj --configuration Release --no-restore /p:IsOfficialBuild=true /p:PublicApiGeneratorGenerateOnBuild=false /p:PublicApiGeneratorVerifyNoChangeOnBuild=true -warnaserror
+        if: steps.package-project.outputs.has-project == 'true'
       - run: dotnet build ${{ steps.package-project.outputs.project }} --configuration Release --no-restore /p:IsOfficialBuild=true /p:PublicApiGeneratorGenerateOnBuild=false /p:PublicApiGeneratorVerifyNoChangeOnBuild=true /bl:build.binlog -warnaserror
         if: steps.package-project.outputs.has-project == 'true'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,9 @@ jobs:
             .github/workflows/ci.yml
             eng/**/*.proj
 
-      - run: dotnet build ${{ steps.package-project.outputs.project }} --configuration Release /p:IsOfficialBuild=true /p:PublicApiGeneratorGenerateOnBuild=false /p:PublicApiGeneratorVerifyNoChangeOnBuild=true /bl:build.binlog -warnaserror
+      - run: dotnet restore ${{ steps.package-project.outputs.project }} -p:Configuration=Release /p:IsOfficialBuild=true /p:PublicApiGeneratorGenerateOnBuild=false /p:PublicApiGeneratorVerifyNoChangeOnBuild=true -warnaserror
+        if: steps.package-project.outputs.has-project == 'true'
+      - run: dotnet build ${{ steps.package-project.outputs.project }} --configuration Release --no-restore /p:IsOfficialBuild=true /p:PublicApiGeneratorGenerateOnBuild=false /p:PublicApiGeneratorVerifyNoChangeOnBuild=true /bl:build.binlog -warnaserror
         if: steps.package-project.outputs.has-project == 'true'
 
       - name: Prepare NuGet artifact directory


### PR DESCRIPTION
The create_nuget delta build can try to build impacted projects before a restore-generated assets file exists, which causes NETSDK1004 failures (missing project.assets.json) for projects like `Meziantou.Framework.PublicApiGenerator.Tool`.

This change makes the packaging build sequence explicit:
- run `dotnet restore` for the generated delta project (Release configuration)
- run `dotnet build --no-restore` with the existing build properties

This keeps the existing packaging behavior while ensuring restore outputs are present before build.