### PR TITLE
Fix CI by updating count assertions for MFAS rules

### DIFF
--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -1424,7 +1424,7 @@ jobs:
         // Ensure getting scanning in parallel gives the same result
         options.DegreeOfParallelism = 16;
         var dependencies2 = await Scan(options);
-        Assert.Equal(dependencies.Length, dependencies2.Length);
+        Assert.HasCount(dependencies.Length, dependencies2);
         return dependencies;
 
         async Task<Dependency[]> Scan(ScannerOptions options)

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsRecordExtensionsTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsRecordExtensionsTests.cs
@@ -19,7 +19,7 @@ public sealed class DnsRecordExtensionsTests
 
         var addresses = records.GetIPAddresses().ToList();
 
-        Assert.Equal(3, addresses.Count);
+        Assert.HasCount(3, addresses);
         Assert.Equal(IPAddress.Parse("1.2.3.4"), addresses[0]);
         Assert.Equal(IPAddress.Parse("::1"), addresses[1]);
         Assert.Equal(IPAddress.Parse("5.6.7.8"), addresses[2]);
@@ -38,7 +38,7 @@ public sealed class DnsRecordExtensionsTests
 
         var addresses = records.GetIPAddresses().ToList();
 
-        Assert.Equal(2, addresses.Count);
+        Assert.HasCount(2, addresses);
         Assert.Equal(IPAddress.Parse("1.1.1.1"), addresses[0]);
         Assert.Equal(IPAddress.Parse("2606:4700::1"), addresses[1]);
     }
@@ -63,7 +63,7 @@ public sealed class DnsRecordExtensionsTests
 
         var addresses = records.GetIPv4Addresses().ToList();
 
-        Assert.Equal(2, addresses.Count);
+        Assert.HasCount(2, addresses);
         Assert.All(addresses, a => Assert.Equal(AddressFamily.InterNetwork, a.AddressFamily));
     }
 
@@ -79,7 +79,7 @@ public sealed class DnsRecordExtensionsTests
 
         var addresses = records.GetIPv6Addresses().ToList();
 
-        Assert.Equal(2, addresses.Count);
+        Assert.HasCount(2, addresses);
         Assert.All(addresses, a => Assert.Equal(AddressFamily.InterNetworkV6, a.AddressFamily));
     }
 

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
@@ -14,7 +14,7 @@ public sealed class DnsWireFormatTests
         var bytes = writer.ToArray();
 
         // \x07example\x03com\x00
-        Assert.Equal(13, bytes.Length);
+        Assert.HasCount(13, bytes);
         Assert.Equal(7, bytes[0]);
         Assert.Equal((byte)'e', bytes[1]);
         Assert.Equal(3, bytes[8]);
@@ -41,7 +41,7 @@ public sealed class DnsWireFormatTests
         var bytes = writer.ToArray();
 
         // Should be same as without trailing dot
-        Assert.Equal(13, bytes.Length);
+        Assert.HasCount(13, bytes);
         Assert.Equal(0, bytes[12]);
     }
 

--- a/tests/Meziantou.Framework.DnsServer.Tests/DnsMessageEncoderTests.cs
+++ b/tests/Meziantou.Framework.DnsServer.Tests/DnsMessageEncoderTests.cs
@@ -194,7 +194,7 @@ public sealed class DnsMessageEncoderTests
         var decoded = DnsMessageEncoder.DecodeQuery(bytes);
 
         var data = Assert.IsType<DnsTxtRecordData>(Assert.Single(decoded.Answers).Data);
-        Assert.Equal(2, data.Text.Count);
+        Assert.HasCount(2, data.Text);
         Assert.Equal("v=spf1 include:_spf.google.com ~all", data.Text[0]);
         Assert.Equal("hello world", data.Text[1]);
     }
@@ -537,7 +537,7 @@ public sealed class DnsMessageEncoderTests
         Assert.Contains(DnsQueryType.A, data.TypeBitMaps);
         Assert.Contains(DnsQueryType.AAAA, data.TypeBitMaps);
         Assert.Contains(DnsQueryType.MX, data.TypeBitMaps);
-        Assert.Equal(3, data.TypeBitMaps.Count);
+        Assert.HasCount(3, data.TypeBitMaps);
     }
 
     [Fact]
@@ -665,7 +665,7 @@ public sealed class DnsMessageEncoderTests
         var bytes = DnsMessageEncoder.EncodeResponse(response);
         var decoded = DnsMessageEncoder.DecodeQuery(bytes);
 
-        Assert.Equal(2, decoded.Answers.Count);
+        Assert.HasCount(2, decoded.Answers);
         Assert.Single(decoded.Authorities);
         Assert.Equal(IPAddress.Parse("192.168.1.1"), ((DnsARecordData)decoded.Answers[0].Data!).Address);
         Assert.Equal(IPAddress.Parse("192.168.1.2"), ((DnsARecordData)decoded.Answers[1].Data!).Address);
@@ -766,7 +766,7 @@ public sealed class DnsMessageEncoderTests
         var bytes = DnsMessageEncoder.EncodeResponse(query);
         var decoded = DnsMessageEncoder.DecodeQuery(bytes);
 
