### PR TITLE
Add hierarchical multi-level API to TextDiff

### DIFF
--- a/ref/Meziantou.Framework.TextDiff.cs
+++ b/ref/Meziantou.Framework.TextDiff.cs
@@ -14,6 +14,7 @@ namespace Meziantou.Framework
     public static class TextDiff
     {
         public static Meziantou.Framework.TextDiffResult ComputeDiff(string oldText, string newText, Meziantou.Framework.TextDiffOptions? options = null) => throw null;
+        public static Meziantou.Framework.TextDiffHierarchyResult ComputeHierarchyDiff(string oldText, string newText, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.TextChunker> chunkers, Meziantou.Framework.TextDiffOptions? options = null) => throw null;
     }
 
     public enum TextDiffAlgorithm
@@ -35,6 +36,29 @@ namespace Meziantou.Framework
         public static bool operator ==(Meziantou.Framework.TextDiffEntry left, Meziantou.Framework.TextDiffEntry right) => throw null;
         public static bool operator !=(Meziantou.Framework.TextDiffEntry left, Meziantou.Framework.TextDiffEntry right) => throw null;
         public override string ToString() => throw null;
+    }
+
+    public sealed class TextDiffHierarchyEntry
+    {
+        public Meziantou.Framework.TextDiffHierarchyOperation Operation { get => throw null; }
+        public string? OldText { get => throw null; }
+        public string? NewText { get => throw null; }
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.TextDiffHierarchyEntry> Children { get => throw null; }
+        public TextDiffHierarchyEntry(Meziantou.Framework.TextDiffHierarchyOperation operation, string? oldText, string? newText, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.TextDiffHierarchyEntry>? children = null) { }
+    }
+
+    public enum TextDiffHierarchyOperation
+    {
+        Equal = 0,
+        Insert = 1,
+        Delete = 2,
+        Replace = 3
+    }
+
+    public sealed class TextDiffHierarchyResult
+    {
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.TextDiffHierarchyEntry> Entries { get => throw null; }
+        public bool HasDifferences { get => throw null; }
     }
 
     public enum TextDiffOperation

--- a/src/Meziantou.Framework.TextDiff/TextDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiff.cs
@@ -25,6 +25,22 @@ public static class TextDiff
         return BuildResult(oldChunks, newChunks, diff);
     }
 
+    public static TextDiffHierarchyResult ComputeHierarchyDiff(string oldText, string newText, IReadOnlyList<TextChunker> chunkers, TextDiffOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldText);
+        ArgumentNullException.ThrowIfNull(newText);
+        ArgumentNullException.ThrowIfNull(chunkers);
+
+        options ??= new TextDiffOptions();
+
+        var chunkerArray = ValidateChunkers(chunkers);
+        var processedOld = options.IgnoreEndOfLine ? NormalizeLineEndings(oldText) : oldText;
+        var processedNew = options.IgnoreEndOfLine ? NormalizeLineEndings(newText) : newText;
+
+        var comparer = BuildComparer(options);
+        return ComputeHierarchyDiffCore(processedOld, processedNew, chunkerArray, chunkerIndex: 0, options, comparer);
+    }
+
     private static IEqualityComparer<string> BuildComparer(TextDiffOptions options)
     {
         if (!options.IgnoreWhitespace)
@@ -78,6 +94,107 @@ public static class TextDiff
         return new TextDiffResult(entries, hasDifferences);
     }
 
