### PR TITLE
Add async ValueTask provider callbacks for ProjectedFileSystem

### DIFF
--- a/ref/Meziantou.Framework.Win32.ProjectedFileSystem.cs
+++ b/ref/Meziantou.Framework.Win32.ProjectedFileSystem.cs
@@ -83,9 +83,9 @@ namespace Meziantou.Framework.Win32.ProjectedFileSystem
         protected static bool FileNameMatch(string fileName, string pattern) => throw null;
         protected static bool AreFileNamesEqual(string fileName1, string fileName2) => throw null;
         protected static int CompareFileName(string fileName1, string fileName2) => throw null;
-        protected abstract System.Collections.Generic.IEnumerable<Meziantou.Framework.Win32.ProjectedFileSystem.ProjectedFileSystemEntry> GetEntries(string path);
-        protected virtual Meziantou.Framework.Win32.ProjectedFileSystem.ProjectedFileSystemEntry? GetEntry(string path) => throw null;
-        protected abstract System.IO.Stream? OpenRead(string path);
+        protected abstract System.Threading.Tasks.ValueTask<System.Collections.Generic.IEnumerable<Meziantou.Framework.Win32.ProjectedFileSystem.ProjectedFileSystemEntry>> GetEntriesAsync(string path);
+        protected virtual System.Threading.Tasks.ValueTask<Meziantou.Framework.Win32.ProjectedFileSystem.ProjectedFileSystemEntry?> GetEntryAsync(string path) => throw null;
+        protected abstract System.Threading.Tasks.ValueTask<System.IO.Stream?> OpenReadAsync(string path);
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
     }

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
@@ -68,7 +68,11 @@ internal static class NativeMethods
 
     [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjCompleteCommand(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, in PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS extendedParameters);
+    internal static extern HResult PrjCompleteCommand(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, IntPtr extendedParameters);
+
+    [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode, EntryPoint = nameof(PrjCompleteCommand))]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static extern HResult PrjCompleteCommandWithExtendedParameters(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, in PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS extendedParameters);
 
     [StructLayout(LayoutKind.Explicit)]
     internal struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
