### PR TITLE
Add configurable ProcessWrapper log verbosity

### DIFF
--- a/ref/Meziantou.Framework.ProcessWrapper.cs
+++ b/ref/Meziantou.Framework.ProcessWrapper.cs
@@ -108,6 +108,7 @@ namespace Meziantou.Framework
         public ProcessExecutionException(string message) { }
         public ProcessExecutionException(string message, System.Exception innerException) { }
         public ProcessExecutionException(Meziantou.Framework.ProcessExitCode exitCode) { }
+        public ProcessExecutionException(Meziantou.Framework.ProcessExitCode exitCode, string message) { }
     }
 
     public readonly struct ProcessExitCode : System.IEquatable<Meziantou.Framework.ProcessExitCode>
@@ -142,6 +143,14 @@ namespace Meziantou.Framework
         public int? CpuPercentage { get => throw null; set { } }
         public long? MemoryLimitInBytes { get => throw null; set { } }
         public int? ProcessCountLimit { get => throw null; set { } }
+    }
+
+    [System.Flags]
+    public enum ProcessLogVerbosity
+    {
+        None = 0,
+        IncludeProcessPath = 1,
+        IncludeArguments = 2
     }
 
     public sealed class ProcessOutput
@@ -204,6 +213,7 @@ namespace Meziantou.Framework
     public sealed class ProcessWrapper
     {
         public static Meziantou.Framework.IProcessFactory DefaultProcessFactory { get => throw null; set { } }
+        public static Meziantou.Framework.ProcessLogVerbosity DefaultLogVerbosity { get => throw null; set { } }
         public static System.IDisposable AddInterceptor(Meziantou.Framework.IProcessWrapperInterceptor interceptor) => throw null;
         public static System.IDisposable AddInterceptor(Meziantou.Framework.IProcessStartInfoInterceptor interceptor) => throw null;
         public static Meziantou.Framework.ProcessWrapper Create(string fileName) => throw null;
@@ -217,6 +227,7 @@ namespace Meziantou.Framework
         public Meziantou.Framework.ProcessWrapper WithEnvironmentVariables(System.Action<Meziantou.Framework.ProcessWrapperEnvironmentVariables> configure) => throw null;
         public Meziantou.Framework.ProcessWrapper WithEnvironmentVariables(System.Collections.Generic.IReadOnlyDictionary<string, string?> variables) => throw null;
         public Meziantou.Framework.ProcessWrapper WithValidation(Meziantou.Framework.ProcessValidationMode mode) => throw null;
+        public Meziantou.Framework.ProcessWrapper WithLogVerbosity(Meziantou.Framework.ProcessLogVerbosity verbosity) => throw null;
         public Meziantou.Framework.ProcessWrapper WithProcessFactory(Meziantou.Framework.IProcessFactory processFactory) => throw null;
         public Meziantou.Framework.ProcessWrapper WithInterceptor(Meziantou.Framework.IProcessWrapperInterceptor interceptor) => throw null;
         public Meziantou.Framework.ProcessWrapper WithInterceptor(Meziantou.Framework.IProcessStartInfoInterceptor interceptor) => throw null;

--- a/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/BufferedProcessInstance.cs
@@ -9,8 +9,8 @@ public sealed class BufferedProcessInstance : ProcessInstance
     private readonly ProcessOutputCollection _output;
     private Task<BufferedProcessResult>? _waitTask;
 
-    internal BufferedProcessInstance(IProcessHandle process, Task inputTask, Task outputTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, Activity? activity, string processFileName, IReadOnlyList<string> arguments, CancellationToken cancellationToken)
-        : base(process, inputTask, outputTask, cancellationRegistration, processLimiter, validationMode, hasStandardErrorOutput, activity, processFileName, arguments, cancellationToken)
+    internal BufferedProcessInstance(IProcessHandle process, Task inputTask, Task outputTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, ProcessOutputCollection output, Func<bool> hasStandardErrorOutput, Activity? activity, string processFileName, IReadOnlyList<string> arguments, ProcessLogVerbosity logVerbosity, CancellationToken cancellationToken)
+        : base(process, inputTask, outputTask, cancellationRegistration, processLimiter, validationMode, hasStandardErrorOutput, activity, processFileName, arguments, logVerbosity, cancellationToken)
     {
         _output = output;
     }
@@ -44,6 +44,6 @@ public sealed class BufferedProcessInstance : ProcessInstance
 
     private protected override ProcessResult CreateProcessResult(ProcessExitCode exitCode, DateTimeOffset exitDate)
     {
-        return new BufferedProcessResult(processId: ProcessId, exitCode: exitCode, startDate: StartDate, exitDate: exitDate, output: _output, processFileName: ProcessFileName, arguments: Arguments);
+        return new BufferedProcessResult(processId: ProcessId, exitCode: exitCode, startDate: StartDate, exitDate: exitDate, output: _output, processFileName: ProcessFileName, arguments: Arguments, logVerbosity: LogVerbosity);
     }
 }

