### PR TITLE
Add package README for Meziantou.AspNetCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version | Readme |
 | :--- | :---: | :---: |
-| Meziantou.AspNetCore | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore/) | |
+| Meziantou.AspNetCore | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore/) | [readme](src/Meziantou.AspNetCore/readme.md) |
 | Meziantou.AspNetCore.Authentication.HttpBasic | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.Authentication.HttpBasic.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore.Authentication.HttpBasic/) | [readme](src/Meziantou.AspNetCore.Authentication.HttpBasic/readme.md) |
 | Meziantou.AspNetCore.Components | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.Components.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore.Components/) | |
 | Meziantou.AspNetCore.Components.LogViewer | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.Components.LogViewer.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore.Components.LogViewer/) | [readme](src/Meziantou.AspNetCore.Components.LogViewer/readme.md) |

--- a/src/Meziantou.AspNetCore/readme.md
+++ b/src/Meziantou.AspNetCore/readme.md
@@ -1,0 +1,54 @@
+# Meziantou.AspNetCore
+
+Helpers for ASP.NET Core middleware diagnostics and response cache-control behavior.
+
+## Features
+
+- Capture and inspect the middleware pipeline
+- Expose a debug endpoint returning the pipeline and endpoints as JSON
+- Access middleware pipeline snapshots from code
+- Add a default non-cacheable `Cache-Control` response header when none is set
+
+## Usage
+
+### Middleware pipeline debugging
+
+```csharp
+using Meziantou.AspNetCore.Diagnostics;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddMiddlewarePipelineDebugging();
+
+var app = builder.Build();
+
+app.UseRouting();
+app.MapGet("/hello", static () => "hello");
+
+// Mapped by default only in Development
+app.MapMiddlewarePipelineDebugEndpoint();
+
+app.MapGet("/pipeline.txt", () =>
+{
+    var snapshot = app.GetMiddlewarePipelineDebugSnapshot();
+    return Results.Text(snapshot.ToString(), "text/plain");
+});
+
+app.Run();
+```
+
+### Default no-cache response header
+
+```csharp
+using Meziantou.AspNetCore;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.UseMiddleware<NoCacheMiddleware>();
+
+app.MapGet("/", static () => "Hello World!");
+
+app.Run();
+```
+
+`NoCacheMiddleware` sets `Cache-Control: no-cache,no-store,must-revalidate` only when the response does not already define `Cache-Control`.


### PR DESCRIPTION
## Why
Meziantou.AspNetCore did not have a package README, so NuGet users had no package-specific usage guidance.

## What changed
- Added `src/Meziantou.AspNetCore/readme.md` with package overview and features.
- Added usage examples for middleware pipeline debugging (`AddMiddlewarePipelineDebugging`, `MapMiddlewarePipelineDebugEndpoint`, `GetMiddlewarePipelineDebugSnapshot`).
- Added usage example for `NoCacheMiddleware` and documented its default `Cache-Control` behavior.
- Updated the root `README.md` package table to link to the new package README.