### PR TITLE
Add Yamlish option to control block list indentation

### DIFF
--- a/ref/Meziantou.Framework.Yamlish.cs
+++ b/ref/Meziantou.Framework.Yamlish.cs
@@ -141,6 +141,7 @@ namespace Meziantou.Framework.Yamlish
         public System.StringComparer PropertyNameComparer { get => throw null; set { } }
         public int IndentSize { get => throw null; set { } }
         public char IndentCharacter { get => throw null; set { } }
+        public bool IndentBlockSequenceItems { get => throw null; set { } }
         public string NewLine { get => throw null; set { } }
         public int MaxDepth { get => throw null; set { } }
         public Meziantou.Framework.Yamlish.YamlishIgnoreCondition DefaultIgnoreCondition { get => throw null; set { } }

--- a/src/Meziantou.Framework.Yamlish/Internals/YamlishWriter.cs
+++ b/src/Meziantou.Framework.Yamlish/Internals/YamlishWriter.cs
@@ -2,10 +2,10 @@ namespace Meziantou.Framework.Yamlish.Internals;
 
 internal static class YamlishWriter
 {
-    public static void Write(TextWriter writer, YamlishNode node, char indentCharacter, int indentSize, string newLine)
+    public static void Write(TextWriter writer, YamlishNode node, char indentCharacter, int indentSize, bool indentBlockSequenceItems, string newLine)
     {
         using var buffer = new StringWriter(CultureInfo.InvariantCulture) { NewLine = newLine };
-        WriteNode(buffer, node, indent: 0, indentCharacter, indentSize);
+        WriteNode(buffer, node, indent: 0, indentCharacter, indentSize, indentBlockSequenceItems);
 
         var content = buffer.ToString();
         if (content.EndsWith(newLine, StringComparison.Ordinal))
@@ -14,7 +14,7 @@ internal static class YamlishWriter
         writer.Write(content);
     }
 
-    private static void WriteNode(TextWriter writer, YamlishNode node, int indent, char indentCharacter, int indentSize)
+    private static void WriteNode(TextWriter writer, YamlishNode node, int indent, char indentCharacter, int indentSize, bool indentBlockSequenceItems)
     {
         switch (node)
         {
@@ -23,24 +23,24 @@ internal static class YamlishWriter
                 break;
 
             case YamlishMapping mapping:
-                WriteMapping(writer, mapping, indent, indentCharacter, indentSize);
+                WriteMapping(writer, mapping, indent, indentCharacter, indentSize, indentBlockSequenceItems);
                 break;
 
             case YamlishSequence sequence:
-                WriteSequence(writer, sequence, indent, indentCharacter, indentSize);
+                WriteSequence(writer, sequence, indent, indentCharacter, indentSize, indentBlockSequenceItems);
                 break;
         }
     }
 
-    private static void WriteMapping(TextWriter writer, YamlishMapping mapping, int indent, char indentCharacter, int indentSize)
+    private static void WriteMapping(TextWriter writer, YamlishMapping mapping, int indent, char indentCharacter, int indentSize, bool indentBlockSequenceItems)
     {
         foreach (var entry in mapping)
         {
-            WriteMappingEntry(writer, entry, indent, writeIndent: true, indentCharacter, indentSize);
+            WriteMappingEntry(writer, entry, indent, writeIndent: true, indentCharacter, indentSize, indentBlockSequenceItems);
         }
     }
 
-    private static void WriteSequence(TextWriter writer, YamlishSequence sequence, int indent, char indentCharacter, int indentSize)
+    private static void WriteSequence(TextWriter writer, YamlishSequence sequence, int indent, char indentCharacter, int indentSize, bool indentBlockSequenceItems)
     {
         if (sequence.Count is 0)
         {
@@ -74,31 +74,31 @@ internal static class YamlishWriter
                 if (item is YamlishMapping { Count: > 0 } mapping)
                 {
                     writer.Write(' ');
-                    WriteCompactMapping(writer, mapping, indent + indentSize, indentCharacter, indentSize);
+                    WriteCompactMapping(writer, mapping, indent + indentSize, indentCharacter, indentSize, indentBlockSequenceItems);
                 }
                 else
                 {
                     writer.WriteLine();
-                    WriteNode(writer, item, indent + indentSize, indentCharacter, indentSize);
+                    WriteNode(writer, item, indent + indentSize, indentCharacter, indentSize, indentBlockSequenceItems);
                 }
             }
         }
     }
 
