### PR TITLE
Add README for Meziantou.Framework.WPF

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@
 | Meziantou.Framework.Win32.ProjectedFileSystem | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.Win32.ProjectedFileSystem.svg)](https://www.nuget.org/packages/Meziantou.Framework.Win32.ProjectedFileSystem/) | [readme](src/Meziantou.Framework.Win32.ProjectedFileSystem/readme.md) |
 | Meziantou.Framework.Win32.RecentDocuments | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.Win32.RecentDocuments.svg)](https://www.nuget.org/packages/Meziantou.Framework.Win32.RecentDocuments/) | [readme](src/Meziantou.Framework.Win32.RecentDocuments/readme.md) |
 | Meziantou.Framework.Win32.RestartManager | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.Win32.RestartManager.svg)](https://www.nuget.org/packages/Meziantou.Framework.Win32.RestartManager/) | [readme](src/Meziantou.Framework.Win32.RestartManager/readme.md) |
-| Meziantou.Framework.WPF | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.WPF.svg)](https://www.nuget.org/packages/Meziantou.Framework.WPF/) | |
+| Meziantou.Framework.WPF | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.WPF.svg)](https://www.nuget.org/packages/Meziantou.Framework.WPF/) | [readme](src/Meziantou.Framework.WPF/readme.md) |
 | Meziantou.Xunit | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Xunit.svg)](https://www.nuget.org/packages/Meziantou.Xunit/) | [readme](src/Meziantou.Xunit/readme.md) |
 
 # How to contribute

--- a/src/Meziantou.Framework.WPF/readme.md
+++ b/src/Meziantou.Framework.WPF/readme.md
@@ -1,0 +1,66 @@
+# Meziantou.Framework.WPF
+
+[![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.WPF.svg)](https://www.nuget.org/packages/Meziantou.Framework.WPF/)
+
+Utilities for WPF applications, including:
+
+- `DelegateCommand` for synchronous and asynchronous commands
+- `ConcurrentObservableCollection<T>` for thread-safe collections that can be bound to WPF controls
+- Enum markup extensions (`EnumValuesExtension`, `LocalizedEnumValuesExtension`)
+- `BooleanToValueConverter` for flexible bool-to-value conversion in bindings
+- Dispatcher helpers (`SwitchToDispatcherThread`)
+
+## Install
+
+```powershell
+dotnet add package Meziantou.Framework.WPF
+```
+
+## Usage
+
+### Commands
+
+```csharp
+using Meziantou.Framework.WPF;
+
+public sealed class SampleViewModel
+{
+    public IDelegateCommand SaveCommand { get; } = DelegateCommand.Create(
+        execute: () => Console.WriteLine("Saved"),
+        canExecute: () => true);
+}
+```
+
+### Thread-safe bindable collection
+
+```csharp
+using Meziantou.Framework.WPF.Collections;
+
+var collection = new ConcurrentObservableCollection<string>();
+listBox.ItemsSource = collection.AsObservable;
+
+await Task.Run(() => collection.Add("Item from background thread"));
+```
+
+### Enum values in XAML
+
+```xml
+<Window
+    xmlns:wpf="clr-namespace:Meziantou.Framework.WPF;assembly=Meziantou.Framework.WPF">
+    <ComboBox
+        ItemsSource="{wpf:LocalizedEnumValues {x:Type local:MyEnum}}"
+        DisplayMemberPath="Name"
+        SelectedValuePath="Value" />
+</Window>
+```
+
+### Boolean converter
+
+```xml
+<Window.Resources>
+    <wpf:BooleanToValueConverter
+        x:Key="BoolToVisibility"
+        TrueValue="{x:Static Visibility.Visible}"
+        FalseValue="{x:Static Visibility.Collapsed}" />
+</Window.Resources>
+```


### PR DESCRIPTION
## Why
The WPF package had no package-level README, so users could not quickly discover usage guidance from the package folder and the root package table had no readme link.

## What changed
- Added `src/Meziantou.Framework.WPF/readme.md` with package overview, install instructions, and usage examples for commands, concurrent observable collections, enum XAML extensions, and boolean conversion.
- Updated the root `README.md` package table to include the WPF readme link.

## Notes
- Built `src/Meziantou.Framework.WPF/Meziantou.Framework.WPF.csproj` with `/p:TreatsWarningsAsErrors=true`.
- WPF test binaries build, but test execution cannot run in this macOS environment because `Microsoft.WindowsDesktop.App` runtimes for `*-windows` targets are unavailable.