### PR TITLE
Add assertion analyzer rules for type-pattern readability

### DIFF
--- a/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
@@ -13,4 +13,6 @@ internal static class RuleIdentifiers
     internal const string NotNullWithValueTypeDiagnosticId = "MFAS0009";
     internal const string SameWithValueTypeDiagnosticId = "MFAS0010";
     internal const string NotSameWithValueTypeDiagnosticId = "MFAS0011";
+    internal const string UseIsAssignableToDiagnosticId = "MFAS0012";
+    internal const string UseIsNotAssignableToDiagnosticId = "MFAS0013";
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzer.cs
@@ -56,7 +56,23 @@ public sealed class AssertionMethodSelectionAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [UseNullDescriptor, UseNotNullDescriptor, NullWithValueTypeDescriptor, NotNullWithValueTypeDescriptor, SameWithValueTypeDescriptor, NotSameWithValueTypeDescriptor];
+    public static readonly DiagnosticDescriptor UseIsAssignableToDescriptor = new(
+        id: RuleIdentifiers.UseIsAssignableToDiagnosticId,
+        title: "Use Assert.IsAssignableTo for type pattern checks",
+        messageFormat: "Use Assert.IsAssignableTo<T>(value) for readability",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseIsNotAssignableToDescriptor = new(
+        id: RuleIdentifiers.UseIsNotAssignableToDiagnosticId,
+        title: "Use Assert.IsNotAssignableTo for type pattern checks",
+        messageFormat: "Use Assert.IsNotAssignableTo<T>(value) for readability",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [UseNullDescriptor, UseNotNullDescriptor, NullWithValueTypeDescriptor, NotNullWithValueTypeDescriptor, SameWithValueTypeDescriptor, NotSameWithValueTypeDescriptor, UseIsAssignableToDescriptor, UseIsNotAssignableToDescriptor];
 
     public override void Initialize(AnalysisContext context)
     {
@@ -86,6 +102,13 @@ public sealed class AssertionMethodSelectionAnalyzer : DiagnosticAnalyzer
         {
             var descriptor = nullNotNullValueTypeMatch.AssertionMethodName == "Equal" ? NullWithValueTypeDescriptor : NotNullWithValueTypeDescriptor;
             context.ReportDiagnostic(Diagnostic.Create(descriptor, nullNotNullValueTypeMatch.ActualOperation.Syntax.GetLocation(), nullNotNullValueTypeMatch.ValueType.ToDisplayString()));
+            return;
+        }
+
+        if (AssertionMethodSelectionAnalyzerCommon.TryGetAssignableTypeCheckMatch(invocationOperation, assertType, out var assignableTypeCheckMatch))
+        {
+            var descriptor = assignableTypeCheckMatch.AssertionMethodName == "IsAssignableTo" ? UseIsAssignableToDescriptor : UseIsNotAssignableToDescriptor;
+            context.ReportDiagnostic(Diagnostic.Create(descriptor, assignableTypeCheckMatch.ActualOperation.Syntax.GetLocation()));
             return;
         }
 

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzerCommon.cs
@@ -81,22 +81,22 @@ internal static class AssertionMethodSelectionAnalyzerCommon
         }
 
         if (conditionOperation is IIsTypeOperation isTypeOperation &&
-            TryGetIsTypeOperationTypeSyntax(isTypeOperation, out var isTypeOperationTypeSyntax))
+            TryGetIsTypeOperationType(isTypeOperation, out var isTypeOperationType))
         {
             var assertionMethodName = conditionExpectedToBeFalse ? IsNotAssignableToAssertionMethodName : IsAssignableToAssertionMethodName;
-            match = new AssignableTypeCheckMatch(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(isTypeOperation.ValueOperand), isTypeOperationTypeSyntax, assertionMethodName);
+            match = new AssignableTypeCheckMatch(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(isTypeOperation.ValueOperand), isTypeOperationType, assertionMethodName);
             return true;
         }
 
         if (conditionOperation is not IIsPatternOperation isPatternOperation ||
-            !TryGetTypePattern(isPatternOperation.Pattern, out var typeSyntax, out var isNegated))
+            !TryGetTypePattern(isPatternOperation.Pattern, out var type, out var isNegated))
         {
             match = default;
             return false;
         }
 
         var patternAssertionMethodName = conditionExpectedToBeFalse == isNegated ? IsAssignableToAssertionMethodName : IsNotAssignableToAssertionMethodName;