--- a/src/Meziantou.Framework.ProcessWrapper/BufferedProcessResult.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/BufferedProcessResult.cs
@@ -3,8 +3,8 @@ namespace Meziantou.Framework;
 /// <summary>Represents a completed buffered process execution.</summary>
 public sealed class BufferedProcessResult : ProcessResult
 {
-    internal BufferedProcessResult(int processId, ProcessExitCode exitCode, DateTimeOffset startDate, DateTimeOffset exitDate, ProcessOutputCollection output, string processFileName, IReadOnlyList<string> arguments)
-        : base(processId, exitCode, startDate, exitDate, processFileName, arguments)
+    internal BufferedProcessResult(int processId, ProcessExitCode exitCode, DateTimeOffset startDate, DateTimeOffset exitDate, ProcessOutputCollection output, string processFileName, IReadOnlyList<string> arguments, ProcessLogVerbosity logVerbosity)
+        : base(processId, exitCode, startDate, exitDate, processFileName, arguments, logVerbosity)
     {
         Output = output;
     }

--- a/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
+++ b/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework</RootNamespace>
-    <Version>1.0.13</Version>
+    <Version>1.0.14</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Fluent API for wrapping System.Diagnostics.Process</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessCommandLineFormatter.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessCommandLineFormatter.cs
@@ -1,0 +1,45 @@
+using System.Text;
+
+namespace Meziantou.Framework;
+
+internal static class ProcessCommandLineFormatter
+{
+    public static string Format(string processFileName, IEnumerable<string> arguments)
+    {
+        return Format(processFileName, arguments, ProcessLogVerbosity.IncludeProcessPath | ProcessLogVerbosity.IncludeArguments);
+    }
+
+    public static string Format(string processFileName, IEnumerable<string> arguments, ProcessLogVerbosity verbosity)
+    {
+        ArgumentNullException.ThrowIfNull(processFileName);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var includeProcessPath = (verbosity & ProcessLogVerbosity.IncludeProcessPath) == ProcessLogVerbosity.IncludeProcessPath;
+        var includeArguments = (verbosity & ProcessLogVerbosity.IncludeArguments) == ProcessLogVerbosity.IncludeArguments;
+        if (!includeProcessPath && !includeArguments)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        if (includeProcessPath)
+        {
+            sb.Append(CommandLineBuilder.WindowsQuotedArgument(processFileName));
+        }
+
+        if (includeArguments)
+        {
+            foreach (var argument in arguments)
+            {
+                if (sb.Length > 0)
+                {
+                    sb.Append(' ');
+                }
+
+                sb.Append(CommandLineBuilder.WindowsQuotedArgument(argument));
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessExecutionException.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessExecutionException.cs
@@ -23,7 +23,13 @@ public sealed class ProcessExecutionException : Exception
 
     /// <summary>Initializes a new instance of <see cref="ProcessExecutionException"/> with the specified exit code.</summary>
     public ProcessExecutionException(ProcessExitCode exitCode)
-        : base($"Process exited with code {exitCode}.")
+        : this(exitCode, $"Process exited with code {exitCode}.")
+    {
+    }
+
+    /// <summary>Initializes a new instance of <see cref="ProcessExecutionException"/> with the specified exit code and message.</summary>
+    public ProcessExecutionException(ProcessExitCode exitCode, string message)
+        : base(message)
     {
         ExitCode = exitCode;
     }

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
@@ -24,12 +24,14 @@ public class ProcessInstance
     private readonly Task<ProcessCompletion> _processCompletionTask;
     private readonly string _processFileName;
     private readonly IReadOnlyList<string> _arguments;
+    private readonly ProcessLogVerbosity _logVerbosity;
     private protected string ProcessFileName => _processFileName;
     private protected IReadOnlyList<string> Arguments => _arguments;
+    private protected ProcessLogVerbosity LogVerbosity => _logVerbosity;
     private protected readonly Lock WaitTaskLock = new();
     private Task<ProcessResult>? _waitTask;
 
-    internal ProcessInstance(IProcessHandle process, Task inputStreamTask, Task outputStreamTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, Activity? activity, string processFileName, IReadOnlyList<string> arguments, CancellationToken cancellationToken)
+    internal ProcessInstance(IProcessHandle process, Task inputStreamTask, Task outputStreamTask, CancellationTokenRegistration cancellationRegistration, IDisposable? processLimiter, ProcessValidationMode validationMode, Func<bool> hasStandardErrorOutput, Activity? activity, string processFileName, IReadOnlyList<string> arguments, ProcessLogVerbosity logVerbosity, CancellationToken cancellationToken)
     {
         _process = process;
         _inputStreamTask = inputStreamTask;
@@ -42,6 +44,7 @@ public class ProcessInstance
         _activity = activity;
         _processFileName = processFileName ?? throw new ArgumentNullException(nameof(processFileName));
         _arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+        _logVerbosity = logVerbosity;
 
         ProcessId = process.Id;
         StartDate = DateTimeOffset.UtcNow;
@@ -135,17 +138,30 @@ public class ProcessInstance
 
     private ProcessExecutionException? GetValidationException(ProcessExitCode exitCode)
     {
+        var messageContext = GetValidationMessageContext();
+
         if ((_validationMode & ProcessValidationMode.FailIfNonZeroExitCode) == ProcessValidationMode.FailIfNonZeroExitCode && !exitCode.IsSuccess)
         {
-            return new ProcessExecutionException(exitCode);
+            return new ProcessExecutionException(exitCode, $"Process exited with code {exitCode}.{messageContext}");
         }
 
         if ((_validationMode & ProcessValidationMode.FailIfStdError) == ProcessValidationMode.FailIfStdError && _hasStandardErrorOutput())
         {
-            return new ProcessExecutionException("Process wrote to standard error.");
+            return new ProcessExecutionException($"Process wrote to standard error.{messageContext}");
         }
 
         return null;
+    }
+
+    private string GetValidationMessageContext()
+    {
+        var commandLine = ProcessCommandLineFormatter.Format(_processFileName, _arguments, _logVerbosity);
+        if (string.IsNullOrEmpty(commandLine))
+        {
+            return string.Empty;
+        }
+
+        return $" Command: {commandLine}";
     }
 
     // Wait for process exit and dispose all resources (do not wait for user to await the instance)
@@ -221,7 +237,7 @@ public class ProcessInstance
 
     private protected virtual ProcessResult CreateProcessResult(ProcessExitCode exitCode, DateTimeOffset exitDate)
     {
-        return new ProcessResult(processId: ProcessId, exitCode: exitCode, startDate: StartDate, exitDate: exitDate, processFileName: _processFileName, arguments: _arguments);
+        return new ProcessResult(processId: ProcessId, exitCode: exitCode, startDate: StartDate, exitDate: exitDate, processFileName: _processFileName, arguments: _arguments, logVerbosity: _logVerbosity);
     }
 
     private sealed class ProcessCompletion

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessLogVerbosity.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessLogVerbosity.cs
@@ -1,0 +1,15 @@
+namespace Meziantou.Framework;
+
+/// <summary>Specifies which process command details are included in log-oriented text outputs.</summary>
+[Flags]
+public enum ProcessLogVerbosity
+{
+    /// <summary>No process command details are included.</summary>
+    None = 0,
+
+    /// <summary>Includes the resolved executable path.</summary>
+    IncludeProcessPath = 1,
+
+    /// <summary>Includes process arguments.</summary>
+    IncludeArguments = 2,
+}

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessResult.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessResult.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 namespace Meziantou.Framework;
 
 /// <summary>Represents a completed process execution.</summary>
@@ -7,8 +5,9 @@ public class ProcessResult
 {
     private readonly string _processFileName;
     private readonly IReadOnlyList<string> _arguments;
+    private readonly ProcessLogVerbosity _logVerbosity;
 
-    internal ProcessResult(int processId, ProcessExitCode exitCode, DateTimeOffset startDate, DateTimeOffset exitDate, string processFileName, IReadOnlyList<string> arguments)
+    internal ProcessResult(int processId, ProcessExitCode exitCode, DateTimeOffset startDate, DateTimeOffset exitDate, string processFileName, IReadOnlyList<string> arguments, ProcessLogVerbosity logVerbosity)
     {
         ProcessId = processId;
         ExitCode = exitCode;
@@ -16,6 +15,7 @@ public class ProcessResult
         ExitDate = exitDate;
         _processFileName = processFileName ?? throw new ArgumentNullException(nameof(processFileName));
         _arguments = [.. arguments ?? throw new ArgumentNullException(nameof(arguments))];
+        _logVerbosity = logVerbosity;
     }
 
     /// <summary>Gets the process ID.</summary>
@@ -33,21 +33,12 @@ public class ProcessResult
     /// <summary>Returns the command line and exit code of the process execution result.</summary>
     public override string ToString()
     {
-        var commandLine = CommandLineBuilder.WindowsQuotedArgument(_processFileName);
-        if (_arguments.Count == 0)
-            return $"{commandLine} (ExitCode: {ExitCode})";
-
-        var sb = new StringBuilder(commandLine);
-
-        foreach (var argument in _arguments)
+        var commandLine = ProcessCommandLineFormatter.Format(_processFileName, _arguments, _logVerbosity);
+        if (string.IsNullOrEmpty(commandLine))
         {
-            sb.Append(' ');
-            sb.Append(CommandLineBuilder.WindowsQuotedArgument(argument));
+            return $"(ExitCode: {ExitCode})";
         }
 
-        sb.Append(" (ExitCode: ");
-        sb.Append(ExitCode);
-        sb.Append(')');
-        return sb.ToString();
+        return $"{commandLine} (ExitCode: {ExitCode})";
     }
 }

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -16,6 +16,7 @@ namespace Meziantou.Framework;
 public sealed class ProcessWrapper
 {
     private static IProcessFactory s_defaultProcessFactory = SystemProcessFactory.Instance;
+    private static int s_defaultLogVerbosity = (int)ProcessLogVerbosity.IncludeProcessPath;
     private static readonly Lock DefaultInterceptorsLock = new();
     private static ImmutableArray<IProcessWrapperInterceptor> s_defaultProcessWrapperInterceptors = [];
     private static ImmutableArray<IProcessStartInfoInterceptor> s_defaultProcessStartInfoInterceptors = [];
@@ -24,6 +25,7 @@ public sealed class ProcessWrapper
     private ImmutableArray<IProcessStartInfoInterceptor> _processStartInfoInterceptors;
     private readonly ProcessStartInfo _startInfo;
     private ProcessValidationMode _validationMode;
+    private ProcessLogVerbosity _logVerbosity;
     private ImmutableArray<OutputTarget> _outputTargets;
     private ImmutableArray<OutputTarget> _errorTargets;
     private InputSource? _inputSource;
@@ -36,6 +38,7 @@ public sealed class ProcessWrapper
         ArgumentNullException.ThrowIfNull(fileName);
         _startInfo = CreateStartInfo(fileName);
         _validationMode = ProcessValidationMode.FailIfNonZeroExitCode;
+        _logVerbosity = DefaultLogVerbosity;
         _outputTargets = [];
         _errorTargets = [];
         _processWrapperInterceptors = [];
@@ -48,6 +51,7 @@ public sealed class ProcessWrapper
 
         _startInfo = CloneStartInfo(other._startInfo);
         _validationMode = other._validationMode;
+        _logVerbosity = other._logVerbosity;
         _outputTargets = other._outputTargets;
         _errorTargets = other._errorTargets;
         _inputSource = other._inputSource;
@@ -64,6 +68,13 @@ public sealed class ProcessWrapper
     {
         get => Volatile.Read(ref s_defaultProcessFactory);
         set => s_defaultProcessFactory = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    /// <summary>Gets or sets the default verbosity used in process validation messages and process result string formatting.</summary>
+    public static ProcessLogVerbosity DefaultLogVerbosity
+    {
+        get => (ProcessLogVerbosity)Volatile.Read(ref s_defaultLogVerbosity);
+        set => Volatile.Write(ref s_defaultLogVerbosity, (int)value);
     }
 
     /// <summary>Adds a global process-wrapper interceptor.</summary>
@@ -135,19 +146,7 @@ public sealed class ProcessWrapper
     /// <summary>Returns the command line representation of this process configuration.</summary>
     public override string ToString()
     {
-        var fileName = CommandLineBuilder.WindowsQuotedArgument(_startInfo.FileName);
-        if (_startInfo.ArgumentList.Count == 0)
-            return fileName;
-
-        var sb = new StringBuilder(fileName);
-
-        foreach (var argument in _startInfo.ArgumentList)
-        {
-            sb.Append(' ');
-            sb.Append(CommandLineBuilder.WindowsQuotedArgument(argument));
-        }
-
-        return sb.ToString();
+        return ProcessCommandLineFormatter.Format(_startInfo.FileName, _startInfo.ArgumentList);
     }
 
     /// <summary>Sets the arguments for the process, replacing any previously set arguments.</summary>
@@ -225,6 +224,13 @@ public sealed class ProcessWrapper
     public ProcessWrapper WithValidation(ProcessValidationMode mode)
     {
         _validationMode = mode;
+        return this;
+    }
+
+    /// <summary>Sets the verbosity used in process validation messages and process result string formatting.</summary>
+    public ProcessWrapper WithLogVerbosity(ProcessLogVerbosity verbosity)
+    {
+        _logVerbosity = verbosity;
         return this;
     }
 
@@ -355,7 +361,7 @@ public sealed class ProcessWrapper
     {
         ApplyProcessWrapperInterceptors();
         return StartProcess(_outputTargets, _errorTargets,
-            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, processFileName, arguments, ct) => new ProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, hasStandardErrorOutput, activity, processFileName, arguments, ct),
+            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, processFileName, arguments, logVerbosity, ct) => new ProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, hasStandardErrorOutput, activity, processFileName, arguments, logVerbosity, ct),
             cancellationToken);
     }
 
@@ -373,12 +379,12 @@ public sealed class ProcessWrapper
         var errorTargets = _errorTargets.Add(OutputTarget.ToProcessOutputCollection(output).ForOutputType(ProcessOutputType.StandardError));
 
         return StartProcess(outputTargets, errorTargets,
-            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, processFileName, arguments, ct) => new BufferedProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, output, hasStandardErrorOutput, activity, processFileName, arguments, ct),
+            (processHandle, inputTask, outputTask, registration, limiter, hasStandardErrorOutput, activity, processFileName, arguments, logVerbosity, ct) => new BufferedProcessInstance(processHandle, inputTask, outputTask, registration, limiter, _validationMode, output, hasStandardErrorOutput, activity, processFileName, arguments, logVerbosity, ct),
             cancellationToken);
     }
 
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "ProcessInstance will dispose it")]
-    private T StartProcess<T>(ImmutableArray<OutputTarget> outputTargets, ImmutableArray<OutputTarget> errorTargets, Func<IProcessHandle, Task, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, Activity?, string, IReadOnlyList<string>, CancellationToken, T> factory, CancellationToken cancellationToken)
+    private T StartProcess<T>(ImmutableArray<OutputTarget> outputTargets, ImmutableArray<OutputTarget> errorTargets, Func<IProcessHandle, Task, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, Activity?, string, IReadOnlyList<string>, ProcessLogVerbosity, CancellationToken, T> factory, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -477,7 +483,7 @@ public sealed class ProcessWrapper
         var activity = ProcessWrapperTelemetry.ActivitySource.StartActivity("process.execute");
         activity?.SetTag("process.executable.path", resolvedFileName);
 
-        return factory(processHandle, inputStreamTask, Task.WhenAll(outputStreamTask, errorStreamTask), registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, activity, processFileName, arguments, cancellationToken);
+        return factory(processHandle, inputStreamTask, Task.WhenAll(outputStreamTask, errorStreamTask), registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, activity, processFileName, arguments, _logVerbosity, cancellationToken);
     }
 
     private void ApplyProcessWrapperInterceptors()

