### PR TITLE
Internalize Scheduling recurrence implementation types

### DIFF
--- a/ref/Meziantou.Framework.Scheduling.cs
+++ b/ref/Meziantou.Framework.Scheduling.cs
@@ -8,20 +8,6 @@ namespace Meziantou.Framework.Scheduling
         public Meziantou.Framework.Scheduling.InternetCalendarUserAddress? Address { get => throw null; set { } }
     }
 
-    public sealed class ByDay : System.IEquatable<Meziantou.Framework.Scheduling.ByDay>
-    {
-        public System.DayOfWeek DayOfWeek { get => throw null; set { } }
-        public int? Ordinal { get => throw null; set { } }
-        public ByDay(System.DayOfWeek dayOfWeek) { }
-        public ByDay(System.DayOfWeek dayOfWeek, int? ordinal) { }
-        public bool Equals(Meziantou.Framework.Scheduling.ByDay? other) => throw null;
-        public override bool Equals(object? obj) => throw null;
-        public override int GetHashCode() => throw null;
-        public static bool operator ==(Meziantou.Framework.Scheduling.ByDay left, Meziantou.Framework.Scheduling.ByDay right) => throw null;
-        public static bool operator !=(Meziantou.Framework.Scheduling.ByDay left, Meziantou.Framework.Scheduling.ByDay right) => throw null;
-        public override string ToString() => throw null;
-    }
-
     public sealed class CronExpression : Meziantou.Framework.Scheduling.IRecurrenceRule, System.IParsable<Meziantou.Framework.Scheduling.CronExpression>, System.ISpanParsable<Meziantou.Framework.Scheduling.CronExpression>
     {
         public static Meziantou.Framework.Scheduling.CronExpression Parse(string expression) => throw null;
@@ -29,13 +15,6 @@ namespace Meziantou.Framework.Scheduling
         public static Meziantou.Framework.Scheduling.CronExpression Parse(System.ReadOnlySpan<char> expression) => throw null;
         public static bool TryParse(System.ReadOnlySpan<char> expression, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Scheduling.CronExpression? cronExpression) => throw null;
         public System.Collections.Generic.IEnumerable<System.DateTime> GetNextOccurrences(System.DateTime startDate) => throw null;
-    }
-
-    public sealed class DailyRecurrenceRule : Meziantou.Framework.Scheduling.RecurrenceRule
-    {
-        public System.Collections.Generic.IList<System.DayOfWeek> ByWeekDays { get => throw null; set { } }
-        public string Text { get => throw null; }
-        protected override System.Collections.Generic.IEnumerable<System.DateTime> GetNextOccurrencesInternal(System.DateTime startDate) => throw null;
     }
 
     public sealed class Event
@@ -61,25 +40,6 @@ namespace Meziantou.Framework.Scheduling
         Cancelled = 2
     }
 
-    public enum Frequency
-    {
-        None = 0,
-        Secondly = 1,
-        Minutely = 2,
-        Hourly = 3,
-        Daily = 4,
-        Weekly = 5,
-        Monthly = 6,
-        Yearly = 7
-    }
-
-    public sealed class HourlyRecurrenceRule : Meziantou.Framework.Scheduling.RecurrenceRule
-    {
-        public System.Collections.Generic.IList<System.DayOfWeek> ByWeekDays { get => throw null; set { } }
-        public string Text { get => throw null; }
-        protected override System.Collections.Generic.IEnumerable<System.DateTime> GetNextOccurrencesInternal(System.DateTime startDate) => throw null;
-    }
-
     public interface IRecurrenceRule
     {
         System.Collections.Generic.IEnumerable<System.DateTime> GetNextOccurrences(System.DateTime startDate);
@@ -102,36 +62,6 @@ namespace Meziantou.Framework.Scheduling
         public override string ToString() => throw null;
     }
 
