### PR TITLE
Add README for Meziantou.AspNetCore.Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 | :--- | :---: | :---: |
 | Meziantou.AspNetCore | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore/) | |
 | Meziantou.AspNetCore.Authentication.HttpBasic | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.Authentication.HttpBasic.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore.Authentication.HttpBasic/) | [readme](src/Meziantou.AspNetCore.Authentication.HttpBasic/readme.md) |
-| Meziantou.AspNetCore.Components | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.Components.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore.Components/) | |
+| Meziantou.AspNetCore.Components | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.Components.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore.Components/) | [readme](src/Meziantou.AspNetCore.Components/readme.md) |
 | Meziantou.AspNetCore.Components.LogViewer | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.Components.LogViewer.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore.Components.LogViewer/) | [readme](src/Meziantou.AspNetCore.Components.LogViewer/readme.md) |
 | Meziantou.AspNetCore.Components.WebAssembly | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.Components.WebAssembly.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore.Components.WebAssembly/) | [readme](src/Meziantou.AspNetCore.Components.WebAssembly/readme.md) |
 | Meziantou.AspNetCore.Mvc | [![NuGet](https://img.shields.io/nuget/v/Meziantou.AspNetCore.Mvc.svg)](https://www.nuget.org/packages/Meziantou.AspNetCore.Mvc/) | |

--- a/src/Meziantou.AspNetCore.Components/readme.md
+++ b/src/Meziantou.AspNetCore.Components/readme.md
@@ -1,0 +1,72 @@
+# Meziantou.AspNetCore.Components
+
+A collection of reusable Blazor components and services for common UI and browser-integration scenarios.
+
+## Features
+
+- **UI components**: `DataGrid`, `Repeater`, `GenericForm`, `LoadingIndicator`, `AnchorNavigation`, `InfiniteScrolling`
+- **Input components**: `InputDateTime<TValue>`, `InputEnumSelect<TEnum>`, `InputGuid<TValue>`, `InputUrl<TValue>`
+- **Browser services**: `ClipboardService`, `QueryStringService`, `TimeZoneService`
+
+## Installation
+
+```bash
+dotnet add package Meziantou.AspNetCore.Components
+```
+
+## Usage
+
+Add the package namespace in your app:
+
+```razor
+@using Meziantou.AspNetCore.Components
+```
+
+Register optional services:
+
+```csharp
+using Meziantou.AspNetCore.Components;
+
+builder.Services.AddClipboard();
+builder.Services.AddQueryStringParameters();
+builder.Services.AddTimeZoneServices();
+```
+
+### Example: Repeater component
+
+```razor
+<Repeater Items="items">
+    <ItemTemplate Context="item">
+        <span>@item</span>
+    </ItemTemplate>
+    <ItemSeparatorTemplate>, </ItemSeparatorTemplate>
+    <EmptyTemplate><em>No item</em></EmptyTemplate>
+    <LoadingTemplate><em>Loading...</em></LoadingTemplate>
+</Repeater>
+
+@code {
+    private List<string>? items = new() { "A", "B", "C" };
+}
+```
+
+### Example: Query string synchronization
+
+```razor
+@inject QueryStringService QueryStringService
+
+@code {
+    [Parameter]
+    [SupplyParameterFromQuery]
+    public string? Search { get; set; }
+
+    protected override void OnInitialized()
+    {
+        QueryStringService.SetParametersFromQueryString(this);
+    }
+}
+```
+
+## Additional resources
+
+- [Anchor navigation in a Blazor application](https://www.meziantou.net/anchor-navigation-in-a-blazor-application.htm)
+- [Copying text to clipboard in a Blazor application](https://www.meziantou.net/copying-text-to-clipboard-in-a-blazor-application.htm)


### PR DESCRIPTION
The `Meziantou.AspNetCore.Components` package did not have a dedicated README, which made the NuGet package harder to discover and use quickly. This adds package-level documentation and wires it into the repository package index.

## Summary
- Add `src/Meziantou.AspNetCore.Components/readme.md` with feature overview, installation, DI registration snippets, and usage examples.
- Update the root `README.md` package table to link to the new package README.

## Notes
- This is a documentation-only change; no runtime behavior was modified.