### PR TITLE
Improve ProcessResult.ToString with executed command context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         run: dotnet run ./eng/validate-nuget.cs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NUGET_VALIDATION_IS_DELTA: ${{ case(github.event_name == 'pull_request' && needs.create_nuget.outputs.has-project == 'true', 'true', 'false') }}
+          NUGET_VALIDATION_IS_DELTA: ${{ case((github.event_name == 'pull_request' || github.event_name == 'push') && needs.create_nuget.outputs.has-project == 'true', 'true', 'false') }}
 
   build_and_test:
     runs-on: ${{ matrix.runs-on }}

--- a/ref/Meziantou.Framework.ProcessWrapper.cs
+++ b/ref/Meziantou.Framework.ProcessWrapper.cs
@@ -189,6 +189,7 @@ namespace Meziantou.Framework
         public Meziantou.Framework.ProcessExitCode ExitCode { get => throw null; }
         public System.DateTimeOffset StartDate { get => throw null; }
         public System.DateTimeOffset ExitDate { get => throw null; }
+        public override string ToString() => throw null;
     }
 
     [System.Flags]

--- a/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
@@ -9,8 +9,8 @@ public sealed class BufferedProcessInstance : ProcessInstance
     private readonly ProcessOutputCollection _output;
     private Task<BufferedProcessResult>? _waitTask;
 
-    internal BufferedProcessInstance(IProcessHandle process, Task inputTask, Task outputTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, Activity? activity, CancellationToken cancellationToken, string processFileName, IReadOnlyList<string> arguments)
-        : base(process, inputTask, outputTask, cancellationRegistration, processLimiter, validationMode, hasStandardErrorOutput, activity, cancellationToken, processFileName, arguments)
+    internal BufferedProcessInstance(IProcessHandle process, Task inputTask, Task outputTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, Activity? activity, string processFileName, IReadOnlyList<string> arguments, CancellationToken cancellationToken)
+        : base(process, inputTask, outputTask, cancellationRegistration, processLimiter, validationMode, hasStandardErrorOutput, activity, processFileName, arguments, cancellationToken)
     {
         _output = output;
     }
@@ -44,6 +44,6 @@ public sealed class BufferedProcessInstance : ProcessInstance
 
     private protected override ProcessResult CreateProcessResult(ProcessExitCode exitCode, DateTimeOffset exitDate)
     {
-        return new BufferedProcessResult(processId: ProcessId, exitCode: exitCode, startDate: StartDate, exitDate: exitDate, output: _output, processFileName: _processFileName, arguments: _arguments);
+        return new BufferedProcessResult(processId: ProcessId, exitCode: exitCode, startDate: StartDate, exitDate: exitDate, output: _output, processFileName: ProcessFileName, arguments: Arguments);
     }
 }

--- a/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
@@ -9,8 +9,8 @@ public sealed class BufferedProcessInstance : ProcessInstance
     private readonly ProcessOutputCollection _output;
     private Task<BufferedProcessResult>? _waitTask;
 
-    internal BufferedProcessInstance(IProcessHandle process, Task inputTask, Task outputTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, Activity? activity, CancellationToken cancellationToken)
-        : base(process, inputTask, outputTask, cancellationRegistration, processLimiter, validationMode, hasStandardErrorOutput, activity, cancellationToken)
+    internal BufferedProcessInstance(IProcessHandle process, Task inputTask, Task outputTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, Activity? activity, CancellationToken cancellationToken, string processFileName, IReadOnlyList<string> arguments)
+        : base(process, inputTask, outputTask, cancellationRegistration, processLimiter, validationMode, hasStandardErrorOutput, activity, cancellationToken, processFileName, arguments)
     {
         _output = output;
     }
@@ -44,6 +44,6 @@ public sealed class BufferedProcessInstance : ProcessInstance
 
     private protected override ProcessResult CreateProcessResult(ProcessExitCode exitCode, DateTimeOffset exitDate)
     {
-        return new BufferedProcessResult(processId: ProcessId, exitCode: exitCode, startDate: StartDate, exitDate: exitDate, output: _output);
+        return new BufferedProcessResult(processId: ProcessId, exitCode: exitCode, startDate: StartDate, exitDate: exitDate, output: _output, processFileName: _processFileName, arguments: _arguments);
     }
 }

