### PR TITLE
Distinguish quoted null scalars from actual null values

### DIFF
--- a/ref/Meziantou.Framework.Yamlish.cs
+++ b/ref/Meziantou.Framework.Yamlish.cs
@@ -198,10 +198,20 @@ namespace Meziantou.Framework.Yamlish.Nodes
     {
         public Meziantou.Framework.Yamlish.Nodes.YamlishNodeKind Kind { get => throw null; }
         public string Value { get => throw null; }
+        public Meziantou.Framework.Yamlish.Nodes.YamlishScalarKind ScalarKind { get => throw null; }
         public bool IsNull { get => throw null; }
         public Meziantou.Framework.Yamlish.YamlishScalarStyle Style { get => throw null; set { } }
         public Meziantou.Framework.Yamlish.YamlishScalarChomping Chomping { get => throw null; set { } }
         public YamlishScalar(string value) { }
+        public YamlishScalar(string value, Meziantou.Framework.Yamlish.Nodes.YamlishScalarKind scalarKind) { }
+        public static Meziantou.Framework.Yamlish.Nodes.YamlishScalar CreateNull() => throw null;
+    }
+
+    public enum YamlishScalarKind
+    {
+        Unknown = 0,
+        Null = 1,
+        String = 2
     }
 
     public sealed class YamlishSequence : Meziantou.Framework.Yamlish.Nodes.YamlishNode, System.Collections.Generic.IEnumerable<Meziantou.Framework.Yamlish.Nodes.YamlishNode>, System.Collections.Generic.IReadOnlyCollection<Meziantou.Framework.Yamlish.Nodes.YamlishNode>, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Yamlish.Nodes.YamlishNode>, System.Collections.IEnumerable

--- a/src/Meziantou.Framework.Yamlish/Converters/DBNullYamlishConverter.cs
+++ b/src/Meziantou.Framework.Yamlish/Converters/DBNullYamlishConverter.cs
@@ -1,13 +1,17 @@
 namespace Meziantou.Framework.Yamlish.Converters;
 
-internal sealed class DBNullYamlishConverter : ScalarYamlishConverter<DBNull>
+internal sealed class DBNullYamlishConverter : YamlishConverter<DBNull>
 {
     public override bool HandleNullValues => true;
 
-    protected override DBNull Parse(string value)
+    public override DBNull Read(YamlishNode node, YamlishSerializerOptions options)
     {
+        var value = ConverterUtilities.GetScalarValue(node, typeof(DBNull));
         return value is "null" ? DBNull.Value : throw new FormatException($"Cannot convert '{value}' to '{typeof(DBNull)}'.");
     }
 
-    protected override string Format(DBNull value) => "null";
+    public override YamlishNode Write(DBNull value, YamlishSerializerOptions options)
+    {
+        return YamlishScalar.CreateNull();
+    }
 }

--- a/src/Meziantou.Framework.Yamlish/Internals/YamlishWriter.cs
+++ b/src/Meziantou.Framework.Yamlish/Internals/YamlishWriter.cs
@@ -166,7 +166,7 @@ internal static class YamlishWriter
 
     private static void WriteInlineScalar(TextWriter writer, YamlishScalar scalar)
     {
-        if (scalar.Style is YamlishScalarStyle.Plain || scalar.Style is YamlishScalarStyle.Auto && !RequiresQuotes(scalar.Value))
+        if (scalar.Style is YamlishScalarStyle.Plain || scalar.Style is YamlishScalarStyle.Auto && !RequiresQuotes(scalar))
         {
             writer.Write(scalar.Value);
             return;
@@ -202,8 +202,12 @@ internal static class YamlishWriter
         writer.Write('"');
     }
 
-    private static bool RequiresQuotes(string value)
+    private static bool RequiresQuotes(YamlishScalar scalar)
     {
+        var value = scalar.Value;
+        if (scalar.ScalarKind is not YamlishScalarKind.Null && value is "null")
+            return true;
+
         if (value.Length is 0 || char.IsWhiteSpace(value[0]) || char.IsWhiteSpace(value[^1]))
             return true;
 

--- a/src/Meziantou.Framework.Yamlish/Nodes/YamlishScalar.cs
+++ b/src/Meziantou.Framework.Yamlish/Nodes/YamlishScalar.cs
@@ -6,8 +6,29 @@ public sealed class YamlishScalar : YamlishNode
     /// <summary>Initializes a new instance of the <see cref="YamlishScalar" /> class.</summary>
     /// <param name="value">The scalar value.</param>
     public YamlishScalar(string value)
+        : this(value, YamlishScalarKind.String)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="YamlishScalar" /> class.</summary>
+    /// <param name="value">The scalar value.</param>
+    /// <param name="scalarKind">The scalar kind.</param>
+    public YamlishScalar(string value, YamlishScalarKind scalarKind)
     {
         Value = value ?? throw new ArgumentNullException(nameof(value));
+        if (!Enum.IsDefined(scalarKind))
+            throw new ArgumentOutOfRangeException(nameof(scalarKind));
+
+        if (scalarKind is YamlishScalarKind.Null && value is not "null")
+            throw new ArgumentException("A null scalar must have the value 'null'.", nameof(value));
+
+        ScalarKind = scalarKind;
+    }
+
+    /// <summary>Creates a null scalar.</summary>
+    public static YamlishScalar CreateNull()
+    {
+        return new YamlishScalar("null", YamlishScalarKind.Null);
     }
 
     /// <inheritdoc />
@@ -16,7 +37,11 @@ public sealed class YamlishScalar : YamlishNode
     /// <summary>Gets the scalar value.</summary>
     public string Value { get; }
 
-    public bool IsNull => Value is "null";
+    /// <summary>Gets the scalar kind.</summary>
+    public YamlishScalarKind ScalarKind { get; }
+
+    /// <summary>Gets a value indicating whether this scalar represents a null value.</summary>
+    public bool IsNull => ScalarKind is YamlishScalarKind.Null;
 
     /// <summary>Gets or sets the style used when writing the scalar value.</summary>
     public YamlishScalarStyle Style { get; set; }

--- a/src/Meziantou.Framework.Yamlish/Nodes/YamlishScalarKind.cs
+++ b/src/Meziantou.Framework.Yamlish/Nodes/YamlishScalarKind.cs
@@ -1,0 +1,17 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Meziantou.Framework.Yamlish.Nodes;
+
+/// <summary>Specifies the kind of a Yamlish scalar node.</summary>
+[SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "Names match Yamlish scalar kinds.")]
+public enum YamlishScalarKind
+{
+    /// <summary>The scalar kind is unknown.</summary>
+    Unknown,
+
+    /// <summary>A null scalar.</summary>
+    Null,
+
+    /// <summary>A string scalar.</summary>
+    String,
+}

--- a/src/Meziantou.Framework.Yamlish/YamlishParser.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishParser.cs
@@ -309,6 +309,9 @@ internal sealed class YamlishParser
         if (value[0] is '|' or '>' or '&' or '*' or '!' or '%')
             Throw("Unsupported YAML syntax", lineIndex);
 
+        if (value is "null")
+            return YamlishScalar.CreateNull();
+
         return new YamlishScalar(value.ToString());
     }
 

