### PR TITLE
Refine bencode dictionary and UTF-8 writer APIs

### DIFF
--- a/ref/Meziantou.Framework.Bencode.cs
+++ b/ref/Meziantou.Framework.Bencode.cs
@@ -4,19 +4,19 @@
 
 namespace Meziantou.Framework.Bencode
 {
-    public sealed class BencodeDictionary : Meziantou.Framework.Bencode.BencodeValue, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Meziantou.Framework.Bencode.BencodeValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, Meziantou.Framework.Bencode.BencodeValue>>, System.Collections.Generic.IReadOnlyDictionary<string, Meziantou.Framework.Bencode.BencodeValue>, System.Collections.IEnumerable
+    public sealed class BencodeDictionary : Meziantou.Framework.Bencode.BencodeValue, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<Meziantou.Framework.Bencode.BencodeString, Meziantou.Framework.Bencode.BencodeValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<Meziantou.Framework.Bencode.BencodeString, Meziantou.Framework.Bencode.BencodeValue>>, System.Collections.Generic.IReadOnlyDictionary<Meziantou.Framework.Bencode.BencodeString, Meziantou.Framework.Bencode.BencodeValue>, System.Collections.IEnumerable
     {
         public Meziantou.Framework.Bencode.BencodeValueKind Kind { get => throw null; }
         public int Count { get => throw null; }
-        public System.Collections.Generic.IEnumerable<string> Keys { get => throw null; }
+        public System.Collections.Generic.IEnumerable<Meziantou.Framework.Bencode.BencodeString> Keys { get => throw null; }
         public System.Collections.Generic.IEnumerable<Meziantou.Framework.Bencode.BencodeValue> Values { get => throw null; }
-        public Meziantou.Framework.Bencode.BencodeValue this[string key] { get => throw null; }
-        public BencodeDictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Meziantou.Framework.Bencode.BencodeValue>> entries) { }
-        public void Add(string key, Meziantou.Framework.Bencode.BencodeValue value) { }
-        public bool ContainsKey(string key) => throw null;
-        public bool TryGetValue(string key, out Meziantou.Framework.Bencode.BencodeValue value) => throw null;
+        public Meziantou.Framework.Bencode.BencodeValue this[Meziantou.Framework.Bencode.BencodeString key] { get => throw null; }
+        public BencodeDictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<Meziantou.Framework.Bencode.BencodeString, Meziantou.Framework.Bencode.BencodeValue>> entries) { }
+        public void Add(Meziantou.Framework.Bencode.BencodeString key, Meziantou.Framework.Bencode.BencodeValue value) { }
+        public bool ContainsKey(Meziantou.Framework.Bencode.BencodeString key) => throw null;
+        public bool TryGetValue(Meziantou.Framework.Bencode.BencodeString key, out Meziantou.Framework.Bencode.BencodeValue value) => throw null;
         public override void WriteTo(Meziantou.Framework.Bencode.BencodeWriter writer, bool canonical) { }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, Meziantou.Framework.Bencode.BencodeValue>> GetEnumerator() => throw null;
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<Meziantou.Framework.Bencode.BencodeString, Meziantou.Framework.Bencode.BencodeValue>> GetEnumerator() => throw null;
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
     }
 
@@ -31,11 +31,15 @@ namespace Meziantou.Framework.Bencode
         public System.Threading.Tasks.ValueTask WriteToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = null) => throw null;
     }
 
-    public sealed class BencodeInteger : Meziantou.Framework.Bencode.BencodeValue
+    public sealed class BencodeInteger : Meziantou.Framework.Bencode.BencodeValue, System.IEquatable<Meziantou.Framework.Bencode.BencodeInteger>
     {
         public Meziantou.Framework.Bencode.BencodeValueKind Kind { get => throw null; }
         public long Value { get => throw null; }
         public BencodeInteger(long value) { }
+        public bool Equals(Meziantou.Framework.Bencode.BencodeInteger? other) => throw null;
+        public override bool Equals(object? obj) => throw null;
+        public override int GetHashCode() => throw null;
+        public override string ToString() => throw null;
         public override void WriteTo(Meziantou.Framework.Bencode.BencodeWriter writer, bool canonical) { }
     }
 
@@ -51,12 +55,15 @@ namespace Meziantou.Framework.Bencode
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
     }
 
