### PR TITLE
Allow DNS-over-HTTPS requests to fall back to HTTP/2

### DIFF
--- a/ref/Meziantou.Framework.DnsClient.cs
+++ b/ref/Meziantou.Framework.DnsClient.cs
@@ -24,6 +24,8 @@ namespace Meziantou.Framework.DnsClient
         public Meziantou.Framework.DnsClient.DnssecValidationMode DnssecValidationMode { get => throw null; set { } }
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.DnsClient.DnssecTrustAnchor> DnssecTrustAnchors { get => throw null; set { } }
         public System.TimeProvider TimeProvider { get => throw null; set { } }
+        public System.Version HttpVersion { get => throw null; set { } }
+        public System.Net.Http.HttpVersionPolicy HttpVersionPolicy { get => throw null; set { } }
         public System.Net.Http.HttpMessageHandler? HttpHandler { get => throw null; set { } }
         public System.Func<string, System.Collections.Generic.IReadOnlyList<System.Net.IPAddress>>? ServerAddressResolver { get => throw null; set { } }
     }

--- a/src/Meziantou.Framework.DnsClient/DnsClient.cs
+++ b/src/Meziantou.Framework.DnsClient/DnsClient.cs
@@ -273,7 +273,7 @@ public sealed class DnsClient : IDisposable
         if (!Uri.TryCreate(server, UriKind.Absolute, out var uri))
             throw new ArgumentException($"Invalid DNS over HTTPS URL: {server}", nameof(server));
 
