### PR TITLE
Add union declaration support in PublicApiGenerator

### DIFF
--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
@@ -10,6 +10,8 @@ internal static class PublicApiModelBuilder
     private const string RequiresPreviewFeaturesAttributeFullName = "System.Runtime.Versioning.RequiresPreviewFeaturesAttribute";
     private const string ClosedAttributeFullName = "System.Runtime.CompilerServices.ClosedAttribute";
     private const string IsClosedTypeAttributeFullName = "System.Runtime.CompilerServices.IsClosedTypeAttribute";
+    private const string UnionAttributeFullName = "System.Runtime.CompilerServices.UnionAttribute";
+    private const string IUnionInterfaceFullName = "System.Runtime.CompilerServices.IUnion";
     private const GenericParameterAttributes AllowByRefLikeGenericParameterConstraint = (GenericParameterAttributes)0x20;
 
     private static readonly HashSet<string> IrrelevantAttributes = new(StringComparer.Ordinal)
@@ -137,15 +139,16 @@ internal static class PublicApiModelBuilder
             return BuildEnum(type, indentationLevel);
 
         var sb = new StringBuilder();
-        AppendAttributes(sb, type.CustomAttributes, indentationLevel);
+        var isUnionDeclaration = IsUnionDeclarationType(type);
+        AppendAttributes(sb, type.CustomAttributes.Where(attribute => !isUnionDeclaration || attribute.AttributeType.FullName != UnionAttributeFullName), indentationLevel);
 
-        var typeHeader = BuildTypeHeader(type);
+        var typeHeader = BuildTypeHeader(type, isUnionDeclaration);
         AppendIndentedLine(sb, indentationLevel, typeHeader.Declaration + FormatConstraintsInline(typeHeader.Constraints));
 
         AppendIndentedLine(sb, indentationLevel, "{");
         if (!IsRecordClass(type) && !IsRecordStruct(type))
         {
-            AppendMembers(sb, type, indentationLevel + 1);
+            AppendMembers(sb, type, indentationLevel + 1, isUnionDeclaration);
         }
         AppendNestedTypes(sb, type, indentationLevel + 1);
         AppendIndentedLine(sb, indentationLevel, "}");
@@ -173,7 +176,7 @@ internal static class PublicApiModelBuilder
         }
     }
 
-    private static void AppendMembers(StringBuilder sb, Type type, int indentationLevel)
+    private static void AppendMembers(StringBuilder sb, Type type, int indentationLevel, bool isUnionDeclaration)
     {
         var members = new List<string>();
 
@@ -189,6 +192,9 @@ internal static class PublicApiModelBuilder
                      .Where(IsExternallyVisible)
                      .OrderBy(static property => property.MetadataToken))
         {
+            if (isUnionDeclaration && IsGeneratedUnionValueProperty(property))
+                continue;
+
             members.Add(BuildProperty(property, indentationLevel));
         }
 
@@ -203,6 +209,9 @@ internal static class PublicApiModelBuilder
                      .Where(IsExternallyVisible)
                      .OrderBy(static constructor => constructor.MetadataToken))
         {
+            if (isUnionDeclaration && IsGeneratedUnionCaseConstructor(constructor))
+                continue;
+
             var constructorText = BuildConstructor(constructor, indentationLevel);
             if (constructorText is not null)
             {
@@ -1113,7 +1122,7 @@ internal static class PublicApiModelBuilder
             : "ref " + FormatType(elementType, elementNullability);
     }
 
-    private static (string Declaration, IReadOnlyList<string> Constraints) BuildTypeHeader(Type type)
+    private static (string Declaration, IReadOnlyList<string> Constraints) BuildTypeHeader(Type type, bool isUnionDeclaration)
     {
         var modifiers = new List<string> { GetTypeAccessibility(type) };
         var isClosedType = IsClosedType(type);
@@ -1148,10 +1157,11 @@ internal static class PublicApiModelBuilder
         var keyword = GetTypeKeyword(type);
         var typeName = EscapeIdentifier(RemoveGenericArity(type.Name));
         var genericArguments = BuildGenericArguments(type);
-        var inheritance = BuildInheritance(type);
+        var unionCaseTypes = isUnionDeclaration ? BuildUnionCaseTypes(type) : string.Empty;
+        var inheritance = BuildInheritance(type, isUnionDeclaration);
         var constraints = BuildTypeConstraints(type, indentationLevel: 0);
 
-        var declaration = $"{string.Join(' ', modifiers.Where(static value => !string.IsNullOrEmpty(value)))} {keyword} {typeName}{genericArguments}{inheritance}";
+        var declaration = $"{string.Join(' ', modifiers.Where(static value => !string.IsNullOrEmpty(value)))} {keyword} {typeName}{genericArguments}{unionCaseTypes}{inheritance}";
         return (declaration, constraints);
     }
 
@@ -1164,7 +1174,7 @@ internal static class PublicApiModelBuilder
             attribute.AttributeType.FullName is ClosedAttributeFullName or IsClosedTypeAttributeFullName);
     }
 
