### PR TITLE
Add count comparison analyzer fixes for Assert.True/False

### DIFF
--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzer.cs
@@ -11,15 +11,15 @@ public sealed class CountAssertionAnalyzer : DiagnosticAnalyzer
     public static readonly DiagnosticDescriptor UseEmptyDescriptor = new(
         id: RuleIdentifiers.UseEmptyAssertionDiagnosticId,
         title: "Use Assert.Empty for zero count checks",
-        messageFormat: "Use Assert.Empty instead of Assert.Equal(0, count)",
+        messageFormat: "Use Assert.Empty for count checks equal to zero",
         category: "Assertions",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
     public static readonly DiagnosticDescriptor UseHasCountDescriptor = new(
         id: RuleIdentifiers.UseHasCountAssertionDiagnosticId,
-        title: "Use Assert.HasCount for count checks",
-        messageFormat: "Use Assert.HasCount instead of Assert.Equal(expected, count)",
+        title: "Use specialized count assertions",
+        messageFormat: "Use a specialized count assertion method",
         category: "Assertions",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzerCommon.cs
@@ -7,6 +7,14 @@ namespace Meziantou.Framework.Analyzers.Assertions;
 
 internal static class CountAssertionAnalyzerCommon
 {
+    private const string EmptyAssertionMethodName = "Empty";
+    private const string HasCountAssertionMethodName = "HasCount";
+    private const string DoesNotHaveCountAssertionMethodName = "DoesNotHaveCount";
+    private const string HasCountLessThanAssertionMethodName = "HasCountLessThan";
+    private const string HasCountLessThanOrEqualAssertionMethodName = "HasCountLessThanOrEqual";
+    private const string HasCountGreaterThanAssertionMethodName = "HasCountGreaterThan";
+    private const string HasCountGreaterThanOrEqualAssertionMethodName = "HasCountGreaterThanOrEqual";
+
     internal static bool TryCreateSymbols(Compilation compilation, out Symbols symbols)
     {
         var arrayType = compilation.GetSpecialType(SpecialType.System_Array);
@@ -44,13 +52,31 @@ internal static class CountAssertionAnalyzerCommon
 
     internal static bool TryGetAssertionMatch(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, Symbols symbols, out AssertionMatch match)
     {
-        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "Equal" } targetMethod ||
+        if (invocationOperation.TargetMethod is not { IsStatic: true } targetMethod ||
             !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, assertType))
         {
             match = default;
             return false;
         }
 
+        switch (targetMethod.Name)
+        {
+            case "Equal":
+                return TryGetAssertEqualAssertionMatch(invocationOperation, symbols, out match);
+
+            case "True":
+                return TryGetAssertBooleanAssertionMatch(invocationOperation, symbols, conditionExpectedToBeFalse: false, out match);
+
+            case "False":
+                return TryGetAssertBooleanAssertionMatch(invocationOperation, symbols, conditionExpectedToBeFalse: true, out match);
+        }
+
+        match = default;
+        return false;
+    }
+
+    private static bool TryGetAssertEqualAssertionMatch(IInvocationOperation invocationOperation, Symbols symbols, out AssertionMatch match)
+    {
         IArgumentOperation? expectedArgument = null;
         IArgumentOperation? actualArgument = null;
         foreach (var argument in invocationOperation.Arguments)
@@ -78,16 +104,172 @@ internal static class CountAssertionAnalyzerCommon
             return false;
         }
 
-        var expectedValue = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(expectedArgument.Value);
-        var useEmptyAssertion = NumericHelpers.IsZero(expectedValue.ConstantValue);
-        if (!useEmptyAssertion && expectedValue.Type?.SpecialType != SpecialType.System_Int32)
+        if (!TryGetAssertionMethodForEquality(expectedArgument.Value, out var expectedOperation, out var assertionMethodName))
         {
             match = default;
             return false;
         }
 
-        match = new AssertionMatch(expectedArgument, actualArgument, collectionOperation, countOperation, useEmptyAssertion);
+        match = new AssertionMatch(expectedOperation, collectionOperation, countOperation, assertionMethodName);
         return true;
+    }
+
+    private static bool TryGetAssertBooleanAssertionMatch(IInvocationOperation invocationOperation, Symbols symbols, bool conditionExpectedToBeFalse, out AssertionMatch match)
+    {
+        var conditionArgument = invocationOperation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "condition");
+        if (conditionArgument is null)
+        {
+            match = default;
+            return false;
+        }
+
+        if (!TryGetCollectionComparisonCondition(conditionArgument.Value, symbols, out var expectedOperation, out var collectionOperation, out var countOperation, out var comparisonOperator, out var collectionOperationOnLeftSide))
+        {
+            match = default;
+            return false;
+        }
+
+        if (!TryGetAssertionMethodForComparison(expectedOperation, comparisonOperator, collectionOperationOnLeftSide, conditionExpectedToBeFalse, out var unwrappedExpectedOperation, out var assertionMethodName))
+        {
+            match = default;
+            return false;
+        }
+
+        match = new AssertionMatch(unwrappedExpectedOperation, collectionOperation, countOperation, assertionMethodName);
+        return true;
+    }
+
+    private static bool TryGetCollectionComparisonCondition(
+        IOperation conditionOperation,
+        Symbols symbols,
+        out IOperation expectedOperation,
+        out IOperation collectionOperation,
+        out IOperation countOperation,
+        out BinaryOperatorKind comparisonOperator,
+        out bool collectionOperationOnLeftSide)
+    {
+        conditionOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(conditionOperation);
+        if (conditionOperation is not IBinaryOperation binaryOperation ||
+            binaryOperation.OperatorKind is not (BinaryOperatorKind.Equals or
+                                                BinaryOperatorKind.NotEquals or
+                                                BinaryOperatorKind.LessThan or
+                                                BinaryOperatorKind.LessThanOrEqual or
+                                                BinaryOperatorKind.GreaterThan or
+                                                BinaryOperatorKind.GreaterThanOrEqual))
+        {
+            expectedOperation = null!;
+            collectionOperation = null!;
+            countOperation = null!;
+            comparisonOperator = default;
+            collectionOperationOnLeftSide = default;
+            return false;
+        }
+
+        if (TryGetCollectionOperation(binaryOperation.LeftOperand, symbols, out collectionOperation, out countOperation))
+        {
+            expectedOperation = binaryOperation.RightOperand;
+            comparisonOperator = binaryOperation.OperatorKind;
+            collectionOperationOnLeftSide = true;
+            return true;
+        }
+
+        if (TryGetCollectionOperation(binaryOperation.RightOperand, symbols, out collectionOperation, out countOperation))
+        {
+            expectedOperation = binaryOperation.LeftOperand;
+            comparisonOperator = binaryOperation.OperatorKind;
+            collectionOperationOnLeftSide = false;
+            return true;
+        }
+
+        expectedOperation = null!;
+        collectionOperation = null!;
+        countOperation = null!;
+        comparisonOperator = default;
+        collectionOperationOnLeftSide = default;
+        return false;
+    }
+
+    private static bool TryGetAssertionMethodForEquality(IOperation operation, out IOperation expectedOperation, out string assertionMethodName)
+    {
+        expectedOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(operation);
+        if (NumericHelpers.IsZero(expectedOperation.ConstantValue))
+        {
+            assertionMethodName = EmptyAssertionMethodName;
+            return true;
+        }
+
+        if (expectedOperation.Type?.SpecialType == SpecialType.System_Int32)
+        {
+            assertionMethodName = HasCountAssertionMethodName;
+            return true;
+        }
+
+        expectedOperation = null!;
+        assertionMethodName = null!;
+        return false;
+    }
+
+    private static bool TryGetAssertionMethodForComparison(IOperation expectedOperation, BinaryOperatorKind comparisonOperator, bool collectionOperationOnLeftSide, bool conditionExpectedToBeFalse, out IOperation unwrappedExpectedOperation, out string assertionMethodName)
+    {
+        if (conditionExpectedToBeFalse)
+            comparisonOperator = NegateComparisonOperator(comparisonOperator);
+
+        if (comparisonOperator == BinaryOperatorKind.Equals)
+            return TryGetAssertionMethodForEquality(expectedOperation, out unwrappedExpectedOperation, out assertionMethodName);
+
+        if (!TryGetIntExpectedOperation(expectedOperation, out unwrappedExpectedOperation))
+        {
+            assertionMethodName = null!;
+            return false;
+        }
+
+        assertionMethodName = GetAssertionMethodName(comparisonOperator, collectionOperationOnLeftSide);
+        return true;
+    }
+
+    private static bool TryGetIntExpectedOperation(IOperation operation, out IOperation expectedOperation)
+    {
+        expectedOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(operation);
+        if (expectedOperation.Type?.SpecialType != SpecialType.System_Int32)
+        {
+            expectedOperation = null!;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string GetAssertionMethodName(BinaryOperatorKind comparisonOperator, bool collectionOperationOnLeftSide)
+    {
+        if (comparisonOperator == BinaryOperatorKind.NotEquals)
+            return DoesNotHaveCountAssertionMethodName;
+
+        return (comparisonOperator, collectionOperationOnLeftSide) switch
+        {
+            (BinaryOperatorKind.LessThan, true) => HasCountLessThanAssertionMethodName,
+            (BinaryOperatorKind.LessThanOrEqual, true) => HasCountLessThanOrEqualAssertionMethodName,
+            (BinaryOperatorKind.GreaterThan, true) => HasCountGreaterThanAssertionMethodName,
+            (BinaryOperatorKind.GreaterThanOrEqual, true) => HasCountGreaterThanOrEqualAssertionMethodName,
+            (BinaryOperatorKind.LessThan, false) => HasCountGreaterThanAssertionMethodName,
+            (BinaryOperatorKind.LessThanOrEqual, false) => HasCountGreaterThanOrEqualAssertionMethodName,
+            (BinaryOperatorKind.GreaterThan, false) => HasCountLessThanAssertionMethodName,
+            (BinaryOperatorKind.GreaterThanOrEqual, false) => HasCountLessThanOrEqualAssertionMethodName,
+            _ => throw new ArgumentOutOfRangeException(nameof(comparisonOperator)),
+        };
+    }
+
+    private static BinaryOperatorKind NegateComparisonOperator(BinaryOperatorKind comparisonOperator)
+    {
+        return comparisonOperator switch
+        {
+            BinaryOperatorKind.Equals => BinaryOperatorKind.NotEquals,
+            BinaryOperatorKind.NotEquals => BinaryOperatorKind.Equals,
+            BinaryOperatorKind.LessThan => BinaryOperatorKind.GreaterThanOrEqual,
+            BinaryOperatorKind.LessThanOrEqual => BinaryOperatorKind.GreaterThan,
+            BinaryOperatorKind.GreaterThan => BinaryOperatorKind.LessThanOrEqual,
+            BinaryOperatorKind.GreaterThanOrEqual => BinaryOperatorKind.LessThan,
+            _ => throw new ArgumentOutOfRangeException(nameof(comparisonOperator)),
+        };
     }
 
     private static bool TryGetCollectionOperation(IOperation operation, Symbols symbols, out IOperation collectionOperation, out IOperation countOperation)
@@ -177,11 +359,13 @@ internal static class CountAssertionAnalyzerCommon
     }
 
     internal readonly record struct AssertionMatch(
-        IArgumentOperation ExpectedArgument,
-        IArgumentOperation ActualArgument,
+        IOperation ExpectedOperation,
         IOperation CollectionOperation,
         IOperation CountOperation,
-        bool UseEmptyAssertion);
+        string AssertionMethodName)
+    {
+        internal bool UseEmptyAssertion => AssertionMethodName == EmptyAssertionMethodName;
+    }
 
     internal readonly record struct Symbols(
         INamedTypeSymbol ArrayType,

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/CountAssertionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/CountAssertionCodeFixProvider.cs
@@ -42,7 +42,7 @@ public sealed class CountAssertionCodeFixProvider : CodeFixProvider
 
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    title: match.UseEmptyAssertion ? "Use Assert.Empty" : "Use Assert.HasCount",
+                    title: "Use Assert." + match.AssertionMethodName,
                     createChangedDocument: cancellationToken => ApplyFixAsync(context.Document, invocationExpression, assertType, symbols, cancellationToken),
                     equivalenceKey: GetType().FullName),
                 diagnostic);