--- a/src/Meziantou.Framework.ProcessWrapper/BufferedProcessResult.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/BufferedProcessResult.cs
@@ -3,8 +3,8 @@ namespace Meziantou.Framework;
 /// <summary>Represents a completed buffered process execution.</summary>
 public sealed class BufferedProcessResult : ProcessResult
 {
-    internal BufferedProcessResult(int processId, ProcessExitCode exitCode, DateTimeOffset startDate, DateTimeOffset exitDate, ProcessOutputCollection output)
-        : base(processId, exitCode, startDate, exitDate)
+    internal BufferedProcessResult(int processId, ProcessExitCode exitCode, DateTimeOffset startDate, DateTimeOffset exitDate, ProcessOutputCollection output, string processFileName, IReadOnlyList<string> arguments)
+        : base(processId, exitCode, startDate, exitDate, processFileName, arguments)
     {
         Output = output;
     }

--- a/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
+++ b/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework</RootNamespace>
-    <Version>1.0.11</Version>
+    <Version>1.0.12</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Fluent API for wrapping System.Diagnostics.Process</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
@@ -22,10 +22,12 @@ public class ProcessInstance
     private readonly Func<bool> _hasStandardErrorOutput;
     private readonly Activity? _activity;
     private readonly Task<ProcessCompletion> _processCompletionTask;
+    private protected readonly string _processFileName;
+    private protected readonly IReadOnlyList<string> _arguments;
     private protected readonly Lock WaitTaskLock = new();
     private Task<ProcessResult>? _waitTask;
 
-    internal ProcessInstance(IProcessHandle process, Task inputStreamTask, Task outputStreamTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, Activity? activity, CancellationToken cancellationToken)
+    internal ProcessInstance(IProcessHandle process, Task inputStreamTask, Task outputStreamTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, Activity? activity, CancellationToken cancellationToken, string processFileName, IReadOnlyList<string> arguments)
     {
         _process = process;
         _inputStreamTask = inputStreamTask;
@@ -36,6 +38,8 @@ public class ProcessInstance
         _cancellationToken = cancellationToken;
         _hasStandardErrorOutput = hasStandardErrorOutput;
         _activity = activity;
+        _processFileName = processFileName ?? throw new ArgumentNullException(nameof(processFileName));
+        _arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
 
         ProcessId = process.Id;
         StartDate = DateTimeOffset.UtcNow;
@@ -215,7 +219,7 @@ public class ProcessInstance
 
     private protected virtual ProcessResult CreateProcessResult(ProcessExitCode exitCode, DateTimeOffset exitDate)
     {
-        return new ProcessResult(processId: ProcessId, exitCode: exitCode, startDate: StartDate, exitDate: exitDate);
+        return new ProcessResult(processId: ProcessId, exitCode: exitCode, startDate: StartDate, exitDate: exitDate, processFileName: _processFileName, arguments: _arguments);
     }
 
     private sealed class ProcessCompletion

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
@@ -22,12 +22,14 @@ public class ProcessInstance
     private readonly Func<bool> _hasStandardErrorOutput;
     private readonly Activity? _activity;
     private readonly Task<ProcessCompletion> _processCompletionTask;
-    private protected readonly string _processFileName;
-    private protected readonly IReadOnlyList<string> _arguments;
+    private readonly string _processFileName;
+    private readonly IReadOnlyList<string> _arguments;
+    private protected string ProcessFileName => _processFileName;
+    private protected IReadOnlyList<string> Arguments => _arguments;
     private protected readonly Lock WaitTaskLock = new();
     private Task<ProcessResult>? _waitTask;
 
-    internal ProcessInstance(IProcessHandle process, Task inputStreamTask, Task outputStreamTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, Activity? activity, CancellationToken cancellationToken, string processFileName, IReadOnlyList<string> arguments)
+    internal ProcessInstance(IProcessHandle process, Task inputStreamTask, Task outputStreamTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, Activity? activity, string processFileName, IReadOnlyList<string> arguments, CancellationToken cancellationToken)
     {
         _process = process;
         _inputStreamTask = inputStreamTask;

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessResult.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessResult.cs
@@ -1,14 +1,21 @@
+using System.Text;
+
 namespace Meziantou.Framework;
 
 /// <summary>Represents a completed process execution.</summary>
 public class ProcessResult
 {
-    internal ProcessResult(int processId, ProcessExitCode exitCode, DateTimeOffset startDate, DateTimeOffset exitDate)
+    private readonly string _processFileName;
+    private readonly IReadOnlyList<string> _arguments;
+
+    internal ProcessResult(int processId, ProcessExitCode exitCode, DateTimeOffset startDate, DateTimeOffset exitDate, string processFileName, IReadOnlyList<string> arguments)
     {
         ProcessId = processId;
         ExitCode = exitCode;
         StartDate = startDate;
         ExitDate = exitDate;
+        _processFileName = processFileName ?? throw new ArgumentNullException(nameof(processFileName));
+        _arguments = [.. arguments ?? throw new ArgumentNullException(nameof(arguments))];
     }
 
     /// <summary>Gets the process ID.</summary>
@@ -22,4 +29,25 @@ public class ProcessResult
 
     /// <summary>Gets the time the process exited.</summary>
     public DateTimeOffset ExitDate { get; }
+
+    /// <summary>Returns the command line and exit code of the process execution result.</summary>
+    public override string ToString()
+    {
+        var commandLine = CommandLineBuilder.WindowsQuotedArgument(_processFileName);
+        if (_arguments.Count == 0)
+            return $"{commandLine} (ExitCode: {ExitCode})";
+
+        var sb = new StringBuilder(commandLine);
+
+        foreach (var argument in _arguments)
+        {
+            sb.Append(' ');
+            sb.Append(CommandLineBuilder.WindowsQuotedArgument(argument));
+        }
+
+        sb.Append(" (ExitCode: ");
+        sb.Append(ExitCode);
+        sb.Append(')');
+        return sb.ToString();
+    }
 }

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -341,7 +341,7 @@ public sealed class ProcessWrapper
     {
         ApplyProcessWrapperInterceptors();
         return StartProcess(_outputTargets, _errorTargets,
-            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, ct) => new ProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, hasStandardErrorOutput, activity, ct),
+            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, ct, processFileName, arguments) => new ProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, hasStandardErrorOutput, activity, ct, processFileName, arguments),
             cancellationToken);
     }
 
