### PR TITLE
Add activity tracing to DNS filter refreshes

### DIFF
--- a/src/Meziantou.DnsProxy/DnsProxyTelemetry.cs
+++ b/src/Meziantou.DnsProxy/DnsProxyTelemetry.cs
@@ -1,0 +1,8 @@
+using System.Diagnostics;
+
+namespace Meziantou.DnsProxy;
+
+internal static class DnsProxyTelemetry
+{
+    public static readonly ActivitySource ActivitySource = new("Meziantou.DnsProxy");
+}

--- a/src/Meziantou.DnsProxy/Filtering/FilterEngineProvider.cs
+++ b/src/Meziantou.DnsProxy/Filtering/FilterEngineProvider.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Meziantou.Framework.DnsFilter;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -33,6 +34,10 @@ internal sealed class FilterEngineProvider
         var options = _options.Value;
         var ruleSet = new DnsFilterRuleSet();
         using var httpClient = _httpClientFactory.CreateClient();
+        using var activity = DnsProxyTelemetry.ActivitySource.StartActivity("dns_proxy.filters.refresh");
+        var filterCount = 0;
+        var loadedFilterCount = 0;
+        var failedFilterCount = 0;
 
         foreach (var filter in options.Filters)
         {
@@ -41,28 +46,68 @@ internal sealed class FilterEngineProvider
                 continue;
             }
 
-            try
+            filterCount++;
+            if (await TryLoadFilterAsync(httpClient, ruleSet, filter, cancellationToken).ConfigureAwait(false))
             {
-                var listText = await httpClient.GetStringAsync(filter.Url, cancellationToken).ConfigureAwait(false);
-                var format = Enum.TryParse<DnsFilterListFormat>(filter.Format, ignoreCase: true, out var parsedFormat)
-                    ? parsedFormat
-                    : DnsFilterListFormat.AutoDetect;
-                ruleSet.AddFromList(listText, format);
+                loadedFilterCount++;
             }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            else
             {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Cannot load filter list {FilterUrl}", filter.Url);
+                failedFilterCount++;
             }
         }
 
         AddRewriteRules(ruleSet, options);
 
+        activity?.SetTag("dns_proxy.filter.count", filterCount);
+        activity?.SetTag("dns_proxy.filter.loaded_count", loadedFilterCount);
+        activity?.SetTag("dns_proxy.filter.failed_count", failedFilterCount);
+        activity?.SetTag("dns_proxy.rule.count", ruleSet.Rules.Count);
+
+        if (failedFilterCount == 0)
+        {
+            activity?.SetStatus(ActivityStatusCode.Ok);
+        }
+        else
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, $"{failedFilterCount} filter lists failed to load");
+        }
+
         Volatile.Write(ref _ruleCount, ruleSet.Rules.Count);
         Volatile.Write(ref _engine, new DnsFilterEngine(ruleSet));
+    }
+
+    private async Task<bool> TryLoadFilterAsync(HttpClient httpClient, DnsFilterRuleSet ruleSet, FilterListOption filter, CancellationToken cancellationToken)
+    {
+        using var activity = DnsProxyTelemetry.ActivitySource.StartActivity("dns_proxy.filters.load");
+        activity?.SetTag("dns_proxy.filter.url", filter.Url);
+
+        try
+        {
+            var format = Enum.TryParse<DnsFilterListFormat>(filter.Format, ignoreCase: true, out var parsedFormat)
+                ? parsedFormat
+                : DnsFilterListFormat.AutoDetect;
+            activity?.SetTag("dns_proxy.filter.format", format.ToString());
+
+            var ruleCount = ruleSet.Rules.Count;
+            var listText = await httpClient.GetStringAsync(filter.Url, cancellationToken).ConfigureAwait(false);
+            ruleSet.AddFromList(listText, format);
+            activity?.SetTag("dns_proxy.filter.rule_count", ruleSet.Rules.Count - ruleCount);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+
+            return true;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            _logger.LogWarning(ex, "Cannot load filter list {FilterUrl}", filter.Url);
+
+            return false;
+        }
     }
 
     private void AddRewriteRules(DnsFilterRuleSet ruleSet, DnsProxyOptions options)

