### PR TITLE
Refactor snapshot serializers to TrySerialize API

### DIFF
--- a/ref/Meziantou.Framework.SnapshotTesting.cs
+++ b/ref/Meziantou.Framework.SnapshotTesting.cs
@@ -33,8 +33,7 @@ namespace Meziantou.Framework.SnapshotTesting
 
     public interface ISnapshotSerializer
     {
-        bool CanSerialize(Meziantou.Framework.SnapshotTesting.SnapshotType type, object? value);
-        Meziantou.Framework.SnapshotTesting.SerializedSnapshot Serialize(Meziantou.Framework.SnapshotTesting.SnapshotType type, object? value);
+        bool TrySerialize(Meziantou.Framework.SnapshotTesting.SnapshotType type, object? value, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.SnapshotTesting.SerializedSnapshot? result);
     }
 
     public abstract class MergeTool
@@ -193,7 +192,7 @@ namespace Meziantou.Framework.SnapshotTesting
         public void Add(Meziantou.Framework.SnapshotTesting.ISnapshotSerializer serializer) { }
         public bool Remove(Meziantou.Framework.SnapshotTesting.ISnapshotSerializer serializer) => throw null;
         public void Clear() { }
-        public Meziantou.Framework.SnapshotTesting.ISnapshotSerializer Get(Meziantou.Framework.SnapshotTesting.SnapshotType type, object? value) => throw null;
+        public Meziantou.Framework.SnapshotTesting.SerializedSnapshot Serialize(Meziantou.Framework.SnapshotTesting.SnapshotType type, object? value) => throw null;
         public System.Collections.Generic.IEnumerator<Meziantou.Framework.SnapshotTesting.ISnapshotSerializer> GetEnumerator() => throw null;
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
     }

--- a/src/Meziantou.Framework.SnapshotTesting.ImageSharp/ImageSnapshotSerializer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting.ImageSharp/ImageSnapshotSerializer.cs
@@ -4,11 +4,13 @@ namespace Meziantou.Framework.SnapshotTesting.ImageSharp;
 
 internal sealed class ImageSnapshotSerializer : ISnapshotSerializer
 {
-    public bool CanSerialize(SnapshotType type, object? value) => value is Image;
-    public SerializedSnapshot Serialize(SnapshotType type, object? value)
+    public bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)
     {
         if (value is not Image image)
-            throw new ArgumentException("Value must be an Image.", nameof(value));
+        {
+            result = null;
+            return false;
+        }
 
         using var ms = new MemoryStream();
         if (type == SnapshotType.Png)
@@ -31,7 +33,13 @@ internal sealed class ImageSnapshotSerializer : ISnapshotSerializer
         {
             image.SaveAsWebp(ms);
         }
+        else
+        {
+            result = null;
+            return false;
+        }
 
-        return new SerializedSnapshot([new SnapshotData(type.FileExtension, ms.ToArray())]);
+        result = new SerializedSnapshot([new SnapshotData(type.FileExtension, ms.ToArray())]);
+        return true;
     }
 }

--- a/src/Meziantou.Framework.SnapshotTesting.ImageSharp/ImageSnapshotSerializer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting.ImageSharp/ImageSnapshotSerializer.cs
@@ -4,7 +4,7 @@ namespace Meziantou.Framework.SnapshotTesting.ImageSharp;
 
 internal sealed class ImageSnapshotSerializer : ISnapshotSerializer
 {
-    public bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)
+    public bool TrySerialize(SnapshotType type, object? value, [NotNullWhen(true)] out SerializedSnapshot? result)
     {
         if (value is not Image image)
         {

--- a/src/Meziantou.Framework.SnapshotTesting/ByteArraySnapshotSerializer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/ByteArraySnapshotSerializer.cs
@@ -4,7 +4,7 @@ internal sealed class ByteArraySnapshotSerializer : ISnapshotSerializer
 {
     public static ISnapshotSerializer Instance { get; } = new ByteArraySnapshotSerializer();
 
-    public bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)
+    public bool TrySerialize(SnapshotType type, object? value, [NotNullWhen(true)] out SerializedSnapshot? result)
     {
         if (value is not byte[] byteArray)
         {

--- a/src/Meziantou.Framework.SnapshotTesting/ByteArraySnapshotSerializer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/ByteArraySnapshotSerializer.cs
@@ -4,12 +4,15 @@ internal sealed class ByteArraySnapshotSerializer : ISnapshotSerializer
 {
     public static ISnapshotSerializer Instance { get; } = new ByteArraySnapshotSerializer();
 
-    public bool CanSerialize(SnapshotType type, object? value) => value is byte[];
-    public SerializedSnapshot Serialize(SnapshotType type, object? value)
+    public bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)
     {
         if (value is not byte[] byteArray)
-            throw new ArgumentException("Value must be a byte array.", nameof(value));
+        {
+            result = null;
+            return false;
+        }
 
-        return new SerializedSnapshot([new SnapshotData(type.FileExtension, byteArray)]);
+        result = new SerializedSnapshot([new SnapshotData(type.FileExtension, byteArray)]);
+        return true;
     }
 }

--- a/src/Meziantou.Framework.SnapshotTesting/HumanReadableSnapshotSerializer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/HumanReadableSnapshotSerializer.cs
@@ -38,11 +38,9 @@ internal sealed class HumanReadableSnapshotSerializer : ISnapshotSerializer
         Options = options;
     }
 
-    public SerializedSnapshot Serialize(SnapshotType type, object? value)
+    public bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)
     {
-        return new SerializedSnapshot([new SnapshotData(type.FileExtension, Encoding.UTF8.GetBytes(HumanReadableSerializer.Serialize(value, Options)))]);
+        result = new SerializedSnapshot([new SnapshotData(type.FileExtension, Encoding.UTF8.GetBytes(HumanReadableSerializer.Serialize(value, Options)))]);
+        return true;
     }
-
-    public bool CanSerialize(SnapshotType type, object? value) => true;
 }