+    private static TextDiffHierarchyResult ComputeHierarchyDiffCore(
+        string oldText,
+        string newText,
+        TextChunker[] chunkers,
+        int chunkerIndex,
+        TextDiffOptions options,
+        IEqualityComparer<string> comparer)
+    {
+        var chunker = chunkers[chunkerIndex];
+        var oldChunks = ToArray(chunker.Chunk(oldText));
+        var newChunks = ToArray(chunker.Chunk(newText));
+        var diff = DiffAlgorithmDispatcher.Compute(options.Algorithm, oldChunks, newChunks, comparer);
+        return BuildHierarchyResult(oldChunks, newChunks, diff, chunkers, chunkerIndex, options, comparer);
+    }
+
+    private static TextDiffHierarchyResult BuildHierarchyResult(
+        string[] oldChunks,
+        string[] newChunks,
+        DiffComputationResult diff,
+        TextChunker[] chunkers,
+        int chunkerIndex,
+        TextDiffOptions options,
+        IEqualityComparer<string> comparer)
+    {
+        var leftModified = diff.LeftModified;
+        var rightModified = diff.RightModified;
+        var leftLength = leftModified.Length;
+        var rightLength = rightModified.Length;
+        var entries = new List<TextDiffHierarchyEntry>(leftLength + rightLength);
+        var hasDifferences = false;
+        var hasInnerLevel = chunkerIndex + 1 < chunkers.Length;
+
+        var left = 0;
+        var right = 0;
+        while (left < leftLength || right < rightLength)
+        {
+            while (left < leftLength
+                && right < rightLength
+                && !leftModified[left]
+                && !rightModified[right])
+            {
+                entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Equal, oldChunks[left], newChunks[right]));
+                left++;
+                right++;
+            }
+
+            if (left >= leftLength && right >= rightLength)
+                break;
+
+            hasDifferences = true;
+
+            var deletedChunks = new List<string>();
+            while (left < leftLength && (right >= rightLength || leftModified[left]))
+            {
+                deletedChunks.Add(oldChunks[left]);
+                left++;
+            }
+
+            var insertedChunks = new List<string>();
+            while (right < rightLength && (left >= leftLength || rightModified[right]))
+            {
+                insertedChunks.Add(newChunks[right]);
+                right++;
+            }
+
+            if (!hasInnerLevel)
+            {
+                for (var i = 0; i < deletedChunks.Count; i++)
+                {
+                    entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Delete, deletedChunks[i], null));
+                }
+
+                for (var i = 0; i < insertedChunks.Count; i++)
+                {
+                    entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Insert, null, insertedChunks[i]));
+                }
+
+                continue;
+            }
+
+            var pairedCount = Math.Min(deletedChunks.Count, insertedChunks.Count);
+            for (var i = 0; i < pairedCount; i++)
+            {
+                var children = ComputeHierarchyDiffCore(deletedChunks[i], insertedChunks[i], chunkers, chunkerIndex + 1, options, comparer);
+                entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Replace, deletedChunks[i], insertedChunks[i], children.Entries));
+            }
+
+            for (var i = pairedCount; i < deletedChunks.Count; i++)
+            {
+                entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Delete, deletedChunks[i], null));
+            }
+
+            for (var i = pairedCount; i < insertedChunks.Count; i++)
+            {
+                entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Insert, null, insertedChunks[i]));
+            }
+        }
+
+        return new TextDiffHierarchyResult(entries, hasDifferences);
+    }
+
     private static string NormalizeLineEndings(string text)
     {
         return text.ReplaceLineEndings("\n");
@@ -92,6 +209,20 @@ public static class TextDiff
             return list.ToArray();
 
         return source.ToArray();
+    }
+
+    private static TextChunker[] ValidateChunkers(IReadOnlyList<TextChunker> chunkers)
+    {
+        if (chunkers.Count < 2)
+            throw new ArgumentException("At least 2 chunkers must be provided.", nameof(chunkers));
+
+        var chunkerArray = new TextChunker[chunkers.Count];
+        for (var i = 0; i < chunkers.Count; i++)
+        {
+            chunkerArray[i] = chunkers[i] ?? throw new ArgumentException("Chunkers cannot contain null values.", nameof(chunkers));
+        }
+
+        return chunkerArray;
     }
 
     private sealed class WhitespaceTrimmingComparer(StringComparer inner) : IEqualityComparer<string>

--- a/src/Meziantou.Framework.TextDiff/TextDiffHierarchyEntry.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiffHierarchyEntry.cs
@@ -1,0 +1,20 @@
+namespace Meziantou.Framework;
+
+public sealed class TextDiffHierarchyEntry
+{
+    public TextDiffHierarchyEntry(TextDiffHierarchyOperation operation, string? oldText, string? newText, IReadOnlyList<TextDiffHierarchyEntry>? children = null)
+    {
+        Operation = operation;
+        OldText = oldText;
+        NewText = newText;
+        Children = children ?? [];
+    }
+
+    public TextDiffHierarchyOperation Operation { get; }
+
+    public string? OldText { get; }
+
+    public string? NewText { get; }
+
+    public IReadOnlyList<TextDiffHierarchyEntry> Children { get; }
+}

--- a/src/Meziantou.Framework.TextDiff/TextDiffHierarchyOperation.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiffHierarchyOperation.cs
@@ -1,0 +1,9 @@
+namespace Meziantou.Framework;
+
+public enum TextDiffHierarchyOperation
+{
+    Equal,
+    Insert,
+    Delete,
+    Replace,
+}

