### PR TITLE
Add UTC timestamps to ProcessWrapper output entries

### DIFF
--- a/ref/Meziantou.Framework.ProcessWrapper.cs
+++ b/ref/Meziantou.Framework.ProcessWrapper.cs
@@ -157,7 +157,9 @@ namespace Meziantou.Framework
     {
         public Meziantou.Framework.ProcessOutputType Type { get => throw null; }
         public string Text { get => throw null; }
+        public System.DateTime TimestampUtc { get => throw null; }
         public void Deconstruct(out Meziantou.Framework.ProcessOutputType type, out string text) => throw null;
+        public void Deconstruct(out Meziantou.Framework.ProcessOutputType type, out string text, out System.DateTime timestampUtc) => throw null;
         public override string ToString() => throw null;
     }
 

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessOutput.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessOutput.cs
@@ -1,12 +1,13 @@
 namespace Meziantou.Framework;
 
-/// <summary>Represents a single line of process output with its stream type.</summary>
+/// <summary>Represents a single line of process output with its stream type and UTC timestamp.</summary>
 public sealed class ProcessOutput
 {
     internal ProcessOutput(ProcessOutputType type, string text)
     {
         Type = type;
         Text = text;
+        TimestampUtc = DateTime.UtcNow;
     }
 
     /// <summary>Gets the type of output stream this line came from.</summary>
@@ -15,11 +16,22 @@ public sealed class ProcessOutput
     /// <summary>Gets the text content of this output line.</summary>
     public string Text { get; }
 
+    /// <summary>Gets the UTC timestamp at which this output line was captured.</summary>
+    public DateTime TimestampUtc { get; }
+
     /// <summary>Deconstructs the output into its type and text components.</summary>
     public void Deconstruct(out ProcessOutputType type, out string text)
     {
         type = Type;
         text = Text;
+    }
+
+    /// <summary>Deconstructs the output into its type, text, and UTC timestamp components.</summary>
+    public void Deconstruct(out ProcessOutputType type, out string text, out DateTime timestampUtc)
+    {
+        type = Type;
+        text = Text;
+        timestampUtc = TimestampUtc;
     }
 
     /// <inheritdoc/>

--- a/src/Meziantou.Framework.ProcessWrapper/readme.md
+++ b/src/Meziantou.Framework.ProcessWrapper/readme.md
@@ -207,7 +207,7 @@ await ProcessWrapper.Create("dotnet")
 
 foreach (var line in output.StandardError)
 {
-    Console.Error.WriteLine(line.Text);
+    Console.Error.WriteLine($"[{line.TimestampUtc:O}] {line.Text}");
 }
 
 // Capture raw bytes from stdout/stderr

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -252,8 +252,10 @@ public class ProcessWrapperTests
 
         await process;
 
-        Assert.Single(output.StandardOutput);
-        Assert.Equal("test", output.StandardOutput.First().Text);
+        var line = Assert.Single(output.StandardOutput);
+        Assert.Equal("test", line.Text);
+        Assert.Equal(DateTimeKind.Utc, line.TimestampUtc.Kind);
+        Assert.NotEqual(default, line.TimestampUtc);
     }
 
     [Fact]


### PR DESCRIPTION
## Why
`ProcessOutput` entries in ProcessWrapper exposed stream type and text only, so callers could not reliably correlate lines with capture time.

## What changed
- Added `TimestampUtc` (`DateTime`) to `ProcessOutput`, populated with `DateTime.UtcNow` when each line is captured.
- Kept existing API usage intact (`Type`, `Text`, and the existing 2-value `Deconstruct` overload).
- Added a 3-value `Deconstruct` overload to expose type, text, and timestamp together.
- Updated the ProcessWrapper test for `ProcessOutputCollection` to assert timestamps are set and UTC.
- Updated the ProcessWrapper README example to show timestamped output usage.

## Verification
- Ran required repository scripts:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`
- Ran `dotnet test tests/Meziantou.Framework.ProcessWrapper.Tests/Meziantou.Framework.ProcessWrapper.Tests.csproj /p:TreatsWarningsAsErrors=true` (all tests passed).