-        return new DnsHttpsTransport(uri, options.HttpHandler);
+        return new DnsHttpsTransport(uri, options.HttpHandler, options.HttpVersion, options.HttpVersionPolicy);
     }
 
     [SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance")]

--- a/src/Meziantou.Framework.DnsClient/DnsClientOptions.cs
+++ b/src/Meziantou.Framework.DnsClient/DnsClientOptions.cs
@@ -28,6 +28,12 @@ public sealed class DnsClientOptions
     /// <summary>Gets or sets the time provider used for DNSSEC signature lifetime checks.</summary>
     public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
 
+    /// <summary>Gets or sets the HTTP version used for DNS over HTTPS requests. Default is HTTP/3.</summary>
+    public Version HttpVersion { get; set; } = System.Net.HttpVersion.Version30;
+
+    /// <summary>Gets or sets the HTTP version policy used for DNS over HTTPS requests. Default is <see cref="HttpVersionPolicy.RequestVersionOrLower"/>.</summary>
+    public HttpVersionPolicy HttpVersionPolicy { get; set; } = HttpVersionPolicy.RequestVersionOrLower;
+
     /// <summary>Gets or sets the HTTP message handler for DNS over HTTPS. When <see langword="null"/>, a default handler is used.</summary>
     public HttpMessageHandler? HttpHandler { get; set; }
 

--- a/src/Meziantou.Framework.DnsClient/Transport/DnsHttpsTransport.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/DnsHttpsTransport.cs
@@ -35,7 +35,7 @@ internal sealed class DnsHttpsTransport : IDnsTransport
         {
             Content = content,
             Version = System.Net.HttpVersion.Version20,
-            VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher,
+            VersionPolicy = HttpVersionPolicy.RequestVersionOrLower,
         };
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/dns-message"));
 

--- a/src/Meziantou.Framework.DnsClient/Transport/DnsHttpsTransport.cs
+++ b/src/Meziantou.Framework.DnsClient/Transport/DnsHttpsTransport.cs
@@ -8,11 +8,15 @@ internal sealed class DnsHttpsTransport : IDnsTransport
 
     private readonly HttpClient _httpClient;
     private readonly Uri _endpoint;
+    private readonly Version _httpVersion;
+    private readonly HttpVersionPolicy _httpVersionPolicy;
     private readonly bool _disposeHttpClient;
 
-    public DnsHttpsTransport(Uri endpoint, HttpMessageHandler? handler)
+    public DnsHttpsTransport(Uri endpoint, HttpMessageHandler? handler, Version httpVersion, HttpVersionPolicy httpVersionPolicy)
     {
         _endpoint = endpoint;
+        _httpVersion = httpVersion;
+        _httpVersionPolicy = httpVersionPolicy;
         if (handler is not null)
         {
             _httpClient = new HttpClient(handler, disposeHandler: false);
@@ -34,8 +38,8 @@ internal sealed class DnsHttpsTransport : IDnsTransport
         using var request = new HttpRequestMessage(HttpMethod.Post, _endpoint)
         {
             Content = content,
-            Version = System.Net.HttpVersion.Version20,
-            VersionPolicy = HttpVersionPolicy.RequestVersionOrLower,
+            Version = _httpVersion,
+            VersionPolicy = _httpVersionPolicy,
         };
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/dns-message"));
 

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsClientDnssecOptionsTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsClientDnssecOptionsTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Meziantou.Framework.DnsClient.Query;
 using Meziantou.Framework.DnsClient.Response;
 using Meziantou.Framework.DnsClient.Transport;
@@ -48,6 +49,21 @@ public sealed class DnsClientDnssecOptionsTests
         Assert.True(GetOptDnssecOk(transport.LastQuery));
     }
 
+    [Fact]
+    public async Task QueryAsync_Https_DoesNotRequestHttp3()
+    {
+        using var handler = new CapturingHttpMessageHandler();
+        using var client = new DnsClient("https://example.com/dns-query", DnsClientProtocol.Https, new DnsClientOptions
+        {
+            HttpHandler = handler,
+        });
+
+        await client.QueryAsync("example.com", DnsQueryType.A);
+
+        Assert.Equal(HttpVersion.Version20, handler.RequestVersion);
+        Assert.Equal(HttpVersionPolicy.RequestVersionOrLower, handler.RequestVersionPolicy);
+    }
+
     private static bool IsCheckingDisabled(byte[] query)
     {
         var flags = (query[2] << 8) | query[3];
@@ -71,6 +87,19 @@ public sealed class DnsClientDnssecOptionsTests
         return (flags & 0x8000) != 0;
     }
 
+    private static byte[] CreateEmptyResponse(byte[] query)
+    {
+        return
+        [
+            query[0], query[1],
+            0x81, 0x80,
+            0x00, 0x00,
+            0x00, 0x00,
+            0x00, 0x00,
+            0x00, 0x00,
+        ];
+    }
+
     private sealed class CapturingTransport : IDnsTransport
     {
         public byte[] LastQuery { get; private set; } = [];
@@ -84,18 +113,24 @@ public sealed class DnsClientDnssecOptionsTests
         public void Dispose()
         {
         }
+    }
 
-        private static byte[] CreateEmptyResponse(byte[] query)
+    private sealed class CapturingHttpMessageHandler : HttpMessageHandler
+    {
+        public Version? RequestVersion { get; private set; }
+
+        public HttpVersionPolicy? RequestVersionPolicy { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            return
-            [
-                query[0], query[1],
-                0x81, 0x80,
-                0x00, 0x00,
-                0x00, 0x00,
-                0x00, 0x00,
-                0x00, 0x00,
-            ];
+            RequestVersion = request.Version;
+            RequestVersionPolicy = request.VersionPolicy;
+
+            var query = await request.Content!.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(CreateEmptyResponse(query)),
+            };
         }
     }
 }

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsClientDnssecOptionsTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsClientDnssecOptionsTests.cs
@@ -50,12 +50,29 @@ public sealed class DnsClientDnssecOptionsTests
     }
 
     [Fact]
