### PR TITLE
Add PNG split serializers for GIF and ICO snapshots

### DIFF
--- a/ref/Meziantou.Framework.SnapshotTesting.cs
+++ b/ref/Meziantou.Framework.SnapshotTesting.cs
@@ -218,6 +218,11 @@ namespace Meziantou.Framework.SnapshotTesting
         public static void AddGifSerializer(this Meziantou.Framework.SnapshotTesting.SnapshotSerializerCollection serializers) { }
     }
 
+    public static class SnapshotSerializerCollectionIcoSerializerExtensions
+    {
+        public static void AddIcoSerializer(this Meziantou.Framework.SnapshotTesting.SnapshotSerializerCollection serializers) { }
+    }
+
     public sealed class SnapshotSettings : System.IEquatable<Meziantou.Framework.SnapshotTesting.SnapshotSettings>
     {
         public static Meziantou.Framework.SnapshotTesting.SnapshotSettings Default { get => throw null; set { } }
@@ -290,6 +295,7 @@ namespace Meziantou.Framework.SnapshotTesting
         public static Meziantou.Framework.SnapshotTesting.SnapshotType Tiff { get => throw null; }
         public static Meziantou.Framework.SnapshotTesting.SnapshotType Webp { get => throw null; }
         public static Meziantou.Framework.SnapshotTesting.SnapshotType Gif { get => throw null; }
+        public static Meziantou.Framework.SnapshotTesting.SnapshotType Ico { get => throw null; }
         public string Type { get => throw null; }
         public string? MimeType { get => throw null; }
         public string? DisplayName { get => throw null; }

--- a/src/Meziantou.Framework.SnapshotTesting/Images/GifImageLoader.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/GifImageLoader.cs
@@ -1,0 +1,396 @@
+using System.Buffers.Binary;
+
+namespace Meziantou.Framework.SnapshotTesting;
+
+internal static class GifImageLoader
+{
+    private static readonly int[] InterlacedRowStarts = [0, 4, 2, 1];
+    private static readonly int[] InterlacedRowSteps = [8, 8, 4, 2];
+
+    internal static bool TryLoadSingleFrame(ReadOnlySpan<byte> data, [NotNullWhen(true)] out Image? image)
+    {
+        image = null;
+        if (!IsGifHeader(data))
+            return false;
+
+        var logicalWidth = BinaryPrimitives.ReadUInt16LittleEndian(data[6..8]);
+        var logicalHeight = BinaryPrimitives.ReadUInt16LittleEndian(data[8..10]);
+        if (logicalWidth == 0 || logicalHeight == 0)
+            return false;
+
+        var packedFields = data[10];
+        var hasGlobalColorTable = (packedFields & 0b1000_0000) != 0;
+        var globalColorTableEntryCount = 1 << ((packedFields & 0b0000_0111) + 1);
+        var backgroundColorIndex = data[11];
+        var offset = 13;
+
+        Argb[]? globalPalette = null;
+        if (hasGlobalColorTable && !TryReadColorTable(data, ref offset, globalColorTableEntryCount, out globalPalette))
+            return false;
+
+        var transparentColorIndex = -1;
+        while (offset < data.Length)
+        {
+            var blockType = data[offset];
+            offset++;
+            switch (blockType)
+            {
+                case 0x21:
+                {
+                    if (offset >= data.Length)
+                        return false;
+
+                    var extensionLabel = data[offset];
+                    offset++;
+                    if (extensionLabel == 0xF9)
+                    {
+                        if (!TryReadGraphicControlExtension(data, ref offset, out transparentColorIndex))
+                            return false;
+                    }
+                    else
+                    {
+                        if (!TrySkipSubBlocks(data, ref offset))
+                            return false;
+                    }
+
+                    break;
+                }
+                case 0x2C:
+                {
+                    if (offset + 9 > data.Length)
+                        return false;
+
+                    var left = BinaryPrimitives.ReadUInt16LittleEndian(data[offset..(offset + 2)]);
+                    var top = BinaryPrimitives.ReadUInt16LittleEndian(data[(offset + 2)..(offset + 4)]);
+                    var width = BinaryPrimitives.ReadUInt16LittleEndian(data[(offset + 4)..(offset + 6)]);
+                    var height = BinaryPrimitives.ReadUInt16LittleEndian(data[(offset + 6)..(offset + 8)]);
+                    if (width == 0 || height == 0)
+                        return false;
+
+                    var imagePackedFields = data[offset + 8];
+                    var isInterlaced = (imagePackedFields & 0b0100_0000) != 0;
+                    var hasLocalColorTable = (imagePackedFields & 0b1000_0000) != 0;
+                    offset += 9;
+
+                    Argb[]? localPalette = null;
+                    if (hasLocalColorTable)
+                    {
+                        var localColorTableEntryCount = 1 << ((imagePackedFields & 0b0000_0111) + 1);
+                        if (!TryReadColorTable(data, ref offset, localColorTableEntryCount, out localPalette))
+                            return false;
+                    }
+
+                    var palette = localPalette ?? globalPalette;
+                    if (palette is null)
+                        return false;
+
+                    if (offset >= data.Length)
+                        return false;
+
+                    var lzwMinimumCodeSize = data[offset];
+                    offset++;
+                    if (!TryReadSubBlocks(data, ref offset, out var compressedImageData))
+                        return false;
+
+                    var pixelCount = checked((int)width * height);
+                    if (!TryDecodeLzwImageData(compressedImageData, lzwMinimumCodeSize, pixelCount, out var colorIndexes))
+                        return false;
+
+                    var pixels = new Argb[checked((int)logicalWidth * logicalHeight)];
+                    if (globalPalette is not null && backgroundColorIndex < globalPalette.Length && backgroundColorIndex != transparentColorIndex)
+                    {
+                        Array.Fill(pixels, globalPalette[backgroundColorIndex]);
+                    }
+
+                    if (left > logicalWidth - width || top > logicalHeight - height)
+                        return false;
+
+                    var rowMapping = isInterlaced ? CreateInterlacedRowMapping(height) : null;
+                    for (var sourceRow = 0; sourceRow < height; sourceRow++)
+                    {
+                        var targetRow = rowMapping is null ? sourceRow : rowMapping[sourceRow];
+                        var destinationRow = checked((int)(top + targetRow) * logicalWidth + left);
+                        var sourceRowOffset = checked((int)sourceRow * width);
+                        for (var x = 0; x < width; x++)
+                        {
+                            var paletteIndex = colorIndexes[sourceRowOffset + x];
+                            if (paletteIndex >= palette.Length)
+                                return false;
+
+                            if (paletteIndex == transparentColorIndex)
+                                continue;
+
+                            pixels[destinationRow + x] = palette[paletteIndex];
+                        }
+                    }
+
+                    image = Image.Create(logicalWidth, logicalHeight, pixels);
+                    return true;
+                }
+                case 0x3B:
+                    return false;
+                default:
+                    return false;
+            }
+        }
+
+        return false;
+    }
+
+    private static int[] CreateInterlacedRowMapping(int height)
+    {
+        var rows = new int[height];
+        var index = 0;
+        for (var pass = 0; pass < InterlacedRowStarts.Length; pass++)
+        {
+            for (var row = InterlacedRowStarts[pass]; row < height; row += InterlacedRowSteps[pass])
+            {
+                rows[index] = row;
+                index++;
+            }
+        }
+
+        return rows;
+    }
+
+    private static bool TryReadGraphicControlExtension(ReadOnlySpan<byte> data, ref int offset, out int transparentColorIndex)
+    {
+        transparentColorIndex = -1;
+        if (offset >= data.Length)
+            return false;
+
+        var blockSize = data[offset];
+        offset++;
+        if (blockSize < 4 || offset + blockSize > data.Length)
+            return false;
+
+        var packedFields = data[offset];
+        if ((packedFields & 0b0000_0001) != 0)
+        {
+            transparentColorIndex = data[offset + 3];
+        }
+
+        offset += blockSize;
+        if (offset >= data.Length || data[offset] != 0)
+            return false;
+
+        offset++;
+        return true;
+    }
+
+    private static bool TryReadColorTable(ReadOnlySpan<byte> data, ref int offset, int entryCount, [NotNullWhen(true)] out Argb[]? palette)
+    {
+        palette = null;
+        if (entryCount <= 0)
+            return false;
+
+        var size = checked(entryCount * 3);
+        if (offset + size > data.Length)
+            return false;
+
+        var table = new Argb[entryCount];
+        for (var index = 0; index < entryCount; index++)
+        {
+            var tableOffset = offset + index * 3;
+            var red = data[tableOffset];
+            var green = data[tableOffset + 1];
+            var blue = data[tableOffset + 2];
+            table[index] = new Argb(0xFF, red, green, blue);
+        }
+
+        offset += size;
+        palette = table;
+        return true;
+    }
+
+    private static bool TryReadSubBlocks(ReadOnlySpan<byte> data, ref int offset, [NotNullWhen(true)] out byte[]? result)
+    {
+        result = null;
+        using var stream = new MemoryStream();
+        while (offset < data.Length)
+        {
+            var blockLength = data[offset];
+            offset++;
+            if (blockLength == 0)
+            {
+                result = stream.ToArray();
+                return true;
+            }
+
+            if (offset + blockLength > data.Length)
+                return false;
+
+            stream.Write(data[offset..(offset + blockLength)]);
+            offset += blockLength;
+        }
+
+        return false;
+    }
+
+    private static bool TrySkipSubBlocks(ReadOnlySpan<byte> data, ref int offset)
+    {
+        while (offset < data.Length)
+        {
+            var blockLength = data[offset];
+            offset++;
+            if (blockLength == 0)
+                return true;
+
+            if (offset + blockLength > data.Length)
+                return false;
+
+            offset += blockLength;
+        }
+
+        return false;
+    }
+
+    private static bool TryDecodeLzwImageData(ReadOnlySpan<byte> compressedData, byte minimumCodeSize, int expectedPixelCount, [NotNullWhen(true)] out byte[]? indexes)
+    {
+        indexes = null;
+        if (minimumCodeSize is < 2 or > 8)
+            return false;
+
+        Span<ushort> prefix = stackalloc ushort[4096];
+        Span<byte> suffix = stackalloc byte[4096];
+        Span<byte> decodeStack = stackalloc byte[4096];
+
+        var clearCode = 1 << minimumCodeSize;
+        var endCode = clearCode + 1;
+        var nextCode = endCode + 1;
+        var codeSize = minimumCodeSize + 1;
+
+        for (var code = 0; code < clearCode; code++)
+        {
+            suffix[code] = (byte)code;
+        }
+
+        var output = new byte[expectedPixelCount];
+        var outputOffset = 0;
+        var previousCode = -1;
+
+        var bitBuffer = 0;
+        var bitCount = 0;
+        var sourceOffset = 0;
+        while (TryReadLzwCode(compressedData, ref sourceOffset, ref bitBuffer, ref bitCount, codeSize, out var code))
+        {
+            if (code == clearCode)
+            {
+                codeSize = minimumCodeSize + 1;
+                nextCode = endCode + 1;
+                previousCode = -1;
+                continue;
+            }
+
+            if (code == endCode)
+            {
+                if (outputOffset != expectedPixelCount)
+                    return false;
+
+                indexes = output;
+                return true;
+            }
+
+            if (code > nextCode || code >= 4096)
+                return false;
+
+            var decodeStackLength = 0;
+            var inputCode = code;
+            if (code == nextCode)
+            {
+                if (previousCode < 0)
+                    return false;
+
+                decodeStack[decodeStackLength] = GetFirstDecodedSuffix(previousCode, clearCode, prefix, suffix);
+                decodeStackLength++;
+                code = previousCode;
+            }
+
+            while (code >= clearCode)
+            {
+                if (code >= 4096 || decodeStackLength >= decodeStack.Length)
+                    return false;
+
+                decodeStack[decodeStackLength] = suffix[code];
+                decodeStackLength++;
+                code = prefix[code];
+            }
+
+            if (decodeStackLength >= decodeStack.Length)
+                return false;
+
+            var firstSuffix = suffix[code];
+            decodeStack[decodeStackLength] = firstSuffix;
+            decodeStackLength++;
+
+            for (var index = decodeStackLength - 1; index >= 0; index--)
+            {
+                if (outputOffset >= output.Length)
+                    return false;
+
+                output[outputOffset] = decodeStack[index];
+                outputOffset++;
+            }
+
+            if (previousCode >= 0 && nextCode < 4096)
+            {
+                prefix[nextCode] = (ushort)previousCode;
+                suffix[nextCode] = firstSuffix;
+                nextCode++;
+                if (nextCode == (1 << codeSize) && codeSize < 12)
+                {
+                    codeSize++;
+                }
+            }
+
+            previousCode = inputCode;
+        }
+
+        return false;
+    }
+
+    private static byte GetFirstDecodedSuffix(int code, int clearCode, ReadOnlySpan<ushort> prefix, ReadOnlySpan<byte> suffix)
+    {
+        while (code >= clearCode)
+        {
+            code = prefix[code];
+        }
+
+        return suffix[code];
+    }
+
+    private static bool TryReadLzwCode(ReadOnlySpan<byte> data, ref int sourceOffset, ref int bitBuffer, ref int bitCount, int codeSize, out int code)
+    {
+        while (bitCount < codeSize)
+        {
+            if (sourceOffset >= data.Length)
+            {
+                code = 0;
+                return false;
+            }
+
+            bitBuffer |= data[sourceOffset] << bitCount;
+            sourceOffset++;
+            bitCount += 8;
+        }
+
+        code = bitBuffer & ((1 << codeSize) - 1);
+        bitBuffer >>= codeSize;
+        bitCount -= codeSize;
+        return true;
+    }
+
+    private static bool IsGifHeader(ReadOnlySpan<byte> source)
+    {
+        if (source.Length < 14)
+            return false;
+
+        if (source[0] != (byte)'G' || source[1] != (byte)'I' || source[2] != (byte)'F')
+            return false;
+
+        if (source[3] != (byte)'8')
+            return false;
+
+        return (source[4], source[5]) is ((byte)'7', (byte)'a') or ((byte)'9', (byte)'a');
+    }
+}

--- a/src/Meziantou.Framework.SnapshotTesting/Images/GifSnapshotSerializer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/GifSnapshotSerializer.cs
@@ -15,7 +15,13 @@ internal sealed class GifSnapshotSerializer : ISnapshotSerializer
         var snapshotData = new SnapshotData[frames.Count];
         for (var i = 0; i < frames.Count; i++)
         {
-            snapshotData[i] = new SnapshotData(type.FileExtension, frames[i]);
+            if (!GifImageLoader.TryLoadSingleFrame(frames[i], out var image))
+            {
+                result = null;
+                return false;
+            }
+
+            snapshotData[i] = new SnapshotData(".png", PngImageEncoder.Encode(image));
         }
 
         result = new SerializedSnapshot(snapshotData);

--- a/src/Meziantou.Framework.SnapshotTesting/Images/IcoSnapshotSerializer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/IcoSnapshotSerializer.cs
@@ -1,0 +1,156 @@
+using System.Buffers.Binary;
+
+namespace Meziantou.Framework.SnapshotTesting;
+
+internal sealed class IcoSnapshotSerializer : ISnapshotSerializer
+{
+    public static ISnapshotSerializer Instance { get; } = new IcoSnapshotSerializer();
+
+    public bool TrySerialize(SnapshotType type, object? value, [NotNullWhen(true)] out SerializedSnapshot? result)
+    {
+        if (type != SnapshotType.Ico || value is not byte[] icoData || !TryExtractPngImages(icoData, out var pngImages))
+        {
+            result = null;
+            return false;
+        }
+
+        var snapshotData = new SnapshotData[pngImages.Count];
+        for (var i = 0; i < pngImages.Count; i++)
+        {
+            snapshotData[i] = new SnapshotData(".png", pngImages[i]);
+        }
+
+        result = new SerializedSnapshot(snapshotData);
+        return true;
+    }
+
+    private static bool TryExtractPngImages(byte[] source, [NotNullWhen(true)] out List<byte[]>? pngImages)
+    {
+        pngImages = null;
+        if (source.Length < 6)
+            return false;
+
+        var reserved = BinaryPrimitives.ReadUInt16LittleEndian(source.AsSpan(0, 2));
+        var type = BinaryPrimitives.ReadUInt16LittleEndian(source.AsSpan(2, 2));
+        var count = BinaryPrimitives.ReadUInt16LittleEndian(source.AsSpan(4, 2));
+        if (reserved != 0 || type != 1 || count == 0)
+            return false;
+
+        var directorySize = checked(6 + count * 16);
+        if (directorySize > source.Length)
+            return false;
+
+        var images = new List<byte[]>(count);
+        for (var index = 0; index < count; index++)
+        {
+            var entryOffset = 6 + index * 16;
+            if (!TryReadEntryData(source, entryOffset, out var entryData))
+                return false;
+
+            if (PngImageLoader.IsPng(entryData))
+            {
+                images.Add(entryData.ToArray());
+                continue;
+            }
+
+            if (!TryLoadIconBitmap(entryData, out var image))
+                return false;
+
+            images.Add(PngImageEncoder.Encode(image));
+        }
+
+        pngImages = images;
+        return true;
+    }
+
+    private static bool TryReadEntryData(byte[] source, int entryOffset, out ReadOnlySpan<byte> entryData)
+    {
+        entryData = default;
+
+        var bytesInResource = BinaryPrimitives.ReadUInt32LittleEndian(source.AsSpan(entryOffset + 8, 4));
+        var imageOffset = BinaryPrimitives.ReadUInt32LittleEndian(source.AsSpan(entryOffset + 12, 4));
+        if (bytesInResource == 0 || bytesInResource > int.MaxValue || imageOffset > int.MaxValue)
+            return false;
+
+        var bytesInResourceInt = (int)bytesInResource;
+        var imageOffsetInt = (int)imageOffset;
+        if (imageOffsetInt < 0 || bytesInResourceInt < 0 || imageOffsetInt > source.Length - bytesInResourceInt)
+            return false;
+
+        entryData = source.AsSpan(imageOffsetInt, bytesInResourceInt);
+        return true;
+    }
+
+    private static bool TryLoadIconBitmap(ReadOnlySpan<byte> entryData, [NotNullWhen(true)] out Image? image)
+    {
+        image = null;
+        if (entryData.Length < 40)
+            return false;
+
+        var headerSize = BinaryPrimitives.ReadInt32LittleEndian(entryData[0..4]);
+        if (headerSize < 40 || headerSize > entryData.Length)
+            return false;
+
+        var width = BinaryPrimitives.ReadInt32LittleEndian(entryData[4..8]);
+        var combinedHeight = BinaryPrimitives.ReadInt32LittleEndian(entryData[8..12]);
+        var planes = BinaryPrimitives.ReadUInt16LittleEndian(entryData[12..14]);
+        var bitsPerPixel = BinaryPrimitives.ReadUInt16LittleEndian(entryData[14..16]);
+        var compression = BinaryPrimitives.ReadUInt32LittleEndian(entryData[16..20]);
+        if (width <= 0 || combinedHeight <= 0 || planes != 1 || compression != 0)
+            return false;
+
+        if (combinedHeight % 2 != 0)
+            return false;
+
+        var height = combinedHeight / 2;
+        if (height <= 0)
+            return false;
+
+        if (bitsPerPixel is not 24 and not 32)
+            return false;
+
+        var xorStride = checked(((width * bitsPerPixel + 31) / 32) * 4);
+        var xorSize = checked(xorStride * height);
+        var xorOffset = headerSize;
+        if (xorOffset > entryData.Length - xorSize)
+            return false;
+
+        var andStride = checked(((width + 31) / 32) * 4);
+        var andSize = checked(andStride * height);
+        var hasMask = xorOffset + xorSize + andSize <= entryData.Length;
+        var andOffset = xorOffset + xorSize;
+
+        var pixels = new Argb[checked(width * height)];
+        var bytesPerPixel = bitsPerPixel / 8;
+        for (var y = 0; y < height; y++)
+        {
+            var sourceRow = height - y - 1;
+            var xorRowOffset = xorOffset + sourceRow * xorStride;
+            var destinationRowOffset = y * width;
+            var andRowOffset = hasMask ? andOffset + sourceRow * andStride : -1;
+            for (var x = 0; x < width; x++)
+            {
+                var pixelOffset = xorRowOffset + x * bytesPerPixel;
+                var blue = entryData[pixelOffset];
+                var green = entryData[pixelOffset + 1];
+                var red = entryData[pixelOffset + 2];
+                var alpha = bitsPerPixel == 32 ? entryData[pixelOffset + 3] : (byte)255;
+
+                if (hasMask)
+                {
+                    var maskByte = entryData[andRowOffset + x / 8];
+                    var isTransparent = (maskByte & (0x80 >> (x % 8))) != 0;
+                    if (isTransparent)
+                    {
+                        alpha = 0;
+                    }
+                }
+
+                pixels[destinationRowOffset + x] = new Argb(alpha, red, green, blue);
+            }
+        }
+
+        image = Image.Create(width, height, pixels);
+        return true;
+    }
+}

--- a/src/Meziantou.Framework.SnapshotTesting/Images/PngImageEncoder.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/PngImageEncoder.cs
@@ -1,0 +1,110 @@
+using System.Buffers.Binary;
+using System.IO.Compression;
+
+namespace Meziantou.Framework.SnapshotTesting;
+
+internal static class PngImageEncoder
+{
+    private static readonly byte[] PngSignature = [137, 80, 78, 71, 13, 10, 26, 10];
+    private static readonly uint[] PngCrc32Table = InitializePngCrc32Table();
+
+    internal static byte[] Encode(Image image)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+
+        var width = image.Width;
+        var height = image.Height;
+        var rawData = new byte[checked(height * (checked(width * 4) + 1))];
+        var pixels = image.Pixels.Span;
+        for (var y = 0; y < height; y++)
+        {
+            var rawRowOffset = y * (width * 4 + 1);
+            rawData[rawRowOffset] = 0;
+            var pixelRowOffset = y * width;
+            for (var x = 0; x < width; x++)
+            {
+                var pixel = pixels[pixelRowOffset + x];
+                var destinationOffset = rawRowOffset + 1 + x * 4;
+                rawData[destinationOffset] = pixel.R;
+                rawData[destinationOffset + 1] = pixel.G;
+                rawData[destinationOffset + 2] = pixel.B;
+                rawData[destinationOffset + 3] = pixel.A;
+            }
+        }
+
+        byte[] compressedData;
+        using (var compressedStream = new MemoryStream())
+        {
+            using (var zlibStream = new ZLibStream(compressedStream, CompressionLevel.Optimal, leaveOpen: true))
+            {
+                zlibStream.Write(rawData);
+            }
+
+            compressedData = compressedStream.ToArray();
+        }
+
+        using var output = new MemoryStream();
+        output.Write(PngSignature);
+
+        Span<byte> ihdrData = stackalloc byte[13];
+        BinaryPrimitives.WriteUInt32BigEndian(ihdrData[0..4], (uint)width);
+        BinaryPrimitives.WriteUInt32BigEndian(ihdrData[4..8], (uint)height);
+        ihdrData[8] = 8;
+        ihdrData[9] = 6;
+        ihdrData[10] = 0;
+        ihdrData[11] = 0;
+        ihdrData[12] = 0;
+        WritePngChunk(output, "IHDR"u8, ihdrData);
+        WritePngChunk(output, "IDAT"u8, compressedData);
+        WritePngChunk(output, "IEND"u8, ReadOnlySpan<byte>.Empty);
+        return output.ToArray();
+    }
+
+    private static void WritePngChunk(Stream stream, ReadOnlySpan<byte> type, ReadOnlySpan<byte> data)
+    {
+        Span<byte> uintBuffer = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(uintBuffer, (uint)data.Length);
+        stream.Write(uintBuffer);
+        stream.Write(type);
+        stream.Write(data);
+
+        var crc = ComputePngCrc32(type, data);
+        BinaryPrimitives.WriteUInt32BigEndian(uintBuffer, crc);
+        stream.Write(uintBuffer);
+    }
+
+    private static uint ComputePngCrc32(ReadOnlySpan<byte> type, ReadOnlySpan<byte> data)
+    {
+        var crc = uint.MaxValue;
+        crc = UpdatePngCrc32(crc, type);
+        crc = UpdatePngCrc32(crc, data);
+        return ~crc;
+    }
+
+    private static uint UpdatePngCrc32(uint crc, ReadOnlySpan<byte> data)
+    {
+        foreach (var value in data)
+        {
+            crc = PngCrc32Table[(crc ^ value) & 0xFF] ^ (crc >> 8);
+        }
+
+        return crc;
+    }
+
+    private static uint[] InitializePngCrc32Table()
+    {
+        var table = new uint[256];
+        for (var i = 0; i < table.Length; i++)
+        {
+            var c = (uint)i;
+            for (var bit = 0; bit < 8; bit++)
+            {
+                c = (c & 1) == 0 ? c >> 1 : 0xEDB88320u ^ (c >> 1);
+            }
+
+            table[i] = c;
+        }
+
+        return table;
+    }
+}

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
@@ -226,7 +226,7 @@ internal static class SnapshotEngine
         for (var index = 0; index < serialized.Count; index++)
         {
             var snapshotData = serialized[index];
-            var extension = string.IsNullOrEmpty(type.Type) ? snapshotData.Extension : type.Type;
+            var extension = ResolveSnapshotExtension(type, snapshotData);
             var path = settings.SnapshotPathStrategy(new SnapshotPathContext(
                 callerContext.SourceFilePath,
                 callerContext.ContainingTypeName,
@@ -243,6 +243,15 @@ internal static class SnapshotEngine
         }
 
         return result;
+    }
+
+    private static string? ResolveSnapshotExtension(SnapshotType type, SnapshotData snapshotData)
+    {
+        var extension = snapshotData.Extension;
+        if (string.IsNullOrWhiteSpace(extension))
+            return type.Type;
+
+        return extension.TrimStart('.');
     }
 
     private static IReadOnlyCollection<FullPath> DiscoverExpectedFilePaths(List<SnapshotFile> actualFiles)

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotSerializerCollectionIcoSerializerExtensions.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotSerializerCollectionIcoSerializerExtensions.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+
+namespace Meziantou.Framework.SnapshotTesting;
+
+public static class SnapshotSerializerCollectionIcoSerializerExtensions
+{
+    extension(SnapshotSerializerCollection serializers)
+    {
+        public void AddIcoSerializer()
+        {
+            if (serializers.Any(static serializer => serializer is IcoSnapshotSerializer))
+                return;
+
+            serializers.Add(IcoSnapshotSerializer.Instance);
+        }
+    }
+}

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotType.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotType.cs
@@ -11,6 +11,7 @@ public sealed class SnapshotType : IEquatable<SnapshotType>
     public static SnapshotType Tiff { get; } = new("tiff", "image/tiff", "TIFF image");
     public static SnapshotType Webp { get; } = new("webp", "image/webp", "WebP image");
     public static SnapshotType Gif { get; } = new("gif", "image/gif", "GIF image");
+    public static SnapshotType Ico { get; } = new("ico", "image/x-icon", "ICO image");
 
     private static readonly Dictionary<string, SnapshotType> Cache = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -22,6 +23,7 @@ public sealed class SnapshotType : IEquatable<SnapshotType>
         ["tiff"] = Tiff,
         ["webp"] = Webp,
         ["gif"] = Gif,
+        ["ico"] = Ico,
     };
 
     private SnapshotType(string type, string? mimeType = null, string? displayName = null)