-        Assert.Equal(2, decoded.Questions.Count);
+        Assert.HasCount(2, decoded.Questions);
         Assert.Equal(DnsQueryType.A, decoded.Questions[0].Type);
         Assert.Equal(DnsQueryType.AAAA, decoded.Questions[1].Type);
     }

--- a/tests/Meziantou.Framework.Http.Recording.Tests/ThreadSafetyTests.cs
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/ThreadSafetyTests.cs
@@ -45,7 +45,7 @@ public sealed class ThreadSafetyTests
 
         await Task.WhenAll(tasks);
 
-        Assert.Equal(RequestCount, results.Count);
+        Assert.HasCount(RequestCount, results);
         Assert.Equal(0, innerHandler.CallCount);
 
         // Verify all unique responses were returned

--- a/tests/Meziantou.Framework.Http.Tests/LinkHeaderValueTests.cs
+++ b/tests/Meziantou.Framework.Http.Tests/LinkHeaderValueTests.cs
@@ -36,7 +36,7 @@ public sealed class LinkHeaderValueTests
             { "link", "<e>;rel=f" },
         };
 
-        Assert.Equal(3, header.EnumerateLinkHeaders().Count());
+        Assert.HasCount(3, header.EnumerateLinkHeaders());
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.HttpArchive.Tests/HarDocumentTests.cs
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/HarDocumentTests.cs
@@ -143,7 +143,7 @@ public sealed class HarDocumentTests
         Assert.Equal("https://example.com/api/data", entry.Request.Url);
         Assert.Equal("HTTP/1.1", entry.Request.HttpVersion);
         Assert.Equal(200, entry.Request.HeadersSize);
-        Assert.Equal(2, entry.Request.Headers.Count);
+        Assert.HasCount(2, entry.Request.Headers);
         var cookie = Assert.Single(entry.Request.Cookies);
         Assert.Equal("session", cookie.Name);
         Assert.Equal("abc123", cookie.Value);
@@ -180,7 +180,7 @@ public sealed class HarDocumentTests
         Assert.Equal(doc.Log.Version, doc2.Log.Version);
         Assert.Equal(doc.Log.Creator.Name, doc2.Log.Creator.Name);
         Assert.Equal(doc.Log.Browser?.Name, doc2.Log.Browser?.Name);
-        Assert.Equal(doc.Log.Entries.Count, doc2.Log.Entries.Count);
+        Assert.HasCount(doc.Log.Entries.Count, doc2.Log.Entries);
 
         var entry1 = doc.Log.Entries[0];
         var entry2 = doc2.Log.Entries[0];

--- a/tests/Meziantou.Framework.JsonPath.Tests/ComplianceTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/ComplianceTests.cs
@@ -110,7 +110,7 @@ public sealed class ComplianceTests
             case JsonValueKind.Object:
                 var expectedObj = expected.AsObject();
                 var actualObj = actual.AsObject();
-                Assert.Equal(expectedObj.Count, actualObj.Count);
+                Assert.HasCount(expectedObj.Count, actualObj);
                 foreach (var prop in expectedObj)
                 {
                     Assert.True(actualObj.ContainsKey(prop.Key), $"{context}: missing property '{prop.Key}'");
@@ -122,7 +122,7 @@ public sealed class ComplianceTests
             case JsonValueKind.Array:
                 var expectedArr = expected.AsArray();
                 var actualArr = actual.AsArray();
-                Assert.Equal(expectedArr.Count, actualArr.Count);
+                Assert.HasCount(expectedArr.Count, actualArr);
                 for (var i = 0; i < expectedArr.Count; i++)
                 {
                     AssertJsonNodesEqual(expectedArr[i], actualArr[i], $"{context}[{i}]");

--- a/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/NugetPackageValidateToolTests.cs
+++ b/tests/Meziantou.Framework.NuGetPackageValidation.Tool.Tests/NugetPackageValidateToolTests.cs
@@ -51,7 +51,7 @@ public sealed class NugetPackageValidateToolTests(ITestOutputHelper testOutputHe
         var path2 = FullPath.FromPath("Packages/Release.1.0.0.nupkg");
         var result = await RunValidation(path1, path2);
         Assert.Equal(1, result.ExitCode);
-        Assert.Equal(2, result.ValidationResults!.Packages.Count);
+        Assert.HasCount(2, result.ValidationResults!.Packages);
         Assert.False(result.ValidationResults.Packages[path1].IsValid);
         Assert.Contains(result.ValidationResults.Packages[path1].Errors, item => item.ErrorCode == 81);
         Assert.False(result.ValidationResults.Packages[path2].IsValid);

--- a/tests/Meziantou.Framework.OpenTelemetry.Tests/OpenTelemetryReceiverTests.cs
+++ b/tests/Meziantou.Framework.OpenTelemetry.Tests/OpenTelemetryReceiverTests.cs
@@ -170,7 +170,7 @@ public sealed class OpenTelemetryReceiverTests
         await SendTracesAsync(app.HttpClient, CreateTraceRequest("00000000000000000000000000000021", ("0000000000000021", null, "root-keep")));
 
         var spans = GetTraceSpans(app.Receiver);
-        Assert.Equal(2, spans.Count);
+        Assert.HasCount(2, spans);
         Assert.Contains(spans, span => span.Name == "root-keep");
         Assert.Contains(spans, span => span.Name == "child");
     }
@@ -193,7 +193,7 @@ public sealed class OpenTelemetryReceiverTests
         _ = await client.ExportAsync(CreateTraceRequest("00000000000000000000000000000031", ("0000000000000031", null, "root-keep")), cancellationToken: XunitCancellationToken).ResponseAsync;
 
         var spans = GetTraceSpans(app.Receiver);
-        Assert.Equal(2, spans.Count);
+        Assert.HasCount(2, spans);
         Assert.Contains(spans, span => span.Name == "root-keep");
         Assert.Contains(spans, span => span.Name == "child");
     }
@@ -264,7 +264,7 @@ public sealed class OpenTelemetryReceiverTests
             ("0000000000000063", "0000000000000061", "child-2")));
 
         var spans = GetTraceSpans(app.Receiver);