--- a/src/Meziantou.Framework.ProcessWrapper/readme.md
+++ b/src/Meziantou.Framework.ProcessWrapper/readme.md
@@ -326,6 +326,14 @@ bool isSuccess = result.ExitCode.IsSuccess;
 await ProcessWrapper.Create("my-command")
     .WithValidation(ProcessValidationMode.FailIfNonZeroExitCode | ProcessValidationMode.FailIfStdError)
     .ExecuteAsync();
+
+// Control command details included in exception messages and ProcessResult.ToString()
+ProcessWrapper.DefaultLogVerbosity = ProcessLogVerbosity.IncludeProcessPath;
+
+await ProcessWrapper.Create("my-command")
+    .WithArguments("--token", "secret")
+    .WithLogVerbosity(ProcessLogVerbosity.IncludeProcessPath | ProcessLogVerbosity.IncludeArguments)
+    .ExecuteAsync();
 ````
 
 ## Cancellation

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -440,11 +440,26 @@ public class ProcessWrapperTests
                 .ExecuteAsync();
 
             Assert.Single(createdProcesses);
-            var expectedCommandLine = ProcessWrapper.Create(createdProcesses[0].FileName)
-                .WithArguments([.. createdProcesses[0].Arguments])
-                .ToString();
+            var expectedCommandLine = ProcessWrapper.Create(createdProcesses[0].FileName).ToString();
             Assert.Equal($"{expectedCommandLine} (ExitCode: {processResult.ExitCode})", processResult.ToString());
