### PR TITLE
Add MultiValueDictionary<TKey, TValue> collection

### DIFF
--- a/ref/Meziantou.Framework.cs
+++ b/ref/Meziantou.Framework.cs
@@ -918,6 +918,30 @@ namespace Meziantou.Framework.Collections
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
     }
 
+    public sealed class MultiValueDictionary<TKey, TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, System.Collections.Generic.IReadOnlyCollection<TValue>>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, System.Collections.Generic.IReadOnlyCollection<TValue>>>, System.Collections.Generic.IReadOnlyDictionary<TKey, System.Collections.Generic.IReadOnlyCollection<TValue>>, System.Collections.IEnumerable
+    {
+        public System.Collections.Generic.IEnumerable<TKey> Keys { get => throw null; }
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.IReadOnlyCollection<TValue>> Values { get => throw null; }
+        public System.Collections.Generic.IReadOnlyCollection<TValue> this[TKey key] { get => throw null; }
+        public int Count { get => throw null; }
+        public MultiValueDictionary(int capacity) { }
+        public MultiValueDictionary(System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
+        public MultiValueDictionary(int capacity, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
+        public MultiValueDictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, System.Collections.Generic.IReadOnlyCollection<TValue>>> enumerable) { }
+        public MultiValueDictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, System.Collections.Generic.IReadOnlyCollection<TValue>>> enumerable, System.Collections.Generic.IEqualityComparer<TKey>? comparer) { }
+        public void Add(TKey key, TValue value) { }
+        public void AddRange(TKey key, System.Collections.Generic.IEnumerable<TValue> values) { }
+        public bool Remove(TKey key) => throw null;
+        public bool Remove(TKey key, TValue value) => throw null;
+        public bool Contains(TKey key, TValue value) => throw null;
+        public bool ContainsValue(TValue value) => throw null;
+        public void Clear() { }
+        public bool ContainsKey(TKey key) => throw null;
+        public bool TryGetValue(TKey key, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out System.Collections.Generic.IReadOnlyCollection<TValue> value) => throw null;
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, System.Collections.Generic.IReadOnlyCollection<TValue>>> GetEnumerator() => throw null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+    }
+
     public sealed class SortedList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable
     {
         public int Count { get => throw null; }

--- a/src/Meziantou.Framework/Collections/MultiValueDictionary.cs
+++ b/src/Meziantou.Framework/Collections/MultiValueDictionary.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.Collections;
@@ -9,25 +8,10 @@ public sealed class MultiValueDictionary<TKey, TValue> : IReadOnlyDictionary<TKe
 {
     private readonly Dictionary<TKey, ValueCollection> _dictionary;
 
-    public MultiValueDictionary()
-    {
-        _dictionary = [];
-    }
-
-    public MultiValueDictionary(int capacity)
-    {
-        _dictionary = new(capacity);
-    }
-
-    public MultiValueDictionary(IEqualityComparer<TKey>? comparer)
-    {
-        _dictionary = new(comparer);
-    }
-
-    public MultiValueDictionary(int capacity, IEqualityComparer<TKey>? comparer)
-    {
-        _dictionary = new(capacity, comparer);
-    }
+    public MultiValueDictionary() => _dictionary = [];
+    public MultiValueDictionary(int capacity) => _dictionary = new(capacity);
+    public MultiValueDictionary(IEqualityComparer<TKey>? comparer) => _dictionary = new(comparer);
+    public MultiValueDictionary(int capacity, IEqualityComparer<TKey>? comparer) => _dictionary = new(capacity, comparer);
 
     public MultiValueDictionary(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable)
         : this(enumerable, comparer: null)
@@ -48,10 +32,7 @@ public sealed class MultiValueDictionary<TKey, TValue> : IReadOnlyDictionary<TKe
         }
     }
 
