### PR TITLE
Optimize unordered assertions and structural equivalence traversal

### DIFF
--- a/src/Meziantou.Framework.Assertions/Assert.EqualUnordered.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.EqualUnordered.cs
@@ -22,6 +22,12 @@ public partial class Assert
             throw new AssertionException(ErrorFormatter.Format(new NullActualAssertionError<IEnumerable<T>>(nameof(EqualUnordered), "Expected expression", "Expected", expected, actualExpression, expectedExpression, message)));
         }
 
+        if (comparer is null)
+        {
+            EqualUnorderedCollections<T>(expected, actual, EqualityComparer<T>.Default, message, actualExpression, expectedExpression);
+            return;
+        }
+
         EqualUnorderedCollections(expected, actual, comparer, message, actualExpression, expectedExpression);
     }
 
@@ -44,7 +50,10 @@ public partial class Assert
         expectedSnapshot.EnsureComplete();
         comparer ??= EqualityComparer<T>.Default;
 
-        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer.Equals);
+        if (comparer == EqualityComparer<T>.Default && EqualUnorderedUsingDefaultComparer(expectedSnapshot.Items, actualSnapshot.Items))
+            return;
+
+        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer);
         if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
         {
             throw new AssertionException(ErrorFormatter.Format(new CollectionEqualUnorderedAssertionError<T, T>(expectedSnapshot, actualSnapshot, missingExpectedIndex, unexpectedActualIndex, message, actualExpression, expectedExpression)));
@@ -58,7 +67,7 @@ public partial class Assert
         actualSnapshot.EnsureComplete();
         expectedSnapshot.EnsureComplete();
 
-        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, (expectedItem, actualItem) => ValuesEqual(expectedItem, actualItem, comparer));
+        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer);
         if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
         {
             throw new AssertionException(ErrorFormatter.Format(new CollectionEqualUnorderedAssertionError<TExpected, TActual>(expectedSnapshot, actualSnapshot, missingExpectedIndex, unexpectedActualIndex, message, actualExpression, expectedExpression)));
@@ -86,6 +95,12 @@ public partial class Assert
             throw new AssertionException(ErrorFormatter.Format(new NullActualAssertionError<IReadOnlyList<T>>(nameof(EqualUnordered), "Expected expression", "Expected", expectedSnapshot.Items, actualExpression, expectedExpression, message)));
         }
 
+        if (comparer is null)
+        {
+            await EqualUnorderedAsyncCollections<T>(expected, actual, EqualityComparer<T>.Default, message, actualExpression, expectedExpression).ConfigureAwait(false);
+            return;
+        }
+
         await EqualUnorderedAsyncCollections(expected, actual, comparer, message, actualExpression, expectedExpression).ConfigureAwait(false);
     }
 
@@ -110,7 +125,10 @@ public partial class Assert
         await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
         comparer ??= EqualityComparer<T>.Default;
 
-        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer.Equals);
+        if (comparer == EqualityComparer<T>.Default && EqualUnorderedUsingDefaultComparer(expectedSnapshot.Items, actualSnapshot.Items))
+            return;
+
+        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer);
         if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
         {
             throw new AssertionException(await ErrorFormatter.FormatAsync(new AsyncCollectionEqualUnorderedAssertionError<T, T>(expectedSnapshot, actualSnapshot, missingExpectedIndex, unexpectedActualIndex, message, actualExpression, expectedExpression)).ConfigureAwait(false));
@@ -124,7 +142,7 @@ public partial class Assert
         await actualSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
         await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
 
-        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, (expectedItem, actualItem) => ValuesEqual(expectedItem, actualItem, comparer));
+        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer);
         if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
         {
             throw new AssertionException(await ErrorFormatter.FormatAsync(new AsyncCollectionEqualUnorderedAssertionError<TExpected, TActual>(expectedSnapshot, actualSnapshot, missingExpectedIndex, unexpectedActualIndex, message, actualExpression, expectedExpression)).ConfigureAwait(false));
@@ -151,7 +169,39 @@ public partial class Assert
         EqualUnorderedCollections(EnumerateObjects(expected), EnumerateObjects(actual), comparer, message, actualExpression, expectedExpression);
     }
 
