### PR TITLE
Add bootstrap DNS servers and URI-based upstream configuration

### DIFF
--- a/src/Meziantou.DnsProxy/DnsProxyOptions.cs
+++ b/src/Meziantou.DnsProxy/DnsProxyOptions.cs
@@ -30,11 +30,26 @@ internal sealed class DnsProxyOptions
 
     public DnssecValidationMode DnssecValidationMode { get; set; }
 
+    public List<string> BootstrapDnsServers { get; set; } =
+    [
+        "9.9.9.9",
+        "149.112.112.112",
+        "1.1.1.1",
+        "1.0.0.1",
+        "2620:fe::fe",
+        "2620:fe::9",
+        "2606:4700:4700::1111",
+        "2606:4700:4700::1001",
+    ];
+
     public List<UpstreamServerOption> Upstreams { get; set; } =
     [
-        new UpstreamServerOption { Name = "Cloudflare", Endpoint = "cloudflare-dns.com", Protocol = "Quic" },
-        new UpstreamServerOption { Name = "Quad9", Endpoint = "dns.quad9.net", Protocol = "Quic" },
-        new UpstreamServerOption { Name = "NextDNS", Endpoint = "dns.nextdns.io", Protocol = "Quic" },
+        new UpstreamServerOption { Name = "Cloudflare H3", Url = new("h3://cloudflare-dns.com/dns-query"), Priority = 0 },
+        new UpstreamServerOption { Name = "NextDNS DoQ", Url = new("quic://dns.nextdns.io"), Priority = 1 },
+        new UpstreamServerOption { Name = "Quad9 DoQ", Url = new("quic://dns.quad9.net"), Priority = 2 },
+        new UpstreamServerOption { Name = "Cloudflare DoH", Url = new("https://cloudflare-dns.com/dns-query"), Priority = 3 },
+        new UpstreamServerOption { Name = "NextDNS DoH", Url = new("https://dns.nextdns.io"), Priority = 4 },
+        new UpstreamServerOption { Name = "Quad9 DoH", Url = new("https://dns.quad9.net/dns-query"), Priority = 5 },
     ];
 
     public List<FilterListOption> Filters { get; set; } =

--- a/src/Meziantou.DnsProxy/Forwarding/UpstreamDnsClientFactory.cs
+++ b/src/Meziantou.DnsProxy/Forwarding/UpstreamDnsClientFactory.cs
@@ -1,6 +1,10 @@
 using Meziantou.Framework.DnsClient;
+using Meziantou.Framework.DnsClient.Query;
+using Meziantou.Framework.DnsClient.Response;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Net;
+using System.Net.Sockets;
 
 namespace Meziantou.DnsProxy.Forwarding;
 
