### PR TITLE
Include LLM context in snapshot detection

### DIFF
--- a/slnx/Meziantou.AspNetCore.Components.LogViewer.slnx
+++ b/slnx/Meziantou.AspNetCore.Components.LogViewer.slnx
@@ -9,6 +9,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/slnx/Meziantou.AspNetCore.Components.slnx
+++ b/slnx/Meziantou.AspNetCore.Components.slnx
@@ -8,6 +8,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/slnx/Meziantou.AspNetCore.slnx
+++ b/slnx/Meziantou.AspNetCore.slnx
@@ -8,6 +8,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/slnx/Meziantou.Framework.Avatar.slnx
+++ b/slnx/Meziantou.Framework.Avatar.slnx
@@ -6,6 +6,7 @@
     <Project Path="../src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/slnx/Meziantou.Framework.Http.Caching.InMemory.slnx
+++ b/slnx/Meziantou.Framework.Http.Caching.InMemory.slnx
@@ -11,6 +11,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/slnx/Meziantou.Framework.Http.Caching.Redis.slnx
+++ b/slnx/Meziantou.Framework.Http.Caching.Redis.slnx
@@ -11,6 +11,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/slnx/Meziantou.Framework.Http.Caching.Sqlite.slnx
+++ b/slnx/Meziantou.Framework.Http.Caching.Sqlite.slnx
@@ -11,6 +11,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/slnx/Meziantou.Framework.Http.Caching.slnx
+++ b/slnx/Meziantou.Framework.Http.Caching.slnx
@@ -11,6 +11,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/slnx/Meziantou.Framework.InlineSnapshotTesting.slnx
+++ b/slnx/Meziantou.Framework.InlineSnapshotTesting.slnx
@@ -15,6 +15,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj" />
     <Project Path="../src/Meziantou.Framework.PublicApiGenerator/Meziantou.Framework.PublicApiGenerator.csproj" />

--- a/slnx/Meziantou.Framework.ProcessWrapper.slnx
+++ b/slnx/Meziantou.Framework.ProcessWrapper.slnx
@@ -9,6 +9,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj" />
     <Project Path="../src/Meziantou.Framework.PublicApiGenerator/Meziantou.Framework.PublicApiGenerator.csproj" />

--- a/slnx/Meziantou.Framework.PublicApiGenerator.Tool.slnx
+++ b/slnx/Meziantou.Framework.PublicApiGenerator.Tool.slnx
@@ -7,6 +7,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj" />
     <Project Path="../src/Meziantou.Framework.PublicApiGenerator/Meziantou.Framework.PublicApiGenerator.csproj" />

--- a/slnx/Meziantou.Framework.PublicApiGenerator.slnx
+++ b/slnx/Meziantou.Framework.PublicApiGenerator.slnx
@@ -7,6 +7,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj" />
     <Project Path="../src/Meziantou.Framework.PublicApiGenerator/Meziantou.Framework.PublicApiGenerator.csproj" />

--- a/slnx/Meziantou.Framework.QRCode.slnx
+++ b/slnx/Meziantou.Framework.QRCode.slnx
@@ -7,6 +7,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.QRCode/Meziantou.Framework.QRCode.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />

--- a/slnx/Meziantou.Framework.SnapshotTesting.ImageSharp.slnx
+++ b/slnx/Meziantou.Framework.SnapshotTesting.ImageSharp.slnx
@@ -5,6 +5,7 @@
     <Project Path="../src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
   </Folder>

--- a/slnx/Meziantou.Framework.SnapshotTesting.slnx
+++ b/slnx/Meziantou.Framework.SnapshotTesting.slnx
@@ -8,6 +8,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.QRCode/Meziantou.Framework.QRCode.csproj" />
     <Project Path="../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />

--- a/slnx/Meziantou.Framework.TemporaryDirectory.slnx
+++ b/slnx/Meziantou.Framework.TemporaryDirectory.slnx
@@ -15,6 +15,7 @@
     <Project Path="../src/Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <Project Path="../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <Project Path="../src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <Project Path="../src/Meziantou.Framework.NuGetPackageValidation/Meziantou.Framework.NuGetPackageValidation.csproj" />
     <Project Path="../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
     <Project Path="../src/Meziantou.Framework.PublicApiGenerator.Tool/Meziantou.Framework.PublicApiGenerator.Tool.csproj" />

--- a/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettings.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettings.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Meziantou.Framework.InlineSnapshotTesting.MergeTools;
 using Meziantou.Framework.InlineSnapshotTesting.Serialization;
+using Meziantou.Framework.LLMContext;
 
 namespace Meziantou.Framework.InlineSnapshotTesting;
 
@@ -28,7 +29,7 @@ public sealed record InlineSnapshotSettings
     /// <summary>Gets or sets the file encoding to use when writing snapshots. If null, the encoding is detected from the source file.</summary>
     public Encoding? FileEncoding { get; set; }
 
-    /// <summary>Gets or sets a value indicating whether to automatically detect CI environments and disable snapshot updates.</summary>
+    /// <summary>Gets or sets a value indicating whether to automatically detect continuous integration, continuous testing, and LLM environments and disable snapshot updates.</summary>
     public bool AutoDetectContinuousEnvironment { get; set; } = true;
 
     /// <summary>Gets or sets the allowed C# string formats for writing snapshots (quoted, verbatim, raw, etc.).</summary>
