### PR TITLE
Add process factory and interceptor APIs to ProcessWrapper

### DIFF
--- a/ref/Meziantou.Framework.ProcessWrapper.cs
+++ b/ref/Meziantou.Framework.ProcessWrapper.cs
@@ -35,8 +35,7 @@ namespace Meziantou.Framework
     {
         public FakeProcessFactory(System.Func<System.Diagnostics.ProcessStartInfo, Meziantou.Framework.FakeProcess> factory) { }
         public FakeProcessFactory(params Meziantou.Framework.FakeProcess[] processes) { }
-        public Meziantou.Framework.FakeProcess CreateProcess(System.Diagnostics.ProcessStartInfo processStartInfo) => throw null;
-        Meziantou.Framework.IProcessHandle Meziantou.Framework.IProcessFactory.Create(System.Diagnostics.ProcessStartInfo startInfo) => throw null;
+        Meziantou.Framework.IProcessHandle Meziantou.Framework.IProcessFactory.Create(System.Diagnostics.ProcessStartInfo processStartInfo) => throw null;
     }
 
     public interface IProcessFactory
@@ -56,6 +55,16 @@ namespace Meziantou.Framework
         bool Start();
         System.Threading.Tasks.Task WaitForExitAsync(System.Threading.CancellationToken cancellationToken);
         void Kill(bool entireProcessTree = true);
+    }
+
+    public interface IProcessStartInfoInterceptor
+    {
+        void Intercept(Meziantou.Framework.ProcessWrapper processWrapper, System.Diagnostics.ProcessStartInfo processStartInfo);
+    }
+
+    public interface IProcessWrapperInterceptor
+    {
+        void Intercept(Meziantou.Framework.ProcessWrapper processWrapper);
     }
 
     public abstract class InputSource
@@ -192,6 +201,8 @@ namespace Meziantou.Framework
     public sealed class ProcessWrapper
     {
         public static Meziantou.Framework.IProcessFactory DefaultProcessFactory { get => throw null; set { } }
+        public static System.IDisposable AddInterceptor(Meziantou.Framework.IProcessWrapperInterceptor interceptor) => throw null;
+        public static System.IDisposable AddInterceptor(Meziantou.Framework.IProcessStartInfoInterceptor interceptor) => throw null;
         public static Meziantou.Framework.ProcessWrapper Create(string fileName) => throw null;
         public static Meziantou.Framework.ProcessPipeline operator |(Meziantou.Framework.ProcessWrapper left, Meziantou.Framework.ProcessWrapper right) => throw null;
         public Meziantou.Framework.ProcessWrapper WithArguments(params string[] arguments) => throw null;
@@ -201,6 +212,8 @@ namespace Meziantou.Framework
         public Meziantou.Framework.ProcessWrapper WithEnvironmentVariables(System.Collections.Generic.IReadOnlyDictionary<string, string?> variables) => throw null;
         public Meziantou.Framework.ProcessWrapper WithValidation(Meziantou.Framework.ProcessValidationMode mode) => throw null;
         public Meziantou.Framework.ProcessWrapper WithProcessFactory(Meziantou.Framework.IProcessFactory processFactory) => throw null;
+        public Meziantou.Framework.ProcessWrapper WithInterceptor(Meziantou.Framework.IProcessWrapperInterceptor interceptor) => throw null;
+        public Meziantou.Framework.ProcessWrapper WithInterceptor(Meziantou.Framework.IProcessStartInfoInterceptor interceptor) => throw null;
         public Meziantou.Framework.ProcessWrapper WithOutputEncoding(System.Text.Encoding encoding) => throw null;
         public Meziantou.Framework.ProcessWrapper WithErrorEncoding(System.Text.Encoding encoding) => throw null;
         public Meziantou.Framework.ProcessWrapper WithLimits(Meziantou.Framework.ProcessLimits limits) => throw null;

--- a/ref/Meziantou.Framework.ProcessWrapper.cs
+++ b/ref/Meziantou.Framework.ProcessWrapper.cs
@@ -15,6 +15,49 @@ namespace Meziantou.Framework
         public Meziantou.Framework.ProcessOutputCollection Output { get => throw null; }
     }
 
