### PR TITLE
Refactor round-trip tests to conditionally skip cases

### DIFF
--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/MarkdownRoundTrippingTests.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/MarkdownRoundTrippingTests.cs
@@ -37,7 +37,11 @@ public sealed class MarkdownRoundTrippingTests
         var data = new TheoryData<MarkdigTestCase>();
         foreach (var testCase in AllCases.Value)
         {
-            data.Add(testCase);
+            // Some tests may not round-trip due to extension-specific parsing behaviors
+            if (!ShouldSkip(testCase, out var reason))
+            {
+                data.Add(testCase);
+            }
         }
         return data;
     }
@@ -50,13 +54,6 @@ public sealed class MarkdownRoundTrippingTests
     [MemberData(nameof(GetTestCases))]
     public void RoundTrip(MarkdigTestCase testCase)
     {
-        // Some tests may not round-trip due to extension-specific parsing behaviors
-        if (ShouldSkip(testCase, out var reason))
-        {
-            Assert.Skip(reason);
-            return;
-        }
-
         // 1. Convert the spec HTML to Markdown using our converter
         var markdown = HtmlToMarkdown.Convert(testCase.Html);
 

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/MarkdownRoundTrippingTests.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/MarkdownRoundTrippingTests.cs
@@ -38,7 +38,7 @@ public sealed class MarkdownRoundTrippingTests
         foreach (var testCase in AllCases.Value)
         {
             // Some tests may not round-trip due to extension-specific parsing behaviors
-            if (!ShouldSkip(testCase, out var reason))
+            if (!ShouldSkip(testCase, out _))
             {
                 data.Add(testCase);
             }


### PR DESCRIPTION
Skip tests that do not round-trip due to parsing behaviors.