-        match = new AssignableTypeCheckMatch(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(isPatternOperation.Value), typeSyntax, patternAssertionMethodName);
+        match = new AssignableTypeCheckMatch(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(isPatternOperation.Value), type, patternAssertionMethodName);
         return true;
     }
 
@@ -251,46 +251,39 @@ internal static class AssertionMethodSelectionAnalyzerCommon
         };
     }
 
-    private static bool TryGetTypePattern(IPatternOperation pattern, out TypeSyntax typeSyntax, out bool isNegated)
+    private static bool TryGetTypePattern(IPatternOperation pattern, out ITypeSymbol type, out bool isNegated)
     {
-        if (pattern.Syntax is TypePatternSyntax { Type: var directTypeSyntax })
+        if (pattern is ITypePatternOperation { MatchedType: { } directType })
         {
-            typeSyntax = directTypeSyntax;
+            type = directType;
             isNegated = false;
             return true;
         }
 
-        if (pattern.Syntax is UnaryPatternSyntax
+        if (pattern is INegatedPatternOperation
             {
-                OperatorToken.RawKind: (int)SyntaxKind.NotKeyword,
-                Pattern: TypePatternSyntax { Type: var negatedTypeSyntax },
+                Pattern: ITypePatternOperation { MatchedType: { } negatedType },
             })
         {
-            typeSyntax = negatedTypeSyntax;
+            type = negatedType;
             isNegated = true;
             return true;
         }
 
-        typeSyntax = null!;
+        type = null!;
         isNegated = false;
         return false;
     }
 
-    private static bool TryGetIsTypeOperationTypeSyntax(IIsTypeOperation isTypeOperation, out TypeSyntax typeSyntax)
+    private static bool TryGetIsTypeOperationType(IIsTypeOperation isTypeOperation, out ITypeSymbol type)
     {
-        if (isTypeOperation.Syntax is BinaryExpressionSyntax { Right: TypeSyntax rightTypeSyntax })
-        {
-            typeSyntax = rightTypeSyntax;
-            return true;
-        }
-
         if (isTypeOperation.TypeOperand is not null)
         {
-            typeSyntax = SyntaxFactory.ParseTypeName(isTypeOperation.TypeOperand.ToDisplayString());
+            type = isTypeOperation.TypeOperand;
             return true;
         }
 
-        typeSyntax = null!;
+        type = null!;
         return false;
     }
 
@@ -298,7 +291,7 @@ internal static class AssertionMethodSelectionAnalyzerCommon
 
     internal readonly record struct NullNotNullValueTypeMatch(IOperation ActualOperation, ITypeSymbol ValueType, string AssertionMethodName);
 
-    internal readonly record struct AssignableTypeCheckMatch(IOperation ActualOperation, TypeSyntax TypeSyntax, string AssertionMethodName);
+    internal readonly record struct AssignableTypeCheckMatch(IOperation ActualOperation, ITypeSymbol Type, string AssertionMethodName);
 
     internal readonly record struct SameNotSameValueTypeMatch(IOperation ExpectedOperation, IOperation ActualOperation, string AssertionMethodName);
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzerCommon.cs
@@ -12,6 +12,8 @@ internal static class AssertionMethodSelectionAnalyzerCommon
     private const string NotNullAssertionMethodName = "NotNull";
     private const string EqualAssertionMethodName = "Equal";
     private const string NotEqualAssertionMethodName = "NotEqual";
+    private const string IsAssignableToAssertionMethodName = "IsAssignableTo";
+    private const string IsNotAssignableToAssertionMethodName = "IsNotAssignableTo";
 
     internal static bool TryGetNullCheckMatch(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, out NullCheckMatch match)
     {
@@ -70,6 +72,34 @@ internal static class AssertionMethodSelectionAnalyzerCommon
         return true;
     }
 
+    internal static bool TryGetAssignableTypeCheckMatch(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, out AssignableTypeCheckMatch match)
+    {
+        if (!TryGetAssertCondition(invocationOperation, assertType, out var conditionOperation, out var conditionExpectedToBeFalse))
+        {
+            match = default;
+            return false;
+        }
+
+        if (conditionOperation is IIsTypeOperation isTypeOperation &&
+            TryGetIsTypeOperationTypeSyntax(isTypeOperation, out var isTypeOperationTypeSyntax))
+        {
+            var assertionMethodName = conditionExpectedToBeFalse ? IsNotAssignableToAssertionMethodName : IsAssignableToAssertionMethodName;
+            match = new AssignableTypeCheckMatch(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(isTypeOperation.ValueOperand), isTypeOperationTypeSyntax, assertionMethodName);
+            return true;
+        }
+
+        if (conditionOperation is not IIsPatternOperation isPatternOperation ||
+            !TryGetTypePattern(isPatternOperation.Pattern, out var typeSyntax, out var isNegated))
+        {
+            match = default;
+            return false;
+        }
+
+        var patternAssertionMethodName = conditionExpectedToBeFalse == isNegated ? IsAssignableToAssertionMethodName : IsNotAssignableToAssertionMethodName;
+        match = new AssignableTypeCheckMatch(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(isPatternOperation.Value), typeSyntax, patternAssertionMethodName);
+        return true;
+    }
+
     internal static bool TryGetSameNotSameValueTypeMatch(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, out SameNotSameValueTypeMatch match)
     {
         if (!IsAssertInvocation(invocationOperation, assertType, "Same", "NotSame"))
@@ -120,6 +150,34 @@ internal static class AssertionMethodSelectionAnalyzerCommon
         return invocationOperation.TargetMethod is { IsStatic: true } targetMethod &&
             SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, assertType) &&
             methodNames.Contains(targetMethod.Name);
+    }
+
+    private static bool TryGetAssertCondition(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, out IOperation conditionOperation, out bool conditionExpectedToBeFalse)
+    {
+        if (IsAssertInvocation(invocationOperation, assertType, "True"))
+        {
+            conditionExpectedToBeFalse = false;
+        }
+        else if (IsAssertInvocation(invocationOperation, assertType, "False"))
+        {
+            conditionExpectedToBeFalse = true;
+        }
+        else
+        {
+            conditionOperation = null!;
+            conditionExpectedToBeFalse = false;
+            return false;
+        }
+
+        var conditionArgument = invocationOperation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "condition");
+        if (conditionArgument is null)
+        {
+            conditionOperation = null!;
+            return false;
+        }
+
+        conditionOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(conditionArgument.Value);
+        return true;
     }
 
     private static bool TryGetNullComparedValue(IOperation leftOperation, IOperation rightOperation, out IOperation actualOperation)
