### PR TITLE
Move optional assertion messages higher in the generated output

### DIFF
--- a/src/Meziantou.Framework.Assertions/AssertionFormatter.cs
+++ b/src/Meziantou.Framework.Assertions/AssertionFormatter.cs
@@ -1369,7 +1369,7 @@ internal class AssertionFormatter
         if (string.IsNullOrEmpty(message))
             return exception.GetType().FullName ?? exception.GetType().Name;
 
-        return message.Replace(Environment.NewLine, Environment.NewLine + "           ", StringComparison.Ordinal);
+        return message.Replace("\n", "\n           ", StringComparison.Ordinal);
     }
 
     private static void EnsureObservedItems<T>(CollectionSnapshot<T> snapshot, int maxIndex)

--- a/src/Meziantou.Framework.Assertions/AssertionFormatter.cs
+++ b/src/Meziantou.Framework.Assertions/AssertionFormatter.cs
@@ -4,16 +4,12 @@ namespace Meziantou.Framework.Assertions;
 internal class AssertionFormatter
 {
     private const char CombiningLowLine = '\u0332';
-    private const string NewLine = "\n";
 
     public static AssertionFormatter Default { get; } = new AssertionFormatter();
 
-    internal static string AppendMessage(string formattedMessage, string? message)
+    private static AssertionMessageBuilder CreateMessage(string header, string? message)
     {
-        if (string.IsNullOrEmpty(message) || formattedMessage.Contains(NewLine + "Message: ", StringComparison.Ordinal))
-            return formattedMessage;
-
-        return formattedMessage + NewLine + "Message: " + message;
+        return new AssertionMessageBuilder(header).AppendUserMessage("Message", message);
     }
 
     internal FormatterOptions Options
@@ -70,47 +66,27 @@ internal class AssertionFormatter
 
     public string Format(FailAssertionError error)
     {
-        var result = "Assert.Fail() assertion failed.";
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage("Assert.Fail() assertion failed.", error.Message).ToString();
     }
 
     public virtual string Format(TrueAssertionError error)
     {
-        var result = $"""
-            Assert.True() assertion failed.
-            Expression: {error.Expression}
-            Expected: true
-            Actual:   {FormatBoolean(error.Actual)}
-            """;
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage("Assert.True() assertion failed.", error.Message)
+            .Append("Expression", error.Expression)
+            .AppendGroup(
+                ("Expected", "true"),
+                ("Actual", FormatBoolean(error.Actual)))
+            .ToString();
     }
 
     public virtual string Format(FalseAssertionError error)
     {
-        var result = $"""
-            Assert.False() assertion failed.
-            Expression: {error.Expression}
-            Expected: false
-            Actual:   {FormatBoolean(error.Actual)}
-            """;
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage("Assert.False() assertion failed.", error.Message)
+            .Append("Expression", error.Expression)
+            .AppendGroup(
+                ("Expected", "false"),
+                ("Actual", FormatBoolean(error.Actual)))
+            .ToString();
     }
 
     private static string FormatBoolean(bool? value)
@@ -123,135 +99,85 @@ internal class AssertionFormatter
         };
     }
 
