### PR TITLE
Fix unnecessary quotes for typed YAML scalar values

### DIFF
--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -1052,6 +1052,15 @@ namespace Meziantou.Framework.Yaml.Serialization
         public void WriteScalar(char value) { }
         public void WriteScalar(double value) { }
         public void WriteScalar(float value) { }
+        public void WriteScalar(System.DateTime value) { }
+        public void WriteScalar(System.DateTimeOffset value) { }
+        public void WriteScalar(System.Guid value) { }
+        public void WriteScalar(System.TimeSpan value) { }
+        public void WriteScalar(System.DateOnly value) { }
+        public void WriteScalar(System.TimeOnly value) { }
+        public void WriteScalar(System.Half value) { }
+        public void WriteScalar(System.Int128 value) { }
+        public void WriteScalar(System.UInt128 value) { }
         public void WriteScalar<T>(T value) where T : System.IFormattable { }
         public void WriteNullValue() { }
         public readonly struct BlockSequenceItemStyleScope : System.IDisposable

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
@@ -4355,26 +4355,26 @@ public sealed partial class YamlSerializerContextGenerator
             if (string.Equals(systemType.Name, "DateTime", StringComparison.Ordinal) ||
                 string.Equals(systemType.Name, "DateTimeOffset", StringComparison.Ordinal))
             {
-                builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine(".ToString(\"O\", global::System.Globalization.CultureInfo.InvariantCulture));");
+                builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine(");");
                 return true;
             }
 
             if (string.Equals(systemType.Name, "Guid", StringComparison.Ordinal))
             {
-                builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine(".ToString(\"D\"));");
+                builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine(");");
                 return true;
             }
 
             if (string.Equals(systemType.Name, "TimeSpan", StringComparison.Ordinal))
             {
-                builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine(".ToString(\"c\", global::System.Globalization.CultureInfo.InvariantCulture));");
+                builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine(");");
                 return true;
             }
 
             if (string.Equals(systemType.Name, "DateOnly", StringComparison.Ordinal) ||
                 string.Equals(systemType.Name, "TimeOnly", StringComparison.Ordinal))
             {
-                builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine(".ToString(\"O\", global::System.Globalization.CultureInfo.InvariantCulture));");
+                builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine(");");
                 return true;
             }
 
@@ -4382,7 +4382,7 @@ public sealed partial class YamlSerializerContextGenerator
                 string.Equals(systemType.Name, "Int128", StringComparison.Ordinal) ||
                 string.Equals(systemType.Name, "UInt128", StringComparison.Ordinal))
             {
-                builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine(".ToString(global::System.Globalization.CultureInfo.InvariantCulture));");
+                builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine(");");
                 return true;
             }
         }

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlBooleanConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlBooleanConverter.cs
@@ -22,6 +22,6 @@ internal sealed class YamlBooleanConverter : YamlConverter<bool>
 
     public override void Write(YamlWriter writer, bool value)
     {
-        writer.WriteScalar(value ? "true" : "false");
+        writer.WriteScalar(value);
     }
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDateOnlyConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDateOnlyConverter.cs
@@ -23,6 +23,6 @@ internal sealed class YamlDateOnlyConverter : YamlConverter<DateOnly>
 
     public override void Write(YamlWriter writer, DateOnly value)
     {
-        writer.WriteScalar(value.ToString("O", CultureInfo.InvariantCulture));
+        writer.WriteScalar(value);
     }
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDateTimeConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDateTimeConverter.cs
@@ -23,6 +23,6 @@ internal sealed class YamlDateTimeConverter : YamlConverter<DateTime>
 
     public override void Write(YamlWriter writer, DateTime value)
     {
-        writer.WriteScalar(value.ToString("O", CultureInfo.InvariantCulture));
+        writer.WriteScalar(value);
     }
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDateTimeOffsetConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDateTimeOffsetConverter.cs
@@ -23,6 +23,6 @@ internal sealed class YamlDateTimeOffsetConverter : YamlConverter<DateTimeOffset
 
     public override void Write(YamlWriter writer, DateTimeOffset value)
     {
-        writer.WriteScalar(value.ToString("O", CultureInfo.InvariantCulture));
+        writer.WriteScalar(value);
     }
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlGuidConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlGuidConverter.cs
@@ -23,6 +23,6 @@ internal sealed class YamlGuidConverter : YamlConverter<Guid>
 
     public override void Write(YamlWriter writer, Guid value)
     {
-        writer.WriteScalar(value.ToString("D"));
+        writer.WriteScalar(value);
     }
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlHalfConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlHalfConverter.cs
@@ -23,6 +23,6 @@ internal sealed class YamlHalfConverter : YamlConverter<Half>
 
     public override void Write(YamlWriter writer, Half value)
     {
-        writer.WriteScalar(value.ToString(CultureInfo.InvariantCulture));
+        writer.WriteScalar(value);
     }
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlInt128Converter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlInt128Converter.cs
@@ -23,6 +23,6 @@ internal sealed class YamlInt128Converter : YamlConverter<Int128>
 
     public override void Write(YamlWriter writer, Int128 value)
     {
-        writer.WriteScalar(value.ToString(CultureInfo.InvariantCulture));
+        writer.WriteScalar(value);
     }
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlTimeOnlyConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlTimeOnlyConverter.cs
@@ -23,6 +23,6 @@ internal sealed class YamlTimeOnlyConverter : YamlConverter<TimeOnly>
 
     public override void Write(YamlWriter writer, TimeOnly value)
     {
-        writer.WriteScalar(value.ToString("O", CultureInfo.InvariantCulture));
+        writer.WriteScalar(value);
     }
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlTimeSpanConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlTimeSpanConverter.cs
@@ -23,6 +23,6 @@ internal sealed class YamlTimeSpanConverter : YamlConverter<TimeSpan>
 
     public override void Write(YamlWriter writer, TimeSpan value)
     {
-        writer.WriteScalar(value.ToString("c", CultureInfo.InvariantCulture));
+        writer.WriteScalar(value);
     }
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlUInt128Converter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlUInt128Converter.cs
@@ -23,6 +23,6 @@ internal sealed class YamlUInt128Converter : YamlConverter<UInt128>
 
     public override void Write(YamlWriter writer, UInt128 value)
     {
-        writer.WriteScalar(value.ToString(CultureInfo.InvariantCulture));
+        writer.WriteScalar(value);
     }
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
@@ -413,6 +413,69 @@ public sealed class YamlWriter : YamlReaderWriterBase
         WriteFormattableScalar(value, format: "R", plainSafe: true);
     }
 
