### PR TITLE
Optimize bloom filter storage and benchmark coverage

### DIFF
--- a/benchmarks/BloomFiltersBenchmarks/BloomFilterBenchmark.cs
+++ b/benchmarks/BloomFiltersBenchmarks/BloomFilterBenchmark.cs
@@ -8,12 +8,15 @@ public class BloomFilterBenchmark
 {
     private const long ExpectedItemCount = 100_000;
     private const double FalsePositiveProbability = 0.01;
+    private const int OperationsPerInvoke = 1000;
 
     private static readonly BloomFilterSize FilterSize = BloomFilterSize.CreateOptimalSize(ExpectedItemCount, FalsePositiveProbability);
 
     private BloomFilterXXHash128 _filter = null!;
 
+    private byte[] _bytes = null!;
     private string[] _items = null!;
+    private string[] _newItems = null!;
     private string _existingItem = null!;
     private string _newItem = null!;
 
@@ -29,6 +32,13 @@ public class BloomFilterBenchmark
             _filter.Add(_items[i]);
         }
 
+        _bytes = [1, 2, 3, 4, 5, 6, 7, 8];
+        _newItems = new string[OperationsPerInvoke];
+        for (var i = 0; i < _newItems.Length; i++)
+        {
+            _newItems[i] = $"nonexistent_{i}";
+        }
+
         _existingItem = _items[ExpectedItemCount / 2];
         _newItem = $"nonexistent_item_{Guid.NewGuid()}";
     }
@@ -36,7 +46,7 @@ public class BloomFilterBenchmark
     [Benchmark]
     public void Add_Int()
     {
-        for (var i = 0; i < 1000; i++)
+        for (var i = 0; i < OperationsPerInvoke; i++)
         {
             _filter.Add(i);
         }
@@ -45,19 +55,18 @@ public class BloomFilterBenchmark
     [Benchmark]
     public void Add_String()
     {
-        for (var i = 0; i < 1000; i++)
+        for (var i = 0; i < OperationsPerInvoke; i++)
         {
-            _filter.Add($"value_{i}");
+            _filter.Add(_newItems[i]);
         }
     }
 
     [Benchmark]
     public void Add_ReadOnlySpanByte()
     {
-        var bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
-        for (var i = 0; i < 1000; i++)
+        for (var i = 0; i < OperationsPerInvoke; i++)
         {
-            _filter.Add(bytes.AsSpan());
+            _filter.Add(_bytes.AsSpan());
         }
     }
 
@@ -74,24 +83,28 @@ public class BloomFilterBenchmark
     }
 
     [Benchmark]
-    public void MayContain_ExistingItems()
+    public int MayContain_ExistingItems()
     {
         var count = 0;
-        for (var i = 0; i < 1000; i++)
+        for (var i = 0; i < OperationsPerInvoke; i++)
         {
             if (_filter.MayContain(_items[i]))
                 count++;
         }
+
+        return count;
     }
 
     [Benchmark]
-    public void MayContain_NewItems()
+    public int MayContain_NewItems()
     {
         var count = 0;
-        for (var i = 0; i < 1000; i++)
+        for (var i = 0; i < OperationsPerInvoke; i++)
         {
-            if (_filter.MayContain($"nonexistent_{i}"))
+            if (_filter.MayContain(_newItems[i]))
                 count++;
         }
+
+        return count;
     }
 }

--- a/benchmarks/BloomFiltersBenchmarks/LargeBloomFilterBenchmark.cs
+++ b/benchmarks/BloomFiltersBenchmarks/LargeBloomFilterBenchmark.cs
@@ -1,0 +1,66 @@
+using BenchmarkDotNet.Attributes;
+using Meziantou.Framework.BloomFilters;
+
+namespace BloomFiltersBenchmarks;
+
+[MemoryDiagnoser]
+public class LargeBloomFilterBenchmark
+{
+    private const int OperationsPerInvoke = 10_000;
+
+    private static readonly BloomFilterSize FilterSize = BloomFilterSize.CreateExact(128L * 1024 * 1024 * 8, 7);
+
+    private BloomFilterXXHash128 _filter = null!;
+    private int[] _existingItems = null!;
+    private int[] _newItems = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _filter = BloomFilter.CreateXXHash128(FilterSize);
+        _existingItems = new int[OperationsPerInvoke];
+        _newItems = new int[OperationsPerInvoke];
+
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            _existingItems[i] = i;
+            _newItems[i] = int.MinValue + i;
+            _filter.Add(_existingItems[i]);
+        }
+    }
+
+    [Benchmark]
+    public void Add()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            _filter.Add(_newItems[i]);
+        }
+    }
+
+    [Benchmark]
+    public int MayContain_ExistingItems()
+    {
+        var count = 0;
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            if (_filter.MayContain(_existingItems[i]))
+                count++;
+        }
+
+        return count;
+    }
+
+    [Benchmark]
+    public int MayContain_NewItems()
+    {
+        var count = 0;
+        for (var i = 0; i < OperationsPerInvoke; i++)
+        {
+            if (_filter.MayContain(_newItems[i]))
+                count++;
+        }
+
+        return count;
+    }
+}