-    private static (int? MissingExpectedIndex, int? UnexpectedActualIndex) GetEqualUnorderedMismatch<TExpected, TActual>(IReadOnlyList<TExpected> expected, IReadOnlyList<TActual> actual, Func<TExpected, TActual, bool> equals)
+    private static bool EqualUnorderedUsingDefaultComparer<T>(IReadOnlyList<T> expected, IReadOnlyList<T> actual)
+    {
+        if (expected.Count != actual.Count)
+            return false;
+
+        var counts = new Dictionary<DefaultComparerKey<T>, int>(expected.Count);
+        for (var index = 0; index < expected.Count; index++)
+        {
+            var key = new DefaultComparerKey<T>(expected[index]);
+            counts.TryGetValue(key, out var count);
+            counts[key] = count + 1;
+        }
+
+        for (var index = 0; index < actual.Count; index++)
+        {
+            var key = new DefaultComparerKey<T>(actual[index]);
+            if (!counts.TryGetValue(key, out var count))
+                return false;
+
+            if (count == 1)
+            {
+                counts.Remove(key);
+            }
+            else
+            {
+                counts[key] = count - 1;
+            }
+        }
+
+        return counts.Count == 0;
+    }
+
+    private static (int? MissingExpectedIndex, int? UnexpectedActualIndex) GetEqualUnorderedMismatch<T>(IReadOnlyList<T> expected, IReadOnlyList<T> actual, IEqualityComparer<T> comparer)
     {
         var matchedActualIndexes = new bool[actual.Count];
         int? missingExpectedIndex = null;
@@ -164,7 +214,67 @@ public partial class Assert
                 if (matchedActualIndexes[actualIndex])
                     continue;
 
-                if (!equals(expected[expectedIndex], actual[actualIndex]))
+                if (!comparer.Equals(expected[expectedIndex], actual[actualIndex]))
+                    continue;
+
+                matchedActualIndexes[actualIndex] = true;
+                found = true;
+                break;
+            }
+
+            if (!found && missingExpectedIndex is null)
+            {
+                missingExpectedIndex = expectedIndex;
+            }
+        }
+
+        int? unexpectedActualIndex = null;
+        for (var actualIndex = 0; actualIndex < matchedActualIndexes.Length; actualIndex++)
+        {
+            if (!matchedActualIndexes[actualIndex])
+            {
+                unexpectedActualIndex = actualIndex;
+                break;
+            }
+        }
+
+        return (missingExpectedIndex, unexpectedActualIndex);
+    }
+
+    private readonly struct DefaultComparerKey<T>(T value) : IEquatable<DefaultComparerKey<T>>
+    {
+        private T Value { get; } = value;
+
+        public bool Equals(DefaultComparerKey<T> other)
+        {
+            return EqualityComparer<T>.Default.Equals(Value, other.Value);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is DefaultComparerKey<T> other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value is null ? 0 : EqualityComparer<T>.Default.GetHashCode(Value);
+        }
+    }
+
+    private static (int? MissingExpectedIndex, int? UnexpectedActualIndex) GetEqualUnorderedMismatch<TExpected, TActual>(IReadOnlyList<TExpected> expected, IReadOnlyList<TActual> actual, System.Collections.IEqualityComparer? comparer)
+    {
+        var matchedActualIndexes = new bool[actual.Count];
+        int? missingExpectedIndex = null;
+
+        for (var expectedIndex = 0; expectedIndex < expected.Count; expectedIndex++)
+        {
+            var found = false;
+            for (var actualIndex = 0; actualIndex < actual.Count; actualIndex++)
+            {
+                if (matchedActualIndexes[actualIndex])
+                    continue;
+
+                if (!ValuesEqual(expected[expectedIndex], actual[actualIndex], comparer))
                     continue;
 
                 matchedActualIndexes[actualIndex] = true;

--- a/src/Meziantou.Framework.Assertions/Assert.Equality.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Equality.cs
@@ -1,7 +1,14 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+
 namespace Meziantou.Framework.Assertions;
 
 public partial class Assert
 {
+    private static readonly ConcurrentDictionary<Type, MemoryToArrayMethod> MemoryToArrayMethods = new();
+    private static readonly ConcurrentDictionary<ImplicitConversionCacheKey, MethodInfo[]> ImplicitConversionMethods = new();
+    private const BindingFlags PublicStatic = BindingFlags.Public | BindingFlags.Static;
+
     private static bool TryEqualMemory<TExpected, TActual>(TExpected expected, TActual actual, string? message, string? actualExpression, string? expectedExpression)
     {
         if (TryGetMemoryItems(expected, out var expectedItems) && TryGetMemoryItems(actual, out var actualItems))
@@ -16,19 +23,34 @@ public partial class Assert
     private static bool TryGetMemoryItems<T>(T value, [NotNullWhen(true)] out System.Collections.IEnumerable? items)
     {
         items = null;
+        var declaredType = typeof(T);
+        if (declaredType != typeof(object) && !declaredType.IsInterface && !declaredType.IsAbstract && !IsMemoryType(declaredType))
+            return false;
+
         if (value is null)
             return false;
 
         var type = value.GetType();
-        if (!type.IsConstructedGenericType)
+        var toArrayMethod = MemoryToArrayMethods.GetOrAdd(type, GetMemoryToArrayMethod).Method;
+        if (toArrayMethod is null)
             return false;
 
-        var genericTypeDefinition = type.GetGenericTypeDefinition();
-        if (genericTypeDefinition != typeof(Memory<>) && genericTypeDefinition != typeof(ReadOnlyMemory<>))
-            return false;
-
-        items = (System.Collections.IEnumerable?)type.GetMethod(nameof(Memory<int>.ToArray), Type.EmptyTypes)?.Invoke(value, parameters: null);
+        items = (System.Collections.IEnumerable?)toArrayMethod.Invoke(value, parameters: null);
         return items is not null;
+    }
+
+    private static bool IsMemoryType(Type type)
+    {
+        return type.IsConstructedGenericType
+            && (type.GetGenericTypeDefinition() == typeof(Memory<>) || type.GetGenericTypeDefinition() == typeof(ReadOnlyMemory<>));
+    }
+
+    private static MemoryToArrayMethod GetMemoryToArrayMethod(Type type)
+    {
+        if (!IsMemoryType(type))
+            return default;
+
+        return new MemoryToArrayMethod(type.GetMethod(nameof(Memory<int>.ToArray), Type.EmptyTypes));
     }
 
     private static bool ValuesEqual<TExpected, TActual>(TExpected expected, TActual actual, System.Collections.IEqualityComparer? comparer = null)
@@ -165,7 +187,31 @@ public partial class Assert
         if (sourceType is null || sourceType == targetType)
             return false;
 
-        foreach (var method in sourceType.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static).Concat(targetType.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)))
+        foreach (var method in ImplicitConversionMethods.GetOrAdd(new ImplicitConversionCacheKey(sourceType, targetType), GetImplicitConversionMethods))
+        {
+            var convertedValue = method.Invoke(obj: null, [source]);
+            if (object.Equals(convertedValue, target))
+            {
+                result = true;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static MethodInfo[] GetImplicitConversionMethods(ImplicitConversionCacheKey key)
+    {
+        var methods = new List<MethodInfo>();
+        AddImplicitConversionMethods(methods, key.SourceType.GetMethods(PublicStatic), key.SourceType, key.TargetType);
+        AddImplicitConversionMethods(methods, key.TargetType.GetMethods(PublicStatic), key.SourceType, key.TargetType);
+
+        return methods.Count == 0 ? [] : methods.ToArray();
+    }
+
+    private static void AddImplicitConversionMethods(List<MethodInfo> methods, MethodInfo[] candidateMethods, Type sourceType, Type targetType)
+    {
+        foreach (var method in candidateMethods)
         {
             if (method.Name != "op_Implicit" || method.ReturnType != targetType)
                 continue;
@@ -173,15 +219,34 @@ public partial class Assert
             var parameters = method.GetParameters();
             if (parameters.Length == 1 && parameters[0].ParameterType.IsAssignableFrom(sourceType))
             {
-                var convertedValue = method.Invoke(obj: null, [source]);
-                if (object.Equals(convertedValue, target))
-                {
-                    result = true;
-                    return true;
-                }
+                methods.Add(method);
             }
         }
+    }
 
-        return false;
+    private readonly struct MemoryToArrayMethod(MethodInfo? method)
+    {
+        public MethodInfo? Method { get; } = method;
+    }
+
+    private readonly struct ImplicitConversionCacheKey(Type sourceType, Type targetType) : IEquatable<ImplicitConversionCacheKey>
+    {
+        public Type SourceType { get; } = sourceType;
+        public Type TargetType { get; } = targetType;
+
+        public bool Equals(ImplicitConversionCacheKey other)
+        {
+            return SourceType == other.SourceType && TargetType == other.TargetType;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is ImplicitConversionCacheKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(SourceType, TargetType);
+        }
     }
 }

--- a/src/Meziantou.Framework.Assertions/Assert.Equivalent.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Equivalent.cs
@@ -16,14 +16,14 @@ public partial class Assert
 
     public static void Equivalent(object? expected, object? actual, EquivalentOptions? options, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
     {
-        var failure = GetStructuralDifference(expected, actual, "$", new HashSet<StructuralReferencePair>(), StructuralComparisonOptions.Create(options));
+        var failure = GetStructuralDifference(expected, actual, "$", new HashSet<StructuralReferencePair>(), [], StructuralComparisonOptions.Create(options));
         if (failure is null)
             return;
 
         throw new AssertionException(ErrorFormatter.Format(new EquivalentAssertionError(failure.Value.ExpectedValue, failure.Value.ActualValue, failure.Value.Path, failure.Value.Reason, message, actualExpression, expectedExpression)));
     }
 
-    private static StructuralDifference? GetStructuralDifference(object? expected, object? actual, string path, HashSet<StructuralReferencePair> visited, StructuralComparisonOptions options)
+    private static StructuralDifference? GetStructuralDifference(object? expected, object? actual, string path, HashSet<StructuralReferencePair> visited, List<StructuralReferencePair> visitedAdditions, StructuralComparisonOptions options)
     {
         if (object.ReferenceEquals(expected, actual))
             return null;
@@ -41,23 +41,25 @@ public partial class Assert
             var pair = new StructuralReferencePair(expected, actual);
             if (!visited.Add(pair))
                 return null;
+
+            visitedAdditions.Add(pair);
         }
 
         if (expected is System.Collections.IEnumerable expectedEnumerable && actual is System.Collections.IEnumerable actualEnumerable)
-            return GetStructuralEnumerableDifference(expectedEnumerable, actualEnumerable, path, visited, options);
+            return GetStructuralEnumerableDifference(expectedEnumerable, actualEnumerable, path, visited, visitedAdditions, options);
 
-        return GetStructuralMemberDifference(expected, actual, path, visited, options);
+        return GetStructuralMemberDifference(expected, actual, path, visited, visitedAdditions, options);
     }
 
-    private static StructuralDifference? GetStructuralEnumerableDifference(System.Collections.IEnumerable expected, System.Collections.IEnumerable actual, string path, HashSet<StructuralReferencePair> visited, StructuralComparisonOptions options)
+    private static StructuralDifference? GetStructuralEnumerableDifference(System.Collections.IEnumerable expected, System.Collections.IEnumerable actual, string path, HashSet<StructuralReferencePair> visited, List<StructuralReferencePair> visitedAdditions, StructuralComparisonOptions options)
     {
         if (options.IgnoreCollectionOrder)
-            return GetStructuralUnorderedEnumerableDifference(expected, actual, path, visited, options);
+            return GetStructuralUnorderedEnumerableDifference(expected, actual, path, visited, visitedAdditions, options);
 
-        return GetStructuralOrderedEnumerableDifference(expected, actual, path, visited, options);
+        return GetStructuralOrderedEnumerableDifference(expected, actual, path, visited, visitedAdditions, options);
     }
 
-    private static StructuralDifference? GetStructuralOrderedEnumerableDifference(System.Collections.IEnumerable expected, System.Collections.IEnumerable actual, string path, HashSet<StructuralReferencePair> visited, StructuralComparisonOptions options)
+    private static StructuralDifference? GetStructuralOrderedEnumerableDifference(System.Collections.IEnumerable expected, System.Collections.IEnumerable actual, string path, HashSet<StructuralReferencePair> visited, List<StructuralReferencePair> visitedAdditions, StructuralComparisonOptions options)
     {
         var index = 0;
         var expectedEnumerator = expected.GetEnumerator();
@@ -80,7 +82,7 @@ public partial class Assert
                 if (!actualHasNext)
                     return new StructuralDifference(itemPath, expectedEnumerator.Current, StructuralMissingValue.Instance, "Actual collection is missing an item.");
 
-                var difference = GetStructuralDifference(expectedEnumerator.Current, actualEnumerator.Current, itemPath, visited, options);
+                var difference = GetStructuralDifference(expectedEnumerator.Current, actualEnumerator.Current, itemPath, visited, visitedAdditions, options);
                 if (difference is not null)
                     return difference;
 
@@ -94,7 +96,7 @@ public partial class Assert
         }
     }
 
-    private static StructuralDifference? GetStructuralUnorderedEnumerableDifference(System.Collections.IEnumerable expected, System.Collections.IEnumerable actual, string path, HashSet<StructuralReferencePair> visited, StructuralComparisonOptions options)
+    private static StructuralDifference? GetStructuralUnorderedEnumerableDifference(System.Collections.IEnumerable expected, System.Collections.IEnumerable actual, string path, HashSet<StructuralReferencePair> visited, List<StructuralReferencePair> visitedAdditions, StructuralComparisonOptions options)
     {
         var expectedItems = new List<object?>(EnumerateObjects(expected));
         var actualItems = new List<object?>(EnumerateObjects(actual));
@@ -111,8 +113,9 @@ public partial class Assert
                 if (matchedActualIndexes[actualIndex])
                     continue;
 
-                var candidateVisited = new HashSet<StructuralReferencePair>(visited);
-                var difference = GetStructuralDifference(expectedItem, actualItems[actualIndex], itemPath, candidateVisited, options);
+                var visitedAdditionsCount = visitedAdditions.Count;
+                var difference = GetStructuralDifference(expectedItem, actualItems[actualIndex], itemPath, visited, visitedAdditions, options);
+                RollbackStructuralVisitedAdditions(visited, visitedAdditions, visitedAdditionsCount);
                 if (difference is not null)
                     continue;
 
@@ -137,7 +140,16 @@ public partial class Assert
         return null;
     }
 
-    private static StructuralDifference? GetStructuralMemberDifference(object expected, object actual, string path, HashSet<StructuralReferencePair> visited, StructuralComparisonOptions options)
+    private static void RollbackStructuralVisitedAdditions(HashSet<StructuralReferencePair> visited, List<StructuralReferencePair> visitedAdditions, int count)
+    {
+        for (var index = visitedAdditions.Count - 1; index >= count; index--)
+        {
+            visited.Remove(visitedAdditions[index]);
+            visitedAdditions.RemoveAt(index);
+        }
+    }
+
+    private static StructuralDifference? GetStructuralMemberDifference(object expected, object actual, string path, HashSet<StructuralReferencePair> visited, List<StructuralReferencePair> visitedAdditions, StructuralComparisonOptions options)
     {
         var expectedMembers = GetStructuralMembers(expected.GetType(), options.MemberNameComparer);
         var actualMembers = GetStructuralMembers(actual.GetType(), options.MemberNameComparer);
@@ -148,7 +160,7 @@ public partial class Assert
             if (!actualMembers.TryGetValue(expectedMember.Name, out var actualMember))
                 return new StructuralDifference(memberPath, expectedMember.GetValue(expected), StructuralMissingValue.Instance, "Actual member is missing.");
 
-            var difference = GetStructuralDifference(expectedMember.GetValue(expected), actualMember.GetValue(actual), memberPath, visited, options);
+            var difference = GetStructuralDifference(expectedMember.GetValue(expected), actualMember.GetValue(actual), memberPath, visited, visitedAdditions, options);
             if (difference is not null)
                 return difference;
         }

--- a/src/Meziantou.Framework.Assertions/Assert.NotEqualUnordered.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.NotEqualUnordered.cs
@@ -13,8 +13,7 @@ public partial class Assert
         using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
         actualSnapshot.EnsureComplete();
         expectedSnapshot.EnsureComplete();
-        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, EqualityComparer<T>.Default.Equals);
-        if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
+        if (!EqualUnorderedUsingDefaultComparer(expectedSnapshot.Items, actualSnapshot.Items))
             return;
 
         throw new AssertionException(ErrorFormatter.Format(new NotEqualUnorderedAssertionError<IEnumerable<T>, IEnumerable<T>>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
@@ -29,10 +28,17 @@ public partial class Assert
         using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
         actualSnapshot.EnsureComplete();
         expectedSnapshot.EnsureComplete();
-        comparer ??= EqualityComparer<T>.Default;
-        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer.Equals);
-        if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
-            return;
+        if (comparer is null)
+        {
+            if (!EqualUnorderedUsingDefaultComparer(expectedSnapshot.Items, actualSnapshot.Items))
+                return;
+        }
+        else
+        {
+            var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer);
+            if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
+                return;
+        }
 
         throw new AssertionException(ErrorFormatter.Format(new NotEqualUnorderedAssertionError<IEnumerable<T>, IEnumerable<T>>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
     }
@@ -47,7 +53,7 @@ public partial class Assert
         using var expectedSnapshot = CollectionSnapshot.Create<TExpected>(expected);
         actualSnapshot.EnsureComplete();
         expectedSnapshot.EnsureComplete();
-        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, (expectedItem, actualItem) => ValuesEqual(expectedItem, actualItem));
+        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, (System.Collections.IEqualityComparer?)null);
         if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
             return;
 
@@ -63,8 +69,7 @@ public partial class Assert
         await using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
         await actualSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
         await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, EqualityComparer<T>.Default.Equals);
