### PR TITLE
Add Assert.Equivalent with configurable structural comparison

### DIFF
--- a/ref/Meziantou.Framework.Assertions.cs
+++ b/ref/Meziantou.Framework.Assertions.cs
@@ -179,6 +179,8 @@ namespace Meziantou.Framework.Assertions
         public static System.Threading.Tasks.Task Equal<T>(System.Collections.Generic.IAsyncEnumerable<T> expected, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] System.Collections.Generic.IEnumerable<T>? actual, string? message = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? expectedExpression = null) => throw null;
         public static void Equal(System.Collections.IEnumerable expected, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] System.Collections.IEnumerable? actual, string? message = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? expectedExpression = null) { }
         public static void Equal(System.Collections.IEnumerable expected, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] System.Collections.IEnumerable? actual, System.Collections.IEqualityComparer? comparer, string? message = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? expectedExpression = null) { }
+        public static void Equivalent(object? expected, object? actual, string? message = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? expectedExpression = null) { }
+        public static void Equivalent(object? expected, object? actual, Meziantou.Framework.Assertions.EquivalentOptions? options, string? message = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? expectedExpression = null) { }
         public static void EqualByStructure(object? expected, object? actual, string? message = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? expectedExpression = null) { }
         public static void EqualUnordered<T>(System.Collections.Generic.IEnumerable<T> expected, [System.Diagnostics.CodeAnalysis.NotNull] System.Collections.Generic.IEnumerable<T>? actual, string? message = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? expectedExpression = null) { }
         public static void EqualUnordered<T>(System.Collections.Generic.IEnumerable<T> expected, [System.Diagnostics.CodeAnalysis.NotNull] System.Collections.Generic.IEnumerable<T>? actual, System.Collections.Generic.IEqualityComparer<T>? comparer, string? message = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null, [System.Runtime.CompilerServices.CallerArgumentExpression("expected")] string? expectedExpression = null) { }
@@ -311,6 +313,13 @@ namespace Meziantou.Framework.Assertions
     {
         public AssertionException(string? message) { }
         public AssertionException(string? message, System.Exception? innerException) { }
+    }
+
+    public sealed class EquivalentOptions
+    {
+        public bool IgnoreCollectionOrder { get => throw null; set { } }
+        public bool IgnoreMemberNameCase { get => throw null; set { } }
+        public bool IgnoreStringCase { get => throw null; set { } }
     }
 
     public sealed class FormatterOptions

