### PR TITLE
Fix MFAS assertion warnings failing CI build

### DIFF
--- a/tests/Meziantou.AspNetCore.ServiceDefaults.Tests/ServiceDefaultTests.cs
+++ b/tests/Meziantou.AspNetCore.ServiceDefaults.Tests/ServiceDefaultTests.cs
@@ -134,10 +134,11 @@ public sealed class ServiceDefaultTests
         using var httpClient = new HttpClient() { BaseAddress = new Uri(address) };
         using var response = await httpClient.GetAsync("/test", XunitCancellationToken);
 
-        Assert.True(response.Headers.CacheControl is not null);
-        Assert.True(response.Headers.CacheControl.NoCache);
-        Assert.True(response.Headers.CacheControl.NoStore);
-        Assert.True(response.Headers.CacheControl.MustRevalidate);
+        var cacheControl = response.Headers.CacheControl;
+        Assert.NotNull(cacheControl);
+        Assert.True(cacheControl.NoCache);
+        Assert.True(cacheControl.NoStore);
+        Assert.True(cacheControl.MustRevalidate);
     }
 
     [Fact]
@@ -160,10 +161,11 @@ public sealed class ServiceDefaultTests
         using var httpClient = new HttpClient() { BaseAddress = new Uri(address) };
         using var response = await httpClient.GetAsync("/test", XunitCancellationToken);
 
-        Assert.True(response.Headers.CacheControl is not null);
-        Assert.True(response.Headers.CacheControl.Public);
-        Assert.Equal(3600, response.Headers.CacheControl.MaxAge?.TotalSeconds);
-        Assert.False(response.Headers.CacheControl.NoCache);
+        var cacheControl = response.Headers.CacheControl;
+        Assert.NotNull(cacheControl);
+        Assert.True(cacheControl.Public);
+        Assert.Equal(3600, cacheControl.MaxAge?.TotalSeconds);
+        Assert.False(cacheControl.NoCache);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnsWireFormatTests.cs
@@ -92,7 +92,7 @@ public sealed class DnsWireFormatTests
 
         var bytes = DnsMessageEncoder.EncodeQuery(query);
 
-        Assert.True(bytes.Length >= 12); // At least header
+        Assert.HasCountGreaterThanOrEqual(12, bytes); // At least header
 
         // Check header ID
         Assert.Equal(0x12, bytes[0]);

--- a/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
+++ b/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
@@ -214,7 +214,7 @@ public sealed class PooledMemoryStreamTests
         Assert.Equal(data, stream.ToArray());
 
         var buffer = stream.GetBuffer();
-        Assert.True(buffer.Length >= length);
+        Assert.HasCountGreaterThanOrEqual(length, buffer);
         Assert.Equal(data, buffer.AsSpan(0, length).ToArray());
 
         Assert.True(stream.TryGetBuffer(out var segment));

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableArrayTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableArrayTests.cs
@@ -93,7 +93,10 @@ public sealed class ImmutableEquatableArrayTests
         Assert.False(array.Equals(null));
         Assert.False(array == null);
         Assert.False(null == array);
-        Assert.NotNull(array);
+#pragma warning disable MFAS0007 // Preserve == and != operator validation
+        Assert.True(array != null);
+        Assert.True(null != array);
+#pragma warning restore MFAS0007
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableArrayTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableArrayTests.cs
@@ -93,8 +93,7 @@ public sealed class ImmutableEquatableArrayTests
         Assert.False(array.Equals(null));
         Assert.False(array == null);
         Assert.False(null == array);
-        Assert.True(array != null);
-        Assert.True(null != array);
+        Assert.NotNull(array);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableDictionaryTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableDictionaryTests.cs
@@ -181,8 +181,7 @@ public sealed class ImmutableEquatableDictionaryTests
         Assert.False(dict.Equals(null));
         Assert.False(dict == null);
         Assert.False(null == dict);
