### PR TITLE
Set SYSLIB1054 analyzer severity to warning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,6 +48,7 @@ dotnet_diagnostic.CA1508.severity = none
 dotnet_diagnostic.CA2237.severity = none
 dotnet_diagnostic.RS2008.severity = none
 dotnet_diagnostic.IDE0130.severity = none
+dotnet_diagnostic.SYSLIB1054.severity = warning
 
 [samples/**/*.cs]
 dotnet_diagnostic.CA1852.severity = none


### PR DESCRIPTION
This change makes SYSLIB1054 visible during development without turning it into a build-breaking error. The goal is to keep the diagnostic actionable while preserving the current build flow.

## What changed
- Added `dotnet_diagnostic.SYSLIB1054.severity = warning` under the `[*.cs]` section in `.editorconfig`.

## Notes
- No other analyzer severities were changed.