### PR TITLE
Harden DNSSEC validation for signer ancestry and DNSKEY usage

### DIFF
--- a/src/Meziantou.Framework.DnsClient/Internal/DnssecCanonicalizer.cs
+++ b/src/Meziantou.Framework.DnsClient/Internal/DnssecCanonicalizer.cs
@@ -139,22 +139,25 @@ internal static class DnssecCanonicalizer
             return [];
 
         var owner = GetCanonicalDomainNameBytes(name);
-        var buffer = new byte[owner.Length + record.Salt.Length];
+        var salt = record.Salt.AsSpan();
+        Span<byte> buffer = stackalloc byte[owner.Length + salt.Length];
         owner.CopyTo(buffer);
-        record.Salt.CopyTo(buffer.AsSpan(owner.Length));
+        salt.CopyTo(buffer[owner.Length..]);
 #pragma warning disable CA5350 // NSEC3 hash algorithm 1 is SHA-1 by specification.
-        var hash = SHA1.HashData(buffer);
-        var iterationBuffer = new byte[hash.Length + record.Salt.Length];
+        Span<byte> hash = stackalloc byte[SHA1.HashSizeInBytes];
+        _ = SHA1.HashData(buffer, hash);
+
+        Span<byte> iterationBuffer = stackalloc byte[SHA1.HashSizeInBytes + salt.Length];
 
         for (var i = 0; i < record.Iterations; i++)
         {
             hash.CopyTo(iterationBuffer);
-            record.Salt.CopyTo(iterationBuffer.AsSpan(hash.Length));
-            hash = SHA1.HashData(iterationBuffer);
+            salt.CopyTo(iterationBuffer[hash.Length..]);
+            _ = SHA1.HashData(iterationBuffer, hash);
         }
 #pragma warning restore CA5350
 
-        return hash;
+        return hash.ToArray();
     }
 
     public static byte[] DecodeBase32Hex(string value)

--- a/src/Meziantou.Framework.DnsClient/Internal/DnssecCanonicalizer.cs
+++ b/src/Meziantou.Framework.DnsClient/Internal/DnssecCanonicalizer.cs
@@ -509,9 +509,7 @@ internal static class DnssecCanonicalizer
 
     private static int CompareCanonicalLabels(string left, string right)
     {
-        var leftBytes = Encoding.ASCII.GetBytes(left.ToLowerInvariant());
-        var rightBytes = Encoding.ASCII.GetBytes(right.ToLowerInvariant());
-        return leftBytes.AsSpan().SequenceCompareTo(rightBytes);
+        return string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
     }
 
     private sealed class ByteArrayComparer : IComparer<byte[]>

--- a/src/Meziantou.Framework.DnsClient/Internal/DnssecCanonicalizer.cs
+++ b/src/Meziantou.Framework.DnsClient/Internal/DnssecCanonicalizer.cs
@@ -144,20 +144,18 @@ internal static class DnssecCanonicalizer
         owner.CopyTo(buffer);
         salt.CopyTo(buffer[owner.Length..]);
 #pragma warning disable CA5350 // NSEC3 hash algorithm 1 is SHA-1 by specification.
-        Span<byte> hash = stackalloc byte[SHA1.HashSizeInBytes];
-        _ = SHA1.HashData(buffer, hash);
+        var hash = SHA1.HashData(buffer);
 
         Span<byte> iterationBuffer = stackalloc byte[SHA1.HashSizeInBytes + salt.Length];
-
         for (var i = 0; i < record.Iterations; i++)
         {
             hash.CopyTo(iterationBuffer);
             salt.CopyTo(iterationBuffer[hash.Length..]);
-            _ = SHA1.HashData(iterationBuffer, hash);
+            hash = SHA1.HashData(iterationBuffer);
         }
 #pragma warning restore CA5350
 
-        return hash.ToArray();
+        return hash;
     }
 
     public static byte[] DecodeBase32Hex(string value)