-    private static string BuildInheritance(Type type)
+    private static string BuildInheritance(Type type, bool isUnionDeclaration)
     {
         var baseTypes = new List<string>();
         if (!type.IsInterface &&
@@ -1179,6 +1189,7 @@ internal static class PublicApiModelBuilder
 
         var interfaces = type.GetInterfaces()
             .Where(@interface => IsExternallyVisible(@interface) || @interface.IsPublic)
+            .Where(@interface => !isUnionDeclaration || @interface.FullName != IUnionInterfaceFullName)
             .OrderBy(static @interface => @interface.FullName, StringComparer.Ordinal)
             .Select(static @interface => FormatType(@interface))
             .ToList();
@@ -1192,6 +1203,9 @@ internal static class PublicApiModelBuilder
 
     private static string GetTypeKeyword(Type type)
     {
+        if (IsUnionDeclarationType(type))
+            return "union";
+
         if (type.IsInterface)
             return "interface";
 
@@ -1241,6 +1255,39 @@ internal static class PublicApiModelBuilder
     {
         return type.IsValueType &&
                type.GetCustomAttributesData().Any(static attribute => attribute.AttributeType.FullName == "System.Runtime.CompilerServices.IsReadOnlyAttribute");
+    }
+
+    private static bool IsUnionDeclarationType(Type type)
+    {
+        return type.IsValueType &&
+               !type.IsEnum &&
+               type.GetCustomAttributesData().Any(static attribute => attribute.AttributeType.FullName == UnionAttributeFullName) &&
+               type.GetInterfaces().Any(static @interface => @interface.FullName == IUnionInterfaceFullName);
+    }
+
+    private static string BuildUnionCaseTypes(Type type)
+    {
+        var caseTypes = type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(IsGeneratedUnionCaseConstructor)
+            .OrderBy(static constructor => constructor.MetadataToken)
+            .Select(constructor => FormatType(constructor.GetParameters()[0].ParameterType, NullabilityInfoContext.Create(constructor.GetParameters()[0])))
+            .ToArray();
+        return "(" + string.Join(", ", caseTypes) + ")";
+    }
+
+    private static bool IsGeneratedUnionCaseConstructor(ConstructorInfo constructor)
+    {
+        return IsExternallyVisible(constructor) &&
+               !constructor.IsStatic &&
+               constructor.GetParameters() is [var parameter] &&
+               !parameter.ParameterType.IsByRef;
+    }
+
+    private static bool IsGeneratedUnionValueProperty(PropertyInfo property)
+    {
+        return string.Equals(property.Name, "Value", StringComparison.Ordinal) &&
+               property.PropertyType == typeof(object) &&
+               property.GetIndexParameters().Length == 0;
     }
 
     private static string GetTypeAccessibility(Type type)
@@ -1765,6 +1812,6 @@ internal static class PublicApiModelBuilder
         "out", "override", "params", "private", "protected", "public", "readonly", "record", "ref", "return",
         "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this",
         "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
-        "void", "volatile", "while", "required", "file", "scoped",
+        "void", "volatile", "while", "required", "file", "scoped", "union",
     };
 }

--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
@@ -13,6 +13,8 @@ internal static class PublicApiModelReader
     private const string RequiresPreviewFeaturesAttributeFullName = "System.Runtime.Versioning.RequiresPreviewFeaturesAttribute";
     private const string ClosedAttributeFullName = "System.Runtime.CompilerServices.ClosedAttribute";
     private const string IsClosedTypeAttributeFullName = "System.Runtime.CompilerServices.IsClosedTypeAttribute";
+    private const string UnionAttributeFullName = "System.Runtime.CompilerServices.UnionAttribute";
+    private const string IUnionInterfaceFullName = "System.Runtime.CompilerServices.IUnion";
     private const GenericParameterAttributes AllowByRefLikeGenericParameterConstraint = (GenericParameterAttributes)0x20;
     private static readonly Lock EnumMetadataCacheLock = new();
     private static readonly Dictionary<string, EnumMetadata?> EnumMetadataCache = new(StringComparer.Ordinal);
@@ -120,9 +122,14 @@ internal static class PublicApiModelReader
         var accessibility = GetAccessibility(typeDefinition.Attributes);
         var genericArguments = BuildGenericArguments(metadataReader, typeDefinitionHandle);
         var keyword = GetTypeKeyword(metadataReader, typeDefinition);
-        var inheritance = BuildTypeInheritance(metadataReader, typeDefinitionHandle, typeDefinition);
+        var isUnionDeclaration = keyword == "union";
+        var inheritance = BuildTypeInheritance(metadataReader, typeDefinitionHandle, typeDefinition, isUnionDeclaration);
         var constraints = BuildTypeConstraints(metadataReader, typeDefinitionHandle);
         var typeAttributes = BuildAttributes(metadataReader, typeDefinition.GetCustomAttributes());
+        if (isUnionDeclaration)
+        {
+            typeAttributes = typeAttributes.Where(static attribute => !attribute.StartsWith("[System.Runtime.CompilerServices.Union", StringComparison.Ordinal)).ToList();
+        }
 
         if (keyword == "delegate")
         {
@@ -210,12 +217,17 @@ internal static class PublicApiModelReader
         sb.Append(' ');
         sb.Append(escapedTypeName);
         sb.Append(genericArguments);
+        if (isUnionDeclaration)
+        {
+            sb.Append(BuildUnionCaseTypes(metadataReader, typeDefinitionHandle));
+        }
+
         sb.Append(inheritance);
         sb.Append(FormatConstraintsInline(constraints));
         sb.AppendLine();
         sb.AppendLine("{");
 
-        foreach (var member in BuildMembers(metadataReader, typeDefinitionHandle, typeDefinition))
+        foreach (var member in BuildMembers(metadataReader, typeDefinitionHandle, typeDefinition, isUnionDeclaration))
         {
             AppendIndentedLine(sb, 1, member);
         }
@@ -236,7 +248,7 @@ internal static class PublicApiModelReader
         return sb.ToString();
     }
 
-    private static IEnumerable<string> BuildMembers(MetadataReader metadataReader, TypeDefinitionHandle typeDefinitionHandle, TypeDefinition typeDefinition)
+    private static IEnumerable<string> BuildMembers(MetadataReader metadataReader, TypeDefinitionHandle typeDefinitionHandle, TypeDefinition typeDefinition, bool isUnionDeclaration)
     {
         foreach (var fieldHandle in typeDefinition.GetFields())
         {
@@ -250,6 +262,9 @@ internal static class PublicApiModelReader
         foreach (var propertyHandle in EnumerateProperties(typeDefinition))
         {
             var property = metadataReader.GetPropertyDefinition(propertyHandle);
+            if (isUnionDeclaration && IsGeneratedUnionValueProperty(metadataReader, typeDefinitionHandle, property))
+                continue;
+
             var propertyText = BuildProperty(metadataReader, typeDefinitionHandle, property);
             if (propertyText is not null)
             {
@@ -281,6 +296,9 @@ internal static class PublicApiModelReader
             if (string.Equals(name, ".ctor", StringComparison.Ordinal))
             {
                 if (!IsExternallyVisible(method.Attributes))
+                    continue;
+
+                if (isUnionDeclaration && IsGeneratedUnionCaseConstructor(metadataReader, typeDefinitionHandle, methodHandle, method))
                     continue;
 
                 var constructorText = BuildConstructor(metadataReader, typeDefinitionHandle, methodHandle, method);
@@ -367,7 +385,7 @@ internal static class PublicApiModelReader
         }
     }
 
-    private static string BuildTypeInheritance(MetadataReader metadataReader, TypeDefinitionHandle typeDefinitionHandle, TypeDefinition typeDefinition)
+    private static string BuildTypeInheritance(MetadataReader metadataReader, TypeDefinitionHandle typeDefinitionHandle, TypeDefinition typeDefinition, bool isUnionDeclaration)
     {
         var keyword = GetTypeKeyword(metadataReader, typeDefinition);
         var genericContext = BuildSignatureGenericContext(metadataReader, typeDefinitionHandle);
@@ -385,6 +403,10 @@ internal static class PublicApiModelReader
         foreach (var interfaceImplementationHandle in typeDefinition.GetInterfaceImplementations())
         {
             var interfaceImplementation = metadataReader.GetInterfaceImplementation(interfaceImplementationHandle);
+            var interfaceTypeName = GetTypeFullName(metadataReader, interfaceImplementation.Interface);
+            if (isUnionDeclaration && string.Equals(interfaceTypeName, IUnionInterfaceFullName, StringComparison.Ordinal))
+                continue;
+
             baseTypes.Add(FormatDecodedTypeWithoutNullable(DecodeTypeFromEntityHandle(metadataReader, interfaceImplementation.Interface, genericContext)));
         }
 
@@ -1868,7 +1890,7 @@ internal static class PublicApiModelReader
     private static DecodedType DecodeTypeDefinitionHandle(MetadataReader metadataReader, MetadataTypeNameProvider provider, TypeDefinitionHandle typeDefinitionHandle)
     {
         var typeDefinition = metadataReader.GetTypeDefinition(typeDefinitionHandle);
-        var rawTypeKind = GetTypeKeyword(metadataReader, typeDefinition) is "struct" or "enum"
+        var rawTypeKind = GetTypeKeyword(metadataReader, typeDefinition) is "struct" or "enum" or "union"
             ? (byte)0x11
             : (byte)0x12;
         return provider.GetTypeFromDefinition(metadataReader, typeDefinitionHandle, rawTypeKind);
@@ -1916,6 +1938,9 @@ internal static class PublicApiModelReader
         if ((typeDefinition.Attributes & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Interface)
             return "interface";
 
+        if (IsUnionDeclarationType(metadataReader, typeDefinition))
+            return "union";
+
         var baseTypeName = GetTypeFullName(metadataReader, typeDefinition.BaseType);
         if (string.Equals(baseTypeName, "System.Enum", StringComparison.Ordinal))
             return "enum";
@@ -1935,6 +1960,79 @@ internal static class PublicApiModelReader
         }
 
         return "class";
+    }
+
+    private static bool IsUnionDeclarationType(MetadataReader metadataReader, TypeDefinition typeDefinition)
+    {
+        if (!string.Equals(GetTypeFullName(metadataReader, typeDefinition.BaseType), "System.ValueType", StringComparison.Ordinal))
+            return false;
+
+        if (!HasAttribute(metadataReader, typeDefinition.GetCustomAttributes(), UnionAttributeFullName))
+            return false;
+
+        foreach (var interfaceImplementationHandle in typeDefinition.GetInterfaceImplementations())
+        {
+            var interfaceImplementation = metadataReader.GetInterfaceImplementation(interfaceImplementationHandle);
+            if (string.Equals(GetTypeFullName(metadataReader, interfaceImplementation.Interface), IUnionInterfaceFullName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string BuildUnionCaseTypes(MetadataReader metadataReader, TypeDefinitionHandle typeDefinitionHandle)
+    {
+        var typeDefinition = metadataReader.GetTypeDefinition(typeDefinitionHandle);
+        var caseTypes = new List<string>();
+        foreach (var methodHandle in typeDefinition.GetMethods())
+        {
+            var method = metadataReader.GetMethodDefinition(methodHandle);
+            if (!IsGeneratedUnionCaseConstructor(metadataReader, typeDefinitionHandle, methodHandle, method))
+                continue;
+
+            var signature = DecodeMethodSignature(metadataReader, typeDefinitionHandle, methodHandle, method);
+            var nullableInfo = GetNullableMetadataInfo(metadataReader, typeDefinitionHandle, GetParameterCustomAttributes(metadataReader, method, sequenceNumber: 1), methodHandle);
+            var parameterType = ApplyNullableReferenceType(signature.Signature.ParameterTypes[0], nullableInfo);
+            caseTypes.Add(parameterType);
+        }
+
+        return "(" + string.Join(", ", caseTypes) + ")";
+    }
+
+    private static bool IsGeneratedUnionCaseConstructor(MetadataReader metadataReader, TypeDefinitionHandle declaringTypeHandle, MethodDefinitionHandle methodHandle, MethodDefinition method)
+    {
+        if (!string.Equals(metadataReader.GetString(method.Name), ".ctor", StringComparison.Ordinal) ||
+            !IsExternallyVisible(method.Attributes))
+        {
+            return false;
+        }
+
+        var signature = DecodeMethodSignature(metadataReader, declaringTypeHandle, methodHandle, method);
+        return !method.Attributes.HasFlag(MethodAttributes.Static) &&
+               signature.Signature.ParameterTypes.Length == 1 &&
+               signature.Signature.ParameterTypes[0].Kind != DecodedTypeKind.ByReference;
+    }
+
+    private static bool IsGeneratedUnionValueProperty(MetadataReader metadataReader, TypeDefinitionHandle declaringTypeHandle, PropertyDefinition property)
+    {
+        if (!string.Equals(metadataReader.GetString(property.Name), "Value", StringComparison.Ordinal))
+            return false;
+
+        var accessors = property.GetAccessors();
+        if (accessors.Getter.IsNil)
+            return false;
+
+        var getter = metadataReader.GetMethodDefinition(accessors.Getter);
+        if (!IsExternallyVisible(getter.Attributes))
+            return false;
+
+        var propertySignature = DecodePropertySignature(metadataReader, declaringTypeHandle, property);
+        var propertyType = ApplyNullableReferenceType(propertySignature.ReturnType, GetNullableMetadataInfo(metadataReader, declaringTypeHandle, property.GetCustomAttributes()));
+        return propertySignature.ParameterTypes.Length == 0 &&
+               (string.Equals(propertyType, "object", StringComparison.Ordinal) ||
+                string.Equals(propertyType, "object?", StringComparison.Ordinal));
     }
 
     private static bool IsExternallyVisible(TypeAttributes attributes)
@@ -2719,7 +2817,7 @@ internal static class PublicApiModelReader
         "out", "override", "params", "private", "protected", "public", "readonly", "record", "ref", "return",
         "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this",
         "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
-        "void", "volatile", "while", "required", "file", "scoped",
+        "void", "volatile", "while", "required", "file", "scoped", "union",
     };
 
     private readonly record struct SignatureGenericContext(ImmutableArray<string> TypeParameterNames, ImmutableArray<string> MethodParameterNames)

--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
@@ -2424,6 +2424,65 @@ public sealed class PublicApiGeneratorTests
             });
     }
 
+    [Fact]
+    public async Task Struct_Union()
+    {
+        await Validate("""
+            namespace System.Runtime.CompilerServices
+            {
+                public sealed class UnionAttribute : System.Attribute
+                {
+                }
+
+                public interface IUnion
+                {
+                    object Value { get; }
+                }
+            }
+
+            public class Cat
+            {
+            }
+
+            public class Dog
+            {
+            }
+
+            public union Pet(Cat, Dog);
+            """, """
+            #nullable enable
+
+            public class Cat
+            {
+            }
+
+
+            public class Dog
+            {
+            }
+
+
+            public union Pet(Cat, Dog)
+            {
+            }
+
+            namespace System.Runtime.CompilerServices
+            {
+                public interface IUnion
+                {
+                    object Value { get; }
+                }
+
+                public sealed class UnionAttribute : System.Attribute
+                {
+                }
+            }
+            """, compilerOptions: new CompilerOptions
+            {
+                TargetFramework = "net10.0",
+            });
+    }
+
     [InlineSnapshotAssertion(nameof(expected))]
     private static async Task Validate(string source, string expected, PublicApiOptions? options = null, CompilerOptions? compilerOptions = null, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = -1)
     {


### PR DESCRIPTION
## Why
C# now supports `union` declarations, and generated public API files should preserve that shape instead of exposing compiler-lowered implementation details (`struct`, generated constructors, `Value`, and `IUnion`). This keeps output aligned with source-level APIs.

## What changed
- Added union detection in both generation paths:
  - reflection path (`PublicApiModelBuilder`)
  - metadata path (`PublicApiModelReader`)
- Emitted union declarations as `union Type(Case1, Case2, ...)`.
- Filtered compiler-synthesized union artifacts from emitted API:
  - generated single-parameter case constructors
  - generated `Value` property
  - generated `IUnion` interface from inheritance list
  - generated `UnionAttribute` from emitted type attributes
- Added `union` to keyword escaping logic.
- Added a regression test (`Struct_Union`) validating reflection and metadata outputs match and compile for union types.

## Notes for reviewers
The implementation is intentionally conservative and only treats a type as a union declaration when it matches the lowered compiler pattern (`[Union]` + `IUnion` on a value type). This avoids changing behavior for custom types that merely happen to use similar member names.