### PR TITLE
Add XML documentation to Yamlish public API

### DIFF
--- a/src/Meziantou.Framework.Yamlish/Attributes/YamlishDerivedTypeAttribute.cs
+++ b/src/Meziantou.Framework.Yamlish/Attributes/YamlishDerivedTypeAttribute.cs
@@ -1,8 +1,11 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Declares a derived type that can be used when serializing or deserializing polymorphic values.</summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
 public sealed class YamlishDerivedTypeAttribute : YamlishAttribute
 {
+    /// <summary>Initializes a new instance of the <see cref="YamlishDerivedTypeAttribute" /> class.</summary>
+    /// <param name="derivedType">The derived type.</param>
     public YamlishDerivedTypeAttribute(Type derivedType)
     {
         ArgumentNullException.ThrowIfNull(derivedType);
@@ -10,6 +13,9 @@ public sealed class YamlishDerivedTypeAttribute : YamlishAttribute
         TypeDiscriminator = derivedType.Name;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="YamlishDerivedTypeAttribute" /> class.</summary>
+    /// <param name="derivedType">The derived type.</param>
+    /// <param name="typeDiscriminator">The discriminator value used to identify the derived type.</param>
     public YamlishDerivedTypeAttribute(Type derivedType, string typeDiscriminator)
     {
         ArgumentNullException.ThrowIfNull(derivedType);
@@ -18,6 +24,9 @@ public sealed class YamlishDerivedTypeAttribute : YamlishAttribute
         TypeDiscriminator = typeDiscriminator;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="YamlishDerivedTypeAttribute" /> class.</summary>
+    /// <param name="derivedType">The derived type.</param>
+    /// <param name="typeDiscriminator">The discriminator value used to identify the derived type.</param>
     public YamlishDerivedTypeAttribute(Type derivedType, int typeDiscriminator)
     {
         ArgumentNullException.ThrowIfNull(derivedType);
@@ -25,7 +34,9 @@ public sealed class YamlishDerivedTypeAttribute : YamlishAttribute
         TypeDiscriminator = typeDiscriminator.ToString(CultureInfo.InvariantCulture);
     }
 
+    /// <summary>Gets the derived type.</summary>
     public Type DerivedType { get; }
 
+    /// <summary>Gets the discriminator value used to identify the derived type.</summary>
     public string TypeDiscriminator { get; }
 }

--- a/src/Meziantou.Framework.Yamlish/Attributes/YamlishIgnoreAttribute.cs
+++ b/src/Meziantou.Framework.Yamlish/Attributes/YamlishIgnoreAttribute.cs
@@ -1,7 +1,9 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Controls whether a field or property is ignored during Yamlish serialization.</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public sealed class YamlishIgnoreAttribute : YamlishAttribute
 {
+    /// <summary>Gets or sets the condition that determines when the member is ignored.</summary>
     public YamlishIgnoreCondition Condition { get; set; } = YamlishIgnoreCondition.Always;
 }

--- a/src/Meziantou.Framework.Yamlish/Attributes/YamlishPolymorphicAttribute.cs
+++ b/src/Meziantou.Framework.Yamlish/Attributes/YamlishPolymorphicAttribute.cs
@@ -1,10 +1,12 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Configures a type for polymorphic Yamlish serialization and deserialization.</summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct, Inherited = false)]
 public sealed class YamlishPolymorphicAttribute : YamlishAttribute
 {
     private string _typeDiscriminatorPropertyName = "$type";
 
+    /// <summary>Gets or sets the mapping key used to store the type discriminator.</summary>
     public string TypeDiscriminatorPropertyName
     {
         get => _typeDiscriminatorPropertyName;

--- a/src/Meziantou.Framework.Yamlish/Attributes/YamlishPropertyNameAttribute.cs
+++ b/src/Meziantou.Framework.Yamlish/Attributes/YamlishPropertyNameAttribute.cs
@@ -1,13 +1,17 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Specifies the Yamlish property name used for a field or property.</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public sealed class YamlishPropertyNameAttribute : YamlishAttribute
 {
+    /// <summary>Initializes a new instance of the <see cref="YamlishPropertyNameAttribute" /> class.</summary>
+    /// <param name="name">The Yamlish property name.</param>
     public YamlishPropertyNameAttribute(string name)
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
         Name = name;
     }
 
+    /// <summary>Gets the Yamlish property name.</summary>
     public string Name { get; }
 }

--- a/src/Meziantou.Framework.Yamlish/Attributes/YamlishScalarStyleAttribute.cs
+++ b/src/Meziantou.Framework.Yamlish/Attributes/YamlishScalarStyleAttribute.cs
@@ -1,14 +1,19 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Specifies the scalar style used when serializing a field or property.</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public sealed class YamlishScalarStyleAttribute : YamlishAttribute
 {
+    /// <summary>Initializes a new instance of the <see cref="YamlishScalarStyleAttribute" /> class.</summary>
+    /// <param name="style">The scalar style.</param>
     public YamlishScalarStyleAttribute(YamlishScalarStyle style)
     {
         Style = style;
     }
 
+    /// <summary>Gets the scalar style.</summary>
     public YamlishScalarStyle Style { get; }
 
+    /// <summary>Gets or sets the chomping behavior used for block scalar values.</summary>
     public YamlishScalarChomping Chomping { get; set; } = YamlishScalarChomping.Clip;
 }

--- a/src/Meziantou.Framework.Yamlish/Attributes/YamlishSequenceStyleAttribute.cs
+++ b/src/Meziantou.Framework.Yamlish/Attributes/YamlishSequenceStyleAttribute.cs
@@ -1,12 +1,16 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Specifies the sequence style used when serializing a field or property.</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public sealed class YamlishSequenceStyleAttribute : YamlishAttribute
 {
+    /// <summary>Initializes a new instance of the <see cref="YamlishSequenceStyleAttribute" /> class.</summary>
+    /// <param name="style">The sequence style.</param>
     public YamlishSequenceStyleAttribute(YamlishSequenceStyle style)
     {
         Style = style;
     }
 
+    /// <summary>Gets the sequence style.</summary>
     public YamlishSequenceStyle Style { get; }
 }

--- a/src/Meziantou.Framework.Yamlish/Nodes/YamlishDocument.cs
+++ b/src/Meziantou.Framework.Yamlish/Nodes/YamlishDocument.cs
@@ -1,32 +1,45 @@
 namespace Meziantou.Framework.Yamlish.Nodes;
 
+/// <summary>Represents a Yamlish document.</summary>
 public sealed class YamlishDocument
 {
+    /// <summary>Initializes a new instance of the <see cref="YamlishDocument" /> class.</summary>
+    /// <param name="root">The root node of the document.</param>
     public YamlishDocument(YamlishNode root)
     {
         Root = root ?? throw new ArgumentNullException(nameof(root));
     }
 
+    /// <summary>Gets the root node of the document.</summary>
     public YamlishNode Root { get; }
 
+    /// <summary>Parses Yamlish content into a document.</summary>
+    /// <param name="content">The Yamlish content to parse.</param>
+    /// <returns>The parsed document.</returns>
     public static YamlishDocument Parse(string content)
     {
         ArgumentNullException.ThrowIfNull(content);
         return new YamlishDocument(YamlishParser.Parse(content));
     }
 
+    /// <summary>Reads Yamlish content from a text reader and parses it into a document.</summary>
+    /// <param name="reader">The reader that provides the Yamlish content.</param>
+    /// <returns>The parsed document.</returns>
     public static YamlishDocument Parse(TextReader reader)
     {
         ArgumentNullException.ThrowIfNull(reader);
         return Parse(reader.ReadToEnd());
     }
 
+    /// <summary>Writes the document to a text writer.</summary>
+    /// <param name="writer">The writer that receives the Yamlish content.</param>
     public void WriteTo(TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(writer);
         YamlishWriter.Write(writer, Root, indentCharacter: ' ', indentSize: 2, newLine: writer.NewLine);
     }
 
+    /// <inheritdoc />
     public override string ToString()
     {
         using var writer = new StringWriter(CultureInfo.InvariantCulture);

--- a/src/Meziantou.Framework.Yamlish/Nodes/YamlishMapping.cs
+++ b/src/Meziantou.Framework.Yamlish/Nodes/YamlishMapping.cs
@@ -2,15 +2,19 @@ using System.Collections;
 
 namespace Meziantou.Framework.Yamlish.Nodes;
 
+/// <summary>Represents a Yamlish mapping node.</summary>
 public sealed class YamlishMapping : YamlishNode, IReadOnlyDictionary<string, YamlishNode>
 {
     private readonly List<KeyValuePair<string, YamlishNode>> _entries = [];
     private readonly Dictionary<string, YamlishNode> _lookup = new(StringComparer.Ordinal);
 
+    /// <summary>Initializes a new instance of the <see cref="YamlishMapping" /> class.</summary>
     public YamlishMapping()
     {
     }
 
+    /// <summary>Initializes a new instance of the <see cref="YamlishMapping" /> class with the specified entries.</summary>
+    /// <param name="entries">The mapping entries.</param>
     public YamlishMapping(IEnumerable<KeyValuePair<string, YamlishNode>> entries)
     {
         ArgumentNullException.ThrowIfNull(entries);
@@ -20,16 +24,24 @@ public sealed class YamlishMapping : YamlishNode, IReadOnlyDictionary<string, Ya
         }
     }
 
+    /// <inheritdoc />
     public override YamlishNodeKind Kind => YamlishNodeKind.Mapping;
 
+    /// <inheritdoc />
     public int Count => _entries.Count;
 
+    /// <inheritdoc />
     public IEnumerable<string> Keys => _entries.Select(entry => entry.Key);
 
+    /// <inheritdoc />
     public IEnumerable<YamlishNode> Values => _entries.Select(entry => entry.Value);
 
+    /// <inheritdoc />
     public YamlishNode this[string key] => _lookup[key];
 
+    /// <summary>Adds a mapping entry.</summary>
+    /// <param name="key">The mapping key.</param>
+    /// <param name="value">The mapping value.</param>
     public void Add(string key, YamlishNode value)
     {
         ArgumentException.ThrowIfNullOrEmpty(key);
@@ -53,10 +65,13 @@ public sealed class YamlishMapping : YamlishNode, IReadOnlyDictionary<string, Ya
         _entries[index] = new KeyValuePair<string, YamlishNode>(key, value);
     }
 
+    /// <inheritdoc />
     public bool ContainsKey(string key) => _lookup.ContainsKey(key);
 
+    /// <inheritdoc />
     public bool TryGetValue(string key, out YamlishNode value) => _lookup.TryGetValue(key, out value!);
 
+    /// <inheritdoc />
     public IEnumerator<KeyValuePair<string, YamlishNode>> GetEnumerator() => _entries.GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/Meziantou.Framework.Yamlish/Nodes/YamlishNode.cs
+++ b/src/Meziantou.Framework.Yamlish/Nodes/YamlishNode.cs
@@ -1,9 +1,12 @@
 namespace Meziantou.Framework.Yamlish.Nodes;
 
+/// <summary>Represents a node in a Yamlish document.</summary>
 public abstract class YamlishNode
 {
+    /// <summary>Gets the kind of the Yamlish node.</summary>
     public abstract YamlishNodeKind Kind { get; }
 
+    /// <inheritdoc />
     public override string ToString()
     {
         using var writer = new StringWriter(CultureInfo.InvariantCulture);

--- a/src/Meziantou.Framework.Yamlish/Nodes/YamlishNodeKind.cs
+++ b/src/Meziantou.Framework.Yamlish/Nodes/YamlishNodeKind.cs
@@ -1,8 +1,14 @@
 namespace Meziantou.Framework.Yamlish.Nodes;
 
+/// <summary>Specifies the kind of a Yamlish node.</summary>
 public enum YamlishNodeKind
 {
+    /// <summary>A scalar node.</summary>
     Scalar,
+
+    /// <summary>A mapping node.</summary>
     Mapping,
+
+    /// <summary>A sequence node.</summary>
     Sequence,
 }

--- a/src/Meziantou.Framework.Yamlish/Nodes/YamlishScalar.cs
+++ b/src/Meziantou.Framework.Yamlish/Nodes/YamlishScalar.cs
@@ -1,17 +1,24 @@
 namespace Meziantou.Framework.Yamlish.Nodes;
 
+/// <summary>Represents a Yamlish scalar node.</summary>
 public sealed class YamlishScalar : YamlishNode
 {
+    /// <summary>Initializes a new instance of the <see cref="YamlishScalar" /> class.</summary>
+    /// <param name="value">The scalar value.</param>
     public YamlishScalar(string value)
     {
         Value = value ?? throw new ArgumentNullException(nameof(value));
     }
 
+    /// <inheritdoc />
     public override YamlishNodeKind Kind => YamlishNodeKind.Scalar;
 
+    /// <summary>Gets the scalar value.</summary>
     public string Value { get; }
 
+    /// <summary>Gets or sets the style used when writing the scalar value.</summary>
     public YamlishScalarStyle Style { get; set; }
 
+    /// <summary>Gets or sets the chomping behavior used when writing a block scalar value.</summary>
     public YamlishScalarChomping Chomping { get; set; } = YamlishScalarChomping.Clip;
 }

--- a/src/Meziantou.Framework.Yamlish/Nodes/YamlishSequence.cs
+++ b/src/Meziantou.Framework.Yamlish/Nodes/YamlishSequence.cs
@@ -2,14 +2,18 @@ using System.Collections;
 
 namespace Meziantou.Framework.Yamlish.Nodes;
 
+/// <summary>Represents a Yamlish sequence node.</summary>
 public sealed class YamlishSequence : YamlishNode, IReadOnlyList<YamlishNode>
 {
     private readonly List<YamlishNode> _items = [];
 
+    /// <summary>Initializes a new instance of the <see cref="YamlishSequence" /> class.</summary>
     public YamlishSequence()
     {
     }
 
+    /// <summary>Initializes a new instance of the <see cref="YamlishSequence" /> class with the specified items.</summary>
+    /// <param name="items">The sequence items.</param>
     public YamlishSequence(IEnumerable<YamlishNode> items)
     {
         ArgumentNullException.ThrowIfNull(items);
@@ -19,20 +23,27 @@ public sealed class YamlishSequence : YamlishNode, IReadOnlyList<YamlishNode>
         }
     }
 
+    /// <inheritdoc />
     public override YamlishNodeKind Kind => YamlishNodeKind.Sequence;
 
+    /// <summary>Gets or sets the style used when writing the sequence.</summary>
     public YamlishSequenceStyle Style { get; set; }
 
+    /// <inheritdoc />
     public int Count => _items.Count;
 
+    /// <inheritdoc />
     public YamlishNode this[int index] => _items[index];
 
+    /// <summary>Adds a node to the sequence.</summary>
+    /// <param name="item">The node to add.</param>
     public void Add(YamlishNode item)
     {
         ArgumentNullException.ThrowIfNull(item);
         _items.Add(item);
     }
 
+    /// <inheritdoc />
     public IEnumerator<YamlishNode> GetEnumerator() => _items.GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/Meziantou.Framework.Yamlish/YamlishConverter.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishConverter.cs
@@ -4,8 +4,9 @@ namespace Meziantou.Framework.Yamlish;
 public abstract class YamlishConverter
 {
     /// <summary>
-    /// Gets a value that indicates whether <see langword="null" /> should be passed to the converter on serialization, and whether <see langword="null" /> should be passed on deserialization.
-    /// </sumary>
+    /// Gets a value that indicates whether <see langword="null" /> should be passed to the converter
+    /// on serialization, and whether <see langword="null" /> should be passed on deserialization.
+    /// </summary>
     public virtual bool HandleNullValues => false;
 
     /// <summary>Determines whether this converter can convert the specified type.</summary>

--- a/src/Meziantou.Framework.Yamlish/YamlishConverter.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishConverter.cs
@@ -1,10 +1,24 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Provides a converter for reading and writing Yamlish nodes.</summary>
 public abstract class YamlishConverter
 {
+    /// <summary>Determines whether this converter can convert the specified type.</summary>
+    /// <param name="typeToConvert">The type to convert.</param>
+    /// <returns><see langword="true" /> if this converter can convert <paramref name="typeToConvert" />; otherwise, <see langword="false" />.</returns>
     public abstract bool CanConvert(Type typeToConvert);
 
+    /// <summary>Reads a value from a Yamlish node.</summary>
+    /// <param name="node">The node to read.</param>
+    /// <param name="typeToConvert">The type to convert the node to.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The converted value.</returns>
     public abstract object? Read(YamlishNode node, Type typeToConvert, YamlishSerializerOptions options);
 
+    /// <summary>Writes a value as a Yamlish node.</summary>
+    /// <param name="value">The value to write.</param>
+    /// <param name="typeToConvert">The declared type of the value.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The Yamlish node that represents the value.</returns>
     public abstract YamlishNode Write(object value, Type typeToConvert, YamlishSerializerOptions options);
 }

--- a/src/Meziantou.Framework.Yamlish/YamlishConverterFactory.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishConverterFactory.cs
@@ -1,10 +1,17 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Provides a factory that creates Yamlish converters for supported types.</summary>
 public abstract class YamlishConverterFactory : YamlishConverter
 {
+    /// <summary>Creates a converter for the specified type.</summary>
+    /// <param name="typeToConvert">The type to convert.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The converter for <paramref name="typeToConvert" />, or <see langword="null" /> if no converter can be created.</returns>
     public abstract YamlishConverter? CreateConverter(Type typeToConvert, YamlishSerializerOptions options);
 
+    /// <inheritdoc />
     public sealed override object? Read(YamlishNode node, Type typeToConvert, YamlishSerializerOptions options) => throw new InvalidOperationException();
 
+    /// <inheritdoc />
     public sealed override YamlishNode Write(object value, Type typeToConvert, YamlishSerializerOptions options) => throw new InvalidOperationException();
 }

--- a/src/Meziantou.Framework.Yamlish/YamlishConverter`1.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishConverter`1.cs
@@ -1,18 +1,31 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Provides a strongly typed converter for reading and writing Yamlish nodes.</summary>
+/// <typeparam name="T">The type handled by the converter.</typeparam>
 public abstract class YamlishConverter<T> : YamlishConverter
 {
+    /// <inheritdoc />
     public sealed override bool CanConvert(Type typeToConvert) => typeToConvert == typeof(T);
 
+    /// <summary>Reads a value from a Yamlish node.</summary>
+    /// <param name="node">The node to read.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The converted value.</returns>
     public abstract T? Read(YamlishNode node, YamlishSerializerOptions options);
 
+    /// <summary>Writes a value as a Yamlish node.</summary>
+    /// <param name="value">The value to write.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The Yamlish node that represents the value.</returns>
     public abstract YamlishNode Write(T value, YamlishSerializerOptions options);
 
+    /// <inheritdoc />
     public sealed override object? Read(YamlishNode node, Type typeToConvert, YamlishSerializerOptions options)
     {
         return Read(node, options);
     }
 
+    /// <inheritdoc />
     public sealed override YamlishNode Write(object value, Type typeToConvert, YamlishSerializerOptions options)
     {
         return Write((T)value, options);

--- a/src/Meziantou.Framework.Yamlish/YamlishIgnoreCondition.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishIgnoreCondition.cs
@@ -1,9 +1,17 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Specifies when a member is ignored during Yamlish serialization.</summary>
 public enum YamlishIgnoreCondition
 {
+    /// <summary>The member is never ignored.</summary>
     Never,
+
+    /// <summary>The member is always ignored.</summary>
     Always,
+
+    /// <summary>The member is ignored when its value is the default value for its type.</summary>
     WhenWritingDefault,
+
+    /// <summary>The member is ignored when its value is <see langword="null" />.</summary>
     WhenWritingNull,
 }

--- a/src/Meziantou.Framework.Yamlish/YamlishNamingPolicy.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishNamingPolicy.cs
@@ -2,20 +2,30 @@ using System.Text.Json;
 
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Determines how Yamlish property names are converted during serialization and deserialization.</summary>
 public abstract class YamlishNamingPolicy
 {
+    /// <summary>Gets a naming policy that converts property names to camel case.</summary>
     public static YamlishNamingPolicy CamelCase { get; } = new JsonNamingPolicyAdapter(JsonNamingPolicy.CamelCase);
 
+    /// <summary>Gets a naming policy that converts property names to lower snake case.</summary>
     public static YamlishNamingPolicy SnakeCaseLower { get; } = new JsonNamingPolicyAdapter(JsonNamingPolicy.SnakeCaseLower);
 
+    /// <summary>Gets a naming policy that converts property names to upper snake case.</summary>
     public static YamlishNamingPolicy SnakeCaseUpper { get; } = new JsonNamingPolicyAdapter(JsonNamingPolicy.SnakeCaseUpper);
 
+    /// <summary>Gets a naming policy that converts property names to lower kebab case.</summary>
     public static YamlishNamingPolicy KebabCaseLower { get; } = new JsonNamingPolicyAdapter(JsonNamingPolicy.KebabCaseLower);
 
+    /// <summary>Gets a naming policy that converts property names to upper kebab case.</summary>
     public static YamlishNamingPolicy KebabCaseUpper { get; } = new JsonNamingPolicyAdapter(JsonNamingPolicy.KebabCaseUpper);
 
+    /// <summary>Gets a naming policy that converts property names to Pascal case.</summary>
     public static YamlishNamingPolicy PascalCase { get; } = new PascalCaseNamingPolicy();
 
+    /// <summary>Converts the specified property name according to the naming policy.</summary>
+    /// <param name="name">The property name to convert.</param>
+    /// <returns>The converted property name.</returns>
     public abstract string ConvertName(string name);
 
     private sealed class JsonNamingPolicyAdapter(JsonNamingPolicy policy) : YamlishNamingPolicy

--- a/src/Meziantou.Framework.Yamlish/YamlishObjectCreationHandling.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishObjectCreationHandling.cs
@@ -1,7 +1,11 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Specifies how existing object instances are handled during deserialization.</summary>
 public enum YamlishObjectCreationHandling
 {
+    /// <summary>Creates a new object instance instead of reusing an existing value.</summary>
     Replace,
+
+    /// <summary>Populates an existing object instance when possible.</summary>
     Populate,
 }

--- a/src/Meziantou.Framework.Yamlish/YamlishScalarChomping.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishScalarChomping.cs
@@ -1,8 +1,14 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Specifies how trailing line breaks are handled for block scalar values.</summary>
 public enum YamlishScalarChomping
 {
+    /// <summary>Keeps one trailing line break.</summary>
     Clip,
+
+    /// <summary>Removes trailing line breaks.</summary>
     Strip,
+
+    /// <summary>Keeps all trailing line breaks.</summary>
     Keep,
 }

--- a/src/Meziantou.Framework.Yamlish/YamlishScalarStyle.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishScalarStyle.cs
@@ -1,11 +1,23 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Specifies how scalar values are emitted in Yamlish.</summary>
 public enum YamlishScalarStyle
 {
+    /// <summary>Automatically selects the scalar style.</summary>
     Auto,
+
+    /// <summary>Emits the scalar as a plain value.</summary>
     Plain,
+
+    /// <summary>Emits the scalar as a double-quoted value (<c>"</c>).</summary>
     DoubleQuoted,
+
+    /// <summary>Emits the scalar as a single-quoted value (<c>'</c>).</summary>
     SingleQuoted,
+
+    /// <summary>Emits the scalar using the literal block style (<c>|</c>).</summary>
     Literal,
+
+    /// <summary>Emits the scalar using the folded block style (<c>&gt;</c>).</summary>
     Folded,
 }

--- a/src/Meziantou.Framework.Yamlish/YamlishSequenceStyle.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishSequenceStyle.cs
@@ -1,8 +1,14 @@
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Specifies how sequence values are emitted in Yamlish.</summary>
 public enum YamlishSequenceStyle
 {
+    /// <summary>Automatically selects the sequence style.</summary>
     Auto,
+
+    /// <summary>Emits the sequence using block style.</summary>
     Block,
+
+    /// <summary>Emits the sequence using flow style.</summary>
     Flow,
 }

--- a/src/Meziantou.Framework.Yamlish/YamlishSerializer.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishSerializer.cs
@@ -2,13 +2,24 @@ using System.Collections;
 
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Provides methods for serializing objects to Yamlish and deserializing Yamlish content.</summary>
 public static class YamlishSerializer
 {
+    /// <summary>Serializes a value to a Yamlish string.</summary>
+    /// <typeparam name="T">The declared type of the value to serialize.</typeparam>
+    /// <param name="value">The value to serialize.</param>
+    /// <param name="options">The serializer options to use.</param>
+    /// <returns>The Yamlish representation of <paramref name="value" />.</returns>
     public static string Serialize<T>(T? value, YamlishSerializerOptions? options = null)
     {
         return Serialize(value, typeof(T), options);
     }
 
+    /// <summary>Serializes a value to a Yamlish string.</summary>
+    /// <param name="value">The value to serialize.</param>
+    /// <param name="type">The declared type of the value to serialize.</param>
+    /// <param name="options">The serializer options to use.</param>
+    /// <returns>The Yamlish representation of <paramref name="value" />.</returns>
     public static string Serialize(object? value, Type type, YamlishSerializerOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(type);
@@ -24,11 +35,21 @@ public static class YamlishSerializer
         return writer.ToString();
     }
 
+    /// <summary>Deserializes Yamlish content to a value.</summary>
+    /// <typeparam name="T">The type to deserialize.</typeparam>
+    /// <param name="content">The Yamlish content to deserialize.</param>
+    /// <param name="options">The serializer options to use.</param>
+    /// <returns>The deserialized value.</returns>
     public static T? Deserialize<T>(string content, YamlishSerializerOptions? options = null)
     {
         return (T?)Deserialize(content, typeof(T), options);
     }
 
+    /// <summary>Deserializes Yamlish content to a value.</summary>
+    /// <param name="content">The Yamlish content to deserialize.</param>
+    /// <param name="type">The type to deserialize.</param>
+    /// <param name="options">The serializer options to use.</param>
+    /// <returns>The deserialized value.</returns>
     public static object? Deserialize(string content, Type type, YamlishSerializerOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(content);

--- a/src/Meziantou.Framework.Yamlish/YamlishSerializerOptions.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishSerializerOptions.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 
 namespace Meziantou.Framework.Yamlish;
 
+/// <summary>Provides options that control Yamlish serialization and deserialization.</summary>
 public sealed class YamlishSerializerOptions
 {
     private readonly ConcurrentDictionary<Type, YamlishTypeInfo> _typeInfoCache = new();
@@ -11,15 +12,19 @@ public sealed class YamlishSerializerOptions
     private readonly List<(Func<Type, bool> Condition, YamlishAttribute Attribute)> _typeAttributes = [];
     private readonly List<(Func<MemberInfo, bool> Condition, YamlishAttribute Attribute)> _memberAttributes = [];
 
+    /// <summary>Initializes a new instance of the <see cref="YamlishSerializerOptions" /> class.</summary>
     public YamlishSerializerOptions()
     {
         Converters = new ConverterList(this);
     }
 
+    /// <summary>Gets a value indicating whether this instance is read-only.</summary>
     public bool IsReadOnly { get; private set; }
 
+    /// <summary>Gets the list of converters used by the serializer.</summary>
     public IList<YamlishConverter> Converters { get; }
 
+    /// <summary>Gets or sets the naming policy used to convert property names.</summary>
     public YamlishNamingPolicy? PropertyNamingPolicy
     {
         get;
@@ -30,6 +35,7 @@ public sealed class YamlishSerializerOptions
         }
     }
 
+    /// <summary>Gets or sets the comparer used to match property names during deserialization.</summary>
     public StringComparer PropertyNameComparer
     {
         get;
@@ -40,6 +46,7 @@ public sealed class YamlishSerializerOptions
         }
     } = StringComparer.OrdinalIgnoreCase;
 
+    /// <summary>Gets or sets the number of indentation characters to write for each nesting level.</summary>
     public int IndentSize
     {
         get;
@@ -50,6 +57,7 @@ public sealed class YamlishSerializerOptions
         }
     } = 2;
 
+    /// <summary>Gets or sets the indentation character used when writing Yamlish.</summary>
     public char IndentCharacter
     {
         get;
@@ -60,6 +68,7 @@ public sealed class YamlishSerializerOptions
         }
     } = ' ';
 
+    /// <summary>Gets or sets the newline sequence used when writing Yamlish.</summary>
     public string NewLine
     {
         get;
@@ -70,6 +79,7 @@ public sealed class YamlishSerializerOptions
         }
     } = Environment.NewLine;
 
+    /// <summary>Gets or sets the maximum depth allowed during serialization and deserialization.</summary>
     public int MaxDepth
     {
         get;
@@ -80,6 +90,7 @@ public sealed class YamlishSerializerOptions
         }
     } = 64;
 
+    /// <summary>Gets or sets the default condition that determines when members are ignored during serialization.</summary>
     public YamlishIgnoreCondition DefaultIgnoreCondition
     {
         get;
@@ -90,6 +101,7 @@ public sealed class YamlishSerializerOptions
         }
     } = YamlishIgnoreCondition.WhenWritingNull;
 
+    /// <summary>Gets or sets a value indicating whether public fields are included during serialization and deserialization.</summary>
     public bool IncludeFields
     {
         get;
@@ -100,6 +112,7 @@ public sealed class YamlishSerializerOptions
         }
     }
 
+    /// <summary>Gets or sets a value indicating whether read-only fields are ignored during serialization.</summary>
     public bool IgnoreReadOnlyFields
     {
         get;
@@ -110,6 +123,7 @@ public sealed class YamlishSerializerOptions
         }
     }
 
+    /// <summary>Gets or sets a value indicating whether read-only properties are ignored during serialization.</summary>
     public bool IgnoreReadOnlyProperties
     {
         get;
@@ -120,6 +134,7 @@ public sealed class YamlishSerializerOptions
         }
     }
 
+    /// <summary>Gets or sets the preferred behavior for object creation during deserialization.</summary>
     public YamlishObjectCreationHandling PreferredObjectCreationHandling
     {
         get;
@@ -130,6 +145,7 @@ public sealed class YamlishSerializerOptions
         }
     } = YamlishObjectCreationHandling.Replace;
 
+    /// <summary>Gets or sets a value indicating whether duplicate mapping keys are allowed when parsing Yamlish.</summary>
     public bool AllowDuplicateProperties
     {
         get;
@@ -140,6 +156,7 @@ public sealed class YamlishSerializerOptions
         }
     } = true;
 