@@ -68,7 +68,7 @@ internal static partial class NativeMethods
 
     [LibraryImport("ProjectedFSLib.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial HResult PrjCompleteCommand(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, in PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS extendedParameters);
+    internal static partial HResult PrjCompleteCommand(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, IntPtr extendedParameters);
 
     [LibraryImport("ProjectedFSLib.dll", EntryPoint = nameof(PrjCompleteCommand))]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
@@ -70,9 +70,9 @@ internal static partial class NativeMethods
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     internal static partial HResult PrjCompleteCommand(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, in PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS extendedParameters);
 
-    [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode, EntryPoint = nameof(PrjCompleteCommand))]
+    [LibraryImport("ProjectedFSLib.dll", EntryPoint = nameof(PrjCompleteCommand))]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjCompleteCommandWithExtendedParameters(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, in PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS extendedParameters);
+    internal static partial HResult PrjCompleteCommandWithExtendedParameters(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, in PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS extendedParameters);
 
     [StructLayout(LayoutKind.Explicit)]
     internal struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Threading.Tasks;
 
 namespace Meziantou.Framework.Win32.ProjectedFileSystem;
 
@@ -12,20 +13,26 @@ namespace Meziantou.Framework.Win32.ProjectedFileSystem;
 /// {
 ///     public MyVirtualFileSystem(string rootFolder) : base(rootFolder) { }
 ///
-///     protected override IEnumerable&lt;ProjectedFileSystemEntry&gt; GetEntries(string path)
+///     protected override ValueTask&lt;IEnumerable&lt;ProjectedFileSystemEntry&gt;&gt; GetEntriesAsync(string path)
 ///     {
 ///         if (string.IsNullOrEmpty(path))
 ///         {
-///             yield return ProjectedFileSystemEntry.File("file.txt", length: 100);
-///             yield return ProjectedFileSystemEntry.Directory("folder");
+///             return ValueTask.FromResult&lt;IEnumerable&lt;ProjectedFileSystemEntry&gt;&gt;(
+///             [
+///                 ProjectedFileSystemEntry.File("file.txt", length: 100),
+///                 ProjectedFileSystemEntry.Directory("folder"),
+///             ]);
 ///         }
+///
+///         return ValueTask.FromResult(Enumerable.Empty&lt;ProjectedFileSystemEntry&gt;());
 ///     }
 ///
-///     protected override Stream? OpenRead(string path)
+///     protected override ValueTask&lt;Stream?&gt; OpenReadAsync(string path)
 ///     {
 ///         if (AreFileNamesEqual(path, "file.txt"))
-///             return new MemoryStream(Encoding.UTF8.GetBytes("Hello, World!"));
-///         return null;
+///             return ValueTask.FromResult&lt;Stream?&gt;(new MemoryStream(Encoding.UTF8.GetBytes("Hello, World!")));
+///
+///         return ValueTask.FromResult&lt;Stream?&gt;(null);
 ///     }
 /// }
 ///
@@ -41,7 +48,6 @@ public abstract class ProjectedFileSystemBase : IDisposable
 {
     // Remaining work
     // * Use VersionInfo
-    // * Async loading, GetEntries should return ValueTask (https://docs.microsoft.com/en-us/windows/desktop/api/projectedfslib/nf-projectedfslib-prjcompletecommand)
     // * https://docs.microsoft.com/en-us/windows/desktop/api/projectedfslib/nf-projectedfslib-prjupdatefileifneeded
 
     private readonly Guid _virtualizationInstanceId;
@@ -222,23 +228,24 @@ public abstract class ProjectedFileSystemBase : IDisposable
 
     /// <summary>When overridden in a derived class, returns the list of files and directories for the specified path.</summary>
     /// <param name="path">The relative path of the directory to enumerate. Empty string represents the root directory.</param>
-    /// <returns>An enumerable collection of <see cref="ProjectedFileSystemEntry"/> objects representing the files and directories.</returns>
-    protected abstract IEnumerable<ProjectedFileSystemEntry> GetEntries(string path);
+    /// <returns>A <see cref="ValueTask{TResult}"/> resolving to an enumerable collection of <see cref="ProjectedFileSystemEntry"/> objects representing the files and directories.</returns>
+    protected abstract ValueTask<IEnumerable<ProjectedFileSystemEntry>> GetEntriesAsync(string path);
 
     /// <summary>Gets metadata for a specific file or directory at the specified path.</summary>
     /// <param name="path">The relative path of the file or directory.</param>
-    /// <returns>The <see cref="ProjectedFileSystemEntry"/> for the specified path, or <see langword="null"/> if not found.</returns>
-    protected virtual ProjectedFileSystemEntry? GetEntry(string path)
+    /// <returns>A <see cref="ValueTask{TResult}"/> resolving to the <see cref="ProjectedFileSystemEntry"/> for the specified path, or <see langword="null"/> if not found.</returns>
+    protected virtual async ValueTask<ProjectedFileSystemEntry?> GetEntryAsync(string path)
     {
         var directory = Path.GetDirectoryName(path);
         var fileName = Path.GetFileName(path);
-        return GetEntries(directory ?? "").FirstOrDefault(entry => CompareFileName(entry.Name, fileName) == 0);
+        var entries = await GetEntriesAsync(directory ?? "").ConfigureAwait(false);
+        return entries.FirstOrDefault(entry => CompareFileName(entry.Name, fileName) == 0);
     }
 
     /// <summary>When overridden in a derived class, opens a stream to read the content of a file at the specified path.</summary>
     /// <param name="path">The relative path of the file to read.</param>
-    /// <returns>A <see cref="Stream"/> to read the file content, or <see langword="null"/> if the file does not exist.</returns>
-    protected abstract Stream? OpenRead(string path);
+    /// <returns>A <see cref="ValueTask{TResult}"/> resolving to a <see cref="Stream"/> to read the file content, or <see langword="null"/> if the file does not exist.</returns>
+    protected abstract ValueTask<Stream?> OpenReadAsync(string path);
 
     public void Dispose()
     {
@@ -253,12 +260,16 @@ public abstract class ProjectedFileSystemBase : IDisposable
 
     private HResult QueryFileNameCallback(in NativeMethods.PrjCallbackData callbackData)
     {
-        var fileName = callbackData.FilePathName;
-        var entry = GetEntry(fileName);
-        if (entry is null)
-            return HResult.E_FILENOTFOUND;
+        return ExecuteCallback(
+            in callbackData,
+            QueryFileNameCallbackAsync(callbackData.FilePathName),
+            extendedParameters: null);
+    }
 
-        return HResult.S_OK;
+    private async ValueTask<HResult> QueryFileNameCallbackAsync(string fileName)
+    {
+        var entry = await GetEntryAsync(fileName).ConfigureAwait(false);
+        return entry is null ? HResult.E_FILENOTFOUND : HResult.S_OK;
     }
 
     private static HResult NotificationCallback(in NativeMethods.PrjCallbackData callbackData, bool isDirectory, NativeMethods.PRJ_NOTIFICATION notification, string destinationFileName, IntPtr operationParameters)
@@ -275,7 +286,15 @@ public abstract class ProjectedFileSystemBase : IDisposable
 
     private HResult StartDirectoryEnumerationCallback(in NativeMethods.PrjCallbackData callbackData, in Guid enumerationId)
     {
-        var entries = GetEntries(callbackData.FilePathName);
+        return ExecuteCallback(
+            in callbackData,
+            StartDirectoryEnumerationCallbackAsync(callbackData.FilePathName, enumerationId),
+            extendedParameters: null);
+    }
+
+    private async ValueTask<HResult> StartDirectoryEnumerationCallbackAsync(string filePathName, Guid enumerationId)
+    {
+        var entries = await GetEntriesAsync(filePathName).ConfigureAwait(false);
         _activeEnumerations[enumerationId] = new DirectoryEnumerationSession(entries);
         return HResult.S_OK;
     }
@@ -322,7 +341,15 @@ public abstract class ProjectedFileSystemBase : IDisposable
 
     private HResult GetPlaceholderInfoCallback(in NativeMethods.PrjCallbackData callbackData)
     {
-        var entry = GetEntry(callbackData.FilePathName);
+        return ExecuteCallback(
+            in callbackData,
+            GetPlaceholderInfoCallbackAsync(callbackData.FilePathName, callbackData.NamespaceVirtualizationContext),
+            extendedParameters: null);
+    }
+
+    private async ValueTask<HResult> GetPlaceholderInfoCallbackAsync(string filePathName, IntPtr namespaceVirtualizationContext)
+    {
+        var entry = await GetEntryAsync(filePathName).ConfigureAwait(false);
         if (entry is null)
             return HResult.E_FILENOTFOUND;
 
@@ -332,19 +359,30 @@ public abstract class ProjectedFileSystemBase : IDisposable
 
 #pragma warning disable CA2000 // Dispose objects before losing scope (ownHandle: false)
         var hr = NativeMethods.PrjWritePlaceholderInfo(
-                    new ProjFSSafeHandle(callbackData.NamespaceVirtualizationContext, ownHandle: false),
-                    callbackData.FilePathName, // Use the full relative path from the callback, not just the entry name
+                    new ProjFSSafeHandle(namespaceVirtualizationContext, ownHandle: false),
+                    filePathName, // Use the full relative path from the callback, not just the entry name
                     in info,
                     (uint)Marshal.SizeOf(info));
 #pragma warning restore CA2000
-
-        hr.EnsureSuccess();
-        return HResult.S_OK;
+        return hr;
     }
 
     private HResult GetFileDataCallback(in NativeMethods.PrjCallbackData callbackData, ulong byteOffset, uint length)
     {
-        using var stream = OpenRead(callbackData.FilePathName);
+        return ExecuteCallback(
+            in callbackData,
+            GetFileDataCallbackAsync(
+                callbackData.FilePathName,
+                callbackData.NamespaceVirtualizationContext,
+                callbackData.DataStreamId,
+                byteOffset,
+                length),
+            extendedParameters: null);
+    }
+
+    private async ValueTask<HResult> GetFileDataCallbackAsync(string filePathName, IntPtr namespaceVirtualizationContext, Guid dataStreamId, ulong byteOffset, uint length)
+    {
+        using var stream = await OpenReadAsync(filePathName).ConfigureAwait(false);
         if (stream is null)
             return HResult.E_FILENOTFOUND;
 
@@ -372,7 +410,7 @@ public abstract class ProjectedFileSystemBase : IDisposable
             }
         }
 
-        using var safeHandle = new ProjFSSafeHandle(callbackData.NamespaceVirtualizationContext, ownHandle: false);
+        using var safeHandle = new ProjFSSafeHandle(namespaceVirtualizationContext, ownHandle: false);
 
         var maxBufferSize = (uint)BufferSize;
         uint writeLength;
@@ -421,7 +459,7 @@ public abstract class ProjectedFileSystemBase : IDisposable
 
                 // Write the data to the file in the local file system.
                 var hr = NativeMethods.PrjWriteFileData(safeHandle,
-                    callbackData.DataStreamId,
+                    dataStreamId,
                     writeBuffer,
                     currentOffset,
                     (uint)read);
@@ -438,6 +476,41 @@ public abstract class ProjectedFileSystemBase : IDisposable
         finally
         {
             NativeMethods.PrjFreeAlignedBuffer(writeBuffer);
+        }
+    }
+
+    private static HResult ExecuteCallback(in NativeMethods.PrjCallbackData callbackData, ValueTask<HResult> callbackResult, NativeMethods.PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS? extendedParameters)
+    {
+        if (callbackResult.IsCompletedSuccessfully)
+            return callbackResult.Result;
+
+        _ = CompleteCommandAsync(callbackData.NamespaceVirtualizationContext, callbackData.CommandId, callbackResult.AsTask(), extendedParameters);
+        return HResult.ERROR_IO_PENDING;
+    }
+
+    private static async Task CompleteCommandAsync(IntPtr namespaceVirtualizationContext, int commandId, Task<HResult> callbackTask, NativeMethods.PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS? extendedParameters)
+    {
+        HResult completionResult;
+        try
+        {
+            completionResult = await callbackTask.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            completionResult = new HResult(Marshal.GetHRForException(ex));
+        }
+
+#pragma warning disable CA2000 // Dispose objects before losing scope (ownHandle: false)
+        using var instanceHandle = new ProjFSSafeHandle(namespaceVirtualizationContext, ownHandle: false);
+#pragma warning restore CA2000
+
+        var completionHr = extendedParameters is { } value
+            ? NativeMethods.PrjCompleteCommandWithExtendedParameters(instanceHandle, commandId, completionResult, in value)
+            : NativeMethods.PrjCompleteCommand(instanceHandle, commandId, completionResult, IntPtr.Zero);
+
+        if (!completionHr.IsSuccess)
+        {
+            Debug.WriteLine($"PrjCompleteCommand failed for command {commandId}: 0x{completionHr.Value:X8}");
         }
     }
 

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/readme.md
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/readme.md
@@ -27,37 +27,46 @@ public class MyVirtualFileSystem : ProjectedFileSystemBase
     }
 
     // Return the list of files and folders for a given path
