### PR TITLE
Fix CA1416 warning in Win32 dialogs sample

### DIFF
--- a/samples/Meziantou.Framework.Win32.DialogsSamples/MainWindow.xaml.cs
+++ b/samples/Meziantou.Framework.Win32.DialogsSamples/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Versioning;
 using System.Windows;
 
 namespace Meziantou.Framework.Win32.DialogsSamples;
@@ -10,6 +11,7 @@ public partial class MainWindow : Window
         InitializeComponent();
     }
 
+    [SupportedOSPlatform("windows6.0.6000")]
     private void ButtonOpenFolder_Click(object sender, RoutedEventArgs e)
     {
         var dialog = new OpenFolderDialog


### PR DESCRIPTION
The publish workflow started failing on Windows builds because CA1416 began enforcing platform compatibility for `OpenFolderDialog` usage in the dialogs sample.

This change marks the click handler as supported on `windows6.0.6000` and adds the required `System.Runtime.Versioning` import. That aligns the sample's platform contract with the APIs it calls and removes the analyzer failure without changing runtime behavior.