### PR TITLE
Add DNSSEC validation support to DnsClient

### DIFF
--- a/ref/Meziantou.Framework.DnsClient.cs
+++ b/ref/Meziantou.Framework.DnsClient.cs
@@ -21,7 +21,11 @@ namespace Meziantou.Framework.DnsClient
         public bool EnableEdns { get => throw null; set { } }
         public ushort EdnsUdpPayloadSize { get => throw null; set { } }
         public bool DnssecOk { get => throw null; set { } }
+        public Meziantou.Framework.DnsClient.DnssecValidationMode DnssecValidationMode { get => throw null; set { } }
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsClient.DnssecTrustAnchor> DnssecTrustAnchors { get => throw null; set { } }
+        public System.TimeProvider TimeProvider { get => throw null; set { } }
         public System.Net.Http.HttpMessageHandler? HttpHandler { get => throw null; set { } }
+        public System.Func<string, System.Collections.Generic.IReadOnlyList<System.Net.IPAddress>>? ServerAddressResolver { get => throw null; set { } }
     }
 
     public enum DnsClientProtocol
@@ -45,6 +49,27 @@ namespace Meziantou.Framework.DnsClient
         public Meziantou.Framework.DnsClient.Query.DnsQueryType Type { get => throw null; }
         public Meziantou.Framework.DnsClient.Query.DnsQueryClass QueryClass { get => throw null; }
         public DnsQuestion(string name, Meziantou.Framework.DnsClient.Query.DnsQueryType type, Meziantou.Framework.DnsClient.Query.DnsQueryClass queryClass = 1) { }
+    }
+
+    public sealed class DnssecTrustAnchor
+    {
+        public string Name { get => throw null; }
+        public ushort KeyTag { get => throw null; }
+        public byte Algorithm { get => throw null; }
+        public byte DigestType { get => throw null; }
+        public byte[] Digest { get => throw null; }
+        public DnssecTrustAnchor(string name, ushort keyTag, byte algorithm, byte digestType, byte[] digest) { }
+    }
+
+    public static class DnssecTrustAnchors
+    {
+        public static System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsClient.DnssecTrustAnchor> Root { get => throw null; }
+    }
+
+    public enum DnssecValidationMode
+    {
+        None = 0,
+        Local = 1
     }
 }
 namespace Meziantou.Framework.DnsClient.Query
@@ -222,6 +247,50 @@ namespace Meziantou.Framework.DnsClient.Response
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsClient.Response.DnsRecord> Answers { get => throw null; }
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsClient.Response.DnsRecord> Authorities { get => throw null; }
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsClient.Response.DnsRecord> AdditionalRecords { get => throw null; }
+        public Meziantou.Framework.DnsClient.Response.DnssecValidationResult DnssecValidationResult { get => throw null; }
+    }
+
+    public sealed class DnssecValidationIssue
+    {
+        public Meziantou.Framework.DnsClient.Response.DnssecValidationIssueCode Code { get => throw null; }
+        public string Message { get => throw null; }
+        public string? Name { get => throw null; }
+        public Meziantou.Framework.DnsClient.Query.DnsQueryType? RecordType { get => throw null; }
+    }
+
+    public enum DnssecValidationIssueCode
+    {
+        None = 0,
+        MissingQuestion = 1,
+        TruncatedResponse = 2,
+        MissingRecord = 3,
+        MissingRrsig = 4,
+        MissingDnskey = 5,
+        MissingDs = 6,
+        DigestMismatch = 7,
+        UnsupportedAlgorithm = 8,
+        UnsupportedDigest = 9,
+        SignatureNotYetValid = 10,
+        SignatureExpired = 11,
+        SignatureVerificationFailed = 12,
+        InvalidDenialProof = 13,
+        TrustChainIncomplete = 14,
+        InvalidData = 15
+    }
+
+    public sealed class DnssecValidationResult
+    {
+        public Meziantou.Framework.DnsClient.Response.DnssecValidationStatus Status { get => throw null; }
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsClient.Response.DnssecValidationIssue> Issues { get => throw null; }
+    }
+
+    public enum DnssecValidationStatus
+    {
+        NotValidated = 0,
+        Secure = 1,
+        Insecure = 2,
+        Bogus = 3,
+        Indeterminate = 4
     }
 }
 namespace Meziantou.Framework.DnsClient.Response.Records

--- a/src/Meziantou.Framework.DnsClient/DnsClient.cs
+++ b/src/Meziantou.Framework.DnsClient/DnsClient.cs
@@ -135,7 +135,9 @@ public sealed class DnsClient : IDisposable
             cts.CancelAfter(_options.Timeout);
 
             var responseBytes = await _transport.SendAsync(queryBytes, cts.Token).ConfigureAwait(false);
-            var response = DnsMessageEncoder.DecodeResponse(responseBytes);
+            var response = DnsMessageEncoder.DecodeResponse(
+                responseBytes,
+                preserveRawRecordData: _options.DnssecValidationMode is DnssecValidationMode.Local);
 
             if (validateResponse && _options.DnssecValidationMode is DnssecValidationMode.Local)
             {

--- a/src/Meziantou.Framework.DnsClient/DnsClient.cs
+++ b/src/Meziantou.Framework.DnsClient/DnsClient.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Meziantou.Framework.DnsClient.Helpers;
+using Meziantou.Framework.DnsClient.Internal;
 using Meziantou.Framework.DnsClient.Protocol;
 using Meziantou.Framework.DnsClient.Query;
 using Meziantou.Framework.DnsClient.Response;
@@ -37,8 +39,19 @@ public sealed class DnsClient : IDisposable
         ArgumentNullException.ThrowIfNull(server);
 
         _options = options ?? new DnsClientOptions();
+        ValidateOptions(_options);
         _protocol = protocol;
         _transport = CreateTransport(server, protocol, _options);
+    }
+
+    internal DnsClient(IDnsTransport transport, DnsClientProtocol protocol, DnsClientOptions? options)
+    {
+        ArgumentNullException.ThrowIfNull(transport);
+
+        _options = options ?? new DnsClientOptions();
+        ValidateOptions(_options);
+        _protocol = protocol;
+        _transport = transport;
     }
 
     /// <summary>Sends a DNS query for the specified domain name and record type.</summary>
@@ -95,7 +108,14 @@ public sealed class DnsClient : IDisposable
     /// <returns>The DNS response message.</returns>
     public async Task<DnsResponseMessage> SendAsync(DnsQueryMessage message, CancellationToken cancellationToken = default)
     {
+        return await SendCoreAsync(message, validateResponse: true, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<DnsResponseMessage> SendCoreAsync(DnsQueryMessage message, bool validateResponse, CancellationToken cancellationToken)
+    {
         ArgumentNullException.ThrowIfNull(message);
+        ValidateOptions(_options);
+        ApplyOptions(message);
 
         var questionName = message.Questions.Count > 0 ? message.Questions[0].Name : "unknown";
         var questionType = message.Questions.Count > 0 ? message.Questions[0].Type.ToString() : "unknown";
@@ -117,6 +137,16 @@ public sealed class DnsClient : IDisposable
             var responseBytes = await _transport.SendAsync(queryBytes, cts.Token).ConfigureAwait(false);
             var response = DnsMessageEncoder.DecodeResponse(responseBytes);
 
+            if (validateResponse && _options.DnssecValidationMode is DnssecValidationMode.Local)
+            {
+                var validator = new DnssecValidator(
+                    SendWithoutValidationAsync,
+                    _options.DnssecTrustAnchors,
+                    _options.TimeProvider);
+                response.DnssecValidationResult = await validator.ValidateAsync(response, cts.Token).ConfigureAwait(false);
+                activity?.SetTag("dns.dnssec.validation_status", response.DnssecValidationResult.Status.ToString());
+            }
+
             activity?.SetTag("dns.response.code", response.Header.ResponseCode.ToString());
 
             if (response.Header.ResponseCode != DnsResponseCode.NoError)
@@ -135,6 +165,11 @@ public sealed class DnsClient : IDisposable
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             throw;
         }
+    }
+
+    private Task<DnsResponseMessage> SendWithoutValidationAsync(DnsQueryMessage message, CancellationToken cancellationToken)
+    {
+        return SendCoreAsync(message, validateResponse: false, cancellationToken);
     }
 
     /// <summary>Releases the resources used by this instance.</summary>
@@ -160,30 +195,74 @@ public sealed class DnsClient : IDisposable
     {
         return protocol switch
         {
-            DnsClientProtocol.Udp => CreateUdpTransport(server),
-            DnsClientProtocol.Tcp => CreateTcpTransport(server),
-            DnsClientProtocol.Tls => CreateTlsTransport(server),
+            DnsClientProtocol.Udp => CreateUdpTransport(server, options),
+            DnsClientProtocol.Tcp => CreateTcpTransport(server, options),
+            DnsClientProtocol.Tls => CreateTlsTransport(server, options),
             DnsClientProtocol.Https => CreateHttpsTransport(server, options),
-            DnsClientProtocol.Quic => CreateQuicTransport(server),
+            DnsClientProtocol.Quic => CreateQuicTransport(server, options),
             _ => throw new ArgumentOutOfRangeException(nameof(protocol), protocol, "Unsupported DNS protocol."),
         };
     }
 
-    private static DnsUdpTransport CreateUdpTransport(string server)
+    private static void ValidateOptions(DnsClientOptions options)
     {
-        var endpoint = ParseEndpoint(server, defaultPort: 53);
+        if (options.DnssecValidationMode is DnssecValidationMode.Local && !options.EnableEdns)
+            throw new ArgumentException("Local DNSSEC validation requires EDNS to be enabled.", nameof(options));
+
+        if (options.DnssecTrustAnchors is null)
+            throw new ArgumentException("DNSSEC trust anchors cannot be null.", nameof(options));
+
+        if (options.TimeProvider is null)
+            throw new ArgumentException("The DNSSEC time provider cannot be null.", nameof(options));
+    }
+
+    private void ApplyOptions(DnsQueryMessage message)
+    {
+        var localValidation = _options.DnssecValidationMode is DnssecValidationMode.Local;
+        var requiresDnssecEdns = localValidation || _options.DnssecOk;
+
+        if (_options.EnableEdns && message.EdnsOptions is null && requiresDnssecEdns)
+        {
+            message.EdnsOptions = new DnsEdnsOptions
+            {
+                UdpPayloadSize = _options.EdnsUdpPayloadSize,
+            };
+        }
+
+        if (message.EdnsOptions is not null)
+        {
+            if (message.EdnsOptions.UdpPayloadSize == 0)
+            {
+                message.EdnsOptions.UdpPayloadSize = _options.EdnsUdpPayloadSize;
+            }
+
+            if (requiresDnssecEdns)
+            {
+                message.EdnsOptions.DnssecOk = true;
+            }
+        }
+
+        if (localValidation)
+        {
+            message.CheckingDisabled = true;
+        }
+    }
+
+    private static DnsUdpTransport CreateUdpTransport(string server, DnsClientOptions options)
+    {
+        var endpoint = ParseEndpoint(server, defaultPort: 53, options);
         return new DnsUdpTransport(endpoint);
     }
 
-    private static DnsTcpTransport CreateTcpTransport(string server)
+    private static DnsTcpTransport CreateTcpTransport(string server, DnsClientOptions options)
     {
-        var endpoint = ParseEndpoint(server, defaultPort: 53);
+        var endpoint = ParseEndpoint(server, defaultPort: 53, options);
         return new DnsTcpTransport(endpoint);
     }
 
-    private static DnsTlsTransport CreateTlsTransport(string server)
+    private static DnsTlsTransport CreateTlsTransport(string server, DnsClientOptions options)
     {
-        var (host, endpoint) = ParseHostAndEndpoint(server, defaultPort: 853);
+        var (host, endpoint) = ParseHostAndEndpoint(server, defaultPort: 853, options);
         return new DnsTlsTransport(host, endpoint);
     }
 
@@ -196,20 +275,32 @@ public sealed class DnsClient : IDisposable
     }
 
     [SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance")]
-    private static IDnsTransport CreateQuicTransport(string server)
+    private static IDnsTransport CreateQuicTransport(string server, DnsClientOptions options)
     {
 #if NET9_0_OR_GREATER
-        var (host, endpoint) = ParseHostAndEndpoint(server, defaultPort: 853);
+        var (host, endpoint) = ParseHostAndEndpoint(server, defaultPort: 853, options);
         return new DnsQuicTransport(host, endpoint);
 #else
         throw new PlatformNotSupportedException("DNS over QUIC requires .NET 9.0 or later.");
 #endif
     }
 
-    private static IPEndPoint ParseEndpoint(string server, int defaultPort)
+    private static IPEndPoint ParseEndpoint(string server, int defaultPort, DnsClientOptions? options)
     {
         if (IPAddress.TryParse(server, out var address))
             return new IPEndPoint(address, defaultPort);
+
+        if (TryParseBracketedHostAndPort(server, out var bracketedHost, out var bracketedPort))
+        {
+            if (IPAddress.TryParse(bracketedHost, out var hostAddress))
+                return new IPEndPoint(hostAddress, bracketedPort);
+
+            var addresses = ResolveHost(bracketedHost, options);
+            if (addresses.Length is 0)
+                throw new ArgumentException($"Could not resolve host: {bracketedHost}", nameof(server));
+
+            return new IPEndPoint(addresses[0], bracketedPort);
+        }
 
         // Try host:port format
         var colonIndex = server.LastIndexOf(':', StringComparison.Ordinal);
@@ -219,7 +310,7 @@ public sealed class DnsClient : IDisposable
             if (IPAddress.TryParse(host, out var hostAddress))
                 return new IPEndPoint(hostAddress, port);
 
-            var addresses = Dns.GetHostAddresses(host);
+            var addresses = ResolveHost(host, options);
             if (addresses.Length is 0)
                 throw new ArgumentException($"Could not resolve host: {host}", nameof(server));
 
@@ -227,17 +318,29 @@ public sealed class DnsClient : IDisposable
         }
 
         // Resolve hostname
-        var resolved = Dns.GetHostAddresses(server);
+        var resolved = ResolveHost(server, options);
         if (resolved.Length is 0)
             throw new ArgumentException($"Could not resolve host: {server}", nameof(server));
 
         return new IPEndPoint(resolved[0], defaultPort);
     }
 
