### PR TITLE
Fix MP4 ReplayGain write/read roundtrip

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Writer.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Writer.cs
@@ -129,6 +129,22 @@ internal sealed class Mp4Writer : IMediaTagWriter
         WriteTextAtom(ms, ItunesAtomNames.Copyright, tags.Copyright);
         WriteFreeformTextAtom(ms, "com.apple.iTunes", "ISRC", tags.Isrc);
 
+        if (tags.ReplayGain is not null)
+        {
+            var replayGain = tags.ReplayGain.Value;
+            if (replayGain.TrackGain is not null)
+                WriteFreeformTextAtom(ms, "com.apple.iTunes", "REPLAYGAIN_TRACK_GAIN", replayGain.TrackGain.Value.ToString("F2", CultureInfo.InvariantCulture) + " dB");
+
+            if (replayGain.TrackPeak is not null)
+                WriteFreeformTextAtom(ms, "com.apple.iTunes", "REPLAYGAIN_TRACK_PEAK", replayGain.TrackPeak.Value.ToString("F6", CultureInfo.InvariantCulture));
+
+            if (replayGain.AlbumGain is not null)
+                WriteFreeformTextAtom(ms, "com.apple.iTunes", "REPLAYGAIN_ALBUM_GAIN", replayGain.AlbumGain.Value.ToString("F2", CultureInfo.InvariantCulture) + " dB");
+
+            if (replayGain.AlbumPeak is not null)
+                WriteFreeformTextAtom(ms, "com.apple.iTunes", "REPLAYGAIN_ALBUM_PEAK", replayGain.AlbumPeak.Value.ToString("F6", CultureInfo.InvariantCulture));
+        }
+
         if (tags.Bpm is not null)
             WriteUInt16Atom(ms, ItunesAtomNames.Bpm, (ushort)tags.Bpm.Value);
 

--- a/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
+++ b/src/Meziantou.Framework.MediaTags/Meziantou.Framework.MediaTags.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>1.1.11</Version>
+    <Version>1.1.12</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>A library for reading and writing metadata tags in media files (MP3, OGG, FLAC, MP4/M4A, WAV, AIFF)</Description>
   </PropertyGroup>

--- a/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
@@ -159,6 +159,37 @@ public sealed class Mp4Tests
     }
 
     [Fact]
+    public void WriteTags_ReplayGain_RoundTrip_OnM4aWithFlacExtension()
+    {
+        var tempFile = Path.GetTempFileName() + ".flac";
+        try
+        {
+            File.Copy(GetTestFilePath("basic.m4a"), tempFile, overwrite: true);
+
+            var newTags = new MediaTagInfo
+            {
+                ReplayGain = new ReplayGainInfo
+                {
+                    TrackGain = -11.19,
+                },
+            };
+
+            var writeResult = MediaFile.WriteTags(tempFile, newTags);
+            Assert.True(writeResult.IsSuccess);
+
+            var readResult = MediaFile.ReadTags(tempFile);
+            Assert.True(readResult.IsSuccess);
+            Assert.Equal(MediaFormat.Mp4, readResult.Value.Format);
+            Assert.NotNull(readResult.Value.ReplayGain);
+            Assert.Equal(-11.19, readResult.Value.ReplayGain.Value.TrackGain);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
     public void ReadTags_InvalidFile_ReturnsError()
     {
         using var stream = new MemoryStream([0x00, 0x00, 0x00, 0x08, (byte)'f', (byte)'t', (byte)'y', (byte)'p']);


### PR DESCRIPTION
MP4 tags could read ReplayGain from iTunes freeform atoms, but the writer never emitted those fields. This made write-then-read flows lose ReplayGain values (for example TrackGain = -11.19), including files with a `.flac` extension that are actually MP4/M4A by magic bytes.

This change writes ReplayGain fields in `Mp4Writer` as `com.apple.iTunes` freeform atoms:
- `REPLAYGAIN_TRACK_GAIN`
- `REPLAYGAIN_TRACK_PEAK`
- `REPLAYGAIN_ALBUM_GAIN`
- `REPLAYGAIN_ALBUM_PEAK`

It also adds a regression test that copies `basic.m4a` to a `.flac` filename, writes `TrackGain = -11.19`, then verifies readback returns `MediaFormat.Mp4` and the same gain value.