### PR TITLE
Add DoubleEndedQueue collection with lazy allocation

### DIFF
--- a/ref/Meziantou.Framework.cs
+++ b/ref/Meziantou.Framework.cs
@@ -875,6 +875,30 @@ namespace Meziantou.Framework.Collections
         }
     }
 
+    public sealed class DoubleEndedQueue<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+    {
+        public int Count { get => throw null; }
+        public T this[int index] { get => throw null; }
+        public DoubleEndedQueue(int capacity) { }
+        public void AddFirst(T value) { }
+        public void AddLast(T value) { }
+        public T RemoveFirst() => throw null;
+        public T RemoveLast() => throw null;
+        public void Clear() { }
+        public bool Contains(T item) => throw null;
+        public int IndexOf(T item) => throw null;
+        public void CopyTo(T[] array, int arrayIndex) { }
+        public Enumerator<T> GetEnumerator() => throw null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+        public struct Enumerator<T> : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+        {
+            public T Current { get => throw null; }
+            public void Dispose() { }
+            public bool MoveNext() => throw null;
+            void System.Collections.IEnumerator.Reset() { }
+        }
+    }
+
     public static class ImmutableEquatableArray
     {
         public static Meziantou.Framework.Collections.ImmutableEquatableArray<T> ToImmutableEquatableArray<T>(this System.Collections.Generic.IEnumerable<T> values) where T : System.IEquatable<T> => throw null;

--- a/src/Meziantou.Framework/Collections/DoubleEndedQueue.cs
+++ b/src/Meziantou.Framework/Collections/DoubleEndedQueue.cs
@@ -1,0 +1,288 @@
+using System.Collections;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Meziantou.Framework.Collections;
+
+/// <summary>Represents a growable double-ended queue.</summary>
+public sealed class DoubleEndedQueue<T> : ICollection<T>, IReadOnlyList<T>
+{
+    private readonly int _initialCapacity;
+    private T[]? _items;
+    private int _startIndex;
+    private int _version;
+
+    /// <summary>Initializes a new instance of <see cref="DoubleEndedQueue{T}"/> with the specified initial capacity.</summary>
+    public DoubleEndedQueue(int capacity)
+    {
+        if (capacity <= 0)
+            throw new ArgumentException("Capacity must be greater than 0.", nameof(capacity));
+
+        _initialCapacity = capacity;
+    }
+
+    /// <summary>Gets the number of elements contained in the collection.</summary>
+    public int Count { get; private set; }
+
+    bool ICollection<T>.IsReadOnly => false;
+
+    /// <summary>Adds an item at the beginning of the collection.</summary>
+    public void AddFirst(T value)
+    {
+        EnsureCapacityForOneMore();
+
+        if (Count is 0)
+        {
+            _startIndex = 0;
+            _items[0] = value;
+        }
+        else
+        {
+            _startIndex = (_startIndex - 1 + _items.Length) % _items.Length;
+            _items[_startIndex] = value;
+        }
+
+        Count++;
+        _version++;
+    }
+
+    /// <summary>Adds an item at the end of the collection.</summary>
+    public void AddLast(T value)
+    {
+        EnsureCapacityForOneMore();
+
+        var index = (_startIndex + Count) % _items.Length;
+        _items[index] = value;
+        Count++;
+        _version++;
+    }
+
+    /// <summary>Removes and returns the first item.</summary>
+    public T RemoveFirst()
+    {
+        if (Count is 0)
+            throw new InvalidOperationException("The collection is empty");
+
+        Debug.Assert(_items is not null);
+        ref var item = ref _items[_startIndex];
+        var result = item;
+        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+        {
+            item = default!;
+        }
+
+        Count--;
+        _startIndex = Count is 0 ? 0 : (_startIndex + 1) % _items.Length;
+        _version++;
+        return result;
+    }
+
+    /// <summary>Removes and returns the last item.</summary>
+    public T RemoveLast()
+    {
+        if (Count is 0)
+            throw new InvalidOperationException("The collection is empty");
+
+        Debug.Assert(_items is not null);
+        var index = (_startIndex + Count - 1) % _items.Length;
+        ref var item = ref _items[index];
+        var result = item;
+        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+        {
+            item = default!;
+        }
+
+        Count--;
+        if (Count is 0)
+        {
+            _startIndex = 0;
+        }
+
+        _version++;
+        return result;
+    }
+
+    /// <summary>Gets the item at the specified index.</summary>
+    public T this[int index]
+    {
+        get
+        {
+            if ((uint)index >= (uint)Count)
+                ThrowHelper.ThrowArgumentOutOfRange_IndexException();
+
+            Debug.Assert(_items is not null);
+            return _items[(_startIndex + index) % _items.Length];
+        }
+    }
+
+    public void Clear()
+    {
+        if (_items is not null && RuntimeHelpers.IsReferenceOrContainsReferences<T>() && Count > 0)
+        {
+            var length = Math.Min(Count, _items.Length - _startIndex);
+            Array.Clear(_items, _startIndex, length);
+            if (_startIndex + Count > _items.Length)
+            {
+                Array.Clear(_items, 0, (_startIndex + Count) % _items.Length);
+            }
+        }
+
+        Count = 0;
+        _startIndex = 0;
+        _version++;
+    }
+
+    public bool Contains(T item)
+    {
+        return IndexOf(item) >= 0;
+    }
+
+    public int IndexOf(T item)
+    {
+        if (Count is 0)
+            return -1;
+
+        Debug.Assert(_items is not null);
+        var comparer = EqualityComparer<T>.Default;
+        for (var i = 0; i < Count; i++)
+        {
+            var index = (_startIndex + i) % _items.Length;
+            if (comparer.Equals(item, _items[index]))
+                return i;
+        }
+
+        return -1;
+    }
+
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        ArgumentNullException.ThrowIfNull(array);
+
+        if (array.Rank is not 1)
+            throw new ArgumentException("Array must be single-dimensional", nameof(array));
+
+        if (arrayIndex < 0 || arrayIndex > array.Length)
+            throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+
+        if (array.Length - arrayIndex < Count)
+            throw new ArgumentException("The number of elements in the source collection is greater than the available space from arrayIndex to the end of the destination array.", nameof(array));
+
+        if (Count is 0)
+            return;
+
+        Debug.Assert(_items is not null);
+        var length = Math.Min(Count, _items.Length - _startIndex);
+        Array.Copy(_items, _startIndex, array, arrayIndex, length);
+        if (_startIndex + Count > _items.Length)
+        {
+            Array.Copy(_items, 0, array, arrayIndex + length, (_startIndex + Count) % _items.Length);
+        }
+    }
+
+    void ICollection<T>.Add(T item)
+    {
+        AddLast(item);
+    }
+
+    bool ICollection<T>.Remove(T item)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Enumerator GetEnumerator() => new(this);
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => new Enumerator(this);
+    IEnumerator IEnumerable.GetEnumerator() => new Enumerator(this);
+
+    [MemberNotNull(nameof(_items))]
+    private void EnsureCapacityForOneMore()
+    {
+        if (_items is null)
+        {
+            _items = new T[_initialCapacity];
+            _startIndex = 0;
+            return;
+        }
+
+        if (Count < _items.Length)
+            return;
+
+        var newCapacity = Count * 2;
+        if (newCapacity <= Count)
+        {
+            newCapacity = Count + 1;
+        }
+
+        var newItems = new T[newCapacity];
+        CopyTo(newItems, 0);
+        _items = newItems;
+        _startIndex = 0;
+    }
+
+    public struct Enumerator : IEnumerator<T>, IEnumerator
+    {
+        private readonly DoubleEndedQueue<T> _queue;
+        private int _index;
+        private readonly int _version;
+
+        internal Enumerator(DoubleEndedQueue<T> queue)
+        {
+            _queue = queue;
+            _index = 0;
+            _version = queue._version;
+            Current = default!;
+        }
+
+        public readonly void Dispose()
+        {
+        }
+
+        public bool MoveNext()
+        {
+            var localQueue = _queue;
+            if (_version == localQueue._version && ((uint)_index < (uint)localQueue.Count))
+            {
+                Debug.Assert(localQueue._items is not null);
+                var actualIndex = (localQueue._startIndex + _index) % localQueue._items.Length;
+                Current = localQueue._items[actualIndex];
+                _index++;
+                return true;
+            }
+
+            return MoveNextRare();
+        }
+
+        private bool MoveNextRare()
+        {
+            if (_version != _queue._version)
+                ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
+
+            _index = _queue.Count + 1;
+            Current = default!;
+            return false;
+        }
+
+        public T Current { readonly get => field; private set; }
+
+        readonly object? IEnumerator.Current
+        {
+            get
+            {
+                if (_index is 0 || _index == _queue.Count + 1)
+                    ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumOpCantHappen();
+
+                return Current;
+            }
+        }
+
+        void IEnumerator.Reset()
+        {
+            if (_version != _queue._version)
+            {
+                ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion();
+            }
+
+            _index = 0;
+            Current = default!;
+        }
+    }
+}

