### PR TITLE
Support TdsQueryContext in stored procedure delegates

### DIFF
--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
@@ -106,7 +106,7 @@ internal sealed class TdsQueryEngineExecutor
         }
 
         EnsureAuthorized(context, TdsQueryEngineResourceKind.StoredProcedure, context.ProcedureName);
-        var value = await InvokeStoredProcedureAsync(storedProcedure, context.Parameters, cancellationToken).ConfigureAwait(false);
+        var value = await InvokeStoredProcedureAsync(storedProcedure, context, context.Parameters, cancellationToken).ConfigureAwait(false);
         return TdsQueryResultBuilder.FromValue(value);
     }
 
@@ -121,13 +121,19 @@ internal sealed class TdsQueryEngineExecutor
         }
     }
 
-    private static async ValueTask<object?> InvokeStoredProcedureAsync(Delegate storedProcedure, IReadOnlyList<TdsQueryParameter> parameters, CancellationToken cancellationToken)
+    private static async ValueTask<object?> InvokeStoredProcedureAsync(Delegate storedProcedure, TdsQueryContext context, IReadOnlyList<TdsQueryParameter> parameters, CancellationToken cancellationToken)
     {
         var methodParameters = storedProcedure.Method.GetParameters();
         var arguments = new object?[methodParameters.Length];
         for (var i = 0; i < methodParameters.Length; i++)
         {
             var parameter = methodParameters[i];
+            if (parameter.ParameterType == typeof(TdsQueryContext))
+            {
+                arguments[i] = context;
+                continue;
+            }
+
             if (parameter.ParameterType == typeof(CancellationToken))
             {
                 arguments[i] = cancellationToken;

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
@@ -106,7 +106,7 @@ internal sealed class TdsQueryEngineExecutor
         }
 
         EnsureAuthorized(context, TdsQueryEngineResourceKind.StoredProcedure, context.ProcedureName);
-        var value = await InvokeStoredProcedureAsync(storedProcedure, context, context.Parameters, cancellationToken).ConfigureAwait(false);
+        var value = await InvokeStoredProcedureAsync(storedProcedure, context, cancellationToken).ConfigureAwait(false);
         return TdsQueryResultBuilder.FromValue(value);
     }
 
@@ -121,7 +121,7 @@ internal sealed class TdsQueryEngineExecutor
         }
     }
 
-    private static async ValueTask<object?> InvokeStoredProcedureAsync(Delegate storedProcedure, TdsQueryContext context, IReadOnlyList<TdsQueryParameter> parameters, CancellationToken cancellationToken)
+    private static async ValueTask<object?> InvokeStoredProcedureAsync(Delegate storedProcedure, TdsQueryContext context, CancellationToken cancellationToken)
     {
         var methodParameters = storedProcedure.Method.GetParameters();
         var arguments = new object?[methodParameters.Length];
@@ -140,7 +140,7 @@ internal sealed class TdsQueryEngineExecutor
                 continue;
             }
 
-            var queryParameter = parameters.FirstOrDefault(candidate => string.Equals(NormalizeName(candidate.Name), NormalizeName(parameter.Name), StringComparison.OrdinalIgnoreCase));
+            var queryParameter = context.Parameters.FirstOrDefault(candidate => string.Equals(NormalizeName(candidate.Name), NormalizeName(parameter.Name), StringComparison.OrdinalIgnoreCase));
             if (queryParameter is null)
             {
                 if (parameter.HasDefaultValue)

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineOptions.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineOptions.cs
@@ -17,6 +17,7 @@ public sealed class TdsQueryEngineOptions
     };
 
     /// <summary>Gets the stored procedures available to RPC requests.</summary>
+    /// <remarks>Stored procedure delegates can declare parameters matching RPC parameters, plus optional injected <see cref="TdsQueryContext" /> and <see cref="CancellationToken" /> parameters.</remarks>
     public IDictionary<string, Delegate> StoredProcedures { get; } = new Dictionary<string, Delegate>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Gets the query roots available to SQL text queries.</summary>