-    private static (string Host, IPEndPoint Endpoint) ParseHostAndEndpoint(string server, int defaultPort)
+    private static (string Host, IPEndPoint Endpoint) ParseHostAndEndpoint(string server, int defaultPort, DnsClientOptions? options)
     {
         if (IPAddress.TryParse(server, out var address))
             return (server, new IPEndPoint(address, defaultPort));
+
+        if (TryParseBracketedHostAndPort(server, out var bracketedHost, out var bracketedPort))
+        {
+            if (IPAddress.TryParse(bracketedHost, out var hostAddress))
+                return (bracketedHost, new IPEndPoint(hostAddress, bracketedPort));
+
+            var addresses = ResolveHost(bracketedHost, options);
+            if (addresses.Length is 0)
+                throw new ArgumentException($"Could not resolve host: {bracketedHost}", nameof(server));
+
+            return (bracketedHost, new IPEndPoint(addresses[0], bracketedPort));
+        }
 
         var colonIndex = server.LastIndexOf(':', StringComparison.Ordinal);
         if (colonIndex > 0 && int.TryParse(server.AsSpan(colonIndex + 1), System.Globalization.CultureInfo.InvariantCulture, out var port))
@@ -246,17 +349,44 @@ public sealed class DnsClient : IDisposable
             if (IPAddress.TryParse(host, out var hostAddress))
                 return (host, new IPEndPoint(hostAddress, port));
 
-            var addresses = Dns.GetHostAddresses(host);
+            var addresses = ResolveHost(host, options);
             if (addresses.Length is 0)
                 throw new ArgumentException($"Could not resolve host: {host}", nameof(server));
 
             return (host, new IPEndPoint(addresses[0], port));
         }
 
-        var resolved = Dns.GetHostAddresses(server);
+        var resolved = ResolveHost(server, options);
         if (resolved.Length is 0)
             throw new ArgumentException($"Could not resolve host: {server}", nameof(server));
 
         return (server, new IPEndPoint(resolved[0], defaultPort));
+    }
+
+    private static bool TryParseBracketedHostAndPort(string server, [NotNullWhen(true)] out string? host, out int port)
+    {
+        host = null;
+        port = 0;
+        if (!server.StartsWith('[', StringComparison.Ordinal))
+            return false;
+
+        var closingBracketIndex = server.IndexOf(']', StringComparison.Ordinal);
+        if (closingBracketIndex <= 1 || closingBracketIndex + 2 > server.Length || server[closingBracketIndex + 1] != ':')
+            return false;
+
+        if (!int.TryParse(server.AsSpan(closingBracketIndex + 2), System.Globalization.CultureInfo.InvariantCulture, out port))
+            return false;
+
+        host = server[1..closingBracketIndex];
+        return true;
+    }
+
+    private static IPAddress[] ResolveHost(string host, DnsClientOptions? options)
+    {
+        var resolved = options?.ServerAddressResolver?.Invoke(host);
+        if (resolved is not null)
+            return resolved.ToArray();
+
+        return Dns.GetHostAddresses(host);
     }
 }

--- a/src/Meziantou.Framework.DnsClient/DnsClientOptions.cs
+++ b/src/Meziantou.Framework.DnsClient/DnsClientOptions.cs
@@ -1,3 +1,5 @@
+using System.Net;
+
 namespace Meziantou.Framework.DnsClient;
 
 /// <summary>
@@ -17,6 +19,18 @@ public sealed class DnsClientOptions
     /// <summary>Gets or sets a value indicating whether to set the DNSSEC OK (DO) flag. Default is <see langword="false"/>.</summary>
     public bool DnssecOk { get; set; }
 
+    /// <summary>Gets or sets how DNSSEC responses are validated. Default is <see cref="DnssecValidationMode.None"/>.</summary>
+    public DnssecValidationMode DnssecValidationMode { get; set; }
+
+    /// <summary>Gets or sets the DNSSEC trust anchors used for local validation.</summary>
+    public IReadOnlyList<DnssecTrustAnchor> DnssecTrustAnchors { get; set; } = global::Meziantou.Framework.DnsClient.DnssecTrustAnchors.Root;
+
+    /// <summary>Gets or sets the time provider used for DNSSEC signature lifetime checks.</summary>
+    public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+
     /// <summary>Gets or sets the HTTP message handler for DNS over HTTPS. When <see langword="null"/>, a default handler is used.</summary>
     public HttpMessageHandler? HttpHandler { get; set; }
+
+    /// <summary>Gets or sets the resolver used to resolve DNS server hostnames to IP addresses.</summary>
+    public Func<string, IReadOnlyList<IPAddress>>? ServerAddressResolver { get; set; }
 }

--- a/src/Meziantou.Framework.DnsClient/DnssecTrustAnchor.cs
+++ b/src/Meziantou.Framework.DnsClient/DnssecTrustAnchor.cs
@@ -1,0 +1,39 @@
+namespace Meziantou.Framework.DnsClient;
+
+/// <summary>Represents a DNSSEC trust anchor as a DS-style key digest.</summary>
+public sealed class DnssecTrustAnchor
+{
+    /// <summary>Initializes a new instance of the <see cref="DnssecTrustAnchor"/> class.</summary>
+    /// <param name="name">The DNS name the trust anchor applies to.</param>
+    /// <param name="keyTag">The DNSKEY key tag.</param>
+    /// <param name="algorithm">The DNSSEC algorithm number.</param>
+    /// <param name="digestType">The DS digest type.</param>
+    /// <param name="digest">The DS digest bytes.</param>
+    public DnssecTrustAnchor(string name, ushort keyTag, byte algorithm, byte digestType, byte[] digest)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(digest);
+
+        Name = name;
+        KeyTag = keyTag;
+        Algorithm = algorithm;
+        DigestType = digestType;
+        Digest = digest.AsSpan().ToArray();
+    }
+
+    /// <summary>Gets the DNS name the trust anchor applies to.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets the DNSKEY key tag.</summary>
+    public ushort KeyTag { get; }
+
+    /// <summary>Gets the DNSSEC algorithm number.</summary>
+    public byte Algorithm { get; }
+
+    /// <summary>Gets the DS digest type.</summary>
+    public byte DigestType { get; }
+
+    /// <summary>Gets the DS digest bytes.</summary>
+    [SuppressMessage("Performance", "CA1819:Properties should not return arrays")]
+    public byte[] Digest { get; }
+}

--- a/src/Meziantou.Framework.DnsClient/DnssecTrustAnchors.cs
+++ b/src/Meziantou.Framework.DnsClient/DnssecTrustAnchors.cs
@@ -1,0 +1,12 @@
+namespace Meziantou.Framework.DnsClient;
+
+/// <summary>Provides built-in DNSSEC trust anchors.</summary>
+public static class DnssecTrustAnchors
+{
+    /// <summary>Gets the IANA root DNSSEC trust anchors.</summary>
+    public static IReadOnlyList<DnssecTrustAnchor> Root { get; } =
+    [
+        new(".", 20326, 8, 2, Convert.FromHexString("E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D")),
+        new(".", 38696, 8, 2, Convert.FromHexString("683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16")),
+    ];
+}

--- a/src/Meziantou.Framework.DnsClient/DnssecValidationMode.cs
+++ b/src/Meziantou.Framework.DnsClient/DnssecValidationMode.cs
@@ -1,0 +1,11 @@
+namespace Meziantou.Framework.DnsClient;
+
+/// <summary>Specifies how DNSSEC validation is performed.</summary>
+public enum DnssecValidationMode
+{
+    /// <summary>DNSSEC records can be requested and parsed, but responses are not locally validated.</summary>
+    None,
+
+    /// <summary>Responses are locally validated against configured DNSSEC trust anchors.</summary>
+    Local,
+}

