### PR TITLE
Support C# 15 closed classes in PublicApiGenerator

### DIFF
--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
@@ -8,6 +8,8 @@ internal static class PublicApiModelBuilder
     private static readonly NullabilityInfoContext NullabilityInfoContext = new();
     private const string CompilerGeneratedRefStructObsoleteMessage = "Types with embedded references are not supported in this version of your compiler.";
     private const string RequiresPreviewFeaturesAttributeFullName = "System.Runtime.Versioning.RequiresPreviewFeaturesAttribute";
+    private const string ClosedAttributeFullName = "System.Runtime.CompilerServices.ClosedAttribute";
+    private const string IsClosedTypeAttributeFullName = "System.Runtime.CompilerServices.IsClosedTypeAttribute";
     private const GenericParameterAttributes AllowByRefLikeGenericParameterConstraint = (GenericParameterAttributes)0x20;
 
     private static readonly HashSet<string> IrrelevantAttributes = new(StringComparer.Ordinal)
@@ -39,6 +41,8 @@ internal static class PublicApiModelBuilder
         "System.ParamArrayAttribute",
         "System.Runtime.CompilerServices.ParamCollectionAttribute",
         "System.Runtime.CompilerServices.ScopedRefAttribute",
+        "System.Runtime.CompilerServices.ClosedAttribute",
+        "System.Runtime.CompilerServices.IsClosedTypeAttribute",
         "System.Reflection.AssemblyCompanyAttribute",
         "System.Reflection.AssemblyConfigurationAttribute",
         "System.Reflection.AssemblyCopyrightAttribute",
