### PR TITLE
Add #:ref and block-comment support to file-based app scanner

### DIFF
--- a/ref/Meziantou.Framework.DependencyScanning.cs
+++ b/ref/Meziantou.Framework.DependencyScanning.cs
@@ -73,7 +73,8 @@ namespace Meziantou.Framework.DependencyScanning
         RubyGem = 13,
         RenovateConfiguration = 14,
         SwiftPackage = 15,
-        MSBuildProjectReference = 16
+        MSBuildProjectReference = 16,
+        DotNetAssemblyReference = 17
     }
 
     public delegate bool FileSystemEntryPredicate(ref System.IO.Enumeration.FileSystemEntry entry);

--- a/src/Meziantou.Framework.DependencyScanning.Tool/readme.md
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/readme.md
@@ -53,7 +53,7 @@ Usage:
 Options:
   --directory <directory>              Root directory
   --files <files>                      Glob patterns to find files to scan
-  --dependency-type <dependency-type>  Dependency types to include. Available values: Unknown, NuGet, Npm, PyPi, DockerImage, GitReference, DotNetSdk, DotNetTargetFramework, GitHubActions, AzureDevOpsVMPool, AzureDevOpsTask, AzureDevOpsTemplate, HelmChart, RubyGem, RenovateConfiguration, SwiftPackage, MSBuildProjectReference
+  --dependency-type <dependency-type>  Dependency types to include. Available values: Unknown, NuGet, Npm, PyPi, DockerImage, GitReference, DotNetSdk, DotNetTargetFramework, GitHubActions, AzureDevOpsVMPool, AzureDevOpsTask, AzureDevOpsTemplate, HelmChart, RubyGem, RenovateConfiguration, SwiftPackage, MSBuildProjectReference, DotNetAssemblyReference
   --upgradable                         Only list dependencies that can be upgraded
   --format <Json|Text>                 Output format. Available values: Text, Json
   -?, -h, --help                       Show help and usage information
@@ -71,7 +71,7 @@ Usage:
 Options:
   --directory <directory>              Root directory
   --files <files>                      Glob patterns to find files to scan
-  --dependency-type <dependency-type>  Dependency types to include. Available values: Unknown, NuGet, Npm, PyPi, DockerImage, GitReference, DotNetSdk, DotNetTargetFramework, GitHubActions, AzureDevOpsVMPool, AzureDevOpsTask, AzureDevOpsTemplate, HelmChart, RubyGem, RenovateConfiguration, SwiftPackage, MSBuildProjectReference
+  --dependency-type <dependency-type>  Dependency types to include. Available values: Unknown, NuGet, Npm, PyPi, DockerImage, GitReference, DotNetSdk, DotNetTargetFramework, GitHubActions, AzureDevOpsVMPool, AzureDevOpsTask, AzureDevOpsTemplate, HelmChart, RubyGem, RenovateConfiguration, SwiftPackage, MSBuildProjectReference, DotNetAssemblyReference
   --update-lock-files                  Update lock files when dependencies are updated
   --minimum-age <minimum-age>          Minimum age in days for package versions to consider for update (default: 7). Use 0 or negative to disable filtering. Not applied to Docker images as registries don't expose publication dates. [default: 7]
   -?, -h, --help                       Show help and usage information

--- a/src/Meziantou.Framework.DependencyScanning/DependencyType.cs
+++ b/src/Meziantou.Framework.DependencyScanning/DependencyType.cs
@@ -53,4 +53,7 @@ public enum DependencyType
 
     /// <summary>MSBuild project reference.</summary>
     MSBuildProjectReference,
+
+    /// <summary>.NET assembly file reference.</summary>
+    DotNetAssemblyReference,
 }

--- a/src/Meziantou.Framework.DependencyScanning/Scanners/DotNetFileBasedAppDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/DotNetFileBasedAppDependencyScanner.cs
@@ -3,13 +3,14 @@ using Meziantou.Framework.DependencyScanning.Internals;
 
 namespace Meziantou.Framework.DependencyScanning.Scanners;
 
