### PR TITLE
Add DNSSEC validation configuration to DnsProxy

### DIFF
--- a/src/Meziantou.DnsProxy/Diagnostics/DiagnosticsPageRenderer.cs
+++ b/src/Meziantou.DnsProxy/Diagnostics/DiagnosticsPageRenderer.cs
@@ -38,6 +38,7 @@ internal static class DiagnosticsPageRenderer
         stringBuilder.Append("<li><span class='mono'>DnsOverQuicPort</span>: ").Append(HtmlEncode(options.DnsOverQuicPort.ToString(System.Globalization.CultureInfo.InvariantCulture))).Append("</li>");
         stringBuilder.Append("<li><span class='mono'>CertificatePath</span>: ").Append(HtmlEncode(options.CertificatePath ?? string.Empty)).Append("</li>");
         stringBuilder.Append("<li><span class='mono'>FilterRefreshInterval</span>: ").Append(HtmlEncode(options.FilterRefreshInterval.ToString())).Append("</li>");
+        stringBuilder.Append("<li><span class='mono'>DnssecValidationMode</span>: ").Append(HtmlEncode(options.DnssecValidationMode.ToString())).Append("</li>");
         stringBuilder.Append("<li><span class='mono'>DiagnosticsHistoryCapacity</span>: ").Append(HtmlEncode(options.DiagnosticsHistoryCapacity.ToString(System.Globalization.CultureInfo.InvariantCulture))).Append("</li>");
         stringBuilder.Append("<li><span class='mono'>Upstreams</span>: ").Append(HtmlEncode(string.Join(", ", upstreams.Select(u => u.DisplayName)))).Append("</li>");
         stringBuilder.Append("<li><span class='mono'>FilterLists</span>: ").Append(HtmlEncode(string.Join(", ", options.Filters.Select(f => f.Url)))).Append("</li>");

--- a/src/Meziantou.DnsProxy/DnsProxyOptions.cs
+++ b/src/Meziantou.DnsProxy/DnsProxyOptions.cs
@@ -1,3 +1,5 @@
+using Meziantou.Framework.DnsClient;
+
 namespace Meziantou.DnsProxy;
 
 internal sealed class DnsProxyOptions
@@ -25,6 +27,8 @@ internal sealed class DnsProxyOptions
     public int DiagnosticsHistoryCapacity { get; set; } = 10_000;
 
     public TimeSpan FilterRefreshInterval { get; set; } = TimeSpan.FromMinutes(30);