-    public sealed class MinutelyRecurrenceRule : Meziantou.Framework.Scheduling.RecurrenceRule
-    {
-        public System.Collections.Generic.IList<System.DayOfWeek> ByWeekDays { get => throw null; set { } }
-        public string Text { get => throw null; }
-        protected override System.Collections.Generic.IEnumerable<System.DateTime> GetNextOccurrencesInternal(System.DateTime startDate) => throw null;
-    }
-
-    public enum Month
-    {
-        January = 1,
-        February = 2,
-        March = 3,
-        April = 4,
-        May = 5,
-        June = 6,
-        July = 7,
-        August = 8,
-        September = 9,
-        October = 10,
-        November = 11,
-        December = 12
-    }
-
-    public sealed class MonthlyRecurrenceRule : Meziantou.Framework.Scheduling.RecurrenceRule
-    {
-        public System.Collections.Generic.IList<Meziantou.Framework.Scheduling.ByDay> ByWeekDays { get => throw null; set { } }
-        public string Text { get => throw null; }
-        protected override System.Collections.Generic.IEnumerable<System.DateTime> GetNextOccurrencesInternal(System.DateTime startDate) => throw null;
-    }
-
     public sealed class Organizer
     {
         public Meziantou.Framework.Scheduling.InternetCalendarUserAddress? Address { get => throw null; set { } }
@@ -148,7 +78,7 @@ namespace Meziantou.Framework.Scheduling
         public System.Collections.Generic.IList<int>? BySeconds { get => throw null; set { } }
         public System.Collections.Generic.IList<int>? ByMinutes { get => throw null; set { } }
         public System.Collections.Generic.IList<int>? ByHours { get => throw null; set { } }
-        public System.Collections.Generic.IList<Meziantou.Framework.Scheduling.Month> ByMonths { get => throw null; set { } }
+        public System.Collections.Generic.IList<int> ByMonths { get => throw null; set { } }
         public System.Collections.Generic.IList<int> ByMonthDays { get => throw null; set { } }
         public System.Collections.Generic.IList<int>? BySetPositions { get => throw null; set { } }
         public bool IsForever { get => throw null; }
@@ -169,76 +99,9 @@ namespace Meziantou.Framework.Scheduling
         public static System.DateTime? GetNextOccurrence(this Meziantou.Framework.Scheduling.IRecurrenceRule recurrenceRule, System.DateTime startDate) => throw null;
     }
 
