### PR TITLE
ExecutableFinder: only consider files with +x flag on Unix

### DIFF
--- a/src/Meziantou.Framework/ExecutableFinder.cs
+++ b/src/Meziantou.Framework/ExecutableFinder.cs
@@ -43,17 +43,26 @@ static class ExecutableFinder
         static string? TryFindInDirectory(string executableName, string directory, string[] extensions)
         {
             var fullPath = Path.Combine(directory, executableName);
-            if (File.Exists(fullPath))
+            if (File.Exists(fullPath) && IsExecutable(fullPath))
                 return fullPath;
 
             foreach (var extension in extensions)
             {
                 var pathWithExt = fullPath + extension;
-                if (File.Exists(pathWithExt))
+                if (File.Exists(pathWithExt) && IsExecutable(pathWithExt))
                     return pathWithExt;
             }
 
             return null;
+        }
+
+        static bool IsExecutable(string path)
+        {
+            if (OperatingSystem.IsWindows())
+                return true;
+
+            var mode = File.GetUnixFileMode(path);
+            return (mode & (UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute)) != UnixFileMode.None;
         }
     }
 }

--- a/tests/Meziantou.Framework.Tests/ExecutableFinderTests.cs
+++ b/tests/Meziantou.Framework.Tests/ExecutableFinderTests.cs
@@ -27,4 +27,48 @@ public class ExecutableFinderTests
         var result = ExecutableFinder.GetFullExecutablePath("ls");
         Assert.True(result is "/bin/ls" or "/usr/bin/ls");
     }
+
+    [Fact, RunIf(TestOperatingSystems.Linux | TestOperatingSystems.MacOS)]
+    public void GetFullExecutablePathTests_Unix_WithoutExecuteBit_ReturnsNull()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var fileName = $"meziantou.{Guid.NewGuid():N}";
+            var filePath = Path.Combine(dir, fileName);
+            File.WriteAllBytes(filePath, []);
+            File.SetUnixFileMode(filePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+            var result = ExecutableFinder.GetFullExecutablePath(fileName, dir);
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Linux | TestOperatingSystems.MacOS)]
+    public void GetFullExecutablePathTests_Unix_WithExecuteBit_ReturnsPath()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var fileName = $"meziantou.{Guid.NewGuid():N}";
+            var filePath = Path.Combine(dir, fileName);
+            File.WriteAllBytes(filePath, []);
+            File.SetUnixFileMode(filePath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+            var result = ExecutableFinder.GetFullExecutablePath(fileName, dir);
+
+            Assert.Equal(filePath, result);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
 }


### PR DESCRIPTION
On Unix, a file should only be considered executable if it has at least one execute bit set. Previously, `ExecutableFinder.GetFullExecutablePath` accepted any existing file, regardless of permissions.

**Changes:**

- Added a private `IsExecutable(string path)` helper in `ExecutableFinder`. On Windows it always returns `true` (no behavior change). On Unix it calls `File.GetUnixFileMode()` and checks for any of `UserExecute | GroupExecute | OtherExecute`.
- `TryFindInDirectory` now requires both `File.Exists()` and `IsExecutable()` before returning a candidate path.
- Added two new Unix-only tests: one verifying that a file with only `rw` permissions is not returned, and one verifying that a file with `rwx` permissions is found correctly.