--- a/src/Meziantou.Framework.TextDiff/TextDiffHierarchyResult.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiffHierarchyResult.cs
@@ -1,0 +1,14 @@
+namespace Meziantou.Framework;
+
+public sealed class TextDiffHierarchyResult
+{
+    internal TextDiffHierarchyResult(IReadOnlyList<TextDiffHierarchyEntry> entries, bool hasDifferences)
+    {
+        Entries = entries;
+        HasDifferences = hasDifferences;
+    }
+
+    public IReadOnlyList<TextDiffHierarchyEntry> Entries { get; }
+
+    public bool HasDifferences { get; }
+}

--- a/src/Meziantou.Framework.TextDiff/readme.md
+++ b/src/Meziantou.Framework.TextDiff/readme.md
@@ -36,6 +36,27 @@ var options = new TextDiffOptions
 var result = TextDiff.ComputeDiff("Hello   world\r\n", "hello world\n", options);
 ````
 
+## Compute a hierarchical diff with multiple chunking levels
+
+````csharp
+var result = TextDiff.ComputeHierarchyDiff(
+    oldText: "line1\nhello world\nline3",
+    newText: "line1\nhello brave world\nline3",
+    chunkers: [TextChunker.Lines, TextChunker.Words, TextChunker.Characters]);
+
+foreach (var entry in result.Entries)
+{
+    Console.WriteLine($"{entry.Operation}: old={entry.OldText} new={entry.NewText}");
+
+    foreach (var child in entry.Children)
+    {
+        Console.WriteLine($"  {child.Operation}: old={child.OldText} new={child.NewText}");
+    }
+}
+````
+
+The hierarchy API lets you refine changed chunks progressively (`Lines -> Words -> Characters`, `Words -> Characters`, etc.).
+
 ## Choose a diff algorithm
 
 ````csharp