-    public sealed class BencodeString : Meziantou.Framework.Bencode.BencodeValue
+    public sealed class BencodeString : Meziantou.Framework.Bencode.BencodeValue, System.IEquatable<Meziantou.Framework.Bencode.BencodeString>
     {
         public Meziantou.Framework.Bencode.BencodeValueKind Kind { get => throw null; }
         public System.ReadOnlyMemory<byte> Value { get => throw null; }
         public BencodeString(System.ReadOnlyMemory<byte> value) { }
         public string ToUtf8String() => throw null;
+        public bool Equals(Meziantou.Framework.Bencode.BencodeString? other) => throw null;
+        public override bool Equals(object? obj) => throw null;
+        public override int GetHashCode() => throw null;
         public override void WriteTo(Meziantou.Framework.Bencode.BencodeWriter writer, bool canonical) { }
         public override string ToString() => throw null;
     }
@@ -87,11 +94,12 @@ namespace Meziantou.Framework.Bencode
         public void WriteInteger(long value) { }
         public void WriteString(System.ReadOnlyMemory<byte> value) { }
         public void WriteString(System.ReadOnlySpan<byte> value) { }
-        public void WriteString(string value) { }
+        public void WriteUtf8String(string value) { }
         public void WriteStartList() { }
         public void WriteEndList() { }
         public void WriteStartDictionary() { }
-        public void WriteKey(string key) { }
+        public void WriteUtf8Key(string key) { }
+        public void WriteKey(System.ReadOnlySpan<byte> key) { }
         public void WriteEndDictionary() { }
         public void Complete() { }
     }

--- a/src/Meziantou.Framework.Bencode/BencodeDecoder.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeDecoder.cs
@@ -115,17 +115,7 @@ internal static class BencodeDecoder
                 return result;
             }
 
-            var keyBytes = ParseString(data, ref index);
-            string key;
-            try
-            {
-                key = keyBytes.ToUtf8String();
-            }
-            catch (DecoderFallbackException ex)
-            {
-                throw new FormatException("Bencode dictionary keys must be valid UTF-8 strings.", ex);
-            }
-
+            var key = ParseString(data, ref index);
             var value = ParseValue(data, ref index);
             try
             {
@@ -133,7 +123,7 @@ internal static class BencodeDecoder
             }
             catch (ArgumentException ex)
             {
-                throw new FormatException($"Duplicate bencode dictionary key '{key}'.", ex);
+                throw new FormatException("Duplicate bencode dictionary key.", ex);
             }
         }
     }

--- a/src/Meziantou.Framework.Bencode/BencodeDictionary.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeDictionary.cs
@@ -1,18 +1,17 @@
 using System.Collections;
-using System.Text;
 
 namespace Meziantou.Framework.Bencode;
 
