### PR TITLE
Fix BOM detection when streams return partial reads

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Internals/StreamUtilities.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Internals/StreamUtilities.cs
@@ -50,15 +50,13 @@ internal static class StreamUtilities
     private static async ValueTask<int> ReadUntilCountOrEndAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken = default)
     {
         var totalRead = 0;
-        var count = buffer.Length;
-        while (count > 0)
+        while (totalRead < buffer.Length)
         {
-            var read = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            var read = await stream.ReadAsync(buffer.Slice(totalRead), cancellationToken).ConfigureAwait(false);
             if (read == 0)
                 return totalRead;
 
             totalRead += read;
-            count -= read;
         }
 
         return totalRead;

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
@@ -183,6 +183,16 @@ public sealed class DependencyScannerTests
     }
 
     [Fact]
+    public async Task GetEncodingAsync_ReadUntilCountOrEndAsync_ReadsBufferUsingSlices()
+    {
+        await using var stream = new PartialReadMemoryStream([0xEF, 0xBB, 0xBF, (byte)'a'], maxBytesPerRead: 1);
+
+        var encoding = await StreamUtilities.GetEncodingAsync(stream, XunitCancellationToken);
+
+        Assert.Equal(Encoding.UTF8.WebName, encoding.WebName);
+    }
+
+    [Fact]
     public async Task DetectUnsupportedType()
     {
         await using var directory = TemporaryDirectory.Create();
@@ -354,5 +364,16 @@ public sealed class DependencyScannerTests
 
         public IEnumerable<string> GetFiles(string path, string pattern, SearchOption searchOptions) => throw new NotSupportedException();
         public Stream OpenReadWrite(string path) => throw new NotSupportedException();
+    }
+
+    private sealed class PartialReadMemoryStream(byte[] buffer, int maxBytesPerRead) : MemoryStream(buffer)
+    {
+        private readonly int _maxBytesPerRead = maxBytesPerRead;
+
+        public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
+        {
+            var bytesToRead = Math.Min(_maxBytesPerRead, destination.Length);
+            return base.ReadAsync(destination[..bytesToRead], cancellationToken);
+        }
     }
 }

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
@@ -1,6 +1,7 @@
 using Meziantou.Framework.DependencyScanning.Internals;
 using Meziantou.Framework.DependencyScanning.Scanners;
 using Meziantou.Framework.Globbing;
+using Meziantou.Framework;
 
 namespace Meziantou.Framework.DependencyScanning.Tests;
 
@@ -185,7 +186,12 @@ public sealed class DependencyScannerTests
     [Fact]
     public async Task GetEncodingAsync_ReadUntilCountOrEndAsync_ReadsBufferUsingSlices()
     {
-        await using var stream = new PartialReadMemoryStream([0xEF, 0xBB, 0xBF, (byte)'a'], maxBytesPerRead: 1);
+        await using var stream = new RestrictedStream(new MemoryStream([0xEF, 0xBB, 0xBF, (byte)'a']), new RestrictedStreamOptions
+        {
+            AllowAsynchronousCalls = true,
+            AllowReading = true,
+            MaxReadLength = 1,
+        });
 
         var encoding = await StreamUtilities.GetEncodingAsync(stream, XunitCancellationToken);
 
@@ -364,16 +370,5 @@ public sealed class DependencyScannerTests
 
         public IEnumerable<string> GetFiles(string path, string pattern, SearchOption searchOptions) => throw new NotSupportedException();
         public Stream OpenReadWrite(string path) => throw new NotSupportedException();
-    }
-
-    private sealed class PartialReadMemoryStream(byte[] buffer, int maxBytesPerRead) : MemoryStream(buffer)
-    {
-        private readonly int _maxBytesPerRead = maxBytesPerRead;
-
-        public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
-        {
-            var bytesToRead = Math.Min(_maxBytesPerRead, destination.Length);
-            return base.ReadAsync(destination[..bytesToRead], cancellationToken);
-        }
     }
 }


### PR DESCRIPTION
BOM and encoding detection can fail when a stream returns fewer bytes than requested, because `ReadUntilCountOrEndAsync` was reusing the full destination buffer on each read instead of advancing the write offset.

## Summary
- Update `ReadUntilCountOrEndAsync` to read into `buffer.Slice(totalRead)` until the requested count is filled or EOF is reached.
- Add a regression test that uses a partial-read stream and verifies `GetEncodingAsync` still detects a UTF-8 BOM correctly.
- Keep fallback behavior unchanged (`Encoding.Default`) to keep this PR focused on the read-loop bug.

## Validation
- `dotnet run ./eng/update-bom.cs`
- `dotnet run ./eng/update-readme.cs`
- `dotnet run ./eng/update-project-slnx.cs`
- `dotnet run ./eng/validate-testprojects-configuration.cs`
- `dotnet run ./eng/update-trimmable.cs`
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tests/Meziantou.Framework.DependencyScanning.Tests.csproj /p:TreatsWarningsAsErrors=true`
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests/Meziantou.Framework.DependencyScanning.Tool.Tests.csproj /p:TreatsWarningsAsErrors=true`