@@ -12,43 +16,36 @@ internal sealed class UpstreamDnsClientFactory : IDisposable
     {
         var upstreams = new List<UpstreamDnsClientInfo>();
         var dnsProxyOptions = options.Value;
-        foreach (var upstream in dnsProxyOptions.Upstreams)
+        var serverAddressResolver = CreateBootstrapResolver(dnsProxyOptions);
+        foreach (var upstream in dnsProxyOptions.Upstreams.OrderBy(upstream => upstream.Priority))
         {
-            if (string.IsNullOrWhiteSpace(upstream.Endpoint))
+            if (upstream.Url is null)
             {
                 continue;
             }
 
-            var protocol = Enum.TryParse<DnsClientProtocol>(upstream.Protocol, ignoreCase: true, out var parsedProtocol)
-                ? parsedProtocol
-                : DnsClientProtocol.Https;
-            var displayName = string.IsNullOrWhiteSpace(upstream.Name) ? upstream.Endpoint : $"{upstream.Name} ({upstream.Endpoint})";
-            SocketsHttpHandler? httpHandler = protocol == DnsClientProtocol.Https ? CreateHttpHandler(upstream.UseHttp3) : null;
+            var protocol = GetProtocol(upstream.Url);
+            var endpoint = GetEndpoint(upstream.Url, protocol);
+            var displayName = string.IsNullOrWhiteSpace(upstream.Name) ? upstream.Url.OriginalString : $"{upstream.Name} ({upstream.Url.OriginalString})";
+            SocketsHttpHandler? httpHandler = protocol == DnsClientProtocol.Https ? CreateHttpHandler(upstream.Url.Scheme.Equals("h3", StringComparison.OrdinalIgnoreCase), serverAddressResolver) : null;
             DnsClient dnsClient;
             DnsClientProtocol effectiveProtocol = protocol;
+            var clientOptions = CreateDnsClientOptions(dnsProxyOptions, httpHandler, serverAddressResolver);
             try
             {
-                dnsClient = protocol == DnsClientProtocol.Https
-                    ? new DnsClient(upstream.Endpoint, protocol, CreateDnsClientOptions(dnsProxyOptions, httpHandler))
-                    : new DnsClient(upstream.Endpoint, protocol, CreateDnsClientOptions(dnsProxyOptions, httpHandler: null));
+                dnsClient = new DnsClient(endpoint, protocol, clientOptions);
             }
             catch (PlatformNotSupportedException ex) when (protocol == DnsClientProtocol.Quic)
             {
                 httpHandler?.Dispose();
-                httpHandler = CreateHttpHandler(useHttp3: false);
-                dnsClient = new DnsClient($"https://{upstream.Endpoint}/dns-query", DnsClientProtocol.Https, CreateDnsClientOptions(dnsProxyOptions, httpHandler));
+                httpHandler = CreateHttpHandler(useHttp3: false, serverAddressResolver);
+                endpoint = GetHttpsFallbackEndpoint(upstream.Url);
+                dnsClient = new DnsClient(endpoint, DnsClientProtocol.Https, CreateDnsClientOptions(dnsProxyOptions, httpHandler, serverAddressResolver));
                 effectiveProtocol = DnsClientProtocol.Https;
-                logger.LogWarning(ex, "DNS over QUIC is not supported on this platform for {Upstream}. Falling back to DNS over HTTPS.", upstream.Endpoint);
+                logger.LogWarning(ex, "DNS over QUIC is not supported on this platform for {Upstream}. Falling back to DNS over HTTPS.", upstream.Url);
             }
 
-            if (effectiveProtocol == DnsClientProtocol.Https && !upstream.Endpoint.StartsWith("http", StringComparison.OrdinalIgnoreCase))
-            {
-                upstreams.Add(new UpstreamDnsClientInfo(displayName, $"https://{upstream.Endpoint}/dns-query", dnsClient, httpHandler));
-            }
-            else
-            {
-                upstreams.Add(new UpstreamDnsClientInfo(displayName, upstream.Endpoint, dnsClient, httpHandler));
-            }
+            upstreams.Add(new UpstreamDnsClientInfo(displayName, endpoint, dnsClient, httpHandler));
         }
 
         _upstreams = upstreams;
@@ -64,9 +61,80 @@ internal sealed class UpstreamDnsClientFactory : IDisposable
         }
     }
 
