### PR TITLE
Make bencode async parsing truly streaming with PipeReader

### DIFF
--- a/ref/Meziantou.Framework.Bencode.cs
+++ b/ref/Meziantou.Framework.Bencode.cs
@@ -25,6 +25,7 @@ namespace Meziantou.Framework.Bencode
         public Meziantou.Framework.Bencode.BencodeValue Root { get => throw null; }
         public BencodeDocument(Meziantou.Framework.Bencode.BencodeValue root) { }
         public static Meziantou.Framework.Bencode.BencodeDocument Parse(System.ReadOnlySpan<byte> data) => throw null;
+        public static System.Threading.Tasks.ValueTask<Meziantou.Framework.Bencode.BencodeDocument> ParseAsync(System.IO.Pipelines.PipeReader reader, System.Threading.CancellationToken cancellationToken = null) => throw null;
         public static System.Threading.Tasks.ValueTask<Meziantou.Framework.Bencode.BencodeDocument> ParseAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = null) => throw null;
         public byte[] ToArray() => throw null;
         public System.Threading.Tasks.ValueTask WriteToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = null) => throw null;

--- a/src/Meziantou.Framework.Bencode/BencodeDocument.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeDocument.cs
@@ -1,3 +1,5 @@
+using System.IO.Pipelines;
+
 namespace Meziantou.Framework.Bencode;
 
 public sealed class BencodeDocument
@@ -15,13 +17,27 @@ public sealed class BencodeDocument
         return new BencodeDocument(value);
     }
 
