### PR TITLE
Clarify FullPath analyzer rule titles

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/FullPathDivisionWithFullPathRightAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FullPathDivisionWithFullPathRightAnalyzer.cs
@@ -10,7 +10,7 @@ public sealed class FullPathDivisionWithFullPathRightAnalyzer : DiagnosticAnalyz
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.DivisionWithFullPathRightDiagnosticId,
-        title: "Combining with a FullPath right operand is redundant",
+        title: "Use the right FullPath operand directly",
         messageFormat: "Use the right FullPath operand directly instead of combining with '/'",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,

--- a/src/Meziantou.Framework.FullPath.Analyzer/MethodShouldReturnFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/MethodShouldReturnFullPathAnalyzer.cs
@@ -11,7 +11,7 @@ public sealed class MethodShouldReturnFullPathAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.MethodShouldReturnFullPathDiagnosticId,
-        title: "Method should return FullPath",
+        title: "Return FullPath instead of string",
         messageFormat: "Method '{0}' returns FullPath values and should return FullPath instead of string",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,

--- a/src/Meziantou.Framework.FullPath.Analyzer/PathChangeExtensionWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathChangeExtensionWithFullPathAnalyzer.cs
@@ -10,7 +10,7 @@ public sealed class PathChangeExtensionWithFullPathAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathChangeExtensionWithFullPathDiagnosticId,
-        title: "Path.ChangeExtension is redundant on FullPath",
+        title: "Use FullPath.ChangeExtension instead of Path.ChangeExtension",
         messageFormat: "Use FullPath.ChangeExtension instead of calling Path.ChangeExtension",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,

--- a/src/Meziantou.Framework.FullPath.Analyzer/PathCombineWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathCombineWithFullPathAnalyzer.cs
@@ -10,7 +10,7 @@ public sealed class PathCombineWithFullPathAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathCombineWithFullPathDiagnosticId,
-        title: "Path.Combine is redundant with FullPath arguments",
+        title: "Use '/' operator instead of Path.Combine",
         messageFormat: "Use FullPath '/' operations instead of calling Path.Combine",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,

--- a/src/Meziantou.Framework.FullPath.Analyzer/PathGetDirectoryNameWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathGetDirectoryNameWithFullPathAnalyzer.cs
@@ -10,7 +10,7 @@ public sealed class PathGetDirectoryNameWithFullPathAnalyzer : DiagnosticAnalyze
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathGetDirectoryNameWithFullPathDiagnosticId,
-        title: "Path.GetDirectoryName is redundant on FullPath",
+        title: "Use FullPath.Parent instead of Path.GetDirectoryName",
         messageFormat: "Use FullPath.Parent instead of calling Path.GetDirectoryName",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,

--- a/src/Meziantou.Framework.FullPath.Analyzer/PathGetExtensionWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathGetExtensionWithFullPathAnalyzer.cs
@@ -10,7 +10,7 @@ public sealed class PathGetExtensionWithFullPathAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathGetExtensionWithFullPathDiagnosticId,
-        title: "Path.GetExtension is redundant on FullPath",
+        title: "Use FullPath.Extension instead of Path.GetExtension",
         messageFormat: "Use FullPath.Extension instead of calling Path.GetExtension",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,

--- a/src/Meziantou.Framework.FullPath.Analyzer/PathGetFileNameWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathGetFileNameWithFullPathAnalyzer.cs
@@ -10,7 +10,7 @@ public sealed class PathGetFileNameWithFullPathAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathGetFileNameWithFullPathDiagnosticId,
-        title: "Path.GetFileName is redundant on FullPath",
+        title: "Use FullPath.Name instead of Path.GetFileName",
         messageFormat: "Use FullPath.Name instead of calling Path.GetFileName",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,

--- a/src/Meziantou.Framework.FullPath.Analyzer/PathGetFileNameWithoutExtensionWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathGetFileNameWithoutExtensionWithFullPathAnalyzer.cs
@@ -10,7 +10,7 @@ public sealed class PathGetFileNameWithoutExtensionWithFullPathAnalyzer : Diagno
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathGetFileNameWithoutExtensionWithFullPathDiagnosticId,
-        title: "Path.GetFileNameWithoutExtension is redundant on FullPath",
+        title: "Use FullPath.NameWithoutExtension instead of Path.GetFileNameWithoutExtension",
         messageFormat: "Use FullPath.NameWithoutExtension instead of calling Path.GetFileNameWithoutExtension",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,

--- a/src/Meziantou.Framework.FullPath.Analyzer/PathGetFullPathOnFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathGetFullPathOnFullPathAnalyzer.cs
@@ -10,7 +10,7 @@ public sealed class PathGetFullPathOnFullPathAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathGetFullPathDiagnosticId,
-        title: "Path.GetFullPath is redundant on FullPath",
+        title: "Use FullPath directly instead of Path.GetFullPath",
         messageFormat: "Use the FullPath value directly instead of calling Path.GetFullPath",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,

