### PR TITLE
Use CsWin32-generated interop in ProcessExtensions

### DIFF
--- a/src/Meziantou.Framework/Meziantou.Framework.csproj
+++ b/src/Meziantou.Framework/Meziantou.Framework.csproj
@@ -34,6 +34,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.275">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
 </Project>

--- a/src/Meziantou.Framework/NativeMethods.txt
+++ b/src/Meziantou.Framework/NativeMethods.txt
@@ -1,0 +1,6 @@
+CreateToolhelp32Snapshot
+Process32First
+Process32Next
+CloseHandle
+PROCESSENTRY32
+CREATE_TOOLHELP_SNAPSHOT_FLAGS

--- a/src/Meziantou.Framework/ProcessExtensions.cs
+++ b/src/Meziantou.Framework/ProcessExtensions.cs
@@ -1,7 +1,8 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using Microsoft.Win32.SafeHandles;
+using Windows.Win32;
+using Windows.Win32.System.Diagnostics.ToolHelp;
 
 namespace Meziantou.Framework;
 
@@ -202,17 +203,20 @@ public static partial class ProcessExtensions
         if (!OperatingSystem.IsWindows())
             throw new PlatformNotSupportedException("Only supported on Windows");
 
-        using var snapShotHandle = CreateToolhelp32Snapshot(SnapshotFlags.TH32CS_SNAPPROCESS, 0);
-        var entry = new ProcessEntry32
+        if (!OperatingSystem.IsWindowsVersionAtLeast(5, 1, 2600))
+            throw new PlatformNotSupportedException("Only supported on Windows");
+
+        using var snapShotHandle = PInvoke.CreateToolhelp32Snapshot_SafeHandle(CREATE_TOOLHELP_SNAPSHOT_FLAGS.TH32CS_SNAPPROCESS, 0);
+        var entry = new PROCESSENTRY32
         {
-            dwSize = (uint)Marshal.SizeOf<ProcessEntry32>(),
+            dwSize = (uint)Marshal.SizeOf<PROCESSENTRY32>(),
         };
 
-        var result = Process32First(snapShotHandle, ref entry);
-        while (result != 0)
+        var result = PInvoke.Process32First(snapShotHandle, ref entry);
+        while (result)
         {
-            yield return new ProcessEntry(entry.th32ProcessID, entry.th32ParentProcessID);
-            result = Process32Next(snapShotHandle, ref entry);
+            yield return new ProcessEntry(unchecked((int)entry.th32ProcessID), unchecked((int)entry.th32ParentProcessID));
+            result = PInvoke.Process32Next(snapShotHandle, ref entry);
         }
     }
 
@@ -257,67 +261,4 @@ public static partial class ProcessExtensions
         }
     }
 
-    [LibraryImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static partial bool CloseHandle(IntPtr hObject);
-
-    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern int Process32First(SnapshotSafeHandle handle, ref ProcessEntry32 entry);
-
-    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static extern int Process32Next(SnapshotSafeHandle handle, ref ProcessEntry32 entry);
-
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms682489.aspx
-    [LibraryImport("kernel32.dll", SetLastError = true)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    private static partial SnapshotSafeHandle CreateToolhelp32Snapshot(SnapshotFlags dwFlags, uint th32ProcessID);
-
-    private const int MAX_PATH = 260;
-
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684839.aspx
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-    internal struct ProcessEntry32
-    {
-#pragma warning disable IDE1006 // Naming Styles
-        public uint dwSize;
-        public uint cntUsage;
-        public int th32ProcessID;
-        public IntPtr th32DefaultHeapID;
-        public uint th32ModuleID;
-        public uint cntThreads;
-        public int th32ParentProcessID;
-        public int pcPriClassBase;
-        public uint dwFlags;
-
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = MAX_PATH)]
-        public string szExeFile;
-#pragma warning restore IDE1006 // Naming Styles
-    }
-
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms682489.aspx
-    private enum SnapshotFlags : uint
-    {
-        TH32CS_SNAPHEAPLIST = 0x00000001,
-        TH32CS_SNAPPROCESS = 0x00000002,
-        TH32CS_SNAPTHREAD = 0x00000004,
-        TH32CS_SNAPMODULE = 0x00000008,
-        TH32CS_SNAPMODULE32 = 0x00000010,
-        TH32CS_INHERIT = 0x80000000,
-    }
-
-    private sealed class SnapshotSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
-    {
-        public SnapshotSafeHandle()
-            : base(ownsHandle: true)
-        {
-        }
-
-        protected override bool ReleaseHandle()
-        {
-            return CloseHandle(handle);
-        }
-    }
 }


### PR DESCRIPTION
## Why
`ProcessExtensions` used hand-written Win32 interop declarations and custom native structs/handles for process snapshot enumeration. Moving this to CsWin32 centralizes native signatures in generated code and aligns this project with the existing Win32 interop pattern used across the repo.

## What changed
- Added `Microsoft.Windows.CsWin32` to `Meziantou.Framework.csproj`.
- Added `src/Meziantou.Framework/NativeMethods.txt` to request generation for the process snapshot APIs and related types.
- Refactored `ProcessExtensions.GetProcesses()` to use `Windows.Win32.PInvoke` with generated `PROCESSENTRY32` and `CREATE_TOOLHELP_SNAPSHOT_FLAGS`.
- Removed the custom `DllImport`/`LibraryImport` declarations and local native interop types (`ProcessEntry32`, snapshot flags, and custom snapshot handle wrapper).
- Added an explicit `OperatingSystem.IsWindowsVersionAtLeast(5, 1, 2600)` guard to match the generated APIs' platform requirements.

## Notes for reviewers
This keeps the public `ProcessExtensions` API and behavior unchanged while replacing only the native interop implementation details.