### PR TITLE
Add custom JSONPath support

### DIFF
--- a/ref/Meziantou.Framework.JsonPath.cs
+++ b/ref/Meziantou.Framework.JsonPath.cs
@@ -10,10 +10,14 @@ namespace Meziantou.Framework.Json
         public static Meziantou.Framework.Json.JsonPath Parse(System.ReadOnlySpan<char> expression) => throw null;
         public static bool TryParse(string? expression, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Json.JsonPath? result) => throw null;
         public static bool TryParse(System.ReadOnlySpan<char> expression, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Json.JsonPath? result) => throw null;
+        public Meziantou.Framework.Json.JsonPathResult<TValue> Evaluate<TValue>(TValue root, Meziantou.Framework.Json.JsonPathNavigator<TValue> navigator) where TValue : class => throw null;
+        public Meziantou.Framework.Json.JsonPathResult<TValue> Evaluate<TValue>(TValue root, Meziantou.Framework.Json.JsonPathNavigator<TValue> navigator, Meziantou.Framework.Json.JsonPathEvaluationMode mode) where TValue : class => throw null;
         public Meziantou.Framework.Json.JsonPathResult Evaluate(System.Text.Json.Nodes.JsonNode? root) => throw null;
         public Meziantou.Framework.Json.JsonPathResult Evaluate(System.Text.Json.Nodes.JsonNode? root, Meziantou.Framework.Json.JsonPathEvaluationMode mode) => throw null;
         public Meziantou.Framework.Json.JsonPathResult Evaluate(System.Text.Json.JsonDocument? root) => throw null;
         public Meziantou.Framework.Json.JsonPathResult Evaluate(System.Text.Json.JsonDocument? root, Meziantou.Framework.Json.JsonPathEvaluationMode mode) => throw null;
+        public TValue EvaluateValue<TValue>(TValue root, Meziantou.Framework.Json.JsonPathNavigator<TValue> navigator) where TValue : class => throw null;
+        public TValue EvaluateValue<TValue>(TValue root, Meziantou.Framework.Json.JsonPathNavigator<TValue> navigator, Meziantou.Framework.Json.JsonPathEvaluationMode mode) where TValue : class => throw null;
         public System.Text.Json.Nodes.JsonNode? EvaluateValue(System.Text.Json.Nodes.JsonNode? root) => throw null;
         public System.Text.Json.Nodes.JsonNode? EvaluateValue(System.Text.Json.Nodes.JsonNode? root, Meziantou.Framework.Json.JsonPathEvaluationMode mode) => throw null;
         public System.Text.Json.Nodes.JsonNode? EvaluateValue(System.Text.Json.JsonDocument? root) => throw null;
@@ -39,6 +43,41 @@ namespace Meziantou.Framework.Json
         public string Path { get => throw null; }
     }
 
+    public readonly struct JsonPathMatch<TValue> where TValue : class
+    {
+        public TValue Value { get => throw null; }
+        public string Path { get => throw null; }
+    }
+
+    public abstract class JsonPathNavigator<TValue> where TValue : class
+    {
+        public abstract Meziantou.Framework.Json.JsonPathNodeKind GetKind(TValue value);
+        public abstract bool TryGetPropertyValue(TValue value, string name, out TValue result);
+        public abstract System.Collections.Generic.IEnumerable<Meziantou.Framework.Json.JsonPathProperty<TValue>> GetProperties(TValue value);
+        public abstract int GetArrayLength(TValue value);
+        public abstract bool TryGetElement(TValue value, int index, out TValue result);
+        public abstract bool TryGetString(TValue value, out string? result);
+        public abstract bool TryGetNumber(TValue value, out double result);
+        public abstract bool TryGetBoolean(TValue value, out bool result);
+    }
+
+    public enum JsonPathNodeKind
+    {
+        Null = 0,
+        Boolean = 1,
+        Number = 2,
+        String = 3,
+        Array = 4,
+        Object = 5
+    }
+
+    public readonly struct JsonPathProperty<TValue> where TValue : class
+    {
+        public string Name { get => throw null; }
+        public TValue Value { get => throw null; }
+        public JsonPathProperty(string name, TValue value) { }
+    }
+
     public sealed class JsonPathResult : System.Collections.Generic.IEnumerable<Meziantou.Framework.Json.JsonPathMatch>, System.Collections.Generic.IReadOnlyCollection<Meziantou.Framework.Json.JsonPathMatch>, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Json.JsonPathMatch>, System.Collections.IEnumerable
     {
         public int Count { get => throw null; }
@@ -46,5 +85,13 @@ namespace Meziantou.Framework.Json
         public System.Collections.Generic.IEnumerator<Meziantou.Framework.Json.JsonPathMatch> GetEnumerator() => throw null;
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
         public System.Text.Json.Nodes.JsonArray ToJsonArray() => throw null;
+    }
+
+    public sealed class JsonPathResult<TValue> : System.Collections.Generic.IEnumerable<Meziantou.Framework.Json.JsonPathMatch<TValue>>, System.Collections.Generic.IReadOnlyCollection<Meziantou.Framework.Json.JsonPathMatch<TValue>>, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Json.JsonPathMatch<TValue>>, System.Collections.IEnumerable where TValue : class
+    {
+        public int Count { get => throw null; }
+        public Meziantou.Framework.Json.JsonPathMatch<TValue> this[int index] { get => throw null; }
+        public System.Collections.Generic.IEnumerator<Meziantou.Framework.Json.JsonPathMatch<TValue>> GetEnumerator() => throw null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
     }
 }

--- a/src/Meziantou.Framework.JsonPath/Internals/JsonNodeNavigator.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/JsonNodeNavigator.cs
@@ -1,0 +1,196 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Meziantou.Framework.Json.Internals;
+
+internal sealed class JsonNodeNavigator : JsonPathNavigator<JsonNode>
+{
+    public static JsonNodeNavigator Instance { get; } = new();
+
+    private JsonNodeNavigator()
+    {
+    }
+
+    public override JsonPathNodeKind GetKind(JsonNode? value)
+    {
+        return value switch
+        {
+            null => JsonPathNodeKind.Null,
+            JsonArray => JsonPathNodeKind.Array,
+            JsonObject => JsonPathNodeKind.Object,
+            JsonValue jsonValue => jsonValue.GetValueKind() switch
+            {
+                JsonValueKind.True or JsonValueKind.False => JsonPathNodeKind.Boolean,
+                JsonValueKind.Number => JsonPathNodeKind.Number,
+                JsonValueKind.String => JsonPathNodeKind.String,
+                JsonValueKind.Null => JsonPathNodeKind.Null,
+                _ => JsonPathNodeKind.Null,
+            },
+            _ => JsonPathNodeKind.Null,
+        };
+    }
+
+    public override bool TryGetPropertyValue(JsonNode? value, string name, out JsonNode? result)
+    {
+        if (value is JsonObject obj)
+        {
+            return obj.TryGetPropertyValue(name, out result);
+        }
+
+        result = null;
+        return false;
+    }
+
+    public override IEnumerable<JsonPathProperty<JsonNode>> GetProperties(JsonNode? value)
+    {
+        if (value is not JsonObject obj)
+        {
+            yield break;
+        }
+
+        foreach (var property in obj)
+        {
+            yield return new JsonPathProperty<JsonNode>(property.Key, property.Value);
+        }
+    }
+
+    public override int GetArrayLength(JsonNode? value)
+    {
+        return value is JsonArray array ? array.Count : 0;
+    }
+
+    public override bool TryGetElement(JsonNode? value, int index, out JsonNode? result)
+    {
+        if (value is JsonArray array && index >= 0 && index < array.Count)
+        {
+            result = array[index];
+            return true;
+        }
+
+        result = null;
+        return false;
+    }
+
+    public override bool TryGetString(JsonNode? value, out string? result)
+    {
+        if (value is JsonValue jsonValue && jsonValue.GetValueKind() is JsonValueKind.String)
+        {
+            result = GetStringValue(jsonValue);
+            return true;
+        }
+
+        result = null;
+        return false;
+    }
+
+    public override bool TryGetNumber(JsonNode? value, out double result)
+    {
+        if (value is JsonValue jsonValue && jsonValue.GetValueKind() is JsonValueKind.Number)
+        {
+            result = GetDoubleValue(jsonValue);
+            return true;
+        }
+
+        result = 0;
+        return false;
+    }
+
+    public override bool TryGetBoolean(JsonNode? value, out bool result)
+    {
+        if (value is JsonValue jsonValue)
+        {
+            switch (jsonValue.GetValueKind())
+            {
+                case JsonValueKind.True:
+                    result = true;
+                    return true;
+                case JsonValueKind.False:
+                    result = false;
+                    return true;
+            }
+        }
+
+        result = false;
+        return false;
+    }
+
+    private static double GetDoubleValue(JsonValue value)
+    {
+        if (value.TryGetValue<JsonElement>(out var element))
+        {
+            return element.GetDouble();
+        }
+
+        if (value.TryGetValue<double>(out var d))
+        {
+            return d;
+        }
+
+        if (value.TryGetValue<float>(out var f))
+        {
+            return f;
+        }
+
+        if (value.TryGetValue<decimal>(out var dec))
+        {
+            return (double)dec;
+        }
+
+        if (value.TryGetValue<long>(out var l))
+        {
+            return l;
+        }
+
+        if (value.TryGetValue<ulong>(out var ul))
+        {
+            return ul;
+        }
+
+        if (value.TryGetValue<int>(out var i))
+        {
+            return i;
+        }
+
+        if (value.TryGetValue<uint>(out var ui))
+        {
+            return ui;
+        }
+
+        if (value.TryGetValue<short>(out var s))
+        {
+            return s;
+        }
+
+        if (value.TryGetValue<ushort>(out var us))
+        {
+            return us;
+        }
+
+        if (value.TryGetValue<byte>(out var b))
+        {
+            return b;
+        }
+
+        if (value.TryGetValue<sbyte>(out var sb))
+        {
+            return sb;
+        }
+
+        return 0;
+    }
+
+    private static string? GetStringValue(JsonValue value)
+    {
+        if (value.TryGetValue<JsonElement>(out var element))
+        {
+            return element.GetString();
+        }
+
+        if (value.TryGetValue<string>(out var s))
+        {
+            return s;
+        }
+
+        return value.ToString();
+    }
+}

--- a/src/Meziantou.Framework.JsonPath/Internals/JsonPathEvaluator.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/JsonPathEvaluator.cs
@@ -1,10 +1,9 @@
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 
 namespace Meziantou.Framework.Json.Internals;
 
