### PR TITLE
Add symbol-based count assertion analyzers and fixes

### DIFF
--- a/src/Meziantou.Framework.Assertions.Analyzer/Internals/NumericHelpers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Internals/NumericHelpers.cs
@@ -1,0 +1,28 @@
+using Microsoft.CodeAnalysis;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+internal static class NumericHelpers
+{
+    public static bool IsZero(Optional<object?> value)
+    {
+        if (!value.HasValue || value.Value is null)
+            return false;
+
+        return value.Value switch
+        {
+            byte v => v == 0,
+            sbyte v => v == 0,
+            short v => v == 0,
+            ushort v => v == 0,
+            int v => v == 0,
+            uint v => v == 0,
+            long v => v == 0,
+            ulong v => v == 0,
+            float v => v == 0,
+            double v => v == 0,
+            decimal v => v == 0,
+            _ => false,
+        };
+    }
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
@@ -5,4 +5,6 @@ internal static class RuleIdentifiers
     internal const string AssertionArgumentOrderDiagnosticId = "MFAS0001";
     internal const string ReferenceEqualsDiagnosticId = "MFAS0002";
     internal const string IsTypeInvalidTypeDiagnosticId = "MFAS0003";
+    internal const string UseEmptyAssertionDiagnosticId = "MFAS0004";
+    internal const string UseHasCountAssertionDiagnosticId = "MFAS0005";
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzer.cs
@@ -1,0 +1,51 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class CountAssertionAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor UseEmptyDescriptor = new(
+        id: RuleIdentifiers.UseEmptyAssertionDiagnosticId,
+        title: "Use Assert.Empty for zero count checks",
+        messageFormat: "Use Assert.Empty instead of Assert.Equal(0, count)",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseHasCountDescriptor = new(
+        id: RuleIdentifiers.UseHasCountAssertionDiagnosticId,
+        title: "Use Assert.HasCount for count checks",
+        messageFormat: "Use Assert.HasCount instead of Assert.Equal(expected, count)",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [UseEmptyDescriptor, UseHasCountDescriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var assertType = context.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+            if (assertType is null || !CountAssertionAnalyzerCommon.TryCreateSymbols(context.Compilation, out var symbols))
+                return;
+
+            context.RegisterOperationAction(context => Analyze(context, assertType, symbols), OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, INamedTypeSymbol assertType, CountAssertionAnalyzerCommon.Symbols symbols)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        if (!CountAssertionAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, symbols, out var match))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(match.UseEmptyAssertion ? UseEmptyDescriptor : UseHasCountDescriptor, match.CountOperation.Syntax.GetLocation()));
+    }
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzerCommon.cs
@@ -1,0 +1,191 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+internal static class CountAssertionAnalyzerCommon
+{
+    internal static bool TryCreateSymbols(Compilation compilation, out Symbols symbols)
+    {
+        var arrayType = compilation.GetSpecialType(SpecialType.System_Array);
+        if (arrayType is null)
+        {
+            symbols = default;
+            return false;
+        }
+
+        var collectionType = compilation.GetTypeByMetadataName("System.Collections.ICollection");
+        var genericCollectionType = compilation.GetTypeByMetadataName("System.Collections.Generic.ICollection`1");
+        var enumerableType = compilation.GetTypeByMetadataName("System.Linq.Enumerable");
+        if (collectionType is null || genericCollectionType is null || enumerableType is null)
+        {
+            symbols = default;
+            return false;
+        }
+
+        var nonGenericICollectionCountProperty = collectionType.GetMembers("Count").OfType<IPropertySymbol>().FirstOrDefault();
+        var genericICollectionCountPropertyDefinition = genericCollectionType.GetMembers("Count").OfType<IPropertySymbol>().FirstOrDefault();
+        var enumerableCountMethodDefinitions = enumerableType.GetMembers("Count")
+            .OfType<IMethodSymbol>()
+            .Where(m => m is { IsStatic: true, IsExtensionMethod: true, Parameters.Length: 1 })
+            .Select(m => m.OriginalDefinition)
+            .ToImmutableArray();
+        if (nonGenericICollectionCountProperty is null || genericICollectionCountPropertyDefinition is null || enumerableCountMethodDefinitions.IsDefaultOrEmpty)
+        {
+            symbols = default;
+            return false;
+        }
+
+        symbols = new Symbols(arrayType, nonGenericICollectionCountProperty, genericICollectionCountPropertyDefinition, enumerableCountMethodDefinitions);
+        return true;
+    }
+
+    internal static bool TryGetAssertionMatch(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, Symbols symbols, out AssertionMatch match)
+    {
+        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "Equal" } targetMethod ||
+            !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, assertType))
+        {
+            match = default;
+            return false;
+        }
+
+        IArgumentOperation? expectedArgument = null;
+        IArgumentOperation? actualArgument = null;
+        foreach (var argument in invocationOperation.Arguments)
+        {
+            switch (argument.Parameter?.Name)
+            {
+                case "expected":
+                    expectedArgument = argument;
+                    break;
+                case "actual":
+                    actualArgument = argument;
+                    break;
+            }
+        }
+
+        if (expectedArgument is null || actualArgument is null)
+        {
+            match = default;
+            return false;
+        }
+
+        if (!TryGetCollectionOperation(actualArgument.Value, symbols, out var collectionOperation, out var countOperation))
+        {
+            match = default;
+            return false;
+        }
+
+        var expectedValue = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(expectedArgument.Value);
+        var useEmptyAssertion = NumericHelpers.IsZero(expectedValue.ConstantValue);
+        if (!useEmptyAssertion && expectedValue.Type?.SpecialType != SpecialType.System_Int32)
+        {
+            match = default;
+            return false;
+        }
+
+        match = new AssertionMatch(expectedArgument, actualArgument, collectionOperation, countOperation, useEmptyAssertion);
+        return true;
+    }
+
+    private static bool TryGetCollectionOperation(IOperation operation, Symbols symbols, out IOperation collectionOperation, out IOperation countOperation)
+    {
+        operation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(operation);
+
+        switch (operation)
+        {
+            case IPropertyReferenceOperation { Instance: { } instance } propertyReferenceOperation
+                when IsArrayLengthProperty(propertyReferenceOperation.Property, symbols) ||
+                     IsCollectionCountProperty(propertyReferenceOperation.Property, symbols):
+                collectionOperation = instance;
+                countOperation = propertyReferenceOperation;
+                return true;
+
+            case IInvocationOperation invocationOperation when IsEnumerableCountInvocation(invocationOperation, symbols):
+                countOperation = invocationOperation;
+                if (invocationOperation.Instance is not null)
+                {
+                    collectionOperation = invocationOperation.Instance;
+                    return true;
+                }
+
+                if (invocationOperation.Arguments.FirstOrDefault(a => a.Parameter?.Name == "source") is { } sourceArgument)
+                {
+                    collectionOperation = sourceArgument.Value;
+                    return true;
+                }
+
+                break;
+        }
+
+        collectionOperation = null!;
+        countOperation = null!;
+        return false;
+    }
+
+    private static bool IsArrayLengthProperty(IPropertySymbol property, Symbols symbols)
+    {
+        return property is { Name: "Length" } &&
+               SymbolEqualityComparer.Default.Equals(property.ContainingType, symbols.ArrayType);
+    }
+
+    private static bool IsCollectionCountProperty(IPropertySymbol property, Symbols symbols)
+    {
+        if (property.Name != "Count")
+            return false;
+
+        if (SymbolEqualityComparer.Default.Equals(property, symbols.NonGenericICollectionCountProperty) ||
+            SymbolEqualityComparer.Default.Equals(property.OriginalDefinition, symbols.GenericICollectionCountPropertyDefinition))
+        {
+            return true;
+        }
+
+        if (property.ContainingType.FindImplementationForInterfaceMember(symbols.NonGenericICollectionCountProperty) is { } nonGenericImplementation &&
+            SymbolEqualityComparer.Default.Equals(nonGenericImplementation, property))
+        {
+            return true;
+        }
+
+        foreach (var interfaceType in property.ContainingType.AllInterfaces)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(interfaceType.OriginalDefinition, symbols.GenericICollectionCountPropertyDefinition.ContainingType))
+                continue;
+
+            var interfaceCountProperty = interfaceType.GetMembers("Count").OfType<IPropertySymbol>().FirstOrDefault();
+            if (interfaceCountProperty is null)
+                continue;
+
+            if (property.ContainingType.FindImplementationForInterfaceMember(interfaceCountProperty) is { } implementation &&
+                SymbolEqualityComparer.Default.Equals(implementation, property))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsEnumerableCountInvocation(IInvocationOperation invocationOperation, Symbols symbols)
+    {
+        var targetMethod = invocationOperation.TargetMethod.ReducedFrom ?? invocationOperation.TargetMethod;
+        if (targetMethod.Name != "Count")
+            return false;
+
+        return symbols.EnumerableCountMethodDefinitions.Any(method => SymbolEqualityComparer.Default.Equals(targetMethod.OriginalDefinition, method));
+    }
+
+    internal readonly record struct AssertionMatch(
+        IArgumentOperation ExpectedArgument,
+        IArgumentOperation ActualArgument,
+        IOperation CollectionOperation,
+        IOperation CountOperation,
+        bool UseEmptyAssertion);
+
+    internal readonly record struct Symbols(
+        INamedTypeSymbol ArrayType,
+        IPropertySymbol NonGenericICollectionCountProperty,
+        IPropertySymbol GenericICollectionCountPropertyDefinition,
+        ImmutableArray<IMethodSymbol> EnumerableCountMethodDefinitions);
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Meziantou.Framework.Assertions.CodeFix.csproj
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Meziantou.Framework.Assertions.CodeFix.csproj
@@ -11,6 +11,8 @@
 
   <ItemGroup>
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/AssertionArgumentOrderAnalyzerCommon.cs" Link="Rules/AssertionArgumentOrderAnalyzerCommon.cs" />
+    <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzerCommon.cs" Link="Rules/CountAssertionAnalyzerCommon.cs" />
+    <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Internals/NumericHelpers.cs" Link="Internals/NumericHelpers.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/AssertionsAnalyzerHelpers.cs" Link="AssertionsAnalyzerHelpers.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs" Link="RuleIdentifiers.cs" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/CountAssertionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/CountAssertionCodeFixProvider.cs
@@ -1,0 +1,170 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CountAssertionCodeFixProvider))]
+public sealed class CountAssertionCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => [RuleIdentifiers.UseEmptyAssertionDiagnosticId, RuleIdentifiers.UseHasCountAssertionDiagnosticId];
+
+    public override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var assertType = semanticModel.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+        if (assertType is null || !CountAssertionAnalyzerCommon.TryCreateSymbols(semanticModel.Compilation, out var symbols))
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            if (!TryFindFixableInvocation(semanticModel, node, assertType, symbols, context.CancellationToken, out var invocationExpression, out var match))
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: match.UseEmptyAssertion ? "Use Assert.Empty" : "Use Assert.HasCount",
+                    createChangedDocument: cancellationToken => ApplyFixAsync(context.Document, invocationExpression, assertType, symbols, cancellationToken),
+                    equivalenceKey: GetType().FullName),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocationExpression, INamedTypeSymbol assertType, CountAssertionAnalyzerCommon.Symbols symbols, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return document;
+
+        if (!TryGetAssertionMatch(semanticModel, invocationExpression, assertType, symbols, cancellationToken, out var match))
+            return document;
+
+        if (!TryGetCollectionExpression(match.CollectionOperation, out var collectionExpression))
+            return document;
+
+        var newInvocationExpression = invocationExpression
+            .WithExpression(ReplaceMethodName(invocationExpression.Expression, match.UseEmptyAssertion ? "Empty" : "HasCount"))
+            .WithArgumentList(CreateArgumentList(match, collectionExpression))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+        var newRoot = root.ReplaceNode(invocationExpression, newInvocationExpression);
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static bool TryGetAssertionMatch(
+        SemanticModel semanticModel,
+        InvocationExpressionSyntax invocationExpression,
+        INamedTypeSymbol assertType,
+        CountAssertionAnalyzerCommon.Symbols symbols,
+        CancellationToken cancellationToken,
+        out CountAssertionAnalyzerCommon.AssertionMatch match)
+    {
+        if (semanticModel.GetOperation(invocationExpression, cancellationToken) is IInvocationOperation invocationOperation &&
+            CountAssertionAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, symbols, out match))
+        {
+            return true;
+        }
+
+        match = default;
+        return false;
+    }
+
+    private static bool TryFindFixableInvocation(
+        SemanticModel semanticModel,
+        SyntaxNode diagnosticNode,
+        INamedTypeSymbol assertType,
+        CountAssertionAnalyzerCommon.Symbols symbols,
+        CancellationToken cancellationToken,
+        out InvocationExpressionSyntax invocationExpression,
+        out CountAssertionAnalyzerCommon.AssertionMatch match)
+    {
+        foreach (var candidate in diagnosticNode.AncestorsAndSelf().OfType<InvocationExpressionSyntax>())
+        {
+            if (TryGetAssertionMatch(semanticModel, candidate, assertType, symbols, cancellationToken, out match))
+            {
+                invocationExpression = candidate;
+                return true;
+            }
+        }
+
+        invocationExpression = null!;
+        match = default;
+        return false;
+    }
+
+    private static bool TryGetCollectionExpression(IOperation operation, out ExpressionSyntax collectionExpression)
+    {
+        var syntax = operation.Syntax;
+        if (syntax is ArgumentSyntax argumentSyntax)
+        {
+            collectionExpression = argumentSyntax.Expression;
+            return true;
+        }
+
+        if (syntax is ExpressionSyntax expressionSyntax)
+        {
+            collectionExpression = expressionSyntax;
+            return true;
+        }
+
+        collectionExpression = null!;
+        return false;
+    }
+
+    private static ExpressionSyntax ReplaceMethodName(ExpressionSyntax expression, string methodName)
+    {
+        if (expression is MemberAccessExpressionSyntax memberAccessExpression)
+        {
+            return memberAccessExpression.WithName(SyntaxFactory.IdentifierName(CreateIdentifier(memberAccessExpression.Name.Identifier, methodName)));
+        }
+
+        if (expression is IdentifierNameSyntax identifierName)
+            return identifierName.WithIdentifier(CreateIdentifier(identifierName.Identifier, methodName));
+
+        return expression;
+    }
+
+    private static SyntaxToken CreateIdentifier(SyntaxToken identifier, string text)
+    {
+        return SyntaxFactory.Identifier(identifier.LeadingTrivia, text, identifier.TrailingTrivia);
+    }
+
+    private static ArgumentListSyntax CreateArgumentList(CountAssertionAnalyzerCommon.AssertionMatch match, ExpressionSyntax collectionExpression)
+    {
+        if (match.UseEmptyAssertion)
+        {
+            var actualArgument = (ArgumentSyntax)match.ActualArgument.Syntax;
+            return SyntaxFactory.ArgumentList([SyntaxFactory.Argument(collectionExpression.WithoutTrivia()).WithTriviaFrom(actualArgument)]);
+        }
+
+        var expectedArgument = (ArgumentSyntax)match.ExpectedArgument.Syntax;
+        var actualCountArgument = (ArgumentSyntax)match.ActualArgument.Syntax;
+        return SyntaxFactory.ArgumentList(
+        [
+            SyntaxFactory.Argument(expectedArgument.Expression.WithoutTrivia()).WithTriviaFrom(expectedArgument),
+            SyntaxFactory.Argument(collectionExpression.WithoutTrivia()).WithTriviaFrom(actualCountArgument),
+        ]);
+    }
+}

