### PR TITLE
Enable runtime-async only on net11.0 targets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,11 @@
     <DefineConstants Condition="$(InvariantGlobalization) == 'true'">$(DefineConstants);INVARIANT_GLOBALIZATION_MODE_ENABLED</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <Features>$(Features);runtime-async=on</Features>
+  </PropertyGroup>
+
   <!-- disable the nullable warnings when compiling for target that haven't annotation -->
   <PropertyGroup Condition="!$(TargetFramework.StartsWith('$(LatestTargetFramework)'))">
     <NoWarn>$(NoWarn);nullable;IDE0370</NoWarn>

--- a/src/Meziantou.Framework.InlineSnapshotTesting/CallerContext.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/CallerContext.cs
@@ -218,11 +218,16 @@ internal record struct CallerContext(FullPath FilePath, int LineNumber, int Colu
                             blobReader.ReadByte();
 
                             nullIndex = blobReader.IndexOf(0);
-
-                            if (key == "language-version")
+                            if (key is "language-version")
                             {
                                 if (Version.TryParse(value, out var version))
                                     return version;
+
+                                if (value is "preview")
+                                {
+                                    // We don't know the exact version, but we know it's at least 12.0 as the minimum supported TFM version is .NET 8 which requires C# 12.
+                                    return new Version(12, 0);
+                                }
 
                                 return default;
                             }

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -1170,14 +1170,15 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
         testOutputHelper.WriteLine("Using dotnet: " + dotnetPath);
         Assert.NotNull(dotnetPath);
 
+        // force language-version because otherwise it may be "preview" instead of a numeric value, so autodection won't work.
         testOutputHelper.WriteLine("Restoring project");
-        await ExecuteDotNet("restore --disable-build-servers", expectedExitCode: 0);
+        await ExecuteDotNet($"restore --disable-build-servers -p:LangVersion={languageVersion}", expectedExitCode: 0);
 
         testOutputHelper.WriteLine("Building project");
-        await ExecuteDotNet("build --no-restore --disable-build-servers", expectedExitCode: 0);
+        await ExecuteDotNet($"build --no-restore --disable-build-servers -p:LangVersion={languageVersion}", expectedExitCode: 0);
 
         testOutputHelper.WriteLine("Running project");
-        await ExecuteDotNet("run --no-build --disable-build-servers");
+        await ExecuteDotNet($"run --no-build --disable-build-servers -p:LangVersion={languageVersion}");
 
         var actual = File.ReadAllText(mainPath);
         expected ??= source;

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -239,19 +239,6 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task UpdateSnapshotUsingVerbatimWhenCSharpLanguageIs10()
     {
-        var expected = string.Join('\n',
-        [
-            "var data = new",
-            "{",
-            "    FirstName = \"Gérald\",",
-            "    LastName = \"Barré\",",
-            "    NickName = \"meziantou\",",
-            "};",
-            "InlineSnapshot.Validate(data, @\"FirstName: Gérald",
-            "LastName: Barré",
-            "NickName: meziantou\");",
-        ]);
-
         await AssertSnapshot(
             """"
             var data = new
@@ -1183,6 +1170,7 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
         testOutputHelper.WriteLine("Using dotnet: " + dotnetPath);
         Assert.NotNull(dotnetPath);
 
+        // force language-version with preview versions
         testOutputHelper.WriteLine("Restoring project");
         await ExecuteDotNet($"restore --disable-build-servers -p:LangVersion={languageVersion}", expectedExitCode: 0);
 

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -239,6 +239,19 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task UpdateSnapshotUsingVerbatimWhenCSharpLanguageIs10()
     {
+        var expected = string.Join('\n',
+        [
+            "var data = new",
+            "{",
+            "    FirstName = \"Gérald\",",
+            "    LastName = \"Barré\",",
+            "    NickName = \"meziantou\",",
+            "};",
+            "InlineSnapshot.Validate(data, @\"FirstName: Gérald",
+            "LastName: Barré",
+            "NickName: meziantou\");",
+        ]);
+
         await AssertSnapshot(
             """"
             var data = new
@@ -249,17 +262,7 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
             };
             InlineSnapshot.Validate(data, "");
             """",
-            """"
-            var data = new
-            {
-                FirstName = "Gérald",
-                LastName = "Barré",
-                NickName = "meziantou",
-            };
-            InlineSnapshot.Validate(data, @"FirstName: Gérald
-            LastName: Barré
-            NickName: meziantou");
-            """",
+            expected,
             languageVersion: "10", forceUpdateSnapshots: true);
     }
 
@@ -1171,13 +1174,13 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
         Assert.NotNull(dotnetPath);
 
         testOutputHelper.WriteLine("Restoring project");
-        await ExecuteDotNet("restore --disable-build-servers", expectedExitCode: 0);
+        await ExecuteDotNet($"restore --disable-build-servers -p:LangVersion={languageVersion}", expectedExitCode: 0);
 
         testOutputHelper.WriteLine("Building project");
-        await ExecuteDotNet("build --no-restore --disable-build-servers", expectedExitCode: 0);
+        await ExecuteDotNet($"build --no-restore --disable-build-servers -p:LangVersion={languageVersion}", expectedExitCode: 0);
 
         testOutputHelper.WriteLine("Running project");
-        await ExecuteDotNet("run --no-build --disable-build-servers");
+        await ExecuteDotNet($"run --no-build --disable-build-servers -p:LangVersion={languageVersion}");
 
         var actual = File.ReadAllText(mainPath);
         expected ??= source;

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -262,7 +262,17 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
             };
             InlineSnapshot.Validate(data, "");
             """",
-            expected,
+            """"
+            var data = new
+            {
+                FirstName = "Gérald",
+                LastName = "Barré",
+                NickName = "meziantou",
+            };
+            InlineSnapshot.Validate(data, @"FirstName: Gérald
+            LastName: Barré
+            NickName: meziantou");
+            """",
             languageVersion: "10", forceUpdateSnapshots: true);
     }
 

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -1118,6 +1118,7 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
                 <Nullable>disable</Nullable>
                 <DebugType>portable</DebugType>
                 <DefineConstants>{{string.Join(';', preprocessorSymbols ?? [])}}</DefineConstants>
+                <EnablePreviewFeatures>true</EnablePreviewFeatures>
               </PropertyGroup>
               <ItemGroup>
                 <Reference Include="{{typeof(HumanReadableSerializer).Assembly.Location}}" />

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -1170,15 +1170,14 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
         testOutputHelper.WriteLine("Using dotnet: " + dotnetPath);
         Assert.NotNull(dotnetPath);
 
-        // force language-version with preview versions
         testOutputHelper.WriteLine("Restoring project");
-        await ExecuteDotNet($"restore --disable-build-servers -p:LangVersion={languageVersion}", expectedExitCode: 0);
+        await ExecuteDotNet($"restore --disable-build-servers", expectedExitCode: 0);
 
         testOutputHelper.WriteLine("Building project");
-        await ExecuteDotNet($"build --no-restore --disable-build-servers -p:LangVersion={languageVersion}", expectedExitCode: 0);
+        await ExecuteDotNet($"build --no-restore --disable-build-servers", expectedExitCode: 0);
 
         testOutputHelper.WriteLine("Running project");
-        await ExecuteDotNet($"run --no-build --disable-build-servers -p:LangVersion={languageVersion}");
+        await ExecuteDotNet($"run --no-build --disable-build-servers");
 
         var actual = File.ReadAllText(mainPath);
         expected ??= source;

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -1171,13 +1171,13 @@ public sealed class InlineSnapshotTests(ITestOutputHelper testOutputHelper)
         Assert.NotNull(dotnetPath);
 
         testOutputHelper.WriteLine("Restoring project");
-        await ExecuteDotNet($"restore --disable-build-servers", expectedExitCode: 0);
+        await ExecuteDotNet("restore --disable-build-servers", expectedExitCode: 0);
 
         testOutputHelper.WriteLine("Building project");
-        await ExecuteDotNet($"build --no-restore --disable-build-servers", expectedExitCode: 0);
+        await ExecuteDotNet("build --no-restore --disable-build-servers", expectedExitCode: 0);
 
         testOutputHelper.WriteLine("Running project");
-        await ExecuteDotNet($"run --no-build --disable-build-servers");
+        await ExecuteDotNet("run --no-build --disable-build-servers");
 
         var actual = File.ReadAllText(mainPath);
         expected ??= source;

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -1140,6 +1140,7 @@ public sealed class SnapshotEndToEndTests
                 <TargetFramework>{{targetFramework ?? TargetFrameworkHelper.GetTargetFrameworkMoniker()}}</TargetFramework>
                 <Nullable>disable</Nullable>
                 <IsPackable>false</IsPackable>
+                <EnablePreviewFeatures>true</EnablePreviewFeatures>
                 {{GetAdditionalProjectProperties(testFramework)}}
               </PropertyGroup>
               <ItemGroup>


### PR DESCRIPTION
## Why
The runtime-async feature should only be enabled where it is supported, while older target frameworks must keep their current behavior.

## What changed
This updates `Directory.Build.props` to apply the following settings only when the target framework is compatible with `net11.0`:

- `EnablePreviewFeatures=true`
- `Features=$(Features);runtime-async=on`

The condition uses `IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0')`, so non-net11 targets are left unchanged.