-public sealed class BencodeDictionary : BencodeValue, IReadOnlyDictionary<string, BencodeValue>
+public sealed class BencodeDictionary : BencodeValue, IReadOnlyDictionary<BencodeString, BencodeValue>
 {
-    private readonly List<KeyValuePair<string, BencodeValue>> _entries = [];
-    private readonly Dictionary<string, BencodeValue> _lookup = new(StringComparer.Ordinal);
+    private readonly List<KeyValuePair<BencodeString, BencodeValue>> _entries = [];
+    private readonly Dictionary<BencodeString, BencodeValue> _lookup = [];
 
     public BencodeDictionary()
     {
     }
 
-    public BencodeDictionary(IEnumerable<KeyValuePair<string, BencodeValue>> entries)
+    public BencodeDictionary(IEnumerable<KeyValuePair<BencodeString, BencodeValue>> entries)
     {
         ArgumentNullException.ThrowIfNull(entries);
 
@@ -26,31 +25,42 @@ public sealed class BencodeDictionary : BencodeValue, IReadOnlyDictionary<string
 
     public int Count => _entries.Count;
 
-    public IEnumerable<string> Keys => _entries.Select(entry => entry.Key);
+    public IEnumerable<BencodeString> Keys => _entries.Select(entry => entry.Key);
 
     public IEnumerable<BencodeValue> Values => _entries.Select(entry => entry.Value);
 
-    public BencodeValue this[string key] => _lookup[key];
+    public BencodeValue this[BencodeString key]
+    {
+        get
+        {
+            ArgumentNullException.ThrowIfNull(key);
+            return _lookup[key];
+        }
+    }
 
-    public void Add(string key, BencodeValue value)
+    public void Add(BencodeString key, BencodeValue value)
     {
         ArgumentNullException.ThrowIfNull(key);
         ArgumentNullException.ThrowIfNull(value);
 
-        if (_lookup.ContainsKey(key))
-            throw new ArgumentException($"An entry with key '{key}' already exists.", nameof(key));
+        var normalizedKey = new BencodeString(key.Value.ToArray());
 
-        _lookup.Add(key, value);
-        _entries.Add(new KeyValuePair<string, BencodeValue>(key, value));
+        if (_lookup.ContainsKey(normalizedKey))
+            throw new ArgumentException("An entry with the same key already exists.", nameof(key));
+
+        _lookup.Add(normalizedKey, value);
+        _entries.Add(new KeyValuePair<BencodeString, BencodeValue>(normalizedKey, value));
     }
 
-    public bool ContainsKey(string key)
+    public bool ContainsKey(BencodeString key)
     {
+        ArgumentNullException.ThrowIfNull(key);
         return _lookup.ContainsKey(key);
     }
 
-    public bool TryGetValue(string key, out BencodeValue value)
+    public bool TryGetValue(BencodeString key, out BencodeValue value)
     {
+        ArgumentNullException.ThrowIfNull(key);
         return _lookup.TryGetValue(key, out value!);
     }
 
@@ -61,31 +71,29 @@ public sealed class BencodeDictionary : BencodeValue, IReadOnlyDictionary<string
         writer.WriteStartDictionary();
         foreach (var entry in GetEntries(canonical))
         {
-            writer.WriteKey(entry.Key);
+            writer.WriteKey(entry.Key.Value.Span);
             entry.Value.WriteTo(writer, canonical);
         }
 
         writer.WriteEndDictionary();
     }
 
-    public IEnumerator<KeyValuePair<string, BencodeValue>> GetEnumerator() => _entries.GetEnumerator();
+    public IEnumerator<KeyValuePair<BencodeString, BencodeValue>> GetEnumerator() => _entries.GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    private IEnumerable<KeyValuePair<string, BencodeValue>> GetEntries(bool canonical)
+    private IEnumerable<KeyValuePair<BencodeString, BencodeValue>> GetEntries(bool canonical)
     {
         if (!canonical)
             return _entries;
 
         var entries = _entries.ToArray();
-        Array.Sort(entries, CompareByUtf8Key);
+        Array.Sort(entries, CompareByKeyBytes);
         return entries;
     }
 
-    private static int CompareByUtf8Key(KeyValuePair<string, BencodeValue> left, KeyValuePair<string, BencodeValue> right)
+    private static int CompareByKeyBytes(KeyValuePair<BencodeString, BencodeValue> left, KeyValuePair<BencodeString, BencodeValue> right)
     {
-        var leftBytes = Encoding.UTF8.GetBytes(left.Key);
-        var rightBytes = Encoding.UTF8.GetBytes(right.Key);
-        return leftBytes.AsSpan().SequenceCompareTo(rightBytes);
+        return left.Key.Value.Span.SequenceCompareTo(right.Key.Value.Span);
     }
 }

--- a/src/Meziantou.Framework.Bencode/BencodeInteger.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeInteger.cs
@@ -1,6 +1,8 @@
+using System.Globalization;
+
 namespace Meziantou.Framework.Bencode;
 
-public sealed class BencodeInteger : BencodeValue
+public sealed class BencodeInteger : BencodeValue, IEquatable<BencodeInteger>
 {
     public BencodeInteger(long value)
     {
@@ -10,6 +12,14 @@ public sealed class BencodeInteger : BencodeValue
     public override BencodeValueKind Kind => BencodeValueKind.Integer;
 
     public long Value { get; }
+
+    public bool Equals(BencodeInteger? other) => other is not null && Value == other.Value;
+
+    public override bool Equals(object? obj) => obj is BencodeInteger other && Equals(other);
+
+    public override int GetHashCode() => Value.GetHashCode();
+
+    public override string ToString() => Value.ToString(CultureInfo.InvariantCulture);
 
     public override void WriteTo(BencodeWriter writer, bool canonical)
     {

--- a/src/Meziantou.Framework.Bencode/BencodePipeReaderDecoder.cs
+++ b/src/Meziantou.Framework.Bencode/BencodePipeReaderDecoder.cs
@@ -150,17 +150,7 @@ internal sealed class BencodePipeReaderDecoder
                 return result;
             }
 
-            var keyBytes = await ParseStringAsync(cancellationToken).ConfigureAwait(false);
-            string key;
-            try
-            {
-                key = keyBytes.ToUtf8String();
-            }
-            catch (DecoderFallbackException ex)
-            {
-                throw new FormatException("Bencode dictionary keys must be valid UTF-8 strings.", ex);
-            }
-
+            var key = await ParseStringAsync(cancellationToken).ConfigureAwait(false);
             var value = await ParseValueAsync(cancellationToken).ConfigureAwait(false);
             try
             {
@@ -168,7 +158,7 @@ internal sealed class BencodePipeReaderDecoder
             }
             catch (ArgumentException ex)
             {
-                throw new FormatException($"Duplicate bencode dictionary key '{key}'.", ex);
+                throw new FormatException("Duplicate bencode dictionary key.", ex);
             }
         }
     }