-    private static void WriteCompactMapping(TextWriter writer, YamlishMapping mapping, int indent, char indentCharacter, int indentSize)
+    private static void WriteCompactMapping(TextWriter writer, YamlishMapping mapping, int indent, char indentCharacter, int indentSize, bool indentBlockSequenceItems)
     {
         using var enumerator = mapping.GetEnumerator();
         if (!enumerator.MoveNext())
             return;
 
-        WriteMappingEntry(writer, enumerator.Current, indent, writeIndent: false, indentCharacter, indentSize);
+        WriteMappingEntry(writer, enumerator.Current, indent, writeIndent: false, indentCharacter, indentSize, indentBlockSequenceItems);
         while (enumerator.MoveNext())
         {
-            WriteMappingEntry(writer, enumerator.Current, indent, writeIndent: true, indentCharacter, indentSize);
+            WriteMappingEntry(writer, enumerator.Current, indent, writeIndent: true, indentCharacter, indentSize, indentBlockSequenceItems);
         }
     }
 
-    private static void WriteMappingEntry(TextWriter writer, KeyValuePair<string, YamlishNode> entry, int indent, bool writeIndent, char indentCharacter, int indentSize)
+    private static void WriteMappingEntry(TextWriter writer, KeyValuePair<string, YamlishNode> entry, int indent, bool writeIndent, char indentCharacter, int indentSize, bool indentBlockSequenceItems)
     {
         if (writeIndent)
             WriteIndent(writer, indent, indentCharacter);
@@ -123,7 +123,8 @@ internal static class YamlishWriter
         else
         {
             writer.WriteLine();
-            WriteNode(writer, entry.Value, indent + indentSize, indentCharacter, indentSize);
+            var childIndent = entry.Value is YamlishSequence && !indentBlockSequenceItems ? indent : indent + indentSize;
+            WriteNode(writer, entry.Value, childIndent, indentCharacter, indentSize, indentBlockSequenceItems);
         }
     }
 

--- a/src/Meziantou.Framework.Yamlish/Meziantou.Framework.Yamlish.csproj
+++ b/src/Meziantou.Framework.Yamlish/Meziantou.Framework.Yamlish.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
     <Description>A parser and serializer for a small, deliberate subset of YAML.</Description>
     <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.Yamlish/Nodes/YamlishDocument.cs
+++ b/src/Meziantou.Framework.Yamlish/Nodes/YamlishDocument.cs
@@ -36,7 +36,7 @@ public sealed class YamlishDocument
     public void WriteTo(TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(writer);
-        YamlishWriter.Write(writer, Root, indentCharacter: ' ', indentSize: 2, newLine: writer.NewLine);
+        YamlishWriter.Write(writer, Root, indentCharacter: ' ', indentSize: 2, indentBlockSequenceItems: true, newLine: writer.NewLine);
     }
 
     /// <inheritdoc />

--- a/src/Meziantou.Framework.Yamlish/Nodes/YamlishNode.cs
+++ b/src/Meziantou.Framework.Yamlish/Nodes/YamlishNode.cs
@@ -10,7 +10,7 @@ public abstract class YamlishNode
     public override string ToString()
     {
         using var writer = new StringWriter(CultureInfo.InvariantCulture);
-        YamlishWriter.Write(writer, this, indentCharacter: ' ', indentSize: 2, newLine: writer.NewLine);
+        YamlishWriter.Write(writer, this, indentCharacter: ' ', indentSize: 2, indentBlockSequenceItems: true, newLine: writer.NewLine);
         return writer.ToString();
     }
 }

--- a/src/Meziantou.Framework.Yamlish/YamlishSerializer.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishSerializer.cs
@@ -31,7 +31,7 @@ public static class YamlishSerializer
         options.MakeReadOnly();
         var root = ObjectBinder.Serialize(value, type, options, depth: 0);
         using var writer = new StringWriter(CultureInfo.InvariantCulture);
-        YamlishWriter.Write(writer, root, options.IndentCharacter, options.IndentSize, options.NewLine);
+        YamlishWriter.Write(writer, root, options.IndentCharacter, options.IndentSize, options.IndentBlockSequenceItems, options.NewLine);
         return writer.ToString();
     }
 

--- a/src/Meziantou.Framework.Yamlish/YamlishSerializerOptions.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishSerializerOptions.cs
@@ -68,6 +68,17 @@ public sealed class YamlishSerializerOptions
         }
     } = ' ';
 
+    /// <summary>Gets or sets a value indicating whether block sequence items are indented relative to their parent mapping key.</summary>
+    public bool IndentBlockSequenceItems
+    {
+        get;
+        set
+        {
+            VerifyMutable();
+            field = value;
+        }
+    } = true;
+
     /// <summary>Gets or sets the newline sequence used when writing Yamlish.</summary>
     public string NewLine
     {

--- a/src/Meziantou.Framework.Yamlish/YamlishSerializerOptions.cs
+++ b/src/Meziantou.Framework.Yamlish/YamlishSerializerOptions.cs
@@ -77,7 +77,7 @@ public sealed class YamlishSerializerOptions
             VerifyMutable();
             field = value;
         }