-    private static SocketsHttpHandler CreateHttpHandler(bool useHttp3)
+    private static DnsClientProtocol GetProtocol(Uri url)
+    {
+        return url.Scheme.ToLowerInvariant() switch
+        {
+            "quic" => DnsClientProtocol.Quic,
+            "h3" or "https" => DnsClientProtocol.Https,
+            "tls" => DnsClientProtocol.Tls,
+            "tcp" => DnsClientProtocol.Tcp,
+            "udp" => DnsClientProtocol.Udp,
+            _ => DnsClientProtocol.Https,
+        };
+    }
+
+    private static string GetEndpoint(Uri url, DnsClientProtocol protocol)
+    {
+        if (protocol == DnsClientProtocol.Https)
+            return url.Scheme.Equals("h3", StringComparison.OrdinalIgnoreCase) ? ChangeScheme(url, "https").ToString() : url.ToString();
+
+        return url.IsDefaultPort ? url.Host : FormatHostAndPort(url.Host, url.Port);
+    }
+
+    private static string FormatHostAndPort(string host, int port)
+    {
+        return IPAddress.TryParse(host, out var address) && address.AddressFamily == AddressFamily.InterNetworkV6
+            ? $"[{host}]:{port}"
+            : $"{host}:{port}";
+    }
+
+    private static string GetHttpsFallbackEndpoint(Uri url)
+    {
+        return ChangeScheme(new UriBuilder(url) { Path = "/dns-query" }.Uri, "https").ToString();
+    }
+
+    private static Uri ChangeScheme(Uri url, string scheme)
+    {
+        var builder = new UriBuilder(url)
+        {
+            Scheme = scheme,
+        };
+
+        if (url.IsDefaultPort)
+        {
+            builder.Port = -1;
+        }
+
+        return builder.Uri;
+    }
+
+    private static SocketsHttpHandler CreateHttpHandler(bool useHttp3, Func<string, IReadOnlyList<IPAddress>>? serverAddressResolver)
     {
         var handler = new SocketsHttpHandler();
+        if (serverAddressResolver is not null)
+        {
+            handler.ConnectCallback = async (context, cancellationToken) =>
+            {
+                var addresses = serverAddressResolver(context.DnsEndPoint.Host);
+                foreach (var address in addresses)
+                {
+                    var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+                    try
+                    {
+                        await socket.ConnectAsync(address, context.DnsEndPoint.Port, cancellationToken).ConfigureAwait(false);
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+                    catch
+                    {
+                        socket.Dispose();
+                    }
+                }
+
+                throw new SocketException((int)SocketError.HostNotFound);
+            };
+        }
+
         if (useHttp3)
         {
             handler.EnableMultipleHttp2Connections = true;
@@ -80,12 +148,60 @@ internal sealed class UpstreamDnsClientFactory : IDisposable
         return handler;
     }
 
-    private static DnsClientOptions CreateDnsClientOptions(DnsProxyOptions options, HttpMessageHandler? httpHandler)
+    private static DnsClientOptions CreateDnsClientOptions(DnsProxyOptions options, HttpMessageHandler? httpHandler, Func<string, IReadOnlyList<IPAddress>>? serverAddressResolver)
     {
         return new DnsClientOptions
         {
             DnssecValidationMode = options.DnssecValidationMode,
             HttpHandler = httpHandler,
+            ServerAddressResolver = serverAddressResolver,
         };
+    }
+
+    private static Func<string, IReadOnlyList<IPAddress>>? CreateBootstrapResolver(DnsProxyOptions options)
+    {
+        var bootstrapServers = options.BootstrapDnsServers
+            .Select(server => IPAddress.TryParse(server, out var address) ? address : null)
+            .OfType<IPAddress>()
+            .ToArray();
+        if (bootstrapServers.Length == 0)
+            return null;
+
+        return host => ResolveWithBootstrapServers(host, bootstrapServers);
+    }
+
+    private static List<IPAddress> ResolveWithBootstrapServers(string host, IReadOnlyList<IPAddress> bootstrapServers)
+    {
+        if (IPAddress.TryParse(host, out var address))
+            return [address];
+
+        var addresses = new List<IPAddress>();
+        foreach (var bootstrapServer in bootstrapServers)
+        {
+            using var client = new DnsClient(bootstrapServer.ToString(), DnsClientProtocol.Udp, new DnsClientOptions
+            {
+                Timeout = TimeSpan.FromSeconds(2),
+                EnableEdns = false,
+            });
+
+            QueryBootstrapServer(client, host, DnsQueryType.A, addresses);
+            QueryBootstrapServer(client, host, DnsQueryType.AAAA, addresses);
+            if (addresses.Count > 0)
+                break;
+        }
+
+        return addresses;
+    }
+
+    private static void QueryBootstrapServer(DnsClient client, string host, DnsQueryType queryType, List<IPAddress> addresses)
+    {
+        try
+        {
+            var response = client.QueryAsync(host, queryType).GetAwaiter().GetResult();
+            addresses.AddRange(response.Answers.GetIPAddresses());
+        }
+        catch
+        {
+        }
     }
 }

--- a/src/Meziantou.DnsProxy/UpstreamServerOption.cs
+++ b/src/Meziantou.DnsProxy/UpstreamServerOption.cs
@@ -4,9 +4,7 @@ internal sealed class UpstreamServerOption
 {
     public string Name { get; set; } = "";
 
-    public string Endpoint { get; set; } = "";
+    public Uri Url { get; set; } = new("https://cloudflare-dns.com/dns-query");
 
-    public string Protocol { get; set; } = "Https";
-
-    public bool UseHttp3 { get; set; } = true;
+    public int Priority { get; set; }
 }

--- a/src/Meziantou.DnsProxy/appsettings.json
+++ b/src/Meziantou.DnsProxy/appsettings.json
@@ -18,21 +18,46 @@
     "DiagnosticsHistoryCapacity": 10000,
     "FilterRefreshInterval": "00:30:00",
     "DnssecValidationMode": "None",
+    "BootstrapDnsServers": [
+      "9.9.9.9",
+      "149.112.112.112",
+      "1.1.1.1",
+      "1.0.0.1",
+      "2620:fe::fe",
+      "2620:fe::9",
+      "2606:4700:4700::1111",
+      "2606:4700:4700::1001"
+    ],
     "Upstreams": [
       {
-        "Name": "Cloudflare",
-        "Endpoint": "cloudflare-dns.com",
-        "Protocol": "Quic"
+        "Name": "Cloudflare H3",
+        "Url": "h3://cloudflare-dns.com/dns-query",
+        "Priority": 0
       },
       {
-        "Name": "Quad9",
-        "Endpoint": "dns.quad9.net",
-        "Protocol": "Quic"
+        "Name": "NextDNS DoQ",
+        "Url": "quic://dns.nextdns.io",
+        "Priority": 1
       },
       {
-        "Name": "NextDNS",
-        "Endpoint": "dns.nextdns.io",
-        "Protocol": "Quic"
+        "Name": "Quad9 DoQ",
+        "Url": "quic://dns.quad9.net",
+        "Priority": 2
+      },
+      {
+        "Name": "Cloudflare DoH",
+        "Url": "https://cloudflare-dns.com/dns-query",
+        "Priority": 3
+      },
+      {
+        "Name": "NextDNS DoH",
+        "Url": "https://dns.nextdns.io",
+        "Priority": 4
+      },
+      {
+        "Name": "Quad9 DoH",
+        "Url": "https://dns.quad9.net/dns-query",
+        "Priority": 5
       }
     ],
     "Filters": [

--- a/src/Meziantou.DnsProxy/readme.md
+++ b/src/Meziantou.DnsProxy/readme.md
@@ -19,10 +19,11 @@ Default configuration:
 - DNS over QUIC listener: disabled by default (`DnsOverQuicPort=0`)
 - Filter list refresh interval: `00:30:00`
 - DNSSEC validation: disabled by default (`DnssecValidationMode=None`; use `Local` to enable local validation)
+- Bootstrap DNS servers: Quad9 (`9.9.9.9`, `149.112.112.112`, `2620:fe::fe`, `2620:fe::9`) and Cloudflare (`1.1.1.1`, `1.0.0.1`, `2606:4700:4700::1111`, `2606:4700:4700::1001`)
 - Default filter lists:
   - AdGuard DNS filter (`https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt`)
   - StevenBlack hosts (`https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts`)
-- Remote DNS servers (DoQ): Cloudflare (`cloudflare-dns.com`), Quad9 (`dns.quad9.net`), and NextDNS (`dns.nextdns.io`)
+- Remote DNS servers: Cloudflare H3, NextDNS DoQ, Quad9 DoQ, Cloudflare DoH, NextDNS DoH, and Quad9 DoH
 - In-memory diagnostics history size: `10000` entries
 
 Enabling secure listeners (DoH/DoT/DoQ):
@@ -53,3 +54,5 @@ Parallel instances:
   - `DnsProxy__HttpPort`
   - `DnsProxy__FilterRefreshInterval`
   - `DnsProxy__DnssecValidationMode`
+  - `DnsProxy__BootstrapDnsServers__0`
+  - `DnsProxy__Upstreams__0__Url`

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
@@ -33,9 +33,7 @@ public sealed class DiagnosticsPageRendererTests
                 new UpstreamServerOption
                 {
                     Name = "Custom",
-                    Endpoint = "https://1.1.1.1/dns-query",
-                    Protocol = "Https",
-                    UseHttp3 = false,
+                    Url = new Uri("https://1.1.1.1/dns-query"),
                 },
             ],
         };

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyIntegrationTests.cs
@@ -16,41 +16,26 @@ public sealed class DnsProxyIntegrationTests
         const string DnsPortVariableName = "DnsProxy__DnsPort";
         const string HttpPortVariableName = "DnsProxy__HttpPort";
         const string FilterRefreshIntervalVariableName = "DnsProxy__FilterRefreshInterval";
