### PR TITLE
Add alternate Windows credentials support to ProcessWrapper

### DIFF
--- a/ref/Meziantou.Framework.ProcessWrapper.cs
+++ b/ref/Meziantou.Framework.ProcessWrapper.cs
@@ -226,6 +226,12 @@ namespace Meziantou.Framework
         public Meziantou.Framework.ProcessWrapper WithArguments(params System.ReadOnlySpan<string> arguments) => throw null;
         public Meziantou.Framework.ProcessWrapper WithArguments(System.Collections.Generic.IEnumerable<string> arguments) => throw null;
         public Meziantou.Framework.ProcessWrapper WithWorkingDirectory(string workingDirectory) => throw null;
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        public Meziantou.Framework.ProcessWrapper WithCredentials(string userName, string passwordInClearText, string? domain = null) => throw null;
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        public Meziantou.Framework.ProcessWrapper WithCredentials(string userName, System.Security.SecureString password, string? domain = null) => throw null;
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        public Meziantou.Framework.ProcessWrapper WithUseCredentialsForNetworkingOnly(bool useCredentialsForNetworkingOnly = true) => throw null;
         public Meziantou.Framework.ProcessWrapper WithEnvironmentVariables(System.Action<Meziantou.Framework.ProcessWrapperEnvironmentVariables> configure) => throw null;
         public Meziantou.Framework.ProcessWrapper WithEnvironmentVariables(System.Collections.Generic.IReadOnlyDictionary<string, string?> variables) => throw null;
         public Meziantou.Framework.ProcessWrapper WithValidation(Meziantou.Framework.ProcessValidationMode mode) => throw null;

--- a/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
+++ b/src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework</RootNamespace>
-    <Version>1.0.17</Version>
+    <Version>1.0.18</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Fluent API for wrapping System.Diagnostics.Process</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Security;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using Meziantou.Framework.Unix.ControlGroups;
@@ -134,7 +135,22 @@ public sealed class ProcessWrapper
             startInfo.Environment[name] = value;
         }
 
+        CopyWindowsStartInfoCredentials(source, startInfo);
+
         return startInfo;
+    }
+
+    private static void CopyWindowsStartInfoCredentials(ProcessStartInfo source, ProcessStartInfo destination)
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        destination.UserName = source.UserName;
+        destination.Domain = source.Domain;
+        destination.PasswordInClearText = source.PasswordInClearText;
+        destination.Password = source.Password?.Copy();
+        destination.LoadUserProfile = source.LoadUserProfile;
+        destination.UseCredentialsForNetworkingOnly = source.UseCredentialsForNetworkingOnly;
     }
 
     /// <summary>Creates a new <see cref="ProcessWrapper"/> for the specified executable.</summary>
@@ -190,6 +206,45 @@ public sealed class ProcessWrapper
     public ProcessWrapper WithWorkingDirectory(string workingDirectory)
     {
         _startInfo.WorkingDirectory = workingDirectory;
+        return this;
+    }
+
+    /// <summary>Sets alternate Windows credentials used to start the process.</summary>
+    /// <remarks><paramref name="userName"/> can be in the <c>user@domain</c> format when <paramref name="domain"/> is not set.</remarks>
+    [SupportedOSPlatform("windows")]
+    public ProcessWrapper WithCredentials(string userName, string passwordInClearText, string? domain = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userName);
+        ArgumentNullException.ThrowIfNull(passwordInClearText);
+
+        _startInfo.UserName = userName;
+        _startInfo.Domain = domain;
+        _startInfo.PasswordInClearText = passwordInClearText;
+        _startInfo.Password = null;
+        return this;
+    }
+
+    /// <summary>Sets alternate Windows credentials used to start the process.</summary>
+    /// <remarks><paramref name="userName"/> can be in the <c>user@domain</c> format when <paramref name="domain"/> is not set.</remarks>
+    [SupportedOSPlatform("windows")]
+    public ProcessWrapper WithCredentials(string userName, SecureString password, string? domain = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userName);
+        ArgumentNullException.ThrowIfNull(password);
+
+        _startInfo.UserName = userName;
+        _startInfo.Domain = domain;
+        _startInfo.Password = password.Copy();
+        _startInfo.PasswordInClearText = null;
+        return this;
+    }
+
+    /// <summary>Sets whether to use <c>LOGON_NETCREDENTIALS_ONLY</c> when starting the process on Windows.</summary>
+    /// <remarks>When enabled, this behaves similarly to <c>runas /netonly</c>.</remarks>
+    [SupportedOSPlatform("windows")]
+    public ProcessWrapper WithUseCredentialsForNetworkingOnly(bool useCredentialsForNetworkingOnly = true)
+    {
+        _startInfo.UseCredentialsForNetworkingOnly = useCredentialsForNetworkingOnly;
         return this;
     }
 

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -519,6 +519,95 @@ public class ProcessWrapperTests
     }
 
     [Fact]
