### PR TITLE
Add Trie collection with prefix lookup support

### DIFF
--- a/ref/Meziantou.Framework.cs
+++ b/ref/Meziantou.Framework.cs
@@ -979,6 +979,20 @@ namespace Meziantou.Framework.Collections
         }
     }
 
+    public sealed class Trie<TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, TValue>>, System.Collections.IEnumerable
+    {
+        public int Count { get => throw null; }
+        public bool IgnoreCase { get => throw null; }
+        public Trie(bool ignoreCase) { }
+        public void Add(string key, TValue value) { }
+        public bool Remove(string key) => throw null;
+        public bool TryGetValue(string key, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out TValue value) => throw null;
+        public bool ContainsKey(string key) => throw null;
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, TValue>> StartsWith(string prefix) => throw null;
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, TValue>> GetEnumerator() => throw null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+    }
+
     public sealed class UnsafeListDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.IEnumerable
     {
         public TValue this[TKey key] { get => throw null; set { } }

--- a/src/Meziantou.Framework/Collections/Trie.cs
+++ b/src/Meziantou.Framework/Collections/Trie.cs
@@ -1,0 +1,210 @@
+using System.Collections;
+
+namespace Meziantou.Framework.Collections;
+
+public sealed class Trie<TValue> : IEnumerable<KeyValuePair<string, TValue>>
+{
+    private readonly bool _ignoreCase;
+    private readonly TrieNode _root = new();
+
+    public Trie()
+        : this(ignoreCase: false)
+    {
+    }
+
+    public Trie(bool ignoreCase)
+    {
+        _ignoreCase = ignoreCase;
+    }
+
+    public int Count { get; private set; }
+    public bool IgnoreCase => _ignoreCase;
+
+    public void Add(string key, TValue value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        var node = GetOrCreateNode(key);
+        if (node.HasValue)
+            throw new ArgumentException("An item with the same key has already been added.", nameof(key));
+
+        node.SetValue(key, value);
+        Count++;
+    }
+
+    public bool Remove(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        var nodes = new TrieNode[key.Length + 1];
+        var edges = key.Length is 0 ? [] : new char[key.Length];
+        nodes[0] = _root;
+
+        var node = _root;
+        for (var i = 0; i < key.Length; i++)
+        {
+            var normalized = NormalizeChar(key[i]);
+            if (!node.TryGetChild(normalized, out var child))
+                return false;
+
+            edges[i] = normalized;
+            node = child;
+            nodes[i + 1] = node;
+        }
+
+        if (!node.HasValue)
+            return false;
+
+        node.ClearValue();
+        Count--;
+
+        for (var i = key.Length - 1; i >= 0; i--)
+        {
+            var child = nodes[i + 1];
+            if (child.HasValue || child.HasChildren)
+                break;
+
+            nodes[i].RemoveChild(edges[i]);
+        }
+
+        return true;
+    }
+
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out TValue value)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        if (TryGetNode(key, out var node) && node.HasValue)
+        {
+            value = node.Value;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    public bool ContainsKey(string key)
+    {
+        return TryGetValue(key, out _);
+    }
+
+    public IEnumerable<KeyValuePair<string, TValue>> StartsWith(string prefix)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+
+        if (!TryGetNode(prefix, out var node))
+            return [];
+
+        return EnumerateFrom(node);
+    }
+
+    public IEnumerator<KeyValuePair<string, TValue>> GetEnumerator() => StartsWith(string.Empty).GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private TrieNode GetOrCreateNode(string key)
+    {
+        var node = _root;
+        foreach (var c in key)
+        {
+            node = node.GetOrAddChild(NormalizeChar(c));
+        }
+
+        return node;
+    }
+
+    private bool TryGetNode(string key, out TrieNode node)
+    {
+        node = _root;
+        foreach (var c in key)
+        {
+            if (!node.TryGetChild(NormalizeChar(c), out var child))
+                return false;
+
+            node = child;
+        }
+
+        return true;
+    }
+
+    private char NormalizeChar(char c)
+    {
+        return _ignoreCase ? char.ToUpperInvariant(c) : c;
+    }
+
+    private static IEnumerable<KeyValuePair<string, TValue>> EnumerateFrom(TrieNode node)
+    {
+        if (node.HasValue)
+            yield return new KeyValuePair<string, TValue>(node.Key!, node.Value);
+
+        if (node.Children is null)
+            yield break;
+
+        foreach (var child in node.Children.Values)
+        {
+            foreach (var item in EnumerateFrom(child))
+            {
+                yield return item;
+            }
+        }
+    }
+
+    private sealed class TrieNode
+    {
+        private Dictionary<char, TrieNode>? _children;
+
+        public bool HasValue { get; private set; }
+        public TValue Value { get; private set; } = default!;
+        public string? Key { get; private set; }
+        public bool HasChildren => _children is { Count: > 0 };
+        public Dictionary<char, TrieNode>? Children => _children;
+
+        public TrieNode GetOrAddChild(char c)
+        {
+            _children ??= [];
+
+            if (!_children.TryGetValue(c, out var child))
+            {
+                child = new TrieNode();
+                _children.Add(c, child);
+            }
+
+            return child;
+        }
+
+        public bool TryGetChild(char c, [NotNullWhen(true)] out TrieNode? child)
+        {
+            if (_children is not null && _children.TryGetValue(c, out child))
+                return child is not null;
+
+            child = null;
+            return false;
+        }
+
+        public void RemoveChild(char c)
+        {
+            if (_children is null)
+                return;
+
+            _children.Remove(c);
+            if (_children.Count is 0)
+            {
+                _children = null;
+            }
+        }
+
+        public void SetValue(string key, TValue value)
+        {
+            HasValue = true;
+            Key = key;
+            Value = value;
+        }
+
+        public void ClearValue()
+        {
+            HasValue = false;
+            Key = null;
+            Value = default!;
+        }
+    }
+}