--- a/src/Meziantou.Framework.Bencode/BencodeString.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeString.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.Framework.Bencode;
 
-public sealed class BencodeString : BencodeValue
+public sealed class BencodeString : BencodeValue, IEquatable<BencodeString>
 {
     private static readonly Encoding Utf8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
@@ -16,6 +16,27 @@ public sealed class BencodeString : BencodeValue
     public string ToUtf8String()
     {
         return Utf8Encoding.GetString(Value.Span);
+    }
+
+    public bool Equals(BencodeString? other)
+    {
+        if (other is null)
+            return false;
+
+        return Value.Span.SequenceEqual(other.Value.Span);
+    }
+
+    public override bool Equals(object? obj) => obj is BencodeString other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var item in Value.Span)
+        {
+            hash.Add(item);
+        }
+
+        return hash.ToHashCode();
     }
 
     public override void WriteTo(BencodeWriter writer, bool canonical)

--- a/src/Meziantou.Framework.Bencode/BencodeValueExtensions.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeValueExtensions.cs
@@ -7,7 +7,7 @@ public static class BencodeValueExtensions
     /// <summary>Encodes a bencode value to a UTF-8 byte array.</summary>
     /// <param name="value">The value to encode.</param>
     /// <param name="canonical">
-    /// <see langword="true"/> to sort dictionary keys by their UTF-8 byte order (canonical bencode);
+    /// <see langword="true"/> to sort dictionary keys by their byte order (canonical bencode);
     /// <see langword="false"/> to keep dictionary insertion order.
     /// </param>
     /// <remarks>

--- a/src/Meziantou.Framework.Bencode/BencodeWriter.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeWriter.cs
@@ -45,7 +45,7 @@ public sealed class BencodeWriter
         }
     }
 
-    public void WriteString(string value)
+    public void WriteUtf8String(string value)
     {
         ArgumentNullException.ThrowIfNull(value);
         WriteString(Encoding.UTF8.GetBytes(value));
@@ -72,10 +72,14 @@ public sealed class BencodeWriter
         _containers.Add(new ContainerState(ContainerKind.Dictionary, ExpectingDictionaryKey: true));
     }
 
-    public void WriteKey(string key)
+    public void WriteUtf8Key(string key)
     {
         ArgumentNullException.ThrowIfNull(key);
+        WriteKey(Encoding.UTF8.GetBytes(key));
+    }
 
+    public void WriteKey(ReadOnlySpan<byte> key)
+    {
         var state = GetCurrentContainer();
         if (state.Kind != ContainerKind.Dictionary)
             throw new InvalidOperationException("Dictionary keys can only be written while inside a dictionary.");
@@ -83,7 +87,7 @@ public sealed class BencodeWriter
         if (!state.ExpectingDictionaryKey)
             throw new InvalidOperationException("Cannot write a dictionary key while expecting a value.");
 
-        WriteStringCore(Encoding.UTF8.GetBytes(key));
+        WriteStringCore(key);
         _containers[^1] = state with { ExpectingDictionaryKey = false };
     }
 

--- a/src/Meziantou.Framework.Bencode/Meziantou.Framework.Bencode.csproj
+++ b/src/Meziantou.Framework.Bencode/Meziantou.Framework.Bencode.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Bencode parser/writer and torrent file model</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentFile.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentFile.cs
@@ -4,6 +4,13 @@ namespace Meziantou.Framework.Bencode.Torrent;
 
 public sealed class TorrentFile
 {
+    private static readonly BencodeString InfoKey = CreateKey("info");
+    private static readonly BencodeString AnnounceKey = CreateKey("announce");
+    private static readonly BencodeString AnnounceListKey = CreateKey("announce-list");
+    private static readonly BencodeString CommentKey = CreateKey("comment");
+    private static readonly BencodeString CreatedByKey = CreateKey("created by");
+    private static readonly BencodeString CreationDateKey = CreateKey("creation date");
+
     public string? Announce { get; set; }
 
     public IReadOnlyList<IReadOnlyList<string>>? AnnounceList { get; set; }
@@ -76,7 +83,7 @@ public sealed class TorrentFile
         if (root is not BencodeDictionary dictionary)
             throw new FormatException("Torrent metainfo root must be a bencode dictionary.");
 
-        if (!dictionary.TryGetValue("info", out var infoValue) || infoValue is not BencodeDictionary infoDictionary)
+        if (!dictionary.TryGetValue(InfoKey, out var infoValue) || infoValue is not BencodeDictionary infoDictionary)
             throw new FormatException("Torrent metainfo must contain an 'info' dictionary.");
 
         var result = new TorrentFile
@@ -84,7 +91,7 @@ public sealed class TorrentFile
             Info = TorrentInfo.Parse(infoDictionary),
         };
 
