### PR TITLE
Add ISet and IReadOnlySet support to ConcurrentHashSet

### DIFF
--- a/ref/Meziantou.Framework.Threading.cs
+++ b/ref/Meziantou.Framework.Threading.cs
@@ -4,7 +4,7 @@
 
 namespace Meziantou.Framework.Collections.Concurrent
 {
-    public sealed class ConcurrentHashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.IEnumerable
+    public sealed class ConcurrentHashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlySet<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
     {
         public int Count { get => throw null; }
         public bool IsEmpty { get => throw null; }
@@ -16,6 +16,16 @@ namespace Meziantou.Framework.Collections.Concurrent
         public void AddRange(System.Collections.Generic.IEnumerable<T>? values) { }
         public bool Remove(T item) => throw null;
         public void Clear() { }
+        public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+        public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
+        public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
+        public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
+        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) => throw null;
+        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) => throw null;
+        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) => throw null;
+        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) => throw null;
+        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) => throw null;
+        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) => throw null;
         public KeyEnumerator<T> GetEnumerator() => throw null;
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
         public void CopyTo(T[] array, int arrayIndex) { }

--- a/src/Meziantou.Framework.Threading/Collections/Concurrent/ConcurrentHashSet.cs
+++ b/src/Meziantou.Framework.Threading/Collections/Concurrent/ConcurrentHashSet.cs
@@ -17,7 +17,7 @@ namespace Meziantou.Framework.Collections.Concurrent;
 /// }
 /// ]]></code>
 /// </example>
-public sealed class ConcurrentHashSet<T> : ICollection<T>, IReadOnlyCollection<T>
+public sealed class ConcurrentHashSet<T> : ISet<T>, IReadOnlySet<T>
     where T : notnull
 {
     private readonly ConcurrentDictionary<T, byte> _dictionary;
@@ -84,6 +84,121 @@ public sealed class ConcurrentHashSet<T> : ICollection<T>, IReadOnlyCollection<T
 
     /// <summary>Removes all elements from the <see cref="ConcurrentHashSet{T}"/>.</summary>
     public void Clear() => _dictionary.Clear();
+
+    /// <summary>Modifies the current <see cref="ConcurrentHashSet{T}"/> to contain all elements that are present in itself, the specified collection, or both.</summary>
+    /// <param name="other">The collection to compare to the current <see cref="ConcurrentHashSet{T}"/>.</param>
+    public void UnionWith(IEnumerable<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        foreach (var item in other)
+        {
+            Add(item);
+        }
+    }
+
+    /// <summary>Modifies the current <see cref="ConcurrentHashSet{T}"/> to contain only elements that are present in itself and in the specified collection.</summary>
+    /// <param name="other">The collection to compare to the current <see cref="ConcurrentHashSet{T}"/>.</param>
+    public void IntersectWith(IEnumerable<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        var otherSet = CreateSet(other);
+        foreach (var item in this)
+        {
+            if (!otherSet.Contains(item))
+            {
+                Remove(item);
+            }
+        }
+    }
+
+    /// <summary>Removes all elements in the specified collection from the current <see cref="ConcurrentHashSet{T}"/>.</summary>
+    /// <param name="other">The collection to remove from the current <see cref="ConcurrentHashSet{T}"/>.</param>
+    public void ExceptWith(IEnumerable<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        foreach (var item in other)
+        {
+            Remove(item);
+        }
+    }
+
+    /// <summary>Modifies the current <see cref="ConcurrentHashSet{T}"/> to contain only elements that are present either in itself or in the specified collection, but not both.</summary>
+    /// <param name="other">The collection to compare to the current <see cref="ConcurrentHashSet{T}"/>.</param>
+    public void SymmetricExceptWith(IEnumerable<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        foreach (var item in CreateSet(other))
+        {
+            if (!Remove(item))
+            {
+                Add(item);
+            }
+        }
+    }
+
+    /// <summary>Determines whether the current <see cref="ConcurrentHashSet{T}"/> is a subset of a specified collection.</summary>
+    /// <param name="other">The collection to compare to the current <see cref="ConcurrentHashSet{T}"/>.</param>
+    /// <returns><see langword="true"/> if the current <see cref="ConcurrentHashSet{T}"/> is a subset of <paramref name="other"/>; otherwise, <see langword="false"/>.</returns>
+    public bool IsSubsetOf(IEnumerable<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        return CreateSet(this).IsSubsetOf(other);
+    }
+
+    /// <summary>Determines whether the current <see cref="ConcurrentHashSet{T}"/> is a superset of a specified collection.</summary>
+    /// <param name="other">The collection to compare to the current <see cref="ConcurrentHashSet{T}"/>.</param>
+    /// <returns><see langword="true"/> if the current <see cref="ConcurrentHashSet{T}"/> is a superset of <paramref name="other"/>; otherwise, <see langword="false"/>.</returns>
+    public bool IsSupersetOf(IEnumerable<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        return CreateSet(this).IsSupersetOf(other);
+    }
+
+    /// <summary>Determines whether the current <see cref="ConcurrentHashSet{T}"/> is a proper subset of a specified collection.</summary>
+    /// <param name="other">The collection to compare to the current <see cref="ConcurrentHashSet{T}"/>.</param>
+    /// <returns><see langword="true"/> if the current <see cref="ConcurrentHashSet{T}"/> is a proper subset of <paramref name="other"/>; otherwise, <see langword="false"/>.</returns>
+    public bool IsProperSubsetOf(IEnumerable<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        return CreateSet(this).IsProperSubsetOf(other);
+    }
+
+    /// <summary>Determines whether the current <see cref="ConcurrentHashSet{T}"/> is a proper superset of a specified collection.</summary>
+    /// <param name="other">The collection to compare to the current <see cref="ConcurrentHashSet{T}"/>.</param>
+    /// <returns><see langword="true"/> if the current <see cref="ConcurrentHashSet{T}"/> is a proper superset of <paramref name="other"/>; otherwise, <see langword="false"/>.</returns>
+    public bool IsProperSupersetOf(IEnumerable<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        return CreateSet(this).IsProperSupersetOf(other);
+    }
+
+    /// <summary>Determines whether the current <see cref="ConcurrentHashSet{T}"/> overlaps with the specified collection.</summary>
+    /// <param name="other">The collection to compare to the current <see cref="ConcurrentHashSet{T}"/>.</param>
+    /// <returns><see langword="true"/> if the current <see cref="ConcurrentHashSet{T}"/> and <paramref name="other"/> share at least one common element; otherwise, <see langword="false"/>.</returns>
+    public bool Overlaps(IEnumerable<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        return CreateSet(this).Overlaps(other);
+    }
+
+    /// <summary>Determines whether the current <see cref="ConcurrentHashSet{T}"/> and the specified collection contain the same elements.</summary>
+    /// <param name="other">The collection to compare to the current <see cref="ConcurrentHashSet{T}"/>.</param>
+    /// <returns><see langword="true"/> if the current <see cref="ConcurrentHashSet{T}"/> is equal to <paramref name="other"/>; otherwise, <see langword="false"/>.</returns>
+    public bool SetEquals(IEnumerable<T> other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        return CreateSet(this).SetEquals(other);
+    }
 
     /// <summary>Enumerates the elements of a <see cref="ConcurrentHashSet{T}"/>.</summary>
     public readonly struct KeyEnumerator : IEnumerator<T>
@@ -155,4 +270,6 @@ public sealed class ConcurrentHashSet<T> : ICollection<T>, IReadOnlyCollection<T
             array[arrayIndex++] = element;
         }
     }