+
+    public DnssecValidationMode DnssecValidationMode { get; set; }
 
     public List<UpstreamServerOption> Upstreams { get; set; } =
     [

--- a/src/Meziantou.DnsProxy/Forwarding/UpstreamDnsClientFactory.cs
+++ b/src/Meziantou.DnsProxy/Forwarding/UpstreamDnsClientFactory.cs
@@ -11,7 +11,8 @@ internal sealed class UpstreamDnsClientFactory : IDisposable
     public UpstreamDnsClientFactory(IOptions<DnsProxyOptions> options, ILogger<UpstreamDnsClientFactory> logger)
     {
         var upstreams = new List<UpstreamDnsClientInfo>();
-        foreach (var upstream in options.Value.Upstreams)
+        var dnsProxyOptions = options.Value;
+        foreach (var upstream in dnsProxyOptions.Upstreams)
         {
             if (string.IsNullOrWhiteSpace(upstream.Endpoint))
             {
@@ -28,14 +29,14 @@ internal sealed class UpstreamDnsClientFactory : IDisposable
             try
             {
                 dnsClient = protocol == DnsClientProtocol.Https
-                    ? new DnsClient(upstream.Endpoint, protocol, new DnsClientOptions { HttpHandler = httpHandler })
-                    : new DnsClient(upstream.Endpoint, protocol);
+                    ? new DnsClient(upstream.Endpoint, protocol, CreateDnsClientOptions(dnsProxyOptions, httpHandler))
+                    : new DnsClient(upstream.Endpoint, protocol, CreateDnsClientOptions(dnsProxyOptions, httpHandler: null));
             }
             catch (PlatformNotSupportedException ex) when (protocol == DnsClientProtocol.Quic)
             {
                 httpHandler?.Dispose();
                 httpHandler = CreateHttpHandler(useHttp3: false);
-                dnsClient = new DnsClient($"https://{upstream.Endpoint}/dns-query", DnsClientProtocol.Https, new DnsClientOptions { HttpHandler = httpHandler });
+                dnsClient = new DnsClient($"https://{upstream.Endpoint}/dns-query", DnsClientProtocol.Https, CreateDnsClientOptions(dnsProxyOptions, httpHandler));
                 effectiveProtocol = DnsClientProtocol.Https;
                 logger.LogWarning(ex, "DNS over QUIC is not supported on this platform for {Upstream}. Falling back to DNS over HTTPS.", upstream.Endpoint);
             }
@@ -77,5 +78,14 @@ internal sealed class UpstreamDnsClientFactory : IDisposable
         }
 
         return handler;
+    }
+
+    private static DnsClientOptions CreateDnsClientOptions(DnsProxyOptions options, HttpMessageHandler? httpHandler)
+    {
+        return new DnsClientOptions
+        {
+            DnssecValidationMode = options.DnssecValidationMode,
+            HttpHandler = httpHandler,
+        };
     }
 }

--- a/src/Meziantou.DnsProxy/appsettings.json
+++ b/src/Meziantou.DnsProxy/appsettings.json
@@ -17,6 +17,7 @@
     "CertificatePassword": "",
     "DiagnosticsHistoryCapacity": 10000,
     "FilterRefreshInterval": "00:30:00",
+    "DnssecValidationMode": "None",
     "Upstreams": [
       {
         "Name": "Cloudflare",

--- a/src/Meziantou.DnsProxy/readme.md
+++ b/src/Meziantou.DnsProxy/readme.md
@@ -18,6 +18,7 @@ Default configuration:
 - DNS over TLS listener: disabled by default (`DnsOverTlsPort=0`)
 - DNS over QUIC listener: disabled by default (`DnsOverQuicPort=0`)
 - Filter list refresh interval: `00:30:00`
+- DNSSEC validation: disabled by default (`DnssecValidationMode=None`; use `Local` to enable local validation)
 - Default filter lists:
   - AdGuard DNS filter (`https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt`)
   - StevenBlack hosts (`https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts`)
@@ -51,3 +52,4 @@ Parallel instances:
   - `DnsProxy__DnsPort`
   - `DnsProxy__HttpPort`
   - `DnsProxy__FilterRefreshInterval`
+  - `DnsProxy__DnssecValidationMode`

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
@@ -3,6 +3,7 @@ using Meziantou.DnsProxy.Diagnostics;
 using Meziantou.DnsProxy.Filtering;
 using Meziantou.DnsProxy.Forwarding;
 using Meziantou.DnsProxy.History;
+using Meziantou.Framework.DnsClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -24,6 +25,7 @@ public sealed class DiagnosticsPageRendererTests
             DnsOverQuicPort = 8853,
             CertificatePath = "certs/proxy.pfx",
             FilterRefreshInterval = TimeSpan.FromMinutes(5),
+            DnssecValidationMode = DnssecValidationMode.Local,
             Filters = [],
             Rewrites = [],
             Upstreams =
@@ -72,6 +74,7 @@ public sealed class DiagnosticsPageRendererTests
         Assert.Contains("<span class='mono'>DnsOverQuicPort</span>: 8853", html, StringComparison.Ordinal);
         Assert.Contains("<span class='mono'>CertificatePath</span>: certs/proxy.pfx", html, StringComparison.Ordinal);
         Assert.Contains("<span class='mono'>FilterRefreshInterval</span>: 00:05:00", html, StringComparison.Ordinal);
+        Assert.Contains("<span class='mono'>DnssecValidationMode</span>: Local", html, StringComparison.Ordinal);
         Assert.Contains("example.com A 1.2.3.4", html, StringComparison.Ordinal);
     }
 }

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyOptionsTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyOptionsTests.cs
@@ -1,5 +1,6 @@
 using Meziantou.DnsProxy;
 using Meziantou.DnsProxy.History;
+using Meziantou.Framework.DnsClient;
 using Microsoft.Extensions.Options;
 
 namespace Meziantou.Framework.DnsProxy.Tests;
@@ -22,6 +23,7 @@ public sealed class DnsProxyOptionsTests
         Assert.False(options.HasSecureServerListenerConfigured);
         Assert.Equal(10_000, options.DiagnosticsHistoryCapacity);
         Assert.Equal(TimeSpan.FromMinutes(30), options.FilterRefreshInterval);
+        Assert.Equal(DnssecValidationMode.None, options.DnssecValidationMode);
         Assert.Collection(options.Filters,
             item =>
             {

--- a/tests/Meziantou.Framework.DnsProxy.Tests/UpstreamDnsClientFactoryTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/UpstreamDnsClientFactoryTests.cs
@@ -1,6 +1,8 @@
+using System.Reflection;
 using TestUtilities;
 using Meziantou.DnsProxy;
 using Meziantou.DnsProxy.Forwarding;
+using Meziantou.Framework.DnsClient;
 using Meziantou.Framework.DnsClient.Query;
 using Meziantou.Framework.DnsClient.Response;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -13,6 +15,8 @@ namespace Meziantou.Framework.DnsProxy.Tests;
 
 public sealed class UpstreamDnsClientFactoryTests
 {
+    private static readonly FieldInfo DnsClientOptionsField = typeof(DnsClientType).GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
     [Fact]
     public void UpstreamDnsClientFactory_UsesConfiguredUpstreams()
     {
@@ -36,6 +40,31 @@ public sealed class UpstreamDnsClientFactoryTests
         var upstream = Assert.Single(upstreams);
         Assert.Equal("Custom (https://1.1.1.1/dns-query)", upstream.DisplayName);
         Assert.Equal("https://1.1.1.1/dns-query", upstream.Endpoint);
+    }
+
+    [Fact]
+    public void UpstreamDnsClientFactory_UsesConfiguredDnssecValidationMode()
+    {
+        var options = Options.Create(new DnsProxyOptions
+        {
+            DnssecValidationMode = DnssecValidationMode.Local,
+            Upstreams =
+            [
+                new UpstreamServerOption
+                {
+                    Name = "Custom",
+                    Endpoint = "https://1.1.1.1/dns-query",
+                    Protocol = "Https",
+                    UseHttp3 = false,
+                },
+            ],
+        });
+
+        using var factory = new UpstreamDnsClientFactory(options, NullLogger<UpstreamDnsClientFactory>.Instance);
+        var upstream = Assert.Single(factory.GetUpstreams());
+        var clientOptions = Assert.IsType<DnsClientOptions>(DnsClientOptionsField.GetValue(upstream.Client));
+
+        Assert.Equal(DnssecValidationMode.Local, clientOptions.DnssecValidationMode);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- Add `DnssecValidationMode` to proxy options and default it to `None`
- Pass the configured DNSSEC validation mode into upstream DNS client creation for HTTPS and QUIC fallback paths
- Surface the new setting in diagnostics, config, and documentation
- Add tests covering the default option value, diagnostics output, and DNS client option wiring

## Testing
- Updated and reviewed unit tests covering the new configuration and diagnostics output
- Not run (not requested)