+    /// <summary>Writes a date and time scalar value using the round-trip format.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteScalar(DateTime value)
+    {
+        WritePlainScalar(value.ToString("O", CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>Writes a date and time with offset scalar value using the round-trip format.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteScalar(DateTimeOffset value)
+    {
+        WritePlainScalar(value.ToString("O", CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>Writes a GUID scalar value.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteScalar(Guid value)
+    {
+        WritePlainScalar(value.ToString("D"));
+    }
+
+    /// <summary>Writes a time interval scalar value using the constant format.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteScalar(TimeSpan value)
+    {
+        WritePlainScalar(value.ToString("c", CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>Writes a date-only scalar value using the round-trip format.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteScalar(DateOnly value)
+    {
+        WritePlainScalar(value.ToString("O", CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>Writes a time-only scalar value using the round-trip format.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteScalar(TimeOnly value)
+    {
+        WritePlainScalar(value.ToString("O", CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>Writes a half-precision floating-point scalar value.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteScalar(Half value)
+    {
+        WritePlainScalar(value.ToString(CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>Writes a 128-bit signed integer scalar value.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteScalar(Int128 value)
+    {
+        WritePlainScalar(value.ToString(CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>Writes a 128-bit unsigned integer scalar value.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteScalar(UInt128 value)
+    {
+        WritePlainScalar(value.ToString(CultureInfo.InvariantCulture));
+    }
+
     /// <summary>Writes a scalar value for a span-formattable type using invariant culture formatting.</summary>
     /// <typeparam name="T">The value type to write.</typeparam>
     /// <param name="value">The value to write.</param>

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -1042,10 +1042,11 @@ public class YamlSerializerSourceGenerationTests
 
         var yaml = YamlSerializer.Serialize(payload, typeInfo);
 
-        Assert.Contains("PublishDate: 2019-06-17T00:00:00.0000000+00:00", yaml);
-        Assert.Contains("AllowPostingOnSocialMedia: false", yaml);
-        Assert.DoesNotContain("PublishDate: \"", yaml);
-        Assert.DoesNotContain("AllowPostingOnSocialMedia: \"false\"", yaml);
+        Assert.Equal("""
+            PublishDate: 2019-06-17T00:00:00.0000000+00:00
+            AllowPostingOnSocialMedia: false
+
+            """.ReplaceLineEndings("\n"), yaml);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -132,6 +132,12 @@ internal sealed class GeneratedWellKnownScalars
     public TimeSpan Duration { get; set; }
 }
 
+internal sealed class GeneratedNullableScalars
+{
+    public DateTimeOffset? PublishDate { get; set; }
+    public bool? AllowPostingOnSocialMedia { get; set; }
+}
+
 internal sealed class GeneratedModernScalars
 {
     public DateOnly Date { get; set; }
@@ -604,6 +610,7 @@ internal sealed class GeneratedReadOnlyPopulateStructContainer
 [YamlSerializable(typeof(GeneratedContainer))]
 [YamlSerializable(typeof(GeneratedPrimitives))]
 [YamlSerializable(typeof(GeneratedWellKnownScalars))]
+[YamlSerializable(typeof(GeneratedNullableScalars))]
 [YamlSerializable(typeof(GeneratedModernScalars))]
 [YamlSerializable(typeof(GeneratedColor))]
 [YamlSerializable(typeof(bool))]
@@ -1020,6 +1027,25 @@ public class YamlSerializerSourceGenerationTests
         Assert.Equal(payload.WhenOffset, roundTrip.WhenOffset);
         Assert.Equal(payload.Id, roundTrip.Id);
         Assert.Equal(payload.Duration, roundTrip.Duration);
+    }
+
+    [Fact]
+    public void GeneratedContext_NullableDateTimeOffsetAndBoolean_AreEmittedPlain()
+    {
+        var context = TestYamlSerializerContext.Default;
+        var typeInfo = context.GeneratedNullableScalars;
+        var payload = new GeneratedNullableScalars
+        {
+            PublishDate = new DateTimeOffset(2019, 06, 17, 0, 0, 0, TimeSpan.Zero),
+            AllowPostingOnSocialMedia = false,
+        };
+
+        var yaml = YamlSerializer.Serialize(payload, typeInfo);
+
+        Assert.Contains("PublishDate: 2019-06-17T00:00:00.0000000+00:00", yaml);
+        Assert.Contains("AllowPostingOnSocialMedia: false", yaml);
+        Assert.DoesNotContain("PublishDate: \"", yaml);
+        Assert.DoesNotContain("AllowPostingOnSocialMedia: \"false\"", yaml);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -1046,7 +1046,7 @@ public class YamlSerializerSourceGenerationTests
             PublishDate: 2019-06-17T00:00:00.0000000+00:00
             AllowPostingOnSocialMedia: false
 
-            """.ReplaceLineEndings("\n"), yaml);
+            """, yaml, ignoreLineEndingDifferences: true);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
@@ -18,6 +18,12 @@ public sealed class YamlWellKnownScalarConverterTests
         public UInt128 UBig { get; set; }
     }
 
+    private sealed class NullablePayload
+    {
+        public DateTimeOffset? PublishDate { get; set; }
+        public bool? AllowPostingOnSocialMedia { get; set; }
+    }
+
     [Fact]
     public void RoundTrip_WellKnownScalarTypes_ShouldSucceed()
     {
@@ -79,5 +85,22 @@ public sealed class YamlWellKnownScalarConverterTests
         Assert.Contains("Int128", ex.Message);
         Assert.Contains("Lin:", ex.Message);
         Assert.Contains("Col:", ex.Message);
+    }
+
+    [Fact]
+    public void Serialize_NullableDateTimeOffsetAndBoolean_ShouldRemainPlain()
+    {
+        var payload = new NullablePayload
+        {
+            PublishDate = new DateTimeOffset(2019, 06, 17, 0, 0, 0, TimeSpan.Zero),
+            AllowPostingOnSocialMedia = false,
+        };
+
+        var yaml = YamlSerializer.Serialize(payload);
+
+        Assert.Contains("PublishDate: 2019-06-17T00:00:00.0000000+00:00", yaml);
+        Assert.Contains("AllowPostingOnSocialMedia: false", yaml);
+        Assert.DoesNotContain("PublishDate: \"", yaml);
+        Assert.DoesNotContain("AllowPostingOnSocialMedia: \"false\"", yaml);
     }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
@@ -102,6 +102,6 @@ public sealed class YamlWellKnownScalarConverterTests
             PublishDate: 2019-06-17T00:00:00.0000000+00:00
             AllowPostingOnSocialMedia: false
 
-            """.ReplaceLineEndings("\n"), yaml);
+            """, yaml, ignoreLineEndingDifferences: true);
     }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
@@ -98,9 +98,10 @@ public sealed class YamlWellKnownScalarConverterTests
 
         var yaml = YamlSerializer.Serialize(payload);
 
-        Assert.Contains("PublishDate: 2019-06-17T00:00:00.0000000+00:00", yaml);
-        Assert.Contains("AllowPostingOnSocialMedia: false", yaml);
-        Assert.DoesNotContain("PublishDate: \"", yaml);
-        Assert.DoesNotContain("AllowPostingOnSocialMedia: \"false\"", yaml);
+        Assert.Equal("""
+            PublishDate: 2019-06-17T00:00:00.0000000+00:00
+            AllowPostingOnSocialMedia: false
+
+            """.ReplaceLineEndings("\n"), yaml);
     }
 }


### PR DESCRIPTION
YAML serialization currently emits some typed values through the string scalar path, which makes nullable values like `DateTimeOffset?` and `bool?` appear quoted (`"..."`) even when plain YAML scalars are expected. This change makes typed scalar output consistently use plain emission by default.

## What changed
- Added typed `YamlWriter.WriteScalar(...)` overloads for date/time-related types, `Guid`, `TimeSpan`, `Half`, `Int128`, and `UInt128` that emit plain scalars.
- Updated built-in converters to use typed scalar overloads instead of preformatted string writes for those types, including `bool`.
- Updated source-generated serializer emission so well-known system scalar types call typed `writer.WriteScalar(value)` directly instead of writing formatted strings.
- Added regression tests for both reflection and source-generated serializers to ensure `DateTimeOffset?` and `bool?` serialize without unnecessary quotes.
- Updated generated public API reference (`ref/Meziantou.Framework.Yaml.cs`) for the new writer overloads.

## Notes
- This keeps existing ambiguity-quoting behavior for CLR string values (`WriteString`) while avoiding it for strongly typed scalar values.