### PR TITLE
Fix parsing of negative values in comparison expressions

### DIFF
--- a/src/Meziantou.Framework.SimpleQueryLanguage/Syntax/QuerySyntax.Parser.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/Syntax/QuerySyntax.Parser.cs
@@ -240,6 +240,7 @@ public partial class QuerySyntax
             {
                 case QuerySyntaxKind.TextToken:
                 case QuerySyntaxKind.ColonToken:
+                case QuerySyntaxKind.NotKeyword:
                     return true;
                 default:
                     return false;

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
@@ -30,6 +30,22 @@ public sealed class ExpressionQueryBuilderTests
         Assert.Equal(10, result[0].Int32Value);
     }
 
+    [Theory]
+    [InlineData(-11, true)]
+    [InlineData(-10, false)]
+    [InlineData(-9, false)]
+    public void FieldEquals_LessThan_NegativeValue(int value, bool expectedResult)
+    {
+        var queryBuilder = new ExpressionQueryBuilder<Sample>();
+        queryBuilder.AddHandler("amount", item => item.Int32Value);
+        var query = queryBuilder.Build("amount<-10");
+
+        var items = new[] { new Sample { Int32Value = value } }.AsQueryable();
+        var result = query.Apply(items).ToList();
+
+        Assert.Equal(expectedResult, result.Count == 1);
+    }
+
     [Fact]
     public void FieldEquals_Range()
     {

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
@@ -474,6 +474,20 @@ public sealed class QueryBuilderTests
     }
 
     [Theory]
+    [InlineData(-11, true)]
+    [InlineData(-10, false)]
+    [InlineData(-9, false)]
+    public void FieldRange_Int32_LessThan_NegativeValue(int value, bool expectedResult)
+    {
+        var queryBuilder = new QueryBuilder<Sample>();
+        queryBuilder.AddRangeHandler<int>("amount", (obj, range) => range.IsInRange(obj.Int32Value));
+
+        var query = queryBuilder.Build("amount<-10");
+
+        Assert.Equal(expectedResult, query.Evaluate(new() { Int32Value = value }));
+    }
+
+    [Theory]
     [InlineData(10)]
     [InlineData(int.MaxValue)]
     public void FieldRange_Int32_LessThan_False(int value)


### PR DESCRIPTION
## Why
Queries with comparison operators and negative values (for example `amount<-10`) were parsed incorrectly because `-` after an operator was treated as negation syntax instead of part of the numeric value.

## What changed
- Added regression coverage for `amount<-10` in both query builders:
  - `QueryBuilderTests.FieldRange_Int32_LessThan_NegativeValue`
  - `ExpressionQueryBuilderTests.FieldEquals_LessThan_NegativeValue`
- Updated `QuerySyntax.Parser.CanFollowOperator` to allow `NotKeyword` while reading key/value arguments, so `-` can be consumed as part of a value token after an operator.

## Notes
This change is parser-only and preserves existing negation behavior outside key/value operator arguments.