-    public void Add(TKey key, TValue value)
-    {
-        GetOrAddCollection(key).Add(value);
-    }
+    public void Add(TKey key, TValue value) => GetOrAddCollection(key).Add(value);
 
     public void AddRange(TKey key, IEnumerable<TValue> values)
     {
@@ -60,10 +41,7 @@ public sealed class MultiValueDictionary<TKey, TValue> : IReadOnlyDictionary<TKe
         GetOrAddCollection(key).AddRange(values);
     }
 
-    public bool Remove(TKey key)
-    {
-        return _dictionary.Remove(key);
-    }
+    public bool Remove(TKey key) => _dictionary.Remove(key);
 
     public bool Remove(TKey key, TValue value)
     {
@@ -81,10 +59,7 @@ public sealed class MultiValueDictionary<TKey, TValue> : IReadOnlyDictionary<TKe
         return true;
     }
 
-    public bool Contains(TKey key, TValue value)
-    {
-        return _dictionary.TryGetValue(key, out var collection) && collection.Contains(value);
-    }
+    public bool Contains(TKey key, TValue value) => _dictionary.TryGetValue(key, out var collection) && collection.Contains(value);
 
     public bool ContainsValue(TValue value)
     {
@@ -97,15 +72,9 @@ public sealed class MultiValueDictionary<TKey, TValue> : IReadOnlyDictionary<TKe
         return false;
     }
 
-    public void Clear()
-    {
-        _dictionary.Clear();
-    }
+    public void Clear() => _dictionary.Clear();
 
-    public bool ContainsKey(TKey key)
-    {
-        return _dictionary.ContainsKey(key);
-    }
+    public bool ContainsKey(TKey key) => _dictionary.ContainsKey(key);
 
     public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out IReadOnlyCollection<TValue> value)
     {
@@ -115,11 +84,9 @@ public sealed class MultiValueDictionary<TKey, TValue> : IReadOnlyDictionary<TKe
     }
 
     public IEnumerable<TKey> Keys => _dictionary.Keys;
-
     public IEnumerable<IReadOnlyCollection<TValue>> Values => _dictionary.Values;
 
     public IReadOnlyCollection<TValue> this[TKey key] => _dictionary[key];
-
     public int Count => _dictionary.Count;
 
     public IEnumerator<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> GetEnumerator()
@@ -130,15 +97,9 @@ public sealed class MultiValueDictionary<TKey, TValue> : IReadOnlyDictionary<TKe
         }
     }
 
-    IEnumerator<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>>.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
+    IEnumerator<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>>.GetEnumerator() => GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     private ValueCollection GetOrAddCollection(TKey key)
     {
@@ -149,43 +110,14 @@ public sealed class MultiValueDictionary<TKey, TValue> : IReadOnlyDictionary<TKe
 
     private sealed class ValueCollection : IReadOnlyCollection<TValue>
     {
-        private readonly List<TValue> _values = [];
-
+        private readonly List<TValue> _values = new List<TValue>(1); // Most of the time, there will be only one value per key, so we start with a capacity of 1
         public int Count => _values.Count;
-
-        internal void Add(TValue value)
-        {
-            _values.Add(value);
-        }
-
-        internal void AddRange(IEnumerable<TValue> values)
-        {
-            _values.AddRange(values);
-        }
-
-        internal bool Remove(TValue value)
-        {
-            return _values.Remove(value);
-        }
-
-        internal bool Contains(TValue value)
-        {
-            return _values.Contains(value);
-        }
-
-        public List<TValue>.Enumerator GetEnumerator()
-        {
-            return _values.GetEnumerator();
-        }
-
-        IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator()
-        {
-            return _values.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return _values.GetEnumerator();
-        }
+        public void Add(TValue value) => _values.Add(value);
+        public void AddRange(IEnumerable<TValue> values) => _values.AddRange(values);
+        public bool Remove(TValue value) => _values.Remove(value);
+        public bool Contains(TValue value) => _values.Contains(value);
+        public List<TValue>.Enumerator GetEnumerator() => _values.GetEnumerator();
+        IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() => _values.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => _values.GetEnumerator();
     }
 }