--- a/src/Meziantou.Framework.Assertions/Assert.EqualByStructure.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.EqualByStructure.cs
@@ -5,16 +5,32 @@ namespace Meziantou.Framework.Assertions;
 
 public partial class Assert
 {
+    public static void Equivalent(object? expected, object? actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
+    {
+        Equivalent(expected, actual, options: null, message, actualExpression, expectedExpression);
+    }
+
+    public static void Equivalent(object? expected, object? actual, EquivalentOptions? options, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
+    {
+        AssertEquivalent(expected, actual, options, assertionName: nameof(Equivalent), message, actualExpression, expectedExpression);
+    }
+
     public static void EqualByStructure(object? expected, object? actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
     {
-        var failure = GetStructuralDifference(expected, actual, "$", new HashSet<StructuralReferencePair>());
+        AssertEquivalent(expected, actual, options: null, assertionName: nameof(EqualByStructure), message, actualExpression, expectedExpression);
+    }
+
+    private static void AssertEquivalent(object? expected, object? actual, EquivalentOptions? options, string assertionName, string? message, string? actualExpression, string? expectedExpression)
+    {
+        var comparisonOptions = StructuralComparisonOptions.Create(options);
+        var failure = GetStructuralDifference(expected, actual, "$", new HashSet<StructuralReferencePair>(), comparisonOptions);
         if (failure is null)
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new EqualByStructureAssertionError(failure.Value.ExpectedValue, failure.Value.ActualValue, failure.Value.Path, failure.Value.Reason, message, actualExpression, expectedExpression)));
+        throw new AssertionException(ErrorFormatter.Format(new EqualByStructureAssertionError(assertionName, failure.Value.ExpectedValue, failure.Value.ActualValue, failure.Value.Path, failure.Value.Reason, message, actualExpression, expectedExpression)));
     }
 
-    private static StructuralDifference? GetStructuralDifference(object? expected, object? actual, string path, HashSet<StructuralReferencePair> visited)
+    private static StructuralDifference? GetStructuralDifference(object? expected, object? actual, string path, HashSet<StructuralReferencePair> visited, StructuralComparisonOptions options)
     {
         if (object.ReferenceEquals(expected, actual))
             return null;
@@ -25,7 +41,7 @@ public partial class Assert
         var expectedType = expected.GetType();
         var actualType = actual.GetType();
         if (IsSimpleStructuralValue(expectedType) || IsSimpleStructuralValue(actualType))
-            return ValuesEqual(expected, actual) ? null : new StructuralDifference(path, expected, actual, "Values differ.");
+            return StructuralValuesEqual(expected, actual, options) ? null : new StructuralDifference(path, expected, actual, "Values differ.");
 
         if (!expectedType.IsValueType && !actualType.IsValueType)
         {
@@ -35,12 +51,20 @@ public partial class Assert
         }
 
         if (expected is System.Collections.IEnumerable expectedEnumerable && actual is System.Collections.IEnumerable actualEnumerable)
-            return GetStructuralEnumerableDifference(expectedEnumerable, actualEnumerable, path, visited);
+            return GetStructuralEnumerableDifference(expectedEnumerable, actualEnumerable, path, visited, options);
 
-        return GetStructuralMemberDifference(expected, actual, path, visited);
+        return GetStructuralMemberDifference(expected, actual, path, visited, options);
     }
 
-    private static StructuralDifference? GetStructuralEnumerableDifference(System.Collections.IEnumerable expected, System.Collections.IEnumerable actual, string path, HashSet<StructuralReferencePair> visited)
+    private static StructuralDifference? GetStructuralEnumerableDifference(System.Collections.IEnumerable expected, System.Collections.IEnumerable actual, string path, HashSet<StructuralReferencePair> visited, StructuralComparisonOptions options)
+    {
+        if (options.IgnoreCollectionOrder)
+            return GetStructuralUnorderedEnumerableDifference(expected, actual, path, visited, options);
+
+        return GetStructuralOrderedEnumerableDifference(expected, actual, path, visited, options);
+    }
+
+    private static StructuralDifference? GetStructuralOrderedEnumerableDifference(System.Collections.IEnumerable expected, System.Collections.IEnumerable actual, string path, HashSet<StructuralReferencePair> visited, StructuralComparisonOptions options)
     {
         var index = 0;
         var expectedEnumerator = expected.GetEnumerator();
@@ -63,7 +87,7 @@ public partial class Assert
                 if (!actualHasNext)
                     return new StructuralDifference(itemPath, expectedEnumerator.Current, StructuralMissingValue.Instance, "Actual collection is missing an item.");
 
-                var difference = GetStructuralDifference(expectedEnumerator.Current, actualEnumerator.Current, itemPath, visited);
+                var difference = GetStructuralDifference(expectedEnumerator.Current, actualEnumerator.Current, itemPath, visited, options);
                 if (difference is not null)
                     return difference;
 
@@ -77,10 +101,53 @@ public partial class Assert
         }
     }
 
-    private static StructuralDifference? GetStructuralMemberDifference(object expected, object actual, string path, HashSet<StructuralReferencePair> visited)
+    private static StructuralDifference? GetStructuralUnorderedEnumerableDifference(System.Collections.IEnumerable expected, System.Collections.IEnumerable actual, string path, HashSet<StructuralReferencePair> visited, StructuralComparisonOptions options)
     {
-        var expectedMembers = GetStructuralMembers(expected.GetType());
-        var actualMembers = GetStructuralMembers(actual.GetType());
+        var expectedItems = new List<object?>(EnumerateObjects(expected));
+        var actualItems = new List<object?>(EnumerateObjects(actual));
+        var matchedActualIndexes = new bool[actualItems.Count];
+
+        for (var expectedIndex = 0; expectedIndex < expectedItems.Count; expectedIndex++)
+        {
+            var itemPath = path + "[" + expectedIndex.ToString(CultureInfo.InvariantCulture) + "]";
+            var expectedItem = expectedItems[expectedIndex];
+            var found = false;
+
+            for (var actualIndex = 0; actualIndex < actualItems.Count; actualIndex++)
+            {
+                if (matchedActualIndexes[actualIndex])
+                    continue;
+
+                var candidateVisited = new HashSet<StructuralReferencePair>(visited);
+                var difference = GetStructuralDifference(expectedItem, actualItems[actualIndex], itemPath, candidateVisited, options);
+                if (difference is not null)
+                    continue;
+
+                matchedActualIndexes[actualIndex] = true;
+                found = true;
+                break;
+            }
+
+            if (!found)
+                return new StructuralDifference(itemPath, expectedItem, StructuralMissingValue.Instance, "Actual collection is missing an equivalent item.");
+        }
+
+        for (var actualIndex = 0; actualIndex < matchedActualIndexes.Length; actualIndex++)
+        {
+            if (matchedActualIndexes[actualIndex])
+                continue;
+
+            var itemPath = path + "[" + actualIndex.ToString(CultureInfo.InvariantCulture) + "]";
+            return new StructuralDifference(itemPath, StructuralMissingValue.Instance, actualItems[actualIndex], "Actual collection contains an unexpected item.");
+        }
+
+        return null;
+    }
+
+    private static StructuralDifference? GetStructuralMemberDifference(object expected, object actual, string path, HashSet<StructuralReferencePair> visited, StructuralComparisonOptions options)
+    {
+        var expectedMembers = GetStructuralMembers(expected.GetType(), options.MemberNameComparer);
+        var actualMembers = GetStructuralMembers(actual.GetType(), options.MemberNameComparer);
 
         foreach (var expectedMember in expectedMembers.Values)
         {
@@ -88,7 +155,7 @@ public partial class Assert
             if (!actualMembers.TryGetValue(expectedMember.Name, out var actualMember))
                 return new StructuralDifference(memberPath, expectedMember.GetValue(expected), StructuralMissingValue.Instance, "Actual member is missing.");
 
-            var difference = GetStructuralDifference(expectedMember.GetValue(expected), actualMember.GetValue(actual), memberPath, visited);
+            var difference = GetStructuralDifference(expectedMember.GetValue(expected), actualMember.GetValue(actual), memberPath, visited, options);
             if (difference is not null)
                 return difference;
         }
@@ -105,9 +172,9 @@ public partial class Assert
         return null;
     }
 
-    private static Dictionary<string, StructuralMember> GetStructuralMembers(Type type)
+    private static Dictionary<string, StructuralMember> GetStructuralMembers(Type type, StringComparer comparer)
     {
-        var result = new Dictionary<string, StructuralMember>(StringComparer.Ordinal);
+        var result = new Dictionary<string, StructuralMember>(comparer);
         foreach (var property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
         {
             if (property.GetMethod is null || property.GetIndexParameters().Length != 0)
@@ -122,6 +189,14 @@ public partial class Assert
         }
 
         return result;
+    }
+
+    private static bool StructuralValuesEqual(object? expected, object? actual, StructuralComparisonOptions options)
+    {
+        if (expected is string expectedString && actual is string actualString)
+            return string.Equals(expectedString, actualString, options.StringComparison);
+
+        return ValuesEqual(expected, actual);
     }
 
     private static bool IsSimpleStructuralValue(Type type)
@@ -176,6 +251,24 @@ public partial class Assert
         public object? GetValue(object obj)
         {
             return getValue(obj);
+        }
+    }
+
+    private readonly struct StructuralComparisonOptions(bool ignoreCollectionOrder, StringComparer memberNameComparer, StringComparison stringComparison)
+    {
+        public bool IgnoreCollectionOrder { get; } = ignoreCollectionOrder;
+        public StringComparer MemberNameComparer { get; } = memberNameComparer;
+        public StringComparison StringComparison { get; } = stringComparison;
+
+        public static StructuralComparisonOptions Create(EquivalentOptions? options)
+        {
+            if (options is null)
+                return new StructuralComparisonOptions(ignoreCollectionOrder: false, StringComparer.Ordinal, StringComparison.Ordinal);
+
+            return new StructuralComparisonOptions(
+                options.IgnoreCollectionOrder,
+                options.IgnoreMemberNameCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal,
+                options.IgnoreStringCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
         }
     }
 }

--- a/src/Meziantou.Framework.Assertions/Assert.NotEqualByStructure.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.NotEqualByStructure.cs
@@ -6,7 +6,7 @@ public partial class Assert
 {
     public static void NotEqualByStructure(object? expected, object? actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
     {
-        var failure = GetStructuralDifference(expected, actual, "$", new HashSet<StructuralReferencePair>());
+        var failure = GetStructuralDifference(expected, actual, "$", new HashSet<StructuralReferencePair>(), StructuralComparisonOptions.Create(options: null));
         if (failure is not null)
             return;
 

--- a/src/Meziantou.Framework.Assertions/AssertionFormatter.cs
+++ b/src/Meziantou.Framework.Assertions/AssertionFormatter.cs
@@ -521,7 +521,7 @@ internal class AssertionFormatter
     public virtual string Format(EqualByStructureAssertionError error)
     {
         var result = $"""
-            Assert.EqualByStructure() assertion failed.
+            Assert.{error.AssertionName}() assertion failed.
             Expected expression: {error.ExpectedExpression}
             Actual expression:   {error.ActualExpression}
             Path: {error.Path}

--- a/src/Meziantou.Framework.Assertions/EquivalentOptions.cs
+++ b/src/Meziantou.Framework.Assertions/EquivalentOptions.cs
@@ -1,0 +1,8 @@
+namespace Meziantou.Framework.Assertions;
+
+public sealed class EquivalentOptions
+{
+    public bool IgnoreCollectionOrder { get; set; }
+    public bool IgnoreMemberNameCase { get; set; }
+    public bool IgnoreStringCase { get; set; }
+}

--- a/src/Meziantou.Framework.Assertions/Errors/EqualByStructureAssertionError.cs
+++ b/src/Meziantou.Framework.Assertions/Errors/EqualByStructureAssertionError.cs
@@ -1,7 +1,8 @@
 namespace Meziantou.Framework.Assertions;
 
-internal readonly struct EqualByStructureAssertionError(object? expectedValue, object? actualValue, string path, string reason, string? message, string? actualExpression, string? expectedExpression)
+internal readonly struct EqualByStructureAssertionError(string assertionName, object? expectedValue, object? actualValue, string path, string reason, string? message, string? actualExpression, string? expectedExpression)
 {
+    public string AssertionName { get; } = assertionName;
     public string? Message { get; } = message;
     public string? ExpectedExpression { get; } = expectedExpression;
     public string? ActualExpression { get; } = actualExpression;

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEqualByStructureTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEqualByStructureTests.cs
@@ -71,6 +71,93 @@ public sealed class AssertEqualByStructureTests
     }
 
     [Fact]
+    public void Equivalent_Success()
+    {
+        var expected = new ExpectedPerson { Name = "Alice", Age = 42 };
+        var actual = new ActualPerson { Name = "Alice", Age = 42 };
+
+        AssertionsAssert.Equivalent(expected, actual);
+    }
+
+    [Fact]
+    public void Equivalent_FailsWhenCollectionOrderDiffersByDefault()
+    {
+        var expected = new PersonWithScores { Name = "Alice", Scores = new[] { 1, 2, 3 } };
+        var actual = new PersonWithScores { Name = "Alice", Scores = new[] { 3, 2, 1 } };
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.Equivalent(expected, actual), """
+            Assert.Equivalent() assertion failed.
+            Expected expression: expected
+            Actual expression:   actual
+            Path: $.Scores[0]
+            Reason: Values differ.
+            Expected: 1
+            Actual:   3
+            """);
+    }
+
+    [Fact]
+    public void Equivalent_IgnoresCollectionOrderWhenConfigured()
+    {
+        var expected = new PersonWithScores { Name = "Alice", Scores = new[] { 1, 2, 3 } };
+        var actual = new PersonWithScores { Name = "Alice", Scores = new[] { 3, 2, 1 } };
+
+        AssertionsAssert.Equivalent(expected, actual, new EquivalentOptions { IgnoreCollectionOrder = true });
+    }
+
+    [Fact]
+    public void Equivalent_FailsWhenMemberNameCaseDiffersByDefault()
+    {
+        var expected = new ZipCodeContainerExpected { ZipCode = 75000 };
+        var actual = new ZipCodeContainerActual { Zipcode = 75000 };
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.Equivalent(expected, actual), """
+            Assert.Equivalent() assertion failed.
+            Expected expression: expected
+            Actual expression:   actual
+            Path: $.ZipCode
+            Reason: Actual member is missing.
+            Expected: 75000
+            Actual:   <missing>
+            """);
+    }
+
+    [Fact]
+    public void Equivalent_IgnoresMemberNameCaseWhenConfigured()
+    {
+        var expected = new ZipCodeContainerExpected { ZipCode = 75000 };
+        var actual = new ZipCodeContainerActual { Zipcode = 75000 };
+
+        AssertionsAssert.Equivalent(expected, actual, new EquivalentOptions { IgnoreMemberNameCase = true });
+    }
+
+    [Fact]
+    public void Equivalent_FailsWhenStringCaseDiffersByDefault()
+    {
+        var expected = new ExpectedPerson { Name = "Alice", Age = 42 };
+        var actual = new ActualPerson { Name = "alice", Age = 42 };
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.Equivalent(expected, actual), """
+            Assert.Equivalent() assertion failed.
+            Expected expression: expected
+            Actual expression:   actual
+            Path: $.Name
+            Reason: Values differ.
+            Expected: "Alice"
+            Actual:   "alice"
+            """);
+    }
+
+    [Fact]
+    public void Equivalent_IgnoresStringCaseWhenConfigured()
+    {
+        var expected = new ExpectedPerson { Name = "Alice", Age = 42 };
+        var actual = new ActualPerson { Name = "alice", Age = 42 };
+
+        AssertionsAssert.Equivalent(expected, actual, new EquivalentOptions { IgnoreStringCase = true });
+    }
+
+    [Fact]
     public void Cycles_Success()
     {
         var expected = new Node { Name = "root" };
@@ -307,6 +394,16 @@ public sealed class AssertEqualByStructureTests
     {
         public string? City { get; set; }
         public long ZipCode { get; set; }
+    }
+
+    private sealed class ZipCodeContainerExpected
+    {
+        public int ZipCode { get; set; }
+    }
+
+    private sealed class ZipCodeContainerActual
+    {
+        public int Zipcode { get; set; }
     }
 
     private sealed class PersonWithScores


### PR DESCRIPTION
## Why
`Meziantou.Framework.Assertions` had `EqualByStructure`, but it did not expose an assertion designed for semantic equivalence with explicit comparison options. This change adds that API so tests can choose strict or relaxed structural matching.

## What changed
- Added `Assert.Equivalent(expected, actual, options?, message?, ...)`.
- Added new public `EquivalentOptions`:
  - `IgnoreCollectionOrder`
  - `IgnoreMemberNameCase`
  - `IgnoreStringCase`
- Refactored structural comparison internals to be options-aware while still comparing only public instance properties and fields.
- Kept strict defaults when options are omitted: collection order matters, member names are case-sensitive, and strings are case-sensitive.
- Updated formatter plumbing so failures are labeled with the active assertion name (`Assert.Equivalent()` or `Assert.EqualByStructure()`).
- Added targeted tests for `Equivalent` default behavior and each option override.
- Updated public API reference file.

## Notes for reviewers
`EqualByStructure` now uses the same internal comparison pipeline as `Equivalent` with strict options, preserving existing behavior while avoiding duplicate logic.

## Validation
- `dotnet run ./eng/update-all.cs`
- `dotnet build src/Meziantou.Framework.Assertions/Meziantou.Framework.Assertions.csproj /p:TreatsWarningsAsErrors=true`
- `dotnet test tests/Meziantou.Framework.Assertions.Tests/Meziantou.Framework.Assertions.Tests.csproj /p:TreatsWarningsAsErrors=true`