### PR TITLE
Handle C# union types in the null-value analyzer

### DIFF
--- a/src/Meziantou.Framework.Assertions.Analyzer/AssertionsAnalyzerHelpers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/AssertionsAnalyzerHelpers.cs
@@ -6,6 +6,8 @@ namespace Meziantou.Framework.Analyzers.Assertions;
 internal static class AssertionsAnalyzerHelpers
 {
     public const string AssertMetadataName = "Meziantou.Framework.Assertions.Assert";
+    public const string CSharpUnionAttributeMetadataName = "System.Runtime.CompilerServices.UnionAttribute";
+    public const string CSharpUnionInterfaceMetadataName = "System.Runtime.CompilerServices.IUnion";
 
     public static bool IsAssertReferenceEqualsInvocation(IInvocationOperation invocationOperation, INamedTypeSymbol assertType)
     {
@@ -34,11 +36,11 @@ internal static class AssertionsAnalyzerHelpers
         return type?.IsValueType == true;
     }
 
-    public static bool IsNonNullableValueType(ITypeSymbol? type)
+    public static bool IsNonNullableValueType(ITypeSymbol? type, INamedTypeSymbol? unionAttributeType, INamedTypeSymbol? unionInterfaceType)
     {
         return type is { IsValueType: true } &&
                !IsNullableValueType(type) &&
-               !IsCSharpUnionType(type);
+               !IsCSharpUnionType(type, unionAttributeType, unionInterfaceType);
     }
 
     private static bool IsNullableValueType(ITypeSymbol type)
@@ -46,11 +48,16 @@ internal static class AssertionsAnalyzerHelpers
         return type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
     }
 
-    private static bool IsCSharpUnionType(ITypeSymbol type)
+    private static bool IsCSharpUnionType(ITypeSymbol type, INamedTypeSymbol? unionAttributeType, INamedTypeSymbol? unionInterfaceType)
     {
+        if (unionAttributeType is null ||
+            unionInterfaceType is null ||
+            !type.AllInterfaces.Contains(unionInterfaceType, SymbolEqualityComparer.Default))
+            return false;
+
         foreach (var attribute in type.GetAttributes())
         {
-            if (attribute.AttributeClass?.ToDisplayString() == "System.Runtime.CompilerServices.UnionAttribute")
+            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, unionAttributeType))
                 return true;
         }
 

--- a/src/Meziantou.Framework.Assertions.Analyzer/AssertionsAnalyzerHelpers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/AssertionsAnalyzerHelpers.cs
@@ -37,11 +37,23 @@ internal static class AssertionsAnalyzerHelpers
     public static bool IsNonNullableValueType(ITypeSymbol? type)
     {
         return type is { IsValueType: true } &&
-               !IsNullableValueType(type);
+               !IsNullableValueType(type) &&
+               !IsCSharpUnionType(type);
     }
 
     private static bool IsNullableValueType(ITypeSymbol type)
     {
         return type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
+    }
+
+    private static bool IsCSharpUnionType(ITypeSymbol type)
+    {
+        foreach (var attribute in type.GetAttributes())
+        {
+            if (attribute.AttributeClass?.ToDisplayString() == "System.Runtime.CompilerServices.UnionAttribute")
+                return true;
+        }
+
+        return false;
     }
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzerCommon.cs
@@ -42,7 +42,12 @@ internal static class AssertionMethodSelectionAnalyzerCommon
         return false;
     }
 
-    internal static bool TryGetNullNotNullValueTypeMatch(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, out NullNotNullValueTypeMatch match)
+    internal static bool TryGetNullNotNullValueTypeMatch(
+        IInvocationOperation invocationOperation,
+        INamedTypeSymbol assertType,
+        INamedTypeSymbol? unionAttributeType,
+        INamedTypeSymbol? unionInterfaceType,
+        out NullNotNullValueTypeMatch match)
     {
         if (!IsAssertInvocation(invocationOperation, assertType, NullAssertionMethodName, NotNullAssertionMethodName))
         {
@@ -52,7 +57,7 @@ internal static class AssertionMethodSelectionAnalyzerCommon
 
         var actualArgument = invocationOperation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "actual");
         if (actualArgument is null ||
-            !AssertionsAnalyzerHelpers.IsNonNullableValueType(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(actualArgument.Value).Type))
+            !AssertionsAnalyzerHelpers.IsNonNullableValueType(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(actualArgument.Value).Type, unionAttributeType, unionInterfaceType))
         {
             match = default;
             return false;

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/NullWithValueTypeAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/NullWithValueTypeAnalyzer.cs
@@ -36,16 +36,19 @@ public sealed class NullWithValueTypeAnalyzer : DiagnosticAnalyzer
             if (assertType is null)
                 return;
 
+            var unionAttributeType = context.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.CSharpUnionAttributeMetadataName);
+            var unionInterfaceType = context.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.CSharpUnionInterfaceMetadataName);
+
             context.RegisterOperationAction(
-                context => Analyze(context, assertType),
+                context => Analyze(context, assertType, unionAttributeType, unionInterfaceType),
                 OperationKind.Invocation);
         });
     }
 