+
+    private HashSet<T> CreateSet(IEnumerable<T> values) => new(values, _dictionary.Comparer);
 }

--- a/tests/Meziantou.Framework.Threading.Tests/ConcurrentHashSetTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/ConcurrentHashSetTests.cs
@@ -64,4 +64,46 @@ public class ConcurrentHashSetTests
         Assert.Equal(0, array[4]);
         Assert.Equal([1, 2, 3], array[1..4].Order());
     }
+
+    [Fact]
+    public void ImplementsSetInterfaces()
+    {
+        var set = new ConcurrentHashSet<int>();
+
+        Assert.IsAssignableTo<ISet<int>>(set);
+        Assert.IsAssignableTo<IReadOnlySet<int>>(set);
+    }
+
+    [Fact]
+    public void SetComparisonMethods_UseEqualityComparer()
+    {
+        var set = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
+        set.AddRange("a", "b");
+
+        Assert.True(set.IsSubsetOf(["A", "B", "C"]));
+        Assert.True(set.IsProperSubsetOf(["A", "B", "C"]));
+        Assert.True(set.IsSupersetOf(["A"]));
+        Assert.True(set.IsProperSupersetOf(["A"]));
+        Assert.True(set.Overlaps(["A", "C"]));
+        Assert.True(set.SetEquals(["A", "B"]));
+    }
+
+    [Fact]
+    public void SetMutationMethods_UseEqualityComparer()
+    {
+        var set = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
+        set.AddRange("a", "b");
+
+        set.UnionWith(["B", "c"]);
+        Assert.Equal(["a", "b", "c"], set.Order(StringComparer.OrdinalIgnoreCase));
+
+        set.IntersectWith(["A", "C"]);
+        Assert.Equal(["a", "c"], set.Order(StringComparer.OrdinalIgnoreCase));
+
+        set.SymmetricExceptWith(["A", "d", "D"]);
+        Assert.Equal(["c", "d"], set.Order(StringComparer.OrdinalIgnoreCase));
+
+        set.ExceptWith(["C"]);
+        Assert.Equal(["d"], set);
+    }
 }


### PR DESCRIPTION
## Summary
- Make `ConcurrentHashSet<T>` implement `ISet<T>` and `IReadOnlySet<T>`.
- Add set algebra and comparison APIs backed by the collection comparer.
- Update the reference assembly surface and add coverage for the new behavior.

## Testing
- Added tests for interface implementation, comparer-aware set comparisons, and comparer-aware set mutations.
- Not run (not requested).