-        if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
+        if (!EqualUnorderedUsingDefaultComparer(expectedSnapshot.Items, actualSnapshot.Items))
             return;
 
         throw new AssertionException(ErrorFormatter.Format(new NotEqualUnorderedAssertionError<IReadOnlyList<T>, IReadOnlyList<T>>("Not expected", expectedSnapshot.Items, actualSnapshot.Items, actualExpression, expectedExpression, message)));
@@ -79,10 +84,17 @@ public partial class Assert
         await using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
         await actualSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
         await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-        comparer ??= EqualityComparer<T>.Default;
-        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer.Equals);
-        if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
-            return;
+        if (comparer is null)
+        {
+            if (!EqualUnorderedUsingDefaultComparer(expectedSnapshot.Items, actualSnapshot.Items))
+                return;
+        }
+        else
+        {
+            var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer);
+            if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
+                return;
+        }
 
         throw new AssertionException(ErrorFormatter.Format(new NotEqualUnorderedAssertionError<IReadOnlyList<T>, IReadOnlyList<T>>("Not expected", expectedSnapshot.Items, actualSnapshot.Items, actualExpression, expectedExpression, message)));
     }
@@ -97,7 +109,7 @@ public partial class Assert
         await using var expectedSnapshot = CollectionSnapshot.Create<TExpected>(expected);
         await actualSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
         await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, (expectedItem, actualItem) => ValuesEqual(expectedItem, actualItem));
