### PR TITLE
Use CsWin32 source generation for AMSI interop

### DIFF
--- a/src/Meziantou.Framework.Win32.Amsi/Internals/Amsi.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/Internals/Amsi.cs
@@ -1,8 +1,11 @@
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Windows.Win32;
+using Windows.Win32.System.Antimalware;
 
 namespace Meziantou.Framework.Win32;
 
+[SupportedOSPlatform("windows")]
+#pragma warning disable CA1416 // The containing APIs are Windows-only.
 internal static partial class Amsi
 {
     internal static bool AmsiResultIsMalware(AmsiResult result)
@@ -10,33 +13,42 @@ internal static partial class Amsi
         return result >= AmsiResult.AMSI_RESULT_DETECTED;
     }
 
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [LibraryImport("Amsi.dll", EntryPoint = "AmsiInitialize", StringMarshalling = StringMarshalling.Utf16)]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
-    internal static partial int AmsiInitialize(string appName, out AmsiContextSafeHandle amsiContext);
+    internal static int AmsiInitialize(string appName, out AmsiContextSafeHandle amsiContext)
+    {
+        var result = PInvoke.AmsiInitialize(appName, out var context);
+        amsiContext = new AmsiContextSafeHandle((nint)context);
+        return result;
+    }
 
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [LibraryImport("Amsi.dll", EntryPoint = "AmsiUninitialize")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
-    internal static partial void AmsiUninitialize(IntPtr amsiContext);
+    internal static void AmsiUninitialize(IntPtr amsiContext)
+    {
+        PInvoke.AmsiUninitialize((HAMSICONTEXT)amsiContext);
+    }
 
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [LibraryImport("Amsi.dll", EntryPoint = "AmsiOpenSession")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
-    internal static partial int AmsiOpenSession(AmsiContextSafeHandle amsiContext, out AmsiSessionSafeHandle session);
+    internal static int AmsiOpenSession(AmsiContextSafeHandle amsiContext, out AmsiSessionSafeHandle session)
+    {
+        var result = PInvoke.AmsiOpenSession((HAMSICONTEXT)amsiContext.DangerousGetHandle(), out var nativeSession);
+        session = new AmsiSessionSafeHandle(amsiContext, (nint)nativeSession);
+        return result;
+    }
 
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [LibraryImport("Amsi.dll", EntryPoint = "AmsiCloseSession")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
-    internal static partial void AmsiCloseSession(AmsiContextSafeHandle amsiContext, IntPtr session);
+    internal static void AmsiCloseSession(AmsiContextSafeHandle amsiContext, IntPtr session)
+    {
+        PInvoke.AmsiCloseSession((HAMSICONTEXT)amsiContext.DangerousGetHandle(), (HAMSISESSION)session);
+    }
 
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [LibraryImport("Amsi.dll", EntryPoint = "AmsiScanString", StringMarshalling = StringMarshalling.Utf16)]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
-    internal static partial int AmsiScanString(AmsiContextSafeHandle amsiContext, string payload, string contentName, AmsiSessionSafeHandle session, out AmsiResult result);
+    internal static int AmsiScanString(AmsiContextSafeHandle amsiContext, string payload, string contentName, AmsiSessionSafeHandle session, out AmsiResult result)
+    {
+        var returnValue = PInvoke.AmsiScanString((HAMSICONTEXT)amsiContext.DangerousGetHandle(), payload, contentName, (HAMSISESSION)session.DangerousGetHandle(), out var nativeResult);
+        result = (AmsiResult)nativeResult;
+        return returnValue;
+    }
 
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [LibraryImport("Amsi.dll", EntryPoint = "AmsiScanBuffer", StringMarshalling = StringMarshalling.Utf16)]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvStdcall)])]
-    internal static partial int AmsiScanBuffer(AmsiContextSafeHandle amsiContext, byte[] buffer, uint length, string contentName, AmsiSessionSafeHandle session, out AmsiResult result);
+    internal static int AmsiScanBuffer(AmsiContextSafeHandle amsiContext, byte[] buffer, uint length, string contentName, AmsiSessionSafeHandle session, out AmsiResult result)
+    {
+        var returnValue = PInvoke.AmsiScanBuffer((HAMSICONTEXT)amsiContext.DangerousGetHandle(), buffer.AsSpan(0, checked((int)length)), contentName, (HAMSISESSION)session.DangerousGetHandle(), out var nativeResult);
+        result = (AmsiResult)nativeResult;
+        return returnValue;
+    }
 }