-/// <summary>Scans .NET file-based app (.cs) files for package, SDK, project, and target framework directives.</summary>
+/// <summary>Scans .NET file-based app (.cs) files for package, SDK, project, reference, and target framework directives.</summary>
 public sealed partial class DotNetFileBasedAppDependencyScanner : DependencyScanner
 {
     protected internal override IReadOnlyCollection<DependencyType> SupportedDependencyTypes { get; } =
     [
         DependencyType.NuGet,
         DependencyType.MSBuildProjectReference,
+        DependencyType.DotNetAssemblyReference,
         DependencyType.DotNetTargetFramework,
     ];
 
@@ -22,21 +23,46 @@ public sealed partial class DotNetFileBasedAppDependencyScanner : DependencyScan
     {
         using var sr = await StreamUtilities.CreateReaderAsync(context.Content, context.CancellationToken).ConfigureAwait(false);
         var lineNo = 0;
+        var isInsideMultilineComment = false;
         string? line;
         while ((line = await sr.ReadLineAsync(context.CancellationToken).ConfigureAwait(false)) is not null)
         {
             lineNo++;
 
+            var remainingLine = line;
+            while (true)
+            {
+                if (isInsideMultilineComment)
+                {
+                    var commentEndIndex = remainingLine.IndexOf("*/", StringComparison.Ordinal);
+                    if (commentEndIndex < 0)
+                    {
+                        remainingLine = "";
+                        break;
+                    }
+
+                    remainingLine = remainingLine[(commentEndIndex + 2)..];
+                    isInsideMultilineComment = false;
+                }
+
+                remainingLine = remainingLine.TrimStart();
+                if (!remainingLine.StartsWith("/*", StringComparison.Ordinal))
+                    break;
+
+                remainingLine = remainingLine[2..];
+                isInsideMultilineComment = true;
+            }
+
             // Skip empty lines, comments, and shebang lines at the top of the file
-            if (string.IsNullOrWhiteSpace(line) || line.StartsWith("//", StringComparison.Ordinal) || line.StartsWith("#!", StringComparison.Ordinal))
+            if (string.IsNullOrWhiteSpace(remainingLine) || remainingLine.StartsWith("//", StringComparison.Ordinal) || remainingLine.StartsWith("#!", StringComparison.Ordinal))
                 continue;
 
             // Stop scanning at first non-directive line
-            if (!line.StartsWith("#:", StringComparison.Ordinal))
+            if (!remainingLine.StartsWith("#:", StringComparison.Ordinal))
                 break;
 
             // Package directive: #:package Name or #:package Name@Version
-            var match = PackageRegex().Match(line);
+            var match = PackageRegex().Match(remainingLine);
             if (match.Success)
             {
                 ReportNameVersionDependency(context, match, lineNo, DependencyType.NuGet);
@@ -44,7 +70,7 @@ public sealed partial class DotNetFileBasedAppDependencyScanner : DependencyScan
             }
 
             // SDK directive: #:sdk Name or #:sdk Name@Version
-            match = SdkRegex().Match(line);
+            match = SdkRegex().Match(remainingLine);
             if (match.Success)
             {
                 ReportNameVersionDependency(context, match, lineNo, DependencyType.NuGet);
@@ -52,19 +78,23 @@ public sealed partial class DotNetFileBasedAppDependencyScanner : DependencyScan
             }
 
             // Project directive: #:project Path
-            match = ProjectRegex().Match(line);
+            match = ProjectRegex().Match(remainingLine);
             if (match.Success)
             {
-                var pathGroup = match.Groups["Path"];
-                context.ReportDependency(this, pathGroup.Value, version: null,
-                    DependencyType.MSBuildProjectReference,
-                    nameLocation: new TextLocation(context.FileSystem, context.FullPath, lineNo, pathGroup.Index + 1, pathGroup.Length),
-                    versionLocation: null);
+                ReportPathDependency(context, match, lineNo, DependencyType.MSBuildProjectReference);
+                continue;
+            }
+
+            // Reference directive: #:ref Path
+            match = RefRegex().Match(remainingLine);
+            if (match.Success)
+            {
+                ReportPathDependency(context, match, lineNo, DependencyType.DotNetAssemblyReference);
                 continue;
             }
 
             // Property directive: #:property TargetFramework=value
-            match = TargetFrameworkPropertyRegex().Match(line);
+            match = TargetFrameworkPropertyRegex().Match(remainingLine);
             if (match.Success)
             {
                 var valueGroup = match.Groups["Value"];
@@ -88,6 +118,15 @@ public sealed partial class DotNetFileBasedAppDependencyScanner : DependencyScan
             versionLocation: versionGroup.Success ? new TextLocation(context.FileSystem, context.FullPath, lineNo, versionGroup.Index + 1, versionGroup.Length) : null);
     }
 
+    private void ReportPathDependency(ScanFileContext context, Match match, int lineNo, DependencyType type)
+    {
+        var pathGroup = match.Groups["Path"];
+        context.ReportDependency(this, pathGroup.Value, version: null,
+            type,
+            nameLocation: new TextLocation(context.FileSystem, context.FullPath, lineNo, pathGroup.Index + 1, pathGroup.Length),
+            versionLocation: null);
+    }
+
     [GeneratedRegex(@"^#:package\s+(?<Name>[^\s@]+)(?:@(?<Version>\S+))?\s*$", RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: Timeout.Infinite)]
     private static partial Regex PackageRegex();
 
@@ -96,6 +135,9 @@ public sealed partial class DotNetFileBasedAppDependencyScanner : DependencyScan
 
     [GeneratedRegex(@"^#:project\s+(?<Path>\S+)\s*$", RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: Timeout.Infinite)]
     private static partial Regex ProjectRegex();
+
+    [GeneratedRegex(@"^#:ref\s+(?<Path>\S+)\s*$", RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: Timeout.Infinite)]
+    private static partial Regex RefRegex();
 
     [GeneratedRegex(@"^#:property\s+TargetFramework=(?<Value>\S+)\s*$", RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: Timeout.Infinite)]
     private static partial Regex TargetFrameworkPropertyRegex();

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -344,6 +344,7 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
             "#:package Serilog@3.1.1\n" +
             "#:package Spectre.Console@*\n" +
             "#:project ../SharedLibrary/SharedLibrary.csproj\n" +
+            "#:ref ../SharedLibrary/bin/Debug/net10.0/SharedLibrary.dll\n" +
             "#:property TargetFramework=net10.0\n" +
             "\n" +
             "Console.WriteLine(\"Hello, World!\");\n";
@@ -356,6 +357,7 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
             "#:package dummy4@2.0.0\n" +
             "#:package dummy5@2.0.0\n" +
             "#:project dummy6\n" +
+            "#:ref dummy7\n" +
             "#:property TargetFramework=2.0.0\n" +
             "\n" +
             "Console.WriteLine(\"Hello, World!\");\n";
@@ -369,7 +371,8 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
             (DependencyType.NuGet, "Serilog", "3.1.1", 5, 19),
             (DependencyType.NuGet, "Spectre.Console", "*", 6, 27),
             (DependencyType.MSBuildProjectReference, "../SharedLibrary/SharedLibrary.csproj", null, 0, 0),
-            (DependencyType.DotNetTargetFramework, null, "net10.0", 8, 28));
+            (DependencyType.DotNetAssemblyReference, "../SharedLibrary/bin/Debug/net10.0/SharedLibrary.dll", null, 0, 0),
+            (DependencyType.DotNetTargetFramework, null, "net10.0", 9, 28));
 
         await UpdateDependencies(result, "dummy", "2.0.0");
         AssertFileContentEqual("app.cs", Expected, ignoreNewLines: false);
