### PR TITLE
Add a temporary filtering disable action to the diagnostics page

### DIFF
--- a/src/Meziantou.DnsProxy/Diagnostics/DiagnosticsPageRenderer.cs
+++ b/src/Meziantou.DnsProxy/Diagnostics/DiagnosticsPageRenderer.cs
@@ -6,7 +6,7 @@ namespace Meziantou.DnsProxy.Diagnostics;
 
 internal static class DiagnosticsPageRenderer
 {
-    public static string Render(DnsProxyOptions options, FilterEngineProvider filters, IReadOnlyList<UpstreamDnsClientInfo> upstreams, IReadOnlyList<RequestHistoryEntry> historyEntries)
+    public static string Render(DnsProxyOptions options, FilterEngineProvider filters, FilteringPauseState filteringPauseState, IReadOnlyList<UpstreamDnsClientInfo> upstreams, IReadOnlyList<RequestHistoryEntry> historyEntries)
     {
         var stringBuilder = new StringBuilder();
         stringBuilder.Append("""
@@ -22,6 +22,7 @@ internal static class DiagnosticsPageRenderer
                 th { background: #f7f7f7; position: sticky; top: 0; }
                 .small { color: #666; font-size: 0.85rem; }
                 .mono { font-family: ui-monospace, Consolas, monospace; }
+                button { padding: 0.45rem 0.7rem; }
               </style>
             </head>
             <body>
@@ -45,6 +46,21 @@ internal static class DiagnosticsPageRenderer
         stringBuilder.Append("<li><span class='mono'>Rewrites</span>: ").Append(HtmlEncode(string.Join(", ", options.Rewrites.Select(r => $"{r.Domain} => {r.Type}:{r.Value}")))).Append("</li>");
         stringBuilder.Append("<li><span class='mono'>LoadedFilterRules</span>: ").Append(HtmlEncode(filters.RuleCount.ToString(System.Globalization.CultureInfo.InvariantCulture))).Append("</li>");
         stringBuilder.Append("</ul>");
+        stringBuilder.Append("<h2>Filtering</h2>");
+        var disabledUntilUtc = filteringPauseState.DisabledUntilUtc;
+        if (disabledUntilUtc is null)
+        {
+            stringBuilder.Append("<p>Filtering is enabled.</p>");
+            stringBuilder.Append("<form method='post' action='/filtering/disable'><button type='submit'>Disable filtering for 15 minutes</button></form>");
+        }
+        else
+        {
+            stringBuilder.Append("<p>Filtering is disabled until <span class='mono'>")
+                .Append(HtmlEncode(disabledUntilUtc.Value.ToString("u", System.Globalization.CultureInfo.InvariantCulture)))
+                .Append("</span>.</p>");
+            stringBuilder.Append("<form method='post' action='/filtering/disable'><button type='submit' disabled>Disable filtering for 15 minutes</button></form>");
+        }
+
         stringBuilder.Append("<h2>Recent Requests</h2>");
         stringBuilder.Append("<p class='small'>Stored entries: ").Append(HtmlEncode(historyEntries.Count.ToString(System.Globalization.CultureInfo.InvariantCulture))).Append("</p>");
         stringBuilder.Append("""

--- a/src/Meziantou.DnsProxy/Filtering/FilteringPauseState.cs
+++ b/src/Meziantou.DnsProxy/Filtering/FilteringPauseState.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.DnsProxy.Filtering;
 
-internal sealed class FilteringPauseState
+internal sealed class FilteringPauseState(TimeProvider timeProvider)
 {
     private long _disabledUntilUtcTicks;
 
@@ -15,8 +15,9 @@ internal sealed class FilteringPauseState
             }
 
             var disabledUntilUtc = new DateTimeOffset(ticks, TimeSpan.Zero);
-            if (disabledUntilUtc <= DateTimeOffset.UtcNow)
+            if (disabledUntilUtc <= timeProvider.GetUtcNow())
             {
+                Interlocked.CompareExchange(ref _disabledUntilUtcTicks, 0, ticks);
                 return null;
             }
 
@@ -31,7 +32,7 @@ internal sealed class FilteringPauseState
         if (duration <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(duration), duration, "The duration must be greater than zero.");
 
-        var disabledUntilUtc = DateTimeOffset.UtcNow.Add(duration);
+        var disabledUntilUtc = timeProvider.GetUtcNow().Add(duration);
         Volatile.Write(ref _disabledUntilUtcTicks, disabledUntilUtc.UtcDateTime.Ticks);
 
         return disabledUntilUtc;

--- a/src/Meziantou.DnsProxy/Filtering/FilteringPauseState.cs
+++ b/src/Meziantou.DnsProxy/Filtering/FilteringPauseState.cs
@@ -1,0 +1,39 @@
+namespace Meziantou.DnsProxy.Filtering;
+
+internal sealed class FilteringPauseState
+{
+    private long _disabledUntilUtcTicks;
+
+    public DateTimeOffset? DisabledUntilUtc
+    {
+        get
+        {
+            var ticks = Volatile.Read(ref _disabledUntilUtcTicks);
+            if (ticks is 0)
+            {
+                return null;
+            }
+
+            var disabledUntilUtc = new DateTimeOffset(ticks, TimeSpan.Zero);
+            if (disabledUntilUtc <= DateTimeOffset.UtcNow)
+            {
+                return null;
+            }
+
+            return disabledUntilUtc;
+        }
+    }
+
+    public bool IsDisabled => DisabledUntilUtc is not null;
+
+    public DateTimeOffset DisableFor(TimeSpan duration)
+    {
+        if (duration <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(duration), duration, "The duration must be greater than zero.");
+
+        var disabledUntilUtc = DateTimeOffset.UtcNow.Add(duration);
+        Volatile.Write(ref _disabledUntilUtcTicks, disabledUntilUtc.UtcDateTime.Ticks);
+
+        return disabledUntilUtc;
+    }
+}

--- a/src/Meziantou.DnsProxy/Program.cs
+++ b/src/Meziantou.DnsProxy/Program.cs
@@ -22,6 +22,7 @@ var dnsOverHttpsPath = string.IsNullOrWhiteSpace(bootstrapOptions.DnsOverHttpsPa
 builder.Services.AddHttpClient();
 builder.Services.Configure<DnsProxyOptions>(builder.Configuration.GetSection(DnsProxyOptions.SectionName));
 builder.Services.AddSingleton<RequestHistoryStore>();
+builder.Services.AddSingleton<FilteringPauseState>();
 builder.Services.AddSingleton<FilterEngineProvider>();
 builder.Services.AddHostedService<FilterEngineRefreshService>();
 builder.Services.AddSingleton<UpstreamDnsClientFactory>();
@@ -64,10 +65,17 @@ try
     app.MapDnsHandler(dnsProxyHandler.HandleAsync);
     app.MapDnsOverHttps(dnsOverHttpsPath);
 
-    app.MapGet("/", (RequestHistoryStore historyStore, IOptions<DnsProxyOptions> optionsAccessor, FilterEngineProvider filters, UpstreamDnsClientFactory upstreams) =>
+    app.MapGet("/", (RequestHistoryStore historyStore, IOptions<DnsProxyOptions> optionsAccessor, FilterEngineProvider filters, FilteringPauseState filteringPauseState, UpstreamDnsClientFactory upstreams) =>
     {
-        var html = DiagnosticsPageRenderer.Render(optionsAccessor.Value, filters, upstreams.GetUpstreams(), historyStore.GetSnapshot());
+        var html = DiagnosticsPageRenderer.Render(optionsAccessor.Value, filters, filteringPauseState, upstreams.GetUpstreams(), historyStore.GetSnapshot());
         return Results.Content(html, "text/html; charset=utf-8");
+    });
+
+    app.MapPost("/filtering/disable", (FilteringPauseState filteringPauseState) =>
+    {
+        filteringPauseState.DisableFor(TimeSpan.FromMinutes(15));
+
+        return Results.Redirect("/");
     });
 
     await app.RunAsync().ConfigureAwait(false);

--- a/src/Meziantou.DnsProxy/Program.cs
+++ b/src/Meziantou.DnsProxy/Program.cs
@@ -21,6 +21,7 @@ var dnsOverHttpsPath = string.IsNullOrWhiteSpace(bootstrapOptions.DnsOverHttpsPa
 
 builder.Services.AddHttpClient();
 builder.Services.Configure<DnsProxyOptions>(builder.Configuration.GetSection(DnsProxyOptions.SectionName));
+builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<RequestHistoryStore>();
 builder.Services.AddSingleton<FilteringPauseState>();
 builder.Services.AddSingleton<FilterEngineProvider>();

--- a/src/Meziantou.DnsProxy/Proxy/DnsProxyHandler.cs
+++ b/src/Meziantou.DnsProxy/Proxy/DnsProxyHandler.cs
@@ -14,13 +14,15 @@ namespace Meziantou.DnsProxy.Proxy;
 internal sealed class DnsProxyHandler
 {
     private readonly FilterEngineProvider _filterEngineProvider;
+    private readonly FilteringPauseState _filteringPauseState;
     private readonly UpstreamDnsClientFactory _upstreamDnsClientFactory;
     private readonly RequestHistoryStore _requestHistoryStore;
     private readonly ILogger<DnsProxyHandler> _logger;
 
-    public DnsProxyHandler(FilterEngineProvider filterEngineProvider, UpstreamDnsClientFactory upstreamDnsClientFactory, RequestHistoryStore requestHistoryStore, ILogger<DnsProxyHandler> logger)
+    public DnsProxyHandler(FilterEngineProvider filterEngineProvider, FilteringPauseState filteringPauseState, UpstreamDnsClientFactory upstreamDnsClientFactory, RequestHistoryStore requestHistoryStore, ILogger<DnsProxyHandler> logger)
     {
         _filterEngineProvider = filterEngineProvider;
+        _filteringPauseState = filteringPauseState;
         _upstreamDnsClientFactory = upstreamDnsClientFactory;
         _requestHistoryStore = requestHistoryStore;
         _logger = logger;
@@ -44,27 +46,30 @@ internal sealed class DnsProxyHandler
                 Upstream = "-",
             };
 
-            var filterResult = _filterEngineProvider.Engine.Evaluate(
-                question.Name,
-                ConvertToFilterQueryType(question.Type),
-                new DnsClientInfo
+            if (!_filteringPauseState.IsDisabled)
+            {
+                var filterResult = _filterEngineProvider.Engine.Evaluate(
+                    question.Name,
+                    ConvertToFilterQueryType(question.Type),
+                    new DnsClientInfo
+                    {
+                        Address = context.RemoteEndPoint is IPEndPoint endpoint ? endpoint.Address : null,
+                    });
+
+                if (TryApplyRewrite(question, filterResult, response, historyEntryBuilder))
                 {
-                    Address = context.RemoteEndPoint is IPEndPoint endpoint ? endpoint.Address : null,
-                });
+                    _requestHistoryStore.Add(historyEntryBuilder.Build(response));
+                    continue;
+                }
 
-            if (TryApplyRewrite(question, filterResult, response, historyEntryBuilder))
-            {
-                _requestHistoryStore.Add(historyEntryBuilder.Build(response));
-                continue;
-            }
-
-            if (filterResult.IsMatched && filterResult.Action == DnsFilterAction.Block)
-            {
-                response.ResponseCode = DnsResponseCode.NameError;
-                historyEntryBuilder.Result = "Blocked";
-                historyEntryBuilder.ResponseCode = response.ResponseCode.ToString();
-                _requestHistoryStore.Add(historyEntryBuilder.Build(response));
-                continue;
+                if (filterResult.IsMatched && filterResult.Action == DnsFilterAction.Block)
+                {
+                    response.ResponseCode = DnsResponseCode.NameError;
+                    historyEntryBuilder.Result = "Blocked";
+                    historyEntryBuilder.ResponseCode = response.ResponseCode.ToString();
+                    _requestHistoryStore.Add(historyEntryBuilder.Build(response));
+                    continue;
+                }
             }
 
             var forwardResult = await ForwardToFastestUpstreamAsync(question, cancellationToken).ConfigureAwait(false);

--- a/src/Meziantou.DnsProxy/Proxy/DnsProxyHandler.cs
+++ b/src/Meziantou.DnsProxy/Proxy/DnsProxyHandler.cs
@@ -17,14 +17,16 @@ internal sealed class DnsProxyHandler
     private readonly FilteringPauseState _filteringPauseState;
     private readonly UpstreamDnsClientFactory _upstreamDnsClientFactory;
     private readonly RequestHistoryStore _requestHistoryStore;
+    private readonly TimeProvider _timeProvider;
     private readonly ILogger<DnsProxyHandler> _logger;
 
-    public DnsProxyHandler(FilterEngineProvider filterEngineProvider, FilteringPauseState filteringPauseState, UpstreamDnsClientFactory upstreamDnsClientFactory, RequestHistoryStore requestHistoryStore, ILogger<DnsProxyHandler> logger)
+    public DnsProxyHandler(FilterEngineProvider filterEngineProvider, FilteringPauseState filteringPauseState, UpstreamDnsClientFactory upstreamDnsClientFactory, RequestHistoryStore requestHistoryStore, TimeProvider timeProvider, ILogger<DnsProxyHandler> logger)
     {
         _filterEngineProvider = filterEngineProvider;
         _filteringPauseState = filteringPauseState;
         _upstreamDnsClientFactory = upstreamDnsClientFactory;
         _requestHistoryStore = requestHistoryStore;
+        _timeProvider = timeProvider;
         _logger = logger;
     }
 
@@ -37,7 +39,7 @@ internal sealed class DnsProxyHandler
         {
             var historyEntryBuilder = new RequestHistoryEntryBuilder
             {
-                TimestampUtc = DateTimeOffset.UtcNow,
+                TimestampUtc = _timeProvider.GetUtcNow(),
                 Client = context.RemoteEndPoint is IPEndPoint ipEndPoint ? ipEndPoint.Address.ToString() : context.RemoteEndPoint.ToString() ?? "unknown",
                 Protocol = context.Protocol.ToString(),
                 QuestionName = question.Name,

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
@@ -63,6 +63,7 @@ public sealed class DiagnosticsPageRendererTests
         var html = DiagnosticsPageRenderer.Render(
             options,
             filterEngineProvider,
+            new FilteringPauseState(),
             upstreamFactory.GetUpstreams(),
             [historyEntry]);
 
@@ -75,6 +76,37 @@ public sealed class DiagnosticsPageRendererTests
         Assert.Contains("<span class='mono'>CertificatePath</span>: certs/proxy.pfx", html, StringComparison.Ordinal);
         Assert.Contains("<span class='mono'>FilterRefreshInterval</span>: 00:05:00", html, StringComparison.Ordinal);
         Assert.Contains("<span class='mono'>DnssecValidationMode</span>: Local", html, StringComparison.Ordinal);
+        Assert.Contains("Filtering is enabled.", html, StringComparison.Ordinal);
+        Assert.Contains("Disable filtering for 15 minutes", html, StringComparison.Ordinal);
         Assert.Contains("example.com A 1.2.3.4", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_ContainsFilteringPauseStatus()
+    {
+        var options = new DnsProxyOptions
+        {
+            Filters = [],
+            Rewrites = [],
+            Upstreams = [],
+        };
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddHttpClient();
+        using var serviceProvider = serviceCollection.BuildServiceProvider();
+        var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+        var filterEngineProvider = new FilterEngineProvider(httpClientFactory, Options.Create(options), NullLogger<FilterEngineProvider>.Instance);
+        var filteringPauseState = new FilteringPauseState();
+        var disabledUntilUtc = filteringPauseState.DisableFor(TimeSpan.FromMinutes(15));
+
+        var html = DiagnosticsPageRenderer.Render(
+            options,
+            filterEngineProvider,
+            filteringPauseState,
+            [],
+            []);
+
+        Assert.Contains("Filtering is disabled until", html, StringComparison.Ordinal);
+        Assert.Contains(disabledUntilUtc.ToString("u", CultureInfo.InvariantCulture), html, StringComparison.Ordinal);
+        Assert.Contains("<button type='submit' disabled>Disable filtering for 15 minutes</button>", html, StringComparison.Ordinal);
     }
 }

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
@@ -7,11 +7,28 @@ using Meziantou.Framework.DnsClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Meziantou.Framework.DnsProxy.Tests;
 
 public sealed class DiagnosticsPageRendererTests
 {
+    [Fact]
+    public void FilteringPauseState_ClearsExpiredPause()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 06, 28, 12, 0, 0, TimeSpan.Zero));
+        var filteringPauseState = new FilteringPauseState(timeProvider);
+
+        var disabledUntilUtc = filteringPauseState.DisableFor(TimeSpan.FromMinutes(15));
+        Assert.Equal(new DateTimeOffset(2026, 06, 28, 12, 15, 0, TimeSpan.Zero), disabledUntilUtc);
+        Assert.True(filteringPauseState.IsDisabled);
+
+        timeProvider.SetUtcNow(disabledUntilUtc);
+
+        Assert.Null(filteringPauseState.DisabledUntilUtc);
+        Assert.False(filteringPauseState.IsDisabled);
+    }
+
     [Fact]
     public void Render_ContainsConfiguredPorts()
     {

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
@@ -112,7 +112,7 @@ public sealed class DiagnosticsPageRendererTests
         using var serviceProvider = serviceCollection.BuildServiceProvider();
         var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
         var filterEngineProvider = new FilterEngineProvider(httpClientFactory, Options.Create(options), NullLogger<FilterEngineProvider>.Instance);
-        var filteringPauseState = new FilteringPauseState();
+        var filteringPauseState = new FilteringPauseState(TimeProvider.System);
         var disabledUntilUtc = filteringPauseState.DisableFor(TimeSpan.FromMinutes(15));
 
         var html = DiagnosticsPageRenderer.Render(

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
@@ -80,7 +80,7 @@ public sealed class DiagnosticsPageRendererTests
         var html = DiagnosticsPageRenderer.Render(
             options,
             filterEngineProvider,
-            new FilteringPauseState(),
+            new FilteringPauseState(TimeProvider.System),
             upstreamFactory.GetUpstreams(),
             [historyEntry]);
 

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyIntegrationTests.cs
@@ -1,6 +1,10 @@
 using System.Net;
 using System.Net.Http.Headers;
+using Meziantou.DnsProxy;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using DnsProxyProgram = global::Program;
 
 namespace Meziantou.Framework.DnsProxy.Tests;
@@ -95,6 +99,71 @@ public sealed class DnsProxyIntegrationTests
         }
     }
 
+    [Fact]
+    public async Task DisableFilteringEndpoint_DisablesRewriteRulesTemporarily()
+    {
+        using var baseFactory = new WebApplicationFactory<DnsProxyProgram>();
+        using var factory = baseFactory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, configurationBuilder) =>
+            {
+                configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+                {
+                    ["DnsProxy:DnsPort"] = "0",
+                    ["DnsProxy:HttpPort"] = "5080",
+                    ["DnsProxy:DiagnosticsHistoryCapacity"] = "1",
+                });
+            });
+            builder.ConfigureServices(services =>
+            {
+                services.PostConfigure<DnsProxyOptions>(options =>
+                {
+                    options.Filters = [];
+                    options.Upstreams = [];
+                });
+            });
+        });
+        var webClient = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+        });
+
+        var query = CreateAQuery("localhost", id: 0x1234);
+        using var requestBeforePause = new HttpRequestMessage(HttpMethod.Post, "/dns-query")
+        {
+            Content = new ByteArrayContent(query),
+        };
+        requestBeforePause.Content.Headers.ContentType = new MediaTypeHeaderValue("application/dns-message");
+        requestBeforePause.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/dns-message"));
+        using var responseBeforePause = await webClient.SendAsync(requestBeforePause);
+        responseBeforePause.EnsureSuccessStatusCode();
+        var responseBeforePauseBytes = await responseBeforePause.Content.ReadAsByteArrayAsync();
+        AssertDnsResponseHasARecord(responseBeforePauseBytes, expectedId: 0x1234, expectedAddress: IPAddress.Parse("127.0.0.1"));
+
+        using var disableContent = new StringContent("");
+        using var disableResponse = await webClient.PostAsync("/filtering/disable", disableContent);
+        Assert.Equal(HttpStatusCode.Redirect, disableResponse.StatusCode);
+        Assert.Equal("/", disableResponse.Headers.Location?.ToString());
+
+        var html = await webClient.GetStringAsync("/");
+        Assert.Contains("Filtering is disabled until", html, StringComparison.Ordinal);
+
+        using var requestAfterPause = new HttpRequestMessage(HttpMethod.Post, "/dns-query")
+        {
+            Content = new ByteArrayContent(query),
+        };
+        requestAfterPause.Content.Headers.ContentType = new MediaTypeHeaderValue("application/dns-message");
+        requestAfterPause.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/dns-message"));
+        using var responseAfterPause = await webClient.SendAsync(requestAfterPause);
+        responseAfterPause.EnsureSuccessStatusCode();
+        var responseAfterPauseBytes = await responseAfterPause.Content.ReadAsByteArrayAsync();
+        AssertDnsResponseHasServerFailureWithoutAnswers(responseAfterPauseBytes, expectedId: 0x1234);
+
+        var htmlAfterQuery = await webClient.GetStringAsync("/");
+        Assert.Contains("UpstreamFailure", htmlAfterQuery, StringComparison.Ordinal);
+        Assert.DoesNotContain("Rewritten", htmlAfterQuery, StringComparison.Ordinal);
+    }
+
     private static byte[] CreateAQuery(string domain, ushort id)
     {
         using var ms = new MemoryStream();
@@ -145,6 +214,23 @@ public sealed class DnsProxyIntegrationTests
 
         var address = new IPAddress(response.AsSpan(offset, rdLength));
         Assert.Equal(expectedAddress, address);
+    }
+
+    private static void AssertDnsResponseHasServerFailureWithoutAnswers(byte[] response, ushort expectedId)
+    {
+        Assert.True(response.Length >= 12);
+
+        var offset = 0;
+        var id = ReadUInt16(response, ref offset);
+        Assert.Equal(expectedId, id);
+
+        var flags = ReadUInt16(response, ref offset);
+        Assert.Equal(2, flags & 0x000F); // RCODE=SERVFAIL
+        var questionCount = ReadUInt16(response, ref offset);
+        var answerCount = ReadUInt16(response, ref offset);
+
+        Assert.Equal(1, questionCount);
+        Assert.Equal(0, answerCount);
     }
 
     private static void WriteDomainName(MemoryStream stream, string domain)

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyIntegrationTests.cs
@@ -1,10 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
-using Meziantou.DnsProxy;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using DnsProxyProgram = global::Program;
 
 namespace Meziantou.Framework.DnsProxy.Tests;