-        Assert.Equal(2, spans.Count);
+        Assert.HasCount(2, spans);
         Assert.Contains(spans, span => span.Name == "root");
         Assert.Contains(spans, span => span.Name == "child-1");
         Assert.DoesNotContain(spans, span => span.Name == "child-2");
@@ -296,7 +296,7 @@ public sealed class OpenTelemetryReceiverTests
 
         var spans = GetTraceSpans(app.Receiver);
         var names = spans.Select(span => span.Name).ToList();
-        Assert.Equal(2, names.Count);
+        Assert.HasCount(2, names);
         Assert.DoesNotContain("root", names);
         Assert.Contains("child-1", names);
         Assert.Contains("child-2", names);
@@ -315,7 +315,7 @@ public sealed class OpenTelemetryReceiverTests
         await SendLogsAsync(app.HttpClient, "third");
 
         var items = app.Receiver.Logs.ToList();
-        Assert.Equal(2, items.Count);
+        Assert.HasCount(2, items);
 
         var first = Assert.IsType<OpenTelemetryLogsItem>(items[0]);
         var second = Assert.IsType<OpenTelemetryLogsItem>(items[1]);
@@ -332,7 +332,7 @@ public sealed class OpenTelemetryReceiverTests
         await SendLogsAsync(app.HttpClient, "second");
         await SendLogsAsync(app.HttpClient, "third");
 
-        Assert.Equal(3, app.Receiver.Logs.Count());
+        Assert.HasCount(3, app.Receiver.Logs);
     }
 
     private static async Task SendLogsAsync(HttpClient httpClient, string body, string endpoint = "/v1/logs")

--- a/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
+++ b/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
@@ -135,7 +135,7 @@ public sealed class PooledMemoryStreamTests
         stream.Write(overwrite);
 
         var result = stream.ToArray();
-        Assert.Equal(100, result.Length);
+        Assert.HasCount(100, result);
         Assert.Equal(overwrite, result.AsSpan(20, overwrite.Length));
     }
 
@@ -149,7 +149,7 @@ public sealed class PooledMemoryStreamTests
         stream.Write("xyz"u8);
 
         var result = stream.ToArray();
-        Assert.Equal(23, result.Length);
+        Assert.HasCount(23, result);
         Assert.Equal("abc"u8, result.AsSpan()[0..3]);
         Assert.All(result.AsSpan()[3..20], b => Assert.Equal(0, b));
         Assert.Equal("xyz"u8, result.AsSpan()[20..23]);
@@ -165,7 +165,7 @@ public sealed class PooledMemoryStreamTests
         Assert.Equal(100, stream.Length);
 
         var result = stream.ToArray();
-        Assert.Equal(100, result.Length);
+        Assert.HasCount(100, result);
         Assert.All(result.AsSpan()[10..], b => Assert.Equal(0, b));
     }
 
@@ -218,7 +218,7 @@ public sealed class PooledMemoryStreamTests
         Assert.Equal(data, buffer.AsSpan(0, length).ToArray());
 
         Assert.True(stream.TryGetBuffer(out var segment));
-        Assert.Equal(length, segment.Count);
+        Assert.HasCount(length, segment);
         Assert.Equal(data, segment.AsSpan().ToArray());
 
         using var target = new MemoryStream();
@@ -294,7 +294,7 @@ public sealed class PooledMemoryStreamTests
         writer.Advance(10);
 
         var result = stream.ToArray();
-        Assert.Equal(30, result.Length);
+        Assert.HasCount(30, result);
         for (var i = 0; i < 20; i++)
             Assert.Equal((byte)i, result[i]);
         for (var i = 0; i < 10; i++)