+    public sealed class FakeProcess : Meziantou.Framework.IProcessHandle, System.IDisposable
+    {
+        public static Meziantou.Framework.FakeProcess Create(int exitCode) => throw null;
+        public static Meziantou.Framework.FakeProcess Create(int exitCode, System.IO.Stream outputStream, System.IO.Stream errorStream) => throw null;
+        public static Meziantou.Framework.FakeProcess Create(int exitCode, string outputText, string errorText) => throw null;
+        public static Meziantou.Framework.FakeProcess CreatePending(int exitCode) => throw null;
+        public static Meziantou.Framework.FakeProcess CreatePending(int exitCode, System.IO.Stream outputStream, System.IO.Stream errorStream) => throw null;
+        public static Meziantou.Framework.FakeProcess CreatePending(int exitCode, string outputText, string errorText) => throw null;
+        public void Complete(int? exitCode = null) { }
+        public string ReadInputAsText(System.Text.Encoding? encoding = null) => throw null;
+        bool Meziantou.Framework.IProcessHandle.Start() => throw null;
+        System.Threading.Tasks.Task Meziantou.Framework.IProcessHandle.WaitForExitAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+        void Meziantou.Framework.IProcessHandle.Kill(bool entireProcessTree) { }
+        void System.IDisposable.Dispose() { }
+    }
+
+    public sealed class FakeProcessFactory : Meziantou.Framework.IProcessFactory
+    {
+        public FakeProcessFactory(System.Func<System.Diagnostics.ProcessStartInfo, Meziantou.Framework.FakeProcess> factory) { }
+        public FakeProcessFactory(params Meziantou.Framework.FakeProcess[] processes) { }
+        public Meziantou.Framework.FakeProcess CreateProcess(System.Diagnostics.ProcessStartInfo processStartInfo) => throw null;
+        Meziantou.Framework.IProcessHandle Meziantou.Framework.IProcessFactory.Create(System.Diagnostics.ProcessStartInfo startInfo) => throw null;
+    }
+
+    public interface IProcessFactory
+    {
+        Meziantou.Framework.IProcessHandle Create(System.Diagnostics.ProcessStartInfo startInfo);
+    }
+
+    public interface IProcessHandle : System.IDisposable
+    {
+        int Id { get; }
+        bool HasExited { get; }
+        int ExitCode { get; }
+        System.IO.Stream InputStream { get; }
+        System.IO.Stream OutputStream { get; }
+        System.IO.Stream ErrorStream { get; }
+        Microsoft.Win32.SafeHandles.SafeProcessHandle? SafeProcessHandle { get; }
+        bool Start();
+        System.Threading.Tasks.Task WaitForExitAsync(System.Threading.CancellationToken cancellationToken);
+        void Kill(bool entireProcessTree = true);
+    }
+
     public abstract class InputSource
     {
         public static Meziantou.Framework.InputSource FromStream(System.IO.Stream stream) => throw null;
@@ -148,6 +191,7 @@ namespace Meziantou.Framework
 
     public sealed class ProcessWrapper
     {
+        public static Meziantou.Framework.IProcessFactory DefaultProcessFactory { get => throw null; set { } }
         public static Meziantou.Framework.ProcessWrapper Create(string fileName) => throw null;
         public static Meziantou.Framework.ProcessPipeline operator |(Meziantou.Framework.ProcessWrapper left, Meziantou.Framework.ProcessWrapper right) => throw null;
         public Meziantou.Framework.ProcessWrapper WithArguments(params string[] arguments) => throw null;
@@ -156,6 +200,7 @@ namespace Meziantou.Framework
         public Meziantou.Framework.ProcessWrapper WithEnvironmentVariables(System.Action<Meziantou.Framework.ProcessWrapperEnvironmentVariables> configure) => throw null;
         public Meziantou.Framework.ProcessWrapper WithEnvironmentVariables(System.Collections.Generic.IReadOnlyDictionary<string, string?> variables) => throw null;
         public Meziantou.Framework.ProcessWrapper WithValidation(Meziantou.Framework.ProcessValidationMode mode) => throw null;
+        public Meziantou.Framework.ProcessWrapper WithProcessFactory(Meziantou.Framework.IProcessFactory processFactory) => throw null;
         public Meziantou.Framework.ProcessWrapper WithOutputEncoding(System.Text.Encoding encoding) => throw null;
         public Meziantou.Framework.ProcessWrapper WithErrorEncoding(System.Text.Encoding encoding) => throw null;
         public Meziantou.Framework.ProcessWrapper WithLimits(Meziantou.Framework.ProcessLimits limits) => throw null;
@@ -175,5 +220,11 @@ namespace Meziantou.Framework
     {
         public Meziantou.Framework.ProcessWrapperEnvironmentVariables Set(string name, string value) => throw null;
         public Meziantou.Framework.ProcessWrapperEnvironmentVariables Remove(string name) => throw null;
+    }
+
+    public sealed class SystemProcessFactory : Meziantou.Framework.IProcessFactory
+    {
+        public static Meziantou.Framework.SystemProcessFactory Instance { get => throw null; }
+        public Meziantou.Framework.IProcessHandle Create(System.Diagnostics.ProcessStartInfo startInfo) => throw null;
     }
 }

--- a/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
@@ -9,7 +9,7 @@ public sealed class BufferedProcessInstance : ProcessInstance
     private readonly ProcessOutputCollection _output;
     private Task<BufferedProcessResult>? _waitTask;
 
-    internal BufferedProcessInstance(Process process, Task inputTask, Task outputTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, Activity? activity, CancellationToken cancellationToken)
+    internal BufferedProcessInstance(IProcessHandle process, Task inputTask, Task outputTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, Activity? activity, CancellationToken cancellationToken)
         : base(process, inputTask, outputTask, cancellationRegistration, processLimiter, validationMode, hasStandardErrorOutput, activity, cancellationToken)
     {
         _output = output;

--- a/src/Meziantou.Framework.ProcessWrapper/FakeProcess.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/FakeProcess.cs
@@ -1,0 +1,168 @@
+using Microsoft.Win32.SafeHandles;
+
+namespace Meziantou.Framework;
+
+/// <summary>Represents an in-memory process handle intended for tests.</summary>
+public sealed class FakeProcess : IProcessHandle
+{
+    private static int s_processId;
+    private readonly TaskCompletionSource _waitForExitTaskSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly int _id;
+    private readonly Stream _inputStream;
+    private readonly Stream _outputStream;
+    private readonly Stream _errorStream;
+    private readonly int _initialExitCode;
+    private bool _completeOnStart = true;
+    private bool _isDisposed;
+    private int _exitCode;
+    private bool _hasExited;
+
+    private FakeProcess(int exitCode, Stream outputStream, Stream errorStream)
+    {
+        ArgumentNullException.ThrowIfNull(outputStream);
+        ArgumentNullException.ThrowIfNull(errorStream);
+
+        _initialExitCode = exitCode;
+        _exitCode = exitCode;
+        _outputStream = outputStream;
+        _errorStream = errorStream;
+        _inputStream = new MemoryStream();
+        _id = Interlocked.Increment(ref s_processId);
+    }
+
+    /// <summary>Creates a fake process with empty standard output and standard error streams.</summary>
+    /// <param name="exitCode">The process exit code.</param>
+    public static FakeProcess Create(int exitCode)
+    {
+        return new FakeProcess(exitCode, Stream.Null, Stream.Null);
+    }
+
+    /// <summary>Creates a fake process with the specified standard output and standard error streams.</summary>
+    /// <param name="exitCode">The process exit code.</param>
+    /// <param name="outputStream">The stream used as standard output.</param>
+    /// <param name="errorStream">The stream used as standard error.</param>
+    public static FakeProcess Create(int exitCode, Stream outputStream, Stream errorStream)
+    {
+        return new FakeProcess(exitCode, outputStream, errorStream);
+    }
+
+    /// <summary>Creates a fake process with UTF-8 encoded text output.</summary>
+    /// <param name="exitCode">The process exit code.</param>
+    /// <param name="outputText">The standard output text.</param>
+    /// <param name="errorText">The standard error text.</param>
+    public static FakeProcess Create(int exitCode, string outputText, string errorText)
+    {
+        return new FakeProcess(exitCode, CreateTextStream(outputText), CreateTextStream(errorText));
+    }
+
+    /// <summary>Creates a fake process that does not complete automatically when started.</summary>
+    /// <param name="exitCode">The process exit code.</param>
+    public static FakeProcess CreatePending(int exitCode)
+    {
+        var process = Create(exitCode);
+        process._completeOnStart = false;
+        return process;
+    }
+
+    /// <summary>Creates a fake process with provided streams that does not complete automatically when started.</summary>
+    /// <param name="exitCode">The process exit code.</param>
+    /// <param name="outputStream">The stream used as standard output.</param>
+    /// <param name="errorStream">The stream used as standard error.</param>
+    public static FakeProcess CreatePending(int exitCode, Stream outputStream, Stream errorStream)
+    {
+        var process = Create(exitCode, outputStream, errorStream);
+        process._completeOnStart = false;
+        return process;
+    }
+
+    /// <summary>Creates a fake process with text output that does not complete automatically when started.</summary>
+    /// <param name="exitCode">The process exit code.</param>
+    /// <param name="outputText">The standard output text.</param>
+    /// <param name="errorText">The standard error text.</param>
+    public static FakeProcess CreatePending(int exitCode, string outputText, string errorText)
+    {
+        var process = Create(exitCode, outputText, errorText);
+        process._completeOnStart = false;
+        return process;
+    }
+
+    /// <summary>Completes the process execution and sets the process exit code.</summary>
+    /// <param name="exitCode">Optional exit code override. If <see langword="null" />, keeps the configured code.</param>
+    public void Complete(int? exitCode = null)
+    {
+        if (_hasExited)
+            return;
+
+        _exitCode = exitCode ?? _initialExitCode;
+        _hasExited = true;
+        _waitForExitTaskSource.TrySetResult();
+    }
+
+    /// <summary>Reads the captured standard input text as UTF-8 by default.</summary>
+    /// <param name="encoding">The text encoding.</param>
+    /// <returns>The captured standard input content.</returns>
+    public string ReadInputAsText(Encoding? encoding = null)
+    {
+        if (_inputStream is not MemoryStream inputStream)
+            throw new NotSupportedException("Reading captured input is supported only when input stream is a MemoryStream.");
+
+        return (encoding ?? Encoding.UTF8).GetString(inputStream.ToArray());
+    }
+
+    private static MemoryStream CreateTextStream(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return new MemoryStream(Encoding.UTF8.GetBytes(text));
+    }
+
+    private bool StartCore()
+    {
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+
+        if (_completeOnStart)
+        {
+            Complete();
+        }
+
+        return true;
+    }
+
+    private Task WaitForExitCoreAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+        return _waitForExitTaskSource.Task.WaitAsync(cancellationToken);
+    }
+
+    private void KillCore()
+    {
+        ObjectDisposedException.ThrowIf(_isDisposed, this);
+
+        if (!_hasExited)
+        {
+            Complete(_initialExitCode == 0 ? -1 : _initialExitCode);
+        }
+    }
+
+    private void DisposeCore()
+    {
+        if (_isDisposed)
+            return;
+
+        _isDisposed = true;
+        _inputStream.Dispose();
+        _outputStream.Dispose();
+        _errorStream.Dispose();
+    }
+
+    bool IProcessHandle.Start() => StartCore();
+    int IProcessHandle.Id => _id;
+    bool IProcessHandle.HasExited => _hasExited;
+    int IProcessHandle.ExitCode => _exitCode;
+    Stream IProcessHandle.InputStream => _inputStream;
+    Stream IProcessHandle.OutputStream => _outputStream;
+    Stream IProcessHandle.ErrorStream => _errorStream;
+    SafeProcessHandle? IProcessHandle.SafeProcessHandle => null;
+    Task IProcessHandle.WaitForExitAsync(CancellationToken cancellationToken) => WaitForExitCoreAsync(cancellationToken);
+    void IProcessHandle.Kill(bool entireProcessTree) => KillCore();
+    void IDisposable.Dispose() => DisposeCore();
+}

--- a/src/Meziantou.Framework.ProcessWrapper/FakeProcessFactory.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/FakeProcessFactory.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics;
+
+namespace Meziantou.Framework;
+
+/// <summary>
+/// Represents a process factory creating <see cref="FakeProcess" /> instances.
+/// </summary>
+public sealed class FakeProcessFactory : IProcessFactory
+{
+    private readonly Func<ProcessStartInfo, FakeProcess> _factory;
+
+    /// <summary>Initializes a factory using a callback to create fake processes.</summary>
+    /// <param name="factory">The callback creating fake processes.</param>
+    public FakeProcessFactory(Func<ProcessStartInfo, FakeProcess> factory)
+    {
+        _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+    }
+
+    /// <summary>Initializes a factory that returns the provided fake processes in sequence.</summary>
+    /// <param name="processes">The sequence of fake processes to return.</param>
+    public FakeProcessFactory(params FakeProcess[] processes)
+    {
+        ArgumentNullException.ThrowIfNull(processes);
+
+        if (processes.Length == 0)
+            throw new ArgumentException("At least one fake process must be provided.", nameof(processes));
+
+        foreach (var process in processes)
+        {
+            if(process == null)
+                throw new ArgumentException("Fake processes cannot contain null values.", nameof(processes));
+        }
+
+        var queue = new Queue<FakeProcess>(processes);
+        var syncObject = new Lock();
+        _factory = _ =>
+        {
+            lock (syncObject)
+            {
+                if (!queue.TryDequeue(out var process))
+                    throw new InvalidOperationException("No fake process is available for this execution.");
+
+                return process;
+            }
+        };
+    }
+
+    IProcessHandle IProcessFactory.Create(ProcessStartInfo processStartInfo)
+    {
+            ArgumentNullException.ThrowIfNull(processStartInfo);
+
+        var process = _factory(processStartInfo);
+        return process ?? throw new InvalidOperationException("Fake process factory returned null.");
+    }
+}

--- a/src/Meziantou.Framework.ProcessWrapper/IProcessFactory.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/IProcessFactory.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics;
+
+namespace Meziantou.Framework;
+
+/// <summary>
+/// Represents a factory used by <see cref="ProcessWrapper"/> to create process handles.
+/// </summary>
+public interface IProcessFactory
+{
+    /// <summary>Creates a process handle from the provided start information.</summary>
+    /// <param name="startInfo">The process start information.</param>
+    /// <returns>A process handle.</returns>
+    IProcessHandle Create(ProcessStartInfo startInfo);
+}

--- a/src/Meziantou.Framework.ProcessWrapper/IProcessHandle.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/IProcessHandle.cs
@@ -1,0 +1,44 @@
+using Microsoft.Win32.SafeHandles;
+
+namespace Meziantou.Framework;
+
+/// <summary>
+/// Represents a process handle used by <see cref="ProcessWrapper"/>.
+/// </summary>
+public interface IProcessHandle : IDisposable
+{
+    /// <summary>Starts the process.</summary>
+    /// <returns><see langword="true" /> if the process starts successfully; otherwise, <see langword="false" />.</returns>
+    bool Start();
+
+    /// <summary>Gets the process identifier.</summary>
+    int Id { get; }
+
+    /// <summary>Gets a value indicating whether the process has exited.</summary>
+    bool HasExited { get; }
+
+    /// <summary>Gets the process exit code.</summary>
+    int ExitCode { get; }
+
+    /// <summary>Gets the process standard input stream.</summary>
+    Stream InputStream { get; }
+
+    /// <summary>Gets the process standard output stream.</summary>
+    Stream OutputStream { get; }
+
+    /// <summary>Gets the process standard error stream.</summary>
+    Stream ErrorStream { get; }
+
+    /// <summary>
+    /// Gets the process safe handle, or <see langword="null" /> if it is not available.
+    /// </summary>
+    SafeProcessHandle? SafeProcessHandle { get; }
+
+    /// <summary>Asynchronously waits for the process to exit.</summary>
+    /// <param name="cancellationToken">A token to cancel waiting.</param>
+    Task WaitForExitAsync(CancellationToken cancellationToken);
+
+    /// <summary>Kills the process.</summary>
+    /// <param name="entireProcessTree"><see langword="true" /> to kill the entire process tree.</param>
+    void Kill(bool entireProcessTree = true);
+}

--- a/src/Meziantou.Framework.ProcessWrapper/IProcessHandleWithEncoding.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/IProcessHandleWithEncoding.cs
@@ -1,0 +1,8 @@
+namespace Meziantou.Framework;
+
+internal interface IProcessHandleWithEncoding
+{
+    Encoding OutputEncoding { get; }
+
+    Encoding ErrorEncoding { get; }
+}

--- a/src/Meziantou.Framework.ProcessWrapper/IProcessStartInfoInterceptor.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/IProcessStartInfoInterceptor.cs
@@ -1,0 +1,16 @@
+using System.Diagnostics;
+
+namespace Meziantou.Framework;
+
+/// <summary>
+/// Represents an interceptor that can inspect or mutate the <see cref="ProcessStartInfo"/> before process creation.
+/// </summary>
+public interface IProcessStartInfoInterceptor
+{
+    /// <summary>
+    /// Invoked before a process is created from the start information.
+    /// </summary>
+    /// <param name="processWrapper">The process wrapper being executed.</param>
+    /// <param name="processStartInfo">The process start information that will be used to create the process.</param>
+    void Intercept(ProcessWrapper processWrapper, ProcessStartInfo processStartInfo);
+}

--- a/src/Meziantou.Framework.ProcessWrapper/IProcessWrapperInterceptor.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/IProcessWrapperInterceptor.cs
@@ -1,0 +1,13 @@
+namespace Meziantou.Framework;
+
+/// <summary>
+/// Represents an interceptor that can inspect or mutate a <see cref="ProcessWrapper"/> before execution.
+/// </summary>
+public interface IProcessWrapperInterceptor
+{
+    /// <summary>
+    /// Invoked before process execution starts.
+    /// </summary>
+    /// <param name="processWrapper">The process wrapper being executed.</param>
+    void Intercept(ProcessWrapper processWrapper);
+}

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
@@ -12,7 +12,7 @@ namespace Meziantou.Framework;
 /// </summary>
 public class ProcessInstance
 {
-    private Process? _process;
+    private IProcessHandle? _process;
     private readonly Task _inputStreamTask;
     private readonly Task _outputStreamTask;
     private readonly CancellationTokenRegistration _cancellationRegistration;
@@ -25,7 +25,7 @@ public class ProcessInstance
     private protected readonly Lock WaitTaskLock = new();
     private Task<ProcessResult>? _waitTask;
 
-    internal ProcessInstance(Process process, Task inputStreamTask, Task outputStreamTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, Activity? activity, CancellationToken cancellationToken)
+    internal ProcessInstance(IProcessHandle process, Task inputStreamTask, Task outputStreamTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, Activity? activity, CancellationToken cancellationToken)
     {
         _process = process;
         _inputStreamTask = inputStreamTask;
@@ -55,14 +55,7 @@ public class ProcessInstance
         if (process is null)
             return null;
 
-        try
-        {
-            return process.SafeHandle;
-        }
-        catch (InvalidOperationException)
-        {
-            return null;
-        }
+        return process.SafeProcessHandle;
     }
 
     /// <summary>Gets an awaiter that waits for the process to exit and returns the process result.</summary>
@@ -84,31 +77,13 @@ public class ProcessInstance
         KillProcess(process, entireProcessTree);
     }
 
-    internal static void KillProcess(Process process, bool entireProcessTree)
+    internal static void KillProcess(IProcessHandle process, bool entireProcessTree)
     {
+        ArgumentNullException.ThrowIfNull(process);
+
         try
         {
             process.Kill(entireProcessTree);
-        }
-        catch (AggregateException) when (entireProcessTree)
-        {
-            try
-            {
-                process.Kill();
-            }
-            catch (InvalidOperationException)
-            {
-            }
-        }
-        catch (InvalidOperationException) when (entireProcessTree)
-        {
-            try
-            {
-                process.Kill();
-            }
-            catch (InvalidOperationException)
-            {
-            }
         }
         catch (InvalidOperationException)
         {
@@ -168,7 +143,7 @@ public class ProcessInstance
     }
 
     // Wait for process exit and dispose all resources (do not wait for user to await the instance)
-    private async Task<ProcessCompletion> WaitForProcessExitAsync(Process process)
+    private async Task<ProcessCompletion> WaitForProcessExitAsync(IProcessHandle process)
     {
         Exception? inputStreamException = null;
         Exception? outputStreamException = null;

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessPipeline.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessPipeline.cs
@@ -2,9 +2,7 @@ using System.Collections.Immutable;
 
 namespace Meziantou.Framework;
 
-/// <summary>
-/// Represents an ordered set of commands connected through standard streams.
-/// </summary>
+/// <summary>Represents an ordered set of commands connected through standard streams.</summary>
 public sealed class ProcessPipeline
 {
     private readonly ImmutableArray<ProcessWrapper> _commands;
@@ -25,9 +23,7 @@ public sealed class ProcessPipeline
         return new ProcessPipeline([first, second]);
     }
 
-    /// <summary>
-    /// Appends a command to the pipeline.
-    /// </summary>
+    /// <summary>Appends a command to the pipeline.</summary>
     public static ProcessPipeline operator |(ProcessPipeline left, ProcessWrapper right)
     {
         ArgumentNullException.ThrowIfNull(left);
@@ -36,9 +32,7 @@ public sealed class ProcessPipeline
         return left.Append(right);
     }
 
-    /// <summary>
-    /// Prepends a command to the pipeline.
-    /// </summary>
+    /// <summary>Prepends a command to the pipeline.</summary>
     public static ProcessPipeline operator |(ProcessWrapper left, ProcessPipeline right)
     {
         ArgumentNullException.ThrowIfNull(left);
@@ -47,18 +41,14 @@ public sealed class ProcessPipeline
         return right.Prepend(left);
     }
 
-    /// <summary>
-    /// Executes the pipeline and returns the result of the last command.
-    /// </summary>
+    /// <summary>Executes the pipeline and returns the result of the last command.</summary>
     public Task<ProcessResult> ExecuteAsync(CancellationToken cancellationToken = default)
     {
         var execution = StartStages(bufferLastCommand: false, cancellationToken);
         return WaitForPipelineAsync(execution);
     }
 
-    /// <summary>
-    /// Executes the pipeline with buffering enabled for the last command.
-    /// </summary>
+    /// <summary>Executes the pipeline with buffering enabled for the last command.</summary>
     public Task<BufferedProcessResult> ExecuteBufferedAsync(CancellationToken cancellationToken = default)
     {
         var execution = StartStages(bufferLastCommand: true, cancellationToken);

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -366,7 +366,6 @@ public sealed class ProcessWrapper
 
         var processFactory = _processFactory ?? DefaultProcessFactory;
         var processHandle = processFactory.Create(startInfo);
-        ArgumentNullException.ThrowIfNull(processHandle);
         var processLimiter = CreateProcessLimiter();
 
         var processStarted = false;

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -15,7 +15,12 @@ namespace Meziantou.Framework;
 public sealed class ProcessWrapper
 {
     private static IProcessFactory s_defaultProcessFactory = SystemProcessFactory.Instance;
+    private static readonly Lock DefaultInterceptorsLock = new();
+    private static ImmutableArray<IProcessWrapperInterceptor> s_defaultProcessWrapperInterceptors = [];
+    private static ImmutableArray<IProcessStartInfoInterceptor> s_defaultProcessStartInfoInterceptors = [];
     private IProcessFactory? _processFactory;
+    private ImmutableArray<IProcessWrapperInterceptor> _processWrapperInterceptors;
+    private ImmutableArray<IProcessStartInfoInterceptor> _processStartInfoInterceptors;
     private readonly ProcessStartInfo _startInfo;
     private ProcessValidationMode _validationMode;
     private ImmutableArray<OutputTarget> _outputTargets;
@@ -32,6 +37,8 @@ public sealed class ProcessWrapper
         _validationMode = ProcessValidationMode.FailIfNonZeroExitCode;
         _outputTargets = [];
         _errorTargets = [];
+        _processWrapperInterceptors = [];
+        _processStartInfoInterceptors = [];
     }
 
     private ProcessWrapper(ProcessWrapper other)
@@ -47,6 +54,8 @@ public sealed class ProcessWrapper
         _windowsJobObjectConfiguration = other._windowsJobObjectConfiguration;
         _linuxControlGroupConfiguration = other._linuxControlGroupConfiguration;
         _processFactory = other._processFactory;
+        _processWrapperInterceptors = other._processWrapperInterceptors;
+        _processStartInfoInterceptors = other._processStartInfoInterceptors;
     }
 
     /// <summary>Gets or sets the default process factory used to create process handles.</summary>
@@ -54,6 +63,34 @@ public sealed class ProcessWrapper
     {
         get => Volatile.Read(ref s_defaultProcessFactory);
         set => s_defaultProcessFactory = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>Adds a global process-wrapper interceptor.</summary>
+    /// <remarks>Dispose the returned registration to remove the interceptor.</remarks>
+    public static IDisposable AddInterceptor(IProcessWrapperInterceptor interceptor)
+    {
+        ArgumentNullException.ThrowIfNull(interceptor);
+
+        lock (DefaultInterceptorsLock)
+        {
+            s_defaultProcessWrapperInterceptors = s_defaultProcessWrapperInterceptors.Add(interceptor);
+        }
+
+        return new DefaultProcessWrapperInterceptorRegistration(interceptor);
+    }
+
+    /// <summary>Adds a global process-start-info interceptor.</summary>
+    /// <remarks>Dispose the returned registration to remove the interceptor.</remarks>
+    public static IDisposable AddInterceptor(IProcessStartInfoInterceptor interceptor)
+    {
+        ArgumentNullException.ThrowIfNull(interceptor);
+
+        lock (DefaultInterceptorsLock)
+        {
+            s_defaultProcessStartInfoInterceptors = s_defaultProcessStartInfoInterceptors.Add(interceptor);
+        }
+
+        return new DefaultProcessStartInfoInterceptorRegistration(interceptor);
     }
 
     private static ProcessStartInfo CreateStartInfo(string fileName)
@@ -166,6 +203,22 @@ public sealed class ProcessWrapper
         return this;
     }
 
+    /// <summary>Sets the process-wrapper interceptor for this process wrapper instance.</summary>
+    public ProcessWrapper WithInterceptor(IProcessWrapperInterceptor interceptor)
+    {
+        ArgumentNullException.ThrowIfNull(interceptor);
+        _processWrapperInterceptors = [interceptor];
+        return this;
+    }
+
+    /// <summary>Sets the process-start-info interceptor for this process wrapper instance.</summary>
+    public ProcessWrapper WithInterceptor(IProcessStartInfoInterceptor interceptor)
+    {
+        ArgumentNullException.ThrowIfNull(interceptor);
+        _processStartInfoInterceptors = [interceptor];
+        return this;
+    }
+
     /// <summary>Sets the encoding used to decode standard output.</summary>
     public ProcessWrapper WithOutputEncoding(Encoding encoding)
     {
@@ -268,6 +321,7 @@ public sealed class ProcessWrapper
     /// </summary>
     public ProcessInstance ExecuteAsync(CancellationToken cancellationToken = default)
     {
+        ApplyProcessWrapperInterceptors();
         return StartProcess(_outputTargets, _errorTargets,
             (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, ct) => new ProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, hasStandardErrorOutput, activity, ct),
             cancellationToken);
@@ -280,6 +334,7 @@ public sealed class ProcessWrapper
     /// </summary>
     public BufferedProcessInstance ExecuteBufferedAsync(CancellationToken cancellationToken = default)
     {
+        ApplyProcessWrapperInterceptors();
         var output = new ProcessOutputCollection();
 
         var outputTargets = _outputTargets.Add(OutputTarget.ToProcessOutputCollection(output).ForOutputType(ProcessOutputType.StandardOutput));
@@ -307,6 +362,7 @@ public sealed class ProcessWrapper
         startInfo.RedirectStandardError = hasErrorHandlers;
         startInfo.RedirectStandardInput = hasInputStream;
         startInfo.FileName = resolvedFileName;
+        ApplyProcessStartInfoInterceptors(startInfo);
 
         var processFactory = _processFactory ?? DefaultProcessFactory;
         var processHandle = processFactory.Create(startInfo);
@@ -382,13 +438,53 @@ public sealed class ProcessWrapper
         var registration = default(CancellationTokenRegistration);
         if (cancellationToken.CanBeCanceled && !processHandle.HasExited)
         {
-            registration = cancellationToken.Register(() => ProcessInstance.KillProcess(processHandle, entireProcessTree: true));
+            registration = cancellationToken.Register(static state => ProcessInstance.KillProcess((IProcessHandle)state!, entireProcessTree: true), processHandle);
         }
 
         var activity = ProcessWrapperTelemetry.ActivitySource.StartActivity("process.execute");
         activity?.SetTag("process.executable.path", resolvedFileName);
 
         return factory(processHandle, inputStreamTask, Task.WhenAll(outputStreamTask, errorStreamTask), registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, activity, cancellationToken);
+    }
+
+    private void ApplyProcessWrapperInterceptors()
+    {
+        ImmutableArray<IProcessWrapperInterceptor> defaultInterceptors;
+        lock (DefaultInterceptorsLock)
+        {
+            defaultInterceptors = s_defaultProcessWrapperInterceptors;
+        }
+
+        foreach (var interceptor in defaultInterceptors)
+        {
+            interceptor.Intercept(this);
+        }
+
+        foreach (var interceptor in _processWrapperInterceptors)
+        {
+            interceptor.Intercept(this);
+        }
+    }
+
+    private void ApplyProcessStartInfoInterceptors(ProcessStartInfo processStartInfo)
+    {
+        ArgumentNullException.ThrowIfNull(processStartInfo);
+
+        ImmutableArray<IProcessStartInfoInterceptor> defaultInterceptors;
+        lock (DefaultInterceptorsLock)
+        {
+            defaultInterceptors = s_defaultProcessStartInfoInterceptors;
+        }
+
+        foreach (var interceptor in defaultInterceptors)
+        {
+            interceptor.Intercept(this, processStartInfo);
+        }
+
+        foreach (var interceptor in _processStartInfoInterceptors)
+        {
+            interceptor.Intercept(this, processStartInfo);
+        }
     }
 
     private static async Task PumpStreamAsync(Stream stream, Encoding encoding, ImmutableArray<OutputTarget> targets, Action? onDataRead)
@@ -536,6 +632,50 @@ public sealed class ProcessWrapper
             throw new InvalidOperationException($"Process limits require {nameof(DefaultProcessFactory)} to be set to {nameof(SystemProcessFactory)}.");
 
         return systemProcessHandle.Process;
+    }
+
+    private sealed class DefaultProcessWrapperInterceptorRegistration(IProcessWrapperInterceptor interceptor) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            lock (DefaultInterceptorsLock)
+            {
+                var index = s_defaultProcessWrapperInterceptors.IndexOf(interceptor);
+                if (index >= 0)
+                {
+                    s_defaultProcessWrapperInterceptors = s_defaultProcessWrapperInterceptors.RemoveAt(index);
+                }
+            }
+
+            _disposed = true;
+        }
+    }
+
+    private sealed class DefaultProcessStartInfoInterceptorRegistration(IProcessStartInfoInterceptor interceptor) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            lock (DefaultInterceptorsLock)
+            {
+                var index = s_defaultProcessStartInfoInterceptors.IndexOf(interceptor);
+                if (index >= 0)
+                {
+                    s_defaultProcessStartInfoInterceptors = s_defaultProcessStartInfoInterceptors.RemoveAt(index);
+                }
+            }
+
+            _disposed = true;
+        }
     }
 
     private interface IProcessLimiter : IDisposable

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -14,6 +14,8 @@ namespace Meziantou.Framework;
 /// </summary>
 public sealed class ProcessWrapper
 {
+    private static IProcessFactory s_defaultProcessFactory = SystemProcessFactory.Instance;
+    private IProcessFactory? _processFactory;
     private readonly ProcessStartInfo _startInfo;
     private ProcessValidationMode _validationMode;
     private ImmutableArray<OutputTarget> _outputTargets;
@@ -44,6 +46,14 @@ public sealed class ProcessWrapper
         _limits = other._limits;
         _windowsJobObjectConfiguration = other._windowsJobObjectConfiguration;
         _linuxControlGroupConfiguration = other._linuxControlGroupConfiguration;
+        _processFactory = other._processFactory;
+    }
+
+    /// <summary>Gets or sets the default process factory used to create process handles.</summary>
+    public static IProcessFactory DefaultProcessFactory
+    {
+        get => Volatile.Read(ref s_defaultProcessFactory);
+        set => s_defaultProcessFactory = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     private static ProcessStartInfo CreateStartInfo(string fileName)
@@ -146,6 +156,13 @@ public sealed class ProcessWrapper
     public ProcessWrapper WithValidation(ProcessValidationMode mode)
     {
         _validationMode = mode;
+        return this;
+    }
+
+    /// <summary>Sets the process factory for this process wrapper instance.</summary>
+    public ProcessWrapper WithProcessFactory(IProcessFactory processFactory)
+    {
+        _processFactory = processFactory ?? throw new ArgumentNullException(nameof(processFactory));
         return this;
     }
 
@@ -252,7 +269,7 @@ public sealed class ProcessWrapper
     public ProcessInstance ExecuteAsync(CancellationToken cancellationToken = default)
     {
         return StartProcess(_outputTargets, _errorTargets,
-            (process, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, ct) => new ProcessInstance(process, inputTask, outputTask, registration, limiter, _validationMode, hasStandardErrorOutput, activity, ct),
+            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, ct) => new ProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, hasStandardErrorOutput, activity, ct),
             cancellationToken);
     }
 
