### PR TITLE
Add Bloom filter estimated count support

### DIFF
--- a/ref/Meziantou.Framework.BloomFilters.cs
+++ b/ref/Meziantou.Framework.BloomFilters.cs
@@ -6,6 +6,7 @@ namespace Meziantou.Framework.BloomFilters
 {
     public abstract class BloomFilter
     {
+        public double GetEstimateCount() => throw null;
         public static Meziantou.Framework.BloomFilters.BloomFilterXXHash128 CreateXXHash128(Meziantou.Framework.BloomFilters.BloomFilterSize size) => throw null;
         public static Meziantou.Framework.BloomFilters.BloomFilterXXHash64 CreateXXHash64(Meziantou.Framework.BloomFilters.BloomFilterSize size) => throw null;
         public static Meziantou.Framework.BloomFilters.BloomFilterXXHash32 CreateXXHash32(Meziantou.Framework.BloomFilters.BloomFilterSize size) => throw null;
@@ -162,6 +163,7 @@ namespace Meziantou.Framework.BloomFilters
 
     public interface IBloomFilter
     {
+        double GetEstimateCount();
         void Add(int value);
         bool MayContain(int value);
         void Add(uint value);

--- a/src/Meziantou.Framework.BloomFilters/BloomFilter.cs
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilter.cs
@@ -13,6 +13,16 @@ public abstract partial class BloomFilter
         HashCount = hashCount;
     }
 
+    public double GetEstimateCount()
+    {
+        var setBitCount = Bits.CountSetBits();
+        if (setBitCount == Bits.BitCount)
+            return double.PositiveInfinity;
+
+        var setBitRatio = (double)setBitCount / Bits.BitCount;
+        return -Bits.BitCount / (double)HashCount * Math.Log(1 - setBitRatio);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private protected void AddHash(Hash128 hash)
     {

--- a/src/Meziantou.Framework.BloomFilters/BloomFilter.g.cs
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilter.g.cs
@@ -10,6 +10,7 @@ namespace Meziantou.Framework.BloomFilters;
 
 public partial interface IBloomFilter
 {
+    double GetEstimateCount();
     void Add(int value);
     bool MayContain(int value);
     void Add(uint value);

--- a/src/Meziantou.Framework.BloomFilters/BloomFilter.tt
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilter.tt
@@ -35,6 +35,7 @@ namespace Meziantou.Framework.BloomFilters;
 
 public partial interface IBloomFilter
 {
+    double GetEstimateCount();
 <# foreach (var type in types) { #>
     void Add(<#= ToCsharpTypeName(type) #> value);
     bool MayContain(<#= ToCsharpTypeName(type) #> value);

--- a/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
+++ b/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -38,6 +39,20 @@ internal sealed class SegmentedBitStorage
         {
             Array.Clear(segment);
         }
+    }
+
+    public long CountSetBits()
+    {
+        long count = 0;
+        foreach (var segment in _segments)
+        {
+            for (var index = 0; index < segment.Length; index++)
+            {
+                count += BitOperations.PopCount(Volatile.Read(ref segment[index]));
+            }
+        }
+
+        return count;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tests/Meziantou.Framework.BloomFilters.Tests/BloomFilterTests.cs
+++ b/tests/Meziantou.Framework.BloomFilters.Tests/BloomFilterTests.cs
@@ -29,6 +29,36 @@ public sealed class BloomFilterTests
     }
 
     [Fact]
+    public void GetEstimateCount_EmptyFilter_ReturnsZero()
+    {
+        var filter = BloomFilter.CreateXXHash128(BloomFilterSize.CreateOptimalSize(1000, 0.01));
+
+        Assert.Equal(0, filter.GetEstimateCount());
+    }
+
+    [Fact]
+    public void GetEstimateCount_FullFilter_ReturnsPositiveInfinity()
+    {
+        var filter = BloomFilter.CreateXXHash128(BloomFilterSize.CreateExact(1, 1));
+        filter.Add(0);
+
+        Assert.Equal(double.PositiveInfinity, filter.GetEstimateCount());
+    }
+
+    [Fact]
+    public void GetEstimateCount_PopulatedFilter_ReturnsApproximateCount()
+    {
+        const int ItemCount = 1000;
+        var filter = BloomFilter.CreateXXHash128(BloomFilterSize.CreateOptimalSize(ItemCount, 0.01));
+        for (var value = 0; value < ItemCount; value++)
+        {
+            filter.Add(value);
+        }
+
+        Assert.InRange(filter.GetEstimateCount(), ItemCount * 0.95, ItemCount * 1.05);
+    }
+
+    [Fact]
     public void XXHash32_AddRange_ThenMayContain_ReturnsTrue()
     {
         var filter = BloomFilter.CreateXXHash32(BloomFilterSize.CreateOptimalSize(1000, 0.01));


### PR DESCRIPTION
## Summary
- Add `GetEstimateCount()` to Bloom filters to estimate the number of inserted items from the current bit occupancy.
- Treat a fully saturated filter as `double.PositiveInfinity`.
- Update the generated interface so all Bloom filter implementations expose the new API.
- Add tests for empty, full, and populated filters.

## Testing
- Added unit coverage for the new count estimation behavior.
- Not run (not requested).