-    } = true;
+    }
 
     /// <summary>Gets or sets the newline sequence used when writing Yamlish.</summary>
     public string NewLine

--- a/tests/Meziantou.Framework.Yamlish.Tests/YamlishSerializerTests.cs
+++ b/tests/Meziantou.Framework.Yamlish.Tests/YamlishSerializerTests.cs
@@ -12,6 +12,7 @@ public sealed class YamlishSerializerTests
         Assert.False(options.IncludeFields);
         Assert.Equal(' ', options.IndentCharacter);
         Assert.Equal(2, options.IndentSize);
+        Assert.True(options.IndentBlockSequenceItems);
         Assert.Equal(Environment.NewLine, options.NewLine);
         Assert.Equal(YamlishObjectCreationHandling.Replace, options.PreferredObjectCreationHandling);
         Assert.True(options.AllowDuplicateProperties);
@@ -119,6 +120,7 @@ public sealed class YamlishSerializerTests
         Assert.Equal(countAfterFirstUse, predicateEvaluationCount);
         Assert.Throws<InvalidOperationException>(() => options.IncludeFields = true);
         Assert.Throws<InvalidOperationException>(() => options.IndentCharacter = '\t');
+        Assert.Throws<InvalidOperationException>(() => options.IndentBlockSequenceItems = false);
         Assert.Throws<InvalidOperationException>(() => options.NewLine = "\n");
         Assert.Throws<InvalidOperationException>(() => options.AllowDuplicateProperties = false);
         Assert.Throws<InvalidOperationException>(() => options.RejectUnmatchedProperties = true);
@@ -605,6 +607,20 @@ public sealed class YamlishSerializerTests
     }
 
     [Fact]