--- a/tests/Meziantou.Framework.Scheduling.Tests/CronExpressionTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/CronExpressionTests.cs
@@ -269,7 +269,7 @@ public sealed class CronExpressionTests
     private static void AssertOccurrencesStartWith(IEnumerable<DateTime> occurrences, params DateTime[] expectedOccurrences)
     {
         var actualList = occurrences.Take(expectedOccurrences.Length).ToList();
-        Assert.Equal(expectedOccurrences.Length, actualList.Count);
+        Assert.HasCount(expectedOccurrences.Length, actualList);
         for (var i = 0; i < expectedOccurrences.Length; i++)
         {
             Assert.Equal(expectedOccurrences[i], actualList[i]);

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
@@ -40,7 +40,7 @@ public sealed class ExpressionQueryBuilderTests
         var items = new[] { new Sample { Int32Value = 3 }, new Sample { Int32Value = 5 }, new Sample { Int32Value = 7 }, new Sample { Int32Value = 10 }, new Sample { Int32Value = 12 } }.AsQueryable();
         var result = query.Apply(items).ToList();
 
-        Assert.Equal(3, result.Count);
+        Assert.HasCount(3, result);
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public sealed class ExpressionQueryBuilderTests
         }.AsQueryable();
         var result = query.Apply(items).ToList();
 
-        Assert.Equal(2, result.Count);
+        Assert.HasCount(2, result);
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public sealed class ExpressionQueryBuilderTests
         var items = new[] { new Sample { Int32Value = 1 }, new Sample { Int32Value = 2 } }.AsQueryable();
         var result = query.Apply(items).ToList();
 
-        Assert.Equal(2, result.Count);
+        Assert.HasCount(2, result);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
+++ b/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
@@ -27,7 +27,7 @@ public sealed class SingleInstanceTests
             await Task.Delay(50);
         }
 
-        Assert.Equal(2, events.Count);
+        Assert.HasCount(2, events);
         var orderedEvents = events.OrderBy(args => args.Arguments.Length).ToList();
         Assert.Equal(["123"], orderedEvents[0].Arguments);
         Assert.Equal(["a", "b", "c"], orderedEvents[1].Arguments);

--- a/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
@@ -192,7 +192,7 @@ public class TemplateTest
         var textBlocks = template.Blocks.OfType<TextBlock>().ToArray();
 
         Assert.Equal("a\nb", template.Run());
-        Assert.Equal(2, textBlocks.Length);
+        Assert.HasCount(2, textBlocks);
         Assert.Equal("a\n", textBlocks[0].Text);
         Assert.Equal("b", textBlocks[1].Text);
     }
@@ -210,7 +210,7 @@ public class TemplateTest
         var textBlocks = template.Blocks.OfType<TextBlock>().ToArray();
 
         Assert.Equal("a\nb", template.Run());
-        Assert.Equal(2, textBlocks.Length);
+        Assert.HasCount(2, textBlocks);
         Assert.Equal("a\n", textBlocks[0].Text);
         Assert.Equal("b", textBlocks[1].Text);
     }

--- a/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
+++ b/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
@@ -16,7 +16,7 @@ public class TemporaryDirectoryTests
                 dirs[i].CreateEmptyFile("test.txt");
             });
 
-            Assert.Equal(Iterations, dirs.Select(dir => dir.FullPath).Distinct().Count());
+            Assert.HasCount(Iterations, dirs.Select(dir => dir.FullPath).Distinct());
 
             foreach (var dir in dirs)
             {

--- a/tests/Meziantou.Framework.Tests/Collections/AppendOnlyCollectionTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/AppendOnlyCollectionTests.cs
@@ -21,7 +21,7 @@ public sealed class AppendOnlyCollectionTests
             collection.Add(i);
         }
 
-        Assert.Equal(10000, collection.Count);
+        Assert.HasCount(10000, collection);
         for (var i = 0; i < 1000; i++)
         {
             Assert.Equal(i, collection[i]);
@@ -49,7 +49,7 @@ public sealed class AppendOnlyCollectionTests
             collection.Add(i);
         }
 
-        Assert.Equal(10000, collection.Count);
+        Assert.HasCount(10000, collection);
         for (var i = 0; i < 1000; i++)
         {
             Assert.Equal(i, collection[i]);
@@ -199,6 +199,6 @@ public sealed class AppendOnlyCollectionTests
         cts.Cancel();
         await Task.WhenAll(readers);
 
-        Assert.Equal(Count, collection.Count);
+        Assert.HasCount(Count, collection);
     }
 }

--- a/tests/Meziantou.Framework.Tests/Collections/DoubleEndedQueueTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/DoubleEndedQueueTests.cs
@@ -25,7 +25,7 @@ public sealed class DoubleEndedQueueTests
         list.AddLast(3);
 
         Assert.Equal([1, 2, 3], list);
-        Assert.Equal(3, list.Count);
+        Assert.HasCount(3, list);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableArrayTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableArrayTests.cs
@@ -168,7 +168,7 @@ public sealed class ImmutableEquatableArrayTests
         var array = ImmutableEquatableArray.Create(new[] { "a", "b", "c" });
         var readOnlyList = (IReadOnlyList<string>)array;
 
-        Assert.Equal(3, readOnlyList.Count);
+        Assert.HasCount(3, readOnlyList);
         Assert.Equal("a", readOnlyList[0]);
         Assert.Equal("b", readOnlyList[1]);
         Assert.Equal("c", readOnlyList[2]);
@@ -181,7 +181,7 @@ public sealed class ImmutableEquatableArrayTests
         var collection = (ICollection<string>)array;
 
         Assert.True(collection.IsReadOnly);
-        Assert.Equal(2, collection.Count);
+        Assert.HasCount(2, collection);
     }
 
     [Fact]
@@ -192,7 +192,7 @@ public sealed class ImmutableEquatableArrayTests
 
         Assert.True(list.IsReadOnly);
         Assert.True(list.IsFixedSize);
