### PR TITLE
Move temporary container factory methods

### DIFF
--- a/ref/Meziantou.Framework.TemporaryContainers.cs
+++ b/ref/Meziantou.Framework.TemporaryContainers.cs
@@ -53,10 +53,18 @@ namespace Meziantou.Framework.TemporaryContainers
         public ContainerDefinition(Meziantou.Framework.TemporaryContainers.ImageSource image) { }
         public ContainerDefinition(Meziantou.Framework.TemporaryContainers.ContainerDefinition other) { }
         public virtual Meziantou.Framework.TemporaryContainers.TemporaryContainer CreateContainer() => throw null;
-        public static Meziantou.Framework.TemporaryContainers.RedisContainerDefinition CreateRedis() => throw null;
-        public static Meziantou.Framework.TemporaryContainers.RedisContainerDefinition CreateRedis(Meziantou.Framework.TemporaryContainers.ImageSource image) => throw null;
+    }
+
+    public static class ContainerDefinitionPostgreSqlExtensions
+    {
         public static Meziantou.Framework.TemporaryContainers.PostgreSqlContainerDefinition CreatePostgreSql() => throw null;
         public static Meziantou.Framework.TemporaryContainers.PostgreSqlContainerDefinition CreatePostgreSql(Meziantou.Framework.TemporaryContainers.ImageSource image) => throw null;
+    }
+
+    public static class ContainerDefinitionRedisExtensions
+    {
+        public static Meziantou.Framework.TemporaryContainers.RedisContainerDefinition CreateRedis() => throw null;
+        public static Meziantou.Framework.TemporaryContainers.RedisContainerDefinition CreateRedis(Meziantou.Framework.TemporaryContainers.ImageSource image) => throw null;
     }
 
     public sealed class ContainerEnvironmentCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerDefinition.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerDefinition.cs
@@ -132,46 +132,4 @@ public class ContainerDefinition
         return new TemporaryContainer(new ContainerDefinition(this));
     }
 