--- a/src/Meziantou.Framework.DnsClient/Internal/DnssecCanonicalizer.cs
+++ b/src/Meziantou.Framework.DnsClient/Internal/DnssecCanonicalizer.cs
@@ -1,0 +1,510 @@
+using System.Collections;
+using System.Security.Cryptography;
+using Meziantou.Framework.DnsClient.Protocol;
+using Meziantou.Framework.DnsClient.Query;
+using Meziantou.Framework.DnsClient.Response;
+using Meziantou.Framework.DnsClient.Response.Records;
+
+namespace Meziantou.Framework.DnsClient.Internal;
+
+internal static class DnssecCanonicalizer
+{
+    public static string NormalizeName(string name)
+    {
+        if (string.IsNullOrEmpty(name) || name is ".")
+            return "";
+
+        return name.TrimEnd('.').ToLowerInvariant();
+    }
+
+    public static string ToDisplayName(string name)
+    {
+        var normalized = NormalizeName(name);
+        return normalized.Length is 0 ? "." : normalized;
+    }
+
+    public static string GetParentName(string name)
+    {
+        var normalized = NormalizeName(name);
+        if (normalized.Length is 0)
+            return "";
+
+        var index = normalized.IndexOf('.', StringComparison.Ordinal);
+        return index < 0 ? "" : normalized[(index + 1)..];
+    }
+
+    public static int CountLabels(string name)
+    {
+        var normalized = NormalizeName(name);
+        if (normalized.Length is 0)
+            return 0;
+
+        var count = 1;
+        foreach (var ch in normalized)
+        {
+            if (ch == '.')
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    public static byte[] GetSignedData(IReadOnlyList<DnsRecord> rrset, DnsRrsigRecord signature)
+    {
+        var writer = new DnsWireWriter(1024);
+        WriteRrsigCoveredFields(ref writer, signature);
+
+        var records = rrset
+            .Select(record => GetCanonicalRecordData(record, signature))
+            .Order(ByteArrayComparer.Instance)
+            .ToArray();
+
+        foreach (var record in records)
+        {
+            writer.WriteBytes(record);
+        }
+
+        return writer.ToArray();
+    }
+
+    public static ushort ComputeKeyTag(DnsDnskeyRecord key)
+    {
+        var data = GetCanonicalRData(key);
+        var accumulator = 0;
+
+        for (var i = 0; i < data.Length; i++)
+        {
+            accumulator += (i & 1) is 0 ? data[i] << 8 : data[i];
+        }
+
+        accumulator += (accumulator >> 16) & 0xFFFF;
+        return (ushort)(accumulator & 0xFFFF);
+    }
+
+    public static byte[] ComputeDigest(string ownerName, DnsDnskeyRecord key, byte digestType)
+    {
+        var writer = new DnsWireWriter(512);
+        WriteCanonicalDomainName(ref writer, ownerName);
+        writer.WriteBytes(GetCanonicalRData(key));
+        var data = writer.ToArray();
+
+        return digestType switch
+        {
+#pragma warning disable CA5350 // DNSSEC DS digest type 1 is SHA-1 by specification.
+            1 => SHA1.HashData(data),
+#pragma warning restore CA5350
+            2 => SHA256.HashData(data),
+            4 => SHA384.HashData(data),
+            _ => [],
+        };
+    }
+
+    public static bool IsSupportedDigest(byte digestType)
+    {
+        return digestType is 1 or 2 or 4;
+    }
+
+    public static byte[] GetCanonicalRData(DnsRecord record)
+    {
+        var writer = new DnsWireWriter(Math.Max(record.DataLength, (ushort)32));
+        WriteCanonicalRData(ref writer, record);
+        return writer.ToArray();
+    }
+
+    public static bool NsecCovers(string ownerName, string nextName, string name)
+    {
+        var ownerToNext = CompareCanonicalNames(ownerName, nextName);
+        if (ownerToNext < 0)
+            return CompareCanonicalNames(ownerName, name) < 0 && CompareCanonicalNames(name, nextName) < 0;
+
+        return CompareCanonicalNames(ownerName, name) < 0 || CompareCanonicalNames(name, nextName) < 0;
+    }
+
+    public static bool Nsec3Covers(ReadOnlySpan<byte> ownerHash, ReadOnlySpan<byte> nextHash, ReadOnlySpan<byte> hash)
+    {
+        var ownerToNext = ownerHash.SequenceCompareTo(nextHash);
+        if (ownerToNext < 0)
+            return ownerHash.SequenceCompareTo(hash) < 0 && hash.SequenceCompareTo(nextHash) < 0;
+
+        return ownerHash.SequenceCompareTo(hash) < 0 || hash.SequenceCompareTo(nextHash) < 0;
+    }
+
+    public static byte[] ComputeNsec3Hash(string name, DnsNsec3Record record)
+    {
+        if (record.HashAlgorithm is not 1)
+            return [];
+
+        var owner = GetCanonicalDomainNameBytes(name);
+        var buffer = new byte[owner.Length + record.Salt.Length];
+        owner.CopyTo(buffer);
+        record.Salt.CopyTo(buffer.AsSpan(owner.Length));
+#pragma warning disable CA5350 // NSEC3 hash algorithm 1 is SHA-1 by specification.
+        var hash = SHA1.HashData(buffer);
+
+        for (var i = 0; i < record.Iterations; i++)
+        {
+            buffer = new byte[hash.Length + record.Salt.Length];
+            hash.CopyTo(buffer);
+            record.Salt.CopyTo(buffer.AsSpan(hash.Length));
+            hash = SHA1.HashData(buffer);
+        }
+#pragma warning restore CA5350
+
+        return hash;
+    }
+
+    public static byte[] DecodeBase32Hex(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        var output = new List<byte>((value.Length * 5) / 8);
+        var buffer = 0;
+        var bits = 0;
+
+        foreach (var ch in value)
+        {
+            if (ch is '=')
+                break;
+
+            var digit = ch switch
+            {
+                >= '0' and <= '9' => ch - '0',
+                >= 'A' and <= 'V' => ch - 'A' + 10,
+                >= 'a' and <= 'v' => ch - 'a' + 10,
+                _ => -1,
+            };
+
+            if (digit < 0)
+                return [];
+
+            buffer = (buffer << 5) | digit;
+            bits += 5;
+
+            while (bits >= 8)
+            {
+                output.Add((byte)(buffer >> (bits - 8)));
+                bits -= 8;
+                buffer &= (1 << bits) - 1;
+            }
+        }
+
+        return output.ToArray();
+    }
+
+    public static int CompareCanonicalNames(string left, string right)
+    {
+        var leftLabels = GetLabels(left);
+        var rightLabels = GetLabels(right);
+        var leftIndex = leftLabels.Length - 1;
+        var rightIndex = rightLabels.Length - 1;
+
+        while (leftIndex >= 0 && rightIndex >= 0)
+        {
+            var comparison = string.CompareOrdinal(leftLabels[leftIndex], rightLabels[rightIndex]);
+            if (comparison != 0)
+                return comparison;
+
+            leftIndex--;
+            rightIndex--;
+        }
+
+        if (leftIndex == rightIndex)
+            return 0;
+
+        return leftIndex < rightIndex ? -1 : 1;
+    }
+
+    private static byte[] GetCanonicalRecordData(DnsRecord record, DnsRrsigRecord signature)
+    {
+        var writer = new DnsWireWriter(Math.Max(record.DataLength + 32, (ushort)128));
+        WriteCanonicalDomainName(ref writer, GetSignedOwnerName(record.Name, signature.Labels));
+        writer.WriteUInt16((ushort)record.RecordType);
+        writer.WriteUInt16((ushort)record.RecordClass);
+        writer.WriteUInt32(signature.OriginalTtl);
+
+        var rdata = GetCanonicalRData(record);
+        writer.WriteUInt16((ushort)rdata.Length);
+        writer.WriteBytes(rdata);
+        return writer.ToArray();
+    }
+
+    private static string GetSignedOwnerName(string name, byte labels)
+    {
+        var normalized = NormalizeName(name);
+        var currentLabels = CountLabels(normalized);
+        if (labels >= currentLabels)
+            return normalized;
+
+        var split = GetLabels(normalized);
+        var suffix = labels is 0 ? "" : string.Join('.', split.Skip(split.Length - labels));
+        return suffix.Length is 0 ? "*" : "*." + suffix;
+    }
+
+    private static void WriteRrsigCoveredFields(ref DnsWireWriter writer, DnsRrsigRecord signature)
+    {
+        writer.WriteUInt16((ushort)signature.TypeCovered);
+        writer.WriteByte(signature.Algorithm);
+        writer.WriteByte(signature.Labels);
+        writer.WriteUInt32(signature.OriginalTtl);
+        writer.WriteUInt32(signature.SignatureExpiration);
+        writer.WriteUInt32(signature.SignatureInception);
+        writer.WriteUInt16(signature.KeyTag);
+        WriteCanonicalDomainName(ref writer, signature.SignerName);
+    }
+
+    private static void WriteCanonicalRData(ref DnsWireWriter writer, DnsRecord record)
+    {
+        switch (record)
+        {
+            case DnsARecord aRecord:
+                writer.WriteBytes(aRecord.Address.GetAddressBytes());
+                break;
+
+            case DnsAaaaRecord aaaaRecord:
+                writer.WriteBytes(aaaaRecord.Address.GetAddressBytes());
+                break;
+
+            case DnsCnameRecord cnameRecord:
+                WriteCanonicalDomainName(ref writer, cnameRecord.CanonicalName);
+                break;
+
+            case DnsDnameRecord dnameRecord:
+                WriteCanonicalDomainName(ref writer, dnameRecord.Target);
+                break;
+
+            case DnsDnskeyRecord dnskeyRecord:
+                writer.WriteUInt16(dnskeyRecord.Flags);
+                writer.WriteByte(dnskeyRecord.Protocol);
+                writer.WriteByte(dnskeyRecord.Algorithm);
+                writer.WriteBytes(dnskeyRecord.PublicKey);
+                break;
+
+            case DnsDsRecord dsRecord:
+                writer.WriteUInt16(dsRecord.KeyTag);
+                writer.WriteByte(dsRecord.Algorithm);
+                writer.WriteByte(dsRecord.DigestType);
+                writer.WriteBytes(dsRecord.Digest);
+                break;
+
+            case DnsMxRecord mxRecord:
+                writer.WriteUInt16(mxRecord.Preference);
+                WriteCanonicalDomainName(ref writer, mxRecord.Exchange);
+                break;
+
+            case DnsNsRecord nsRecord:
+                WriteCanonicalDomainName(ref writer, nsRecord.NameServer);
+                break;
+
+            case DnsPtrRecord ptrRecord:
+                WriteCanonicalDomainName(ref writer, ptrRecord.DomainName);
+                break;
+
+            case DnsRrsigRecord rrsigRecord:
+                WriteRrsigCoveredFields(ref writer, rrsigRecord);
+                writer.WriteBytes(rrsigRecord.Signature);
+                break;
+
+            case DnsSoaRecord soaRecord:
+                WriteCanonicalDomainName(ref writer, soaRecord.PrimaryNameServer);
+                WriteCanonicalDomainName(ref writer, soaRecord.ResponsibleMailbox);
+                writer.WriteUInt32(soaRecord.Serial);
+                writer.WriteUInt32(unchecked((uint)soaRecord.Refresh));
+                writer.WriteUInt32(unchecked((uint)soaRecord.Retry));
+                writer.WriteUInt32(unchecked((uint)soaRecord.Expire));
+                writer.WriteUInt32(soaRecord.Minimum);
+                break;
+
+            case DnsSrvRecord srvRecord:
+                writer.WriteUInt16(srvRecord.Priority);
+                writer.WriteUInt16(srvRecord.Weight);
+                writer.WriteUInt16(srvRecord.Port);
+                WriteCanonicalDomainName(ref writer, srvRecord.Target);
+                break;
+
+            case DnsTxtRecord txtRecord:
+                WriteRawOrText(ref writer, txtRecord);
+                break;
+
+            case DnsCaaRecord caaRecord:
+                writer.WriteByte(caaRecord.Flags);
+                WriteCharacterString(ref writer, caaRecord.Tag, Encoding.ASCII);
+                writer.WriteBytes(Encoding.ASCII.GetBytes(caaRecord.Value));
+                break;
+
+            case DnsNaptrRecord naptrRecord:
+                writer.WriteUInt16(naptrRecord.Order);
+                writer.WriteUInt16(naptrRecord.Preference);
+                WriteCharacterString(ref writer, naptrRecord.Flags, Encoding.ASCII);
+                WriteCharacterString(ref writer, naptrRecord.Services, Encoding.ASCII);
+                WriteCharacterString(ref writer, naptrRecord.Regexp, Encoding.UTF8);
+                WriteCanonicalDomainName(ref writer, naptrRecord.Replacement);
+                break;
+
+            case DnsNsecRecord nsecRecord:
+                WriteCanonicalDomainName(ref writer, nsecRecord.NextDomainName);
+                WriteTypeBitMaps(ref writer, nsecRecord.TypeBitMaps);
+                break;
+
+            case DnsNsec3Record nsec3Record:
+                writer.WriteByte(nsec3Record.HashAlgorithm);
+                writer.WriteByte(nsec3Record.Flags);
+                writer.WriteUInt16(nsec3Record.Iterations);
+                writer.WriteByte((byte)nsec3Record.Salt.Length);
+                writer.WriteBytes(nsec3Record.Salt);
+                writer.WriteByte((byte)nsec3Record.NextHashedOwnerName.Length);
+                writer.WriteBytes(nsec3Record.NextHashedOwnerName);
+                WriteTypeBitMaps(ref writer, nsec3Record.TypeBitMaps);
+                break;
+
+            case DnsNsec3ParamRecord nsec3ParamRecord:
+                writer.WriteByte(nsec3ParamRecord.HashAlgorithm);
+                writer.WriteByte(nsec3ParamRecord.Flags);
+                writer.WriteUInt16(nsec3ParamRecord.Iterations);
+                writer.WriteByte((byte)nsec3ParamRecord.Salt.Length);
+                writer.WriteBytes(nsec3ParamRecord.Salt);
+                break;
+
+            case DnsTlsaRecord tlsaRecord:
+                writer.WriteByte(tlsaRecord.CertificateUsage);
+                writer.WriteByte(tlsaRecord.Selector);
+                writer.WriteByte(tlsaRecord.MatchingType);
+                writer.WriteBytes(tlsaRecord.CertificateAssociationData);
+                break;
+
+            case DnsSshfpRecord sshfpRecord:
+                writer.WriteByte(sshfpRecord.Algorithm);
+                writer.WriteByte(sshfpRecord.FingerprintType);
+                writer.WriteBytes(sshfpRecord.Fingerprint);
+                break;
+
+            case DnsSvcbRecord svcbRecord:
+                writer.WriteUInt16(svcbRecord.Priority);
+                WriteCanonicalDomainName(ref writer, svcbRecord.TargetName);
+                foreach (var parameter in svcbRecord.Parameters.OrderBy(parameter => parameter.Key))
+                {
+                    writer.WriteUInt16(parameter.Key);
+                    writer.WriteUInt16((ushort)parameter.Value.Length);
+                    writer.WriteBytes(parameter.Value);
+                }
+
+                break;
+
+            case DnsLocRecord locRecord:
+                writer.WriteByte(locRecord.Version);
+                writer.WriteByte(locRecord.Size);
+                writer.WriteByte(locRecord.HorizontalPrecision);
+                writer.WriteByte(locRecord.VerticalPrecision);
+                writer.WriteUInt32(locRecord.Latitude);
+                writer.WriteUInt32(locRecord.Longitude);
+                writer.WriteUInt32(locRecord.Altitude);
+                break;
+
+            case DnsHinfoRecord hinfoRecord:
+                WriteCharacterString(ref writer, hinfoRecord.Cpu, Encoding.ASCII);
+                WriteCharacterString(ref writer, hinfoRecord.Os, Encoding.ASCII);
+                break;
+
+            case DnsRpRecord rpRecord:
+                WriteCanonicalDomainName(ref writer, rpRecord.Mailbox);
+                WriteCanonicalDomainName(ref writer, rpRecord.TxtDomainName);
+                break;
+
+            case DnsUriRecord uriRecord:
+                writer.WriteUInt16(uriRecord.Priority);
+                writer.WriteUInt16(uriRecord.Weight);
+                writer.WriteBytes(Encoding.UTF8.GetBytes(uriRecord.Target));
+                break;
+
+            case DnsUnknownRecord unknownRecord:
+                writer.WriteBytes(unknownRecord.Data);
+                break;
+
+            default:
+                writer.WriteBytes(record.RawData);
+                break;
+        }
+    }
+
+    private static void WriteRawOrText(ref DnsWireWriter writer, DnsTxtRecord record)
+    {
+        if (record.RawData.Length > 0)
+        {
+            writer.WriteBytes(record.RawData);
+            return;
+        }
+
+        foreach (var text in record.Text)
+        {
+            WriteCharacterString(ref writer, text, Encoding.UTF8);
+        }
+    }
+
+    private static void WriteTypeBitMaps(ref DnsWireWriter writer, IReadOnlyList<DnsQueryType> types)
+    {
+        foreach (var window in types.Select(type => (ushort)type).Distinct().Order().GroupBy(type => type / 256))
+        {
+            var values = window.ToArray();
+            var bitmapLength = (values.Max() % 256 / 8) + 1;
+            var bitmap = new byte[bitmapLength];
+
+            foreach (var value in values)
+            {
+                var offset = value % 256;
+                bitmap[offset / 8] |= (byte)(1 << (7 - (offset % 8)));
+            }
+
+            writer.WriteByte((byte)window.Key);
+            writer.WriteByte((byte)bitmapLength);
+            writer.WriteBytes(bitmap);
+        }
+    }
+
+    private static void WriteCharacterString(ref DnsWireWriter writer, string value, Encoding encoding)
+    {
+        var bytes = encoding.GetBytes(value);
+        if (bytes.Length > 255)
+            throw new DnsProtocolException("DNS character-string values cannot exceed 255 bytes.");
+
+        writer.WriteByte((byte)bytes.Length);
+        writer.WriteBytes(bytes);
+    }
+
+    private static byte[] GetCanonicalDomainNameBytes(string name)
+    {
+        var writer = new DnsWireWriter(256);
+        WriteCanonicalDomainName(ref writer, name);
+        return writer.ToArray();
+    }
+
+    private static void WriteCanonicalDomainName(ref DnsWireWriter writer, string name)
+    {
+        writer.WriteDomainName(NormalizeName(name));
+    }
+
+    private static string[] GetLabels(string name)
+    {
+        var normalized = NormalizeName(name);
+        return normalized.Length is 0 ? [] : normalized.Split('.');
+    }
+
+    private sealed class ByteArrayComparer : IComparer<byte[]>
+    {
+        public static ByteArrayComparer Instance { get; } = new();
+
+        public int Compare(byte[]? x, byte[]? y)
+        {
+            if (ReferenceEquals(x, y))
+                return 0;
+
+            if (x is null)
+                return -1;
+
+            if (y is null)
+                return 1;
+
+            return StructuralComparisons.StructuralComparer.Compare(x, y);
+        }
+    }
+}

--- a/src/Meziantou.Framework.DnsClient/Internal/DnssecCrypto.cs
+++ b/src/Meziantou.Framework.DnsClient/Internal/DnssecCrypto.cs
@@ -1,0 +1,105 @@
+using System.Security.Cryptography;
+using Meziantou.Framework.DnsClient.Response.Records;
+
+namespace Meziantou.Framework.DnsClient.Internal;
+
+internal static class DnssecCrypto
+{
+    public static bool IsSupportedAlgorithm(byte algorithm)
+    {
+        return algorithm is 8 or 10 or 13 or 14;
+    }
+
+    public static DnssecSignatureVerificationStatus VerifySignature(DnsDnskeyRecord key, byte[] data, byte[] signature)
+    {
+        return key.Algorithm switch
+        {
+            8 => VerifyRsa(key.PublicKey, data, signature, HashAlgorithmName.SHA256),
+            10 => VerifyRsa(key.PublicKey, data, signature, HashAlgorithmName.SHA512),
+            13 => VerifyEcdsa(key.PublicKey, data, signature, HashAlgorithmName.SHA256, 32, ECCurve.NamedCurves.nistP256),
+            14 => VerifyEcdsa(key.PublicKey, data, signature, HashAlgorithmName.SHA384, 48, ECCurve.NamedCurves.nistP384),
+            _ => DnssecSignatureVerificationStatus.UnsupportedAlgorithm,
+        };
+    }
+
+    private static DnssecSignatureVerificationStatus VerifyRsa(byte[] publicKey, byte[] data, byte[] signature, HashAlgorithmName hashAlgorithmName)
+    {
+        if (!TryReadRsaPublicKey(publicKey, out var parameters))
+            return DnssecSignatureVerificationStatus.InvalidKey;
+
+        try
+        {
+            using var rsa = RSA.Create();
+            rsa.ImportParameters(parameters);
+            return rsa.VerifyData(data, signature, hashAlgorithmName, RSASignaturePadding.Pkcs1)
+                ? DnssecSignatureVerificationStatus.Valid
+                : DnssecSignatureVerificationStatus.Invalid;
+        }
+        catch (CryptographicException)
+        {
+            return DnssecSignatureVerificationStatus.InvalidKey;
+        }
+    }
+
+    private static DnssecSignatureVerificationStatus VerifyEcdsa(byte[] publicKey, byte[] data, byte[] signature, HashAlgorithmName hashAlgorithmName, int coordinateLength, ECCurve curve)
+    {
+        if (publicKey.Length != coordinateLength * 2)
+            return DnssecSignatureVerificationStatus.InvalidKey;
+
+        try
+        {
+            var parameters = new ECParameters
+            {
+                Curve = curve,
+                Q = new ECPoint
+                {
+                    X = publicKey.AsSpan(0, coordinateLength).ToArray(),
+                    Y = publicKey.AsSpan(coordinateLength, coordinateLength).ToArray(),
+                },
+            };
+
+            using var ecdsa = ECDsa.Create(parameters);
+            return ecdsa.VerifyData(data, signature, hashAlgorithmName, DSASignatureFormat.IeeeP1363FixedFieldConcatenation)
+                ? DnssecSignatureVerificationStatus.Valid
+                : DnssecSignatureVerificationStatus.Invalid;
+        }
+        catch (CryptographicException)
+        {
+            return DnssecSignatureVerificationStatus.InvalidKey;
+        }
+    }
+
+    private static bool TryReadRsaPublicKey(byte[] publicKey, out RSAParameters parameters)
+    {
+        parameters = default;
+        if (publicKey.Length < 3)
+            return false;
+
+        var offset = 0;
+        int exponentLength;
+        if (publicKey[offset] is 0)
+        {
+            if (publicKey.Length < 3)
+                return false;
+
+            exponentLength = (publicKey[1] << 8) | publicKey[2];
+            offset = 3;
+        }
+        else
+        {
+            exponentLength = publicKey[offset];
+            offset++;
+        }
+
+        if (exponentLength <= 0 || offset + exponentLength >= publicKey.Length)
+            return false;
+
+        parameters = new RSAParameters
+        {
+            Exponent = publicKey.AsSpan(offset, exponentLength).ToArray(),
+            Modulus = publicKey.AsSpan(offset + exponentLength).ToArray(),
+        };
+
+        return parameters.Modulus.Length > 0;
+    }
+}

--- a/src/Meziantou.Framework.DnsClient/Internal/DnssecSignatureVerificationStatus.cs
+++ b/src/Meziantou.Framework.DnsClient/Internal/DnssecSignatureVerificationStatus.cs
@@ -1,0 +1,9 @@
+namespace Meziantou.Framework.DnsClient.Internal;
+
+internal enum DnssecSignatureVerificationStatus
+{
+    Valid,
+    Invalid,
+    UnsupportedAlgorithm,
+    InvalidKey,
+}

--- a/src/Meziantou.Framework.DnsClient/Internal/DnssecValidator.cs
+++ b/src/Meziantou.Framework.DnsClient/Internal/DnssecValidator.cs
@@ -1,0 +1,544 @@
+using Meziantou.Framework.DnsClient.Query;
+using Meziantou.Framework.DnsClient.Response;
+using Meziantou.Framework.DnsClient.Response.Records;
+
+namespace Meziantou.Framework.DnsClient.Internal;
+
+internal sealed class DnssecValidator
+{
+    private readonly Func<DnsQueryMessage, CancellationToken, Task<DnsResponseMessage>> _queryAsync;
+    private readonly IReadOnlyList<DnssecTrustAnchor> _trustAnchors;
+    private readonly TimeProvider _timeProvider;
+    private readonly Dictionary<string, KeyValidationResult> _keyCache = new(StringComparer.Ordinal);
+
+    public DnssecValidator(
+        Func<DnsQueryMessage, CancellationToken, Task<DnsResponseMessage>> queryAsync,
+        IReadOnlyList<DnssecTrustAnchor> trustAnchors,
+        TimeProvider timeProvider)
+    {
+        _queryAsync = queryAsync;
+        _trustAnchors = trustAnchors;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<DnssecValidationResult> ValidateAsync(DnsResponseMessage response, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        if (response.Header.IsTruncated)
+        {
+            return CreateResult(DnssecValidationStatus.Indeterminate, new DnssecValidationIssue(DnssecValidationIssueCode.TruncatedResponse, "The DNS response is truncated."));
+        }
+
+        if (response.Questions.Count is 0)
+        {
+            return CreateResult(DnssecValidationStatus.Indeterminate, new DnssecValidationIssue(DnssecValidationIssueCode.MissingQuestion, "The DNS response does not contain a question."));
+        }
+
+        var question = response.Questions[0];
+        if (response.Header.ResponseCode is DnsResponseCode.NameError)
+        {
+            var denial = await ValidateDenialAsync(response, question.Name, question.Type, knownKeys: null, cancellationToken).ConfigureAwait(false);
+            return ToResult(denial);
+        }
+
+        if (response.Header.ResponseCode is not DnsResponseCode.NoError)
+        {
+            return CreateResult(DnssecValidationStatus.Indeterminate, new DnssecValidationIssue(DnssecValidationIssueCode.InvalidData, $"DNSSEC validation is not defined for response code {response.Header.ResponseCode}.", question.Name, question.Type));
+        }
+
+        var answerRrsets = GroupRrsets(response.Answers).ToArray();
+        if (answerRrsets.Length is 0)
+        {
+            var denial = await ValidateDenialAsync(response, question.Name, question.Type, knownKeys: null, cancellationToken).ConfigureAwait(false);
+            return ToResult(denial);
+        }
+
+        var outcomes = new List<ValidationOutcome>(answerRrsets.Length);
+        foreach (var rrset in answerRrsets)
+        {
+            outcomes.Add(await ValidateRrsetAsync(rrset.Records, rrset.Signatures, cancellationToken).ConfigureAwait(false));
+        }
+
+        return ToResult(CombineAll(outcomes));
+    }
+
+    private async Task<ValidationOutcome> ValidateRrsetAsync(IReadOnlyList<DnsRecord> rrset, IReadOnlyList<DnsRrsigRecord> signatures, CancellationToken cancellationToken)
+    {
+        if (rrset.Count is 0)
+            return ValidationOutcome.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.MissingRecord, "The RRset is empty."));
+
+        var record = rrset[0];
+        if (signatures.Count is 0)
+        {
+            var insecure = await FindInsecureDelegationAsync(record.Name, cancellationToken).ConfigureAwait(false);
+            if (insecure.Status is DnssecValidationStatus.Insecure)
+                return insecure;
+
+            return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.MissingRrsig, "The RRset does not contain a matching RRSIG.", record.Name, record.RecordType));
+        }
+
+        var outcomes = new List<ValidationOutcome>(signatures.Count);
+        foreach (var signature in signatures)
+        {
+            var keys = await GetValidatedDnsKeysAsync(signature.SignerName, cancellationToken).ConfigureAwait(false);
+            if (keys.Status is not DnssecValidationStatus.Secure)
+            {
+                outcomes.Add(ValidationOutcome.From(keys.Status, keys.Issues));
+                continue;
+            }
+
+            outcomes.Add(VerifyRrsetWithKeys(rrset, [signature], keys.Keys));
+        }
+
+        return CombineAny(outcomes);
+    }
+
+    private async Task<KeyValidationResult> GetValidatedDnsKeysAsync(string zoneName, CancellationToken cancellationToken)
+    {
+        var normalizedZoneName = DnssecCanonicalizer.NormalizeName(zoneName);
+        if (_keyCache.TryGetValue(normalizedZoneName, out var cachedResult))
+            return cachedResult;
+
+        KeyValidationResult result;
+        if (normalizedZoneName.Length is 0)
+        {
+            result = await ValidateRootDnsKeysAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            result = await ValidateDelegatedDnsKeysAsync(normalizedZoneName, cancellationToken).ConfigureAwait(false);
+        }
+
+        _keyCache[normalizedZoneName] = result;
+        return result;
+    }
+
+    private async Task<KeyValidationResult> ValidateRootDnsKeysAsync(CancellationToken cancellationToken)
+    {
+        var response = await QueryAsync(".", DnsQueryType.DNSKEY, cancellationToken).ConfigureAwait(false);
+        var keys = GetRecords<DnsDnskeyRecord>(response.Answers, "").ToArray();
+        if (keys.Length is 0)
+            return KeyValidationResult.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.MissingDnskey, "The root DNSKEY RRset is missing.", ".", DnsQueryType.DNSKEY));
+
+        var trustedKeys = keys
+            .Where(key => _trustAnchors.Any(anchor => IsTrustAnchorMatch(anchor, "", key)))
+            .ToArray();
+        if (trustedKeys.Length is 0)
+            return KeyValidationResult.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.MissingDs, "No configured trust anchor matches the root DNSKEY RRset.", ".", DnsQueryType.DNSKEY));
+
+        var signatures = GetSignatures(response.Answers, "", DnsQueryType.DNSKEY).ToArray();
+        var validation = VerifyRrsetWithKeys(keys, signatures, trustedKeys);
+        return validation.Status is DnssecValidationStatus.Secure
+            ? KeyValidationResult.Secure(keys)
+            : KeyValidationResult.From(validation.Status, validation.Issues);
+    }
+
+    private async Task<KeyValidationResult> ValidateDelegatedDnsKeysAsync(string zoneName, CancellationToken cancellationToken)
+    {
+        var parentName = DnssecCanonicalizer.GetParentName(zoneName);
+        var parentKeys = await GetValidatedDnsKeysAsync(parentName, cancellationToken).ConfigureAwait(false);
+        if (parentKeys.Status is DnssecValidationStatus.Insecure)
+            return parentKeys;
+
+        if (parentKeys.Status is not DnssecValidationStatus.Secure)
+            return parentKeys;
+
+        var dsResponse = await QueryAsync(zoneName, DnsQueryType.DS, cancellationToken).ConfigureAwait(false);
+        var dsRecords = GetRecords<DnsDsRecord>(dsResponse.Answers, zoneName).ToArray();
+        if (dsRecords.Length is 0)
+        {
+            var denial = await ValidateDenialAsync(dsResponse, zoneName, DnsQueryType.DS, parentKeys.Keys, cancellationToken).ConfigureAwait(false);
+            return denial.Status is DnssecValidationStatus.Secure
+                ? KeyValidationResult.Insecure(new DnssecValidationIssue(DnssecValidationIssueCode.MissingDs, "The delegation is authenticated as unsigned.", zoneName, DnsQueryType.DS))
+                : KeyValidationResult.From(denial.Status, denial.Issues);
+        }
+
+        var dsSignatures = GetSignatures(dsResponse.Answers, zoneName, DnsQueryType.DS).ToArray();
+        var dsValidation = VerifyRrsetWithKeys(dsRecords, dsSignatures, parentKeys.Keys);
+        if (dsValidation.Status is not DnssecValidationStatus.Secure)
+            return KeyValidationResult.From(dsValidation.Status, dsValidation.Issues);
+
+        var dnskeyResponse = await QueryAsync(zoneName, DnsQueryType.DNSKEY, cancellationToken).ConfigureAwait(false);
+        var keys = GetRecords<DnsDnskeyRecord>(dnskeyResponse.Answers, zoneName).ToArray();
+        if (keys.Length is 0)
+            return KeyValidationResult.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.MissingDnskey, "The DNSKEY RRset is missing.", zoneName, DnsQueryType.DNSKEY));
+
+        var digestIssues = new List<DnssecValidationIssue>();
+        var matchingKeys = keys.Where(key => IsDsMatch(zoneName, key, dsRecords, digestIssues)).ToArray();
+        if (matchingKeys.Length is 0)
+        {
+            return digestIssues.Count is 0
+                ? KeyValidationResult.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.DigestMismatch, "No DNSKEY matches the DS RRset.", zoneName, DnsQueryType.DNSKEY))
+                : KeyValidationResult.Bogus(digestIssues);
+        }
+
+        var dnskeySignatures = GetSignatures(dnskeyResponse.Answers, zoneName, DnsQueryType.DNSKEY).ToArray();
+        var dnskeyValidation = VerifyRrsetWithKeys(keys, dnskeySignatures, matchingKeys);
+        return dnskeyValidation.Status is DnssecValidationStatus.Secure
+            ? KeyValidationResult.Secure(keys)
+            : KeyValidationResult.From(dnskeyValidation.Status, dnskeyValidation.Issues);
+    }
+
+    private async Task<ValidationOutcome> FindInsecureDelegationAsync(string name, CancellationToken cancellationToken)
+    {
+        var zoneName = DnssecCanonicalizer.NormalizeName(name);
+        while (zoneName.Length > 0)
+        {
+            var parentName = DnssecCanonicalizer.GetParentName(zoneName);
+            var parentKeys = await GetValidatedDnsKeysAsync(parentName, cancellationToken).ConfigureAwait(false);
+            if (parentKeys.Status is DnssecValidationStatus.Secure)
+            {
+                var dsResponse = await QueryAsync(zoneName, DnsQueryType.DS, cancellationToken).ConfigureAwait(false);
+                var dsRecords = GetRecords<DnsDsRecord>(dsResponse.Answers, zoneName).ToArray();
+                if (dsRecords.Length is 0)
+                {
+                    var denial = await ValidateDenialAsync(dsResponse, zoneName, DnsQueryType.DS, parentKeys.Keys, cancellationToken).ConfigureAwait(false);
+                    if (denial.Status is DnssecValidationStatus.Secure)
+                        return ValidationOutcome.Insecure(new DnssecValidationIssue(DnssecValidationIssueCode.MissingDs, "The closest delegation is authenticated as unsigned.", zoneName, DnsQueryType.DS));
+                }
+            }
+            else if (parentKeys.Status is DnssecValidationStatus.Insecure)
+            {
+                return ValidationOutcome.Insecure(parentKeys.Issues);
+            }
+            else
+            {
+                return ValidationOutcome.From(parentKeys.Status, parentKeys.Issues);
+            }
+
+            zoneName = parentName;
+        }
+
+        return ValidationOutcome.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.TrustChainIncomplete, "No authenticated insecure delegation was found.", name));
+    }
+
+    private async Task<ValidationOutcome> ValidateDenialAsync(DnsResponseMessage response, string questionName, DnsQueryType questionType, IReadOnlyList<DnsDnskeyRecord>? knownKeys, CancellationToken cancellationToken)
+    {
+        var nsecRrsets = GroupRrsets(response.Authorities)
+            .Where(rrset => rrset.Type is DnsQueryType.NSEC or DnsQueryType.NSEC3)
+            .ToArray();
+        if (nsecRrsets.Length is 0)
+        {
+            return ValidationOutcome.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.InvalidDenialProof, "No NSEC or NSEC3 denial records were present.", questionName, questionType));
+        }
+
+        var outcomes = new List<ValidationOutcome>(nsecRrsets.Length);
+        var proofFound = false;
+
+        foreach (var rrset in nsecRrsets)
+        {
+            var validation = knownKeys is null
+                ? await ValidateRrsetAsync(rrset.Records, rrset.Signatures, cancellationToken).ConfigureAwait(false)
+                : VerifyRrsetWithKeys(rrset.Records, rrset.Signatures, knownKeys);
+            outcomes.Add(validation);
+
+            if (validation.Status is DnssecValidationStatus.Secure && ProvesDenial(response.Header.ResponseCode, questionName, questionType, rrset.Records))
+            {
+                proofFound = true;
+            }
+        }
+
+        var combined = CombineAll(outcomes);
+        if (combined.Status is not DnssecValidationStatus.Secure)
+            return combined;
+
+        return proofFound
+            ? ValidationOutcome.Secure()
+            : ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.InvalidDenialProof, "The denial records are signed but do not prove the requested denial.", questionName, questionType));
+    }
+
+    private ValidationOutcome VerifyRrsetWithKeys(IReadOnlyList<DnsRecord> rrset, IReadOnlyList<DnsRrsigRecord> signatures, IReadOnlyList<DnsDnskeyRecord> keys)
+    {
+        if (rrset.Count is 0)
+            return ValidationOutcome.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.MissingRecord, "The RRset is empty."));
+
+        var record = rrset[0];
+        if (signatures.Count is 0)
+            return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.MissingRrsig, "The RRset does not contain a matching RRSIG.", record.Name, record.RecordType));
+
+        var outcomes = new List<ValidationOutcome>(signatures.Count);
+        foreach (var signature in signatures)
+        {
+            outcomes.Add(VerifySignature(rrset, signature, keys));
+        }
+
+        return CombineAny(outcomes);
+    }
+
+    private ValidationOutcome VerifySignature(IReadOnlyList<DnsRecord> rrset, DnsRrsigRecord signature, IReadOnlyList<DnsDnskeyRecord> keys)
+    {
+        var record = rrset[0];
+        var now = _timeProvider.GetUtcNow().ToUnixTimeSeconds();
+        if (now < signature.SignatureInception)
+        {
+            return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.SignatureNotYetValid, "The RRSIG inception time is in the future.", record.Name, record.RecordType));
+        }
+
+        if (now > signature.SignatureExpiration)
+        {
+            return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.SignatureExpired, "The RRSIG has expired.", record.Name, record.RecordType));
+        }
+
+        if (!DnssecCrypto.IsSupportedAlgorithm(signature.Algorithm))
+        {
+            return ValidationOutcome.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.UnsupportedAlgorithm, $"DNSSEC algorithm {signature.Algorithm} is not supported.", record.Name, record.RecordType));
+        }
+
+        var candidateKeys = keys
+            .Where(key => key.Algorithm == signature.Algorithm && DnssecCanonicalizer.ComputeKeyTag(key) == signature.KeyTag)
+            .ToArray();
+        if (candidateKeys.Length is 0)
+        {
+            return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.MissingDnskey, "No DNSKEY matches the RRSIG key tag and algorithm.", record.Name, record.RecordType));
+        }
+
+        var signedData = DnssecCanonicalizer.GetSignedData(rrset, signature);
+        foreach (var key in candidateKeys)
+        {
+            var verification = DnssecCrypto.VerifySignature(key, signedData, signature.Signature);
+            if (verification is DnssecSignatureVerificationStatus.Valid)
+                return ValidationOutcome.Secure();
+
+            if (verification is DnssecSignatureVerificationStatus.UnsupportedAlgorithm)
+            {
+                return ValidationOutcome.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.UnsupportedAlgorithm, $"DNSSEC algorithm {key.Algorithm} is not supported.", record.Name, record.RecordType));
+            }
+        }
+
+        return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.SignatureVerificationFailed, "No RRSIG signature could be verified with the matching DNSKEY.", record.Name, record.RecordType));
+    }
+
+    private async Task<DnsResponseMessage> QueryAsync(string name, DnsQueryType type, CancellationToken cancellationToken)
+    {
+        var query = new DnsQueryMessage
+        {
+            RecursionDesired = true,
+            CheckingDisabled = true,
+            EdnsOptions = new DnsEdnsOptions
+            {
+                UdpPayloadSize = 4096,
+                DnssecOk = true,
+            },
+        };
+        query.Questions.Add(new DnsQuestion(DnssecCanonicalizer.ToDisplayName(name), type));
+
+        return await _queryAsync(query, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool ProvesDenial(DnsResponseCode responseCode, string questionName, DnsQueryType questionType, IReadOnlyList<DnsRecord> records)
+    {
+        foreach (var record in records)
+        {
+            if (record is DnsNsecRecord nsecRecord && NsecProvesDenial(responseCode, questionName, questionType, nsecRecord))
+                return true;
+
+            if (record is DnsNsec3Record nsec3Record && Nsec3ProvesDenial(responseCode, questionName, questionType, nsec3Record))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool NsecProvesDenial(DnsResponseCode responseCode, string questionName, DnsQueryType questionType, DnsNsecRecord record)
+    {
+        var ownerName = DnssecCanonicalizer.NormalizeName(record.Name);
+        var normalizedQuestionName = DnssecCanonicalizer.NormalizeName(questionName);
+
+        if (ownerName == normalizedQuestionName)
+        {
+            return !record.TypeBitMaps.Contains(questionType) && !record.TypeBitMaps.Contains(DnsQueryType.CNAME);
+        }
+
+        return responseCode is DnsResponseCode.NameError && DnssecCanonicalizer.NsecCovers(ownerName, record.NextDomainName, normalizedQuestionName);
+    }
+
+    private static bool Nsec3ProvesDenial(DnsResponseCode responseCode, string questionName, DnsQueryType questionType, DnsNsec3Record record)
+    {
+        var ownerHashLabel = DnssecCanonicalizer.NormalizeName(record.Name).Split('.')[0];
+        var ownerHash = DnssecCanonicalizer.DecodeBase32Hex(ownerHashLabel);
+        if (ownerHash.Length is 0)
+            return false;
+
+        var questionHash = DnssecCanonicalizer.ComputeNsec3Hash(questionName, record);
+        if (questionHash.Length is 0)
+            return false;
+
+        if (ownerHash.AsSpan().SequenceEqual(questionHash))
+            return !record.TypeBitMaps.Contains(questionType) && !record.TypeBitMaps.Contains(DnsQueryType.CNAME);
+
+        return responseCode is DnsResponseCode.NameError && DnssecCanonicalizer.Nsec3Covers(ownerHash, record.NextHashedOwnerName, questionHash);
+    }
+
+    private static IEnumerable<DnsRecordRrset> GroupRrsets(IReadOnlyList<DnsRecord> records)
+    {
+        return records
+            .Where(record => record is not DnsRrsigRecord and not DnsOptRecord)
+            .GroupBy(record => new RrsetKey(DnssecCanonicalizer.NormalizeName(record.Name), record.RecordType, record.RecordClass))
+            .Select(group => new DnsRecordRrset(
+                group.Key.Name,
+                group.Key.Type,
+                group.Key.RecordClass,
+                group.ToArray(),
+                GetSignatures(records, group.Key.Name, group.Key.Type).ToArray()));
+    }
+
+    private static IEnumerable<T> GetRecords<T>(IReadOnlyList<DnsRecord> records, string name)
+        where T : DnsRecord
+    {
+        var normalizedName = DnssecCanonicalizer.NormalizeName(name);
+        return records.OfType<T>().Where(record => DnssecCanonicalizer.NormalizeName(record.Name) == normalizedName);
+    }
+
+    private static IEnumerable<DnsRrsigRecord> GetSignatures(IReadOnlyList<DnsRecord> records, string name, DnsQueryType type)
+    {
+        var normalizedName = DnssecCanonicalizer.NormalizeName(name);
+        return records
+            .OfType<DnsRrsigRecord>()
+            .Where(record => record.TypeCovered == type && DnssecCanonicalizer.NormalizeName(record.Name) == normalizedName);
+    }
+
+    private static bool IsTrustAnchorMatch(DnssecTrustAnchor anchor, string ownerName, DnsDnskeyRecord key)
+    {
+        return DnssecCanonicalizer.NormalizeName(anchor.Name) == DnssecCanonicalizer.NormalizeName(ownerName)
+            && anchor.KeyTag == DnssecCanonicalizer.ComputeKeyTag(key)
+            && anchor.Algorithm == key.Algorithm
+            && DnssecCanonicalizer.IsSupportedDigest(anchor.DigestType)
+            && DnssecCanonicalizer.ComputeDigest(ownerName, key, anchor.DigestType).AsSpan().SequenceEqual(anchor.Digest);
+    }
+
+    private static bool IsDsMatch(string ownerName, DnsDnskeyRecord key, IReadOnlyList<DnsDsRecord> dsRecords, List<DnssecValidationIssue> issues)
+    {
+        foreach (var ds in dsRecords)
+        {
+            if (ds.KeyTag != DnssecCanonicalizer.ComputeKeyTag(key) || ds.Algorithm != key.Algorithm)
+                continue;
+
+            if (!DnssecCanonicalizer.IsSupportedDigest(ds.DigestType))
+            {
+                issues.Add(new DnssecValidationIssue(DnssecValidationIssueCode.UnsupportedDigest, $"DS digest type {ds.DigestType} is not supported.", ownerName, DnsQueryType.DS));
+                continue;
+            }
+
+            if (DnssecCanonicalizer.ComputeDigest(ownerName, key, ds.DigestType).AsSpan().SequenceEqual(ds.Digest))
+                return true;
+
+            issues.Add(new DnssecValidationIssue(DnssecValidationIssueCode.DigestMismatch, "The DS digest does not match the DNSKEY.", ownerName, DnsQueryType.DNSKEY));
+        }
+
+        return false;
+    }
+
+    private static DnssecValidationResult ToResult(ValidationOutcome outcome)
+    {
+        return new(outcome.Status, outcome.Issues);
+    }
+
+    private static DnssecValidationResult CreateResult(DnssecValidationStatus status, DnssecValidationIssue issue)
+    {
+        return new(status, [issue]);
+    }
+
+    private static ValidationOutcome CombineAny(IReadOnlyList<ValidationOutcome> outcomes)
+    {
+        if (outcomes.Count is 0)
+            return ValidationOutcome.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.MissingRecord, "No DNSSEC validation outcomes were produced."));
+
+        if (outcomes.Any(outcome => outcome.Status is DnssecValidationStatus.Secure))
+            return ValidationOutcome.Secure();
+
+        var issues = outcomes.SelectMany(outcome => outcome.Issues).ToArray();
+        if (outcomes.Any(outcome => outcome.Status is DnssecValidationStatus.Bogus))
+            return ValidationOutcome.From(DnssecValidationStatus.Bogus, issues);
+
+        if (outcomes.Any(outcome => outcome.Status is DnssecValidationStatus.Indeterminate))
+            return ValidationOutcome.From(DnssecValidationStatus.Indeterminate, issues);
+
+        if (outcomes.Any(outcome => outcome.Status is DnssecValidationStatus.Insecure))
+            return ValidationOutcome.From(DnssecValidationStatus.Insecure, issues);
+
+        return ValidationOutcome.From(DnssecValidationStatus.NotValidated, issues);
+    }
+
+    private static ValidationOutcome CombineAll(IReadOnlyList<ValidationOutcome> outcomes)
+    {
+        if (outcomes.Count is 0)
+            return ValidationOutcome.Indeterminate(new DnssecValidationIssue(DnssecValidationIssueCode.MissingRecord, "No DNSSEC validation outcomes were produced."));
+
+        var issues = outcomes.SelectMany(outcome => outcome.Issues).ToArray();
+        if (outcomes.Any(outcome => outcome.Status is DnssecValidationStatus.Bogus))
+            return ValidationOutcome.From(DnssecValidationStatus.Bogus, issues);
+
+        if (outcomes.Any(outcome => outcome.Status is DnssecValidationStatus.Indeterminate))
+            return ValidationOutcome.From(DnssecValidationStatus.Indeterminate, issues);
+
+        if (outcomes.Any(outcome => outcome.Status is DnssecValidationStatus.Insecure))
+            return ValidationOutcome.From(DnssecValidationStatus.Insecure, issues);
+
+        if (outcomes.All(outcome => outcome.Status is DnssecValidationStatus.Secure))
+            return ValidationOutcome.Secure();
+
+        return ValidationOutcome.From(DnssecValidationStatus.NotValidated, issues);
+    }
+
+    private readonly record struct RrsetKey(string Name, DnsQueryType Type, DnsQueryClass RecordClass);
+
+    private sealed record DnsRecordRrset(string Name, DnsQueryType Type, DnsQueryClass RecordClass, IReadOnlyList<DnsRecord> Records, IReadOnlyList<DnsRrsigRecord> Signatures);
+
+    private sealed class KeyValidationResult
+    {
+        private KeyValidationResult(DnssecValidationStatus status, IReadOnlyList<DnssecValidationIssue> issues, IReadOnlyList<DnsDnskeyRecord> keys)
+        {
+            Status = status;
+            Issues = issues;
+            Keys = keys;
+        }
+
+        public DnssecValidationStatus Status { get; }
+
+        public IReadOnlyList<DnssecValidationIssue> Issues { get; }
+
+        public IReadOnlyList<DnsDnskeyRecord> Keys { get; }
+
+        public static KeyValidationResult Secure(IReadOnlyList<DnsDnskeyRecord> keys) => new(DnssecValidationStatus.Secure, [], keys);
+
+        public static KeyValidationResult Insecure(params DnssecValidationIssue[] issues) => new(DnssecValidationStatus.Insecure, issues, []);
+
+        public static KeyValidationResult Insecure(IReadOnlyList<DnssecValidationIssue> issues) => new(DnssecValidationStatus.Insecure, issues, []);
+
+        public static KeyValidationResult Bogus(params DnssecValidationIssue[] issues) => new(DnssecValidationStatus.Bogus, issues, []);
+
+        public static KeyValidationResult Bogus(IReadOnlyList<DnssecValidationIssue> issues) => new(DnssecValidationStatus.Bogus, issues, []);
+
+        public static KeyValidationResult Indeterminate(params DnssecValidationIssue[] issues) => new(DnssecValidationStatus.Indeterminate, issues, []);
+
+        public static KeyValidationResult From(DnssecValidationStatus status, IReadOnlyList<DnssecValidationIssue> issues) => new(status, issues, []);
+    }
+
+    private sealed class ValidationOutcome
+    {
+        private ValidationOutcome(DnssecValidationStatus status, IReadOnlyList<DnssecValidationIssue> issues)
+        {
+            Status = status;
+            Issues = issues;
+        }
+
+        public DnssecValidationStatus Status { get; }
+
+        public IReadOnlyList<DnssecValidationIssue> Issues { get; }
+
+        public static ValidationOutcome Secure() => new(DnssecValidationStatus.Secure, []);
+
+        public static ValidationOutcome Insecure(params DnssecValidationIssue[] issues) => new(DnssecValidationStatus.Insecure, issues);
+
+        public static ValidationOutcome Insecure(IReadOnlyList<DnssecValidationIssue> issues) => new(DnssecValidationStatus.Insecure, issues);
+
+        public static ValidationOutcome Bogus(params DnssecValidationIssue[] issues) => new(DnssecValidationStatus.Bogus, issues);
+
+        public static ValidationOutcome Bogus(IReadOnlyList<DnssecValidationIssue> issues) => new(DnssecValidationStatus.Bogus, issues);
+
+        public static ValidationOutcome Indeterminate(params DnssecValidationIssue[] issues) => new(DnssecValidationStatus.Indeterminate, issues);
+
+        public static ValidationOutcome From(DnssecValidationStatus status, IReadOnlyList<DnssecValidationIssue> issues) => new(status, issues);
+    }
+}

--- a/src/Meziantou.Framework.DnsClient/Protocol/DnsMessageEncoder.cs
+++ b/src/Meziantou.Framework.DnsClient/Protocol/DnsMessageEncoder.cs
@@ -59,7 +59,7 @@ internal static class DnsMessageEncoder
         return writer.ToArray();
     }
 
