### PR TITLE
Add counting bloom filter support

### DIFF
--- a/ref/Meziantou.Framework.BloomFilters.cs
+++ b/ref/Meziantou.Framework.BloomFilters.cs
@@ -160,6 +160,276 @@ namespace Meziantou.Framework.BloomFilters
         public void AddRange(params System.ReadOnlySpan<ulong> values) { }
     }
 
+    public abstract class CountingBloomFilter
+    {
+        public static Meziantou.Framework.BloomFilters.CountingBloomFilterXXHash128 CreateXXHash128(Meziantou.Framework.BloomFilters.CountingBloomFilterSize size) => throw null;
+        public static Meziantou.Framework.BloomFilters.CountingBloomFilterXXHash64 CreateXXHash64(Meziantou.Framework.BloomFilters.CountingBloomFilterSize size) => throw null;
+        public static Meziantou.Framework.BloomFilters.CountingBloomFilterXXHash32 CreateXXHash32(Meziantou.Framework.BloomFilters.CountingBloomFilterSize size) => throw null;
+        public static Meziantou.Framework.BloomFilters.CountingBloomFilterXXHash3 CreateXXHash3(Meziantou.Framework.BloomFilters.CountingBloomFilterSize size) => throw null;
+        public static Meziantou.Framework.BloomFilters.CountingBloomFilterCrc64 CreateCrc64(Meziantou.Framework.BloomFilters.CountingBloomFilterSize size) => throw null;
+        public static Meziantou.Framework.BloomFilters.CountingBloomFilterCrc32 CreateCrc32(Meziantou.Framework.BloomFilters.CountingBloomFilterSize size) => throw null;
+    }
+
+    public sealed class CountingBloomFilterCrc32 : Meziantou.Framework.BloomFilters.CountingBloomFilter, Meziantou.Framework.BloomFilters.ICountingBloomFilter
+    {
+        public void Add(int value) { }
+        public void Remove(int value) { }
+        public bool MayContain(int value) => throw null;
+        public int GetEstimatedCount(int value) => throw null;
+        public void Add(uint value) { }
+        public void Remove(uint value) { }
+        public bool MayContain(uint value) => throw null;
+        public int GetEstimatedCount(uint value) => throw null;
+        public void Add(long value) { }
+        public void Remove(long value) { }
+        public bool MayContain(long value) => throw null;
+        public int GetEstimatedCount(long value) => throw null;
+        public void Add(ulong value) { }
+        public void Remove(ulong value) { }
+        public bool MayContain(ulong value) => throw null;
+        public int GetEstimatedCount(ulong value) => throw null;
+        public void Add(System.Guid value) { }
+        public void Remove(System.Guid value) { }
+        public bool MayContain(System.Guid value) => throw null;
+        public int GetEstimatedCount(System.Guid value) => throw null;
+        public void Add(string value) { }
+        public void Remove(string value) { }
+        public bool MayContain(string value) => throw null;
+        public int GetEstimatedCount(string value) => throw null;
+        public void Add(System.UInt128 value) { }
+        public void Remove(System.UInt128 value) { }
+        public bool MayContain(System.UInt128 value) => throw null;
+        public int GetEstimatedCount(System.UInt128 value) => throw null;
+        public void Add(System.Int128 value) { }
+        public void Remove(System.Int128 value) { }
+        public bool MayContain(System.Int128 value) => throw null;
+        public int GetEstimatedCount(System.Int128 value) => throw null;
+        public void Add(System.ReadOnlySpan<byte> value) { }
+        public void Remove(System.ReadOnlySpan<byte> value) { }
+        public bool MayContain(System.ReadOnlySpan<byte> value) => throw null;
+        public int GetEstimatedCount(System.ReadOnlySpan<byte> value) => throw null;
+    }
+
+    public sealed class CountingBloomFilterCrc64 : Meziantou.Framework.BloomFilters.CountingBloomFilter, Meziantou.Framework.BloomFilters.ICountingBloomFilter
+    {
+        public void Add(int value) { }
+        public void Remove(int value) { }
+        public bool MayContain(int value) => throw null;
+        public int GetEstimatedCount(int value) => throw null;
+        public void Add(uint value) { }
+        public void Remove(uint value) { }
+        public bool MayContain(uint value) => throw null;
+        public int GetEstimatedCount(uint value) => throw null;
+        public void Add(long value) { }
+        public void Remove(long value) { }
+        public bool MayContain(long value) => throw null;
+        public int GetEstimatedCount(long value) => throw null;
+        public void Add(ulong value) { }
+        public void Remove(ulong value) { }
+        public bool MayContain(ulong value) => throw null;
+        public int GetEstimatedCount(ulong value) => throw null;
+        public void Add(System.Guid value) { }
+        public void Remove(System.Guid value) { }
+        public bool MayContain(System.Guid value) => throw null;
+        public int GetEstimatedCount(System.Guid value) => throw null;
+        public void Add(string value) { }
+        public void Remove(string value) { }
+        public bool MayContain(string value) => throw null;
+        public int GetEstimatedCount(string value) => throw null;
+        public void Add(System.UInt128 value) { }
+        public void Remove(System.UInt128 value) { }
+        public bool MayContain(System.UInt128 value) => throw null;
+        public int GetEstimatedCount(System.UInt128 value) => throw null;
+        public void Add(System.Int128 value) { }
+        public void Remove(System.Int128 value) { }
+        public bool MayContain(System.Int128 value) => throw null;
+        public int GetEstimatedCount(System.Int128 value) => throw null;
+        public void Add(System.ReadOnlySpan<byte> value) { }
+        public void Remove(System.ReadOnlySpan<byte> value) { }
+        public bool MayContain(System.ReadOnlySpan<byte> value) => throw null;
+        public int GetEstimatedCount(System.ReadOnlySpan<byte> value) => throw null;
+    }
+
+    public readonly struct CountingBloomFilterSize
+    {
+        public long CounterCount { get => throw null; }
+        public int HashCount { get => throw null; }
+        public static Meziantou.Framework.BloomFilters.CountingBloomFilterSize CreateOptimalSize(long expectedItemCount, double falsePositiveProbability) => throw null;
+        public static Meziantou.Framework.BloomFilters.CountingBloomFilterSize CreateExact(long counterCount, int hashCount) => throw null;
+    }
+
+    public sealed class CountingBloomFilterXXHash128 : Meziantou.Framework.BloomFilters.CountingBloomFilter, Meziantou.Framework.BloomFilters.ICountingBloomFilter
+    {
+        public void Add(int value) { }
+        public void Remove(int value) { }
+        public bool MayContain(int value) => throw null;
+        public int GetEstimatedCount(int value) => throw null;
+        public void Add(uint value) { }
+        public void Remove(uint value) { }
+        public bool MayContain(uint value) => throw null;
+        public int GetEstimatedCount(uint value) => throw null;
+        public void Add(long value) { }
+        public void Remove(long value) { }
+        public bool MayContain(long value) => throw null;
+        public int GetEstimatedCount(long value) => throw null;
+        public void Add(ulong value) { }
+        public void Remove(ulong value) { }
+        public bool MayContain(ulong value) => throw null;
+        public int GetEstimatedCount(ulong value) => throw null;
+        public void Add(System.Guid value) { }
+        public void Remove(System.Guid value) { }
+        public bool MayContain(System.Guid value) => throw null;
+        public int GetEstimatedCount(System.Guid value) => throw null;
+        public void Add(string value) { }
+        public void Remove(string value) { }
+        public bool MayContain(string value) => throw null;
+        public int GetEstimatedCount(string value) => throw null;
+        public void Add(System.UInt128 value) { }
+        public void Remove(System.UInt128 value) { }
+        public bool MayContain(System.UInt128 value) => throw null;
+        public int GetEstimatedCount(System.UInt128 value) => throw null;
+        public void Add(System.Int128 value) { }
+        public void Remove(System.Int128 value) { }
+        public bool MayContain(System.Int128 value) => throw null;
+        public int GetEstimatedCount(System.Int128 value) => throw null;
+        public void Add(System.ReadOnlySpan<byte> value) { }
+        public void Remove(System.ReadOnlySpan<byte> value) { }
+        public bool MayContain(System.ReadOnlySpan<byte> value) => throw null;
+        public int GetEstimatedCount(System.ReadOnlySpan<byte> value) => throw null;
+        public void AddRange(params System.ReadOnlySpan<long> values) { }
+        public void RemoveRange(params System.ReadOnlySpan<long> values) { }
+        public void AddRange(params System.ReadOnlySpan<ulong> values) { }
+        public void RemoveRange(params System.ReadOnlySpan<ulong> values) { }
+    }
+
+    public sealed class CountingBloomFilterXXHash3 : Meziantou.Framework.BloomFilters.CountingBloomFilter, Meziantou.Framework.BloomFilters.ICountingBloomFilter
+    {
+        public void Add(int value) { }
+        public void Remove(int value) { }
+        public bool MayContain(int value) => throw null;
+        public int GetEstimatedCount(int value) => throw null;
+        public void Add(uint value) { }
+        public void Remove(uint value) { }
+        public bool MayContain(uint value) => throw null;
+        public int GetEstimatedCount(uint value) => throw null;
+        public void Add(long value) { }
+        public void Remove(long value) { }
+        public bool MayContain(long value) => throw null;
+        public int GetEstimatedCount(long value) => throw null;
+        public void Add(ulong value) { }
+        public void Remove(ulong value) { }
+        public bool MayContain(ulong value) => throw null;
+        public int GetEstimatedCount(ulong value) => throw null;
+        public void Add(System.Guid value) { }
+        public void Remove(System.Guid value) { }
+        public bool MayContain(System.Guid value) => throw null;
+        public int GetEstimatedCount(System.Guid value) => throw null;
+        public void Add(string value) { }
+        public void Remove(string value) { }
+        public bool MayContain(string value) => throw null;
+        public int GetEstimatedCount(string value) => throw null;
+        public void Add(System.UInt128 value) { }
+        public void Remove(System.UInt128 value) { }
+        public bool MayContain(System.UInt128 value) => throw null;
+        public int GetEstimatedCount(System.UInt128 value) => throw null;
+        public void Add(System.Int128 value) { }
+        public void Remove(System.Int128 value) { }
+        public bool MayContain(System.Int128 value) => throw null;
+        public int GetEstimatedCount(System.Int128 value) => throw null;
+        public void Add(System.ReadOnlySpan<byte> value) { }
+        public void Remove(System.ReadOnlySpan<byte> value) { }
+        public bool MayContain(System.ReadOnlySpan<byte> value) => throw null;
+        public int GetEstimatedCount(System.ReadOnlySpan<byte> value) => throw null;
+    }
+
+    public sealed class CountingBloomFilterXXHash32 : Meziantou.Framework.BloomFilters.CountingBloomFilter, Meziantou.Framework.BloomFilters.ICountingBloomFilter
+    {
+        public void Add(int value) { }
+        public void Remove(int value) { }
+        public bool MayContain(int value) => throw null;
+        public int GetEstimatedCount(int value) => throw null;
+        public void Add(uint value) { }
+        public void Remove(uint value) { }
+        public bool MayContain(uint value) => throw null;
+        public int GetEstimatedCount(uint value) => throw null;
+        public void Add(long value) { }
+        public void Remove(long value) { }
+        public bool MayContain(long value) => throw null;
+        public int GetEstimatedCount(long value) => throw null;
+        public void Add(ulong value) { }
+        public void Remove(ulong value) { }
+        public bool MayContain(ulong value) => throw null;
+        public int GetEstimatedCount(ulong value) => throw null;
+        public void Add(System.Guid value) { }
+        public void Remove(System.Guid value) { }
+        public bool MayContain(System.Guid value) => throw null;
+        public int GetEstimatedCount(System.Guid value) => throw null;
+        public void Add(string value) { }
+        public void Remove(string value) { }
+        public bool MayContain(string value) => throw null;
+        public int GetEstimatedCount(string value) => throw null;
+        public void Add(System.UInt128 value) { }
+        public void Remove(System.UInt128 value) { }
+        public bool MayContain(System.UInt128 value) => throw null;
+        public int GetEstimatedCount(System.UInt128 value) => throw null;
+        public void Add(System.Int128 value) { }
+        public void Remove(System.Int128 value) { }
+        public bool MayContain(System.Int128 value) => throw null;
+        public int GetEstimatedCount(System.Int128 value) => throw null;
+        public void Add(System.ReadOnlySpan<byte> value) { }
+        public void Remove(System.ReadOnlySpan<byte> value) { }
+        public bool MayContain(System.ReadOnlySpan<byte> value) => throw null;
+        public int GetEstimatedCount(System.ReadOnlySpan<byte> value) => throw null;
+        public void AddRange(params System.ReadOnlySpan<int> values) { }
+        public void RemoveRange(params System.ReadOnlySpan<int> values) { }
+        public void AddRange(params System.ReadOnlySpan<uint> values) { }
+        public void RemoveRange(params System.ReadOnlySpan<uint> values) { }
+    }
+
+    public sealed class CountingBloomFilterXXHash64 : Meziantou.Framework.BloomFilters.CountingBloomFilter, Meziantou.Framework.BloomFilters.ICountingBloomFilter
+    {
+        public void Add(int value) { }
+        public void Remove(int value) { }
+        public bool MayContain(int value) => throw null;
+        public int GetEstimatedCount(int value) => throw null;
+        public void Add(uint value) { }
+        public void Remove(uint value) { }
+        public bool MayContain(uint value) => throw null;
+        public int GetEstimatedCount(uint value) => throw null;
+        public void Add(long value) { }
+        public void Remove(long value) { }
+        public bool MayContain(long value) => throw null;
+        public int GetEstimatedCount(long value) => throw null;
+        public void Add(ulong value) { }
+        public void Remove(ulong value) { }
+        public bool MayContain(ulong value) => throw null;
+        public int GetEstimatedCount(ulong value) => throw null;
+        public void Add(System.Guid value) { }
+        public void Remove(System.Guid value) { }
+        public bool MayContain(System.Guid value) => throw null;
+        public int GetEstimatedCount(System.Guid value) => throw null;
+        public void Add(string value) { }
+        public void Remove(string value) { }
+        public bool MayContain(string value) => throw null;
+        public int GetEstimatedCount(string value) => throw null;
+        public void Add(System.UInt128 value) { }
+        public void Remove(System.UInt128 value) { }
+        public bool MayContain(System.UInt128 value) => throw null;
+        public int GetEstimatedCount(System.UInt128 value) => throw null;
+        public void Add(System.Int128 value) { }
+        public void Remove(System.Int128 value) { }
+        public bool MayContain(System.Int128 value) => throw null;
+        public int GetEstimatedCount(System.Int128 value) => throw null;
+        public void Add(System.ReadOnlySpan<byte> value) { }
+        public void Remove(System.ReadOnlySpan<byte> value) { }
+        public bool MayContain(System.ReadOnlySpan<byte> value) => throw null;
+        public int GetEstimatedCount(System.ReadOnlySpan<byte> value) => throw null;
+        public void AddRange(params System.ReadOnlySpan<long> values) { }
+        public void RemoveRange(params System.ReadOnlySpan<long> values) { }
+        public void AddRange(params System.ReadOnlySpan<ulong> values) { }
+        public void RemoveRange(params System.ReadOnlySpan<ulong> values) { }
+    }
+
     public interface IBloomFilter
     {
         void Add(int value);
@@ -180,5 +450,45 @@ namespace Meziantou.Framework.BloomFilters
         bool MayContain(System.Int128 value);
         void Add(System.ReadOnlySpan<byte> value);
         bool MayContain(System.ReadOnlySpan<byte> value);
+    }
+
+    public interface ICountingBloomFilter
+    {
+        void Add(int value);
+        void Remove(int value);
+        bool MayContain(int value);
+        int GetEstimatedCount(int value);
+        void Add(uint value);
+        void Remove(uint value);
+        bool MayContain(uint value);
+        int GetEstimatedCount(uint value);
+        void Add(long value);
+        void Remove(long value);
+        bool MayContain(long value);
+        int GetEstimatedCount(long value);
+        void Add(ulong value);
+        void Remove(ulong value);
+        bool MayContain(ulong value);
+        int GetEstimatedCount(ulong value);
+        void Add(System.Guid value);
+        void Remove(System.Guid value);
+        bool MayContain(System.Guid value);
+        int GetEstimatedCount(System.Guid value);
+        void Add(string value);
+        void Remove(string value);
+        bool MayContain(string value);
+        int GetEstimatedCount(string value);
+        void Add(System.UInt128 value);
+        void Remove(System.UInt128 value);
+        bool MayContain(System.UInt128 value);
+        int GetEstimatedCount(System.UInt128 value);
+        void Add(System.Int128 value);
+        void Remove(System.Int128 value);
+        bool MayContain(System.Int128 value);
+        int GetEstimatedCount(System.Int128 value);
+        void Add(System.ReadOnlySpan<byte> value);
+        void Remove(System.ReadOnlySpan<byte> value);
+        bool MayContain(System.ReadOnlySpan<byte> value);
+        int GetEstimatedCount(System.ReadOnlySpan<byte> value);
     }
 }