--- a/src/Meziantou.Framework.SnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.SnapshotTesting/readme.md
@@ -32,6 +32,15 @@ settings.Serializers.AddGifSerializer();
 Snapshot.Validate(gifBytes, SnapshotType.Gif, settings);
 ```
 
+For ICO image snapshots (opt-in):
+
+```csharp
+var settings = SnapshotSettings.Default with { };
+settings.Serializers.AddIcoSerializer();
+
+Snapshot.Validate(icoBytes, SnapshotType.Ico, settings);
+```
+
 ## File naming convention
 
 Snapshots are stored in a `__snapshots__` directory next to the test source file:
@@ -102,7 +111,8 @@ Snapshot.Validate(value, SnapshotType.Default, settings);
 ```
 
 The default serializers handle human-readable objects, `byte[]`, and `Stream`.
-GIF frame extraction is opt-in via `Serializers.AddGifSerializer()`: when enabled and `SnapshotType.Gif` is used with a valid GIF `byte[]`, each frame is serialized as a separate `.gif` snapshot.
+GIF frame extraction is opt-in via `Serializers.AddGifSerializer()`: when enabled and `SnapshotType.Gif` is used with a valid GIF `byte[]`, each frame is serialized as a separate `.png` snapshot.
+ICO image extraction is opt-in via `Serializers.AddIcoSerializer()`: when enabled and `SnapshotType.Ico` is used with a valid ICO `byte[]`, each embedded icon image is serialized as a separate `.png` snapshot.
 BMP/PNG image comparison is opt-in via `Comparers.AddImageComparer()`. When enabled, `SnapshotType.Bmp` and `SnapshotType.Png` snapshots are compared by decoded pixel content (ARGB), so format metadata differences do not trigger snapshot mismatches.
 To allow small visual differences, configure the image comparer with an SSIM threshold:
 

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Buffers.Binary;
 using System.Globalization;
