### PR TITLE
Support scoped parameter modifiers in PublicApiGenerator

### DIFF
--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
@@ -658,6 +658,11 @@ internal static class PublicApiModelBuilder
             sb.Append("this ");
         }
 
+        if (IsScopedParameter(parameter) && !parameter.IsOut && !IsParamsParameter(parameter))
+        {
+            sb.Append("scoped ");
+        }
+
         if (parameter.IsOut)
         {
             sb.Append("out ");
@@ -1080,6 +1085,11 @@ internal static class PublicApiModelBuilder
     private static bool IsRefReadOnlyParameter(ParameterInfo parameter)
     {
         return parameter.GetCustomAttributesData().Any(static attribute => attribute.AttributeType.FullName == "System.Runtime.CompilerServices.RequiresLocationAttribute");
+    }
+
+    private static bool IsScopedParameter(ParameterInfo parameter)
+    {
+        return parameter.GetCustomAttributesData().Any(static attribute => attribute.AttributeType.FullName == "System.Runtime.CompilerServices.ScopedRefAttribute");
     }
 
     private static string BuildByRefFieldType(FieldInfo field, NullabilityInfo fieldNullability)

--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
@@ -710,6 +710,7 @@ internal static class PublicApiModelReader
             var hasInAttribute = false;
             var hasIsReadOnlyAttribute = false;
             var hasRequiresLocationAttribute = false;
+            var hasScopedRefAttribute = false;
             var hasParamArrayAttribute = false;
             var hasParamCollectionAttribute = false;
             var defaultValue = string.Empty;
@@ -724,6 +725,7 @@ internal static class PublicApiModelReader
                 hasInAttribute = HasAttribute(metadataReader, parameterAttributes.Value, "System.Runtime.InteropServices.InAttribute");
                 hasIsReadOnlyAttribute = HasAttribute(metadataReader, parameterAttributes.Value, "System.Runtime.CompilerServices.IsReadOnlyAttribute");
                 hasRequiresLocationAttribute = HasAttribute(metadataReader, parameterAttributes.Value, "System.Runtime.CompilerServices.RequiresLocationAttribute");
+                hasScopedRefAttribute = HasAttribute(metadataReader, parameterAttributes.Value, "System.Runtime.CompilerServices.ScopedRefAttribute");
                 hasParamArrayAttribute = HasAttribute(metadataReader, parameterAttributes.Value, "System.ParamArrayAttribute");
                 hasParamCollectionAttribute = HasAttribute(metadataReader, parameterAttributes.Value, "System.Runtime.CompilerServices.ParamCollectionAttribute");
                 if (parameter.Attributes.HasFlag(ParameterAttributes.HasDefault) && !parameter.GetDefaultValue().IsNil)
@@ -761,6 +763,7 @@ internal static class PublicApiModelReader
                 hasInAttribute,
                 hasIsReadOnlyAttribute,
                 hasRequiresLocationAttribute,
+                hasScopedRefAttribute,
                 hasParamArrayAttribute,
                 hasParamCollectionAttribute);
             var extensionThisModifier = isExtensionMethod && i == 0 ? "this " : string.Empty;
@@ -982,6 +985,7 @@ internal static class PublicApiModelReader
             var hasInAttribute = false;
             var hasIsReadOnlyAttribute = false;
             var hasRequiresLocationAttribute = false;
+            var hasScopedRefAttribute = false;
             var hasParamArrayAttribute = false;
             var hasParamCollectionAttribute = false;
             if (parametersBySequence.TryGetValue(sequence, out var parameter))
@@ -992,6 +996,7 @@ internal static class PublicApiModelReader
                 hasInAttribute = HasAttribute(metadataReader, customAttributes.Value, "System.Runtime.InteropServices.InAttribute");
                 hasIsReadOnlyAttribute = HasAttribute(metadataReader, customAttributes.Value, "System.Runtime.CompilerServices.IsReadOnlyAttribute");
                 hasRequiresLocationAttribute = HasAttribute(metadataReader, customAttributes.Value, "System.Runtime.CompilerServices.RequiresLocationAttribute");
