### PR TITLE
Obsolete legacy process APIs in Meziantou.Framework

### DIFF
--- a/ref/Meziantou.Framework.cs
+++ b/ref/Meziantou.Framework.cs
@@ -447,19 +447,19 @@ namespace Meziantou.Framework
         public static System.Diagnostics.Process? GetParentProcess(this System.Diagnostics.Process process) => throw null;
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
         public static System.Collections.Generic.IEnumerable<Meziantou.Framework.ProcessEntry> GetProcesses() => throw null;
-        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper.")]
         public static System.Threading.Tasks.Task<Meziantou.Framework.ProcessResult> RunAsTaskAsync(string fileName, string? arguments, System.Threading.CancellationToken cancellationToken = null) => throw null;
-        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper.")]
         public static System.Threading.Tasks.Task<Meziantou.Framework.ProcessResult> RunAsTaskAsync(string fileName, string? arguments, string? workingDirectory, System.Threading.CancellationToken cancellationToken = null) => throw null;
-        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper.")]
         public static System.Threading.Tasks.Task<Meziantou.Framework.ProcessResult> RunAsTaskAsync(string fileName, System.Collections.Generic.IEnumerable<string>? arguments, string? workingDirectory, System.Threading.CancellationToken cancellationToken = null) => throw null;
-        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper.")]
         public static System.Threading.Tasks.Task<Meziantou.Framework.ProcessResult> RunAsTaskAsync(this System.Diagnostics.ProcessStartInfo psi, bool redirectOutput, System.Threading.CancellationToken cancellationToken = null) => throw null;
-        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper.")]
         public static System.Threading.Tasks.Task<Meziantou.Framework.ProcessResult> RunAsTaskAsync(this System.Diagnostics.ProcessStartInfo psi, System.Threading.CancellationToken cancellationToken = null) => throw null;
     }
 