-        Assert.Equal(2, list.Count);
+        Assert.HasCount(2, list);
         Assert.False(list.IsSynchronized);
         Assert.Same(array, list.SyncRoot);
     }

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableDictionaryTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableDictionaryTests.cs
@@ -11,7 +11,7 @@ public sealed class ImmutableEquatableDictionaryTests
     {
         var empty = ImmutableEquatableDictionary<string, int>.Empty;
 
-        Assert.Equal(0, empty.Count);
+        Assert.Empty(empty);
         Assert.Empty(empty);
         Assert.False(empty.ContainsKey("test"));
     }
@@ -30,7 +30,7 @@ public sealed class ImmutableEquatableDictionaryTests
     {
         var empty = ImmutableEquatableDictionary.Empty<string, int>();
 
-        Assert.Equal(0, empty.Count);
+        Assert.Empty(empty);
         Assert.Empty(empty);
     }
 
@@ -46,7 +46,7 @@ public sealed class ImmutableEquatableDictionaryTests
 
         var dict = pairs.ToImmutableEquatableDictionary();
 
-        Assert.Equal(3, dict.Count);
+        Assert.HasCount(3, dict);
         Assert.Equal(1, dict["a"]);
         Assert.Equal(2, dict["b"]);
         Assert.Equal(3, dict["c"]);
@@ -67,7 +67,7 @@ public sealed class ImmutableEquatableDictionaryTests
 
         var dict = values.ToImmutableEquatableDictionary(s => s[0]);
 
-        Assert.Equal(3, dict.Count);
+        Assert.HasCount(3, dict);
         Assert.Equal("apple", dict['a']);
         Assert.Equal("banana", dict['b']);
         Assert.Equal("cherry", dict['c']);
@@ -80,7 +80,7 @@ public sealed class ImmutableEquatableDictionaryTests
 
         var dict = values.ToImmutableEquatableDictionary(s => s[0], s => s.Length);
 
-        Assert.Equal(3, dict.Count);
+        Assert.HasCount(3, dict);
         Assert.Equal(5, dict['a']); // "apple".Length
         Assert.Equal(6, dict['b']); // "banana".Length
         Assert.Equal(6, dict['c']); // "cherry".Length
@@ -226,7 +226,7 @@ public sealed class ImmutableEquatableDictionaryTests
             actual.Add((kvp.Key, kvp.Value));
         }
 
-        Assert.Equal(expected.Length, actual.Count);
+        Assert.HasCount(expected.Length, actual);
         foreach (var item in expected)
         {
             Assert.Contains(item, actual);
@@ -240,7 +240,7 @@ public sealed class ImmutableEquatableDictionaryTests
 
         var keys = dict.Keys;
 
-        Assert.Equal(3, keys.Count);
+        Assert.HasCount(3, keys);
         Assert.Contains("a", keys);
         Assert.Contains("b", keys);
         Assert.Contains("c", keys);
@@ -253,7 +253,7 @@ public sealed class ImmutableEquatableDictionaryTests
 
         var values = dict.Values;
 
-        Assert.Equal(3, values.Count);
+        Assert.HasCount(3, values);
         Assert.Contains(1, values);
         Assert.Contains(2, values);
         Assert.Contains(3, values);
@@ -339,7 +339,7 @@ public sealed class ImmutableEquatableDictionaryTests
         var source = new Dictionary<string, int>(StringComparer.Ordinal) { ["a"] = 1, ["b"] = 2 };
         var dict = source.ToImmutableEquatableDictionary();
 
-        Assert.Equal(2, dict.Count);
+        Assert.HasCount(2, dict);
         Assert.Equal(1, dict["a"]);
         Assert.Equal(2, dict["b"]);
     }

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
@@ -10,7 +10,7 @@ public sealed class ImmutableEquatableSetTests
     public void Empty_ShouldReturnEmptySet()
     {
         var empty = ImmutableEquatableSet<string>.Empty;
-        Assert.Equal(0, empty.Count);
+        Assert.Empty(empty);
     }
 
     [Fact]
@@ -19,7 +19,7 @@ public sealed class ImmutableEquatableSetTests
         var values = new HashSet<string>(StringComparer.Ordinal) { "a", "b", "c" };
         var set = ImmutableEquatableSet.Create(values);
 
-        Assert.Equal(3, set.Count);
+        Assert.HasCount(3, set);
         Assert.Contains("a", set);
         Assert.Contains("b", set);
         Assert.Contains("c", set);
@@ -166,7 +166,7 @@ public sealed class ImmutableEquatableSetTests
         var collection = (ICollection<string>)set;
 
         Assert.True(collection.IsReadOnly);
-        Assert.Equal(2, collection.Count);
+        Assert.HasCount(2, collection);
     }
 
     [Fact]
@@ -175,7 +175,7 @@ public sealed class ImmutableEquatableSetTests
         var set = ImmutableEquatableSet.Create(new HashSet<string>(StringComparer.Ordinal) { "a", "b" });
         var collection = (System.Collections.ICollection)set;
 
-        Assert.Equal(2, collection.Count);
+        Assert.HasCount(2, collection);
         Assert.False(collection.IsSynchronized);
         Assert.Same(set, collection.SyncRoot);
     }