+        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, (System.Collections.IEqualityComparer?)null);
         if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
             return;
 
@@ -113,7 +125,7 @@ public partial class Assert
         using var actualSnapshot = CollectionSnapshot.Create(actual);
         expectedSnapshot.EnsureComplete();
         actualSnapshot.EnsureComplete();
-        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, (expectedItem, actualItem) => ValuesEqual(expectedItem, actualItem));
+        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, (System.Collections.IEqualityComparer?)null);
         if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
             return;
 
@@ -129,7 +141,7 @@ public partial class Assert
         using var actualSnapshot = CollectionSnapshot.Create(actual);
         expectedSnapshot.EnsureComplete();
         actualSnapshot.EnsureComplete();
-        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, (expectedItem, actualItem) => ValuesEqual(expectedItem, actualItem, comparer));
+        var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer);
         if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
             return;
 

--- a/src/Meziantou.Framework.Assertions/Assert.NotEquivalent.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.NotEquivalent.cs
@@ -11,7 +11,7 @@ public partial class Assert
 
     public static void NotEquivalent(object? expected, object? actual, EquivalentOptions? options, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
     {
-        var failure = GetStructuralDifference(expected, actual, "$", new HashSet<StructuralReferencePair>(), StructuralComparisonOptions.Create(options));
+        var failure = GetStructuralDifference(expected, actual, "$", new HashSet<StructuralReferencePair>(), [], StructuralComparisonOptions.Create(options));
         if (failure is not null)
             return;
 

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEqualByStructureTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEqualByStructureTests.cs
@@ -106,6 +106,44 @@ public sealed class AssertEqualByStructureTests
     }
 
     [Fact]
+    public void Equivalent_IgnoresCollectionOrderWithSharedCyclicReferences()
+    {
+        var expectedShared = new GraphNode { Name = "shared" };
+        expectedShared.Next = expectedShared;
+        var expectedFirst = new GraphNode { Name = "first", Next = expectedShared };
+        var expectedSecond = new GraphNode { Name = "second", Next = expectedShared };
+
+        var actualShared = new GraphNode { Name = "shared" };
+        actualShared.Next = actualShared;
+        var actualFirst = new GraphNode { Name = "first", Next = actualShared };
+        var actualSecond = new GraphNode { Name = "second", Next = actualShared };
+
+        AssertionsAssert.Equivalent(new[] { expectedFirst, expectedSecond }, new[] { actualSecond, actualFirst }, new EquivalentOptions { IgnoreCollectionOrder = true });
+    }
+
+    [Fact]
+    public void Equivalent_FailsWithIgnoredCollectionOrderAndSharedCyclicReferences()
+    {
+        var expectedShared = new GraphNode { Name = "shared" };
+        expectedShared.Next = expectedShared;
+        var expected = new[] { new GraphNode { Name = "first", Next = expectedShared } };
+
+        var actualShared = new GraphNode { Name = "shared" };
+        actualShared.Next = actualShared;
+        var actual = new[] { new GraphNode { Name = "second", Next = actualShared } };
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.Equivalent(expected, actual, new EquivalentOptions { IgnoreCollectionOrder = true }), """
+            Assert.Equivalent() assertion failed.
+            Expected expression: expected
+            Actual expression:   actual
+            Path: $[0]
+            Reason: Actual collection is missing an equivalent item.
+            Expected: Meziantou.Framework.Assertions.Tests.AssertEqualByStructureTests+GraphNode
+            Actual:   <missing>
+            """);
+    }
+
+    [Fact]
     public void Equivalent_FailsWhenMemberNameCaseDiffersByDefault()
     {
         var expected = new ZipCodeContainerExpected { ZipCode = 75000 };
@@ -430,6 +468,12 @@ public sealed class AssertEqualByStructureTests
     private sealed class NullablePerson
     {
         public string? Name { get; set; }
+    }
+
+    private sealed class GraphNode
+    {
+        public string? Name { get; set; }
+        public GraphNode? Next { get; set; }
     }
 
     private sealed class Node

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
@@ -84,6 +84,15 @@ public sealed class AssertEqualTests
     }
 
     [Fact]