--- a/src/Meziantou.Framework.FullPath.Analyzer/PathGetFullPathWithFullPathBaseAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathGetFullPathWithFullPathBaseAnalyzer.cs
@@ -10,7 +10,7 @@ public sealed class PathGetFullPathWithFullPathBaseAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathGetFullPathWithFullPathBaseDiagnosticId,
-        title: "Path.GetFullPath with FullPath base is redundant",
+        title: "Use '/' with a FullPath base instead of Path.GetFullPath",
         messageFormat: "Use the FullPath base value with '/' instead of calling Path.GetFullPath",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,

--- a/src/Meziantou.Framework.FullPath.Analyzer/PathGetRelativePathWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathGetRelativePathWithFullPathAnalyzer.cs
@@ -10,7 +10,7 @@ public sealed class PathGetRelativePathWithFullPathAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathGetRelativePathWithFullPathDiagnosticId,
-        title: "Path.GetRelativePath is redundant on FullPath",
+        title: "Use FullPath.MakePathRelativeTo instead of Path.GetRelativePath",
         messageFormat: "Use FullPath.MakePathRelativeTo instead of calling Path.GetRelativePath",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,

--- a/src/Meziantou.Framework.FullPath/readme.md
+++ b/src/Meziantou.Framework.FullPath/readme.md
@@ -52,17 +52,17 @@ System.IO.File.WriteAllText(filePath, content);
 <!-- analyzer-rules -->
 | Id | Category | Description | Severity | Enabled |
 | -- | -- | -- | :--: | :--: |
-| `MFFP0001` | FullPath | Path.GetFullPath is redundant on FullPath | Info | ✔️ |
-| `MFFP0002` | FullPath | Combining with a FullPath right operand is redundant | Info | ✔️ |
-| `MFFP0003` | FullPath | Path.GetFullPath with FullPath base is redundant | Info | ✔️ |
-| `MFFP0004` | FullPath | Path.Combine is redundant with FullPath arguments | Info | ✔️ |
-| `MFFP0005` | FullPath | Path.GetFileName is redundant on FullPath | Info | ✔️ |
-| `MFFP0006` | FullPath | Path.GetFileNameWithoutExtension is redundant on FullPath | Info | ✔️ |
-| `MFFP0007` | FullPath | Path.GetExtension is redundant on FullPath | Info | ✔️ |
-| `MFFP0008` | FullPath | Path.GetDirectoryName is redundant on FullPath | Info | ✔️ |
-| `MFFP0009` | FullPath | Path.ChangeExtension is redundant on FullPath | Info | ✔️ |
-| `MFFP0010` | FullPath | Path.GetRelativePath is redundant on FullPath | Info | ✔️ |
-| `MFFP0011` | FullPath | Method should return FullPath | Info | ✔️ |
+| `MFFP0001` | FullPath | Use FullPath directly instead of Path.GetFullPath | Info | ✔️ |
+| `MFFP0002` | FullPath | Use the right FullPath operand directly | Info | ✔️ |
+| `MFFP0003` | FullPath | Use '/' with a FullPath base instead of Path.GetFullPath | Info | ✔️ |
+| `MFFP0004` | FullPath | Use '/' operator instead of Path.Combine | Info | ✔️ |
+| `MFFP0005` | FullPath | Use FullPath.Name instead of Path.GetFileName | Info | ✔️ |
+| `MFFP0006` | FullPath | Use FullPath.NameWithoutExtension instead of Path.GetFileNameWithoutExtension | Info | ✔️ |
+| `MFFP0007` | FullPath | Use FullPath.Extension instead of Path.GetExtension | Info | ✔️ |
+| `MFFP0008` | FullPath | Use FullPath.Parent instead of Path.GetDirectoryName | Info | ✔️ |
+| `MFFP0009` | FullPath | Use FullPath.ChangeExtension instead of Path.ChangeExtension | Info | ✔️ |
+| `MFFP0010` | FullPath | Use FullPath.MakePathRelativeTo instead of Path.GetRelativePath | Info | ✔️ |
+| `MFFP0011` | FullPath | Return FullPath instead of string | Info | ✔️ |
 <!-- analyzer-rules -->
 
 # Additional resources


### PR DESCRIPTION
## Why
The current FullPath analyzer rule titles are mostly phrased as "redundant", which makes some diagnostics less actionable at first glance.

## What changed
This updates the 11 rule titles in `Meziantou.Framework.FullPath.Analyzer` to action-oriented wording that clearly states the preferred API or operator (for example, using `/` instead of `Path.Combine`, or using `FullPath.Name` instead of `Path.GetFileName`).

The analyzer rules table in `src/Meziantou.Framework.FullPath/readme.md` was regenerated to keep the published rule descriptions aligned with the descriptor titles.

## Notes
No analyzer behavior changed; only titles/descriptions surfaced to users were clarified.