### PR TITLE
Remove LibGit2Sharp from Git submodule dependency scanner

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Meziantou.Framework.DependencyScanning.csproj
+++ b/src/Meziantou.Framework.DependencyScanning/Meziantou.Framework.DependencyScanning.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="YamlDotNet" Version="17.1.0" />
   </ItemGroup>
 

--- a/src/Meziantou.Framework.DependencyScanning/Scanners/GitSubmoduleDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/GitSubmoduleDependencyScanner.cs
@@ -136,12 +136,59 @@ public sealed class GitSubmoduleDependencyScanner : DependencyScanner
 
     private static string Unquote(string value)
     {
+        string unquotedValue;
         if (value.Length >= 2 && value[0] is '"' && value[^1] is '"')
         {
-            return value[1..^1];
+            unquotedValue = value[1..^1];
+        }
+        else
+        {
+            unquotedValue = value;
         }
 
-        return value;
+        return UnescapeGitConfigValue(unquotedValue);
+    }
+
+    private static string UnescapeGitConfigValue(string value)
+    {
+        if (value.AsSpan().IndexOf('\\') < 0)
+            return value;
+
+        var builder = new System.Text.StringBuilder(value.Length);
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] is not '\\' || i == value.Length - 1)
+            {
+                builder.Append(value[i]);
+                continue;
+            }
+
+            i++;
+            switch (value[i])
+            {
+                case '\\':
+                    builder.Append('\\');
+                    break;
+                case '"':
+                    builder.Append('"');
+                    break;
+                case 'n':
+                    builder.Append('\n');
+                    break;
+                case 't':
+                    builder.Append('\t');
+                    break;
+                case 'b':
+                    builder.Append('\b');
+                    break;
+                default:
+                    builder.Append('\\');
+                    builder.Append(value[i]);
+                    break;
+            }
+        }
+
+        return builder.ToString();
     }
 
     private static string NormalizeGitPath(string path)

--- a/src/Meziantou.Framework.DependencyScanning/Scanners/GitSubmoduleDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/GitSubmoduleDependencyScanner.cs
@@ -313,17 +313,7 @@ public sealed class GitSubmoduleDependencyScanner : DependencyScanner
 
     private static bool TryReadExactly(Stream stream, Span<byte> buffer)
     {
-        var totalRead = 0;
-        while (totalRead < buffer.Length)
-        {
-            var read = stream.Read(buffer[totalRead..]);
-            if (read <= 0)
-                return false;
-
-            totalRead += read;
-        }
-
-        return true;
+        return stream.ReadAtLeast(buffer, buffer.Length, throwOnEndOfStream: false) == buffer.Length;
     }
 
     private readonly record struct SubmoduleEntry(string Path, string Url);