@@ -65,9 +65,12 @@ public sealed class CountAssertionCodeFixProvider : CodeFixProvider
         if (!TryGetCollectionExpression(match.CollectionOperation, out var collectionExpression))
             return document;
 
+        if (!TryGetExpressionSyntax(match.ExpectedOperation, out var expectedExpression))
+            return document;
+
         var newInvocationExpression = invocationExpression
-            .WithExpression(ReplaceMethodName(invocationExpression.Expression, match.UseEmptyAssertion ? "Empty" : "HasCount"))
-            .WithArgumentList(CreateArgumentList(match, collectionExpression))
+            .WithExpression(ReplaceMethodName(invocationExpression.Expression, match.AssertionMethodName))
+            .WithArgumentList(CreateArgumentList(match.UseEmptyAssertion, expectedExpression, collectionExpression))
             .WithAdditionalAnnotations(Formatter.Annotation);
         var newRoot = root.ReplaceNode(invocationExpression, newInvocationExpression);
         return document.WithSyntaxRoot(newRoot);
@@ -116,20 +119,25 @@ public sealed class CountAssertionCodeFixProvider : CodeFixProvider
 
     private static bool TryGetCollectionExpression(IOperation operation, out ExpressionSyntax collectionExpression)
     {
+        return TryGetExpressionSyntax(operation, out collectionExpression);
+    }
+
+    private static bool TryGetExpressionSyntax(IOperation operation, out ExpressionSyntax expression)
+    {
         var syntax = operation.Syntax;
         if (syntax is ArgumentSyntax argumentSyntax)
         {
-            collectionExpression = argumentSyntax.Expression;
+            expression = argumentSyntax.Expression;
             return true;
         }
 
         if (syntax is ExpressionSyntax expressionSyntax)
         {
-            collectionExpression = expressionSyntax;
+            expression = expressionSyntax;
             return true;
         }
 
-        collectionExpression = null!;
+        expression = null!;
         return false;
     }
 