@@ -294,7 +294,7 @@ public sealed class ImmutableEquatableSetTests
         var values = new[] { "a", "b", "c", "a" }; // Include duplicate
         var result = values.ToImmutableEquatableSet();
 
-        Assert.Equal(3, result.Count); // Should remove duplicate
+        Assert.HasCount(3, result); // Should remove duplicate
         Assert.Contains("a", result);
         Assert.Contains("b", result);
         Assert.Contains("c", result);
@@ -322,7 +322,7 @@ public sealed class ImmutableEquatableSetTests
         var values = new[] { "a", "b", "c", "a" }; // Include duplicate
         var result = ImmutableEquatableSet.Create(values.AsSpan());
 
-        Assert.Equal(3, result.Count); // Should remove duplicate
+        Assert.HasCount(3, result); // Should remove duplicate
         Assert.Contains("a", result);
         Assert.Contains("b", result);
         Assert.Contains("c", result);
@@ -333,7 +333,7 @@ public sealed class ImmutableEquatableSetTests
     {
         ImmutableEquatableSet<string> set = ["a", "b", "c", "a"]; // Include duplicate
 
-        Assert.Equal(3, set.Count); // Should remove duplicate
+        Assert.HasCount(3, set); // Should remove duplicate
         Assert.Contains("a", set);
         Assert.Contains("b", set);
         Assert.Contains("c", set);
@@ -345,7 +345,7 @@ public sealed class ImmutableEquatableSetTests
         var empty = ImmutableEquatableSet<string>.Empty;
         var iset = (ISet<string>)empty;
 
-        Assert.Equal(0, empty.Count);
+        Assert.Empty(empty);
         Assert.DoesNotContain("anything", empty);
         Assert.True(iset.IsSubsetOf(new[] { "a", "b" }));
         Assert.False(iset.IsSupersetOf(new[] { "a" }));

--- a/tests/Meziantou.Framework.Tests/Collections/SkipListTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/SkipListTests.cs
@@ -10,7 +10,7 @@ public sealed class SkipListTests
         var list = new SkipList<int> { 3, 1, 2, 1, 3 };
 
         Assert.Equal([1, 2, 3], list);
-        Assert.Equal(3, list.Count);
+        Assert.HasCount(3, list);
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public sealed class SkipListTests
         var list = new SkipList<int>([5, 1, 5, 2, 1]);
 
         Assert.Equal([1, 2, 5], list);
-        Assert.Equal(3, list.Count);
+        Assert.HasCount(3, list);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Tests/Collections/UnsafeListDictionaryTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/UnsafeListDictionaryTests.cs
@@ -15,13 +15,13 @@ public class UnsafeListDictionaryTests
             { 2, "c" },
         };
 
-        Assert.Equal(3, dict.Count); // Allows duplicate values
+        Assert.HasCount(3, dict); // Allows duplicate values
         Assert.Contains(1, (IReadOnlyDictionary<int, string>)dict);
         Assert.Contains(2, (IReadOnlyDictionary<int, string>)dict);
         Assert.DoesNotContain(4, (IReadOnlyDictionary<int, string>)dict);
 
         dict[1] = "d";
-        Assert.Equal(3, dict.Count); // Replace existing item
+        Assert.HasCount(3, dict); // Replace existing item
         Assert.Equal([1, 2, 2], dict.Keys);
         Assert.Equal(["d", "b", "c"], dict.Values);
 

--- a/tests/Meziantou.Framework.Tests/EnumerableTests.cs
+++ b/tests/Meziantou.Framework.Tests/EnumerableTests.cs
@@ -69,7 +69,7 @@ public class EnumerableTests
             bag.Add(i);
         });
 
-        Assert.Equal(100, bag.Count);
+        Assert.HasCount(100, bag);
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class EnumerableTests
             bag.Add(i);
         });
 
-        Assert.Equal(100, bag.Count);
+        Assert.HasCount(100, bag);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Tests/LoremIpsumGeneratorTests.cs
+++ b/tests/Meziantou.Framework.Tests/LoremIpsumGeneratorTests.cs
@@ -12,7 +12,7 @@ public class LoremIpsumGeneratorTests
         Assert.EndsWith(".", sentence, StringComparison.Ordinal);
         var content = sentence[..^1];
         Assert.True(char.IsUpper(content[0]));
-        Assert.Equal(4, content.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length);
+        Assert.HasCount(4, content.Split(' ', StringSplitOptions.RemoveEmptyEntries));
     }
 
     [Fact]
@@ -22,12 +22,12 @@ public class LoremIpsumGeneratorTests
 
         Assert.EndsWith(".", paragraph, StringComparison.Ordinal);
         var sentences = paragraph.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        Assert.Equal(3, sentences.Length);
+        Assert.HasCount(3, sentences);
 
         foreach (var sentence in sentences)
         {
             Assert.True(char.IsUpper(sentence[0]));
-            Assert.Equal(5, sentence.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length);
+            Assert.HasCount(5, sentence.Split(' ', StringSplitOptions.RemoveEmptyEntries));
         }
     }
 
@@ -36,7 +36,7 @@ public class LoremIpsumGeneratorTests
     {
         var paragraphs = LoremIpsumGenerator.Paragraphs(wordsPerSentence: 3, sentencesPerParagraph: 2, paragraphCount: 4).ToArray();
 
-        Assert.Equal(4, paragraphs.Length);
+        Assert.HasCount(4, paragraphs);
         Assert.All(paragraphs, item => Assert.NotEmpty(item));
     }
 }