--- a/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
+++ b/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
@@ -538,16 +538,16 @@ public sealed class TextDiffTests
     [Fact]
     public void ComputeHierarchyDiff_LinesThenWords_NestedChange()
     {
-        const string oldText = "line1\nhello world\nline3";
-        const string newText = "line1\nhello brave world\nline3";
+        const string OldText = "line1\nhello world\nline3";
+        const string NewText = "line1\nhello brave world\nline3";
 
-        var result = Diff.ComputeHierarchyDiff(oldText, newText, [TextChunker.Lines, TextChunker.Words]);
+        var result = Diff.ComputeHierarchyDiff(OldText, NewText, [TextChunker.Lines, TextChunker.Words]);
 
         Assert.True(result.HasDifferences);
-        Assert.Equal(oldText, ReconstructHierarchyOldText(result));
-        Assert.Equal(newText, ReconstructHierarchyNewText(result));
+        Assert.Equal(OldText, ReconstructHierarchyOldText(result));
+        Assert.Equal(NewText, ReconstructHierarchyNewText(result));
 
-        var replacedLine = Assert.Single(result.Entries.Where(e => e.Operation == TextDiffHierarchyOperation.Replace));
+        var replacedLine = Assert.Single(result.Entries, e => e.Operation == TextDiffHierarchyOperation.Replace);
         Assert.Equal("hello world\n", replacedLine.OldText);
         Assert.Equal("hello brave world\n", replacedLine.NewText);
         Assert.Contains(replacedLine.Children, e => e.Operation == TextDiffHierarchyOperation.Insert && e.NewText == "brave");
@@ -556,31 +556,31 @@ public sealed class TextDiffTests
     [Fact]
     public void ComputeHierarchyDiff_LinesWordsCharacters_NestedReplaceWithChildren()
     {
-        const string oldText = "line1\ncolor";
-        const string newText = "line1\ncolour";
+        const string OldText = "line1\ncolor";
+        const string NewText = "line1\ncolour";
 
-        var result = Diff.ComputeHierarchyDiff(oldText, newText, [TextChunker.Lines, TextChunker.Words, TextChunker.Characters]);
+        var result = Diff.ComputeHierarchyDiff(OldText, NewText, [TextChunker.Lines, TextChunker.Words, TextChunker.Characters]);
 
         Assert.True(result.HasDifferences);
-        Assert.Equal(oldText, ReconstructHierarchyOldText(result));
-        Assert.Equal(newText, ReconstructHierarchyNewText(result));
+        Assert.Equal(OldText, ReconstructHierarchyOldText(result));
+        Assert.Equal(NewText, ReconstructHierarchyNewText(result));
 
-        var replacedLine = Assert.Single(result.Entries.Where(e => e.Operation == TextDiffHierarchyOperation.Replace));
-        var replacedWord = Assert.Single(replacedLine.Children.Where(e => e.Operation == TextDiffHierarchyOperation.Replace));
+        var replacedLine = Assert.Single(result.Entries, e => e.Operation == TextDiffHierarchyOperation.Replace);
+        var replacedWord = Assert.Single(replacedLine.Children, e => e.Operation == TextDiffHierarchyOperation.Replace);
         Assert.Contains(replacedWord.Children, e => e.Operation == TextDiffHierarchyOperation.Insert && e.NewText == "u");
     }
 
     [Fact]
     public void ComputeHierarchyDiff_WordsThenCharacters_NestedChanges()
     {
-        const string oldText = "cat dog";
-        const string newText = "cot doge";
+        const string OldText = "cat dog";
+        const string NewText = "cot doge";
 
-        var result = Diff.ComputeHierarchyDiff(oldText, newText, [TextChunker.Words, TextChunker.Characters]);
+        var result = Diff.ComputeHierarchyDiff(OldText, NewText, [TextChunker.Words, TextChunker.Characters]);
 
         Assert.True(result.HasDifferences);
-        Assert.Equal(oldText, ReconstructHierarchyOldText(result));
-        Assert.Equal(newText, ReconstructHierarchyNewText(result));
+        Assert.Equal(OldText, ReconstructHierarchyOldText(result));
+        Assert.Equal(NewText, ReconstructHierarchyNewText(result));
 
         var replacedEntries = result.Entries.Where(e => e.Operation == TextDiffHierarchyOperation.Replace).ToList();
         Assert.Equal(2, replacedEntries.Count);

--- a/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
+++ b/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
@@ -515,6 +515,91 @@ public sealed class TextDiffTests
         Assert.Equal("Insertions: 1, Deletions: 1, Equals: 2", text);
     }
 
+    [Fact]
+    public void ComputeHierarchyDiff_NullChunkers_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => Diff.ComputeHierarchyDiff("a", "b", chunkers: null!));
+    }
+
+    [Fact]
+    public void ComputeHierarchyDiff_InvalidChunkers_Throws()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => Diff.ComputeHierarchyDiff("a", "b", [TextChunker.Lines]));
+        Assert.Equal("chunkers", exception.ParamName);
+
+        exception = Assert.Throws<ArgumentException>(() =>
+        {
+            IReadOnlyList<TextChunker> chunkers = [TextChunker.Lines, null!];
+            _ = Diff.ComputeHierarchyDiff("a", "b", chunkers);
+        });
+        Assert.Equal("chunkers", exception.ParamName);
+    }
+
+    [Fact]
+    public void ComputeHierarchyDiff_LinesThenWords_NestedChange()
+    {
+        const string oldText = "line1\nhello world\nline3";
+        const string newText = "line1\nhello brave world\nline3";
+
+        var result = Diff.ComputeHierarchyDiff(oldText, newText, [TextChunker.Lines, TextChunker.Words]);
+
+        Assert.True(result.HasDifferences);
+        Assert.Equal(oldText, ReconstructHierarchyOldText(result));
+        Assert.Equal(newText, ReconstructHierarchyNewText(result));
+
+        var replacedLine = Assert.Single(result.Entries.Where(e => e.Operation == TextDiffHierarchyOperation.Replace));
+        Assert.Equal("hello world\n", replacedLine.OldText);
+        Assert.Equal("hello brave world\n", replacedLine.NewText);
+        Assert.Contains(replacedLine.Children, e => e.Operation == TextDiffHierarchyOperation.Insert && e.NewText == "brave");
+    }
+
+    [Fact]
+    public void ComputeHierarchyDiff_LinesWordsCharacters_NestedReplaceWithChildren()
+    {
+        const string oldText = "line1\ncolor";
+        const string newText = "line1\ncolour";
+
+        var result = Diff.ComputeHierarchyDiff(oldText, newText, [TextChunker.Lines, TextChunker.Words, TextChunker.Characters]);
+
+        Assert.True(result.HasDifferences);
+        Assert.Equal(oldText, ReconstructHierarchyOldText(result));
+        Assert.Equal(newText, ReconstructHierarchyNewText(result));
+
+        var replacedLine = Assert.Single(result.Entries.Where(e => e.Operation == TextDiffHierarchyOperation.Replace));
+        var replacedWord = Assert.Single(replacedLine.Children.Where(e => e.Operation == TextDiffHierarchyOperation.Replace));
+        Assert.Contains(replacedWord.Children, e => e.Operation == TextDiffHierarchyOperation.Insert && e.NewText == "u");
+    }
+
+    [Fact]
+    public void ComputeHierarchyDiff_WordsThenCharacters_NestedChanges()
+    {
+        const string oldText = "cat dog";
+        const string newText = "cot doge";
+
+        var result = Diff.ComputeHierarchyDiff(oldText, newText, [TextChunker.Words, TextChunker.Characters]);
+
+        Assert.True(result.HasDifferences);
+        Assert.Equal(oldText, ReconstructHierarchyOldText(result));
+        Assert.Equal(newText, ReconstructHierarchyNewText(result));
+
+        var replacedEntries = result.Entries.Where(e => e.Operation == TextDiffHierarchyOperation.Replace).ToList();
+        Assert.Equal(2, replacedEntries.Count);
+
+        Assert.Contains(replacedEntries[0].Children, e => e.Operation == TextDiffHierarchyOperation.Delete && e.OldText == "a");
+        Assert.Contains(replacedEntries[0].Children, e => e.Operation == TextDiffHierarchyOperation.Insert && e.NewText == "o");
+        Assert.Contains(replacedEntries[1].Children, e => e.Operation == TextDiffHierarchyOperation.Insert && e.NewText == "e");
+    }
+
+    [Fact]
+    public void ComputeHierarchyDiff_IgnoreCase_PropagatesToNestedLevels()
+    {
+        var options = new TextDiffOptions { IgnoreCase = true };
+        var result = Diff.ComputeHierarchyDiff("Hello World", "hello world", [TextChunker.Words, TextChunker.Characters], options);
+
+        Assert.False(result.HasDifferences);
+        Assert.All(result.Entries, e => Assert.Equal(TextDiffHierarchyOperation.Equal, e.Operation));
+    }
+
     // Custom TextChunker
     [Fact]
     public void ComputeDiff_CustomChunker()
