### PR TITLE
Migrate supported DllImport callsites to LibraryImport

### DIFF
--- a/src/Meziantou.Framework.FullPath/CanonicalPath.cs
+++ b/src/Meziantou.Framework.FullPath/CanonicalPath.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace Meziantou.Framework;
 
-internal static class CanonicalPath
+internal static partial class CanonicalPath
 {
     public static bool TryGetCanonicalPath(string path, [NotNullWhen(true)] out string? canonicalPath)
     {
@@ -69,7 +69,7 @@ internal static class CanonicalPath
         }
     }
 
-    private static class UnixCanonicalPath
+    private static partial class UnixCanonicalPath
     {
         public static bool TryGetCanonicalPath(string path, [NotNullWhen(true)] out string? canonicalPath)
         {
@@ -92,15 +92,15 @@ internal static class CanonicalPath
             }
         }
 
-        private static class Interop
+        private static partial class Interop
         {
-            [DllImport("libc", EntryPoint = "realpath", SetLastError = true, ExactSpelling = true)]
+            [LibraryImport("libc", EntryPoint = "realpath", SetLastError = true)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-            private static extern IntPtr RealPathCore(byte[] path, IntPtr resolvedPath);
+            private static partial IntPtr RealPathCore(byte[] path, IntPtr resolvedPath);
 
-            [DllImport("libc", EntryPoint = "free", SetLastError = false, ExactSpelling = true)]
+            [LibraryImport("libc", EntryPoint = "free", SetLastError = false)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-            private static extern void FreeCore(IntPtr pointer);
+            private static partial void FreeCore(IntPtr pointer);
 
             internal static IntPtr RealPath(byte[] path, IntPtr resolvedPath)
             {

--- a/src/Meziantou.Framework.FullPath/Interop/Windows.cs
+++ b/src/Meziantou.Framework.FullPath/Interop/Windows.cs
@@ -36,9 +36,9 @@ namespace Meziantou.Framework
             private const string Kernel32Name = "kernel32.dll";
 
             /// <summary>WARNING: This method does not implicitly handle long paths. Use CreateFile.</summary>
-            [DllImport(Kernel32Name, EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
+            [LibraryImport(Kernel32Name, EntryPoint = "CreateFileW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-            private static extern unsafe SafeFileHandle CreateFilePrivate(
+            private static unsafe partial SafeFileHandle CreateFilePrivate(
                 string lpFileName,
                 int dwDesiredAccess,
                 FileShare dwShareMode,
@@ -88,14 +88,15 @@ namespace Meziantou.Framework
                 internal const int FILE_LIST_DIRECTORY = 0x0001;
             }
 
-            [DllImport(Kernel32Name, SetLastError = true)]
+            [LibraryImport(Kernel32Name, SetLastError = true)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-            internal static extern bool FindClose(IntPtr hFindFile);
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static partial bool FindClose(IntPtr hFindFile);
 
             /// <summary>WARNING: This method does not implicitly handle long paths. Use FindFirstFile.</summary>
-            [DllImport(Kernel32Name, EntryPoint = "FindFirstFileExW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            [LibraryImport(Kernel32Name, EntryPoint = "FindFirstFileExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-            private static extern SafeFindHandle FindFirstFileExPrivate(string lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, ref WIN32_FIND_DATA lpFindFileData, FINDEX_SEARCH_OPS fSearchOp, IntPtr lpSearchFilter, int dwAdditionalFlags);
+            private static partial SafeFindHandle FindFirstFileExPrivate(string lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, ref WIN32_FIND_DATA lpFindFileData, FINDEX_SEARCH_OPS fSearchOp, IntPtr lpSearchFilter, int dwAdditionalFlags);
 
             internal static SafeFindHandle FindFirstFile(string fileName, ref WIN32_FIND_DATA data)
             {
@@ -138,9 +139,10 @@ namespace Meziantou.Framework
                 public uint Flags;
             }
 
-            [DllImport(Kernel32Name, CharSet = CharSet.Unicode, SetLastError = true)]
+            [LibraryImport(Kernel32Name, SetLastError = true)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-            internal static extern bool DeviceIoControl
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static partial bool DeviceIoControl
             (
                 SafeFileHandle fileHandle,
                 uint ioControlCode,

--- a/src/Meziantou.Framework.FullPath/Symlink.cs
+++ b/src/Meziantou.Framework.FullPath/Symlink.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Meziantou.Framework;
 
-internal static class Symlink
+internal static partial class Symlink
 {
     public static bool IsSymbolicLink(string path)
     {
@@ -31,7 +31,7 @@ internal static class Symlink
         }
     }
 
-    private static class UnixSymlink
+    private static partial class UnixSymlink
     {
         internal static bool TryGetSymLinkTarget(string path, [NotNullWhen(true)] out string? target)
         {
@@ -90,7 +90,7 @@ internal static class Symlink
             }
         }
 
-        private static class Interop
+        private static partial class Interop
         {
             internal static nint ReadLink(string path, byte[] buffer, nuint bufferSize)
             {
@@ -98,9 +98,9 @@ internal static class Symlink
                 return ReadLinkCore(utf8Path, buffer, bufferSize);
             }
 
-            [DllImport("libc", EntryPoint = "readlink", SetLastError = true, ExactSpelling = true)]
+            [LibraryImport("libc", EntryPoint = "readlink", SetLastError = true)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-            private static extern nint ReadLinkCore(byte[] path, byte[] buffer, nuint bufferSize);
+            private static partial nint ReadLinkCore(byte[] path, byte[] buffer, nuint bufferSize);
         }
     }
 

--- a/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
+++ b/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
@@ -26,7 +26,7 @@ namespace Meziantou.Framework;
 /// byte[] revealedKey = sensitiveKey.RevealToArray();
 /// </code>
 /// </example>
-public static class SensitiveData
+public static partial class SensitiveData
 {
     /// <summary>Creates an instance of <see cref="SensitiveData{Char}" /> from a string.</summary>
     /// <param name="value">The sensitive string data to protect.</param>
@@ -62,7 +62,7 @@ public static class SensitiveData
         return string.Create(secret.GetLength(), secret, (span, buffer) => buffer.RevealInto(span));
     }
 
-    internal static class UnixMemoryProtection
+    internal static partial class UnixMemoryProtection
     {
         public const int PROT_NONE = 0;
         public const int PROT_READ = 1;
@@ -130,29 +130,29 @@ public static class SensitiveData
             return MAP_ANON_LINUX;
         }
 
-        private static class Interop
+        private static partial class Interop
         {
             private const string Libc = "libc";
 
-            [DllImport(Libc, EntryPoint = "mlock", SetLastError = true)]
+            [LibraryImport(Libc, EntryPoint = "mlock", SetLastError = true)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-            internal static extern int mlock(IntPtr addr, nuint len);
+            internal static partial int mlock(IntPtr addr, nuint len);
 
-            [DllImport(Libc, EntryPoint = "mmap", SetLastError = true)]
+            [LibraryImport(Libc, EntryPoint = "mmap", SetLastError = true)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-            internal static extern IntPtr mmap(IntPtr addr, nuint len, int prot, int flags, int fd, nint offset);
+            internal static partial IntPtr mmap(IntPtr addr, nuint len, int prot, int flags, int fd, nint offset);
 
-            [DllImport(Libc, EntryPoint = "mprotect", SetLastError = true)]
+            [LibraryImport(Libc, EntryPoint = "mprotect", SetLastError = true)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-            internal static extern int mprotect(IntPtr addr, nuint len, int prot);
+            internal static partial int mprotect(IntPtr addr, nuint len, int prot);
 
-            [DllImport(Libc, EntryPoint = "munlock", SetLastError = true)]
+            [LibraryImport(Libc, EntryPoint = "munlock", SetLastError = true)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-            internal static extern int munlock(IntPtr addr, nuint len);
+            internal static partial int munlock(IntPtr addr, nuint len);
 
-            [DllImport(Libc, EntryPoint = "munmap", SetLastError = true)]
+            [LibraryImport(Libc, EntryPoint = "munmap", SetLastError = true)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-            internal static extern int munmap(IntPtr addr, nuint len);
+            internal static partial int munmap(IntPtr addr, nuint len);
         }
     }
 }

--- a/src/Meziantou.Framework.SnapshotTesting/common/Utils/ProcessExtensions.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/common/Utils/ProcessExtensions.cs
@@ -132,10 +132,10 @@ internal static partial class ProcessExtensions
         }
     }
 
-    [DllImport("kernel32.dll", SetLastError = true)]
+    [LibraryImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern bool CloseHandle(IntPtr hObject);
+    private static partial bool CloseHandle(IntPtr hObject);
 
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
@@ -146,9 +146,9 @@ internal static partial class ProcessExtensions
     private static extern int Process32Next(SnapshotSafeHandle handle, ref ProcessEntry32 entry);
 
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ms682489.aspx
-    [DllImport("kernel32.dll", SetLastError = true)]
+    [LibraryImport("kernel32.dll", SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern SnapshotSafeHandle CreateToolhelp32Snapshot(SnapshotFlags dwFlags, uint th32ProcessID);
+    private static partial SnapshotSafeHandle CreateToolhelp32Snapshot(SnapshotFlags dwFlags, uint th32ProcessID);
 
     private const int MAX_PATH = 260;
 

--- a/src/Meziantou.Framework.Win32.Amsi/Internals/Amsi.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/Internals/Amsi.cs
@@ -1,8 +1,9 @@
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.Win32;
 
-internal static class Amsi
+internal static partial class Amsi
 {
     internal static bool AmsiResultIsMalware(AmsiResult result)
     {
@@ -10,26 +11,32 @@ internal static class Amsi
     }
 
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [DllImport("Amsi.dll", EntryPoint = "AmsiInitialize", CallingConvention = CallingConvention.StdCall)]
-    internal static extern int AmsiInitialize([MarshalAs(UnmanagedType.LPWStr)] string appName, out AmsiContextSafeHandle amsiContext);
+    [LibraryImport("Amsi.dll", EntryPoint = "AmsiInitialize", StringMarshalling = StringMarshalling.Utf16)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    internal static partial int AmsiInitialize(string appName, out AmsiContextSafeHandle amsiContext);
 
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [DllImport("Amsi.dll", EntryPoint = "AmsiUninitialize", CallingConvention = CallingConvention.StdCall)]
-    internal static extern void AmsiUninitialize(IntPtr amsiContext);
+    [LibraryImport("Amsi.dll", EntryPoint = "AmsiUninitialize")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    internal static partial void AmsiUninitialize(IntPtr amsiContext);
 
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [DllImport("Amsi.dll", EntryPoint = "AmsiOpenSession", CallingConvention = CallingConvention.StdCall)]
-    internal static extern int AmsiOpenSession(AmsiContextSafeHandle amsiContext, out AmsiSessionSafeHandle session);
+    [LibraryImport("Amsi.dll", EntryPoint = "AmsiOpenSession")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    internal static partial int AmsiOpenSession(AmsiContextSafeHandle amsiContext, out AmsiSessionSafeHandle session);
 
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [DllImport("Amsi.dll", EntryPoint = "AmsiCloseSession", CallingConvention = CallingConvention.StdCall)]
-    internal static extern void AmsiCloseSession(AmsiContextSafeHandle amsiContext, IntPtr session);
+    [LibraryImport("Amsi.dll", EntryPoint = "AmsiCloseSession")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    internal static partial void AmsiCloseSession(AmsiContextSafeHandle amsiContext, IntPtr session);
 
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [DllImport("Amsi.dll", EntryPoint = "AmsiScanString", CallingConvention = CallingConvention.StdCall)]
-    internal static extern int AmsiScanString(AmsiContextSafeHandle amsiContext, [In, MarshalAs(UnmanagedType.LPWStr)] string payload, [In, MarshalAs(UnmanagedType.LPWStr)] string contentName, AmsiSessionSafeHandle session, out AmsiResult result);
+    [LibraryImport("Amsi.dll", EntryPoint = "AmsiScanString", StringMarshalling = StringMarshalling.Utf16)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    internal static partial int AmsiScanString(AmsiContextSafeHandle amsiContext, string payload, string contentName, AmsiSessionSafeHandle session, out AmsiResult result);
 
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [DllImport("Amsi.dll", EntryPoint = "AmsiScanBuffer", CallingConvention = CallingConvention.StdCall)]
-    internal static extern int AmsiScanBuffer(AmsiContextSafeHandle amsiContext, byte[] buffer, uint length, [In, MarshalAs(UnmanagedType.LPWStr)] string contentName, AmsiSessionSafeHandle session, out AmsiResult result);
+    [LibraryImport("Amsi.dll", EntryPoint = "AmsiScanBuffer", StringMarshalling = StringMarshalling.Utf16)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
+    internal static partial int AmsiScanBuffer(AmsiContextSafeHandle amsiContext, byte[] buffer, uint length, string contentName, AmsiSessionSafeHandle session, out AmsiResult result);
 }

--- a/src/Meziantou.Framework.Win32.Dialogs/Natives/NativeMethods.cs
+++ b/src/Meziantou.Framework.Win32.Dialogs/Natives/NativeMethods.cs
@@ -2,7 +2,7 @@ using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.Win32.Natives;
 
-internal static class NativeMethods
+internal static partial class NativeMethods
 {
 #pragma warning disable IDE1006 // Naming Styles
     internal const int S_OK = 0x00000000;
@@ -10,9 +10,9 @@ internal static class NativeMethods
     internal const int FILE_NOT_FOUND = unchecked((int)0x80070002);
 #pragma warning restore IDE1006 // Naming Styles
 
-    [DllImport("user32")]
+    [LibraryImport("user32")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern IntPtr GetActiveWindow();
+    internal static partial IntPtr GetActiveWindow();
 
     [DllImport("shell32")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
@@ -2,21 +2,21 @@ using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.Win32.ProjectedFileSystem;
 
-internal static class NativeMethods
+internal static partial class NativeMethods
 {
     // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17763.0\um\projectedfslib.h
 
-    [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
+    [LibraryImport("ProjectedFSLib.dll", StringMarshalling = StringMarshalling.Utf16)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjMarkDirectoryAsPlaceholder(string rootPathName, string? targetPathName, IntPtr versionInfo, in Guid virtualizationInstanceID);
+    internal static partial HResult PrjMarkDirectoryAsPlaceholder(string rootPathName, string? targetPathName, IntPtr versionInfo, in Guid virtualizationInstanceID);
 
     [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     internal static extern HResult PrjStartVirtualizing(string virtualizationRootPath, in PrjCallbacks callbacks, IntPtr instanceContext, in PRJ_STARTVIRTUALIZING_OPTIONS options, out ProjFSSafeHandle namespaceVirtualizationContext);
 
-    [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
+    [LibraryImport("ProjectedFSLib.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjStopVirtualizing(IntPtr namespaceVirtualizationContext);
+    internal static partial HResult PrjStopVirtualizing(IntPtr namespaceVirtualizationContext);
 
     [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
@@ -26,49 +26,49 @@ internal static class NativeMethods
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     internal static extern HResult PrjWritePlaceholderInfo(ProjFSSafeHandle namespaceVirtualizationContext, string destinationFileName, in PRJ_PLACEHOLDER_INFO placeholderInfo, uint placeholderInfoSize);
 
-    [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
+    [LibraryImport("ProjectedFSLib.dll", StringMarshalling = StringMarshalling.Utf16)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern int PrjFileNameCompare(string fileName1, string fileName2);
+    internal static partial int PrjFileNameCompare(string fileName1, string fileName2);
 
     [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     internal static extern bool PrjFileNameMatch(string fileNameToCheck, string pattern);
 
-    [DllImport("ProjectedFSLib.dll")]
+    [LibraryImport("ProjectedFSLib.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjGetVirtualizationInstanceInfo(ProjFSSafeHandle namespaceVirtualizationContext, out PRJ_VIRTUALIZATION_INSTANCE_INFO virtualizationInstanceInfo);
+    internal static partial HResult PrjGetVirtualizationInstanceInfo(ProjFSSafeHandle namespaceVirtualizationContext, out PRJ_VIRTUALIZATION_INSTANCE_INFO virtualizationInstanceInfo);
 
-    [DllImport("ProjectedFSLib.dll")]
+    [LibraryImport("ProjectedFSLib.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern IntPtr PrjAllocateAlignedBuffer(ProjFSSafeHandle namespaceVirtualizationContext, uint size);
+    internal static partial IntPtr PrjAllocateAlignedBuffer(ProjFSSafeHandle namespaceVirtualizationContext, uint size);
 
-    [DllImport("ProjectedFSLib.dll")]
+    [LibraryImport("ProjectedFSLib.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern void PrjFreeAlignedBuffer(IntPtr buffer);
+    internal static partial void PrjFreeAlignedBuffer(IntPtr buffer);
 
-    [DllImport("ProjectedFSLib.dll")]
+    [LibraryImport("ProjectedFSLib.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjWriteFileData(ProjFSSafeHandle namespaceVirtualizationContext, in Guid dataStreamId, IntPtr buffer, ulong byteOffset, uint length);
+    internal static partial HResult PrjWriteFileData(ProjFSSafeHandle namespaceVirtualizationContext, in Guid dataStreamId, IntPtr buffer, ulong byteOffset, uint length);
 
-    [DllImport("ProjectedFSLib.dll")]
+    [LibraryImport("ProjectedFSLib.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjClearNegativePathCache(ProjFSSafeHandle namespaceVirtualizationContext, out uint totalEntryNumber);
+    internal static partial HResult PrjClearNegativePathCache(ProjFSSafeHandle namespaceVirtualizationContext, out uint totalEntryNumber);
 
-    [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
+    [LibraryImport("ProjectedFSLib.dll", StringMarshalling = StringMarshalling.Utf16)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjGetOnDiskFileState(string destinationFileName, out PRJ_FILE_STATE fileState);
+    internal static partial HResult PrjGetOnDiskFileState(string destinationFileName, out PRJ_FILE_STATE fileState);
 
-    [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
+    [LibraryImport("ProjectedFSLib.dll", StringMarshalling = StringMarshalling.Utf16)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjDeleteFile(ProjFSSafeHandle namespaceVirtualizationContext, string destinationFileName, PRJ_UPDATE_TYPES updateFlags, out PRJ_UPDATE_FAILURE_CAUSES failureReason);
+    internal static partial HResult PrjDeleteFile(ProjFSSafeHandle namespaceVirtualizationContext, string destinationFileName, PRJ_UPDATE_TYPES updateFlags, out PRJ_UPDATE_FAILURE_CAUSES failureReason);
 
     [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     internal static extern HResult PrjUpdateFileIfNeeded(ProjFSSafeHandle namespaceVirtualizationContext, string destinationFileName, in PRJ_PLACEHOLDER_INFO placeholderInfo, uint placeholderInfoSize, PRJ_UPDATE_TYPES updateFlags, out PRJ_UPDATE_FAILURE_CAUSES failureReason);
 
-    [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
+    [LibraryImport("ProjectedFSLib.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjCompleteCommand(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, in PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS extendedParameters);
+    internal static partial HResult PrjCompleteCommand(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, in PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS extendedParameters);
 
     [StructLayout(LayoutKind.Explicit)]
     internal struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS

--- a/src/Meziantou.Framework.Win32.RestartManager/Natives/NativeMethods.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/Natives/NativeMethods.cs
@@ -3,7 +3,7 @@ using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 
 namespace Meziantou.Framework.Win32.Natives;
 
-internal static class NativeMethods
+internal static partial class NativeMethods
 {
     /// <summary>
     /// Registers resources to a Restart Manager session.
@@ -46,17 +46,17 @@ internal static class NativeMethods
     /// The string must be allocated before calling the RmStartSession function.
     /// </param>
     /// <returns>This is the most recent error received. The function can return one of the system error codes that are defined in Winerror.h.</returns>
-    [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)]
+    [LibraryImport("rstrtmgr.dll", StringMarshalling = StringMarshalling.Utf16)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    public static extern RmResult RmStartSession(out int pSessionHandle, int dwSessionFlags, string strSessionKey);
+    public static partial RmResult RmStartSession(out int pSessionHandle, int dwSessionFlags, string strSessionKey);
 
     /// <summary>Joins a secondary installer to an existing Restart Manager session. This function must be called with a session key that can only be obtained from the primary installer that started the session. A valid session key is required to use any of the Restart Manager functions. After a secondary installer joins a session, it can call the RmRegisterResources function to register resources.</summary>
     /// <param name="pSessionHandle">A pointer to the handle of a Restart Manager session.</param>
     /// <param name="strSessionKey">A null-terminated string that contains the session key of an existing session.</param>
     /// <returns>This is the most recent error received. The function can return one of the system error codes that are defined in Winerror.h.</returns>
-    [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)]
+    [LibraryImport("rstrtmgr.dll", StringMarshalling = StringMarshalling.Utf16)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    public static extern RmResult RmJoinSession(out int pSessionHandle, string strSessionKey);
+    public static partial RmResult RmJoinSession(out int pSessionHandle, string strSessionKey);
 
     /// <summary>
     /// Ends the Restart Manager session.
@@ -66,9 +66,9 @@ internal static class NativeMethods
     /// </summary>
     /// <param name="dwSessionHandle">A handle to an existing Restart Manager session.</param>
     /// <returns>This is the most recent error received. The function can return one of the system error codes that are defined in Winerror.h.</returns>
-    [DllImport("rstrtmgr.dll")]
+    [LibraryImport("rstrtmgr.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    public static extern RmResult RmEndSession(int dwSessionHandle);
+    public static partial RmResult RmEndSession(int dwSessionHandle);
 
     /// <summary>Gets a list of all applications and services that are currently using resources that have been registered with the Restart Manager session.</summary>
     /// <param name="dwSessionHandle">A handle to an existing Restart Manager session.</param>
@@ -91,18 +91,18 @@ internal static class NativeMethods
     /// <param name="lActionFlags">One or more RM_SHUTDOWN_TYPE options that configure the shut down of components. The following values can be combined by an OR operator to specify that unresponsive applications and services are to be forced to shut down if, and only if, all applications have been registered for restart.</param>
     /// <param name="fnStatus">A pointer to an RM_WRITE_STATUS_CALLBACK function that is used to communicate detailed status while this function is executing. If NULL, no status is provided.</param>
     /// <returns>This is the most recent error received. The function can return one of the system error codes that are defined in Winerror.h.</returns>
-    [DllImport("rstrtmgr.dll")]
+    [LibraryImport("rstrtmgr.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    public static extern RmResult RmShutdown(int pSessionHandle, RestartManagerShutdownType lActionFlags, RestartManagerWriteStatusCallback? fnStatus);
+    public static partial RmResult RmShutdown(int pSessionHandle, RestartManagerShutdownType lActionFlags, RestartManagerWriteStatusCallback? fnStatus);
 
     /// <summary>Restarts applications and services that have been shut down by the RmShutdown function and that have been registered to be restarted using the RegisterApplicationRestart function. This function can only be called by the primary installer that called the RmStartSession function to start the Restart Manager session.</summary>
     /// <param name="pSessionHandle">A handle to the existing Restart Manager session.</param>
     /// <param name="dwRestartFlags">Reserved. This parameter should be 0.</param>
     /// <param name="fnStatus">A pointer to a status message callback function that is used to communicate status while the RmRestart function is running. If NULL, no status is provided.</param>
     /// <returns>This is the most recent error received. The function can return one of the system error codes that are defined in Winerror.h.</returns>
-    [DllImport("rstrtmgr.dll")]
+    [LibraryImport("rstrtmgr.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    public static extern RmResult RmRestart(int pSessionHandle, int dwRestartFlags, RestartManagerWriteStatusCallback? fnStatus);
+    public static partial RmResult RmRestart(int pSessionHandle, int dwRestartFlags, RestartManagerWriteStatusCallback? fnStatus);
 
     [DllImport("kernel32.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]

--- a/src/Meziantou.Framework/ProcessExtensions.cs
+++ b/src/Meziantou.Framework/ProcessExtensions.cs
@@ -257,10 +257,10 @@ public static partial class ProcessExtensions
         }
     }
 
-    [DllImport("kernel32.dll", SetLastError = true)]
+    [LibraryImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern bool CloseHandle(IntPtr hObject);
+    private static partial bool CloseHandle(IntPtr hObject);
 
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
@@ -271,9 +271,9 @@ public static partial class ProcessExtensions
     private static extern int Process32Next(SnapshotSafeHandle handle, ref ProcessEntry32 entry);
 
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ms682489.aspx
-    [DllImport("kernel32.dll", SetLastError = true)]
+    [LibraryImport("kernel32.dll", SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern SnapshotSafeHandle CreateToolhelp32Snapshot(SnapshotFlags dwFlags, uint th32ProcessID);
+    private static partial SnapshotSafeHandle CreateToolhelp32Snapshot(SnapshotFlags dwFlags, uint th32ProcessID);
 
     private const int MAX_PATH = 260;
 

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Meziantou.Framework.Tests;
 
-public sealed class FullPathTests
+public sealed partial class FullPathTests
 {
     [Fact]
     public void IsEmpty()
@@ -574,15 +574,15 @@ public sealed class FullPathTests
         return CreateUnixSymbolicLinkCore(utf8TargetPath, utf8LinkPath);
     }
 
-    [DllImport("libc", EntryPoint = "symlink", SetLastError = true, ExactSpelling = true)]
+    [LibraryImport("libc", EntryPoint = "symlink", SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-    private static extern int CreateUnixSymbolicLinkCore(byte[] targetPath, byte[] linkPath);
+    private static partial int CreateUnixSymbolicLinkCore(byte[] targetPath, byte[] linkPath);
 #endif
 
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [LibraryImport("kernel32.dll", EntryPoint = "CreateSymbolicLinkW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
     [return: MarshalAs(UnmanagedType.I1)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern bool CreateSymbolicLink(string lpSymlinkFileName, string lpTargetFileName, SymbolicLink dwFlags);
+    private static partial bool CreateSymbolicLink(string lpSymlinkFileName, string lpTargetFileName, SymbolicLink dwFlags);
 
     private enum SymbolicLink
     {


### PR DESCRIPTION
This updates interop declarations to use `LibraryImport` where source-generated marshalling can preserve the current behavior, reducing manual P/Invoke surface while keeping compatibility.

## What changed
- Migrated supported callsites in `Meziantou.Framework`, `Meziantou.Framework.FullPath`, `Meziantou.Framework.SensitiveData`, `Meziantou.Framework.SnapshotTesting`, `Meziantou.Framework.Win32.Amsi`, and `tests/Meziantou.Framework.FullPath.Tests`.
- Added required `partial` modifiers on containing types/methods for source-generated P/Invokes.
- Preserved interop behavior by carrying over `SetLastError`, `EntryPoint`, UTF-16 string marshalling, search paths, and stdcall conventions where needed.

## Non-obvious decisions
- Kept `DllImport` for signatures that are currently unsupported by `LibraryImport` in this codebase (for example, selected structs/COM-heavy signatures and specific Windows APIs). This keeps behavior stable while still migrating all compatible signatures.
- A few Windows-focused test projects are environment-limited on macOS (AMSI DLL availability and ProjectedFS host/runtime constraints), so cross-platform relevant test suites were used here alongside full solution build.

## Validation
- Ran required scripts:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`
- `dotnet build Meziantou.Framework.slnx`
- `DiffEngine_Disabled=true dotnet test` for:
  - `tests/Meziantou.Framework.Tests`
  - `tests/Meziantou.Framework.FullPath.Tests`
  - `tests/Meziantou.Framework.SensitiveData.Tests`
  - `tests/Meziantou.Framework.SnapshotTesting.Tests`
  - `tests/Meziantou.Framework.Win32.RestartManager.Tests`