+using System.IO.Compression;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using TestUtilities;
@@ -499,7 +500,7 @@ public sealed class SnapshotEndToEndTests
     }
 
     [Fact]
-    public async Task Validate_EndToEnd_SerializesGifFrames_WhenGifSerializerIsEnabled()
+    public async Task Validate_EndToEnd_SerializesGifFramesAsPng_WhenGifSerializerIsEnabled()
     {
         var payload = CreateTwoFrameGif();
         var sourcePayload = ToByteArraySource(payload);
@@ -520,11 +521,44 @@ public sealed class SnapshotEndToEndTests
 
         Assert.Equal(
         [
-            "__snapshots__/GeneratedSnapshotTests_SampleTest_0.verified.gif",
-            "__snapshots__/GeneratedSnapshotTests_SampleTest_1.verified.gif",
+            "__snapshots__/GeneratedSnapshotTests_SampleTest_0.verified.png",
+            "__snapshots__/GeneratedSnapshotTests_SampleTest_1.verified.png",
         ], snapshotFiles.Select(static item => item.RelativePath));
-        Assert.Equal(CreateSingleFrameGif(), snapshotFiles[0].Content);
-        Assert.Equal(CreateSingleFrameGif(), snapshotFiles[1].Content);
+        Assert.All(snapshotFiles, static snapshotFile => Assert.True(PngImageLoader.IsPng(snapshotFile.Content)));
+        var firstFrame = Image.Load(snapshotFiles[0].Content);
+        var secondFrame = Image.Load(snapshotFiles[1].Content);
+        Assert.Equal(firstFrame, secondFrame);
+    }
+
+    [Fact]
+    public async Task Validate_EndToEnd_SerializesIcoImagesAsPng_WhenIcoSerializerIsEnabled()
+    {
+        var payload = CreateTwoImageIco();
+        var sourcePayload = ToByteArraySource(payload);
+        var snapshotFiles = await AssertSnapshot(
+            $$"""
+            public sealed class GeneratedSnapshotTests
+            {
+                [Fact]
+                public void SampleTest()
+                {
+                    var payload = new byte[] { {{sourcePayload}} };
+                    var settings = SnapshotTestUtilities.CreateSuccessSettings();
+                    settings.Serializers.AddIcoSerializer();
+                    Snapshot.Validate(payload, SnapshotType.Ico, settings);
+                }
+            }
+            """);
+
+        Assert.Equal(
+        [
+            "__snapshots__/GeneratedSnapshotTests_SampleTest_0.verified.png",
+            "__snapshots__/GeneratedSnapshotTests_SampleTest_1.verified.png",
+        ], snapshotFiles.Select(static item => item.RelativePath));
+        Assert.All(snapshotFiles, static snapshotFile => Assert.True(PngImageLoader.IsPng(snapshotFile.Content)));
+        var firstFrame = Image.Load(snapshotFiles[0].Content);
+        var secondFrame = Image.Load(snapshotFiles[1].Content);
+        Assert.NotEqual(firstFrame, secondFrame);
     }
 
     [Fact]