-        const string Upstream0ProtocolVariableName = "DnsProxy__Upstreams__0__Protocol";
-        const string Upstream0EndpointVariableName = "DnsProxy__Upstreams__0__Endpoint";
-        const string Upstream0UseHttp3VariableName = "DnsProxy__Upstreams__0__UseHttp3";
-        const string Upstream1ProtocolVariableName = "DnsProxy__Upstreams__1__Protocol";
-        const string Upstream1EndpointVariableName = "DnsProxy__Upstreams__1__Endpoint";
-        const string Upstream1UseHttp3VariableName = "DnsProxy__Upstreams__1__UseHttp3";
-        const string Upstream2ProtocolVariableName = "DnsProxy__Upstreams__2__Protocol";
-        const string Upstream2EndpointVariableName = "DnsProxy__Upstreams__2__Endpoint";
-        const string Upstream2UseHttp3VariableName = "DnsProxy__Upstreams__2__UseHttp3";
+        const string Upstream0UrlVariableName = "DnsProxy__Upstreams__0__Url";
+        const string Upstream1UrlVariableName = "DnsProxy__Upstreams__1__Url";
+        const string Upstream2UrlVariableName = "DnsProxy__Upstreams__2__Url";
+        const string BootstrapDnsServersVariableName = "DnsProxy__BootstrapDnsServers__0";
 
         var previousDnsPort = Environment.GetEnvironmentVariable(DnsPortVariableName);
         var previousHttpPort = Environment.GetEnvironmentVariable(HttpPortVariableName);
         var previousFilterRefreshInterval = Environment.GetEnvironmentVariable(FilterRefreshIntervalVariableName);