-    public virtual string Format(NegativeTextAssertionError error)
-    {
-        var result = $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Not expected: {error.NotExpectedText}
-            Actual:       {error.ActualText}
-            """;
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
-    }
-
     public virtual string Format(NegativeExpressionAssertionError error)
     {
-        var result = $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Not expected: {error.NotExpectedText}
-            Actual:       {error.Expression}
-            """;
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Not expected", error.NotExpectedText),
+                ("Actual", error.Expression))
+            .ToString();
     }
 
     public virtual string Format(NegativeExceptionAssertionError error)
     {
-        var result = $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expression: {error.Expression}
-            Not expected: {error.NotExpectedText}
-            Exception: {error.ExceptionType.FullName}
-            """;
+        var builder = CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .Append("Expression", error.Expression)
+            .Append("Not expected", error.NotExpectedText)
+            .Append("Exception", error.ExceptionType.FullName ?? string.Empty);
 
         if (!string.IsNullOrEmpty(error.ExceptionMessage))
         {
-            result += NewLine + "Exception message: " + error.ExceptionMessage;
+            builder.Append("Exception message", error.ExceptionMessage);
         }
 
-        return AppendMessage(result, error.Message);
+        return builder.ToString();
     }
 
     public virtual string Format<T>(NegativeReadOnlySpanActualValueAssertionError<T> error)
     {
-        var result = $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expression: {error.ActualExpression}
-            Not expected: {error.NotExpectedText}
-            Actual:       {FormatReadOnlySpanValue(error.ActualValue.Span)}
-            """;
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Not expected", error.NotExpectedText),
+                ("Actual", FormatReadOnlySpanValue(error.ActualValue.Span)))
+            .ToString();
     }
 
     public virtual string Format<TExpected, TActual>(NegativeReadOnlySpanValueAssertionError<TExpected, TActual> error)
     {
-        var result = $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            {error.NotExpectedLabel}: {FormatReadOnlySpanValue(error.ExpectedValue.Span)}
-            Actual:              {FormatReadOnlySpanValue(error.ActualValue.Span)}
-            """;
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                (error.NotExpectedLabel, FormatReadOnlySpanValue(error.ExpectedValue.Span)),
+                ("Actual", FormatReadOnlySpanValue(error.ActualValue.Span)))
+            .ToString();
     }
 
     public virtual string Format<TExpected, TActual>(NegativeReadOnlySpanExpectedActualValueAssertionError<TExpected, TActual> error)
     {
-        var result = $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            {error.NotExpectedLabel}: {FormatValue(error.ExpectedValue)}
-            Actual:              {FormatReadOnlySpanValue(error.ActualValue.Span)}
-            """;
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                (error.NotExpectedLabel, FormatValue(error.ExpectedValue)),
+                ("Actual", FormatReadOnlySpanValue(error.ActualValue.Span)))
+            .ToString();
     }
 
     public virtual string Format<T>(NegativeReadOnlySpanCountAssertionError<T> error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expression: {error.ActualExpression}
-            Not expected count: {error.NotExpectedCount}
-            Actual count:       {error.ActualCount}
-            Actual:             {FormatReadOnlySpanValue(error.ActualValue.Span)}
-            """), error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Not expected count", error.NotExpectedCount.ToString(CultureInfo.InvariantCulture)),
+                ("Actual count", error.ActualCount.ToString(CultureInfo.InvariantCulture)))
+            .Append("Actual", FormatReadOnlySpanValue(error.ActualValue.Span))
+            .ToString();
     }
 
     private string FormatNegativeValue(string assertionName, string? expectedExpression, string? actualExpression, string notExpectedLabel, object? expectedValue, object? actualValue, string? message)
     {
-        var result = $"""
-            Assert.{assertionName}() assertion failed.
-            Expected expression: {expectedExpression}
-            Actual expression:   {actualExpression}
-            {notExpectedLabel}: {FormatValue(expectedValue)}
-            Actual:              {FormatValue(actualValue)}
-            """;
-
-        if (!string.IsNullOrEmpty(message))
-        {
-            result += NewLine + "Message: " + message;
-        }
-
-        return result;
+        return CreateMessage($"Assert.{assertionName}() assertion failed.", message)
+            .AppendGroup(
+                ("Expected expression", expectedExpression ?? string.Empty),
+                ("Actual expression", actualExpression ?? string.Empty))
+            .AppendGroup(
+                (notExpectedLabel, FormatValue(expectedValue)),
+                ("Actual", FormatValue(actualValue)))
+            .ToString();
     }
 
     public virtual string Format<TExpected, TActual>(DoesNotContainAssertionError<TExpected, TActual> error)
@@ -291,823 +217,777 @@ internal class AssertionFormatter
 
     public virtual string Format<TActual>(NegativeActualValueAssertionError<TActual> error)
     {
-        var result = $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expression: {error.ActualExpression}
-            Not expected: {error.NotExpectedText}
-            Actual:       {FormatValue(error.ActualValue)}
-            """;
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Not expected", error.NotExpectedText),
+                ("Actual", FormatValue(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format(NegativeSameAssertionError error)
     {
-        return AppendMessage($"""
-            Assert.NotSame() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Not expected: same instance as {FormatValue(error.ExpectedValue)}
-            Actual:       {FormatValue(error.ActualValue)}
-            """, error.Message);
+        return CreateMessage("Assert.NotSame() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Not expected", "same instance as " + FormatValue(error.ExpectedValue)),
+                ("Actual", FormatValue(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format<T>(NegativeRangeAssertionError<T> error)
     {
-        return AppendMessage($"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expression: {error.ActualExpression}
-            Not expected: in range [{FormatValue(error.LowValue)}, {FormatValue(error.HighValue)}]
-            Actual:       {FormatValue(error.ActualValue)}
-            """, error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Not expected", $"in range [{FormatValue(error.LowValue)}, {FormatValue(error.HighValue)}]"),
+                ("Actual", FormatValue(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format(NegativeTypeAssertionError error)
     {
-        return AppendMessage($"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expression:          {error.ActualExpression}
-            {error.NotExpectedTypeLabel}: {FormatType(error.ExpectedType)}
-            Actual type:         {FormatType(error.ActualValue?.GetType())}
-            Actual value:        {FormatValue(error.ActualValue)}
-            """, error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                (error.NotExpectedTypeLabel, FormatType(error.ExpectedType)),
+                ("Actual type", FormatType(error.ActualValue?.GetType())))
+            .Append("Actual value", FormatValue(error.ActualValue))
+            .ToString();
     }
 
     public virtual string Format(NegativeSetAssertionError error)
     {
         var setName = error.IsSuperset ? "superset" : "subset";
-        var expectedExpressionLabel = $"Expected {setName} expression:";
-        var actualExpressionLabel = "Actual expression:";
-        var notExpectedValueLabel = $"Not expected {setName}:";
-        var actualValueLabel = "Actual:";
-
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.NotProper{(error.IsSuperset ? "Superset" : "Subset")}() assertion failed.
-            {expectedExpressionLabel} {error.ExpectedExpression}
-            {actualExpressionLabel.PadRight(expectedExpressionLabel.Length)} {error.ActualExpression}
-            {notExpectedValueLabel} {FormatValue(error.ExpectedValue)}
-            {actualValueLabel.PadRight(notExpectedValueLabel.Length)} {FormatValue(error.ActualValue)}
-            """), error.Message);
+        return CreateMessage($"Assert.NotProper{(error.IsSuperset ? "Superset" : "Subset")}() assertion failed.", error.Message)
+            .AppendGroup(
+                ($"Expected {setName} expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ($"Not expected {setName}", FormatValue(error.ExpectedValue)),
+                ("Actual", FormatValue(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format<T>(NegativeCountAssertionError<T> error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expression: {error.ActualExpression}
-            Not expected count: {error.NotExpectedCount}
-            Actual count:       {error.ActualCount}
-            Actual:             {FormatValue(error.ActualValue)}
-            """), error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Not expected count", error.NotExpectedCount.ToString(CultureInfo.InvariantCulture)),
+                ("Actual count", error.ActualCount.ToString(CultureInfo.InvariantCulture)))
+            .Append("Actual", FormatValue(error.ActualValue))
+            .ToString();
     }
 
     public virtual string Format<T>(NegativeEqualWithToleranceAssertionError<T> error)
     {
-        var result = $"""
-            Assert.NotEqual() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Not expected: {FormatValue(error.ExpectedValue)}
-            Actual:       {FormatValue(error.ActualValue)}
-            Tolerance:    {FormatValue(error.Tolerance)}
-            """;
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage("Assert.NotEqual() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Not expected", FormatValue(error.ExpectedValue)),
+                ("Actual", FormatValue(error.ActualValue)))
+            .Append("Tolerance", FormatValue(error.Tolerance))
+            .ToString();
     }
 
     public virtual string Format(NullAssertionError error)
     {
-        return AppendMessage($"""
-            Assert.Null() assertion failed.
-            Expression: {error.ActualExpression}
-            Expected: <null>
-            Actual:   {FormatValue(error.ActualValue)}
-            """, error.Message);
+        return CreateMessage("Assert.Null() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Expected", "<null>"),
+                ("Actual", FormatValue(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format(IsTypeAssertionError error)
     {
-        return AppendMessage($"""
-            Assert.IsType() assertion failed.
-            Expression:    {error.ActualExpression}
-            Expected type: {FormatType(error.ExpectedType)}
-            Actual type:   {FormatType(error.ActualValue?.GetType())}
-            Actual value:  {FormatValue(error.ActualValue)}
-            """, error.Message);
+        return CreateMessage("Assert.IsType() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Expected type", FormatType(error.ExpectedType)),
+                ("Actual type", FormatType(error.ActualValue?.GetType())))
+            .Append("Actual value", FormatValue(error.ActualValue))
+            .ToString();
     }
 
     public virtual string Format(IsAssignableToAssertionError error)
     {
-        return AppendMessage($"""
-            Assert.IsAssignableTo() assertion failed.
-            Expression:    {error.ActualExpression}
-            Expected type: {FormatType(error.ExpectedType)}
-            Actual type:   {FormatType(error.ActualValue?.GetType())}
-            Actual value:  {FormatValue(error.ActualValue)}
-            """, error.Message);
+        return CreateMessage("Assert.IsAssignableTo() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Expected type", FormatType(error.ExpectedType)),
+                ("Actual type", FormatType(error.ActualValue?.GetType())))
+            .Append("Actual value", FormatValue(error.ActualValue))
+            .ToString();
     }
 
     public virtual string Format(SameAssertionError error)
     {
-        return AppendMessage($"""
-            Assert.Same() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Expected: same instance as {FormatValue(error.ExpectedValue)}
-            Actual:   {FormatValue(error.ActualValue)}
-            """, error.Message);
+        return CreateMessage("Assert.Same() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected", "same instance as " + FormatValue(error.ExpectedValue)),
+                ("Actual", FormatValue(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format<T>(InRangeAssertionError<T> error)
     {
-        return AppendMessage($"""
-            Assert.InRange() assertion failed.
-            Expression: {error.ActualExpression}
-            Expected:   in range [{FormatValue(error.LowValue)}, {FormatValue(error.HighValue)}]
-            Actual:     {FormatValue(error.ActualValue)}
-            """, error.Message);
+        return CreateMessage("Assert.InRange() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Expected", $"in range [{FormatValue(error.LowValue)}, {FormatValue(error.HighValue)}]"),
+                ("Actual", FormatValue(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format(ThrowsAssertionError error)
     {
-        return AppendMessage($"""
-            Assert.{(error.AllowDerivedTypes ? "ThrowsAny" : "Throws")}() assertion failed.
-            Expression:              {error.ActionExpression}
-            Expected exception type: {FormatType(error.ExpectedExceptionType)}
-            Actual exception type:   {FormatType(error.ActualException?.GetType())}
-            Exception:               {FormatException(error.ActualException)}
-            """, error.Message);
+        return CreateMessage($"Assert.{(error.AllowDerivedTypes ? "ThrowsAny" : "Throws")}() assertion failed.", error.Message)
+            .Append("Expression", error.ActionExpression)
+            .AppendGroup(
+                ("Expected exception type", FormatType(error.ExpectedExceptionType)),
+                ("Actual exception type", FormatType(error.ActualException?.GetType())))
+            .Append("Exception", FormatException(error.ActualException))
+            .ToString();
     }
 
     public virtual string Format(RegexMatchesAssertionError error)
     {
-        return AppendMessage($"""
-            Assert.Match() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Expected pattern: {FormatValue(error.ExpectedPattern)}
-            Actual:           {FormatValue(error.ActualValue)}
-            """, error.Message);
+        return CreateMessage("Assert.Match() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected pattern", FormatValue(error.ExpectedPattern)),
+                ("Actual", FormatValue(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format(RaiseAssertionError error)
     {
-        return AppendMessage($"""
-            Assert.{(error.AllowDerivedTypes ? "RaiseAny" : "Raise")}() assertion failed.
-            Expression:               {error.ActionExpression}
-            Expected event args type: {FormatType(error.ExpectedEventArgsType)}
-            Actual event args type:   {FormatType(error.ActualEventArgsType)}
-            """, error.Message);
+        return CreateMessage($"Assert.{(error.AllowDerivedTypes ? "RaiseAny" : "Raise")}() assertion failed.", error.Message)
+            .Append("Expression", error.ActionExpression)
+            .AppendGroup(
+                ("Expected event args type", FormatType(error.ExpectedEventArgsType)),
+                ("Actual event args type", FormatType(error.ActualEventArgsType)))
+            .ToString();
     }
 
     public virtual string Format<T>(CollectionSetAssertionError<T> error)
     {
         var setName = error.IsSuperset ? "superset" : "subset";
-        var expectedExpressionLabel = $"Expected {setName} expression:";
-        var actualExpressionLabel = "Actual expression:";
-        var expectedValueLabel = $"Expected {setName}:";
-        var actualValueLabel = "Actual:";
-
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.{(error.IsSuperset ? "ProperSuperset" : "ProperSubset")}() assertion failed.
-            {expectedExpressionLabel} {error.ExpectedExpression}
-            {actualExpressionLabel.PadRight(expectedExpressionLabel.Length)} {error.ActualExpression}
-            {expectedValueLabel} {FormatValue(error.ExpectedValue.Items)}
-            {actualValueLabel.PadRight(expectedValueLabel.Length)} {FormatValue(error.ActualValue.Items)}
-            """), error.Message);
+        return CreateMessage($"Assert.{(error.IsSuperset ? "ProperSuperset" : "ProperSubset")}() assertion failed.", error.Message)
+            .AppendGroup(
+                ($"Expected {setName} expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ($"Expected {setName}", FormatValue(error.ExpectedValue.Items)),
+                ("Actual", FormatValue(error.ActualValue.Items)))
+            .ToString();
     }
 
     public virtual string Format<TExpected, TActual>(EqualAssertionError<TExpected, TActual> error)
     {
-        var result = $"""
-            Assert.Equal() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            """;
-
-        result += NewLine + "Expected: " + FormatValue(error.ExpectedValue);
-        result += NewLine + "Actual:   " + FormatValue(error.ActualValue);
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage("Assert.Equal() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected", FormatValue(error.ExpectedValue)),
+                ("Actual", FormatValue(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format<T>(EqualWithToleranceAssertionError<T> error)
     {
-        var result = $"""
-            Assert.Equal() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            """;
-
-        result += NewLine + "Expected: " + FormatValue(error.ExpectedValue);
-        result += NewLine + "Actual:   " + FormatValue(error.ActualValue);
-        result += NewLine + "Tolerance: " + FormatValue(error.Tolerance);
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage("Assert.Equal() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected", FormatValue(error.ExpectedValue)),
+                ("Actual", FormatValue(error.ActualValue)))
+            .Append("Tolerance", FormatValue(error.Tolerance))
+            .ToString();
     }
 
     public virtual string Format(EquivalentAssertionError error)
     {
-        var result = $"""
-            Assert.Equivalent() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Path: {error.Path}
-            Reason: {error.Reason}
-            """;
-
-        result += NewLine + "Expected: " + FormatStructuralValue(error.ExpectedValue);
-        result += NewLine + "Actual:   " + FormatStructuralValue(error.ActualValue);
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage("Assert.Equivalent() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Path", error.Path)
+            .Append("Reason", error.Reason)
+            .AppendGroup(
+                ("Expected", FormatStructuralValue(error.ExpectedValue)),
+                ("Actual", FormatStructuralValue(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format<TExpected, TActual>(ReadOnlySpanEqualAssertionError<TExpected, TActual> error)
     {
-        var result = string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Equal() assertion failed: Item at index {error.FirstDifferenceIndex} differs.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Index of first difference: {error.FirstDifferenceIndex}
-            Expected item: {FormatReadOnlySpanValue(error.ExpectedValue, error.FirstDifferenceIndex)}
-            Actual item:   {FormatReadOnlySpanValue(error.ActualValue, error.FirstDifferenceIndex)}
-            """);
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage($"Assert.Equal() assertion failed: Item at index {error.FirstDifferenceIndex} differs.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Index of first difference", error.FirstDifferenceIndex.ToString(CultureInfo.InvariantCulture))
+            .AppendGroup(
+                ("Expected item", FormatReadOnlySpanValue(error.ExpectedValue, error.FirstDifferenceIndex)),
+                ("Actual item", FormatReadOnlySpanValue(error.ActualValue, error.FirstDifferenceIndex)))
+            .ToString();
     }
 
     public virtual string Format<TExpected, TActual>(ReadOnlySpanLengthAssertionError<TExpected, TActual> error)
     {
-        var result = string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Equal() assertion failed: Lengths differ.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Expected length: {error.ExpectedValue.Length}
-            Actual length:   {error.ActualValue.Length}
-            Expected: {FormatReadOnlySpanValue(error.ExpectedValue)}
-            Actual:   {FormatReadOnlySpanValue(error.ActualValue)}
-            """);
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage("Assert.Equal() assertion failed: Lengths differ.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected length", error.ExpectedValue.Length.ToString(CultureInfo.InvariantCulture)),
+                ("Actual length", error.ActualValue.Length.ToString(CultureInfo.InvariantCulture)))
+            .AppendGroup(
+                ("Expected", FormatReadOnlySpanValue(error.ExpectedValue)),
+                ("Actual", FormatReadOnlySpanValue(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format<T>(ValueStartsWithAssertionError<T> error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.StartsWith() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Expected prefix: {FormatValue(error.ExpectedValue)}
-            Actual:          {FormatReadOnlySpanValue(error.ActualValue, error.ActualValue.IsEmpty ? null : 0)}
-            """), error.Message);
+        return CreateMessage("Assert.StartsWith() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected prefix", FormatValue(error.ExpectedValue)),
+                ("Actual", FormatReadOnlySpanValue(error.ActualValue, error.ActualValue.IsEmpty ? null : 0)))
+            .ToString();
     }
 
     public virtual string Format<T>(ValueCollectionStartsWithAssertionError<T> error)
     {
         EnsureObservedItems(error.ActualValue, MaxFormattedItems - 1);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.StartsWith() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Expected prefix: {FormatValue(error.ExpectedValue)}
-            Actual:          {FormatValue(error.ActualValue.Items, error.ActualValue.Items.Count > 0 ? 0 : null)}
-            """), error.Message);
+        return CreateMessage("Assert.StartsWith() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected prefix", FormatValue(error.ExpectedValue)),
+                ("Actual", FormatValue(error.ActualValue.Items, error.ActualValue.Items.Count > 0 ? 0 : null)))
+            .ToString();
     }
 
     public virtual string Format<T>(ReadOnlySpanEmptyAssertionError<T> error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Empty() assertion failed.
-            Expression: {error.ActualExpression}
-            Actual:     {FormatReadOnlySpanValue(error.ActualValue, error.ActualValue.IsEmpty ? null : 0)}
-            """), error.Message);
+        return CreateMessage("Assert.Empty() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .Append("Actual", FormatReadOnlySpanValue(error.ActualValue, error.ActualValue.IsEmpty ? null : 0))
+            .ToString();
     }
 
     public virtual string Format(StringEmptyAssertionError error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Empty() assertion failed.
-            Expression: {error.ActualExpression}
-            Actual:     {FormatStringValue(error.ActualValue, error.ActualValue.IsEmpty ? null : 0)}
-            """), error.Message);
+        return CreateMessage("Assert.Empty() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .Append("Actual", FormatStringValue(error.ActualValue, error.ActualValue.IsEmpty ? null : 0))
+            .ToString();
     }
 
     public virtual string Format<T>(CollectionEmptyAssertionError<T> error)
     {
         EnsureObservedItems(error.ActualValue, MaxFormattedItems - 1);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Empty() assertion failed.
-            Expression: {error.ActualExpression}
-            Actual:     {FormatValue(error.ActualValue.Items, error.ActualValue.Items.Count > 0 ? 0 : null)}
-            """), error.Message);
+        return CreateMessage("Assert.Empty() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .Append("Actual", FormatValue(error.ActualValue.Items, error.ActualValue.Items.Count > 0 ? 0 : null))
+            .ToString();
     }
 
     public virtual async Task<string> FormatAsync<T>(AsyncCollectionEmptyAssertionError<T> error)
     {
         await EnsureObservedItemsAsync(error.ActualValue, MaxFormattedItems - 1).ConfigureAwait(false);
 
-        return string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Empty() assertion failed.
-            Expression: {error.ActualExpression}
-            Actual:     {FormatValue(error.ActualValue.Items, error.ActualValue.Items.Count > 0 ? 0 : null)}
-            """);
+        return CreateMessage("Assert.Empty() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .Append("Actual", FormatValue(error.ActualValue.Items, error.ActualValue.Items.Count > 0 ? 0 : null))
+            .ToString();
     }
 
     public virtual string Format<T>(ReadOnlySpanSingleAssertionError<T> error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Single() assertion failed.
-            Expression: {error.ActualExpression}
-            Actual:     {FormatReadOnlySpanValue(error.ActualValue, GetSingleFailureHighlightedIndex(error.ActualValue.Length))}
-            """), error.Message);
+        return CreateMessage("Assert.Single() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .Append("Actual", FormatReadOnlySpanValue(error.ActualValue, GetSingleFailureHighlightedIndex(error.ActualValue.Length)))
+            .ToString();
     }
 
     public virtual string Format(StringSingleAssertionError error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Single() assertion failed.
-            Expression: {error.ActualExpression}
-            Actual:     {FormatStringValue(error.ActualValue, GetSingleFailureHighlightedIndex(error.ActualValue.Length))}
-            """), error.Message);
+        return CreateMessage("Assert.Single() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .Append("Actual", FormatStringValue(error.ActualValue, GetSingleFailureHighlightedIndex(error.ActualValue.Length)))
+            .ToString();
     }
 
     public virtual string Format<T>(CollectionSingleAssertionError<T> error)
     {
         EnsureObservedItems(error.ActualValue, MaxFormattedItems - 1);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Single() assertion failed.
-            Expression: {error.ActualExpression}
-            Actual:     {FormatValue(error.ActualValue.Items, GetSingleFailureHighlightedIndex(error.ActualValue.Items.Count))}
-            """), error.Message);
+        return CreateMessage("Assert.Single() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .Append("Actual", FormatValue(error.ActualValue.Items, GetSingleFailureHighlightedIndex(error.ActualValue.Items.Count)))
+            .ToString();
     }
 
     public virtual string Format<T>(CollectionSinglePredicateAssertionError<T> error)
     {
         EnsureObservedItems(error.MatchingValues, MaxFormattedItems - 1);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Single() assertion failed.
-            Expression: {error.ActualExpression}
-            Predicate expression: {error.PredicateExpression}
-            Matching items:       {FormatValue(error.MatchingValues.Items, GetSingleFailureHighlightedIndex(error.MatchingValues.Items.Count))}
-            """), error.Message);
+        return CreateMessage("Assert.Single() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expression", error.ActualExpression),
+                ("Predicate expression", error.PredicateExpression))
+            .Append("Matching items", FormatValue(error.MatchingValues.Items, GetSingleFailureHighlightedIndex(error.MatchingValues.Items.Count)))
+            .ToString();
     }
 
     public virtual string Format<T>(CollectionContainsPredicateAssertionError<T> error)
     {
         EnsureObservedItems(error.MatchingValues, MaxFormattedItems - 1);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Contains() assertion failed.
-            Expression: {error.ActualExpression}
-            Predicate expression: {error.PredicateExpression}
-            Matching items:       {FormatValue(error.MatchingValues.Items)}
-            """), error.Message);
+        return CreateMessage("Assert.Contains() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expression", error.ActualExpression),
+                ("Predicate expression", error.PredicateExpression))
+            .Append("Matching items", FormatValue(error.MatchingValues.Items))
+            .ToString();
     }
 
     public virtual string Format(ContainsPredicateNullActualAssertionError error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Contains() assertion failed.
-            Expression: {error.ActualExpression}
-            Predicate expression: {error.PredicateExpression}
-            Actual: <null>
-            """), error.Message);
+        return CreateMessage("Assert.Contains() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expression", error.ActualExpression),
+                ("Predicate expression", error.PredicateExpression))
+            .Append("Actual", "<null>")
+            .ToString();
     }
 
     public virtual string Format<T>(CollectionDoesNotContainPredicateAssertionError<T> error)
     {
         EnsureObservedItems(error.MatchingValues, MaxFormattedItems - 1);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.DoesNotContain() assertion failed.
-            Expression: {error.ActualExpression}
-            Predicate expression: {error.PredicateExpression}
-            Not expected: any matching item
-            Matching items: {FormatValue(error.MatchingValues.Items)}
-            """), error.Message);
+        return CreateMessage("Assert.DoesNotContain() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expression", error.ActualExpression),
+                ("Predicate expression", error.PredicateExpression))
+            .AppendGroup(
+                ("Not expected", "any matching item"),
+                ("Matching items", FormatValue(error.MatchingValues.Items)))
+            .ToString();
     }
 
     public virtual async Task<string> FormatAsync<T>(AsyncCollectionSingleAssertionError<T> error)
     {
         await EnsureObservedItemsAsync(error.ActualValue, MaxFormattedItems - 1).ConfigureAwait(false);
 
-        return string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Single() assertion failed.
-            Expression: {error.ActualExpression}
-            Actual:     {FormatValue(error.ActualValue.Items, GetSingleFailureHighlightedIndex(error.ActualValue.Items.Count))}
-            """);
+        return CreateMessage("Assert.Single() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .Append("Actual", FormatValue(error.ActualValue.Items, GetSingleFailureHighlightedIndex(error.ActualValue.Items.Count)))
+            .ToString();
     }
 
     public virtual string Format<T>(CollectionAssertionError<T> error)
     {
         EnsureObservedItems(error.ActualValue, MaxFormattedItems - 1);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Collection() assertion failed: Collection count does not match inspector count.
-            Expression: {error.ActualExpression}
-            Expected count: {error.ExpectedCount}
-            Actual count:   {error.ActualValue.Items.Count}
-            Actual:         {FormatValue(error.ActualValue.Items)}
-            """), error.Message);
+        return CreateMessage("Assert.Collection() assertion failed: Collection count does not match inspector count.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Expected count", error.ExpectedCount.ToString(CultureInfo.InvariantCulture)),
+                ("Actual count", error.ActualValue.Items.Count.ToString(CultureInfo.InvariantCulture)))
+            .Append("Actual", FormatValue(error.ActualValue.Items))
+            .ToString();
     }
 
     public virtual string Format<T>(CollectionInspectorAssertionError<T> error)
     {
         EnsureObservedItems(error.ActualValue, GetMaxFormattedIndex(error.Index));
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Collection() assertion failed: Item at index {error.Index} failed.
-            Expression: {error.ActualExpression}
-            Actual:     {FormatValue(error.ActualValue.Items, error.Index)}
-            Exception:  {FormatException(error.Exception)}
-            """), error.Message);
+        return CreateMessage($"Assert.Collection() assertion failed: Item at index {error.Index} failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .Append("Actual", FormatValue(error.ActualValue.Items, error.Index))
+            .Append("Exception", FormatException(error.Exception))
+            .ToString();
     }
 
     public virtual string Format<T>(ReadOnlySpanAllAssertionError<T> error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.All() assertion failed: Item at index {error.Index} failed.
-            Expression: {error.ActualExpression}
-            Assertion expression: {error.AssertionExpression}
-            Actual:     {FormatReadOnlySpanValue(error.ActualValue, error.Index)}
-            Exception:  {FormatException(error.Exception)}
-            """), error.Message);
+        return CreateMessage($"Assert.All() assertion failed: Item at index {error.Index} failed.", error.Message)
+            .AppendGroup(
+                ("Expression", error.ActualExpression),
+                ("Assertion expression", error.AssertionExpression))
+            .Append("Actual", FormatReadOnlySpanValue(error.ActualValue, error.Index))
+            .Append("Exception", FormatException(error.Exception))
+            .ToString();
     }
 
     public virtual string Format<T>(CollectionAllPredicateAssertionError<T> error)
     {
         EnsureObservedItems(error.ActualValue, GetMaxFormattedIndex(error.Index));
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.All() assertion failed: Item at index {error.Index} did not satisfy the predicate.
-            Expression:          {error.ActualExpression}
-            Predicate expression: {error.PredicateExpression}
-            Actual:              {FormatValue(error.ActualValue.Items, error.Index)}
-            """), error.Message);
+        return CreateMessage($"Assert.All() assertion failed: Item at index {error.Index} did not satisfy the predicate.", error.Message)
+            .AppendGroup(
+                ("Expression", error.ActualExpression),
+                ("Predicate expression", error.PredicateExpression))
+            .Append("Actual", FormatValue(error.ActualValue.Items, error.Index))
+            .ToString();
     }
 
     public virtual string Format<T>(CollectionDoesNotAllPredicateAssertionError<T> error)
     {
         EnsureObservedItems(error.ActualValue, MaxFormattedItems - 1);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.DoesNotAll() assertion failed: All items satisfy the predicate, but expected at least one that does not.
-            Expression:           {error.ActualExpression}
-            Predicate expression: {error.PredicateExpression}
-            Actual:               {FormatValue(error.ActualValue.Items)}
-            """), error.Message);
+        return CreateMessage("Assert.DoesNotAll() assertion failed: All items satisfy the predicate, but expected at least one that does not.", error.Message)
+            .AppendGroup(
+                ("Expression", error.ActualExpression),
+                ("Predicate expression", error.PredicateExpression))
+            .Append("Actual", FormatValue(error.ActualValue.Items))
+            .ToString();
     }
 
     public virtual string Format<T>(CollectionAllAssertionError<T> error)
     {
         EnsureObservedItems(error.ActualValue, GetMaxFormattedIndex(error.Index));
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.All() assertion failed: Item at index {error.Index} failed.
-            Expression: {error.ActualExpression}
-            Assertion expression: {error.AssertionExpression}
-            Actual:     {FormatValue(error.ActualValue.Items, error.Index)}
-            Exception:  {FormatException(error.Exception)}
-            """), error.Message);
+        return CreateMessage($"Assert.All() assertion failed: Item at index {error.Index} failed.", error.Message)
+            .AppendGroup(
+                ("Expression", error.ActualExpression),
+                ("Assertion expression", error.AssertionExpression))
+            .Append("Actual", FormatValue(error.ActualValue.Items, error.Index))
+            .Append("Exception", FormatException(error.Exception))
+            .ToString();
     }
 
     public virtual async Task<string> FormatAsync<T>(AsyncCollectionAllAssertionError<T> error)
     {
         await EnsureObservedItemsAsync(error.ActualValue, GetMaxFormattedIndex(error.Index)).ConfigureAwait(false);
 
-        return string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.All() assertion failed: Item at index {error.Index} failed.
-            Expression: {error.ActualExpression}
-            Assertion expression: {error.AssertionExpression}
-            Actual:     {FormatValue(error.ActualValue.Items, error.Index)}
-            Exception:  {FormatException(error.Exception)}
-            """);
+        return CreateMessage($"Assert.All() assertion failed: Item at index {error.Index} failed.", error.Message)
+            .AppendGroup(
+                ("Expression", error.ActualExpression),
+                ("Assertion expression", error.AssertionExpression))
+            .Append("Actual", FormatValue(error.ActualValue.Items, error.Index))
+            .Append("Exception", FormatException(error.Exception))
+            .ToString();
     }
 
     public virtual string Format<T>(ReadOnlySpanDistinctAssertionError<T> error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Distinct() assertion failed: Duplicate item found at index {error.DuplicateIndex}.
-            Expression: {error.ActualExpression}
-            First index:     {error.FirstIndex}
-            Duplicate index: {error.DuplicateIndex}
-            Actual:          {FormatReadOnlySpanValue(error.ActualValue, error.DuplicateIndex)}
-            """), error.Message);
+        return CreateMessage($"Assert.Distinct() assertion failed: Duplicate item found at index {error.DuplicateIndex}.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("First index", error.FirstIndex.ToString(CultureInfo.InvariantCulture)),
+                ("Duplicate index", error.DuplicateIndex.ToString(CultureInfo.InvariantCulture)))
+            .Append("Actual", FormatReadOnlySpanValue(error.ActualValue, error.DuplicateIndex))
+            .ToString();
     }
 
     public virtual string Format<T>(CollectionDistinctAssertionError<T> error)
     {
         EnsureObservedItems(error.ActualValue, GetMaxFormattedIndex(error.DuplicateIndex));
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Distinct() assertion failed: Duplicate item found at index {error.DuplicateIndex}.
-            Expression: {error.ActualExpression}
-            First index:     {error.FirstIndex}
-            Duplicate index: {error.DuplicateIndex}
-            Actual:          {FormatValue(error.ActualValue.Items, error.DuplicateIndex)}
-            """), error.Message);
+        return CreateMessage($"Assert.Distinct() assertion failed: Duplicate item found at index {error.DuplicateIndex}.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("First index", error.FirstIndex.ToString(CultureInfo.InvariantCulture)),
+                ("Duplicate index", error.DuplicateIndex.ToString(CultureInfo.InvariantCulture)))
+            .Append("Actual", FormatValue(error.ActualValue.Items, error.DuplicateIndex))
+            .ToString();
     }
 
     public virtual async Task<string> FormatAsync<T>(AsyncCollectionDistinctAssertionError<T> error)
     {
         await EnsureObservedItemsAsync(error.ActualValue, GetMaxFormattedIndex(error.DuplicateIndex)).ConfigureAwait(false);
 
-        return string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Distinct() assertion failed: Duplicate item found at index {error.DuplicateIndex}.
-            Expression: {error.ActualExpression}
-            First index:     {error.FirstIndex}
-            Duplicate index: {error.DuplicateIndex}
-            Actual:          {FormatValue(error.ActualValue.Items, error.DuplicateIndex)}
-            """);
+        return CreateMessage($"Assert.Distinct() assertion failed: Duplicate item found at index {error.DuplicateIndex}.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("First index", error.FirstIndex.ToString(CultureInfo.InvariantCulture)),
+                ("Duplicate index", error.DuplicateIndex.ToString(CultureInfo.InvariantCulture)))
+            .Append("Actual", FormatValue(error.ActualValue.Items, error.DuplicateIndex))
+            .ToString();
     }
 
     public virtual string Format<T>(ReadOnlySpanCountAssertionError<T> error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expression: {error.ActualExpression}
-            Expected count: {error.ExpectedCount}
-            Actual count:   {error.ActualCount}
-            Actual:         {FormatReadOnlySpanValue(error.ActualValue)}
-            """), error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Expected count", error.ExpectedCount.ToString(CultureInfo.InvariantCulture)),
+                ("Actual count", error.ActualCount.ToString(CultureInfo.InvariantCulture)))
+            .Append("Actual", FormatReadOnlySpanValue(error.ActualValue))
+            .ToString();
     }
 
     public virtual string Format(StringCountAssertionError error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expression: {error.ActualExpression}
-            Expected count: {error.ExpectedCount}
-            Actual count:   {error.ActualCount}
-            Actual:         {FormatStringValue(error.ActualValue, highlightedIndex: null)}
-            """), error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Expected count", error.ExpectedCount.ToString(CultureInfo.InvariantCulture)),
+                ("Actual count", error.ActualCount.ToString(CultureInfo.InvariantCulture)))
+            .Append("Actual", FormatStringValue(error.ActualValue, highlightedIndex: null))
+            .ToString();
     }
 
     public virtual string Format<T>(CollectionCountAssertionError<T> error)
     {
         EnsureObservedItems(error.ActualValue, MaxFormattedItems - 1);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expression: {error.ActualExpression}
-            Expected count: {error.ExpectedCount}
-            Actual count:   {error.ActualCount}
-            Actual:         {FormatValue(error.ActualValue.Items)}
-            """), error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Expected count", error.ExpectedCount.ToString(CultureInfo.InvariantCulture)),
+                ("Actual count", error.ActualCount.ToString(CultureInfo.InvariantCulture)))
+            .Append("Actual", FormatValue(error.ActualValue.Items))
+            .ToString();
     }
 
     public virtual async Task<string> FormatAsync<T>(AsyncCollectionCountAssertionError<T> error)
     {
         await EnsureObservedItemsAsync(error.ActualValue, MaxFormattedItems - 1).ConfigureAwait(false);
 
-        return string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expression: {error.ActualExpression}
-            Expected count: {error.ExpectedCount}
-            Actual count:   {error.ActualCount}
-            Actual:         {FormatValue(error.ActualValue.Items)}
-            """);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .Append("Expression", error.ActualExpression)
+            .AppendGroup(
+                ("Expected count", error.ExpectedCount.ToString(CultureInfo.InvariantCulture)),
+                ("Actual count", error.ActualCount.ToString(CultureInfo.InvariantCulture)))
+            .Append("Actual", FormatValue(error.ActualValue.Items))
+            .ToString();
     }
 
     public virtual string Format<T>(ValueContainsAssertionError<T> error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Contains() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Expected item: {FormatValue(error.ExpectedValue)}
-            Actual:        {FormatReadOnlySpanValue(error.ActualValue)}
-            """), error.Message);
+        return CreateMessage("Assert.Contains() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected item", FormatValue(error.ExpectedValue)),
+                ("Actual", FormatReadOnlySpanValue(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format<T>(ValueCollectionContainsAssertionError<T> error)
     {
         EnsureObservedItems(error.ActualValue, MaxFormattedItems - 1);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Contains() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Expected item: {FormatValue(error.ExpectedValue)}
-            Actual:        {FormatValue(error.ActualValue.Items)}
-            """), error.Message);
+        return CreateMessage("Assert.Contains() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected item", FormatValue(error.ExpectedValue)),
+                ("Actual", FormatValue(error.ActualValue.Items)))
+            .ToString();
     }
 
     public virtual string Format<TExpected>(ContainsNullActualAssertionError<TExpected> error)
     {
-        var actualExpressionPadding = new string(' ', error.ExpectedExpressionLabel.Length - "Actual expression".Length + 1);
-        var actualValuePadding = new string(' ', error.ExpectedValueLabel.Length - "Actual".Length + 1);
-
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Contains() assertion failed.
-            {error.ExpectedExpressionLabel}: {error.ExpectedExpression}
-            Actual expression:{actualExpressionPadding}{error.ActualExpression}
-            {error.ExpectedValueLabel}: {FormatValue(error.ExpectedValue)}
-            Actual:{actualValuePadding}<null>
-            """), error.Message);
+        return CreateMessage("Assert.Contains() assertion failed.", error.Message)
+            .AppendGroup(
+                (error.ExpectedExpressionLabel, error.ExpectedExpression ?? string.Empty),
+                ("Actual expression", error.ActualExpression ?? string.Empty))
+            .AppendGroup(
+                (error.ExpectedValueLabel, FormatValue(error.ExpectedValue)),
+                ("Actual", "<null>"))
+            .ToString();
     }
 
     public virtual string Format<TExpected>(NullActualAssertionError<TExpected> error)
     {
-        var actualExpressionPadding = new string(' ', error.ExpectedExpressionLabel.Length - "Actual expression".Length + 1);
-        var actualValuePadding = new string(' ', error.ExpectedValueLabel.Length - "Actual".Length + 1);
-
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.{error.AssertionName}() assertion failed.
-            {error.ExpectedExpressionLabel}: {error.ExpectedExpression}
-            Actual expression:{actualExpressionPadding}{error.ActualExpression}
-            {error.ExpectedValueLabel}: {FormatValue(error.ExpectedValue)}
-            Actual:{actualValuePadding}<null>
-            """), error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .AppendGroup(
+                (error.ExpectedExpressionLabel, error.ExpectedExpression ?? string.Empty),
+                ("Actual expression", error.ActualExpression ?? string.Empty))
+            .AppendGroup(
+                (error.ExpectedValueLabel, FormatValue(error.ExpectedValue)),
+                ("Actual", "<null>"))
+            .ToString();
     }
 
     public virtual string Format<TKey, TValue>(KeyValuePairCollectionContainsAssertionError<TKey, TValue> error)
     {
         EnsureObservedItems(error.ActualValue, MaxFormattedItems - 1);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Contains() assertion failed.
-            Expected key expression: {error.ExpectedExpression}
-            Actual expression:       {error.ActualExpression}
-            Expected key: {FormatValue(error.ExpectedKey)}
-            Actual:       {FormatKeyValuePairs(error.ActualValue.Items)}
-            """), error.Message);
+        return CreateMessage("Assert.Contains() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected key expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected key", FormatValue(error.ExpectedKey)),
+                ("Actual", FormatKeyValuePairs(error.ActualValue.Items)))
+            .ToString();
     }
 
     public virtual string Format(DictionaryContainsAssertionError error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Contains() assertion failed.
-            Expected key expression: {error.ExpectedExpression}
-            Actual expression:       {error.ActualExpression}
-            Expected key: {FormatValue(error.ExpectedKey)}
-            Actual:       {FormatDictionary(error.ActualValue)}
-            """), error.Message);
+        return CreateMessage("Assert.Contains() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected key expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected key", FormatValue(error.ExpectedKey)),
+                ("Actual", FormatDictionary(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format<T>(ReadOnlySpanContainsAssertionError<T> error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Contains() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Expected: {FormatReadOnlySpanValue(error.ExpectedValue)}
-            Actual:   {FormatReadOnlySpanValue(error.ActualValue)}
-            """), error.Message);
+        return CreateMessage("Assert.Contains() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected", FormatReadOnlySpanValue(error.ExpectedValue)),
+                ("Actual", FormatReadOnlySpanValue(error.ActualValue)))
+            .ToString();
     }
 
     public virtual string Format(ReadOnlySpanCharContainsAssertionError error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Contains() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Comparison: {error.Comparison}
-            Expected: {FormatStringValue(error.ExpectedValue, highlightedIndex: null)}
-            Actual:   {FormatStringValue(error.ActualValue, highlightedIndex: null)}
-            """), error.Message);
+        return CreateMessage("Assert.Contains() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Comparison", error.Comparison.ToString())
+            .AppendGroup(
+                ("Expected", FormatStringValue(error.ExpectedValue, highlightedIndex: null)),
+                ("Actual", FormatStringValue(error.ActualValue, highlightedIndex: null)))
+            .ToString();
     }
 
     public virtual string Format(StringContainsNullActualAssertionError error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Contains() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Comparison: {error.Comparison}
-            Expected: {FormatValue(error.ExpectedValue)}
-            Actual:   <null>
-            """), error.Message);
+        return CreateMessage("Assert.Contains() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Comparison", error.Comparison.ToString())
+            .AppendGroup(
+                ("Expected", FormatValue(error.ExpectedValue)),
+                ("Actual", "<null>"))
+            .ToString();
     }
 
     public virtual string Format(StringNullActualAssertionError error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.{error.AssertionName}() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Comparison: {error.Comparison}
-            {error.ExpectedValueLabel}: {FormatValue(error.ExpectedValue)}
-            Actual:          <null>
-            """), error.Message);
+        return CreateMessage($"Assert.{error.AssertionName}() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Comparison", error.Comparison.ToString())
+            .AppendGroup(
+                (error.ExpectedValueLabel, FormatValue(error.ExpectedValue)),
+                ("Actual", "<null>"))
+            .ToString();
     }
 
     public virtual async Task<string> FormatAsync<TExpected, TActual>(CollectionAsyncCollectionContainsAssertionError<TExpected, TActual> error)
     {
         await EnsureObservedItemsAsync(error.ActualValue, MaxFormattedItems - 1).ConfigureAwait(false);
 
-        return string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Contains() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Expected: {FormatValue(error.ExpectedValue.Items)}
-            Actual:   {FormatValue(error.ActualValue.Items)}
-            """);
+        return CreateMessage("Assert.Contains() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected", FormatValue(error.ExpectedValue.Items)),
+                ("Actual", FormatValue(error.ActualValue.Items)))
+            .ToString();
     }
 
     public virtual string Format<TExpected, TActual>(CollectionContainsAssertionError<TExpected, TActual> error)
     {
         EnsureObservedItems(error.ActualValue, MaxFormattedItems - 1);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Contains() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Expected: {FormatValue(error.ExpectedValue.Items)}
-            Actual:   {FormatValue(error.ActualValue.Items)}
-            """), error.Message);
+        return CreateMessage("Assert.Contains() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected", FormatValue(error.ExpectedValue.Items)),
+                ("Actual", FormatValue(error.ActualValue.Items)))
+            .ToString();
     }
 
     public virtual string Format<T>(ValueEndsWithAssertionError<T> error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.EndsWith() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Expected suffix: {FormatValue(error.ExpectedValue)}
-            Actual:          {FormatReadOnlySpanValue(error.ActualValue, error.ActualValue.IsEmpty ? null : error.ActualValue.Length - 1)}
-            """), error.Message);
+        return CreateMessage("Assert.EndsWith() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected suffix", FormatValue(error.ExpectedValue)),
+                ("Actual", FormatReadOnlySpanValue(error.ActualValue, error.ActualValue.IsEmpty ? null : error.ActualValue.Length - 1)))
+            .ToString();
     }
 
     public virtual string Format<T>(ValueCollectionEndsWithAssertionError<T> error)
     {
         var highlightedIndex = error.ActualValue.Items.Count > 0 ? error.ActualValue.Items.Count - 1 : (int?)null;
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.EndsWith() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Expected suffix: {FormatValue(error.ExpectedValue)}
-            Actual:          {FormatValue(error.ActualValue.Items, highlightedIndex)}
-            """), error.Message);
+        return CreateMessage("Assert.EndsWith() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .AppendGroup(
+                ("Expected suffix", FormatValue(error.ExpectedValue)),
+                ("Actual", FormatValue(error.ActualValue.Items, highlightedIndex)))
+            .ToString();
     }
 
     public virtual string Format<T>(ReadOnlySpanEndsWithAssertionError<T> error)
     {
         var actualIndex = GetActualSuffixIndex(error.ExpectedValue.Length, error.ActualValue.Length, error.FirstDifferenceIndex);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.EndsWith() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Index of first difference: {error.FirstDifferenceIndex}
-            Expected suffix: {FormatReadOnlySpanValue(error.ExpectedValue, error.FirstDifferenceIndex < error.ExpectedValue.Length ? error.FirstDifferenceIndex : null)}
-            Actual:          {FormatReadOnlySpanValue(error.ActualValue, actualIndex)}
-            """), error.Message);
+        return CreateMessage("Assert.EndsWith() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Index of first difference", error.FirstDifferenceIndex.ToString(CultureInfo.InvariantCulture))
+            .AppendGroup(
+                ("Expected suffix", FormatReadOnlySpanValue(error.ExpectedValue, error.FirstDifferenceIndex < error.ExpectedValue.Length ? error.FirstDifferenceIndex : null)),
+                ("Actual", FormatReadOnlySpanValue(error.ActualValue, actualIndex)))
+            .ToString();
     }
 
     public virtual string Format(ReadOnlySpanCharEndsWithAssertionError error)
     {
         var actualIndex = GetActualSuffixIndex(error.ExpectedValue.Length, error.ActualValue.Length, error.FirstDifferenceIndex);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.EndsWith() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Comparison: {error.Comparison}
-            Index of first difference: {error.FirstDifferenceIndex}
-            Expected suffix: {FormatStringValue(error.ExpectedValue, error.FirstDifferenceIndex < error.ExpectedValue.Length ? error.FirstDifferenceIndex : null)}
-            Actual:          {FormatStringValue(error.ActualValue, actualIndex)}
-            """), error.Message);
+        return CreateMessage("Assert.EndsWith() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Comparison", error.Comparison.ToString())
+            .Append("Index of first difference", error.FirstDifferenceIndex.ToString(CultureInfo.InvariantCulture))
+            .AppendGroup(
+                ("Expected suffix", FormatStringValue(error.ExpectedValue, error.FirstDifferenceIndex < error.ExpectedValue.Length ? error.FirstDifferenceIndex : null)),
+                ("Actual", FormatStringValue(error.ActualValue, actualIndex)))
+            .ToString();
     }
 
     public virtual async Task<string> FormatAsync<TExpected, TActual>(CollectionAsyncCollectionEndsWithAssertionError<TExpected, TActual> error)
@@ -1115,53 +995,57 @@ internal class AssertionFormatter
         await EnsureObservedItemsAsync(error.ActualValue, int.MaxValue - 1).ConfigureAwait(false);
         var actualIndex = GetActualSuffixIndex(error.ExpectedValue.Items.Count, error.ActualValue.Items.Count, error.FirstDifferenceIndex);
 
-        return string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.EndsWith() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Index of first difference: {error.FirstDifferenceIndex}
-            Expected suffix: {FormatValue(error.ExpectedValue.Items, error.FirstDifferenceIndex < error.ExpectedValue.Items.Count ? error.FirstDifferenceIndex : null)}
-            Actual:          {FormatValue(error.ActualValue.Items, actualIndex)}
-            """);
+        return CreateMessage("Assert.EndsWith() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Index of first difference", error.FirstDifferenceIndex.ToString(CultureInfo.InvariantCulture))
+            .AppendGroup(
+                ("Expected suffix", FormatValue(error.ExpectedValue.Items, error.FirstDifferenceIndex < error.ExpectedValue.Items.Count ? error.FirstDifferenceIndex : null)),
+                ("Actual", FormatValue(error.ActualValue.Items, actualIndex)))
+            .ToString();
     }
 
     public virtual string Format<TExpected, TActual>(CollectionEndsWithAssertionError<TExpected, TActual> error)
     {
         var actualIndex = GetActualSuffixIndex(error.ExpectedValue.Items.Count, error.ActualValue.Items.Count, error.FirstDifferenceIndex);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.EndsWith() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Index of first difference: {error.FirstDifferenceIndex}
-            Expected suffix: {FormatValue(error.ExpectedValue.Items, error.FirstDifferenceIndex < error.ExpectedValue.Items.Count ? error.FirstDifferenceIndex : null)}
-            Actual:          {FormatValue(error.ActualValue.Items, actualIndex)}
-            """), error.Message);
+        return CreateMessage("Assert.EndsWith() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Index of first difference", error.FirstDifferenceIndex.ToString(CultureInfo.InvariantCulture))
+            .AppendGroup(
+                ("Expected suffix", FormatValue(error.ExpectedValue.Items, error.FirstDifferenceIndex < error.ExpectedValue.Items.Count ? error.FirstDifferenceIndex : null)),
+                ("Actual", FormatValue(error.ActualValue.Items, actualIndex)))
+            .ToString();
     }
 
     public virtual string Format<T>(ReadOnlySpanStartsWithAssertionError<T> error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.StartsWith() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Index of first difference: {error.FirstDifferenceIndex}
-            Expected prefix: {FormatReadOnlySpanValue(error.ExpectedValue, error.FirstDifferenceIndex)}
-            Actual:          {FormatReadOnlySpanValue(error.ActualValue, error.FirstDifferenceIndex < error.ActualValue.Length ? error.FirstDifferenceIndex : null)}
-            """), error.Message);
+        return CreateMessage("Assert.StartsWith() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Index of first difference", error.FirstDifferenceIndex.ToString(CultureInfo.InvariantCulture))
+            .AppendGroup(
+                ("Expected prefix", FormatReadOnlySpanValue(error.ExpectedValue, error.FirstDifferenceIndex)),
+                ("Actual", FormatReadOnlySpanValue(error.ActualValue, error.FirstDifferenceIndex < error.ActualValue.Length ? error.FirstDifferenceIndex : null)))
+            .ToString();
     }
 
     public virtual string Format(ReadOnlySpanCharStartsWithAssertionError error)
     {
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.StartsWith() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Comparison: {error.Comparison}
-            Index of first difference: {error.FirstDifferenceIndex}
-            Expected prefix: {FormatStringValue(error.ExpectedValue, error.FirstDifferenceIndex)}
-            Actual:          {FormatStringValue(error.ActualValue, error.FirstDifferenceIndex < error.ActualValue.Length ? error.FirstDifferenceIndex : null)}
-            """), error.Message);
+        return CreateMessage("Assert.StartsWith() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Comparison", error.Comparison.ToString())
+            .Append("Index of first difference", error.FirstDifferenceIndex.ToString(CultureInfo.InvariantCulture))
+            .AppendGroup(
+                ("Expected prefix", FormatStringValue(error.ExpectedValue, error.FirstDifferenceIndex)),
+                ("Actual", FormatStringValue(error.ActualValue, error.FirstDifferenceIndex < error.ActualValue.Length ? error.FirstDifferenceIndex : null)))
+            .ToString();
     }
 
     public virtual async Task<string> FormatAsync<T>(AsyncCollectionStartsWithAssertionError<T> error)
@@ -1170,14 +1054,15 @@ internal class AssertionFormatter
         await EnsureObservedItemsAsync(error.ExpectedValue, maxIndex).ConfigureAwait(false);
         await EnsureObservedItemsAsync(error.ActualValue, maxIndex).ConfigureAwait(false);
 
-        return string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.StartsWith() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Index of first difference: {error.FirstDifferenceIndex}
-            Expected prefix: {FormatValue(error.ExpectedValue.Items, error.FirstDifferenceIndex)}
-            Actual:          {FormatValue(error.ActualValue.Items, error.FirstDifferenceIndex < error.ActualValue.Items.Count ? error.FirstDifferenceIndex : null)}
-            """);
+        return CreateMessage("Assert.StartsWith() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Index of first difference", error.FirstDifferenceIndex.ToString(CultureInfo.InvariantCulture))
+            .AppendGroup(
+                ("Expected prefix", FormatValue(error.ExpectedValue.Items, error.FirstDifferenceIndex)),
+                ("Actual", FormatValue(error.ActualValue.Items, error.FirstDifferenceIndex < error.ActualValue.Items.Count ? error.FirstDifferenceIndex : null)))
+            .ToString();
     }
 
     public virtual async Task<string> FormatAsync<TExpected, TActual>(CollectionAsyncCollectionStartsWithAssertionError<TExpected, TActual> error)