@@ -82,33 +79,33 @@ public sealed class DnsProxyIntegrationTests
     [Fact]
     public async Task DisableFilteringEndpoint_DisablesRewriteRulesTemporarily()
     {
+        const int DnsPort = 0;
+        const int HttpPort = 5080;
+        const int DiagnosticsHistoryCapacity = 1;
+        const string RewriteDomain = "temporary-filter-disable.example";
+        const string RewriteAddress = "203.0.113.123";
+
         using var baseFactory = new WebApplicationFactory<DnsProxyProgram>();
         using var factory = baseFactory.WithWebHostBuilder(builder =>
         {
-            builder.ConfigureAppConfiguration((_, configurationBuilder) =>
-            {
-                configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
-                {
-                    ["DnsProxy:DnsPort"] = "0",
-                    ["DnsProxy:HttpPort"] = "5080",
-                    ["DnsProxy:DiagnosticsHistoryCapacity"] = "1",
-                });
-            });
-            builder.ConfigureServices(services =>
-            {
-                services.PostConfigure<DnsProxyOptions>(options =>
-                {
-                    options.Filters = [];
-                    options.Upstreams = [];
-                });
-            });
+            builder.UseSetting("DnsProxy:DnsPort", DnsPort.ToString(CultureInfo.InvariantCulture));
+            builder.UseSetting("DnsProxy:HttpPort", HttpPort.ToString(CultureInfo.InvariantCulture));
+            builder.UseSetting("DnsProxy:DiagnosticsHistoryCapacity", DiagnosticsHistoryCapacity.ToString(CultureInfo.InvariantCulture));
+            builder.UseSetting("DnsProxy:Filters:0:Url", "");
+            builder.UseSetting("DnsProxy:Filters:1:Url", "");
+            builder.UseSetting("DnsProxy:Rewrites:0:Domain", RewriteDomain);
+            builder.UseSetting("DnsProxy:Rewrites:0:Type", "A");
+            builder.UseSetting("DnsProxy:Rewrites:0:Value", RewriteAddress);
+            builder.UseSetting("DnsProxy:Upstreams:0:Endpoint", "");
+            builder.UseSetting("DnsProxy:Upstreams:1:Endpoint", "");
+            builder.UseSetting("DnsProxy:Upstreams:2:Endpoint", "");
         });
         var webClient = factory.CreateClient(new WebApplicationFactoryClientOptions
         {
             AllowAutoRedirect = false,
         });
 