@@ -627,6 +712,34 @@ public sealed class TextDiffTests
             if (entry.Operation is TextDiffOperation.Equal or TextDiffOperation.Insert)
             {
                 sb.Append(entry.Text);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string ReconstructHierarchyOldText(TextDiffHierarchyResult result)
+    {
+        var sb = new StringBuilder();
+        foreach (var entry in result.Entries)
+        {
+            if (entry.Operation is TextDiffHierarchyOperation.Equal or TextDiffHierarchyOperation.Delete or TextDiffHierarchyOperation.Replace)
+            {
+                sb.Append(entry.OldText);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string ReconstructHierarchyNewText(TextDiffHierarchyResult result)
+    {
+        var sb = new StringBuilder();
+        foreach (var entry in result.Entries)
+        {
+            if (entry.Operation is TextDiffHierarchyOperation.Equal or TextDiffHierarchyOperation.Insert or TextDiffHierarchyOperation.Replace)
+            {
+                sb.Append(entry.NewText);
             }
         }
 


### PR DESCRIPTION
## Why
`TextDiff.ComputeDiff` only returns a flat diff for a single chunking strategy. That makes it hard to build VS Code-like output where changes are refined progressively (for example `Lines -> Words -> Characters`).

## What changed
- Added `TextDiff.ComputeHierarchyDiff(string oldText, string newText, IReadOnlyList<TextChunker> chunkers, TextDiffOptions? options = null)`.
- Added hierarchical result types:
  - `TextDiffHierarchyResult`
  - `TextDiffHierarchyEntry`
  - `TextDiffHierarchyOperation` (`Equal`, `Insert`, `Delete`, `Replace`)
- Implemented recursive multi-level diffing:
  - diff at the current chunker level,
  - pair delete/insert runs deterministically,
  - recurse into the next level for paired chunks,
  - keep unmatched chunks as insert/delete leaves.
- Added input validation for chunker pipelines (minimum 2 chunkers, no null entries).
- Updated docs with usage examples for hierarchical pipelines.
- Added tests covering:
  - validation behavior,
  - `Lines -> Words`,
  - `Lines -> Words -> Characters`,
  - `Words -> Characters`,
  - option propagation (`IgnoreCase`) and reconstruction behavior.

## Notes for reviewers
- Existing `TextDiff.ComputeDiff` behavior is unchanged.
- `Replace` is introduced only in the new hierarchy model; existing `TextDiffOperation` remains unchanged.
- Deterministic pairing in changed runs is intentionally `min(deletes, inserts)` to keep output stable.