### PR TITLE
Increase segmented bit storage segment size

### DIFF
--- a/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
+++ b/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
@@ -6,7 +6,7 @@ namespace Meziantou.Framework.BloomFilters;
 
 internal sealed class SegmentedBitStorage
 {
-    private const int SegmentShift = 23;
+    private const int SegmentShift = 30;
     private const int WordsPerSegment = 1 << SegmentShift;
     private const int SegmentMask = WordsPerSegment - 1;
 


### PR DESCRIPTION
## Summary
- Raise the segmented bit storage segment shift from 23 to 30
- Allow larger per-segment capacity before allocating additional segments

## Testing
- Not run (not requested)