-    /// <summary>Creates a definition pre-configured for a Redis container (port 6379 and a readiness wait strategy).</summary>
-    /// <returns>A Redis container definition using the <c>redis:8.2</c> image.</returns>
-    public static RedisContainerDefinition CreateRedis()
-    {
-        return CreateRedis(ImageSource.FromRegistry("redis:8.2"));
-    }
-
-    /// <summary>Creates a definition pre-configured for a Redis container (port 6379 and a readiness wait strategy).</summary>
-    /// <param name="image">The Redis image to use.</param>
-    /// <returns>A Redis container definition.</returns>
-    public static RedisContainerDefinition CreateRedis(ImageSource image)
-    {
-        ArgumentNullException.ThrowIfNull(image);
-        var definition = new RedisContainerDefinition(image);
-        definition.Ports.Add(6379);
-        definition.WaitStrategies.Add(Wait.ForLogMessage("Ready to accept connections"));
-        definition.WaitStrategies.Add(Wait.ForPort(6379));
-        return definition;
-    }
-
-    /// <summary>Creates a definition pre-configured for a PostgreSQL container (port 5432, a default password, and a readiness wait strategy).</summary>
-    /// <returns>A PostgreSQL container definition using the <c>postgres:17</c> image.</returns>
-    public static PostgreSqlContainerDefinition CreatePostgreSql()
-    {
-        return CreatePostgreSql(ImageSource.FromRegistry("postgres:17"));
-    }
-
-    /// <summary>Creates a definition pre-configured for a PostgreSQL container (port 5432, a default password, and a readiness wait strategy).</summary>
-    /// <param name="image">The PostgreSQL image to use.</param>
-    /// <returns>A PostgreSQL container definition.</returns>
-    public static PostgreSqlContainerDefinition CreatePostgreSql(ImageSource image)
-    {
-        ArgumentNullException.ThrowIfNull(image);
-        var definition = new PostgreSqlContainerDefinition(image);
-        if (!definition.Environment.Contains("POSTGRES_PASSWORD"))
-            definition.Environment.Add("POSTGRES_PASSWORD", "postgres");
-
-        definition.Ports.Add(5432);
-        definition.WaitStrategies.Add(Wait.ForLogMessage("database system is ready to accept connections", occurrences: 2));
-        definition.WaitStrategies.Add(Wait.ForPort(5432));
-        return definition;
-    }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/Postgresql/ContainerDefinitionPostgreSqlExtensions.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/Postgresql/ContainerDefinitionPostgreSqlExtensions.cs
@@ -1,0 +1,34 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>
+/// Provides PostgreSQL factory members for <see cref="ContainerDefinition"/>.
+/// </summary>
+public static class ContainerDefinitionPostgreSqlExtensions
+{
+    extension(ContainerDefinition)
+    {
+        /// <summary>Creates a definition pre-configured for a PostgreSQL container (port 5432, a default password, and a readiness wait strategy).</summary>
+        /// <returns>A PostgreSQL container definition using the <c>postgres:17</c> image.</returns>
+        public static PostgreSqlContainerDefinition CreatePostgreSql()
+        {
+            return CreatePostgreSql(ImageSource.FromRegistry("postgres:17"));
+        }
+
+        /// <summary>Creates a definition pre-configured for a PostgreSQL container (port 5432, a default password, and a readiness wait strategy).</summary>
+        /// <param name="image">The PostgreSQL image to use.</param>
+        /// <returns>A PostgreSQL container definition.</returns>
+        public static PostgreSqlContainerDefinition CreatePostgreSql(ImageSource image)
+        {
+            ArgumentNullException.ThrowIfNull(image);
+
+            var definition = new PostgreSqlContainerDefinition(image);
+            if (!definition.Environment.Contains("POSTGRES_PASSWORD"))
+                definition.Environment.Add("POSTGRES_PASSWORD", "postgres");
+
+            definition.Ports.Add(5432);
+            definition.WaitStrategies.Add(Wait.ForLogMessage("database system is ready to accept connections", occurrences: 2));
+            definition.WaitStrategies.Add(Wait.ForPort(5432));
+            return definition;
+        }
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/Postgresql/PostgreSqlContainerDefinition.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/Postgresql/PostgreSqlContainerDefinition.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.Framework.TemporaryContainers;
 
-/// <summary>A <see cref="ContainerDefinition"/> pre-configured for PostgreSQL. Create one with <see cref="ContainerDefinition.CreatePostgreSql()"/>.</summary>
+/// <summary>A <see cref="ContainerDefinition"/> pre-configured for PostgreSQL. Create one with <see cref="ContainerDefinitionPostgreSqlExtensions.CreatePostgreSql()"/>.</summary>
 public sealed class PostgreSqlContainerDefinition : ContainerDefinition
 {
     internal PostgreSqlContainerDefinition(ImageSource image)

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/Redis/ContainerDefinitionRedisExtensions.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/Redis/ContainerDefinitionRedisExtensions.cs
@@ -1,0 +1,31 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>
+/// Provides Redis factory members for <see cref="ContainerDefinition"/>.
+/// </summary>
+public static class ContainerDefinitionRedisExtensions
+{
+    extension(ContainerDefinition)
+    {
+        /// <summary>Creates a definition pre-configured for a Redis container (port 6379 and a readiness wait strategy).</summary>
+        /// <returns>A Redis container definition using the <c>redis:8.2</c> image.</returns>
+        public static RedisContainerDefinition CreateRedis()
+        {
+            return CreateRedis(ImageSource.FromRegistry("redis:8.2"));
+        }
+
+        /// <summary>Creates a definition pre-configured for a Redis container (port 6379 and a readiness wait strategy).</summary>
+        /// <param name="image">The Redis image to use.</param>
+        /// <returns>A Redis container definition.</returns>
+        public static RedisContainerDefinition CreateRedis(ImageSource image)
+        {
+            ArgumentNullException.ThrowIfNull(image);
+
+            var definition = new RedisContainerDefinition(image);
+            definition.Ports.Add(6379);
+            definition.WaitStrategies.Add(Wait.ForLogMessage("Ready to accept connections"));
+            definition.WaitStrategies.Add(Wait.ForPort(6379));
+            return definition;
+        }
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/Redis/RedisContainerDefinition.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/Redis/RedisContainerDefinition.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.Framework.TemporaryContainers;
 
-/// <summary>A <see cref="ContainerDefinition"/> pre-configured for Redis. Create one with <see cref="ContainerDefinition.CreateRedis()"/>.</summary>
+/// <summary>A <see cref="ContainerDefinition"/> pre-configured for Redis. Create one with <see cref="ContainerDefinitionRedisExtensions.CreateRedis()"/>.</summary>
 public sealed class RedisContainerDefinition : ContainerDefinition
 {
     internal RedisContainerDefinition(ImageSource image)


### PR DESCRIPTION
This keeps the Redis and PostgreSQL factory methods next to their container-specific implementations instead of on `ContainerDefinition`, while preserving the existing call shape for consumers.

The change moves `CreateRedis(...)` and `CreatePostgreSql(...)` into C# 14 extension blocks under the corresponding `Containers/Redis` and `Containers/Postgresql` folders. The factory behavior is unchanged; only the implementation location and generated public API surface move to the new extension types. I also updated the XML docs to reference the new methods and regenerated the `ref/` API file.

Validation:
- `dotnet run ./eng/update-all.cs`
- `dotnet build src/Meziantou.Framework.TemporaryContainers/Meziantou.Framework.TemporaryContainers.csproj /p:TreatsWarningsAsErrors=true`
- `dotnet test tests/Meziantou.Framework.TemporaryContainers.Tests/Meziantou.Framework.TemporaryContainers.Tests.csproj /p:TreatsWarningsAsErrors=true --filter "FullyQualifiedName~RedisContainerTests|FullyQualifiedName~PostgreSqlContainerTests"`

Note: a full `Meziantou.Framework.TemporaryContainers.Tests` run still hits existing `AppleContainerContainerTests` failures from `/usr/local/bin/container`, which are unrelated to this refactor.