### PR TITLE
Add ProcessWrapper.ToString

### DIFF
--- a/ref/Meziantou.Framework.ProcessWrapper.cs
+++ b/ref/Meziantou.Framework.ProcessWrapper.cs
@@ -114,6 +114,7 @@ namespace Meziantou.Framework
         public int Value { get => throw null; }
         public bool IsSuccess { get => throw null; }
         public ProcessExitCode(int value) { }
+        public bool IsAnyOf(params System.ReadOnlySpan<int> expectedValues) => throw null;
         public bool Equals(Meziantou.Framework.ProcessExitCode other) => throw null;
         public override bool Equals(object? obj) => throw null;
         public override int GetHashCode() => throw null;
@@ -205,6 +206,7 @@ namespace Meziantou.Framework
         public static System.IDisposable AddInterceptor(Meziantou.Framework.IProcessStartInfoInterceptor interceptor) => throw null;
         public static Meziantou.Framework.ProcessWrapper Create(string fileName) => throw null;
         public static Meziantou.Framework.ProcessPipeline operator |(Meziantou.Framework.ProcessWrapper left, Meziantou.Framework.ProcessWrapper right) => throw null;
+        public override string ToString() => throw null;
         public Meziantou.Framework.ProcessWrapper WithArguments(params string[] arguments) => throw null;
         public Meziantou.Framework.ProcessWrapper WithArguments(System.Collections.Generic.IEnumerable<string> arguments) => throw null;
         public Meziantou.Framework.ProcessWrapper WithWorkingDirectory(string workingDirectory) => throw null;

--- a/src/Meziantou.Framework.CommandLine/CommandLineBuilder.cs
+++ b/src/Meziantou.Framework.CommandLine/CommandLineBuilder.cs
@@ -34,13 +34,11 @@ static class CommandLineBuilder
     {
         for (var i = 0; i < value.Length; i++)
         {
-            var c = value[i];
             var numberBackslashes = 0;
 
-            while (i < value.Length && c == '\\')
+            while (i < value.Length && value[i] == '\\')
             {
                 i++;
-                c = value[i];
                 numberBackslashes++;
             }
 
@@ -49,7 +47,9 @@ static class CommandLineBuilder
                 sb.Append(new string('\\', numberBackslashes * 2));
                 break;
             }
-            else if (c == '"')
+
+            var c = value[i];
+            if (c == '"')
             {
                 sb.Append(new string('\\', (numberBackslashes * 2) + 1));
                 sb.Append(c);

--- a/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
+++ b/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
@@ -3,12 +3,13 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework</RootNamespace>
-    <Version>1.0.10</Version>
+    <Version>1.0.11</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Fluent API for wrapping System.Diagnostics.Process</Description>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="../Meziantou.Framework.CommandLine/CommandLineBuilder.cs" Link="Utils/CommandLineBuilder.cs" />
     <Compile Include="../Meziantou.Framework/ExecutableFinder.cs" Link="Utils/ExecutableFinder.cs" />
   </ItemGroup>
 

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -131,6 +131,24 @@ public sealed class ProcessWrapper
     /// <summary>Creates a pipeline between 2 commands.</summary>
     public static ProcessPipeline operator |(ProcessWrapper left, ProcessWrapper right) => ProcessPipeline.Create(left, right);
 
+    /// <summary>Returns the command line representation of this process configuration.</summary>
+    public override string ToString()
+    {
+        var fileName = CommandLineBuilder.WindowsQuotedArgument(_startInfo.FileName)!;
+        if (_startInfo.ArgumentList.Count == 0)
+            return fileName;
+
+        var sb = new StringBuilder(fileName);
+
+        foreach (var argument in _startInfo.ArgumentList)
+        {
+            sb.Append(' ');
+            sb.Append(CommandLineBuilder.WindowsQuotedArgument(argument));
+        }
+
+        return sb.ToString();
+    }
+
     /// <summary>Sets the arguments for the process, replacing any previously set arguments.</summary>
     public ProcessWrapper WithArguments(params string[] arguments)
     {

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -134,7 +134,7 @@ public sealed class ProcessWrapper
     /// <summary>Returns the command line representation of this process configuration.</summary>
     public override string ToString()
     {
-        var fileName = CommandLineBuilder.WindowsQuotedArgument(_startInfo.FileName)!;
+        var fileName = CommandLineBuilder.WindowsQuotedArgument(_startInfo.FileName);
         if (_startInfo.ArgumentList.Count == 0)
             return fileName;
 

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -407,6 +407,23 @@ public class ProcessWrapperTests
     }
 
     [Fact]
+    public void ToString_WithoutArguments_ReturnsCommand()
+    {
+        var command = ProcessWrapper.Create("dotnet");
+
+        Assert.Equal("dotnet", command.ToString());
+    }
+
+    [Fact]
+    public void ToString_QuotesFileNameAndArguments()
+    {
+        var command = ProcessWrapper.Create("my tool")
+            .WithArguments("arg", "with spaces", @"C:\path with spaces\", "with\"quote", "");
+
+        Assert.Equal("\"my tool\" arg \"with spaces\" \"C:\\path with spaces\\\\\" \"with\\\"quote\" \"\"", command.ToString());
+    }
+
+    [Fact]
     public async Task WithWorkingDirectory_SetsWorkingDirectory()
     {
         ProcessWrapper command;


### PR DESCRIPTION
`ProcessWrapper` did not provide a command-line representation, and the initial implementation duplicated argument-quoting logic. This change adds `ToString()` while reusing the existing shared quoting implementation to keep behavior consistent.

## What changed

- Added `ProcessWrapper.ToString()` to render executable + arguments as a command line.
- Reused `CommandLineBuilder.WindowsQuotedArgument(...)` instead of maintaining a second quoting implementation.
- Imported `CommandLineBuilder.cs` into `Meziantou.Framework.ProcessWrapper.csproj` via an MSBuild `Compile` item.
- Added tests that validate `ToString()` output for plain and quoted/escaped argument scenarios.
- Fixed a trailing-backslash edge case in `CommandLineBuilder.EscapeArgument` that surfaced when reusing the shared quoting path.

## Notes for reviewers

- The API surface change in `ProcessWrapper` updates the generated `ref/` file accordingly.
- The `EscapeArgument` fix is small but important: it prevents indexing past the end of the string when an argument ends with backslashes.