+    /// <summary>Gets or sets a value indicating whether required constructor parameters must be present during deserialization.</summary>
     public bool RespectRequiredConstructorParameters
     {
         get;
@@ -150,6 +167,7 @@ public sealed class YamlishSerializerOptions
         }
     } = true;
 
+    /// <summary>Gets or sets a value indicating whether nullable annotations are enforced during serialization and deserialization.</summary>
     public bool RespectNullableAnnotations
     {
         get;
@@ -160,6 +178,9 @@ public sealed class YamlishSerializerOptions
         }
     } = true;
 
+    /// <summary>Adds a Yamlish attribute that applies to the specified type.</summary>
+    /// <param name="type">The type to which the attribute applies.</param>
+    /// <param name="attribute">The attribute to apply.</param>
     public void AddAttribute(Type type, YamlishAttribute attribute)
     {
         ArgumentNullException.ThrowIfNull(type);
@@ -169,6 +190,10 @@ public sealed class YamlishSerializerOptions
         _typeAttributes.Add((candidate => candidate == type, attribute));
     }
 
+    /// <summary>Adds a Yamlish attribute that applies to a member with the specified name on the specified type.</summary>
+    /// <param name="type">The type that declares the member.</param>
+    /// <param name="memberName">The name of the member to which the attribute applies.</param>
+    /// <param name="attribute">The attribute to apply.</param>
     public void AddAttribute(Type type, string memberName, YamlishAttribute attribute)
     {
         ArgumentNullException.ThrowIfNull(type);
@@ -186,10 +211,20 @@ public sealed class YamlishSerializerOptions
         }
     }
 