--- a/tests/Meziantou.Framework.Tests/Collections/TrieTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/TrieTests.cs
@@ -1,0 +1,119 @@
+using Meziantou.Framework.Collections;
+
+namespace Meziantou.Framework.Tests.Collections;
+
+public sealed class TrieTests
+{
+    [Fact]
+    public void AddAndTryGetValue()
+    {
+        var trie = new Trie<int>();
+
+        trie.Add("car", 1);
+        trie.Add("cat", 2);
+        trie.Add("", 42);
+
+        Assert.Equal(3, trie.Count);
+        Assert.True(trie.TryGetValue("car", out var car));
+        Assert.Equal(1, car);
+        Assert.True(trie.TryGetValue("cat", out var cat));
+        Assert.Equal(2, cat);
+        Assert.True(trie.TryGetValue(string.Empty, out var rootValue));
+        Assert.Equal(42, rootValue);
+        Assert.False(trie.TryGetValue("dog", out _));
+    }
+
+    [Fact]
+    public void AddDuplicateKeyThrows()
+    {
+        var trie = new Trie<int>();
+        trie.Add("car", 1);
+
+        Assert.Throws<ArgumentException>(() => trie.Add("car", 2));
+    }
+
+    [Fact]
+    public void RemoveExistingAndMissingKeys()
+    {
+        var trie = new Trie<int>();
+        trie.Add("car", 1);
+        trie.Add("cart", 2);
+        trie.Add("cat", 3);
+
+        Assert.True(trie.Remove("cart"));
+        Assert.Equal(2, trie.Count);
+        Assert.False(trie.TryGetValue("cart", out _));
+
+        Assert.False(trie.Remove("cart"));
+        Assert.False(trie.Remove("dog"));
+        Assert.Equal(2, trie.Count);
+    }
+
+    [Fact]
+    public void StartsWithReturnsMatchingEntries()
+    {
+        var trie = new Trie<int>();
+        trie.Add("car", 1);
+        trie.Add("cart", 2);
+        trie.Add("cat", 3);
+        trie.Add("dog", 4);
+
+        var entries = trie.StartsWith("ca").OrderBy(entry => entry.Key, StringComparer.Ordinal).ToArray();
+
+        Assert.Equal(["car", "cart", "cat"], entries.Select(entry => entry.Key).ToArray());
+        Assert.Equal([1, 2, 3], entries.Select(entry => entry.Value).ToArray());
+    }
+
+    [Fact]
+    public void StartsWithMissingPrefixReturnsEmpty()
+    {
+        var trie = new Trie<int>();
+        trie.Add("car", 1);
+
+        Assert.Empty(trie.StartsWith("zzz"));
+    }
+
+    [Fact]
+    public void EnumerationReturnsAllEntries()
+    {
+        var trie = new Trie<int>();
+        trie.Add("car", 1);
+        trie.Add("dog", 2);
+        trie.Add("", 3);
+
+        var entries = trie.OrderBy(entry => entry.Key, StringComparer.Ordinal).ToArray();
+
+        Assert.Equal(["", "car", "dog"], entries.Select(entry => entry.Key).ToArray());
+        Assert.Equal([3, 1, 2], entries.Select(entry => entry.Value).ToArray());
+    }
+
+    [Fact]
+    public void IgnoreCaseMatchesLookupRemoveAndPrefix()
+    {
+        var trie = new Trie<int>(ignoreCase: true);
+        trie.Add("Hello", 1);
+        trie.Add("heaven", 2);
+
+        Assert.Throws<ArgumentException>(() => trie.Add("HELLO", 3));
+
+        Assert.True(trie.TryGetValue("hello", out var hello));
+        Assert.Equal(1, hello);
+        Assert.True(trie.ContainsKey("HEAVEN"));
+
+        var entries = trie.StartsWith("he").OrderBy(entry => entry.Key, StringComparer.Ordinal).ToArray();
+        Assert.Equal(["Hello", "heaven"], entries.Select(entry => entry.Key).ToArray());
+
+        Assert.True(trie.Remove("hElLo"));
+        Assert.False(trie.TryGetValue("HELLO", out _));
+    }
+
+    [Fact]
+    public void CaseSensitiveDoesNotMatchDifferentCase()
+    {
+        var trie = new Trie<int>(ignoreCase: false);
+        trie.Add("Hello", 1);
+
+        Assert.False(trie.TryGetValue("hello", out _));
+        Assert.Empty(trie.StartsWith("he"));
+    }
+}


### PR DESCRIPTION
## Why
The collections package did not have a trie implementation for efficient prefix-based string lookups. This adds a dedicated type for that scenario while keeping a simple dictionary-like API.

## What changed
- Added `Trie<TValue>` in `Meziantou.Framework.Collections` with:
  - `Add`, `Remove`, `TryGetValue`, and `ContainsKey`
  - `StartsWith(string prefix)` returning `IEnumerable<KeyValuePair<string, TValue>>`
  - optional case-insensitive behavior via `ignoreCase`
  - full entry enumeration through `IEnumerable<KeyValuePair<string, TValue>>`
- Added focused collection tests for:
  - add/lookup/remove behavior
  - duplicate key handling
  - prefix enumeration
  - empty key support
  - case-sensitive vs ignore-case behavior
- Updated `ref/Meziantou.Framework.cs` public API surface.

## Validation
- Ran required repository scripts:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`
- Ran:
  - `dotnet build src/Meziantou.Framework/Meziantou.Framework.csproj /p:TreatWarningsAsErrors=true`
  - `dotnet test tests/Meziantou.Framework.Tests/Meziantou.Framework.Tests.csproj /p:TreatWarningsAsErrors=true --filter "FullyQualifiedName~Meziantou.Framework.Tests.Collections"`