@@ -1037,6 +1071,94 @@ public sealed class SnapshotEndToEndTests
         return data;
     }
 
+    private static byte[] CreatePngRgba32(int width, int height, IReadOnlyList<uint> pixels)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+
+        if (pixels.Count != checked(width * height))
+            throw new ArgumentOutOfRangeException(nameof(pixels));
+
+        var rowStride = checked(width * 4 + 1);
+        var imageData = new byte[checked(rowStride * height)];
+        for (var y = 0; y < height; y++)
+        {
+            var rowOffset = y * rowStride;
+            imageData[rowOffset] = 0;
+            for (var x = 0; x < width; x++)
+            {
+                var pixel = pixels[y * width + x];
+                var pixelOffset = rowOffset + 1 + x * 4;
+                imageData[pixelOffset] = (byte)((pixel >> 16) & 0xFF);
+                imageData[pixelOffset + 1] = (byte)((pixel >> 8) & 0xFF);
+                imageData[pixelOffset + 2] = (byte)(pixel & 0xFF);
+                imageData[pixelOffset + 3] = (byte)(pixel >> 24);
+            }
+        }
+
+        byte[] compressedData;
+        using (var compressedStream = new MemoryStream())
+        {
+            using (var zlib = new ZLibStream(compressedStream, CompressionLevel.SmallestSize, leaveOpen: true))
+            {
+                zlib.Write(imageData);
+            }
+
+            compressedData = compressedStream.ToArray();
+        }
+
+        using var stream = new MemoryStream();
+        stream.Write([137, 80, 78, 71, 13, 10, 26, 10]);
+
+        Span<byte> ihdrData = stackalloc byte[13];
+        BinaryPrimitives.WriteUInt32BigEndian(ihdrData, (uint)width);
+        BinaryPrimitives.WriteUInt32BigEndian(ihdrData[4..], (uint)height);
+        ihdrData[8] = 8;
+        ihdrData[9] = 6;
+        ihdrData[10] = 0;
+        ihdrData[11] = 0;
+        ihdrData[12] = 0;
+        WritePngChunk(stream, "IHDR"u8, ihdrData);
+        WritePngChunk(stream, "IDAT"u8, compressedData);
+        WritePngChunk(stream, "IEND"u8, ReadOnlySpan<byte>.Empty);
+        return stream.ToArray();
+    }
+
+    private static void WritePngChunk(Stream stream, ReadOnlySpan<byte> type, ReadOnlySpan<byte> data)
+    {
+        Span<byte> uintBuffer = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(uintBuffer, (uint)data.Length);
+        stream.Write(uintBuffer);
+        stream.Write(type);
+        stream.Write(data);
+
+        var crc = ComputePngCrc32(type, data);
+        BinaryPrimitives.WriteUInt32BigEndian(uintBuffer, crc);
+        stream.Write(uintBuffer);
+    }
+
+    private static uint ComputePngCrc32(ReadOnlySpan<byte> type, ReadOnlySpan<byte> data)
+    {
+        var crc = uint.MaxValue;
+        crc = UpdatePngCrc32(crc, type);
+        crc = UpdatePngCrc32(crc, data);
+        return ~crc;
+    }
+
+    private static uint UpdatePngCrc32(uint crc, ReadOnlySpan<byte> data)
+    {
+        foreach (var value in data)
+        {
+            crc ^= value;
+            for (var i = 0; i < 8; i++)
+            {
+                crc = (crc & 1) == 0 ? crc >> 1 : 0xEDB88320u ^ (crc >> 1);
+            }
+        }
+
+        return crc;
+    }
+
     private static void WriteUInt32LittleEndian(byte[] data, int offset, uint value)
     {
         BinaryPrimitives.WriteUInt32LittleEndian(data.AsSpan(offset, 4), value);
@@ -1097,6 +1219,50 @@ public sealed class SnapshotEndToEndTests
             0x00,
             0x3B,
         ];