+    /// <summary>Adds a Yamlish attribute that applies to the specified property.</summary>
+    /// <param name="member">The property to which the attribute applies.</param>
+    /// <param name="attribute">The attribute to apply.</param>
     public void AddAttribute(PropertyInfo member, YamlishAttribute attribute) => AddAttribute((MemberInfo)member, attribute);
 
+    /// <summary>Adds a Yamlish attribute that applies to the specified field.</summary>
+    /// <param name="member">The field to which the attribute applies.</param>
+    /// <param name="attribute">The attribute to apply.</param>
     public void AddAttribute(FieldInfo member, YamlishAttribute attribute) => AddAttribute((MemberInfo)member, attribute);
 
+    /// <summary>Adds a Yamlish attribute that applies to the member selected by the specified expression.</summary>
+    /// <typeparam name="T">The type that declares the member.</typeparam>
+    /// <param name="member">An expression that selects one or more fields or properties.</param>
+    /// <param name="attribute">The attribute to apply.</param>
     public void AddAttribute<T>(Expression<Func<T, object>> member, YamlishAttribute attribute)
     {
         ArgumentNullException.ThrowIfNull(member);
@@ -206,6 +241,9 @@ public sealed class YamlishSerializerOptions
         }
     }
 
+    /// <summary>Adds a Yamlish attribute that applies to properties matching the specified condition.</summary>
+    /// <param name="condition">The condition used to select properties.</param>
+    /// <param name="attribute">The attribute to apply.</param>
     public void AddPropertyAttribute(Func<PropertyInfo, bool> condition, YamlishAttribute attribute)
     {
         ArgumentNullException.ThrowIfNull(condition);
@@ -214,6 +252,9 @@ public sealed class YamlishSerializerOptions
         _memberAttributes.Add((member => member is PropertyInfo property && condition(property), attribute));
     }
 