--- a/src/Meziantou.Framework/Collections/MultiValueDictionary.cs
+++ b/src/Meziantou.Framework/Collections/MultiValueDictionary.cs
@@ -40,7 +40,9 @@ public sealed class MultiValueDictionary<TKey, TValue> : IReadOnlyDictionary<TKe
         _dictionary = new(comparer);
         foreach (var pair in enumerable)
         {
-            ArgumentNullException.ThrowIfNull(pair.Value);
+            if (pair.Value is null)
+                throw new ArgumentException("The value collection cannot be null.", nameof(enumerable));
+
             AddRange(pair.Key, pair.Value);
         }
     }

--- a/src/Meziantou.Framework/Collections/MultiValueDictionary.cs
+++ b/src/Meziantou.Framework/Collections/MultiValueDictionary.cs
@@ -1,0 +1,193 @@
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Meziantou.Framework.Collections;
+
+public sealed class MultiValueDictionary<TKey, TValue> : IReadOnlyDictionary<TKey, IReadOnlyCollection<TValue>>
+    where TKey : notnull
+{
+    private readonly Dictionary<TKey, ValueCollection> _dictionary;
+
+    public MultiValueDictionary()
+    {
+        _dictionary = [];
+    }
+
+    public MultiValueDictionary(int capacity)
+    {
+        _dictionary = new(capacity);
+    }
+
+    public MultiValueDictionary(IEqualityComparer<TKey>? comparer)
+    {
+        _dictionary = new(comparer);
+    }
+
+    public MultiValueDictionary(int capacity, IEqualityComparer<TKey>? comparer)
+    {
+        _dictionary = new(capacity, comparer);
+    }
+
+    public MultiValueDictionary(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable)
+        : this(enumerable, comparer: null)
+    {
+    }
+
+    public MultiValueDictionary(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey>? comparer)
+    {
+        ArgumentNullException.ThrowIfNull(enumerable);
+
+        _dictionary = new(comparer);
+        foreach (var pair in enumerable)
+        {
+            ArgumentNullException.ThrowIfNull(pair.Value);
+            AddRange(pair.Key, pair.Value);
+        }
+    }
+
+    public void Add(TKey key, TValue value)
+    {
+        if (!_dictionary.TryGetValue(key, out var collection))
+        {
+            collection = new();
+            _dictionary.Add(key, collection);
+        }
+
+        collection.Add(value);
+    }
+
+    public void AddRange(TKey key, IEnumerable<TValue> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        if (!_dictionary.TryGetValue(key, out var collection))
+        {
+            collection = new();
+            _dictionary.Add(key, collection);
+        }
+
+        collection.AddRange(values);
+    }
+
+    public bool Remove(TKey key)
+    {
+        return _dictionary.Remove(key);
+    }
+
+    public bool Remove(TKey key, TValue value)
+    {
+        if (!_dictionary.TryGetValue(key, out var collection))
+            return false;
+
+        if (!collection.Remove(value))
+            return false;
+
+        if (collection.Count is 0)
+        {
+            _dictionary.Remove(key);
+        }
+
+        return true;
+    }
+
+    public bool Contains(TKey key, TValue value)
+    {
+        return _dictionary.TryGetValue(key, out var collection) && collection.Contains(value);
+    }
+
+    public bool ContainsValue(TValue value)
+    {
+        foreach (var collection in _dictionary.Values)
+        {
+            if (collection.Contains(value))
+                return true;
+        }
+
+        return false;
+    }
+
+    public void Clear()
+    {
+        _dictionary.Clear();
+    }
+
+    public bool ContainsKey(TKey key)
+    {
+        return _dictionary.ContainsKey(key);
+    }
+
+    public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out IReadOnlyCollection<TValue> value)
+    {
+        var success = _dictionary.TryGetValue(key, out var collection);
+        value = collection;
+        return success;
+    }
+
+    public IEnumerable<TKey> Keys => _dictionary.Keys;
+
+    public IEnumerable<IReadOnlyCollection<TValue>> Values => _dictionary.Values;
+
+    public IReadOnlyCollection<TValue> this[TKey key] => _dictionary[key];
+
+    public int Count => _dictionary.Count;
+
+    public IEnumerator<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> GetEnumerator()
+    {
+        foreach (var pair in _dictionary)
+        {
+            yield return new(pair.Key, pair.Value);
+        }
+    }
+
+    IEnumerator<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>>.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    private sealed class ValueCollection : IReadOnlyCollection<TValue>
+    {
+        private readonly List<TValue> _values = [];
+
+        public int Count => _values.Count;
+
+        internal void Add(TValue value)
+        {
+            _values.Add(value);
+        }
+
+        internal void AddRange(IEnumerable<TValue> values)
+        {
+            _values.AddRange(values);
+        }
+
+        internal bool Remove(TValue value)
+        {
+            return _values.Remove(value);
+        }
+
+        internal bool Contains(TValue value)
+        {
+            return _values.Contains(value);
+        }
+
+        public List<TValue>.Enumerator GetEnumerator()
+        {
+            return _values.GetEnumerator();
+        }
+
+        IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator()
+        {
+            return _values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _values.GetEnumerator();
+        }
+    }
+}