@@ -1186,14 +1071,15 @@ internal class AssertionFormatter
         EnsureObservedItems(error.ExpectedValue, maxIndex);
         await EnsureObservedItemsAsync(error.ActualValue, maxIndex).ConfigureAwait(false);
 
-        return string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.StartsWith() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Index of first difference: {error.FirstDifferenceIndex}
-            Expected prefix: {FormatValue(error.ExpectedValue.Items, error.FirstDifferenceIndex)}
-            Actual:          {FormatValue(error.ActualValue.Items, error.FirstDifferenceIndex < error.ActualValue.Items.Count ? error.FirstDifferenceIndex : null)}
-            """);
+        return CreateMessage("Assert.StartsWith() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Index of first difference", error.FirstDifferenceIndex.ToString(CultureInfo.InvariantCulture))
+            .AppendGroup(
+                ("Expected prefix", FormatValue(error.ExpectedValue.Items, error.FirstDifferenceIndex)),
+                ("Actual", FormatValue(error.ActualValue.Items, error.FirstDifferenceIndex < error.ActualValue.Items.Count ? error.FirstDifferenceIndex : null)))
+            .ToString();
     }
 
     public virtual string Format<TExpected, TActual>(CollectionStartsWithAssertionError<TExpected, TActual> error)
@@ -1202,62 +1088,52 @@ internal class AssertionFormatter
         EnsureObservedItems(error.ExpectedValue, maxIndex);
         EnsureObservedItems(error.ActualValue, maxIndex);
 
-        return AppendMessage(string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.StartsWith() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Index of first difference: {error.FirstDifferenceIndex}
-            Expected prefix: {FormatValue(error.ExpectedValue.Items, error.FirstDifferenceIndex)}
-            Actual:          {FormatValue(error.ActualValue.Items, error.FirstDifferenceIndex < error.ActualValue.Items.Count ? error.FirstDifferenceIndex : null)}
-            """), error.Message);
+        return CreateMessage("Assert.StartsWith() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Index of first difference", error.FirstDifferenceIndex.ToString(CultureInfo.InvariantCulture))
+            .AppendGroup(
+                ("Expected prefix", FormatValue(error.ExpectedValue.Items, error.FirstDifferenceIndex)),
+                ("Actual", FormatValue(error.ActualValue.Items, error.FirstDifferenceIndex < error.ActualValue.Items.Count ? error.FirstDifferenceIndex : null)))
+            .ToString();
     }
 
     public virtual string Format<TExpected, TActual>(CollectionEqualAssertionError<TExpected, TActual> error)
     {
-        var result = string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Equal() assertion failed: Lengths differ.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Index of first difference: {error.FirstDifferenceIndex}
-            Expected: {FormatValue(error.ExpectedValue, error.FirstDifferenceIndex)}
-            Actual:   {FormatValue(error.ActualValue, error.FirstDifferenceIndex)}
-            """);
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return CreateMessage("Assert.Equal() assertion failed: Lengths differ.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Index of first difference", error.FirstDifferenceIndex.ToString(CultureInfo.InvariantCulture))
+            .AppendGroup(
+                ("Expected", FormatValue(error.ExpectedValue, error.FirstDifferenceIndex)),
+                ("Actual", FormatValue(error.ActualValue, error.FirstDifferenceIndex)))
+            .ToString();
     }
 
     public virtual string Format<TExpected, TActual>(CollectionEqualUnorderedAssertionError<TExpected, TActual> error)
     {
-        var result = $"""
-            Assert.EqualUnordered() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            """;
+        var builder = CreateMessage("Assert.EqualUnordered() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression));
 
         if (error.MissingExpectedIndex is not null)
         {
-            result += NewLine + "Missing expected item index: " + error.MissingExpectedIndex.Value.ToString(CultureInfo.InvariantCulture);
+            builder.Append("Missing expected item index", error.MissingExpectedIndex.Value.ToString(CultureInfo.InvariantCulture));
         }
 
         if (error.UnexpectedActualIndex is not null)
         {
-            result += NewLine + "Unexpected actual item index: " + error.UnexpectedActualIndex.Value.ToString(CultureInfo.InvariantCulture);
+            builder.Append("Unexpected actual item index", error.UnexpectedActualIndex.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        result += NewLine + "Expected: " + FormatValue(error.ExpectedValue.Items, error.MissingExpectedIndex);
-        result += NewLine + "Actual:   " + FormatValue(error.ActualValue.Items, error.UnexpectedActualIndex);
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return AppendMessage(result, error.Message);
+        return builder
+            .AppendGroup(
+                ("Expected", FormatValue(error.ExpectedValue.Items, error.MissingExpectedIndex)),
+                ("Actual", FormatValue(error.ActualValue.Items, error.UnexpectedActualIndex)))
+            .ToString();
     }
 
     public virtual async Task<string> FormatAsync<TExpected, TActual>(AsyncCollectionEqualAssertionError<TExpected, TActual> error)
@@ -1266,50 +1142,39 @@ internal class AssertionFormatter
         await EnsureObservedItemsAsync(error.ExpectedValue, maxIndex).ConfigureAwait(false);
         await EnsureObservedItemsAsync(error.ActualValue, maxIndex).ConfigureAwait(false);
 
-        var result = string.Create(CultureInfo.InvariantCulture, $"""
-            Assert.Equal() assertion failed: Lengths differ.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            Index of first difference: {error.FirstDifferenceIndex}
-            Expected: {FormatValue(error.ExpectedValue.Items, error.FirstDifferenceIndex)}
-            Actual:   {FormatValue(error.ActualValue.Items, error.FirstDifferenceIndex)}
-            """);
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return result;
+        return CreateMessage("Assert.Equal() assertion failed: Lengths differ.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression))
+            .Append("Index of first difference", error.FirstDifferenceIndex.ToString(CultureInfo.InvariantCulture))
+            .AppendGroup(
+                ("Expected", FormatValue(error.ExpectedValue.Items, error.FirstDifferenceIndex)),
+                ("Actual", FormatValue(error.ActualValue.Items, error.FirstDifferenceIndex)))
+            .ToString();
     }
 
     public virtual Task<string> FormatAsync<TExpected, TActual>(AsyncCollectionEqualUnorderedAssertionError<TExpected, TActual> error)
     {
-        var result = $"""
-            Assert.EqualUnordered() assertion failed.
-            Expected expression: {error.ExpectedExpression}
-            Actual expression:   {error.ActualExpression}
-            """;
+        var builder = CreateMessage("Assert.EqualUnordered() assertion failed.", error.Message)
+            .AppendGroup(
+                ("Expected expression", error.ExpectedExpression),
+                ("Actual expression", error.ActualExpression));
 
         if (error.MissingExpectedIndex is not null)
         {
-            result += NewLine + "Missing expected item index: " + error.MissingExpectedIndex.Value.ToString(CultureInfo.InvariantCulture);
+            builder.Append("Missing expected item index", error.MissingExpectedIndex.Value.ToString(CultureInfo.InvariantCulture));
         }
 
         if (error.UnexpectedActualIndex is not null)
         {
-            result += NewLine + "Unexpected actual item index: " + error.UnexpectedActualIndex.Value.ToString(CultureInfo.InvariantCulture);
+            builder.Append("Unexpected actual item index", error.UnexpectedActualIndex.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        result += NewLine + "Expected: " + FormatValue(error.ExpectedValue.Items, error.MissingExpectedIndex);
-        result += NewLine + "Actual:   " + FormatValue(error.ActualValue.Items, error.UnexpectedActualIndex);
-
-        if (!string.IsNullOrEmpty(error.Message))
-        {
-            result += NewLine + "Message: " + error.Message;
-        }
-
-        return Task.FromResult(AppendMessage(result, error.Message));
+        return Task.FromResult(builder
+            .AppendGroup(
+                ("Expected", FormatValue(error.ExpectedValue.Items, error.MissingExpectedIndex)),
+                ("Actual", FormatValue(error.ActualValue.Items, error.UnexpectedActualIndex)))
+            .ToString());
     }
 
     protected virtual string FormatValue(object? value, int? highlightedIndex = null)
@@ -1504,7 +1369,7 @@ internal class AssertionFormatter
         if (string.IsNullOrEmpty(message))
             return exception.GetType().FullName ?? exception.GetType().Name;
 
-        return message.Replace(NewLine, NewLine + "            ", StringComparison.Ordinal);
+        return message.Replace(Environment.NewLine, Environment.NewLine + "           ", StringComparison.Ordinal);
     }
 
     private static void EnsureObservedItems<T>(CollectionSnapshot<T> snapshot, int maxIndex)

--- a/src/Meziantou.Framework.Assertions/AssertionMessageBuilder.cs
+++ b/src/Meziantou.Framework.Assertions/AssertionMessageBuilder.cs
@@ -1,0 +1,56 @@
+namespace Meziantou.Framework.Assertions;
+
+internal readonly struct AssertionMessageBuilder
+{
+    private readonly StringBuilder _builder;
+
+    public AssertionMessageBuilder(string header)
+    {
+        _builder = new StringBuilder(header);
+    }
+
+    public AssertionMessageBuilder AppendUserMessage(string label, string? message)
+    {
+        if (!string.IsNullOrEmpty(message))
+        {
+            Append(label, message);
+        }
+
+        return this;
+    }
+
+    public AssertionMessageBuilder AppendGroup(params (string Label, string? Value)[] rows)
+    {
+        var maxLabelLength = 0;
+        foreach (var row in rows)
+        {
+            maxLabelLength = Math.Max(maxLabelLength, row.Label.Length);
+        }
+
+        foreach (var row in rows)
+        {
+            _builder.Append('\n');
+            _builder.Append(row.Label);
+            _builder.Append(':');
+            _builder.Append(' ', maxLabelLength - row.Label.Length + 1);
+            _builder.Append(row.Value);
+        }
+
+        return this;
+    }
+
+    public AssertionMessageBuilder Append(string label, string? value)
+    {
+        _builder.Append('\n');
+        _builder.Append(label);
+        _builder.Append(": ");
+        _builder.Append(value);
+
+        return this;
+    }
+
+    public override string ToString()
+    {
+        return _builder.ToString();
+    }
+}

--- a/src/Meziantou.Framework.Assertions/Errors/NegativeTextAssertionError.cs
+++ b/src/Meziantou.Framework.Assertions/Errors/NegativeTextAssertionError.cs
@@ -1,9 +1,0 @@
-namespace Meziantou.Framework.Assertions;
-
-internal readonly struct NegativeTextAssertionError(string assertionName, string notExpectedText, string actualText, string? message)
-{
-    public string AssertionName { get; } = assertionName;
-    public string NotExpectedText { get; } = notExpectedText;
-    public string ActualText { get; } = actualText;
-    public string? Message { get; } = message;
-}

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertAllTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertAllTests.cs
@@ -15,13 +15,13 @@ public sealed class AssertAllTests
     {
         AssertionTestHelpers.Validate(() => AssertionsAssert.All<int>([1, -2, 3], item => AssertionsAssert.True(item > 0)), """
             Assert.All() assertion failed: Item at index 1 failed.
-            Expression: [1, -2, 3]
+            Expression:           [1, -2, 3]
             Assertion expression: item => AssertionsAssert.True(item > 0)
-            Actual:     [1, -̲2̲, 3]
-            Exception:  Assert.True() assertion failed.
-                        Expression: item > 0
-                        Expected: true
-                        Actual:   false
+            Actual: [1, -̲2̲, 3]
+            Exception: Assert.True() assertion failed.
+                       Expression: item > 0
+                       Expected: true
+                       Actual:   false
             """);
     }
 
@@ -30,13 +30,13 @@ public sealed class AssertAllTests
     {
         AssertionTestHelpers.Validate(() => AssertionsAssert.All("aBc".AsSpan(), item => AssertionsAssert.True(char.IsLower(item))), """
             Assert.All() assertion failed: Item at index 1 failed.
-            Expression: "aBc".AsSpan()
+            Expression:           "aBc".AsSpan()
             Assertion expression: item => AssertionsAssert.True(char.IsLower(item))
-            Actual:     "aB̲c"
-            Exception:  Assert.True() assertion failed.
-                        Expression: char.IsLower(item)
-                        Expected: true
-                        Actual:   false
+            Actual: "aB̲c"
+            Exception: Assert.True() assertion failed.
+                       Expression: char.IsLower(item)
+                       Expected: true
+                       Actual:   false
             """);
     }
 
@@ -55,13 +55,13 @@ public sealed class AssertAllTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.All(actual, item => AssertionsAssert.True(item > 0)), """
             Assert.All() assertion failed: Item at index 1 failed.
-            Expression: actual
+            Expression:           actual
             Assertion expression: item => AssertionsAssert.True(item > 0)
-            Actual:     [1, -̲2̲, 3]
-            Exception:  Assert.True() assertion failed.
-                        Expression: item > 0
-                        Expected: true
-                        Actual:   false
+            Actual: [1, -̲2̲, 3]
+            Exception: Assert.True() assertion failed.
+                       Expression: item > 0
+                       Expected: true
+                       Actual:   false
             """);
     }
 
@@ -72,14 +72,14 @@ public sealed class AssertAllTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.All(actual, (item, index) => AssertionsAssert.Equal(index, item)), """
             Assert.All() assertion failed: Item at index 2 failed.
-            Expression: actual
+            Expression:           actual
             Assertion expression: (item, index) => AssertionsAssert.Equal(index, item)
-            Actual:     [0, 1, 3̲]
-            Exception:  Assert.Equal() assertion failed.
-                        Expected expression: index
-                        Actual expression:   item
-                        Expected: 2
-                        Actual:   3
+            Actual: [0, 1, 3̲]
+            Exception: Assert.Equal() assertion failed.
+                       Expected expression: index
+                       Actual expression:   item
+                       Expected: 2
+                       Actual:   3
             """);
     }
 
@@ -90,13 +90,13 @@ public sealed class AssertAllTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.All(actual, item => AssertionsAssert.True((int)item! > 0)), """
             Assert.All() assertion failed: Item at index 1 failed.
-            Expression: actual
+            Expression:           actual
             Assertion expression: item => AssertionsAssert.True((int)item! > 0)
-            Actual:     [1, -̲2̲, 3]
-            Exception:  Assert.True() assertion failed.
-                        Expression: (int)item! > 0
-                        Expected: true
-                        Actual:   false
+            Actual: [1, -̲2̲, 3]
+            Exception: Assert.True() assertion failed.
+                       Expression: (int)item! > 0
+                       Expected: true
+                       Actual:   false
             """);
     }
 
@@ -115,13 +115,13 @@ public sealed class AssertAllTests
 
         await AssertionTestHelpers.ValidateAsync(() => AssertionsAssert.All(actual, item => AssertionsAssert.True(item > 0)), """
             Assert.All() assertion failed: Item at index 1 failed.
-            Expression: actual
+            Expression:           actual
             Assertion expression: item => AssertionsAssert.True(item > 0)
-            Actual:     [1, -̲2̲, 3]
-            Exception:  Assert.True() assertion failed.
-                        Expression: item > 0
-                        Expected: true
-                        Actual:   false
+            Actual: [1, -̲2̲, 3]
+            Exception: Assert.True() assertion failed.
+                       Expression: item > 0
+                       Expected: true
+                       Actual:   false
             """);
     }
 
@@ -137,14 +137,14 @@ public sealed class AssertAllTests
 
         await AssertionTestHelpers.ValidateAsync(() => AssertionsAssert.All(actual, Assertion), """
             Assert.All() assertion failed: Item at index 2 failed.
-            Expression: actual
+            Expression:           actual
             Assertion expression: Assertion
-            Actual:     [0, 1, 3̲]
-            Exception:  Assert.Equal() assertion failed.
-                        Expected expression: index
-                        Actual expression:   item
-                        Expected: 2
-                        Actual:   3
+            Actual: [0, 1, 3̲]
+            Exception: Assert.Equal() assertion failed.
+                       Expected expression: index
+                       Actual expression:   item
+                       Expected: 2
+                       Actual:   3
             """);
     }
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertApiTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertApiTests.cs
@@ -34,10 +34,10 @@ public sealed class AssertApiTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.Null(actual, "custom message"), """
             Assert.Null() assertion failed.
+            Message: custom message
             Expression: actual
             Expected: <null>
             Actual:   "Hello"
-            Message: custom message
             """);
     }
 

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertCollectionTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertCollectionTests.cs
@@ -77,7 +77,7 @@ public sealed class AssertCollectionTests
             Expression: actual
             Expected count: 3
             Actual count:   2
-            Actual:         [1, 2]
+            Actual: [1, 2]
             """);
     }
 