-        Assert.True(dict != null);
-        Assert.True(null != dict);
+        Assert.NotNull(dict);
         Assert.False(dict.Equals((object?)null));
     }
 

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableDictionaryTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableDictionaryTests.cs
@@ -181,7 +181,10 @@ public sealed class ImmutableEquatableDictionaryTests
         Assert.False(dict.Equals(null));
         Assert.False(dict == null);
         Assert.False(null == dict);
-        Assert.NotNull(dict);
+#pragma warning disable MFAS0007 // Preserve == and != operator validation
+        Assert.True(dict != null);
+        Assert.True(null != dict);
+#pragma warning restore MFAS0007
         Assert.False(dict.Equals((object?)null));
     }
 

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
@@ -89,8 +89,7 @@ public sealed class ImmutableEquatableSetTests
         Assert.False(set.Equals(null));
         Assert.False(set == null);
         Assert.False(null == set);
-        Assert.True(set != null);
-        Assert.True(null != set);
+        Assert.NotNull(set);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
@@ -89,7 +89,10 @@ public sealed class ImmutableEquatableSetTests
         Assert.False(set.Equals(null));
         Assert.False(set == null);
         Assert.False(null == set);
-        Assert.NotNull(set);
+#pragma warning disable MFAS0007 // Preserve == and != operator validation
+        Assert.True(set != null);
+        Assert.True(null != set);
+#pragma warning restore MFAS0007
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
@@ -134,7 +134,7 @@ public sealed class ProjectedFileSystemTests
             // Read the entire file and verify content integrity
             // The file contains predictable data: byte[i] = i % 256
             var allData = File.ReadAllBytes(filePath);
-            Assert.Equal(10000, allData.Length);
+            Assert.HasCount(10000, allData);
 
             // Verify data at various positions - with the bug, data would be from offset 0
             // Check beginning
@@ -187,7 +187,7 @@ public sealed class ProjectedFileSystemTests
 
             // Read the entire file and verify content integrity
             var allData = File.ReadAllBytes(filePath);
-            Assert.Equal(10000, allData.Length);
+            Assert.HasCount(10000, allData);
 
             // Verify data at various positions
             Assert.Equal(0, allData[0]);
@@ -235,7 +235,7 @@ public sealed class ProjectedFileSystemTests
 
             // Step 1: First enumeration - ProjFS queries provider for entries
             var firstEnum = Directory.GetFileSystemEntries(fullPath).OrderBy(Path.GetFileName, StringComparer.Ordinal).ToList();
-            Assert.Equal(5, firstEnum.Count);
+            Assert.HasCount(5, firstEnum);
 
             // Step 2: Access each entry to create on-disk placeholders
             // This is critical - ProjFS creates placeholder metadata on disk when entries are accessed
@@ -250,8 +250,8 @@ public sealed class ProjectedFileSystemTests
             var thirdEnum = Directory.GetFileSystemEntries(fullPath).OrderBy(Path.GetFileName, StringComparer.Ordinal).ToList();
 
             // All enumerations should return exactly 5 unique entries
-            Assert.Equal(5, secondEnum.Count);
-            Assert.Equal(5, thirdEnum.Count);
+            Assert.HasCount(5, secondEnum);
+            Assert.HasCount(5, thirdEnum);
 
             // Verify the expected entries exist (in sorted order by filename)
             var expectedNames = new[] { "apple.txt", "banana", "mango.txt", "yellow.txt", "zebra.txt" };


### PR DESCRIPTION
## Why
The build on `main` started failing because new assertion analyzer rules are treated as errors in CI. Several tests were still using generic count and null-check assertion patterns that now trigger `MFAS0005` and `MFAS0007`.

## What changed
This updates the affected tests to use the analyzer-preferred assertion APIs:
- Replaced length/count comparisons with specialized count assertions (`Assert.HasCount`, `Assert.HasCountGreaterThanOrEqual`)
- Replaced `Assert.True(value is not null)`-style checks with `Assert.NotNull` patterns
- Kept test intent and behavior unchanged while making the assertions analyzer-compliant

## Notes for reviewers
`Meziantou.Framework.Win32.ProjectedFileSystem.Tests` could not be executed in this local environment because the x64 .NET test host is unavailable on this machine. The rest of the touched test projects were run successfully.