### PR TITLE
Add RoundedSquare avatar shape support

### DIFF
--- a/ref/Meziantou.Framework.Avatar.cs
+++ b/ref/Meziantou.Framework.Avatar.cs
@@ -33,6 +33,7 @@ namespace Meziantou.Framework
     public enum AvatarShape
     {
         Round = 0,
-        Square = 1
+        Square = 1,
+        RoundedSquare = 2
     }
 }

--- a/src/Meziantou.Framework.Avatar/AvatarGenerator.cs
+++ b/src/Meziantou.Framework.Avatar/AvatarGenerator.cs
@@ -42,6 +42,7 @@ public static class AvatarGenerator
         var fontSize = size * 0.5;
         var sizeString = size.ToString(CultureInfo.InvariantCulture);
         var halfSizeString = halfSize.ToString("0.##", CultureInfo.InvariantCulture);
+        var roundedCornerRadiusString = (size * 0.25).ToString("0.##", CultureInfo.InvariantCulture);
         var fontSizeString = fontSize.ToString("0.##", CultureInfo.InvariantCulture);
 
         var sb = new StringBuilder(capacity: 256);
@@ -75,6 +76,20 @@ public static class AvatarGenerator
             sb.Append(sizeString);
             sb.Append("\" height=\"");
             sb.Append(sizeString);
+            sb.Append("\" fill=\"");
+            sb.Append(escapedBackgroundColor);
+            sb.Append("\"/>");
+        }
+        else if (shape == AvatarShape.RoundedSquare)
+        {
+            sb.Append("<rect width=\"");
+            sb.Append(sizeString);
+            sb.Append("\" height=\"");
+            sb.Append(sizeString);
+            sb.Append("\" rx=\"");
+            sb.Append(roundedCornerRadiusString);
+            sb.Append("\" ry=\"");
+            sb.Append(roundedCornerRadiusString);
             sb.Append("\" fill=\"");
             sb.Append(escapedBackgroundColor);
             sb.Append("\"/>");

--- a/src/Meziantou.Framework.Avatar/AvatarShape.cs
+++ b/src/Meziantou.Framework.Avatar/AvatarShape.cs
@@ -14,4 +14,9 @@ public enum AvatarShape
     /// Use a square background.
     /// </summary>
     Square,
+
+    /// <summary>
+    /// Use a square background with rounded corners.
+    /// </summary>
+    RoundedSquare,
 }

--- a/src/Meziantou.Framework.Avatar/readme.md
+++ b/src/Meziantou.Framework.Avatar/readme.md
@@ -20,7 +20,7 @@ using Meziantou.Framework;
 var options = new AvatarOptions
 {
     Bigram = "JD", // optional explicit 1-2 character bigram
-    Shape = AvatarShape.Round, // Round or Square
+    Shape = AvatarShape.Round, // Round, Square, or RoundedSquare
     Size = 128,
 };
 options.Palette.Clear();

--- a/tests/Meziantou.Framework.Avatar.Tests/AvatarGeneratorTests.cs
+++ b/tests/Meziantou.Framework.Avatar.Tests/AvatarGeneratorTests.cs
@@ -175,6 +175,17 @@ public class AvatarGeneratorTests
     }
 
     [Fact]
+    public void CreateSvg_RendersRoundedSquareShape()
+    {
+        var options = new AvatarOptions();
+        options.Shape = AvatarShape.RoundedSquare;
+
+        var svg = AvatarGenerator.CreateSvg("John Doe", options);
+
+        Snapshot.Validate(svg, SnapshotType.Svg);
+    }
+
+    [Fact]
     public void CreateSvg_UsesDefaultSize()
     {
         var svg = AvatarGenerator.CreateSvg("John Doe", new AvatarOptions());

--- a/tests/Meziantou.Framework.Avatar.Tests/__snapshots__/AvatarGeneratorTests_CreateSvg_RendersRoundedSquareShape.verified.svg
+++ b/tests/Meziantou.Framework.Avatar.Tests/__snapshots__/AvatarGeneratorTests_CreateSvg_RendersRoundedSquareShape.verified.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="JD"><rect width="64" height="64" rx="16" ry="16" fill="#cfdade"/><text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" alignment-baseline="middle" dy=".05em" fill="#153037" font-family="monospace" font-weight="700" font-size="32">JD</text></svg>


### PR DESCRIPTION
## Why
Avatar generation currently supports only Round and Square backgrounds. Adding a rounded-square option lets callers use a common avatar style without additional SVG post-processing.

## What changed
- Added `AvatarShape.RoundedSquare`.
- Updated `AvatarGenerator` to render `RoundedSquare` as a `<rect>` with `rx`/`ry` set to 25% of the configured size.
- Added snapshot coverage in `CreateSvg_RendersRoundedSquareShape`.
- Updated the Avatar package readme to document the new shape option.
- Regenerated `ref/Meziantou.Framework.Avatar.cs` to include the new enum member.

## Notes
- Existing `Round` and `Square` rendering behavior is unchanged.