@@ -359,12 +359,12 @@ public sealed class ProcessWrapper
         var errorTargets = _errorTargets.Add(OutputTarget.ToProcessOutputCollection(output).ForOutputType(ProcessOutputType.StandardError));
 
         return StartProcess(outputTargets, errorTargets,
-            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, ct) => new BufferedProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, output, hasStandardErrorOutput, activity, ct),
+            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, ct, processFileName, arguments) => new BufferedProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, output, hasStandardErrorOutput, activity, ct, processFileName, arguments),
             cancellationToken);
     }
 
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "ProcessInstance will dispose it")]
-    private T StartProcess<T>(ImmutableArray<OutputTarget> outputTargets, ImmutableArray<OutputTarget> errorTargets, Func<IProcessHandle, Task, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, Activity?, CancellationToken, T> factory, CancellationToken cancellationToken)
+    private T StartProcess<T>(ImmutableArray<OutputTarget> outputTargets, ImmutableArray<OutputTarget> errorTargets, Func<IProcessHandle, Task, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, Activity?, CancellationToken, string, IReadOnlyList<string>, T> factory, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -381,6 +381,8 @@ public sealed class ProcessWrapper
         startInfo.RedirectStandardInput = hasInputStream;
         startInfo.FileName = resolvedFileName;
         ApplyProcessStartInfoInterceptors(startInfo);
+        var processFileName = startInfo.FileName;
+        var arguments = (IReadOnlyList<string>)[.. startInfo.ArgumentList];
 
         var processFactory = _processFactory ?? DefaultProcessFactory;
         var processHandle = processFactory.Create(startInfo);
@@ -461,7 +463,7 @@ public sealed class ProcessWrapper
         var activity = ProcessWrapperTelemetry.ActivitySource.StartActivity("process.execute");
         activity?.SetTag("process.executable.path", resolvedFileName);
 
-        return factory(processHandle, inputStreamTask, Task.WhenAll(outputStreamTask, errorStreamTask), registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, activity, cancellationToken);
+        return factory(processHandle, inputStreamTask, Task.WhenAll(outputStreamTask, errorStreamTask), registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, activity, cancellationToken, processFileName, arguments);
     }
 
     private void ApplyProcessWrapperInterceptors()

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -341,7 +341,7 @@ public sealed class ProcessWrapper
     {
         ApplyProcessWrapperInterceptors();
         return StartProcess(_outputTargets, _errorTargets,
-            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, ct, processFileName, arguments) => new ProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, hasStandardErrorOutput, activity, ct, processFileName, arguments),
+            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, processFileName, arguments, ct) => new ProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, hasStandardErrorOutput, activity, processFileName, arguments, ct),
             cancellationToken);
     }
 
