### PR TITLE
Remove NodaTime dependency from serializer tests

### DIFF
--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/Meziantou.Framework.HumanReadableSerializer.Tests.csproj
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/Meziantou.Framework.HumanReadableSerializer.Tests.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NodaTime" Version="3.3.2" />
     <PackageReference Include="System.Net.Http.Json" Version="10.0.8" />
   </ItemGroup>
 

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -20,7 +20,6 @@ using System.Numerics;
 using System.Reflection;
 using System.Xml;
 using Meziantou.Framework.HumanReadableSerializer.FSharp.Tests;
-using NodaTime;
 using Meziantou.Xunit;
 
 namespace Meziantou.Framework.HumanReadable.Tests;
@@ -1447,53 +1446,6 @@ public sealed partial class SerializerTests : SerializerTestsBase
             Headers:
               Expires: Fri, 03 Feb 2023 04:05:06 GMT
             Value: AQIDBAUGBwgJ
-            """);
-    }
-
-    [Fact]
-    public void NodaTime_Instant()
-    {
-        AssertSerialization(Instant.FromDateTimeUtc(new DateTime(2023, 1, 2, 3, 4, 5, DateTimeKind.Utc)), """
-            2023-01-02T03:04:05Z
-            """);
-    }
-
-    [Fact]
-    public void NodaTime_LocalDateTime()
-    {
-        AssertSerialization(new LocalDateTime(2012, 3, 27, 0, 45, 00), """
-            2012-03-27T00:45:00
-            """);
-    }
-
-    [Fact]
-    public void NodaTime_Duration()
-    {
-        AssertSerialization(Duration.FromMinutes(3), """
-            0:00:03:00
-            """);
-    }
-
-    [Fact]
-    public void NodaTime_DateTimeZone()
-    {
-        var london = DateTimeZoneProviders.Tzdb["Europe/London"];
-
-        AssertSerialization(london, """
-            Id: Europe/London
-            MinOffset: -00:01:15
-            MaxOffset: +02
-            """);
-    }
-
-    [Fact]
-    public void NodaTime_ZonedDateTime()
-    {
-        var instant = Instant.FromDateTimeUtc(new DateTime(2023, 1, 2, 3, 4, 5, DateTimeKind.Utc));
-        var value = instant.InUtc();
-
-        AssertSerialization(value, """
-            2023-01-02T03:04:05 UTC (+00)
             """);
     }
 


### PR DESCRIPTION
## Why
The HumanReadableSerializer test project still depended on NodaTime only to run a small set of NodaTime-specific test cases. Removing this dependency simplifies the test project and aligns with dropping NodaTime coverage.

## What changed
- Removed the `NodaTime` package reference from `Meziantou.Framework.HumanReadableSerializer.Tests.csproj`.
- Removed NodaTime-specific serializer tests from `SerializerTests`:
  - `NodaTime_Instant`
  - `NodaTime_LocalDateTime`
  - `NodaTime_Duration`
  - `NodaTime_DateTimeZone`
  - `NodaTime_ZonedDateTime`
- Removed the now-unused `using NodaTime;` directive.

## Notes
This PR is scoped to the HumanReadableSerializer test project and test cases only.