--- a/src/Meziantou.Framework/Collections/MultiValueDictionary.cs
+++ b/src/Meziantou.Framework/Collections/MultiValueDictionary.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.Collections;
 
@@ -49,26 +50,14 @@ public sealed class MultiValueDictionary<TKey, TValue> : IReadOnlyDictionary<TKe
 
     public void Add(TKey key, TValue value)
     {
-        if (!_dictionary.TryGetValue(key, out var collection))
-        {
-            collection = new();
-            _dictionary.Add(key, collection);
-        }
-
-        collection.Add(value);
+        GetOrAddCollection(key).Add(value);
     }
 
     public void AddRange(TKey key, IEnumerable<TValue> values)
     {
         ArgumentNullException.ThrowIfNull(values);
 
-        if (!_dictionary.TryGetValue(key, out var collection))
-        {
-            collection = new();
-            _dictionary.Add(key, collection);
-        }
-
-        collection.AddRange(values);
+        GetOrAddCollection(key).AddRange(values);
     }
 
     public bool Remove(TKey key)
@@ -149,6 +138,13 @@ public sealed class MultiValueDictionary<TKey, TValue> : IReadOnlyDictionary<TKe
     IEnumerator IEnumerable.GetEnumerator()
     {
         return GetEnumerator();
+    }
+
+    private ValueCollection GetOrAddCollection(TKey key)
+    {
+        ref var collection = ref CollectionsMarshal.GetValueRefOrAddDefault(_dictionary, key, out _);
+        collection ??= new();
+        return collection;
     }
 
     private sealed class ValueCollection : IReadOnlyCollection<TValue>

