### PR TITLE
Add disk caching for DNS block lists

### DIFF
--- a/slnx/Meziantou.DnsProxy.slnx
+++ b/slnx/Meziantou.DnsProxy.slnx
@@ -4,6 +4,10 @@
     <Project Path="../src/Meziantou.Framework.DnsClient/Meziantou.Framework.DnsClient.csproj" />
     <Project Path="../src/Meziantou.Framework.DnsFilter/Meziantou.Framework.DnsFilter.csproj" />
     <Project Path="../src/Meziantou.Framework.DnsServer/Meziantou.Framework.DnsServer.csproj" />
+    <Project Path="../src/Meziantou.Framework.FullPath.Analyzer/Meziantou.Framework.FullPath.Analyzer.csproj" />
+    <Project Path="../src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj" />
+    <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
+    <Project Path="../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj" />

--- a/slnx/Meziantou.Framework.TemporaryDirectory.slnx
+++ b/slnx/Meziantou.Framework.TemporaryDirectory.slnx
@@ -1,9 +1,13 @@
 <Solution>
   <Folder Name="/src/">
+    <Project Path="../src/Meziantou.DnsProxy/Meziantou.DnsProxy.csproj" />
     <Project Path="../src/Meziantou.Extensions.Logging.FileLogger/Meziantou.Extensions.Logging.FileLogger.csproj" />
     <Project Path="../src/Meziantou.Framework.DependencyScanning.Tool/Meziantou.Framework.DependencyScanning.Tool.csproj" />
     <Project Path="../src/Meziantou.Framework.DependencyScanning/Meziantou.Framework.DependencyScanning.csproj" />
     <Project Path="../src/Meziantou.Framework.DiffEngine/Meziantou.Framework.DiffEngine.csproj" />
+    <Project Path="../src/Meziantou.Framework.DnsClient/Meziantou.Framework.DnsClient.csproj" />
+    <Project Path="../src/Meziantou.Framework.DnsFilter/Meziantou.Framework.DnsFilter.csproj" />
+    <Project Path="../src/Meziantou.Framework.DnsServer/Meziantou.Framework.DnsServer.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath.Analyzer/Meziantou.Framework.FullPath.Analyzer.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj" />
     <Project Path="../src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj" />
@@ -38,6 +42,7 @@
     <Project Path="../tests/Meziantou.Framework.DependencyScanning.Tests/Meziantou.Framework.DependencyScanning.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.DependencyScanning.Tool.Tests/Meziantou.Framework.DependencyScanning.Tool.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.DiffEngine.Tests/Meziantou.Framework.DiffEngine.Tests.csproj" />
+    <Project Path="../tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.FullPath.Tests/Meziantou.Framework.FullPath.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.Globbing.Tests/Meziantou.Framework.Globbing.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.Html.Tool.Tests/Meziantou.Framework.Html.Tool.Tests.csproj" />

--- a/src/Meziantou.DnsProxy/Diagnostics/DiagnosticsPageRenderer.cs
+++ b/src/Meziantou.DnsProxy/Diagnostics/DiagnosticsPageRenderer.cs
@@ -39,6 +39,8 @@ internal static class DiagnosticsPageRenderer
         stringBuilder.Append("<li><span class='mono'>DnsOverQuicPort</span>: ").Append(HtmlEncode(options.DnsOverQuicPort.ToString(System.Globalization.CultureInfo.InvariantCulture))).Append("</li>");
         stringBuilder.Append("<li><span class='mono'>CertificatePath</span>: ").Append(HtmlEncode(options.CertificatePath ?? string.Empty)).Append("</li>");
         stringBuilder.Append("<li><span class='mono'>FilterRefreshInterval</span>: ").Append(HtmlEncode(options.FilterRefreshInterval.ToString())).Append("</li>");
