### PR TITLE
Add SnapshotTesting scrubbing APIs and coverage

### DIFF
--- a/ref/Meziantou.Framework.SnapshotTesting.cs
+++ b/ref/Meziantou.Framework.SnapshotTesting.cs
@@ -13,6 +13,19 @@ namespace Meziantou.Framework.SnapshotTesting
         public abstract string FormatMessage(string? expected, string? actual);
     }
 
+    public static class HumanReadableSerializerScrubExtensions
+    {
+        public static void ScrubGuid(this Meziantou.Framework.HumanReadable.HumanReadableSerializerOptions options) { }
+        public static void ScrubValue<T>(this Meziantou.Framework.HumanReadable.HumanReadableSerializerOptions options) { }
+        public static void ScrubValue<T>(this Meziantou.Framework.HumanReadable.HumanReadableSerializerOptions options, System.Collections.Generic.IEqualityComparer<T>? comparer) { }
+        public static void ScrubValue<T>(this Meziantou.Framework.HumanReadable.HumanReadableSerializerOptions options, System.Func<T, string> scrubber) { }
+        public static void ScrubValue<T>(this Meziantou.Framework.HumanReadable.HumanReadableSerializerOptions options, System.Func<T, int, string> scrubber) { }
+        public static void ScrubValue<T>(this Meziantou.Framework.HumanReadable.HumanReadableSerializerOptions options, System.Func<T, int, string> scrubber, System.Collections.Generic.IEqualityComparer<T>? comparer) { }
+        public static void UseRelativeTimeSpan(this Meziantou.Framework.HumanReadable.HumanReadableSerializerOptions options, System.TimeSpan origin) { }
+        public static void UseRelativeDateTime(this Meziantou.Framework.HumanReadable.HumanReadableSerializerOptions options, System.DateTime origin) { }
+        public static void UseRelativeDateTimeOffset(this Meziantou.Framework.HumanReadable.HumanReadableSerializerOptions options, System.DateTimeOffset origin) { }
+    }
+
     public interface ISnapshotComparer
     {
         bool Equals(Meziantou.Framework.SnapshotTesting.SnapshotData expected, Meziantou.Framework.SnapshotTesting.SnapshotData actual);
@@ -66,6 +79,11 @@ namespace Meziantou.Framework.SnapshotTesting
     {
         public abstract void Dispose();
         public abstract void WaitForExit();
+    }
+
+    public abstract class Scrubber
+    {
+        public abstract string Scrub(string text);
     }
 
     public sealed class SerializedSnapshot
@@ -193,6 +211,7 @@ namespace Meziantou.Framework.SnapshotTesting
         public Meziantou.Framework.SnapshotTesting.SnapshotSerializerCollection Serializers { get => throw null; }
         public System.Collections.Generic.IEnumerable<Meziantou.Framework.SnapshotTesting.MergeTool>? MergeTools { get => throw null; set { } }
         public Meziantou.Framework.SnapshotTesting.SnapshotComparerCollection Comparers { get => throw null; }
+        public System.Collections.Generic.IList<Meziantou.Framework.SnapshotTesting.Scrubber> Scrubbers { get => throw null; }
         public override string ToString() => throw null;
         public static bool operator !=(Meziantou.Framework.SnapshotTesting.SnapshotSettings? left, Meziantou.Framework.SnapshotTesting.SnapshotSettings? right) => throw null;
         public static bool operator ==(Meziantou.Framework.SnapshotTesting.SnapshotSettings? left, Meziantou.Framework.SnapshotTesting.SnapshotSettings? right) => throw null;
@@ -210,6 +229,20 @@ namespace Meziantou.Framework.SnapshotTesting
     {
         public static void ConfigureHumanReadableSerializer(this Meziantou.Framework.SnapshotTesting.SnapshotSettings settings, System.Action<Meziantou.Framework.HumanReadable.HumanReadableSerializerOptions>? options) { }
         public static void AddConverter(this Meziantou.Framework.SnapshotTesting.SnapshotSettings settings, Meziantou.Framework.HumanReadable.HumanReadableConverter converter) { }
+    }
+
+    public static class SnapshotSettingsScrubberExtensions
+    {
+        public static void ScrubLines(this Meziantou.Framework.SnapshotTesting.SnapshotSettings settings, System.Func<string, bool> predicate) { }
+        public static void ScrubLinesContaining(this Meziantou.Framework.SnapshotTesting.SnapshotSettings settings, params string[] searchText) { }
+        public static void ScrubLinesContaining(this Meziantou.Framework.SnapshotTesting.SnapshotSettings settings, System.StringComparison stringComparison, params string[] searchText) { }
+        public static void ScrubLinesMatching(this Meziantou.Framework.SnapshotTesting.SnapshotSettings settings, System.Text.RegularExpressions.Regex regex) { }
+        public static void ScrubLinesMatching(this Meziantou.Framework.SnapshotTesting.SnapshotSettings settings, [System.Diagnostics.CodeAnalysis.StringSyntax("Regex")] string pattern) { }
+        public static void ScrubLinesMatching(this Meziantou.Framework.SnapshotTesting.SnapshotSettings settings, [System.Diagnostics.CodeAnalysis.StringSyntax("Regex")] string pattern, System.Text.RegularExpressions.RegexOptions options) { }
+        public static void ScrubLinesMatching(this Meziantou.Framework.SnapshotTesting.SnapshotSettings settings, [System.Diagnostics.CodeAnalysis.StringSyntax("Regex")] string pattern, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { }
+        public static void ScrubLinesWithReplace(this Meziantou.Framework.SnapshotTesting.SnapshotSettings settings, System.Func<string, string?> replaceLine) { }
+        public static void ScrubMachineName(this Meziantou.Framework.SnapshotTesting.SnapshotSettings settings) { }
+        public static void ScrubUserName(this Meziantou.Framework.SnapshotTesting.SnapshotSettings settings) { }
     }
 
     public sealed class SnapshotTestContext : System.IEquatable<Meziantou.Framework.SnapshotTesting.SnapshotTestContext>

--- a/src/Meziantou.Framework.SnapshotTesting/HumanReadableSerializerScrubExtensions.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/HumanReadableSerializerScrubExtensions.cs
@@ -1,0 +1,121 @@
+using System.Diagnostics;
+using Meziantou.Framework.HumanReadable;
+
+namespace Meziantou.Framework.SnapshotTesting;
+
+/// <summary>
+/// Provides extension methods for scrubbing values during serialization with <see cref="HumanReadableSerializerOptions"/>.
+/// </summary>
+public static class HumanReadableSerializerScrubExtensions
+{
+    /// <summary>Scrubs GUID values by replacing them with deterministic values based on their order of appearance.</summary>
+    public static void ScrubGuid(this HumanReadableSerializerOptions options) => ScrubValue<Guid>(options, (value, index) =>
+    {
+        if (value == Guid.Empty)
+            return "00000000-0000-0000-0000-000000000000";
+
+        index += 1; // Distinct from Guid.Empty
+
+        const string Prefix = "00000000-0000-0000-0000-";
+        Span<char> data = stackalloc char[36];
+        Prefix.AsSpan().CopyTo(data);
+        _ = index.TryFormat(data[Prefix.Length..], out _, "000000000000", CultureInfo.InvariantCulture);
+        return data.ToString();
+    });
+
+    /// <summary>Scrubs values of type T by replacing them with deterministic values like "TypeName_0", "TypeName_1", etc.</summary>
+    public static void ScrubValue<T>(this HumanReadableSerializerOptions options) => ScrubValue<T>(options, comparer: null);
+
+    /// <summary>Scrubs values of type T by replacing them with deterministic values, using the specified comparer to determine uniqueness.</summary>
+    public static void ScrubValue<T>(this HumanReadableSerializerOptions options, IEqualityComparer<T>? comparer) => ScrubValue(options, (value, index) => typeof(T).Name + "_" + index.ToString(CultureInfo.InvariantCulture), comparer);
+
+    /// <summary>Scrubs values of type T by replacing them with the result of the specified scrubber function.</summary>
+    public static void ScrubValue<T>(this HumanReadableSerializerOptions options, Func<T, string> scrubber) => options.Converters.Add(new ValueScrubberConverter<T>(scrubber));
+
+    /// <summary>Scrubs values of type T by replacing them with the result of the specified scrubber function that receives the value and its index.</summary>
+    public static void ScrubValue<T>(this HumanReadableSerializerOptions options, Func<T, int, string> scrubber) => ScrubValue(options, scrubber, comparer: null);
+
+    /// <summary>Scrubs values of type T by replacing them with the result of the specified scrubber function, using the specified comparer to determine uniqueness.</summary>
+    public static void ScrubValue<T>(this HumanReadableSerializerOptions options, Func<T, int, string> scrubber, IEqualityComparer<T>? comparer)
+        => options.Converters.Add(new ScrubValueIncrementalConverter<T>(scrubber, comparer ?? EqualityComparer<T>.Default));
+
+    /// <summary>Serializes TimeSpan values relative to the specified origin.</summary>
+    public static void UseRelativeTimeSpan(this HumanReadableSerializerOptions options, TimeSpan origin) => options.Converters.Add(new RelativeTimeSpanConverter(origin));
+
+    /// <summary>Serializes DateTime values relative to the specified origin.</summary>
+    public static void UseRelativeDateTime(this HumanReadableSerializerOptions options, DateTime origin) => options.Converters.Add(new RelativeDateTimeConverter(origin));
+
+    /// <summary>Serializes DateTimeOffset values relative to the specified origin.</summary>
+    public static void UseRelativeDateTimeOffset(this HumanReadableSerializerOptions options, DateTimeOffset origin) => options.Converters.Add(new RelativeDateTimeOffsetConverter(origin));
+
+    private sealed class ValueScrubberConverter<T>(Func<T, string> scrubber) : HumanReadableConverter<T>
+    {
+        protected override void WriteValue(HumanReadableTextWriter writer, T? value, HumanReadableSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteValue(scrubber(value));
+        }
+    }
+
+    private sealed class RelativeTimeSpanConverter(TimeSpan origin) : HumanReadableConverter<TimeSpan>
+    {
+        protected override void WriteValue(HumanReadableTextWriter writer, TimeSpan value, HumanReadableSerializerOptions options)
+        {
+            WriteValueCore(writer, value - origin);
+        }
+
+        internal static void WriteValueCore(HumanReadableTextWriter writer, TimeSpan value)
+        {
+            writer.WriteValue(value.ToString(format: null, CultureInfo.InvariantCulture));
+        }
+    }
+
+    private sealed class RelativeDateTimeConverter(DateTime origin) : HumanReadableConverter<DateTime>
+    {
+        protected override void WriteValue(HumanReadableTextWriter writer, DateTime value, HumanReadableSerializerOptions options)
+        {
+            var diff = value - origin;
+            RelativeTimeSpanConverter.WriteValueCore(writer, diff);
+        }
+    }
+
+    private sealed class RelativeDateTimeOffsetConverter(DateTimeOffset origin) : HumanReadableConverter<DateTimeOffset>
+    {
+        protected override void WriteValue(HumanReadableTextWriter writer, DateTimeOffset value, HumanReadableSerializerOptions options)
+        {
+            var diff = value - origin;
+            RelativeTimeSpanConverter.WriteValueCore(writer, diff);
+        }
+    }
+
+    private sealed class ScrubValueIncrementalConverter<T>(Func<T, int, string> formatValue, IEqualityComparer<T> comparer) : HumanReadableConverter<T>
+    {
+        private readonly string _uniqueName = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+
+        protected override void WriteValue(HumanReadableTextWriter writer, T? value, HumanReadableSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+#pragma warning disable CS8714 // Nullability of type argument doesn't match 'notnull' constraint.
+            var dictionary = options.GetOrSetSerializationData(_uniqueName, () => new Dictionary<T, string>(comparer));
+#pragma warning restore CS8714
+            Debug.Assert(value is not null);
+            if (!dictionary.TryGetValue(value, out var scrubbedValue))
+            {
+                scrubbedValue = formatValue(value, dictionary.Count);
+                dictionary.Add(value, scrubbedValue);
+            }
+
+            writer.WriteValue(scrubbedValue);
+        }
+    }
+}

--- a/src/Meziantou.Framework.SnapshotTesting/LineFilterScrubber.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/LineFilterScrubber.cs
@@ -1,0 +1,19 @@
+namespace Meziantou.Framework.SnapshotTesting;
+
+internal sealed class LineFilterScrubber : LineScrubber
+{
+    private readonly Func<string, bool> _predicate;
+
+    public LineFilterScrubber(Func<string, bool> predicate)
+    {
+        _predicate = predicate;
+    }
+
+    protected override string? ScrubLine(string line)
+    {
+        if (_predicate(line))
+            return null;
+
+        return line;
+    }
+}

--- a/src/Meziantou.Framework.SnapshotTesting/LineReplaceScrubber.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/LineReplaceScrubber.cs
@@ -1,0 +1,16 @@
+namespace Meziantou.Framework.SnapshotTesting;
+
+internal sealed class LineReplaceScrubber : LineScrubber
+{
+    private readonly Func<string, string?> _replaceLine;
+
+    public LineReplaceScrubber(Func<string, string?> replaceLine)
+    {
+        _replaceLine = replaceLine;
+    }
+
+    protected override string? ScrubLine(string line)
+    {
+        return _replaceLine(line);
+    }
+}

--- a/src/Meziantou.Framework.SnapshotTesting/LineScrubber.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/LineScrubber.cs
@@ -1,0 +1,25 @@
+using Meziantou.Framework.HumanReadable.Utils;
+
+namespace Meziantou.Framework.SnapshotTesting;
+
+internal abstract class LineScrubber : Scrubber
+{
+    public sealed override string Scrub(string text)
+    {
+        var sb = new StringBuilder(text.Length);
+        foreach (var (line, eol) in StringUtils.EnumerateLines(text))
+        {
+            var newLine = ScrubLine(line);
+            if (newLine is not null)
+            {
+                sb.Append(newLine);
+                sb.Append(eol);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    protected virtual string? ScrubLine(ReadOnlySpan<char> line) => ScrubLine(line.ToString());
+    protected virtual string? ScrubLine(string line) => line;
+}

--- a/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="../Meziantou.Framework.HumanReadableSerializer/Utils/StringUtils.cs" Link="Utils/StringUtils.cs" />
     <Compile Include="../Meziantou.Framework/ExecutableFinder.cs" Link="Utils/ExecutableFinder.cs" />
   </ItemGroup>
 

--- a/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>Enables verification of objects using file-based snapshots</Description>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.SnapshotTesting/Scrubber.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Scrubber.cs
@@ -1,0 +1,10 @@
+namespace Meziantou.Framework.SnapshotTesting;
+
+/// <summary>Provides methods for scrubbing (sanitizing or filtering) snapshot text after serialization.</summary>
+public abstract class Scrubber
+{
+    /// <summary>Scrubs the specified text by filtering or transforming it.</summary>
+    /// <param name="text">The text to scrub.</param>
+    /// <returns>The scrubbed text.</returns>
+    public abstract string Scrub(string text);
+}

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
@@ -4,6 +4,8 @@ namespace Meziantou.Framework.SnapshotTesting;
 
 internal static class SnapshotEngine
 {
+    private static readonly UTF8Encoding Utf8WithoutBomExceptionFallback = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
     public static void Validate(SnapshotType? type, object? value, SnapshotSettings settings, string? filePath, int lineNumber, string? memberName, SnapshotTestContext? testContext)
     {
         ArgumentNullException.ThrowIfNull(settings);
@@ -54,7 +56,37 @@ internal static class SnapshotEngine
     private static IReadOnlyList<SnapshotData> Serialize(SnapshotSettings settings, SnapshotType type, object? value)
     {
         var serializer = settings.Serializers.Get(type, value);
-        return serializer.Serialize(type, value).Data;
+        var data = serializer.Serialize(type, value).Data;
+        if (settings.Scrubbers.Count == 0)
+            return data;
+
+        var result = new List<SnapshotData>(data.Count);
+        foreach (var snapshotData in data)
+        {
+            result.Add(ApplyScrubbers(snapshotData, settings.Scrubbers));
+        }
+
+        return result;
+    }
+
+    private static SnapshotData ApplyScrubbers(SnapshotData snapshotData, IList<Scrubber> scrubbers)
+    {
+        string text;
+        try
+        {
+            text = Utf8WithoutBomExceptionFallback.GetString(snapshotData.Data);
+        }
+        catch (DecoderFallbackException ex)
+        {
+            throw new SnapshotException("Snapshot scrubbers can only be applied to UTF-8 text snapshots.", ex);
+        }
+
+        foreach (var scrubber in scrubbers)
+        {
+            text = scrubber.Scrub(text);
+        }
+
+        return new SnapshotData(snapshotData.Extension, Encoding.UTF8.GetBytes(text));
     }
 
     private static SnapshotComparisonResult Compare(SnapshotSettings settings, SnapshotType type, List<SnapshotFile> actualFiles, Dictionary<FullPath, SnapshotData> expectedFiles)

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotSettings.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotSettings.cs
@@ -89,6 +89,8 @@ public sealed record SnapshotSettings
 
     public SnapshotComparerCollection Comparers { get; }
 
+    public IList<Scrubber> Scrubbers { get; }
+
     public SnapshotSettings()
     {
         Serializers =
@@ -99,6 +101,7 @@ public sealed record SnapshotSettings
         ];
         Comparers = new SnapshotComparerCollection();
         Comparers.Set(SnapshotType.None, ByteArraySnapshotComparer.Instance);
+        Scrubbers = [];
         SnapshotUpdateStrategy = SnapshotUpdateStrategy.Default;
         AssertionExceptionCreator = AssertionExceptionBuilder.Default;
         MaxSnapshotFileNameLength = 128;
@@ -112,6 +115,12 @@ public sealed record SnapshotSettings
         ArgumentNullException.ThrowIfNull(options);
         Serializers = new SnapshotSerializerCollection(options.Serializers);
         Comparers = new SnapshotComparerCollection(options.Comparers);
+        Scrubbers = [];
+        foreach (var scrubber in options.Scrubbers)
+        {
+            Scrubbers.Add(scrubber);
+        }
+
         AutoDetectContinuousEnvironment = options.AutoDetectContinuousEnvironment;
         ForceUpdateSnapshots = options.ForceUpdateSnapshots;
         SnapshotUpdateStrategy = options.SnapshotUpdateStrategy;

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotSettingsHumanReadableSerializerExtensions.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotSettingsHumanReadableSerializerExtensions.cs
@@ -11,10 +11,20 @@ public static class SnapshotSettingsHumanReadableSerializerExtensions
             if (options is null)
                 return;
 
-            var serializer = settings.Serializers.OfType<HumanReadableSnapshotSerializer>().FirstOrDefault();
-            if (serializer is not null)
+            var serializers = settings.Serializers.ToList();
+            var index = serializers.FindIndex(serializer => serializer is HumanReadableSnapshotSerializer);
+            if (index < 0)
+                return;
+
+            var serializer = (HumanReadableSnapshotSerializer)serializers[index];
+            var clone = new HumanReadableSnapshotSerializer(serializer.Options with { });
+            options(clone.Options);
+
+            serializers[index] = clone;
+            settings.Serializers.Clear();
+            foreach (var item in serializers)
             {
-                options(serializer.Options);
+                settings.Serializers.Add(item);
             }
         }
 

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotSettingsScrubberExtensions.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotSettingsScrubberExtensions.cs
@@ -1,0 +1,51 @@
+using System.Text.RegularExpressions;
+
+namespace Meziantou.Framework.SnapshotTesting;
+
+/// <summary>
+/// Provides extension methods for adding scrubbers to <see cref="SnapshotSettings"/>.
+/// </summary>
+public static class SnapshotSettingsScrubberExtensions
+{
+    extension(SnapshotSettings settings)
+    {
+        /// <summary>Adds a scrubber that removes lines matching the specified predicate.</summary>
+        public void ScrubLines(Func<string, bool> predicate) => settings.Scrubbers.Add(new LineFilterScrubber(predicate));
+
+        /// <summary>Adds a scrubber that removes lines containing any of the specified text values (case-insensitive).</summary>
+        public void ScrubLinesContaining(params string[] searchText) => settings.ScrubLinesContaining(StringComparison.OrdinalIgnoreCase, searchText);
+
+        /// <summary>Adds a scrubber that removes lines containing any of the specified text values with the specified comparison.</summary>
+        public void ScrubLinesContaining(StringComparison stringComparison, params string[] searchText)
+        {
+            foreach (var text in searchText)
+            {
+                settings.Scrubbers.Add(new LineFilterScrubber(line => line.Contains(text, stringComparison)));
+            }
+        }
+
+        /// <summary>Adds a scrubber that removes lines matching the specified regular expression.</summary>
+        public void ScrubLinesMatching(Regex regex) => settings.Scrubbers.Add(new LineFilterScrubber(regex.IsMatch));
+
+        /// <summary>Adds a scrubber that removes lines matching the specified regular expression pattern.</summary>
+        public void ScrubLinesMatching([StringSyntax(StringSyntaxAttribute.Regex)] string pattern)
+            => settings.ScrubLinesMatching(pattern, RegexOptions.None, Timeout.InfiniteTimeSpan);
+
+        /// <summary>Adds a scrubber that removes lines matching the specified regular expression pattern with options.</summary>
+        public void ScrubLinesMatching([StringSyntax(StringSyntaxAttribute.Regex)] string pattern, RegexOptions options)
+            => settings.ScrubLinesMatching(pattern, options, Timeout.InfiniteTimeSpan);
+
+        /// <summary>Adds a scrubber that removes lines matching the specified regular expression pattern with options and timeout.</summary>
+        public void ScrubLinesMatching([StringSyntax(StringSyntaxAttribute.Regex)] string pattern, RegexOptions options, TimeSpan matchTimeout)
+            => settings.Scrubbers.Add(new LineFilterScrubber(line => Regex.IsMatch(line, pattern, options, matchTimeout)));
+
+        /// <summary>Adds a scrubber that replaces each line using the specified function.</summary>
+        public void ScrubLinesWithReplace(Func<string, string?> replaceLine) => settings.Scrubbers.Add(new LineReplaceScrubber(replaceLine));
+
+        /// <summary>Adds a scrubber that replaces the machine name with a consistent value.</summary>
+        public void ScrubMachineName() => settings.Scrubbers.Add(new LineReplaceScrubber(line => line.Replace(Environment.MachineName, "TheMachineName", StringComparison.OrdinalIgnoreCase)));
+
+        /// <summary>Adds a scrubber that replaces the user name with a consistent value.</summary>
+        public void ScrubUserName() => settings.Scrubbers.Add(new LineReplaceScrubber(line => line.Replace(Environment.UserName, "TheUserName", StringComparison.OrdinalIgnoreCase)));
+    }
+}

--- a/src/Meziantou.Framework.SnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.SnapshotTesting/readme.md
@@ -93,3 +93,23 @@ Snapshot.Validate(value, SnapshotType.Default, settings);
 ```
 
 The default serializers handle human-readable objects, `byte[]`, and `Stream`.
+
+## Scrubbing
+
+Scrubbing helps make snapshots deterministic by removing unstable values or lines.
+
+```csharp
+var settings = SnapshotSettings.Default with { };
+settings.ConfigureHumanReadableSerializer(options => options.ScrubGuid());
+settings.ScrubLinesContaining("GeneratedAt:");
+
+Snapshot.Validate(value, SnapshotType.Default, settings);
+```
+
+You can also scrub relative temporal values:
+
+```csharp
+var now = DateTime.UtcNow;
+var settings = SnapshotSettings.Default with { };
+settings.ConfigureHumanReadableSerializer(options => options.UseRelativeDateTime(now));
+```

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -55,6 +55,7 @@ public sealed class SnapshotTests
         var original = new SnapshotSettings();
         original.Serializers.Add(new FixedCountSerializer(count: 1));
         original.Comparers.Set(SnapshotType.Create("dummy"), ByteArraySnapshotComparer.Instance);
+        original.ScrubLinesContaining(StringComparison.OrdinalIgnoreCase, "line2");
         var originalSerializerCount = original.Serializers.Count;
 
         var clone = original.Clone();
@@ -62,6 +63,8 @@ public sealed class SnapshotTests
 
         Assert.NotSame(original.Serializers, clone.Serializers);
         Assert.NotSame(original.Comparers, clone.Comparers);
+        Assert.NotSame(original.Scrubbers, clone.Scrubbers);
+        Assert.Equal(original.Scrubbers, clone.Scrubbers);
         Assert.Equal(originalSerializerCount + 1, clone.Serializers.Count);
         Assert.Equal(originalSerializerCount, original.Serializers.Count);
     }
@@ -536,6 +539,157 @@ public sealed class SnapshotTests
         ValidateWithSerializerCount(validateSettings, count: 2);
     }
 
+    [Fact]
+    public void ScrubLinesMatching_Regex()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = CreateScrubberSnapshotSettings(directory);
+        settings.ScrubLinesMatching(new Regex("Line[2]", RegexOptions.None, TimeSpan.FromSeconds(10)));
+        settings.Serializers.Add(new FixedValueSerializer("Line1\nLine2\nLine3"));
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.Equal(["Line1", "Line3"], ReadVerifiedSnapshotLines(directory));
+    }
+
+    [Fact]
+    public void ScrubLinesMatching_Pattern()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = CreateScrubberSnapshotSettings(directory);
+        settings.ScrubLinesMatching("Line[2]");
+        settings.Serializers.Add(new FixedValueSerializer("Line1\nLine2\nLine3"));
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.Equal(["Line1", "Line3"], ReadVerifiedSnapshotLines(directory));
+    }
+
+    [Fact]
+    public void ScrubLinesContaining_StringComparison_OrdinalIgnoreCase()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = CreateScrubberSnapshotSettings(directory);
+        settings.ScrubLinesContaining(StringComparison.OrdinalIgnoreCase, "line2");
+        settings.Serializers.Add(new FixedValueSerializer("Line1\nLine2\nLine3"));
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.Equal(["Line1", "Line3"], ReadVerifiedSnapshotLines(directory));
+    }
+
+    [Fact]
+    public void ScrubLinesContaining_StringComparison_Ordinal()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = CreateScrubberSnapshotSettings(directory);
+        settings.ScrubLinesContaining(StringComparison.Ordinal, "line2");
+        settings.Serializers.Add(new FixedValueSerializer("Line1\nLine2\nLine3"));
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.Equal(["Line1", "Line2", "Line3"], ReadVerifiedSnapshotLines(directory));
+    }
+
+    [Fact]
+    public void ScrubLinesWithReplace()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = CreateScrubberSnapshotSettings(directory);
+        settings.ScrubLinesWithReplace(line => line.ToLowerInvariant());
+        settings.Serializers.Add(new FixedValueSerializer("Line1\nLine2\nLine3"));
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.Equal(["line1", "line2", "line3"], ReadVerifiedSnapshotLines(directory));
+    }
+
+    [Fact]
+    public void ScrubLinesWithReplace_RemoveLine()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = CreateScrubberSnapshotSettings(directory);
+        settings.ScrubLinesWithReplace(line => line == "Line2" ? null : line);
+        settings.Serializers.Add(new FixedValueSerializer("Line1\nLine2\nLine3"));
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.Equal(["Line1", "Line3"], ReadVerifiedSnapshotLines(directory));
+    }
+
+    [Fact]
+    public void Scrub_Guid()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = CreateScrubberSnapshotSettings(directory);
+        settings.ConfigureHumanReadableSerializer(options => options.ScrubGuid());
+        var guids = new[]
+        {
+            new Guid("43164674-b264-42b8-a7e5-6565667360b0"),
+            new Guid("43164674-b264-42b8-a7e5-6565667360b0"),
+            new Guid("6ff5182f-7644-4bc1-a3a4-38092cb3663a"),
+            Guid.Empty,
+        };
+
+        Snapshot.Validate(guids, settings);
+
+        Assert.Equal(
+        [
+            "- 00000000-0000-0000-0000-000000000001",
+            "- 00000000-0000-0000-0000-000000000001",
+            "- 00000000-0000-0000-0000-000000000002",
+            "- 00000000-0000-0000-0000-000000000000",
+        ], ReadVerifiedSnapshotLines(directory));
+    }
+
+    [Fact]
+    public void Scrub_UseRelativeTimeSpan()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = CreateScrubberSnapshotSettings(directory);
+        var origin = TimeSpan.FromSeconds(1);
+        settings.ConfigureHumanReadableSerializer(options => options.UseRelativeTimeSpan(origin));
+        var values = new[]
+        {
+            TimeSpan.FromSeconds(0),
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(2),
+        };
+
+        Snapshot.Validate(values, settings);
+
+        Assert.Equal(
+        [
+            "- -00:00:01",
+            "- 00:00:00",
+            "- 00:00:01",
+        ], ReadVerifiedSnapshotLines(directory));
+    }
+
+    [Fact]
+    public void Scrub_UseRelativeDateTime()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = CreateScrubberSnapshotSettings(directory);
+        var origin = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        settings.ConfigureHumanReadableSerializer(options => options.UseRelativeDateTime(origin));
+        var values = new[]
+        {
+            origin,
+            origin.AddSeconds(1),
+            origin.AddSeconds(2),
+        };
+
+        Snapshot.Validate(values, settings);
+
+        Assert.Equal(
+        [
+            "- 00:00:00",
+            "- 00:00:01",
+            "- 00:00:02",
+        ], ReadVerifiedSnapshotLines(directory));
+    }
+
     [Theory]
     [InlineData("ping", "ping", "")]
     [InlineData("ping ", "ping", "")]
@@ -582,6 +736,23 @@ public sealed class SnapshotTests
 
         settings.Serializers.Add(new FixedValueSerializer(serializedValue));
         return settings;
+    }
+
+    private static SnapshotSettings CreateScrubberSnapshotSettings(TemporaryDirectory directory)
+    {
+        return new SnapshotSettings
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            AssertionExceptionCreator = new FixedAssertionExceptionBuilder(),
+            SnapshotPathStrategy = _ => directory / "snapshot.verified.txt",
+        };
+    }
+
+    private static string[] ReadVerifiedSnapshotLines(TemporaryDirectory directory)
+    {
+        var path = directory / "snapshot.verified.txt";
+        return File.ReadAllLines(path);
     }
 
     private static SnapshotUpdateStrategy GetSnapshotUpdateStrategy(string name)


### PR DESCRIPTION
## Why
`Meziantou.Framework.SnapshotTesting` did not have the same scrubbing capabilities demonstrated by `InlineSnapshotTesting` (Guid and line-level scrubbing), so test authors could not make file-based snapshots deterministic in the same way.

## What changed
- Added SnapshotTesting scrubber infrastructure for text snapshots:
  - New `Scrubber` base type and line scrubber implementations.
  - New `SnapshotSettings.Scrubbers` collection.
  - New `SnapshotSettings` extension helpers: `ScrubLines`, `ScrubLinesContaining`, `ScrubLinesMatching`, `ScrubLinesWithReplace`, `ScrubMachineName`, and `ScrubUserName`.
- Integrated scrubbing into `SnapshotEngine` so scrubbers run after serialization and before compare/write.
- Added SnapshotTesting-side human-readable scrub helpers in `HumanReadableSerializerScrubExtensions`:
  - `ScrubGuid`, `ScrubValue<T>`, `UseRelativeTimeSpan`, `UseRelativeDateTime`, `UseRelativeDateTimeOffset`.
- Updated `ConfigureHumanReadableSerializer` to clone and replace the human-readable serializer instance before applying configuration, so configuration remains safe even after options become read-only.
- Added/updated tests in `tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs` to demonstrate and verify:
  - Line scrubbers (regex, contains, replace, remove-line behavior).
  - Guid scrubbing determinism.
  - Relative temporal scrubbing behavior.
  - Deep-clone behavior for scrubber collections.
- Updated `src/Meziantou.Framework.SnapshotTesting/readme.md` with scrubbing usage examples.

## Notes for reviewers
- Scrubbing is intentionally limited to UTF-8 text snapshot payloads; applying scrubbers to non-UTF-8 data now throws a `SnapshotException` instead of silently altering binary data paths.