-        if (dictionary.TryGetValue("announce", out var announceValue))
+        if (dictionary.TryGetValue(AnnounceKey, out var announceValue))
         {
             if (announceValue is not BencodeString announceText)
                 throw new FormatException("The 'announce' field must be a string.");
@@ -92,7 +99,7 @@ public sealed class TorrentFile
             result.Announce = announceText.ToUtf8String();
         }
 
-        if (dictionary.TryGetValue("announce-list", out var announceListValue))
+        if (dictionary.TryGetValue(AnnounceListKey, out var announceListValue))
         {
             if (announceListValue is not BencodeList announceTiers)
                 throw new FormatException("The 'announce-list' field must be a list.");
@@ -118,7 +125,7 @@ public sealed class TorrentFile
             result.AnnounceList = tiers;
         }
 
-        if (dictionary.TryGetValue("comment", out var commentValue))
+        if (dictionary.TryGetValue(CommentKey, out var commentValue))
         {
             if (commentValue is not BencodeString commentText)
                 throw new FormatException("The 'comment' field must be a string.");
@@ -126,7 +133,7 @@ public sealed class TorrentFile
             result.Comment = commentText.ToUtf8String();
         }
 
-        if (dictionary.TryGetValue("created by", out var createdByValue))
+        if (dictionary.TryGetValue(CreatedByKey, out var createdByValue))
         {
             if (createdByValue is not BencodeString createdByText)
                 throw new FormatException("The 'created by' field must be a string.");
@@ -134,7 +141,7 @@ public sealed class TorrentFile
             result.CreatedBy = createdByText.ToUtf8String();
         }
 
-        if (dictionary.TryGetValue("creation date", out var creationDateValue))
+        if (dictionary.TryGetValue(CreationDateKey, out var creationDateValue))
         {
             if (creationDateValue is not BencodeInteger creationDateInteger)
                 throw new FormatException("The 'creation date' field must be an integer.");
@@ -159,12 +166,12 @@ public sealed class TorrentFile
 
         var dictionary = new BencodeDictionary
         {
-            { "info", Info.ToBencodeDictionary() },
+            { InfoKey, Info.ToBencodeDictionary() },
         };
 
         if (Announce is not null)
         {
-            dictionary.Add("announce", new BencodeString(Encoding.UTF8.GetBytes(Announce)));
+            dictionary.Add(AnnounceKey, new BencodeString(Encoding.UTF8.GetBytes(Announce)));
         }
 
         if (AnnounceList is not null)
@@ -187,24 +194,26 @@ public sealed class TorrentFile
                 tiers.Add(tierValues);
             }
 
-            dictionary.Add("announce-list", tiers);
+            dictionary.Add(AnnounceListKey, tiers);
         }
 
         if (Comment is not null)
         {
-            dictionary.Add("comment", new BencodeString(Encoding.UTF8.GetBytes(Comment)));
+            dictionary.Add(CommentKey, new BencodeString(Encoding.UTF8.GetBytes(Comment)));
         }
 
         if (CreatedBy is not null)
         {
-            dictionary.Add("created by", new BencodeString(Encoding.UTF8.GetBytes(CreatedBy)));
+            dictionary.Add(CreatedByKey, new BencodeString(Encoding.UTF8.GetBytes(CreatedBy)));
         }
 
         if (CreationDate.HasValue)
         {
-            dictionary.Add("creation date", new BencodeInteger(CreationDate.Value.ToUnixTimeSeconds()));
+            dictionary.Add(CreationDateKey, new BencodeInteger(CreationDate.Value.ToUnixTimeSeconds()));
         }
 
         return dictionary;
     }
+
+    private static BencodeString CreateKey(string value) => new(Encoding.UTF8.GetBytes(value));
 }

