### PR TITLE
Support class members and parse block prefixes in parser

### DIFF
--- a/ref/Meziantou.Framework.Templating.cs
+++ b/ref/Meziantou.Framework.Templating.cs
@@ -43,10 +43,16 @@ namespace Meziantou.Framework.Templating
         protected override void ValidateItem(Meziantou.Framework.Templating.TemplateBlock item) { }
     }
 
+    public class ClassMemberBlock : Meziantou.Framework.Templating.TemplateBlock
+    {
+        public ClassMemberBlock(Meziantou.Framework.Templating.Template template, string text, int index) : base(default(Meziantou.Framework.Templating.Template), default(string), default(int)) { }
+        public override string BuildCode() => throw null;
+    }
+
     public class CodeBlock : Meziantou.Framework.Templating.TemplateBlock
     {
-        protected string EvalPrefixString { get => throw null; set { } }
-        public CodeBlock(Meziantou.Framework.Templating.Template template, string text, int index) : base(default(Meziantou.Framework.Templating.Template), default(string), default(int)) { }
+        public bool IsExpression { get => throw null; }
+        public CodeBlock(Meziantou.Framework.Templating.Template template, string text, int index, bool isExpression = false) : base(default(Meziantou.Framework.Templating.Template), default(string), default(int)) { }
         public override string BuildCode() => throw null;
     }
 
@@ -175,6 +181,8 @@ namespace Meziantou.Framework.Templating
         public void Build(System.Threading.CancellationToken cancellationToken) { }
         protected virtual Meziantou.Framework.Templating.TextBlock CreateTextBlock(string text, int index) => throw null;
         protected virtual Meziantou.Framework.Templating.CodeBlock CreateCodeBlock(string text, int index) => throw null;
+        protected virtual Meziantou.Framework.Templating.CodeBlock CreateCodeExpressionBlock(string text, int index) => throw null;
+        protected virtual Meziantou.Framework.Templating.ClassMemberBlock CreateClassMemberBlock(string text, int index) => throw null;
         protected virtual Meziantou.Framework.Templating.DirectiveBlock CreateDirectiveBlock(string text, string name, string value, int index) => throw null;
         protected virtual Microsoft.CodeAnalysis.CSharp.CSharpParseOptions CreateParseOptions() => throw null;
         protected virtual Microsoft.CodeAnalysis.SyntaxTree CreateSyntaxTree(string source, System.Threading.CancellationToken cancellationToken) => throw null;

--- a/src/Meziantou.Framework.Templating.Html/HtmlEmailCodeBlock.cs
+++ b/src/Meziantou.Framework.Templating.Html/HtmlEmailCodeBlock.cs
@@ -22,7 +22,6 @@ public class HtmlEmailCodeBlock : CodeBlock
     public HtmlEmailCodeBlock(Template template, string text, int index)
         : base(template, text, index)
     {
-        EvalPrefixString = "#"; // Visual Studio colorizes "{{# Name }}" in HTML file in html file :)
     }
 
     /// <summary>Decodes HTML-encoded text.</summary>
@@ -67,6 +66,11 @@ public class HtmlEmailCodeBlock : CodeBlock
         {
             var cid = Nullify(text[CidPrefixString.Length..]);
             return Template.OutputParameterName + $".{nameof(HtmlEmailOutput.WriteContentIdentifier)}(@\"{EscapeVerbatimString(cid)}\");";
+        }
+
+        if (text.StartsWith("#", StringComparison.Ordinal))
+        {
+            return Template.OutputParameterName + ".Write(\"{0}\", " + text[1..].TrimStart() + ");";
         }
 
         return base.BuildCode();

--- a/src/Meziantou.Framework.Templating.Html/HtmlEmailCodeBlock.cs
+++ b/src/Meziantou.Framework.Templating.Html/HtmlEmailCodeBlock.cs
@@ -68,7 +68,7 @@ public class HtmlEmailCodeBlock : CodeBlock
             return Template.OutputParameterName + $".{nameof(HtmlEmailOutput.WriteContentIdentifier)}(@\"{EscapeVerbatimString(cid)}\");";
         }
 
-        if (text.StartsWith("#", StringComparison.Ordinal))
+        if (text.StartsWith('#', StringComparison.Ordinal))
         {
             return Template.OutputParameterName + ".Write(\"{0}\", " + text[1..].TrimStart() + ");";
         }

--- a/src/Meziantou.Framework.Templating/ClassMemberBlock.cs
+++ b/src/Meziantou.Framework.Templating/ClassMemberBlock.cs
@@ -1,0 +1,13 @@
+namespace Meziantou.Framework.Templating;
+
+/// <summary>Represents a class member block in a template.</summary>
+public class ClassMemberBlock(Template template, string text, int index)
+    : TemplateBlock(template, text, index)
+{
+    /// <summary>Builds the C# code for this class member block.</summary>
+    /// <returns>The generated C# class member code.</returns>
+    public override string BuildCode()
+    {
+        return Text;
+    }
+}