-    public static DnsResponseMessage DecodeResponse(ReadOnlySpan<byte> data)
+    public static DnsResponseMessage DecodeResponse(ReadOnlySpan<byte> data, bool preserveRawRecordData = false)
     {
         if (data.Length < 12)
             throw new DnsProtocolException("DNS message is too short (minimum 12 bytes for header).");
@@ -103,14 +103,14 @@ internal static class DnsMessageEncoder
         response.Questions = questions;
 
         // Answer, Authority, Additional sections
-        response.Answers = ReadRecords(ref reader, header.AnswerCount);
-        response.Authorities = ReadRecords(ref reader, header.AuthorityCount);
-        response.AdditionalRecords = ReadRecords(ref reader, header.AdditionalCount);
+        response.Answers = ReadRecords(ref reader, header.AnswerCount, preserveRawRecordData);
+        response.Authorities = ReadRecords(ref reader, header.AuthorityCount, preserveRawRecordData);
+        response.AdditionalRecords = ReadRecords(ref reader, header.AdditionalCount, preserveRawRecordData);
 
         return response;
     }
 
-    private static List<DnsRecord> ReadRecords(ref DnsWireReader reader, ushort count)
+    private static List<DnsRecord> ReadRecords(ref DnsWireReader reader, ushort count, bool preserveRawRecordData)
     {
         var records = new List<DnsRecord>(count);
         for (var i = 0; i < count; i++)
@@ -129,7 +129,10 @@ internal static class DnsMessageEncoder
             record.RecordClass = recordClass;
             record.TimeToLive = ttl;
             record.DataLength = rdLength;
-            record.RawData = reader.GetBytes(rdataStart, rdLength).ToArray();
+            if (preserveRawRecordData)
+            {
+                record.RawData = reader.GetBytes(rdataStart, rdLength).ToArray();
+            }
 
             if (record is DnsOptRecord optRecord)
             {

--- a/src/Meziantou.Framework.DnsClient/Protocol/DnsMessageEncoder.cs
+++ b/src/Meziantou.Framework.DnsClient/Protocol/DnsMessageEncoder.cs
@@ -129,6 +129,15 @@ internal static class DnsMessageEncoder
             record.RecordClass = recordClass;
             record.TimeToLive = ttl;
             record.DataLength = rdLength;
+            record.RawData = reader.GetBytes(rdataStart, rdLength).ToArray();
+
+            if (record is DnsOptRecord optRecord)
+            {
+                optRecord.UdpPayloadSize = (ushort)recordClass;
+                optRecord.ExtendedRCode = (byte)(ttl >> 24);
+                optRecord.EdnsVersion = (byte)(ttl >> 16);
+                optRecord.DnssecOk = ((ushort)ttl & 0x8000) != 0;
+            }
 
             // Ensure we consumed exactly rdLength bytes
             var consumed = reader.Position - rdataStart;

--- a/src/Meziantou.Framework.DnsClient/Protocol/DnsWireReader.cs
+++ b/src/Meziantou.Framework.DnsClient/Protocol/DnsWireReader.cs
@@ -75,6 +75,14 @@ internal ref struct DnsWireReader
         _position += count;
     }
 
+    public readonly ReadOnlySpan<byte> GetBytes(int offset, int count)
+    {
+        if (offset < 0 || count < 0 || offset + count > _message.Length)
+            throw new DnsProtocolException($"Cannot read {count} bytes at offset {offset}: exceeds message boundary.");
+
+        return _message.Slice(offset, count);
+    }
+
     public string ReadDomainName()
     {
         var sb = new StringBuilder(64);

--- a/src/Meziantou.Framework.DnsClient/Response/DnsRecord.cs
+++ b/src/Meziantou.Framework.DnsClient/Response/DnsRecord.cs
@@ -19,4 +19,6 @@ public abstract class DnsRecord
 
     /// <summary>Gets the length of the resource data in bytes.</summary>
     public ushort DataLength { get; internal set; }
+
+    internal byte[] RawData { get; set; } = [];
 }

--- a/src/Meziantou.Framework.DnsClient/Response/DnsResponseMessage.cs
+++ b/src/Meziantou.Framework.DnsClient/Response/DnsResponseMessage.cs
@@ -22,4 +22,7 @@ public sealed class DnsResponseMessage
 
     /// <summary>Gets the additional resource records.</summary>
     public IReadOnlyList<DnsRecord> AdditionalRecords { get; internal set; } = [];
+
+    /// <summary>Gets the local DNSSEC validation result.</summary>
+    public DnssecValidationResult DnssecValidationResult { get; internal set; } = DnssecValidationResult.NotValidatedResult;
 }