-        var query = CreateAQuery("localhost", id: 0x1234);
+        var query = CreateAQuery(RewriteDomain, id: 0x1234);
         using var requestBeforePause = new HttpRequestMessage(HttpMethod.Post, "/dns-query")
         {
             Content = new ByteArrayContent(query),
@@ -118,7 +115,8 @@ public sealed class DnsProxyIntegrationTests
         using var responseBeforePause = await webClient.SendAsync(requestBeforePause);
         responseBeforePause.EnsureSuccessStatusCode();
         var responseBeforePauseBytes = await responseBeforePause.Content.ReadAsByteArrayAsync();
-        AssertDnsResponseHasARecord(responseBeforePauseBytes, expectedId: 0x1234, expectedAddress: IPAddress.Parse("127.0.0.1"));
+        var rewriteAddress = IPAddress.Parse(RewriteAddress);
+        AssertDnsResponseHasARecord(responseBeforePauseBytes, expectedId: 0x1234, expectedAddress: rewriteAddress);
 
         using var disableContent = new StringContent("");
         using var disableResponse = await webClient.PostAsync("/filtering/disable", disableContent);
@@ -137,10 +135,9 @@ public sealed class DnsProxyIntegrationTests
         using var responseAfterPause = await webClient.SendAsync(requestAfterPause);
         responseAfterPause.EnsureSuccessStatusCode();
         var responseAfterPauseBytes = await responseAfterPause.Content.ReadAsByteArrayAsync();
-        AssertDnsResponseHasServerFailureWithoutAnswers(responseAfterPauseBytes, expectedId: 0x1234);
+        AssertDnsResponseDoesNotHaveARecord(responseAfterPauseBytes, expectedId: 0x1234, unexpectedAddress: rewriteAddress);
 
         var htmlAfterQuery = await webClient.GetStringAsync("/");
-        Assert.Contains("UpstreamFailure", htmlAfterQuery, StringComparison.Ordinal);
         Assert.DoesNotContain("Rewritten", htmlAfterQuery, StringComparison.Ordinal);
     }
 