--- a/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
+++ b/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
@@ -583,7 +583,7 @@ public sealed class TextDiffTests
         Assert.Equal(NewText, ReconstructHierarchyNewText(result));
 
         var replacedEntries = result.Entries.Where(e => e.Operation == TextDiffHierarchyOperation.Replace).ToList();
-        Assert.Equal(2, replacedEntries.Count);
+        Assert.HasCount(2, replacedEntries);
 
         Assert.Contains(replacedEntries[0].Children, e => e.Operation == TextDiffHierarchyOperation.Delete && e.OldText == "a");
         Assert.Contains(replacedEntries[0].Children, e => e.Operation == TextDiffHierarchyOperation.Insert && e.NewText == "o");
@@ -648,7 +648,7 @@ public sealed class TextDiffTests
     {
         var chunks = TextChunker.Lines.Chunk("line1\nline2\r\nline3").ToList();
 
-        Assert.Equal(3, chunks.Count);
+        Assert.HasCount(3, chunks);
         Assert.Equal("line1\n", chunks[0]);
         Assert.Equal("line2\r\n", chunks[1]);
         Assert.Equal("line3", chunks[2]);
@@ -659,7 +659,7 @@ public sealed class TextDiffTests
     {
         var chunks = TextChunker.Lines.Chunk("line1\u0085line2\u2028line3\u2029line4").ToList();
 
-        Assert.Equal(4, chunks.Count);
+        Assert.HasCount(4, chunks);
         Assert.Equal("line1\u0085", chunks[0]);
         Assert.Equal("line2\u2028", chunks[1]);
         Assert.Equal("line3\u2029", chunks[2]);
@@ -672,7 +672,7 @@ public sealed class TextDiffTests
     {
         var chunks = TextChunker.Words.Chunk("hello  world").ToList();
 
-        Assert.Equal(3, chunks.Count);
+        Assert.HasCount(3, chunks);
         Assert.Equal("hello", chunks[0]);
         Assert.Equal("  ", chunks[1]);
         Assert.Equal("world", chunks[2]);
@@ -684,7 +684,7 @@ public sealed class TextDiffTests
     {
         var chunks = TextChunker.Characters.Chunk("abc").ToList();
 
-        Assert.Equal(3, chunks.Count);
+        Assert.HasCount(3, chunks);
         Assert.Equal("a", chunks[0]);
         Assert.Equal("b", chunks[1]);
         Assert.Equal("c", chunks[2]);

--- a/tests/Meziantou.Framework.Threading.Tests/ConcurrentHashSetTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/ConcurrentHashSetTests.cs
@@ -16,7 +16,7 @@ public class ConcurrentHashSetTests
         Assert.Contains(1, set);
         Assert.DoesNotContain(4, set);
 
-        Assert.Equal(3, set.Count);
+        Assert.HasCount(3, set);
         Assert.Equal([1, 2, 3], set.Order());
 
         set.Clear();

--- a/tests/Meziantou.Framework.Threading.Tests/MixedConsumerProducerTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/MixedConsumerProducerTests.cs
@@ -56,7 +56,7 @@ public sealed class MixedConsumerProducerTests
             });
         });
 
-        Assert.Equal(3, exception.InnerExceptions.Count);
+        Assert.HasCount(3, exception.InnerExceptions);
         Assert.All(exception.InnerExceptions, e => Assert.IsType<InvalidOperationException>(e));
     }
 
@@ -77,7 +77,7 @@ public sealed class MixedConsumerProducerTests
         });
 
         Assert.Equal(4, processed); // every item was attempted even though some failed
-        Assert.Equal(2, exception.InnerExceptions.Count); // items 2 and 4
+        Assert.HasCount(2, exception.InnerExceptions); // items 2 and 4
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Threading.Tests/SynchronizedListTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/SynchronizedListTests.cs
@@ -171,7 +171,7 @@ public sealed class SynchronizedListTests
         }
 
         await Task.WhenAll(tasks);
-        Assert.Equal(100, list.Count);
+        Assert.HasCount(100, list);
 
         tasks.Clear();
         for (var i = 0; i < 100; i++)

--- a/tests/Meziantou.Framework.Uri.Tests/UrlPatternCollectionTests.cs
+++ b/tests/Meziantou.Framework.Uri.Tests/UrlPatternCollectionTests.cs
@@ -224,7 +224,7 @@ public sealed class UrlPatternCollectionTests
 
         var collection = new UrlPatternCollection(patterns);
 
-        Assert.Equal(2, collection.Count);
+        Assert.HasCount(2, collection);
     }
 
     [Fact]
@@ -236,7 +236,7 @@ public sealed class UrlPatternCollectionTests
 
         var enumerated = collection.ToList();
 
-        Assert.Equal(2, enumerated.Count);
+        Assert.HasCount(2, enumerated);
         Assert.Contains(pattern1, enumerated);
         Assert.Contains(pattern2, enumerated);
     }