--- a/src/Meziantou.Framework.BloomFilters/BloomFilter.g.cs
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilter.g.cs
@@ -30,6 +30,46 @@ public partial interface IBloomFilter
     bool MayContain(System.ReadOnlySpan<byte> value);
 }
 
+public partial interface ICountingBloomFilter
+{
+    void Add(int value);
+    void Remove(int value);
+    bool MayContain(int value);
+    int GetEstimatedCount(int value);
+    void Add(uint value);
+    void Remove(uint value);
+    bool MayContain(uint value);
+    int GetEstimatedCount(uint value);
+    void Add(long value);
+    void Remove(long value);
+    bool MayContain(long value);
+    int GetEstimatedCount(long value);
+    void Add(ulong value);
+    void Remove(ulong value);
+    bool MayContain(ulong value);
+    int GetEstimatedCount(ulong value);
+    void Add(global::System.Guid value);
+    void Remove(global::System.Guid value);
+    bool MayContain(global::System.Guid value);
+    int GetEstimatedCount(global::System.Guid value);
+    void Add(string value);
+    void Remove(string value);
+    bool MayContain(string value);
+    int GetEstimatedCount(string value);
+    void Add(global::System.UInt128 value);
+    void Remove(global::System.UInt128 value);
+    bool MayContain(global::System.UInt128 value);
+    int GetEstimatedCount(global::System.UInt128 value);
+    void Add(global::System.Int128 value);
+    void Remove(global::System.Int128 value);
+    bool MayContain(global::System.Int128 value);
+    int GetEstimatedCount(global::System.Int128 value);
+    void Add(System.ReadOnlySpan<byte> value);
+    void Remove(System.ReadOnlySpan<byte> value);
+    bool MayContain(System.ReadOnlySpan<byte> value);
+    int GetEstimatedCount(System.ReadOnlySpan<byte> value);
+}
+
 partial class BloomFilter
 {
     public static BloomFilterXXHash128 CreateXXHash128(BloomFilterSize size) => new(size.BitCount, size.HashCount);
@@ -38,6 +78,16 @@ partial class BloomFilter
     public static BloomFilterXXHash3 CreateXXHash3(BloomFilterSize size) => new(size.BitCount, size.HashCount);
     public static BloomFilterCrc64 CreateCrc64(BloomFilterSize size) => new(size.BitCount, size.HashCount);
     public static BloomFilterCrc32 CreateCrc32(BloomFilterSize size) => new(size.BitCount, size.HashCount);
+}
+
+partial class CountingBloomFilter
+{
+    public static CountingBloomFilterXXHash128 CreateXXHash128(CountingBloomFilterSize size) => new(size.CounterCount, size.HashCount);
+    public static CountingBloomFilterXXHash64 CreateXXHash64(CountingBloomFilterSize size) => new(size.CounterCount, size.HashCount);
+    public static CountingBloomFilterXXHash32 CreateXXHash32(CountingBloomFilterSize size) => new(size.CounterCount, size.HashCount);
+    public static CountingBloomFilterXXHash3 CreateXXHash3(CountingBloomFilterSize size) => new(size.CounterCount, size.HashCount);
+    public static CountingBloomFilterCrc64 CreateCrc64(CountingBloomFilterSize size) => new(size.CounterCount, size.HashCount);
+    public static CountingBloomFilterCrc32 CreateCrc32(CountingBloomFilterSize size) => new(size.CounterCount, size.HashCount);
 }
 
 partial class BloomFilterXXHash128 : IBloomFilter