@@ -151,20 +159,17 @@ public sealed class CountAssertionCodeFixProvider : CodeFixProvider
         return SyntaxFactory.Identifier(identifier.LeadingTrivia, text, identifier.TrailingTrivia);
     }
 
-    private static ArgumentListSyntax CreateArgumentList(CountAssertionAnalyzerCommon.AssertionMatch match, ExpressionSyntax collectionExpression)
+    private static ArgumentListSyntax CreateArgumentList(bool useEmptyAssertion, ExpressionSyntax expectedExpression, ExpressionSyntax collectionExpression)
     {
-        if (match.UseEmptyAssertion)
+        if (useEmptyAssertion)
         {
-            var actualArgument = (ArgumentSyntax)match.ActualArgument.Syntax;
-            return SyntaxFactory.ArgumentList([SyntaxFactory.Argument(collectionExpression.WithoutTrivia()).WithTriviaFrom(actualArgument)]);
+            return SyntaxFactory.ArgumentList([SyntaxFactory.Argument(collectionExpression.WithoutTrivia())]);
         }
 
-        var expectedArgument = (ArgumentSyntax)match.ExpectedArgument.Syntax;
-        var actualCountArgument = (ArgumentSyntax)match.ActualArgument.Syntax;
         return SyntaxFactory.ArgumentList(
         [
-            SyntaxFactory.Argument(expectedArgument.Expression.WithoutTrivia()).WithTriviaFrom(expectedArgument),
-            SyntaxFactory.Argument(collectionExpression.WithoutTrivia()).WithTriviaFrom(actualCountArgument),
+            SyntaxFactory.Argument(expectedExpression.WithoutTrivia()),
+            SyntaxFactory.Argument(collectionExpression.WithoutTrivia()),
         ]);
     }
 }