--- a/src/Meziantou.Framework.TdsServer/readme.md
+++ b/src/Meziantou.Framework.TdsServer/readme.md
@@ -85,13 +85,26 @@ queryEngineOptions.AddQueryRoot(
 
         return customers;
     });
-queryEngineOptions.StoredProcedures.Add("GetCustomer", (int id) => customers.Where(customer => customer.Id == id));
+queryEngineOptions.StoredProcedures.Add(
+    "GetCustomer",
+    (TdsQueryContext context, int id) =>
+    {
+        var userIdClaim = context.UserContext?.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!int.TryParse(userIdClaim, out var userId))
+        {
+            return Array.Empty<Customer>().AsQueryable();
+        }
+
+        return customers.Where(customer => customer.Id == id && customer.Id == userId);
+    });
 
 app.MapTdsAuthenticationHandler((context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success()));
 app.MapTdsQueryEngine(queryEngineOptions);
 ```
 
 Query roots are resolved per request and receive the full query `context`, so you can prefilter data for the authenticated user (or use other request metadata) before SQL translation happens.
+
+Stored procedure delegates can also declare a `TdsQueryContext` parameter (and optionally `CancellationToken`) to access authenticated user information and request metadata directly.
 
 You can also deny access to a specific stored procedure or query root:
 

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -2963,6 +2963,41 @@ public sealed class TdsQueryEngineTests
 
     [Fact]
     [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "The stored procedure name is generated within the test and not user-controlled.")]
+    public async Task SqlClient_QueryEngine_StoredProcedure_CanUseQueryContext()
+    {
+        var procedureName = "query_engine_proc_" + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+        var queryEngineOptions = CreateQueryEngineOptions();
+        queryEngineOptions.StoredProcedures.Add(
+            procedureName,
+            (TdsQueryContext context, int id) =>
+            {
+                var userIdClaim = context.UserContext?.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (!int.TryParse(userIdClaim, NumberStyles.Integer, CultureInfo.InvariantCulture, out var userId))
+                {
+                    return Array.Empty<Customer>().AsQueryable();
+                }
+
+                return GetCustomers().Where(customer => customer.Id == id && customer.Id == userId);
+            });
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandType = CommandType.StoredProcedure;
+                command.CommandText = procedureName;
+                _ = command.Parameters.Add(new SqlParameter("@id", SqlDbType.Int) { Value = 2 });
+            },
+            """
+            Id Name
+            2 Bob
+            """,
+            expectedMaterializedQueries: "",
+            userContext: CreateUserContext("2"));
+    }
+
+    [Fact]
+    [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "The stored procedure name is generated within the test and not user-controlled.")]
     public async Task SqlClient_QueryEngine_StoredProcedure_Unauthorized_ReturnsPermissionDenied()
     {
         var procedureName = "query_engine_proc_" + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);


### PR DESCRIPTION
## Why
Stored procedure delegates could not access request context, including the authenticated user, while query roots already could. This made per-user filtering awkward for RPC-based queries.

## What changed
- Inject `TdsQueryContext` into stored procedure delegates when a delegate parameter has that type.
- Keep existing behavior for SQL parameter name matching, type conversion, optional/default parameters, authorization checks, and `CancellationToken` injection.
- Add coverage in `TdsQueryEngineTests` with `SqlClient_QueryEngine_StoredProcedure_CanUseQueryContext`, which filters results using the authenticated user claim.
- Update query engine docs (`TdsQueryEngineOptions` remarks and TDS server README) to document context-aware stored procedure delegates.

## Notes for reviewers
- This is backward compatible: delegates that only use SQL parameters and/or `CancellationToken` continue to behave the same.
- Context injection is type-based (`TdsQueryContext`) and independent of parameter name or position.