@@ -94,7 +94,7 @@ public sealed class AssertCollectionTests
             Expression: actual
             Expected count: 2
             Actual count:   3
-            Actual:         [1, 2, 3]
+            Actual: [1, 2, 3]
             """);
     }
 
@@ -110,12 +110,12 @@ public sealed class AssertCollectionTests
             item => AssertionsAssert.Equal(3, item)), """
             Assert.Collection() assertion failed: Item at index 1 failed.
             Expression: actual
-            Actual:     [1, 2̲, 3]
-            Exception:  Assert.Equal() assertion failed.
-                        Expected expression: 42
-                        Actual expression:   item
-                        Expected: 42
-                        Actual:   2
+            Actual: [1, 2̲, 3]
+            Exception: Assert.Equal() assertion failed.
+                       Expected expression: 42
+                       Actual expression:   item
+                       Expected: 42
+                       Actual:   2
             """);
     }
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertContainsTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertContainsTests.cs
@@ -82,9 +82,9 @@ public sealed class AssertContainsTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.Contains(collection, item => item == "sample"), """
             Assert.Contains() assertion failed.
-            Expression: collection
+            Expression:           collection
             Predicate expression: item => item == "sample"
-            Matching items:       []
+            Matching items: []
             """);
     }
 
@@ -95,7 +95,7 @@ public sealed class AssertContainsTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.Contains(collection, item => item == "sample"), """
             Assert.Contains() assertion failed.
