### PR TITLE
Fix preview feature condition evaluation for net11 targets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,11 +20,6 @@
     <DefineConstants Condition="$(InvariantGlobalization) == 'true'">$(DefineConstants);INVARIANT_GLOBALIZATION_MODE_ENABLED</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    <Features>$(Features);runtime-async=on</Features>
-  </PropertyGroup>
-
   <!-- disable the nullable warnings when compiling for target that haven't annotation -->
   <PropertyGroup Condition="!$(TargetFramework.StartsWith('$(LatestTargetFramework)'))">
     <NoWarn>$(NoWarn);nullable;IDE0370</NoWarn>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,9 @@
 <Project>
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <Features>$(Features);runtime-async=on</Features>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
     <Compile Include="$(MSBuildThisFileDirectory)/common/AssemblyInfo.cs"
              Link="Properties/AssemblyInfo.common.cs"


### PR DESCRIPTION
## Why
CodeQL on `main` started failing with CA2252 in sample projects because preview-only APIs were compiled without `EnablePreviewFeatures` being applied.

The setting existed, but it was declared in `Directory.Build.props`, where `$(TargetFramework)` is not reliably set yet for condition evaluation.

## What changed
- Moved the net11-compatible conditional block that sets `EnablePreviewFeatures` and `Features` (`runtime-async=on`) from `Directory.Build.props` to `Directory.Build.targets`.
- Kept the same condition and values; only the evaluation timing changed so it runs after project `TargetFramework` is known.

## Notes
- This keeps the configuration centralized and avoids per-project overrides while restoring expected behavior for net11 builds.