--- a/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyIntegrationTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/DnsProxyIntegrationTests.cs
@@ -159,7 +159,7 @@ public sealed class DnsProxyIntegrationTests
 
     private static void AssertDnsResponseHasARecord(byte[] response, ushort expectedId, IPAddress expectedAddress)
     {
-        Assert.True(response.Length >= 12);
+        Assert.HasCountGreaterThanOrEqual(12, response);
 
         var offset = 0;
         var id = ReadUInt16(response, ref offset);
@@ -187,7 +187,7 @@ public sealed class DnsProxyIntegrationTests
         Assert.Equal(1, recordType);
         Assert.Equal(1, recordClass);
         Assert.Equal(4, rdLength);
-        Assert.True(offset + rdLength <= response.Length);
+        Assert.HasCountGreaterThanOrEqual(offset + rdLength, response);
 
         var address = new IPAddress(response.AsSpan(offset, rdLength));
         Assert.Equal(expectedAddress, address);
@@ -195,7 +195,7 @@ public sealed class DnsProxyIntegrationTests
 
     private static void AssertDnsResponseDoesNotHaveARecord(byte[] response, ushort expectedId, IPAddress unexpectedAddress)
     {
-        Assert.True(response.Length >= 12);
+        Assert.HasCountGreaterThanOrEqual(12, response);
 
         var offset = 0;
         var id = ReadUInt16(response, ref offset);

--- a/tests/Meziantou.Framework.DnsProxy.Tests/FilterEngineProviderTests.cs
+++ b/tests/Meziantou.Framework.DnsProxy.Tests/FilterEngineProviderTests.cs
@@ -1,5 +1,6 @@
-using System.Net;
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Net;
 using Meziantou.DnsProxy;
 using Meziantou.DnsProxy.Filtering;
 using Meziantou.Framework.DnsFilter;
@@ -76,6 +77,54 @@ public sealed class FilterEngineProviderTests
         var result = provider.Engine.Evaluate("blocked.example.com");
         Assert.True(result.IsMatched);
         Assert.Equal(1, provider.RuleCount);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_EmitsActivitiesWhenLoadingRemoteFilters()
+    {
+        var options = Options.Create(new DnsProxyOptions
+        {
+            Filters =
+            [
+                new FilterListOption
+                {
+                    Url = "https://filters.example/list.txt",
+                    Format = nameof(DnsFilterListFormat.AdBlock),
+                },
+            ],
+            Rewrites = [],
+        });
+
+        var activities = new ConcurrentQueue<Activity>();
+        using var listener = CreateDnsProxyActivityListener(activities.Enqueue);
+        ActivitySource.AddActivityListener(listener);
+
+        using var serviceProvider = CreateServiceProvider(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("||blocked.example.com^"),
+        });
+        var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+
+        var provider = new FilterEngineProvider(
+            factory,
+            options,
+            NullLogger<FilterEngineProvider>.Instance);
+
+        await provider.RefreshAsync(CancellationToken.None);
+
+        var refreshActivity = Assert.Single(activities, activity => activity.OperationName == "dns_proxy.filters.refresh");
+        var loadActivity = Assert.Single(activities, activity => activity.OperationName == "dns_proxy.filters.load");
+
+        Assert.Equal(refreshActivity.SpanId, loadActivity.ParentSpanId);
+        Assert.Equal(ActivityStatusCode.Ok, refreshActivity.Status);
+        Assert.Equal(ActivityStatusCode.Ok, loadActivity.Status);
+        Assert.Equal(1, Assert.IsType<int>(refreshActivity.GetTagItem("dns_proxy.filter.count")));
+        Assert.Equal(1, Assert.IsType<int>(refreshActivity.GetTagItem("dns_proxy.filter.loaded_count")));
+        Assert.Equal(0, Assert.IsType<int>(refreshActivity.GetTagItem("dns_proxy.filter.failed_count")));
+        Assert.Equal(1, Assert.IsType<int>(refreshActivity.GetTagItem("dns_proxy.rule.count")));
+        Assert.Equal("https://filters.example/list.txt", loadActivity.GetTagItem("dns_proxy.filter.url"));
+        Assert.Equal(nameof(DnsFilterListFormat.AdBlock), loadActivity.GetTagItem("dns_proxy.filter.format"));
+        Assert.Equal(1, Assert.IsType<int>(loadActivity.GetTagItem("dns_proxy.filter.rule_count")));
     }
 
     [Fact]
@@ -171,6 +220,17 @@ public sealed class FilterEngineProviderTests
             .AddHttpClient(Options.DefaultName)
             .ConfigurePrimaryHttpMessageHandler(() => new DelegateHttpMessageHandler(responseFactory));
         return services.BuildServiceProvider();
+    }
+
+    private static ActivityListener CreateDnsProxyActivityListener(Action<Activity> activityStopped)
+    {
+        return new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == "Meziantou.DnsProxy",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            SampleUsingParentId = static (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activityStopped,
+        };
     }
 
     private sealed class DelegateHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler


### PR DESCRIPTION
## Summary
- Add `ActivitySource`-based tracing for DNS filter refresh and per-filter load operations.
- Record filter counts, rule counts, and success/failure status as activity tags.
- Expand tests to verify emitted activities and update DNS response assertions.

## Testing
- Added integration coverage for activity emission and parent/child span relationships during remote filter refresh.
- Existing DNS proxy tests were updated to use the newer count assertions.
- Not run (not requested)