+    }
+
+    private static byte[] CreateTwoImageIco()
+    {
+        var firstImage = CreatePngRgba32(
+            width: 1,
+            height: 1,
+            pixels:
+            [
+                0xFFFF0000u,
+            ]);
+        var secondImage = CreatePngRgba32(
+            width: 1,
+            height: 1,
+            pixels:
+            [
+                0xFF00FF00u,
+            ]);
+
+        var firstImageOffset = 6 + 16 + 16;
+        var secondImageOffset = firstImageOffset + firstImage.Length;
+        var data = new byte[secondImageOffset + secondImage.Length];
+        WriteUInt16LittleEndian(data, 0, 0);
+        WriteUInt16LittleEndian(data, 2, 1);
+        WriteUInt16LittleEndian(data, 4, 2);
+
+        WriteIcoDirectoryEntry(data, 6, width: 1, height: 1, bitsPerPixel: 32, firstImage.Length, firstImageOffset);
+        WriteIcoDirectoryEntry(data, 22, width: 1, height: 1, bitsPerPixel: 32, secondImage.Length, secondImageOffset);
+
+        Buffer.BlockCopy(firstImage, 0, data, firstImageOffset, firstImage.Length);
+        Buffer.BlockCopy(secondImage, 0, data, secondImageOffset, secondImage.Length);
+        return data;
+    }
+
+    private static void WriteIcoDirectoryEntry(byte[] data, int offset, byte width, byte height, ushort bitsPerPixel, int imageSize, int imageOffset)
+    {
+        data[offset] = width;
+        data[offset + 1] = height;
+        data[offset + 2] = 0;
+        data[offset + 3] = 0;
+        WriteUInt16LittleEndian(data, offset + 4, 1);
+        WriteUInt16LittleEndian(data, offset + 6, bitsPerPixel);
+        WriteUInt32LittleEndian(data, offset + 8, (uint)imageSize);
+        WriteUInt32LittleEndian(data, offset + 12, (uint)imageOffset);
     }
 
     private static async Task<SnapshotFile[]> AssertSnapshot(

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -341,6 +341,26 @@ public sealed class SnapshotTests
     }
 
     [Fact]