--- a/src/Meziantou.Framework.Assertions/readme.md
+++ b/src/Meziantou.Framework.Assertions/readme.md
@@ -12,4 +12,6 @@ The package ships analyzers and code fixes to help write clearer assertions.
 | `MFAS0001` | Assertions | Pass the expected value before the actual value | Warning | ✔️ |
 | `MFAS0002` | Assertions | Use Assert.Same instead of Assert.ReferenceEquals | Error | ✔️ |
 | `MFAS0003` | Assertions | Do not use Assert.IsType with static or abstract types | Error | ✔️ |
+| `MFAS0004` | Assertions | Use Assert.Empty for zero count checks | Warning | ✔️ |
+| `MFAS0005` | Assertions | Use Assert.HasCount for count checks | Warning | ✔️ |
 <!-- analyzer-rules -->

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CountAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CountAssertionRuleTests.cs
@@ -1,0 +1,253 @@
+using CountAssertionAnalyzerType = Meziantou.Framework.Analyzers.Assertions.CountAssertionAnalyzer;
+using CountAssertionCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.CountAssertionCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class CountAssertionRuleTests : AssertionsAnalyzerTestBase
+{
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForLength()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.Equal(10, {|MFAS0005:collection.Length|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.HasCount(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForCountProperty()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.Equal(10, {|MFAS0005:collection.Count|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.HasCount(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForCountMethod()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.Equal(10, {|MFAS0005:collection.Count()|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.HasCount(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ToEmpty_WhenExpectedCountIsZero()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.Equal(0, {|MFAS0004:collection.Count()|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.Empty(collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ToEmpty_WhenExpectedCountIsLongZero()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.Equal(0L, {|MFAS0004:collection.Count()|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.Empty(collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForUnrelatedAssertions()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection, int value)
+                {
+                    Assert.Equal(10, value);
+                    Assert.Equal(10, collection.Count(i => i > 0));
+                    Assert.Equal(10L, collection.Count());
+                    Assert.NotEqual(10, collection.Count());
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<CountAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForCustomCountLikeMembers()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class EnumerableExtensions
+            {
+                public static int Count<T>(this IEnumerable<T> source)
+                {
+                    return 42;
+                }
+            }
+
+            public sealed class CustomCollection
+            {
+                public int Count => 10;
+                public int Length => 10;
+            }
+
+            public static class TestClass
+            {
+                public static void M(CustomCollection collection, IEnumerable<int> enumerable)
+                {
+                    Assert.Equal(10, collection.Count);
+                    Assert.Equal(10, collection.Length);
+                    Assert.Equal(10, enumerable.Count());
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<CountAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}


### PR DESCRIPTION
## Why
`Assert.Equal(expected, collection.Count/Length)` assertions are less expressive than dedicated count assertions, and name-based matching can produce false positives. This change adds precise analyzer guidance so count checks are consistently rewritten to `Assert.Empty` or `Assert.HasCount`.

## What changed
- Added two diagnostics:
  - `MFAS0004`: prefer `Assert.Empty` for zero-count checks
  - `MFAS0005`: prefer `Assert.HasCount` for non-zero count checks
- Implemented symbol-based matching for count expressions:
  - `Array.Length`
  - `ICollection.Count` (including interface implementations)
  - `System.Linq.Enumerable.Count()` extension method
- Added `NumericHelpers.IsZero(...)` to centralize zero detection and make broader numeric handling easier in future rules.
- Added code fixes for both diagnostics and wired shared analyzer internals into the code-fix project.
- Added focused analyzer/code-fix tests, including negative tests for custom count-like members and a zero-as-`long` case.
- Updated analyzer rule documentation in `src/Meziantou.Framework.Assertions/readme.md`.

## Notes for reviewers
`Assert.HasCount` is intentionally kept type-safe by requiring an `int` expected value for non-zero suggestions, while zero detection uses the shared helper to support more numeric constants.