-            Expression: collection
+            Expression:           collection
             Predicate expression: item => item == "sample"
             Actual: <null>
             """);
@@ -480,7 +480,7 @@ public sealed class AssertContainsTests
             Expected expression: expected
             Actual expression:   actual
             Not expected item: 2
-            Actual:              [1, 2, 3]
+            Actual:            [1, 2, 3]
             """);
     }
 
@@ -495,7 +495,7 @@ public sealed class AssertContainsTests
             Expected expression: expected
             Actual expression:   actual
             Not expected: [2, 3]
-            Actual:              [1, 2, 3, 4]
+            Actual:       [1, 2, 3, 4]
             """);
     }
 
@@ -514,9 +514,9 @@ public sealed class AssertContainsTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.DoesNotContain(collection, item => item == "sample"), """
             Assert.DoesNotContain() assertion failed.
-            Expression: collection
+            Expression:           collection
             Predicate expression: item => item == "sample"
-            Not expected: any matching item
+            Not expected:   any matching item
             Matching items: ["sample", "sample"]
             """);
     }
@@ -531,7 +531,7 @@ public sealed class AssertContainsTests
             Expected expression: "a"
             Actual expression:   actual
             Not expected key: "a"
-            Actual:              [[a, 1]]
+            Actual:           [[a, 1]]
             """);
     }
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertCountTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertCountTests.cs
@@ -22,7 +22,7 @@ public sealed class AssertCountTests
             Expression: actual
             Expected count: 2
             Actual count:   3