--- a/src/Meziantou.Framework.DnsClient/Response/DnssecValidationIssue.cs
+++ b/src/Meziantou.Framework.DnsClient/Response/DnssecValidationIssue.cs
@@ -1,0 +1,27 @@
+using Meziantou.Framework.DnsClient.Query;
+
+namespace Meziantou.Framework.DnsClient.Response;
+
+/// <summary>Represents one DNSSEC validation issue.</summary>
+public sealed class DnssecValidationIssue
+{
+    internal DnssecValidationIssue(DnssecValidationIssueCode code, string message, string? name = null, DnsQueryType? recordType = null)
+    {
+        Code = code;
+        Message = message;
+        Name = name;
+        RecordType = recordType;
+    }
+
+    /// <summary>Gets the issue code.</summary>
+    public DnssecValidationIssueCode Code { get; }
+
+    /// <summary>Gets the human-readable issue message.</summary>
+    public string Message { get; }
+
+    /// <summary>Gets the DNS name associated with the issue, when known.</summary>
+    public string? Name { get; }
+
+    /// <summary>Gets the DNS record type associated with the issue, when known.</summary>
+    public DnsQueryType? RecordType { get; }
+}

--- a/src/Meziantou.Framework.DnsClient/Response/DnssecValidationIssueCode.cs
+++ b/src/Meziantou.Framework.DnsClient/Response/DnssecValidationIssueCode.cs
@@ -1,0 +1,53 @@
+namespace Meziantou.Framework.DnsClient.Response;
+
+/// <summary>Specifies DNSSEC validation issue categories.</summary>
+public enum DnssecValidationIssueCode
+{
+    /// <summary>No issue was reported.</summary>
+    None,
+
+    /// <summary>The response did not contain a question to validate.</summary>
+    MissingQuestion,
+
+    /// <summary>The response was truncated.</summary>
+    TruncatedResponse,
+
+    /// <summary>The response does not contain the records required for validation.</summary>
+    MissingRecord,
+
+    /// <summary>No matching RRSIG record was found.</summary>
+    MissingRrsig,
+
+    /// <summary>No matching DNSKEY record was found.</summary>
+    MissingDnskey,
+
+    /// <summary>No matching DS record or trust anchor was found.</summary>
+    MissingDs,
+
+    /// <summary>A DS digest did not match its DNSKEY.</summary>
+    DigestMismatch,
+
+    /// <summary>The DNSSEC algorithm is not supported by this implementation.</summary>
+    UnsupportedAlgorithm,
+
+    /// <summary>The DS digest algorithm is not supported by this implementation.</summary>
+    UnsupportedDigest,
+
+    /// <summary>A signature is not valid yet.</summary>
+    SignatureNotYetValid,
+
+    /// <summary>A signature has expired.</summary>
+    SignatureExpired,
+
+    /// <summary>A cryptographic signature verification failed.</summary>
+    SignatureVerificationFailed,
+
+    /// <summary>An authenticated denial proof was missing or invalid.</summary>
+    InvalidDenialProof,
+
+    /// <summary>The DNSSEC trust chain could not be completed.</summary>
+    TrustChainIncomplete,
+
+    /// <summary>The response is not valid DNSSEC data.</summary>
+    InvalidData,
+}

