### PR TITLE
Add C# 15 union support to HumanReadableSerializer

### DIFF
--- a/src/Meziantou.Framework.HumanReadableSerializer/Converters/CSharpUnionConverterFactory.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Converters/CSharpUnionConverterFactory.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Meziantou.Framework.HumanReadable.Converters;
+
+internal sealed class CSharpUnionConverterFactory : HumanReadableConverterFactory
+{
+    public override bool CanConvert(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        return HasUnionAttribute(type)
+            && type.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance, binder: null, returnType: typeof(object), types: Type.EmptyTypes, modifiers: null)?.CanRead is true;
+    }
+
+    public override HumanReadableConverter? CreateConverter(Type typeToConvert, HumanReadableSerializerOptions options)
+    {
+        return (HumanReadableConverter)Activator.CreateInstance(typeof(CSharpUnionConverter<>).MakeGenericType(typeToConvert))!;
+    }
+
+    private static bool HasUnionAttribute(Type type)
+    {
+        foreach (var attribute in type.GetCustomAttributes(inherit: true))
+        {
+            if (attribute.GetType().FullName == "System.Runtime.CompilerServices.UnionAttribute")
+                return true;
+        }
+
+        return false;
+    }
+
+    [SuppressMessage("Performance", "CA1812", Justification = "The class is instantiated using Activator.CreateInstance")]
+    private sealed class CSharpUnionConverter<T> : HumanReadableConverter<T>
+    {
+        private readonly PropertyInfo _valueProperty;
+
+        public CSharpUnionConverter()
+        {
+            _valueProperty = typeof(T).GetProperty("Value", BindingFlags.Public | BindingFlags.Instance, binder: null, returnType: typeof(object), types: Type.EmptyTypes, modifiers: null)
+                ?? throw new HumanReadableSerializerException($"Cannot serialize the C# union type '{typeof(T)}' as the 'Value' property does not exist");
+        }
+
+        protected override void WriteValue(HumanReadableTextWriter writer, T? value, HumanReadableSerializerOptions options)
+        {
+            Debug.Assert(value is not null);
+
+            var unionValue = _valueProperty.GetValue(value);
+            if (unionValue is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                HumanReadableSerializer.Serialize(writer, unionValue, options);
+            }
+        }
+    }
+}

--- a/src/Meziantou.Framework.HumanReadableSerializer/HumanReadableSerializerOptions.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/HumanReadableSerializerOptions.cs
@@ -552,6 +552,7 @@ public sealed record HumanReadableSerializerOptions
             new EnumerableKeyValuePairConverterFactory(),
             new EnumerableConverterFactory(),
             new EnumerableConverter(),
+            new CSharpUnionConverterFactory(),
             new FSharpOptionConverterFactory(),
             new FSharpValueOptionConverterFactory(),
             new FSharpDiscriminatedUnionConverter(),

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -55,6 +55,14 @@ public sealed partial class SerializerTests : SerializerTestsBase
     }
 
     [Fact]
+    public void CSharp_Union_Cat()
+    {
+        CSharpPet value = new CSharpCat("Misty");
+
+        AssertSerialization(value, "Name: Misty");
+    }
+
+    [Fact]
     public void CSharp_Union_Default()
     {
         AssertSerialization(default(CSharpPet), "<null>");

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -45,6 +45,22 @@ public sealed partial class SerializerTests : SerializerTestsBase
             """);
     }
 
+#if NET11_0_OR_GREATER
+    [Fact]
+    public void CSharp_Union()
+    {
+        CSharpPet value = new CSharpDog("Rex");
+
+        AssertSerialization(value, "Name: Rex");
+    }
+
+    [Fact]
+    public void CSharp_Union_Default()
+    {
+        AssertSerialization(default(CSharpPet), "<null>");
+    }
+#endif
+
     [Fact]
     public void CultureInfo_Invariant()
         => AssertSerialization(CultureInfo.InvariantCulture, "Invariant Language (Invariant Country)");
@@ -2418,6 +2434,14 @@ public sealed partial class SerializerTests : SerializerTestsBase
     {
         static ClassWithStaticCtor() { Console.WriteLine(); }
     }
+
+#if NET11_0_OR_GREATER
+    private sealed record CSharpCat(string Name);
+
+    private sealed record CSharpDog(string Name);
+
+    private union CSharpPet(CSharpCat, CSharpDog);
+#endif
 
     private interface ICovariantContravariantInterface<in T1, out T2> { }
 


### PR DESCRIPTION
## Summary
C# 15 unions were being serialized as regular objects, which produced a `Value:` wrapper instead of the contained value. This makes the output noisier and inconsistent with union semantics.

This change adds explicit union handling so `Meziantou.Framework.HumanReadableSerializer` serializes the union payload directly.

## What changed
- Added `CSharpUnionConverterFactory` that detects union types via `System.Runtime.CompilerServices.UnionAttribute` and a public `Value` property.
- The converter serializes the contained `Value` directly, and writes `<null>` when the union value is empty/default.
- Registered the converter before `ObjectConverterFactory` so union types are handled before generic object member serialization.
- Added net11 test coverage in `SerializerTests` for:
  - non-null union payload serialization
  - default union serialization

## Notes
- Detection is reflection-based, so it remains compatible across target frameworks and doesn't require a direct compile-time dependency on union runtime types.