-            Actual:         [1, 2, 3]
+            Actual: [1, 2, 3]
             """);
     }
 
@@ -36,7 +36,7 @@ public sealed class AssertCountTests
             Expression: actual
             Expected count: 2
             Actual count:   3
-            Actual:         "abc"
+            Actual: "abc"
             """);
     }
 
@@ -50,7 +50,7 @@ public sealed class AssertCountTests
             Expression: actual
             Expected count: 2
             Actual count:   3
-            Actual:         [1, 2, 3]
+            Actual: [1, 2, 3]
             """);
     }
 
@@ -64,7 +64,7 @@ public sealed class AssertCountTests
             Expression: actual
             Expected count: 2
             Actual count:   3
-            Actual:         [1, 2, 3]
+            Actual: [1, 2, 3]
             """);
     }
 
@@ -84,7 +84,7 @@ public sealed class AssertCountTests
             Expression: [1, 2, 3]
             Expected count: > 3
             Actual count:   3
-            Actual:         [1, 2, 3]
+            Actual: [1, 2, 3]
             """);
     }
 
@@ -98,7 +98,7 @@ public sealed class AssertCountTests
             Expression: actual
             Expected count: > 3
             Actual count:   3
-            Actual:         [1, 2, 3]
+            Actual: [1, 2, 3]
             """);
     }
 