+        var blockListCacheFolderPath = string.IsNullOrWhiteSpace(options.BlockListCacheFolderPath) ? DnsProxyOptions.GetDefaultBlockListCacheFolderPath() : options.BlockListCacheFolderPath;
+        stringBuilder.Append("<li><span class='mono'>BlockListCacheFolderPath</span>: ").Append(HtmlEncode(blockListCacheFolderPath)).Append("</li>");
         stringBuilder.Append("<li><span class='mono'>DnssecValidationMode</span>: ").Append(HtmlEncode(options.DnssecValidationMode.ToString())).Append("</li>");
         stringBuilder.Append("<li><span class='mono'>DiagnosticsHistoryCapacity</span>: ").Append(HtmlEncode(options.DiagnosticsHistoryCapacity.ToString(System.Globalization.CultureInfo.InvariantCulture))).Append("</li>");
         stringBuilder.Append("<li><span class='mono'>Upstreams</span>: ").Append(HtmlEncode(string.Join(", ", upstreams.Select(u => u.DisplayName)))).Append("</li>");

--- a/src/Meziantou.DnsProxy/DnsProxyOptions.cs
+++ b/src/Meziantou.DnsProxy/DnsProxyOptions.cs
@@ -28,6 +28,8 @@ internal sealed class DnsProxyOptions
 
     public TimeSpan FilterRefreshInterval { get; set; } = TimeSpan.FromMinutes(30);
 
+    public string BlockListCacheFolderPath { get; set; } = GetDefaultBlockListCacheFolderPath();
+
     public DnssecValidationMode DnssecValidationMode { get; set; }
 
     public List<string> BootstrapDnsServers { get; set; } =
@@ -59,4 +61,15 @@ internal sealed class DnsProxyOptions
     ];
 
     public List<RewriteRuleOption> Rewrites { get; set; } = [];
+
+    internal static string GetDefaultBlockListCacheFolderPath()
+    {
+        var localApplicationData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (string.IsNullOrWhiteSpace(localApplicationData))
+        {
+            localApplicationData = AppContext.BaseDirectory;
+        }
+
+        return Path.Combine(localApplicationData, "meziantou", "dnsproxy", "block-lists");
+    }
 }

--- a/src/Meziantou.DnsProxy/Filtering/FilterEngineProvider.cs
+++ b/src/Meziantou.DnsProxy/Filtering/FilterEngineProvider.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Meziantou.Framework.DnsFilter;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -19,6 +21,7 @@ internal sealed class FilterEngineProvider
         _logger = logger;
 
         var initialRuleSet = new DnsFilterRuleSet();
+        AddCachedFilterLists(initialRuleSet, options.Value);
         AddRewriteRules(initialRuleSet, options.Value);
         _engine = new DnsFilterEngine(initialRuleSet);
         _ruleCount = initialRuleSet.Rules.Count;
@@ -44,10 +47,8 @@ internal sealed class FilterEngineProvider
             try
             {
                 var listText = await httpClient.GetStringAsync(filter.Url, cancellationToken).ConfigureAwait(false);
-                var format = Enum.TryParse<DnsFilterListFormat>(filter.Format, ignoreCase: true, out var parsedFormat)
-                    ? parsedFormat
-                    : DnsFilterListFormat.AutoDetect;
-                ruleSet.AddFromList(listText, format);
+                AddFilterList(ruleSet, filter, listText);
+                await WriteFilterListToCacheAsync(options, filter, listText, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -56,6 +57,7 @@ internal sealed class FilterEngineProvider
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Cannot load filter list {FilterUrl}", filter.Url);
+                AddCachedFilterList(ruleSet, options, filter);
             }
         }
 
@@ -63,6 +65,99 @@ internal sealed class FilterEngineProvider
 
         Volatile.Write(ref _ruleCount, ruleSet.Rules.Count);
         Volatile.Write(ref _engine, new DnsFilterEngine(ruleSet));