+                hasScopedRefAttribute = HasAttribute(metadataReader, customAttributes.Value, "System.Runtime.CompilerServices.ScopedRefAttribute");
                 hasParamArrayAttribute = HasAttribute(metadataReader, customAttributes.Value, "System.ParamArrayAttribute");
                 hasParamCollectionAttribute = HasAttribute(metadataReader, customAttributes.Value, "System.Runtime.CompilerServices.ParamCollectionAttribute");
             }
@@ -1012,6 +1017,7 @@ internal static class PublicApiModelReader
                 hasInAttribute,
                 hasIsReadOnlyAttribute,
                 hasRequiresLocationAttribute,
+                hasScopedRefAttribute,
                 hasParamArrayAttribute,
                 hasParamCollectionAttribute);
             result[i] = inlineAttributes + parameterModifier + parameterType + " " + parameterName;
@@ -1092,28 +1098,35 @@ internal static class PublicApiModelReader
         bool hasInAttribute,
         bool hasIsReadOnlyAttribute,
         bool hasRequiresLocationAttribute,
+        bool hasScopedRefAttribute,
         bool hasParamArrayAttribute,
         bool hasParamCollectionAttribute)
     {
         if (parameterType.Kind != DecodedTypeKind.ByReference)
-            return (hasParamArrayAttribute || hasParamCollectionAttribute) ? "params " : string.Empty;
+        {
+            if (hasParamArrayAttribute || hasParamCollectionAttribute)
+                return "params ";
+
+            return hasScopedRefAttribute ? "scoped " : string.Empty;
+        }
 
         var hasInModifier = parameterType.ElementType?.HasInModifier == true;
         var hasIsReadOnlyModifier = parameterType.ElementType?.HasIsReadOnlyModifier == true;
         var hasRequiresLocationModifier = parameterType.ElementType?.HasRequiresLocationModifier == true;
+        var scopedPrefix = hasScopedRefAttribute ? "scoped " : string.Empty;
 
         if (parameterAttributes.HasFlag(ParameterAttributes.Out))
             return "out ";
 
         if (hasRequiresLocationAttribute || hasRequiresLocationModifier)
-            return "ref readonly ";
+            return scopedPrefix + "ref readonly ";
 
         if (hasInAttribute || hasInModifier || hasIsReadOnlyAttribute || hasIsReadOnlyModifier)
         {
-            return "in ";
+            return scopedPrefix + "in ";
         }
 
-        return "ref ";
+        return scopedPrefix + "ref ";
     }
 
     private static string BuildConstructorInitializer(MetadataReader metadataReader, TypeDefinition declaringType)

--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
@@ -1300,6 +1300,28 @@ public sealed class PublicApiGeneratorTests
     }
 
     [Fact]
+    public async Task Method_Parameter_ScopedModifiers()
+    {
+        await Validate("""
+            using System;
+
+            public static class SampleExtensions
+            {
+                public static void M(this scoped ref int receiver, scoped Span<int> p0, scoped in int p1, scoped ref int p2, scoped ref readonly int p3)
+                {
+                }
+            }
+            """, """
+            #nullable enable
+
+            public static class SampleExtensions
+            {
+                public static void M(this scoped ref int receiver, scoped System.Span<int> p0, scoped in int p1, scoped ref int p2, scoped ref readonly int p3) { }
+            }
+            """);
+    }
+
+    [Fact]
     public async Task Method_ParamsReadOnlySpanAndObjectArray()
     {
         await Validate("""


### PR DESCRIPTION
## Why
Public API generation currently drops the `scoped` keyword from parameter declarations, which makes generated signatures diverge from source declarations for modern C# parameter forms.

## What changed
This updates both API generation pipelines so scoped parameter modifiers are emitted consistently:

- Reflection path (`PublicApiModelBuilder`) now detects `ScopedRefAttribute` and emits `scoped` for supported parameters.
- Metadata path (`PublicApiModelReader`) now reads `ScopedRefAttribute` and composes modifiers correctly across `scoped`, `in`, `ref`, and `ref readonly` combinations.
- Added test coverage for scoped forms, including extension receiver parameters (`this scoped ref ...`).

## Notes for reviewers
- `params` parameter behavior is intentionally preserved as-is; scoped is not emitted for `params` to keep reflection and metadata output aligned with existing behavior.
- The change is focused on parameter modifier rendering only; no unrelated emission logic was modified.