@@ -120,7 +120,7 @@ public sealed class AssertCountTests
             Expression: actual
             Expected count: >= 4
             Actual count:   3
-            Actual:         [1, 2, 3]
+            Actual: [1, 2, 3]
             """);
     }
 
@@ -142,7 +142,7 @@ public sealed class AssertCountTests
             Expression: actual
             Expected count: < 3
             Actual count:   3
-            Actual:         [1, 2, 3]
+            Actual: [1, 2, 3]
             """);
     }
 
@@ -164,7 +164,7 @@ public sealed class AssertCountTests
             Expression: actual
             Expected count: <= 2
             Actual count:   3
-            Actual:         [1, 2, 3]
+            Actual: [1, 2, 3]
             """);
     }
 
@@ -185,7 +185,7 @@ public sealed class AssertCountTests
             Expression: actual
             Not expected count: 3
             Actual count:       3
-            Actual:             [1, 2, 3]
+            Actual: [1, 2, 3]
             """);
     }
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertDistinctTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertDistinctTests.cs
@@ -18,7 +18,7 @@ public sealed class AssertDistinctTests
             Expression: [1, 2, 1]
             First index:     0
             Duplicate index: 2
-            Actual:          [1, 2, 1̲]
+            Actual: [1, 2, 1̲]
             """);
     }
 
@@ -30,7 +30,7 @@ public sealed class AssertDistinctTests
             Expression: ["a", "A"]
             First index:     0
             Duplicate index: 1
-            Actual:          ["a", "̲A̲"̲]
+            Actual: ["a", "̲A̲"̲]
             """);
     }
 
@@ -42,7 +42,7 @@ public sealed class AssertDistinctTests
             Expression: "aba".AsSpan()
             First index:     0
             Duplicate index: 2
-            Actual:          "aba̲"
+            Actual: "aba̲"
             """);
     }
 
@@ -56,7 +56,7 @@ public sealed class AssertDistinctTests
             Expression: actual
             First index:     0
             Duplicate index: 2
-            Actual:          "aba̲"
+            Actual: "aba̲"
             """);
     }
 
@@ -78,7 +78,7 @@ public sealed class AssertDistinctTests
             Expression: actual
             First index:     0
             Duplicate index: 2
-            Actual:          [1, 2, 1̲]
+            Actual: [1, 2, 1̲]
             """);
     }
 
@@ -92,7 +92,7 @@ public sealed class AssertDistinctTests
             Expression: actual
             First index:     0
             Duplicate index: 1
-            Actual:          ["a", "̲A̲"̲]
+            Actual: ["a", "̲A̲"̲]
             """);
     }
 
@@ -106,7 +106,7 @@ public sealed class AssertDistinctTests
             Expression: actual
             First index:     1
             Duplicate index: 2
-            Actual:          ["a", <null>, <̲n̲u̲l̲l̲>̲]
+            Actual: ["a", <null>, <̲n̲u̲l̲l̲>̲]
             """);
     }
 
@@ -120,7 +120,7 @@ public sealed class AssertDistinctTests
             Expression: actual
             First index:     0
             Duplicate index: 2
-            Actual:          [1, 2, 1̲]
+            Actual: [1, 2, 1̲]
             """);
     }
 
@@ -142,7 +142,7 @@ public sealed class AssertDistinctTests
             Expression: actual
             First index:     0
             Duplicate index: 2
-            Actual:          [1, 2, 1̲]
+            Actual: [1, 2, 1̲]
             """);
     }
 

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEmptyTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEmptyTests.cs
@@ -16,7 +16,7 @@ public sealed class AssertEmptyTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.Empty<int>([1, 2, 3]), """
             Assert.Empty() assertion failed.
             Expression: [1, 2, 3]
-            Actual:     [1̲, 2, 3]
+            Actual: [1̲, 2, 3]
             """);
     }
 
@@ -32,7 +32,7 @@ public sealed class AssertEmptyTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.Empty("Hello".AsSpan()), """
             Assert.Empty() assertion failed.
             Expression: "Hello".AsSpan()
-            Actual:     "H̲ello"
+            Actual: "H̲ello"
             """);
     }
 
@@ -50,7 +50,7 @@ public sealed class AssertEmptyTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.Empty(actual), """
             Assert.Empty() assertion failed.
             Expression: actual
-            Actual:     "H̲ello"
+            Actual: "H̲ello"
             """);
     }
 
@@ -68,7 +68,7 @@ public sealed class AssertEmptyTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.Empty(actual), """
             Assert.Empty() assertion failed.
             Expression: actual
-            Actual:     [1̲, 2, 3]
+            Actual: [1̲, 2, 3]
             """);
     }
 
@@ -88,7 +88,7 @@ public sealed class AssertEmptyTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.Empty(actual), """
             Assert.Empty() assertion failed.
             Expression: actual
-            Actual:     [1̲, 2, 3]
+            Actual: [1̲, 2, 3]
             """);
     }
 
@@ -108,7 +108,7 @@ public sealed class AssertEmptyTests
         await AssertionTestHelpers.ValidateAsync(() => AssertionsAssert.Empty(actual), """
             Assert.Empty() assertion failed.
             Expression: actual
-            Actual:     [1̲, 2, 3]
+            Actual: [1̲, 2, 3]
             """);
     }
 

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEqualByStructureTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEqualByStructureTests.cs
@@ -239,13 +239,13 @@ public sealed class AssertEqualByStructureTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.Equivalent(expected, actual, "custom message"), """
             Assert.Equivalent() assertion failed.
+            Message: custom message
             Expected expression: expected
             Actual expression:   actual
             Path: $.Address.ZipCode
             Reason: Values differ.
             Expected: 75000
             Actual:   69000
-            Message: custom message
             """);
     }
 
@@ -371,7 +371,7 @@ public sealed class AssertEqualByStructureTests
             Expected expression: expected
             Actual expression:   actual
             Not expected: Meziantou.Framework.Assertions.Tests.AssertEqualByStructureTests+ExpectedPerson
-            Actual:              Meziantou.Framework.Assertions.Tests.AssertEqualByStructureTests+ActualPerson
+            Actual:       Meziantou.Framework.Assertions.Tests.AssertEqualByStructureTests+ActualPerson
             """);
     }
 
@@ -386,7 +386,7 @@ public sealed class AssertEqualByStructureTests
             Expected expression: expected
             Actual expression:   actual
             Not expected: Meziantou.Framework.Assertions.Tests.AssertEqualByStructureTests+PersonWithScores
-            Actual:              Meziantou.Framework.Assertions.Tests.AssertEqualByStructureTests+PersonWithScores
+            Actual:       Meziantou.Framework.Assertions.Tests.AssertEqualByStructureTests+PersonWithScores
             """);
     }
 

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
@@ -165,12 +165,12 @@ public sealed class AssertEqualTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.Equal(expected, actual, tolerance, "custom message"), """
             Assert.Equal() assertion failed.
+            Message: custom message
             Expected expression: expected
             Actual expression:   actual
             Expected: 1
             Actual:   1.3
             Tolerance: 0.2
-            Message: custom message
             """);
     }
 
@@ -480,12 +480,12 @@ public sealed class AssertEqualTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.Equal(expected, actual, StringComparer.OrdinalIgnoreCase, "custom message"), """
             Assert.Equal() assertion failed: Lengths differ.
+            Message: custom message
             Expected expression: expected
             Actual expression:   actual
             Index of first difference: 1
             Expected: ["a", "̲b̲"̲]
             Actual:   ["A", "̲c̲"̲]
-            Message: custom message
             """);
     }
 
@@ -662,7 +662,7 @@ public sealed class AssertEqualTests
             Expected expression: expected
             Actual expression:   actual
             Not expected: <null>
-            Actual:              <null>
+            Actual:       <null>
             """);
     }
 
@@ -677,7 +677,7 @@ public sealed class AssertEqualTests
             Expected expression: expected
             Actual expression:   actual
             Not expected: 42
-            Actual:              42
+            Actual:       42
             """);
     }
 
@@ -692,7 +692,7 @@ public sealed class AssertEqualTests
             Expected expression: expected
             Actual expression:   actual
             Not expected: [1, 2]
-            Actual:              [1, 2]
+            Actual:       [1, 2]
             """);
     }
 
@@ -705,12 +705,12 @@ public sealed class AssertEqualTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.NotEqual(expected, actual, tolerance, "custom message"), """
             Assert.NotEqual() assertion failed.
+            Message: custom message
             Expected expression: expected
             Actual expression:   actual
             Not expected: 1
             Actual:       1.1
-            Tolerance:    0.2
-            Message: custom message
+            Tolerance: 0.2
             """);
     }
 

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEqualUnorderedTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEqualUnorderedTests.cs
@@ -112,13 +112,13 @@ public sealed class AssertEqualUnorderedTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.EqualUnordered(expected, actual, StringComparer.OrdinalIgnoreCase, "custom message"), """
             Assert.EqualUnordered() assertion failed.
+            Message: custom message
             Expected expression: expected
             Actual expression:   actual
             Missing expected item index: 0
             Unexpected actual item index: 1
             Expected: ["̲a̲"̲, "b"]
             Actual:   ["B", "̲c̲"̲]
-            Message: custom message
             """);
     }
 
@@ -230,7 +230,7 @@ public sealed class AssertEqualUnorderedTests
             Expected expression: expected
             Actual expression:   actual
             Not expected: [1, 2]
-            Actual:              [2, 1]
+            Actual:       [2, 1]
             """);
     }
 
@@ -245,7 +245,7 @@ public sealed class AssertEqualUnorderedTests
             Expected expression: expected
             Actual expression:   actual
             Not expected: [1, 2]
-            Actual:              [2, 1]
+            Actual:       [2, 1]
             """);
     }
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertFalseTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertFalseTests.cs
@@ -23,13 +23,12 @@ public sealed class AssertFalseTests
             Expected: false
             Actual:   true
             """);
-
         AssertionTestHelpers.Validate(() => AssertionsAssert.False(true, "custom message"), """
             Assert.False() assertion failed.
+            Message: custom message
             Expression: true
             Expected: false
             Actual:   true
-            Message: custom message
             """);
 
         bool? nullableTrue = true;

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertInRangeTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertInRangeTests.cs
@@ -28,8 +28,8 @@ public sealed class AssertInRangeTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.InRange(actual, low, high), """
             Assert.InRange() assertion failed.
             Expression: actual
-            Expected:   in range [1, 3]
-            Actual:     0
+            Expected: in range [1, 3]
+            Actual:   0
             """);
     }
 
@@ -43,8 +43,8 @@ public sealed class AssertInRangeTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.InRange(actual, low, high), """
             Assert.InRange() assertion failed.
             Expression: actual
-            Expected:   in range [1, 3]
-            Actual:     4
+            Expected: in range [1, 3]
+            Actual:   4
             """);
     }
 
@@ -58,8 +58,8 @@ public sealed class AssertInRangeTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.InRange(actual, low, high, StringComparer.OrdinalIgnoreCase), """
             Assert.InRange() assertion failed.
             Expression: actual
