### PR TITLE
Add PNG image snapshot comparer and split image loaders

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/Images/BmpImageLoader.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/BmpImageLoader.cs
@@ -1,0 +1,104 @@
+using System.Buffers.Binary;
+
+namespace Meziantou.Framework.SnapshotTesting;
+
+internal static class BmpImageLoader
+{
+    internal static bool IsBmp(ReadOnlySpan<byte> data)
+    {
+        return data.Length >= 2 && data[0] == 'B' && data[1] == 'M';
+    }
+
+    internal static Image Load(ReadOnlySpan<byte> data)
+    {
+        const int BmpFileHeaderSize = 14;
+        const int BmpInfoHeaderSize = 40;
+
+        if (data.Length < BmpFileHeaderSize + BmpInfoHeaderSize)
+            throw new InvalidDataException("The BMP data is too small.");
+
+        var dibHeaderSize = ReadInt32LittleEndian(data, 14);
+        if (dibHeaderSize < BmpInfoHeaderSize)
+            throw new NotSupportedException("Unsupported BMP DIB header.");
+
+        if (data.Length < BmpFileHeaderSize + dibHeaderSize)
+            throw new InvalidDataException("The BMP data is truncated.");
+
+        var pixelDataOffset = checked((int)ReadUInt32LittleEndian(data, 10));
+        var width = ReadInt32LittleEndian(data, 18);
+        var height = ReadInt32LittleEndian(data, 22);
+        var planes = ReadUInt16LittleEndian(data, 26);
+        var bitsPerPixel = ReadUInt16LittleEndian(data, 28);
+        var compression = ReadUInt32LittleEndian(data, 30);
+
+        if (width <= 0)
+            throw new NotSupportedException("Unsupported BMP width.");
+
+        if (height == 0 || height == int.MinValue)
+            throw new NotSupportedException("Unsupported BMP height.");
+
+        if (planes != 1)
+            throw new NotSupportedException("Unsupported BMP color planes.");
+
+        if (compression != 0)
+            throw new NotSupportedException("Only uncompressed BMP data is supported.");
+
+        if (bitsPerPixel is not 24 and not 32)
+            throw new NotSupportedException("Only 24-bit and 32-bit BMP data is supported.");
+
+        if (pixelDataOffset < BmpFileHeaderSize + dibHeaderSize || pixelDataOffset >= data.Length)
+            throw new InvalidDataException("The BMP pixel data offset is invalid.");
+
+        var bytesPerPixel = bitsPerPixel / 8;
+        var absoluteHeight = Math.Abs(height);
+        var topDown = height < 0;
+        var rowWithoutPadding = checked(width * bytesPerPixel);
+        var rowStride = checked((rowWithoutPadding + 3) & ~3);
+        var pixelDataSize = checked(rowStride * absoluteHeight);
+        if (pixelDataOffset + pixelDataSize > data.Length)
+            throw new InvalidDataException("The BMP pixel data is truncated.");
+
+        var pixels = new Argb[checked(width * absoluteHeight)];
+        for (var y = 0; y < absoluteHeight; y++)
+        {
+            var sourceRow = topDown ? y : absoluteHeight - y - 1;
+            var sourceOffset = pixelDataOffset + sourceRow * rowStride;
+            var destinationOffset = y * width;
+            for (var x = 0; x < width; x++)
+            {
+                var pixelOffset = sourceOffset + x * bytesPerPixel;
+                var b = data[pixelOffset];
+                var g = data[pixelOffset + 1];
+                var r = data[pixelOffset + 2];
+                var a = bitsPerPixel == 32 ? data[pixelOffset + 3] : (byte)0xFF;
+                pixels[destinationOffset + x] = new Argb((uint)(a << 24 | r << 16 | g << 8 | b));
+            }
+        }
+
+        return Image.Create(width, absoluteHeight, pixels);
+    }
+
+    private static int ReadInt32LittleEndian(ReadOnlySpan<byte> data, int offset)
+    {
+        if (offset + 4 > data.Length)
+            throw new InvalidDataException("The image data is truncated.");
+
+        return BinaryPrimitives.ReadInt32LittleEndian(data[offset..(offset + 4)]);
+    }
+
+    private static uint ReadUInt32LittleEndian(ReadOnlySpan<byte> data, int offset)
+    {
+        if (offset + 4 > data.Length)
+            throw new InvalidDataException("The image data is truncated.");
+
+        return BinaryPrimitives.ReadUInt32LittleEndian(data[offset..(offset + 4)]);
+    }
+
+    private static ushort ReadUInt16LittleEndian(ReadOnlySpan<byte> data, int offset)
+    {
+        if (offset + 2 > data.Length)
+            throw new InvalidDataException("The image data is truncated.");
+
+        return BinaryPrimitives.ReadUInt16LittleEndian(data[offset..(offset + 2)]);
+    }
+}

--- a/src/Meziantou.Framework.SnapshotTesting/Images/Image.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/Image.cs
@@ -1,4 +1,3 @@
-using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.SnapshotTesting;
@@ -36,11 +35,25 @@ internal sealed class Image : IEquatable<Image>
 
     internal static Image Load(ReadOnlySpan<byte> data)
     {
-        return DetectFormat(data) switch
-        {
-            DetectedImageFormat.Bmp => LoadBmp(data),
-            _ => throw new NotSupportedException("Unsupported image format. Only BMP is currently supported."),
-        };
+        if (BmpImageLoader.IsBmp(data))
+            return BmpImageLoader.Load(data);
+
+        if (PngImageLoader.IsPng(data))
+            return PngImageLoader.Load(data);
+
+        throw new NotSupportedException("Unsupported image format. Only BMP and PNG are currently supported.");
+    }
+
+    internal static Image Create(int width, int height, Argb[] pixels)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        ArgumentNullException.ThrowIfNull(pixels);
+
+        if (pixels.Length != checked(width * height))
+            throw new ArgumentOutOfRangeException(nameof(pixels));
+
+        return new Image(width, height, pixels);
     }
 
     public bool Equals(Image? other)
@@ -72,117 +85,10 @@ internal sealed class Image : IEquatable<Image>
         return hash.ToHashCode();
     }
 