--- a/src/Meziantou.Framework/Collections/DoubleEndedQueue.cs
+++ b/src/Meziantou.Framework/Collections/DoubleEndedQueue.cs
@@ -68,7 +68,7 @@ public sealed class DoubleEndedQueue<T> : ICollection<T>, IReadOnlyList<T>
         var result = item;
         if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
         {
-            item = default!;
+            item = default;
         }
 
         Count--;

--- a/src/Meziantou.Framework/Collections/DoubleEndedQueue.cs
+++ b/src/Meziantou.Framework/Collections/DoubleEndedQueue.cs
@@ -89,7 +89,7 @@ public sealed class DoubleEndedQueue<T> : ICollection<T>, IReadOnlyList<T>
         var result = item;
         if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
         {
-            item = default!;
+            item = default;
         }
 
         Count--;

--- a/tests/Meziantou.Framework.Tests/Collections/DoubleEndedQueueTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/DoubleEndedQueueTests.cs
@@ -1,0 +1,211 @@
+using Meziantou.Framework.Collections;
+
+namespace Meziantou.Framework.Tests.Collections;
+
+public sealed class DoubleEndedQueueTests
+{
+    [Fact]
+    public void DoesNotAllocateBeforeFirstAdd()
+    {
+        var list = new DoubleEndedQueue<int>(3);
+        var field = typeof(DoubleEndedQueue<int>).GetField("_items", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        Assert.Null(field.GetValue(list));
+
+        list.AddLast(1);
+        Assert.NotNull(field.GetValue(list));
+    }
+
+    [Fact]
+    public void AddFirstAndAddLast()
+    {
+        var list = new DoubleEndedQueue<int>(3);
+        list.AddFirst(2);
+        list.AddFirst(1);
+        list.AddLast(3);
+
+        Assert.Equal([1, 2, 3], list);
+        Assert.Equal(3, list.Count);
+    }
+
+    [Fact]
+    public void RemoveFromBothEnds()
+    {
+        var list = new DoubleEndedQueue<int>(3);
+        list.AddLast(1);
+        list.AddLast(2);
+        list.AddLast(3);
+
+        Assert.Equal(1, list.RemoveFirst());
+        Assert.Equal(3, list.RemoveLast());
+        Assert.Equal([2], list);
+    }
+
+    [Fact]
+    public void ResizeOnAddLast()
+    {
+        var list = new DoubleEndedQueue<int>(2);
+        list.AddLast(1);
+        list.AddLast(2);
+        list.AddLast(3);
+        list.AddLast(4);
+
+        Assert.Equal([1, 2, 3, 4], list);
+    }
+
+    [Fact]
+    public void ResizeOnAddFirst()
+    {
+        var list = new DoubleEndedQueue<int>(2);
+        list.AddLast(1);
+        list.AddLast(2);
+        list.AddFirst(0);
+        list.AddFirst(-1);
+
+        Assert.Equal([-1, 0, 1, 2], list);
+    }
+
+    [Fact]
+    public void IndexerWithWrappedStorage()
+    {
+        var list = new DoubleEndedQueue<int>(3);
+        list.AddLast(1);
+        list.AddLast(2);
+        list.AddLast(3);
+        list.RemoveFirst();
+        list.AddLast(4);
+
+        Assert.Equal(2, list[0]);
+        Assert.Equal(3, list[1]);
+        Assert.Equal(4, list[2]);
+    }
+
+    [Fact]
+    public void ContainsAndIndexOf()
+    {
+        var list = new DoubleEndedQueue<int>(3);
+        list.AddLast(10);
+        list.AddLast(20);
+        list.AddLast(30);
+        list.RemoveFirst();
+        list.AddLast(40);
+
+        Assert.Contains(30, list);
+        Assert.Equal(1, list.IndexOf(30));
+        Assert.DoesNotContain(10, list);
+        Assert.Equal(-1, list.IndexOf(10));
+    }
+
+    [Fact]
+    public void CopyToWithOffset()
+    {
+        var list = new DoubleEndedQueue<int>(3);
+        list.AddLast(1);
+        list.AddLast(2);
+        list.AddLast(3);
+        list.RemoveFirst();
+        list.AddLast(4);
+
+        var array = new[] { -1, -1, -1, -1, -1, -1, };
+        list.CopyTo(array, 2);
+
+        Assert.Equal([-1, -1, 2, 3, 4, -1], array);
+    }
+
+    [Fact]
+    public void CopyToThrowsWhenArrayTooSmall()
+    {
+        var list = new DoubleEndedQueue<int>(2);
+        list.AddLast(1);
+        list.AddLast(2);
+
+        Assert.Throws<ArgumentException>(() => list.CopyTo(new int[1], 0));
+    }
+
+    [Fact]
+    public void ClearRemovesItems()
+    {
+        var list = new DoubleEndedQueue<int>(3);
+        list.AddLast(1);
+        list.AddLast(2);
+        list.Clear();
+
+        Assert.Empty(list);
+
+        list.AddFirst(3);
+        Assert.Equal([3], list);
+    }
+
+    [Fact]
+    public void RemoveFirstThrowsWhenEmpty()
+    {
+        var list = new DoubleEndedQueue<int>(1);
+        Assert.Throws<InvalidOperationException>(() => list.RemoveFirst());
+    }
+
+    [Fact]
+    public void RemoveLastThrowsWhenEmpty()
+    {
+        var list = new DoubleEndedQueue<int>(1);
+        Assert.Throws<InvalidOperationException>(() => list.RemoveLast());
+    }
+
+    [Fact]
+    public void ICollectionRemoveThrowsNotSupportedException()
+    {
+        ICollection<int> list = new DoubleEndedQueue<int>(1);
+        list.Add(1);
+
+        Assert.Throws<NotSupportedException>(() => list.Remove(1));
+    }
+
+    [Fact]
+    public void EnumeratorIteratesInOrder()
+    {
+        var list = new DoubleEndedQueue<int>(3);
+        list.AddLast(1);
+        list.AddLast(2);
+        list.AddLast(3);
+        list.RemoveFirst();
+        list.AddLast(4);
+
+        Assert.Equal([2, 3, 4], list.ToArray());
+    }
+
+    [Fact]
+    public void EnumeratorModificationThrowsException()
+    {
+        var list = new DoubleEndedQueue<int>(3);
+        list.AddLast(1);
+        list.AddLast(2);
+
+        var enumerator = list.GetEnumerator();
+        enumerator.MoveNext();
+        list.AddLast(3);
+
+        Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
+    }
+
+    [Fact]
+    public void EnumeratorCurrentBeforeMoveNextThrowsException()
+    {
+        var list = new DoubleEndedQueue<int>(1);
+        list.AddLast(1);
+
+        var enumerator = (System.Collections.IEnumerator)list.GetEnumerator();
+
+        Assert.Throws<InvalidOperationException>(() => _ = enumerator.Current);
+    }
+
+    [Fact]
+    public void EnumeratorCurrentAfterEndThrowsException()
+    {
+        var list = new DoubleEndedQueue<int>(1);
+        list.AddLast(1);
+
+        var enumerator = (System.Collections.IEnumerator)list.GetEnumerator();
+        while (enumerator.MoveNext()) { }
+
+        Assert.Throws<InvalidOperationException>(() => _ = enumerator.Current);
+    }
+}


### PR DESCRIPTION
## Why
A growable double-ended queue is useful for FIFO/LIFO scenarios that need efficient operations at both ends. This adds that collection while avoiding array allocation for empty instances.

## What changed
- Added `DoubleEndedQueue<T>` in `Meziantou.Framework.Collections` as a ring-buffer-based, growable deque.
- Implemented `AddFirst`, `AddLast`, `RemoveFirst`, `RemoveLast`, indexer, `Clear`, `Contains`, `IndexOf`, `CopyTo`, and fail-fast enumeration semantics.
- Backing storage is now lazily allocated: `_items` is created only when the first element is added.
- Added `DoubleEndedQueueTests` covering both-end operations, wrap-around and growth behavior, copy/search APIs, enumerator semantics, and lazy-allocation behavior.
- Updated `ref/Meziantou.Framework.cs` with the new public API.

## Notes for reviewers
- `ICollection<T>.Remove` is intentionally not supported, matching the explicit-end operation model of this collection.
- The type name is `DoubleEndedQueue<T>` per requested naming.