@@ -383,7 +383,7 @@ public sealed class UrlPatternCollectionTests
         var collection = new UrlPatternCollection { pattern1, pattern2 };
 
         // Unlike URLPatternSet which deduplicates, UrlPatternCollection allows duplicates
-        Assert.Equal(2, collection.Count);
+        Assert.HasCount(2, collection);
     }
 
     // Match priority - first match wins
@@ -626,7 +626,7 @@ public sealed class UrlPatternCollectionTests
             UrlPattern.Create(new UrlPatternInit { Pathname = "/c" }),
         };
 
-        Assert.Equal(3, ((IReadOnlyList<UrlPattern>)collection).Count);
+        Assert.HasCount(3, ((IReadOnlyList<UrlPattern>)collection));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Xml.Tests/XmlSyntaxTreeTests.cs
+++ b/tests/Meziantou.Framework.Xml.Tests/XmlSyntaxTreeTests.cs
@@ -195,7 +195,7 @@ public sealed class XmlSyntaxTreeTests
     {
         var tree = XmlSyntaxTree.ParseText("<root>\n  <a />\n</root>");
 
-        Assert.Equal(3, tree.SourceText.Lines.Count);
+        Assert.HasCount(3, tree.SourceText.Lines);
         Assert.Equal("<root>", tree.SourceText.Lines[0].Text);
     }
 
@@ -217,7 +217,7 @@ public sealed class XmlSyntaxTreeTests
 
         var comments = tree.Root.SelectSyntaxNodes("//comment()").Cast<XmlCommentSyntax>().ToList();
 
-        Assert.Equal(2, comments.Count);
+        Assert.HasCount(2, comments);
         Assert.Equal("first", comments[0].Text);
         Assert.Equal("second", comments[1].Text);
     }
@@ -229,7 +229,7 @@ public sealed class XmlSyntaxTreeTests
 
         var textNodes = tree.Root.SelectSyntaxNodes("//item/text()").ToList();
 
-        Assert.Equal(2, textNodes.Count);
+        Assert.HasCount(2, textNodes);
         Assert.Equal("alpha", Assert.IsType<XmlTextSyntax>(textNodes[0]).Text);
         Assert.Equal("beta", Assert.IsType<XmlCDataSectionSyntax>(textNodes[1]).Text);
     }
@@ -437,7 +437,7 @@ public sealed class XmlSyntaxTreeTests
 
         var attributes = tree.Root.SelectSyntaxNodes("//a:item/@a:value | //a:item/@b:value", namespaceManager).Cast<XmlAttributeSyntax>().ToList();
 
-        Assert.Equal(2, attributes.Count);
+        Assert.HasCount(2, attributes);
         Assert.Contains(attributes, attribute => attribute.Name == "a:value" && attribute.Value == "1");
         Assert.Contains(attributes, attribute => attribute.Name == "b:value" && attribute.Value == "2");
     }
@@ -488,14 +488,14 @@ public sealed class XmlSyntaxTreeTests
         var namespaceManager = CreateNamespaceManager();
 
         var namespacedAttributes = tree.Root.SelectSyntaxNodes("//@a:flag | //@s:flag | //@r:flag", namespaceManager).Cast<XmlAttributeSyntax>().ToList();
-        Assert.Equal(4, namespacedAttributes.Count);
+        Assert.HasCount(4, namespacedAttributes);
         Assert.Contains(namespacedAttributes, attribute => attribute.Name == "a:flag" && attribute.Value == "1");
         Assert.Contains(namespacedAttributes, attribute => attribute.Name == "a:flag" && attribute.Value == "3");
         Assert.Contains(namespacedAttributes, attribute => attribute.Name == "s:flag" && attribute.Value == "2");
         Assert.Contains(namespacedAttributes, attribute => attribute.Name == "r:flag" && attribute.Value == "4");
 
         var nonNamespacedAttributes = tree.Root.SelectSyntaxNodes("//@id | //@flag", namespaceManager).Cast<XmlAttributeSyntax>().ToList();
-        Assert.Equal(5, nonNamespacedAttributes.Count);
+        Assert.HasCount(5, nonNamespacedAttributes);
         Assert.Contains(nonNamespacedAttributes, attribute => attribute.Name == "id" && attribute.Value == "root-default");
         Assert.Contains(nonNamespacedAttributes, attribute => attribute.Name == "id" && attribute.Value == "sub-default");
         Assert.Contains(nonNamespacedAttributes, attribute => attribute.Name == "id" && attribute.Value == "sub-no-ns");


### PR DESCRIPTION
## Why
The CodeQL C# build is failing because the new count assertion analyzer rules (`MFAS0004` and `MFAS0005`) now flag existing test assertions that compare `Count`/`Length` with `Assert.Equal(...)`.

## What changed
This updates affected tests to use the analyzer-preferred assertion APIs:
- `Assert.Equal(0, collection.Count)` -> `Assert.Empty(collection)`
- `Assert.Equal(expected, collection.Count)` / `Assert.Equal(expected, array.Length)` -> `Assert.HasCount(expected, collectionOrArray)`

The changes are test-only and span the projects reported in the failing CI log (plus remaining occurrences caught during repository build), so the C# analysis build can complete without MFAS diagnostics.

## Notes
- No production code behavior is changed.
- Edits are mechanical and preserve original test intent while aligning with the new assertion guidance.