--- a/src/Meziantou.Framework.DnsClient/Internal/DnssecCanonicalizer.cs
+++ b/src/Meziantou.Framework.DnsClient/Internal/DnssecCanonicalizer.cs
@@ -9,6 +9,8 @@ namespace Meziantou.Framework.DnsClient.Internal;
 
 internal static class DnssecCanonicalizer
 {
+    public const ushort MaxNsec3Iterations = 100;
+
     public static string NormalizeName(string name)
     {
         if (string.IsNullOrEmpty(name) || name is ".")
@@ -133,7 +135,7 @@ internal static class DnssecCanonicalizer
 
     public static byte[] ComputeNsec3Hash(string name, DnsNsec3Record record)
     {
-        if (record.HashAlgorithm is not 1)
+        if (record.HashAlgorithm is not 1 || record.Iterations > MaxNsec3Iterations)
             return [];
 
         var owner = GetCanonicalDomainNameBytes(name);
@@ -142,13 +144,13 @@ internal static class DnssecCanonicalizer
         record.Salt.CopyTo(buffer.AsSpan(owner.Length));
 #pragma warning disable CA5350 // NSEC3 hash algorithm 1 is SHA-1 by specification.
         var hash = SHA1.HashData(buffer);
+        var iterationBuffer = new byte[hash.Length + record.Salt.Length];
 
         for (var i = 0; i < record.Iterations; i++)
         {
-            buffer = new byte[hash.Length + record.Salt.Length];
-            hash.CopyTo(buffer);
-            record.Salt.CopyTo(buffer.AsSpan(hash.Length));
-            hash = SHA1.HashData(buffer);
+            hash.CopyTo(iterationBuffer);
+            record.Salt.CopyTo(iterationBuffer.AsSpan(hash.Length));
+            hash = SHA1.HashData(iterationBuffer);
         }
 #pragma warning restore CA5350
 
@@ -202,7 +204,7 @@ internal static class DnssecCanonicalizer
 
         while (leftIndex >= 0 && rightIndex >= 0)
         {
-            var comparison = string.CompareOrdinal(leftLabels[leftIndex], rightLabels[rightIndex]);
+            var comparison = CompareCanonicalLabels(leftLabels[leftIndex], rightLabels[rightIndex]);
             if (comparison != 0)
                 return comparison;
 
@@ -214,6 +216,22 @@ internal static class DnssecCanonicalizer
             return 0;
 
         return leftIndex < rightIndex ? -1 : 1;
+    }
+
+    public static bool IsAncestorOrEqual(string ancestorName, string name)
+    {
+        var ancestorLabels = GetLabels(ancestorName);
+        var labels = GetLabels(name);
+        if (ancestorLabels.Length > labels.Length)
+            return false;
+
+        for (var i = 1; i <= ancestorLabels.Length; i++)
+        {
+            if (CompareCanonicalLabels(ancestorLabels[^i], labels[^i]) != 0)
+                return false;
+        }
+
+        return true;
     }
 
     private static byte[] GetCanonicalRecordData(DnsRecord record, DnsRrsigRecord signature)
@@ -487,6 +505,13 @@ internal static class DnssecCanonicalizer
     {
         var normalized = NormalizeName(name);
         return normalized.Length is 0 ? [] : normalized.Split('.');
+    }
+
+    private static int CompareCanonicalLabels(string left, string right)
+    {
+        var leftBytes = Encoding.ASCII.GetBytes(left.ToLowerInvariant());
+        var rightBytes = Encoding.ASCII.GetBytes(right.ToLowerInvariant());
+        return leftBytes.AsSpan().SequenceCompareTo(rightBytes);
     }
 
     private sealed class ByteArrayComparer : IComparer<byte[]>

--- a/src/Meziantou.Framework.DnsClient/Internal/DnssecValidator.cs
+++ b/src/Meziantou.Framework.DnsClient/Internal/DnssecValidator.cs
@@ -270,6 +270,11 @@ internal sealed class DnssecValidator
     {
         var record = rrset[0];
         var now = _timeProvider.GetUtcNow().ToUnixTimeSeconds();
+        if (!DnssecCanonicalizer.IsAncestorOrEqual(signature.SignerName, record.Name))
+        {
+            return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.InvalidData, "The RRSIG signer name is not an ancestor of the RRset owner name.", record.Name, record.RecordType));
+        }
+
         if (now < signature.SignatureInception)
         {
             return ValidationOutcome.Bogus(new DnssecValidationIssue(DnssecValidationIssueCode.SignatureNotYetValid, "The RRSIG inception time is in the future.", record.Name, record.RecordType));
@@ -286,7 +291,7 @@ internal sealed class DnssecValidator
         }
 
         var candidateKeys = keys
-            .Where(key => key.Algorithm == signature.Algorithm && DnssecCanonicalizer.ComputeKeyTag(key) == signature.KeyTag)
+            .Where(key => IsDnskeyUsableForZoneSigning(key) && key.Algorithm == signature.Algorithm && DnssecCanonicalizer.ComputeKeyTag(key) == signature.KeyTag)
             .ToArray();
         if (candidateKeys.Length is 0)
         {
@@ -400,7 +405,8 @@ internal sealed class DnssecValidator
 
     private static bool IsTrustAnchorMatch(DnssecTrustAnchor anchor, string ownerName, DnsDnskeyRecord key)
     {
-        return DnssecCanonicalizer.NormalizeName(anchor.Name) == DnssecCanonicalizer.NormalizeName(ownerName)
+        return IsDnskeyUsableForZoneSigning(key)
+            && DnssecCanonicalizer.NormalizeName(anchor.Name) == DnssecCanonicalizer.NormalizeName(ownerName)
             && anchor.KeyTag == DnssecCanonicalizer.ComputeKeyTag(key)
             && anchor.Algorithm == key.Algorithm
             && DnssecCanonicalizer.IsSupportedDigest(anchor.DigestType)
@@ -409,6 +415,9 @@ internal sealed class DnssecValidator
 
     private static bool IsDsMatch(string ownerName, DnsDnskeyRecord key, IReadOnlyList<DnsDsRecord> dsRecords, List<DnssecValidationIssue> issues)
     {
+        if (!IsDnskeyUsableForZoneSigning(key))
+            return false;
+
         foreach (var ds in dsRecords)
         {
             if (ds.KeyTag != DnssecCanonicalizer.ComputeKeyTag(key) || ds.Algorithm != key.Algorithm)
@@ -427,6 +436,16 @@ internal sealed class DnssecValidator
         }
 
         return false;
+    }
+
+    private static bool IsDnskeyUsableForZoneSigning(DnsDnskeyRecord key)
+    {
+        const ushort ZoneKeyFlag = 0x0100;
+        const ushort RevokeFlag = 0x0080;
+
+        return key.Protocol is 3
+            && (key.Flags & ZoneKeyFlag) is ZoneKeyFlag
+            && (key.Flags & RevokeFlag) is 0;
     }
 
     private static DnssecValidationResult ToResult(ValidationOutcome outcome)

--- a/tests/Meziantou.Framework.DnsClient.Tests/DnssecValidatorTests.cs
+++ b/tests/Meziantou.Framework.DnsClient.Tests/DnssecValidatorTests.cs
@@ -77,6 +77,25 @@ public sealed class DnssecValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_BogusWhenSignerNameIsNotOwnerAncestor()
+    {
+        var fixture = DnssecTestFixture.Create();
+        var result = await fixture.ValidateAsync(fixture.CrossZoneSignedResponse);
+
+        Assert.Equal(DnssecValidationStatus.Bogus, result.Status);
+        Assert.Contains(result.Issues, issue => issue.Code is DnssecValidationIssueCode.InvalidData);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_BogusWhenDnskeyDoesNotHaveZoneKeyFlag()
+    {
+        var fixture = DnssecTestFixture.Create(exampleKeyFlags: 1);
+        var result = await fixture.ValidateAsync(fixture.PositiveAResponse);
+
+        Assert.Equal(DnssecValidationStatus.Bogus, result.Status);
+    }
+
+    [Fact]
     public async Task ValidateAsync_UnsupportedAlgorithm()
     {
         var fixture = DnssecTestFixture.Create();
@@ -102,6 +121,24 @@ public sealed class DnssecValidatorTests
 
         Assert.Equal(20326, DnssecCanonicalizer.ComputeKeyTag(key));
         Assert.Equal("E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D", Convert.ToHexString(DnssecCanonicalizer.ComputeDigest(".", key, digestType: 2)));
+    }
+
+    [Fact]
+    public void ComputeNsec3Hash_ReturnsEmptyWhenIterationCountExceedsCap()
+    {
+        var accepted = new DnsNsec3Record
+        {
+            HashAlgorithm = 1,
+            Iterations = DnssecCanonicalizer.MaxNsec3Iterations,
+        };
+        var rejected = new DnsNsec3Record
+        {
+            HashAlgorithm = 1,
+            Iterations = DnssecCanonicalizer.MaxNsec3Iterations + 1,
+        };
+
+        Assert.NotEmpty(DnssecCanonicalizer.ComputeNsec3Hash("www.example.com", accepted));
+        Assert.Empty(DnssecCanonicalizer.ComputeNsec3Hash("www.example.com", rejected));
     }
 
     [Fact]
@@ -140,6 +177,7 @@ public sealed class DnssecValidatorTests
             DnsResponseMessage noDataResponse,
             DnsResponseMessage insecureUnsignedResponse,
             DnsResponseMessage expiredSignatureResponse,
+            DnsResponseMessage crossZoneSignedResponse,
             DnsResponseMessage unsupportedAlgorithmResponse)
         {
             Responses = responses;
@@ -151,6 +189,7 @@ public sealed class DnssecValidatorTests
             NoDataResponse = noDataResponse;
             InsecureUnsignedResponse = insecureUnsignedResponse;
             ExpiredSignatureResponse = expiredSignatureResponse;
+            CrossZoneSignedResponse = crossZoneSignedResponse;
             UnsupportedAlgorithmResponse = unsupportedAlgorithmResponse;
         }
 
@@ -172,9 +211,11 @@ public sealed class DnssecValidatorTests
 
         public DnsResponseMessage ExpiredSignatureResponse { get; }
 
+        public DnsResponseMessage CrossZoneSignedResponse { get; }
+
         public DnsResponseMessage UnsupportedAlgorithmResponse { get; }
 
-        public static DnssecTestFixture Create(bool dsMismatch = false)
+        public static DnssecTestFixture Create(bool dsMismatch = false, ushort? exampleKeyFlags = null)
         {
             var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
             var timeProvider = new FixedTimeProvider(now);
@@ -182,10 +223,17 @@ public sealed class DnssecValidatorTests
             using var rootRsa = RSA.Create(2048);
             using var comRsa = RSA.Create(2048);
             using var exampleRsa = RSA.Create(2048);
+            using var attackerRsa = RSA.Create(2048);
 
             var rootKey = CreateDnskey(".", rootRsa);
             var comKey = CreateDnskey("com", comRsa);
             var exampleKey = CreateDnskey("example.com", exampleRsa);
+            var attackerKey = CreateDnskey("attacker.example.com", attackerRsa);
+            if (exampleKeyFlags is not null)
+            {
+                exampleKey.Flags = exampleKeyFlags.Value;
+            }
+
             var trustAnchor = new DnssecTrustAnchor(".", DnssecCanonicalizer.ComputeKeyTag(rootKey), rootKey.Algorithm, 2, DnssecCanonicalizer.ComputeDigest(".", rootKey, digestType: 2));
 
             var responses = new Dictionary<QueryKey, DnsResponseMessage>();
@@ -211,6 +259,13 @@ public sealed class DnssecValidatorTests
             var exampleDnskeySignature = CreateSignature([exampleKey], DnsQueryType.DNSKEY, "example.com", exampleKey, exampleRsa, now);
             responses.Add(new("example.com", DnsQueryType.DNSKEY), CreateMessage("example.com", DnsQueryType.DNSKEY, [exampleKey, exampleDnskeySignature]));
 
+            var attackerDs = CreateDs("attacker.example.com", attackerKey);
+            var attackerDsSignature = CreateSignature([attackerDs], DnsQueryType.DS, "example.com", exampleKey, exampleRsa, now);
+            responses.Add(new("attacker.example.com", DnsQueryType.DS), CreateMessage("attacker.example.com", DnsQueryType.DS, [attackerDs, attackerDsSignature]));
+
+            var attackerDnskeySignature = CreateSignature([attackerKey], DnsQueryType.DNSKEY, "attacker.example.com", attackerKey, attackerRsa, now);
+            responses.Add(new("attacker.example.com", DnsQueryType.DNSKEY), CreateMessage("attacker.example.com", DnsQueryType.DNSKEY, [attackerKey, attackerDnskeySignature]));
+
             var unsignedDsDenial = CreateNsec("unsigned.com", "z.com", [DnsQueryType.NS, DnsQueryType.NSEC, DnsQueryType.RRSIG]);
             var unsignedDsDenialSignature = CreateSignature([unsignedDsDenial], DnsQueryType.NSEC, "com", comKey, comRsa, now);
             responses.Add(new("unsigned.com", DnsQueryType.DS), CreateMessage("unsigned.com", DnsQueryType.DS, [], [unsignedDsDenial, unsignedDsDenialSignature]));
@@ -218,6 +273,8 @@ public sealed class DnssecValidatorTests
             var a = CreateRecord(new DnsARecord { Address = IPAddress.Parse("192.0.2.1") }, "www.example.com", DnsQueryType.A);
             var aSignature = CreateSignature([a], DnsQueryType.A, "example.com", exampleKey, exampleRsa, now);
             var positiveAResponse = CreateMessage("www.example.com", DnsQueryType.A, [a, aSignature]);
+            var crossZoneSignature = CreateSignature([a], DnsQueryType.A, "attacker.example.com", attackerKey, attackerRsa, now);
+            var crossZoneSignedResponse = CreateMessage("www.example.com", DnsQueryType.A, [a, crossZoneSignature]);
 
             var alias = CreateRecord(new DnsCnameRecord { CanonicalName = "www.example.com" }, "alias.example.com", DnsQueryType.CNAME);
             var aliasSignature = CreateSignature([alias], DnsQueryType.CNAME, "example.com", exampleKey, exampleRsa, now);
@@ -240,7 +297,7 @@ public sealed class DnssecValidatorTests
             var unsupportedSignature = CreateUnsupportedSignature(a, exampleKey, now);
             var unsupportedAlgorithmResponse = CreateMessage("www.example.com", DnsQueryType.A, [a, unsupportedSignature]);
 
-            return new(responses, [trustAnchor], timeProvider, positiveAResponse, cnameResponse, nxDomainResponse, noDataResponse, insecureUnsignedResponse, expiredSignatureResponse, unsupportedAlgorithmResponse);
+            return new(responses, [trustAnchor], timeProvider, positiveAResponse, cnameResponse, nxDomainResponse, noDataResponse, insecureUnsignedResponse, expiredSignatureResponse, crossZoneSignedResponse, unsupportedAlgorithmResponse);
         }
 
         public async Task<DnssecValidationResult> ValidateAsync(DnsResponseMessage response)


### PR DESCRIPTION
## Summary
- Reject RRSIGs whose signer name is not an ancestor of the RRset owner name.
- Ignore DNSKEYs that are not valid zone-signing keys when matching DS, trust anchors, and signatures.
- Cap NSEC3 iteration counts and reuse hashing buffers for safer canonicalization.
- Add coverage for cross-zone signatures, invalid DNSKEY flags, and NSEC3 iteration limits.

## Testing
- Added unit tests covering the new DNSSEC validation rules and NSEC3 guard.
- Not run (not requested)