### PR TITLE
TemporaryContainers: use random host ports by default (Apple container runtime fix)

### DIFF
--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Sockets;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
@@ -21,6 +23,34 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
     internal override ContainerRuntime Bind(string executable, ILogger? logger)
     {
         return new AppleContainerRuntime(ToString(), executable, logger);
+    }
+
+    internal override Task<string> EnsureCreatedAsync(ContainerDefinition definition, CancellationToken cancellationToken)
+    {
+        // Apple's container runtime does not support random-port assignment and does not
+        // report host port bindings in inspect output. Pre-assign free host ports so that
+        // GetMappedPort works correctly after the container starts.
+        var portsWithoutHostPort = new List<int>();
+        foreach (var port in definition.Ports)
+        {
+            if (port.HostPort is null)
+                portsWithoutHostPort.Add(port.Port);
+        }
+
+        foreach (var containerPort in portsWithoutHostPort)
+        {
+            definition.Ports.Remove(containerPort);
+            definition.Ports.Add(GetFreeTcpPort(), containerPort);
+        }
+
+        return base.EnsureCreatedAsync(definition, cancellationToken);
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
     }
 
     internal override bool LogsIncludeTimestamps => false;

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerRuntimeAdapterTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerRuntimeAdapterTests.cs
@@ -26,14 +26,14 @@ public sealed class AppleContainerRuntimeAdapterTests
     {
         var runtime = CreateRuntime();
         var definition = new ContainerDefinition(new RegistryImage("nginx"));
-        definition.Ports.Add(8080);
+        definition.Ports.Add(9090, 8080);
         definition.Environment.Add("A", "1");
 
         var args = runtime.BuildCreateArguments(definition, "nginx");
 
         Assert.Equal("create", args[0]);
         Assert.Contains("--publish", args);
-        Assert.Contains("8080:8080", args);
+        Assert.Contains("9090:8080", args);
         Assert.Contains("A=1", args);
         Assert.Contains("nginx", args);
     }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -457,23 +457,9 @@ public abstract class ContainerRuntimeTestsBase
         return definition;
     }
 
-    private void AddHttpPortBinding(ContainerDefinition definition)
+    private static void AddHttpPortBinding(ContainerDefinition definition)
     {
-        if (Runtime == ContainerRuntime.AppleContainer)
-        {
-            definition.Ports.Add(GetFreeTcpPort(), 8080);
-        }
-        else
-        {
-            definition.Ports.Add(8080);
-        }
-    }
-
-    private static int GetFreeTcpPort()
-    {
-        using var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
-        listener.Start();
-        return ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        definition.Ports.Add(8080);
     }
 
     private static async Task<string> GetStringWithRetryAsync(HttpClient client, Uri uri, CancellationToken cancellationToken)
@@ -490,6 +476,20 @@ public abstract class ContainerRuntimeTestsBase
                 await Task.Delay(250, cancellationToken);
             }
         }
+    }
+
+    [Fact]
+    public async Task TwoContainers_SameExposedPort_GetDifferentMappedPorts()
+    {
+        await using var container1 = await StartWithRetryAsync(CreateHttpServerDefinition());
+        await using var container2 = await StartWithRetryAsync(CreateHttpServerDefinition());
+
+        var port1 = container1.GetMappedPort(8080);
+        var port2 = container2.GetMappedPort(8080);
+
+        Assert.True(port1 > 0);
+        Assert.True(port2 > 0);
+        Assert.NotEqual(port1, port2);
     }
 
     private async Task<string> GetIndexContentAsync(TemporaryContainer container)


### PR DESCRIPTION
## Why

When a port is added without an explicit host port (e.g. `definition.Ports.Add(8080)`), the intent is for the runtime to assign a random available host port. Docker/Podman/Wslc already achieve this correctly by passing `-p 8080` to the daemon, which picks a random host port. Callers then use `GetMappedPort(8080)` to discover it at runtime.

Apple's container runtime had a gap: it fell back to the same port number (`port.HostPort ?? port.Port`), producing `--publish 8080:8080`. Because Apple's `container inspect` also does not report actual host port bindings, there was no way to discover the assigned port after the fact. A previous workaround in the test base class manually called `GetFreeTcpPort()` to sidestep this.

## What changed

**`AppleContainerRuntime.cs`** - Override `EnsureCreatedAsync` to pre-assign free host ports before building the create arguments. For each `ContainerPort` where `HostPort` is `null`, a free local port is discovered by temporarily binding to port 0 and reading the OS-assigned port, then the definition entry is replaced with a concrete host port. The definition passed here is already a deep copy (from `CreateContainer()`), so mutation is safe. `ResolvePortMap` reads from the updated `definition.Ports` and `GetMappedPort` then returns the correct host port.

**`ContainerRuntimeTestsBase.cs`** - Removed the Apple-specific `GetFreeTcpPort()` workaround in `AddHttpPortBinding`; all runtimes now uniformly use `definition.Ports.Add(8080)`. Added a new integration test `TwoContainers_SameExposedPort_GetDifferentMappedPorts` that starts two containers each exposing port 8080 without a host port and asserts both start successfully with different mapped ports.

**`AppleContainerRuntimeAdapterTests.cs`** - Updated `BuildCreateUsesAppleFlags` to use an explicit host port (`9090:8080`) rather than relying on the same-port fallback, making the unit test clearer and more representative of real usage.