@@ -193,9 +251,54 @@ internal static class AssertionMethodSelectionAnalyzerCommon
         };
     }
 
+    private static bool TryGetTypePattern(IPatternOperation pattern, out TypeSyntax typeSyntax, out bool isNegated)
+    {
+        if (pattern.Syntax is TypePatternSyntax { Type: var directTypeSyntax })
+        {
+            typeSyntax = directTypeSyntax;
+            isNegated = false;
+            return true;
+        }
+
+        if (pattern.Syntax is UnaryPatternSyntax
+            {
+                OperatorToken.RawKind: (int)SyntaxKind.NotKeyword,
+                Pattern: TypePatternSyntax { Type: var negatedTypeSyntax },
+            })
+        {
+            typeSyntax = negatedTypeSyntax;
+            isNegated = true;
+            return true;
+        }
+
+        typeSyntax = null!;
+        isNegated = false;
+        return false;
+    }
+
+    private static bool TryGetIsTypeOperationTypeSyntax(IIsTypeOperation isTypeOperation, out TypeSyntax typeSyntax)
+    {
+        if (isTypeOperation.Syntax is BinaryExpressionSyntax { Right: TypeSyntax rightTypeSyntax })
+        {
+            typeSyntax = rightTypeSyntax;
+            return true;
+        }
+
+        if (isTypeOperation.TypeOperand is not null)
+        {
+            typeSyntax = SyntaxFactory.ParseTypeName(isTypeOperation.TypeOperand.ToDisplayString());
+            return true;
+        }
+
+        typeSyntax = null!;
+        return false;
+    }
+
     internal readonly record struct NullCheckMatch(IOperation ActualOperation, string AssertionMethodName);
 
     internal readonly record struct NullNotNullValueTypeMatch(IOperation ActualOperation, ITypeSymbol ValueType, string AssertionMethodName);