+    public async Task ExecuteBufferedAsync_WithCredentials_PropagatesToProcessStartInfo()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        using var fakeProcess = FakeProcess.Create(0, outputText: "intercepted output\n", errorText: "");
+        ProcessStartInfo? capturedStartInfo = null;
+        var fakeFactory = new FakeProcessFactory(startInfo =>
+        {
+            capturedStartInfo = startInfo;
+            return fakeProcess;
+        });
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            _ = await CreateEchoCommand("ignored")
+                .WithCredentials("test-user", "test-password", "test-domain")
+                .ExecuteBufferedAsync();
+        });
+
+        Assert.NotNull(capturedStartInfo);
+        Assert.Equal("test-user", capturedStartInfo.UserName);
+        Assert.Equal("test-domain", capturedStartInfo.Domain);
+        Assert.Equal("test-password", capturedStartInfo.PasswordInClearText);
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_WithCredentialsAndNetworkOnly_PropagatesToProcessStartInfo()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        using var fakeProcess = FakeProcess.Create(0, outputText: "intercepted output\n", errorText: "");
+        ProcessStartInfo? capturedStartInfo = null;
+        var fakeFactory = new FakeProcessFactory(startInfo =>
+        {
+            capturedStartInfo = startInfo;
+            return fakeProcess;
+        });
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            _ = await CreateEchoCommand("ignored")
+                .WithCredentials("test-user", "test-password")
+                .WithUseCredentialsForNetworkingOnly()
+                .ExecuteBufferedAsync();
+        });
+
+        Assert.NotNull(capturedStartInfo);
+        Assert.True(capturedStartInfo.UseCredentialsForNetworkingOnly);
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_WithSecureStringCredentials_PropagatesToProcessStartInfo()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        using var fakeProcess = FakeProcess.Create(0, outputText: "intercepted output\n", errorText: "");
+        ProcessStartInfo? capturedStartInfo = null;
+        var fakeFactory = new FakeProcessFactory(startInfo =>
+        {
+            capturedStartInfo = startInfo;
+            return fakeProcess;
+        });
+
+        using var password = new System.Security.SecureString();
+        foreach (var c in "test-password")
+        {
+            password.AppendChar(c);
+        }
+
+        password.MakeReadOnly();
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            _ = await CreateEchoCommand("ignored")
+                .WithCredentials("test-user", password, "test-domain")
+                .ExecuteBufferedAsync();
+        });
+
+        Assert.NotNull(capturedStartInfo);
+        Assert.Equal("test-user", capturedStartInfo.UserName);
+        Assert.Equal("test-domain", capturedStartInfo.Domain);
+        Assert.NotNull(capturedStartInfo.Password);
+        Assert.Null(capturedStartInfo.PasswordInClearText);
+    }
+
+    [Fact]
     public async Task WithEnvironmentVariables_Callback_SetsVariable()
     {
         ProcessWrapper command;


### PR DESCRIPTION
ProcessWrapper did not provide a first-class way to launch processes with alternate Windows credentials, including `/netonly`-style behavior. This adds explicit APIs so callers can configure this scenario without relying on custom interceptors.

### What changed
- Added Windows-specific fluent APIs on `ProcessWrapper`:
  - `WithCredentials(string userName, string passwordInClearText, string? domain = null)`
  - `WithCredentials(string userName, SecureString password, string? domain = null)`
  - `WithUseCredentialsForNetworkingOnly(bool useCredentialsForNetworkingOnly = true)`
- Updated `CloneStartInfo` to preserve Windows credential-related `ProcessStartInfo` fields (`UserName`, `Domain`, password fields, `LoadUserProfile`, `UseCredentialsForNetworkingOnly`) so settings are retained through execution flows.
- Added targeted tests using `FakeProcessFactory` to verify credential and `UseCredentialsForNetworkingOnly` propagation to the effective `ProcessStartInfo`.
- Updated generated reference API and package version for `Meziantou.Framework.ProcessWrapper`.

### Validation
- `dotnet run ./eng/update-all.cs`
- `dotnet build src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj /p:TreatsWarningsAsErrors=true`
- `dotnet test tests/Meziantou.Framework.ProcessWrapper.Tests/Meziantou.Framework.ProcessWrapper.Tests.csproj /p:TreatsWarningsAsErrors=true`

Fixes: #1686