-        var previousUpstream0Protocol = Environment.GetEnvironmentVariable(Upstream0ProtocolVariableName);
-        var previousUpstream0Endpoint = Environment.GetEnvironmentVariable(Upstream0EndpointVariableName);
-        var previousUpstream0UseHttp3 = Environment.GetEnvironmentVariable(Upstream0UseHttp3VariableName);
-        var previousUpstream1Protocol = Environment.GetEnvironmentVariable(Upstream1ProtocolVariableName);
-        var previousUpstream1Endpoint = Environment.GetEnvironmentVariable(Upstream1EndpointVariableName);
-        var previousUpstream1UseHttp3 = Environment.GetEnvironmentVariable(Upstream1UseHttp3VariableName);
-        var previousUpstream2Protocol = Environment.GetEnvironmentVariable(Upstream2ProtocolVariableName);
-        var previousUpstream2Endpoint = Environment.GetEnvironmentVariable(Upstream2EndpointVariableName);
-        var previousUpstream2UseHttp3 = Environment.GetEnvironmentVariable(Upstream2UseHttp3VariableName);
+        var previousUpstream0Url = Environment.GetEnvironmentVariable(Upstream0UrlVariableName);
+        var previousUpstream1Url = Environment.GetEnvironmentVariable(Upstream1UrlVariableName);
+        var previousUpstream2Url = Environment.GetEnvironmentVariable(Upstream2UrlVariableName);
+        var previousBootstrapDnsServers = Environment.GetEnvironmentVariable(BootstrapDnsServersVariableName);
 
         Environment.SetEnvironmentVariable(DnsPortVariableName, DnsPort.ToString(CultureInfo.InvariantCulture));
         Environment.SetEnvironmentVariable(HttpPortVariableName, HttpPort.ToString(CultureInfo.InvariantCulture));
         Environment.SetEnvironmentVariable(FilterRefreshIntervalVariableName, FilterRefreshInterval);