--- a/src/Meziantou.Framework.Templating/CodeBlock.cs
+++ b/src/Meziantou.Framework.Templating/CodeBlock.cs
@@ -1,19 +1,19 @@
 namespace Meziantou.Framework.Templating;
 
 /// <summary>Represents a block of executable code in a template.</summary>
-public class CodeBlock(Template template, string text, int index)
+public class CodeBlock(Template template, string text, int index, bool isExpression = false)
     : TemplateBlock(template, text, index)
 {
-    /// <summary>Gets or sets the prefix string that indicates an evaluation expression.</summary>
-    protected string EvalPrefixString { get; set; } = "=";
+    /// <summary>Gets a value indicating whether this block is an evaluation expression.</summary>
+    public bool IsExpression { get; } = isExpression;
 
     /// <summary>Builds the C# code for this code block.</summary>
     /// <returns>The generated C# code.</returns>
     public override string BuildCode()
     {
-        if (Text.StartsWith(EvalPrefixString, StringComparison.Ordinal))
+        if (IsExpression)
         {
-            return Template.OutputParameterName + ".Write(\"{0}\", " + Text[EvalPrefixString.Length..] + ");";
+            return Template.OutputParameterName + ".Write(\"{0}\", " + Text + ");";
         }
 
         return Text;

--- a/src/Meziantou.Framework.Templating/DirectiveBlock.cs
+++ b/src/Meziantou.Framework.Templating/DirectiveBlock.cs
@@ -5,7 +5,7 @@ public class DirectiveBlock : TemplateBlock
 {
     /// <summary>Initializes a new instance of the <see cref="DirectiveBlock"/> class.</summary>
     /// <param name="template">The template that contains this block.</param>
-    /// <param name="text">The original directive text.</param>
+    /// <param name="text">The directive content without the directive marker.</param>
     /// <param name="index">The index of this block in the template.</param>
     /// <param name="name">The directive name.</param>
     /// <param name="value">The directive value.</param>

--- a/src/Meziantou.Framework.Templating/Template.cs
+++ b/src/Meziantou.Framework.Templating/Template.cs
@@ -207,9 +207,20 @@ public class Template
     private TemplateBlock? CreateBlock(bool codeBlock, string text, int index, TextPosition start, TextPosition end)
     {
         TemplateBlock block;
-        if (codeBlock && TryParseDirective(text, out var name, out var value))
+        if (codeBlock && TryParseDirective(text, out var blockText, out var name, out var value))
         {
-            block = CreateDirectiveBlock(text, name, value, index);
+            block = CreateDirectiveBlock(blockText, name, value, index);
+            start = MoveForward(start);
+        }
+        else if (codeBlock && TryRemovePrefix(text, '+', out blockText))
+        {
+            block = CreateClassMemberBlock(blockText, index);
+            start = MoveForward(start);
+        }
+        else if (codeBlock && TryRemovePrefix(text, '=', out blockText))
+        {
+            block = CreateCodeExpressionBlock(blockText, index);
+            start = MoveForward(start);
         }
         else
         {
@@ -220,19 +231,20 @@ public class Template
         return block;
     }
 
-    private static bool TryParseDirective(string text, [NotNullWhen(true)] out string? name, [NotNullWhen(true)] out string? value)
+    private static bool TryParseDirective(string text, [NotNullWhen(true)] out string? blockText, [NotNullWhen(true)] out string? name, [NotNullWhen(true)] out string? value)
     {
-        var trimmedText = text.Trim();
-        if (!trimmedText.StartsWith('@', StringComparison.Ordinal))
+        if (!TryRemovePrefix(text, '@', out var directiveBlockText))
         {
+            blockText = null;
             name = null;
             value = null;
             return false;
         }
 
-        var directiveText = trimmedText[1..].TrimStart();
+        var directiveText = directiveBlockText.TrimStart();
         if (directiveText.Length == 0)
         {
+            blockText = null;
             name = null;
             value = null;
             return false;
@@ -240,6 +252,7 @@ public class Template
 
         if (!char.IsLetter(directiveText[0]))
         {
+            blockText = null;
             name = null;
             value = null;
             return false;
@@ -259,12 +272,33 @@ public class Template
 
         if (name.Length == 0)
         {
+            blockText = null;
             name = null;
             value = null;
             return false;
         }
 
+        blockText = directiveBlockText;
         return true;
+    }
+
+    private static bool TryRemovePrefix(string text, char prefix, [NotNullWhen(true)] out string? value)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        if (text.Length > 0 && text[0] == prefix)
+        {
+            value = text[1..];
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static TextPosition MoveForward(TextPosition position)
+    {
+        return new TextPosition(position.Line, position.Column + 1, position.Index + 1);
     }
 
     /// <summary>Compiles the template into executable code.</summary>
@@ -333,11 +367,23 @@ public class Template
 
                 foreach (var block in Blocks)
                 {
+                    if (block is ClassMemberBlock)
+                        continue;
+
                     tw.WriteLine(block.BuildCode());
                 }
 
                 tw.Indent--;
                 tw.WriteLine("}");
+
+                foreach (var block in Blocks)
+                {
+                    if (block is not ClassMemberBlock)
+                        continue;
+
+                    tw.WriteLine(block.BuildCode());
+                }
+
                 tw.Indent--;
                 tw.WriteLine("}");
             }
@@ -381,8 +427,26 @@ public class Template
         return new CodeBlock(this, text, index);
     }
 
+    /// <summary>Creates a code block for an evaluation expression.</summary>
+    /// <param name="text">The expression content.</param>
+    /// <param name="index">The block index.</param>
+    /// <returns>A new <see cref="CodeBlock"/> instance.</returns>
+    protected virtual CodeBlock CreateCodeExpressionBlock(string text, int index)
+    {
+        return new CodeBlock(this, text, index, isExpression: true);
+    }
+
+    /// <summary>Creates a class member block for class-level members.</summary>
+    /// <param name="text">The member content.</param>
+    /// <param name="index">The block index.</param>
+    /// <returns>A new <see cref="ClassMemberBlock"/> instance.</returns>
+    protected virtual ClassMemberBlock CreateClassMemberBlock(string text, int index)
+    {
+        return new ClassMemberBlock(this, text, index);
+    }
+
     /// <summary>Creates a directive block.</summary>
-    /// <param name="text">The original directive text.</param>
+    /// <param name="text">The directive content without the directive marker.</param>
     /// <param name="name">The directive name.</param>
     /// <param name="value">The directive value.</param>
     /// <param name="index">The block index.</param>

--- a/src/Meziantou.Framework.Templating/readme.md
+++ b/src/Meziantou.Framework.Templating/readme.md
@@ -10,6 +10,7 @@ A powerful and flexible .NET template engine that allows you to create text temp
 - **Type-safe parameters** - Add strongly-typed or dynamic parameters to your templates
 - **Custom output types** - Use any output writer type for your templates
 - **Using directives** - Import namespaces and types for use in templates
+- **Class member blocks** - Add methods, fields, and properties to the generated template class
 - **Debug support** - Generate debug symbols for template debugging
 
 ## Usage
@@ -60,7 +61,7 @@ var result = template.Run(arguments);
 
 ### Code Blocks
 
-Templates support three types of code blocks:
+Templates support four types of code blocks:
 
 #### 1. Evaluation blocks (`<%=...%>`)
 
@@ -84,7 +85,21 @@ var result = template.Run();
 // result: "Numbers: 12345"
 ```
 
-#### 3. Mixed content
+#### 3. Class member blocks (`<%+...%>`)
+
+Add members to the generated template class:
+
+```csharp
+var template = new Template();
+template.Load("""
+<%+private static string Prefix() => "Item"; %>
+<%= Prefix() %> 1
+""");
+var result = template.Run();
+// result: "Item 1"
+```
+
+#### 4. Mixed content
 
 Combine text, evaluation blocks, and statement blocks:
 
@@ -251,6 +266,7 @@ The default template syntax uses `<%` and `%>` delimiters:
 |--------|-------------|---------|
 | `<%= expression %>` | Evaluates an expression and writes it to output | `<%= 2 + 2 %>` |
 | `<% statement %>` | Executes a C# statement | `<% var x = 10; %>` |
+| `<%+ member %>` | Declares a class member in the generated template class | `<%+private static int Get() => 42; %>` |
 | Text | Any text outside code blocks is written as-is | `Hello World` |
 
 ## Error Handling

--- a/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
@@ -96,6 +96,75 @@ public class TemplateTest
     }
 
     [Fact]
+    public void Template_ClassMemberBlock_IsParsed()
+    {
+        var template = new Template();
+        template.Load("<%+ private static string Sample() => \"Sample\"; %>");
+
+        var block = Assert.Single(template.Blocks.OfType<ClassMemberBlock>());
+        Assert.StartsWith(" private static string Sample()", block.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Template_CodeEvalBlock_IsParsedWithoutPrefix()
+    {
+        var template = new Template();
+        template.Load("<%= 1 %>");
+
+        var block = Assert.Single(template.Blocks.OfType<CodeBlock>(), codeBlock => codeBlock.IsExpression);
+        Assert.StartsWith(" 1", block.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Template_DirectiveBlock_IsParsedWithoutPrefix()
+    {
+        var template = new Template();
+        template.Load("<%@ outputextension .cs %>");
+
+        var block = Assert.Single(template.Blocks.OfType<DirectiveBlock>());
+        Assert.StartsWith(" outputextension .cs", block.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Template_ClassMemberBlock_CanBeInvokedFromTemplate()
+    {
+        var template = new Template();
+        template.Load("""
+            <%+ private static string Sample() => "Sample"; %>
+            <%= Sample() %>
+            """);
+
+        var result = template.Run();
+
+        Assert.Equal("Sample", result.Trim());
+    }
+
+    [Fact]
+    public void Template_ClassMemberBlock_StrictSyntaxOnly()
+    {
+        var template = new Template();
+        template.Load("<% + private static string Sample() => \"Sample\"; %>");
+
+        Assert.Empty(template.Blocks.OfType<ClassMemberBlock>());
+        Assert.Single(template.Blocks.OfType<CodeBlock>());
+    }
+
+    [Fact]
+    public void Template_ClassMemberBlock_IsGeneratedAtClassScope()
+    {
+        var template = new TemplateWithoutCompilation();
+        template.Load("""
+            <%+private static string Sample() => "Sample"; %>
+            <%= Sample() %>
+            """);
+
+        template.Build(CancellationToken.None);
+
+        Assert.Contains("private static string Sample() => \"Sample\";", template.SourceCode, StringComparison.Ordinal);
+        Assert.Contains("}" + Environment.NewLine + "    private static string Sample() => \"Sample\";", template.SourceCode, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Template_UntypedArgument()
     {
         // Arrange
@@ -258,7 +327,7 @@ public class TemplateTest
 
         var directive = Assert.Single(template.Blocks!.OfType<DirectiveBlock>());
         Assert.Equal(2, directive.Start.Line);
-        Assert.Equal(3, directive.Start.Column);
+        Assert.Equal(4, directive.Start.Column);
         Assert.Equal(Source.IndexOf(directive.Text, StringComparison.Ordinal), directive.Start.Index);
         Assert.Equal(2, directive.End.Line);
         Assert.True(directive.End.Column > directive.Start.Column);
@@ -299,9 +368,9 @@ public class TemplateTest
         var template = new Template();
         template.Load(Source);
 
-        var codeBlock = Assert.Single(template.Blocks!.OfType<CodeBlock>());
+        var codeBlock = Assert.Single(template.Blocks!.OfType<CodeBlock>(), codeBlock => codeBlock.IsExpression);
         Assert.Equal(2, codeBlock.Start.Line);
-        Assert.Equal(3, codeBlock.Start.Column);
+        Assert.Equal(4, codeBlock.Start.Column);
         Assert.Equal(codeBlock.Text.Length, codeBlock.Span.Length);
         Assert.Equal(codeBlock.Text, Source.AsSpan(codeBlock.Start.Index, codeBlock.Span.Length).ToString());
     }


### PR DESCRIPTION
## Why
`Meziantou.Framework.Templating` did not support T4 class-member blocks (`<%+ ... %>`), and prefix handling for block kinds was split between parsing and block rendering. This made block behavior harder to reason about and left parsing details in `BuildCode()` implementations.

## What changed
- Added support for class-member blocks with a new `ClassMemberBlock` type.
- Updated template code generation so class-member blocks are emitted at class scope, while non-member blocks stay inside `Run`.
- Moved block marker handling to the parser (`Template.CreateBlock`):
  - `<%+ ... %>` strips `+` at parse time.
  - `<%= ... %>` strips `=` at parse time.
  - `<%@ ... %>` strips `@` at parse time.
- Simplified block implementations:
  - `ClassMemberBlock` now emits `Text` directly.
  - `CodeBlock` no longer parses expression markers from text; expression vs statement is set when creating the block.
- Kept text span metadata aligned with normalized block text by advancing start positions when a marker is removed.
- Updated documentation and public API reference file.

## Validation
- Ran required repository scripts:
  - `dotnet run ./eng/update-bom.cs`
  - `dotnet run ./eng/update-readme.cs`
  - `dotnet run ./eng/update-project-slnx.cs`
  - `dotnet run ./eng/validate-testprojects-configuration.cs`
  - `dotnet run ./eng/update-trimmable.cs`
- Ran:
  - `dotnet build src/Meziantou.Framework.Templating/Meziantou.Framework.Templating.csproj /p:TreatsWarningsAsErrors=true`
  - `dotnet test tests/Meziantou.Framework.Templating.Tests/Meziantou.Framework.Templating.Tests.csproj /p:TreatsWarningsAsErrors=true`
- Added and updated tests for class-member parsing/generation, strict `<%+...%>` behavior, prefix removal, and span/position expectations.