-    protected override IEnumerable<ProjectedFileSystemEntry> GetEntries(string path)
+    protected override ValueTask<IEnumerable<ProjectedFileSystemEntry>> GetEntriesAsync(string path)
     {
         if (string.IsNullOrEmpty(path))
         {
-            yield return ProjectedFileSystemEntry.Directory("folder");
-            yield return ProjectedFileSystemEntry.File("file1.txt", length: 100);
-            yield return ProjectedFileSystemEntry.File("file2.txt", length: 200);
+            return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>(
+            [
+                ProjectedFileSystemEntry.Directory("folder"),
+                ProjectedFileSystemEntry.File("file1.txt", length: 100),
+                ProjectedFileSystemEntry.File("file2.txt", length: 200),
+            ]);
         }
-        else if (AreFileNamesEqual(path, "folder"))
+
+        if (AreFileNamesEqual(path, "folder"))
         {
-            yield return ProjectedFileSystemEntry.File("nested.txt", length: 50);
+            return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>(
+            [
+                ProjectedFileSystemEntry.File("nested.txt", length: 50),
+            ]);
         }
+
+        return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([]);
     }
 
     // Return a stream to read the file content
-    protected override Stream? OpenRead(string path)
+    protected override ValueTask<Stream?> OpenReadAsync(string path)
     {
         if (AreFileNamesEqual(path, "file1.txt"))
         {
-            return new MemoryStream(Encoding.UTF8.GetBytes("Hello, World!"));
+            return ValueTask.FromResult<Stream?>(new MemoryStream(Encoding.UTF8.GetBytes("Hello, World!")));
         }
         else if (AreFileNamesEqual(path, "file2.txt"))
         {
-            return new MemoryStream(Encoding.UTF8.GetBytes("Another file content"));
+            return ValueTask.FromResult<Stream?>(new MemoryStream(Encoding.UTF8.GetBytes("Another file content")));
         }
         else if (AreFileNamesEqual(path, "folder\\nested.txt"))
         {
-            return new MemoryStream(Encoding.UTF8.GetBytes("Nested file"));
+            return ValueTask.FromResult<Stream?>(new MemoryStream(Encoding.UTF8.GetBytes("Nested file")));
         }
 
-        return null;
+        return ValueTask.FromResult<Stream?>(null);
     }
 }
 