+            Assert.DoesNotContain("ignored", processResult.ToString(), StringComparison.Ordinal);
         });
+    }
+
+    [Fact]
+    public async Task ProcessResult_ToString_WithIncludeArguments_IncludesArguments()
+    {
+        using var fakeProcess = FakeProcess.Create(0, outputText: "intercepted output\n", errorText: "");
+        var fakeFactory = new FakeProcessFactory(fakeProcess);
+
+        var processResult = await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            return await CreateEchoCommand("argument-marker")
+                .WithLogVerbosity(ProcessLogVerbosity.IncludeProcessPath | ProcessLogVerbosity.IncludeArguments)
+                .ExecuteAsync();
+        });
+
+        Assert.Contains("argument-marker", processResult.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -596,6 +611,65 @@ public class ProcessWrapperTests
     }
 
     [Fact]
+    public async Task Validation_FailIfNonZeroExitCode_DefaultLogVerbosity_IncludesProcessPathWithoutArguments()
+    {
+        using var fakeProcess = FakeProcess.Create(42, outputText: "", errorText: "");
+        var createdProcesses = new List<CreatedProcessInfo>();
+        var fakeFactory = new FakeProcessFactory(startInfo =>
+        {
+            createdProcesses.Add(new CreatedProcessInfo(startInfo.FileName, startInfo.WorkingDirectory, [.. startInfo.ArgumentList]));
+            return fakeProcess;
+        });
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            var process = CreateEchoCommand("sensitive-argument")
+                .ExecuteAsync();
+
+            var ex = await Assert.ThrowsAsync<ProcessExecutionException>(async () => await process);
+            Assert.Single(createdProcesses);
+            Assert.Contains(createdProcesses[0].FileName, ex.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("sensitive-argument", ex.Message, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public async Task Validation_FailIfNonZeroExitCode_WithLogVerbosityIncludeArguments_IncludesArguments()
+    {
+        using var fakeProcess = FakeProcess.Create(42, outputText: "", errorText: "");
+        var fakeFactory = new FakeProcessFactory(fakeProcess);
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            var process = CreateEchoCommand("sensitive-argument")
+                .WithLogVerbosity(ProcessLogVerbosity.IncludeProcessPath | ProcessLogVerbosity.IncludeArguments)
+                .ExecuteAsync();
+
+            var ex = await Assert.ThrowsAsync<ProcessExecutionException>(async () => await process);
+            Assert.Contains("sensitive-argument", ex.Message, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public async Task Validation_FailIfNonZeroExitCode_WithDefaultLogVerbosityIncludeArguments_IncludesArguments()
+    {
+        using var fakeProcess = FakeProcess.Create(42, outputText: "", errorText: "");
+        var fakeFactory = new FakeProcessFactory(fakeProcess);
+
+        await RunWithDefaultLogVerbosityAsync(ProcessLogVerbosity.IncludeProcessPath | ProcessLogVerbosity.IncludeArguments, async () =>
+        {
+            await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+            {
+                var process = CreateEchoCommand("global-sensitive-argument")
+                    .ExecuteAsync();
+
+                var ex = await Assert.ThrowsAsync<ProcessExecutionException>(async () => await process);
+                Assert.Contains("global-sensitive-argument", ex.Message, StringComparison.Ordinal);
+            });
+        });
+    }
+
+    [Fact]
     public async Task Validation_FailIfNonZeroExitCode_SetsActivityStatusToError()
     {
         var activityTask = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -620,7 +694,10 @@ public class ProcessWrapperTests
 
         var activity = await activityTask.Task.WaitAsync(TimeSpan.FromSeconds(10));
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
-        Assert.Equal("Process exited with code 1.", activity.StatusDescription);
+        var processPath = Assert.IsType<string>(activity.GetTagItem("process.executable.path"));
+        Assert.NotNull(activity.StatusDescription);
+        Assert.StartsWith("Process exited with code 1.", activity.StatusDescription, StringComparison.Ordinal);
+        Assert.Contains(processPath, activity.StatusDescription, StringComparison.Ordinal);
         Assert.Equal(1, activity.GetTagItem("process.exit.code"));
     }
 
@@ -667,7 +744,7 @@ public class ProcessWrapperTests
             .ExecuteAsync();
 
         var ex = await Assert.ThrowsAsync<ProcessExecutionException>(async () => await process);
-        Assert.Equal("Process wrote to standard error.", ex.Message);
+        Assert.StartsWith("Process wrote to standard error.", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1012,6 +1089,7 @@ public class ProcessWrapperTests
         Assert.Same(command, command.WithEnvironmentVariables(env => env.Set("TEST_VAR_45", "value")));
         Assert.Same(command, command.WithEnvironmentVariables(new Dictionary<string, string?>(StringComparer.Ordinal) { ["TEST_VAR_45"] = "updated" }));
         Assert.Same(command, command.WithValidation(ProcessValidationMode.None));
+        Assert.Same(command, command.WithLogVerbosity(ProcessLogVerbosity.IncludeProcessPath));
         Assert.Same(command, command.WithProcessFactory(SystemProcessFactory.Instance));
         Assert.Same(command, command.WithInterceptor(processWrapperInterceptor));
         Assert.Same(command, command.WithInterceptor(processStartInfoInterceptor));
@@ -1254,11 +1332,9 @@ public class ProcessWrapperTests
 
             Assert.Equal("intercepted output", processResult.Output.StandardOutput.First().Text);
             Assert.Single(createdProcesses);
-            Assert.False(string.IsNullOrEmpty(createdProcesses[0].FileName));
-            var expectedCommandLine = ProcessWrapper.Create(createdProcesses[0].FileName)
-                .WithArguments([.. createdProcesses[0].Arguments])
-                .ToString();
+            var expectedCommandLine = ProcessWrapper.Create(createdProcesses[0].FileName).ToString();
             Assert.Equal($"{expectedCommandLine} (ExitCode: {processResult.ExitCode})", processResult.ToString());
+            Assert.DoesNotContain("ignored", processResult.ToString(), StringComparison.Ordinal);
         });
     }
 
@@ -1417,6 +1493,24 @@ public class ProcessWrapperTests
         }
     }
 