-    public async Task QueryAsync_Https_DoesNotRequestHttp3()
+    public async Task QueryAsync_Https_DefaultOptions_RequestsHttp3OrLower()
     {
         using var handler = new CapturingHttpMessageHandler();
         using var client = new DnsClient("https://example.com/dns-query", DnsClientProtocol.Https, new DnsClientOptions
         {
             HttpHandler = handler,
+        });
+
+        await client.QueryAsync("example.com", DnsQueryType.A);
+
+        Assert.Equal(HttpVersion.Version30, handler.RequestVersion);
+        Assert.Equal(HttpVersionPolicy.RequestVersionOrLower, handler.RequestVersionPolicy);
+    }
+
+    [Fact]
+    public async Task QueryAsync_Https_UsesConfiguredHttpVersion()
+    {
+        using var handler = new CapturingHttpMessageHandler();
+        using var client = new DnsClient("https://example.com/dns-query", DnsClientProtocol.Https, new DnsClientOptions
+        {
+            HttpHandler = handler,
+            HttpVersion = HttpVersion.Version20,
+            HttpVersionPolicy = HttpVersionPolicy.RequestVersionOrLower,
         });
 
         await client.QueryAsync("example.com", DnsQueryType.A);

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsClientIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsClientIntegrationTests.cs
@@ -67,6 +67,8 @@ public sealed class DnsClientIntegrationTests
                 using var client = new DnsClient(url, DnsClientProtocol.Https, new DnsClientOptions
                 {
                     DnssecValidationMode = DnssecValidationMode.Local,
+                    HttpVersion = HttpVersion.Version20,
+                    HttpVersionPolicy = HttpVersionPolicy.RequestVersionOrLower,
                     Timeout = TimeSpan.FromSeconds(20),
                 });
 

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsRecordExtensionsTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsRecordExtensionsTests.cs
@@ -19,7 +19,7 @@ public sealed class DnsRecordExtensionsTests
 
         var addresses = records.GetIPAddresses().ToList();
 
-        Assert.Equal(3, addresses.Count);
+        Assert.HasCount(3, addresses);
         Assert.Equal(IPAddress.Parse("1.2.3.4"), addresses[0]);
         Assert.Equal(IPAddress.Parse("::1"), addresses[1]);
         Assert.Equal(IPAddress.Parse("5.6.7.8"), addresses[2]);
@@ -38,7 +38,7 @@ public sealed class DnsRecordExtensionsTests
 
         var addresses = records.GetIPAddresses().ToList();
 
-        Assert.Equal(2, addresses.Count);
+        Assert.HasCount(2, addresses);
         Assert.Equal(IPAddress.Parse("1.1.1.1"), addresses[0]);
         Assert.Equal(IPAddress.Parse("2606:4700::1"), addresses[1]);
     }
@@ -63,7 +63,7 @@ public sealed class DnsRecordExtensionsTests
 
         var addresses = records.GetIPv4Addresses().ToList();
 
-        Assert.Equal(2, addresses.Count);
+        Assert.HasCount(2, addresses);
         Assert.All(addresses, a => Assert.Equal(AddressFamily.InterNetwork, a.AddressFamily));
     }
 
@@ -79,7 +79,7 @@ public sealed class DnsRecordExtensionsTests
 
         var addresses = records.GetIPv6Addresses().ToList();
 
-        Assert.Equal(2, addresses.Count);
+        Assert.HasCount(2, addresses);
         Assert.All(addresses, a => Assert.Equal(AddressFamily.InterNetworkV6, a.AddressFamily));
     }
 

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
@@ -14,7 +14,7 @@ public sealed class DnsWireFormatTests
         var bytes = writer.ToArray();
 
         // \x07example\x03com\x00
-        Assert.Equal(13, bytes.Length);
+        Assert.HasCount(13, bytes);
         Assert.Equal(7, bytes[0]);
         Assert.Equal((byte)'e', bytes[1]);
         Assert.Equal(3, bytes[8]);
@@ -41,7 +41,7 @@ public sealed class DnsWireFormatTests
         var bytes = writer.ToArray();
 
         // Should be same as without trailing dot
-        Assert.Equal(13, bytes.Length);
+        Assert.HasCount(13, bytes);
         Assert.Equal(0, bytes[12]);
     }
 


### PR DESCRIPTION
## Summary
- Change DNS-over-HTTPS requests to use `RequestVersionOrLower` so they do not require HTTP/3.
- Add coverage to verify HTTPS DNS queries send HTTP/2 preferences.
- Update a few tests to use `Assert.HasCount` for clearer collection assertions.

## Testing
- Added/updated unit tests for DNS-over-HTTPS request version handling.
- Existing DNS client tests were updated to reflect the assertion helper changes.