-/// <summary>Evaluates a parsed JSONPath AST against a JsonNode tree.</summary>
+/// <summary>Evaluates a parsed JSONPath AST against a JSON value tree.</summary>
 internal static class JsonPathEvaluator
 {
     public static JsonPathResult Evaluate(JsonPathExpression expression, JsonNode? root)
@@ -14,158 +13,187 @@ internal static class JsonPathEvaluator
 
     public static JsonPathResult Evaluate(JsonPathExpression expression, JsonNode? root, JsonPathEvaluationMode mode)
     {
-        // Start with the root node
-        var currentNodes = new List<(JsonNode? Node, List<PathComponent> Path)>
+        var result = Evaluate(expression, root, JsonNodeNavigator.Instance, mode);
+        var matches = new List<JsonPathMatch>(result.Count);
+        foreach (var match in result)
         {
-            (root, []),
-        };
-
-        // Apply each segment in sequence
-        foreach (var segment in expression.Segments)
-        {
-            currentNodes = ApplySegment(segment, currentNodes, root, mode);
-        }
-
-        // Build results
-        var matches = new List<JsonPathMatch>(currentNodes.Count);
-        foreach (var (node, path) in currentNodes)
-        {
-            matches.Add(new JsonPathMatch(node, NormalizedPathBuilder.Build(path)));
+            matches.Add(new JsonPathMatch(match.Value, match.Path));
         }
 
         return new JsonPathResult(matches);
     }
 
-    private static List<(JsonNode? Node, List<PathComponent> Path)> ApplySegment(
-        Segment segment,
-        List<(JsonNode? Node, List<PathComponent> Path)> inputNodes,
-        JsonNode? root,
+    public static JsonPathResult<TValue> Evaluate<TValue>(
+        JsonPathExpression expression,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator,
         JsonPathEvaluationMode mode)
+        where TValue : class
     {
-        var result = new List<(JsonNode? Node, List<PathComponent> Path)>();
+        var currentNodes = new List<(TValue? Node, List<PathComponent> Path)>
+        {
+            (root, []),
+        };
+
+        foreach (var segment in expression.Segments)
+        {
+            currentNodes = ApplySegment(segment, currentNodes, root, navigator, mode);
+        }
+
+        var matches = new List<JsonPathMatch<TValue>>(currentNodes.Count);
+        foreach (var (node, path) in currentNodes)
+        {
+            matches.Add(new JsonPathMatch<TValue>(node, NormalizedPathBuilder.Build(path)));
+        }
+
+        return new JsonPathResult<TValue>(matches);
+    }
+
+    private static List<(TValue? Node, List<PathComponent> Path)> ApplySegment<TValue>(
+        Segment segment,
+        List<(TValue? Node, List<PathComponent> Path)> inputNodes,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator,
+        JsonPathEvaluationMode mode)
+        where TValue : class
+    {
+        var result = new List<(TValue? Node, List<PathComponent> Path)>();
 
         foreach (var (node, path) in inputNodes)
         {
             if (segment.Kind is SegmentKind.Child)
             {
-                ApplyChildSegment(segment.Selectors, node, path, root, mode, result, strictFailure: true);
+                ApplyChildSegment(segment.Selectors, node, path, root, navigator, mode, result, strictFailure: true);
             }
             else
             {
-                ApplyDescendantSegment(segment.Selectors, node, path, root, mode, result);
+                ApplyDescendantSegment(segment.Selectors, node, path, root, navigator, mode, result);
             }
         }
 
         return result;
     }
 
-    private static void ApplyChildSegment(
+    private static void ApplyChildSegment<TValue>(
         Selector[] selectors,
-        JsonNode? node,
+        TValue? node,
         List<PathComponent> path,
-        JsonNode? root,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator,
         JsonPathEvaluationMode mode,
-        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        List<(TValue? Node, List<PathComponent> Path)> result,
         bool strictFailure)
+        where TValue : class
     {
         foreach (var selector in selectors)
         {
-            ApplySelector(selector, node, path, root, mode, result, strictFailure);
+            ApplySelector(selector, node, path, root, navigator, mode, result, strictFailure);
         }
     }
 
-    private static void ApplyDescendantSegment(
+    private static void ApplyDescendantSegment<TValue>(
         Selector[] selectors,
-        JsonNode? node,
+        TValue? node,
         List<PathComponent> path,
-        JsonNode? root,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator,
         JsonPathEvaluationMode mode,
-        List<(JsonNode? Node, List<PathComponent> Path)> result)
+        List<(TValue? Node, List<PathComponent> Path)> result)
+        where TValue : class
     {
-        // Visit nodes in pre-order: node first, then descendants
-        // For each visited node, apply the selectors as a child segment
-        VisitDescendants(node, path, selectors, root, mode, result);
+        VisitDescendants(node, path, selectors, root, navigator, mode, result);
     }
 
-    private static void VisitDescendants(
-        JsonNode? node,
+    private static void VisitDescendants<TValue>(
+        TValue? node,
         List<PathComponent> path,
         Selector[] selectors,
-        JsonNode? root,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator,
         JsonPathEvaluationMode mode,
-        List<(JsonNode? Node, List<PathComponent> Path)> result)
+        List<(TValue? Node, List<PathComponent> Path)> result)
+        where TValue : class
     {
-        // Apply selectors to current node
-        ApplyChildSegment(selectors, node, path, root, mode, result, strictFailure: false);
+        ApplyChildSegment(selectors, node, path, root, navigator, mode, result, strictFailure: false);
 
-        // Recurse into children
-        switch (node)
+        switch (navigator.GetKind(node))
         {
-            case JsonObject obj:
-                foreach (var property in obj)
+            case JsonPathNodeKind.Object:
+                foreach (var property in navigator.GetProperties(node))
                 {
                     var childPath = new List<PathComponent>(path)
                     {
-                        PathComponent.FromName(property.Key),
+                        PathComponent.FromName(property.Name),
                     };
-                    VisitDescendants(property.Value, childPath, selectors, root, mode, result);
+                    VisitDescendants(property.Value, childPath, selectors, root, navigator, mode, result);
                 }
 
                 break;
-            case JsonArray array:
-                for (var i = 0; i < array.Count; i++)
+
+            case JsonPathNodeKind.Array:
+                var length = navigator.GetArrayLength(node);
+                for (var i = 0; i < length; i++)
                 {
+                    if (!navigator.TryGetElement(node, i, out var value))
+                    {
+                        continue;
+                    }
+
                     var childPath = new List<PathComponent>(path)
                     {
                         PathComponent.FromIndex(i),
                     };
-                    VisitDescendants(array[i], childPath, selectors, root, mode, result);
+                    VisitDescendants(value, childPath, selectors, root, navigator, mode, result);
                 }
 
                 break;
         }
     }
 
-    private static void ApplySelector(
+    private static void ApplySelector<TValue>(
         Selector selector,
-        JsonNode? node,
+        TValue? node,
         List<PathComponent> path,
-        JsonNode? root,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator,
         JsonPathEvaluationMode mode,
-        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        List<(TValue? Node, List<PathComponent> Path)> result,
         bool strictFailure)
+        where TValue : class
     {
         switch (selector)
         {
             case NameSelector nameSelector:
-                ApplyNameSelector(nameSelector, node, path, mode, result, strictFailure);
+                ApplyNameSelector(nameSelector, node, path, navigator, mode, result, strictFailure);
                 break;
             case WildcardSelector:
-                ApplyWildcardSelector(node, path, mode, result, strictFailure);
+                ApplyWildcardSelector(node, path, navigator, mode, result, strictFailure);
                 break;
             case IndexSelector indexSelector:
-                ApplyIndexSelector(indexSelector, node, path, mode, result, strictFailure);
+                ApplyIndexSelector(indexSelector, node, path, navigator, mode, result, strictFailure);
                 break;
             case SliceSelector sliceSelector:
-                ApplySliceSelector(sliceSelector, node, path, mode, result, strictFailure);
+                ApplySliceSelector(sliceSelector, node, path, navigator, mode, result, strictFailure);
                 break;
             case FilterSelector filterSelector:
-                ApplyFilterSelector(filterSelector, node, path, root, mode, result, strictFailure);
+                ApplyFilterSelector(filterSelector, node, path, root, navigator, mode, result, strictFailure);
                 break;
         }
     }
 
-    private static void ApplyNameSelector(
+    private static void ApplyNameSelector<TValue>(
         NameSelector selector,
-        JsonNode? node,
+        TValue? node,
         List<PathComponent> path,
+        JsonPathNavigator<TValue> navigator,
         JsonPathEvaluationMode mode,
-        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        List<(TValue? Node, List<PathComponent> Path)> result,
         bool strictFailure)
+        where TValue : class
     {
-        if (node is JsonObject obj)
+        if (navigator.GetKind(node) is JsonPathNodeKind.Object)
         {
-            if (!obj.TryGetPropertyValue(selector.Name, out var value))
+            if (!navigator.TryGetPropertyValue(node, selector.Name, out var value))
             {
                 ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, $"Object member '{selector.Name}' does not exist");
                 return;
@@ -182,91 +210,106 @@ internal static class JsonPathEvaluator
         ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, $"Name selector '{selector.Name}' requires an object");
     }
 
-    private static void ApplyWildcardSelector(
-        JsonNode? node,
+    private static void ApplyWildcardSelector<TValue>(
+        TValue? node,
         List<PathComponent> path,
+        JsonPathNavigator<TValue> navigator,
         JsonPathEvaluationMode mode,
-        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        List<(TValue? Node, List<PathComponent> Path)> result,
         bool strictFailure)
+        where TValue : class
     {
-        switch (node)
+        switch (navigator.GetKind(node))
         {
-            case JsonObject obj:
-                foreach (var property in obj)
+            case JsonPathNodeKind.Object:
+                foreach (var property in navigator.GetProperties(node))
                 {
                     var newPath = new List<PathComponent>(path)
                     {
-                        PathComponent.FromName(property.Key),
+                        PathComponent.FromName(property.Name),
                     };
                     result.Add((property.Value, newPath));
                 }
 
                 break;
-            case JsonArray array:
-                for (var i = 0; i < array.Count; i++)
+
+            case JsonPathNodeKind.Array:
+                var length = navigator.GetArrayLength(node);
+                for (var i = 0; i < length; i++)
                 {
+                    if (!navigator.TryGetElement(node, i, out var value))
+                    {
+                        continue;
+                    }
+
                     var newPath = new List<PathComponent>(path)
                     {
                         PathComponent.FromIndex(i),
                     };
-                    result.Add((array[i], newPath));
+                    result.Add((value, newPath));
                 }
 
                 break;
+
             default:
                 ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, "Wildcard selector requires an object or an array");
                 break;
         }
     }
 
-    private static void ApplyIndexSelector(
+    private static void ApplyIndexSelector<TValue>(
         IndexSelector selector,
-        JsonNode? node,
+        TValue? node,
         List<PathComponent> path,
+        JsonPathNavigator<TValue> navigator,
         JsonPathEvaluationMode mode,
-        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        List<(TValue? Node, List<PathComponent> Path)> result,
         bool strictFailure)
+        where TValue : class
     {
-        if (node is not JsonArray array)
+        if (navigator.GetKind(node) is not JsonPathNodeKind.Array)
         {
             ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, $"Index selector [{selector.Index}] requires an array");
             return;
         }
 
-        var index = NormalizeIndex(selector.Index, array.Count);
-        if (index >= 0 && index < array.Count)
+        var length = navigator.GetArrayLength(node);
+        var index = NormalizeIndex(selector.Index, length);
+        if (index >= 0 && index < length && navigator.TryGetElement(node, (int)index, out var value))
         {
             var newPath = new List<PathComponent>(path)
             {
                 PathComponent.FromIndex(index),
             };
-            result.Add((array[(int)index], newPath));
+            result.Add((value, newPath));
             return;
         }
 
         ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, $"Array index [{selector.Index}] is out of range");
     }
 
-    private static void ApplySliceSelector(
+    private static void ApplySliceSelector<TValue>(
         SliceSelector selector,
-        JsonNode? node,
+        TValue? node,
         List<PathComponent> path,
+        JsonPathNavigator<TValue> navigator,
         JsonPathEvaluationMode mode,
-        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        List<(TValue? Node, List<PathComponent> Path)> result,
         bool strictFailure)
+        where TValue : class
     {
-        if (node is not JsonArray array)
+        if (navigator.GetKind(node) is not JsonPathNodeKind.Array)
         {
             ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, "Slice selector requires an array");
             return;
         }
 
-        var len = array.Count;
+        var len = navigator.GetArrayLength(node);
         var step = selector.Step ?? 1;
 
         if (step == 0)
         {
-            return; // step=0 selects nothing
+            return;
         }
 
         var start = selector.Start ?? (step >= 0 ? 0 : len - 1);
@@ -291,65 +334,85 @@ internal static class JsonPathEvaluator
         {
             for (var i = lower; i < upper; i += step)
             {
+                if (!navigator.TryGetElement(node, (int)i, out var value))
+                {
+                    continue;
+                }
+
                 var newPath = new List<PathComponent>(path)
                 {
                     PathComponent.FromIndex(i),
                 };
-                result.Add((array[(int)i], newPath));
+                result.Add((value, newPath));
             }
         }
         else
         {
             for (var i = upper; lower < i; i += step)
             {
+                if (!navigator.TryGetElement(node, (int)i, out var value))
+                {
+                    continue;
+                }
+
                 var newPath = new List<PathComponent>(path)
                 {
                     PathComponent.FromIndex(i),
                 };
-                result.Add((array[(int)i], newPath));
+                result.Add((value, newPath));
             }
         }
     }
 
-    private static void ApplyFilterSelector(
+    private static void ApplyFilterSelector<TValue>(
         FilterSelector selector,
-        JsonNode? node,
+        TValue? node,
         List<PathComponent> path,
-        JsonNode? root,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator,
         JsonPathEvaluationMode mode,
-        List<(JsonNode? Node, List<PathComponent> Path)> result,
+        List<(TValue? Node, List<PathComponent> Path)> result,
         bool strictFailure)
+        where TValue : class
     {
-        switch (node)
+        switch (navigator.GetKind(node))
         {
-            case JsonObject obj:
-                foreach (var property in obj)
+            case JsonPathNodeKind.Object:
+                foreach (var property in navigator.GetProperties(node))
                 {
-                    if (EvaluateLogicalExpression(selector.Expression, property.Value, root))
+                    if (EvaluateLogicalExpression(selector.Expression, property.Value, root, navigator))
                     {
                         var newPath = new List<PathComponent>(path)
                         {
-                            PathComponent.FromName(property.Key),
+                            PathComponent.FromName(property.Name),
                         };
                         result.Add((property.Value, newPath));
                     }
                 }
 
                 break;
-            case JsonArray array:
-                for (var i = 0; i < array.Count; i++)
+
+            case JsonPathNodeKind.Array:
+                var length = navigator.GetArrayLength(node);
+                for (var i = 0; i < length; i++)
                 {
-                    if (EvaluateLogicalExpression(selector.Expression, array[i], root))
+                    if (!navigator.TryGetElement(node, i, out var value))
+                    {
+                        continue;
+                    }
+
+                    if (EvaluateLogicalExpression(selector.Expression, value, root, navigator))
                     {
                         var newPath = new List<PathComponent>(path)
                         {
                             PathComponent.FromIndex(i),
                         };
-                        result.Add((array[i], newPath));
+                        result.Add((value, newPath));
                     }
                 }
 
                 break;
+
             default:
                 ThrowPathEvaluationErrorIfStrict(mode, strictFailure, path, "Filter selector requires an object or an array");
                 break;
@@ -366,192 +429,317 @@ internal static class JsonPathEvaluator
         throw new JsonPathEvaluationException($"Path error at {NormalizedPathBuilder.Build(path)}: {error}");
     }
 
-    // ---- Filter Expression Evaluation ----
-
-    private static bool EvaluateLogicalExpression(LogicalExpression expr, JsonNode? currentNode, JsonNode? root)
+    private static bool EvaluateLogicalExpression<TValue>(
+        LogicalExpression expr,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
         return expr switch
         {
-            OrExpression or => EvaluateLogicalExpression(or.Left, currentNode, root)
-                               || EvaluateLogicalExpression(or.Right, currentNode, root),
-            AndExpression and => EvaluateLogicalExpression(and.Left, currentNode, root)
-                                && EvaluateLogicalExpression(and.Right, currentNode, root),
-            NotExpression not => !EvaluateLogicalExpression(not.Operand, currentNode, root),
-            ComparisonExpression comp => EvaluateComparison(comp, currentNode, root),
-            ExistenceTestExpression existence => EvaluateExistenceTest(existence, currentNode, root),
-            FunctionCallExpression func => EvaluateFunctionAsLogical(func, currentNode, root),
+            OrExpression or => EvaluateLogicalExpression(or.Left, currentNode, root, navigator)
+                               || EvaluateLogicalExpression(or.Right, currentNode, root, navigator),
+            AndExpression and => EvaluateLogicalExpression(and.Left, currentNode, root, navigator)
+                                && EvaluateLogicalExpression(and.Right, currentNode, root, navigator),
+            NotExpression not => !EvaluateLogicalExpression(not.Operand, currentNode, root, navigator),
+            ComparisonExpression comp => EvaluateComparison(comp, currentNode, root, navigator),
+            ExistenceTestExpression existence => EvaluateExistenceTest(existence, currentNode, root, navigator),
+            FunctionCallExpression func => EvaluateFunctionAsLogical(func, currentNode, root, navigator),
             _ => false,
         };
     }
 
-    private static bool EvaluateExistenceTest(ExistenceTestExpression test, JsonNode? currentNode, JsonNode? root)
+    private static bool EvaluateExistenceTest<TValue>(
+        ExistenceTestExpression test,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
-        var nodes = EvaluateFilterQuery(test.Query, currentNode, root);
+        var nodes = EvaluateFilterQuery(test.Query, currentNode, root, navigator);
         return nodes.Count > 0;
     }
 
-    private static bool EvaluateComparison(ComparisonExpression comp, JsonNode? currentNode, JsonNode? root)
+    private static bool EvaluateComparison<TValue>(
+        ComparisonExpression comp,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
-        var left = ResolveComparable(comp.Left, currentNode, root);
-        var right = ResolveComparable(comp.Right, currentNode, root);
+        var left = ResolveComparable(comp.Left, currentNode, root, navigator);
+        var right = ResolveComparable(comp.Right, currentNode, root, navigator);
 
         return comp.Operator switch
         {
-            ComparisonOperator.Equal => CompareEqual(left, right),
-            ComparisonOperator.NotEqual => !CompareEqual(left, right),
-            ComparisonOperator.LessThan => CompareLessThan(left, right),
-            ComparisonOperator.LessThanOrEqual => CompareLessThan(left, right) || CompareEqual(left, right),
-            ComparisonOperator.GreaterThan => CompareLessThan(right, left),
-            ComparisonOperator.GreaterThanOrEqual => CompareLessThan(right, left) || CompareEqual(left, right),
+            ComparisonOperator.Equal => CompareEqual(left, right, navigator),
+            ComparisonOperator.NotEqual => !CompareEqual(left, right, navigator),
+            ComparisonOperator.LessThan => CompareLessThan(left, right, navigator),
+            ComparisonOperator.LessThanOrEqual => CompareLessThan(left, right, navigator) || CompareEqual(left, right, navigator),
+            ComparisonOperator.GreaterThan => CompareLessThan(right, left, navigator),
+            ComparisonOperator.GreaterThanOrEqual => CompareLessThan(right, left, navigator) || CompareEqual(left, right, navigator),
             _ => false,
         };
     }
 
-    /// <summary>
-    /// Represents a resolved comparable value for filter expression evaluation.
-    /// Nothing represents the absence of a value (empty nodelist or Nothing from functions).
-    /// </summary>
-    private sealed class ResolvedValue
+    private enum ResolvedValueKind
     {
-        public static readonly ResolvedValue Nothing = new() { IsNothing = true };
-
-        public JsonNode? Node { get; private init; }
-
-        public bool IsNothing { get; private init; }
-
-        public static ResolvedValue FromNode(JsonNode? node) => new() { Node = node, IsNothing = false };
-
-        public static ResolvedValue FromNothing() => Nothing;
+        Nothing,
+        Node,
+        Scalar,
     }
 
-    private static ResolvedValue ResolveComparable(Comparable comparable, JsonNode? currentNode, JsonNode? root)
+    private readonly struct ResolvedValue<TValue>
+        where TValue : class
+    {
+        private ResolvedValue(TValue? node)
+        {
+            Kind = ResolvedValueKind.Node;
+            Node = node;
+            Scalar = default;
+        }
+
+        private ResolvedValue(ScalarValue scalar)
+        {
+            Kind = ResolvedValueKind.Scalar;
+            Node = null;
+            Scalar = scalar;
+        }
+
+        public ResolvedValueKind Kind { get; }
+
+        public TValue? Node { get; }
+
+        public ScalarValue Scalar { get; }
+
+        public bool IsNothing => Kind is ResolvedValueKind.Nothing;
+
+        public static ResolvedValue<TValue> FromNode(TValue? node) => new(node);
+
+        public static ResolvedValue<TValue> FromScalar(ScalarValue scalar) => new(scalar);
+
+        public static ResolvedValue<TValue> FromNothing() => default;
+    }
+
+    private readonly struct ScalarValue
+    {
+        private ScalarValue(JsonPathNodeKind kind, string? stringValue, double numberValue, bool booleanValue)
+        {
+            Kind = kind;
+            StringValue = stringValue;
+            NumberValue = numberValue;
+            BooleanValue = booleanValue;
+        }
+
+        public JsonPathNodeKind Kind { get; }
+
+        public string? StringValue { get; }
+
+        public double NumberValue { get; }
+
+        public bool BooleanValue { get; }
+
+        public static ScalarValue Null() => new(JsonPathNodeKind.Null, stringValue: null, numberValue: 0, booleanValue: false);
+
+        public static ScalarValue FromBoolean(bool value) => new(JsonPathNodeKind.Boolean, stringValue: null, numberValue: 0, booleanValue: value);
+
+        public static ScalarValue FromNumber(double value) => new(JsonPathNodeKind.Number, stringValue: null, numberValue: value, booleanValue: false);
+
+        public static ScalarValue FromString(string value) => new(JsonPathNodeKind.String, value, numberValue: 0, booleanValue: false);
+    }
+
+    private static ResolvedValue<TValue> ResolveComparable<TValue>(
+        Comparable comparable,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
         switch (comparable)
         {
             case LiteralComparable literal:
                 return literal.Value switch
                 {
-                    null => ResolvedValue.FromNode(node: null),
-                    true => ResolvedValue.FromNode(JsonValue.Create(value: true)),
-                    false => ResolvedValue.FromNode(JsonValue.Create(value: false)),
-                    string s => ResolvedValue.FromNode(JsonValue.Create(s)),
-                    double d => ResolvedValue.FromNode(JsonValue.Create(d)),
-                    _ => ResolvedValue.FromNothing(),
+                    null => ResolvedValue<TValue>.FromScalar(ScalarValue.Null()),
+                    true => ResolvedValue<TValue>.FromScalar(ScalarValue.FromBoolean(value: true)),
+                    false => ResolvedValue<TValue>.FromScalar(ScalarValue.FromBoolean(value: false)),
+                    string s => ResolvedValue<TValue>.FromScalar(ScalarValue.FromString(s)),
+                    double d => ResolvedValue<TValue>.FromScalar(ScalarValue.FromNumber(d)),
+                    _ => ResolvedValue<TValue>.FromNothing(),
                 };
 
             case SingularQueryComparable sq:
                 {
-                    var nodes = EvaluateSingularQuery(sq.Query, currentNode, root);
+                    var nodes = EvaluateSingularQuery(sq.Query, currentNode, root, navigator);
                     if (nodes.Count is 1)
                     {
-                        return ResolvedValue.FromNode(nodes[0]);
+                        return ResolvedValue<TValue>.FromNode(nodes[0]);
                     }
 
-                    return ResolvedValue.FromNothing();
+                    return ResolvedValue<TValue>.FromNothing();
                 }
 
             case FunctionCallComparable fc:
-                {
-                    var result = EvaluateFunction(fc.FunctionCall, currentNode, root);
-                    return result;
-                }
+                return EvaluateFunction(fc.FunctionCall, currentNode, root, navigator);
 
             default:
-                return ResolvedValue.FromNothing();
+                return ResolvedValue<TValue>.FromNothing();
         }
     }
 
-    // RFC 9535 §2.3.5.2.2: Comparison semantics
-    private static bool CompareEqual(ResolvedValue left, ResolvedValue right)
+    private static bool CompareEqual<TValue>(
+        ResolvedValue<TValue> left,
+        ResolvedValue<TValue> right,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
-        // Both Nothing/empty → true
         if (left.IsNothing && right.IsNothing)
         {
             return true;
         }
 
-        // One Nothing/empty → false
         if (left.IsNothing || right.IsNothing)
         {
             return false;
         }
 
-        return JsonNodesEqual(left.Node, right.Node);
+        if (left.Kind is ResolvedValueKind.Scalar && right.Kind is ResolvedValueKind.Scalar)
+        {
+            return ScalarValuesEqual(left.Scalar, right.Scalar);
+        }
+
+        if (left.Kind is ResolvedValueKind.Scalar)
+        {
+            return ScalarAndNodeEqual(left.Scalar, right.Node, navigator);
+        }
+
+        if (right.Kind is ResolvedValueKind.Scalar)
+        {
+            return ScalarAndNodeEqual(right.Scalar, left.Node, navigator);
+        }
+
+        return NodesEqual(left.Node, right.Node, navigator);
     }
 
-    private static bool CompareLessThan(ResolvedValue left, ResolvedValue right)
+    private static bool CompareLessThan<TValue>(
+        ResolvedValue<TValue> left,
+        ResolvedValue<TValue> right,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
-        // Any Nothing → false
         if (left.IsNothing || right.IsNothing)
         {
             return false;
         }
 
-        return JsonNodeLessThan(left.Node, right.Node);
-    }
-
-    private static bool JsonNodesEqual(JsonNode? left, JsonNode? right)
-    {
-        // Both null → equal
-        if (left is null && right is null)
+        if (TryGetNumber(left, navigator, out var leftNumber) && TryGetNumber(right, navigator, out var rightNumber))
         {
-            return true;
+            return leftNumber < rightNumber;
         }
 
-        if (left is null || right is null)
+        if (TryGetString(left, navigator, out var leftString) && TryGetString(right, navigator, out var rightString))
         {
-            return false;
-        }
-
-        // Compare by kind
-        if (left is JsonValue leftVal && right is JsonValue rightVal)
-        {
-            return JsonValuesEqual(leftVal, rightVal);
-        }
-
-        if (left is JsonArray leftArr && right is JsonArray rightArr)
-        {
-            return JsonArraysEqual(leftArr, rightArr);
-        }
-
-        if (left is JsonObject leftObj && right is JsonObject rightObj)
-        {
-            return JsonObjectsEqual(leftObj, rightObj);
+            return string.Compare(leftString, rightString, StringComparison.Ordinal) < 0;
         }
 
         return false;
     }
 
-    private static bool JsonValuesEqual(JsonValue left, JsonValue right)
+    private static bool ScalarValuesEqual(ScalarValue left, ScalarValue right)
     {
-        var leftKind = left.GetValueKind();
-        var rightKind = right.GetValueKind();
+        if (left.Kind != right.Kind)
+        {
+            return false;
+        }
 
+        return left.Kind switch
+        {
+            JsonPathNodeKind.Null => true,
+            JsonPathNodeKind.Boolean => left.BooleanValue == right.BooleanValue,
+            JsonPathNodeKind.Number => left.NumberValue.CompareTo(right.NumberValue) is 0,
+            JsonPathNodeKind.String => left.StringValue == right.StringValue,
+            _ => false,
+        };
+    }
+
+    private static bool ScalarAndNodeEqual<TValue>(ScalarValue scalar, TValue? node, JsonPathNavigator<TValue> navigator)
+        where TValue : class
+    {
+        var kind = navigator.GetKind(node);
+        if (scalar.Kind != kind)
+        {
+            return false;
+        }
+
+        return scalar.Kind switch
+        {
+            JsonPathNodeKind.Null => true,
+            JsonPathNodeKind.Boolean => navigator.TryGetBoolean(node, out var value) && scalar.BooleanValue == value,
+            JsonPathNodeKind.Number => navigator.TryGetNumber(node, out var value) && scalar.NumberValue.CompareTo(value) is 0,
+            JsonPathNodeKind.String => navigator.TryGetString(node, out var value) && scalar.StringValue == value,
+            _ => false,
+        };
+    }
+
+    private static bool NodesEqual<TValue>(TValue? left, TValue? right, JsonPathNavigator<TValue> navigator)
+        where TValue : class
+    {
+        var leftKind = navigator.GetKind(left);
+        var rightKind = navigator.GetKind(right);
         if (leftKind != rightKind)
         {
             return false;
         }
 
-        return leftKind switch
+        switch (leftKind)
         {
-            JsonValueKind.True or JsonValueKind.False => true,
-            JsonValueKind.Null => true,
-            JsonValueKind.String => GetStringValue(left) == GetStringValue(right),
-            JsonValueKind.Number => CompareNumberValues(left, right) is 0,
-            _ => false,
-        };
+            case JsonPathNodeKind.Null:
+                return true;
+
+            case JsonPathNodeKind.Boolean:
+                return navigator.TryGetBoolean(left, out var leftBoolean)
+                       && navigator.TryGetBoolean(right, out var rightBoolean)
+                       && leftBoolean == rightBoolean;
+
+            case JsonPathNodeKind.Number:
+                return navigator.TryGetNumber(left, out var leftNumber)
+                       && navigator.TryGetNumber(right, out var rightNumber)
+                       && leftNumber.CompareTo(rightNumber) is 0;
+
+            case JsonPathNodeKind.String:
+                return navigator.TryGetString(left, out var leftString)
+                       && navigator.TryGetString(right, out var rightString)
+                       && leftString == rightString;
+
+            case JsonPathNodeKind.Array:
+                return ArraysEqual(left, right, navigator);
+
+            case JsonPathNodeKind.Object:
+                return ObjectsEqual(left, right, navigator);
+
+            default:
+                return false;
+        }
     }
 
-    private static bool JsonArraysEqual(JsonArray left, JsonArray right)
+    private static bool ArraysEqual<TValue>(TValue? left, TValue? right, JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
-        if (left.Count != right.Count)
+        var length = navigator.GetArrayLength(left);
+        if (navigator.GetArrayLength(right) != length)
         {
             return false;
         }
 
-        for (var i = 0; i < left.Count; i++)
+        for (var i = 0; i < length; i++)
         {
-            if (!JsonNodesEqual(left[i], right[i]))
+            if (!navigator.TryGetElement(left, i, out var leftValue) || !navigator.TryGetElement(right, i, out var rightValue))
+            {
+                return false;
+            }
+
+            if (!NodesEqual(leftValue, rightValue, navigator))
             {
                 return false;
             }
@@ -560,160 +748,94 @@ internal static class JsonPathEvaluator
         return true;
     }
 
-    private static bool JsonObjectsEqual(JsonObject left, JsonObject right)
+    private static bool ObjectsEqual<TValue>(TValue? left, TValue? right, JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
-        if (left.Count != right.Count)
+        var leftCount = 0;
+        foreach (var property in navigator.GetProperties(left))
         {
-            return false;
-        }
-
-        foreach (var property in left)
-        {
-            if (!right.TryGetPropertyValue(property.Key, out var rightValue))
+            leftCount++;
+            if (!navigator.TryGetPropertyValue(right, property.Name, out var rightValue))
             {
                 return false;
             }
 
-            if (!JsonNodesEqual(property.Value, rightValue))
+            if (!NodesEqual(property.Value, rightValue, navigator))
             {
                 return false;
             }
         }
 
-        return true;
+        return leftCount == CountProperties(right, navigator);
     }
 
-    private static bool JsonNodeLessThan(JsonNode? left, JsonNode? right)
+    private static bool TryGetNumber<TValue>(ResolvedValue<TValue> value, JsonPathNavigator<TValue> navigator, out double result)
+        where TValue : class
     {
-        if (left is null || right is null)
+        if (value.Kind is ResolvedValueKind.Scalar)
         {
+            if (value.Scalar.Kind is JsonPathNodeKind.Number)
+            {
+                result = value.Scalar.NumberValue;
+                return true;
+            }
+
+            result = 0;
             return false;
         }
 
-        if (left is not JsonValue leftVal || right is not JsonValue rightVal)
+        if (navigator.GetKind(value.Node) is JsonPathNodeKind.Number)
         {
-            return false;
+            return navigator.TryGetNumber(value.Node, out result);
         }
 
-        var leftKind = leftVal.GetValueKind();
-        var rightKind = rightVal.GetValueKind();
-
-        if (leftKind is JsonValueKind.Number && rightKind is JsonValueKind.Number)
-        {
-            return CompareNumberValues(leftVal, rightVal) < 0;
-        }
-
-        if (leftKind is JsonValueKind.String && rightKind is JsonValueKind.String)
-        {
-            return string.Compare(GetStringValue(leftVal), GetStringValue(rightVal), StringComparison.Ordinal) < 0;
-        }
-
+        result = 0;
         return false;
     }
 
-    private static int CompareNumberValues(JsonValue left, JsonValue right)
+    private static bool TryGetString<TValue>(ResolvedValue<TValue> value, JsonPathNavigator<TValue> navigator, out string? result)
+        where TValue : class
     {
-        var leftDouble = GetDoubleValue(left);
-        var rightDouble = GetDoubleValue(right);
-        return leftDouble.CompareTo(rightDouble);
+        if (value.Kind is ResolvedValueKind.Scalar)
+        {
+            if (value.Scalar.Kind is JsonPathNodeKind.String)
+            {
+                result = value.Scalar.StringValue;
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+
+        if (navigator.GetKind(value.Node) is JsonPathNodeKind.String)
+        {
+            return navigator.TryGetString(value.Node, out result);
+        }
+
+        result = null;
+        return false;
     }
 
-    private static double GetDoubleValue(JsonValue value)
-    {
-        if (value.TryGetValue<JsonElement>(out var element))
-        {
-            return element.GetDouble();
-        }
-
-        if (value.TryGetValue<double>(out var d))
-        {
-            return d;
-        }
-
-        if (value.TryGetValue<float>(out var f))
-        {
-            return f;
-        }
-
-        if (value.TryGetValue<decimal>(out var dec))
-        {
-            return (double)dec;
-        }
-
-        if (value.TryGetValue<long>(out var l))
-        {
-            return l;
-        }
-
-        if (value.TryGetValue<ulong>(out var ul))
-        {
-            return ul;
-        }
-
-        if (value.TryGetValue<int>(out var i))
-        {
-            return i;
-        }
-
-        if (value.TryGetValue<uint>(out var ui))
-        {
-            return ui;
-        }
-
-        if (value.TryGetValue<short>(out var s))
-        {
-            return s;
-        }
-
-        if (value.TryGetValue<ushort>(out var us))
-        {
-            return us;
-        }
-
-        if (value.TryGetValue<byte>(out var b))
-        {
-            return b;
-        }
-
-        if (value.TryGetValue<sbyte>(out var sb))
-        {
-            return sb;
-        }
-
-        return 0;
-    }
-
-    private static string? GetStringValue(JsonValue value)
-    {
-        if (value.TryGetValue<JsonElement>(out var element))
-        {
-            return element.GetString();
-        }
-
-        if (value.TryGetValue<string>(out var s))
-        {
-            return s;
-        }
-
-        return value.ToString();
-    }
-
-    // ---- Query Evaluation ----
-
-    private static List<JsonNode?> EvaluateFilterQuery(FilterQuery query, JsonNode? currentNode, JsonNode? root)
+    private static List<TValue?> EvaluateFilterQuery<TValue>(
+        FilterQuery query,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
         var startNode = query.Kind is FilterQueryKind.Relative ? currentNode : root;
-        var nodes = new List<(JsonNode? Node, List<PathComponent> Path)>
+        var nodes = new List<(TValue? Node, List<PathComponent> Path)>
         {
             (startNode, []),
         };
 
         foreach (var segment in query.Segments)
         {
-            nodes = ApplySegment(segment, nodes, root, JsonPathEvaluationMode.Lax);
+            nodes = ApplySegment(segment, nodes, root, navigator, JsonPathEvaluationMode.Lax);
         }
 
-        var result = new List<JsonNode?>(nodes.Count);
+        var result = new List<TValue?>(nodes.Count);
         foreach (var (node, _) in nodes)
         {
             result.Add(node);
@@ -722,23 +844,24 @@ internal static class JsonPathEvaluator
         return result;
     }
 
-    private static List<JsonNode?> EvaluateSingularQuery(SingularQuery query, JsonNode? currentNode, JsonNode? root)
+    private static List<TValue?> EvaluateSingularQuery<TValue>(
+        SingularQuery query,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
         var node = query.IsRelative ? currentNode : root;
 
         foreach (var segment in query.Segments)
         {
-            if (node is null && segment.Kind is SingularQuerySegmentKind.Name)
-            {
-                return [];
-            }
-
             switch (segment.Kind)
             {
                 case SingularQuerySegmentKind.Name:
-                    if (node is JsonObject obj && obj.TryGetPropertyValue(segment.Name!, out var value))
+                    if (navigator.GetKind(node) is JsonPathNodeKind.Object
+                        && navigator.TryGetPropertyValue(node, segment.Name!, out var propertyValue))
                     {
-                        node = value;
+                        node = propertyValue;
                     }
                     else
                     {
@@ -746,13 +869,15 @@ internal static class JsonPathEvaluator
                     }
 
                     break;
+
                 case SingularQuerySegmentKind.Index:
-                    if (node is JsonArray array)
+                    if (navigator.GetKind(node) is JsonPathNodeKind.Array)
                     {
-                        var idx = NormalizeIndex(segment.Index, array.Count);
-                        if (idx >= 0 && idx < array.Count)
+                        var length = navigator.GetArrayLength(node);
+                        var index = NormalizeIndex(segment.Index, length);
+                        if (index >= 0 && index < length && navigator.TryGetElement(node, (int)index, out var elementValue))
                         {
-                            node = array[(int)idx];
+                            node = elementValue;
                         }
                         else
                         {
@@ -771,104 +896,138 @@ internal static class JsonPathEvaluator
         return [node];
     }
 
-    // ---- Built-in Functions ----
-
-    private static bool EvaluateFunctionAsLogical(FunctionCallExpression func, JsonNode? currentNode, JsonNode? root)
+    private static bool EvaluateFunctionAsLogical<TValue>(
+        FunctionCallExpression func,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
         if (func.ResultType is FunctionExpressionType.LogicalType)
         {
             return func.Name switch
             {
-                "match" => EvaluateMatchFunction(func, currentNode, root),
-                "search" => EvaluateSearchFunction(func, currentNode, root),
+                "match" => EvaluateMatchFunction(func, currentNode, root, navigator),
+                "search" => EvaluateSearchFunction(func, currentNode, root, navigator),
                 _ => false,
             };
         }
 
-        // NodesType → convert to logical (non-empty = true)
         if (func.ResultType is FunctionExpressionType.NodesType)
         {
-            var nodes = EvaluateFunctionAsNodes(func, currentNode, root);
+            var nodes = EvaluateFunctionAsNodes(func, currentNode, root, navigator);
             return nodes.Count > 0;
         }
 
         return false;
     }
 
-    private static ResolvedValue EvaluateFunction(FunctionCallExpression func, JsonNode? currentNode, JsonNode? root)
+    private static ResolvedValue<TValue> EvaluateFunction<TValue>(
+        FunctionCallExpression func,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
         return func.Name switch
         {
-            "length" => EvaluateLengthFunction(func, currentNode, root),
-            "count" => EvaluateCountFunction(func, currentNode, root),
-            "value" => EvaluateValueFunction(func, currentNode, root),
-            "match" => EvaluateMatchFunction(func, currentNode, root)
-                ? ResolvedValue.FromNode(JsonValue.Create(value: true))
-                : ResolvedValue.FromNode(JsonValue.Create(value: false)),
-            "search" => EvaluateSearchFunction(func, currentNode, root)
-                ? ResolvedValue.FromNode(JsonValue.Create(value: true))
-                : ResolvedValue.FromNode(JsonValue.Create(value: false)),
-            _ => ResolvedValue.FromNothing(),
+            "length" => EvaluateLengthFunction(func, currentNode, root, navigator),
+            "count" => EvaluateCountFunction(func, currentNode, root, navigator),
+            "value" => EvaluateValueFunction(func, currentNode, root, navigator),
+            "match" => ResolvedValue<TValue>.FromScalar(ScalarValue.FromBoolean(EvaluateMatchFunction(func, currentNode, root, navigator))),
+            "search" => ResolvedValue<TValue>.FromScalar(ScalarValue.FromBoolean(EvaluateSearchFunction(func, currentNode, root, navigator))),
+            _ => ResolvedValue<TValue>.FromNothing(),
         };
     }
 
-    private static List<JsonNode?> EvaluateFunctionAsNodes(FunctionCallExpression func, JsonNode? currentNode, JsonNode? root)
+    private static List<TValue?> EvaluateFunctionAsNodes<TValue>(
+        FunctionCallExpression func,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
-        // Currently no built-in functions return NodesType
         _ = func;
         _ = currentNode;
         _ = root;
+        _ = navigator;
         return [];
     }
 
-    private static ResolvedValue EvaluateLengthFunction(FunctionCallExpression func, JsonNode? currentNode, JsonNode? root)
+    private static ResolvedValue<TValue> EvaluateLengthFunction<TValue>(
+        FunctionCallExpression func,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
-        var argValue = ResolveFunctionArgumentAsValue(func.Arguments[0], currentNode, root);
+        var argValue = ResolveFunctionArgumentAsValue(func.Arguments[0], currentNode, root, navigator);
         if (argValue.IsNothing)
         {
-            return ResolvedValue.FromNothing();
+            return ResolvedValue<TValue>.FromNothing();
         }
 
-        var node = argValue.Node;
-        return node switch
+        if (argValue.Kind is ResolvedValueKind.Scalar)
         {
-            JsonArray array => ResolvedValue.FromNode(JsonValue.Create(array.Count)),
-            JsonObject obj => ResolvedValue.FromNode(JsonValue.Create(obj.Count)),
-            JsonValue val when val.GetValueKind() is JsonValueKind.String =>
-                ResolvedValue.FromNode(JsonValue.Create(CountUnicodeScalarValues(GetStringValue(val)!))),
-            _ => ResolvedValue.FromNothing(),
+            return argValue.Scalar.Kind is JsonPathNodeKind.String
+                ? ResolvedValue<TValue>.FromScalar(ScalarValue.FromNumber(CountUnicodeScalarValues(argValue.Scalar.StringValue!)))
+                : ResolvedValue<TValue>.FromNothing();
+        }
+
+        return navigator.GetKind(argValue.Node) switch
+        {
+            JsonPathNodeKind.Array => ResolvedValue<TValue>.FromScalar(ScalarValue.FromNumber(navigator.GetArrayLength(argValue.Node))),
+            JsonPathNodeKind.Object => ResolvedValue<TValue>.FromScalar(ScalarValue.FromNumber(CountProperties(argValue.Node, navigator))),
+            JsonPathNodeKind.String when navigator.TryGetString(argValue.Node, out var value) =>
+                ResolvedValue<TValue>.FromScalar(ScalarValue.FromNumber(CountUnicodeScalarValues(value!))),
+            _ => ResolvedValue<TValue>.FromNothing(),
         };
     }
 
-    private static ResolvedValue EvaluateCountFunction(FunctionCallExpression func, JsonNode? currentNode, JsonNode? root)
+    private static ResolvedValue<TValue> EvaluateCountFunction<TValue>(
+        FunctionCallExpression func,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
-        var nodes = ResolveFunctionArgumentAsNodes(func.Arguments[0], currentNode, root);
-        return ResolvedValue.FromNode(JsonValue.Create(nodes.Count));
+        var nodes = ResolveFunctionArgumentAsNodes(func.Arguments[0], currentNode, root, navigator);
+        return ResolvedValue<TValue>.FromScalar(ScalarValue.FromNumber(nodes.Count));
     }
 
-    private static ResolvedValue EvaluateValueFunction(FunctionCallExpression func, JsonNode? currentNode, JsonNode? root)
+    private static ResolvedValue<TValue> EvaluateValueFunction<TValue>(
+        FunctionCallExpression func,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
-        var nodes = ResolveFunctionArgumentAsNodes(func.Arguments[0], currentNode, root);
+        var nodes = ResolveFunctionArgumentAsNodes(func.Arguments[0], currentNode, root, navigator);
         if (nodes.Count is 1)
         {
-            return ResolvedValue.FromNode(nodes[0]);
+            return ResolvedValue<TValue>.FromNode(nodes[0]);
         }
 
-        return ResolvedValue.FromNothing();
+        return ResolvedValue<TValue>.FromNothing();
     }
 
-    private static bool EvaluateMatchFunction(FunctionCallExpression func, JsonNode? currentNode, JsonNode? root)
+    private static bool EvaluateMatchFunction<TValue>(
+        FunctionCallExpression func,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
-        var strValue = ResolveFunctionArgumentAsValue(func.Arguments[0], currentNode, root);
-        var patternValue = ResolveFunctionArgumentAsValue(func.Arguments[1], currentNode, root);
+        var strValue = ResolveFunctionArgumentAsValue(func.Arguments[0], currentNode, root, navigator);
+        var patternValue = ResolveFunctionArgumentAsValue(func.Arguments[1], currentNode, root, navigator);
 
         if (strValue.IsNothing || patternValue.IsNothing)
         {
             return false;
         }
 
-        var str = GetStringFromNode(strValue.Node);
-        var pattern = GetStringFromNode(patternValue.Node);
+        var str = GetStringFromValue(strValue, navigator);
+        var pattern = GetStringFromValue(patternValue, navigator);
 
         if (str is null || pattern is null)
         {
@@ -877,7 +1036,6 @@ internal static class JsonPathEvaluator
 
         try
         {
-            // match() requires the ENTIRE string to match (anchored)
             var regex = ConvertIRegexpToRegex(pattern);
             var fullPattern = $"^(?:{regex})$";
             return Regex.IsMatch(str, fullPattern, RegexOptions.CultureInvariant, TimeSpan.FromSeconds(5));
@@ -888,18 +1046,23 @@ internal static class JsonPathEvaluator
         }
     }
 
-    private static bool EvaluateSearchFunction(FunctionCallExpression func, JsonNode? currentNode, JsonNode? root)
+    private static bool EvaluateSearchFunction<TValue>(
+        FunctionCallExpression func,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
-        var strValue = ResolveFunctionArgumentAsValue(func.Arguments[0], currentNode, root);
-        var patternValue = ResolveFunctionArgumentAsValue(func.Arguments[1], currentNode, root);
+        var strValue = ResolveFunctionArgumentAsValue(func.Arguments[0], currentNode, root, navigator);
+        var patternValue = ResolveFunctionArgumentAsValue(func.Arguments[1], currentNode, root, navigator);
 
         if (strValue.IsNothing || patternValue.IsNothing)
         {
             return false;
         }
 
-        var str = GetStringFromNode(strValue.Node);
-        var pattern = GetStringFromNode(patternValue.Node);
+        var str = GetStringFromValue(strValue, navigator);
+        var pattern = GetStringFromValue(patternValue, navigator);
 
         if (str is null || pattern is null)
         {
@@ -908,7 +1071,6 @@ internal static class JsonPathEvaluator
 
         try
         {
-            // search() checks if any substring matches (unanchored)
             var regex = ConvertIRegexpToRegex(pattern);
             return Regex.IsMatch(str, regex, RegexOptions.CultureInvariant, TimeSpan.FromSeconds(5));
         }
@@ -918,62 +1080,96 @@ internal static class JsonPathEvaluator
         }
     }
 
-    private static ResolvedValue ResolveFunctionArgumentAsValue(FunctionArgument arg, JsonNode? currentNode, JsonNode? root)
+    private static ResolvedValue<TValue> ResolveFunctionArgumentAsValue<TValue>(
+        FunctionArgument arg,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
         switch (arg.Kind)
         {
             case FunctionArgumentKind.Literal:
                 return arg.Value switch
                 {
-                    null => ResolvedValue.FromNode(node: null),
-                    true => ResolvedValue.FromNode(JsonValue.Create(value: true)),
-                    false => ResolvedValue.FromNode(JsonValue.Create(value: false)),
-                    string s => ResolvedValue.FromNode(JsonValue.Create(s)),
-                    double d => ResolvedValue.FromNode(JsonValue.Create(d)),
-                    _ => ResolvedValue.FromNothing(),
+                    null => ResolvedValue<TValue>.FromScalar(ScalarValue.Null()),
+                    true => ResolvedValue<TValue>.FromScalar(ScalarValue.FromBoolean(value: true)),
+                    false => ResolvedValue<TValue>.FromScalar(ScalarValue.FromBoolean(value: false)),
+                    string s => ResolvedValue<TValue>.FromScalar(ScalarValue.FromString(s)),
+                    double d => ResolvedValue<TValue>.FromScalar(ScalarValue.FromNumber(d)),
+                    _ => ResolvedValue<TValue>.FromNothing(),
                 };
 
             case FunctionArgumentKind.FilterQuery:
                 {
                     var query = (FilterQuery)arg.Value!;
-                    var nodes = EvaluateFilterQuery(query, currentNode, root);
+                    var nodes = EvaluateFilterQuery(query, currentNode, root, navigator);
                     if (nodes.Count is 1)
                     {
-                        return ResolvedValue.FromNode(nodes[0]);
+                        return ResolvedValue<TValue>.FromNode(nodes[0]);
                     }
 
-                    return ResolvedValue.FromNothing();
+                    return ResolvedValue<TValue>.FromNothing();
                 }
 
             case FunctionArgumentKind.FunctionCall:
                 {
                     var func = (FunctionCallExpression)arg.Value!;
-                    return EvaluateFunction(func, currentNode, root);
+                    return EvaluateFunction(func, currentNode, root, navigator);
                 }
 
             default:
-                return ResolvedValue.FromNothing();
+                return ResolvedValue<TValue>.FromNothing();
         }
     }
 
-    private static List<JsonNode?> ResolveFunctionArgumentAsNodes(FunctionArgument arg, JsonNode? currentNode, JsonNode? root)
+    private static List<TValue?> ResolveFunctionArgumentAsNodes<TValue>(
+        FunctionArgument arg,
+        TValue? currentNode,
+        TValue? root,
+        JsonPathNavigator<TValue> navigator)
+        where TValue : class
     {
         if (arg.Kind is FunctionArgumentKind.FilterQuery)
         {
             var query = (FilterQuery)arg.Value!;
-            return EvaluateFilterQuery(query, currentNode, root);
+            return EvaluateFilterQuery(query, currentNode, root, navigator);
         }
 
         if (arg.Kind is FunctionArgumentKind.FunctionCall)
         {
             var func = (FunctionCallExpression)arg.Value!;
-            return EvaluateFunctionAsNodes(func, currentNode, root);
+            return EvaluateFunctionAsNodes(func, currentNode, root, navigator);
         }
 
         return [];
     }
 
-    // ---- Helpers ----
+    private static string? GetStringFromValue<TValue>(ResolvedValue<TValue> value, JsonPathNavigator<TValue> navigator)
+        where TValue : class
+    {
+        if (value.Kind is ResolvedValueKind.Scalar)
+        {
+            return value.Scalar.Kind is JsonPathNodeKind.String ? value.Scalar.StringValue : null;
+        }
+
+        return navigator.GetKind(value.Node) is JsonPathNodeKind.String && navigator.TryGetString(value.Node, out var result)
+            ? result
+            : null;
+    }
+
+    private static int CountProperties<TValue>(TValue? value, JsonPathNavigator<TValue> navigator)
+        where TValue : class
+    {
+        var count = 0;
+        foreach (var property in navigator.GetProperties(value))
+        {
+            _ = property;
+            count++;
+        }
+
+        return count;
+    }
 
     private static long NormalizeIndex(long index, int length)
     {
@@ -995,16 +1191,6 @@ internal static class JsonPathEvaluator
         return length + value;
     }
 
-    private static string? GetStringFromNode(JsonNode? node)
-    {
-        if (node is JsonValue val && val.GetValueKind() is JsonValueKind.String)
-        {
-            return GetStringValue(val);
-        }
-
-        return null;
-    }
-
     private static int CountUnicodeScalarValues(string s)
     {
         var count = 0;
@@ -1013,20 +1199,13 @@ internal static class JsonPathEvaluator
             count++;
             if (char.IsHighSurrogate(s[i]) && i + 1 < s.Length && char.IsLowSurrogate(s[i + 1]))
             {
-                i++; // Skip the low surrogate
+                i++;
             }
         }
 
         return count;
     }
 
-    /// <summary>
-    /// Converts I-Regexp (RFC 9485) to .NET Regex pattern.
-    /// I-Regexp '.' matches any single Unicode code point except U+000A and U+000D.
-    /// .NET Regex '.' matches any char except '\n', so we need to:
-    /// 1. Exclude '\r' (which .NET '.' matches)
-    /// 2. Handle surrogate pairs as single code points
-    /// </summary>
     private static string ConvertIRegexpToRegex(string iregexp)
     {
         var sb = new StringBuilder(iregexp.Length * 2);
@@ -1038,7 +1217,6 @@ internal static class JsonPathEvaluator
 
             if (ch == '\\' && i + 1 < iregexp.Length)
             {
-                // Escaped character — pass through as-is
                 sb.Append(ch);
                 sb.Append(iregexp[i + 1]);
                 i++;
@@ -1061,8 +1239,6 @@ internal static class JsonPathEvaluator
 
             if (ch == '.' && !inCharClass)
             {
-                // I-Regexp dot: any Unicode code point except \n and \r
-                // Must handle surrogate pairs as single code points
                 sb.Append(@"(?:[\uD800-\uDBFF][\uDC00-\uDFFF]|[^\n\r])");
                 continue;
             }

--- a/src/Meziantou.Framework.JsonPath/JsonPath.cs
+++ b/src/Meziantou.Framework.JsonPath/JsonPath.cs
@@ -64,6 +64,34 @@ public sealed class JsonPath : IParsable<JsonPath>, ISpanParsable<JsonPath>
         return TryParse(expression, originalString: null, out result);
     }
 
+    /// <summary>Evaluates this JSONPath expression against a custom object model.</summary>
+    /// <typeparam name="TValue">The node type used by the JSONPath navigator.</typeparam>
+    /// <param name="root">The root value to query. May be <see langword="null"/> when the root value is JSON <c>null</c>.</param>
+    /// <param name="navigator">The navigator used to inspect values.</param>
+    /// <returns>A <see cref="JsonPathResult{TValue}"/> containing all matched nodes.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="navigator"/> is <see langword="null"/>.</exception>
+    public JsonPathResult<TValue> Evaluate<TValue>(TValue? root, JsonPathNavigator<TValue> navigator)
+        where TValue : class
+    {
+        return Evaluate(root, navigator, JsonPathEvaluationMode.Lax);
+    }
+
+    /// <summary>Evaluates this JSONPath expression against a custom object model.</summary>
+    /// <typeparam name="TValue">The node type used by the JSONPath navigator.</typeparam>
+    /// <param name="root">The root value to query. May be <see langword="null"/> when the root value is JSON <c>null</c>.</param>
+    /// <param name="navigator">The navigator used to inspect values.</param>
+    /// <param name="mode">The evaluation mode.</param>
+    /// <returns>A <see cref="JsonPathResult{TValue}"/> containing all matched nodes.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="navigator"/> is <see langword="null"/>.</exception>
+    /// <exception cref="JsonPathEvaluationException">The path cannot be evaluated in <see cref="JsonPathEvaluationMode.Strict"/> mode.</exception>
+    public JsonPathResult<TValue> Evaluate<TValue>(TValue? root, JsonPathNavigator<TValue> navigator, JsonPathEvaluationMode mode)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(navigator);
+
+        return JsonPathEvaluator.Evaluate(_ast, root, navigator, mode);
+    }
+
     /// <summary>Evaluates this JSONPath expression against a JSON value.</summary>
     /// <param name="root">The root JSON value to query. May be <see langword="null"/>.</param>
     /// <returns>A <see cref="JsonPathResult"/> containing all matched nodes.</returns>
@@ -105,6 +133,37 @@ public sealed class JsonPath : IParsable<JsonPath>, ISpanParsable<JsonPath>
         }
 
         return JsonPathEvaluator.Evaluate(_ast, node, mode);
+    }
+
+    /// <summary>
+    /// Evaluates this JSONPath expression and returns the first matched custom value, or <see langword="null"/> when there is no match.
+    /// </summary>
+    /// <typeparam name="TValue">The node type used by the JSONPath navigator.</typeparam>
+    /// <param name="root">The root value to query. May be <see langword="null"/> when the root value is JSON <c>null</c>.</param>
+    /// <param name="navigator">The navigator used to inspect values.</param>
+    /// <returns>The first matched value, or <see langword="null"/> when there is no match.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="navigator"/> is <see langword="null"/>.</exception>
+    public TValue? EvaluateValue<TValue>(TValue? root, JsonPathNavigator<TValue> navigator)
+        where TValue : class
+    {
+        return EvaluateValue(root, navigator, JsonPathEvaluationMode.Lax);
+    }
+
+    /// <summary>
+    /// Evaluates this JSONPath expression and returns the first matched custom value, or <see langword="null"/> when there is no match.
+    /// </summary>
+    /// <typeparam name="TValue">The node type used by the JSONPath navigator.</typeparam>
+    /// <param name="root">The root value to query. May be <see langword="null"/> when the root value is JSON <c>null</c>.</param>
+    /// <param name="navigator">The navigator used to inspect values.</param>
+    /// <param name="mode">The evaluation mode.</param>
+    /// <returns>The first matched value, or <see langword="null"/> when there is no match.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="navigator"/> is <see langword="null"/>.</exception>
+    /// <exception cref="JsonPathEvaluationException">The path cannot be evaluated in <see cref="JsonPathEvaluationMode.Strict"/> mode.</exception>
+    public TValue? EvaluateValue<TValue>(TValue? root, JsonPathNavigator<TValue> navigator, JsonPathEvaluationMode mode)
+        where TValue : class
+    {
+        var result = Evaluate(root, navigator, mode);
+        return result.Count > 0 ? result[0].Value : null;
     }
 
     /// <summary>

--- a/src/Meziantou.Framework.JsonPath/JsonPathMatch`1.cs
+++ b/src/Meziantou.Framework.JsonPath/JsonPathMatch`1.cs
@@ -1,0 +1,23 @@
+namespace Meziantou.Framework.Json;
+
+/// <summary>Represents a single value matched by a JSONPath evaluation.</summary>
+/// <typeparam name="TValue">The node type used by the JSONPath navigator.</typeparam>
+public readonly struct JsonPathMatch<TValue>
+    where TValue : class
+{
+    internal JsonPathMatch(TValue? value, string path)
+    {
+        Value = value;
+        Path = path;
+    }
+
+    /// <summary>
+    /// Gets the value of the matched node. May be <see langword="null"/> when the matched value is JSON <c>null</c>.
+    /// </summary>
+    public TValue? Value { get; }
+
+    /// <summary>
+    /// Gets the normalized path of the matched node (e.g. <c>$['store']['book'][0]</c>).
+    /// </summary>
+    public string Path { get; }
+}

--- a/src/Meziantou.Framework.JsonPath/JsonPathNavigator`1.cs
+++ b/src/Meziantou.Framework.JsonPath/JsonPathNavigator`1.cs
@@ -1,0 +1,54 @@
+namespace Meziantou.Framework.Json;
+
+/// <summary>Provides JSONPath navigation services for a custom object model.</summary>
+/// <typeparam name="TValue">The node type used by the custom object model.</typeparam>
+public abstract class JsonPathNavigator<TValue>
+    where TValue : class
+{
+    /// <summary>Gets the JSON node kind represented by <paramref name="value"/>.</summary>
+    /// <param name="value">The value to inspect. A <see langword="null"/> value represents JSON <c>null</c>.</param>
+    /// <returns>The JSON node kind represented by <paramref name="value"/>.</returns>
+    public abstract JsonPathNodeKind GetKind(TValue? value);
+
+    /// <summary>Gets an object property value.</summary>
+    /// <param name="value">The object value.</param>
+    /// <param name="name">The property name.</param>
+    /// <param name="result">When this method returns, contains the property value if it exists.</param>
+    /// <returns><see langword="true"/> when the property exists; otherwise, <see langword="false"/>.</returns>
+    public abstract bool TryGetPropertyValue(TValue? value, string name, out TValue? result);
+
+    /// <summary>Gets object properties in enumeration order.</summary>
+    /// <param name="value">The object value.</param>
+    /// <returns>The object properties in enumeration order.</returns>
+    public abstract IEnumerable<JsonPathProperty<TValue>> GetProperties(TValue? value);
+
+    /// <summary>Gets an array length.</summary>
+    /// <param name="value">The array value.</param>
+    /// <returns>The array length.</returns>
+    public abstract int GetArrayLength(TValue? value);
+
+    /// <summary>Gets an array element by zero-based index.</summary>
+    /// <param name="value">The array value.</param>
+    /// <param name="index">The zero-based array index.</param>
+    /// <param name="result">When this method returns, contains the element value if it exists.</param>
+    /// <returns><see langword="true"/> when the element exists; otherwise, <see langword="false"/>.</returns>
+    public abstract bool TryGetElement(TValue? value, int index, out TValue? result);
+
+    /// <summary>Gets a string scalar value.</summary>
+    /// <param name="value">The scalar value.</param>
+    /// <param name="result">When this method returns, contains the string value.</param>
+    /// <returns><see langword="true"/> when <paramref name="value"/> represents a string; otherwise, <see langword="false"/>.</returns>
+    public abstract bool TryGetString(TValue? value, out string? result);
+
+    /// <summary>Gets a number scalar value.</summary>
+    /// <param name="value">The scalar value.</param>
+    /// <param name="result">When this method returns, contains the number value.</param>
+    /// <returns><see langword="true"/> when <paramref name="value"/> represents a number; otherwise, <see langword="false"/>.</returns>
+    public abstract bool TryGetNumber(TValue? value, out double result);
+
+    /// <summary>Gets a boolean scalar value.</summary>
+    /// <param name="value">The scalar value.</param>
+    /// <param name="result">When this method returns, contains the boolean value.</param>
+    /// <returns><see langword="true"/> when <paramref name="value"/> represents a boolean; otherwise, <see langword="false"/>.</returns>
+    public abstract bool TryGetBoolean(TValue? value, out bool result);
+}

--- a/src/Meziantou.Framework.JsonPath/JsonPathNodeKind.cs
+++ b/src/Meziantou.Framework.JsonPath/JsonPathNodeKind.cs
@@ -1,0 +1,25 @@
+namespace Meziantou.Framework.Json;
+
+/// <summary>Represents the JSON node kind exposed by a <see cref="JsonPathNavigator{TValue}"/>.</summary>
+#pragma warning disable CA1720
+public enum JsonPathNodeKind
+{
+    /// <summary>A JSON null value.</summary>
+    Null,
+
+    /// <summary>A JSON boolean value.</summary>
+    Boolean,
+
+    /// <summary>A JSON number value.</summary>
+    Number,
+
+    /// <summary>A JSON string value.</summary>
+    String,
+
+    /// <summary>A JSON array value.</summary>
+    Array,
+
+    /// <summary>A JSON object value.</summary>
+    Object,
+}
+#pragma warning restore CA1720

--- a/src/Meziantou.Framework.JsonPath/JsonPathProperty`1.cs
+++ b/src/Meziantou.Framework.JsonPath/JsonPathProperty`1.cs
@@ -1,0 +1,24 @@
+namespace Meziantou.Framework.Json;
+
+/// <summary>Represents an object property exposed by a <see cref="JsonPathNavigator{TValue}"/>.</summary>
+/// <typeparam name="TValue">The node type used by the JSONPath navigator.</typeparam>
+public readonly struct JsonPathProperty<TValue>
+    where TValue : class
+{
+    /// <summary>Initializes a new instance of the <see cref="JsonPathProperty{TValue}"/> struct.</summary>
+    /// <param name="name">The property name.</param>
+    /// <param name="value">The property value.</param>
+    public JsonPathProperty(string name, TValue? value)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        Name = name;
+        Value = value;
+    }
+
+    /// <summary>Gets the property name.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets the property value. May be <see langword="null"/> when the property value is JSON <c>null</c>.</summary>
+    public TValue? Value { get; }
+}

--- a/src/Meziantou.Framework.JsonPath/JsonPathResult`1.cs
+++ b/src/Meziantou.Framework.JsonPath/JsonPathResult`1.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+
+namespace Meziantou.Framework.Json;
+
+/// <summary>
+/// Represents the result of evaluating a JSONPath expression against a custom object model.
+/// Contains the ordered list of matched nodes.
+/// </summary>
+/// <typeparam name="TValue">The node type used by the JSONPath navigator.</typeparam>
+public sealed class JsonPathResult<TValue> : IReadOnlyList<JsonPathMatch<TValue>>
+    where TValue : class
+{
+    internal static readonly JsonPathResult<TValue> Empty = new([]);
+
+    private readonly List<JsonPathMatch<TValue>> _matches;
+
+    internal JsonPathResult(List<JsonPathMatch<TValue>> matches)
+    {
+        _matches = matches;
+    }
+
+    /// <inheritdoc />
+    public int Count => _matches.Count;
+
+    /// <inheritdoc />
+    public JsonPathMatch<TValue> this[int index] => _matches[index];
+
+    /// <inheritdoc />
+    public IEnumerator<JsonPathMatch<TValue>> GetEnumerator() => _matches.GetEnumerator();
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj
+++ b/src/Meziantou.Framework.JsonPath/Meziantou.Framework.JsonPath.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Json</RootNamespace>
-    <Description>An implementation of JSONPath (RFC 9535) for System.Text.Json.</Description>
+    <Description>An implementation of JSONPath (RFC 9535) for System.Text.Json and custom object models.</Description>
     <Version>2.0.3</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.JsonPath/readme.md
+++ b/src/Meziantou.Framework.JsonPath/readme.md
@@ -1,6 +1,6 @@
 # Meziantou.Framework.JsonPath
 
-An implementation of [JSONPath (RFC 9535)](https://datatracker.ietf.org/doc/html/rfc9535) for `System.Text.Json`.
+An implementation of [JSONPath (RFC 9535)](https://datatracker.ietf.org/doc/html/rfc9535) for `System.Text.Json` and custom object models.
 
 ## Usage
 
@@ -38,6 +38,23 @@ var laxValue = path.EvaluateValue(doc, JsonPathEvaluationMode.Lax); // null
 
 var strictValue = path.EvaluateValue(doc, JsonPathEvaluationMode.Strict); // throws JsonPathEvaluationException
 ```
+
+## Custom object models
+
+Use `JsonPathNavigator<TValue>` to evaluate JSONPath expressions against a custom tree without converting it to `JsonNode`.
+
+```csharp
+var path = JsonPath.Parse("$.items[?@.enabled == true]");
+var result = path.Evaluate(root: myRoot, navigator: MyNodeNavigator.Instance);
+
+foreach (var match in result)
+{
+    MyNode? node = match.Value;
+    Console.WriteLine(match.Path);
+}
+```
+
+Navigator implementations expose JSON-like semantics for the custom node type. A `null` node represents JSON `null`; a `false` return value from `TryGetPropertyValue` or `TryGetElement` means the member or element is missing. Arrays are zero-based, and object property order follows the navigator's `GetProperties` enumeration order.
 
 ## Supported Features
 

--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
@@ -103,8 +103,9 @@ internal static class PublicApiModelReader
     private static PublicApiTypeModel BuildTypeModel(MetadataReader metadataReader, TypeDefinitionHandle typeDefinitionHandle, TypeDefinition typeDefinition)
     {
         var namespaceName = typeDefinition.Namespace.IsNil ? string.Empty : metadataReader.GetString(typeDefinition.Namespace);
-        var name = RemoveGenericArity(metadataReader.GetString(typeDefinition.Name));
-        var qualifiedName = string.IsNullOrEmpty(namespaceName) ? name : namespaceName + "." + name;
+        var metadataName = metadataReader.GetString(typeDefinition.Name);
+        var name = RemoveGenericArity(metadataName);
+        var qualifiedName = string.IsNullOrEmpty(namespaceName) ? metadataName : namespaceName + "." + metadataName;
         var source = BuildTypeSource(metadataReader, typeDefinitionHandle, typeDefinition, name);
         return new PublicApiTypeModel(namespaceName, name, qualifiedName, source);
     }

--- a/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
@@ -510,4 +510,273 @@ public sealed class JsonPathEvaluateTests
         var result = JsonPath.Parse("$[?@.a > 42]").Evaluate(json);
         Assert.Single(result);
     }
+
+    [Fact]
+    public void Evaluate_CustomNavigator_ReturnsTypedMatches()
+    {
+        var document = CreateCustomDocument();
+        var path = JsonPath.Parse("$.items[1].name");
+        var result = path.Evaluate(document, TestValueNavigator.Instance);
+
+        Assert.Single(result);
+        Assert.Equal("$['items'][1]['name']", result[0].Path);
+        Assert.Equal("bar", result[0].Value!.StringValue);
+    }
+
+    [Fact]
+    public void EvaluateValue_CustomNavigator_ReturnsTypedValue()
+    {
+        var document = CreateCustomDocument();
+        var path = JsonPath.Parse("$.items[-1].name");
+        var result = path.EvaluateValue(document, TestValueNavigator.Instance);
+
+        Assert.NotNull(result);
+        Assert.Equal("foobar", result.StringValue);
+    }
+
+    [Fact]
+    public void Evaluate_CustomNavigator_Selectors()
+    {
+        var document = CreateCustomDocument();
+
+        AssertNames(JsonPath.Parse("$.items[*]").Evaluate(document, TestValueNavigator.Instance), "foo", "bar", "foobar");
+        AssertNames(JsonPath.Parse("$.items[0:3:2]").Evaluate(document, TestValueNavigator.Instance), "foo", "foobar");
+
+        var descendantResult = JsonPath.Parse("$..title").Evaluate(document, TestValueNavigator.Instance);
+        Assert.Single(descendantResult);
+        Assert.Equal("$['metadata']['title']", descendantResult[0].Path);
+        Assert.Equal("Catalog", descendantResult[0].Value!.StringValue);
+    }
+
+    [Fact]
+    public void Evaluate_CustomNavigator_NullValue()
+    {
+        var document = CreateCustomDocument();
+        var result = JsonPath.Parse("$.none").Evaluate(document, TestValueNavigator.Instance);
+
+        Assert.Single(result);
+        Assert.Null(result[0].Value);
+        Assert.Equal("$['none']", result[0].Path);
+    }
+
+    [Fact]
+    public void Evaluate_CustomNavigator_MissingMember_StrictMode()
+    {
+        var document = CreateCustomDocument();
+        var path = JsonPath.Parse("$.missing");
+
+        Assert.Throws<JsonPathEvaluationException>(() => path.Evaluate(document, TestValueNavigator.Instance, JsonPathEvaluationMode.Strict));
+    }
+
+    [Fact]
+    public void Evaluate_CustomNavigator_FiltersAndFunctions()
+    {
+        var document = CreateCustomDocument();
+        var navigator = TestValueNavigator.Instance;
+
+        AssertNames(JsonPath.Parse("$.items[?@.price < $.limit]").Evaluate(document, navigator), "foo", "foobar");
+        AssertNames(JsonPath.Parse("$.items[?@.available == true]").Evaluate(document, navigator), "foo", "foobar");
+        AssertNames(JsonPath.Parse("$.items[?length(@.tags) > 1]").Evaluate(document, navigator), "foo");
+        AssertNames(JsonPath.Parse("$.items[?count(@.*) == 6]").Evaluate(document, navigator), "bar");
+        AssertNames(JsonPath.Parse("$.items[?value(@.id) == 2]").Evaluate(document, navigator), "bar");
+        AssertNames(JsonPath.Parse("""$.items[?match(@.name, "foo")]""").Evaluate(document, navigator), "foo");
+        AssertNames(JsonPath.Parse("""$.items[?search(@.name, "foo")]""").Evaluate(document, navigator), "foo", "foobar");
+    }
+
+    private static TestValue CreateCustomDocument()
+    {
+        return Object(
+            Property("limit", Number(10)),
+            Property("items", Array(
+                Object(
+                    Property("id", Number(1)),
+                    Property("name", String("foo")),
+                    Property("price", Number(8)),
+                    Property("available", Boolean(value: true)),
+                    Property("tags", Array(String("a"), String("b")))),
+                Object(
+                    Property("id", Number(2)),
+                    Property("name", String("bar")),
+                    Property("price", Number(12)),
+                    Property("available", Boolean(value: false)),
+                    Property("tags", Array(String("c"))),
+                    Property("isbn", String("123"))),
+                Object(
+                    Property("id", Number(3)),
+                    Property("name", String("foobar")),
+                    Property("price", Number(7)),
+                    Property("available", Boolean(value: true)),
+                    Property("tags", Array(String("d")))))),
+            Property("metadata", Object(Property("title", String("Catalog")))),
+            Property("none", null));
+    }
+
+    private static void AssertNames(JsonPathResult<TestValue> result, params string[] expectedNames)
+    {
+        Assert.Equal(expectedNames.Length, result.Count);
+        for (var i = 0; i < expectedNames.Length; i++)
+        {
+            Assert.True(TestValueNavigator.Instance.TryGetPropertyValue(result[i].Value, "name", out var name));
+            Assert.Equal(JsonPathNodeKind.String, name!.Kind);
+            Assert.Equal(expectedNames[i], name.StringValue);
+        }
+    }
+
+    private static JsonPathProperty<TestValue> Property(string name, TestValue? value) => new(name, value);
+
+    private static TestValue Object(params JsonPathProperty<TestValue>[] properties) => TestValue.Object(properties);
+
+    private static TestValue Array(params TestValue?[] items) => TestValue.Array(items);
+
+    private static TestValue String(string value) => TestValue.String(value);
+
+    private static TestValue Number(double value) => TestValue.Number(value);
+
+    private static TestValue Boolean(bool value) => TestValue.Boolean(value);
+
+    private sealed class TestValue
+    {
+        private TestValue(
+            JsonPathNodeKind kind,
+            IReadOnlyList<JsonPathProperty<TestValue>>? properties = null,
+            IReadOnlyList<TestValue?>? items = null,
+            string? stringValue = null,
+            double numberValue = 0,
+            bool booleanValue = false)
+        {
+            Kind = kind;
+            Properties = properties ?? [];
+            Items = items ?? [];
+            StringValue = stringValue;
+            NumberValue = numberValue;
+            BooleanValue = booleanValue;
+        }
+
+        public JsonPathNodeKind Kind { get; }
+
+        public IReadOnlyList<JsonPathProperty<TestValue>> Properties { get; }
+
+        public IReadOnlyList<TestValue?> Items { get; }
+
+        public string? StringValue { get; }
+
+        public double NumberValue { get; }
+
+        public bool BooleanValue { get; }
+
+        public static TestValue Object(params JsonPathProperty<TestValue>[] properties)
+        {
+            return new TestValue(JsonPathNodeKind.Object, properties: properties);
+        }
+
+        public static TestValue Array(params TestValue?[] items)
+        {
+            return new TestValue(JsonPathNodeKind.Array, items: items);
+        }
+
+        public static TestValue String(string value)
+        {
+            return new TestValue(JsonPathNodeKind.String, stringValue: value);
+        }
+
+        public static TestValue Number(double value)
+        {
+            return new TestValue(JsonPathNodeKind.Number, numberValue: value);
+        }
+
+        public static TestValue Boolean(bool value)
+        {
+            return new TestValue(JsonPathNodeKind.Boolean, booleanValue: value);
+        }
+    }
+
+    private sealed class TestValueNavigator : JsonPathNavigator<TestValue>
+    {
+        public static TestValueNavigator Instance { get; } = new();
+
+        private TestValueNavigator()
+        {
+        }
+
+        public override JsonPathNodeKind GetKind(TestValue? value)
+        {
+            return value?.Kind ?? JsonPathNodeKind.Null;
+        }
+
+        public override bool TryGetPropertyValue(TestValue? value, string name, out TestValue? result)
+        {
+            if (value?.Kind is JsonPathNodeKind.Object)
+            {
+                foreach (var property in value.Properties)
+                {
+                    if (property.Name == name)
+                    {
+                        result = property.Value;
+                        return true;
+                    }
+                }
+            }
+
+            result = null;
+            return false;
+        }
+
+        public override IEnumerable<JsonPathProperty<TestValue>> GetProperties(TestValue? value)
+        {
+            return value?.Kind is JsonPathNodeKind.Object ? value.Properties : [];
+        }
+
+        public override int GetArrayLength(TestValue? value)
+        {
+            return value?.Kind is JsonPathNodeKind.Array ? value.Items.Count : 0;
+        }
+
+        public override bool TryGetElement(TestValue? value, int index, out TestValue? result)
+        {
+            if (value?.Kind is JsonPathNodeKind.Array && index >= 0 && index < value.Items.Count)
+            {
+                result = value.Items[index];
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+
+        public override bool TryGetString(TestValue? value, out string? result)
+        {
+            if (value?.Kind is JsonPathNodeKind.String)
+            {
+                result = value.StringValue;
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+
+        public override bool TryGetNumber(TestValue? value, out double result)
+        {
+            if (value?.Kind is JsonPathNodeKind.Number)
+            {
+                result = value.NumberValue;
+                return true;
+            }
+
+            result = 0;
+            return false;
+        }
+
+        public override bool TryGetBoolean(TestValue? value, out bool result)
+        {
+            if (value?.Kind is JsonPathNodeKind.Boolean)
+            {
+                result = value.BooleanValue;
+                return true;
+            }
+
+            result = false;
+            return false;
+        }
+    }
 }

--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
@@ -2185,6 +2185,35 @@ public sealed class PublicApiGeneratorTests
     }
 
     [Fact]
+    public async Task GenericClass_WithNonGenericTypeOfSameName()
+    {
+        await Validate("""
+            public class Sample
+            {
+                public int Value => 0;
+            }
+
+            public class Sample<T0>
+            {
+                public T0 Value => default;
+            }
+            """, """
+            #nullable enable
+
+            public class Sample
+            {
+                public int Value { get => throw null; }
+            }
+
+
+            public class Sample<T0>
+            {
+                public T0 Value { get => throw null; }
+            }
+            """);
+    }
+
+    [Fact]
     public async Task GenericClass_ImplementsGenericInterface()
     {
         await Validate("""


### PR DESCRIPTION
## Summary
- Add custom JSONPath parsing and evaluation support in `Meziantou.Framework.JsonPath`
- Extend the navigator, result, and match types to expose the new behavior
- Update public API generation metadata and regenerate the reference file
- Add and update tests covering JSONPath evaluation and public API output

## Testing
- Added/updated unit tests for JSONPath evaluation and public API generation
- Not run (not requested)