--- a/src/Meziantou.Framework.DnsClient/Response/DnssecValidationResult.cs
+++ b/src/Meziantou.Framework.DnsClient/Response/DnssecValidationResult.cs
@@ -1,0 +1,19 @@
+namespace Meziantou.Framework.DnsClient.Response;
+
+/// <summary>Represents the result of local DNSSEC validation.</summary>
+public sealed class DnssecValidationResult
+{
+    internal static DnssecValidationResult NotValidatedResult { get; } = new(DnssecValidationStatus.NotValidated, []);
+
+    internal DnssecValidationResult(DnssecValidationStatus status, IReadOnlyList<DnssecValidationIssue> issues)
+    {
+        Status = status;
+        Issues = issues;
+    }
+
+    /// <summary>Gets the validation status.</summary>
+    public DnssecValidationStatus Status { get; }
+
+    /// <summary>Gets the validation issues.</summary>
+    public IReadOnlyList<DnssecValidationIssue> Issues { get; }
+}

--- a/src/Meziantou.Framework.DnsClient/Response/DnssecValidationStatus.cs
+++ b/src/Meziantou.Framework.DnsClient/Response/DnssecValidationStatus.cs
@@ -1,0 +1,20 @@
+namespace Meziantou.Framework.DnsClient.Response;
+
+/// <summary>Specifies the result of local DNSSEC validation.</summary>
+public enum DnssecValidationStatus
+{
+    /// <summary>The response was not locally validated.</summary>
+    NotValidated,
+
+    /// <summary>The response was validated successfully.</summary>
+    Secure,
+
+    /// <summary>The response belongs to an authenticated unsigned delegation.</summary>
+    Insecure,
+
+    /// <summary>The response failed DNSSEC validation.</summary>
+    Bogus,
+
+    /// <summary>The validator could not determine the DNSSEC status.</summary>
+    Indeterminate,
+}