@@ -102,9 +111,9 @@ vfs.Start(options);
 
 The base class for creating a virtual file system. Override these methods:
 
-- **`GetEntries(string path)`**: Returns the files and folders for a given directory path
-- **`OpenRead(string path)`**: Returns a stream to read file content
-- **`GetEntry(string path)`** (optional): Returns metadata for a specific file or folder
+- **`GetEntriesAsync(string path)`**: Returns the files and folders for a given directory path
+- **`OpenReadAsync(string path)`**: Returns a stream to read file content
+- **`GetEntryAsync(string path)`** (optional): Returns metadata for a specific file or folder
 
 Protected helper methods:
 

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
@@ -269,7 +269,7 @@ public sealed class ProjectedFileSystemTests
     }
 
     [ProjectedFileSystemFact]
-    public void AsyncCallbackCompletion()
+    public void AsyncCallbacksAllMethods()
     {
         var guid = Guid.NewGuid();
         var fullPath = Path.Combine(Path.GetTempPath(), "projFS", guid.ToString("N"));
@@ -279,12 +279,25 @@ public sealed class ProjectedFileSystemTests
             using var vfs = new AsyncSampleVirtualFileSystem(fullPath);
             vfs.Start(options: null);
 
-            var files = Directory.GetFiles(fullPath);
-            Assert.Single(files);
-            Assert.Equal("async-file.bin", Path.GetFileName(files[0]));
+            var entries = Directory.GetFileSystemEntries(fullPath).Select(path => Path.GetFileName(path)!).OrderBy(name => name, StringComparer.Ordinal).ToArray();
+            Assert.Equal(["async-dir", "async-file.bin"], entries);
 
             var content = File.ReadAllBytes(Path.Combine(fullPath, "async-file.bin"));
             Assert.Equal([10, 20, 30, 40], content);
+
+            var nestedContent = File.ReadAllBytes(Path.Combine(fullPath, "async-dir", "nested-async.txt"));
+            Assert.Equal([50, 60, 70], nestedContent);
+
+            var missingFile = new FileInfo(Path.Combine(fullPath, "missing.txt"));
+            Assert.False(missingFile.Exists);
+            Assert.Throws<FileNotFoundException>(() => missingFile.Length);
+
+            Assert.True(vfs.GetEntriesAsyncCalls > 0);
+            Assert.Equal(vfs.GetEntriesAsyncCalls, vfs.GetEntriesAsyncContinuations);
+            Assert.True(vfs.GetEntryAsyncCalls > 0);
+            Assert.Equal(vfs.GetEntryAsyncCalls, vfs.GetEntryAsyncContinuations);
+            Assert.True(vfs.OpenReadAsyncCalls > 0);
+            Assert.Equal(vfs.OpenReadAsyncCalls, vfs.OpenReadAsyncContinuations);
         }
         finally
         {

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
@@ -267,4 +267,28 @@ public sealed class ProjectedFileSystemTests
             try { Directory.Delete(fullPath, recursive: true); } catch { }
         }
     }
