### PR TITLE
Use RestrictedStream in non-seekable VFS test

### DIFF
--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/NonSeekableStreamVirtualFileSystem.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/NonSeekableStreamVirtualFileSystem.cs
@@ -30,39 +30,17 @@ internal sealed class NonSeekableStreamVirtualFileSystem : ProjectedFileSystemBa
                 data[i] = (byte)(i % 256);
             // CA2000 can't track ownership transfer through ValueTask.FromResult.
 #pragma warning disable CA2000 // Dispose objects before losing scope
-            return ValueTask.FromResult<Stream?>(new NonSeekableStream(new MemoryStream(data)));
+            return ValueTask.FromResult<Stream?>(new RestrictedStream(new MemoryStream(data), new RestrictedStreamOptions
+            {
+                AllowSynchronousCalls = true,
+                AllowAsynchronousCalls = true,
+                AllowReading = true,
+                AllowWriting = true,
+                AllowSeeking = false,
+            }));
 #pragma warning restore CA2000 // Dispose objects before losing scope
         }
 
         return ValueTask.FromResult<Stream?>(null);
-    }
-
-    /// <summary>
-    /// Wraps a stream to make it non-seekable, simulating network or pipe streams.
-    /// </summary>
-    private sealed class NonSeekableStream(Stream inner) : Stream
-    {
-        public override bool CanRead => inner.CanRead;
-        public override bool CanSeek => false;
-        public override bool CanWrite => inner.CanWrite;
-        public override long Length => throw new NotSupportedException();
-        public override long Position
-        {
-            get => throw new NotSupportedException();
-            set => throw new NotSupportedException();
-        }
-
-        public override void Flush() => inner.Flush();
-        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
-        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
-        public override void SetLength(long value) => throw new NotSupportedException();
-        public override void Write(byte[] buffer, int offset, int count) => inner.Write(buffer, offset, count);
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-                inner.Dispose();
-            base.Dispose(disposing);
-        }
     }
 }


### PR DESCRIPTION
The projected file system test needs a non-seekable stream behavior without keeping a custom stream wrapper implementation in the test project.

This change replaces the private `NonSeekableStream` class with `RestrictedStream` configured with `AllowSeeking = false`. Read/write and sync/async operations remain enabled so the test still exercises a stream that is only restricted for seeking. The duplicated inner wrapper code is removed, and the existing CA2000 suppression around `ValueTask.FromResult` ownership transfer is kept in place.