+    public void Validate_UsesSerializerProvidedExtension_WhenSet()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var settings = new SnapshotSettings()
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            AssertionExceptionCreator = new FixedAssertionExceptionBuilder(),
+            SnapshotPathStrategy = context => directory / ("snapshot_" + context.Index.ToString(CultureInfo.InvariantCulture) + ".verified." + context.Extension),
+        };
+
+        settings.Serializers.Add(new FixedExtensionSerializer(".png"));
+        Snapshot.Validate("sample", SnapshotType.Gif, settings);
+
+        var filePath = directory / "snapshot_0.verified.png";
+        Assert.True(File.Exists(filePath));
+        Assert.Equal("sample", File.ReadAllText(filePath));
+    }
+
+    [Fact]
     public void SnapshotType_DefaultsExposeOptionalMetadata()
     {
         Assert.Equal("text/plain", SnapshotType.Default.MimeType);
@@ -351,6 +371,8 @@ public sealed class SnapshotTests
         Assert.Equal("SVG image", SnapshotType.Svg.DisplayName);
         Assert.Equal("image/gif", SnapshotType.Gif.MimeType);
         Assert.Equal("GIF image", SnapshotType.Gif.DisplayName);
+        Assert.Equal("image/x-icon", SnapshotType.Ico.MimeType);
+        Assert.Equal("ICO image", SnapshotType.Ico.DisplayName);
     }
 
     [Fact]