-    private static DetectedImageFormat DetectFormat(ReadOnlySpan<byte> data)
-    {
-        if (data.Length >= 2 && data[0] == 'B' && data[1] == 'M')
-            return DetectedImageFormat.Bmp;
-
-        return DetectedImageFormat.Unknown;
-    }
-
-    private static Image LoadBmp(ReadOnlySpan<byte> data)
-    {
-        const int BmpFileHeaderSize = 14;
-        const int BmpInfoHeaderSize = 40;
-
-        if (data.Length < BmpFileHeaderSize + BmpInfoHeaderSize)
-            throw new InvalidDataException("The BMP data is too small.");
-
-        var dibHeaderSize = ReadInt32LittleEndian(data, 14);
-        if (dibHeaderSize < BmpInfoHeaderSize)
-            throw new NotSupportedException("Unsupported BMP DIB header.");
-
-        if (data.Length < BmpFileHeaderSize + dibHeaderSize)
-            throw new InvalidDataException("The BMP data is truncated.");
-
-        var pixelDataOffset = checked((int)ReadUInt32LittleEndian(data, 10));
-        var width = ReadInt32LittleEndian(data, 18);
-        var height = ReadInt32LittleEndian(data, 22);
-        var planes = ReadUInt16LittleEndian(data, 26);
-        var bitsPerPixel = ReadUInt16LittleEndian(data, 28);
-        var compression = ReadUInt32LittleEndian(data, 30);
-
-        if (width <= 0)
-            throw new NotSupportedException("Unsupported BMP width.");
-
-        if (height == 0 || height == int.MinValue)
-            throw new NotSupportedException("Unsupported BMP height.");
-
-        if (planes != 1)
-            throw new NotSupportedException("Unsupported BMP color planes.");
-
-        if (compression != 0)
-            throw new NotSupportedException("Only uncompressed BMP data is supported.");
-
-        if (bitsPerPixel is not 24 and not 32)
-            throw new NotSupportedException("Only 24-bit and 32-bit BMP data is supported.");
-
-        if (pixelDataOffset < BmpFileHeaderSize + dibHeaderSize || pixelDataOffset >= data.Length)
-            throw new InvalidDataException("The BMP pixel data offset is invalid.");
-
-        var bytesPerPixel = bitsPerPixel / 8;
-        var absoluteHeight = Math.Abs(height);
-        var topDown = height < 0;
-        var rowWithoutPadding = checked(width * bytesPerPixel);
-        var rowStride = checked((rowWithoutPadding + 3) & ~3);
-        var pixelDataSize = checked(rowStride * absoluteHeight);
-        if (pixelDataOffset + pixelDataSize > data.Length)
-            throw new InvalidDataException("The BMP pixel data is truncated.");
-
-        var pixels = new Argb[checked(width * absoluteHeight)];
-        for (var y = 0; y < absoluteHeight; y++)
-        {
-            var sourceRow = topDown ? y : absoluteHeight - y - 1;
-            var sourceOffset = pixelDataOffset + sourceRow * rowStride;
-            var destinationOffset = y * width;
-            for (var x = 0; x < width; x++)
-            {
-                var pixelOffset = sourceOffset + x * bytesPerPixel;
-                var b = data[pixelOffset];
-                var g = data[pixelOffset + 1];
-                var r = data[pixelOffset + 2];
-                var a = bitsPerPixel == 32 ? data[pixelOffset + 3] : (byte)0xFF;
-                pixels[destinationOffset + x] = new Argb((uint)(a << 24 | r << 16 | g << 8 | b));
-            }
-        }
-
-        return new Image(width, absoluteHeight, pixels);
-    }
-
     private static async Task<byte[]> ReadAllBytesAsync(Stream stream)
     {
         using var memoryStream = new MemoryStream();
         await stream.CopyToAsync(memoryStream).ConfigureAwait(false);
         return memoryStream.ToArray();
-    }
-
-    private static int ReadInt32LittleEndian(ReadOnlySpan<byte> data, int offset)
-    {
-        if (offset + 4 > data.Length)
-            throw new InvalidDataException("The image data is truncated.");
-
-        return BinaryPrimitives.ReadInt32LittleEndian(data[offset..(offset + 4)]);
-    }
-
-    private static uint ReadUInt32LittleEndian(ReadOnlySpan<byte> data, int offset)
-    {
-        if (offset + 4 > data.Length)
-            throw new InvalidDataException("The image data is truncated.");
-
-        return BinaryPrimitives.ReadUInt32LittleEndian(data[offset..(offset + 4)]);
-    }
-
-    private static ushort ReadUInt16LittleEndian(ReadOnlySpan<byte> data, int offset)
-    {
-        if (offset + 2 > data.Length)
-            throw new InvalidDataException("The image data is truncated.");
-
-        return BinaryPrimitives.ReadUInt16LittleEndian(data[offset..(offset + 2)]);
-    }
-
-    private enum DetectedImageFormat
-    {
-        Unknown,
-        Bmp,
     }
 }

--- a/src/Meziantou.Framework.SnapshotTesting/Images/ImageComparer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/ImageComparer.cs
@@ -1,7 +1,7 @@
 namespace Meziantou.Framework.SnapshotTesting;
 
 /// <summary>