--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentInfo.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentInfo.cs
@@ -2,6 +2,14 @@ namespace Meziantou.Framework.Bencode.Torrent;
 
 public sealed class TorrentInfo
 {
+    private static readonly BencodeString NameKey = CreateKey("name");
+    private static readonly BencodeString PieceLengthKey = CreateKey("piece length");
+    private static readonly BencodeString PiecesKey = CreateKey("pieces");
+    private static readonly BencodeString PrivateKey = CreateKey("private");
+    private static readonly BencodeString LengthKey = CreateKey("length");
+    private static readonly BencodeString FilesKey = CreateKey("files");
+    private static readonly BencodeString PathKey = CreateKey("path");
+
     public string Name { get; set; } = "";
 
     public long PieceLength { get; set; }
@@ -18,9 +26,9 @@ public sealed class TorrentInfo
     {
         ArgumentNullException.ThrowIfNull(dictionary);
 
-        var name = GetRequiredString(dictionary, "name");
-        var pieceLength = GetRequiredInteger(dictionary, "piece length");
-        var pieces = GetRequiredByteString(dictionary, "pieces").Value;
+        var name = GetRequiredString(dictionary, NameKey, "name");
+        var pieceLength = GetRequiredInteger(dictionary, PieceLengthKey, "piece length");
+        var pieces = GetRequiredByteString(dictionary, PiecesKey, "pieces").Value;
 
         var info = new TorrentInfo
         {
@@ -29,7 +37,7 @@ public sealed class TorrentInfo
             Pieces = pieces,
         };
 
-        if (dictionary.TryGetValue("private", out var privateValue))
+        if (dictionary.TryGetValue(PrivateKey, out var privateValue))
         {
             if (privateValue is not BencodeInteger privateInteger)
                 throw new FormatException("The 'private' field must be an integer.");
@@ -37,7 +45,7 @@ public sealed class TorrentInfo
             info.IsPrivate = privateInteger.Value != 0;
         }
 
-        if (dictionary.TryGetValue("length", out var lengthValue))
+        if (dictionary.TryGetValue(LengthKey, out var lengthValue))
         {
             if (lengthValue is not BencodeInteger lengthInteger)
                 throw new FormatException("The 'length' field must be an integer.");
@@ -45,7 +53,7 @@ public sealed class TorrentInfo
             info.Length = lengthInteger.Value;
         }
 
-        if (dictionary.TryGetValue("files", out var filesValue))
+        if (dictionary.TryGetValue(FilesKey, out var filesValue))
         {
             if (filesValue is not BencodeList filesList)
                 throw new FormatException("The 'files' field must be a list.");
@@ -56,8 +64,8 @@ public sealed class TorrentInfo
                 if (fileValue is not BencodeDictionary fileDictionary)
                     throw new FormatException("Each torrent file entry must be a dictionary.");
 
-                var fileLength = GetRequiredInteger(fileDictionary, "length");
-                if (!fileDictionary.TryGetValue("path", out var pathValue) || pathValue is not BencodeList pathList)
+                var fileLength = GetRequiredInteger(fileDictionary, LengthKey, "length");
+                if (!fileDictionary.TryGetValue(PathKey, out var pathValue) || pathValue is not BencodeList pathList)
                     throw new FormatException("Each torrent file entry must contain a 'path' list.");
 
                 var path = new List<string>();
@@ -89,19 +97,19 @@ public sealed class TorrentInfo
 
         var dictionary = new BencodeDictionary
         {
-            { "name", new BencodeString(Encoding.UTF8.GetBytes(Name)) },
-            { "piece length", new BencodeInteger(PieceLength) },
-            { "pieces", new BencodeString(Pieces.ToArray()) },
+            { NameKey, new BencodeString(Encoding.UTF8.GetBytes(Name)) },
+            { PieceLengthKey, new BencodeInteger(PieceLength) },
+            { PiecesKey, new BencodeString(Pieces.ToArray()) },
         };
 
         if (IsPrivate)
         {
-            dictionary.Add("private", new BencodeInteger(1));
+            dictionary.Add(PrivateKey, new BencodeInteger(1));
         }
 
         if (Length.HasValue)
         {
-            dictionary.Add("length", new BencodeInteger(Length.Value));
+            dictionary.Add(LengthKey, new BencodeInteger(Length.Value));
         }
         else if (Files is not null)
         {
@@ -114,12 +122,12 @@ public sealed class TorrentInfo
                 var path = new BencodeList(file.Path.Select(segment => (BencodeValue)new BencodeString(Encoding.UTF8.GetBytes(segment))));
                 files.Add(new BencodeDictionary
                 {
-                    { "length", new BencodeInteger(file.Length) },
-                    { "path", path },
+                    { LengthKey, new BencodeInteger(file.Length) },
+                    { PathKey, path },
                 });
             }
 
-            dictionary.Add("files", files);
+            dictionary.Add(FilesKey, files);
         }
 
         return dictionary;
@@ -172,27 +180,29 @@ public sealed class TorrentInfo
         }
     }
 
