### PR TITLE
Fix flakiness because of mutex

### DIFF
--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
@@ -3,73 +3,64 @@ using Meziantou.Xunit;
 namespace Meziantou.Framework.Win32.Tests;
 
 [Collection("CredentialManagerTests")]
-public sealed class CredentialManagerTests : IDisposable
+public sealed class CredentialManagerTests
 {
-    private readonly Mutex _mutex;
-
-    private readonly string _prefix;
-    private readonly string _credentialName1;
-    private readonly string _credentialName2;
-
-    public CredentialManagerTests()
-    {
-        var guid = Guid.NewGuid().ToString("N");
-        _prefix = "CredentialManagerTests_" + guid + "_";
-        _credentialName1 = _prefix + "_1";
-        _credentialName2 = _prefix + "_2";
-
-        _mutex = new Mutex(initiallyOwned: false, typeof(CredentialManagerTests).FullName);
-    }
-
     [Fact, RunIf(TestOperatingSystems.Windows)]
     public void CredentialManager_01()
     {
-        CredentialManager.WriteCredential(_credentialName1, "John", "Doe", "Test", CredentialPersistence.Session);
+        using var context = new IsolatedContext();
+        var credentialName = context.GetCredentialName();
+        CredentialManager.WriteCredential(credentialName, "John", "Doe", "Test", CredentialPersistence.Session);
 
-        var cred = CredentialManager.ReadCredential(_credentialName1);
+        var cred = CredentialManager.ReadCredential(credentialName);
         Assert.NotNull(cred);
-        Assert.Equal(_credentialName1, cred.ApplicationName);
+        Assert.Equal(credentialName, cred.ApplicationName);
         Assert.Equal("John", cred.UserName);
         Assert.Equal("Doe", cred.Password);
         Assert.Equal("Test", cred.Comment);
 
-        CredentialManager.DeleteCredential(_credentialName1);
-        cred = CredentialManager.ReadCredential(_credentialName1);
+        CredentialManager.DeleteCredential(credentialName);
+        cred = CredentialManager.ReadCredential(credentialName);
         Assert.Null(cred);
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
     public void CredentialManager_Enumerate()
     {
-        CredentialManager.WriteCredential(_credentialName1, "John", "Doe", "Test", CredentialPersistence.Session);
-        CredentialManager.WriteCredential(_credentialName2, "John", "Doe", "Test", CredentialPersistence.Session);
+        using var context = new IsolatedContext();
+        var credentialName1 = context.GetCredentialName("1");
+        var credentialName2 = context.GetCredentialName("2");
+        CredentialManager.WriteCredential(credentialName1, "John", "Doe", "Test", CredentialPersistence.Session);
+        CredentialManager.WriteCredential(credentialName2, "John", "Doe", "Test", CredentialPersistence.Session);
         try
         {
-            var creds = CredentialManager.EnumerateCredentials(_prefix + "*");
+            var creds = CredentialManager.EnumerateCredentials(context.GetCredentialName("*"));
             Assert.Equal(2, creds.Count);
         }
         finally
         {
-            CredentialManager.DeleteCredential(_credentialName1);
-            CredentialManager.DeleteCredential(_credentialName2);
+            CredentialManager.DeleteCredential(credentialName1);
+            CredentialManager.DeleteCredential(credentialName2);
         }
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
     public void CredentialManager_LimitComment()
     {
+        using var context = new IsolatedContext();
         var comment = new string('a', 255);
-        CredentialManager.WriteCredential(_credentialName1, "John", "Doe", comment, CredentialPersistence.Session);
+        var credentialName = context.GetCredentialName();
+        CredentialManager.WriteCredential(credentialName, "John", "Doe", comment, CredentialPersistence.Session);
 
-        var cred = CredentialManager.ReadCredential(_credentialName1);
+        var cred = CredentialManager.ReadCredential(credentialName);
         Assert.NotNull(cred);
-        Assert.Equal(_credentialName1, cred.ApplicationName);
+        Assert.Equal(credentialName, cred.ApplicationName);
         Assert.Equal("John", cred.UserName);
         Assert.Equal("Doe", cred.Password);
         Assert.Equal(comment, cred.Comment);
 
-        CredentialManager.DeleteCredential(_credentialName1);
-        cred = CredentialManager.ReadCredential(_credentialName1);
+        CredentialManager.DeleteCredential(credentialName);
+        cred = CredentialManager.ReadCredential(credentialName);
         Assert.Null(cred);
     }
 
@@ -80,15 +71,17 @@ public sealed class CredentialManagerTests : IDisposable
     [InlineData(512 * 5 / 2)]
     public void CredentialManager_LimitSecret(int secretLength)
     {
+        using var context = new IsolatedContext();
         var secret = new string('a', secretLength);
-        CredentialManager.WriteCredential(_credentialName1, "John", secret, CredentialPersistence.Session);
+        var credentialName = context.GetCredentialName();
+        CredentialManager.WriteCredential(credentialName, "John", secret, CredentialPersistence.Session);
 
-        var cred = CredentialManager.ReadCredential(_credentialName1);
+        var cred = CredentialManager.ReadCredential(credentialName);
         Assert.NotNull(cred);
         Assert.Equal(secret, cred.Password);
 
-        CredentialManager.DeleteCredential(_credentialName1);
-        cred = CredentialManager.ReadCredential(_credentialName1);
+        CredentialManager.DeleteCredential(credentialName);
+        cred = CredentialManager.ReadCredential(credentialName);
         Assert.Null(cred);
     }
 
@@ -96,28 +89,22 @@ public sealed class CredentialManagerTests : IDisposable
     [Trait("Issue", "https://github.com/meziantou/Meziantou.Framework/issues/32")]
     public void CredentialManager_EnumerateCredential()
     {
-        _mutex.WaitOne();
+        using var context = new IsolatedContext(requiresMutex: true);
+        var credentialName = context.GetCredentialName();
+        CredentialManager.WriteCredential(credentialName, "John", "Doe", "Test", CredentialPersistence.Session);
         try
         {
-            CredentialManager.WriteCredential(_credentialName1, "John", "Doe", "Test", CredentialPersistence.Session);
-            try
+            var credentials = CredentialManager.EnumerateCredentials();
+            foreach (var credential in credentials)
             {
-                var credentials = CredentialManager.EnumerateCredentials();
-                foreach (var credential in credentials)
-                {
-                    _ = credential.UserName;
-                }
+                _ = credential.UserName;
+            }
 
-                Assert.NotEmpty(credentials);
-            }
-            finally
-            {
-                CredentialManager.DeleteCredential(_credentialName1);
-            }
+            Assert.NotEmpty(credentials);
         }
         finally
         {
-            _mutex.ReleaseMutex();
+            CredentialManager.DeleteCredential(credentialName);
         }
     }
 
@@ -127,48 +114,44 @@ public sealed class CredentialManagerTests : IDisposable
     [InlineData("*")]
     public void CredentialManager_EnumerateCredential_FilterNull(string? filter)
     {
-        _mutex.WaitOne();
+        using var context = new IsolatedContext(requiresMutex: true);
+        var credentialName = context.GetCredentialName();
+        CredentialManager.WriteCredential(credentialName, "John", "Doe", "Test", CredentialPersistence.Session);
         try
         {
-            CredentialManager.WriteCredential(_credentialName1, "John", "Doe", "Test", CredentialPersistence.Session);
-            try
+            var credentials = CredentialManager.EnumerateCredentials(filter);
+            foreach (var credential in credentials)
             {
-                var credentials = CredentialManager.EnumerateCredentials(filter);
-                foreach (var credential in credentials)
-                {
-                    Assert.NotEmpty(credential.ApplicationName);
-                }
+                Assert.NotEmpty(credential.ApplicationName);
+            }
 
-                Assert.Single(credentials, cred => cred.ApplicationName == _credentialName1);
-            }
-            finally
-            {
-                CredentialManager.DeleteCredential(_credentialName1);
-            }
+            Assert.Single(credentials, cred => cred.ApplicationName == credentialName);
         }
         finally
         {
-            _mutex.ReleaseMutex();
+            CredentialManager.DeleteCredential(credentialName);
         }
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
     public void CredentialManager_CredentialType_DomainPassword()
     {
+        using var context = new IsolatedContext();
         var credType = CredentialType.DomainPassword;
 
-        CredentialManager.WriteCredential(_credentialName1, "John", "Doe", "Test", CredentialPersistence.Session, credType);
+        var credentialName = context.GetCredentialName();
+        CredentialManager.WriteCredential(credentialName, "John", "Doe", "Test", CredentialPersistence.Session, credType);
 
-        var cred = CredentialManager.ReadCredential(_credentialName1, credType);
+        var cred = CredentialManager.ReadCredential(credentialName, credType);
         Assert.NotNull(cred);
-        Assert.Equal(_credentialName1, cred.ApplicationName);
+        Assert.Equal(credentialName, cred.ApplicationName);
         Assert.Equal("John", cred.UserName);
         Assert.Null(cred.Password); // Domain Passwords can not be read back using CredRead API
         Assert.Equal("Test", cred.Comment);
         Assert.Equal(credType, cred.CredentialType);
 
-        CredentialManager.DeleteCredential(_credentialName1, credType);
-        cred = CredentialManager.ReadCredential(_credentialName1, credType);
+        CredentialManager.DeleteCredential(credentialName, credType);
+        cred = CredentialManager.ReadCredential(credentialName, credType);
         Assert.Null(cred);
     }
 
@@ -177,18 +160,22 @@ public sealed class CredentialManagerTests : IDisposable
     {
         var credType = CredentialType.DomainPassword;
 
-        CredentialManager.WriteCredential(_credentialName1, "John", "Doe", "Test", CredentialPersistence.Session, credType);
-        CredentialManager.WriteCredential(_credentialName2, "John", "Doe", "Test", CredentialPersistence.Session, credType);
+        using var context = new IsolatedContext();
+        var credentialName1 = context.GetCredentialName();
+        var credentialName2 = context.GetCredentialName();
+
+        CredentialManager.WriteCredential(credentialName1, "John", "Doe", "Test", CredentialPersistence.Session, credType);
+        CredentialManager.WriteCredential(credentialName2, "John", "Doe", "Test", CredentialPersistence.Session, credType);
         try
         {
-            var creds = CredentialManager.EnumerateCredentials(_prefix + "*");
+            var creds = CredentialManager.EnumerateCredentials(context.ScopeName + "*");
             Assert.Equal(2, creds.Count);
             Assert.True(creds.All(cred => cred.CredentialType == credType));
         }
         finally
         {
-            CredentialManager.DeleteCredential(_credentialName1, credType);
-            CredentialManager.DeleteCredential(_credentialName2, credType);
+            CredentialManager.DeleteCredential(credentialName1, credType);
+            CredentialManager.DeleteCredential(credentialName2, credType);
         }
     }
 
@@ -199,8 +186,38 @@ public sealed class CredentialManagerTests : IDisposable
         Assert.StartsWith("Only CredentialType.Generic and CredentialType.DomainPassword is supported", ex.Message, StringComparison.Ordinal);
     }
 
-    public void Dispose()
+    private sealed class IsolatedContext : IDisposable
     {
-        _mutex?.Dispose();
+        private readonly Mutex? _mutex;
+
+        public string ScopeName { get; }
+
+        public string GetCredentialName(string? context = null) => ScopeName + "_" + (context ?? "default");
+
+        public IsolatedContext(bool requiresMutex = false)
+        {
+            var guid = Guid.NewGuid().ToString("N");
+            ScopeName = "CredentialManagerTests_" + guid;
+
+            if (requiresMutex)
+            {
+                _mutex = new Mutex(initiallyOwned: false, typeof(CredentialManagerTests).FullName);
+                try
+                {
+                    _mutex.WaitOne();
+                }
+                catch (AbandonedMutexException)
+                {
+                    // The mutex was abandoned, which means that the previous owner terminated without releasing it.
+                    // We can still acquire the mutex, but we should be aware that the state of the shared resource may be inconsistent.
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _mutex?.ReleaseMutex();
+            _mutex?.Dispose();
+        }
     }
 }

--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
@@ -161,14 +161,14 @@ public sealed class CredentialManagerTests
         var credType = CredentialType.DomainPassword;
 
         using var context = new IsolatedContext();
-        var credentialName1 = context.GetCredentialName();
-        var credentialName2 = context.GetCredentialName();
+        var credentialName1 = context.GetCredentialName("1");
+        var credentialName2 = context.GetCredentialName("2");
 
         CredentialManager.WriteCredential(credentialName1, "John", "Doe", "Test", CredentialPersistence.Session, credType);
         CredentialManager.WriteCredential(credentialName2, "John", "Doe", "Test", CredentialPersistence.Session, credType);
         try
         {
-            var creds = CredentialManager.EnumerateCredentials(context.ScopeName + "*");
+            var creds = CredentialManager.EnumerateCredentials(context.GetCredentialName("*"));
             Assert.Equal(2, creds.Count);
             Assert.True(creds.All(cred => cred.CredentialType == credType));
         }

--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
@@ -182,7 +182,8 @@ public sealed class CredentialManagerTests
     [Fact, RunIf(TestOperatingSystems.Windows)]
     public void CredentialManager_CredentialType_Invalid()
     {
-        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => CredentialManager.WriteCredential(_credentialName1, "John", "Doe", "Test", CredentialPersistence.Session, CredentialType.DomainCertificate));
+        using var context = new IsolatedContext();
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => CredentialManager.WriteCredential(context.GetCredentialName(), "John", "Doe", "Test", CredentialPersistence.Session, CredentialType.DomainCertificate));
         Assert.StartsWith("Only CredentialType.Generic and CredentialType.DomainPassword is supported", ex.Message, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
Sometimes, mutex creation in the ctor fails on non-windows platform. The tests is skipped, but only after the initialization. By defering mutex creation, it should avoid issues.