-/// Compares BMP snapshots by decoding image pixels and comparing RGB similarity.
+/// Compares BMP/PNG snapshots by decoding image pixels and comparing RGB similarity.
 /// </summary>
 public sealed class ImageComparer(ImageComparisonSettings? settings = null) : ISnapshotComparer
 {

--- a/src/Meziantou.Framework.SnapshotTesting/Images/PngImageLoader.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/PngImageLoader.cs
@@ -1,0 +1,742 @@
+using System.Buffers.Binary;
+using System.IO.Compression;
+
+namespace Meziantou.Framework.SnapshotTesting;
+
+internal static class PngImageLoader
+{
+    private static readonly byte[] PngSignature = [137, 80, 78, 71, 13, 10, 26, 10];
+    private static readonly int[] Adam7XStarts = [0, 4, 0, 2, 0, 1, 0];
+    private static readonly int[] Adam7YStarts = [0, 0, 4, 0, 2, 0, 1];
+    private static readonly int[] Adam7XSteps = [8, 8, 4, 4, 2, 2, 1];
+    private static readonly int[] Adam7YSteps = [8, 8, 8, 4, 4, 2, 2];
+    private static readonly uint[] PngCrc32Table = InitializePngCrc32Table();
+
+    internal static bool IsPng(ReadOnlySpan<byte> data)
+    {
+        return data.StartsWith(PngSignature);
+    }
+
+    internal static Image Load(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < PngSignature.Length)
+            throw new InvalidDataException("The PNG data is too small.");
+
+        if (!data.StartsWith(PngSignature))
+            throw new InvalidDataException("Invalid PNG signature.");
+
+        var offset = PngSignature.Length;
+        var seenIhdr = false;
+        var seenPlte = false;
+        var seenIdat = false;
+        var seenIend = false;
+        var seenTrns = false;
+        var idatEnded = false;
+
+        var width = 0;
+        var height = 0;
+        byte bitDepth = 0;
+        byte colorType = 0;
+        byte interlaceMethod = 0;
+        byte[]? palette = null;
+        byte[]? paletteAlpha = null;
+        ushort transparentGray = 0;
+        var hasTransparentGray = false;
+        ushort transparentRed = 0;
+        ushort transparentGreen = 0;
+        ushort transparentBlue = 0;
+        var hasTransparentRgb = false;
+
+        using var idatData = new MemoryStream();
+        while (offset < data.Length)
+        {
+            var chunkLengthValue = ReadUInt32BigEndian(data, offset);
+            if (chunkLengthValue > int.MaxValue)
+                throw new InvalidDataException("The PNG chunk length is too large.");
+
+            var chunkLength = (int)chunkLengthValue;
+            var chunkTypeOffset = offset + 4;
+            var chunkDataOffset = offset + 8;
+            var chunkCrcOffset = checked(chunkDataOffset + chunkLength);
+            if (chunkCrcOffset > data.Length - 4)
+                throw new InvalidDataException("The PNG chunk is truncated.");
+
+            var chunkType = data[chunkTypeOffset..(chunkTypeOffset + 4)];
+            var chunkData = data[chunkDataOffset..chunkCrcOffset];
+            var expectedChunkCrc = ReadUInt32BigEndian(data, chunkCrcOffset);
+            var actualChunkCrc = ComputePngCrc32(chunkType, chunkData);
+            if (expectedChunkCrc != actualChunkCrc)
+                throw new InvalidDataException("The PNG chunk CRC is invalid.");
+
+            offset = chunkCrcOffset + 4;
+
+            if (!seenIhdr && !chunkType.SequenceEqual("IHDR"u8))
+                throw new InvalidDataException("The PNG IHDR chunk must be the first chunk.");
+
+            if (chunkType.SequenceEqual("IHDR"u8))
+            {
+                if (seenIhdr)
+                    throw new InvalidDataException("The PNG IHDR chunk is duplicated.");
+
+                if (chunkData.Length != 13)
+                    throw new InvalidDataException("The PNG IHDR chunk length is invalid.");
+
+                var widthValue = ReadUInt32BigEndian(chunkData, 0);
+                var heightValue = ReadUInt32BigEndian(chunkData, 4);
+                if (widthValue > int.MaxValue || heightValue > int.MaxValue)
+                    throw new NotSupportedException("Unsupported PNG dimensions.");
+
+                width = (int)widthValue;
+                height = (int)heightValue;
+                bitDepth = chunkData[8];
+                colorType = chunkData[9];
+                var compressionMethod = chunkData[10];
+                var filterMethod = chunkData[11];
+                interlaceMethod = chunkData[12];
+
+                ValidatePngHeader(width, height, bitDepth, colorType, compressionMethod, filterMethod, interlaceMethod);
+                seenIhdr = true;
+                continue;
+            }
+
+            if (chunkType.SequenceEqual("PLTE"u8))
+            {
+                if (!seenIhdr || seenPlte || seenIdat)
+                    throw new InvalidDataException("The PNG PLTE chunk is invalid.");
+
+                if (colorType is 0 or 4)
+                    throw new NotSupportedException("PLTE is not allowed for grayscale PNG images.");
+
+                if (chunkData.Length == 0 || chunkData.Length % 3 != 0)
+                    throw new InvalidDataException("The PNG PLTE chunk length is invalid.");
+
+                var paletteEntryCount = chunkData.Length / 3;
+                if (paletteEntryCount > 256)
+                    throw new InvalidDataException("The PNG PLTE chunk contains too many entries.");
+
+                if (colorType == 3 && paletteEntryCount > (1 << bitDepth))
+                    throw new InvalidDataException("The PNG PLTE chunk contains too many entries for the bit depth.");
+
+                palette = chunkData.ToArray();
+                seenPlte = true;
+                continue;
+            }
+
+            if (chunkType.SequenceEqual("tRNS"u8))
+            {
+                if (!seenIhdr || seenIdat || seenTrns)
+                    throw new InvalidDataException("The PNG tRNS chunk is invalid.");
+
+                seenTrns = true;
+                switch (colorType)
+                {
+                    case 0:
+                        if (chunkData.Length != 2)
+                            throw new InvalidDataException("The PNG tRNS chunk length is invalid for grayscale PNG images.");
+
+                        transparentGray = ReadUInt16BigEndian(chunkData, 0);
+                        hasTransparentGray = true;
+                        break;
+                    case 2:
+                        if (chunkData.Length != 6)
+                            throw new InvalidDataException("The PNG tRNS chunk length is invalid for truecolor PNG images.");
+
+                        transparentRed = ReadUInt16BigEndian(chunkData, 0);
+                        transparentGreen = ReadUInt16BigEndian(chunkData, 2);
+                        transparentBlue = ReadUInt16BigEndian(chunkData, 4);
+                        hasTransparentRgb = true;
+                        break;
+                    case 3:
+                    {
+                        if (!seenPlte || palette is null)
+                            throw new InvalidDataException("The PNG tRNS chunk requires a preceding PLTE chunk.");
+
+                        var paletteEntryCount = palette.Length / 3;
+                        if (chunkData.Length > paletteEntryCount)
+                            throw new InvalidDataException("The PNG tRNS chunk length is invalid for indexed PNG images.");
+
+                        paletteAlpha = chunkData.ToArray();
+                        break;
+                    }
+                    default:
+                        throw new NotSupportedException("The PNG tRNS chunk is not allowed for this color type.");
+                }
+
+                continue;
+            }
+
+            if (chunkType.SequenceEqual("IDAT"u8))
+            {
+                if (!seenIhdr)
+                    throw new InvalidDataException("The PNG IDAT chunk appears before IHDR.");
+
+                if (idatEnded)
+                    throw new InvalidDataException("The PNG IDAT chunks must be consecutive.");
+
+                if (colorType == 3 && palette is null)
+                    throw new InvalidDataException("Indexed PNG images require a PLTE chunk before IDAT.");
+
+                idatData.Write(chunkData);
+                seenIdat = true;
+                continue;
+            }
+
+            if (chunkType.SequenceEqual("IEND"u8))
+            {
+                if (chunkData.Length != 0)
+                    throw new InvalidDataException("The PNG IEND chunk length is invalid.");
+
+                seenIend = true;
+                break;
+            }
+
+            if (chunkType.SequenceEqual("acTL"u8) || chunkType.SequenceEqual("fcTL"u8) || chunkType.SequenceEqual("fdAT"u8))
+                throw new NotSupportedException("Animated PNG (APNG) is not supported.");
+
+            if (seenIdat)
+                idatEnded = true;
+
+            if (IsPngCriticalChunk(chunkType))
+                throw new NotSupportedException($"Unsupported critical PNG chunk: {GetChunkTypeName(chunkType)}");
+        }
+
+        if (!seenIhdr)
+            throw new InvalidDataException("The PNG IHDR chunk is missing.");
+
+        if (!seenIdat)
+            throw new InvalidDataException("The PNG IDAT chunk is missing.");
+
+        if (!seenIend)
+            throw new InvalidDataException("The PNG IEND chunk is missing.");
+
+        if (offset != data.Length)
+            throw new InvalidDataException("The PNG data has trailing bytes.");
+
+        var bitsPerPixel = checked(GetPngChannelCount(colorType) * bitDepth);
+        var decompressedData = DecompressPngIdatData(idatData.GetBuffer().AsSpan(0, checked((int)idatData.Length)));
+        var expectedImageDataLength = GetExpectedPngImageDataLength(width, height, bitsPerPixel, interlaceMethod);
+        if (decompressedData.Length != expectedImageDataLength)
+            throw new InvalidDataException("The PNG decompressed image data size is invalid.");
+
+        var pixels = new Argb[checked(width * height)];
+        if (interlaceMethod == 0)
+        {
+            DecodePngRows(
+                decompressedData,
+                width,
+                height,
+                bitsPerPixel,
+                colorType,
+                bitDepth,
+                palette,
+                paletteAlpha,
+                transparentGray,
+                hasTransparentGray,
+                transparentRed,
+                transparentGreen,
+                transparentBlue,
+                hasTransparentRgb,
+                pixels);
+        }
+        else
+        {
+            DecodePngInterlacedRows(
+                decompressedData,
+                width,
+                height,
+                bitsPerPixel,
+                colorType,
+                bitDepth,
+                palette,
+                paletteAlpha,
+                transparentGray,
+                hasTransparentGray,
+                transparentRed,
+                transparentGreen,
+                transparentBlue,
+                hasTransparentRgb,
+                pixels);
+        }
+
+        return Image.Create(width, height, pixels);
+    }
+
+    private static byte[] DecompressPngIdatData(ReadOnlySpan<byte> compressedData)
+    {
+        using var compressedStream = new MemoryStream(compressedData.ToArray());
+        using var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress);
+        using var output = new MemoryStream();
+        zlibStream.CopyTo(output);
+
+        return output.ToArray();
+    }
+
+    private static void DecodePngRows(
+        ReadOnlySpan<byte> data,
+        int width,
+        int height,
+        int bitsPerPixel,
+        byte colorType,
+        byte bitDepth,
+        byte[]? palette,
+        byte[]? paletteAlpha,
+        ushort transparentGray,
+        bool hasTransparentGray,
+        ushort transparentRed,
+        ushort transparentGreen,
+        ushort transparentBlue,
+        bool hasTransparentRgb,
+        Argb[] pixels)
+    {
+        var bytesPerPixel = GetPngFilterBytesPerPixel(colorType, bitDepth);
+        var rowLength = GetPngScanlineLength(width, bitsPerPixel);
+        var currentDataOffset = 0;
+        var previousRow = new byte[rowLength];
+        var currentRow = new byte[rowLength];
+
+        for (var y = 0; y < height; y++)
+        {
+            var filterType = data[currentDataOffset];
+            currentDataOffset++;
+            var rowData = data[currentDataOffset..(currentDataOffset + rowLength)];
+            currentDataOffset += rowLength;
+
+            UnfilterPngRow(filterType, rowData, previousRow, bytesPerPixel, currentRow);
+            DecodePngScanline(
+                currentRow,
+                width,
+                colorType,
+                bitDepth,
+                palette,
+                paletteAlpha,
+                transparentGray,
+                hasTransparentGray,
+                transparentRed,
+                transparentGreen,
+                transparentBlue,
+                hasTransparentRgb,
+                pixels.AsSpan(y * width, width));
+
+            (previousRow, currentRow) = (currentRow, previousRow);
+        }
+    }
+
+    private static void DecodePngInterlacedRows(
+        ReadOnlySpan<byte> data,
+        int width,
+        int height,
+        int bitsPerPixel,
+        byte colorType,
+        byte bitDepth,
+        byte[]? palette,
+        byte[]? paletteAlpha,
+        ushort transparentGray,
+        bool hasTransparentGray,
+        ushort transparentRed,
+        ushort transparentGreen,
+        ushort transparentBlue,
+        bool hasTransparentRgb,
+        Argb[] pixels)
+    {
+        var bytesPerPixel = GetPngFilterBytesPerPixel(colorType, bitDepth);
+        var currentDataOffset = 0;
+
+        for (var pass = 0; pass < Adam7XStarts.Length; pass++)
+        {
+            var passWidth = GetAdam7PassDimension(width, Adam7XStarts[pass], Adam7XSteps[pass]);
+            var passHeight = GetAdam7PassDimension(height, Adam7YStarts[pass], Adam7YSteps[pass]);
+            if (passWidth == 0 || passHeight == 0)
+                continue;
+
+            var rowLength = GetPngScanlineLength(passWidth, bitsPerPixel);
+            var previousRow = new byte[rowLength];
+            var currentRow = new byte[rowLength];
+            var decodedPassRow = new Argb[passWidth];
+            for (var passY = 0; passY < passHeight; passY++)
+            {
+                var filterType = data[currentDataOffset];
+                currentDataOffset++;
+                var rowData = data[currentDataOffset..(currentDataOffset + rowLength)];
+                currentDataOffset += rowLength;
+
+                UnfilterPngRow(filterType, rowData, previousRow, bytesPerPixel, currentRow);
+                DecodePngScanline(
+                    currentRow,
+                    passWidth,
+                    colorType,
+                    bitDepth,
+                    palette,
+                    paletteAlpha,
+                    transparentGray,
+                    hasTransparentGray,
+                    transparentRed,
+                    transparentGreen,
+                    transparentBlue,
+                    hasTransparentRgb,
+                    decodedPassRow);
+
+                var destinationY = Adam7YStarts[pass] + (passY * Adam7YSteps[pass]);
+                for (var passX = 0; passX < passWidth; passX++)
+                {
+                    var destinationX = Adam7XStarts[pass] + (passX * Adam7XSteps[pass]);
+                    pixels[(destinationY * width) + destinationX] = decodedPassRow[passX];
+                }
+
+                (previousRow, currentRow) = (currentRow, previousRow);
+            }
+        }
+    }
+
+    private static void DecodePngScanline(
+        ReadOnlySpan<byte> rowData,
+        int pixelCount,
+        byte colorType,
+        byte bitDepth,
+        byte[]? palette,
+        byte[]? paletteAlpha,
+        ushort transparentGray,
+        bool hasTransparentGray,
+        ushort transparentRed,
+        ushort transparentGreen,
+        ushort transparentBlue,
+        bool hasTransparentRgb,
+        Span<Argb> destinationPixels)
+    {
+        for (var x = 0; x < pixelCount; x++)
+        {
+            destinationPixels[x] = DecodePngPixel(
+                rowData,
+                x,
+                colorType,
+                bitDepth,
+                palette,
+                paletteAlpha,
+                transparentGray,
+                hasTransparentGray,
+                transparentRed,
+                transparentGreen,
+                transparentBlue,
+                hasTransparentRgb);
+        }
+    }
+
+    private static Argb DecodePngPixel(
+        ReadOnlySpan<byte> rowData,
+        int pixelIndex,
+        byte colorType,
+        byte bitDepth,
+        byte[]? palette,
+        byte[]? paletteAlpha,
+        ushort transparentGray,
+        bool hasTransparentGray,
+        ushort transparentRed,
+        ushort transparentGreen,
+        ushort transparentBlue,
+        bool hasTransparentRgb)
+    {
+        switch (colorType)
+        {
+            case 0:
+            {
+                var graySample = ReadPngSample(rowData, pixelIndex, bitDepth, samplesPerPixel: 1, sampleIndexInPixel: 0);
+                var gray = NormalizePngSampleToByte(graySample, bitDepth);
+                var alpha = hasTransparentGray && graySample == transparentGray ? (byte)0 : (byte)255;
+                return new Argb(alpha, gray, gray, gray);
+            }
+            case 2:
+            {
+                var rSample = ReadPngSample(rowData, pixelIndex, bitDepth, samplesPerPixel: 3, sampleIndexInPixel: 0);
+                var gSample = ReadPngSample(rowData, pixelIndex, bitDepth, samplesPerPixel: 3, sampleIndexInPixel: 1);
+                var bSample = ReadPngSample(rowData, pixelIndex, bitDepth, samplesPerPixel: 3, sampleIndexInPixel: 2);
+                var r = NormalizePngSampleToByte(rSample, bitDepth);
+                var g = NormalizePngSampleToByte(gSample, bitDepth);
+                var b = NormalizePngSampleToByte(bSample, bitDepth);
+                var alpha = hasTransparentRgb && rSample == transparentRed && gSample == transparentGreen && bSample == transparentBlue ? (byte)0 : (byte)255;
+                return new Argb(alpha, r, g, b);
+            }
+            case 3:
+            {
+                if (palette is null)
+                    throw new InvalidDataException("Indexed PNG images require a palette.");
+
+                var paletteIndex = ReadPngSample(rowData, pixelIndex, bitDepth, samplesPerPixel: 1, sampleIndexInPixel: 0);
+                if (paletteIndex >= palette.Length / 3)
+                    throw new InvalidDataException("The PNG palette index is out of range.");
+
+                var paletteOffset = checked((int)paletteIndex * 3);
+                var r = palette[paletteOffset];
+                var g = palette[paletteOffset + 1];
+                var b = palette[paletteOffset + 2];
+                var alpha = paletteAlpha is not null && paletteIndex < paletteAlpha.Length ? paletteAlpha[paletteIndex] : (byte)255;
+                return new Argb(alpha, r, g, b);
+            }
+            case 4:
+            {
+                var graySample = ReadPngSample(rowData, pixelIndex, bitDepth, samplesPerPixel: 2, sampleIndexInPixel: 0);
+                var alphaSample = ReadPngSample(rowData, pixelIndex, bitDepth, samplesPerPixel: 2, sampleIndexInPixel: 1);
+                var gray = NormalizePngSampleToByte(graySample, bitDepth);
+                var alpha = NormalizePngSampleToByte(alphaSample, bitDepth);
+                return new Argb(alpha, gray, gray, gray);
+            }
+            case 6:
+            {
+                var rSample = ReadPngSample(rowData, pixelIndex, bitDepth, samplesPerPixel: 4, sampleIndexInPixel: 0);
+                var gSample = ReadPngSample(rowData, pixelIndex, bitDepth, samplesPerPixel: 4, sampleIndexInPixel: 1);
+                var bSample = ReadPngSample(rowData, pixelIndex, bitDepth, samplesPerPixel: 4, sampleIndexInPixel: 2);
+                var aSample = ReadPngSample(rowData, pixelIndex, bitDepth, samplesPerPixel: 4, sampleIndexInPixel: 3);
+                var r = NormalizePngSampleToByte(rSample, bitDepth);
+                var g = NormalizePngSampleToByte(gSample, bitDepth);
+                var b = NormalizePngSampleToByte(bSample, bitDepth);
+                var a = NormalizePngSampleToByte(aSample, bitDepth);
+                return new Argb(a, r, g, b);
+            }
+            default:
+                throw new NotSupportedException("Unsupported PNG color type.");
+        }
+    }
+
+    private static ushort ReadPngSample(ReadOnlySpan<byte> rowData, int pixelIndex, byte bitDepth, int samplesPerPixel, int sampleIndexInPixel)
+    {
+        if (bitDepth < 8)
+        {
+            var sampleIndex = checked((pixelIndex * samplesPerPixel) + sampleIndexInPixel);
+            return ReadPngPackedSample(rowData, sampleIndex, bitDepth);
+        }
+
+        if (bitDepth == 8)
+        {
+            var sampleOffset = checked((pixelIndex * samplesPerPixel) + sampleIndexInPixel);
+            return rowData[sampleOffset];
+        }
+
+        var sampleByteOffset = checked(((pixelIndex * samplesPerPixel) + sampleIndexInPixel) * 2);
+        return BinaryPrimitives.ReadUInt16BigEndian(rowData[sampleByteOffset..(sampleByteOffset + 2)]);
+    }
+
+    private static ushort ReadPngPackedSample(ReadOnlySpan<byte> rowData, int sampleIndex, byte bitDepth)
+    {
+        var samplesPerByte = 8 / bitDepth;
+        var byteIndex = sampleIndex / samplesPerByte;
+        var sampleOffsetInByte = sampleIndex % samplesPerByte;
+        var shift = 8 - ((sampleOffsetInByte + 1) * bitDepth);
+        var mask = (1 << bitDepth) - 1;
+        return (ushort)((rowData[byteIndex] >> shift) & mask);
+    }
+
+    private static byte NormalizePngSampleToByte(ushort sample, byte bitDepth)
+    {
+        if (bitDepth == 16)
+            return (byte)(sample >> 8);
+
+        if (bitDepth == 8)
+            return (byte)sample;
+
+        var maxValue = (1 << bitDepth) - 1;
+        return (byte)((sample * 255 + (maxValue / 2)) / maxValue);
+    }
+
+    private static void ValidatePngHeader(int width, int height, byte bitDepth, byte colorType, byte compressionMethod, byte filterMethod, byte interlaceMethod)
+    {
+        if (width <= 0 || height <= 0)
+            throw new NotSupportedException("Unsupported PNG dimensions.");
+
+        if (compressionMethod != 0)
+            throw new NotSupportedException("Unsupported PNG compression method.");
+
+        if (filterMethod != 0)
+            throw new NotSupportedException("Unsupported PNG filter method.");
+
+        if (interlaceMethod is not 0 and not 1)
+            throw new NotSupportedException("Unsupported PNG interlace method.");
+
+        var bitDepthValid = colorType switch
+        {
+            0 => bitDepth is 1 or 2 or 4 or 8 or 16,
+            2 => bitDepth is 8 or 16,
+            3 => bitDepth is 1 or 2 or 4 or 8,
+            4 => bitDepth is 8 or 16,
+            6 => bitDepth is 8 or 16,
+            _ => false,
+        };
+
+        if (!bitDepthValid)
+            throw new NotSupportedException("Unsupported PNG bit depth for the color type.");
+    }
+
+    private static int GetPngChannelCount(byte colorType)
+    {
+        return colorType switch
+        {
+            0 => 1,
+            2 => 3,
+            3 => 1,
+            4 => 2,
+            6 => 4,
+            _ => throw new NotSupportedException("Unsupported PNG color type."),
+        };
+    }
+
+    private static int GetPngFilterBytesPerPixel(byte colorType, byte bitDepth)
+    {
+        var channelCount = GetPngChannelCount(colorType);
+        var bitsPerPixel = checked(channelCount * bitDepth);
+        return Math.Max(1, (bitsPerPixel + 7) / 8);
+    }
+
+    private static int GetPngScanlineLength(int width, int bitsPerPixel)
+    {
+        return checked((width * bitsPerPixel + 7) / 8);
+    }
+
+    private static int GetExpectedPngImageDataLength(int width, int height, int bitsPerPixel, byte interlaceMethod)
+    {
+        if (interlaceMethod == 0)
+            return checked(height * (1 + GetPngScanlineLength(width, bitsPerPixel)));
+
+        var totalLength = 0;
+        for (var pass = 0; pass < Adam7XStarts.Length; pass++)
+        {
+            var passWidth = GetAdam7PassDimension(width, Adam7XStarts[pass], Adam7XSteps[pass]);
+            var passHeight = GetAdam7PassDimension(height, Adam7YStarts[pass], Adam7YSteps[pass]);
+            if (passWidth == 0 || passHeight == 0)
+                continue;
+
+            var rowLength = GetPngScanlineLength(passWidth, bitsPerPixel);
+            totalLength = checked(totalLength + passHeight * (1 + rowLength));
+        }
+
+        return totalLength;
+    }
+
+    private static int GetAdam7PassDimension(int fullLength, int start, int step)
+    {
+        if (fullLength <= start)
+            return 0;
+
+        return ((fullLength - start) + step - 1) / step;
+    }
+
+    private static void UnfilterPngRow(byte filterType, ReadOnlySpan<byte> rowData, ReadOnlySpan<byte> previousRow, int bytesPerPixel, Span<byte> destination)
+    {
+        switch (filterType)
+        {
+            case 0:
+                rowData.CopyTo(destination);
+                break;
+            case 1:
+                for (var i = 0; i < rowData.Length; i++)
+                {
+                    var left = i >= bytesPerPixel ? destination[i - bytesPerPixel] : (byte)0;
+                    destination[i] = (byte)(rowData[i] + left);
+                }
+
+                break;
+            case 2:
+                for (var i = 0; i < rowData.Length; i++)
+                {
+                    var up = previousRow.Length > 0 ? previousRow[i] : (byte)0;
+                    destination[i] = (byte)(rowData[i] + up);
+                }
+
+                break;
+            case 3:
+                for (var i = 0; i < rowData.Length; i++)
+                {
+                    var left = i >= bytesPerPixel ? destination[i - bytesPerPixel] : (byte)0;
+                    var up = previousRow.Length > 0 ? previousRow[i] : (byte)0;
+                    destination[i] = (byte)(rowData[i] + ((left + up) >> 1));
+                }
+
+                break;
+            case 4:
+                for (var i = 0; i < rowData.Length; i++)
+                {
+                    var left = i >= bytesPerPixel ? destination[i - bytesPerPixel] : (byte)0;
+                    var up = previousRow.Length > 0 ? previousRow[i] : (byte)0;
+                    var upperLeft = i >= bytesPerPixel && previousRow.Length > 0 ? previousRow[i - bytesPerPixel] : (byte)0;
+                    destination[i] = (byte)(rowData[i] + PaethPredictor(left, up, upperLeft));
+                }
+
+                break;
+            default:
+                throw new NotSupportedException("Unsupported PNG filter type.");
+        }
+    }
+
+    private static byte PaethPredictor(byte left, byte up, byte upperLeft)
+    {
+        var p = left + up - upperLeft;
+        var pa = Math.Abs(p - left);
+        var pb = Math.Abs(p - up);
+        var pc = Math.Abs(p - upperLeft);
+
+        if (pa <= pb && pa <= pc)
+            return left;
+
+        if (pb <= pc)
+            return up;
+
+        return upperLeft;
+    }
+
+    private static bool IsPngCriticalChunk(ReadOnlySpan<byte> chunkType)
+    {
+        return (chunkType[0] & 0x20) == 0;
+    }
+
+    private static string GetChunkTypeName(ReadOnlySpan<byte> chunkType)
+    {
+        return new string([(char)chunkType[0], (char)chunkType[1], (char)chunkType[2], (char)chunkType[3]]);
+    }
+
+    private static uint ComputePngCrc32(ReadOnlySpan<byte> chunkType, ReadOnlySpan<byte> chunkData)
+    {
+        var crc = uint.MaxValue;
+        crc = UpdatePngCrc32(crc, chunkType);
+        crc = UpdatePngCrc32(crc, chunkData);
+        return ~crc;
+    }
+
+    private static uint UpdatePngCrc32(uint crc, ReadOnlySpan<byte> data)
+    {
+        foreach (var value in data)
+        {
+            crc = PngCrc32Table[(int)((crc ^ value) & 0xFF)] ^ (crc >> 8);
+        }
+
+        return crc;
+    }
+
+    private static uint[] InitializePngCrc32Table()
+    {
+        var table = new uint[256];
+        for (uint index = 0; index < table.Length; index++)
+        {
+            var crc = index;
+            for (var bit = 0; bit < 8; bit++)
+            {
+                crc = (crc & 1) == 0 ? crc >> 1 : 0xEDB88320u ^ (crc >> 1);
+            }
+
+            table[index] = crc;
+        }
+
+        return table;
+    }
+
+    private static uint ReadUInt32BigEndian(ReadOnlySpan<byte> data, int offset)
+    {
+        if (offset + 4 > data.Length)
+            throw new InvalidDataException("The image data is truncated.");
+
+        return BinaryPrimitives.ReadUInt32BigEndian(data[offset..(offset + 4)]);
+    }
+
+    private static ushort ReadUInt16BigEndian(ReadOnlySpan<byte> data, int offset)
+    {
+        if (offset + 2 > data.Length)
+            throw new InvalidDataException("The image data is truncated.");
+
+        return BinaryPrimitives.ReadUInt16BigEndian(data[offset..(offset + 2)]);
+    }
+}

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotComparerCollectionImageComparerExtensions.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotComparerCollectionImageComparerExtensions.cs
@@ -8,7 +8,9 @@ public static class SnapshotComparerCollectionImageComparerExtensions
         {
             ArgumentNullException.ThrowIfNull(comparers);
 
-            comparers.Set(SnapshotType.Bmp, settings is null ? ImageComparer.Instance : new ImageComparer(settings));
+            var comparer = settings is null ? ImageComparer.Instance : new ImageComparer(settings);
+            comparers.Set(SnapshotType.Bmp, comparer);
+            comparers.Set(SnapshotType.Png, comparer);
         }
     }
 }