@@ -269,12 +286,12 @@ public sealed class ProcessWrapper
         var errorTargets = _errorTargets.Add(OutputTarget.ToProcessOutputCollection(output).ForOutputType(ProcessOutputType.StandardError));
 
         return StartProcess(outputTargets, errorTargets,
-            (process, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, ct) => new BufferedProcessInstance(process, inputTask, outputTask, registration, limiter, _validationMode, output, hasStandardErrorOutput, activity, ct),
+            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, ct) => new BufferedProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, output, hasStandardErrorOutput, activity, ct),
             cancellationToken);
     }
 
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "ProcessInstance will dispose it")]
-    private T StartProcess<T>(ImmutableArray<OutputTarget> outputTargets, ImmutableArray<OutputTarget> errorTargets, Func<Process, Task, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, Activity?, CancellationToken, T> factory, CancellationToken cancellationToken)
+    private T StartProcess<T>(ImmutableArray<OutputTarget> outputTargets, ImmutableArray<OutputTarget> errorTargets, Func<IProcessHandle, Task, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, Activity?, CancellationToken, T> factory, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -284,43 +301,37 @@ public sealed class ProcessWrapper
         var hasInputStream = _inputSource is not null;
         var hasStandardErrorOutput = 0;
 
-        var configuredFileName = _startInfo.FileName;
-        var resolvedFileName = ResolveFileName(configuredFileName, _startInfo.WorkingDirectory);
-        _startInfo.RedirectStandardOutput = hasOutputHandlers;
-        _startInfo.RedirectStandardError = hasErrorHandlers;
-        _startInfo.RedirectStandardInput = hasInputStream;
-        _startInfo.FileName = resolvedFileName;
+        var startInfo = CloneStartInfo(_startInfo);
+        var resolvedFileName = ResolveFileName(startInfo.FileName, startInfo.WorkingDirectory);
+        startInfo.RedirectStandardOutput = hasOutputHandlers;
+        startInfo.RedirectStandardError = hasErrorHandlers;
+        startInfo.RedirectStandardInput = hasInputStream;
+        startInfo.FileName = resolvedFileName;
 
-        var process = new Process { StartInfo = _startInfo };
+        var processFactory = _processFactory ?? DefaultProcessFactory;
+        var processHandle = processFactory.Create(startInfo);
+        ArgumentNullException.ThrowIfNull(processHandle);
         var processLimiter = CreateProcessLimiter();
 
         var processStarted = false;
         try
         {
-            try
+            if (!processHandle.Start())
             {
-                if (!process.Start())
-                {
-                    throw new Win32Exception("Cannot start the process");
-                }
-
-                processStarted = true;
-            }
-            finally
-            {
-                _startInfo.FileName = configuredFileName;
+                throw new Win32Exception("Cannot start the process");
             }
 
-            processLimiter?.Apply(process);
+            processStarted = true;
+            processLimiter?.Apply(processHandle);
         }
         catch
         {
             if (processStarted)
             {
-                ProcessInstance.KillProcess(process, entireProcessTree: true);
+                ProcessInstance.KillProcess(processHandle, entireProcessTree: true);
             }
 
-            process.Dispose();
+            processHandle.Dispose();
             processLimiter?.Dispose();
             throw;
         }
@@ -328,19 +339,20 @@ public sealed class ProcessWrapper
         var outputStreamTask = Task.CompletedTask;
         if (hasOutputHandlers)
         {
-            outputStreamTask = PumpStreamAsync(process.StandardOutput.BaseStream, process.StandardOutput.CurrentEncoding, outputTargets, onDataRead: null);
+            outputStreamTask = PumpStreamAsync(processHandle.OutputStream, GetStreamEncoding(processHandle, startInfo.StandardOutputEncoding, ProcessOutputType.StandardOutput), outputTargets, onDataRead: null);
         }
 
         var errorStreamTask = Task.CompletedTask;
         if (hasErrorHandlers)
         {
-            errorStreamTask = PumpStreamAsync(process.StandardError.BaseStream, process.StandardError.CurrentEncoding, errorTargets, onDataRead: () => Interlocked.Exchange(ref hasStandardErrorOutput, 1));
+            errorStreamTask = PumpStreamAsync(processHandle.ErrorStream, GetStreamEncoding(processHandle, startInfo.StandardErrorEncoding, ProcessOutputType.StandardError), errorTargets, onDataRead: () => Interlocked.Exchange(ref hasStandardErrorOutput, 1));
         }
 
         var inputStreamTask = Task.CompletedTask;
         if (_inputSource is not null)
         {
             var inputSource = _inputSource;
+            var inputStream = processHandle.InputStream;
             inputStreamTask = Task.Run(() =>
             {
                 var buffer = new byte[4096];
@@ -354,29 +366,29 @@ public sealed class ProcessWrapper
                             break;
                         }
 
-                        process.StandardInput.BaseStream.Write(buffer, 0, bytesRead);
+                        inputStream.Write(buffer, 0, bytesRead);
                     }
 
-                    process.StandardInput.BaseStream.Flush();
+                    inputStream.Flush();
                 }
                 finally
                 {
                     inputSource.NotifyProcessCompleted();
-                    process.StandardInput.Close();
+                    inputStream.Close();
                 }
             }, cancellationToken);
         }
 
         var registration = default(CancellationTokenRegistration);