+    /// <summary>Adds a Yamlish attribute that applies to fields matching the specified condition.</summary>
+    /// <param name="condition">The condition used to select fields.</param>
+    /// <param name="attribute">The attribute to apply.</param>
     public void AddFieldAttribute(Func<FieldInfo, bool> condition, YamlishAttribute attribute)
     {
         ArgumentNullException.ThrowIfNull(condition);
@@ -222,6 +263,9 @@ public sealed class YamlishSerializerOptions
         _memberAttributes.Add((member => member is FieldInfo field && condition(field), attribute));
     }
 
+    /// <summary>Adds a Yamlish attribute that applies to types matching the specified condition.</summary>
+    /// <param name="condition">The condition used to select types.</param>
+    /// <param name="attribute">The attribute to apply.</param>
     public void AddTypeAttribute(Func<Type, bool> condition, YamlishAttribute attribute)
     {
         ArgumentNullException.ThrowIfNull(condition);
@@ -230,6 +274,7 @@ public sealed class YamlishSerializerOptions
         _typeAttributes.Add((condition, attribute));
     }
 
+    /// <summary>Makes this instance read-only.</summary>
     public void MakeReadOnly() => IsReadOnly = true;
 
     internal YamlishTypeInfo GetTypeInfo(Type type)
@@ -302,17 +347,22 @@ public sealed class YamlishSerializerOptions
     internal IEnumerable<T> GetCustomAttributes<T>(Type type) where T : YamlishAttribute
     {
         ArgumentNullException.ThrowIfNull(type);
-        MakeReadOnly();
 
-        for (var i = _typeAttributes.Count - 1; i >= 0; i--)
+        return GetCustomAttributes(type);
+        IEnumerable<T> GetCustomAttributes(Type type)
         {
-            var attribute = _typeAttributes[i];
-            if (attribute.Attribute is T result && attribute.Condition(type))
-                yield return result;
-        }
+            MakeReadOnly();
 
-        foreach (var attribute in type.GetCustomAttributes<T>())
-            yield return attribute;
+            for (var i = _typeAttributes.Count - 1; i >= 0; i--)
+            {
+                var attribute = _typeAttributes[i];
+                if (attribute.Attribute is T result && attribute.Condition(type))
+                    yield return result;
+            }
+
+            foreach (var attribute in type.GetCustomAttributes<T>())
+                yield return attribute;
+        }
     }
 
     internal void VerifyMutable()


### PR DESCRIPTION
## Summary
- Added XML documentation to Yamlish attributes, enums, node types, converters, naming policies, and serializer APIs
- Documented constructors, properties, and key behaviors to improve generated API reference and IntelliSense
- Kept implementation behavior unchanged

## Testing
- Not run (not requested)