-        Environment.SetEnvironmentVariable(Upstream0ProtocolVariableName, "Https");
-        Environment.SetEnvironmentVariable(Upstream0EndpointVariableName, "https://1.1.1.1/dns-query");
-        Environment.SetEnvironmentVariable(Upstream0UseHttp3VariableName, bool.FalseString);
-        Environment.SetEnvironmentVariable(Upstream1ProtocolVariableName, "Https");
-        Environment.SetEnvironmentVariable(Upstream1EndpointVariableName, "https://9.9.9.9/dns-query");
-        Environment.SetEnvironmentVariable(Upstream1UseHttp3VariableName, bool.FalseString);
-        Environment.SetEnvironmentVariable(Upstream2ProtocolVariableName, "Https");
-        Environment.SetEnvironmentVariable(Upstream2EndpointVariableName, "https://dns.nextdns.io/dns-query");
-        Environment.SetEnvironmentVariable(Upstream2UseHttp3VariableName, bool.FalseString);
+        Environment.SetEnvironmentVariable(Upstream0UrlVariableName, "https://1.1.1.1/dns-query");
+        Environment.SetEnvironmentVariable(Upstream1UrlVariableName, "https://9.9.9.9/dns-query");
+        Environment.SetEnvironmentVariable(Upstream2UrlVariableName, "https://dns.nextdns.io/dns-query");
+        Environment.SetEnvironmentVariable(BootstrapDnsServersVariableName, "1.1.1.1");
 
         try
         {
@@ -83,15 +68,10 @@ public sealed class DnsProxyIntegrationTests
             Environment.SetEnvironmentVariable(DnsPortVariableName, previousDnsPort);
             Environment.SetEnvironmentVariable(HttpPortVariableName, previousHttpPort);
             Environment.SetEnvironmentVariable(FilterRefreshIntervalVariableName, previousFilterRefreshInterval);
-            Environment.SetEnvironmentVariable(Upstream0ProtocolVariableName, previousUpstream0Protocol);
-            Environment.SetEnvironmentVariable(Upstream0EndpointVariableName, previousUpstream0Endpoint);
-            Environment.SetEnvironmentVariable(Upstream0UseHttp3VariableName, previousUpstream0UseHttp3);
-            Environment.SetEnvironmentVariable(Upstream1ProtocolVariableName, previousUpstream1Protocol);
-            Environment.SetEnvironmentVariable(Upstream1EndpointVariableName, previousUpstream1Endpoint);
-            Environment.SetEnvironmentVariable(Upstream1UseHttp3VariableName, previousUpstream1UseHttp3);
-            Environment.SetEnvironmentVariable(Upstream2ProtocolVariableName, previousUpstream2Protocol);
-            Environment.SetEnvironmentVariable(Upstream2EndpointVariableName, previousUpstream2Endpoint);
-            Environment.SetEnvironmentVariable(Upstream2UseHttp3VariableName, previousUpstream2UseHttp3);
+            Environment.SetEnvironmentVariable(Upstream0UrlVariableName, previousUpstream0Url);
+            Environment.SetEnvironmentVariable(Upstream1UrlVariableName, previousUpstream1Url);
+            Environment.SetEnvironmentVariable(Upstream2UrlVariableName, previousUpstream2Url);
+            Environment.SetEnvironmentVariable(BootstrapDnsServersVariableName, previousBootstrapDnsServers);
         }
     }
 

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyOptionsTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyOptionsTests.cs
@@ -24,6 +24,15 @@ public sealed class DnsProxyOptionsTests
         Assert.Equal(10_000, options.DiagnosticsHistoryCapacity);
         Assert.Equal(TimeSpan.FromMinutes(30), options.FilterRefreshInterval);
         Assert.Equal(DnssecValidationMode.None, options.DnssecValidationMode);