@@ -415,7 +437,19 @@ public sealed class SnapshotTests
     }
 
     [Fact]
-    public void AddGifSerializer_SerializesGifByteArrayAsOneSnapshotPerFrame()
+    public void DefaultSerializer_HandlesIcoByteArrayAsSingleBinarySnapshot()
+    {
+        var snapshotType = SnapshotType.Ico;
+        var expectedBytes = CreateTwoImageIco();
+        var data = new SnapshotSettings().Serializers.Serialize(snapshotType, expectedBytes);
+
+        var snapshot = Assert.Single(data.Data);
+        Assert.Equal(snapshotType.FileExtension, snapshot.Extension);
+        Assert.Equal(expectedBytes, snapshot.Data);
+    }
+
+    [Fact]
+    public void AddGifSerializer_SerializesGifByteArrayAsOnePngSnapshotPerFrame()
     {
         var snapshotType = SnapshotType.Gif;
         var settings = new SnapshotSettings();
@@ -423,9 +457,11 @@ public sealed class SnapshotTests
         var data = settings.Serializers.Serialize(snapshotType, CreateTwoFrameGif());
 
         Assert.Equal(2, data.Data.Count);
-        Assert.All(data.Data, snapshot => Assert.Equal(snapshotType.FileExtension, snapshot.Extension));
-        Assert.Equal(CreateSingleFrameGif(), data.Data[0].Data);
-        Assert.Equal(CreateSingleFrameGif(), data.Data[1].Data);
+        Assert.All(data.Data, snapshot => Assert.Equal(".png", snapshot.Extension));
+        Assert.All(data.Data, static snapshot => Assert.True(PngImageLoader.IsPng(snapshot.Data)));
+        var firstFrame = Image.Load(data.Data[0].Data);
+        var secondFrame = Image.Load(data.Data[1].Data);
+        Assert.Equal(firstFrame, secondFrame);
     }
 
     [Fact]
@@ -435,6 +471,36 @@ public sealed class SnapshotTests
         var payload = "not-a-gif"u8.ToArray();
         var settings = new SnapshotSettings();
         settings.Serializers.AddGifSerializer();
+        var data = settings.Serializers.Serialize(snapshotType, payload);
+
+        var snapshot = Assert.Single(data.Data);
+        Assert.Equal(snapshotType.FileExtension, snapshot.Extension);
+        Assert.Equal(payload, snapshot.Data);
+    }
+
+    [Fact]
+    public void AddIcoSerializer_SerializesIcoByteArrayAsOnePngSnapshotPerImage()
+    {
+        var snapshotType = SnapshotType.Ico;
+        var settings = new SnapshotSettings();
+        settings.Serializers.AddIcoSerializer();
+        var data = settings.Serializers.Serialize(snapshotType, CreateTwoImageIco());
+
+        Assert.Equal(2, data.Data.Count);
+        Assert.All(data.Data, snapshot => Assert.Equal(".png", snapshot.Extension));
+        Assert.All(data.Data, static snapshot => Assert.True(PngImageLoader.IsPng(snapshot.Data)));
+        var firstFrame = Image.Load(data.Data[0].Data);
+        var secondFrame = Image.Load(data.Data[1].Data);
+        Assert.NotEqual(firstFrame, secondFrame);
+    }
+
+    [Fact]
+    public void AddIcoSerializer_FallsBackToBinarySerializerWhenPayloadIsNotIco()
+    {
+        var snapshotType = SnapshotType.Ico;
+        var payload = "not-an-ico"u8.ToArray();
+        var settings = new SnapshotSettings();
+        settings.Serializers.AddIcoSerializer();
         var data = settings.Serializers.Serialize(snapshotType, payload);
 
         var snapshot = Assert.Single(data.Data);
@@ -1226,6 +1292,50 @@ public sealed class SnapshotTests
         ];
     }
 