@@ -196,7 +193,7 @@ public sealed class DnsProxyIntegrationTests
         Assert.Equal(expectedAddress, address);
     }
 
-    private static void AssertDnsResponseHasServerFailureWithoutAnswers(byte[] response, ushort expectedId)
+    private static void AssertDnsResponseDoesNotHaveARecord(byte[] response, ushort expectedId, IPAddress unexpectedAddress)
     {
         Assert.True(response.Length >= 12);
 
@@ -204,13 +201,33 @@ public sealed class DnsProxyIntegrationTests
         var id = ReadUInt16(response, ref offset);
         Assert.Equal(expectedId, id);
 
-        var flags = ReadUInt16(response, ref offset);
-        Assert.Equal(2, flags & 0x000F); // RCODE=SERVFAIL
+        _ = ReadUInt16(response, ref offset); // flags
         var questionCount = ReadUInt16(response, ref offset);
         var answerCount = ReadUInt16(response, ref offset);
+        _ = ReadUInt16(response, ref offset); // authorityCount
+        _ = ReadUInt16(response, ref offset); // additionalCount
 
         Assert.Equal(1, questionCount);
-        Assert.Equal(0, answerCount);
+
+        SkipDomainName(response, ref offset);
+        offset += 4; // QTYPE + QCLASS
+
+        for (var i = 0; i < answerCount; i++)
+        {
+            SkipDomainName(response, ref offset);
+            var recordType = ReadUInt16(response, ref offset);
+            _ = ReadUInt16(response, ref offset); // recordClass
+            offset += 4; // TTL
+            var rdLength = ReadUInt16(response, ref offset);
+
+            if (recordType == 1 && rdLength == 4)
+            {
+                var address = new IPAddress(response.AsSpan(offset, rdLength));
+                Assert.NotEqual(unexpectedAddress, address);
+            }
+
+            offset += rdLength;
+        }
     }
 
     private static void WriteDomainName(MemoryStream stream, string domain)

--- a/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <ProjectReference Include="../../src/Meziantou.DnsProxy/Meziantou.DnsProxy.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
**Summary**
- Add a filtering pause state and expose it through the diagnostics page.
- Render the current filtering status and a button to disable filtering for 15 minutes.
- Skip rewrite and block evaluation while filtering is paused.
- Add integration coverage for the new `/filtering/disable` endpoint and diagnostics state.

**Testing**
- Added and updated unit tests for diagnostics page rendering.
- Added an integration test that verifies filtering can be paused temporarily and that DNS handling changes accordingly.
- Not run (not requested).