@@ -394,6 +397,36 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
         var result = await GetDependencies<DotNetFileBasedAppDependencyScanner>();
         AssertContainDependency(result,
             (DependencyType.NuGet, "Serilog", "3.1.1", 2, 19));
+
+        await UpdateDependencies(result, "dummy", "2.0.0");
+        AssertFileContentEqual("app.cs", Expected, ignoreNewLines: false);
+    }
+
+    [Fact]
+    public async Task DotNetFileBasedAppDependencies_WithMultilineComments()
+    {
+        const string Original = """
+            /*
+            This is a file-based app
+            */
+            #:package Serilog@3.1.1
+
+            Console.WriteLine("Hello");
+            """;
+
+        const string Expected = """
+            /*
+            This is a file-based app
+            */
+            #:package dummy1@2.0.0
+
+            Console.WriteLine("Hello");
+            """;
+
+        AddFile("app.cs", Original);
+        var result = await GetDependencies<DotNetFileBasedAppDependencyScanner>();
+        AssertContainDependency(result,
+            (DependencyType.NuGet, "Serilog", "3.1.1", 4, 19));
 
         await UpdateDependencies(result, "dummy", "2.0.0");
         AssertFileContentEqual("app.cs", Expected, ignoreNewLines: false);


### PR DESCRIPTION
File-based app scanning already handled `#:package`, `#:sdk`, and `#:project`, but missed `#:ref` directives used for assembly references. It also stopped too early when scripts started with `/* ... */` comments.

This change extends `DotNetFileBasedAppDependencyScanner` to:

- Recognize `#:ref <path>` and report it as a new dependency type, `DotNetAssemblyReference`.
- Continue scanning directives after multiline block comments in the file preamble.
- Reuse shared path-reporting logic for `#:project` and `#:ref`.

Tests were updated to cover:

- `#:ref` detection and update rewriting in file-based apps.
- Multiline `/* ... */` preamble comments followed by directives.

Generated outputs were refreshed to include the new dependency type in the public API/reference and tool help/readme text.