+    }
+
+    private void AddCachedFilterLists(DnsFilterRuleSet ruleSet, DnsProxyOptions options)
+    {
+        foreach (var filter in options.Filters)
+        {
+            if (string.IsNullOrWhiteSpace(filter.Url))
+            {
+                continue;
+            }
+
+            AddCachedFilterList(ruleSet, options, filter);
+        }
+    }
+
+    private void AddCachedFilterList(DnsFilterRuleSet ruleSet, DnsProxyOptions options, FilterListOption filter)
+    {
+        try
+        {
+            var cacheFilePath = GetCacheFilePath(options, filter);
+            if (!File.Exists(cacheFilePath))
+            {
+                return;
+            }
+
+            var listText = File.ReadAllText(cacheFilePath);
+            AddFilterList(ruleSet, filter, listText);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Cannot load cached filter list {FilterUrl}", filter.Url);
+        }
+    }
+
+    private async Task WriteFilterListToCacheAsync(DnsProxyOptions options, FilterListOption filter, string listText, CancellationToken cancellationToken)
+    {
+        string? temporaryFilePath = null;
+        try
+        {
+            var cacheFilePath = GetCacheFilePath(options, filter);
+            var cacheDirectory = Path.GetDirectoryName(cacheFilePath);
+            if (string.IsNullOrWhiteSpace(cacheDirectory))
+            {
+                return;
+            }
+
+            Directory.CreateDirectory(cacheDirectory);
+
+            temporaryFilePath = Path.Combine(cacheDirectory, Path.GetRandomFileName());
+            await File.WriteAllTextAsync(temporaryFilePath, listText, cancellationToken).ConfigureAwait(false);
+            File.Move(temporaryFilePath, cacheFilePath, overwrite: true);
+            temporaryFilePath = null;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Cannot cache filter list {FilterUrl}", filter.Url);
+        }
+        finally
+        {
+            if (temporaryFilePath is not null)
+            {
+                try
+                {
+                    File.Delete(temporaryFilePath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Cannot delete temporary cached filter list {TemporaryFilePath}", temporaryFilePath);
+                }
+            }
+        }
+    }
+
+    private static void AddFilterList(DnsFilterRuleSet ruleSet, FilterListOption filter, string listText)
+    {
+        var format = Enum.TryParse<DnsFilterListFormat>(filter.Format, ignoreCase: true, out var parsedFormat)
+            ? parsedFormat
+            : DnsFilterListFormat.AutoDetect;
+        ruleSet.AddFromList(listText, format);
+    }
+
+    private static string GetCacheFilePath(DnsProxyOptions options, FilterListOption filter)
+    {
+        var cacheFolderPath = string.IsNullOrWhiteSpace(options.BlockListCacheFolderPath)
+            ? DnsProxyOptions.GetDefaultBlockListCacheFolderPath()
+            : options.BlockListCacheFolderPath;
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(filter.Url))).ToLowerInvariant();
+
+        return Path.Combine(cacheFolderPath, hash + ".txt");
     }
 
     private void AddRewriteRules(DnsFilterRuleSet ruleSet, DnsProxyOptions options)

--- a/src/Meziantou.DnsProxy/appsettings.json
+++ b/src/Meziantou.DnsProxy/appsettings.json
@@ -17,6 +17,7 @@
     "CertificatePassword": "",
     "DiagnosticsHistoryCapacity": 10000,
     "FilterRefreshInterval": "00:30:00",