-    public abstract class RecurrenceRuleHumanizer
-    {
-        protected static readonly System.Globalization.CultureInfo EnglishCultureInfo;
-        protected static readonly System.Globalization.CultureInfo FrenchCultureInfo;
-        public static System.Collections.Generic.IDictionary<System.Globalization.CultureInfo, Meziantou.Framework.Scheduling.RecurrenceRuleHumanizer> SupportedHumanizers { get => throw null; }
-        public static string? GetText(Meziantou.Framework.Scheduling.RecurrenceRule rrule) => throw null;
-        public static string? GetText(Meziantou.Framework.Scheduling.RecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-        protected abstract string GetText(Meziantou.Framework.Scheduling.SecondlyRecurrenceRule rrule, System.Globalization.CultureInfo cultureInfo);
-        protected abstract string GetText(Meziantou.Framework.Scheduling.MinutelyRecurrenceRule rrule, System.Globalization.CultureInfo cultureInfo);
-        protected abstract string GetText(Meziantou.Framework.Scheduling.HourlyRecurrenceRule rrule, System.Globalization.CultureInfo cultureInfo);
-        protected abstract string GetText(Meziantou.Framework.Scheduling.DailyRecurrenceRule rrule, System.Globalization.CultureInfo cultureInfo);
-        protected abstract string GetText(Meziantou.Framework.Scheduling.WeeklyRecurrenceRule rrule, System.Globalization.CultureInfo cultureInfo);
-        protected abstract string GetText(Meziantou.Framework.Scheduling.MonthlyRecurrenceRule rrule, System.Globalization.CultureInfo cultureInfo);
-        protected abstract string GetText(Meziantou.Framework.Scheduling.YearlyRecurrenceRule rrule, System.Globalization.CultureInfo cultureInfo);
-        protected static void ListToHumanText<T>(System.Text.StringBuilder sb, System.Globalization.CultureInfo cultureInfo, System.Collections.Generic.IList<T> list, string separator, string lastSeparator) { }
-        protected static string ListToHumanText<T>(System.Globalization.CultureInfo cultureInfo, System.Collections.Generic.IList<T> list, string separator, string lastSeparator) => throw null;
-        protected static bool IsWeekday(System.Collections.Generic.ICollection<System.DayOfWeek> daysOfWeek) => throw null;
-        protected static bool IsWeekendDay(System.Collections.Generic.ICollection<System.DayOfWeek> daysOfWeek) => throw null;
-        protected static bool IsFullWeek(System.Collections.Generic.ICollection<System.DayOfWeek> daysOfWeek) => throw null;
-    }
-
-    public sealed class RecurrenceRuleHumanizerEnglish : Meziantou.Framework.Scheduling.RecurrenceRuleHumanizer
-    {
-        protected override string GetText(Meziantou.Framework.Scheduling.DailyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-        protected override string GetText(Meziantou.Framework.Scheduling.SecondlyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-        protected override string GetText(Meziantou.Framework.Scheduling.MinutelyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-        protected override string GetText(Meziantou.Framework.Scheduling.HourlyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-        protected override string GetText(Meziantou.Framework.Scheduling.WeeklyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-        protected override string GetText(Meziantou.Framework.Scheduling.MonthlyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-        protected override string GetText(Meziantou.Framework.Scheduling.YearlyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-    }
-
     public static class RecurrenceRuleHumanizerExtensions
     {
         public static string? GetHumanText(this Meziantou.Framework.Scheduling.RecurrenceRule rrule) => throw null;
         public static string? GetHumanText(this Meziantou.Framework.Scheduling.RecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-    }
-
-    public sealed class RecurrenceRuleHumanizerFrench : Meziantou.Framework.Scheduling.RecurrenceRuleHumanizer
-    {
-        protected override string GetText(Meziantou.Framework.Scheduling.DailyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-        protected override string GetText(Meziantou.Framework.Scheduling.SecondlyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-        protected override string GetText(Meziantou.Framework.Scheduling.MinutelyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-        protected override string GetText(Meziantou.Framework.Scheduling.HourlyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-        protected override string GetText(Meziantou.Framework.Scheduling.WeeklyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-        protected override string GetText(Meziantou.Framework.Scheduling.MonthlyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-        protected override string GetText(Meziantou.Framework.Scheduling.YearlyRecurrenceRule rrule, System.Globalization.CultureInfo? cultureInfo) => throw null;
-    }
-
-    public sealed class SecondlyRecurrenceRule : Meziantou.Framework.Scheduling.RecurrenceRule
-    {
-        public System.Collections.Generic.IList<System.DayOfWeek> ByWeekDays { get => throw null; set { } }
-        public string Text { get => throw null; }
-        protected override System.Collections.Generic.IEnumerable<System.DateTime> GetNextOccurrencesInternal(System.DateTime startDate) => throw null;
-    }
-
-    public sealed class WeeklyRecurrenceRule : Meziantou.Framework.Scheduling.RecurrenceRule
-    {
-        public System.Collections.Generic.IList<System.DayOfWeek> ByWeekDays { get => throw null; set { } }
-        public string Text { get => throw null; }
-        protected override System.Collections.Generic.IEnumerable<System.DateTime> GetNextOccurrencesInternal(System.DateTime startDate) => throw null;
-    }
-
-    public sealed class YearlyRecurrenceRule : Meziantou.Framework.Scheduling.RecurrenceRule
-    {
-        public System.Collections.Generic.IList<int>? ByMonthDays { get => throw null; set { } }
-        public System.Collections.Generic.IList<Meziantou.Framework.Scheduling.ByDay>? ByWeekDays { get => throw null; set { } }
-        public System.Collections.Generic.IList<Meziantou.Framework.Scheduling.Month>? ByMonths { get => throw null; set { } }
-        public System.Collections.Generic.IList<int>? ByYearDays { get => throw null; set { } }
-        public string Text { get => throw null; }
-        protected override System.Collections.Generic.IEnumerable<System.DateTime> GetNextOccurrencesInternal(System.DateTime startDate) => throw null;
     }
 }

--- a/src/Meziantou.Framework.Scheduling/ByDay.cs
+++ b/src/Meziantou.Framework.Scheduling/ByDay.cs
@@ -1,7 +1,7 @@
 namespace Meziantou.Framework.Scheduling;
 
 /// <summary>Represents a day of the week with an optional ordinal position for recurrence rules.</summary>
-public sealed class ByDay : IEquatable<ByDay>
+internal sealed class ByDay : IEquatable<ByDay>
 {
     /// <summary>Initializes a new instance of the <see cref="ByDay"/> class.</summary>
     public ByDay()

--- a/src/Meziantou.Framework.Scheduling/DailyRecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/DailyRecurrenceRule.cs
@@ -7,7 +7,7 @@ namespace Meziantou.Framework.Scheduling;
 /// var nextOccurrences = rrule.GetNextOccurrences(DateTime.Now).ToArray();
 /// </code>
 /// </example>
-public sealed class DailyRecurrenceRule : RecurrenceRule
+internal sealed class DailyRecurrenceRule : RecurrenceRule
 {
     /// <summary>Limits occurrences to specific days of the week.</summary>
     public IList<DayOfWeek> ByWeekDays { get; set; } = new List<DayOfWeek>();
@@ -22,7 +22,7 @@ public sealed class DailyRecurrenceRule : RecurrenceRule
 
             if (!IsEmpty(ByMonths))
             {
-                if (!ByMonths.Contains((Month)startDate.Month))
+                if (!ByMonths.Contains(startDate.Month))
                 {
                     b = false;
                 }
@@ -123,7 +123,7 @@ public sealed class DailyRecurrenceRule : RecurrenceRule
             if (!IsEmpty(ByMonths))
             {
                 sb.Append(";BYMONTH=");
-                sb.AppendJoin(',', ByMonths.Cast<int>());
+                sb.AppendJoin(',', ByMonths);
             }
 
             if (!IsEmpty(ByMonthDays))

--- a/src/Meziantou.Framework.Scheduling/Frequency.cs
+++ b/src/Meziantou.Framework.Scheduling/Frequency.cs
@@ -1,7 +1,7 @@
 namespace Meziantou.Framework.Scheduling;
 
 /// <summary>Specifies the frequency of a recurrence rule.</summary>
-public enum Frequency
+internal enum Frequency
 {
     /// <summary>No frequency specified.</summary>
     None,

--- a/src/Meziantou.Framework.Scheduling/HourlyRecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/HourlyRecurrenceRule.cs
@@ -7,7 +7,7 @@ namespace Meziantou.Framework.Scheduling;
 /// var nextOccurrences = rrule.GetNextOccurrences(DateTime.Now).ToArray();
 /// </code>
 /// </example>
-public sealed class HourlyRecurrenceRule : RecurrenceRule
+internal sealed class HourlyRecurrenceRule : RecurrenceRule
 {
     /// <summary>Limits occurrences to specific days of the week.</summary>
     public IList<DayOfWeek> ByWeekDays { get; set; } = [];
@@ -21,7 +21,7 @@ public sealed class HourlyRecurrenceRule : RecurrenceRule
         {
             var matches = true;
 
-            if (!IsEmpty(ByMonths) && !ByMonths.Contains((Month)current.Month))
+            if (!IsEmpty(ByMonths) && !ByMonths.Contains(current.Month))
                 matches = false;
 
             if (!IsEmpty(ByMonthDays) && !ByMonthDays.Contains(current.Day))
@@ -105,7 +105,7 @@ public sealed class HourlyRecurrenceRule : RecurrenceRule
             if (!IsEmpty(ByMonths))
             {
                 sb.Append(";BYMONTH=");
-                sb.AppendJoin(',', ByMonths.Cast<int>());
+                sb.AppendJoin(',', ByMonths);
             }
 
             if (!IsEmpty(ByMonthDays))

--- a/src/Meziantou.Framework.Scheduling/Meziantou.Framework.Scheduling.csproj
+++ b/src/Meziantou.Framework.Scheduling/Meziantou.Framework.Scheduling.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>RecurrenceRule (RFC 5545) and Cron expression parser and evaluator</Description>
-    <Version>2.0.12</Version>
+    <Version>3.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Scheduling/MinutelyRecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/MinutelyRecurrenceRule.cs
@@ -9,7 +9,7 @@ namespace Meziantou.Framework.Scheduling;
 /// var nextOccurrences = rrule.GetNextOccurrences(DateTime.Now).ToArray();
 /// </code>
 /// </example>
-public sealed class MinutelyRecurrenceRule : RecurrenceRule
+internal sealed class MinutelyRecurrenceRule : RecurrenceRule
 {
     /// <summary>Limits occurrences to specific days of the week.</summary>
     public IList<DayOfWeek> ByWeekDays { get; set; } = [];
@@ -23,7 +23,7 @@ public sealed class MinutelyRecurrenceRule : RecurrenceRule
         {
             var matches = true;
 
-            if (!IsEmpty(ByMonths) && !ByMonths.Contains((Month)current.Month))
+            if (!IsEmpty(ByMonths) && !ByMonths.Contains(current.Month))
                 matches = false;
 
             if (!IsEmpty(ByMonthDays) && !ByMonthDays.Contains(current.Day))
@@ -94,7 +94,7 @@ public sealed class MinutelyRecurrenceRule : RecurrenceRule
             if (!IsEmpty(ByMonths))
             {
                 sb.Append(";BYMONTH=");
-                sb.AppendJoin(',', ByMonths.Cast<int>());
+                sb.AppendJoin(',', ByMonths);
             }
 
             if (!IsEmpty(ByMonthDays))

--- a/src/Meziantou.Framework.Scheduling/Month.cs
+++ b/src/Meziantou.Framework.Scheduling/Month.cs
@@ -1,7 +1,7 @@
 namespace Meziantou.Framework.Scheduling;
 
 /// <summary>Specifies the months of the year.</summary>
-public enum Month
+internal enum Month
 {
     /// <summary>January (month 1).</summary>
     January = 1,

--- a/src/Meziantou.Framework.Scheduling/MonthlyRecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/MonthlyRecurrenceRule.cs
@@ -7,7 +7,7 @@ namespace Meziantou.Framework.Scheduling;
 /// var nextOccurrences = rrule.GetNextOccurrences(DateTime.Now).ToArray();
 /// </code>
 /// </example>
-public sealed class MonthlyRecurrenceRule : RecurrenceRule
+internal sealed class MonthlyRecurrenceRule : RecurrenceRule
 {
     /// <summary>Limits occurrences to specific days of the week with optional ordinal positions.</summary>
     public IList<ByDay> ByWeekDays { get; set; } = [];
@@ -41,7 +41,7 @@ public sealed class MonthlyRecurrenceRule : RecurrenceRule
             var b = true;
             if (!IsEmpty(ByMonths))
             {
-                if (ByMonths.Contains((Month)startOfMonth.Month))
+                if (ByMonths.Contains(startOfMonth.Month))
                 {
                     b = false;
                 }
@@ -135,7 +135,7 @@ public sealed class MonthlyRecurrenceRule : RecurrenceRule
             if (!IsEmpty(ByMonths))
             {
                 sb.Append(";BYMONTH=");
-                sb.AppendJoin(',', ByMonths.Cast<int>());
+                sb.AppendJoin(',', ByMonths);
             }
 
             if (!IsEmpty(ByMonthDays))

--- a/src/Meziantou.Framework.Scheduling/RecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/RecurrenceRule.cs
@@ -55,7 +55,7 @@ public abstract class RecurrenceRule : IRecurrenceRule
     public IList<int>? ByHours { get; set; }
 
     /// <summary>Limits occurrences to specific months (1-12).</summary>
-    public IList<Month> ByMonths { get; set; } = [];
+    public IList<int> ByMonths { get; set; } = [];
 
     /// <summary>Limits occurrences to specific days of the month (1-31, -1 to -31).</summary>
     public IList<int> ByMonthDays { get; set; } = [];
@@ -318,7 +318,7 @@ public abstract class RecurrenceRule : IRecurrenceRule
         return monthDays;
     }
 
-    private static List<Month> ParseByMonth(Dictionary<string, string> values)
+    private static List<int> ParseByMonth(Dictionary<string, string> values)
     {
         if (values.TryGetNonEmptyValue("BYMONTH", out var str))
             return ParseByMonth(str.AsSpan());
@@ -326,12 +326,12 @@ public abstract class RecurrenceRule : IRecurrenceRule
         return [];
     }
 
-    private static List<Month> ParseByMonth(ReadOnlySpan<char> str)
+    private static List<int> ParseByMonth(ReadOnlySpan<char> str)
     {
         var months = SplitToMonthList(str);
         foreach (var month in months)
         {
-            if (!Enum.IsDefined(month))
+            if (month is < 1 or > 12)
                 throw new FormatException($"BYMONTH value '{month}' is invalid.");
         }
 
@@ -696,9 +696,9 @@ public abstract class RecurrenceRule : IRecurrenceRule
         return list;
     }
 
-    private static List<Month> SplitToMonthList(ReadOnlySpan<char> text)
+    private static List<int> SplitToMonthList(ReadOnlySpan<char> text)
     {
-        var list = new List<Month>();
+        var list = new List<int>();
         if (text.IsEmpty)
             return list;
 
@@ -710,9 +710,18 @@ public abstract class RecurrenceRule : IRecurrenceRule
             remaining = commaIndex >= 0 ? remaining[(commaIndex + 1)..] : [];
 
             var trimmed = part.Trim();
-            if (!trimmed.IsEmpty && Enum.TryParse<Month>(trimmed, ignoreCase: true, out var month))
+            if (trimmed.IsEmpty)
+                continue;
+
+            if (int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var monthValue))
             {
-                list.Add(month);
+                list.Add(monthValue);
+                continue;
+            }
+
+            if (Enum.TryParse<Month>(trimmed, ignoreCase: true, out var month))
+            {
+                list.Add((int)month);
             }
         }
 

--- a/src/Meziantou.Framework.Scheduling/RecurrenceRuleHumanizer.cs
+++ b/src/Meziantou.Framework.Scheduling/RecurrenceRuleHumanizer.cs
@@ -1,7 +1,7 @@
 namespace Meziantou.Framework.Scheduling;
 
 /// <summary>Provides functionality to convert recurrence rules to human-readable text.</summary>
-public abstract class RecurrenceRuleHumanizer
+internal abstract class RecurrenceRuleHumanizer
 {
     /// <summary>The English culture information.</summary>
     protected static readonly CultureInfo EnglishCultureInfo = GetCulture("en");

--- a/src/Meziantou.Framework.Scheduling/RecurrenceRuleHumanizerEnglish.cs
+++ b/src/Meziantou.Framework.Scheduling/RecurrenceRuleHumanizerEnglish.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.Framework.Scheduling;
 
-public sealed class RecurrenceRuleHumanizerEnglish : RecurrenceRuleHumanizer
+internal sealed class RecurrenceRuleHumanizerEnglish : RecurrenceRuleHumanizer
 {
     [Flags]
     private enum WeekdayHumanTextOptions
@@ -95,6 +95,14 @@ public sealed class RecurrenceRuleHumanizerEnglish : RecurrenceRuleHumanizer
             4 => "fourth",
             _ => Extensions.ToEnglishOrdinal(setPosition),
         };
+    }
+
+    private static string MonthToString(int month)
+    {
+        if (month is < 1 or > 12)
+            throw new ArgumentOutOfRangeException(nameof(month), month, message: null);
+
+        return EnglishCultureInfo.DateTimeFormat.GetMonthName(month);
     }
 
     protected override string GetText(DailyRecurrenceRule rrule, CultureInfo? cultureInfo)
@@ -311,7 +319,7 @@ public sealed class RecurrenceRuleHumanizerEnglish : RecurrenceRuleHumanizer
                 if (rrule.ByMonths is not null && rrule.ByMonths.Any())
                 {
                     sb.Append(" of ");
-                    sb.Append(rrule.ByMonths[0]);
+                    sb.Append(MonthToString(rrule.ByMonths[0]));
                 }
             }
             else
@@ -319,7 +327,7 @@ public sealed class RecurrenceRuleHumanizerEnglish : RecurrenceRuleHumanizer
                 if (rrule.ByMonths is not null && rrule.ByMonths.Any())
                 {
                     sb.Append(" on ");
-                    sb.Append(rrule.ByMonths[0]);
+                    sb.Append(MonthToString(rrule.ByMonths[0]));
                 }
 
                 sb.Append(" the ");
@@ -342,7 +350,7 @@ public sealed class RecurrenceRuleHumanizerEnglish : RecurrenceRuleHumanizer
             if (rrule.ByMonths is not null && rrule.ByMonths.Any())
             {
                 sb.Append(" of ");
-                sb.Append(rrule.ByMonths[0]);
+                sb.Append(MonthToString(rrule.ByMonths[0]));
             }
         }
 

--- a/src/Meziantou.Framework.Scheduling/RecurrenceRuleHumanizerFrench.cs
+++ b/src/Meziantou.Framework.Scheduling/RecurrenceRuleHumanizerFrench.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.Framework.Scheduling;
 
-public sealed class RecurrenceRuleHumanizerFrench : RecurrenceRuleHumanizer
+internal sealed class RecurrenceRuleHumanizerFrench : RecurrenceRuleHumanizer
 {
     private static readonly char[] PrecededByApostropheChars = ['a', 'e', 'i', 'o', 'u', 'y', 'h'];
 
@@ -336,22 +336,22 @@ public sealed class RecurrenceRuleHumanizerFrench : RecurrenceRuleHumanizer
         };
     }
 
-    private static string MonthToString(Month month)
+    private static string MonthToString(int month)
     {
         return month switch
         {
-            Month.January => "janvier",
-            Month.February => "février",
-            Month.March => "mars",
-            Month.April => "avril",
-            Month.May => "mai",
-            Month.June => "juin",
-            Month.July => "juillet",
-            Month.August => "aout",
-            Month.September => "septembre",
-            Month.October => "octobre",
-            Month.November => "novembre",
-            Month.December => "décembre",
+            1 => "janvier",
+            2 => "février",
+            3 => "mars",
+            4 => "avril",
+            5 => "mai",
+            6 => "juin",
+            7 => "juillet",
+            8 => "aout",
+            9 => "septembre",
+            10 => "octobre",
+            11 => "novembre",
+            12 => "décembre",
             _ => throw new ArgumentOutOfRangeException(nameof(month), month, message: null),
         };
     }

--- a/src/Meziantou.Framework.Scheduling/SecondlyRecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/SecondlyRecurrenceRule.cs
@@ -7,7 +7,7 @@ namespace Meziantou.Framework.Scheduling;
 /// var nextOccurrences = rrule.GetNextOccurrences(DateTime.Now).ToArray();
 /// </code>
 /// </example>
-public sealed class SecondlyRecurrenceRule : RecurrenceRule
+internal sealed class SecondlyRecurrenceRule : RecurrenceRule
 {
     /// <summary>Limits occurrences to specific days of the week.</summary>
     public IList<DayOfWeek> ByWeekDays { get; set; } = [];
@@ -19,7 +19,7 @@ public sealed class SecondlyRecurrenceRule : RecurrenceRule
         {
             var matches = true;
 
-            if (!IsEmpty(ByMonths) && !ByMonths.Contains((Month)current.Month))
+            if (!IsEmpty(ByMonths) && !ByMonths.Contains(current.Month))
                 matches = false;
 
             if (!IsEmpty(ByMonthDays) && !ByMonthDays.Contains(current.Day))
@@ -80,7 +80,7 @@ public sealed class SecondlyRecurrenceRule : RecurrenceRule
             if (!IsEmpty(ByMonths))
             {
                 sb.Append(";BYMONTH=");
-                sb.AppendJoin(',', ByMonths.Cast<int>());
+                sb.AppendJoin(',', ByMonths);
             }
 
             if (!IsEmpty(ByMonthDays))

--- a/src/Meziantou.Framework.Scheduling/WeeklyRecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/WeeklyRecurrenceRule.cs
@@ -7,7 +7,7 @@ namespace Meziantou.Framework.Scheduling;
 /// var nextOccurrences = rrule.GetNextOccurrences(DateTime.Now).ToArray();
 /// </code>
 /// </example>
-public sealed class WeeklyRecurrenceRule : RecurrenceRule
+internal sealed class WeeklyRecurrenceRule : RecurrenceRule
 {
     /// <summary>Limits occurrences to specific days of the week.</summary>
     public IList<DayOfWeek> ByWeekDays { get; set; } = new List<DayOfWeek>();
@@ -35,7 +35,7 @@ public sealed class WeeklyRecurrenceRule : RecurrenceRule
 
                     if (!IsEmpty(ByMonths))
                     {
-                        if (!ByMonths.Contains((Month)next.Month))
+                        if (!ByMonths.Contains(next.Month))
                         {
                             b = false;
                         }
@@ -128,7 +128,7 @@ public sealed class WeeklyRecurrenceRule : RecurrenceRule
             if (!IsEmpty(ByMonths))
             {
                 sb.Append(";BYMONTH=");
-                sb.AppendJoin(',', ByMonths.Cast<int>());
+                sb.AppendJoin(',', ByMonths);
             }
 
             if (!IsEmpty(ByMonthDays))

--- a/src/Meziantou.Framework.Scheduling/YearlyRecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/YearlyRecurrenceRule.cs
@@ -3,11 +3,11 @@ namespace Meziantou.Framework.Scheduling;
 /// <summary>Represents a yearly recurrence rule.</summary>
 /// <example>
 /// <code>
-/// var rrule = new YearlyRecurrenceRule { ByMonths = { Month.January }, ByMonthDays = { 1 } };
+/// var rrule = new YearlyRecurrenceRule { ByMonths = { 1 }, ByMonthDays = { 1 } };
 /// var nextOccurrences = rrule.GetNextOccurrences(DateTime.Now).ToArray();
 /// </code>
 /// </example>
-public sealed class YearlyRecurrenceRule : RecurrenceRule
+internal sealed class YearlyRecurrenceRule : RecurrenceRule
 {
     /// <summary>Limits occurrences to specific days of the month.</summary>
     public new IList<int>? ByMonthDays { get; set; }
@@ -16,7 +16,7 @@ public sealed class YearlyRecurrenceRule : RecurrenceRule
     public IList<ByDay>? ByWeekDays { get; set; }
 
     /// <summary>Limits occurrences to specific months.</summary>
-    public new IList<Month>? ByMonths { get; set; }
+    public new IList<int>? ByMonths { get; set; }
     //public IList<int> ByWeekNo { get; set; }
 
     /// <summary>Limits occurrences to specific days of the year (1-366).</summary>
@@ -241,9 +241,9 @@ public sealed class YearlyRecurrenceRule : RecurrenceRule
             result = [];
             foreach (var month in ByMonths.Distinct().Order())
             {
-                if (month is >= Month.January and <= Month.December)
+                if (month is >= 1 and <= 12)
                 {
-                    for (var dt = startOfYear.AddMonths((int)month - 1); dt.Month == (int)month; dt = dt.AddDays(1))
+                    for (var dt = startOfYear.AddMonths(month - 1); dt.Month == month; dt = dt.AddDays(1))
                     {
                         result.Add(dt);
                     }
@@ -309,7 +309,7 @@ public sealed class YearlyRecurrenceRule : RecurrenceRule
             if (!IsEmpty(ByMonths))
             {
                 sb.Append(";BYMONTH=");
-                sb.AppendJoin(',', ByMonths.Cast<int>());
+                sb.AppendJoin(',', ByMonths);
             }
 
             //if (!IsEmpty(ByWeekNo))


### PR DESCRIPTION
## Why
`RecurrenceRule` should stay public, but concrete recurrence rule implementations and related helper types are implementation details. This change intentionally narrows the public API surface and requires a major version bump.

## What changed
- Internalized recurrence implementation types in `Meziantou.Framework.Scheduling`:
  - `Daily/Weekly/Monthly/Yearly/Hourly/Minutely/SecondlyRecurrenceRule`
  - `ByDay`, `Month`, `Frequency`
  - `RecurrenceRuleHumanizer` and language-specific humanizer implementations
- Kept `RecurrenceRule` public and reshaped its month surface from `IList<Month>` to `IList<int>` (`1..12`) to avoid exposing internal types.
- Updated month parsing and humanization logic accordingly while preserving RRULE behavior.
- Bumped package version from `2.0.12` to `3.0.0`.
- Rebuilt the solution to regenerate API references and updated `ref/Meziantou.Framework.Scheduling.cs`.

## Notes for reviewers
- This is an intentional breaking API change for the Scheduling package.
- The reference API diff is the key artifact for validating the new public surface.