### PR TITLE
Use CsWin32-generated interop in ProjectedFileSystem

### DIFF
--- a/ref/Meziantou.Framework.Win32.ProjectedFileSystem.cs
+++ b/ref/Meziantou.Framework.Win32.ProjectedFileSystem.cs
@@ -3,7 +3,7 @@
 
 namespace Meziantou.Framework.Win32.ProjectedFileSystem
 {
-    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows10.0.17763")]
     public sealed class FileNameComparer : System.Collections.Generic.IComparer<string>
     {
         public static System.Collections.Generic.IComparer<string> Instance { get => throw null; }
@@ -69,7 +69,7 @@ namespace Meziantou.Framework.Win32.ProjectedFileSystem
         PRJ_UPDATE_MAX_VAL = 64
     }
 
-    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows10.0.17763")]
     public abstract class ProjectedFileSystemBase : System.IDisposable
     {
         public string RootFolder { get => throw null; }

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/DirectoryEnumerationSession.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/DirectoryEnumerationSession.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.Framework.Win32.ProjectedFileSystem;
 
-[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+[System.Runtime.Versioning.SupportedOSPlatform("windows10.0.17763")]
 internal sealed class DirectoryEnumerationSession : IDisposable
 {
     private IEnumerator<ProjectedFileSystemEntry>? _enumerator;

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/FileNameComparer.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/FileNameComparer.cs
@@ -3,7 +3,7 @@ using System.Runtime.Versioning;
 namespace Meziantou.Framework.Win32.ProjectedFileSystem;
 
 /// <summary>Compares file names using Windows file name comparison rules.</summary>
-[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("windows10.0.17763")]
 public sealed class FileNameComparer : IComparer<string?>
 {
     private FileNameComparer()

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/Meziantou.Framework.Win32.ProjectedFileSystem.csproj
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/Meziantou.Framework.Win32.ProjectedFileSystem.csproj
@@ -7,4 +7,15 @@
     <Version>2.0.11</Version>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="NativeMethods.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.275">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/Meziantou.Framework.Win32.ProjectedFileSystem.csproj
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/Meziantou.Framework.Win32.ProjectedFileSystem.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="NativeMethods.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.275">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/NativeMethods.txt
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/NativeMethods.txt
@@ -1,0 +1,16 @@
+PrjMarkDirectoryAsPlaceholder
+PrjStartVirtualizing
+PrjStopVirtualizing
+PrjFillDirEntryBuffer
+PrjWritePlaceholderInfo
+PrjFileNameCompare
+PrjFileNameMatch
+PrjGetVirtualizationInstanceInfo
+PrjAllocateAlignedBuffer
+PrjFreeAlignedBuffer
+PrjWriteFileData
+PrjClearNegativePathCache
+PrjGetOnDiskFileState
+PrjDeleteFile
+PrjUpdateFileIfNeeded
+PrjCompleteCommand

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
@@ -1,253 +1,136 @@
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using ProjFs = Windows.Win32.Storage.ProjectedFileSystem;
 
 namespace Meziantou.Framework.Win32.ProjectedFileSystem;
 
-internal static partial class NativeMethods
+[SupportedOSPlatform("windows10.0.17763")]
+internal static class NativeMethods
 {
-    // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17763.0\um\projectedfslib.h
-
-    [LibraryImport("ProjectedFSLib.dll", StringMarshalling = StringMarshalling.Utf16)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial HResult PrjMarkDirectoryAsPlaceholder(string rootPathName, string? targetPathName, IntPtr versionInfo, in Guid virtualizationInstanceID);
-
-    [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjStartVirtualizing(string virtualizationRootPath, in PrjCallbacks callbacks, IntPtr instanceContext, in PRJ_STARTVIRTUALIZING_OPTIONS options, out ProjFSSafeHandle namespaceVirtualizationContext);
-
-    [LibraryImport("ProjectedFSLib.dll")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial HResult PrjStopVirtualizing(IntPtr namespaceVirtualizationContext);
-
-    [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjFillDirEntryBuffer(string fileName, in PRJ_FILE_BASIC_INFO callbacks, IntPtr dirEntryBufferHandle);
-
-    [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjWritePlaceholderInfo(ProjFSSafeHandle namespaceVirtualizationContext, string destinationFileName, in PRJ_PLACEHOLDER_INFO placeholderInfo, uint placeholderInfoSize);
-
-    [LibraryImport("ProjectedFSLib.dll", StringMarshalling = StringMarshalling.Utf16)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial int PrjFileNameCompare(string fileName1, string fileName2);
-
-    [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern bool PrjFileNameMatch(string fileNameToCheck, string pattern);
-
-    [LibraryImport("ProjectedFSLib.dll")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial HResult PrjGetVirtualizationInstanceInfo(ProjFSSafeHandle namespaceVirtualizationContext, out PRJ_VIRTUALIZATION_INSTANCE_INFO virtualizationInstanceInfo);
-
-    [LibraryImport("ProjectedFSLib.dll")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial IntPtr PrjAllocateAlignedBuffer(ProjFSSafeHandle namespaceVirtualizationContext, uint size);
-
-    [LibraryImport("ProjectedFSLib.dll")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial void PrjFreeAlignedBuffer(IntPtr buffer);
-
-    [LibraryImport("ProjectedFSLib.dll")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial HResult PrjWriteFileData(ProjFSSafeHandle namespaceVirtualizationContext, in Guid dataStreamId, IntPtr buffer, ulong byteOffset, uint length);
-
-    [LibraryImport("ProjectedFSLib.dll")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial HResult PrjClearNegativePathCache(ProjFSSafeHandle namespaceVirtualizationContext, out uint totalEntryNumber);
-
-    [LibraryImport("ProjectedFSLib.dll", StringMarshalling = StringMarshalling.Utf16)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial HResult PrjGetOnDiskFileState(string destinationFileName, out PRJ_FILE_STATE fileState);
-
-    [LibraryImport("ProjectedFSLib.dll", StringMarshalling = StringMarshalling.Utf16)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial HResult PrjDeleteFile(ProjFSSafeHandle namespaceVirtualizationContext, string destinationFileName, PRJ_UPDATE_TYPES updateFlags, out PRJ_UPDATE_FAILURE_CAUSES failureReason);
-
-    [DllImport("ProjectedFSLib.dll", CharSet = CharSet.Unicode)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern HResult PrjUpdateFileIfNeeded(ProjFSSafeHandle namespaceVirtualizationContext, string destinationFileName, in PRJ_PLACEHOLDER_INFO placeholderInfo, uint placeholderInfoSize, PRJ_UPDATE_TYPES updateFlags, out PRJ_UPDATE_FAILURE_CAUSES failureReason);
-
-    [LibraryImport("ProjectedFSLib.dll")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial HResult PrjCompleteCommand(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, IntPtr extendedParameters);
-
-    [LibraryImport("ProjectedFSLib.dll", EntryPoint = nameof(PrjCompleteCommand))]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial HResult PrjCompleteCommandWithExtendedParameters(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, in PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS extendedParameters);
-
-    [StructLayout(LayoutKind.Explicit)]
-    internal struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS
+    internal static HResult PrjMarkDirectoryAsPlaceholder(string rootPathName, string? targetPathName, IntPtr versionInfo, in Guid virtualizationInstanceID)
     {
-        [FieldOffset(0)]
-        public PRJ_COMPLETE_COMMAND_TYPE CommandType;
+        if (versionInfo != IntPtr.Zero)
+            throw new NotSupportedException($"'{nameof(versionInfo)}' must be {nameof(IntPtr)}.{nameof(IntPtr.Zero)}");
 
-        [FieldOffset(4)]
-        public PRJ_NOTIFY_TYPES NotificationMask;
-
-        [FieldOffset(4)]
-        public IntPtr DirEntryBufferHandle;
+        return ToHResult(PInvoke.PrjMarkDirectoryAsPlaceholder(rootPathName, targetPathName, versionInfo: null, in virtualizationInstanceID));
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    internal unsafe struct PRJ_PLACEHOLDER_INFO
+    internal static unsafe HResult PrjStartVirtualizing(string virtualizationRootPath, in ProjFs.PRJ_CALLBACKS callbacks, IntPtr instanceContext, in ProjFs.PRJ_STARTVIRTUALIZING_OPTIONS options, out ProjFSSafeHandle namespaceVirtualizationContext)
     {
-        public PRJ_FILE_BASIC_INFO FileBasicInfo;
-        public EaInformation EaInformation;
-        public SecurityInformation SecurityInformation;
-        public StreamsInformation StreamsInformation;
-        public PRJ_PLACEHOLDER_VERSION_INFO VersionInfo;
-        public byte VariableData;
+        var hr = ToHResult(PInvoke.PrjStartVirtualizing(virtualizationRootPath, in callbacks, (void*)instanceContext, options, out var context));
+        namespaceVirtualizationContext = new ProjFSSafeHandle((IntPtr)context, ownHandle: true);
+        return hr;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct EaInformation
+    internal static HResult PrjStopVirtualizing(IntPtr namespaceVirtualizationContext)
     {
-        public uint EaBufferSize;
-        public uint OffsetToFirstEa;
+        PInvoke.PrjStopVirtualizing((ProjFs.PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT)namespaceVirtualizationContext);
+        return HResult.S_OK;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct SecurityInformation
+    internal static HResult PrjFillDirEntryBuffer(string fileName, in ProjFs.PRJ_FILE_BASIC_INFO callbacks, IntPtr dirEntryBufferHandle)
     {
-        public uint SecurityBufferSize;
-        public uint OffsetToSecurityDescriptor;
+        return ToHResult(PInvoke.PrjFillDirEntryBuffer(fileName, callbacks, (ProjFs.PRJ_DIR_ENTRY_BUFFER_HANDLE)dirEntryBufferHandle));
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct StreamsInformation
+    internal static unsafe HResult PrjWritePlaceholderInfo(ProjFSSafeHandle namespaceVirtualizationContext, string destinationFileName, in ProjFs.PRJ_PLACEHOLDER_INFO placeholderInfo, uint placeholderInfoSize)
     {
-        public uint StreamsInfoBufferSize;
-        public uint OffsetToFirstStreamInfo;
+        fixed (ProjFs.PRJ_PLACEHOLDER_INFO* placeholderInfoPointer = &placeholderInfo)
+        {
+            var placeholderInfoData = new ReadOnlySpan<byte>((byte*)placeholderInfoPointer, checked((int)placeholderInfoSize));
+            return ToHResult(PInvoke.PrjWritePlaceholderInfo(ToContext(namespaceVirtualizationContext), destinationFileName, placeholderInfoData));
+        }
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct PRJ_PLACEHOLDER_VERSION_INFO
+    internal static int PrjFileNameCompare(string fileName1, string fileName2)
     {
-        public const int PRJ_PLACEHOLDER_ID_LENGTH = 128;
-
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 128)]
-        public byte[] ProviderID;
-
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 128)]
-        public byte[] ContentID;
+        return PInvoke.PrjFileNameCompare(fileName1, fileName2);
     }
 
-    // Structure configuring the projection provider callbacks.
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct PrjCallbacks
+    internal static bool PrjFileNameMatch(string fileNameToCheck, string pattern)
     {
-        public PrjStartDirectoryEnumerationCb StartDirectoryEnumerationCallback;
-        public PrjEndDirectoryEnumerationCb EndDirectoryEnumerationCallback;
-        public PrjGetDirectoryEnumerationCb GetDirectoryEnumerationCallback;
-        public PrjGetPlaceholderInfoCb GetPlaceholderInfoCallback;
-        public PrjGetFileDataCb GetFileDataCallback;
-        public PrjQueryFileNameCb QueryFileNameCallback;
-        public PrjNotificationCb NotificationCallback;
-        public PrjCancelCommandCb CancelCommandCallback;
+        return PInvoke.PrjFileNameMatch(fileNameToCheck, pattern);
     }
 
-    // Callback signatures.
-    internal delegate HResult PrjStartDirectoryEnumerationCb(in PrjCallbackData callbackData, in Guid enumerationId);
-    internal delegate HResult PrjGetDirectoryEnumerationCb(in PrjCallbackData callbackData, in Guid enumerationId, [MarshalAs(UnmanagedType.LPWStr), In] string searchExpression, IntPtr dirEntryBufferHandle);
-    internal delegate HResult PrjEndDirectoryEnumerationCb(in PrjCallbackData callbackData, in Guid enumerationId);
-
-    internal delegate HResult PrjGetPlaceholderInfoCb(in PrjCallbackData callbackData);
-    internal delegate HResult PrjGetFileDataCb(in PrjCallbackData callbackData, ulong byteOffset, uint length);
-    internal delegate HResult PrjQueryFileNameCb(in PrjCallbackData callbackData);
-    internal delegate HResult PrjNotificationCb(in PrjCallbackData callbackData, bool isDirectory, PRJ_NOTIFICATION notification, [MarshalAs(UnmanagedType.LPWStr), In] string destinationFileName, [In, Out] IntPtr operationParameters);
-    internal delegate HResult PrjCancelCommandCb(in PrjCallbackData callbackData);
-
-    // Callback data passed to each of the callbacks above.
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    internal struct PrjCallbackData
+    internal static HResult PrjGetVirtualizationInstanceInfo(ProjFSSafeHandle namespaceVirtualizationContext, out ProjFs.PRJ_VIRTUALIZATION_INSTANCE_INFO virtualizationInstanceInfo)
     {
-        public uint Size;
-        public PRJ_CALLBACK_DATA_FLAGS Flags;
-        public IntPtr NamespaceVirtualizationContext;
-        public int CommandId;
-        public Guid FileId;
-        public Guid DataStreamId;
-        public string FilePathName;
-        public IntPtr VersionInfo;
-        public uint TriggeringProcessId;
-        public string TriggeringProcessImageFileName;
-        public IntPtr InstanceContext;
+        return ToHResult(PInvoke.PrjGetVirtualizationInstanceInfo(ToContext(namespaceVirtualizationContext), out virtualizationInstanceInfo));
     }
 
-    internal enum PRJ_CALLBACK_DATA_FLAGS : uint
+    internal static unsafe IntPtr PrjAllocateAlignedBuffer(ProjFSSafeHandle namespaceVirtualizationContext, uint size)
     {
-        PRJ_CB_DATA_FLAG_ENUM_RESTART_SCAN = 1,
-        PRJ_CB_DATA_FLAG_ENUM_RETURN_SINGLE_ENTRY = 2,
+        return (IntPtr)PInvoke.PrjAllocateAlignedBuffer(ToContext(namespaceVirtualizationContext), (nuint)size);
     }
 
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    internal struct PRJ_FILE_BASIC_INFO
+    internal static unsafe void PrjFreeAlignedBuffer(IntPtr buffer)
     {
-        public bool IsDirectory;
-        public long FileSize;
-        public LARGE_INTEGER CreationTime;
-        public LARGE_INTEGER LastAccessTime;
-        public LARGE_INTEGER LastWriteTime;
-        public LARGE_INTEGER ChangeTime;
-        public FileAttributes FileAttributes;
+        PInvoke.PrjFreeAlignedBuffer((void*)buffer);
     }
 
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    internal struct PRJ_VIRTUALIZATION_INSTANCE_INFO
+    internal static unsafe HResult PrjWriteFileData(ProjFSSafeHandle namespaceVirtualizationContext, in Guid dataStreamId, IntPtr buffer, ulong byteOffset, uint length)
     {
-        public Guid InstanceID;
-        public uint WriteAlignment;
+        var payload = new ReadOnlySpan<byte>((void*)buffer, checked((int)length));
+        return ToHResult(PInvoke.PrjWriteFileData(ToContext(namespaceVirtualizationContext), in dataStreamId, payload, byteOffset));
     }
 
-    [StructLayout(LayoutKind.Explicit, Size = 8)]
-    internal struct LARGE_INTEGER
+    internal static HResult PrjClearNegativePathCache(ProjFSSafeHandle namespaceVirtualizationContext, out uint totalEntryNumber)
     {
-        [FieldOffset(0)] public long QuadPart;
-        [FieldOffset(0)] public uint LowPart;
-        [FieldOffset(4)] public int HighPart;
+        return ToHResult(PInvoke.PrjClearNegativePathCache(ToContext(namespaceVirtualizationContext), out totalEntryNumber));
     }
 
-    internal enum PRJ_STARTVIRTUALIZING_FLAGS
+    internal static HResult PrjGetOnDiskFileState(string destinationFileName, out PRJ_FILE_STATE fileState)
     {
-        PRJ_FLAG_NONE,
-        PRJ_FLAG_USE_NEGATIVE_PATH_CACHE,
-    };
-
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct PRJ_STARTVIRTUALIZING_OPTIONS
-    {
-        public PRJ_STARTVIRTUALIZING_FLAGS Flags;
-        public uint PoolThreadCount;
-        public uint ConcurrentThreadCount;
-        public IntPtr NotificationMappings;
-        public uint NotificationMappingsCount;
+        var hr = ToHResult(PInvoke.PrjGetOnDiskFileState(destinationFileName, out var nativeFileState));
+        fileState = (PRJ_FILE_STATE)nativeFileState;
+        return hr;
     }
 
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    internal struct PRJ_NOTIFICATION_MAPPING
+    internal static HResult PrjDeleteFile(ProjFSSafeHandle namespaceVirtualizationContext, string destinationFileName, PRJ_UPDATE_TYPES updateFlags, out PRJ_UPDATE_FAILURE_CAUSES failureReason)
     {
-        public PRJ_NOTIFY_TYPES NotificationBitMask;
-        public string NotificationRoot;
+        var hr = ToHResult(PInvoke.PrjDeleteFile(ToContext(namespaceVirtualizationContext), destinationFileName, (ProjFs.PRJ_UPDATE_TYPES)updateFlags, out var nativeFailureReason));
+        failureReason = (PRJ_UPDATE_FAILURE_CAUSES)nativeFailureReason;
+        return hr;
     }
 
-    internal enum PRJ_NOTIFICATION
+    internal static unsafe HResult PrjUpdateFileIfNeeded(ProjFSSafeHandle namespaceVirtualizationContext, string destinationFileName, in ProjFs.PRJ_PLACEHOLDER_INFO placeholderInfo, uint placeholderInfoSize, PRJ_UPDATE_TYPES updateFlags, out PRJ_UPDATE_FAILURE_CAUSES failureReason)
     {
-        PRJ_NOTIFICATION_FILE_OPENED = 0x00000002,
-        PRJ_NOTIFICATION_NEW_FILE_CREATED = 0x00000004,
-        PRJ_NOTIFICATION_FILE_OVERWRITTEN = 0x00000008,
-        PRJ_NOTIFICATION_PRE_DELETE = 0x00000010,
-        PRJ_NOTIFICATION_PRE_RENAME = 0x00000020,
-        PRJ_NOTIFICATION_PRE_SET_HARDLINK = 0x00000040,
-        PRJ_NOTIFICATION_FILE_RENAMED = 0x00000080,
-        PRJ_NOTIFICATION_HARDLINK_CREATED = 0x00000100,
-        PRJ_NOTIFICATION_FILE_HANDLE_CLOSED_NO_MODIFICATION = 0x00000200,
-        PRJ_NOTIFICATION_FILE_HANDLE_CLOSED_FILE_MODIFIED = 0x00000400,
-        PRJ_NOTIFICATION_FILE_HANDLE_CLOSED_FILE_DELETED = 0x00000800,
-        PRJ_NOTIFICATION_FILE_PRE_CONVERT_TO_FULL = 0x00001000,
+        ProjFs.PRJ_UPDATE_FAILURE_CAUSES nativeFailureReason;
+        fixed (ProjFs.PRJ_PLACEHOLDER_INFO* placeholderInfoPointer = &placeholderInfo)
+        {
+            var placeholderInfoData = new ReadOnlySpan<byte>((byte*)placeholderInfoPointer, checked((int)placeholderInfoSize));
+            var hr = ToHResult(PInvoke.PrjUpdateFileIfNeeded(ToContext(namespaceVirtualizationContext), destinationFileName, placeholderInfoData, (ProjFs.PRJ_UPDATE_TYPES)updateFlags, out nativeFailureReason));
+            failureReason = (PRJ_UPDATE_FAILURE_CAUSES)nativeFailureReason;
+            return hr;
+        }
     }
 
-    internal enum PRJ_COMPLETE_COMMAND_TYPE
+    internal static HResult PrjCompleteCommand(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, IntPtr extendedParameters)
     {
-        PRJ_COMPLETE_COMMAND_TYPE_NOTIFICATION = 1,
-        PRJ_COMPLETE_COMMAND_TYPE_ENUMERATION = 2,
+        ProjFs.PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS? parameters = extendedParameters == IntPtr.Zero
+            ? null
+            : Marshal.PtrToStructure<ProjFs.PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS>(extendedParameters);
+        return ToHResult(PInvoke.PrjCompleteCommand(ToContext(namespaceVirtualizationContext), commandId, ToHRESULT(completionResult), parameters));
+    }
+
+    internal static HResult PrjCompleteCommandWithExtendedParameters(ProjFSSafeHandle namespaceVirtualizationContext, int commandId, HResult completionResult, in ProjFs.PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS extendedParameters)
+    {
+        return ToHResult(PInvoke.PrjCompleteCommand(ToContext(namespaceVirtualizationContext), commandId, ToHRESULT(completionResult), extendedParameters));
+    }
+
+    private static ProjFs.PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT ToContext(ProjFSSafeHandle handle)
+    {
+        return (ProjFs.PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT)handle.DangerousGetHandle();
+    }
+
+    private static HResult ToHResult(HRESULT value)
+    {
+        return new HResult(value.Value);
+    }
+
+    private static HRESULT ToHRESULT(HResult value)
+    {
+        return (HRESULT)value.Value;
     }
 }

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/ProjFSSafeHandle.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/ProjFSSafeHandle.cs
@@ -1,7 +1,9 @@
 using Microsoft.Win32.SafeHandles;
+using System.Runtime.Versioning;
 
 namespace Meziantou.Framework.Win32.ProjectedFileSystem;
 
+[SupportedOSPlatform("windows10.0.17763")]
 internal sealed class ProjFSSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
 {
     public ProjFSSafeHandle()

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
@@ -3,6 +3,8 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
+using Windows.Win32.Foundation;
+using ProjFs = Windows.Win32.Storage.ProjectedFileSystem;
 
 namespace Meziantou.Framework.Win32.ProjectedFileSystem;
 
@@ -43,7 +45,7 @@ namespace Meziantou.Framework.Win32.ProjectedFileSystem;
 /// </code>
 /// </example>
 // https://github.com/Microsoft/Windows-classic-samples/blob/master/Samples/ProjectedFileSystem/regfsProvider.cpp
-[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("windows10.0.17763")]
 public abstract class ProjectedFileSystemBase : IDisposable
 {
     // Remaining work
@@ -52,10 +54,10 @@ public abstract class ProjectedFileSystemBase : IDisposable
 
     private readonly Guid _virtualizationInstanceId;
     private ProjFSSafeHandle? _instanceHandle;
-    private NativeMethods.PrjCallbacks _callbacks;
+    private ProjFs.PRJ_CALLBACKS _callbacks;
+    private GCHandle _instanceContextHandle;
 
     private readonly ConcurrentDictionary<Guid, DirectoryEnumerationSession> _activeEnumerations = new();
-    private long _context;
 
     /// <summary>Gets the root folder path where the virtual file system is mounted.</summary>
     public string RootFolder { get; }
@@ -81,7 +83,7 @@ public abstract class ProjectedFileSystemBase : IDisposable
     /// <summary>Starts the virtual file system with the specified options.</summary>
     /// <param name="options">Configuration options for the virtual file system. Can be null to use default settings.</param>
     /// <exception cref="NotSupportedException">Thrown when the Projected File System Windows feature is not installed.</exception>
-    public void Start(ProjectedFileSystemStartOptions? options)
+    public unsafe void Start(ProjectedFileSystemStartOptions? options)
     {
         if (_instanceHandle is not null)
             return;
@@ -97,53 +99,74 @@ public abstract class ProjectedFileSystemBase : IDisposable
         }
 
         // Set up the callback table for the projection provider.
-        _callbacks = new NativeMethods.PrjCallbacks
+        _callbacks = new ProjFs.PRJ_CALLBACKS
         {
-            StartDirectoryEnumerationCallback = StartDirectoryEnumerationCallback,
-            EndDirectoryEnumerationCallback = EndDirectoryEnumerationCallback,
-            GetDirectoryEnumerationCallback = GetDirectoryEnumerationCallback,
-            GetPlaceholderInfoCallback = GetPlaceholderInfoCallback,
-            GetFileDataCallback = GetFileDataCallback,
-            CancelCommandCallback = CancelCommandCallback,
-            NotificationCallback = NotificationCallback,
-            QueryFileNameCallback = QueryFileNameCallback,
+            StartDirectoryEnumerationCallback = StartDirectoryEnumerationCallbackNative,
+            EndDirectoryEnumerationCallback = EndDirectoryEnumerationCallbackNative,
+            GetDirectoryEnumerationCallback = GetDirectoryEnumerationCallbackNative,
+            GetPlaceholderInfoCallback = GetPlaceholderInfoCallbackNative,
+            GetFileDataCallback = GetFileDataCallbackNative,
+            CancelCommandCallback = CancelCommandCallbackNative,
+            NotificationCallback = NotificationCallbackNative,
+            QueryFileNameCallback = QueryFileNameCallbackNative,
         };
 
-        var opt = new NativeMethods.PRJ_STARTVIRTUALIZING_OPTIONS();
-        var notificationMappingsPtr = IntPtr.Zero;
+        var opt = new ProjFs.PRJ_STARTVIRTUALIZING_OPTIONS();
+        ProjFs.PRJ_NOTIFICATION_MAPPING* notificationMappingsPointer = null;
+        IntPtr[]? notificationRoots = null;
+        var instanceContextHandle = GCHandle.Alloc(this);
         try
         {
             if (options is not null)
             {
-                opt.Flags = options.UseNegativePathCache ? NativeMethods.PRJ_STARTVIRTUALIZING_FLAGS.PRJ_FLAG_USE_NEGATIVE_PATH_CACHE : NativeMethods.PRJ_STARTVIRTUALIZING_FLAGS.PRJ_FLAG_NONE;
+                opt.Flags = options.UseNegativePathCache ? ProjFs.PRJ_STARTVIRTUALIZING_FLAGS.PRJ_FLAG_USE_NEGATIVE_PATH_CACHE : ProjFs.PRJ_STARTVIRTUALIZING_FLAGS.PRJ_FLAG_NONE;
 
-                var structureSize = Marshal.SizeOf<NativeMethods.PRJ_NOTIFICATION_MAPPING>();
-                notificationMappingsPtr = Marshal.AllocHGlobal(structureSize * options.Notifications.Count);
+                var structureSize = sizeof(ProjFs.PRJ_NOTIFICATION_MAPPING);
+                notificationRoots = new IntPtr[options.Notifications.Count];
+                notificationMappingsPointer = (ProjFs.PRJ_NOTIFICATION_MAPPING*)Marshal.AllocHGlobal(structureSize * options.Notifications.Count);
 
                 for (var i = 0; i < options.Notifications.Count; i++)
                 {
-                    var copy = new NativeMethods.PRJ_NOTIFICATION_MAPPING()
+                    var notificationRoot = options.Notifications[i].Path ?? "";
+                    notificationRoots[i] = Marshal.StringToHGlobalUni(notificationRoot);
+                    notificationMappingsPointer[i] = new ProjFs.PRJ_NOTIFICATION_MAPPING
                     {
-                        NotificationBitMask = options.Notifications[i].NotificationType,
-                        NotificationRoot = options.Notifications[i].Path ?? "",
+                        NotificationBitMask = (ProjFs.PRJ_NOTIFY_TYPES)options.Notifications[i].NotificationType,
+                        NotificationRoot = (char*)notificationRoots[i],
                     };
-
-                    Marshal.StructureToPtr(copy, IntPtr.Add(notificationMappingsPtr, structureSize * i), fDeleteOld: false);
                 }
 
-                opt.NotificationMappings = notificationMappingsPtr;
+                opt.NotificationMappings = notificationMappingsPointer;
                 opt.NotificationMappingsCount = (uint)options.Notifications.Count;
             }
 
-            var context = ++_context;
-            var hr = NativeMethods.PrjStartVirtualizing(RootFolder, in _callbacks, new IntPtr(context), in opt, out _instanceHandle);
+            var context = GCHandle.ToIntPtr(instanceContextHandle);
+            var hr = NativeMethods.PrjStartVirtualizing(RootFolder, in _callbacks, context, in opt, out _instanceHandle);
             hr.EnsureSuccess();
+            _instanceContextHandle = instanceContextHandle;
+            instanceContextHandle = default;
         }
         finally
         {
-            if (notificationMappingsPtr != IntPtr.Zero)
+            if (instanceContextHandle.IsAllocated)
             {
-                Marshal.FreeHGlobal(notificationMappingsPtr);
+                instanceContextHandle.Free();
+            }
+
+            if (notificationRoots is not null)
+            {
+                foreach (var notificationRoot in notificationRoots)
+                {
+                    if (notificationRoot != IntPtr.Zero)
+                    {
+                        Marshal.FreeHGlobal(notificationRoot);
+                    }
+                }
+            }
+
+            if (notificationMappingsPointer is not null)
+            {
+                Marshal.FreeHGlobal((IntPtr)notificationMappingsPointer);
             }
         }
     }
@@ -197,6 +220,12 @@ public abstract class ProjectedFileSystemBase : IDisposable
         _callbacks = default;
         _instanceHandle.Dispose();
         _instanceHandle = null;
+
+        if (_instanceContextHandle.IsAllocated)
+        {
+            _instanceContextHandle.Free();
+            _instanceContextHandle = default;
+        }
     }
 
     /// <summary>Determines whether a file name matches a pattern using Windows file name matching rules.</summary>
@@ -258,11 +287,151 @@ public abstract class ProjectedFileSystemBase : IDisposable
         Stop();
     }
 
-    private HResult QueryFileNameCallback(in NativeMethods.PrjCallbackData callbackData)
+    private static unsafe HRESULT QueryFileNameCallbackNative(ProjFs.PRJ_CALLBACK_DATA* callbackData)
+    {
+        if (callbackData is null)
+            return ToHRESULT(HResult.E_INVALIDARG);
+
+        try
+        {
+            var instance = GetInstance(callbackData);
+            return ToHRESULT(instance.QueryFileNameCallback(in *callbackData));
+        }
+        catch (Exception ex)
+        {
+            return (HRESULT)Marshal.GetHRForException(ex);
+        }
+    }
+
+    private static unsafe HRESULT StartDirectoryEnumerationCallbackNative(ProjFs.PRJ_CALLBACK_DATA* callbackData, Guid* enumerationId)
+    {
+        if (callbackData is null || enumerationId is null)
+            return ToHRESULT(HResult.E_INVALIDARG);
+
+        try
+        {
+            var instance = GetInstance(callbackData);
+            return ToHRESULT(instance.StartDirectoryEnumerationCallback(in *callbackData, in *enumerationId));
+        }
+        catch (Exception ex)
+        {
+            return (HRESULT)Marshal.GetHRForException(ex);
+        }
+    }
+
+    private static unsafe HRESULT EndDirectoryEnumerationCallbackNative(ProjFs.PRJ_CALLBACK_DATA* callbackData, Guid* enumerationId)
+    {
+        if (callbackData is null || enumerationId is null)
+            return ToHRESULT(HResult.E_INVALIDARG);
+
+        try
+        {
+            var instance = GetInstance(callbackData);
+            return ToHRESULT(instance.EndDirectoryEnumerationCallback(in *callbackData, in *enumerationId));
+        }
+        catch (Exception ex)
+        {
+            return (HRESULT)Marshal.GetHRForException(ex);
+        }
+    }
+
+    private static unsafe HRESULT GetDirectoryEnumerationCallbackNative(ProjFs.PRJ_CALLBACK_DATA* callbackData, Guid* enumerationId, PCWSTR searchExpression, ProjFs.PRJ_DIR_ENTRY_BUFFER_HANDLE dirEntryBufferHandle)
+    {
+        if (callbackData is null || enumerationId is null)
+            return ToHRESULT(HResult.E_INVALIDARG);
+
+        try
+        {
+            var instance = GetInstance(callbackData);
+            return ToHRESULT(instance.GetDirectoryEnumerationCallback(in *callbackData, in *enumerationId, searchExpression.ToString() ?? "", (IntPtr)dirEntryBufferHandle));
+        }
+        catch (Exception ex)
+        {
+            return (HRESULT)Marshal.GetHRForException(ex);
+        }
+    }
+
+    private static unsafe HRESULT GetPlaceholderInfoCallbackNative(ProjFs.PRJ_CALLBACK_DATA* callbackData)
+    {
+        if (callbackData is null)
+            return ToHRESULT(HResult.E_INVALIDARG);
+
+        try
+        {
+            var instance = GetInstance(callbackData);
+            return ToHRESULT(instance.GetPlaceholderInfoCallback(in *callbackData));
+        }
+        catch (Exception ex)
+        {
+            return (HRESULT)Marshal.GetHRForException(ex);
+        }
+    }
+
+    private static unsafe HRESULT GetFileDataCallbackNative(ProjFs.PRJ_CALLBACK_DATA* callbackData, ulong byteOffset, uint length)
+    {
+        if (callbackData is null)
+            return ToHRESULT(HResult.E_INVALIDARG);
+
+        try
+        {
+            var instance = GetInstance(callbackData);
+            return ToHRESULT(instance.GetFileDataCallback(in *callbackData, byteOffset, length));
+        }
+        catch (Exception ex)
+        {
+            return (HRESULT)Marshal.GetHRForException(ex);
+        }
+    }
+
+    private static unsafe HRESULT NotificationCallbackNative(ProjFs.PRJ_CALLBACK_DATA* callbackData, BOOLEAN isDirectory, ProjFs.PRJ_NOTIFICATION notification, PCWSTR destinationFileName, ProjFs.PRJ_NOTIFICATION_PARAMETERS* operationParameters)
+    {
+        if (callbackData is null)
+            return ToHRESULT(HResult.E_INVALIDARG);
+
+        try
+        {
+            return ToHRESULT(NotificationCallback(in *callbackData, isDirectory, notification, destinationFileName.ToString() ?? "", (IntPtr)operationParameters));
+        }
+        catch (Exception ex)
+        {
+            return (HRESULT)Marshal.GetHRForException(ex);
+        }
+    }
+
+    private static unsafe void CancelCommandCallbackNative(ProjFs.PRJ_CALLBACK_DATA* callbackData)
+    {
+        if (callbackData is null)
+            return;
+
+        try
+        {
+            _ = CancelCommandCallback(in *callbackData);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine(ex);
+        }
+    }
+
+    private static unsafe ProjectedFileSystemBase GetInstance(ProjFs.PRJ_CALLBACK_DATA* callbackData)
+    {
+        if (callbackData->InstanceContext is null)
+            throw new InvalidOperationException("Cannot resolve callback instance context");
+
+        var handle = GCHandle.FromIntPtr((IntPtr)callbackData->InstanceContext);
+        return (ProjectedFileSystemBase)handle.Target!;
+    }
+
+    private static HRESULT ToHRESULT(HResult value)
+    {
+        return (HRESULT)value.Value;
+    }
+
+    private HResult QueryFileNameCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData)
     {
         return ExecuteCallback(
             in callbackData,
-            QueryFileNameCallbackAsync(callbackData.FilePathName),
+            QueryFileNameCallbackAsync(callbackData.FilePathName.ToString() ?? ""),
             extendedParameters: null);
     }
 
@@ -272,23 +441,23 @@ public abstract class ProjectedFileSystemBase : IDisposable
         return entry is null ? HResult.E_FILENOTFOUND : HResult.S_OK;
     }
 
-    private static HResult NotificationCallback(in NativeMethods.PrjCallbackData callbackData, bool isDirectory, NativeMethods.PRJ_NOTIFICATION notification, string destinationFileName, IntPtr operationParameters)
+    private static HResult NotificationCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData, bool isDirectory, ProjFs.PRJ_NOTIFICATION notification, string destinationFileName, IntPtr operationParameters)
     {
         Debug.WriteLine($"{notification} {callbackData.FilePathName} {callbackData.Flags}");
         return HResult.S_OK;
     }
 
-    private static HResult CancelCommandCallback(in NativeMethods.PrjCallbackData callbackData)
+    private static HResult CancelCommandCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData)
     {
         Debug.WriteLine($"CancelCommandCallback {callbackData.FilePathName}");
         return HResult.S_OK;
     }
 
-    private HResult StartDirectoryEnumerationCallback(in NativeMethods.PrjCallbackData callbackData, in Guid enumerationId)
+    private HResult StartDirectoryEnumerationCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData, in Guid enumerationId)
     {
         return ExecuteCallback(
             in callbackData,
-            StartDirectoryEnumerationCallbackAsync(callbackData.FilePathName, enumerationId),
+            StartDirectoryEnumerationCallbackAsync(callbackData.FilePathName.ToString() ?? "", enumerationId),
             extendedParameters: null);
     }
 
@@ -299,7 +468,7 @@ public abstract class ProjectedFileSystemBase : IDisposable
         return HResult.S_OK;
     }
 
-    private HResult EndDirectoryEnumerationCallback(in NativeMethods.PrjCallbackData callbackData, in Guid enumerationId)
+    private HResult EndDirectoryEnumerationCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData, in Guid enumerationId)
     {
         if (_activeEnumerations.TryRemove(enumerationId, out _))
             return HResult.S_OK;
@@ -307,14 +476,14 @@ public abstract class ProjectedFileSystemBase : IDisposable
         return HResult.E_INVALIDARG;
     }
 
-    private HResult GetDirectoryEnumerationCallback(in NativeMethods.PrjCallbackData callbackData, in Guid enumerationId, string searchExpression, IntPtr dirEntryBufferHandle)
+    private HResult GetDirectoryEnumerationCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData, in Guid enumerationId, string searchExpression, IntPtr dirEntryBufferHandle)
     {
         if (!_activeEnumerations.TryGetValue(enumerationId, out var session))
         {
             return HResult.E_INVALIDARG;
         }
 
-        if ((callbackData.Flags & NativeMethods.PRJ_CALLBACK_DATA_FLAGS.PRJ_CB_DATA_FLAG_ENUM_RESTART_SCAN) == NativeMethods.PRJ_CALLBACK_DATA_FLAGS.PRJ_CB_DATA_FLAG_ENUM_RESTART_SCAN)
+        if ((callbackData.Flags & ProjFs.PRJ_CALLBACK_DATA_FLAGS.PRJ_CB_DATA_FLAG_ENUM_RESTART_SCAN) == ProjFs.PRJ_CALLBACK_DATA_FLAGS.PRJ_CB_DATA_FLAG_ENUM_RESTART_SCAN)
         {
             session.Reset();
         }
@@ -322,7 +491,7 @@ public abstract class ProjectedFileSystemBase : IDisposable
         ProjectedFileSystemEntry? entry;
         while ((entry = session.GetNextEntry()) is not null)
         {
-            var info = new NativeMethods.PRJ_FILE_BASIC_INFO
+            var info = new ProjFs.PRJ_FILE_BASIC_INFO
             {
                 FileSize = entry.Length,
                 IsDirectory = entry.IsDirectory,
@@ -339,11 +508,11 @@ public abstract class ProjectedFileSystemBase : IDisposable
         return HResult.S_OK;
     }
 
-    private HResult GetPlaceholderInfoCallback(in NativeMethods.PrjCallbackData callbackData)
+    private HResult GetPlaceholderInfoCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData)
     {
         return ExecuteCallback(
             in callbackData,
-            GetPlaceholderInfoCallbackAsync(callbackData.FilePathName, callbackData.NamespaceVirtualizationContext),
+            GetPlaceholderInfoCallbackAsync(callbackData.FilePathName.ToString() ?? "", callbackData.NamespaceVirtualizationContext),
             extendedParameters: null);
     }
 
@@ -353,7 +522,7 @@ public abstract class ProjectedFileSystemBase : IDisposable
         if (entry is null)
             return HResult.E_FILENOTFOUND;
 
-        var info = new NativeMethods.PRJ_PLACEHOLDER_INFO();
+        var info = new ProjFs.PRJ_PLACEHOLDER_INFO();
         info.FileBasicInfo.IsDirectory = entry.IsDirectory;
         info.FileBasicInfo.FileSize = entry.Length;
 
@@ -367,12 +536,12 @@ public abstract class ProjectedFileSystemBase : IDisposable
         return hr;
     }
 
-    private HResult GetFileDataCallback(in NativeMethods.PrjCallbackData callbackData, ulong byteOffset, uint length)
+    private HResult GetFileDataCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData, ulong byteOffset, uint length)
     {
         return ExecuteCallback(
             in callbackData,
             GetFileDataCallbackAsync(
-                callbackData.FilePathName,
+                callbackData.FilePathName.ToString() ?? "",
                 callbackData.NamespaceVirtualizationContext,
                 callbackData.DataStreamId,
                 byteOffset,
@@ -479,7 +648,7 @@ public abstract class ProjectedFileSystemBase : IDisposable
         }
     }
 
-    private static HResult ExecuteCallback(in NativeMethods.PrjCallbackData callbackData, ValueTask<HResult> callbackResult, NativeMethods.PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS? extendedParameters)
+    private static HResult ExecuteCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData, ValueTask<HResult> callbackResult, ProjFs.PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS? extendedParameters)
     {
         if (callbackResult.IsCompletedSuccessfully)
             return callbackResult.Result;
@@ -488,7 +657,7 @@ public abstract class ProjectedFileSystemBase : IDisposable
         return HResult.ERROR_IO_PENDING;
     }
 
-    private static async Task CompleteCommandAsync(IntPtr namespaceVirtualizationContext, int commandId, Task<HResult> callbackTask, NativeMethods.PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS? extendedParameters)
+    private static async Task CompleteCommandAsync(IntPtr namespaceVirtualizationContext, int commandId, Task<HResult> callbackTask, ProjFs.PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS? extendedParameters)
     {
         HResult completionResult;
         try

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
@@ -443,6 +443,9 @@ public abstract class ProjectedFileSystemBase : IDisposable
 
     private static HResult NotificationCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData, bool isDirectory, ProjFs.PRJ_NOTIFICATION notification, string destinationFileName, IntPtr operationParameters)
     {
+        _ = isDirectory;
+        _ = destinationFileName;
+        _ = operationParameters;
         Debug.WriteLine($"{notification} {callbackData.FilePathName} {callbackData.Flags}");
         return HResult.S_OK;
     }
@@ -470,6 +473,7 @@ public abstract class ProjectedFileSystemBase : IDisposable
 
     private HResult EndDirectoryEnumerationCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData, in Guid enumerationId)
     {
+        _ = callbackData;
         if (_activeEnumerations.TryRemove(enumerationId, out _))
             return HResult.S_OK;
 
@@ -478,6 +482,7 @@ public abstract class ProjectedFileSystemBase : IDisposable
 
     private HResult GetDirectoryEnumerationCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData, in Guid enumerationId, string searchExpression, IntPtr dirEntryBufferHandle)
     {
+        _ = searchExpression;
         if (!_activeEnumerations.TryGetValue(enumerationId, out var session))
         {
             return HResult.E_INVALIDARG;


### PR DESCRIPTION
## Why
The ProjectedFileSystem package still carried a custom ProjFS interop layer with hand-written native declarations and callback types. Moving to CsWin32-generated bindings reduces maintenance burden and keeps the interop surface aligned with the Windows metadata.

## What changed
- Added CsWin32 configuration to the project:
  - `Microsoft.Windows.CsWin32` package reference
  - `NativeMethods.txt` with the required ProjFS APIs
- Replaced manual native declaration code in `Natives/NativeMethods.cs` with wrappers over generated `Windows.Win32` projected file system bindings.
- Updated `ProjectedFileSystemBase` callback registration and callback handling to use generated ProjFS callback/data types and instance context handling.
- Kept the existing package-facing enum surface (`PRJ_FILE_STATE`, `PRJ_UPDATE_TYPES`, `PRJ_UPDATE_FAILURE_CAUSES`, `PRJ_NOTIFY_TYPES`) and mapped to generated native enums at interop boundaries.
- Updated platform support attributes to the ProjFS minimum (`windows10.0.17763`) on relevant types, which also updates the ref file accordingly.

## Notes for reviewers
A non-obvious part of this migration is callback wiring: generated ProjFS callback fields are function pointers in the generated declarations, so callback dispatch now goes through native-signature-compatible static handlers that resolve back to the managed instance via `InstanceContext`.

## Validation
- `dotnet run ./eng/update-bom.cs`
- `dotnet run ./eng/update-readme.cs`
- `dotnet run ./eng/update-project-slnx.cs`
- `dotnet run ./eng/validate-testprojects-configuration.cs`
- `dotnet run ./eng/update-trimmable.cs`
- `dotnet build src/Meziantou.Framework.Win32.ProjectedFileSystem/Meziantou.Framework.Win32.ProjectedFileSystem.csproj /p:TreatsWarningsAsErrors=true`
- `DiffEngine_Disabled=true dotnet test tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests.csproj -f net10.0 -p:PlatformTarget=AnyCPU /p:PublicApiGeneratorGenerateOnBuild=false /p:TreatsWarningsAsErrors=true`