+        Assert.Collection(options.BootstrapDnsServers,
+            item => Assert.Equal("9.9.9.9", item),
+            item => Assert.Equal("149.112.112.112", item),
+            item => Assert.Equal("1.1.1.1", item),
+            item => Assert.Equal("1.0.0.1", item),
+            item => Assert.Equal("2620:fe::fe", item),
+            item => Assert.Equal("2620:fe::9", item),
+            item => Assert.Equal("2606:4700:4700::1111", item),
+            item => Assert.Equal("2606:4700:4700::1001", item));
         Assert.Collection(options.Filters,
             item =>
             {
@@ -38,21 +47,39 @@ public sealed class DnsProxyOptionsTests
         Assert.Collection(options.Upstreams,
             item =>
             {
-                Assert.Equal("Cloudflare", item.Name);
-                Assert.Equal("cloudflare-dns.com", item.Endpoint);
-                Assert.Equal("Quic", item.Protocol);
+                Assert.Equal("Cloudflare H3", item.Name);
+                Assert.Equal(new Uri("h3://cloudflare-dns.com/dns-query"), item.Url);
+                Assert.Equal(0, item.Priority);
             },
             item =>
             {
-                Assert.Equal("Quad9", item.Name);
-                Assert.Equal("dns.quad9.net", item.Endpoint);
-                Assert.Equal("Quic", item.Protocol);
+                Assert.Equal("NextDNS DoQ", item.Name);
+                Assert.Equal(new Uri("quic://dns.nextdns.io"), item.Url);
+                Assert.Equal(1, item.Priority);
             },
             item =>
             {
-                Assert.Equal("NextDNS", item.Name);
-                Assert.Equal("dns.nextdns.io", item.Endpoint);
-                Assert.Equal("Quic", item.Protocol);
+                Assert.Equal("Quad9 DoQ", item.Name);
+                Assert.Equal(new Uri("quic://dns.quad9.net"), item.Url);
+                Assert.Equal(2, item.Priority);
+            },
+            item =>
+            {
+                Assert.Equal("Cloudflare DoH", item.Name);
+                Assert.Equal(new Uri("https://cloudflare-dns.com/dns-query"), item.Url);
+                Assert.Equal(3, item.Priority);
+            },
+            item =>
+            {
+                Assert.Equal("NextDNS DoH", item.Name);
+                Assert.Equal(new Uri("https://dns.nextdns.io"), item.Url);
+                Assert.Equal(4, item.Priority);
+            },
+            item =>
+            {
+                Assert.Equal("Quad9 DoH", item.Name);
+                Assert.Equal(new Uri("https://dns.quad9.net/dns-query"), item.Url);
+                Assert.Equal(5, item.Priority);
             });
     }
 

--- a/tests/Meziantou.Framework.DnsProxy.Tests/UpstreamDnsClientFactoryTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/UpstreamDnsClientFactoryTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Reflection;
 using TestUtilities;
 using Meziantou.DnsProxy;
@@ -27,9 +28,7 @@ public sealed class UpstreamDnsClientFactoryTests
                 new UpstreamServerOption
                 {
                     Name = "Custom",
-                    Endpoint = "https://1.1.1.1/dns-query",
-                    Protocol = "Https",
-                    UseHttp3 = false,
+                    Url = new Uri("https://1.1.1.1/dns-query"),
                 },
             ],
         });