-        if (cancellationToken.CanBeCanceled && !process.HasExited)
+        if (cancellationToken.CanBeCanceled && !processHandle.HasExited)
         {
-            registration = cancellationToken.Register(() => ProcessInstance.KillProcess(process, entireProcessTree: true));
+            registration = cancellationToken.Register(() => ProcessInstance.KillProcess(processHandle, entireProcessTree: true));
         }
 
         var activity = ProcessWrapperTelemetry.ActivitySource.StartActivity("process.execute");
         activity?.SetTag("process.executable.path", resolvedFileName);
 
-        return factory(process, inputStreamTask, Task.WhenAll(outputStreamTask, errorStreamTask), registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, activity, cancellationToken);
+        return factory(processHandle, inputStreamTask, Task.WhenAll(outputStreamTask, errorStreamTask), registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, activity, cancellationToken);
     }
 
     private static async Task PumpStreamAsync(Stream stream, Encoding encoding, ImmutableArray<OutputTarget> targets, Action? onDataRead)
@@ -508,9 +520,27 @@ public sealed class ProcessWrapper
             throw new ArgumentOutOfRangeException(nameof(limits), limits.ProcessCountLimit, $"{nameof(ProcessLimits.ProcessCountLimit)} must be greater than 0.");
     }
 
