### PR TITLE
Exclude AsyncIteratorStateMachineAttribute from generated public API

### DIFF
--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
@@ -19,6 +19,7 @@ internal static class PublicApiModelBuilder
         "System.CodeDom.Compiler.GeneratedCodeAttribute",
         "System.ComponentModel.EditorBrowsableAttribute",
         "System.Runtime.CompilerServices.AsyncStateMachineAttribute",
+        "System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute",
         "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
         "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
         "System.Runtime.CompilerServices.ExtensionAttribute",

--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
@@ -24,6 +24,7 @@ internal static class PublicApiModelReader
         "System.CodeDom.Compiler.GeneratedCodeAttribute",
         "System.ComponentModel.EditorBrowsableAttribute",
         "System.Runtime.CompilerServices.AsyncStateMachineAttribute",
+        "System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute",
         "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
         "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
         "System.Runtime.CompilerServices.ExtensionAttribute",


### PR DESCRIPTION
Compiler-generated async iterator metadata should not appear in generated public API files, just like other state machine attributes.

This change adds `System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute` to the ignored attribute list in both generation paths:
- reflection-based model building (`PublicApiModelBuilder`)
- metadata-based model reading (`PublicApiModelReader`)

This keeps output consistent regardless of how the assembly is loaded and prevents noisy API diffs for async iterators.