### PR TITLE
Fix Git submodule scanner support for worktrees

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Scanners/GitSubmoduleDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/GitSubmoduleDependencyScanner.cs
@@ -207,10 +207,15 @@ public sealed class GitSubmoduleDependencyScanner : DependencyScanner
         var dotGitPath = Path.Combine(repositoryDirectory, ".git");
         if (Directory.Exists(dotGitPath))
         {
-            gitDirectory = dotGitPath;
+            gitDirectory = Path.GetFullPath(dotGitPath);
             return true;
         }
 
+        return TryGetGitDirectoryFromFile(dotGitPath, out gitDirectory);
+    }
+
+    private static bool TryGetGitDirectoryFromFile(string dotGitPath, out string gitDirectory)
+    {
         if (!File.Exists(dotGitPath))
         {
             gitDirectory = "";
@@ -219,15 +224,17 @@ public sealed class GitSubmoduleDependencyScanner : DependencyScanner
 
         try
         {
-            var dotGitContent = File.ReadAllText(dotGitPath).Trim();
-            if (!dotGitContent.StartsWith(GitDirectoryPrefix, StringComparison.OrdinalIgnoreCase))
+            using var reader = File.OpenText(dotGitPath);
+            var dotGitContent = reader.ReadLine()?.TrimStart('\uFEFF').Trim();
+            if (string.IsNullOrEmpty(dotGitContent) || !dotGitContent.StartsWith(GitDirectoryPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 gitDirectory = "";
                 return false;
             }
 
             var relativeGitDirectory = dotGitContent[GitDirectoryPrefix.Length..].Trim();
-            if (string.IsNullOrEmpty(relativeGitDirectory))
+            var dotGitDirectory = Path.GetDirectoryName(dotGitPath);
+            if (string.IsNullOrEmpty(relativeGitDirectory) || string.IsNullOrEmpty(dotGitDirectory))
             {
                 gitDirectory = "";
                 return false;
@@ -235,7 +242,7 @@ public sealed class GitSubmoduleDependencyScanner : DependencyScanner
 
             gitDirectory = Path.IsPathRooted(relativeGitDirectory)
                 ? Path.GetFullPath(relativeGitDirectory)
-                : Path.GetFullPath(Path.Combine(repositoryDirectory, relativeGitDirectory));
+                : Path.GetFullPath(Path.Combine(dotGitDirectory, relativeGitDirectory));
             return Directory.Exists(gitDirectory);
         }
         catch (IOException)

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -652,6 +652,83 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
     }
 
     [Fact]
+    public async Task GitSubmodulesFromDependenciesInWorktree()
+    {
+        await using var remote = TemporaryDirectory.Create();
+        await ExecuteProcess("git", ["init"], remote.FullPath);
+        await ExecuteProcess("git", ["config", "user.name", "test"], remote.FullPath);
+        await ExecuteProcess("git", ["config", "user.email", "test@example.com"], remote.FullPath);
+        await ExecuteProcess("git", ["config", "commit.gpgsign", "false"], remote.FullPath);
+        await File.WriteAllTextAsync(remote.GetFullPath("test.txt"), "content");
+        await ExecuteProcess("git", ["add", "."], remote.FullPath);
+        await ExecuteProcess("git", ["commit", "-m", "commit-message"], remote.FullPath);
+
+        var head = (await ExecuteProcess("git", ["rev-parse", "HEAD"], remote.FullPath)).Trim();
+        testOutputHelper.WriteLine("Head: " + head);
+
+        await ExecuteProcess("git", ["init"], _directory.FullPath);
+        await ExecuteProcess("git", ["config", "user.name", "test"], _directory.FullPath);
+        await ExecuteProcess("git", ["config", "user.email", "test@example.com"], _directory.FullPath);
+        await ExecuteProcess("git", ["config", "commit.gpgsign", "false"], _directory.FullPath);
+        await File.WriteAllTextAsync(_directory.GetFullPath("test.txt"), "content");
+        await ExecuteProcess("git", ["add", "."], _directory.FullPath);
+        await ExecuteProcess("git", ["commit", "-m", "commit-message"], _directory.FullPath);
+
+        await ExecuteProcess("git", ["-c", "protocol.file.allow=always", "submodule", "add", remote.FullPath, "submodule_path"], _directory.FullPath);
+        await ExecuteProcess("git", ["add", ".gitmodules", "submodule_path"], _directory.FullPath);
+        await ExecuteProcess("git", ["commit", "-m", "add-submodule"], _directory.FullPath);
+
+        await using var worktree = TemporaryDirectory.Create();
+        await ExecuteProcess("git", ["worktree", "add", "-b", "scanner-test-worktree", worktree.FullPath], _directory.FullPath);
+
+        var dotGitPath = Path.Combine(worktree.FullPath, ".git");
+        Assert.True(File.Exists(dotGitPath));
+        Assert.False(Directory.Exists(dotGitPath));
+
+        var options = new ScannerOptions
+        {
+            DegreeOfParallelism = 1,
+            Scanners = [new GitSubmoduleDependencyScanner()],
+        };
+
+        var result = await DependencyScanner.ScanDirectoryAsync(worktree.FullPath, options);
+        Assert.Contains(result, d =>
+            d.Type == DependencyType.GitReference &&
+            d.Version == head &&
+            IsEquivalentPath(d.Name, remote.FullPath));
+
+        async Task<string> ExecuteProcess(string process, string[] args, string workingDirectory)
+        {
+            testOutputHelper.WriteLine($"Executing: '{process}' {string.Join(' ', args)} ({workingDirectory})");
+            var processInstance = ProcessWrapper.Create(process)
+                .WithArguments(args)
+                .WithWorkingDirectory(workingDirectory)
+                .WithValidation(ProcessValidationMode.None)
+                .ExecuteBufferedAsync(XunitCancellationToken);
+
+            var processResult = await processInstance;
+            AssertProcessResult(processResult.ExitCode, string.Join('\n', processResult.Output));
+            return string.Join('\n', processResult.Output);
+        }
+
+        void AssertProcessResult(int exitCode, string output)
+        {
+            Assert.Equal(0, exitCode);
+            testOutputHelper.WriteLine("git command succeeds\n" + output);
+        }
+
+        static bool IsEquivalentPath(string? left, string? right)
+        {
+            if (left is null || right is null)
+                return left is null && right is null;
+
+            var normalizedLeft = left.Replace('\\', '/').TrimEnd('/');
+            var normalizedRight = right.Replace('\\', '/').TrimEnd('/');
+            return string.Equals(normalizedLeft, normalizedRight, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
     public async Task GitHubActions()
     {
         const string Path = ".github/workflows/sample.yml";


### PR DESCRIPTION
Git worktrees expose `.git` as a file that points to the actual git directory, and submodule scanning should resolve that layout reliably. This change ensures the scanner follows that indirection path and keeps submodule detection working when scanning from a worktree checkout.

### What changed
1. Refactored git directory resolution in `GitSubmoduleDependencyScanner` to explicitly handle `.git` indirection files.
2. Added robust first-line parsing for `.git` files (including BOM-tolerant reading), then resolved relative `gitdir:` paths from the `.git` file location.
3. Added `GitSubmodulesFromDependenciesInWorktree` regression coverage that creates a real worktree and validates submodule dependency detection there.

### Notes for review
The scanner already had basic `.git` file support; this update makes that path explicit and more defensive, and locks behavior with a dedicated worktree test.