+    private static async Task<T> RunWithDefaultProcessFactoryAsync<T>(IProcessFactory processFactory, Func<Task<T>> callback)
+    {
+        ArgumentNullException.ThrowIfNull(processFactory);
+        ArgumentNullException.ThrowIfNull(callback);
+
+        var previousProcessFactory = ProcessWrapper.DefaultProcessFactory;
+        ProcessWrapper.DefaultProcessFactory = processFactory;
+
+        try
+        {
+            return await callback();
+        }
+        finally
+        {
+            ProcessWrapper.DefaultProcessFactory = previousProcessFactory;
+        }
+    }
+
     private static async Task RunWithGlobalInterceptorsAsync(Func<Task> callback, IProcessWrapperInterceptor? processWrapperInterceptor = null, IProcessStartInfoInterceptor? processStartInfoInterceptor = null)
     {
         ArgumentNullException.ThrowIfNull(callback);
@@ -1424,6 +1518,23 @@ public class ProcessWrapperTests
         using var processWrapperInterceptorRegistration = processWrapperInterceptor is null ? null : ProcessWrapper.AddInterceptor(processWrapperInterceptor);
         using var processStartInfoInterceptorRegistration = processStartInfoInterceptor is null ? null : ProcessWrapper.AddInterceptor(processStartInfoInterceptor);
         await callback();
+    }
+
+    private static async Task RunWithDefaultLogVerbosityAsync(ProcessLogVerbosity verbosity, Func<Task> callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        var previousLogVerbosity = ProcessWrapper.DefaultLogVerbosity;
+        ProcessWrapper.DefaultLogVerbosity = verbosity;
+
+        try
+        {
+            await callback();
+        }
+        finally
+        {
+            ProcessWrapper.DefaultLogVerbosity = previousLogVerbosity;
+        }
     }
 
     private static ActivityListener CreateProcessWrapperActivityListener(Action<Activity> activityStopped)


### PR DESCRIPTION
## Why
Process validation exceptions did not include executable context, making failures harder to diagnose. At the same time, arguments can contain sensitive data, so verbosity needs to be configurable with safe defaults.

## What changed
- Added `ProcessLogVerbosity` flags (`IncludeProcessPath`, `IncludeArguments`).
- Added global and per-instance configuration:
  - `ProcessWrapper.DefaultLogVerbosity` (default: `IncludeProcessPath`)
  - `ProcessWrapper.WithLogVerbosity(...)`
- Updated validation failures in `ProcessInstance` so `ProcessExecutionException` messages include command context based on configured verbosity.
- Updated `ProcessResult.ToString()` to use the same verbosity model.
- Introduced `ProcessCommandLineFormatter` to centralize command formatting.
- Updated ProcessWrapper README and expanded tests for default behavior, opt-in argument logging, activity status text, and fluent API coverage.

## Notes for reviewers
- Default behavior intentionally includes only the resolved executable path. Arguments remain opt-in for security reasons.
- The same verbosity setting now governs both exception messages and `ProcessResult.ToString()` output for consistency.