--- a/src/Meziantou.Framework.Assertions/readme.md
+++ b/src/Meziantou.Framework.Assertions/readme.md
@@ -13,5 +13,5 @@ The package ships analyzers and code fixes to help write clearer assertions.
 | `MFAS0002` | Assertions | Use Assert.Same instead of Assert.ReferenceEquals | Error | ✔️ |
 | `MFAS0003` | Assertions | Do not use Assert.IsType with static or abstract types | Error | ✔️ |
 | `MFAS0004` | Assertions | Use Assert.Empty for zero count checks | Warning | ✔️ |
-| `MFAS0005` | Assertions | Use Assert.HasCount for count checks | Warning | ✔️ |
+| `MFAS0005` | Assertions | Use specialized count assertions | Warning | ✔️ |
 <!-- analyzer-rules -->

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CountAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CountAssertionRuleTests.cs
@@ -114,6 +114,806 @@ public sealed class CountAssertionRuleTests : AssertionsAnalyzerTestBase
     }
 
     [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForTrueWithLengthComparison()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.True({|MFAS0005:collection.Length|} == 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.HasCount(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForTrueWithCountPropertyComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.True({|MFAS0005:collection.Count|} == 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.HasCount(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForTrueWithCountMethodComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.True({|MFAS0005:collection.Count()|} == 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.HasCount(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ToEmpty_WhenTrueWithLengthComparedToZero()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.True({|MFAS0004:collection.Length|} == 0);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.Empty(collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ToEmpty_WhenTrueWithCountPropertyComparedToZero()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.True({|MFAS0004:collection.Count|} == 0);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.Empty(collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ToEmpty_WhenTrueWithCountMethodComparedToZero()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.True({|MFAS0004:collection.Count()|} == 0);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.Empty(collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForTrueWithCountMethodNotEqualsComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.True({|MFAS0005:collection.Count()|} != 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.DoesNotHaveCount(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForTrueWithCountPropertyLessThanComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.True({|MFAS0005:collection.Count|} < 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.HasCountLessThan(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForTrueWithCountMethodLessThanOrEqualComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.True({|MFAS0005:collection.Count()|} <= 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.HasCountLessThanOrEqual(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForTrueWithLengthGreaterThanComparison()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.True({|MFAS0005:collection.Length|} > 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.HasCountGreaterThan(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForTrueWithCountPropertyGreaterThanOrEqualComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.True({|MFAS0005:collection.Count|} >= 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.HasCountGreaterThanOrEqual(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForTrueWithReversedLessThanComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.True(10 < {|MFAS0005:collection.Count()|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.HasCountGreaterThan(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForTrueWithReversedGreaterThanOrEqualComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.True(10 >= {|MFAS0005:collection.Count()|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.HasCountLessThanOrEqual(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForFalseWithLengthEqualsComparison()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.False({|MFAS0005:collection.Length|} == 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.DoesNotHaveCount(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForFalseWithLengthComparedToZero()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.False({|MFAS0005:collection.Length|} == 0);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.DoesNotHaveCount(0, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForFalseWithCountMethodNotEqualsComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.False({|MFAS0005:collection.Count()|} != 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.HasCount(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForFalseWithCountPropertyLessThanComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.False({|MFAS0005:collection.Count|} < 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.HasCountGreaterThanOrEqual(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForFalseWithCountMethodLessThanOrEqualComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.False({|MFAS0005:collection.Count()|} <= 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.HasCountGreaterThan(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForFalseWithLengthGreaterThanComparison()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.False({|MFAS0005:collection.Length|} > 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int[] collection)
+                {
+                    Assert.HasCountLessThanOrEqual(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForFalseWithCountPropertyGreaterThanOrEqualComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.False({|MFAS0005:collection.Count|} >= 10);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ICollection<int> collection)
+                {
+                    Assert.HasCountLessThan(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForFalseWithReversedLessThanComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.False(10 < {|MFAS0005:collection.Count()|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.HasCountLessThanOrEqual(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForFalseWithReversedGreaterThanOrEqualComparison()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.False(10 >= {|MFAS0005:collection.Count()|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IEnumerable<int> collection)
+                {
+                    Assert.HasCountGreaterThan(10, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
     public async Task Analyzer_ReportDiagnostic_AndCodeFix_ToEmpty_WhenExpectedCountIsZero()
     {
         var source = """
@@ -206,6 +1006,18 @@ public sealed class CountAssertionRuleTests : AssertionsAnalyzerTestBase
                     Assert.Equal(10, value);
                     Assert.Equal(10, collection.Count(i => i > 0));
                     Assert.Equal(10L, collection.Count());
+                    Assert.True(collection.Count() == 10L);
+                    Assert.True(collection.Count() != 10L);
+                    Assert.True(collection.Count() < 10L);
+                    Assert.True(collection.Count() <= 10L);
+                    Assert.True(collection.Count() > 10L);
+                    Assert.True(collection.Count() >= 10L);
+                    Assert.False(collection.Count() == 10L);
+                    Assert.False(collection.Count() != 10L);
+                    Assert.False(collection.Count() < 10L);
+                    Assert.False(collection.Count() <= 10L);
+                    Assert.False(collection.Count() > 10L);
+                    Assert.False(collection.Count() >= 10L);
                     Assert.NotEqual(10, collection.Count());
                 }
             }

--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
@@ -59,7 +59,7 @@ public class ChangeJournalTests
             var drive = Path.GetPathRoot(file) ?? throw new InvalidOperationException("Cannot determine drive root");
             using var changeJournal = ChangeJournal.Open(new DriveInfo(drive));
             var entries = changeJournal.Entries.ToList();
-            Assert.True(entries.Count >= 0);
+            Assert.NotEmpty(entries);
         });
     }
 
@@ -72,7 +72,7 @@ public class ChangeJournalTests
             var drive = Path.GetPathRoot(file) ?? throw new InvalidOperationException("Cannot determine drive root");
             using var changeJournal = ChangeJournal.Open(new DriveInfo(drive), unprivileged: true);
             var entries = changeJournal.GetEntries(ChangeReason.FileCreate, returnOnlyOnClose: false, TimeSpan.FromSeconds(10)).ToList();
-            Assert.True(entries.Count >= 0);
+            Assert.NotEmpty(entries);
         });
     }
 


### PR DESCRIPTION
Count comparison assertions were only partially covered when written as boolean checks. This change expands the analyzer so developers get consistent guidance and code fixes when asserting collection counts via `Assert.True(...)` or `Assert.False(...)` comparisons.

## What changed
- Extended `CountAssertionAnalyzerCommon` matching to support boolean comparison assertions for both `Assert.True` and `Assert.False`.
- Added operator-aware mapping for `==`, `!=`, `<`, `<=`, `>`, and `>=` over `collection.Length`, `collection.Count`, and `collection.Count()`.
- Added correct handling for reversed operands (for example `10 < collection.Count()`).
- Kept `== 0` mapped to `Assert.Empty(...)` where appropriate, and mapped negated boolean forms to the corresponding specialized assertion method.
- Updated count assertion code-fix behavior and added broad analyzer/code-fix test coverage for the new mappings.
- Updated the assertions README analyzer description for `MFAS0005` to reflect specialized count assertions.

## Notes
- No behavioral runtime changes were made outside analyzer and code-fix recommendations.
- Tests cover both positive rewrites and non-diagnostic cases for unsupported numeric forms.