+    public void Serialize_IndentBlockSequenceItemsFalse_DoesNotIndentSequenceItemsUnderProperty()
+    {
+        var options = new YamlishSerializerOptions { IndentBlockSequenceItems = false };
+        var content = YamlishSerializer.Serialize(new SequenceStyleValue(), options);
+
+        Assert.Equal("""
+            Block:
+            - item1
+            - item2
+            Flow: [item1, item2]
+            """, content, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
     public void Serialize_UsesScalarStyleAttributes()
     {
         var content = YamlishSerializer.Serialize(new ScalarStyleValue());
@@ -670,6 +686,31 @@ public sealed class YamlishSerializerTests
               -
                 - item2.1
                 - item2.2
+            """, content, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void Serialize_JaggedArray_IndentBlockSequenceItemsFalse_DoesNotIndentRootSequenceItemsInMapping()
+    {
+        var value = new JaggedArrayValue
+        {
+            Items =
+            [
+                ["item1.1", "item1.2"],
+                ["item2.1", "item2.2"],
+            ],
+        };
+        var options = new YamlishSerializerOptions { IndentBlockSequenceItems = false };
+        var content = YamlishSerializer.Serialize(value, options);
+
+        Assert.Equal("""
+            Items:
+            -
+              - item1.1
+              - item1.2
+            -
+              - item2.1
+              - item2.2
             """, content, ignoreLineEndingDifferences: true);
     }
 

--- a/tests/Meziantou.Framework.Yamlish.Tests/YamlishSerializerTests.cs
+++ b/tests/Meziantou.Framework.Yamlish.Tests/YamlishSerializerTests.cs
@@ -12,7 +12,7 @@ public sealed class YamlishSerializerTests
         Assert.False(options.IncludeFields);
         Assert.Equal(' ', options.IndentCharacter);
         Assert.Equal(2, options.IndentSize);
-        Assert.True(options.IndentBlockSequenceItems);
+        Assert.False(options.IndentBlockSequenceItems);
         Assert.Equal(Environment.NewLine, options.NewLine);
         Assert.Equal(YamlishObjectCreationHandling.Replace, options.PreferredObjectCreationHandling);
         Assert.True(options.AllowDuplicateProperties);
@@ -120,7 +120,7 @@ public sealed class YamlishSerializerTests
         Assert.Equal(countAfterFirstUse, predicateEvaluationCount);
         Assert.Throws<InvalidOperationException>(() => options.IncludeFields = true);
         Assert.Throws<InvalidOperationException>(() => options.IndentCharacter = '\t');
-        Assert.Throws<InvalidOperationException>(() => options.IndentBlockSequenceItems = false);
+        Assert.Throws<InvalidOperationException>(() => options.IndentBlockSequenceItems = true);
         Assert.Throws<InvalidOperationException>(() => options.NewLine = "\n");
         Assert.Throws<InvalidOperationException>(() => options.AllowDuplicateProperties = false);
         Assert.Throws<InvalidOperationException>(() => options.RejectUnmatchedProperties = true);
@@ -600,22 +600,22 @@ public sealed class YamlishSerializerTests
 
         Assert.Equal("""
             Block:
-              - item1
-              - item2
+            - item1
+            - item2
             Flow: [item1, item2]
             """, content, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
-    public void Serialize_IndentBlockSequenceItemsFalse_DoesNotIndentSequenceItemsUnderProperty()
+    public void Serialize_IndentBlockSequenceItemsTrue_IndentsSequenceItemsUnderProperty()
     {
-        var options = new YamlishSerializerOptions { IndentBlockSequenceItems = false };
+        var options = new YamlishSerializerOptions { IndentBlockSequenceItems = true };
         var content = YamlishSerializer.Serialize(new SequenceStyleValue(), options);
 
         Assert.Equal("""
             Block:
-            - item1
-            - item2
+              - item1
+              - item2
             Flow: [item1, item2]
             """, content, ignoreLineEndingDifferences: true);
     }
@@ -648,8 +648,8 @@ public sealed class YamlishSerializerTests
 
         Assert.Equal("""
             Values:
-              - item1
-              - item2
+            - item1
+            - item2
             """, content, ignoreLineEndingDifferences: true);
     }
 
@@ -680,17 +680,17 @@ public sealed class YamlishSerializerTests
 
         Assert.Equal("""
             Items:
-              -
-                - item1.1
-                - item1.2
-              -
-                - item2.1
-                - item2.2
+            -
+              - item1.1
+              - item1.2
+            -
+              - item2.1
+              - item2.2
             """, content, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
-    public void Serialize_JaggedArray_IndentBlockSequenceItemsFalse_DoesNotIndentRootSequenceItemsInMapping()
+    public void Serialize_JaggedArray_IndentBlockSequenceItemsTrue_IndentsRootSequenceItemsInMapping()
     {
         var value = new JaggedArrayValue
         {
@@ -700,17 +700,17 @@ public sealed class YamlishSerializerTests
                 ["item2.1", "item2.2"],
             ],
         };
-        var options = new YamlishSerializerOptions { IndentBlockSequenceItems = false };
+        var options = new YamlishSerializerOptions { IndentBlockSequenceItems = true };
         var content = YamlishSerializer.Serialize(value, options);
 
         Assert.Equal("""
             Items:
-            -
-              - item1.1
-              - item1.2
-            -
-              - item2.1
-              - item2.2
+              -
+                - item1.1
+                - item1.2
+              -
+                - item2.1
+                - item2.2
             """, content, ignoreLineEndingDifferences: true);
     }
 
@@ -734,9 +734,9 @@ public sealed class YamlishSerializerTests
 
         Assert.Equal("""
             Assets:
-              - Path: item-alpha
-                HtmlOutput: item-alpha.html
-                ZipOutput: item-alpha.zip
+            - Path: item-alpha
+              HtmlOutput: item-alpha.html
+              ZipOutput: item-alpha.zip
             """, content, ignoreLineEndingDifferences: true);
     }
 


### PR DESCRIPTION
## Why
`YamlishSerializer` always indented block sequence items under mapping properties. Some consumers need the alternative YAML style where list items are aligned with the property key.

## What changed
- Added `YamlishSerializerOptions.IndentBlockSequenceItems` (default `true`) to preserve existing behavior.
- Wired the option through `YamlishSerializer` into `YamlishWriter`.
- Updated block-sequence writing logic so `IndentBlockSequenceItems = false` emits:
  - `Property:\n- item1\n- item2`
  while keeping default output as:
  - `Property:\n  - item1\n  - item2`
- Kept `YamlishDocument`/`YamlishNode` string output on existing default formatting.
- Added serializer tests for default option value, read-only behavior, and both indentation modes (including jagged/nested list output).
- Regenerated the Yamlish public API reference and versioned Yamlish package to `2.0.2` via the repository update script.

## Validation
- Ran `dotnet run ./eng/update-all.cs`
- Ran `dotnet build src/Meziantou.Framework.Yamlish/Meziantou.Framework.Yamlish.csproj /p:TreatsWarningsAsErrors=true`
- Ran `dotnet test tests/Meziantou.Framework.Yamlish.Tests/Meziantou.Framework.Yamlish.Tests.csproj /p:TreatsWarningsAsErrors=true`