@@ -296,5 +346,377 @@ partial class BloomFilterCrc32 : IBloomFilter
     public bool MayContain(global::System.Int128 value) => MayContainHash(Hash(value));
     public void Add(System.ReadOnlySpan<byte> value) => AddHash(Hash(value));
     public bool MayContain(System.ReadOnlySpan<byte> value) => MayContainHash(Hash(value));
+}
+
+partial class CountingBloomFilterXXHash128 : ICountingBloomFilter
+{
+    internal CountingBloomFilterXXHash128(long counterCount, int hashCount)
+        : base(counterCount, hashCount)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash128 Hash<T>(in T value) where T : unmanaged
+    {
+        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        return Hash(bytes);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash128 Hash(string value)
+    {
+        var chars = value.AsSpan();
+        var bytes = MemoryMarshal.AsBytes(chars);
+        return Hash(bytes);
+    }
+
+    public void Add(int value) => AddHash(Hash(value));
+    public void Remove(int value) => RemoveHash(Hash(value));
+    public bool MayContain(int value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(int value) => GetEstimatedCountHash(Hash(value));
+    public void Add(uint value) => AddHash(Hash(value));
+    public void Remove(uint value) => RemoveHash(Hash(value));
+    public bool MayContain(uint value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(uint value) => GetEstimatedCountHash(Hash(value));
+    public void Add(long value) => AddHash(Hash(value));
+    public void Remove(long value) => RemoveHash(Hash(value));
+    public bool MayContain(long value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(long value) => GetEstimatedCountHash(Hash(value));
+    public void Add(ulong value) => AddHash(Hash(value));
+    public void Remove(ulong value) => RemoveHash(Hash(value));
+    public bool MayContain(ulong value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(ulong value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.Guid value) => AddHash(Hash(value));
+    public void Remove(global::System.Guid value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.Guid value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.Guid value) => GetEstimatedCountHash(Hash(value));
+    public void Add(string value) => AddHash(Hash(value));
+    public void Remove(string value) => RemoveHash(Hash(value));
+    public bool MayContain(string value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(string value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.UInt128 value) => AddHash(Hash(value));
+    public void Remove(global::System.UInt128 value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.UInt128 value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.UInt128 value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.Int128 value) => AddHash(Hash(value));
+    public void Remove(global::System.Int128 value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.Int128 value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.Int128 value) => GetEstimatedCountHash(Hash(value));
+    public void Add(System.ReadOnlySpan<byte> value) => AddHash(Hash(value));
+    public void Remove(System.ReadOnlySpan<byte> value) => RemoveHash(Hash(value));
+    public bool MayContain(System.ReadOnlySpan<byte> value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(System.ReadOnlySpan<byte> value) => GetEstimatedCountHash(Hash(value));
+    public void AddRange(params System.ReadOnlySpan<long> values) => AddRangeCore(values);
+    public void RemoveRange(params System.ReadOnlySpan<long> values) => RemoveRangeCore(values);
+    public void AddRange(params System.ReadOnlySpan<ulong> values) => AddRangeCore(values);
+    public void RemoveRange(params System.ReadOnlySpan<ulong> values) => RemoveRangeCore(values);
+}
+
+partial class CountingBloomFilterXXHash64 : ICountingBloomFilter
+{
+    internal CountingBloomFilterXXHash64(long counterCount, int hashCount)
+        : base(counterCount, hashCount)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash64 Hash<T>(in T value) where T : unmanaged
+    {
+        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        return Hash(bytes);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash64 Hash(string value)
+    {
+        var chars = value.AsSpan();
+        var bytes = MemoryMarshal.AsBytes(chars);
+        return Hash(bytes);
+    }
+
+    public void Add(int value) => AddHash(Hash(value));
+    public void Remove(int value) => RemoveHash(Hash(value));
+    public bool MayContain(int value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(int value) => GetEstimatedCountHash(Hash(value));
+    public void Add(uint value) => AddHash(Hash(value));
+    public void Remove(uint value) => RemoveHash(Hash(value));
+    public bool MayContain(uint value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(uint value) => GetEstimatedCountHash(Hash(value));
+    public void Add(long value) => AddHash(Hash(value));
+    public void Remove(long value) => RemoveHash(Hash(value));
+    public bool MayContain(long value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(long value) => GetEstimatedCountHash(Hash(value));
+    public void Add(ulong value) => AddHash(Hash(value));
+    public void Remove(ulong value) => RemoveHash(Hash(value));
+    public bool MayContain(ulong value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(ulong value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.Guid value) => AddHash(Hash(value));
+    public void Remove(global::System.Guid value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.Guid value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.Guid value) => GetEstimatedCountHash(Hash(value));
+    public void Add(string value) => AddHash(Hash(value));
+    public void Remove(string value) => RemoveHash(Hash(value));
+    public bool MayContain(string value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(string value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.UInt128 value) => AddHash(Hash(value));
+    public void Remove(global::System.UInt128 value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.UInt128 value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.UInt128 value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.Int128 value) => AddHash(Hash(value));
+    public void Remove(global::System.Int128 value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.Int128 value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.Int128 value) => GetEstimatedCountHash(Hash(value));
+    public void Add(System.ReadOnlySpan<byte> value) => AddHash(Hash(value));
+    public void Remove(System.ReadOnlySpan<byte> value) => RemoveHash(Hash(value));
+    public bool MayContain(System.ReadOnlySpan<byte> value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(System.ReadOnlySpan<byte> value) => GetEstimatedCountHash(Hash(value));
+    public void AddRange(params System.ReadOnlySpan<long> values) => AddRangeCore(values);
+    public void RemoveRange(params System.ReadOnlySpan<long> values) => RemoveRangeCore(values);
+    public void AddRange(params System.ReadOnlySpan<ulong> values) => AddRangeCore(values);
+    public void RemoveRange(params System.ReadOnlySpan<ulong> values) => RemoveRangeCore(values);
+}
+
+partial class CountingBloomFilterXXHash32 : ICountingBloomFilter
+{
+    internal CountingBloomFilterXXHash32(long counterCount, int hashCount)
+        : base(counterCount, hashCount)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash32 Hash<T>(in T value) where T : unmanaged
+    {
+        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        return Hash(bytes);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash32 Hash(string value)
+    {
+        var chars = value.AsSpan();
+        var bytes = MemoryMarshal.AsBytes(chars);
+        return Hash(bytes);
+    }
+
+    public void Add(int value) => AddHash(Hash(value));
+    public void Remove(int value) => RemoveHash(Hash(value));
+    public bool MayContain(int value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(int value) => GetEstimatedCountHash(Hash(value));
+    public void Add(uint value) => AddHash(Hash(value));
+    public void Remove(uint value) => RemoveHash(Hash(value));
+    public bool MayContain(uint value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(uint value) => GetEstimatedCountHash(Hash(value));
+    public void Add(long value) => AddHash(Hash(value));
+    public void Remove(long value) => RemoveHash(Hash(value));
+    public bool MayContain(long value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(long value) => GetEstimatedCountHash(Hash(value));
+    public void Add(ulong value) => AddHash(Hash(value));
+    public void Remove(ulong value) => RemoveHash(Hash(value));
+    public bool MayContain(ulong value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(ulong value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.Guid value) => AddHash(Hash(value));
+    public void Remove(global::System.Guid value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.Guid value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.Guid value) => GetEstimatedCountHash(Hash(value));
+    public void Add(string value) => AddHash(Hash(value));
+    public void Remove(string value) => RemoveHash(Hash(value));
+    public bool MayContain(string value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(string value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.UInt128 value) => AddHash(Hash(value));
+    public void Remove(global::System.UInt128 value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.UInt128 value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.UInt128 value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.Int128 value) => AddHash(Hash(value));
+    public void Remove(global::System.Int128 value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.Int128 value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.Int128 value) => GetEstimatedCountHash(Hash(value));
+    public void Add(System.ReadOnlySpan<byte> value) => AddHash(Hash(value));
+    public void Remove(System.ReadOnlySpan<byte> value) => RemoveHash(Hash(value));
+    public bool MayContain(System.ReadOnlySpan<byte> value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(System.ReadOnlySpan<byte> value) => GetEstimatedCountHash(Hash(value));
+    public void AddRange(params System.ReadOnlySpan<int> values) => AddRangeCore(values);
+    public void RemoveRange(params System.ReadOnlySpan<int> values) => RemoveRangeCore(values);
+    public void AddRange(params System.ReadOnlySpan<uint> values) => AddRangeCore(values);
+    public void RemoveRange(params System.ReadOnlySpan<uint> values) => RemoveRangeCore(values);
+}
+
+partial class CountingBloomFilterXXHash3 : ICountingBloomFilter
+{
+    internal CountingBloomFilterXXHash3(long counterCount, int hashCount)
+        : base(counterCount, hashCount)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash64 Hash<T>(in T value) where T : unmanaged
+    {
+        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        return Hash(bytes);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash64 Hash(string value)
+    {
+        var chars = value.AsSpan();
+        var bytes = MemoryMarshal.AsBytes(chars);
+        return Hash(bytes);
+    }
+
+    public void Add(int value) => AddHash(Hash(value));
+    public void Remove(int value) => RemoveHash(Hash(value));
+    public bool MayContain(int value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(int value) => GetEstimatedCountHash(Hash(value));
+    public void Add(uint value) => AddHash(Hash(value));
+    public void Remove(uint value) => RemoveHash(Hash(value));
+    public bool MayContain(uint value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(uint value) => GetEstimatedCountHash(Hash(value));
+    public void Add(long value) => AddHash(Hash(value));
+    public void Remove(long value) => RemoveHash(Hash(value));
+    public bool MayContain(long value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(long value) => GetEstimatedCountHash(Hash(value));
+    public void Add(ulong value) => AddHash(Hash(value));
+    public void Remove(ulong value) => RemoveHash(Hash(value));
+    public bool MayContain(ulong value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(ulong value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.Guid value) => AddHash(Hash(value));
+    public void Remove(global::System.Guid value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.Guid value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.Guid value) => GetEstimatedCountHash(Hash(value));
+    public void Add(string value) => AddHash(Hash(value));
+    public void Remove(string value) => RemoveHash(Hash(value));
+    public bool MayContain(string value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(string value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.UInt128 value) => AddHash(Hash(value));
+    public void Remove(global::System.UInt128 value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.UInt128 value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.UInt128 value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.Int128 value) => AddHash(Hash(value));
+    public void Remove(global::System.Int128 value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.Int128 value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.Int128 value) => GetEstimatedCountHash(Hash(value));
+    public void Add(System.ReadOnlySpan<byte> value) => AddHash(Hash(value));
+    public void Remove(System.ReadOnlySpan<byte> value) => RemoveHash(Hash(value));
+    public bool MayContain(System.ReadOnlySpan<byte> value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(System.ReadOnlySpan<byte> value) => GetEstimatedCountHash(Hash(value));
+}
+
+partial class CountingBloomFilterCrc64 : ICountingBloomFilter
+{
+    internal CountingBloomFilterCrc64(long counterCount, int hashCount)
+        : base(counterCount, hashCount)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash64 Hash<T>(in T value) where T : unmanaged
+    {
+        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        return Hash(bytes);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash64 Hash(string value)
+    {
+        var chars = value.AsSpan();
+        var bytes = MemoryMarshal.AsBytes(chars);
+        return Hash(bytes);
+    }
+
+    public void Add(int value) => AddHash(Hash(value));
+    public void Remove(int value) => RemoveHash(Hash(value));
+    public bool MayContain(int value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(int value) => GetEstimatedCountHash(Hash(value));
+    public void Add(uint value) => AddHash(Hash(value));
+    public void Remove(uint value) => RemoveHash(Hash(value));
+    public bool MayContain(uint value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(uint value) => GetEstimatedCountHash(Hash(value));
+    public void Add(long value) => AddHash(Hash(value));
+    public void Remove(long value) => RemoveHash(Hash(value));
+    public bool MayContain(long value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(long value) => GetEstimatedCountHash(Hash(value));
+    public void Add(ulong value) => AddHash(Hash(value));
+    public void Remove(ulong value) => RemoveHash(Hash(value));
+    public bool MayContain(ulong value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(ulong value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.Guid value) => AddHash(Hash(value));
+    public void Remove(global::System.Guid value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.Guid value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.Guid value) => GetEstimatedCountHash(Hash(value));
+    public void Add(string value) => AddHash(Hash(value));
+    public void Remove(string value) => RemoveHash(Hash(value));
+    public bool MayContain(string value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(string value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.UInt128 value) => AddHash(Hash(value));
+    public void Remove(global::System.UInt128 value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.UInt128 value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.UInt128 value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.Int128 value) => AddHash(Hash(value));
+    public void Remove(global::System.Int128 value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.Int128 value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.Int128 value) => GetEstimatedCountHash(Hash(value));
+    public void Add(System.ReadOnlySpan<byte> value) => AddHash(Hash(value));
+    public void Remove(System.ReadOnlySpan<byte> value) => RemoveHash(Hash(value));
+    public bool MayContain(System.ReadOnlySpan<byte> value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(System.ReadOnlySpan<byte> value) => GetEstimatedCountHash(Hash(value));
+}
+
+partial class CountingBloomFilterCrc32 : ICountingBloomFilter
+{
+    internal CountingBloomFilterCrc32(long counterCount, int hashCount)
+        : base(counterCount, hashCount)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash32 Hash<T>(in T value) where T : unmanaged
+    {
+        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        return Hash(bytes);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash32 Hash(string value)
+    {
+        var chars = value.AsSpan();
+        var bytes = MemoryMarshal.AsBytes(chars);
+        return Hash(bytes);
+    }
+
+    public void Add(int value) => AddHash(Hash(value));
+    public void Remove(int value) => RemoveHash(Hash(value));
+    public bool MayContain(int value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(int value) => GetEstimatedCountHash(Hash(value));
+    public void Add(uint value) => AddHash(Hash(value));
+    public void Remove(uint value) => RemoveHash(Hash(value));
+    public bool MayContain(uint value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(uint value) => GetEstimatedCountHash(Hash(value));
+    public void Add(long value) => AddHash(Hash(value));
+    public void Remove(long value) => RemoveHash(Hash(value));
+    public bool MayContain(long value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(long value) => GetEstimatedCountHash(Hash(value));
+    public void Add(ulong value) => AddHash(Hash(value));
+    public void Remove(ulong value) => RemoveHash(Hash(value));
+    public bool MayContain(ulong value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(ulong value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.Guid value) => AddHash(Hash(value));
+    public void Remove(global::System.Guid value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.Guid value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.Guid value) => GetEstimatedCountHash(Hash(value));
+    public void Add(string value) => AddHash(Hash(value));
+    public void Remove(string value) => RemoveHash(Hash(value));
+    public bool MayContain(string value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(string value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.UInt128 value) => AddHash(Hash(value));
+    public void Remove(global::System.UInt128 value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.UInt128 value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.UInt128 value) => GetEstimatedCountHash(Hash(value));
+    public void Add(global::System.Int128 value) => AddHash(Hash(value));
+    public void Remove(global::System.Int128 value) => RemoveHash(Hash(value));
+    public bool MayContain(global::System.Int128 value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(global::System.Int128 value) => GetEstimatedCountHash(Hash(value));
+    public void Add(System.ReadOnlySpan<byte> value) => AddHash(Hash(value));
+    public void Remove(System.ReadOnlySpan<byte> value) => RemoveHash(Hash(value));
+    public bool MayContain(System.ReadOnlySpan<byte> value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(System.ReadOnlySpan<byte> value) => GetEstimatedCountHash(Hash(value));
 }
 

--- a/src/Meziantou.Framework.BloomFilters/BloomFilter.tt
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilter.tt
@@ -41,10 +41,27 @@ public partial interface IBloomFilter
 <# } #>
 }
 
+public partial interface ICountingBloomFilter
+{
+<# foreach (var type in types) { #>
+    void Add(<#= ToCsharpTypeName(type) #> value);
+    void Remove(<#= ToCsharpTypeName(type) #> value);
+    bool MayContain(<#= ToCsharpTypeName(type) #> value);
+    int GetEstimatedCount(<#= ToCsharpTypeName(type) #> value);
+<# } #>
+}
+
 partial class BloomFilter
 {
 <# foreach (var algorithm in hashAlgorithms) { #>
     public static BloomFilter<#= algorithm.Name #> Create<#= algorithm.Name #>(BloomFilterSize size) => new(size.BitCount, size.HashCount);
+<# } #>
+}
+
+partial class CountingBloomFilter
+{
+<# foreach (var algorithm in hashAlgorithms) { #>
+    public static CountingBloomFilter<#= algorithm.Name #> Create<#= algorithm.Name #>(CountingBloomFilterSize size) => new(size.CounterCount, size.HashCount);
 <# } #>
 }
 
@@ -77,6 +94,42 @@ partial class BloomFilter<#= algorithm.Name #> : IBloomFilter
 <# } #>
 <# foreach (var type in algorithm.BatchTypes) { #>
     public void AddRange(params System.ReadOnlySpan<<#= ToCsharpTypeName(type) #>> values) => AddRangeCore(values);
+<# } #>
+}
+
+<# } #>
+<# foreach (var algorithm in hashAlgorithms) { #>
+partial class CountingBloomFilter<#= algorithm.Name #> : ICountingBloomFilter
+{
+    internal CountingBloomFilter<#= algorithm.Name #>(long counterCount, int hashCount)
+        : base(counterCount, hashCount)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash<#= algorithm.HashSize #> Hash<T>(in T value) where T : unmanaged
+    {
+        var bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in value), 1));
+        return Hash(bytes);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash<#= algorithm.HashSize #> Hash(string value)
+    {
+        var chars = value.AsSpan();
+        var bytes = MemoryMarshal.AsBytes(chars);
+        return Hash(bytes);
+    }
+
+<# foreach (var type in types) { #>
+    public void Add(<#= ToCsharpTypeName(type) #> value) => AddHash(Hash(value));
+    public void Remove(<#= ToCsharpTypeName(type) #> value) => RemoveHash(Hash(value));
+    public bool MayContain(<#= ToCsharpTypeName(type) #> value) => GetEstimatedCountHash(Hash(value)) > 0;
+    public int GetEstimatedCount(<#= ToCsharpTypeName(type) #> value) => GetEstimatedCountHash(Hash(value));
+<# } #>
+<# foreach (var type in algorithm.BatchTypes) { #>
+    public void AddRange(params System.ReadOnlySpan<<#= ToCsharpTypeName(type) #>> values) => AddRangeCore(values);
+    public void RemoveRange(params System.ReadOnlySpan<<#= ToCsharpTypeName(type) #>> values) => RemoveRangeCore(values);
 <# } #>
 }
 

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilter.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilter.cs
@@ -1,0 +1,174 @@
+using System.Runtime.CompilerServices;
+
+namespace Meziantou.Framework.BloomFilters;
+
+public abstract partial class CountingBloomFilter
+{
+    private protected readonly SegmentedCounterStorage Counters;
+    private protected readonly int HashCount;
+
+    private protected CountingBloomFilter(long counterCount, int hashCount)
+    {
+        Counters = new SegmentedCounterStorage(counterCount);
+        HashCount = hashCount;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected void AddHash(Hash128 hash)
+    {
+        var counterCount = (ulong)Counters.CounterCount;
+        var combined = hash.Hash1;
+        for (var i = 0; i < HashCount; i++)
+        {
+            Counters.Increment(Reduce(combined, counterCount));
+            combined += hash.Hash2;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected void RemoveHash(Hash128 hash)
+    {
+        var counterCount = (ulong)Counters.CounterCount;
+        var combined = hash.Hash1;
+        for (var i = 0; i < HashCount; i++)
+        {
+            Counters.Decrement(Reduce(combined, counterCount));
+            combined += hash.Hash2;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected int GetEstimatedCountHash(Hash128 hash)
+    {
+        var counterCount = (ulong)Counters.CounterCount;
+        var combined = hash.Hash1;
+        var result = int.MaxValue;
+        for (var i = 0; i < HashCount; i++)
+        {
+            result = Math.Min(result, Counters.Get(Reduce(combined, counterCount)));
+            combined += hash.Hash2;
+        }
+
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected void AddHash(Hash64 hash) => AddHashCore(hash.Hash1, hash.Hash2);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected void RemoveHash(Hash64 hash) => RemoveHashCore(hash.Hash1, hash.Hash2);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected int GetEstimatedCountHash(Hash64 hash) => GetEstimatedCountHashCore(hash.Hash1, hash.Hash2);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected void AddHash(Hash32 hash) => AddHashCore32(hash.Hash1, hash.Hash2);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected void RemoveHash(Hash32 hash) => RemoveHashCore32(hash.Hash1, hash.Hash2);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected int GetEstimatedCountHash(Hash32 hash) => GetEstimatedCountHashCore32(hash.Hash1, hash.Hash2);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void AddHashCore(ulong hash1, ulong hash2)
+    {
+        var counterCount = (ulong)Counters.CounterCount;
+        var combined = hash1;
+        for (var i = 0; i < HashCount; i++)
+        {
+            Counters.Increment(Reduce(combined, counterCount));
+            unchecked
+            {
+                combined += hash2;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void RemoveHashCore(ulong hash1, ulong hash2)
+    {
+        var counterCount = (ulong)Counters.CounterCount;
+        var combined = hash1;
+        for (var i = 0; i < HashCount; i++)
+        {
+            Counters.Decrement(Reduce(combined, counterCount));
+            unchecked
+            {
+                combined += hash2;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int GetEstimatedCountHashCore(ulong hash1, ulong hash2)
+    {
+        var counterCount = (ulong)Counters.CounterCount;
+        var combined = hash1;
+        var result = int.MaxValue;
+        for (var i = 0; i < HashCount; i++)
+        {
+            result = Math.Min(result, Counters.Get(Reduce(combined, counterCount)));
+            unchecked
+            {
+                combined += hash2;
+            }
+        }
+
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void AddHashCore32(uint hash1, uint hash2)
+    {
+        var counterCount = (ulong)Counters.CounterCount;
+        var combined = hash1;
+        for (var i = 0; i < HashCount; i++)
+        {
+            Counters.Increment(Reduce(combined, counterCount));
+            unchecked
+            {
+                combined += hash2;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void RemoveHashCore32(uint hash1, uint hash2)
+    {
+        var counterCount = (ulong)Counters.CounterCount;
+        var combined = hash1;
+        for (var i = 0; i < HashCount; i++)
+        {
+            Counters.Decrement(Reduce(combined, counterCount));
+            unchecked
+            {
+                combined += hash2;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int GetEstimatedCountHashCore32(uint hash1, uint hash2)
+    {
+        var counterCount = (ulong)Counters.CounterCount;
+        var combined = hash1;
+        var result = int.MaxValue;
+        for (var i = 0; i < HashCount; i++)
+        {
+            result = Math.Min(result, Counters.Get(Reduce(combined, counterCount)));
+            unchecked
+            {
+                combined += hash2;
+            }
+        }
+
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static long Reduce(ulong hash, ulong range) => (long)(((UInt128)hash * range) >> 64);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static long Reduce(uint hash, ulong range) => (long)(((UInt128)hash * range) >> 32);
+}

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterCrc32.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterCrc32.cs
@@ -1,0 +1,13 @@
+using System.IO.Hashing;
+using System.Runtime.CompilerServices;
+
+namespace Meziantou.Framework.BloomFilters;
+
+public sealed partial class CountingBloomFilterCrc32 : CountingBloomFilter
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash32 Hash(ReadOnlySpan<byte> value)
+    {
+        return new(Crc32.HashToUInt32(value));
+    }
+}

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterCrc64.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterCrc64.cs
@@ -1,0 +1,13 @@
+using System.IO.Hashing;
+using System.Runtime.CompilerServices;
+
+namespace Meziantou.Framework.BloomFilters;
+
+public sealed partial class CountingBloomFilterCrc64 : CountingBloomFilter
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash64 Hash(ReadOnlySpan<byte> value)
+    {
+        return new(Crc64.HashToUInt64(value));
+    }
+}

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterSize.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterSize.cs
@@ -1,0 +1,34 @@
+using System.Runtime.InteropServices;
+
+namespace Meziantou.Framework.BloomFilters;
+
+[StructLayout(LayoutKind.Auto)]
+public readonly struct CountingBloomFilterSize
+{
+    private CountingBloomFilterSize(long counterCount, int hashCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(counterCount);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(hashCount);
+
+        CounterCount = counterCount;
+        HashCount = hashCount;
+    }
+
+    public long CounterCount { get; }
+    public int HashCount { get; }
+
+    public static CountingBloomFilterSize CreateOptimalSize(long expectedItemCount, double falsePositiveProbability)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(expectedItemCount);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(falsePositiveProbability);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(falsePositiveProbability, 1);
+
+        const double Ln2 = 0.6931471805599453d; // Math.Log(2)
+        var counterCount = (long)Math.Ceiling(-expectedItemCount * Math.Log(falsePositiveProbability) / (Ln2 * Ln2));
+        var hashCount = (int)Math.Ceiling((double)counterCount / expectedItemCount * Ln2);
+
+        return new CountingBloomFilterSize(counterCount, hashCount);
+    }
+
+    public static CountingBloomFilterSize CreateExact(long counterCount, int hashCount) => new(counterCount, hashCount);
+}

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash128.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash128.cs
@@ -1,0 +1,200 @@
+using System.IO.Hashing;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+#if NET9_0_OR_GREATER
+using System.Runtime.Intrinsics.Arm;
+#endif
+using System.Runtime.Intrinsics.X86;
+
+namespace Meziantou.Framework.BloomFilters;
+
+public sealed partial class CountingBloomFilterXXHash128 : CountingBloomFilter
+{
+    private const ulong AvalancheMultiplier = 0x165667919E3779F9UL;
+    private const ulong BitFlip = 0xC4F023344DC994ACUL;
+    private const ulong Prime1 = 0x9E3779B185EBCA87UL;
+    private const ulong RrmxmxMultiplier = 0x9FB21C651E98DF25UL;
+    private const ulong UInt32Mask = uint.MaxValue;
+
+    private void AddRangeCore(ReadOnlySpan<long> values)
+    {
+        AddRangeCore(MemoryMarshal.Cast<long, ulong>(values));
+    }
+
+    private void RemoveRangeCore(ReadOnlySpan<long> values)
+    {
+        RemoveRangeCore(MemoryMarshal.Cast<long, ulong>(values));
+    }
+
+    private void AddRangeCore(ReadOnlySpan<ulong> values)
+    {
+        UpdateRangeCore(values, remove: false);
+    }
+
+    private void RemoveRangeCore(ReadOnlySpan<ulong> values)
+    {
+        UpdateRangeCore(values, remove: true);
+    }
+
+    private void UpdateRangeCore(ReadOnlySpan<ulong> values, bool remove)
+    {
+        if (!BitConverter.IsLittleEndian)
+        {
+            foreach (var value in values)
+            {
+                UpdateHash(Hash(value), remove);
+            }
+
+            return;
+        }
+
+        ref var valuesReference = ref MemoryMarshal.GetReference(values);
+        var index = 0;
+#if NET9_0_OR_GREATER
+        if (AdvSimd.Arm64.IsSupported)
+        {
+            while (index <= values.Length - Vector128<ulong>.Count)
+            {
+                var current = Vector128.LoadUnsafe(ref valuesReference, (nuint)index);
+                Multiply64To128(current ^ Vector128.Create(BitFlip), Prime1 + (sizeof(ulong) << 2), out var low, out var high);
+                high += low << 1;
+                low ^= high >> 3;
+                low ^= low >> 35;
+                low = MultiplyLow(low, RrmxmxMultiplier);
+                low ^= low >> 28;
+                high ^= high >> 37;
+                high = MultiplyLow(high, AvalancheMultiplier);
+                high ^= high >> 32;
+
+                for (var lane = 0; lane < Vector128<ulong>.Count; lane++)
+                {
+                    UpdateHash(new Hash128(low[lane], high[lane]), remove);
+                }
+
+                index += Vector128<ulong>.Count;
+            }
+        }
+        else
+#endif
+        if (Avx2.IsSupported)
+        {
+            while (index <= values.Length - Vector256<ulong>.Count)
+            {
+                var current = Vector256.LoadUnsafe(ref valuesReference, (nuint)index);
+                Multiply64To128(current ^ Vector256.Create(BitFlip), Prime1 + (sizeof(ulong) << 2), out var low, out var high);
+                high += low << 1;
+                low ^= high >> 3;
+                low ^= low >> 35;
+                low = MultiplyLow(low, RrmxmxMultiplier);
+                low ^= low >> 28;
+                high ^= high >> 37;
+                high = MultiplyLow(high, AvalancheMultiplier);
+                high ^= high >> 32;
+
+                for (var lane = 0; lane < Vector256<ulong>.Count; lane++)
+                {
+                    UpdateHash(new Hash128(low[lane], high[lane]), remove);
+                }
+
+                index += Vector256<ulong>.Count;
+            }
+        }
+
+        foreach (var value in values[index..])
+        {
+            UpdateHash(Hash(value), remove);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void UpdateHash(Hash128 hash, bool remove)
+    {
+        if (remove)
+        {
+            RemoveHash(hash);
+        }
+        else
+        {
+            AddHash(hash);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash128 Hash(ReadOnlySpan<byte> value)
+    {
+        return new(XxHash128.HashToUInt128(value));
+    }
+
+#if NET9_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector128<ulong> MultiplyLow(Vector128<ulong> value, ulong multiplier)
+    {
+        Split(value, out var lower, out var upper);
+        var multiplierLower = Vector64.Create((uint)multiplier);
+        var multiplierUpper = Vector64.Create((uint)(multiplier >> 32));
+        var productLower = AdvSimd.MultiplyWideningLower(lower, multiplierLower);
+        var productMiddle1 = AdvSimd.MultiplyWideningLower(lower, multiplierUpper);
+        var productMiddle2 = AdvSimd.MultiplyWideningLower(upper, multiplierLower);
+        return productLower + ((productMiddle1 + productMiddle2) << 32);
+    }
+#endif
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector256<ulong> MultiplyLow(Vector256<ulong> value, ulong multiplier)
+    {
+        var lower = value.AsUInt32();
+        var upper = (value >> 32).AsUInt32();
+        var multiplierLower = Vector256.Create((uint)multiplier);
+        var multiplierUpper = Vector256.Create((uint)(multiplier >> 32));
+        var productLower = Avx2.Multiply(lower, multiplierLower);
+        var productMiddle1 = Avx2.Multiply(lower, multiplierUpper);
+        var productMiddle2 = Avx2.Multiply(upper, multiplierLower);
+        return productLower + ((productMiddle1 + productMiddle2) << 32);
+    }
+
+#if NET9_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Multiply64To128(Vector128<ulong> value, ulong multiplier, out Vector128<ulong> low, out Vector128<ulong> high)
+    {
+        Split(value, out var lower, out var upper);
+        var multiplierLower = Vector64.Create((uint)multiplier);
+        var multiplierUpper = Vector64.Create((uint)(multiplier >> 32));
+        var productLower = AdvSimd.MultiplyWideningLower(lower, multiplierLower);
+        var productMiddle1 = AdvSimd.MultiplyWideningLower(lower, multiplierUpper);
+        var productMiddle2 = AdvSimd.MultiplyWideningLower(upper, multiplierLower);
+        var productUpper = AdvSimd.MultiplyWideningLower(upper, multiplierUpper);
+        var mask = Vector128.Create(UInt32Mask);
+        var middle = (productLower >> 32) + (productMiddle1 & mask) + (productMiddle2 & mask);
+        low = (productLower & mask) | (middle << 32);
+        high = productUpper + (productMiddle1 >> 32) + (productMiddle2 >> 32) + (middle >> 32);
+    }
+#endif
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Multiply64To128(Vector256<ulong> value, ulong multiplier, out Vector256<ulong> low, out Vector256<ulong> high)
+    {
+        var lower = value.AsUInt32();
+        var upper = (value >> 32).AsUInt32();
+        var multiplierLower = Vector256.Create((uint)multiplier);
+        var multiplierUpper = Vector256.Create((uint)(multiplier >> 32));
+        var productLower = Avx2.Multiply(lower, multiplierLower);
+        var productMiddle1 = Avx2.Multiply(lower, multiplierUpper);
+        var productMiddle2 = Avx2.Multiply(upper, multiplierLower);
+        var productUpper = Avx2.Multiply(upper, multiplierUpper);
+        var mask = Vector256.Create(UInt32Mask);
+        var middle = (productLower >> 32) + (productMiddle1 & mask) + (productMiddle2 & mask);
+        low = (productLower & mask) | (middle << 32);
+        high = productUpper + (productMiddle1 >> 32) + (productMiddle2 >> 32) + (middle >> 32);
+    }
+
+#if NET9_0_OR_GREATER
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Split(Vector128<ulong> value, out Vector64<uint> lower, out Vector64<uint> upper)
+    {
+        var words = value.AsUInt32();
+        lower = AdvSimd.Arm64.UnzipEven(words, words).GetLower();
+        upper = AdvSimd.Arm64.UnzipOdd(words, words).GetLower();
+    }
+#endif
+}

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash3.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash3.cs
@@ -1,0 +1,13 @@
+using System.IO.Hashing;
+using System.Runtime.CompilerServices;
+
+namespace Meziantou.Framework.BloomFilters;
+
+public sealed partial class CountingBloomFilterXXHash3 : CountingBloomFilter
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash64 Hash(ReadOnlySpan<byte> value)
+    {
+        return new(XxHash3.HashToUInt64(value));
+    }
+}

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash32.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash32.cs
@@ -1,0 +1,99 @@
+using System.IO.Hashing;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Meziantou.Framework.BloomFilters;
+
+public sealed partial class CountingBloomFilterXXHash32 : CountingBloomFilter
+{
+    private const uint Prime2 = 0x85EBCA77U;
+    private const uint Prime3 = 0xC2B2AE3DU;
+    private const uint Prime4 = 0x27D4EB2FU;
+    private const uint Prime5 = 0x165667B1U;
+
+    private void AddRangeCore(ReadOnlySpan<int> values)
+    {
+        AddRangeCore(MemoryMarshal.Cast<int, uint>(values));
+    }
+
+    private void RemoveRangeCore(ReadOnlySpan<int> values)
+    {
+        RemoveRangeCore(MemoryMarshal.Cast<int, uint>(values));
+    }
+
+    private void AddRangeCore(ReadOnlySpan<uint> values)
+    {
+        UpdateRangeCore(values, remove: false);
+    }
+
+    private void RemoveRangeCore(ReadOnlySpan<uint> values)
+    {
+        UpdateRangeCore(values, remove: true);
+    }
+
+    private void UpdateRangeCore(ReadOnlySpan<uint> values, bool remove)
+    {
+        if (!BitConverter.IsLittleEndian || !Vector.IsHardwareAccelerated || values.Length < Vector<uint>.Count)
+        {
+            foreach (var value in values)
+            {
+                UpdateHash(Hash(value), remove);
+            }
+
+            return;
+        }
+
+        ref var valuesReference = ref MemoryMarshal.GetReference(values);
+        var index = 0;
+        var hash = new Vector<uint>(Prime5 + sizeof(uint));
+        var prime2 = new Vector<uint>(Prime2);
+        var prime3 = new Vector<uint>(Prime3);
+        var prime4 = new Vector<uint>(Prime4);
+        while (index <= values.Length - Vector<uint>.Count)
+        {
+            var current = Vector.LoadUnsafe(ref valuesReference, (nuint)index);
+            var hashes = hash + (current * prime3);
+            hashes = RotateLeft(hashes, 17) * prime4;
+            hashes ^= hashes >> 15;
+            hashes *= prime2;
+            hashes ^= hashes >> 13;
+            hashes *= prime3;
+            hashes ^= hashes >> 16;
+
+            for (var lane = 0; lane < Vector<uint>.Count; lane++)
+            {
+                UpdateHash(new Hash32(hashes[lane]), remove);
+            }
+
+            index += Vector<uint>.Count;
+        }
+
+        foreach (var value in values[index..])
+        {
+            UpdateHash(Hash(value), remove);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void UpdateHash(Hash32 hash, bool remove)
+    {
+        if (remove)
+        {
+            RemoveHash(hash);
+        }
+        else
+        {
+            AddHash(hash);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash32 Hash(ReadOnlySpan<byte> value)
+    {
+        return new(XxHash32.HashToUInt32(value));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector<uint> RotateLeft(Vector<uint> value, int offset) => (value << offset) | (value >> (32 - offset));
+}

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash64.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterXXHash64.cs
@@ -1,0 +1,101 @@
+using System.IO.Hashing;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Meziantou.Framework.BloomFilters;
+
+public sealed partial class CountingBloomFilterXXHash64 : CountingBloomFilter
+{
+    private const ulong Prime1 = 0x9E3779B185EBCA87UL;
+    private const ulong Prime2 = 0xC2B2AE3D27D4EB4FUL;
+    private const ulong Prime3 = 0x165667B19E3779F9UL;
+    private const ulong Prime4 = 0x85EBCA77C2B2AE63UL;
+    private const ulong Prime5 = 0x27D4EB2F165667C5UL;
+
+    private void AddRangeCore(ReadOnlySpan<long> values)
+    {
+        AddRangeCore(MemoryMarshal.Cast<long, ulong>(values));
+    }
+
+    private void RemoveRangeCore(ReadOnlySpan<long> values)
+    {
+        RemoveRangeCore(MemoryMarshal.Cast<long, ulong>(values));
+    }
+
+    private void AddRangeCore(ReadOnlySpan<ulong> values)
+    {
+        UpdateRangeCore(values, remove: false);
+    }
+
+    private void RemoveRangeCore(ReadOnlySpan<ulong> values)
+    {
+        UpdateRangeCore(values, remove: true);
+    }
+
+    private void UpdateRangeCore(ReadOnlySpan<ulong> values, bool remove)
+    {
+        if (!BitConverter.IsLittleEndian || !Vector.IsHardwareAccelerated || values.Length < Vector<ulong>.Count)
+        {
+            foreach (var value in values)
+            {
+                UpdateHash(Hash(value), remove);
+            }
+
+            return;
+        }
+
+        ref var valuesReference = ref MemoryMarshal.GetReference(values);
+        var index = 0;
+        var prime1 = new Vector<ulong>(Prime1);
+        var prime2 = new Vector<ulong>(Prime2);
+        var prime3 = new Vector<ulong>(Prime3);
+        var prime4 = new Vector<ulong>(Prime4);
+        var hash = new Vector<ulong>(Prime5 + sizeof(ulong));
+        while (index <= values.Length - Vector<ulong>.Count)
+        {
+            var current = Vector.LoadUnsafe(ref valuesReference, (nuint)index);
+            var round = RotateLeft(current * prime2, 31) * prime1;
+            var hashes = RotateLeft(hash ^ round, 27) * prime1 + prime4;
+            hashes ^= hashes >> 33;
+            hashes *= prime2;
+            hashes ^= hashes >> 29;
+            hashes *= prime3;
+            hashes ^= hashes >> 32;
+
+            for (var lane = 0; lane < Vector<ulong>.Count; lane++)
+            {
+                UpdateHash(new Hash64(hashes[lane]), remove);
+            }
+
+            index += Vector<ulong>.Count;
+        }
+
+        foreach (var value in values[index..])
+        {
+            UpdateHash(Hash(value), remove);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void UpdateHash(Hash64 hash, bool remove)
+    {
+        if (remove)
+        {
+            RemoveHash(hash);
+        }
+        else
+        {
+            AddHash(hash);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Hash64 Hash(ReadOnlySpan<byte> value)
+    {
+        return new(XxHash64.HashToUInt64(value));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector<ulong> RotateLeft(Vector<ulong> value, int offset) => (value << offset) | (value >> (64 - offset));
+}

--- a/src/Meziantou.Framework.BloomFilters/Meziantou.Framework.BloomFilters.csproj
+++ b/src/Meziantou.Framework.BloomFilters/Meziantou.Framework.BloomFilters.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>1.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
-    <Description>High-performance in-memory Bloom filters with atomic concurrent writes and segmented storage</Description>
+    <Description>High-performance in-memory Bloom filters and counting Bloom filters with atomic concurrent writes and segmented storage</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.BloomFilters/SegmentedCounterStorage.cs
+++ b/src/Meziantou.Framework.BloomFilters/SegmentedCounterStorage.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Meziantou.Framework.BloomFilters;
+
+internal sealed class SegmentedCounterStorage
+{
+    private const int SegmentShift = 30;
+    private const int CountersPerSegment = 1 << SegmentShift;
+    private const int SegmentMask = CountersPerSegment - 1;
+
+    private readonly int[][] _segments;
+
+    public SegmentedCounterStorage(long counterCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(counterCount);
+
+        CounterCount = counterCount;
+        var segmentCount = checked((int)(((counterCount - 1) / CountersPerSegment) + 1));
+        _segments = new int[segmentCount][];
+
+        for (var segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
+        {
+            var remainingCounters = counterCount - ((long)segmentIndex * CountersPerSegment);
+            var currentSegmentLength = (int)Math.Min(CountersPerSegment, remainingCounters);
+            _segments[segmentIndex] = new int[currentSegmentLength];
+        }
+    }
+
+    public long CounterCount { get; }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Increment(long counterIndex)
+    {
+        ref var counter = ref GetCounterReference(counterIndex);
+        var currentValue = Volatile.Read(ref counter);
+        while (currentValue < int.MaxValue)
+        {
+            var previousValue = Interlocked.CompareExchange(ref counter, currentValue + 1, currentValue);
+            if (previousValue == currentValue)
+                return;
+
+            currentValue = previousValue;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Decrement(long counterIndex)
+    {
+        ref var counter = ref GetCounterReference(counterIndex);
+        var currentValue = Volatile.Read(ref counter);
+        while (currentValue > 0)
+        {
+            var previousValue = Interlocked.CompareExchange(ref counter, currentValue - 1, currentValue);
+            if (previousValue == currentValue)
+                return;
+
+            currentValue = previousValue;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int Get(long counterIndex)
+    {
+        return Volatile.Read(ref GetCounterReference(counterIndex));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ref int GetCounterReference(long counterIndex)
+    {
+        ValidateCounterIndex(counterIndex);
+
+        var segment = _segments[(int)(counterIndex >> SegmentShift)];
+        ref var baseRef = ref MemoryMarshal.GetArrayDataReference(segment);
+        return ref Unsafe.Add(ref baseRef, (nint)(counterIndex & SegmentMask));
+    }
+
+    [Conditional("DEBUG")]
+    private void ValidateCounterIndex(long counterIndex)
+    {
+        if ((ulong)counterIndex >= (ulong)CounterCount)
+        {
+            ThrowInvalidCounterIndex(counterIndex);
+        }
+
+        [DoesNotReturn]
+        static void ThrowInvalidCounterIndex(long counterIndex) => throw new ArgumentOutOfRangeException(nameof(counterIndex), $"Counter index must be between 0 and {long.MaxValue} (inclusive). Actual value: {counterIndex}");
+    }
+}

--- a/tests/Meziantou.Framework.BloomFilters.Tests/BloomFilterTests.cs
+++ b/tests/Meziantou.Framework.BloomFilters.Tests/BloomFilterTests.cs
@@ -18,6 +18,20 @@ public sealed class BloomFilterTests
         return data;
     }
 
+    public static TheoryData<string, object> AllCountingAlgorithmsAndValues()
+    {
+        var data = new TheoryData<string, object>();
+        foreach (var method in typeof(CountingBloomFilter).GetMethods().Where(m => m.Name.StartsWith("Create", StringComparison.Ordinal) && m.GetParameters().Length == 1 && m.GetParameters()[0].ParameterType == typeof(CountingBloomFilterSize)))
+        {
+            foreach (var value in GetValues())
+            {
+                data.Add(method.Name, value);
+            }
+        }
+
+        return data;
+    }
+
     [Theory]
     [MemberData(nameof(AllAlgorithmsAndValues))]
     public void Add_ThenMayContain_ReturnsTrue_ForAllAlgorithmsAndTypes(string createMethodName, object value)
@@ -26,6 +40,48 @@ public sealed class BloomFilterTests
         var filter = (IBloomFilter)typeof(BloomFilter).GetMethod(createMethodName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!.Invoke(null, [size])!;
         AddValue(filter, value);
         Assert.True(MayContainValue(filter, value));
+    }
+
+    [Theory]
+    [MemberData(nameof(AllCountingAlgorithmsAndValues))]
+    public void AddRemoveAndGetEstimatedCount_ForAllAlgorithmsAndTypes(string createMethodName, object value)
+    {
+        var size = CountingBloomFilterSize.CreateOptimalSize(1000, 0.01);
+        var filter = (ICountingBloomFilter)typeof(CountingBloomFilter).GetMethod(createMethodName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!.Invoke(null, [size])!;
+
+        AddValue(filter, value);
+        AddValue(filter, value);
+
+        Assert.True(MayContainValue(filter, value));
+        Assert.True(GetEstimatedCountValue(filter, value) >= 2);
+
+        RemoveValue(filter, value);
+        Assert.True(MayContainValue(filter, value));
+        Assert.True(GetEstimatedCountValue(filter, value) >= 1);
+
+        RemoveValue(filter, value);
+        Assert.False(MayContainValue(filter, value));
+        Assert.Equal(0, GetEstimatedCountValue(filter, value));
+    }
+
+    [Fact]
+    public void CountingBloomFilter_ReadOnlySpanOfByte_AddRemoveAndGetEstimatedCount_ForAllAlgorithms()
+    {
+        var size = CountingBloomFilterSize.CreateOptimalSize(1000, 0.01);
+        ReadOnlySpan<byte> value = [1, 2, 3, 4];
+
+        foreach (var method in typeof(CountingBloomFilter).GetMethods().Where(m => m.Name.StartsWith("Create", StringComparison.Ordinal) && m.GetParameters().Length == 1 && m.GetParameters()[0].ParameterType == typeof(CountingBloomFilterSize)))
+        {
+            var filter = (ICountingBloomFilter)method.Invoke(null, [size])!;
+
+            filter.Add(value);
+            Assert.True(filter.MayContain(value));
+            Assert.True(filter.GetEstimatedCount(value) >= 1);
+
+            filter.Remove(value);
+            Assert.False(filter.MayContain(value));
+            Assert.Equal(0, filter.GetEstimatedCount(value));
+        }
     }
 
     [Fact]
@@ -68,6 +124,133 @@ public sealed class BloomFilterTests
 
         Assert.All(signedValues, value => Assert.True(filter.MayContain(value)));
         Assert.All(unsignedValues, value => Assert.True(filter.MayContain(value)));
+    }
+
+    [Fact]
+    public void CountingBloomFilter_RemoveAtZero_DoesNotUnderflow()
+    {
+        var filter = CountingBloomFilter.CreateXXHash128(CountingBloomFilterSize.CreateOptimalSize(1000, 0.01));
+
+        filter.Remove("value");
+        filter.Add("value");
+
+        Assert.True(filter.MayContain("value"));
+        Assert.True(filter.GetEstimatedCount("value") >= 1);
+    }
+
+    [Fact]
+    public void CountingBloomFilter_RepeatedCounterPositions_PreserveUpdates()
+    {
+        var filter = CountingBloomFilter.CreateXXHash128(CountingBloomFilterSize.CreateExact(counterCount: 1, hashCount: 3));
+
+        filter.Add("value");
+        filter.Add("value");
+
+        Assert.Equal(6, filter.GetEstimatedCount("value"));
+
+        filter.Remove("value");
+        Assert.Equal(3, filter.GetEstimatedCount("value"));
+
+        filter.Remove("value");
+        Assert.Equal(0, filter.GetEstimatedCount("value"));
+    }
+
+    [Fact]
+    public void CountingBloomFilter_ConcurrentAddAndRemove_UpdatesAtomically()
+    {
+        var filter = CountingBloomFilter.CreateXXHash128(CountingBloomFilterSize.CreateExact(counterCount: 1, hashCount: 1));
+
+        Parallel.For(0, 10_000, _ => filter.Add("value"));
+        Assert.Equal(10_000, filter.GetEstimatedCount("value"));
+
+        Parallel.For(0, 10_000, _ => filter.Remove("value"));
+        Assert.Equal(0, filter.GetEstimatedCount("value"));
+    }
+
+    [Fact]
+    public void CountingXXHash32_AddRangeAndRemoveRange_UpdatesValues()
+    {
+        var filter = CountingBloomFilter.CreateXXHash32(CountingBloomFilterSize.CreateOptimalSize(1000, 0.01));
+        var signedValues = Enumerable.Range(-50, 100).Append(int.MinValue).Append(int.MaxValue).ToArray();
+        var unsignedValues = Enumerable.Range(0, 100).Select(value => (uint)value).Append(uint.MaxValue).ToArray();
+
+        filter.AddRange(signedValues);
+        filter.AddRange(unsignedValues);
+        Assert.All(signedValues, value => Assert.True(filter.MayContain(value)));
+        Assert.All(unsignedValues, value => Assert.True(filter.MayContain(value)));
+
+        filter.RemoveRange(signedValues);
+        filter.RemoveRange(unsignedValues);
+        Assert.All(signedValues, value => Assert.False(filter.MayContain(value)));
+        Assert.All(unsignedValues, value => Assert.False(filter.MayContain(value)));
+    }
+
+    [Fact]
+    public void CountingXXHash64_AddRangeAndRemoveRange_UpdatesValues()
+    {
+        var filter = CountingBloomFilter.CreateXXHash64(CountingBloomFilterSize.CreateOptimalSize(1000, 0.01));
+        var signedValues = Enumerable.Range(-50, 100).Select(value => (long)value).Append(long.MinValue).Append(long.MaxValue).ToArray();
+        var unsignedValues = Enumerable.Range(0, 100).Select(value => (ulong)value).Append(ulong.MaxValue).ToArray();
+
+        filter.AddRange(signedValues);
+        filter.AddRange(unsignedValues);
+        Assert.All(signedValues, value => Assert.True(filter.MayContain(value)));
+        Assert.All(unsignedValues, value => Assert.True(filter.MayContain(value)));
+
+        filter.RemoveRange(signedValues);
+        filter.RemoveRange(unsignedValues);
+        Assert.All(signedValues, value => Assert.False(filter.MayContain(value)));
+        Assert.All(unsignedValues, value => Assert.False(filter.MayContain(value)));
+    }
+
+    [Fact]
+    public void CountingXXHash128_AddRangeAndRemoveRange_UpdatesValues()
+    {
+        var filter = CountingBloomFilter.CreateXXHash128(CountingBloomFilterSize.CreateOptimalSize(1000, 0.01));
+        var signedValues = Enumerable.Range(-50, 100).Select(value => (long)value).Append(long.MinValue).Append(long.MaxValue).ToArray();
+        var unsignedValues = Enumerable.Range(0, 100).Select(value => (ulong)value).Append(ulong.MaxValue).ToArray();
+
+        filter.AddRange(signedValues);
+        filter.AddRange(unsignedValues);
+        Assert.All(signedValues, value => Assert.True(filter.MayContain(value)));
+        Assert.All(unsignedValues, value => Assert.True(filter.MayContain(value)));
+
+        filter.RemoveRange(signedValues);
+        filter.RemoveRange(unsignedValues);
+        Assert.All(signedValues, value => Assert.False(filter.MayContain(value)));
+        Assert.All(unsignedValues, value => Assert.False(filter.MayContain(value)));
+    }
+
+    [Fact]
+    public void CountingBloomFilterSize_CreateOptimalSize_MatchesBloomFilterSize()
+    {
+        var bloomFilterSize = BloomFilterSize.CreateOptimalSize(1000, 0.01);
+        var countingBloomFilterSize = CountingBloomFilterSize.CreateOptimalSize(1000, 0.01);
+
+        Assert.Equal(bloomFilterSize.BitCount, countingBloomFilterSize.CounterCount);
+        Assert.Equal(bloomFilterSize.HashCount, countingBloomFilterSize.HashCount);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(-1, 1)]
+    [InlineData(1, 0)]
+    [InlineData(1, -1)]
+    public void CountingBloomFilterSize_CreateExact_ValidatesArguments(long counterCount, int hashCount)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => CountingBloomFilterSize.CreateExact(counterCount, hashCount));
+    }
+
+    [Theory]
+    [InlineData(0, 0.01)]
+    [InlineData(-1, 0.01)]
+    [InlineData(1, 0)]
+    [InlineData(1, -0.01)]
+    [InlineData(1, 1)]
+    [InlineData(1, 1.01)]
+    public void CountingBloomFilterSize_CreateOptimalSize_ValidatesArguments(long expectedItemCount, double falsePositiveProbability)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => CountingBloomFilterSize.CreateOptimalSize(expectedItemCount, falsePositiveProbability));
     }
 
     private static IEnumerable<object> GetValues()
@@ -161,6 +344,104 @@ public sealed class BloomFilterTests
             string v => filter.MayContain(v),
             UInt128 v => filter.MayContain(v),
             Int128 v => filter.MayContain(v),
+            _ => throw new ArgumentOutOfRangeException(nameof(value)),
+        };
+    }
+
+    private static void AddValue(ICountingBloomFilter filter, object value)
+    {
+        switch (value)
+        {
+            case int v:
+                filter.Add(v);
+                break;
+            case uint v:
+                filter.Add(v);
+                break;
+            case long v:
+                filter.Add(v);
+                break;
+            case ulong v:
+                filter.Add(v);
+                break;
+            case Guid v:
+                filter.Add(v);
+                break;
+            case string v:
+                filter.Add(v);
+                break;
+            case UInt128 v:
+                filter.Add(v);
+                break;
+            case Int128 v:
+                filter.Add(v);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(value));
+        }
+    }
+
+    private static void RemoveValue(ICountingBloomFilter filter, object value)
+    {
+        switch (value)
+        {
+            case int v:
+                filter.Remove(v);
+                break;
+            case uint v:
+                filter.Remove(v);
+                break;
+            case long v:
+                filter.Remove(v);
+                break;
+            case ulong v:
+                filter.Remove(v);
+                break;
+            case Guid v:
+                filter.Remove(v);
+                break;
+            case string v:
+                filter.Remove(v);
+                break;
+            case UInt128 v:
+                filter.Remove(v);
+                break;
+            case Int128 v:
+                filter.Remove(v);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(value));
+        }
+    }
+
+    private static bool MayContainValue(ICountingBloomFilter filter, object value)
+    {
+        return value switch
+        {
+            int v => filter.MayContain(v),
+            uint v => filter.MayContain(v),
+            long v => filter.MayContain(v),
+            ulong v => filter.MayContain(v),
+            Guid v => filter.MayContain(v),
+            string v => filter.MayContain(v),
+            UInt128 v => filter.MayContain(v),
+            Int128 v => filter.MayContain(v),
+            _ => throw new ArgumentOutOfRangeException(nameof(value)),
+        };
+    }
+
+    private static int GetEstimatedCountValue(ICountingBloomFilter filter, object value)
+    {
+        return value switch
+        {
+            int v => filter.GetEstimatedCount(v),
+            uint v => filter.GetEstimatedCount(v),
+            long v => filter.GetEstimatedCount(v),
+            ulong v => filter.GetEstimatedCount(v),
+            Guid v => filter.GetEstimatedCount(v),
+            string v => filter.GetEstimatedCount(v),
+            UInt128 v => filter.GetEstimatedCount(v),
+            Int128 v => filter.GetEstimatedCount(v),
             _ => throw new ArgumentOutOfRangeException(nameof(value)),
         };
     }


### PR DESCRIPTION
## Summary
- Add a new counting bloom filter implementation with segmented counter storage
- Provide hash-specific counting variants for the existing Bloom filter algorithms
- Update the generated BloomFilter sources and project wiring to include the new types
- Add tests covering counting behavior and related Bloom filter scenarios

## Testing
- Not run (not requested)