--- a/src/Meziantou.Framework.DnsClient/readme.md
+++ b/src/Meziantou.Framework.DnsClient/readme.md
@@ -59,12 +59,10 @@ var response = await client.QueryAsync("münchen.de", DnsQueryType.A);
 
 ```c#
 using var client = new DnsClient("https://cloudflare-dns.com/dns-query", DnsClientProtocol.Https,
-    new DnsClientOptions { DnssecOk = true });
+    new DnsClientOptions { DnssecValidationMode = DnssecValidationMode.Local });
 
-var query = new DnsQueryMessage { RecursionDesired = true };
-query.Questions.Add(new DnsQuestion("cloudflare.com", DnsQueryType.A));
-query.EdnsOptions = new DnsEdnsOptions { UdpPayloadSize = 4096, DnssecOk = true };
-
-var response = await client.SendAsync(query);
-Console.WriteLine($"Authenticated: {response.Header.AuthenticatedData}");
+var response = await client.QueryAsync("cloudflare.com", DnsQueryType.A);
+Console.WriteLine($"Local DNSSEC validation: {response.DnssecValidationResult.Status}");
 ```
+
+`DnsResponseHeader.AuthenticatedData` exposes the upstream resolver's AD flag. Use `DnssecValidationMode.Local` when the client must validate the DNSSEC chain locally.

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsClientDnssecOptionsTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsClientDnssecOptionsTests.cs
@@ -1,0 +1,101 @@
+using Meziantou.Framework.DnsClient.Query;
+using Meziantou.Framework.DnsClient.Response;
+using Meziantou.Framework.DnsClient.Transport;
+
+namespace Meziantou.Framework.DnsClient.Tests;
+
+public sealed class DnsClientDnssecOptionsTests
+{
+    [Fact]
+    public void Constructor_WithLocalValidationAndEdnsDisabled_Throws()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => new DnsClient("1.1.1.1", DnsClientProtocol.Udp, new DnsClientOptions
+        {
+            EnableEdns = false,
+            DnssecValidationMode = DnssecValidationMode.Local,
+        }));
+
+        Assert.Contains("EDNS", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task QueryAsync_DefaultOptions_DoesNotSetDnssecValidationBits()
+    {
+        using var transport = new CapturingTransport();
+        using var client = new DnsClient(transport, DnsClientProtocol.Udp, options: null);
+
+        var response = await client.QueryAsync("example.com", DnsQueryType.A);
+
+        Assert.NotNull(transport.LastQuery);
+        Assert.False(IsCheckingDisabled(transport.LastQuery));
+        Assert.False(GetOptDnssecOk(transport.LastQuery));
+        Assert.Equal(DnssecValidationStatus.NotValidated, response.DnssecValidationResult.Status);
+    }
+
+    [Fact]
+    public async Task QueryAsync_LocalValidation_SetsDoAndCdBits()
+    {
+        using var transport = new CapturingTransport();
+        using var client = new DnsClient(transport, DnsClientProtocol.Udp, new DnsClientOptions
+        {
+            DnssecValidationMode = DnssecValidationMode.Local,
+        });
+
+        await client.QueryAsync("example.com", DnsQueryType.A);
+
+        Assert.NotNull(transport.LastQuery);
+        Assert.True(IsCheckingDisabled(transport.LastQuery));
+        Assert.True(GetOptDnssecOk(transport.LastQuery));
+    }
+
+    private static bool IsCheckingDisabled(byte[] query)
+    {
+        var flags = (query[2] << 8) | query[3];
+        return (flags & 0x0010) != 0;
+    }
+
+    private static bool GetOptDnssecOk(byte[] query)
+    {
+        var position = 12;
+        while (query[position] != 0)
+        {
+            position += query[position] + 1;
+        }
+
+        position += 1 + 2 + 2;
+        Assert.Equal(0, query[position]);
+        Assert.Equal(0, query[position + 1]);
+        Assert.Equal((byte)DnsQueryType.OPT, query[position + 2]);
+
+        var flags = (query[position + 7] << 8) | query[position + 8];
+        return (flags & 0x8000) != 0;
+    }
+
+    private sealed class CapturingTransport : IDnsTransport
+    {
+        public byte[] LastQuery { get; private set; } = [];
+
+        public Task<byte[]> SendAsync(byte[] query, CancellationToken cancellationToken)
+        {
+            LastQuery = query;
+            return Task.FromResult(CreateEmptyResponse(query));
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private static byte[] CreateEmptyResponse(byte[] query)
+        {
+            return
+            [
+                query[0], query[1],
+                0x81, 0x80,
+                0x00, 0x00,
+                0x00, 0x00,
+                0x00, 0x00,
+                0x00, 0x00,
+            ];
+        }
+    }
+}

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsClientIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsClientIntegrationTests.cs
@@ -258,6 +258,21 @@ public sealed class DnsClientIntegrationTests
     }
 
     [Fact]