+
+    [ProjectedFileSystemFact]
+    public void AsyncCallbackCompletion()
+    {
+        var guid = Guid.NewGuid();
+        var fullPath = Path.Combine(Path.GetTempPath(), "projFS", guid.ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(fullPath);
+            using var vfs = new AsyncSampleVirtualFileSystem(fullPath);
+            vfs.Start(options: null);
+
+            var files = Directory.GetFiles(fullPath);
+            Assert.Single(files);
+            Assert.Equal("async-file.bin", Path.GetFileName(files[0]));
+
+            var content = File.ReadAllBytes(Path.Combine(fullPath, "async-file.bin"));
+            Assert.Equal([10, 20, 30, 40], content);
+        }
+        finally
+        {
+            try { Directory.Delete(fullPath, recursive: true); } catch { }
+        }
+    }
 }

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/AsyncSampleVirtualFileSystem.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/AsyncSampleVirtualFileSystem.cs
@@ -1,0 +1,27 @@
+namespace Meziantou.Framework.Win32.ProjectedFileSystem;
+
+internal sealed class AsyncSampleVirtualFileSystem : ProjectedFileSystemBase
+{
+    public AsyncSampleVirtualFileSystem(string rootFolder)
+        : base(rootFolder)
+    {
+    }
+
+    protected override async ValueTask<IEnumerable<ProjectedFileSystemEntry>> GetEntriesAsync(string path)
+    {
+        await Task.Yield();
+        return path switch
+        {
+            "" => [ProjectedFileSystemEntry.File("async-file.bin", 4)],
+            _ => [],
+        };
+    }
+
+    protected override async ValueTask<Stream?> OpenReadAsync(string path)
+    {
+        await Task.Yield();
+        return AreFileNamesEqual(path, "async-file.bin")
+            ? new MemoryStream([10, 20, 30, 40])
+            : null;
+    }
+}

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/AsyncSampleVirtualFileSystem.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/AsyncSampleVirtualFileSystem.cs
@@ -1,27 +1,87 @@
+using System.Threading;
+
 namespace Meziantou.Framework.Win32.ProjectedFileSystem;
 
 internal sealed class AsyncSampleVirtualFileSystem : ProjectedFileSystemBase
 {
+    private int _getEntriesAsyncCalls;
+    private int _getEntriesAsyncContinuations;
+    private int _getEntryAsyncCalls;
+    private int _getEntryAsyncContinuations;
+    private int _openReadAsyncCalls;
+    private int _openReadAsyncContinuations;
+
     public AsyncSampleVirtualFileSystem(string rootFolder)
         : base(rootFolder)
     {
     }
 
+    public int GetEntriesAsyncCalls => _getEntriesAsyncCalls;
+    public int GetEntriesAsyncContinuations => _getEntriesAsyncContinuations;
+    public int GetEntryAsyncCalls => _getEntryAsyncCalls;
+    public int GetEntryAsyncContinuations => _getEntryAsyncContinuations;
+    public int OpenReadAsyncCalls => _openReadAsyncCalls;
+    public int OpenReadAsyncContinuations => _openReadAsyncContinuations;
+
     protected override async ValueTask<IEnumerable<ProjectedFileSystemEntry>> GetEntriesAsync(string path)
     {
+        Interlocked.Increment(ref _getEntriesAsyncCalls);
         await Task.Yield();
-        return path switch
+        Interlocked.Increment(ref _getEntriesAsyncContinuations);
+
+        if (AreFileNamesEqual(path, ""))
         {
-            "" => [ProjectedFileSystemEntry.File("async-file.bin", 4)],
-            _ => [],
-        };
+            return [ProjectedFileSystemEntry.Directory("async-dir"), ProjectedFileSystemEntry.File("async-file.bin", 4)];
+        }
+
+        if (AreFileNamesEqual(path, "async-dir"))
+        {
+            return [ProjectedFileSystemEntry.File("nested-async.txt", 3)];
+        }
+
+        return [];
+    }
+
+    protected override async ValueTask<ProjectedFileSystemEntry?> GetEntryAsync(string path)
+    {
+        Interlocked.Increment(ref _getEntryAsyncCalls);
+        await Task.Yield();
+        Interlocked.Increment(ref _getEntryAsyncContinuations);
+
+        if (AreFileNamesEqual(path, "async-file.bin"))
+        {
+            return ProjectedFileSystemEntry.File("async-file.bin", 4);
+        }
+
+        if (AreFileNamesEqual(path, "async-dir"))
+        {
+            return ProjectedFileSystemEntry.Directory("async-dir");
+        }
+
+        if (AreFileNamesEqual(path, @"async-dir\nested-async.txt"))
+        {
+            return ProjectedFileSystemEntry.File("nested-async.txt", 3);
+        }
+
+        return null;
     }
 
     protected override async ValueTask<Stream?> OpenReadAsync(string path)
     {
+        Interlocked.Increment(ref _openReadAsyncCalls);
         await Task.Yield();
-        return AreFileNamesEqual(path, "async-file.bin")
-            ? new MemoryStream([10, 20, 30, 40])
-            : null;
+        Interlocked.Increment(ref _openReadAsyncContinuations);
+
+        if (AreFileNamesEqual(path, "async-file.bin"))
+        {
+            return new MemoryStream([10, 20, 30, 40]);
+        }
+
+        if (AreFileNamesEqual(path, @"async-dir\nested-async.txt"))
+        {
+            return new MemoryStream([50, 60, 70]);
+        }
+
+        return null;
     }
 }

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/LargeFileVirtualFileSystem.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/LargeFileVirtualFileSystem.cs
@@ -11,13 +11,15 @@ internal sealed class LargeFileVirtualFileSystem : ProjectedFileSystemBase
 
     public LargeFileVirtualFileSystem(string rootFolder) : base(rootFolder) { }
 
