### PR TITLE
Add return type annotation to initialize function in JSDoc

### DIFF
--- a/src/Meziantou.AspNetCore.Components/wwwroot/InfiniteScrolling.js
+++ b/src/Meziantou.AspNetCore.Components/wwwroot/InfiniteScrolling.js
@@ -4,6 +4,7 @@
  *
  * @param {HTMLElement} lastIndicator
  * @param {DotNet.DotNetObject} instance
+ * @returns {{ dispose: () => void, onNewItems: () => void }}
  */
 export function initialize(lastIndicator, instance) {
     const options = {


### PR DESCRIPTION
## Problem
The `initialize` function in `InfiniteScrolling.js` lacked a return type annotation in its JSDoc comment, which could reduce code readability and IDE support for type checking and documentation generation.

## Changes
Added a `@returns` annotation to the JSDoc comment of the `initialize` function, specifying the return type as an object with `dispose` and `onNewItems` methods to improve clarity and tooling support.

## Verification
- Verify that the JSDoc annotation is correctly formatted and aligns with the function's actual return value.
- Ensure the change does not alter the function's behavior or public API.
- Check for compatibility with JSDoc parsing tools and IDE integrations used in the project.