+    public void Scalar_SucceedsWhenExpectedConvertsToActualTypeRepeatedly()
+    {
+        var actual = new ImplicitlyConvertibleValue(42);
+
+        AssertionsAssert.Equal(42, actual);
+        AssertionsAssert.Equal(42, actual);
+    }
+
+    [Fact]
     public void HalfTolerance_Success()
     {
         Half expected = (Half)1;
@@ -399,6 +408,16 @@ public sealed class AssertEqualTests
         var expected = new[] { 1, 2, 3 }.AsMemory();
         var actual = new[] { 1L, 2L, 3L }.AsMemory();
 
+        AssertionsAssert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void DifferentMemoryTypes_BoxedValuesSuccessRepeatedly()
+    {
+        object expected = new[] { 1, 2, 3 }.AsMemory();
+        object actual = new[] { 1L, 2L, 3L }.AsMemory();
+
+        AssertionsAssert.Equal(expected, actual);
         AssertionsAssert.Equal(expected, actual);
     }
 

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEqualUnorderedTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEqualUnorderedTests.cs
@@ -23,6 +23,15 @@ public sealed class AssertEqualUnorderedTests
     }
 
     [Fact]
+    public void EnumerableWithDuplicatesAndNulls_Success()
+    {
+        IEnumerable<string?> expected = ["a", null, "a", "b"];
+        IEnumerable<string?> actual = ["b", "a", null, "a"];
+
+        AssertionsAssert.EqualUnordered(expected, actual);
+    }
+
+    [Fact]
     public void EnumerableWithDuplicates_Fails()
     {
         IEnumerable<int> expected = [1, 1, 2];


### PR DESCRIPTION
## Summary
- Speed up unordered equality checks by short-circuiting the default-comparer path with a hash-based match routine.
- Cache reflection lookups for memory conversion and implicit conversions to reduce repeated inspection overhead.
- Reuse structural-reference tracking during equivalence checks instead of cloning state on every recursive comparison.

## Testing
- Not run (not requested)