+    public static async ValueTask<BencodeDocument> ParseAsync(PipeReader reader, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        var value = await BencodePipeReaderDecoder.ParseAsync(reader, cancellationToken).ConfigureAwait(false);
+        return new BencodeDocument(value);
+    }
+
     public static async ValueTask<BencodeDocument> ParseAsync(Stream stream, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(stream);
 
-        var buffer = new MemoryStream();
-        await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
-        return Parse(buffer.GetBuffer().AsSpan(0, (int)buffer.Length));
+        var reader = PipeReader.Create(stream, new StreamPipeReaderOptions(leaveOpen: true));
+        try
+        {
+            return await ParseAsync(reader, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await reader.CompleteAsync().ConfigureAwait(false);
+        }
     }
 
     public byte[] ToArray()

--- a/src/Meziantou.Framework.Bencode/BencodePipeReaderDecoder.cs
+++ b/src/Meziantou.Framework.Bencode/BencodePipeReaderDecoder.cs
@@ -1,0 +1,295 @@
+using System.Buffers;
+using System.Globalization;
+using System.IO.Pipelines;
+using System.Text;
+
+namespace Meziantou.Framework.Bencode;
+
+internal sealed class BencodePipeReaderDecoder
+{
+    private readonly PipeReader _reader;
+    private ReadOnlySequence<byte> _buffer;
+    private bool _hasPendingReadResult;
+    private long _position;
+
+    private BencodePipeReaderDecoder(PipeReader reader)
+    {
+        _reader = reader;
+    }
+
+    public static async ValueTask<BencodeValue> ParseAsync(PipeReader reader, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        var decoder = new BencodePipeReaderDecoder(reader);
+        try
+        {
+            var value = await decoder.ParseValueAsync(cancellationToken).ConfigureAwait(false);
+            await decoder.EnsureNoTrailingDataAsync(cancellationToken).ConfigureAwait(false);
+            return value;
+        }
+        finally
+        {
+            decoder.AdvanceReader();
+        }
+    }
+
+    private async ValueTask<BencodeValue> ParseValueAsync(CancellationToken cancellationToken)
+    {
+        var token = await PeekByteAsync(cancellationToken).ConfigureAwait(false);
+        return token switch
+        {
+            (byte)'i' => await ParseIntegerAsync(cancellationToken).ConfigureAwait(false),
+            >= (byte)'0' and <= (byte)'9' => await ParseStringAsync(cancellationToken).ConfigureAwait(false),
+            (byte)'l' => await ParseListAsync(cancellationToken).ConfigureAwait(false),
+            (byte)'d' => await ParseDictionaryAsync(cancellationToken).ConfigureAwait(false),
+            null => throw new FormatException("Unexpected end of bencode data."),
+            _ => throw new FormatException($"Invalid bencode token '{(char)token.GetValueOrDefault()}' at position {_position}."),
+        };
+    }
+
+    private async ValueTask<BencodeInteger> ParseIntegerAsync(CancellationToken cancellationToken)
+    {
+        Consume(1); // i
+
+        var integerText = new ArrayBufferWriter<byte>();
+        while (true)
+        {
+            var next = await TryReadByteAsync(cancellationToken).ConfigureAwait(false);
+            if (next is null)
+                throw new FormatException("Unterminated bencode integer.");
+
+            if (next == (byte)'e')
+                break;
+
+            AppendByte(integerText, next.Value);
+        }
+
+        if (!IsValidInteger(integerText.WrittenSpan))
+            throw new FormatException("Invalid bencode integer format.");
+
+        var integerString = Encoding.ASCII.GetString(integerText.WrittenSpan);
+        if (!long.TryParse(integerString, CultureInfo.InvariantCulture, out var value))
+            throw new FormatException("Invalid bencode integer value.");
+
+        return new BencodeInteger(value);
+    }
+
+    private async ValueTask<BencodeString> ParseStringAsync(CancellationToken cancellationToken)
+    {
+        var lengthText = new ArrayBufferWriter<byte>();
+        while (true)
+        {
+            var next = await TryReadByteAsync(cancellationToken).ConfigureAwait(false);
+            if (next is null)
+                throw new FormatException("Invalid bencode string length format.");
+
+            if (next is >= (byte)'0' and <= (byte)'9')
+            {
+                AppendByte(lengthText, next.Value);
+                continue;
+            }
+
+            if (next == (byte)':')
+                break;
+
+            throw new FormatException("Invalid bencode string length format.");
+        }
+
+        if (lengthText.WrittenCount == 0)
+            throw new FormatException("Invalid bencode string length format.");
+
+        var lengthSpan = lengthText.WrittenSpan;
+        if (lengthSpan.Length > 1 && lengthSpan[0] == (byte)'0')
+            throw new FormatException("Bencode string length cannot have leading zeroes.");
+
+        var lengthString = Encoding.ASCII.GetString(lengthSpan);
+        if (!int.TryParse(lengthString, CultureInfo.InvariantCulture, out var stringLength) || stringLength < 0)
+            throw new FormatException("Invalid bencode string length.");
+
+        var stringBytes = new byte[stringLength];
+        if (!await TryReadExactlyAsync(stringBytes.AsMemory(), cancellationToken).ConfigureAwait(false))
+            throw new FormatException("Unexpected end of bencode string data.");
+
+        return new BencodeString(stringBytes);
+    }
+
+    private async ValueTask<BencodeList> ParseListAsync(CancellationToken cancellationToken)
+    {
+        Consume(1); // l
+        var result = new BencodeList();
+        while (true)
+        {
+            var token = await PeekByteAsync(cancellationToken).ConfigureAwait(false);
+            if (token is null)
+                throw new FormatException("Unterminated bencode list.");
+
+            if (token == (byte)'e')
+            {
+                Consume(1);
+                return result;
+            }
+
+            result.Add(await ParseValueAsync(cancellationToken).ConfigureAwait(false));
+        }
+    }
+
+    private async ValueTask<BencodeDictionary> ParseDictionaryAsync(CancellationToken cancellationToken)
+    {
+        Consume(1); // d
+        var result = new BencodeDictionary();
+        while (true)
+        {
+            var token = await PeekByteAsync(cancellationToken).ConfigureAwait(false);
+            if (token is null)
+                throw new FormatException("Unterminated bencode dictionary.");
+
+            if (token == (byte)'e')
+            {
+                Consume(1);
+                return result;
+            }
+
+            var keyBytes = await ParseStringAsync(cancellationToken).ConfigureAwait(false);
+            string key;
+            try
+            {
+                key = keyBytes.ToUtf8String();
+            }
+            catch (DecoderFallbackException ex)
+            {
+                throw new FormatException("Bencode dictionary keys must be valid UTF-8 strings.", ex);
+            }
+
+            var value = await ParseValueAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                result.Add(key, value);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new FormatException($"Duplicate bencode dictionary key '{key}'.", ex);
+            }
+        }
+    }
+
+    private async ValueTask EnsureNoTrailingDataAsync(CancellationToken cancellationToken)
+    {
+        var token = await PeekByteAsync(cancellationToken).ConfigureAwait(false);
+        if (token is not null)
+            throw new FormatException("Unexpected trailing data after bencode value.");
+    }
+
+    private async ValueTask<bool> TryReadExactlyAsync(Memory<byte> destination, CancellationToken cancellationToken)
+    {
+        var offset = 0;
+        while (offset < destination.Length)
+        {
+            if (_buffer.IsEmpty)
+            {
+                if (!await ReadMoreAsync(cancellationToken).ConfigureAwait(false))
+                    return false;
+            }
+
+            var bytesToCopy = (int)Math.Min(_buffer.Length, destination.Length - offset);
+            _buffer.Slice(0, bytesToCopy).CopyTo(destination.Span[offset..(offset + bytesToCopy)]);
+            Consume(bytesToCopy);
+            offset += bytesToCopy;
+        }
+
+        return true;
+    }
+
+    private async ValueTask<byte?> TryReadByteAsync(CancellationToken cancellationToken)
+    {
+        var token = await PeekByteAsync(cancellationToken).ConfigureAwait(false);
+        if (token is null)
+            return null;
+
+        Consume(1);
+        return token;
+    }
+
+    private async ValueTask<byte?> PeekByteAsync(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var reader = new SequenceReader<byte>(_buffer);
+            if (reader.TryPeek(out var token))
+                return token;
+
+            if (!await ReadMoreAsync(cancellationToken).ConfigureAwait(false))
+                return null;
+        }
+    }
+
+    private async ValueTask<bool> ReadMoreAsync(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            AdvanceReader();
+
+            var readResult = await _reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            _buffer = readResult.Buffer;
+            _hasPendingReadResult = true;
+
+            if (!_buffer.IsEmpty)
+                return true;
+
+            if (readResult.IsCompleted)
+                return false;
+        }
+    }
+
+    private void Consume(long length)
+    {
+        _buffer = _buffer.Slice(_buffer.GetPosition(length));
+        _position += length;
+    }
+
+    private void AdvanceReader()
+    {
+        if (!_hasPendingReadResult)
+            return;
+
+        _reader.AdvanceTo(_buffer.Start, _buffer.End);
+        _hasPendingReadResult = false;
+    }
+
+    private static void AppendByte(ArrayBufferWriter<byte> writer, byte value)
+    {
+        var span = writer.GetSpan(1);
+        span[0] = value;
+        writer.Advance(1);
+    }
+
+    private static bool IsValidInteger(ReadOnlySpan<byte> value)
+    {
+        if (value.IsEmpty)
+            return false;
+
+        var offset = 0;
+        if (value[0] == (byte)'-')
+        {
+            if (value.Length == 1)
+                return false;
+
+            if (value[1] == (byte)'0')
+                return false;
+
+            offset = 1;
+        }
+        else if (value.Length > 1 && value[0] == (byte)'0')
+        {
+            return false;
+        }
+
+        for (var i = offset; i < value.Length; i++)
+        {
+            if (value[i] is < (byte)'0' or > (byte)'9')
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Meziantou.Framework.Bencode/Meziantou.Framework.Bencode.csproj
+++ b/src/Meziantou.Framework.Bencode/Meziantou.Framework.Bencode.csproj
@@ -2,9 +2,13 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Bencode parser/writer and torrent file model</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.Pipelines" Version="10.0.8" />
+  </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Framework.Bencode/readme.md
+++ b/src/Meziantou.Framework.Bencode/readme.md
@@ -8,10 +8,16 @@
 ## Parse and write bencode data
 
 ```csharp
+using System.IO.Pipelines;
 using Meziantou.Framework.Bencode;
 
 var data = "d3:cow3:moo4:spam4:eggse"u8.ToArray();
 var document = BencodeDocument.Parse(data);
+
+await using var input = File.OpenRead("input.bencode");
+var pipeReader = PipeReader.Create(input);
+var streamedDocument = await BencodeDocument.ParseAsync(pipeReader);
+await pipeReader.CompleteAsync();
 
 var dictionary = (BencodeDictionary)document.Root;
 var cow = (BencodeString)dictionary["cow"];

--- a/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.IO.Pipelines;
 using System.Text;
 
 namespace Meziantou.Framework.Bencode.Tests;
@@ -28,6 +29,38 @@ public sealed class BencodeDocumentTests
         Assert.Equal(2, list.Count);
         Assert.Equal(1, Assert.IsType<BencodeInteger>(list[0]).Value);
         Assert.Equal("abc", Assert.IsType<BencodeString>(list[1]).ToUtf8String());
+    }
+
+    [Fact]
+    public async Task ParseAsync_FromPipeReader()
+    {
+        var pipe = new Pipe();
+        var parseTask = BencodeDocument.ParseAsync(pipe.Reader).AsTask();
+
+        await pipe.Writer.WriteAsync("li1e3:a"u8.ToArray());
+        await pipe.Writer.WriteAsync("bce"u8.ToArray());
+        await pipe.Writer.CompleteAsync();
+
+        var document = await parseTask;
+
+        var list = Assert.IsType<BencodeList>(document.Root);
+        Assert.Equal(2, list.Count);
+        Assert.Equal(1, Assert.IsType<BencodeInteger>(list[0]).Value);
+        Assert.Equal("abc", Assert.IsType<BencodeString>(list[1]).ToUtf8String());
+
+        await pipe.Reader.CompleteAsync();
+    }
+
+    [Fact]
+    public async Task ParseAsync_FromPipeReader_WithTrailingData_Throws()
+    {
+        var pipe = new Pipe();
+        await pipe.Writer.WriteAsync("i1ee"u8.ToArray());
+        await pipe.Writer.CompleteAsync();
+
+        await Assert.ThrowsAsync<FormatException>(() => BencodeDocument.ParseAsync(pipe.Reader).AsTask());
+
+        await pipe.Reader.CompleteAsync();
     }
 
     [Fact]


### PR DESCRIPTION
## Why
`BencodeDocument.ParseAsync(Stream)` was not truly async. It first copied the entire payload into memory, then parsed it. That increases peak memory and removes streaming/backpressure benefits for large bencode inputs.

## What changed
- Added a new public overload: `BencodeDocument.ParseAsync(PipeReader, CancellationToken)`.
- Reworked `BencodeDocument.ParseAsync(Stream, CancellationToken)` to delegate to a `PipeReader` instead of buffering the full stream.
- Added an incremental internal decoder (`BencodePipeReaderDecoder`) that parses values directly from `PipeReader` buffers.
- Kept existing parsing semantics and validation behavior, including integer format rules, UTF-8 dictionary key validation, duplicate-key detection, and trailing-data detection.
- Added `System.IO.Pipelines` package reference to the bencode project.
- Updated bencode docs with a `PipeReader` parsing example.
- Added async tests for fragmented `PipeReader` input and trailing data failure.

## Notes
- Stream parsing keeps existing call sites intact while using the new streaming parser internally.
- Public API reference file was updated for the new overload.