+    "BlockListCacheFolderPath": "",
     "DnssecValidationMode": "None",
     "BootstrapDnsServers": [
       "9.9.9.9",

--- a/src/Meziantou.DnsProxy/readme.md
+++ b/src/Meziantou.DnsProxy/readme.md
@@ -18,6 +18,7 @@ Default configuration:
 - DNS over TLS listener: disabled by default (`DnsOverTlsPort=0`)
 - DNS over QUIC listener: disabled by default (`DnsOverQuicPort=0`)
 - Filter list refresh interval: `00:30:00`
+- Block list cache folder: local application data under `meziantou/dnsproxy/block-lists`
 - DNSSEC validation: disabled by default (`DnssecValidationMode=None`; use `Local` to enable local validation)
 - Bootstrap DNS servers: Quad9 (`9.9.9.9`, `149.112.112.112`, `2620:fe::fe`, `2620:fe::9`) and Cloudflare (`1.1.1.1`, `1.0.0.1`, `2606:4700:4700::1111`, `2606:4700:4700::1001`)
 - Default filter lists:
@@ -53,6 +54,7 @@ Parallel instances:
   - `DnsProxy__DnsPort`
   - `DnsProxy__HttpPort`
   - `DnsProxy__FilterRefreshInterval`
+  - `DnsProxy__BlockListCacheFolderPath`
   - `DnsProxy__DnssecValidationMode`
   - `DnsProxy__BootstrapDnsServers__0`
   - `DnsProxy__Upstreams__0__Url`

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DiagnosticsPageRendererTests.cs
@@ -42,6 +42,7 @@ public sealed class DiagnosticsPageRendererTests
             DnsOverQuicPort = 8853,
             CertificatePath = "certs/proxy.pfx",
             FilterRefreshInterval = TimeSpan.FromMinutes(5),
+            BlockListCacheFolderPath = "/cache/block-lists",
             DnssecValidationMode = DnssecValidationMode.Local,
             Filters = [],
             Rewrites = [],
@@ -90,6 +91,7 @@ public sealed class DiagnosticsPageRendererTests
         Assert.Contains("<span class='mono'>DnsOverQuicPort</span>: 8853", html, StringComparison.Ordinal);
         Assert.Contains("<span class='mono'>CertificatePath</span>: certs/proxy.pfx", html, StringComparison.Ordinal);
         Assert.Contains("<span class='mono'>FilterRefreshInterval</span>: 00:05:00", html, StringComparison.Ordinal);
+        Assert.Contains("<span class='mono'>BlockListCacheFolderPath</span>: /cache/block-lists", html, StringComparison.Ordinal);
         Assert.Contains("<span class='mono'>DnssecValidationMode</span>: Local", html, StringComparison.Ordinal);
         Assert.Contains("Filtering is enabled.", html, StringComparison.Ordinal);
         Assert.Contains("Disable filtering for 15 minutes", html, StringComparison.Ordinal);

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyOptionsTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyOptionsTests.cs
@@ -23,6 +23,7 @@ public sealed class DnsProxyOptionsTests
         Assert.False(options.HasSecureServerListenerConfigured);
         Assert.Equal(10_000, options.DiagnosticsHistoryCapacity);
         Assert.Equal(TimeSpan.FromMinutes(30), options.FilterRefreshInterval);
+        Assert.Equal(DnsProxyOptions.GetDefaultBlockListCacheFolderPath(), options.BlockListCacheFolderPath);
         Assert.Equal(DnssecValidationMode.None, options.DnssecValidationMode);
         Assert.Collection(options.BootstrapDnsServers,
             item => Assert.Equal("9.9.9.9", item),

--- a/tests/Meziantou.Framework.DnsProxy.Tests/FilterEngineProviderTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/FilterEngineProviderTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Net;
 using Meziantou.DnsProxy;
 using Meziantou.DnsProxy.Filtering;
+using Meziantou.Framework;
 using Meziantou.Framework.DnsFilter;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -43,117 +44,101 @@ public sealed class FilterEngineProviderTests
     [Fact]
     public async Task RefreshAsync_LoadsRemoteFiltersWithoutBlockingCalls()
     {
-        var cacheFolderPath = CreateTemporaryDirectory();
-
-        try
+        using var cacheDirectory = TemporaryDirectory.Create();
+        var options = Options.Create(new DnsProxyOptions
         {
-            var options = Options.Create(new DnsProxyOptions
-            {
-                BlockListCacheFolderPath = cacheFolderPath,
-                Filters =
-                [
-                    new FilterListOption
-                    {
-                        Url = "https://filters.example/list.txt",
-                        Format = nameof(DnsFilterListFormat.AdBlock),
-                    },
-                ],
-                Rewrites = [],
-            });
-
-            using var serviceProvider = CreateServiceProvider(request =>
-            {
-                Assert.Equal("https://filters.example/list.txt", request.RequestUri!.ToString());
-                return new HttpResponseMessage(HttpStatusCode.OK)
+            BlockListCacheFolderPath = cacheDirectory.FullPath,
+            Filters =
+            [
+                new FilterListOption
                 {
-                    Content = new StringContent("||blocked.example.com^"),
-                };
-            });
-            var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+                    Url = "https://filters.example/list.txt",
+                    Format = nameof(DnsFilterListFormat.AdBlock),
+                },
+            ],
+            Rewrites = [],
+        });
 
-            var provider = new FilterEngineProvider(
-                factory,
-                options,
-                NullLogger<FilterEngineProvider>.Instance);
-
-            await provider.RefreshAsync(CancellationToken.None);
-
-            var result = provider.Engine.Evaluate("blocked.example.com");
-            Assert.True(result.IsMatched);
-            Assert.Equal(1, provider.RuleCount);
-        }
-        finally
+        using var serviceProvider = CreateServiceProvider(request =>
         {
-            Directory.Delete(cacheFolderPath, recursive: true);
-        }
+            Assert.Equal("https://filters.example/list.txt", request.RequestUri!.ToString());
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("||blocked.example.com^"),
+            };
+        });
+        var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+
+        var provider = new FilterEngineProvider(
+            factory,
+            options,
+            NullLogger<FilterEngineProvider>.Instance);
+
+        await provider.RefreshAsync(CancellationToken.None);
+
+        var result = provider.Engine.Evaluate("blocked.example.com");
+        Assert.True(result.IsMatched);
+        Assert.Equal(1, provider.RuleCount);
     }
 
     [Fact]
     public async Task RefreshAsync_CachesRemoteFiltersAndLoadsCachedFiltersOnStartup()
     {
-        var cacheFolderPath = CreateTemporaryDirectory();
-
-        try
+        using var cacheDirectory = TemporaryDirectory.Create();
+        var options = Options.Create(new DnsProxyOptions
         {
-            var options = Options.Create(new DnsProxyOptions
-            {
-                BlockListCacheFolderPath = cacheFolderPath,
-                Filters =
-                [
-                    new FilterListOption
-                    {
-                        Url = "https://filters.example/list.txt",
-                        Format = nameof(DnsFilterListFormat.AdBlock),
-                    },
-                ],
-                Rewrites = [],
-            });
+            BlockListCacheFolderPath = cacheDirectory.FullPath,
+            Filters =
+            [
+                new FilterListOption
+                {
+                    Url = "https://filters.example/list.txt",
+                    Format = nameof(DnsFilterListFormat.AdBlock),
+                },
+            ],
+            Rewrites = [],
+        });
 
-            using var serviceProvider = CreateServiceProvider(_ => new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("||cached.example.com^"),
-            });
-            var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
-
-            var provider = new FilterEngineProvider(
-                factory,
-                options,
-                NullLogger<FilterEngineProvider>.Instance);
-
-            await provider.RefreshAsync(CancellationToken.None);
-
-            using var cachedServiceProvider = CreateServiceProvider(_ => throw new InvalidOperationException("Remote refresh failed."));
-            var cachedFactory = cachedServiceProvider.GetRequiredService<IHttpClientFactory>();
-
-            var cachedProvider = new FilterEngineProvider(
-                cachedFactory,
-                options,
-                NullLogger<FilterEngineProvider>.Instance);
-
-            var result = cachedProvider.Engine.Evaluate("cached.example.com");
-            Assert.True(result.IsMatched);
-            Assert.Equal(1, cachedProvider.RuleCount);
-            Assert.Single(Directory.EnumerateFiles(cacheFolderPath, "*.txt"));
-
-            await cachedProvider.RefreshAsync(CancellationToken.None);
-
-            result = cachedProvider.Engine.Evaluate("cached.example.com");
-            Assert.True(result.IsMatched);
-            Assert.Equal(1, cachedProvider.RuleCount);
-        }
-        finally
+        using var serviceProvider = CreateServiceProvider(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Directory.Delete(cacheFolderPath, recursive: true);
-        }
+            Content = new StringContent("||cached.example.com^"),
+        });
+        var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+
+        var provider = new FilterEngineProvider(
+            factory,
+            options,
+            NullLogger<FilterEngineProvider>.Instance);
+
+        await provider.RefreshAsync(CancellationToken.None);
+
+        using var cachedServiceProvider = CreateServiceProvider(_ => throw new InvalidOperationException("Remote refresh failed."));
+        var cachedFactory = cachedServiceProvider.GetRequiredService<IHttpClientFactory>();
+
+        var cachedProvider = new FilterEngineProvider(
+            cachedFactory,
+            options,
+            NullLogger<FilterEngineProvider>.Instance);
+
+        var result = cachedProvider.Engine.Evaluate("cached.example.com");
+        Assert.True(result.IsMatched);
+        Assert.Equal(1, cachedProvider.RuleCount);
+        Assert.Single(Directory.EnumerateFiles(cacheDirectory.FullPath, "*.txt"));
+
+        await cachedProvider.RefreshAsync(CancellationToken.None);
+
+        result = cachedProvider.Engine.Evaluate("cached.example.com");
+        Assert.True(result.IsMatched);
+        Assert.Equal(1, cachedProvider.RuleCount);
     }
 
     [Fact]
     public async Task RefreshAsync_WhenCanceled_ThrowsOperationCanceledException()
     {
-        var cacheFolderPath = CreateTemporaryDirectory();
+        using var cacheDirectory = TemporaryDirectory.Create();
         var options = Options.Create(new DnsProxyOptions
         {
-            BlockListCacheFolderPath = cacheFolderPath,
+            BlockListCacheFolderPath = cacheDirectory.FullPath,
             Filters =
             [
                 new FilterListOption
@@ -179,24 +164,17 @@ public sealed class FilterEngineProviderTests
         using var cancellationTokenSource = new CancellationTokenSource();
         cancellationTokenSource.Cancel();
 
-        try
-        {
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => provider.RefreshAsync(cancellationTokenSource.Token));
-        }
-        finally
-        {
-            Directory.Delete(cacheFolderPath, recursive: true);
-        }
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => provider.RefreshAsync(cancellationTokenSource.Token));
     }
 
     [Fact]
     public async Task FilterEngineRefreshService_RefreshesAtConfiguredInterval()
     {
-        var cacheFolderPath = CreateTemporaryDirectory();
+        using var cacheDirectory = TemporaryDirectory.Create();
         var requestCount = 0;
         var options = Options.Create(new DnsProxyOptions
         {
-            BlockListCacheFolderPath = cacheFolderPath,
+            BlockListCacheFolderPath = cacheDirectory.FullPath,
             FilterRefreshInterval = TimeSpan.FromMilliseconds(100),
             Filters =
             [
@@ -239,7 +217,6 @@ public sealed class FilterEngineProviderTests
         finally
         {
             await service.StopAsync(CancellationToken.None);
-            Directory.Delete(cacheFolderPath, recursive: true);
         }
 
         Assert.True(Volatile.Read(ref requestCount) >= 2, $"Expected at least 2 refresh attempts, but got {requestCount}");
@@ -252,14 +229,6 @@ public sealed class FilterEngineProviderTests
             .AddHttpClient(Options.DefaultName)
             .ConfigurePrimaryHttpMessageHandler(() => new DelegateHttpMessageHandler(responseFactory));
         return services.BuildServiceProvider();
-    }
-
-    private static string CreateTemporaryDirectory()
-    {
-        var path = Path.Combine(Path.GetTempPath(), "meziantou-dnsproxy-tests-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(path);
-
-        return path;
     }
 
     private sealed class DelegateHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler

--- a/tests/Meziantou.Framework.DnsProxy.Tests/FilterEngineProviderTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/FilterEngineProviderTests.cs
@@ -1,5 +1,5 @@
-using System.Net;
 using System.Diagnostics;
+using System.Net;
 using Meziantou.DnsProxy;
 using Meziantou.DnsProxy.Filtering;
 using Meziantou.Framework.DnsFilter;
@@ -43,46 +43,117 @@ public sealed class FilterEngineProviderTests
     [Fact]
     public async Task RefreshAsync_LoadsRemoteFiltersWithoutBlockingCalls()
     {
-        var options = Options.Create(new DnsProxyOptions
-        {
-            Filters =
-            [
-                new FilterListOption
-                {
-                    Url = "https://filters.example/list.txt",
-                    Format = nameof(DnsFilterListFormat.AdBlock),
-                },
-            ],
-            Rewrites = [],
-        });
+        var cacheFolderPath = CreateTemporaryDirectory();
 
-        using var serviceProvider = CreateServiceProvider(request =>
+        try
         {
-            Assert.Equal("https://filters.example/list.txt", request.RequestUri!.ToString());
-            return new HttpResponseMessage(HttpStatusCode.OK)
+            var options = Options.Create(new DnsProxyOptions
             {
-                Content = new StringContent("||blocked.example.com^"),
-            };
-        });
-        var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+                BlockListCacheFolderPath = cacheFolderPath,
+                Filters =
+                [
+                    new FilterListOption
+                    {
+                        Url = "https://filters.example/list.txt",
+                        Format = nameof(DnsFilterListFormat.AdBlock),
+                    },
+                ],
+                Rewrites = [],
+            });
 
-        var provider = new FilterEngineProvider(
-            factory,
-            options,
-            NullLogger<FilterEngineProvider>.Instance);
+            using var serviceProvider = CreateServiceProvider(request =>
+            {
+                Assert.Equal("https://filters.example/list.txt", request.RequestUri!.ToString());
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("||blocked.example.com^"),
+                };
+            });
+            var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
 
-        await provider.RefreshAsync(CancellationToken.None);
+            var provider = new FilterEngineProvider(
+                factory,
+                options,
+                NullLogger<FilterEngineProvider>.Instance);
 
-        var result = provider.Engine.Evaluate("blocked.example.com");
-        Assert.True(result.IsMatched);
-        Assert.Equal(1, provider.RuleCount);
+            await provider.RefreshAsync(CancellationToken.None);
+
+            var result = provider.Engine.Evaluate("blocked.example.com");
+            Assert.True(result.IsMatched);
+            Assert.Equal(1, provider.RuleCount);
+        }
+        finally
+        {
+            Directory.Delete(cacheFolderPath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RefreshAsync_CachesRemoteFiltersAndLoadsCachedFiltersOnStartup()
+    {
+        var cacheFolderPath = CreateTemporaryDirectory();
+
+        try
+        {
+            var options = Options.Create(new DnsProxyOptions
+            {
+                BlockListCacheFolderPath = cacheFolderPath,
+                Filters =
+                [
+                    new FilterListOption
+                    {
+                        Url = "https://filters.example/list.txt",
+                        Format = nameof(DnsFilterListFormat.AdBlock),
+                    },
+                ],
+                Rewrites = [],
+            });
+
+            using var serviceProvider = CreateServiceProvider(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("||cached.example.com^"),
+            });
+            var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+
+            var provider = new FilterEngineProvider(
+                factory,
+                options,
+                NullLogger<FilterEngineProvider>.Instance);
+
+            await provider.RefreshAsync(CancellationToken.None);
+
+            using var cachedServiceProvider = CreateServiceProvider(_ => throw new InvalidOperationException("Remote refresh failed."));
+            var cachedFactory = cachedServiceProvider.GetRequiredService<IHttpClientFactory>();
+
+            var cachedProvider = new FilterEngineProvider(
+                cachedFactory,
+                options,
+                NullLogger<FilterEngineProvider>.Instance);
+
+            var result = cachedProvider.Engine.Evaluate("cached.example.com");
+            Assert.True(result.IsMatched);
+            Assert.Equal(1, cachedProvider.RuleCount);
+            Assert.Single(Directory.EnumerateFiles(cacheFolderPath, "*.txt"));
+
+            await cachedProvider.RefreshAsync(CancellationToken.None);
+
+            result = cachedProvider.Engine.Evaluate("cached.example.com");
+            Assert.True(result.IsMatched);
+            Assert.Equal(1, cachedProvider.RuleCount);
+        }
+        finally
+        {
+            Directory.Delete(cacheFolderPath, recursive: true);
+        }
     }
 
     [Fact]
     public async Task RefreshAsync_WhenCanceled_ThrowsOperationCanceledException()
     {
+        var cacheFolderPath = CreateTemporaryDirectory();
         var options = Options.Create(new DnsProxyOptions
         {
+            BlockListCacheFolderPath = cacheFolderPath,
             Filters =
             [
                 new FilterListOption
@@ -108,15 +179,24 @@ public sealed class FilterEngineProviderTests
         using var cancellationTokenSource = new CancellationTokenSource();
         cancellationTokenSource.Cancel();
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => provider.RefreshAsync(cancellationTokenSource.Token));
+        try
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => provider.RefreshAsync(cancellationTokenSource.Token));
+        }
+        finally
+        {
+            Directory.Delete(cacheFolderPath, recursive: true);
+        }
     }
 
     [Fact]
     public async Task FilterEngineRefreshService_RefreshesAtConfiguredInterval()
     {
+        var cacheFolderPath = CreateTemporaryDirectory();
         var requestCount = 0;
         var options = Options.Create(new DnsProxyOptions
         {
+            BlockListCacheFolderPath = cacheFolderPath,
             FilterRefreshInterval = TimeSpan.FromMilliseconds(100),
             Filters =
             [
@@ -159,6 +239,7 @@ public sealed class FilterEngineProviderTests
         finally
         {
             await service.StopAsync(CancellationToken.None);
+            Directory.Delete(cacheFolderPath, recursive: true);
         }
 
         Assert.True(Volatile.Read(ref requestCount) >= 2, $"Expected at least 2 refresh attempts, but got {requestCount}");
@@ -171,6 +252,14 @@ public sealed class FilterEngineProviderTests
             .AddHttpClient(Options.DefaultName)
             .ConfigurePrimaryHttpMessageHandler(() => new DelegateHttpMessageHandler(responseFactory));
         return services.BuildServiceProvider();
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "meziantou-dnsproxy-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+
+        return path;
     }
 
     private sealed class DelegateHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler

--- a/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/Meziantou.Framework.DnsProxy.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <ProjectReference Include="../../src/Meziantou.DnsProxy/Meziantou.DnsProxy.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">


### PR DESCRIPTION
## Summary
- Add a configurable disk cache for downloaded block lists, with a sensible default under local application data
- Load cached filter lists at startup and refresh the cache after successful downloads
- Surface the cache path in diagnostics and document the new setting
- Extend unit coverage for defaults, diagnostics output, and cache behavior

## Testing
- Unit tests updated for option defaults, diagnostics rendering, and filter engine cache loading/writing
- Not run (not requested)