@@ -53,9 +52,7 @@ public sealed class UpstreamDnsClientFactoryTests
                 new UpstreamServerOption
                 {
                     Name = "Custom",
-                    Endpoint = "https://1.1.1.1/dns-query",
-                    Protocol = "Https",
-                    UseHttp3 = false,
+                    Url = new Uri("https://1.1.1.1/dns-query"),
                 },
             ],
         });
@@ -68,31 +65,55 @@ public sealed class UpstreamDnsClientFactoryTests
     }
 
     [Theory]
-    [InlineData("Cloudflare", "cloudflare-dns.com")]
-    [InlineData("Quad9", "dns.quad9.net")]
-    [InlineData("NextDNS", "dns.nextdns.io")]
-    public async Task UpstreamDnsClientFactory_DefaultUpstream_CanResolveRecordAsync(string name, string endpoint)
+    [InlineData("Cloudflare DoH", "https://cloudflare-dns.com/dns-query")]
+    [InlineData("Quad9 DoH", "https://dns.quad9.net/dns-query")]
+    [InlineData("NextDNS DoH", "https://dns.nextdns.io")]
+    public async Task UpstreamDnsClientFactory_DefaultDohUpstream_CanResolveRecordAsync(string name, string url)
     {
         var options = Options.Create(new DnsProxyOptions
         {
+            BootstrapDnsServers = [],
             Upstreams =
             [
                 new UpstreamServerOption
                 {
                     Name = name,
-                    Endpoint = endpoint,
-                    Protocol = "Quic",
+                    Url = new Uri(url),
                 },
             ],
         });
 
         using var factory = new UpstreamDnsClientFactory(options, NullLogger<UpstreamDnsClientFactory>.Instance);
         var upstream = Assert.Single(factory.GetUpstreams());
-        Assert.Equal($"{name} ({endpoint})", upstream.DisplayName);
+        Assert.Equal($"{name} ({url})", upstream.DisplayName);
 
         var response = await XUnitStaticHelpers.Retry(() => QueryARecordUsingUpstreamAsync(upstream, CancellationToken.None));
         Assert.Equal(DnsResponseCode.NoError, response.Header.ResponseCode);
         Assert.NotEmpty(response.Answers);
+    }
+
+    [Fact]
+    public void UpstreamDnsClientFactory_UsesBootstrapDnsServers()
+    {
+        var options = Options.Create(new DnsProxyOptions
+        {
+            BootstrapDnsServers = ["127.0.0.1"],
+            Upstreams =
+            [
+                new UpstreamServerOption
+                {
+                    Name = "Custom",
+                    Url = new Uri("https://dns.example/dns-query"),
+                },
+            ],
+        });
+
+        using var factory = new UpstreamDnsClientFactory(options, NullLogger<UpstreamDnsClientFactory>.Instance);
+        var upstream = Assert.Single(factory.GetUpstreams());
+        var clientOptions = Assert.IsType<DnsClientOptions>(DnsClientOptionsField.GetValue(upstream.Client));
+        var resolver = Assert.IsType<Func<string, IReadOnlyList<IPAddress>>>(clientOptions.ServerAddressResolver);
+
+        Assert.Equal([IPAddress.Parse("192.0.2.1")], resolver("192.0.2.1"));
     }
 
     private static async Task<DnsResponseMessage> QueryARecordUsingUpstreamAsync(UpstreamDnsClientInfo upstream, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- Add configurable bootstrap DNS servers and use them to resolve upstream endpoints
- Switch upstream configuration from separate endpoint/protocol fields to a single `Uri` plus priority
- Expand default upstreams to cover Cloudflare, Quad9, and NextDNS over H3, DoQ, and DoH
- Update docs and tests to reflect the new configuration model

## Testing
- Updated unit and integration tests for default options, upstream creation, and bootstrap resolver behavior
- Existing DNS proxy tests were adjusted to validate the new URI-based configuration