### PR TITLE
Add StringExtensions.ReplaceAny for SearchValues<char>

### DIFF
--- a/ref/Meziantou.Framework.cs
+++ b/ref/Meziantou.Framework.cs
@@ -644,6 +644,7 @@ namespace Meziantou.Framework
         public static bool EqualsOrdinal(this string? str1, string? str2) => throw null;
         public static bool EqualsIgnoreCase(this string? str1, string? str2) => throw null;
         public static bool ContainsIgnoreCase(this string str, string value) => throw null;
+        public static string ReplaceAny(this string text, System.Buffers.SearchValues<char> values, char newValue) => throw null;
         public static string? RemoveDiacritics(this string? str) => throw null;
         public static string RemoveSuffix(this string str, string suffix) => throw null;
         public static string RemoveSuffix(this string str, string suffix, System.StringComparison stringComparison) => throw null;

--- a/src/Meziantou.Framework/StringExtensions.cs
+++ b/src/Meziantou.Framework/StringExtensions.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+
 namespace Meziantou.Framework;
 
 #if PUBLIC_STRING_EXTENSIONS
@@ -36,6 +38,30 @@ static partial class StringExtensions
     public static bool ContainsIgnoreCase(this string str, string value)
     {
         return str.Contains(value, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static string ReplaceAny(this string text, SearchValues<char> values, char newValue)
+    {
+        if (!text.ContainsAny(values))
+            return text;
+
+        return string.Create(text.Length, (text, values, newValue), static (span, state) =>
+        {
+            var source = state.text.AsSpan();
+            source.CopyTo(span);
+
+            var start = 0;
+            while (start < source.Length)
+            {
+                var index = source[start..].IndexOfAny(state.values);
+                if (index < 0)
+                    break;
+
+                start += index;
+                span[start] = state.newValue;
+                start++;
+            }
+        });
     }
 
     private static readonly Lazy<Dictionary<char, char>> DiacriticDictionary = new(CreateDiacriticDictionary);

--- a/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
@@ -131,7 +131,7 @@ public class StringExtensionsTests
     [Fact]
     public void ReplaceAny_NoMatch_ReturnsSameInstance()
     {
-        const string input = "abcdef";
+        var input = "abcdef";
         var actual = input.ReplaceAny(SearchValues.Create(".,-/"), '_');
         Assert.Same(input, actual);
     }

--- a/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Tests/StringExtensionsTests.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+
 namespace Meziantou.Framework.Tests;
 
 public class StringExtensionsTests
@@ -112,6 +114,26 @@ public class StringExtensionsTests
             { "ab\u0085cd\u2028ef\u2029gh\vij\fkl", LineBreakMode.Unicode, new[] { ("ab", "\u0085"), ("cd", "\u2028"), ("ef", "\u2029"), ("gh\vij\fkl", "") } },
             { "ab\u0085cd\u2028ef\u2029gh\vij\fkl", LineBreakMode.UnicodeWithLegacyControls, new[] { ("ab", "\u0085"), ("cd", "\u2028"), ("ef", "\u2029"), ("gh", "\v"), ("ij", "\f"), ("kl", "") } },
         };
+    }
+
+    [Theory]
+    [InlineData("", "", '_')]
+    [InlineData("abc", "abc", '_')]
+    [InlineData("a,b.c", "a_b_c", '_')]
+    [InlineData("a-b/c", "a_b_c", '_')]
+    [InlineData("..a..", "__a__", '_')]
+    public void ReplaceAny(string input, string expected, char newValue)
+    {
+        var actual = input.ReplaceAny(SearchValues.Create(".,-/"), newValue);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ReplaceAny_NoMatch_ReturnsSameInstance()
+    {
+        const string input = "abcdef";
+        var actual = input.ReplaceAny(SearchValues.Create(".,-/"), '_');
+        Assert.Same(input, actual);
     }
 
     [Theory]


### PR DESCRIPTION
## Why
Consumers need an efficient way to normalize text by replacing any character from a set with one target character.

## What changed
- Added `StringExtensions.ReplaceAny(this string text, SearchValues<char> values, char newValue)`.
- Kept a fast no-match path that returns the original string instance.
- Implemented replacement using `IndexOfAny` jumps to locate only matching positions.
- Added tests for replacement behavior and the no-match same-instance behavior.
- Updated the public reference assembly API (`ref/Meziantou.Framework.cs`).