### PR TITLE
Make Git submodule dependency versions updatable

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Scanners/GitSubmoduleDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/GitSubmoduleDependencyScanner.cs
@@ -1,4 +1,6 @@
 using System.Buffers.Binary;
+using System.ComponentModel;
+using System.Diagnostics;
 using Meziantou.Framework.DependencyScanning.Locations;
 
 namespace Meziantou.Framework.DependencyScanning.Scanners;
@@ -48,7 +50,7 @@ public sealed class GitSubmoduleDependencyScanner : DependencyScanner
 
             context.ReportDependency(this, submodule.Url, sha, DependencyType.GitReference,
                 nameLocation: new NonUpdatableLocation(context),
-                versionLocation: new NonUpdatableLocation(context));
+                versionLocation: new GitSubmoduleVersionLocation(context.FileSystem, context.FullPath, repositoryDirectory, gitDirectory, submodule.Path));
         }
 
         return ValueTask.CompletedTask;
@@ -368,6 +370,111 @@ public sealed class GitSubmoduleDependencyScanner : DependencyScanner
     private static bool TryReadExactly(Stream stream, Span<byte> buffer)
     {
         return stream.ReadAtLeast(buffer, buffer.Length, throwOnEndOfStream: false) == buffer.Length;
+    }
+
+    private sealed class GitSubmoduleVersionLocation : Location
+    {
+        private readonly string _repositoryDirectory;
+        private readonly string _gitDirectory;
+        private readonly string _submodulePath;
+
+        public GitSubmoduleVersionLocation(IFileSystem fileSystem, string filePath, string repositoryDirectory, string gitDirectory, string submodulePath)
+            : base(fileSystem, filePath)
+        {
+            _repositoryDirectory = repositoryDirectory;
+            _gitDirectory = gitDirectory;
+            _submodulePath = submodulePath;
+        }
+
+        public override bool IsUpdatable => true;
+
+        protected internal override async Task UpdateCoreAsync(string? oldValue, string newValue, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(newValue))
+                throw new ArgumentException("The new submodule commit SHA cannot be null or empty.", nameof(newValue));
+
+            if (oldValue is not null)
+            {
+                if (!TryReadGitLinks(_gitDirectory, out var gitLinks) || !gitLinks.TryGetValue(_submodulePath, out var currentValue))
+                    throw new DependencyScannerException($"Submodule '{_submodulePath}' was not found in the git index.");
+
+                if (!string.Equals(currentValue, oldValue, StringComparison.OrdinalIgnoreCase))
+                    throw new DependencyScannerException($"Expected value not found for submodule '{_submodulePath}'. Current value: {currentValue}; expected value: {oldValue}");
+            }
+
+            var gitProcessName = await GetAvailableGitProcessNameAsync(cancellationToken).ConfigureAwait(false);
+            await RunGitCommandAsync(gitProcessName, _repositoryDirectory, ["submodule", "update", "--init", "--", _submodulePath], cancellationToken).ConfigureAwait(false);
+
+            var submoduleDirectory = Path.Combine(_repositoryDirectory, _submodulePath);
+            await RunGitCommandAsync(gitProcessName, submoduleDirectory, ["fetch", "--all", "--tags", "--prune"], cancellationToken).ConfigureAwait(false);
+            await RunGitCommandAsync(gitProcessName, submoduleDirectory, ["checkout", "--detach", newValue], cancellationToken).ConfigureAwait(false);
+            await RunGitCommandAsync(gitProcessName, _repositoryDirectory, ["add", "--", _submodulePath], cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<string> GetAvailableGitProcessNameAsync(CancellationToken cancellationToken)
+    {
+        if (await IsProcessAvailableAsync("git", cancellationToken).ConfigureAwait(false))
+            return "git";
+
+        if (await IsProcessAvailableAsync("mingit", cancellationToken).ConfigureAwait(false))
+            return "mingit";
+
+        throw new InvalidOperationException("Cannot update Git submodule because neither 'git' nor 'mingit' is available.");
+    }
+
+    private static async Task<bool> IsProcessAvailableAsync(string processName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo(processName)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            startInfo.ArgumentList.Add("--version");
+
+            using var process = Process.Start(startInfo);
+            if (process is null)
+                return false;
+
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            return process.ExitCode == 0;
+        }
+        catch (Win32Exception)
+        {
+            return false;
+        }
+    }
+
+    private static async Task RunGitCommandAsync(string processName, string workingDirectory, IReadOnlyList<string> arguments, CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo(processName)
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo) ?? throw new DependencyScannerException($"Cannot start process '{processName}'.");
+
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var errorOutputTask = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        await standardOutputTask.ConfigureAwait(false);
+        var errorOutput = await errorOutputTask.ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new DependencyScannerException($"Command '{processName} {string.Join(" ", arguments)}' failed with exit code {process.ExitCode}: {errorOutput}");
+        }
     }
 
     private readonly record struct SubmoduleEntry(string Path, string Url);

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -600,12 +600,26 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
 
         // Assert
         var result = await GetDependencies<GitSubmoduleDependencyScanner>();
-        Assert.Contains(result, d =>
+        var dependency = Assert.Single(result, d =>
             d.Type == DependencyType.GitReference &&
             d.Version == head &&
             IsEquivalentPath(d.Name, remote.FullPath));
 
-        Assert.All(result, item => Assert.False(item.VersionLocation!.IsUpdatable));
+        Assert.False(dependency.NameLocation!.IsUpdatable);
+        Assert.True(dependency.VersionLocation!.IsUpdatable);
+
+        await File.WriteAllTextAsync(remote.GetFullPath("test.txt"), "updated-content");
+        await ExecuteProcess("git", "add .", remote.FullPath);
+        await ExecuteProcess("git", "commit -m updated-submodule-head", remote.FullPath);
+        var updatedHead = (await ExecuteProcess("git", "rev-parse HEAD", remote.FullPath)).Trim();
+
+        await dependency.UpdateVersionAsync(updatedHead);
+
+        var submoduleHead = (await ExecuteProcess("git", "-C submodule_path rev-parse HEAD", _directory.FullPath)).Trim();
+        Assert.Equal(updatedHead, submoduleHead);
+
+        var indexHead = (await ExecuteProcess("git", "rev-parse :submodule_path", _directory.FullPath)).Trim();
+        Assert.Equal(updatedHead, indexHead);
 
         async Task<string> ExecuteProcess(string process, string args, string workingDirectory)
         {


### PR DESCRIPTION
## Why
`GitSubmoduleDependencyScanner` currently reports submodule SHAs as non-updatable, so the dependency updater cannot move a submodule reference to a newer commit even though the scanner can detect it.

## What changed
This PR introduces an updatable version location for git submodule dependencies.

- Replaced `NonUpdatableLocation` with a dedicated `GitSubmoduleVersionLocation` for submodule SHAs.
- Implemented submodule update logic that:
  - validates the current gitlink still matches the scanned SHA,
  - resolves an available git executable (`git` first, `mingit` fallback),
  - throws `InvalidOperationException` when neither executable is available,
  - updates the submodule checkout to the requested commit and stages the updated gitlink in the parent repository.
- Added a test update in `ScannerTests.GitSubmodulesFromDependencies` to verify the version location is updatable and that updating the dependency moves both submodule `HEAD` and the parent index gitlink to the target SHA.

## Notes
The dependency name location remains non-updatable; only the submodule commit reference is now updatable.