-    private static void Analyze(OperationAnalysisContext context, INamedTypeSymbol assertType)
+    private static void Analyze(OperationAnalysisContext context, INamedTypeSymbol assertType, INamedTypeSymbol? unionAttributeType, INamedTypeSymbol? unionInterfaceType)
     {
         var invocationOperation = (IInvocationOperation)context.Operation;
-        if (!AssertionMethodSelectionAnalyzerCommon.TryGetNullNotNullValueTypeMatch(invocationOperation, assertType, out var match))
+        if (!AssertionMethodSelectionAnalyzerCommon.TryGetNullNotNullValueTypeMatch(invocationOperation, assertType, unionAttributeType, unionInterfaceType, out var match))
             return;
 
         var descriptor = match.AssertionMethodName == "Equal" ? NullWithValueTypeDescriptor : NotNullWithValueTypeDescriptor;

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/NullWithValueTypeCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/NullWithValueTypeCodeFixProvider.cs
@@ -32,6 +32,9 @@ public sealed class NullWithValueTypeCodeFixProvider : CodeFixProvider
         if (assertType is null)
             return;
 
+        var unionAttributeType = semanticModel.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.CSharpUnionAttributeMetadataName);
+        var unionInterfaceType = semanticModel.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.CSharpUnionInterfaceMetadataName);
+
         foreach (var diagnostic in context.Diagnostics)
         {
             var invocationExpression = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true)
@@ -42,14 +45,20 @@ public sealed class NullWithValueTypeCodeFixProvider : CodeFixProvider
             if (!AssertionCodeFixHelpers.TryGetInvocationOperation(semanticModel, invocationExpression, context.CancellationToken, out var invocationOperation))
                 continue;
 
-            if (!AssertionMethodSelectionAnalyzerCommon.TryGetNullNotNullValueTypeMatch(invocationOperation, assertType, out var match) || invocationExpression.ArgumentList.Arguments.Count != 1)
+            if (!AssertionMethodSelectionAnalyzerCommon.TryGetNullNotNullValueTypeMatch(invocationOperation, assertType, unionAttributeType, unionInterfaceType, out var match) || invocationExpression.ArgumentList.Arguments.Count != 1)
                 continue;
 
-            context.RegisterCodeFix(CodeAction.Create(title: "Use Assert." + match.AssertionMethodName, createChangedDocument: ct => ApplyFixAsync(context.Document, invocationExpression, assertType, ct), equivalenceKey: GetType().FullName), diagnostic);
+            context.RegisterCodeFix(CodeAction.Create(title: "Use Assert." + match.AssertionMethodName, createChangedDocument: ct => ApplyFixAsync(context.Document, invocationExpression, assertType, unionAttributeType, unionInterfaceType, ct), equivalenceKey: GetType().FullName), diagnostic);
         }
     }
 
-    private static async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocationExpression, INamedTypeSymbol assertType, CancellationToken cancellationToken)
+    private static async Task<Document> ApplyFixAsync(
+        Document document,
+        InvocationExpressionSyntax invocationExpression,
+        INamedTypeSymbol assertType,
+        INamedTypeSymbol? unionAttributeType,
+        INamedTypeSymbol? unionInterfaceType,
+        CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         if (root is null)
@@ -62,7 +71,7 @@ public sealed class NullWithValueTypeCodeFixProvider : CodeFixProvider
         if (!AssertionCodeFixHelpers.TryGetInvocationOperation(semanticModel, invocationExpression, cancellationToken, out var invocationOperation))
             return document;
 
-        if (!AssertionMethodSelectionAnalyzerCommon.TryGetNullNotNullValueTypeMatch(invocationOperation, assertType, out var match) || invocationExpression.ArgumentList.Arguments.Count != 1 || !AssertionCodeFixHelpers.TryGetExpressionSyntax(match.ActualOperation, out var actualValueExpression))
+        if (!AssertionMethodSelectionAnalyzerCommon.TryGetNullNotNullValueTypeMatch(invocationOperation, assertType, unionAttributeType, unionInterfaceType, out var match) || invocationExpression.ArgumentList.Arguments.Count != 1 || !AssertionCodeFixHelpers.TryGetExpressionSyntax(match.ActualOperation, out var actualValueExpression))
             return document;
 
         var typeName = match.ValueType.ToMinimalDisplayString(semanticModel, invocationExpression.SpanStart);

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/NullWithValueTypeRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/NullWithValueTypeRuleTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using Microsoft.CodeAnalysis;
 using NullWithValueTypeAnalyzerType = Meziantou.Framework.Analyzers.Assertions.NullWithValueTypeAnalyzer;
 using NullWithValueTypeCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.NullWithValueTypeCodeFixProvider;
 
@@ -72,4 +74,29 @@ public sealed class NullWithValueTypeRuleTests : AssertionsAnalyzerTestBase
 
         await CreateCodeFixTest<NullWithValueTypeAnalyzerType, NullWithValueTypeCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForAssertNotNullWithUnion()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(Meziantou.Framework.Tests.NullWithValueTypeRuleTests.SampleUnionForAnalyzerTest value)
+                {
+                    Assert.NotNull(value);
+                }
+            }
+            """;
+
+        var test = CreateAnalyzerTest<NullWithValueTypeAnalyzerType>(source);
+        test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(Assembly.GetExecutingAssembly().Location));
+
+        await test.RunAsync(XunitCancellationToken);
+    }
+
+    public union SampleUnionForAnalyzerTest(string?, int);
 }


### PR DESCRIPTION
## Summary
- Treat C# union types as non-matching for the null-with-value-type analyzer helper
- Add a regression test to verify `Assert.NotNull` is not flagged for a union type

## Testing
- Added analyzer unit coverage for the union-type case