--- a/benchmarks/BloomFiltersBenchmarks/Program.cs
+++ b/benchmarks/BloomFiltersBenchmarks/Program.cs
@@ -1,4 +1,4 @@
 using BenchmarkDotNet.Running;
 using BloomFiltersBenchmarks;
 
-BenchmarkRunner.Run<BloomFilterBenchmark>();
+BenchmarkSwitcher.FromAssembly(typeof(BloomFilterBenchmark).Assembly).Run(args);

--- a/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
+++ b/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
@@ -6,39 +6,31 @@ namespace Meziantou.Framework.BloomFilters;
 
 internal sealed class SegmentedBitStorage
 {
-    private const int SegmentShift = 20;
-    private const int WordsPerSegmentValue = 1 << SegmentShift;
+    private const int SegmentShift = 23;
+    private const int WordsPerSegment = 1 << SegmentShift;
+    private const int SegmentMask = WordsPerSegment - 1;
 
     private readonly ulong[][] _segments;
-    private readonly int _wordsPerSegment;
-    private readonly int _segmentMask;
 
     public SegmentedBitStorage(long bitCount)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bitCount);
 
         BitCount = bitCount;
-        WordCount = checked(((bitCount - 1) / 64) + 1);
-        MemoryBytes = checked(WordCount * sizeof(ulong));
-        _wordsPerSegment = WordsPerSegmentValue;
-        _segmentMask = _wordsPerSegment - 1;
+        var wordCount = checked(((bitCount - 1) / 64) + 1);
 
-        var segmentCount = checked((int)((WordCount + _wordsPerSegment - 1) / _wordsPerSegment));
+        var segmentCount = checked((int)((wordCount + WordsPerSegment - 1) / WordsPerSegment));
         _segments = new ulong[segmentCount][];
 
         for (var segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
         {
-            var remainingWords = WordCount - ((long)segmentIndex * _wordsPerSegment);
-            var currentSegmentLength = (int)Math.Min(_wordsPerSegment, remainingWords);
+            var remainingWords = wordCount - ((long)segmentIndex * WordsPerSegment);
+            var currentSegmentLength = (int)Math.Min(WordsPerSegment, remainingWords);
             _segments[segmentIndex] = new ulong[currentSegmentLength];
         }
     }
 
     public long BitCount { get; }
-    public long WordCount { get; }
-    public long MemoryBytes { get; }
-    public int SegmentCount => _segments.Length;
-    public int WordsPerSegment => _wordsPerSegment;
 
     public void Clear()
     {
@@ -48,37 +40,28 @@ internal sealed class SegmentedBitStorage
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Set(long bitIndex)
     {
         ValidateBitIndex(bitIndex);
 
         var wordIndex = bitIndex >> 6;
-        var bitOffset = (int)(bitIndex & 63);
-        var mask = 1UL << bitOffset;
-        var segmentIndex = (int)(wordIndex >> SegmentShift);
-        var offset = (int)(wordIndex & _segmentMask);
-
-        var segment = _segments[segmentIndex];
+        var segment = _segments[(int)(wordIndex >> SegmentShift)];
         ref var baseRef = ref MemoryMarshal.GetArrayDataReference(segment);
-        ref var wordRef = ref Unsafe.Add(ref baseRef, (nint)offset);
-        Interlocked.Or(ref wordRef, mask);
+        ref var wordRef = ref Unsafe.Add(ref baseRef, (nint)(wordIndex & SegmentMask));
+        Interlocked.Or(ref wordRef, 1UL << (int)bitIndex);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsSet(long bitIndex)
     {
         ValidateBitIndex(bitIndex);
 
         var wordIndex = bitIndex >> 6;
-        var bitOffset = (int)(bitIndex & 63);
-        var mask = 1UL << bitOffset;
-        var segmentIndex = (int)(wordIndex >> SegmentShift);
-        var offset = (int)(wordIndex & _segmentMask);
-
-        var segment = _segments[segmentIndex];
+        var segment = _segments[(int)(wordIndex >> SegmentShift)];
         ref var baseRef = ref MemoryMarshal.GetArrayDataReference(segment);
-        ref var wordRef = ref Unsafe.Add(ref baseRef, (nint)offset);
-        var word = Volatile.Read(ref wordRef);
-        return (word & mask) != 0;
+        ref var wordRef = ref Unsafe.Add(ref baseRef, (nint)(wordIndex & SegmentMask));
+        return (Volatile.Read(ref wordRef) & (1UL << (int)bitIndex)) != 0;
     }
 
     [Conditional("DEBUG")]


### PR DESCRIPTION
## Summary
- Increase segmented bit storage segment size and simplify bit access logic to reduce overhead.
- Rework bloom filter benchmarks to reuse inputs, avoid per-iteration allocations, and return counts for containment checks.
- Add a large bloom filter benchmark suite and switch benchmark entrypoint to run all benchmarks in the assembly.

## Testing
- Not run (not requested)