### PR TITLE
Use CsWin32 for Win32 dialogs native imports

### DIFF
--- a/ref/Meziantou.Framework.Win32.Dialogs.cs
+++ b/ref/Meziantou.Framework.Win32.Dialogs.cs
@@ -16,7 +16,7 @@ namespace Meziantou.Framework.Win32
         No = 7
     }
 
-    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows6.0.6000")]
     public sealed class OpenFolderDialog
     {
         public string? Title { get => throw null; set { } }

--- a/src/Meziantou.Framework.Win32.Dialogs/Meziantou.Framework.Win32.Dialogs.csproj
+++ b/src/Meziantou.Framework.Win32.Dialogs/Meziantou.Framework.Win32.Dialogs.csproj
@@ -7,4 +7,11 @@
     <Description>Provide an OpenFolderDialog that uses Vista+ design</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.275">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Meziantou.Framework.Win32.Dialogs/NativeMethods.txt
+++ b/src/Meziantou.Framework.Win32.Dialogs/NativeMethods.txt
@@ -1,0 +1,2 @@
+GetActiveWindow
+SHCreateItemFromParsingName

--- a/src/Meziantou.Framework.Win32.Dialogs/Natives/NativeMethods.cs
+++ b/src/Meziantou.Framework.Win32.Dialogs/Natives/NativeMethods.cs
@@ -1,20 +1,10 @@
-using System.Runtime.InteropServices;
-
 namespace Meziantou.Framework.Win32.Natives;
 
-internal static partial class NativeMethods
+internal static class NativeMethods
 {
 #pragma warning disable IDE1006 // Naming Styles
     internal const int S_OK = 0x00000000;
     internal const int ERROR_CANCELLED = unchecked((int)0x800704C7);
     internal const int FILE_NOT_FOUND = unchecked((int)0x80070002);
 #pragma warning restore IDE1006 // Naming Styles
-
-    [LibraryImport("user32")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static partial IntPtr GetActiveWindow();
-
-    [DllImport("shell32")]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    internal static extern int SHCreateItemFromParsingName([MarshalAs(UnmanagedType.LPWStr)] string pszPath, IntPtr pbc, [MarshalAs(UnmanagedType.LPStruct)] Guid riid, out IShellItem ppv);
 }

--- a/src/Meziantou.Framework.Win32.Dialogs/OpenFolderDialog.cs
+++ b/src/Meziantou.Framework.Win32.Dialogs/OpenFolderDialog.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Runtime.Versioning;
 using Meziantou.Framework.Win32.Natives;
+using Windows.Win32;
 
 namespace Meziantou.Framework.Win32;
 
@@ -24,7 +25,7 @@ namespace Meziantou.Framework.Win32;
 /// This dialog provides a modern Windows folder picker experience similar to the one used in
 /// File Explorer. It is only supported on Windows platforms.
 /// </remarks>
-[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("windows6.0.6000")]
 public sealed class OpenFolderDialog
 {
     /// <summary>Shows the folder selection dialog.</summary>
@@ -39,7 +40,7 @@ public sealed class OpenFolderDialog
     /// <returns>A <see cref="DialogResult"/> indicating whether the user clicked OK, Cancel, or if the operation was aborted.</returns>
     public DialogResult ShowDialog(IntPtr owner) // IWin32Window
     {
-        var hwndOwner = owner != IntPtr.Zero ? owner : NativeMethods.GetActiveWindow();
+        var hwndOwner = owner != IntPtr.Zero ? owner : (IntPtr)PInvoke.GetActiveWindow();
         var dialog = (IFileOpenDialog)new NativeFileOpenDialog();
         Configure(dialog);
 
@@ -81,11 +82,11 @@ public sealed class OpenFolderDialog
 
         if (!string.IsNullOrEmpty(InitialDirectory))
         {
-            var result = NativeMethods.SHCreateItemFromParsingName(InitialDirectory, IntPtr.Zero, typeof(IShellItem).GUID, out var item);
-            switch (result)
+            var result = PInvoke.SHCreateItemFromParsingName(InitialDirectory, null, typeof(IShellItem).GUID, out var shellItem);
+            switch ((int)result)
             {
                 case NativeMethods.S_OK:
-                    if (item is not null)
+                    if (shellItem is IShellItem item)
                     {
                         dialog.SetFolder(item);
                     }
@@ -94,7 +95,7 @@ public sealed class OpenFolderDialog
                 case NativeMethods.FILE_NOT_FOUND:
                     break;
                 default:
-                    throw new Win32Exception(result);
+                    throw new Win32Exception((int)result);
             }
         }
 


### PR DESCRIPTION
## Why
The dialogs project still used hand-written DllImport/LibraryImport declarations for native entry points. This change aligns it with the rest of the Win32 projects by generating those imports with Microsoft.Windows.CsWin32.

## What changed
- Added `Microsoft.Windows.CsWin32` to `Meziantou.Framework.Win32.Dialogs.csproj`.
- Added `src/Meziantou.Framework.Win32.Dialogs/NativeMethods.txt` with:
  - `GetActiveWindow`
  - `SHCreateItemFromParsingName`
- Updated `OpenFolderDialog` to call `Windows.Win32.PInvoke` for both APIs.
- Removed manual native import declarations from `Natives/NativeMethods.cs` and kept HRESULT constants there.
- Updated `OpenFolderDialog` OS platform annotation to `windows6.0.6000` to match the generated API support metadata.
- Updated `ref/Meziantou.Framework.Win32.Dialogs.cs` accordingly.

## Notes
- CsWin32 generates `SHCreateItemFromParsingName` with an `out object` parameter. The call site now uses a guarded cast to `IShellItem` before passing it to `SetFolder`.

## Validation
- Ran required repository scripts:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`
- Built `src/Meziantou.Framework.Win32.Dialogs/Meziantou.Framework.Win32.Dialogs.csproj` with `/p:TreatsWarningsAsErrors=true`.
- A full `dotnet test ./Meziantou.Framework.slnx` run was attempted with `DiffEngine_Disabled=true`, but failed due to existing unrelated InlineSnapshotTesting test crashes.