-    [System.Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+    [System.Obsolete("Use Meziantou.Framework.ProcessWrapper.")]
     public sealed class ProcessOutput
     {
         public Meziantou.Framework.ProcessOutputType Type { get => throw null; }
@@ -468,7 +468,7 @@ namespace Meziantou.Framework
         public override string ToString() => throw null;
     }
 
-    [System.Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+    [System.Obsolete("Use Meziantou.Framework.ProcessWrapper.")]
     public sealed class ProcessOutputCollection : System.Collections.Generic.IEnumerable<Meziantou.Framework.ProcessOutput>, System.Collections.Generic.IReadOnlyCollection<Meziantou.Framework.ProcessOutput>, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.ProcessOutput>, System.Collections.IEnumerable
     {
         public int Count { get => throw null; }
@@ -478,14 +478,14 @@ namespace Meziantou.Framework
         public override string ToString() => throw null;
     }
 
-    [System.Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+    [System.Obsolete("Use Meziantou.Framework.ProcessWrapper.")]
     public enum ProcessOutputType
     {
         StandardOutput = 0,
         StandardError = 1
     }
 
-    [System.Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+    [System.Obsolete("Use Meziantou.Framework.ProcessWrapper.")]
     public sealed class ProcessResult
     {
         public int ExitCode { get => throw null; }

--- a/ref/Meziantou.Framework.cs
+++ b/ref/Meziantou.Framework.cs
@@ -447,13 +447,19 @@ namespace Meziantou.Framework
         public static System.Diagnostics.Process? GetParentProcess(this System.Diagnostics.Process process) => throw null;
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
         public static System.Collections.Generic.IEnumerable<Meziantou.Framework.ProcessEntry> GetProcesses() => throw null;
+        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
         public static System.Threading.Tasks.Task<Meziantou.Framework.ProcessResult> RunAsTaskAsync(string fileName, string? arguments, System.Threading.CancellationToken cancellationToken = null) => throw null;
+        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
         public static System.Threading.Tasks.Task<Meziantou.Framework.ProcessResult> RunAsTaskAsync(string fileName, string? arguments, string? workingDirectory, System.Threading.CancellationToken cancellationToken = null) => throw null;
+        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
         public static System.Threading.Tasks.Task<Meziantou.Framework.ProcessResult> RunAsTaskAsync(string fileName, System.Collections.Generic.IEnumerable<string>? arguments, string? workingDirectory, System.Threading.CancellationToken cancellationToken = null) => throw null;
+        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
         public static System.Threading.Tasks.Task<Meziantou.Framework.ProcessResult> RunAsTaskAsync(this System.Diagnostics.ProcessStartInfo psi, bool redirectOutput, System.Threading.CancellationToken cancellationToken = null) => throw null;
+        [System.Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
         public static System.Threading.Tasks.Task<Meziantou.Framework.ProcessResult> RunAsTaskAsync(this System.Diagnostics.ProcessStartInfo psi, System.Threading.CancellationToken cancellationToken = null) => throw null;
     }
 
+    [System.Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
     public sealed class ProcessOutput
     {
         public Meziantou.Framework.ProcessOutputType Type { get => throw null; }
@@ -462,6 +468,7 @@ namespace Meziantou.Framework
         public override string ToString() => throw null;
     }
 
+    [System.Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
     public sealed class ProcessOutputCollection : System.Collections.Generic.IEnumerable<Meziantou.Framework.ProcessOutput>, System.Collections.Generic.IReadOnlyCollection<Meziantou.Framework.ProcessOutput>, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.ProcessOutput>, System.Collections.IEnumerable
     {
         public int Count { get => throw null; }
@@ -471,12 +478,14 @@ namespace Meziantou.Framework
         public override string ToString() => throw null;
     }
 
+    [System.Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
     public enum ProcessOutputType
     {
         StandardOutput = 0,
         StandardError = 1
     }
 
+    [System.Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
     public sealed class ProcessResult
     {
         public int ExitCode { get => throw null; }

--- a/src/Meziantou.Framework/ProcessExtensions.RunAsTask.cs
+++ b/src/Meziantou.Framework/ProcessExtensions.RunAsTask.cs
@@ -5,13 +5,13 @@ namespace Meziantou.Framework;
 
 public static partial class ProcessExtensions
 {
-    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper.")]
     public static Task<ProcessResult> RunAsTaskAsync(string fileName, string? arguments, CancellationToken cancellationToken = default)
     {
         return RunAsTaskAsync(fileName, arguments, workingDirectory: null, cancellationToken);
     }
 
-    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper.")]
     public static Task<ProcessResult> RunAsTaskAsync(string fileName, string? arguments, string? workingDirectory, CancellationToken cancellationToken = default)
     {
         var psi = new ProcessStartInfo
@@ -36,7 +36,7 @@ public static partial class ProcessExtensions
         return RunAsTaskAsync(psi, cancellationToken);
     }
 
-    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper.")]
     public static Task<ProcessResult> RunAsTaskAsync(string fileName, IEnumerable<string>? arguments, string? workingDirectory, CancellationToken cancellationToken = default)
     {
         var psi = new ProcessStartInfo
@@ -61,7 +61,7 @@ public static partial class ProcessExtensions
         return RunAsTaskAsync(psi, cancellationToken);
     }
 
-    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper.")]
     public static Task<ProcessResult> RunAsTaskAsync(this ProcessStartInfo psi, bool redirectOutput, CancellationToken cancellationToken = default)
     {
         if (redirectOutput)
@@ -79,7 +79,7 @@ public static partial class ProcessExtensions
         return RunAsTaskAsync(psi, cancellationToken);
     }
 
-    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper.")]
     public static async Task<ProcessResult> RunAsTaskAsync(this ProcessStartInfo psi, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Meziantou.Framework/ProcessExtensions.RunAsTask.cs
+++ b/src/Meziantou.Framework/ProcessExtensions.RunAsTask.cs
@@ -5,11 +5,13 @@ namespace Meziantou.Framework;
 
 public static partial class ProcessExtensions
 {
+    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
     public static Task<ProcessResult> RunAsTaskAsync(string fileName, string? arguments, CancellationToken cancellationToken = default)
     {
         return RunAsTaskAsync(fileName, arguments, workingDirectory: null, cancellationToken);
     }
 
+    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
     public static Task<ProcessResult> RunAsTaskAsync(string fileName, string? arguments, string? workingDirectory, CancellationToken cancellationToken = default)
     {
         var psi = new ProcessStartInfo
@@ -34,6 +36,7 @@ public static partial class ProcessExtensions
         return RunAsTaskAsync(psi, cancellationToken);
     }
 
+    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
     public static Task<ProcessResult> RunAsTaskAsync(string fileName, IEnumerable<string>? arguments, string? workingDirectory, CancellationToken cancellationToken = default)
     {
         var psi = new ProcessStartInfo
@@ -58,6 +61,7 @@ public static partial class ProcessExtensions
         return RunAsTaskAsync(psi, cancellationToken);
     }
 
+    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
     public static Task<ProcessResult> RunAsTaskAsync(this ProcessStartInfo psi, bool redirectOutput, CancellationToken cancellationToken = default)
     {
         if (redirectOutput)
@@ -75,6 +79,7 @@ public static partial class ProcessExtensions
         return RunAsTaskAsync(psi, cancellationToken);
     }
 
+    [Obsolete("Use Process.RunAndCaptureText or Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
     public static async Task<ProcessResult> RunAsTaskAsync(this ProcessStartInfo psi, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Meziantou.Framework/ProcessOutput.cs
+++ b/src/Meziantou.Framework/ProcessOutput.cs
@@ -1,5 +1,6 @@
 namespace Meziantou.Framework;
 
+[Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
 public sealed class ProcessOutput
 {
     internal ProcessOutput(ProcessOutputType type, string text)

--- a/src/Meziantou.Framework/ProcessOutput.cs
+++ b/src/Meziantou.Framework/ProcessOutput.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.Framework;
 
-[Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+[Obsolete("Use Meziantou.Framework.ProcessWrapper.")]
 public sealed class ProcessOutput
 {
     internal ProcessOutput(ProcessOutputType type, string text)

--- a/src/Meziantou.Framework/ProcessOutputCollection.cs
+++ b/src/Meziantou.Framework/ProcessOutputCollection.cs
@@ -2,6 +2,7 @@ using System.Collections;
 
 namespace Meziantou.Framework;
 
+[Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
 public sealed class ProcessOutputCollection : IReadOnlyList<ProcessOutput>
 {
     private readonly IReadOnlyList<ProcessOutput> _output;

--- a/src/Meziantou.Framework/ProcessOutputCollection.cs
+++ b/src/Meziantou.Framework/ProcessOutputCollection.cs
@@ -2,7 +2,7 @@ using System.Collections;
 
 namespace Meziantou.Framework;
 
-[Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+[Obsolete("Use Meziantou.Framework.ProcessWrapper.")]
 public sealed class ProcessOutputCollection : IReadOnlyList<ProcessOutput>
 {
     private readonly IReadOnlyList<ProcessOutput> _output;

--- a/src/Meziantou.Framework/ProcessOutputType.cs
+++ b/src/Meziantou.Framework/ProcessOutputType.cs
@@ -1,6 +1,7 @@
 namespace Meziantou.Framework;
 
 /// <summary>Specifies the type of process output stream.</summary>
+[Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
 public enum ProcessOutputType
 {
     /// <summary>The standard output stream.</summary>

--- a/src/Meziantou.Framework/ProcessOutputType.cs
+++ b/src/Meziantou.Framework/ProcessOutputType.cs
@@ -1,7 +1,7 @@
 namespace Meziantou.Framework;
 
 /// <summary>Specifies the type of process output stream.</summary>
-[Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+[Obsolete("Use Meziantou.Framework.ProcessWrapper.")]
 public enum ProcessOutputType
 {
     /// <summary>The standard output stream.</summary>

--- a/src/Meziantou.Framework/ProcessResult.cs
+++ b/src/Meziantou.Framework/ProcessResult.cs
@@ -1,5 +1,6 @@
 namespace Meziantou.Framework;
 
+[Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
 public sealed class ProcessResult
 {
     internal ProcessResult(int exitCode, IReadOnlyList<ProcessOutput> output)

--- a/src/Meziantou.Framework/ProcessResult.cs
+++ b/src/Meziantou.Framework/ProcessResult.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.Framework;
 
-[Obsolete("Use Meziantou.Framework.ProcessWrapper (add using Meziantou.Framework.ProcessWrapper).")]
+[Obsolete("Use Meziantou.Framework.ProcessWrapper.")]
 public sealed class ProcessResult
 {
     internal ProcessResult(int exitCode, IReadOnlyList<ProcessOutput> output)


### PR DESCRIPTION
## Why
The legacy process output/result types and `RunAsTaskAsync` APIs are superseded by newer alternatives. Marking them obsolete guides consumers toward the supported process APIs while keeping existing behavior intact.

## What changed
- Added `[Obsolete]` to `ProcessOutput`, `ProcessOutputCollection`, `ProcessOutputType`, and `ProcessResult` with guidance to use `Meziantou.Framework.ProcessWrapper`.
- Added `[Obsolete]` to all `RunAsTaskAsync` overloads with guidance to use `Process.RunAndCaptureText` or `Meziantou.Framework.ProcessWrapper`.
- Updated `ref/Meziantou.Framework.cs` to reflect the new obsolete attributes.

## Notes
- This PR is API guidance only; runtime behavior is unchanged.