-    protected override IEnumerable<ProjectedFileSystemEntry> GetEntries(string path)
+    protected override ValueTask<IEnumerable<ProjectedFileSystemEntry>> GetEntriesAsync(string path)
     {
         if (AreFileNamesEqual(path, ""))
-            yield return ProjectedFileSystemEntry.File("largefile.bin", FileSize);
+            return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([ProjectedFileSystemEntry.File("largefile.bin", FileSize)]);
+
+        return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([]);
     }
 
-    protected override Stream? OpenRead(string path)
+    protected override ValueTask<Stream?> OpenReadAsync(string path)
     {
         if (AreFileNamesEqual(path, "largefile.bin"))
         {
@@ -26,8 +28,9 @@ internal sealed class LargeFileVirtualFileSystem : ProjectedFileSystemBase
             var data = new byte[FileSize];
             for (var i = 0; i < FileSize; i++)
                 data[i] = (byte)(i % 256);
-            return new MemoryStream(data);
+            return ValueTask.FromResult<Stream?>(new MemoryStream(data));
         }
-        return null;
+
+        return ValueTask.FromResult<Stream?>(null);
     }
 }

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/NestedVirtualFileSystem.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/NestedVirtualFileSystem.cs
@@ -10,7 +10,7 @@ internal sealed class NestedVirtualFileSystem : ProjectedFileSystemBase
 {
     public NestedVirtualFileSystem(string rootFolder) : base(rootFolder) { }
 
-    protected override IEnumerable<ProjectedFileSystemEntry> GetEntries(string path)
+    protected override ValueTask<IEnumerable<ProjectedFileSystemEntry>> GetEntriesAsync(string path)
     {
         // Structure:
         // /
@@ -18,17 +18,22 @@ internal sealed class NestedVirtualFileSystem : ProjectedFileSystemBase
         //     └── Bar/
         //         └── Baz.txt
         if (AreFileNamesEqual(path, ""))
-            yield return ProjectedFileSystemEntry.Directory("Foo");
-        else if (AreFileNamesEqual(path, "Foo"))
-            yield return ProjectedFileSystemEntry.Directory("Bar");
-        else if (AreFileNamesEqual(path, @"Foo\Bar"))
-            yield return ProjectedFileSystemEntry.File("Baz.txt", 18);
+            return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([ProjectedFileSystemEntry.Directory("Foo")]);
+
+        if (AreFileNamesEqual(path, "Foo"))
+            return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([ProjectedFileSystemEntry.Directory("Bar")]);
+
+        if (AreFileNamesEqual(path, @"Foo\Bar"))
+            return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([ProjectedFileSystemEntry.File("Baz.txt", 18)]);
+
+        return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([]);
     }
 
-    protected override Stream? OpenRead(string path)
+    protected override ValueTask<Stream?> OpenReadAsync(string path)
     {
         if (AreFileNamesEqual(path, @"Foo\Bar\Baz.txt"))
-            return new MemoryStream(Encoding.UTF8.GetBytes("Hello from Foo Bar"));
-        return null;
+            return ValueTask.FromResult<Stream?>(new MemoryStream(Encoding.UTF8.GetBytes("Hello from Foo Bar")));
+
+        return ValueTask.FromResult<Stream?>(null);
     }
 }

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/NonSeekableStreamVirtualFileSystem.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/NonSeekableStreamVirtualFileSystem.cs
@@ -12,13 +12,15 @@ internal sealed class NonSeekableStreamVirtualFileSystem : ProjectedFileSystemBa
 
     public NonSeekableStreamVirtualFileSystem(string rootFolder) : base(rootFolder) { }
 