--- a/tests/Meziantou.Framework.Tests/Collections/MultiValueDictionaryTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/MultiValueDictionaryTests.cs
@@ -1,0 +1,169 @@
+using Meziantou.Framework.Collections;
+
+namespace Meziantou.Framework.Tests.Collections;
+
+public sealed class MultiValueDictionaryTests
+{
+    [Fact]
+    public void Add_AllowsMultipleValuesForSameKey()
+    {
+        var dictionary = new MultiValueDictionary<string, int>();
+
+        dictionary.Add("a", 1);
+        dictionary.Add("a", 2);
+
+        Assert.True(dictionary.ContainsKey("a"));
+        Assert.Equal(1, dictionary.Count);
+        Assert.Equal([1, 2], dictionary["a"]);
+    }
+
+    [Fact]
+    public void AddRange_AddsValuesForNewAndExistingKeys()
+    {
+        var dictionary = new MultiValueDictionary<string, int>();
+
+        dictionary.AddRange("a", [1, 2]);
+        dictionary.AddRange("a", [3, 4]);
+        dictionary.AddRange("b", [5]);
+
+        Assert.Equal(2, dictionary.Count);
+        Assert.Equal([1, 2, 3, 4], dictionary["a"]);
+        Assert.Equal([5], dictionary["b"]);
+    }
+
+    [Fact]
+    public void ReturnedCollection_ReflectsSubsequentChanges()
+    {
+        var dictionary = new MultiValueDictionary<string, int>();
+        dictionary.Add("a", 1);
+        var values = dictionary["a"];
+
+        dictionary.Add("a", 2);
+
+        Assert.Equal([1, 2], values);
+    }
+
+    [Fact]
+    public void Remove_KeyValue_RemovesOnlyOneValue()
+    {
+        var dictionary = new MultiValueDictionary<string, int>();
+        dictionary.Add("a", 1);
+        dictionary.Add("a", 2);
+        dictionary.Add("a", 2);
+
+        Assert.True(dictionary.Remove("a", 2));
+        Assert.Equal([1, 2], dictionary["a"]);
+    }
+
+    [Fact]
+    public void Remove_LastValue_RemovesTheKey()
+    {
+        var dictionary = new MultiValueDictionary<string, int>();
+        dictionary.Add("a", 1);
+
+        Assert.True(dictionary.Remove("a", 1));
+        Assert.False(dictionary.ContainsKey("a"));
+        Assert.Equal(0, dictionary.Count);
+    }
+
+    [Fact]
+    public void Remove_Key_RemovesAllValues()
+    {
+        var dictionary = new MultiValueDictionary<string, int>();
+        dictionary.AddRange("a", [1, 2, 3]);
+
+        Assert.True(dictionary.Remove("a"));
+        Assert.False(dictionary.ContainsKey("a"));
+        Assert.Equal(0, dictionary.Count);
+    }
+
+    [Fact]
+    public void ContainsAndContainsValue_ReturnExpectedValues()
+    {
+        var dictionary = new MultiValueDictionary<string, int>();
+        dictionary.AddRange("a", [1, 2]);
+        dictionary.AddRange("b", [3, 4]);
+
+        Assert.True(dictionary.Contains("a", 1));
+        Assert.False(dictionary.Contains("a", 3));
+        Assert.True(dictionary.ContainsValue(4));
+        Assert.False(dictionary.ContainsValue(42));
+    }
+
+    [Fact]
+    public void TryGetValue_ReturnsCollectionWhenFound()
+    {
+        var dictionary = new MultiValueDictionary<string, int>();
+        dictionary.AddRange("a", [1, 2]);
+
+        Assert.True(dictionary.TryGetValue("a", out var values));
+        Assert.Equal([1, 2], values);
+
+        Assert.False(dictionary.TryGetValue("missing", out var missingValues));
+        Assert.Null(missingValues);
+    }
+
+    [Fact]
+    public void Indexer_ThrowsWhenKeyIsMissing()
+    {
+        var dictionary = new MultiValueDictionary<string, int>();
+
+        Assert.Throws<KeyNotFoundException>(() => _ = dictionary["missing"]);
+    }
+
+    [Fact]
+    public void ConstructorFromEnumerable_CopiesValues()
+    {
+        var sourceValues = new List<int> { 1, 2 };
+        IEnumerable<KeyValuePair<string, IReadOnlyCollection<int>>> source =
+        [
+            new("a", sourceValues),
+            new("b", [3]),
+        ];
+
+        var dictionary = new MultiValueDictionary<string, int>(source);
+        sourceValues.Add(99);
+
+        Assert.Equal(2, dictionary.Count);
+        Assert.Equal([1, 2], dictionary["a"]);
+        Assert.Equal([3], dictionary["b"]);
+    }
+
+    [Fact]
+    public void Constructor_UsesProvidedComparer()
+    {
+        var dictionary = new MultiValueDictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        dictionary.Add("key", 1);
+        dictionary.Add("KEY", 2);
+
+        Assert.Equal(1, dictionary.Count);
+        Assert.Equal([1, 2], dictionary["KeY"]);
+    }
+
+    [Fact]
+    public void Enumeration_ReturnsKeysAndCollections()
+    {
+        var dictionary = new MultiValueDictionary<string, int>();
+        dictionary.AddRange("a", [1, 2]);
+        dictionary.AddRange("b", [3]);
+
+        var pairs = dictionary.ToDictionary(pair => pair.Key, pair => pair.Value.ToArray());
+
+        Assert.Equal([1, 2], pairs["a"]);
+        Assert.Equal([3], pairs["b"]);
+    }
+
+    [Fact]
+    public void AddRange_NullValues_Throws()
+    {
+        var dictionary = new MultiValueDictionary<string, int>();
+
+        Assert.Throws<ArgumentNullException>(() => dictionary.AddRange("a", values: null!));
+    }
+
+    [Fact]
+    public void Constructor_NullEnumerable_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new MultiValueDictionary<string, int>(enumerable: null!));
+    }
+}