+
+    internal readonly record struct AssignableTypeCheckMatch(IOperation ActualOperation, TypeSyntax TypeSyntax, string AssertionMethodName);
 
     internal readonly record struct SameNotSameValueTypeMatch(IOperation ExpectedOperation, IOperation ActualOperation, string AssertionMethodName);
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzerCommon.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -152,7 +153,7 @@ internal static class AssertionMethodSelectionAnalyzerCommon
             methodNames.Contains(targetMethod.Name);
     }
 
-    private static bool TryGetAssertCondition(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, out IOperation conditionOperation, out bool conditionExpectedToBeFalse)
+    private static bool TryGetAssertCondition(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, [NotNullWhen(true)] out IOperation? conditionOperation, out bool conditionExpectedToBeFalse)
     {
         if (IsAssertInvocation(invocationOperation, assertType, "True"))
         {
@@ -164,7 +165,7 @@ internal static class AssertionMethodSelectionAnalyzerCommon
         }
         else
         {
-            conditionOperation = null!;
+            conditionOperation = null;
             conditionExpectedToBeFalse = false;
             return false;
         }
@@ -172,7 +173,7 @@ internal static class AssertionMethodSelectionAnalyzerCommon
         var conditionArgument = invocationOperation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "condition");
         if (conditionArgument is null)
         {
-            conditionOperation = null!;
+            conditionOperation = null;
             return false;
         }
 
@@ -251,7 +252,7 @@ internal static class AssertionMethodSelectionAnalyzerCommon
         };
     }
 
-    private static bool TryGetTypePattern(IPatternOperation pattern, out ITypeSymbol type, out bool isNegated)
+    private static bool TryGetTypePattern(IPatternOperation pattern, [NotNullWhen(true)] out ITypeSymbol? type, out bool isNegated)
     {
         if (pattern is ITypePatternOperation { MatchedType: { } directType })
         {
@@ -270,12 +271,12 @@ internal static class AssertionMethodSelectionAnalyzerCommon
             return true;
         }
 
-        type = null!;
+        type = null;
         isNegated = false;
         return false;
     }
 
-    private static bool TryGetIsTypeOperationType(IIsTypeOperation isTypeOperation, out ITypeSymbol type)
+    private static bool TryGetIsTypeOperationType(IIsTypeOperation isTypeOperation, [NotNullWhen(true)] out ITypeSymbol? type)
     {
         if (isTypeOperation.TypeOperand is not null)
         {
@@ -283,7 +284,7 @@ internal static class AssertionMethodSelectionAnalyzerCommon
             return true;
         }
 
-        type = null!;
+        type = null;
         return false;
     }
 

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/AssertionMethodSelectionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/AssertionMethodSelectionCodeFixProvider.cs
@@ -20,6 +20,8 @@ public sealed class AssertionMethodSelectionCodeFixProvider : CodeFixProvider
         RuleIdentifiers.NotNullWithValueTypeDiagnosticId,
         RuleIdentifiers.SameWithValueTypeDiagnosticId,
         RuleIdentifiers.NotSameWithValueTypeDiagnosticId,
+        RuleIdentifiers.UseIsAssignableToDiagnosticId,
+        RuleIdentifiers.UseIsNotAssignableToDiagnosticId,
     ];
 
     public override FixAllProvider GetFixAllProvider()
@@ -105,6 +107,13 @@ public sealed class AssertionMethodSelectionCodeFixProvider : CodeFixProvider
             return true;
         }
 
