### PR TITLE
Handle null Yamlish scalars during deserialization

### DIFF
--- a/ref/Meziantou.Framework.Yamlish.cs
+++ b/ref/Meziantou.Framework.Yamlish.cs
@@ -198,6 +198,7 @@ namespace Meziantou.Framework.Yamlish.Nodes
     {
         public Meziantou.Framework.Yamlish.Nodes.YamlishNodeKind Kind { get => throw null; }
         public string Value { get => throw null; }
+        public bool IsNull { get => throw null; }
         public Meziantou.Framework.Yamlish.YamlishScalarStyle Style { get => throw null; set { } }
         public Meziantou.Framework.Yamlish.YamlishScalarChomping Chomping { get => throw null; set { } }
         public YamlishScalar(string value) { }

--- a/src/Meziantou.Framework.Yamlish/Converters/DBNullYamlishConverter.cs
+++ b/src/Meziantou.Framework.Yamlish/Converters/DBNullYamlishConverter.cs
@@ -2,6 +2,8 @@ namespace Meziantou.Framework.Yamlish.Converters;
 
 internal sealed class DBNullYamlishConverter : ScalarYamlishConverter<DBNull>
 {
+    public override bool HandleNullValues => true;
+
     protected override DBNull Parse(string value)
     {
         return value is "null" ? DBNull.Value : throw new FormatException($"Cannot convert '{value}' to '{typeof(DBNull)}'.");

--- a/src/Meziantou.Framework.Yamlish/Meziantou.Framework.Yamlish.csproj
+++ b/src/Meziantou.Framework.Yamlish/Meziantou.Framework.Yamlish.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>1.0.2</Version>
+    <Version>1.0.4</Version>
     <Description>A parser and serializer for a small, deliberate subset of YAML.</Description>
     <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.Yamlish/Nodes/YamlishScalar.cs
+++ b/src/Meziantou.Framework.Yamlish/Nodes/YamlishScalar.cs
@@ -11,6 +11,8 @@ public sealed class YamlishScalar : YamlishNode
 
     public string Value { get; }
 
+    public bool IsNull => Value is "null";
+
     public YamlishScalarStyle Style { get; set; }
 
     public YamlishScalarChomping Chomping { get; set; } = YamlishScalarChomping.Clip;

--- a/src/Meziantou.Framework.Yamlish/YamlishConverter.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishConverter.cs
@@ -2,6 +2,8 @@ namespace Meziantou.Framework.Yamlish;
 
 public abstract class YamlishConverter
 {
+    public virtual bool HandleNullValues => false;
+
     public abstract bool CanConvert(Type typeToConvert);
 
     public abstract object? Read(YamlishNode node, Type typeToConvert, YamlishSerializerOptions options);

--- a/src/Meziantou.Framework.Yamlish/YamlishSerializer.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishSerializer.cs
@@ -155,6 +155,9 @@ public static class YamlishSerializer
         {
             EnsureDepth(options, depth);
             var converter = options.GetConverter(type);
+            if (node is YamlishScalar { IsNull: true } && converter?.HandleNullValues is not true && (!type.IsValueType || Nullable.GetUnderlyingType(type) is not null))
+                return null;
+
             if (converter is not null)
             {
                 var result = converter.Read(node, type, options);

--- a/tests/Meziantou.Framework.Yamlish.Tests/YamlishConverterTests.cs
+++ b/tests/Meziantou.Framework.Yamlish.Tests/YamlishConverterTests.cs
@@ -311,6 +311,29 @@ public sealed class YamlishConverterTests
     }
 
     [Fact]
+    public void CustomConverter_NullValue_IsHandledAutomaticallyByDefault()
+    {
+        var options = new YamlishSerializerOptions();
+        options.Converters.Add(new ThrowingNullHandledValueConverter());
+
+        var result = YamlishSerializer.Deserialize<NullHandledValue>("null", options);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void CustomConverter_HandleNullValues_ReadsNullValue()
+    {
+        var options = new YamlishSerializerOptions();
+        options.Converters.Add(new NullHandledValueConverter());
+
+        var result = YamlishSerializer.Deserialize<NullHandledValue>("null", options);
+
+        Assert.NotNull(result);
+        Assert.True(result.Handled);
+    }
+
+    [Fact]
     public void CustomConverters_OverrideBuiltInAndUseRuntimeType()
     {
         var options = new YamlishSerializerOptions();
@@ -472,6 +495,11 @@ public sealed class YamlishConverterTests
 
     private readonly record struct Temperature(int Value);
 
+    private sealed class NullHandledValue
+    {
+        public bool Handled { get; set; }
+    }
+
     private sealed class TemperatureConverter : YamlishConverter<Temperature>
     {
         public override Temperature Read(YamlishNode node, YamlishSerializerOptions options)
@@ -483,6 +511,35 @@ public sealed class YamlishConverterTests
         public override YamlishNode Write(Temperature value, YamlishSerializerOptions options)
         {
             return new YamlishScalar($"{value.Value.ToString(CultureInfo.InvariantCulture)} C");
+        }
+    }
+
+    private sealed class ThrowingNullHandledValueConverter : YamlishConverter<NullHandledValue>
+    {
+        public override NullHandledValue Read(YamlishNode node, YamlishSerializerOptions options)
+        {
+            throw new InvalidOperationException("The converter should not be called for null values.");
+        }
+
+        public override YamlishNode Write(NullHandledValue value, YamlishSerializerOptions options)
+        {
+            return new YamlishScalar("value");
+        }
+    }
+
+    private sealed class NullHandledValueConverter : YamlishConverter<NullHandledValue>
+    {
+        public override bool HandleNullValues => true;
+
+        public override NullHandledValue Read(YamlishNode node, YamlishSerializerOptions options)
+        {
+            Assert.True(Assert.IsType<YamlishScalar>(node).IsNull);
+            return new NullHandledValue { Handled = true };
+        }
+
+        public override YamlishNode Write(NullHandledValue value, YamlishSerializerOptions options)
+        {
+            return new YamlishScalar(value.Handled ? "handled" : "value");
         }
     }
 

--- a/tests/Meziantou.Framework.Yamlish.Tests/YamlishSerializerTests.cs
+++ b/tests/Meziantou.Framework.Yamlish.Tests/YamlishSerializerTests.cs
@@ -721,6 +721,14 @@ public sealed class YamlishSerializerTests
     }
 
     [Fact]
+    public void Deserialize_NullValue()
+    {
+        var result = YamlishSerializer.Deserialize<NullStringValue>("Prop: null");
+
+        Assert.Null(result!.Prop);
+    }
+
+    [Fact]
     public void Serialize_PolymorphicType_AddsDefaultTypeDiscriminator()
     {
         PolymorphicBase value = new PolymorphicDerived { BaseValue = 1, DerivedValue = "derived" };
@@ -979,6 +987,11 @@ public sealed class YamlishSerializerTests
     private sealed class StringValue
     {
         public string? Value { get; set; }
+    }
+
+    private sealed class NullStringValue
+    {
+        public string? Prop { get; set; }
     }
 
     private sealed class SequenceStyleValue


### PR DESCRIPTION
## Summary
- Treat scalar `null` values as `null` for nullable/reference targets before invoking converters
- Allow converters to opt into handling nulls explicitly via `HandleNullValues`
- Add coverage for default null handling, opt-in converter behavior, and null property deserialization

## Testing
- Added unit tests covering automatic null handling and converters that opt in to null values
- Added serializer coverage for deserializing a `null` property value