+    private static Encoding GetStreamEncoding(IProcessHandle processHandle, Encoding? configuredEncoding, ProcessOutputType outputType)
+    {
+        if (processHandle is IProcessHandleWithEncoding processHandleWithEncoding)
+        {
+            return outputType == ProcessOutputType.StandardOutput ? processHandleWithEncoding.OutputEncoding : processHandleWithEncoding.ErrorEncoding;
+        }
+
+        return configuredEncoding ?? Encoding.UTF8;
+    }
+
+    private static Process GetSystemProcessHandle(IProcessHandle processHandle)
+    {
+        if (processHandle is not SystemProcessFactory.SystemProcessHandle systemProcessHandle)
+            throw new InvalidOperationException($"Process limits require {nameof(DefaultProcessFactory)} to be set to {nameof(SystemProcessFactory)}.");
+
+        return systemProcessHandle.Process;
+    }
+
     private interface IProcessLimiter : IDisposable
     {
-        void Apply(Process process);
+        void Apply(IProcessHandle processHandle);
     }
 
     [SupportedOSPlatform("windows5.1.2600")]
@@ -547,10 +577,10 @@ public sealed class ProcessWrapper
             configure?.Invoke(_jobObject);
         }
 
-        public void Apply(Process process)
+        public void Apply(IProcessHandle processHandle)
         {
-            ArgumentNullException.ThrowIfNull(process);
-            _jobObject.AssignProcess(process);
+            ArgumentNullException.ThrowIfNull(processHandle);
+            _jobObject.AssignProcess(GetSystemProcessHandle(processHandle));
         }
 
         public void Dispose()