-    protected override IEnumerable<ProjectedFileSystemEntry> GetEntries(string path)
+    protected override ValueTask<IEnumerable<ProjectedFileSystemEntry>> GetEntriesAsync(string path)
     {
         if (AreFileNamesEqual(path, ""))
-            yield return ProjectedFileSystemEntry.File("nonseekabledatafile.bin", FileSize);
+            return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([ProjectedFileSystemEntry.File("nonseekabledatafile.bin", FileSize)]);
+
+        return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([]);
     }
 
-    protected override Stream? OpenRead(string path)
+    protected override ValueTask<Stream?> OpenReadAsync(string path)
     {
         if (AreFileNamesEqual(path, "nonseekabledatafile.bin"))
         {
@@ -26,9 +28,10 @@ internal sealed class NonSeekableStreamVirtualFileSystem : ProjectedFileSystemBa
             var data = new byte[FileSize];
             for (var i = 0; i < FileSize; i++)
                 data[i] = (byte)(i % 256);
-            return new NonSeekableStream(new MemoryStream(data));
+            return ValueTask.FromResult<Stream?>(new NonSeekableStream(new MemoryStream(data)));
         }
-        return null;
+
+        return ValueTask.FromResult<Stream?>(null);
     }
 
     /// <summary>

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/NonSeekableStreamVirtualFileSystem.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/NonSeekableStreamVirtualFileSystem.cs
@@ -28,7 +28,10 @@ internal sealed class NonSeekableStreamVirtualFileSystem : ProjectedFileSystemBa
             var data = new byte[FileSize];
             for (var i = 0; i < FileSize; i++)
                 data[i] = (byte)(i % 256);
+            // CA2000 can't track ownership transfer through ValueTask.FromResult.
+#pragma warning disable CA2000 // Dispose objects before losing scope
             return ValueTask.FromResult<Stream?>(new NonSeekableStream(new MemoryStream(data)));
+#pragma warning restore CA2000 // Dispose objects before losing scope
         }
 
         return ValueTask.FromResult<Stream?>(null);

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/SampleVirtualFileSystem.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/SampleVirtualFileSystem.cs
@@ -7,38 +7,47 @@ internal sealed class SampleVirtualFileSystem : ProjectedFileSystemBase
     {
     }
 