--- a/src/Meziantou.Framework.SnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.SnapshotTesting/readme.md
@@ -103,8 +103,8 @@ Snapshot.Validate(value, SnapshotType.Default, settings);
 
 The default serializers handle human-readable objects, `byte[]`, and `Stream`.
 GIF frame extraction is opt-in via `Serializers.AddGifSerializer()`: when enabled and `SnapshotType.Gif` is used with a valid GIF `byte[]`, each frame is serialized as a separate `.gif` snapshot.
-BMP image comparison is opt-in via `Comparers.AddImageComparer()`. When enabled, `SnapshotType.Bmp` snapshots are compared by decoded pixel content (ARGB), so BMP header metadata differences do not trigger snapshot mismatches.
-To allow small visual differences, configure the BMP comparer with an SSIM threshold:
+BMP/PNG image comparison is opt-in via `Comparers.AddImageComparer()`. When enabled, `SnapshotType.Bmp` and `SnapshotType.Png` snapshots are compared by decoded pixel content (ARGB), so format metadata differences do not trigger snapshot mismatches.
+To allow small visual differences, configure the image comparer with an SSIM threshold:
 
 ```csharp
 var settings = SnapshotSettings.Default with { };

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.IO.Compression;
 using System.Text.RegularExpressions;
 using Meziantou.Framework.SnapshotTesting.MergeTools;
 
@@ -489,10 +490,34 @@ public sealed class SnapshotTests
     }
 
     [Fact]
+    public async Task Image_LoadAsync_Stream_DecodesPngPixels()
+    {
+        var imageData = CreatePngRgba32(
+            width: 2,
+            height: 1,
+            pixels:
+            [
+                0xFFFF0000u,
+                0x800000FFu,
+            ]);
+
+        using var stream = new MemoryStream(imageData);
+        var image = await Image.LoadAsync(stream);
+
+        Assert.Equal(2, image.Width);
+        Assert.Equal(1, image.Height);
+        Assert.Equal(
+        [
+            new Argb(0xFFFF0000u),
+            new Argb(0x800000FFu),
+        ], image.Pixels.ToArray());
+    }
+
+    [Fact]
     public async Task Image_LoadAsync_ThrowsWhenFormatIsNotSupported()
     {
         var ex = await Assert.ThrowsAsync<NotSupportedException>(() => Image.LoadAsync(new MemoryStream("not-a-bmp"u8.ToArray())));
-        Assert.Contains("Only BMP is currently supported.", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("Only BMP and PNG are currently supported.", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -545,6 +570,56 @@ public sealed class SnapshotTests
         settings.Comparers.AddImageComparer();
         var comparer = settings.Comparers.Get(SnapshotType.Bmp);
         Assert.False(comparer.Equals(new SnapshotData("bmp", expectedData), new SnapshotData("bmp", actualData)));
+    }
+
+    [Fact]
+    public void AddImageComparer_ComparesPngSnapshotsByPixels()
+    {
+        var expectedData = CreatePngRgba32(
+            width: 1,
+            height: 1,
+            pixels:
+            [
+                0xFF010203u,
+            ],
+            gamma: 0.45455f);
+        var actualData = CreatePngRgba32(
+            width: 1,
+            height: 1,
+            pixels:
+            [
+                0xFF010203u,
+            ],
+            gamma: 1.0f);
+
+        var settings = new SnapshotSettings();
+        settings.Comparers.AddImageComparer();
+        var comparer = settings.Comparers.Get(SnapshotType.Png);
+        Assert.True(comparer.Equals(new SnapshotData("png", expectedData), new SnapshotData("png", actualData)));
+    }
+
+    [Fact]
+    public void AddImageComparer_DetectsPngPixelDifferences()
+    {
+        var expectedData = CreatePngRgba32(
+            width: 1,
+            height: 1,
+            pixels:
+            [
+                0xFF010203u,
+            ]);
+        var actualData = CreatePngRgba32(
+            width: 1,
+            height: 1,
+            pixels:
+            [
+                0xFF040506u,
+            ]);
+
+        var settings = new SnapshotSettings();
+        settings.Comparers.AddImageComparer();
+        var comparer = settings.Comparers.Get(SnapshotType.Png);
+        Assert.False(comparer.Equals(new SnapshotData("png", expectedData), new SnapshotData("png", actualData)));
     }
 
     [Fact]
@@ -977,6 +1052,103 @@ public sealed class SnapshotTests
         }
 
         return data;
+    }
+
+    private static byte[] CreatePngRgba32(int width, int height, IReadOnlyList<uint> pixels, float? gamma = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+
+        if (pixels.Count != checked(width * height))
+            throw new ArgumentOutOfRangeException(nameof(pixels));
+
+        var rowStride = checked(width * 4 + 1);
+        var imageData = new byte[checked(rowStride * height)];
+        for (var y = 0; y < height; y++)
+        {
+            var rowOffset = y * rowStride;
+            imageData[rowOffset] = 0;
+            for (var x = 0; x < width; x++)
+            {
+                var pixel = pixels[y * width + x];
+                var pixelOffset = rowOffset + 1 + x * 4;
+                imageData[pixelOffset] = (byte)((pixel >> 16) & 0xFF);
+                imageData[pixelOffset + 1] = (byte)((pixel >> 8) & 0xFF);
+                imageData[pixelOffset + 2] = (byte)(pixel & 0xFF);
+                imageData[pixelOffset + 3] = (byte)(pixel >> 24);
+            }
+        }
+
+        byte[] compressedData;
+        using (var compressedStream = new MemoryStream())
+        {
+            using (var zlib = new ZLibStream(compressedStream, CompressionLevel.SmallestSize, leaveOpen: true))
+            {
+                zlib.Write(imageData);
+            }
+
+            compressedData = compressedStream.ToArray();
+        }
+
+        using var stream = new MemoryStream();
+        stream.Write([137, 80, 78, 71, 13, 10, 26, 10]);
+
+        Span<byte> ihdrData = stackalloc byte[13];
+        BinaryPrimitives.WriteUInt32BigEndian(ihdrData, (uint)width);
+        BinaryPrimitives.WriteUInt32BigEndian(ihdrData[4..], (uint)height);
+        ihdrData[8] = 8;
+        ihdrData[9] = 6;
+        ihdrData[10] = 0;
+        ihdrData[11] = 0;
+        ihdrData[12] = 0;
+        WritePngChunk(stream, "IHDR"u8, ihdrData);
+
+        if (gamma is not null)
+        {
+            Span<byte> gammaData = stackalloc byte[4];
+            var gammaValue = checked((uint)Math.Round(gamma.Value * 100000f, MidpointRounding.AwayFromZero));
+            BinaryPrimitives.WriteUInt32BigEndian(gammaData, gammaValue);
+            WritePngChunk(stream, "gAMA"u8, gammaData);
+        }
+
+        WritePngChunk(stream, "IDAT"u8, compressedData);
+        WritePngChunk(stream, "IEND"u8, ReadOnlySpan<byte>.Empty);
+        return stream.ToArray();
+    }
+
+    private static void WritePngChunk(Stream stream, ReadOnlySpan<byte> type, ReadOnlySpan<byte> data)
+    {
+        Span<byte> uintBuffer = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(uintBuffer, (uint)data.Length);
+        stream.Write(uintBuffer);
+        stream.Write(type);
+        stream.Write(data);
+
+        var crc = ComputePngCrc32(type, data);
+        BinaryPrimitives.WriteUInt32BigEndian(uintBuffer, crc);
+        stream.Write(uintBuffer);
+    }
+
+    private static uint ComputePngCrc32(ReadOnlySpan<byte> type, ReadOnlySpan<byte> data)
+    {
+        var crc = uint.MaxValue;
+        crc = UpdatePngCrc32(crc, type);
+        crc = UpdatePngCrc32(crc, data);
+        return ~crc;
+    }
+
+    private static uint UpdatePngCrc32(uint crc, ReadOnlySpan<byte> data)
+    {
+        foreach (var value in data)
+        {
+            crc ^= value;
+            for (var i = 0; i < 8; i++)
+            {
+                crc = (crc & 1) == 0 ? crc >> 1 : 0xEDB88320u ^ (crc >> 1);
+            }
+        }
+
+        return crc;
     }
 
     private static void WriteUInt32LittleEndian(byte[] data, int offset, uint value)


### PR DESCRIPTION
## Why
Snapshot image comparison supported BMP only, and PNG snapshots still used raw byte comparison. We also needed to reduce the size of `Image` after adding full PNG decoding logic.

## What changed
- Added PNG-aware image comparison registration in `AddImageComparer()` for `SnapshotType.Png` (BMP registration remains).
- Implemented PNG decoding support used by `ImageComparer` so comparisons are based on normalized ARGB pixels instead of PNG metadata or chunk layout differences.
- Kept existing BMP decoding behavior and comparer behavior.
- Refactored decoder responsibilities by extracting:
  - `BmpImageLoader` for BMP parsing/decoding
  - `PngImageLoader` for PNG parsing/decoding
- Reduced `Image` to model/load entry points/dispatch/equality logic.
- Added tests for PNG loading and PNG comparer behavior, and updated SnapshotTesting docs for BMP+PNG comparer support.

## Notes for reviewers
- PNG decoding includes strict validation for signature/chunks, CRC, ordering, filter reconstruction, palette + tRNS handling, 16-bit normalization, and Adam7 interlace decoding.
- APNG chunks are explicitly rejected.