-

--- a/src/Meziantou.Framework.SnapshotTesting/HumanReadableSnapshotSerializer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/HumanReadableSnapshotSerializer.cs
@@ -38,7 +38,7 @@ internal sealed class HumanReadableSnapshotSerializer : ISnapshotSerializer
         Options = options;
     }
 
-    public bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)
+    public bool TrySerialize(SnapshotType type, object? value, [NotNullWhen(true)] out SerializedSnapshot? result)
     {
         result = new SerializedSnapshot([new SnapshotData(type.FileExtension, Encoding.UTF8.GetBytes(HumanReadableSerializer.Serialize(value, Options)))]);
         return true;

--- a/src/Meziantou.Framework.SnapshotTesting/ISnapshotSerializer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/ISnapshotSerializer.cs
@@ -1,8 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Meziantou.Framework.SnapshotTesting;
 
 public interface ISnapshotSerializer
 {
-    bool CanSerialize(SnapshotType type, object? value);
-
-    SerializedSnapshot Serialize(SnapshotType type, object? value);
+    bool TrySerialize(SnapshotType type, object? value, [NotNullWhen(true)] out SerializedSnapshot? result);
 }

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
@@ -55,8 +55,7 @@ internal static class SnapshotEngine
 
     private static IReadOnlyList<SnapshotData> Serialize(SnapshotSettings settings, SnapshotType type, object? value)
     {
-        var serializer = settings.Serializers.Get(type, value);
-        var data = serializer.Serialize(type, value).Data;
+        var data = settings.Serializers.Serialize(type, value).Data;
         if (settings.Scrubbers.Count == 0)
             return data;
 

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotSerializerCollection.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotSerializerCollection.cs
@@ -16,7 +16,7 @@ public sealed class SnapshotSerializerCollection : IEnumerable<ISnapshotSerializ
 
     public int Count => _serializers.Count;
 
-    /// <summary>Adds an untyped serializer. Untyped serializers are matched using <see cref="ISnapshotSerializer.CanSerialize"/>.</summary>
+    /// <summary>Adds an untyped serializer. Untyped serializers are matched using <see cref="ISnapshotSerializer.TrySerialize"/>.</summary>
     public void Add(ISnapshotSerializer serializer)
     {
         ArgumentNullException.ThrowIfNull(serializer);
@@ -26,13 +26,18 @@ public sealed class SnapshotSerializerCollection : IEnumerable<ISnapshotSerializ
     public bool Remove(ISnapshotSerializer serializer) => _serializers.Remove(serializer);
     public void Clear() => _serializers.Clear();
 
-    public ISnapshotSerializer Get(SnapshotType type, object? value)
+    public SerializedSnapshot Serialize(SnapshotType type, object? value)
     {
         for (var i = _serializers.Count - 1; i >= 0; i--)
         {
             var serializer = _serializers[i];
-            if (serializer.CanSerialize(type, value))
-                return serializer;
+            if (!serializer.TrySerialize(type, value, out var result))
+                continue;
+
+            if (result is null)
+                throw new InvalidOperationException($"Serializer '{serializer.GetType()}' returned a null snapshot.");
+
+            return result;
         }
 
         throw new InvalidOperationException($"No suitable serializer found for '{type.DisplayName}' and value type '{value?.GetType()}'.");

--- a/src/Meziantou.Framework.SnapshotTesting/StreamSnapshotSerializer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/StreamSnapshotSerializer.cs
@@ -4,7 +4,7 @@ internal sealed class StreamSnapshotSerializer : ISnapshotSerializer
 {
     public static ISnapshotSerializer Instance { get; } = new StreamSnapshotSerializer();
 
-    public bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)
+    public bool TrySerialize(SnapshotType type, object? value, [NotNullWhen(true)] out SerializedSnapshot? result)
     {
         if (value is not Stream stream)
         {

--- a/src/Meziantou.Framework.SnapshotTesting/StreamSnapshotSerializer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/StreamSnapshotSerializer.cs
@@ -4,15 +4,18 @@ internal sealed class StreamSnapshotSerializer : ISnapshotSerializer
 {
     public static ISnapshotSerializer Instance { get; } = new StreamSnapshotSerializer();
 
-    public bool CanSerialize(SnapshotType type, object? value) => value is Stream;
-    public SerializedSnapshot Serialize(SnapshotType type, object? value)
+    public bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)
     {
         if (value is not Stream stream)
-            throw new ArgumentException("Value must be a stream.", nameof(value));
+        {
+            result = null;
+            return false;
+        }
 
         var ms = new MemoryStream();
         stream.CopyTo(ms);
         var data = ms.ToArray();
-        return new SerializedSnapshot([new SnapshotData(type.FileExtension, data)]);
+        result = new SerializedSnapshot([new SnapshotData(type.FileExtension, data)]);
+        return true;
     }
 }

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -884,17 +884,22 @@ public sealed class SnapshotEndToEndTests
 
             file sealed class FixedCountSerializer(int count) : ISnapshotSerializer
             {
-                public bool CanSerialize(SnapshotType type, object? value) => type == SnapshotType.Default;
-
-                public SerializedSnapshot Serialize(SnapshotType type, object? value)
+                public bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)
                 {
-                    var result = new List<SnapshotData>(count);
-                    for (var i = 0; i < count; i++)
+                    if (type != SnapshotType.Default)
                     {
-                        result.Add(new SnapshotData("txt", Encoding.UTF8.GetBytes("value_" + i.ToString(CultureInfo.InvariantCulture))));
+                        result = null;
+                        return false;
                     }
 
-                    return new SerializedSnapshot(result);
+                    var data = new List<SnapshotData>(count);
+                    for (var i = 0; i < count; i++)
+                    {
+                        data.Add(new SnapshotData("txt", Encoding.UTF8.GetBytes("value_" + i.ToString(CultureInfo.InvariantCulture))));
+                    }
+
+                    result = new SerializedSnapshot(data);
+                    return true;
                 }
             }
             """;

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -377,9 +377,7 @@ public sealed class SnapshotTests
     {
         var snapshotType = SnapshotType.Png;
         var expectedBytes = "binary-data"u8.ToArray();
-        var serializer = new SnapshotSettings().Serializers.Get(snapshotType, expectedBytes);
-
-        var data = serializer.Serialize(snapshotType, expectedBytes);
+        var data = new SnapshotSettings().Serializers.Serialize(snapshotType, expectedBytes);
 
         var snapshot = Assert.Single(data.Data);
         Assert.Equal(snapshotType.FileExtension, snapshot.Extension);
@@ -392,9 +390,7 @@ public sealed class SnapshotTests
         var snapshotType = SnapshotType.Png;
         var expectedBytes = "stream-binary-data"u8.ToArray();
         using var stream = new MemoryStream(expectedBytes);
-        var serializer = new SnapshotSettings().Serializers.Get(snapshotType, stream);
-
-        var data = serializer.Serialize(snapshotType, stream);
+        var data = new SnapshotSettings().Serializers.Serialize(snapshotType, stream);
 
         var snapshot = Assert.Single(data.Data);
         Assert.Equal(snapshotType.FileExtension, snapshot.Extension);
@@ -710,17 +706,22 @@ public sealed class SnapshotTests
 
     private sealed class FixedCountSerializer(int count) : ISnapshotSerializer
     {
-        public bool CanSerialize(SnapshotType type, object? value) => type == SnapshotType.Default;
-
-        public SerializedSnapshot Serialize(SnapshotType type, object? value)
+        public bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)
         {
-            var result = new List<SnapshotData>(count);
-            for (var i = 0; i < count; i++)
+            if (type != SnapshotType.Default)
             {
-                result.Add(new SnapshotData("txt", Encoding.UTF8.GetBytes("value_" + i.ToString(CultureInfo.InvariantCulture))));
+                result = null;
+                return false;
             }
 
-            return new SerializedSnapshot(result);
+            var data = new List<SnapshotData>(count);
+            for (var i = 0; i < count; i++)
+            {
+                data.Add(new SnapshotData("txt", Encoding.UTF8.GetBytes("value_" + i.ToString(CultureInfo.InvariantCulture))));
+            }
+
+            result = new SerializedSnapshot(data);
+            return true;
         }
     }
 
@@ -770,14 +771,32 @@ public sealed class SnapshotTests
 
     private sealed class SnapshotTypeSerializer : ISnapshotSerializer
     {
-        public bool CanSerialize(SnapshotType type, object? value) => type == SnapshotType.Png;
-        public SerializedSnapshot Serialize(SnapshotType type, object? value) => new([new SnapshotData("txt", Encoding.UTF8.GetBytes(type.Type))]);
+        public bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)
+        {
+            if (type != SnapshotType.Png)
+            {
+                result = null;
+                return false;
+            }
+
+            result = new SerializedSnapshot([new SnapshotData("txt", Encoding.UTF8.GetBytes(type.Type))]);
+            return true;
+        }
     }
 
     private sealed class FixedValueSerializer(string value) : ISnapshotSerializer
     {
-        public bool CanSerialize(SnapshotType type, object? value) => type == SnapshotType.Default;
-        public SerializedSnapshot Serialize(SnapshotType type, object? value_) => new([new SnapshotData("txt", Encoding.UTF8.GetBytes(value))]);
+        public bool TrySerialize(SnapshotType type, object? value_, out SerializedSnapshot? result)
+        {
+            if (type != SnapshotType.Default)
+            {
+                result = null;
+                return false;
+            }
+
+            result = new SerializedSnapshot([new SnapshotData("txt", Encoding.UTF8.GetBytes(value))]);
+            return true;
+        }
     }
 
     private sealed class FixedAssertionExceptionBuilder : AssertionExceptionBuilder

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -706,7 +706,7 @@ public sealed class SnapshotTests
 
     private sealed class FixedCountSerializer(int count) : ISnapshotSerializer
     {
-        public bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)
+        public bool TrySerialize(SnapshotType type, object? value, [NotNullWhen(true)] out SerializedSnapshot? result)
         {
             if (type != SnapshotType.Default)
             {
@@ -771,7 +771,7 @@ public sealed class SnapshotTests
 
     private sealed class SnapshotTypeSerializer : ISnapshotSerializer
     {
-        public bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)
+        public bool TrySerialize(SnapshotType type, object? value, [NotNullWhen(true)] out SerializedSnapshot? result)
         {
             if (type != SnapshotType.Png)
             {
@@ -786,7 +786,7 @@ public sealed class SnapshotTests
 
     private sealed class FixedValueSerializer(string value) : ISnapshotSerializer
     {
-        public bool TrySerialize(SnapshotType type, object? value_, out SerializedSnapshot? result)
+        public bool TrySerialize(SnapshotType type, object? value_, [NotNullWhen(true)] out SerializedSnapshot? result)
         {
             if (type != SnapshotType.Default)
             {


### PR DESCRIPTION
## Why
Custom snapshot serializers currently split capability checks and serialization across two methods (`CanSerialize` and `Serialize`). A single `TrySerialize` contract makes matching and serialization atomic and avoids duplicated checks.

## What changed
- Replaced `ISnapshotSerializer` methods with:
  - `bool TrySerialize(SnapshotType type, object? value, out SerializedSnapshot? result)`
- Refactored `SnapshotSerializerCollection` to probe serializers via `TrySerialize` and return the serialized snapshot directly.
- Updated `SnapshotEngine` to consume serialized data from the collection without a second serializer call.
- Migrated built-in serializers (`HumanReadable`, `ByteArray`, `Stream`) and ImageSharp serializer to the new contract.
- Updated snapshot test serializers and end-to-end generated serializer source snippets.
- Regenerated `ref/Meziantou.Framework.SnapshotTesting.cs` for the new public API surface.

## Notes
- Unsupported type/value combinations now return `false` instead of throwing `ArgumentException`.
- This is a breaking change for custom implementations of `ISnapshotSerializer`.