### PR TITLE
Fix YAML scalar quoting and UTC Z suffix formatting

### DIFF
--- a/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
@@ -424,6 +424,12 @@ public sealed class YamlWriter : YamlReaderWriterBase
     /// <param name="value">The value to write.</param>
     public void WriteScalar(DateTimeOffset value)
     {
+        if (value.Offset == TimeSpan.Zero)
+        {
+            WritePlainScalar(value.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffff'Z'", CultureInfo.InvariantCulture));
+            return;
+        }
+
         WritePlainScalar(value.ToString("O", CultureInfo.InvariantCulture));
     }
 

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerApiTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerApiTests.cs
@@ -25,6 +25,11 @@ public class YamlSerializerApiTests
         public YamlNode? Content { get; set; }
     }
 
+    private sealed class StringPayload
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
     private sealed class StringTypeInfo : YamlTypeInfo<string>
     {
         public StringTypeInfo(YamlSerializerOptions options) : base(options)
@@ -232,6 +237,22 @@ public class YamlSerializerApiTests
 
         Assert.Equal("value: hello\n", yaml);
         Assert.Equal("hello", value);
+    }
+
+    [Fact]
+    public void SerializeStringProperty_UsesPlainStyleWhenSafe()
+    {
+        var yaml = YamlSerializer.Serialize(new StringPayload { Value = "sample string" });
+
+        Assert.Equal("Value: sample string\n", yaml);
+    }
+
+    [Fact]
+    public void SerializeStringProperty_QuotesProblematicCharacters()
+    {
+        var yaml = YamlSerializer.Serialize(new StringPayload { Value = "sample: string" });
+
+        Assert.Equal("Value: \"sample: string\"\n", yaml);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -1043,10 +1043,28 @@ public class YamlSerializerSourceGenerationTests
         var yaml = YamlSerializer.Serialize(payload, typeInfo);
 
         Assert.Equal("""
-            PublishDate: 2019-06-17T00:00:00.0000000+00:00
+            PublishDate: 2019-06-17T00:00:00.0000000Z
             AllowPostingOnSocialMedia: false
 
             """, yaml, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void GeneratedContext_DateTimeAndDateTimeOffset_UseZSuffixForUtc()
+    {
+        var payload = new GeneratedWellKnownScalars
+        {
+            WhenUtc = new DateTime(2027, 04, 19, 12, 00, 00, DateTimeKind.Utc),
+            WhenOffset = new DateTimeOffset(2027, 04, 19, 12, 00, 00, TimeSpan.Zero),
+            Id = Guid.Empty,
+            Duration = TimeSpan.Zero,
+        };
+
+        var context = TestYamlSerializerContext.Default;
+        var yaml = YamlSerializer.Serialize(payload, context.GeneratedWellKnownScalars);
+
+        Assert.Contains("WhenUtc: 2027-04-19T12:00:00.0000000Z", yaml);
+        Assert.Contains("WhenOffset: 2027-04-19T12:00:00.0000000Z", yaml);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
@@ -99,9 +99,26 @@ public sealed class YamlWellKnownScalarConverterTests
         var yaml = YamlSerializer.Serialize(payload);
 
         Assert.Equal("""
-            PublishDate: 2019-06-17T00:00:00.0000000+00:00
+            PublishDate: 2019-06-17T00:00:00.0000000Z
             AllowPostingOnSocialMedia: false
 
             """, yaml, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void Serialize_DateTimeAndDateTimeOffset_UseZSuffixForUtc()
+    {
+        var payload = new Payload
+        {
+            WhenUtc = new DateTime(2027, 04, 19, 12, 00, 00, DateTimeKind.Utc),
+            WhenOffset = new DateTimeOffset(2027, 04, 19, 12, 00, 00, TimeSpan.Zero),
+            Id = Guid.Empty,
+            Duration = TimeSpan.Zero,
+        };
+
+        var yaml = YamlSerializer.Serialize(payload);
+
+        Assert.Contains("WhenUtc: 2027-04-19T12:00:00.0000000Z", yaml);
+        Assert.Contains("WhenOffset: 2027-04-19T12:00:00.0000000Z", yaml);
     }
 }


### PR DESCRIPTION
The YAML output should stay readable for safe string scalars while still preserving unambiguous parsing for edge cases, and UTC timestamps should use the canonical `Z` suffix instead of `+00:00`.

## What changed
- Added serializer regression tests to ensure safe strings are emitted as plain scalars (for example `Value: sample string`) and strings with problematic characters are still quoted.
- Updated `YamlWriter.WriteScalar(DateTimeOffset)` to emit `yyyy-MM-ddTHH:mm:ss.fffffffZ` when the offset is zero, while keeping non-zero offsets in round-trip offset format.
- Updated reflection and source-generated scalar tests to assert `Z` output for UTC/zero-offset values and kept round-trip coverage in place.

## Notes for reviewers
- This intentionally changes zero-offset `DateTimeOffset` textual output from `+00:00` to `Z`.
- UTC `DateTime` already serialized with `Z`; tests now explicitly lock that behavior alongside `DateTimeOffset`.