### PR TITLE
Add README for Meziantou.Framework.AnsiFormatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 | Meziantou.Extensions.Logging.Xunit | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Extensions.Logging.Xunit.svg)](https://www.nuget.org/packages/Meziantou.Extensions.Logging.Xunit/) | [readme](src/Meziantou.Extensions.Logging.Xunit/readme.md) |
 | Meziantou.Extensions.Logging.Xunit.v3 | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Extensions.Logging.Xunit.v3.svg)](https://www.nuget.org/packages/Meziantou.Extensions.Logging.Xunit.v3/) | [readme](src/Meziantou.Extensions.Logging.Xunit.v3/readme.md) |
 | Meziantou.Framework | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.svg)](https://www.nuget.org/packages/Meziantou.Framework/) | |
-| Meziantou.Framework.AnsiFormatting | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.AnsiFormatting.svg)](https://www.nuget.org/packages/Meziantou.Framework.AnsiFormatting/) | |
+| Meziantou.Framework.AnsiFormatting | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.AnsiFormatting.svg)](https://www.nuget.org/packages/Meziantou.Framework.AnsiFormatting/) | [readme](src/Meziantou.Framework.AnsiFormatting/readme.md) |
 | Meziantou.Framework.Avatar | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.Avatar.svg)](https://www.nuget.org/packages/Meziantou.Framework.Avatar/) | [readme](src/Meziantou.Framework.Avatar/readme.md) |
 | Meziantou.Framework.Bcrypt | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.Bcrypt.svg)](https://www.nuget.org/packages/Meziantou.Framework.Bcrypt/) | [readme](src/Meziantou.Framework.Bcrypt/readme.md) |
 | Meziantou.Framework.Bencode | [![NuGet](https://img.shields.io/nuget/v/Meziantou.Framework.Bencode.svg)](https://www.nuget.org/packages/Meziantou.Framework.Bencode/) | [readme](src/Meziantou.Framework.Bencode/readme.md) |

--- a/src/Meziantou.Framework.AnsiFormatting/readme.md
+++ b/src/Meziantou.Framework.AnsiFormatting/readme.md
@@ -1,0 +1,29 @@
+# Meziantou.Framework.AnsiFormatting
+
+`Meziantou.Framework.AnsiFormatting` provides helpers to detect, remove, and parse ANSI escape sequences.
+
+## Remove ANSI sequences
+
+```c#
+using Meziantou.Framework;
+
+var input = "\x1b[1;31mError:\x1b[0m Something went wrong";
+var cleanText = AnsiTextProcessor.RemoveAnsiSequences(input);
+var containsAnsi = AnsiTextProcessor.ContainsAnsiSequences(input);
+```
+
+## Parse text with styles
+
+```c#
+using Meziantou.Framework;
+
+var text = "\x1b[1;38;5;208mWarning\x1b[0m and \x1b[4;34mInfo\x1b[0m";
+var parsed = AnsiTextProcessor.ParseTextWithAnsiStyles(text);
+
+Console.WriteLine(parsed.Text); // Warning and Info
+
+foreach (var run in parsed.Runs)
+{
+    Console.WriteLine($"{run.Start}-{run.End}: Bold={run.Style.Bold}, Underline={run.Style.Underline}");
+}
+```


### PR DESCRIPTION
This adds package documentation for `Meziantou.Framework.AnsiFormatting` so users can quickly understand the API and usage patterns from the repository and NuGet package listing.

## What changed
- Added `src/Meziantou.Framework.AnsiFormatting/readme.md` with usage examples for removing ANSI sequences, detecting ANSI sequences, and parsing styled text.
- Updated the root `README.md` NuGet table to link to the new package readme.

## Notes
- This is a documentation-only change and does not modify runtime behavior.