@@ -144,6 +145,7 @@ public sealed record InlineSnapshotSettings
         IsRunningOnContinuousIntegration = {IsRunningOnContinuousIntegration()}
         BuildServerDetector = {BuildServerDetector.Detected}
         ContinuousTestingDetector = {ContinuousTestingDetector.Detected}
+        LLMContextDetector = {LLMContextDetector.IsLLMContext()}
         """;
 
     public InlineSnapshotSettings()
@@ -175,7 +177,7 @@ public sealed record InlineSnapshotSettings
         }
     }
 
-    internal static bool IsRunningOnContinuousIntegration() => BuildServerDetector.Detected || ContinuousTestingDetector.Detected;
+    internal static bool IsRunningOnContinuousIntegration() => BuildServerDetector.Detected || ContinuousTestingDetector.Detected || LLMContextDetector.IsLLMContext();
 
     [DoesNotReturn]
     internal void AssertSnapshot(string? expected, string? actual)

--- a/src/Meziantou.Framework.InlineSnapshotTesting/MergeTool.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/MergeTool.cs
@@ -1,5 +1,6 @@
 using Meziantou.Framework.DiffEngine;
 using Meziantou.Framework.InlineSnapshotTesting.MergeTools;
+using Meziantou.Framework.LLMContext;
 
 namespace Meziantou.Framework.InlineSnapshotTesting;
 
@@ -53,7 +54,8 @@ public abstract class MergeTool
         var variable = Environment.GetEnvironmentVariable("DiffEngine_Disabled");
         return string.Equals(variable, "true", StringComparison.OrdinalIgnoreCase) ||
                BuildServerDetector.Detected ||
-               ContinuousTestingDetector.Detected;
+               ContinuousTestingDetector.Detected ||
+               LLMContextDetector.IsLLMContext();
     }
 
     internal static MergeToolResult? Launch(IEnumerable<MergeTool?>? mergeTools, string currentFilePath, string newFilePath)

--- a/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
@@ -45,6 +45,7 @@
     <ProjectReference Include="../Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
     <ProjectReference Include="../Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
     <ProjectReference Include="../Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
     <ProjectReference Include="../Meziantou.Framework.TextDiff/Meziantou.Framework.TextDiff.csproj" />
   </ItemGroup>
 

--- a/src/Meziantou.Framework.SnapshotTesting/MergeTool.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/MergeTool.cs
@@ -1,4 +1,5 @@
 using Meziantou.Framework.DiffEngine;
+using Meziantou.Framework.LLMContext;
 using Meziantou.Framework.SnapshotTesting.MergeTools;
 
 namespace Meziantou.Framework.SnapshotTesting;
@@ -53,7 +54,8 @@ public abstract class MergeTool
         var variable = Environment.GetEnvironmentVariable("DiffEngine_Disabled");
         return string.Equals(variable, "true", StringComparison.OrdinalIgnoreCase) ||
                BuildServerDetector.Detected ||
-               ContinuousTestingDetector.Detected;
+               ContinuousTestingDetector.Detected ||
+               LLMContextDetector.IsLLMContext();
     }
 
     internal static MergeToolResult? Launch(IEnumerable<MergeTool?>? mergeTools, string currentFilePath, string newFilePath)

--- a/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="../Meziantou.Framework.DiffEngine/Meziantou.Framework.DiffEngine.csproj" />
     <ProjectReference Include="../Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
     <ProjectReference Include="../Meziantou.Framework.HumanReadableSerializer/Meziantou.Framework.HumanReadableSerializer.csproj" />
+    <ProjectReference Include="../Meziantou.Framework.LLMContext/Meziantou.Framework.LLMContext.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotSettings.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotSettings.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Security.Cryptography;
+using Meziantou.Framework.LLMContext;
 using Meziantou.Framework.SnapshotTesting.MergeTools;
 
 namespace Meziantou.Framework.SnapshotTesting;
@@ -18,6 +19,7 @@ public sealed record SnapshotSettings
 
     public static SnapshotSettings Default { get; set; } = new();
 
+    /// <summary>Gets or sets a value indicating whether to automatically detect continuous integration, continuous testing, and LLM environments and disable snapshot updates.</summary>
     public bool AutoDetectContinuousEnvironment { get; set; } = true;
 
     public bool ForceUpdateSnapshots { get; set; }
@@ -131,7 +133,7 @@ public sealed record SnapshotSettings
         MergeTools = options.MergeTools is null ? null : [.. options.MergeTools];
     }
 
-    internal static bool IsRunningOnContinuousIntegration() => BuildServerDetector.Detected || ContinuousTestingDetector.Detected;
+    internal static bool IsRunningOnContinuousIntegration() => BuildServerDetector.Detected || ContinuousTestingDetector.Detected || LLMContextDetector.IsLLMContext();
 
     private static FullPath DefaultSnapshotPath(SnapshotPathContext context)
     {


### PR DESCRIPTION
## Summary
- Treat LLM context as a continuous environment for snapshot and inline snapshot updates
- Disable merge tool launching when running in an LLM context
- Add the `Meziantou.Framework.LLMContext` reference where needed
- Update the `AutoDetectContinuousEnvironment` documentation to reflect the broader detection

## Testing
- Not run (not requested)