+#pragma warning restore CA1416

--- a/src/Meziantou.Framework.Win32.Amsi/Internals/AmsiContextSafeHandle.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/Internals/AmsiContextSafeHandle.cs
@@ -1,12 +1,20 @@
+using System.Runtime.Versioning;
 using Microsoft.Win32.SafeHandles;
 
 namespace Meziantou.Framework.Win32;
 
+[SupportedOSPlatform("windows")]
 internal sealed class AmsiContextSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
 {
     public AmsiContextSafeHandle()
         : base(ownsHandle: true)
     {
+    }
+
+    internal AmsiContextSafeHandle(nint contextHandle)
+        : this()
+    {
+        SetHandle(contextHandle);
     }
 
     protected override bool ReleaseHandle()

--- a/src/Meziantou.Framework.Win32.Amsi/Internals/AmsiSessionSafeHandle.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/Internals/AmsiSessionSafeHandle.cs
@@ -1,8 +1,10 @@
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using Microsoft.Win32.SafeHandles;
 
 namespace Meziantou.Framework.Win32;
 
+[SupportedOSPlatform("windows")]
 internal sealed class AmsiSessionSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
 {
     internal AmsiContextSafeHandle? Context { get; set; }
@@ -10,6 +12,13 @@ internal sealed class AmsiSessionSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
     public AmsiSessionSafeHandle()
         : base(ownsHandle: true)
     {
+    }
+
+    internal AmsiSessionSafeHandle(AmsiContextSafeHandle context, nint sessionHandle)
+        : this()
+    {
+        Context = context;
+        SetHandle(sessionHandle);
     }
 
     public override bool IsInvalid => Context is null || Context.IsInvalid || base.IsInvalid;

--- a/src/Meziantou.Framework.Win32.Amsi/Meziantou.Framework.Win32.Amsi.csproj
+++ b/src/Meziantou.Framework.Win32.Amsi/Meziantou.Framework.Win32.Amsi.csproj
@@ -8,4 +8,11 @@
     <RootNamespace>Meziantou.Framework.Win32</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.275">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Meziantou.Framework.Win32.Amsi/NativeMethods.txt
+++ b/src/Meziantou.Framework.Win32.Amsi/NativeMethods.txt
@@ -1,0 +1,7 @@
+AmsiInitialize
+AmsiUninitialize
+AmsiOpenSession
+AmsiCloseSession
+AmsiScanString
+AmsiScanBuffer
+AMSI_RESULT


### PR DESCRIPTION
Switch the AMSI package to CsWin32-generated interop so native declarations are maintained consistently with other Win32 packages in this repo, instead of keeping custom AMSI `LibraryImport` definitions.

## Summary
- Added `Microsoft.Windows.CsWin32` to `Meziantou.Framework.Win32.Amsi.csproj`.
- Added `src/Meziantou.Framework.Win32.Amsi/NativeMethods.txt` with the AMSI APIs and `AMSI_RESULT` symbol.
- Replaced custom native declarations in `Internals/Amsi.cs` with a thin adapter over `Windows.Win32.PInvoke`.
- Kept existing internal API shape by converting generated AMSI handle/result types to existing safe handles and `AmsiResult`.
- Added constructors in AMSI safe-handle types to wrap generated native handles.

## Notes for reviewers
- `Amsi` now carries a targeted `CA1416` suppression because CsWin32 emits `windows10.0.10240` API annotations while this package is intentionally `[SupportedOSPlatform("windows")]`.
- No public API behavior change is intended; this is an interop-generation migration.

## Validation
- Ran required repository scripts:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`
- Built `Meziantou.Framework.Win32.Amsi` with warnings-as-errors.
- Ran `Meziantou.Framework.Win32.AmsiTests`; execution fails on this macOS environment due expected `Amsi.dll` unavailability (`DllNotFoundException`), consistent with the pre-existing platform limitation.