+        if (AssertionMethodSelectionAnalyzerCommon.TryGetAssignableTypeCheckMatch(invocationOperation, assertType, out var assignableTypeCheckMatch) &&
+            invocationExpression.ArgumentList.Arguments.Count == 1)
+        {
+            title = "Use Assert." + assignableTypeCheckMatch.AssertionMethodName;
+            return true;
+        }
+
         title = null!;
         return false;
     }
@@ -148,6 +157,16 @@ public sealed class AssertionMethodSelectionCodeFixProvider : CodeFixProvider
             invocationExpression.ArgumentList.Arguments.Count == 2)
         {
             fixedInvocation = invocationExpression.WithExpression(ReplaceMethodName(invocationExpression.Expression, sameNotSameValueTypeMatch.AssertionMethodName));
+            return true;
+        }
+
+        if (AssertionMethodSelectionAnalyzerCommon.TryGetAssignableTypeCheckMatch(invocationOperation, assertType, out var assignableTypeCheckMatch) &&
+            invocationExpression.ArgumentList.Arguments.Count == 1 &&
+            TryGetExpressionSyntax(assignableTypeCheckMatch.ActualOperation, out var actualAssignableExpression))
+        {
+            fixedInvocation = invocationExpression
+                .WithExpression(ReplaceMethodNameWithTypeArgument(invocationExpression.Expression, assignableTypeCheckMatch.AssertionMethodName, assignableTypeCheckMatch.TypeSyntax))
+                .WithArgumentList(SyntaxFactory.ArgumentList([SyntaxFactory.Argument(actualAssignableExpression.WithoutTrivia())]));
             return true;
         }
 
@@ -199,8 +218,28 @@ public sealed class AssertionMethodSelectionCodeFixProvider : CodeFixProvider
         return expression;
     }
 
+    private static ExpressionSyntax ReplaceMethodNameWithTypeArgument(ExpressionSyntax expression, string methodName, TypeSyntax typeArgument)
+    {
+        if (expression is MemberAccessExpressionSyntax memberAccessExpression)
+        {
+            return memberAccessExpression.WithName(CreateGenericName(memberAccessExpression.Name.Identifier, methodName, typeArgument));
+        }
+
+        if (expression is IdentifierNameSyntax identifierName)
+            return CreateGenericName(identifierName.Identifier, methodName, typeArgument);
+
+        return expression;
+    }
+
     private static SyntaxToken CreateIdentifier(SyntaxToken identifier, string text)
     {
         return SyntaxFactory.Identifier(identifier.LeadingTrivia, text, identifier.TrailingTrivia);
+    }
+
+    private static GenericNameSyntax CreateGenericName(SyntaxToken identifier, string methodName, TypeSyntax typeArgument)
+    {
+        return SyntaxFactory.GenericName(
+            CreateIdentifier(identifier, methodName),
+            SyntaxFactory.TypeArgumentList([typeArgument.WithoutTrivia()]));
     }
 }

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/AssertionMethodSelectionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/AssertionMethodSelectionCodeFixProvider.cs
@@ -164,8 +164,9 @@ public sealed class AssertionMethodSelectionCodeFixProvider : CodeFixProvider
             invocationExpression.ArgumentList.Arguments.Count == 1 &&
             TryGetExpressionSyntax(assignableTypeCheckMatch.ActualOperation, out var actualAssignableExpression))
         {
+            var assignableTypeSyntax = SyntaxFactory.ParseTypeName(assignableTypeCheckMatch.Type.ToMinimalDisplayString(semanticModel, invocationExpression.SpanStart));
             fixedInvocation = invocationExpression
-                .WithExpression(ReplaceMethodNameWithTypeArgument(invocationExpression.Expression, assignableTypeCheckMatch.AssertionMethodName, assignableTypeCheckMatch.TypeSyntax))
+                .WithExpression(ReplaceMethodNameWithTypeArgument(invocationExpression.Expression, assignableTypeCheckMatch.AssertionMethodName, assignableTypeSyntax))
                 .WithArgumentList(SyntaxFactory.ArgumentList([SyntaxFactory.Argument(actualAssignableExpression.WithoutTrivia())]));
             return true;
         }

