### PR TITLE
Add macOS support for OpenInExplorer

### DIFF
--- a/ref/Meziantou.Framework.FullPath.cs
+++ b/ref/Meziantou.Framework.FullPath.cs
@@ -76,6 +76,7 @@ namespace Meziantou.Framework
         public bool TryGetSymbolicLinkTarget([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.FullPath? result) => throw null;
         public bool TryGetSymbolicLinkTarget(Meziantou.Framework.SymbolicLinkResolutionMode resolutionMode, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.FullPath? result) => throw null;
         [System.Runtime.Versioning.SupportedOSPlatform("windows5.1.2600")]
+        [System.Runtime.Versioning.SupportedOSPlatform("macos")]
         public void OpenInExplorer() { }
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
         public string ToWindowsExtendedPath() => throw null;

--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -721,24 +721,39 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         return false;
     }
 
-    /// <summary>Opens Windows Explorer and selects this file or directory.</summary>
+    /// <summary>Opens the system file manager and selects this file or directory.</summary>
     [SupportedOSPlatform("windows5.1.2600")]
+    [SupportedOSPlatform("macos")]
     public unsafe void OpenInExplorer()
     {
         if (IsEmpty)
             throw new InvalidOperationException("Path is empty");
 
-        var itemList = PInvoke.ILCreateFromPath(Value);
-        if (itemList is not null)
+        if (OperatingSystem.IsWindowsVersionAtLeast(5, 1, 2600))
         {
-            try
+            var itemList = PInvoke.ILCreateFromPath(Value);
+            if (itemList is not null)
             {
-                PInvoke.SHOpenFolderAndSelectItems(itemList, 0u, apidl: null, 0u).ThrowOnFailure();
+                try
+                {
+                    PInvoke.SHOpenFolderAndSelectItems(itemList, 0u, apidl: null, 0u).ThrowOnFailure();
+                }
+                finally
+                {
+                    PInvoke.ILFree(itemList);
+                }
             }
-            finally
-            {
-                PInvoke.ILFree(itemList);
-            }
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            var processStartInfo = new ProcessStartInfo("/usr/bin/open");
+            processStartInfo.ArgumentList.Add("-R");
+            processStartInfo.ArgumentList.Add(Value);
+            using var process = Process.Start(processStartInfo);
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("Opening the system file manager is only supported on Windows 5.1.2600 and later, and macOS.");
         }
     }
 


### PR DESCRIPTION
## Summary
- Extend `FullPath.OpenInExplorer()` to open the selected item in Finder on macOS
- Update platform annotations and XML docs to reflect system file manager support
- Keep the existing Windows behavior and throw a clear exception on unsupported platforms

## Testing
- Not run (not requested)