-            Expected:   in range ["A", "C"]
-            Actual:     "d"
+            Expected: in range ["A", "C"]
+            Actual:   "d"
             """);
     }
 

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertIsAssignableToTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertIsAssignableToTests.cs
@@ -31,10 +31,10 @@ public sealed class AssertIsAssignableToTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.IsAssignableTo<int>(actual), """
             Assert.IsAssignableTo() assertion failed.
-            Expression:    actual
+            Expression: actual
             Expected type: System.Int32
             Actual type:   System.String
-            Actual value:  "Hello"
+            Actual value: "Hello"
             """);
     }
 
@@ -45,10 +45,10 @@ public sealed class AssertIsAssignableToTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.IsAssignableTo<string>(actual), """
             Assert.IsAssignableTo() assertion failed.
-            Expression:    actual
+            Expression: actual
             Expected type: System.String
             Actual type:   <null>
-            Actual value:  <null>
+            Actual value: <null>
             """);
     }
 
@@ -67,10 +67,10 @@ public sealed class AssertIsAssignableToTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.IsNotAssignableTo<object>(actual), """
             Assert.IsNotAssignableTo() assertion failed.
-            Expression:          actual
+            Expression: actual
             Not expected assignable type: System.Object
-            Actual type:         System.String
-            Actual value:        "Hello"
+            Actual type:                  System.String
+            Actual value: "Hello"
             """);
     }
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertIsTypeTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertIsTypeTests.cs
@@ -31,10 +31,10 @@ public sealed class AssertIsTypeTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.IsType<object>(actual), """
             Assert.IsType() assertion failed.
-            Expression:    actual
+            Expression: actual
             Expected type: System.Object
             Actual type:   System.String
-            Actual value:  "Hello"
+            Actual value: "Hello"
             """);
     }
 
@@ -45,10 +45,10 @@ public sealed class AssertIsTypeTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.IsType<string>(actual), """
             Assert.IsType() assertion failed.
-            Expression:    actual
+            Expression: actual
             Expected type: System.String
             Actual type:   <null>
-            Actual value:  <null>
+            Actual value: <null>
             """);
     }
 
@@ -67,10 +67,10 @@ public sealed class AssertIsTypeTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.IsNotType<string>(actual), """
             Assert.IsNotType() assertion failed.
-            Expression:          actual
+            Expression: actual
             Not expected type: System.String
-            Actual type:         System.String
-            Actual value:        "Hello"
+            Actual type:       System.String
+            Actual value: "Hello"
             """);
     }
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertMatchTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertMatchTests.cs
@@ -75,7 +75,7 @@ public sealed class AssertMatchTests
             Expected expression: regex
             Actual expression:   actual
             Not expected pattern: "^sam"
-            Actual:              "sample"
+            Actual:               "sample"
             """);
     }
 
@@ -99,7 +99,7 @@ public sealed class AssertMatchTests
             Expected expression: pattern
             Actual expression:   actual
             Not expected pattern: "^sam"
-            Actual:              "sample"
+            Actual:               "sample"
             """);
     }
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertRaiseTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertRaiseTests.cs
@@ -49,7 +49,7 @@ public sealed class AssertRaiseTests
             handler => source.Raised -= handler,
             () => { }), """
             Assert.Raise() assertion failed.
-            Expression:               () => { }
+            Expression: () => { }
             Expected event args type: Meziantou.Framework.Assertions.Tests.AssertRaiseTests+CustomEventArgs
             Actual event args type:   <null>
             """);
@@ -66,7 +66,7 @@ public sealed class AssertRaiseTests
             handler => source.Raised -= handler,
             () => source.Raise(source, arguments)), """
             Assert.Raise() assertion failed.
-            Expression:               () => source.Raise(source, arguments)
+            Expression: () => source.Raise(source, arguments)
             Expected event args type: Meziantou.Framework.Assertions.Tests.AssertRaiseTests+BaseEventArgs
             Actual event args type:   Meziantou.Framework.Assertions.Tests.AssertRaiseTests+DerivedEventArgs
             """);
@@ -112,7 +112,7 @@ public sealed class AssertRaiseTests
             handler => source.Raised -= handler,
             () => { }), """
             Assert.RaiseAny() assertion failed.
-            Expression:               () => { }
+            Expression: () => { }
             Expected event args type: Meziantou.Framework.Assertions.Tests.AssertRaiseTests+CustomEventArgs
             Actual event args type:   <null>
             """);

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertSingleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertSingleTests.cs
@@ -18,7 +18,7 @@ public sealed class AssertSingleTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.Single<int>([]), """
             Assert.Single() assertion failed.
             Expression: []
-            Actual:     []
+            Actual: []
             """);
     }
 
@@ -28,7 +28,7 @@ public sealed class AssertSingleTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.Single<int>([1, 2, 3]), """
             Assert.Single() assertion failed.
             Expression: [1, 2, 3]
-            Actual:     [1, 2̲, 3]
+            Actual: [1, 2̲, 3]
             """);
     }
 
@@ -46,7 +46,7 @@ public sealed class AssertSingleTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.Single("ab".AsSpan()), """
             Assert.Single() assertion failed.
             Expression: "ab".AsSpan()
-            Actual:     "ab̲"
+            Actual: "ab̲"
             """);
     }
 
@@ -66,7 +66,7 @@ public sealed class AssertSingleTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.Single(actual), """
             Assert.Single() assertion failed.
             Expression: actual
-            Actual:     "ab̲"
+            Actual: "ab̲"
             """);
     }
 
@@ -86,7 +86,7 @@ public sealed class AssertSingleTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.Single(actual), """
             Assert.Single() assertion failed.
             Expression: actual
-            Actual:     []
+            Actual: []
             """);
     }
 
@@ -98,7 +98,7 @@ public sealed class AssertSingleTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.Single(actual), """
             Assert.Single() assertion failed.
             Expression: actual
-            Actual:     [1, 2̲, 3]
+            Actual: [1, 2̲, 3]
             """);
     }
 
@@ -119,9 +119,9 @@ public sealed class AssertSingleTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.Single(actual, item => item > 3), """
             Assert.Single() assertion failed.
-            Expression: actual
+            Expression:           actual
             Predicate expression: item => item > 3
-            Matching items:       []
+            Matching items: []
             """);
     }
 
@@ -132,9 +132,9 @@ public sealed class AssertSingleTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.Single(actual, item => item > 1), """
             Assert.Single() assertion failed.
-            Expression: actual
+            Expression:           actual
             Predicate expression: item => item > 1
-            Matching items:       [2, 3̲]
+            Matching items: [2, 3̲]
             """);
     }
 
@@ -156,7 +156,7 @@ public sealed class AssertSingleTests
         AssertionTestHelpers.Validate(() => AssertionsAssert.Single(actual), """
             Assert.Single() assertion failed.
             Expression: actual
-            Actual:     [1, 2̲, 3]
+            Actual: [1, 2̲, 3]
             """);
     }
 
@@ -178,7 +178,7 @@ public sealed class AssertSingleTests
         await AssertionTestHelpers.ValidateAsync(() => AssertionsAssert.Single(actual), """
             Assert.Single() assertion failed.
             Expression: actual
-            Actual:     [1, 2̲, 3]
+            Actual: [1, 2̲, 3]
             """);
     }
 

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertThrowsTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertThrowsTests.cs
@@ -42,10 +42,10 @@ public sealed class AssertThrowsTests
     {
         AssertionTestHelpers.Validate(() => AssertionsAssert.Throws<InvalidOperationException>(() => { }), """
             Assert.Throws() assertion failed.
-            Expression:              () => { }
+            Expression: () => { }
             Expected exception type: System.InvalidOperationException
             Actual exception type:   <null>
-            Exception:               <none>
+            Exception: <none>
             """);
     }
 
@@ -56,10 +56,10 @@ public sealed class AssertThrowsTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.Throws<Exception>(action), """
             Assert.Throws() assertion failed.
-            Expression:              action
+            Expression: action
             Expected exception type: System.Exception
             Actual exception type:   System.InvalidOperationException
-            Exception:               Failure
+            Exception: Failure
             """);
     }
 
@@ -101,10 +101,10 @@ public sealed class AssertThrowsTests
     {
         AssertionTestHelpers.Validate(() => AssertionsAssert.ThrowsAny<InvalidOperationException>(() => { }), """
             Assert.ThrowsAny() assertion failed.
-            Expression:              () => { }
+            Expression: () => { }
             Expected exception type: System.InvalidOperationException
             Actual exception type:   <null>
-            Exception:               <none>
+            Exception: <none>
             """);
     }
 
@@ -115,10 +115,10 @@ public sealed class AssertThrowsTests
 
         AssertionTestHelpers.Validate(() => AssertionsAssert.ThrowsAny<ArgumentException>(action), """
             Assert.ThrowsAny() assertion failed.
-            Expression:              action
+            Expression: action
             Expected exception type: System.ArgumentException
             Actual exception type:   System.InvalidOperationException
-            Exception:               Failure
+            Exception: Failure
             """);
     }
 
@@ -158,10 +158,10 @@ public sealed class AssertThrowsTests
     {
         await AssertionTestHelpers.ValidateAsync(() => AssertionsAssert.ThrowsAsync<InvalidOperationException>(() => Task.CompletedTask), """
             Assert.Throws() assertion failed.
-            Expression:              () => Task.CompletedTask
+            Expression: () => Task.CompletedTask
             Expected exception type: System.InvalidOperationException
             Actual exception type:   <null>
-            Exception:               <none>
+            Exception: <none>
             """);
     }
 
@@ -201,10 +201,10 @@ public sealed class AssertThrowsTests
     {
         await AssertionTestHelpers.ValidateAsync(() => AssertionsAssert.ThrowsAnyAsync<ArgumentException>(() => ThrowAsync(new InvalidOperationException("Failure"))), """
             Assert.ThrowsAny() assertion failed.
-            Expression:              () => ThrowAsync(new InvalidOperationException("Failure"))
+            Expression: () => ThrowAsync(new InvalidOperationException("Failure"))
             Expected exception type: System.ArgumentException
             Actual exception type:   System.InvalidOperationException
-            Exception:               Failure
+            Exception: Failure
             """);
     }
 

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertTrueTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertTrueTests.cs
@@ -23,13 +23,12 @@ public sealed class AssertTrueTests
             Expected: true
             Actual:   false
             """);
-
         AssertionTestHelpers.Validate(() => AssertionsAssert.True(false, "custom message"), """
             Assert.True() assertion failed.
+            Message: custom message
             Expression: false
             Expected: true
             Actual:   false
-            Message: custom message
             """);
 
         bool? nullableFalse = false;

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertionFormatterTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertionFormatterTests.cs
@@ -58,6 +58,58 @@ public sealed class AssertionFormatterTests
         AssertionsAssert.Equal("[0, 1̲, 2, 3, 4, ...]", value);
     }
 
+    [Fact]
+    public void UserMessageIsWrittenBeforeDetails()
+    {
+        AssertionTestHelpers.Validate(() => AssertionsAssert.Null("Hello", "custom message"), """
+            Assert.Null() assertion failed.
+            Message: custom message
+            Expression: "Hello"
+            Expected: <null>
+            Actual:   "Hello"
+            """);
+    }
+
+    [Fact]
+    public void EmptyUserMessageIsOmitted()
+    {
+        AssertionTestHelpers.Validate(() => AssertionsAssert.True(false, ""), """
+            Assert.True() assertion failed.
+            Expression: false
+            Expected: true
+            Actual:   false
+            """);
+    }
+
+    [Fact]
+    public void GroupsAlignLabels()
+    {
+        var message = new AssertionMessageBuilder("Header")
+            .AppendGroup(
+                ("Short", "1"),
+                ("Long label", "2"))
+            .ToString();
+
+        AssertionsAssert.Equal("""
+            Header
+            Short:      1
+            Long label: 2
+            """, message);
+    }
+
+    [Fact]
+    public async Task AsyncUserMessageIsWrittenBeforeDetails()
+    {
+        var actual = AssertionTestHelpers.ToAsyncEnumerable([1, 2, 3]);
+
+        await AssertionTestHelpers.ValidateAsync(() => AssertionsAssert.Empty(actual, "custom message"), """
+            Assert.Empty() assertion failed.
+            Message: custom message
+            Expression: actual
+            Actual: [1̲, 2, 3]
+            """);
+    }
+
     private sealed class TestAssertionFormatter : AssertionFormatter
     {
         public string FormatValueForTest(object? value, int? highlightedIndex = null)


### PR DESCRIPTION
**Summary**
- Adjust assertion formatting so optional messages are surfaced earlier in failure output.
- Update assertion message construction and related error handling to match the new layout.
- Refresh assertion tests across the assertions suite to cover the revised formatting behavior.

**Testing**
- Not run (not requested).