### PR TITLE
Fix BOM detection for partial async reads

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Internals/StreamUtilities.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Internals/StreamUtilities.cs
@@ -26,7 +26,7 @@ internal static class StreamUtilities
 
         // Read the BOM
         var bom = new byte[4];
-        var readCount = await ReadUntilCountOrEndAsync(stream, bom.AsMemory(), cancellationToken).ConfigureAwait(false);
+        var readCount = await ReadUntilCountOrEndAsync(stream, bom, cancellationToken).ConfigureAwait(false);
         var buffer = bom.AsSpan(0, readCount);
 
         // Analyze the BOM

--- a/src/Meziantou.Framework.DependencyScanning/Internals/StreamUtilities.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Internals/StreamUtilities.cs
@@ -22,26 +22,29 @@ internal static class StreamUtilities
 
     internal static async ValueTask<Encoding> GetEncodingAsync(Stream stream, CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(stream);
+
         // Read the BOM
         var bom = new byte[4];
-        var readCount = await ReadUntilCountOrEndAsync(stream, bom, cancellationToken).ConfigureAwait(false);
+        var readCount = await ReadUntilCountOrEndAsync(stream, bom.AsMemory(), cancellationToken).ConfigureAwait(false);
+        var buffer = bom.AsSpan(0, readCount);
 
         // Analyze the BOM
-        if (readCount >= 3 && bom[0] == 0x2b && bom[1] == 0x2f && bom[2] == 0x76)
+        if (buffer.Length >= 3 && buffer[0] == 0x2b && buffer[1] == 0x2f && buffer[2] == 0x76)
 #pragma warning disable SYSLIB0001 // Type or member is obsolete
             return Encoding.UTF7;
 #pragma warning restore SYSLIB0001
 
-        if (readCount >= 3 && bom[0] == 0xef && bom[1] == 0xbb && bom[2] == 0xbf)
+        if (buffer.Length >= 3 && buffer[0] == 0xef && buffer[1] == 0xbb && buffer[2] == 0xbf)
             return Encoding.UTF8;
 
-        if (readCount >= 2 && bom[0] == 0xff && bom[1] == 0xfe)
+        if (buffer.Length >= 2 && buffer[0] == 0xff && buffer[1] == 0xfe)
             return Encoding.Unicode; //UTF-16LE
 
-        if (readCount >= 2 && bom[0] == 0xfe && bom[1] == 0xff)
+        if (buffer.Length >= 2 && buffer[0] == 0xfe && buffer[1] == 0xff)
             return Encoding.BigEndianUnicode; //UTF-16BE
 
-        if (readCount >= 4 && bom[0] == 0 && bom[1] == 0 && bom[2] == 0xfe && bom[3] == 0xff)
+        if (buffer.Length >= 4 && buffer[0] == 0 && buffer[1] == 0 && buffer[2] == 0xfe && buffer[3] == 0xff)
             return Encoding.UTF32;
 
         return Encoding.Default;

--- a/src/Meziantou.Framework.DependencyScanning/Internals/StreamUtilities.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Internals/StreamUtilities.cs
@@ -30,21 +30,21 @@ internal static class StreamUtilities
         var buffer = bom.AsSpan(0, readCount);
 
         // Analyze the BOM
-        if (buffer.Length >= 3 && buffer[0] == 0x2b && buffer[1] == 0x2f && buffer[2] == 0x76)
+        if (buffer is [0x2b, 0x2f, 0x76, ..])
 #pragma warning disable SYSLIB0001 // Type or member is obsolete
             return Encoding.UTF7;
 #pragma warning restore SYSLIB0001
 
-        if (buffer.Length >= 3 && buffer[0] == 0xef && buffer[1] == 0xbb && buffer[2] == 0xbf)
+        if (buffer is [0xef, 0xbb, 0xbf, ..])
             return Encoding.UTF8;
 
-        if (buffer.Length >= 2 && buffer[0] == 0xff && buffer[1] == 0xfe)
+        if (buffer is [0xff, 0xfe, ..])
             return Encoding.Unicode; //UTF-16LE
 
-        if (buffer.Length >= 2 && buffer[0] == 0xfe && buffer[1] == 0xff)
+        if (buffer is [0xfe, 0xff, ..])
             return Encoding.BigEndianUnicode; //UTF-16BE
 
-        if (buffer.Length >= 4 && buffer[0] == 0 && buffer[1] == 0 && buffer[2] == 0xfe && buffer[3] == 0xff)
+        if (buffer is [0x00, 0x00, 0xfe, 0xff, ..])
             return Encoding.UTF32;
 
         return Encoding.Default;

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
@@ -199,6 +199,23 @@ public sealed class DependencyScannerTests
     }
 
     [Fact]
+    public async Task CreateReaderAsync_DetectsUtf8Bom_WhenStreamReadsOneByteAtATime()
+    {
+        await using var stream = new RestrictedStream(new MemoryStream([0xEF, 0xBB, 0xBF, (byte)'a']), new RestrictedStreamOptions
+        {
+            AllowAsynchronousCalls = true,
+            AllowReading = true,
+            AllowSeeking = true,
+            MaxReadLength = 1,
+        });
+
+        using var reader = await StreamUtilities.CreateReaderAsync(stream, XunitCancellationToken);
+        var text = await reader.ReadToEndAsync(XunitCancellationToken);
+
+        Assert.Equal("a", text);
+    }
+
+    [Fact]
     public async Task DetectUnsupportedType()
     {
         await using var directory = TemporaryDirectory.Create();


### PR DESCRIPTION
## Why
`StreamUtilities.GetEncodingAsync` could fail when the stream only returns a few bytes per async read. That breaks dependency scanning and update flows that rely on encoding detection.

## What changed
- Read BOM bytes with `bom.AsMemory()` and analyze only `bom.AsSpan(0, readCount)`.
- Switched BOM checks to use the bounded span length/indexing instead of indexing the full array directly.
- Added a null guard for the input stream in `GetEncodingAsync`.
- Added regression coverage for `CreateReaderAsync` with a `RestrictedStream` that reads one byte at a time, ensuring UTF-8 BOM handling works in the scan-path caller.

## Validation
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tests/Meziantou.Framework.DependencyScanning.Tests.csproj /p:TreatsWarningsAsErrors=true`
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests/Meziantou.Framework.DependencyScanning.Tool.Tests.csproj /p:TreatsWarningsAsErrors=true`
- `dotnet run ./eng/update-bom.cs /p:TreatsWarningsAsErrors=true`
- `dotnet run ./eng/update-readme.cs /p:TreatsWarningsAsErrors=true`
- `dotnet run ./eng/update-project-slnx.cs /p:TreatsWarningsAsErrors=true`
- `dotnet run ./eng/validate-testprojects-configuration.cs /p:TreatsWarningsAsErrors=true`
- `dotnet run ./eng/update-trimmable.cs /p:TreatsWarningsAsErrors=true`