+    public async Task Query_DNSSEC_LocalValidation()
+    {
+        using var client = new DnsClient(CloudflareDoH, DnsClientProtocol.Https, new DnsClientOptions
+        {
+            DnssecValidationMode = DnssecValidationMode.Local,
+            Timeout = TimeSpan.FromSeconds(20),
+        });
+
+        var response = await QueryWithRetryAsync(client, "cloudflare.com", DnsQueryType.A);
+
+        Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
+        Assert.Equal(DnssecValidationStatus.Secure, response.DnssecValidationResult.Status);
+    }
+
+    [Fact]
     public async Task Query_DNSKEY_Record()
     {
         using var client = new DnsClient(CloudflareDoH, DnsClientProtocol.Https, new DnsClientOptions

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
@@ -130,6 +130,35 @@ public sealed class DnsWireFormatTests
     }
 
     [Fact]
+    public void DecodeResponse_OptRecord_PopulatesEdnsMetadata()
+    {
+        var writer = new DnsWireWriter(512);
+
+        writer.WriteUInt16(0x1234);
+        writer.WriteUInt16(0x8180);
+        writer.WriteUInt16(0);
+        writer.WriteUInt16(0);
+        writer.WriteUInt16(0);
+        writer.WriteUInt16(1);
+
+        writer.WriteByte(0);
+        writer.WriteUInt16((ushort)DnsQueryType.OPT);
+        writer.WriteUInt16(1232);
+        writer.WriteByte(1);
+        writer.WriteByte(0);
+        writer.WriteUInt16(0x8000);
+        writer.WriteUInt16(0);
+
+        var response = DnsMessageEncoder.DecodeResponse(writer.ToArray());
+        var opt = Assert.IsType<Response.Records.DnsOptRecord>(Assert.Single(response.AdditionalRecords));
+
+        Assert.Equal(1232, opt.UdpPayloadSize);
+        Assert.Equal(1, opt.ExtendedRCode);
+        Assert.Equal(0, opt.EdnsVersion);
+        Assert.True(opt.DnssecOk);
+    }
+
+    [Fact]
     public void DecodeResponse_BasicResponse()
     {
         // Craft a minimal DNS response with 1 A record answer

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
@@ -159,6 +159,24 @@ public sealed class DnsWireFormatTests
     }
 
     [Fact]
+    public void DecodeResponse_Default_DoesNotPreserveRawRecordData()
+    {
+        var response = DnsMessageEncoder.DecodeResponse(CreateResponseWithARecord());
+        var record = Assert.Single(response.Answers);
+
+        Assert.Empty(record.RawData);
+    }
+
+    [Fact]
+    public void DecodeResponse_WhenRequested_PreservesRawRecordData()
+    {
+        var response = DnsMessageEncoder.DecodeResponse(CreateResponseWithARecord(), preserveRawRecordData: true);
+        var record = Assert.Single(response.Answers);
+
+        Assert.Equal([1, 2, 3, 4], record.RawData);
+    }
+
+    [Fact]
     public void DecodeResponse_BasicResponse()
     {
         // Craft a minimal DNS response with 1 A record answer
@@ -200,6 +218,31 @@ public sealed class DnsWireFormatTests
         Assert.Equal(System.Net.IPAddress.Parse("1.2.3.4"), aRecord.Address);
         Assert.Equal("example.com", aRecord.Name);
         Assert.Equal((uint)300, aRecord.TimeToLive);
+    }
+
+    private static byte[] CreateResponseWithARecord()
+    {
+        var writer = new DnsWireWriter(512);
+
+        writer.WriteUInt16(0x1234);
+        writer.WriteUInt16(0x8180);
+        writer.WriteUInt16(1);
+        writer.WriteUInt16(1);
+        writer.WriteUInt16(0);
+        writer.WriteUInt16(0);
+
+        writer.WriteDomainName("example.com");
+        writer.WriteUInt16(1);
+        writer.WriteUInt16(1);
+
+        writer.WriteDomainName("example.com");
+        writer.WriteUInt16(1);
+        writer.WriteUInt16(1);
+        writer.WriteUInt32(300);
+        writer.WriteUInt16(4);
+        writer.WriteBytes([1, 2, 3, 4]);
+
+        return writer.ToArray();
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnssecValidatorTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnssecValidatorTests.cs
@@ -1,0 +1,414 @@
+using System.Net;
+using System.Security.Cryptography;
+using Meziantou.Framework.DnsClient.Internal;
+using Meziantou.Framework.DnsClient.Query;
+using Meziantou.Framework.DnsClient.Response;
+using Meziantou.Framework.DnsClient.Response.Records;
+
+namespace Meziantou.Framework.DnsClient.Tests;
+
+public sealed class DnssecValidatorTests
+{
+    [Fact]
+    public async Task ValidateAsync_SecurePositiveA()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.PositiveAResponse);
+
+        Assert.Equal(DnssecValidationStatus.Secure, result.Status);
+        Assert.Empty(result.Issues);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_SecureCnameAndA()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.CnameResponse);
+
+        Assert.Equal(DnssecValidationStatus.Secure, result.Status);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_SecureNxDomain()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.NxDomainResponse);
+
+        Assert.Equal(DnssecValidationStatus.Secure, result.Status);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_SecureNoData()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.NoDataResponse);
+
+        Assert.Equal(DnssecValidationStatus.Secure, result.Status);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_InsecureUnsignedDelegation()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.InsecureUnsignedResponse);
+
+        Assert.Equal(DnssecValidationStatus.Insecure, result.Status);
+        Assert.Contains(result.Issues, issue => issue.Code is DnssecValidationIssueCode.MissingDs);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_BogusExpiredSignature()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.ExpiredSignatureResponse);
+
+        Assert.Equal(DnssecValidationStatus.Bogus, result.Status);
+        Assert.Contains(result.Issues, issue => issue.Code is DnssecValidationIssueCode.SignatureExpired);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_BogusDsMismatch()
+    {
+        var fixture = DnssecTestFixture.Create(dsMismatch: true);
+        var result = await fixture.ValidateAsync(fixture.PositiveAResponse);
+
+        Assert.Equal(DnssecValidationStatus.Bogus, result.Status);
+        Assert.Contains(result.Issues, issue => issue.Code is DnssecValidationIssueCode.DigestMismatch);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_UnsupportedAlgorithm()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.UnsupportedAlgorithmResponse);
+
+        Assert.Equal(DnssecValidationStatus.Indeterminate, result.Status);
+        Assert.Contains(result.Issues, issue => issue.Code is DnssecValidationIssueCode.UnsupportedAlgorithm);
+    }
+
+    [Fact]
+    public void ComputeKeyTag_AndDsDigest_ForIanaRootKsk2017()
+    {
+        var key = CreateRecord(
+            new DnsDnskeyRecord
+            {
+                Flags = 257,
+                Protocol = 3,
+                Algorithm = 8,
+                PublicKey = Convert.FromBase64String("AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU="),
+            },
+            ".",
+            DnsQueryType.DNSKEY);
+
+        Assert.Equal(20326, DnssecCanonicalizer.ComputeKeyTag(key));
+        Assert.Equal("E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D", Convert.ToHexString(DnssecCanonicalizer.ComputeDigest(".", key, digestType: 2)));
+    }
+
+    [Fact]
+    public void GetSignedData_UsesWildcardOwnerWhenRrsigLabelsAreLowerThanOwnerLabels()
+    {
+        var record = CreateRecord(new DnsARecord { Address = IPAddress.Parse("192.0.2.10") }, "www.example.com", DnsQueryType.A);
+        var signature = CreateRecord(
+            new DnsRrsigRecord
+            {
+                TypeCovered = DnsQueryType.A,
+                Algorithm = 8,
+                Labels = 2,
+                OriginalTtl = 3600,
+                SignatureExpiration = 1,
+                SignatureInception = 0,
+                KeyTag = 1,
+                SignerName = "example.com",
+            },
+            "www.example.com",
+            DnsQueryType.RRSIG);
+
+        var signedData = DnssecCanonicalizer.GetSignedData([record], signature);
+
+        Assert.Contains((byte)'*', signedData);
+    }
+
+    private sealed class DnssecTestFixture
+    {
+        private DnssecTestFixture(
+            IReadOnlyDictionary<QueryKey, DnsResponseMessage> responses,
+            IReadOnlyList<DnssecTrustAnchor> trustAnchors,
+            TimeProvider timeProvider,
+            DnsResponseMessage positiveAResponse,
+            DnsResponseMessage cnameResponse,
+            DnsResponseMessage nxDomainResponse,
+            DnsResponseMessage noDataResponse,
+            DnsResponseMessage insecureUnsignedResponse,
+            DnsResponseMessage expiredSignatureResponse,
+            DnsResponseMessage unsupportedAlgorithmResponse)
+        {
+            Responses = responses;
+            TrustAnchors = trustAnchors;
+            TimeProvider = timeProvider;
+            PositiveAResponse = positiveAResponse;
+            CnameResponse = cnameResponse;
+            NxDomainResponse = nxDomainResponse;
+            NoDataResponse = noDataResponse;
+            InsecureUnsignedResponse = insecureUnsignedResponse;
+            ExpiredSignatureResponse = expiredSignatureResponse;
+            UnsupportedAlgorithmResponse = unsupportedAlgorithmResponse;
+        }
+
+        private IReadOnlyDictionary<QueryKey, DnsResponseMessage> Responses { get; }
+
+        private IReadOnlyList<DnssecTrustAnchor> TrustAnchors { get; }
+
+        private TimeProvider TimeProvider { get; }
+
+        public DnsResponseMessage PositiveAResponse { get; }
+
+        public DnsResponseMessage CnameResponse { get; }
+
+        public DnsResponseMessage NxDomainResponse { get; }
+
+        public DnsResponseMessage NoDataResponse { get; }
+
+        public DnsResponseMessage InsecureUnsignedResponse { get; }
+
+        public DnsResponseMessage ExpiredSignatureResponse { get; }
+
+        public DnsResponseMessage UnsupportedAlgorithmResponse { get; }
+
+        public static DnssecTestFixture Create(bool dsMismatch = false)
+        {
+            var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var timeProvider = new FixedTimeProvider(now);
+
+            using var rootRsa = RSA.Create(2048);
+            using var comRsa = RSA.Create(2048);
+            using var exampleRsa = RSA.Create(2048);
+
+            var rootKey = CreateDnskey(".", rootRsa);
+            var comKey = CreateDnskey("com", comRsa);
+            var exampleKey = CreateDnskey("example.com", exampleRsa);
+            var trustAnchor = new DnssecTrustAnchor(".", DnssecCanonicalizer.ComputeKeyTag(rootKey), rootKey.Algorithm, 2, DnssecCanonicalizer.ComputeDigest(".", rootKey, digestType: 2));
+
+            var responses = new Dictionary<QueryKey, DnsResponseMessage>();
+            var rootDnskeySignature = CreateSignature([rootKey], DnsQueryType.DNSKEY, ".", rootKey, rootRsa, now);
+            responses.Add(new(".", DnsQueryType.DNSKEY), CreateMessage(".", DnsQueryType.DNSKEY, [rootKey, rootDnskeySignature]));
+
+            var comDs = CreateDs("com", comKey);
+            var comDsSignature = CreateSignature([comDs], DnsQueryType.DS, ".", rootKey, rootRsa, now);
+            responses.Add(new("com", DnsQueryType.DS), CreateMessage("com", DnsQueryType.DS, [comDs, comDsSignature]));
+
+            var comDnskeySignature = CreateSignature([comKey], DnsQueryType.DNSKEY, "com", comKey, comRsa, now);
+            responses.Add(new("com", DnsQueryType.DNSKEY), CreateMessage("com", DnsQueryType.DNSKEY, [comKey, comDnskeySignature]));
+
+            var exampleDs = CreateDs("example.com", exampleKey);
+            if (dsMismatch)
+            {
+                exampleDs.Digest = SHA256.HashData("wrong digest"u8);
+            }
+
+            var exampleDsSignature = CreateSignature([exampleDs], DnsQueryType.DS, "com", comKey, comRsa, now);
+            responses.Add(new("example.com", DnsQueryType.DS), CreateMessage("example.com", DnsQueryType.DS, [exampleDs, exampleDsSignature]));
+
+            var exampleDnskeySignature = CreateSignature([exampleKey], DnsQueryType.DNSKEY, "example.com", exampleKey, exampleRsa, now);
+            responses.Add(new("example.com", DnsQueryType.DNSKEY), CreateMessage("example.com", DnsQueryType.DNSKEY, [exampleKey, exampleDnskeySignature]));
+
+            var unsignedDsDenial = CreateNsec("unsigned.com", "z.com", [DnsQueryType.NS, DnsQueryType.NSEC, DnsQueryType.RRSIG]);
+            var unsignedDsDenialSignature = CreateSignature([unsignedDsDenial], DnsQueryType.NSEC, "com", comKey, comRsa, now);
+            responses.Add(new("unsigned.com", DnsQueryType.DS), CreateMessage("unsigned.com", DnsQueryType.DS, [], [unsignedDsDenial, unsignedDsDenialSignature]));
+
+            var a = CreateRecord(new DnsARecord { Address = IPAddress.Parse("192.0.2.1") }, "www.example.com", DnsQueryType.A);
+            var aSignature = CreateSignature([a], DnsQueryType.A, "example.com", exampleKey, exampleRsa, now);
+            var positiveAResponse = CreateMessage("www.example.com", DnsQueryType.A, [a, aSignature]);
+
+            var alias = CreateRecord(new DnsCnameRecord { CanonicalName = "www.example.com" }, "alias.example.com", DnsQueryType.CNAME);
+            var aliasSignature = CreateSignature([alias], DnsQueryType.CNAME, "example.com", exampleKey, exampleRsa, now);
+            var cnameResponse = CreateMessage("alias.example.com", DnsQueryType.A, [alias, aliasSignature, a, aSignature]);
+
+            var nxDomainNsec = CreateNsec("a.example.com", "z.example.com", [DnsQueryType.NSEC, DnsQueryType.RRSIG]);
+            var nxDomainNsecSignature = CreateSignature([nxDomainNsec], DnsQueryType.NSEC, "example.com", exampleKey, exampleRsa, now);
+            var nxDomainResponse = CreateMessage("missing.example.com", DnsQueryType.A, [], [nxDomainNsec, nxDomainNsecSignature], DnsResponseCode.NameError);
+
+            var noDataNsec = CreateNsec("www.example.com", "z.example.com", [DnsQueryType.A, DnsQueryType.NSEC, DnsQueryType.RRSIG]);
+            var noDataNsecSignature = CreateSignature([noDataNsec], DnsQueryType.NSEC, "example.com", exampleKey, exampleRsa, now);
+            var noDataResponse = CreateMessage("www.example.com", DnsQueryType.MX, [], [noDataNsec, noDataNsecSignature]);
+
+            var unsignedA = CreateRecord(new DnsARecord { Address = IPAddress.Parse("192.0.2.200") }, "unsigned.com", DnsQueryType.A);
+            var insecureUnsignedResponse = CreateMessage("unsigned.com", DnsQueryType.A, [unsignedA]);
+
+            var expiredSignature = CreateSignature([a], DnsQueryType.A, "example.com", exampleKey, exampleRsa, now, TimeSpan.FromHours(-3), TimeSpan.FromHours(-2));
+            var expiredSignatureResponse = CreateMessage("www.example.com", DnsQueryType.A, [a, expiredSignature]);
+
+            var unsupportedSignature = CreateUnsupportedSignature(a, exampleKey, now);
+            var unsupportedAlgorithmResponse = CreateMessage("www.example.com", DnsQueryType.A, [a, unsupportedSignature]);
+
+            return new(responses, [trustAnchor], timeProvider, positiveAResponse, cnameResponse, nxDomainResponse, noDataResponse, insecureUnsignedResponse, expiredSignatureResponse, unsupportedAlgorithmResponse);
+        }
+
+        public async Task<DnssecValidationResult> ValidateAsync(DnsResponseMessage response)
+        {
+            var validator = new DnssecValidator(ResolveAsync, TrustAnchors, TimeProvider);
+            return await validator.ValidateAsync(response, CancellationToken.None);
+        }
+
+        private Task<DnsResponseMessage> ResolveAsync(DnsQueryMessage query, CancellationToken cancellationToken)
+        {
+            var question = query.Questions[0];
+            var key = new QueryKey(DnssecCanonicalizer.ToDisplayName(question.Name), question.Type);
+            return Task.FromResult(Responses[key]);
+        }
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _utcNow;
+
+        public FixedTimeProvider(DateTimeOffset utcNow)
+        {
+            _utcNow = utcNow;
+        }
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            return _utcNow;
+        }
+    }
+
+    private readonly record struct QueryKey(string Name, DnsQueryType Type);
+
+    private static DnsDnskeyRecord CreateDnskey(string name, RSA rsa)
+    {
+        return CreateRecord(
+            new DnsDnskeyRecord
+            {
+                Flags = 257,
+                Protocol = 3,
+                Algorithm = 8,
+                PublicKey = ExportDnskeyPublicKey(rsa),
+            },
+            name,
+            DnsQueryType.DNSKEY);
+    }
+
+    private static byte[] ExportDnskeyPublicKey(RSA rsa)
+    {
+        var parameters = rsa.ExportParameters(includePrivateParameters: false);
+        var exponent = parameters.Exponent!;
+        var modulus = parameters.Modulus!;
+        var lengthPrefix = exponent.Length < 256
+            ? new[] { (byte)exponent.Length }
+            : [0, (byte)(exponent.Length >> 8), (byte)exponent.Length];
+
+        return [.. lengthPrefix, .. exponent, .. modulus];
+    }
+
+    private static DnsDsRecord CreateDs(string name, DnsDnskeyRecord key)
+    {
+        return CreateRecord(
+            new DnsDsRecord
+            {
+                KeyTag = DnssecCanonicalizer.ComputeKeyTag(key),
+                Algorithm = key.Algorithm,
+                DigestType = 2,
+                Digest = DnssecCanonicalizer.ComputeDigest(name, key, digestType: 2),
+            },
+            name,
+            DnsQueryType.DS);
+    }
+
+    private static DnsNsecRecord CreateNsec(string name, string nextName, IReadOnlyList<DnsQueryType> types)
+    {
+        return CreateRecord(
+            new DnsNsecRecord
+            {
+                NextDomainName = nextName,
+                TypeBitMaps = types,
+            },
+            name,
+            DnsQueryType.NSEC);
+    }
+
+    private static DnsRrsigRecord CreateSignature(
+        IReadOnlyList<DnsRecord> rrset,
+        DnsQueryType typeCovered,
+        string signerName,
+        DnsDnskeyRecord signerKey,
+        RSA signerRsa,
+        DateTimeOffset now,
+        TimeSpan? inceptionOffset = null,
+        TimeSpan? expirationOffset = null)
+    {
+        var signature = CreateRecord(
+            new DnsRrsigRecord
+            {
+                TypeCovered = typeCovered,
+                Algorithm = signerKey.Algorithm,
+                Labels = (byte)DnssecCanonicalizer.CountLabels(rrset[0].Name),
+                OriginalTtl = rrset[0].TimeToLive,
+                SignatureExpiration = checked((uint)now.Add(expirationOffset ?? TimeSpan.FromHours(1)).ToUnixTimeSeconds()),
+                SignatureInception = checked((uint)now.Add(inceptionOffset ?? TimeSpan.FromHours(-1)).ToUnixTimeSeconds()),
+                KeyTag = DnssecCanonicalizer.ComputeKeyTag(signerKey),
+                SignerName = signerName,
+            },
+            rrset[0].Name,
+            DnsQueryType.RRSIG);
+
+        signature.Signature = signerRsa.SignData(DnssecCanonicalizer.GetSignedData(rrset, signature), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return signature;
+    }
+
+    private static DnsRrsigRecord CreateUnsupportedSignature(DnsRecord record, DnsDnskeyRecord signerKey, DateTimeOffset now)
+    {
+        return CreateRecord(
+            new DnsRrsigRecord
+            {
+                TypeCovered = record.RecordType,
+                Algorithm = 15,
+                Labels = (byte)DnssecCanonicalizer.CountLabels(record.Name),
+                OriginalTtl = record.TimeToLive,
+                SignatureExpiration = checked((uint)now.AddHours(1).ToUnixTimeSeconds()),
+                SignatureInception = checked((uint)now.AddHours(-1).ToUnixTimeSeconds()),
+                KeyTag = DnssecCanonicalizer.ComputeKeyTag(signerKey),
+                SignerName = "example.com",
+                Signature = [1, 2, 3],
+            },
+            record.Name,
+            DnsQueryType.RRSIG);
+    }
+
+    private static DnsResponseMessage CreateMessage(
+        string questionName,
+        DnsQueryType questionType,
+        IReadOnlyList<DnsRecord> answers,
+        IReadOnlyList<DnsRecord>? authorities = null,
+        DnsResponseCode responseCode = DnsResponseCode.NoError)
+    {
+        authorities ??= [];
+        var header = new DnsResponseHeader
+        {
+            Id = 1,
+            IsResponse = true,
+            RecursionDesired = true,
+            RecursionAvailable = true,
+            ResponseCode = responseCode,
+            QuestionCount = 1,
+            AnswerCount = (ushort)answers.Count,
+            AuthorityCount = (ushort)authorities.Count,
+        };
+
+        return new(header)
+        {
+            Questions = [new DnsQuestion(questionName, questionType)],
+            Answers = answers,
+            Authorities = authorities,
+        };
+    }
+
+    private static T CreateRecord<T>(T record, string name, DnsQueryType type)
+        where T : DnsRecord
+    {
+        record.Name = DnssecCanonicalizer.ToDisplayName(name);
+        record.RecordType = type;
+        record.RecordClass = DnsQueryClass.IN;
+        record.TimeToLive = 3600;
+        return record;
+    }
+}


### PR DESCRIPTION
## Summary
- Add DNSSEC validation primitives, trust anchors, and validation result/issue types.
- Extend `DnsClient` and wire parsing/encoding to carry DNSSEC-related records and validation metadata.
- Update documentation and add tests covering DNSSEC options, wire format handling, validator behavior, and integration scenarios.

## Testing
- Added and updated unit tests for DNSSEC option handling, validator logic, and DNS wire format parsing.
- Ran relevant integration coverage for DNS client behavior with DNSSEC-enabled responses.