--- a/src/Meziantou.Framework.Assertions/readme.md
+++ b/src/Meziantou.Framework.Assertions/readme.md
@@ -20,4 +20,6 @@ The package ships analyzers and code fixes to help write clearer assertions.
 | `MFAS0009` | Assertions | Do not use Assert.NotNull with value types | Error | ✔️ |
 | `MFAS0010` | Assertions | Do not use Assert.Same with value types | Error | ✔️ |
 | `MFAS0011` | Assertions | Do not use Assert.NotSame with value types | Error | ✔️ |
+| `MFAS0012` | Assertions | Use Assert.IsAssignableTo for type pattern checks | Warning | ✔️ |
+| `MFAS0013` | Assertions | Use Assert.IsNotAssignableTo for type pattern checks | Warning | ✔️ |
 <!-- analyzer-rules -->

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AssertionMethodSelectionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AssertionMethodSelectionRuleTests.cs
@@ -142,6 +142,142 @@ public sealed class AssertionMethodSelectionRuleTests : AssertionsAnalyzerTestBa
     }
 
     [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForAssertTrueIsType()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object value)
+                {
+                    Assert.True({|MFAS0012:value|} is string);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object value)
+                {
+                    Assert.IsAssignableTo<string>(value);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<AssertionMethodSelectionAnalyzerType, AssertionMethodSelectionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForAssertFalseIsType()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object value)
+                {
+                    Assert.False({|MFAS0013:value|} is string);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object value)
+                {
+                    Assert.IsNotAssignableTo<string>(value);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<AssertionMethodSelectionAnalyzerType, AssertionMethodSelectionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForAssertTrueIsNotType()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object value)
+                {
+                    Assert.True({|MFAS0013:value|} is not string);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object value)
+                {
+                    Assert.IsNotAssignableTo<string>(value);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<AssertionMethodSelectionAnalyzerType, AssertionMethodSelectionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForAssertFalseIsNotType()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object value)
+                {
+                    Assert.False({|MFAS0012:value|} is not string);
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object value)
+                {
+                    Assert.IsAssignableTo<string>(value);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<AssertionMethodSelectionAnalyzerType, AssertionMethodSelectionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
     public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForAssertNullWithValueType()
     {
         var source = """
@@ -294,6 +430,8 @@ public sealed class AssertionMethodSelectionRuleTests : AssertionsAnalyzerTestBa
                     Assert.NotNull(nullableValue);
                     Assert.Same(expected, actual);
                     Assert.NotSame(expected, actual);
+                    _ = Assert.IsAssignableTo<object>(actual);
+                    Assert.IsNotAssignableTo<int>(actual);
                 }
             }
             """;


### PR DESCRIPTION
## Why
Using `Assert.True/False` with `is` / `is not` type checks is less expressive than dedicated assertion helpers. This change adds analyzer guidance and fixes so tests read more clearly and intent is explicit.

## What changed
- Added two new analyzer diagnostics:
  - `MFAS0012`: suggest `Assert.IsAssignableTo<T>(value)`
  - `MFAS0013`: suggest `Assert.IsNotAssignableTo<T>(value)`
- Extended assertion method selection analysis to detect and map these patterns:
  - `Assert.True(value is Type)` -> `Assert.IsAssignableTo<Type>(value)`
  - `Assert.False(value is Type)` -> `Assert.IsNotAssignableTo<Type>(value)`
  - `Assert.True(value is not Type)` -> `Assert.IsNotAssignableTo<Type>(value)`
  - `Assert.False(value is not Type)` -> `Assert.IsAssignableTo<Type>(value)`
- Updated the code fix provider to apply the corresponding generic assertion rewrite.
- Added analyzer/code-fix tests for all four transformations and updated analyzer rule documentation.

## Validation
- `dotnet run ./eng/update-all.cs`
- `dotnet test tests/Meziantou.Framework.Assertions.Analyzer.Tests/Meziantou.Framework.Assertions.Analyzer.Tests.csproj /p:TreatsWarningsAsErrors=true --nologo`