@@ -359,12 +359,12 @@ public sealed class ProcessWrapper
         var errorTargets = _errorTargets.Add(OutputTarget.ToProcessOutputCollection(output).ForOutputType(ProcessOutputType.StandardError));
 
         return StartProcess(outputTargets, errorTargets,
-            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, ct, processFileName, arguments) => new BufferedProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, output, hasStandardErrorOutput, activity, ct, processFileName, arguments),
+            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, processFileName, arguments, ct) => new BufferedProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, output, hasStandardErrorOutput, activity, processFileName, arguments, ct),
             cancellationToken);
     }
 
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "ProcessInstance will dispose it")]
-    private T StartProcess<T>(ImmutableArray<OutputTarget> outputTargets, ImmutableArray<OutputTarget> errorTargets, Func<IProcessHandle, Task, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, Activity?, CancellationToken, string, IReadOnlyList<string>, T> factory, CancellationToken cancellationToken)
+    private T StartProcess<T>(ImmutableArray<OutputTarget> outputTargets, ImmutableArray<OutputTarget> errorTargets, Func<IProcessHandle, Task, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, Activity?, string, IReadOnlyList<string>, CancellationToken, T> factory, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -463,7 +463,7 @@ public sealed class ProcessWrapper
         var activity = ProcessWrapperTelemetry.ActivitySource.StartActivity("process.execute");
         activity?.SetTag("process.executable.path", resolvedFileName);
 
-        return factory(processHandle, inputStreamTask, Task.WhenAll(outputStreamTask, errorStreamTask), registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, activity, cancellationToken, processFileName, arguments);
+        return factory(processHandle, inputStreamTask, Task.WhenAll(outputStreamTask, errorStreamTask), registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, activity, processFileName, arguments, cancellationToken);
     }
 
     private void ApplyProcessWrapperInterceptors()

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -424,6 +424,30 @@ public class ProcessWrapperTests
     }
 
     [Fact]
+    public async Task ProcessResult_ToString_ReturnsCommandAndExitCode()
+    {
+        using var fakeProcess = FakeProcess.Create(0, outputText: "intercepted output\n", errorText: "");
+        var createdProcesses = new List<CreatedProcessInfo>();
+        var fakeFactory = new FakeProcessFactory(startInfo =>
+        {
+            createdProcesses.Add(new CreatedProcessInfo(startInfo.FileName, startInfo.WorkingDirectory, [.. startInfo.ArgumentList]));
+            return fakeProcess;
+        });
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            var processResult = await CreateEchoCommand("ignored")
+                .ExecuteAsync();
+
+            Assert.Single(createdProcesses);
+            var expectedCommandLine = ProcessWrapper.Create(createdProcesses[0].FileName)
+                .WithArguments([.. createdProcesses[0].Arguments])
+                .ToString();
+            Assert.Equal($"{expectedCommandLine} (ExitCode: {processResult.ExitCode})", processResult.ToString());
+        });
+    }
+
+    [Fact]
     public async Task WithWorkingDirectory_SetsWorkingDirectory()
     {
         ProcessWrapper command;
@@ -1231,6 +1255,10 @@ public class ProcessWrapperTests
             Assert.Equal("intercepted output", processResult.Output.StandardOutput.First().Text);
             Assert.Single(createdProcesses);
             Assert.False(string.IsNullOrEmpty(createdProcesses[0].FileName));
+            var expectedCommandLine = ProcessWrapper.Create(createdProcesses[0].FileName)
+                .WithArguments([.. createdProcesses[0].Arguments])
+                .ToString();
+            Assert.Equal($"{expectedCommandLine} (ExitCode: {processResult.ExitCode})", processResult.ToString());
         });
     }
 


### PR DESCRIPTION
## Why
`ProcessResult` did not provide a useful string representation for diagnostics. We want `ToString()` to include the executed command context while keeping that metadata internal for now.

## What changed
- Propagated the executed file name and argument list from existing `ProcessStartInfo` data through `ProcessWrapper` and `ProcessInstance` into `ProcessResult` creation.
- Implemented `ProcessResult.ToString()` to output a quoted command line plus exit code.
- Kept command metadata private in `ProcessResult` (no new public properties), per review feedback.
- Updated tests to validate `ToString()` behavior for both regular and buffered execution paths using captured `ProcessStartInfo` values.
- Regenerated the reference assembly surface accordingly (`ToString()` override only).

## Notes for reviewers
The command metadata is intentionally stored only for formatting `ToString()`. If we later need public accessors, that can be introduced as a separate API decision.