### PR TITLE
Fix CsWin32 SHCreateItemFromParsingName call in OpenFolderDialog

### DIFF
--- a/src/Meziantou.Framework.Win32.Dialogs/OpenFolderDialog.cs
+++ b/src/Meziantou.Framework.Win32.Dialogs/OpenFolderDialog.cs
@@ -82,13 +82,13 @@ public sealed class OpenFolderDialog
 
         if (!string.IsNullOrEmpty(InitialDirectory))
         {
-            var result = PInvoke.SHCreateItemFromParsingName(InitialDirectory, null, typeof(IShellItem).GUID, out var shellItem);
+            var result = PInvoke.SHCreateItemFromParsingName(InitialDirectory, null, out IShellItem? shellItem);
             switch ((int)result)
             {
                 case NativeMethods.S_OK:
-                    if (shellItem is IShellItem item)
+                    if (shellItem is not null)
                     {
-                        dialog.SetFolder(item);
+                        dialog.SetFolder(shellItem);
                     }
 
                     break;


### PR DESCRIPTION
This fixes the build break introduced by the CsWin32 API shape for `SHCreateItemFromParsingName`.

`OpenFolderDialog` was calling the older GUID-based overload, which no longer matches the generated signature and caused compile errors in `Meziantou.Framework.Win32.Dialogs`.

## What changed
- Switched to the current generic CsWin32 overload:
  - from: `SHCreateItemFromParsingName(..., typeof(IShellItem).GUID, out var shellItem)`
  - to: `SHCreateItemFromParsingName(..., out IShellItem? shellItem)`
- Updated the null check and `SetFolder` call to use the strongly typed `IShellItem?` result.

## Notes
- Behavior is unchanged; this is an interop-signature compatibility fix so the project builds again across target frameworks.