--- a/tests/Meziantou.Framework.Tests/Collections/MultiValueDictionaryTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/MultiValueDictionaryTests.cs
@@ -4,23 +4,28 @@ namespace Meziantou.Framework.Tests.Collections;
 
 public sealed class MultiValueDictionaryTests
 {
+    private static MultiValueDictionary<string, int> CreateDictionary()
+    {
+        return new(StringComparer.Ordinal);
+    }
+
     [Fact]
     public void Add_AllowsMultipleValuesForSameKey()
     {
-        var dictionary = new MultiValueDictionary<string, int>();
+        var dictionary = CreateDictionary();
 
         dictionary.Add("a", 1);
         dictionary.Add("a", 2);
 
         Assert.True(dictionary.ContainsKey("a"));
-        Assert.Equal(1, dictionary.Count);
+        Assert.Single(dictionary);
         Assert.Equal([1, 2], dictionary["a"]);
     }
 
     [Fact]
     public void AddRange_AddsValuesForNewAndExistingKeys()
     {
-        var dictionary = new MultiValueDictionary<string, int>();
+        var dictionary = CreateDictionary();
 
         dictionary.AddRange("a", [1, 2]);
         dictionary.AddRange("a", [3, 4]);
@@ -34,7 +39,7 @@ public sealed class MultiValueDictionaryTests
     [Fact]
     public void ReturnedCollection_ReflectsSubsequentChanges()
     {
-        var dictionary = new MultiValueDictionary<string, int>();
+        var dictionary = CreateDictionary();
         dictionary.Add("a", 1);
         var values = dictionary["a"];
 
@@ -46,7 +51,7 @@ public sealed class MultiValueDictionaryTests
     [Fact]
     public void Remove_KeyValue_RemovesOnlyOneValue()
     {
-        var dictionary = new MultiValueDictionary<string, int>();
+        var dictionary = CreateDictionary();
         dictionary.Add("a", 1);
         dictionary.Add("a", 2);
         dictionary.Add("a", 2);
@@ -58,29 +63,29 @@ public sealed class MultiValueDictionaryTests
     [Fact]
     public void Remove_LastValue_RemovesTheKey()
     {
-        var dictionary = new MultiValueDictionary<string, int>();
+        var dictionary = CreateDictionary();
         dictionary.Add("a", 1);
 
         Assert.True(dictionary.Remove("a", 1));
         Assert.False(dictionary.ContainsKey("a"));
-        Assert.Equal(0, dictionary.Count);
+        Assert.Empty(dictionary);
     }
 
     [Fact]
     public void Remove_Key_RemovesAllValues()
     {
-        var dictionary = new MultiValueDictionary<string, int>();
+        var dictionary = CreateDictionary();
         dictionary.AddRange("a", [1, 2, 3]);
 
         Assert.True(dictionary.Remove("a"));
         Assert.False(dictionary.ContainsKey("a"));
-        Assert.Equal(0, dictionary.Count);
+        Assert.Empty(dictionary);
     }
 
     [Fact]
     public void ContainsAndContainsValue_ReturnExpectedValues()
     {
-        var dictionary = new MultiValueDictionary<string, int>();
+        var dictionary = CreateDictionary();
         dictionary.AddRange("a", [1, 2]);
         dictionary.AddRange("b", [3, 4]);
 
@@ -93,7 +98,7 @@ public sealed class MultiValueDictionaryTests
     [Fact]
     public void TryGetValue_ReturnsCollectionWhenFound()
     {
-        var dictionary = new MultiValueDictionary<string, int>();
+        var dictionary = CreateDictionary();
         dictionary.AddRange("a", [1, 2]);
 
         Assert.True(dictionary.TryGetValue("a", out var values));
@@ -106,7 +111,7 @@ public sealed class MultiValueDictionaryTests
     [Fact]
     public void Indexer_ThrowsWhenKeyIsMissing()
     {
-        var dictionary = new MultiValueDictionary<string, int>();
+        var dictionary = CreateDictionary();
 
         Assert.Throws<KeyNotFoundException>(() => _ = dictionary["missing"]);
     }
@@ -121,7 +126,7 @@ public sealed class MultiValueDictionaryTests
             new("b", [3]),
         ];
 
-        var dictionary = new MultiValueDictionary<string, int>(source);
+        var dictionary = new MultiValueDictionary<string, int>(source, StringComparer.Ordinal);
         sourceValues.Add(99);
 
         Assert.Equal(2, dictionary.Count);
@@ -136,18 +141,18 @@ public sealed class MultiValueDictionaryTests
         dictionary.Add("key", 1);
         dictionary.Add("KEY", 2);
 
-        Assert.Equal(1, dictionary.Count);
+        Assert.Single(dictionary);
         Assert.Equal([1, 2], dictionary["KeY"]);
     }
 
     [Fact]
     public void Enumeration_ReturnsKeysAndCollections()
     {
-        var dictionary = new MultiValueDictionary<string, int>();
+        var dictionary = CreateDictionary();
         dictionary.AddRange("a", [1, 2]);
         dictionary.AddRange("b", [3]);
 
-        var pairs = dictionary.ToDictionary(pair => pair.Key, pair => pair.Value.ToArray());
+        var pairs = dictionary.ToDictionary(pair => pair.Key, pair => pair.Value.ToArray(), StringComparer.Ordinal);
 
         Assert.Equal([1, 2], pairs["a"]);
         Assert.Equal([3], pairs["b"]);
@@ -156,7 +161,7 @@ public sealed class MultiValueDictionaryTests
     [Fact]
     public void AddRange_NullValues_Throws()
     {
-        var dictionary = new MultiValueDictionary<string, int>();
+        var dictionary = CreateDictionary();
 
         Assert.Throws<ArgumentNullException>(() => dictionary.AddRange("a", values: null!));
     }
@@ -164,6 +169,6 @@ public sealed class MultiValueDictionaryTests
     [Fact]
     public void Constructor_NullEnumerable_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new MultiValueDictionary<string, int>(enumerable: null!));
+        Assert.Throws<ArgumentNullException>(() => new MultiValueDictionary<string, int>(enumerable: null!, comparer: StringComparer.Ordinal));
     }
 }


### PR DESCRIPTION
This adds a first-party multi-value dictionary in `Meziantou.Framework.Collections` so callers can store multiple values per key without manually managing `Dictionary<TKey, IReadOnlyCollection<TValue>>` plumbing.

## What changed
- Added `MultiValueDictionary<TKey, TValue>` with dictionary-like APIs for multi-value scenarios.
- Implemented constructors (default/capacity/comparer/enumerable), `Add`, `AddRange`, key and value removal, lookup helpers (`Contains`, `ContainsValue`, `ContainsKey`, `TryGetValue`), indexer, key/value projections, and enumeration.
- Added `MultiValueDictionaryTests` covering add/remove semantics, comparer behavior, lookup/indexer behavior, constructor guards, and enumeration shape.
- Updated the generated public API surface in `ref/Meziantou.Framework.cs`.

## Notes for reviewers
- The implementation intentionally exposes values as `IReadOnlyCollection<TValue>` while keeping a mutable internal per-key collection.
- Per-key collections are removed when their last value is removed, so `Count` always represents the number of active keys.