+    private static byte[] CreateTwoImageIco()
+    {
+        var firstImage = CreatePngRgba32(
+            width: 1,
+            height: 1,
+            pixels:
+            [
+                0xFFFF0000u,
+            ]);
+        var secondImage = CreatePngRgba32(
+            width: 1,
+            height: 1,
+            pixels:
+            [
+                0xFF00FF00u,
+            ]);
+
+        var firstImageOffset = 6 + 16 + 16;
+        var secondImageOffset = firstImageOffset + firstImage.Length;
+        var data = new byte[secondImageOffset + secondImage.Length];
+        WriteUInt16LittleEndian(data, 0, 0);
+        WriteUInt16LittleEndian(data, 2, 1);
+        WriteUInt16LittleEndian(data, 4, 2);
+
+        WriteIcoDirectoryEntry(data, 6, width: 1, height: 1, bitsPerPixel: 32, firstImage.Length, firstImageOffset);
+        WriteIcoDirectoryEntry(data, 22, width: 1, height: 1, bitsPerPixel: 32, secondImage.Length, secondImageOffset);
+
+        Buffer.BlockCopy(firstImage, 0, data, firstImageOffset, firstImage.Length);
+        Buffer.BlockCopy(secondImage, 0, data, secondImageOffset, secondImage.Length);
+        return data;
+    }
+
+    private static void WriteIcoDirectoryEntry(byte[] data, int offset, byte width, byte height, ushort bitsPerPixel, int imageSize, int imageOffset)
+    {
+        data[offset] = width;
+        data[offset + 1] = height;
+        data[offset + 2] = 0;
+        data[offset + 3] = 0;
+        WriteUInt16LittleEndian(data, offset + 4, 1);
+        WriteUInt16LittleEndian(data, offset + 6, bitsPerPixel);
+        WriteUInt32LittleEndian(data, offset + 8, (uint)imageSize);
+        WriteUInt32LittleEndian(data, offset + 12, (uint)imageOffset);
+    }
+
     private sealed class SnapshotTypeSerializer : ISnapshotSerializer
     {
         public bool TrySerialize(SnapshotType type, object? value, [NotNullWhen(true)] out SerializedSnapshot? result)
@@ -1236,7 +1346,16 @@ public sealed class SnapshotTests
                 return false;
             }
 
-            result = new SerializedSnapshot([new SnapshotData("txt", Encoding.UTF8.GetBytes(type.Type))]);
+            result = new SerializedSnapshot([new SnapshotData(null, Encoding.UTF8.GetBytes(type.Type))]);
+            return true;
+        }
+    }
+
+    private sealed class FixedExtensionSerializer(string extension) : ISnapshotSerializer
+    {
+        public bool TrySerialize(SnapshotType type, object? value, [NotNullWhen(true)] out SerializedSnapshot? result)
+        {
+            result = new SerializedSnapshot([new SnapshotData(extension, Encoding.UTF8.GetBytes("sample"))]);
             return true;
         }
     }

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTypeTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTypeTests.cs
@@ -15,6 +15,7 @@ public sealed class SnapshotTypeTests
         Assert.Equal(SnapshotType.Default, SnapshotType.Create("txt"));
         Assert.Equal(SnapshotType.Png, SnapshotType.Create("png"));
         Assert.Equal(SnapshotType.Gif, SnapshotType.Create("gif"));
+        Assert.Equal(SnapshotType.Ico, SnapshotType.Create("ico"));
     }
 
     [Fact]
@@ -23,6 +24,7 @@ public sealed class SnapshotTypeTests
         Assert.Equal(SnapshotType.Default, SnapshotType.Create("TXT"));
         Assert.Equal(SnapshotType.Png, SnapshotType.Create("PNG"));
         Assert.Equal(SnapshotType.Gif, SnapshotType.Create("GIF"));
+        Assert.Equal(SnapshotType.Ico, SnapshotType.Create("ICO"));
     }
 
     [Fact]
@@ -31,6 +33,7 @@ public sealed class SnapshotTypeTests
         Assert.Equal(SnapshotType.Default, SnapshotType.Create(".txt"));
         Assert.Equal(SnapshotType.Png, SnapshotType.Create(".png"));
         Assert.Equal(SnapshotType.Gif, SnapshotType.Create(".gif"));
+        Assert.Equal(SnapshotType.Ico, SnapshotType.Create(".ico"));
     }
 
     [Fact]


### PR DESCRIPTION
## Why

Snapshot serializers for multi-image payloads needed PNG output consistency. GIF splitting existed but produced `.gif` files, and there was no equivalent split serializer for `.ico` payloads.

## What changed

- Added `SnapshotType.Ico` (`image/x-icon`, `ICO image`) and API surface updates.
- Added opt-in `Serializers.AddIcoSerializer()`.
- Implemented `IcoSnapshotSerializer` to split ICO payloads into one PNG snapshot per embedded image:
  - passes through embedded PNG entries as-is,
  - decodes bitmap icon entries and re-encodes them as PNG.
- Updated `GifSnapshotSerializer` to output one PNG snapshot per frame.
- Added internal image helpers used by split serializers:
  - `GifImageLoader` (single-frame GIF decode),
  - `PngImageEncoder` (deterministic PNG encoding).
- Updated snapshot extension resolution so serializer-provided extensions are honored (enables GIF/ICO split serializers to emit `.png` while using typed snapshots).
- Updated SnapshotTesting docs and reference API.
- Expanded unit and end-to-end tests for GIF and ICO split behavior, PNG output, fallback behavior, and extension override behavior.

## Notes

- GIF and ICO split serializers remain opt-in.
- Default binary serializer behavior for `byte[]` values is preserved when split serializers are not registered.
- Invalid or unsupported split payloads still fall back to normal binary serialization.