--- a/src/Meziantou.Framework.DependencyScanning/Scanners/GitSubmoduleDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/GitSubmoduleDependencyScanner.cs
@@ -121,7 +121,7 @@ public sealed class GitSubmoduleDependencyScanner : DependencyScanner
 
     private static bool TryParseAssignment(string line, out string key, out string value)
     {
-        var equalIndex = line.IndexOf('=');
+        var equalIndex = line.IndexOf('=', StringComparison.Ordinal);
         if (equalIndex < 0)
         {
             key = "";
@@ -240,6 +240,8 @@ public sealed class GitSubmoduleDependencyScanner : DependencyScanner
             result = new Dictionary<string, string>(StringComparer.Ordinal);
 
             Span<byte> entryHeader = stackalloc byte[62];
+            Span<byte> extendedFlagsBuffer = stackalloc byte[2];
+            Span<byte> paddingBuffer = stackalloc byte[8];
             for (uint i = 0; i < entryCount; i++)
             {
                 var entryStart = stream.Position;
@@ -253,8 +255,7 @@ public sealed class GitSubmoduleDependencyScanner : DependencyScanner
                 var flags = BinaryPrimitives.ReadUInt16BigEndian(entryHeader[60..62]);
                 if ((flags & ExtendedFlagsMask) != 0)
                 {
-                    Span<byte> extendedFlags = stackalloc byte[2];
-                    if (!TryReadExactly(stream, extendedFlags))
+                    if (!TryReadExactly(stream, extendedFlagsBuffer))
                     {
                         result = [];
                         return false;
@@ -281,7 +282,6 @@ public sealed class GitSubmoduleDependencyScanner : DependencyScanner
                 var paddingByteCount = (8 - (consumedBytes % 8)) % 8;
                 if (paddingByteCount > 0)
                 {
-                    Span<byte> paddingBuffer = stackalloc byte[8];
                     if (!TryReadExactly(stream, paddingBuffer[..paddingByteCount]))
                     {
                         result = [];

--- a/src/Meziantou.Framework.DependencyScanning/Scanners/GitSubmoduleDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/GitSubmoduleDependencyScanner.cs
@@ -1,4 +1,4 @@
-using LibGit2Sharp;
+using System.Buffers.Binary;
 using Meziantou.Framework.DependencyScanning.Locations;
 
 namespace Meziantou.Framework.DependencyScanning.Scanners;
@@ -6,6 +6,10 @@ namespace Meziantou.Framework.DependencyScanning.Scanners;
 /// <summary>Scans Git .gitmodules files for submodule references.</summary>
 public sealed class GitSubmoduleDependencyScanner : DependencyScanner
 {
+    private const uint GitLinkMode = 0xE000;
+    private const ushort ExtendedFlagsMask = 0x4000;
+    private const string GitDirectoryPrefix = "gitdir:";
+
     protected internal override IReadOnlyCollection<DependencyType> SupportedDependencyTypes { get; } = [DependencyType.GitReference];
 
     protected override bool ShouldScanFileCore(CandidateFileContext context)
@@ -15,20 +19,312 @@ public sealed class GitSubmoduleDependencyScanner : DependencyScanner
 
     public override ValueTask ScanAsync(ScanFileContext context)
     {
-        try
+        var repositoryDirectory = Path.GetDirectoryName(context.FullPath);
+        if (string.IsNullOrEmpty(repositoryDirectory))
         {
-            using var repository = new Repository(Path.GetDirectoryName(context.FullPath));
-            foreach (var module in repository.Submodules)
-            {
-                context.ReportDependency(this, module.Url, module.WorkDirCommitId.Sha, DependencyType.GitReference,
-                    nameLocation: new NonUpdatableLocation(context),
-                    versionLocation: new NonUpdatableLocation(context));
-            }
+            return ValueTask.CompletedTask;
         }
-        catch (LibGit2SharpException)
+
+        var submodules = ParseGitModules(context);
+        if (submodules.Count is 0)
         {
+            return ValueTask.CompletedTask;
+        }
+
+        if (!TryGetGitDirectory(repositoryDirectory, out var gitDirectory))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        if (!TryReadGitLinks(gitDirectory, out var gitLinks))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        foreach (var submodule in submodules)
+        {
+            if (!gitLinks.TryGetValue(submodule.Path, out var sha))
+                continue;
+
+            context.ReportDependency(this, submodule.Url, sha, DependencyType.GitReference,
+                nameLocation: new NonUpdatableLocation(context),
+                versionLocation: new NonUpdatableLocation(context));
         }
 
         return ValueTask.CompletedTask;
     }
+
+    private static List<SubmoduleEntry> ParseGitModules(ScanFileContext context)
+    {
+        var result = new List<SubmoduleEntry>();
+
+        using var reader = new StreamReader(context.Content, System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
+        string? path = null;
+        string? url = null;
+        var inSubmoduleSection = false;
+
+        while (reader.ReadLine() is { } line)
+        {
+            var trimmedLine = line.Trim();
+            if (trimmedLine.Length is 0 || trimmedLine[0] is '#' or ';')
+                continue;
+
+            if (TryGetSection(trimmedLine, out var isSubmoduleSection))
+            {
+                AddCurrentEntryIfValid(result, inSubmoduleSection, path, url);
+                inSubmoduleSection = isSubmoduleSection;
+                path = null;
+                url = null;
+                continue;
+            }
+
+            if (!inSubmoduleSection || !TryParseAssignment(trimmedLine, out var key, out var value))
+                continue;
+
+            if (key.Equals("path", StringComparison.OrdinalIgnoreCase))
+            {
+                path = NormalizeGitPath(Unquote(value));
+            }
+            else if (key.Equals("url", StringComparison.OrdinalIgnoreCase))
+            {
+                url = Unquote(value);
+            }
+        }
+
+        AddCurrentEntryIfValid(result, inSubmoduleSection, path, url);
+        return result;
+    }
+
+    private static void AddCurrentEntryIfValid(List<SubmoduleEntry> submodules, bool inSubmoduleSection, string? path, string? url)
+    {
+        if (!inSubmoduleSection || string.IsNullOrEmpty(path) || string.IsNullOrEmpty(url))
+            return;
+
+        submodules.Add(new SubmoduleEntry(path, url));
+    }
+
+    private static bool TryGetSection(string line, out bool isSubmoduleSection)
+    {
+        isSubmoduleSection = false;
+        if (!line.StartsWith('[') || !line.EndsWith(']'))
+            return false;
+
+        var section = line[1..^1].Trim();
+        if (section.Length is 0)
+            return true;
+
+        var separatorIndex = section.IndexOfAny([' ', '"']);
+        var sectionName = separatorIndex < 0 ? section : section[..separatorIndex];
+        isSubmoduleSection = sectionName.Equals("submodule", StringComparison.OrdinalIgnoreCase);
+        return true;
+    }
+
+    private static bool TryParseAssignment(string line, out string key, out string value)
+    {
+        var equalIndex = line.IndexOf('=');
+        if (equalIndex < 0)
+        {
+            key = "";
+            value = "";
+            return false;
+        }
+
+        key = line[..equalIndex].Trim();
+        value = line[(equalIndex + 1)..].Trim();
+        return key.Length > 0;
+    }
+
+    private static string Unquote(string value)
+    {
+        if (value.Length >= 2 && value[0] is '"' && value[^1] is '"')
+        {
+            return value[1..^1];
+        }
+
+        return value;
+    }
+
+    private static string NormalizeGitPath(string path)
+    {
+        var normalizedPath = path.Replace('\\', '/');
+        while (normalizedPath.StartsWith("./", StringComparison.Ordinal))
+        {
+            normalizedPath = normalizedPath[2..];
+        }
+
+        return normalizedPath.TrimEnd('/');
+    }
+
+    private static bool TryGetGitDirectory(string repositoryDirectory, out string gitDirectory)
+    {
+        var dotGitPath = Path.Combine(repositoryDirectory, ".git");
+        if (Directory.Exists(dotGitPath))
+        {
+            gitDirectory = dotGitPath;
+            return true;
+        }
+
+        if (!File.Exists(dotGitPath))
+        {
+            gitDirectory = "";
+            return false;
+        }
+
+        try
+        {
+            var dotGitContent = File.ReadAllText(dotGitPath).Trim();
+            if (!dotGitContent.StartsWith(GitDirectoryPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                gitDirectory = "";
+                return false;
+            }
+
+            var relativeGitDirectory = dotGitContent[GitDirectoryPrefix.Length..].Trim();
+            if (string.IsNullOrEmpty(relativeGitDirectory))
+            {
+                gitDirectory = "";
+                return false;
+            }
+
+            gitDirectory = Path.IsPathRooted(relativeGitDirectory)
+                ? Path.GetFullPath(relativeGitDirectory)
+                : Path.GetFullPath(Path.Combine(repositoryDirectory, relativeGitDirectory));
+            return Directory.Exists(gitDirectory);
+        }
+        catch (IOException)
+        {
+            gitDirectory = "";
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            gitDirectory = "";
+            return false;
+        }
+    }
+
+    private static bool TryReadGitLinks(string gitDirectory, out Dictionary<string, string> result)
+    {
+        var indexPath = Path.Combine(gitDirectory, "index");
+        if (!File.Exists(indexPath))
+        {
+            result = [];
+            return false;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(indexPath);
+
+            Span<byte> header = stackalloc byte[12];
+            if (!TryReadExactly(stream, header))
+            {
+                result = [];
+                return false;
+            }
+
+            if (!header[..4].SequenceEqual("DIRC"u8))
+            {
+                result = [];
+                return false;
+            }
+
+            var version = BinaryPrimitives.ReadUInt32BigEndian(header[4..8]);
+            if (version is not 2 and not 3)
+            {
+                result = [];
+                return false;
+            }
+
+            var entryCount = BinaryPrimitives.ReadUInt32BigEndian(header[8..12]);
+            result = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            Span<byte> entryHeader = stackalloc byte[62];
+            for (uint i = 0; i < entryCount; i++)
+            {
+                var entryStart = stream.Position;
+                if (!TryReadExactly(stream, entryHeader))
+                {
+                    result = [];
+                    return false;
+                }
+
+                var mode = BinaryPrimitives.ReadUInt32BigEndian(entryHeader[24..28]);
+                var flags = BinaryPrimitives.ReadUInt16BigEndian(entryHeader[60..62]);
+                if ((flags & ExtendedFlagsMask) != 0)
+                {
+                    Span<byte> extendedFlags = stackalloc byte[2];
+                    if (!TryReadExactly(stream, extendedFlags))
+                    {
+                        result = [];
+                        return false;
+                    }
+                }
+
+                var pathBytes = new List<byte>(64);
+                while (true)
+                {
+                    var value = stream.ReadByte();
+                    if (value < 0)
+                    {
+                        result = [];
+                        return false;
+                    }
+
+                    if (value is 0)
+                        break;
+
+                    pathBytes.Add((byte)value);
+                }
+
+                var consumedBytes = checked((int)(stream.Position - entryStart));
+                var paddingByteCount = (8 - (consumedBytes % 8)) % 8;
+                if (paddingByteCount > 0)
+                {
+                    Span<byte> paddingBuffer = stackalloc byte[8];
+                    if (!TryReadExactly(stream, paddingBuffer[..paddingByteCount]))
+                    {
+                        result = [];
+                        return false;
+                    }
+                }
+
+                if (mode != GitLinkMode)
+                    continue;
+
+                var path = NormalizeGitPath(System.Text.Encoding.UTF8.GetString(pathBytes.ToArray()));
+                var sha = Convert.ToHexString(entryHeader[40..60]).ToLowerInvariant();
+                result[path] = sha;
+            }
+
+            return true;
+        }
+        catch (IOException)
+        {
+            result = [];
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            result = [];
+            return false;
+        }
+    }
+
+    private static bool TryReadExactly(Stream stream, Span<byte> buffer)
+    {
+        var totalRead = 0;
+        while (totalRead < buffer.Length)
+        {
+            var read = stream.Read(buffer[totalRead..]);
+            if (read <= 0)
+                return false;
+
+            totalRead += read;
+        }
+
+        return true;
+    }
+
+    private readonly record struct SubmoduleEntry(string Path, string Url);
 }

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -1,7 +1,6 @@
 #pragma warning disable MA0101
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
-using LibGit2Sharp;
 using Meziantou.Framework.DependencyScanning.Scanners;
 using Meziantou.Framework.Globbing;
 using Meziantou.Xunit;
@@ -562,7 +561,7 @@ public sealed class ScannerTests(ITestOutputHelper testOutputHelper) : IDisposab
         AssertFileContentEqual("global.json", Expected, ignoreNewLines: true);
     }
 
-    [Fact, RunIf(TestOperatingSystems.Windows)]
+    [Fact]
     public async Task GitSubmodulesFromDependencies()
     {
         // Initialize remote repository
@@ -575,13 +574,8 @@ public sealed class ScannerTests(ITestOutputHelper testOutputHelper) : IDisposab
         await ExecuteProcess("git", "add .", remote.FullPath);
         await ExecuteProcess("git", "commit -m commit-message", remote.FullPath);
 
-        // Get remote head
-        string head;
-        using (var repository = new Repository(remote.FullPath))
-        {
-            head = repository.Head.Tip.Sha;
-            testOutputHelper.WriteLine("Head: " + head);
-        }
+        var head = (await ExecuteProcess("git", "rev-parse HEAD", remote.FullPath)).Trim();
+        testOutputHelper.WriteLine("Head: " + head);
 
         // Initialize current directory
         await ExecuteProcess("git", "init", _directory.FullPath);
@@ -610,7 +604,7 @@ public sealed class ScannerTests(ITestOutputHelper testOutputHelper) : IDisposab
 
         Assert.All(result, item => Assert.False(item.VersionLocation!.IsUpdatable));
 
-        async Task ExecuteProcess(string process, string args, string workingDirectory)
+        async Task<string> ExecuteProcess(string process, string args, string workingDirectory)
         {
             testOutputHelper.WriteLine($"Executing: '{process}' {args} ({workingDirectory})");
             var processInstance = ProcessWrapper.Create(process)
@@ -621,6 +615,7 @@ public sealed class ScannerTests(ITestOutputHelper testOutputHelper) : IDisposab
 
             var processResult = await processInstance;
             AssertProcessResult(processResult.ExitCode, string.Join('\n', processResult.Output));
+            return string.Join('\n', processResult.Output);
         }
 
         async Task ExecuteProcess2(string process, string[] args, string workingDirectory)

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -600,7 +600,10 @@ public sealed class ScannerTests(ITestOutputHelper testOutputHelper) : IDisposab
 
         // Assert
         var result = await GetDependencies<GitSubmoduleDependencyScanner>();
-        AssertContainDependency(result, (DependencyType.GitReference, remote.FullPath, head, 0, 0));
+        Assert.Contains(result, d =>
+            d.Type == DependencyType.GitReference &&
+            d.Version == head &&
+            IsEquivalentPath(d.Name, remote.FullPath));
 
         Assert.All(result, item => Assert.False(item.VersionLocation!.IsUpdatable));
 
@@ -635,6 +638,16 @@ public sealed class ScannerTests(ITestOutputHelper testOutputHelper) : IDisposab
         {
             Assert.Equal(0, exitCode);
             testOutputHelper.WriteLine("git command succeeds\n" + output);
+        }
+
+        static bool IsEquivalentPath(string? left, string? right)
+        {
+            if (left is null || right is null)
+                return left is null && right is null;
+
+            var normalizedLeft = left.Replace('\\', '/').TrimEnd('/');
+            var normalizedRight = right.Replace('\\', '/').TrimEnd('/');
+            return string.Equals(normalizedLeft, normalizedRight, StringComparison.OrdinalIgnoreCase);
         }
     }
 


### PR DESCRIPTION
## Why
`GitSubmoduleDependencyScanner` depended on LibGit2Sharp only to read submodule metadata and pinned SHAs. Replacing it reduces package dependencies while keeping the same feature.

## What changed
- Replaced LibGit2Sharp usage in `GitSubmoduleDependencyScanner` with a pure managed implementation.
- Added `.gitmodules` parsing to read submodule `path` and `url` entries.
- Added `.git/index` parsing to extract gitlink entries (`mode 160000`) and map submodule path to pinned SHA.
- Added support for `.git` indirection files (`gitdir: ...`) when locating the index.
- Preserved resilient behavior by skipping reporting when repository/index data cannot be read or is unsupported.
- Removed the `LibGit2Sharp` package reference from `Meziantou.Framework.DependencyScanning.csproj`.
- Updated scanner tests to stop using LibGit2Sharp and resolve the expected SHA via `git rev-parse HEAD`.
- Made `GitSubmodulesFromDependencies` run cross-platform (`[Fact]` instead of Windows-only).

## Validation
- Ran required maintenance scripts:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`
- Built dependency scanning project with warnings as errors.
- Ran dependency scanning test suite across target frameworks with warnings as errors.