@@ -573,9 +603,10 @@ public sealed class ProcessWrapper
             _configure = configure;
         }
 
-        public void Apply(Process process)
+        public void Apply(IProcessHandle processHandle)
         {
-            ArgumentNullException.ThrowIfNull(process);
+            ArgumentNullException.ThrowIfNull(processHandle);
+            var process = GetSystemProcessHandle(processHandle);
 
             _parentControlGroup = CGroup2.Root.CreateOrGetChild($"process-wrapper-{Environment.ProcessId}-{Guid.NewGuid():N}");
             var availableControllers = _parentControlGroup.GetAvailableControllers().ToHashSet(StringComparer.Ordinal);

--- a/src/Meziantou.Framework.ProcessWrapper/SystemProcessFactory.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/SystemProcessFactory.cs
@@ -1,0 +1,103 @@
+using System.Diagnostics;
+using Microsoft.Win32.SafeHandles;
+
+namespace Meziantou.Framework;
+
+internal interface IProcessHandleWithEncoding
+{
+    Encoding OutputEncoding { get; }
+
+    Encoding ErrorEncoding { get; }
+}
+
+public sealed class SystemProcessFactory : IProcessFactory
+{
+    public static SystemProcessFactory Instance { get; } = new();
+
+    private SystemProcessFactory()
+    {
+    }
+
+    public IProcessHandle Create(ProcessStartInfo startInfo)
+    {
+        ArgumentNullException.ThrowIfNull(startInfo);
+        return new SystemProcessHandle(new Process { StartInfo = startInfo });
+    }
+
+    internal sealed class SystemProcessHandle(Process process) : IProcessHandle, IProcessHandleWithEncoding
+    {
+        public Process Process { get; } = process ?? throw new ArgumentNullException(nameof(process));
+
+        public int Id => Process.Id;
+
+        public bool HasExited => Process.HasExited;
+
+        public int ExitCode => Process.ExitCode;
+
+        public Stream InputStream => Process.StandardInput.BaseStream;
+
+        public Stream OutputStream => Process.StandardOutput.BaseStream;
+
+        public Stream ErrorStream => Process.StandardError.BaseStream;
+
+        public SafeProcessHandle? SafeProcessHandle
+        {
+            get
+            {
+                try
+                {
+                    return Process.SafeHandle;
+                }
+                catch (InvalidOperationException)
+                {
+                    return null;
+                }
+            }
+        }
+
+        public Encoding OutputEncoding => Process.StandardOutput.CurrentEncoding;
+
+        public Encoding ErrorEncoding => Process.StandardError.CurrentEncoding;
+
+        public bool Start() => Process.Start();
+
+        public Task WaitForExitAsync(CancellationToken cancellationToken) => Process.WaitForExitAsync(cancellationToken);
+
+        public void Kill(bool entireProcessTree = true)
+        {
+            try
+            {
+                Process.Kill(entireProcessTree);
+            }
+            catch (AggregateException) when (entireProcessTree)
+            {
+                try
+                {
+                    Process.Kill();
+                }
+                catch (InvalidOperationException)
+                {
+                }
+            }
+            catch (InvalidOperationException) when (entireProcessTree)
+            {
+                try
+                {
+                    Process.Kill();
+                }
+                catch (InvalidOperationException)
+                {
+                }
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        public void Dispose()
+        {
+            Process.Dispose();
+        }
+
+    }
+}

--- a/src/Meziantou.Framework.ProcessWrapper/SystemProcessFactory.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/SystemProcessFactory.cs
@@ -1,14 +1,8 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Win32.SafeHandles;
 
 namespace Meziantou.Framework;
-
-internal interface IProcessHandleWithEncoding
-{
-    Encoding OutputEncoding { get; }
-
-    Encoding ErrorEncoding { get; }
-}
 
 public sealed class SystemProcessFactory : IProcessFactory
 {
@@ -18,6 +12,7 @@ public sealed class SystemProcessFactory : IProcessFactory
     {
     }
 
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "SystemProcessHandle owns and disposes the Process instance.")]
     public IProcessHandle Create(ProcessStartInfo startInfo)
     {
         ArgumentNullException.ThrowIfNull(startInfo);

--- a/src/Meziantou.Framework.ProcessWrapper/readme.md
+++ b/src/Meziantou.Framework.ProcessWrapper/readme.md
@@ -33,6 +33,40 @@ foreach (var line in result.Output.StandardOutput)
 }
 ````
 
+## Intercepting process execution (for tests)
+
+Use `ProcessWrapper.DefaultProcessFactory` to intercept process creation globally.
+
+````c#
+var previousFactory = ProcessWrapper.DefaultProcessFactory;
+ProcessWrapper.DefaultProcessFactory = new FakeProcessFactory(startInfo =>
+{
+    return FakeProcess.Create(
+        exitCode: 0,
+        outputText: "simulated output",
+        errorText: "");
+});
+
+try
+{
+    var result = await ProcessWrapper.Create("my-command")
+        .WithArguments("--version")
+        .ExecuteBufferedAsync();
+}
+finally
+{
+    ProcessWrapper.DefaultProcessFactory = previousFactory;
+}
+````
+
+You can also override the factory per command:
+
+````c#
+var result = await ProcessWrapper.Create("my-command")
+    .WithProcessFactory(new FakeProcessFactory(_ => FakeProcess.Create(0, "instance output", "")))
+    .ExecuteBufferedAsync();
+````
+
 ## Working directory
 
 ````c#

--- a/src/Meziantou.Framework.ProcessWrapper/readme.md
+++ b/src/Meziantou.Framework.ProcessWrapper/readme.md
@@ -67,6 +67,39 @@ var result = await ProcessWrapper.Create("my-command")
     .ExecuteBufferedAsync();
 ````
 
+## Interceptors
+
+Use interceptors to update commands globally or per instance before execution.
+
+````c#
+public sealed class SampleProcessWrapperInterceptor : IProcessWrapperInterceptor
+{
+    public void Intercept(ProcessWrapper processWrapper)
+    {
+        // You can inspect/mutate the wrapper instance
+        processWrapper.WithEnvironmentVariables(env => env.Set("TRACE_ID", Guid.NewGuid().ToString("N")));
+    }
+}
+
+public sealed class SampleProcessStartInfoInterceptor : IProcessStartInfoInterceptor
+{
+    public void Intercept(ProcessWrapper processWrapper, ProcessStartInfo processStartInfo)
+    {
+        // You can inspect/mutate ProcessStartInfo right before process creation
+        Console.WriteLine($"Executing: {processStartInfo.FileName}");
+    }
+}
+
+using var globalWrapperRegistration = ProcessWrapper.AddInterceptor(new SampleProcessWrapperInterceptor());
+using var globalStartInfoRegistration = ProcessWrapper.AddInterceptor(new SampleProcessStartInfoInterceptor());
+
+var result = await ProcessWrapper.Create("dotnet")
+    .WithArguments("--version")
+    .WithInterceptor(new SampleProcessWrapperInterceptor())
+    .WithInterceptor(new SampleProcessStartInfoInterceptor())
+    .ExecuteBufferedAsync();
+````
+
 ## Working directory
 
 ````c#

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -1198,7 +1198,7 @@ public class ProcessWrapperTests
     [Fact]
     public async Task ExecuteBufferedAsync_UsesCustomProcessFactory()
     {
-        var fakeProcess = FakeProcess.Create(0, outputText: "intercepted output\n", errorText: "");
+        using var fakeProcess = FakeProcess.Create(0, outputText: "intercepted output\n", errorText: "");
         var createdProcesses = new List<CreatedProcessInfo>();
         var fakeFactory = new FakeProcessFactory(startInfo =>
         {

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -969,6 +969,7 @@ public class ProcessWrapperTests
         Assert.Same(command, command.WithEnvironmentVariables(env => env.Set("TEST_VAR_45", "value")));
         Assert.Same(command, command.WithEnvironmentVariables(new Dictionary<string, string?>(StringComparer.Ordinal) { ["TEST_VAR_45"] = "updated" }));
         Assert.Same(command, command.WithValidation(ProcessValidationMode.None));
+        Assert.Same(command, command.WithProcessFactory(SystemProcessFactory.Instance));
         Assert.Same(command, command.WithOutputEncoding(Encoding.UTF8));
         Assert.Same(command, command.WithErrorEncoding(Encoding.UTF8));
         Assert.Same(command, command.WithOutputStream(OutputTarget.ToTextDelegate(_ => { })));
@@ -1162,6 +1163,113 @@ public class ProcessWrapperTests
         Assert.True(processResult.ProcessId > 0);
     }
 
+    [Fact]
+    public void DefaultProcessFactory_SetNull_Throws()
+    {
+        _ = Assert.Throws<ArgumentNullException>(() => ProcessWrapper.DefaultProcessFactory = null!);
+    }
+
+    [Fact]
+    public void WithProcessFactory_SetNull_Throws()
+    {
+        var command = ProcessWrapper.Create("dotnet");
+        _ = Assert.Throws<ArgumentNullException>(() => command.WithProcessFactory(null!));
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_UsesCustomProcessFactory()
+    {
+        var fakeProcess = FakeProcess.Create(0, outputText: "intercepted output\n", errorText: "");
+        var createdProcesses = new List<CreatedProcessInfo>();
+        var fakeFactory = new FakeProcessFactory(startInfo =>
+        {
+            createdProcesses.Add(new CreatedProcessInfo(startInfo.FileName, startInfo.WorkingDirectory, [.. startInfo.ArgumentList]));
+            return fakeProcess;
+        });
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            var processResult = await CreateEchoCommand("ignored")
+                .ExecuteBufferedAsync();
+
+            Assert.Equal("intercepted output", processResult.Output.StandardOutput.First().Text);
+            Assert.Single(createdProcesses);
+            Assert.False(string.IsNullOrEmpty(createdProcesses[0].FileName));
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithCustomProcessFactory_CancellationKillsProcess()
+    {
+        var fakeProcess = FakeProcess.CreatePending(0);
+        var fakeFactory = new FakeProcessFactory(fakeProcess);
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            using var cts = new CancellationTokenSource();
+            var process = CreateEchoCommand("ignored")
+                .WithValidation(ProcessValidationMode.None)
+                .ExecuteAsync(cts.Token);
+
+            cts.Cancel();
+
+            _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await process);
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_WithPipeOperator_UsesCustomProcessFactory()
+    {
+        var downstreamProcess = FakeProcess.Create(0, outputText: "final output\n", errorText: "");
+        var upstreamProcess = FakeProcess.Create(0, outputText: "hello from custom pipe\n", errorText: "");
+        var fakeFactory = new FakeProcessFactory(downstreamProcess, upstreamProcess);
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            var processResult = await (CreateEchoCommand("ignored") | CreatePassthroughCommand())
+                .ExecuteBufferedAsync();
+
+            Assert.Equal("final output", processResult.Output.StandardOutput.First().Text);
+            Assert.Contains("hello from custom pipe", downstreamProcess.ReadInputAsText(), StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_WithInstanceProcessFactory_OverridesGlobalFactory()
+    {
+        var globalProcess = FakeProcess.Create(0, outputText: "global output\n", errorText: "");
+        var instanceProcess = FakeProcess.Create(0, outputText: "instance output\n", errorText: "");
+        var globalFactory = new FakeProcessFactory(globalProcess);
+        var instanceFactory = new FakeProcessFactory(instanceProcess);
+
+        await RunWithDefaultProcessFactoryAsync(globalFactory, async () =>
+        {
+            var processResult = await CreateEchoCommand("ignored")
+                .WithProcessFactory(instanceFactory)
+                .ExecuteBufferedAsync();
+
+            Assert.Equal("instance output", processResult.Output.StandardOutput.First().Text);
+        });
+    }
+
+    private static async Task RunWithDefaultProcessFactoryAsync(IProcessFactory processFactory, Func<Task> callback)
+    {
+        ArgumentNullException.ThrowIfNull(processFactory);
+        ArgumentNullException.ThrowIfNull(callback);
+
+        var previousProcessFactory = ProcessWrapper.DefaultProcessFactory;
+        ProcessWrapper.DefaultProcessFactory = processFactory;
+
+        try
+        {
+            await callback();
+        }
+        finally
+        {
+            ProcessWrapper.DefaultProcessFactory = previousProcessFactory;
+        }
+    }
+
     private static ActivityListener CreateProcessWrapperActivityListener(Action<Activity> activityStopped)
     {
         return new ActivityListener
@@ -1270,4 +1378,6 @@ public class ProcessWrapperTests
 
         return path;
     }
+
+    private sealed record CreatedProcessInfo(string FileName, string WorkingDirectory, IReadOnlyList<string> Arguments);
 }

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -963,6 +963,8 @@ public class ProcessWrapperTests
         using var stream2 = new MemoryStream();
         using var textWriter = new StringWriter();
         using var textReader = new StringReader("stdin");
+        var processWrapperInterceptor = new WrapperEnvironmentVariableInterceptor("TEST_VAR_46", "value");
+        var processStartInfoInterceptor = new StartInfoEnvironmentVariableInterceptor("TEST_VAR_47", "value");
 
         Assert.Same(command, command.WithArguments("--version"));
         Assert.Same(command, command.WithWorkingDirectory(Path.GetTempPath()));
@@ -970,6 +972,8 @@ public class ProcessWrapperTests
         Assert.Same(command, command.WithEnvironmentVariables(new Dictionary<string, string?>(StringComparer.Ordinal) { ["TEST_VAR_45"] = "updated" }));
         Assert.Same(command, command.WithValidation(ProcessValidationMode.None));
         Assert.Same(command, command.WithProcessFactory(SystemProcessFactory.Instance));
+        Assert.Same(command, command.WithInterceptor(processWrapperInterceptor));
+        Assert.Same(command, command.WithInterceptor(processStartInfoInterceptor));
         Assert.Same(command, command.WithOutputEncoding(Encoding.UTF8));
         Assert.Same(command, command.WithErrorEncoding(Encoding.UTF8));
         Assert.Same(command, command.WithOutputStream(OutputTarget.ToTextDelegate(_ => { })));
@@ -1177,6 +1181,21 @@ public class ProcessWrapperTests
     }
 
     [Fact]
+    public void AddInterceptor_SetNull_Throws()
+    {
+        _ = Assert.Throws<ArgumentNullException>(() => ProcessWrapper.AddInterceptor((IProcessWrapperInterceptor)null!));
+        _ = Assert.Throws<ArgumentNullException>(() => ProcessWrapper.AddInterceptor((IProcessStartInfoInterceptor)null!));
+    }
+
+    [Fact]
+    public void WithInterceptor_SetNull_Throws()
+    {
+        var command = ProcessWrapper.Create("dotnet");
+        _ = Assert.Throws<ArgumentNullException>(() => command.WithInterceptor((IProcessWrapperInterceptor)null!));
+        _ = Assert.Throws<ArgumentNullException>(() => command.WithInterceptor((IProcessStartInfoInterceptor)null!));
+    }
+
+    [Fact]
     public async Task ExecuteBufferedAsync_UsesCustomProcessFactory()
     {
         var fakeProcess = FakeProcess.Create(0, outputText: "intercepted output\n", errorText: "");
@@ -1252,6 +1271,89 @@ public class ProcessWrapperTests
         });
     }
 
+    [Fact]
+    public async Task ExecuteBufferedAsync_WithGlobalProcessWrapperInterceptor_Applies()
+    {
+        await RunWithGlobalInterceptorsAsync(
+            callback: async () =>
+            {
+                var processResult = await CreatePrintEnvironmentVariableCommand("TEST_VAR_48")
+                    .ExecuteBufferedAsync();
+
+                Assert.Equal("global-wrapper", processResult.Output.StandardOutput.First().Text);
+            },
+            processWrapperInterceptor: new WrapperEnvironmentVariableInterceptor("TEST_VAR_48", "global-wrapper"));
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_WithInstanceProcessWrapperInterceptor_Applies()
+    {
+        var processResult = await CreatePrintEnvironmentVariableCommand("TEST_VAR_49")
+            .WithInterceptor(new WrapperEnvironmentVariableInterceptor("TEST_VAR_49", "instance-wrapper"))
+            .ExecuteBufferedAsync();
+
+        Assert.Equal("instance-wrapper", processResult.Output.StandardOutput.First().Text);
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_WithGlobalProcessStartInfoInterceptor_Applies()
+    {
+        await RunWithGlobalInterceptorsAsync(
+            callback: async () =>
+            {
+                var processResult = await CreatePrintEnvironmentVariableCommand("TEST_VAR_50")
+                    .ExecuteBufferedAsync();
+
+                Assert.Equal("global-startinfo", processResult.Output.StandardOutput.First().Text);
+            },
+            processStartInfoInterceptor: new StartInfoEnvironmentVariableInterceptor("TEST_VAR_50", "global-startinfo"));
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_WithInstanceProcessStartInfoInterceptor_Applies()
+    {
+        var processResult = await CreatePrintEnvironmentVariableCommand("TEST_VAR_51")
+            .WithInterceptor(new StartInfoEnvironmentVariableInterceptor("TEST_VAR_51", "instance-startinfo"))
+            .ExecuteBufferedAsync();
+
+        Assert.Equal("instance-startinfo", processResult.Output.StandardOutput.First().Text);
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_Interceptors_RunInExpectedOrder()
+    {
+        var events = new List<string>();
+
+        await RunWithGlobalInterceptorsAsync(
+            callback: async () =>
+            {
+                _ = await CreateEchoCommand("test")
+                    .WithInterceptor(new RecordingProcessWrapperInterceptor(events, "instance-wrapper"))
+                    .WithInterceptor(new RecordingProcessStartInfoInterceptor(events, "instance-startinfo"))
+                    .ExecuteBufferedAsync();
+            },
+            processWrapperInterceptor: new RecordingProcessWrapperInterceptor(events, "global-wrapper"),
+            processStartInfoInterceptor: new RecordingProcessStartInfoInterceptor(events, "global-startinfo"));
+
+        Assert.Equal(["global-wrapper", "instance-wrapper", "global-startinfo", "instance-startinfo"], events);
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_WithPipeOperator_AppliesGlobalProcessStartInfoInterceptorsToEachStage()
+    {
+        var interceptor = new CountingProcessStartInfoInterceptor();
+
+        await RunWithGlobalInterceptorsAsync(
+            callback: async () =>
+            {
+                _ = await (CreateEchoCommand("hello from operator") | CreatePassthroughCommand())
+                    .ExecuteBufferedAsync();
+            },
+            processStartInfoInterceptor: interceptor);
+
+        Assert.Equal(2, interceptor.Count);
+    }
+
     private static async Task RunWithDefaultProcessFactoryAsync(IProcessFactory processFactory, Func<Task> callback)
     {
         ArgumentNullException.ThrowIfNull(processFactory);
@@ -1268,6 +1370,15 @@ public class ProcessWrapperTests
         {
             ProcessWrapper.DefaultProcessFactory = previousProcessFactory;
         }
+    }
+
+    private static async Task RunWithGlobalInterceptorsAsync(Func<Task> callback, IProcessWrapperInterceptor? processWrapperInterceptor = null, IProcessStartInfoInterceptor? processStartInfoInterceptor = null)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        using var processWrapperInterceptorRegistration = processWrapperInterceptor is null ? null : ProcessWrapper.AddInterceptor(processWrapperInterceptor);
+        using var processStartInfoInterceptorRegistration = processStartInfoInterceptor is null ? null : ProcessWrapper.AddInterceptor(processStartInfoInterceptor);
+        await callback();
     }
 
     private static ActivityListener CreateProcessWrapperActivityListener(Action<Activity> activityStopped)
@@ -1338,6 +1449,20 @@ public class ProcessWrapperTests
             .WithArguments("-c", $"printf '%s' \"{text}\"");
     }
 
+    private static ProcessWrapper CreatePrintEnvironmentVariableCommand(string variableName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(variableName);
+
+        if (OperatingSystem.IsWindows())
+        {
+            return ProcessWrapper.Create("cmd.exe")
+                .WithArguments("/C", $"echo %{variableName}%");
+        }
+
+        return ProcessWrapper.Create("sh")
+            .WithArguments("-c", $"echo ${variableName}");
+    }
+
     private static ProcessWrapper CreateSingleByteOutputCommand(byte value, bool standardError = false)
     {
         if (OperatingSystem.IsWindows())
@@ -1377,6 +1502,56 @@ public class ProcessWrapperTests
         }
 
         return path;
+    }
+
+    private sealed class WrapperEnvironmentVariableInterceptor(string variableName, string variableValue) : IProcessWrapperInterceptor
+    {
+        public void Intercept(ProcessWrapper processWrapper)
+        {
+            ArgumentNullException.ThrowIfNull(processWrapper);
+            processWrapper.WithEnvironmentVariables(env => env.Set(variableName, variableValue));
+        }
+    }
+
+    private sealed class StartInfoEnvironmentVariableInterceptor(string variableName, string variableValue) : IProcessStartInfoInterceptor
+    {
+        public void Intercept(ProcessWrapper processWrapper, ProcessStartInfo processStartInfo)
+        {
+            ArgumentNullException.ThrowIfNull(processWrapper);
+            ArgumentNullException.ThrowIfNull(processStartInfo);
+            processStartInfo.Environment[variableName] = variableValue;
+        }
+    }
+
+    private sealed class RecordingProcessWrapperInterceptor(List<string> events, string eventName) : IProcessWrapperInterceptor
+    {
+        public void Intercept(ProcessWrapper processWrapper)
+        {
+            ArgumentNullException.ThrowIfNull(processWrapper);
+            events.Add(eventName);
+        }
+    }
+
+    private sealed class RecordingProcessStartInfoInterceptor(List<string> events, string eventName) : IProcessStartInfoInterceptor
+    {
+        public void Intercept(ProcessWrapper processWrapper, ProcessStartInfo processStartInfo)
+        {
+            ArgumentNullException.ThrowIfNull(processWrapper);
+            ArgumentNullException.ThrowIfNull(processStartInfo);
+            events.Add(eventName);
+        }
+    }
+
+    private sealed class CountingProcessStartInfoInterceptor : IProcessStartInfoInterceptor
+    {
+        public int Count { get; private set; }
+
+        public void Intercept(ProcessWrapper processWrapper, ProcessStartInfo processStartInfo)
+        {
+            ArgumentNullException.ThrowIfNull(processWrapper);
+            ArgumentNullException.ThrowIfNull(processStartInfo);
+            Count++;
+        }
     }
 
     private sealed record CreatedProcessInfo(string FileName, string WorkingDirectory, IReadOnlyList<string> Arguments);


### PR DESCRIPTION
## Why
`ProcessWrapper` needed a first-class way to intercept process execution so tests can mock process startup and IO behavior without spawning real processes. This change also adds global and per-instance interception hooks while preserving pipeline behavior.

## What changed
- Added process creation abstractions: `IProcessFactory` and `IProcessHandle` (including nullable `SafeProcessHandle`).
- Added `SystemProcessFactory` as the default runtime implementation and made `SystemProcessFactory.Instance` public.
- Added test helpers: `FakeProcessFactory` and `FakeProcess` (including pending/completable fake process support).
- Added global and per-instance factory configuration:
  - `ProcessWrapper.DefaultProcessFactory`
  - `ProcessWrapper.WithProcessFactory(...)`
- Added interceptor APIs with two interception surfaces:
  - `IProcessWrapperInterceptor` and `ProcessWrapper.AddInterceptor(...)` / `WithInterceptor(...)`
  - `IProcessStartInfoInterceptor` and `ProcessWrapper.AddInterceptor(...)` / `WithInterceptor(...)`
- Wired interceptor execution into `ExecuteAsync` and `ExecuteBufferedAsync`, including pipeline stages.
- Updated `ProcessWrapper` docs and expanded `ProcessWrapperTests` coverage for factories, fakes, interceptor ordering, null guards, and pipeline behavior.

## Notes for reviewers
- Global interceptors are registered via `AddInterceptor(...)` and removed by disposing the returned registration.
- Interceptor execution order is deterministic: global wrapper, instance wrapper, global start-info, instance start-info.
- Pipeline execution still works with process interception and applies interceptors per stage.