### PR TITLE
Add HtmlToMarkdown delimiter safety regression tests

### DIFF
--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlToMarkdownConverterTests.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlToMarkdownConverterTests.cs
@@ -403,6 +403,14 @@ public sealed class HtmlToMarkdownConverterTests
             "`` `code` ``");
     }
 
+    [Fact]
+    public void InlineCode_TripleBackticksAtStartAndEnd()
+    {
+        AssertHtmlToMarkdown(
+            "<code>```code```</code>",
+            "```` ```code``` ````");
+    }
+
     // --- Links ---
 
     [Fact]
@@ -830,6 +838,18 @@ public sealed class HtmlToMarkdownConverterTests
     }
 
     [Fact]
+    public void CodeBlock_FencedWithLanguageAndBackticksInContent()
+    {
+        AssertHtmlToMarkdown(
+            """<pre><code class="language-javascript">const fence = "```";</code></pre>""",
+            """
+            ````javascript
+            const fence = "```";
+            ````
+            """);
+    }
+
+    [Fact]
     public void CodeBlock_FencedWithBackticksInContent()
     {
         AssertHtmlToMarkdown(
@@ -859,6 +879,18 @@ public sealed class HtmlToMarkdownConverterTests
             ```
             preformatted text
             ```
+            """);
+    }
+
+    [Fact]
+    public void CodeBlock_PreWithoutCode_WithBackticksInContent()
+    {
+        AssertHtmlToMarkdown(
+            "<pre>use ``` for code</pre>",
+            """
+            ````
+            use ``` for code
+            ````
             """);
     }
 


### PR DESCRIPTION
## Why
When HTML code content includes fence-like backtick runs, Markdown output must use delimiters that cannot conflict with the content. This behavior is implemented today, but coverage was missing for a few important combinations, which made regressions easier to introduce.

## What changed
This PR adds focused regression tests in `HtmlToMarkdownConverterTests` to validate delimiter selection for both fenced code blocks and inline code spans:

- inline `<code>` content with triple backticks at both boundaries
- fenced code blocks with language info where content contains triple backticks
- `<pre>` blocks without nested `<code>` where content contains triple backticks

## Notes
No converter logic change was needed. The existing implementation already computes safe delimiter lengths; this PR hardens the test suite around those edge cases.