-    protected override IEnumerable<ProjectedFileSystemEntry> GetEntries(string path)
+    protected override ValueTask<IEnumerable<ProjectedFileSystemEntry>> GetEntriesAsync(string path)
     {
         if (AreFileNamesEqual(path, ""))
         {
-            yield return ProjectedFileSystemEntry.Directory("folder");
-            yield return ProjectedFileSystemEntry.File("a", 1);
-            yield return ProjectedFileSystemEntry.File("b", 2);
+            return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>(
+            [
+                ProjectedFileSystemEntry.Directory("folder"),
+                ProjectedFileSystemEntry.File("a", 1),
+                ProjectedFileSystemEntry.File("b", 2),
+            ]);
         }
-        else if (AreFileNamesEqual(path, "folder"))
+
+        if (AreFileNamesEqual(path, "folder"))
         {
-            yield return ProjectedFileSystemEntry.File("c", 3);
+            return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>(
+            [
+                ProjectedFileSystemEntry.File("c", 3),
+            ]);
         }
+
+        return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([]);
     }
 
     [SuppressMessage("Style", "IDE0230:Use UTF-8 string literal", Justification = "")]
-    protected override Stream? OpenRead(string path)
+    protected override ValueTask<Stream?> OpenReadAsync(string path)
     {
         if (AreFileNamesEqual(path, "a"))
         {
-            return new MemoryStream([1]);
+            return ValueTask.FromResult<Stream?>(new MemoryStream([1]));
         }
 
         if (AreFileNamesEqual(path, "b"))
         {
-            return new MemoryStream([1, 2]);
+            return ValueTask.FromResult<Stream?>(new MemoryStream([1, 2]));
         }
 
         if (AreFileNamesEqual(path, "folder\\c"))
         {
-            return new MemoryStream([1, 2, 3]);
+            return ValueTask.FromResult<Stream?>(new MemoryStream([1, 2, 3]));
         }
 
-        return null;
+        return ValueTask.FromResult<Stream?>(null);
     }
 }

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/UnsortedEntriesVirtualFileSystem.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/UnsortedEntriesVirtualFileSystem.cs
@@ -9,18 +9,23 @@ internal sealed class UnsortedEntriesVirtualFileSystem : ProjectedFileSystemBase
 {
     public UnsortedEntriesVirtualFileSystem(string rootFolder) : base(rootFolder) { }
 
-    protected override IEnumerable<ProjectedFileSystemEntry> GetEntries(string path)
+    protected override ValueTask<IEnumerable<ProjectedFileSystemEntry>> GetEntriesAsync(string path)
     {
         if (AreFileNamesEqual(path, ""))
         {
             // Return entries in unsorted order (z, a, m, b, y)
-            yield return ProjectedFileSystemEntry.File("zebra.txt", 1);
-            yield return ProjectedFileSystemEntry.File("apple.txt", 1);
-            yield return ProjectedFileSystemEntry.File("mango.txt", 1);
-            yield return ProjectedFileSystemEntry.Directory("banana");
-            yield return ProjectedFileSystemEntry.File("yellow.txt", 1);
+            return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>(
+            [
+                ProjectedFileSystemEntry.File("zebra.txt", 1),
+                ProjectedFileSystemEntry.File("apple.txt", 1),
+                ProjectedFileSystemEntry.File("mango.txt", 1),
+                ProjectedFileSystemEntry.Directory("banana"),
+                ProjectedFileSystemEntry.File("yellow.txt", 1),
+            ]);
         }
+
+        return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([]);
     }
 
-    protected override Stream? OpenRead(string path) => new MemoryStream([0]);
+    protected override ValueTask<Stream?> OpenReadAsync(string path) => ValueTask.FromResult<Stream?>(new MemoryStream([0]));
 }


### PR DESCRIPTION
## Why
ProjectedFileSystem currently exposes synchronous provider hooks only, which makes async-backed stores hard to implement efficiently and blocks proper ProjFS pending-command completion.

## What changed
This PR migrates the provider surface to async-only `ValueTask` APIs and wires callback completion to ProjFS asynchronous semantics.

- Replaced sync hooks in `ProjectedFileSystemBase` with async hooks:
  - `GetEntries` -> `GetEntriesAsync`
  - `GetEntry` -> `GetEntryAsync`
  - `OpenRead` -> `OpenReadAsync`
- Updated callback handling so each callback:
  - returns immediately when the `ValueTask` is already completed
  - returns `ERROR_IO_PENDING` when not completed, then awaits and completes through `PrjCompleteCommand`
- Updated native interop to support `PrjCompleteCommand` with and without extended parameters.
- Updated ProjectedFileSystem tests and test VFS implementations to the new async API.
- Added an async-specific test fixture (`AsyncSampleVirtualFileSystem`) and test (`AsyncCallbackCompletion`) to exercise deferred callback completion paths.
- Updated ProjectedFileSystem README examples and method references to the async API.

## Notes for reviewers
This is an intentional breaking API change for derived providers in this package: sync override points were removed in favor of async-only override points.

## Validation
- Required scripts executed:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`
- Build completed for `tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests` (`net10.0`).
- `dotnet test` is blocked in this macOS environment for this test project because it targets `x64` and the local `dotnet` x64 host is unavailable, so runtime execution aborts before tests run.