--- a/src/Meziantou.Framework.Yamlish/YamlishSerializer.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishSerializer.cs
@@ -176,7 +176,7 @@ public static class YamlishSerializer
         {
             EnsureDepth(options, depth);
             var converter = options.GetConverter(type);
-            if (node is YamlishScalar { IsNull: true } && converter?.HandleNullValues is not true && (!type.IsValueType || Nullable.GetUnderlyingType(type) is not null))
+            if (node is YamlishScalar { ScalarKind: YamlishScalarKind.Null } && converter?.HandleNullValues is not true && (!type.IsValueType || Nullable.GetUnderlyingType(type) is not null))
                 return null;
 
             if (converter is not null)

--- a/tests/Meziantou.Framework.Yamlish.Tests/YamlishConverterTests.cs
+++ b/tests/Meziantou.Framework.Yamlish.Tests/YamlishConverterTests.cs
@@ -549,7 +549,7 @@ public sealed class YamlishConverterTests
 
         public override NullHandledValue Read(YamlishNode node, YamlishSerializerOptions options)
         {
-            Assert.True(Assert.IsType<YamlishScalar>(node).IsNull);
+            Assert.Equal(YamlishScalarKind.Null, Assert.IsType<YamlishScalar>(node).ScalarKind);
             return new NullHandledValue { Handled = true };
         }
 

--- a/tests/Meziantou.Framework.Yamlish.Tests/YamlishDocumentTests.cs
+++ b/tests/Meziantou.Framework.Yamlish.Tests/YamlishDocumentTests.cs
@@ -61,6 +61,21 @@ public sealed class YamlishDocumentTests
         Assert.Equal("it's literal", Assert.IsType<YamlishScalar>(mapping["single"]).Value);
     }
 
+    [Fact]
+    public void Parse_ScalarKinds()
+    {
+        var document = YamlishDocument.Parse("""
+            nullValue: null
+            quotedNull: "null"
+            plainText: value
+            """);
+
+        var mapping = Assert.IsType<YamlishMapping>(document.Root);
+        Assert.Equal(YamlishScalarKind.Null, Assert.IsType<YamlishScalar>(mapping["nullValue"]).ScalarKind);
+        Assert.Equal(YamlishScalarKind.String, Assert.IsType<YamlishScalar>(mapping["quotedNull"]).ScalarKind);
+        Assert.Equal(YamlishScalarKind.String, Assert.IsType<YamlishScalar>(mapping["plainText"]).ScalarKind);
+    }
+
     [Theory]
     [InlineData("value: plain value", "plain value")]
     [InlineData("value: \"\"", "")]

--- a/tests/Meziantou.Framework.Yamlish.Tests/YamlishSerializerTests.cs
+++ b/tests/Meziantou.Framework.Yamlish.Tests/YamlishSerializerTests.cs
@@ -690,6 +690,7 @@ public sealed class YamlishSerializerTests
     [Theory]
     [InlineData("")]
     [InlineData("plain value")]
+    [InlineData("null")]
     [InlineData(" leading and trailing ")]
     [InlineData("quote: \"; slash: \\; tab: \t")]
     [InlineData("first\nsecond")]
@@ -705,6 +706,7 @@ public sealed class YamlishSerializerTests
 
     [Theory]
     [InlineData("Value: plain value", "plain value")]
+    [InlineData("Value: \"null\"", "null")]
     [InlineData("Value: \" leading and trailing \"", " leading and trailing ")]
     [InlineData("Value: 'it''s literal'", "it's literal")]
     [InlineData("Value: |-\n  first\n  second\n", "first\nsecond")]


### PR DESCRIPTION
## Summary
- Add an explicit scalar kind to preserve whether a scalar represents `null` or a normal string
- Update parsing, serialization, and `DBNull` conversion to treat quoted `"null"` as a string while keeping plain `null` as a null value
- Extend tests to cover scalar kinds and round-tripping of quoted null text

## Testing
- Added and updated unit tests for parsing, serialization, and converter behavior around `null` vs `"null"`
- Not run (not requested)