@@ -1112,13 +1116,18 @@ internal static class PublicApiModelBuilder
     private static (string Declaration, IReadOnlyList<string> Constraints) BuildTypeHeader(Type type)
     {
         var modifiers = new List<string> { GetTypeAccessibility(type) };
+        var isClosedType = IsClosedType(type);
         if (type.IsAbstract && type.IsSealed)
         {
             modifiers.Add("static");
         }
         else
         {
-            if (type.IsAbstract && !type.IsInterface)
+            if (isClosedType)
+            {
+                modifiers.Add("closed");
+            }
+            else if (type.IsAbstract && !type.IsInterface)
             {
                 modifiers.Add("abstract");
             }
@@ -1144,6 +1153,15 @@ internal static class PublicApiModelBuilder
 
         var declaration = $"{string.Join(' ', modifiers.Where(static value => !string.IsNullOrEmpty(value)))} {keyword} {typeName}{genericArguments}{inheritance}";
         return (declaration, constraints);
+    }
+
+    private static bool IsClosedType(Type type)
+    {
+        if (type.IsValueType || type.IsInterface || type.IsEnum || IsDelegate(type))
+            return false;
+
+        return type.GetCustomAttributesData().Any(static attribute =>
+            attribute.AttributeType.FullName is ClosedAttributeFullName or IsClosedTypeAttributeFullName);
     }
 
     private static string BuildInheritance(Type type)

--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
@@ -11,6 +11,8 @@ internal static class PublicApiModelReader
 {
     private const string CompilerGeneratedRefStructObsoleteMessage = "Types with embedded references are not supported in this version of your compiler.";
     private const string RequiresPreviewFeaturesAttributeFullName = "System.Runtime.Versioning.RequiresPreviewFeaturesAttribute";
+    private const string ClosedAttributeFullName = "System.Runtime.CompilerServices.ClosedAttribute";
+    private const string IsClosedTypeAttributeFullName = "System.Runtime.CompilerServices.IsClosedTypeAttribute";
     private const GenericParameterAttributes AllowByRefLikeGenericParameterConstraint = (GenericParameterAttributes)0x20;
     private static readonly Lock EnumMetadataCacheLock = new();
     private static readonly Dictionary<string, EnumMetadata?> EnumMetadataCache = new(StringComparer.Ordinal);
@@ -44,6 +46,8 @@ internal static class PublicApiModelReader
         "System.ParamArrayAttribute",
         "System.Runtime.CompilerServices.ParamCollectionAttribute",
         "System.Runtime.CompilerServices.ScopedRefAttribute",
+        "System.Runtime.CompilerServices.ClosedAttribute",
+        "System.Runtime.CompilerServices.IsClosedTypeAttribute",
         "System.Reflection.AssemblyCompanyAttribute",
         "System.Reflection.AssemblyConfigurationAttribute",
         "System.Reflection.AssemblyCopyrightAttribute",
@@ -176,13 +180,19 @@ internal static class PublicApiModelReader
         var typeModifiers = new List<string> { accessibility };
         if (keyword == "class")
         {
+            var isClosedType = HasAttribute(metadataReader, typeDefinition.GetCustomAttributes(), ClosedAttributeFullName) ||
+                               HasAttribute(metadataReader, typeDefinition.GetCustomAttributes(), IsClosedTypeAttributeFullName);
             if (typeDefinition.Attributes.HasFlag(TypeAttributes.Abstract) && typeDefinition.Attributes.HasFlag(TypeAttributes.Sealed))
             {
                 typeModifiers.Add("static");
             }
             else
             {
-                if (typeDefinition.Attributes.HasFlag(TypeAttributes.Abstract))
+                if (isClosedType)
+                {
+                    typeModifiers.Add("closed");
+                }
+                else if (typeDefinition.Attributes.HasFlag(TypeAttributes.Abstract))
                 {
                     typeModifiers.Add("abstract");
                 }

--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
@@ -2389,6 +2389,41 @@ public sealed class PublicApiGeneratorTests
         });
     }
 
+    [Fact]
+    public async Task Class_Closed()
+    {
+        await Validate("""
+            namespace System.Runtime.CompilerServices
+            {
+                [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+                public sealed class ClosedAttribute : System.Attribute
+                {
+                }
+            }
+
+            public closed class Sample
+            {
+            }
+            """, """
+            #nullable enable
+
+            public closed class Sample
+            {
+            }
+
+            namespace System.Runtime.CompilerServices
+            {
+                [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+                public sealed class ClosedAttribute : System.Attribute
+                {
+                }
+            }
+            """, compilerOptions: new CompilerOptions
+            {
+                TargetFramework = "net10.0",
+            });
+    }
+
     [InlineSnapshotAssertion(nameof(expected))]
     private static async Task Validate(string source, string expected, PublicApiOptions? options = null, CompilerOptions? compilerOptions = null, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = -1)
     {


### PR DESCRIPTION
## Summary
Public API generation should preserve the new C# 15 `closed` class modifier so generated API files stay semantically aligned with source assemblies.

This change adds closed-type detection in both generation pipelines and emits `closed` for class declarations when the type metadata indicates a closed hierarchy.

## What changed
- Updated the reflection pipeline (`PublicApiModelBuilder`) to detect closed classes via:
  - `System.Runtime.CompilerServices.ClosedAttribute`
  - `System.Runtime.CompilerServices.IsClosedTypeAttribute`
- Updated the metadata pipeline (`PublicApiModelReader`) with the same detection logic.
- Switched emitted class modifier from `abstract` to `closed` when a class is detected as closed.
- Added both closed-related attributes to the irrelevant-attribute filters so they are not emitted as explicit attributes in generated API output.
- Added a regression test (`Class_Closed`) in `PublicApiGeneratorTests` to verify emitted output and compilation behavior.

## Validation
- `dotnet run ./eng/update-all.cs`
- `dotnet test tests/Meziantou.Framework.PublicApiGenerator.Tests/Meziantou.Framework.PublicApiGenerator.Tests.csproj -nologo /p:TreatsWarningsAsErrors=true`
- `dotnet test tests/Meziantou.Framework.PublicApiGenerator.Tests/Meziantou.Framework.PublicApiGenerator.Tests.csproj -nologo --filter "FullyQualifiedName~Class_Closed" /p:TreatsWarningsAsErrors=true`