-    private static long GetRequiredInteger(BencodeDictionary dictionary, string key)
+    private static long GetRequiredInteger(BencodeDictionary dictionary, BencodeString key, string fieldName)
     {
         if (!dictionary.TryGetValue(key, out var value) || value is not BencodeInteger integer)
-            throw new FormatException($"The required '{key}' field is missing or not an integer.");
+            throw new FormatException($"The required '{fieldName}' field is missing or not an integer.");
 
         return integer.Value;
     }
 
-    private static string GetRequiredString(BencodeDictionary dictionary, string key)
+    private static string GetRequiredString(BencodeDictionary dictionary, BencodeString key, string fieldName)
     {
         if (!dictionary.TryGetValue(key, out var value) || value is not BencodeString text)
-            throw new FormatException($"The required '{key}' field is missing or not a string.");
+            throw new FormatException($"The required '{fieldName}' field is missing or not a string.");
 
         return text.ToUtf8String();
     }
 
-    private static BencodeString GetRequiredByteString(BencodeDictionary dictionary, string key)
+    private static BencodeString GetRequiredByteString(BencodeDictionary dictionary, BencodeString key, string fieldName)
     {
         if (!dictionary.TryGetValue(key, out var value) || value is not BencodeString text)
-            throw new FormatException($"The required '{key}' field is missing or not a string.");
+            throw new FormatException($"The required '{fieldName}' field is missing or not a string.");
 
         return text;
     }
+
+    private static BencodeString CreateKey(string value) => new(Encoding.UTF8.GetBytes(value));
 }

--- a/src/Meziantou.Framework.Bencode/readme.md
+++ b/src/Meziantou.Framework.Bencode/readme.md
@@ -20,7 +20,7 @@ var streamedDocument = await BencodeDocument.ParseAsync(pipeReader);
 await pipeReader.CompleteAsync();
 
 var dictionary = (BencodeDictionary)document.Root;
-var cow = (BencodeString)dictionary["cow"];
+var cow = (BencodeString)dictionary[new BencodeString("cow"u8.ToArray())];
 Console.WriteLine(cow.ToUtf8String()); // moo
 
 var encoded = dictionary.ToArray();
@@ -39,8 +39,8 @@ var buffer = new ArrayBufferWriter<byte>();
 var writer = new BencodeWriter(buffer);
 
 writer.WriteStartDictionary();
-writer.WriteKey("cow");
-writer.WriteString("moo");
+writer.WriteUtf8Key("cow");
+writer.WriteUtf8String("moo");
 writer.WriteEndDictionary();
 writer.Complete();
 

--- a/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
@@ -14,8 +14,20 @@ public sealed class BencodeDocumentTests
         var document = BencodeDocument.Parse(data);
 
         var dictionary = Assert.IsType<BencodeDictionary>(document.Root);
-        Assert.Equal("moo", Assert.IsType<BencodeString>(dictionary["cow"]).ToUtf8String());
-        Assert.Equal("eggs", Assert.IsType<BencodeString>(dictionary["spam"]).ToUtf8String());
+        Assert.Equal("moo", Assert.IsType<BencodeString>(dictionary[Utf8Key("cow")]).ToUtf8String());
+        Assert.Equal("eggs", Assert.IsType<BencodeString>(dictionary[Utf8Key("spam")]).ToUtf8String());
+    }
+
+    [Fact]
+    public void Parse_Dictionary_WithNonUtf8Key()
+    {
+        var data = new byte[] { (byte)'d', (byte)'1', (byte)':', 0xFF, (byte)'3', (byte)':', (byte)'a', (byte)'b', (byte)'c', (byte)'e' };
+
+        var document = BencodeDocument.Parse(data);
+
+        var dictionary = Assert.IsType<BencodeDictionary>(document.Root);
+        Assert.True(dictionary.TryGetValue(new BencodeString(new byte[] { 0xFF }), out var value));
+        Assert.Equal("abc", Assert.IsType<BencodeString>(value).ToUtf8String());
     }
 
     [Fact]
@@ -80,8 +92,8 @@ public sealed class BencodeDocumentTests
     {
         var value = new BencodeDictionary
         {
-            { "b", new BencodeInteger(1) },
-            { "a", new BencodeInteger(2) },
+            { Utf8Key("b"), new BencodeInteger(1) },
+            { Utf8Key("a"), new BencodeInteger(2) },
         };
 
         var document = new BencodeDocument(value);
@@ -95,8 +107,8 @@ public sealed class BencodeDocumentTests
     {
         BencodeValue value = new BencodeDictionary
         {
-            { "b", new BencodeInteger(1) },
-            { "a", new BencodeInteger(2) },
+            { Utf8Key("b"), new BencodeInteger(1) },
+            { Utf8Key("a"), new BencodeInteger(2) },
         };
 
         var content = Encoding.ASCII.GetString(value.ToUtf8ByteArray(canonical: false));
@@ -124,18 +136,62 @@ public sealed class BencodeDocumentTests
     }
 
     [Fact]
+    public void BencodeInteger_ImplementsValueEqualityAndToString()
+    {
+        var left = new BencodeInteger(42);
+        var equal = new BencodeInteger(42);
+        var different = new BencodeInteger(-1);
+
+        Assert.True(left.Equals(equal));
+        Assert.True(left.Equals((object)equal));
+        Assert.False(left.Equals(different));
+        Assert.Equal(left.GetHashCode(), equal.GetHashCode());
+        Assert.Equal("42", left.ToString());
+        Assert.Equal("-1", different.ToString());
+    }
+
+    [Fact]
     public void BencodeWriter_WriteDictionary()
     {
         var buffer = new ArrayBufferWriter<byte>();
         var writer = new BencodeWriter(buffer);
 
         writer.WriteStartDictionary();
-        writer.WriteKey("cow");
-        writer.WriteString("moo");
-        writer.WriteKey("spam");
+        writer.WriteUtf8Key("cow");
+        writer.WriteUtf8String("moo");
+        writer.WriteUtf8Key("spam");
         writer.WriteStartList();
         writer.WriteInteger(1);
-        writer.WriteString("abc");
+        writer.WriteUtf8String("abc");
+        writer.WriteEndList();
+        writer.WriteEndDictionary();
+        writer.Complete();
+
+        Assert.Equal("d3:cow3:moo4:spamli1e3:abcee", Encoding.ASCII.GetString(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void BencodeDictionary_DuplicateBinaryKey_Throws()
+    {
+        var dictionary = new BencodeDictionary();
+        dictionary.Add(new BencodeString(new byte[] { 0xFF }), new BencodeInteger(1));
+
+        Assert.Throws<ArgumentException>(() => dictionary.Add(new BencodeString(new byte[] { 0xFF }), new BencodeInteger(2)));
+    }
+
+    [Fact]
+    public void BencodeWriter_WriteDictionary_UsingSpanKeysAndValues()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new BencodeWriter(buffer);
+
+        writer.WriteStartDictionary();
+        writer.WriteKey("cow"u8);
+        writer.WriteString("moo"u8);
+        writer.WriteKey("spam"u8);
+        writer.WriteStartList();
+        writer.WriteInteger(1);
+        writer.WriteString("abc"u8);
         writer.WriteEndList();
         writer.WriteEndDictionary();
         writer.Complete();
@@ -157,7 +213,7 @@ public sealed class BencodeDocumentTests
     {
         var writer = new BencodeWriter(new ArrayBufferWriter<byte>());
         writer.WriteStartDictionary();
-        writer.WriteKey("a");
+        writer.WriteUtf8Key("a");
 
         Assert.Throws<InvalidOperationException>(() => writer.WriteEndDictionary());
     }
@@ -189,4 +245,6 @@ public sealed class BencodeDocumentTests
         Assert.Null(typeof(BencodeValue).GetMethod(nameof(BencodeValueExtensions.ToUtf8ByteArray), [typeof(bool)]));
         Assert.Null(typeof(BencodeValue).GetMethod(nameof(BencodeValueExtensions.WriteToAsync), [typeof(Stream), typeof(bool), typeof(CancellationToken)]));
     }
+
+    private static BencodeString Utf8Key(string value) => new(Encoding.UTF8.GetBytes(value));
 }


### PR DESCRIPTION
This updates the bencode DOM/writer API so dictionary keys are byte-accurate and string-specific writer methods are explicit about UTF-8 behavior. The goal is to better represent bencode's binary model while keeping common text workflows clear.

## What changed
- Switched `BencodeDictionary` from `string` keys to `BencodeString` keys.
- Updated dictionary comparison/sorting and lookup logic to use key bytes.
- Updated decoders to preserve raw dictionary key bytes instead of forcing UTF-8 conversion.
- Added value-based equality for `BencodeString` and `BencodeInteger` (`IEquatable`, `Equals`, `GetHashCode`).
- Added `BencodeInteger.ToString()` override.
- Renamed string writer overloads for clarity:
  - `WriteKey(string)` -> `WriteUtf8Key(string)`
  - `WriteString(string)` -> `WriteUtf8String(string)`
- Updated torrent mapping code, tests, readme examples, and generated public API reference.

## Notes for reviewers
- This is intentionally breaking for consumers using `BencodeDictionary` string-key APIs or old writer string overload names.
- Span/memory writer overloads remain available for byte-oriented usage.
- Additional tests were added for non-UTF8 dictionary keys and value-equality behavior.