### PR TITLE
Add MongoDB and SQL Server temporary container definitions

### DIFF
--- a/ref/Meziantou.Framework.TemporaryContainers.cs
+++ b/ref/Meziantou.Framework.TemporaryContainers.cs
@@ -55,6 +55,12 @@ namespace Meziantou.Framework.TemporaryContainers
         public virtual Meziantou.Framework.TemporaryContainers.TemporaryContainer CreateContainer() => throw null;
     }
 
+    public static class ContainerDefinitionMongoDbExtensions
+    {
+        public static Meziantou.Framework.TemporaryContainers.MongoDbContainerDefinition CreateMongoDb() => throw null;
+        public static Meziantou.Framework.TemporaryContainers.MongoDbContainerDefinition CreateMongoDb(Meziantou.Framework.TemporaryContainers.ImageSource image) => throw null;
+    }
+
     public static class ContainerDefinitionPostgreSqlExtensions
     {
         public static Meziantou.Framework.TemporaryContainers.PostgreSqlContainerDefinition CreatePostgreSql() => throw null;
@@ -65,6 +71,12 @@ namespace Meziantou.Framework.TemporaryContainers
     {
         public static Meziantou.Framework.TemporaryContainers.RedisContainerDefinition CreateRedis() => throw null;
         public static Meziantou.Framework.TemporaryContainers.RedisContainerDefinition CreateRedis(Meziantou.Framework.TemporaryContainers.ImageSource image) => throw null;
+    }
+
+    public static class ContainerDefinitionSqlServerExtensions
+    {
+        public static Meziantou.Framework.TemporaryContainers.SqlServerContainerDefinition CreateSqlServer() => throw null;
+        public static Meziantou.Framework.TemporaryContainers.SqlServerContainerDefinition CreateSqlServer(Meziantou.Framework.TemporaryContainers.ImageSource image) => throw null;
     }
 
     public sealed class ContainerEnvironmentCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable
@@ -268,6 +280,19 @@ namespace Meziantou.Framework.TemporaryContainers
         Stderr = 1
     }
 
+    public sealed class MongoDbContainer : Meziantou.Framework.TemporaryContainers.TemporaryContainer
+    {
+        public string GetConnectionString() => throw null;
+    }
+
+    public sealed class MongoDbContainerDefinition : Meziantou.Framework.TemporaryContainers.ContainerDefinition
+    {
+        public string RootUsername { get => throw null; set { } }
+        public string RootPassword { get => throw null; set { } }
+        [System.Runtime.CompilerServices.PreserveBaseOverrides]
+        public virtual Meziantou.Framework.TemporaryContainers.MongoDbContainer CreateContainer() => throw null;
+    }
+
     public sealed class PostgreSqlContainer : Meziantou.Framework.TemporaryContainers.TemporaryContainer
     {
         public string GetConnectionString() => throw null;
@@ -295,6 +320,18 @@ namespace Meziantou.Framework.TemporaryContainers
     {
         [System.Runtime.CompilerServices.PreserveBaseOverrides]
         public virtual Meziantou.Framework.TemporaryContainers.RedisContainer CreateContainer() => throw null;
+    }
+
+    public sealed class SqlServerContainer : Meziantou.Framework.TemporaryContainers.TemporaryContainer
+    {
+        public string GetConnectionString() => throw null;
+    }
+
+    public sealed class SqlServerContainerDefinition : Meziantou.Framework.TemporaryContainers.ContainerDefinition
+    {
+        public string SaPassword { get => throw null; set { } }
+        [System.Runtime.CompilerServices.PreserveBaseOverrides]
+        public virtual Meziantou.Framework.TemporaryContainers.SqlServerContainer CreateContainer() => throw null;
     }
 
     public class TemporaryContainer : System.IAsyncDisposable

--- a/ref/Meziantou.Framework.TemporaryContainers.cs
+++ b/ref/Meziantou.Framework.TemporaryContainers.cs
@@ -289,6 +289,7 @@ namespace Meziantou.Framework.TemporaryContainers
     {
         public string RootUsername { get => throw null; set { } }
         public string RootPassword { get => throw null; set { } }
+        public bool EnableJournaling { get => throw null; set { } }
         [System.Runtime.CompilerServices.PreserveBaseOverrides]
         public virtual Meziantou.Framework.TemporaryContainers.MongoDbContainer CreateContainer() => throw null;
     }

--- a/ref/Meziantou.Framework.TemporaryContainers.cs
+++ b/ref/Meziantou.Framework.TemporaryContainers.cs
@@ -282,14 +282,13 @@ namespace Meziantou.Framework.TemporaryContainers
 
     public sealed class MongoDbContainer : Meziantou.Framework.TemporaryContainers.TemporaryContainer
     {
-        public string GetConnectionString() => throw null;
+        public string GetConnectionString(bool enableJournaling = false) => throw null;
     }
 
     public sealed class MongoDbContainerDefinition : Meziantou.Framework.TemporaryContainers.ContainerDefinition
     {
         public string RootUsername { get => throw null; set { } }
         public string RootPassword { get => throw null; set { } }
-        public bool EnableJournaling { get => throw null; set { } }
         [System.Runtime.CompilerServices.PreserveBaseOverrides]
         public virtual Meziantou.Framework.TemporaryContainers.MongoDbContainer CreateContainer() => throw null;
     }

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/ContainerCredentialGenerator.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/ContainerCredentialGenerator.cs
@@ -1,0 +1,35 @@
+using System.Security.Cryptography;
+
+namespace Meziantou.Framework.TemporaryContainers;
+
+internal static class ContainerCredentialGenerator
+{
+    private const string UppercaseCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private const string LowercaseCharacters = "abcdefghijklmnopqrstuvwxyz";
+    private const string DigitCharacters = "0123456789";
+    private const string SymbolCharacters = "!@$%*+-_.?";
+    private const string AllCharacters = UppercaseCharacters + LowercaseCharacters + DigitCharacters + SymbolCharacters;
+
+    public static string GenerateStrongPassword(int length)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(length, 4);
+
+        Span<char> password = stackalloc char[length];
+        password[0] = UppercaseCharacters[RandomNumberGenerator.GetInt32(UppercaseCharacters.Length)];
+        password[1] = LowercaseCharacters[RandomNumberGenerator.GetInt32(LowercaseCharacters.Length)];
+        password[2] = DigitCharacters[RandomNumberGenerator.GetInt32(DigitCharacters.Length)];
+        password[3] = SymbolCharacters[RandomNumberGenerator.GetInt32(SymbolCharacters.Length)];
+        for (var i = 4; i < password.Length; i++)
+        {
+            password[i] = AllCharacters[RandomNumberGenerator.GetInt32(AllCharacters.Length)];
+        }
+
+        for (var i = password.Length - 1; i > 0; i--)
+        {
+            var j = RandomNumberGenerator.GetInt32(i + 1);
+            (password[i], password[j]) = (password[j], password[i]);
+        }
+
+        return new string(password);
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/ContainerDefinitionMongoDbExtensions.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/ContainerDefinitionMongoDbExtensions.cs
@@ -1,0 +1,31 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>
+/// Provides MongoDB factory members for <see cref="ContainerDefinition"/>.
+/// </summary>
+public static class ContainerDefinitionMongoDbExtensions
+{
+    extension(ContainerDefinition)
+    {
+        /// <summary>Creates a definition pre-configured for a MongoDB container (port 27017 and a readiness wait strategy).</summary>
+        /// <returns>A MongoDB container definition using the <c>mongo:8</c> image.</returns>
+        public static MongoDbContainerDefinition CreateMongoDb()
+        {
+            return CreateMongoDb(ImageSource.FromRegistry("mongo:8"));
+        }
+
+        /// <summary>Creates a definition pre-configured for a MongoDB container (port 27017 and a readiness wait strategy).</summary>
+        /// <param name="image">The MongoDB image to use.</param>
+        /// <returns>A MongoDB container definition.</returns>
+        public static MongoDbContainerDefinition CreateMongoDb(ImageSource image)
+        {
+            ArgumentNullException.ThrowIfNull(image);
+
+            var definition = new MongoDbContainerDefinition(image);
+            definition.Ports.Add(27017);
+            definition.WaitStrategies.Add(Wait.ForLogMessage("Waiting for connections"));
+            definition.WaitStrategies.Add(Wait.ForPort(27017));
+            return definition;
+        }
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/MongoDbContainer.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/MongoDbContainer.cs
@@ -5,12 +5,14 @@ public sealed class MongoDbContainer : TemporaryContainer
 {
     private readonly string _username;
     private readonly string _password;
+    private readonly bool _enableJournaling;
 
-    internal MongoDbContainer(ContainerDefinition definition, string username, string password)
+    internal MongoDbContainer(ContainerDefinition definition, string username, string password, bool enableJournaling)
         : base(definition)
     {
         _username = username;
         _password = password;
+        _enableJournaling = enableJournaling;
     }
 
     /// <summary>Gets a MongoDB connection string for the running container, using root credentials if configured through <c>MONGO_INITDB_ROOT_USERNAME</c> and <c>MONGO_INITDB_ROOT_PASSWORD</c>.</summary>
@@ -19,6 +21,7 @@ public sealed class MongoDbContainer : TemporaryContainer
     public string GetConnectionString()
     {
         var port = GetMappedPort(27017);
-        return string.Create(CultureInfo.InvariantCulture, $"mongodb://{Uri.EscapeDataString(_username)}:{Uri.EscapeDataString(_password)}@127.0.0.1:{port}/?authSource=admin");
+        var journaling = _enableJournaling ? "true" : "false";
+        return string.Create(CultureInfo.InvariantCulture, $"mongodb://{Uri.EscapeDataString(_username)}:{Uri.EscapeDataString(_password)}@127.0.0.1:{port}/?authSource=admin&j={journaling}");
     }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/MongoDbContainer.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/MongoDbContainer.cs
@@ -5,23 +5,22 @@ public sealed class MongoDbContainer : TemporaryContainer
 {
     private readonly string _username;
     private readonly string _password;
-    private readonly bool _enableJournaling;
 
-    internal MongoDbContainer(ContainerDefinition definition, string username, string password, bool enableJournaling)
+    internal MongoDbContainer(ContainerDefinition definition, string username, string password)
         : base(definition)
     {
         _username = username;
         _password = password;
-        _enableJournaling = enableJournaling;
     }
 
-    /// <summary>Gets a MongoDB connection string for the running container, using root credentials if configured through <c>MONGO_INITDB_ROOT_USERNAME</c> and <c>MONGO_INITDB_ROOT_PASSWORD</c>.</summary>
+    /// <summary>Gets a MongoDB connection string for the running container, using root credentials configured on the definition.</summary>
+    /// <param name="enableJournaling">A value indicating whether to enable journaling (<c>j=true</c>) in the connection string.</param>
     /// <returns>The connection string.</returns>
     /// <exception cref="InvalidOperationException">The container has not been started.</exception>
-    public string GetConnectionString()
+    public string GetConnectionString(bool enableJournaling = false)
     {
         var port = GetMappedPort(27017);
-        var journaling = _enableJournaling ? "true" : "false";
+        var journaling = enableJournaling ? "true" : "false";
         return string.Create(CultureInfo.InvariantCulture, $"mongodb://{Uri.EscapeDataString(_username)}:{Uri.EscapeDataString(_password)}@127.0.0.1:{port}/?authSource=admin&j={journaling}");
     }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/MongoDbContainer.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/MongoDbContainer.cs
@@ -1,0 +1,24 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>A temporary MongoDB container. Obtain one from <see cref="MongoDbContainerDefinition.CreateContainer"/>.</summary>
+public sealed class MongoDbContainer : TemporaryContainer
+{
+    private readonly string _username;
+    private readonly string _password;
+
+    internal MongoDbContainer(ContainerDefinition definition, string username, string password)
+        : base(definition)
+    {
+        _username = username;
+        _password = password;
+    }
+
+    /// <summary>Gets a MongoDB connection string for the running container, using root credentials if configured through <c>MONGO_INITDB_ROOT_USERNAME</c> and <c>MONGO_INITDB_ROOT_PASSWORD</c>.</summary>
+    /// <returns>The connection string.</returns>
+    /// <exception cref="InvalidOperationException">The container has not been started.</exception>
+    public string GetConnectionString()
+    {
+        var port = GetMappedPort(27017);
+        return string.Create(CultureInfo.InvariantCulture, $"mongodb://{Uri.EscapeDataString(_username)}:{Uri.EscapeDataString(_password)}@127.0.0.1:{port}/?authSource=admin");
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/MongoDbContainerDefinition.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/MongoDbContainerDefinition.cs
@@ -40,10 +40,14 @@ public sealed class MongoDbContainerDefinition : ContainerDefinition
         }
     }
 
+    /// <summary>Gets or sets a value indicating whether MongoDB journaling is enabled for client operations through the generated connection string.</summary>
+    /// <remarks>When <see langword="false"/> (default), generated connection strings include <c>j=0</c>.</remarks>
+    public bool EnableJournaling { get; set; }
+
     /// <summary>Creates a <see cref="MongoDbContainer"/> from a deep copy of this definition.</summary>
     /// <returns>A new MongoDB container.</returns>
     public override MongoDbContainer CreateContainer()
     {
-        return new MongoDbContainer(new ContainerDefinition(this), RootUsername, RootPassword);
+        return new MongoDbContainer(new ContainerDefinition(this), RootUsername, RootPassword, EnableJournaling);
     }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/MongoDbContainerDefinition.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/MongoDbContainerDefinition.cs
@@ -1,0 +1,49 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>A <see cref="ContainerDefinition"/> pre-configured for MongoDB. Create one with <see cref="ContainerDefinitionMongoDbExtensions.CreateMongoDb()"/>.</summary>
+public sealed class MongoDbContainerDefinition : ContainerDefinition
+{
+    private const int DefaultPasswordLength = 24;
+
+    internal MongoDbContainerDefinition(ImageSource image)
+        : base(image)
+    {
+        RootUsername = "root";
+        RootPassword = ContainerCredentialGenerator.GenerateStrongPassword(DefaultPasswordLength);
+    }
+
+    /// <summary>Gets or sets the MongoDB root username. Setting this value updates <c>MONGO_INITDB_ROOT_USERNAME</c> in <see cref="ContainerDefinition.Environment"/>.</summary>
+    public string RootUsername
+    {
+        get
+        {
+            return Environment.GetValue("MONGO_INITDB_ROOT_USERNAME") ?? throw new InvalidOperationException("The MongoDB root username is not configured.");
+        }
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            Environment.Add("MONGO_INITDB_ROOT_USERNAME", value);
+        }
+    }
+
+    /// <summary>Gets or sets the MongoDB root password. Setting this value updates <c>MONGO_INITDB_ROOT_PASSWORD</c> in <see cref="ContainerDefinition.Environment"/>.</summary>
+    public string RootPassword
+    {
+        get
+        {
+            return Environment.GetValue("MONGO_INITDB_ROOT_PASSWORD") ?? throw new InvalidOperationException("The MongoDB root password is not configured.");
+        }
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            Environment.Add("MONGO_INITDB_ROOT_PASSWORD", value);
+        }
+    }
+
+    /// <summary>Creates a <see cref="MongoDbContainer"/> from a deep copy of this definition.</summary>
+    /// <returns>A new MongoDB container.</returns>
+    public override MongoDbContainer CreateContainer()
+    {
+        return new MongoDbContainer(new ContainerDefinition(this), RootUsername, RootPassword);
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/MongoDbContainerDefinition.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/Mongodb/MongoDbContainerDefinition.cs
@@ -40,14 +40,10 @@ public sealed class MongoDbContainerDefinition : ContainerDefinition
         }
     }
 
-    /// <summary>Gets or sets a value indicating whether MongoDB journaling is enabled for client operations through the generated connection string.</summary>
-    /// <remarks>When <see langword="false"/> (default), generated connection strings include <c>j=0</c>.</remarks>
-    public bool EnableJournaling { get; set; }
-
     /// <summary>Creates a <see cref="MongoDbContainer"/> from a deep copy of this definition.</summary>
     /// <returns>A new MongoDB container.</returns>
     public override MongoDbContainer CreateContainer()
     {
-        return new MongoDbContainer(new ContainerDefinition(this), RootUsername, RootPassword, EnableJournaling);
+        return new MongoDbContainer(new ContainerDefinition(this), RootUsername, RootPassword);
     }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/SqlServer/ContainerDefinitionSqlServerExtensions.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/SqlServer/ContainerDefinitionSqlServerExtensions.cs
@@ -1,0 +1,35 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>
+/// Provides SQL Server factory members for <see cref="ContainerDefinition"/>.
+/// </summary>
+public static class ContainerDefinitionSqlServerExtensions
+{
+    extension(ContainerDefinition)
+    {
+        /// <summary>Creates a definition pre-configured for a SQL Server container (port 1433, required environment variables, a strong random SA password, and a readiness wait strategy).</summary>
+        /// <returns>A SQL Server container definition using the <c>mcr.microsoft.com/mssql/server:2025-latest</c> image.</returns>
+        public static SqlServerContainerDefinition CreateSqlServer()
+        {
+            return CreateSqlServer(ImageSource.FromRegistry("mcr.microsoft.com/mssql/server:2025-latest"));
+        }
+
+        /// <summary>Creates a definition pre-configured for a SQL Server container (port 1433, required environment variables, a strong random SA password, and a readiness wait strategy).</summary>
+        /// <param name="image">The SQL Server image to use.</param>
+        /// <returns>A SQL Server container definition.</returns>
+        public static SqlServerContainerDefinition CreateSqlServer(ImageSource image)
+        {
+            ArgumentNullException.ThrowIfNull(image);
+
+            var definition = new SqlServerContainerDefinition(image);
+            if (!definition.Environment.Contains("ACCEPT_EULA"))
+                definition.Environment.Add("ACCEPT_EULA", "Y");
+
+            definition.Ports.Add(1433);
+            definition.WaitStrategies.Add(Wait.ForLogMessage("SQL Server is now ready for client connections"));
+            definition.WaitStrategies.Add(Wait.ForLogMessage("Recovery is complete."));
+            definition.WaitStrategies.Add(Wait.ForPort(1433));
+            return definition;
+        }
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/SqlServer/SqlServerContainer.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/SqlServer/SqlServerContainer.cs
@@ -1,0 +1,23 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>A temporary SQL Server container. Obtain one from <see cref="SqlServerContainerDefinition.CreateContainer"/>.</summary>
+public sealed class SqlServerContainer : TemporaryContainer
+{
+    internal SqlServerContainer(ContainerDefinition definition)
+        : base(definition)
+    {
+    }
+
+    /// <summary>Gets a SQL Server connection string for the running container, using credentials from the definition's environment variables (<c>MSSQL_SA_PASSWORD</c>).</summary>
+    /// <returns>The connection string.</returns>
+    /// <exception cref="InvalidOperationException">The container has not been started.</exception>
+    public string GetConnectionString()
+    {
+        var port = GetMappedPort(1433);
+        var password = Definition.Environment.GetValue("MSSQL_SA_PASSWORD") ?? Definition.Environment.GetValue("SA_PASSWORD");
+        if (password is null)
+            throw new InvalidOperationException("The SQL Server SA password is not configured.");
+
+        return string.Create(CultureInfo.InvariantCulture, $"Server=127.0.0.1,{port};Database=master;User Id=sa;Pwd={password};Encrypt=True;TrustServerCertificate=True;Connection Timeout=30");
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/SqlServer/SqlServerContainerDefinition.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/SqlServer/SqlServerContainerDefinition.cs
@@ -1,0 +1,40 @@
+namespace Meziantou.Framework.TemporaryContainers;
+
+/// <summary>A <see cref="ContainerDefinition"/> pre-configured for SQL Server. Create one with <see cref="ContainerDefinitionSqlServerExtensions.CreateSqlServer()"/>.</summary>
+public sealed class SqlServerContainerDefinition : ContainerDefinition
+{
+    private const int DefaultPasswordLength = 24;
+
+    internal SqlServerContainerDefinition(ImageSource image)
+        : base(image)
+    {
+        SaPassword = GenerateStrongPassword();
+    }
+
+    /// <summary>Gets or sets the SQL Server SA password. Setting this value updates <c>MSSQL_SA_PASSWORD</c> and <c>SA_PASSWORD</c> in <see cref="ContainerDefinition.Environment"/>.</summary>
+    public string SaPassword
+    {
+        get
+        {
+            return Environment.GetValue("MSSQL_SA_PASSWORD") ?? Environment.GetValue("SA_PASSWORD") ?? throw new InvalidOperationException("The SA password is not configured.");
+        }
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            Environment.Add("MSSQL_SA_PASSWORD", value);
+            Environment.Add("SA_PASSWORD", value);
+        }
+    }
+
+    /// <summary>Creates a <see cref="SqlServerContainer"/> from a deep copy of this definition.</summary>
+    /// <returns>A new SQL Server container.</returns>
+    public override SqlServerContainer CreateContainer()
+    {
+        return new SqlServerContainer(new ContainerDefinition(this));
+    }
+
+    private static string GenerateStrongPassword()
+    {
+        return ContainerCredentialGenerator.GenerateStrongPassword(DefaultPasswordLength);
+    }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/readme.md
+++ b/src/Meziantou.Framework.TemporaryContainers/readme.md
@@ -33,18 +33,29 @@ await container.StartAsync();
 
 ## Database helpers
 
-`CreateRedis` and `CreatePostgreSql` return pre-configured definitions whose container exposes `GetConnectionString()`.
+`CreateRedis`, `CreatePostgreSql`, `CreateMongoDb`, and `CreateSqlServer` return pre-configured definitions whose container exposes `GetConnectionString()`.
 
 ```c#
 await using var redis = ContainerDefinition.CreateRedis().CreateContainer();
 await redis.StartAsync();
 var redisConnectionString = redis.GetConnectionString(); // 127.0.0.1:<port>
 
-var definition = ContainerDefinition.CreatePostgreSql(); // or CreatePostgreSql(ImageSource.FromRegistry("postgres:16"))
-definition.Environment.Add("POSTGRES_DB", "mydb");
-await using var postgres = definition.CreateContainer();
+var postgresDefinition = ContainerDefinition.CreatePostgreSql(); // or CreatePostgreSql(ImageSource.FromRegistry("postgres:16"))
+postgresDefinition.Environment.Add("POSTGRES_DB", "mydb");
+await using var postgres = postgresDefinition.CreateContainer();
 await postgres.StartAsync();
-var postgresConnectionString = postgres.GetConnectionString(); // Host=127.0.0.1;Port=<port>;Username=postgres;Password=postgres;Database=mydb
+var postgresConnectionString = postgres.GetConnectionString(); // Host=127.0.0.1;Port=<port>;Username=postgres;******;Database=mydb
+
+await using var mongo = ContainerDefinition.CreateMongoDb().CreateContainer();
+await mongo.StartAsync();
+var mongoConnectionString = mongo.GetConnectionString(); // mongodb://127.0.0.1:<port>
+
+var sqlDefinition = ContainerDefinition.CreateSqlServer();
+// Optional: override the generated strong random password
+sqlDefinition.SaPassword = "Abcdef1!Abcdef1!";
+await using var sqlServer = sqlDefinition.CreateContainer();
+await sqlServer.StartAsync();
+var sqlServerConnectionString = sqlServer.GetConnectionString(); // Server=127.0.0.1,<port>;Database=master;User Id=sa;Pwd=<password>;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30
 ```
 
 ## Interacting with a container

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/Meziantou.Framework.TemporaryContainers.Tests.csproj
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/Meziantou.Framework.TemporaryContainers.Tests.csproj
@@ -14,6 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MongoDB.Driver" Version="3.10.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageReference Include="StackExchange.Redis" Version="3.0.11" />
     <PackageReference Include="Npgsql" Version="10.0.3" />
   </ItemGroup>

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/MongoDbContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/MongoDbContainerTests.cs
@@ -1,0 +1,94 @@
+using Meziantou.Xunit;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Meziantou.Framework.TemporaryContainers.Tests;
+
+public sealed class MongoDbContainerTests
+{
+    private static void SkipOnNonCompatibleEnvironments()
+    {
+        if (!OperatingSystem.IsLinux() && TestEnvironment.IsOnGitHubActions())
+            global::Xunit.Assert.Skip("Only runs on Linux.");
+    }
+
+    [Fact]
+    public void CreateMongoDb_ConfiguresDefinition()
+    {
+        var definition = ContainerDefinition.CreateMongoDb();
+        var password = definition.RootPassword;
+
+        Assert.StartsWith("mongo:", ((RegistryImage)definition.Image).Name);
+        Assert.Equal("root", definition.RootUsername);
+        Assert.Equal("root", definition.Environment.GetValue("MONGO_INITDB_ROOT_USERNAME"));
+        Assert.Equal(password, definition.Environment.GetValue("MONGO_INITDB_ROOT_PASSWORD"));
+        Assert.Equal(24, password.Length);
+        Assert.Contains(password, static c => char.IsUpper(c));
+        Assert.Contains(password, static c => char.IsLower(c));
+        Assert.Contains(password, static c => char.IsDigit(c));
+        Assert.Contains(password, static c => !char.IsLetterOrDigit(c));
+        Assert.Equal(1, definition.Ports.Count);
+        Assert.Equal(2, definition.WaitStrategies.Count);
+    }
+
+    [Fact]
+    public void CreateMongoDb_RootCredentials_UpdatesEnvironmentVariables()
+    {
+        var definition = ContainerDefinition.CreateMongoDb();
+        definition.RootUsername = "custom-root";
+        definition.RootPassword = "Abcdef1!Abcdef1!";
+
+        Assert.Equal("custom-root", definition.Environment.GetValue("MONGO_INITDB_ROOT_USERNAME"));
+        Assert.Equal("Abcdef1!Abcdef1!", definition.Environment.GetValue("MONGO_INITDB_ROOT_PASSWORD"));
+    }
+
+    [Fact]
+    public void CreateMongoDb_WithImage_UsesProvidedImage()
+    {
+        var definition = ContainerDefinition.CreateMongoDb(new RegistryImage("mongo:7"));
+
+        Assert.Equal("mongo:7", ((RegistryImage)definition.Image).Name);
+    }
+
+    [Fact]
+    public async Task CreateContainer_ReturnsMongoDbContainer()
+    {
+        SkipOnNonCompatibleEnvironments();
+        await using var container = ContainerDefinition.CreateMongoDb().CreateContainer();
+        Assert.IsType<MongoDbContainer>(container);
+    }
+
+    [Fact]
+    public async Task StartAsync_ConnectionStringWorks()
+    {
+        SkipOnNonCompatibleEnvironments();
+
+        await using var container = await StartWithRetryAsync(ContainerDefinition.CreateMongoDb());
+
+        using var client = new MongoClient(container.GetConnectionString());
+        var database = client.GetDatabase("testdb");
+        var collection = database.GetCollection<BsonDocument>("items");
+        await collection.InsertOneAsync(new BsonDocument("value", 1), cancellationToken: XunitCancellationToken);
+        var count = await collection.CountDocumentsAsync(FilterDefinition<BsonDocument>.Empty, cancellationToken: XunitCancellationToken);
+        Assert.Equal(1, count);
+    }
+
+    private static async Task<MongoDbContainer> StartWithRetryAsync(MongoDbContainerDefinition definition)
+    {
+        const int MaxRetries = 3;
+        for (var i = 0; ; i++)
+        {
+            var container = definition.CreateContainer();
+            try
+            {
+                await container.StartAsync(XunitCancellationToken);
+                return container;
+            }
+            catch when (i < MaxRetries)
+            {
+                await container.DisposeAsync();
+                await Task.Delay(1000, XunitCancellationToken);
+            }
+        }
+    }
+}

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/MongoDbContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/MongoDbContainerTests.cs
@@ -22,6 +22,7 @@ public sealed class MongoDbContainerTests
         Assert.Equal("root", definition.RootUsername);
         Assert.Equal("root", definition.Environment.GetValue("MONGO_INITDB_ROOT_USERNAME"));
         Assert.Equal(password, definition.Environment.GetValue("MONGO_INITDB_ROOT_PASSWORD"));
+        Assert.False(definition.EnableJournaling);
         Assert.Equal(24, password.Length);
         Assert.Contains(password, static c => char.IsUpper(c));
         Assert.Contains(password, static c => char.IsLower(c));
@@ -40,6 +41,30 @@ public sealed class MongoDbContainerTests
 
         Assert.Equal("custom-root", definition.Environment.GetValue("MONGO_INITDB_ROOT_USERNAME"));
         Assert.Equal("Abcdef1!Abcdef1!", definition.Environment.GetValue("MONGO_INITDB_ROOT_PASSWORD"));
+    }
+
+    [Fact]
+    public async Task GetConnectionString_JournalingDisabledByDefault()
+    {
+        SkipOnNonCompatibleEnvironments();
+        await using var container = ContainerDefinition.CreateMongoDb().CreateContainer();
+        await container.StartAsync(XunitCancellationToken);
+
+        Assert.Contains("j=false", container.GetConnectionString());
+    }
+
+    [Fact]
+    public async Task GetConnectionString_JournalingCanBeEnabled()
+    {
+        SkipOnNonCompatibleEnvironments();
+
+        var definition = ContainerDefinition.CreateMongoDb();
+        definition.EnableJournaling = true;
+
+        await using var container = definition.CreateContainer();
+        await container.StartAsync(XunitCancellationToken);
+
+        Assert.Contains("j=true", container.GetConnectionString());
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/MongoDbContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/MongoDbContainerTests.cs
@@ -22,7 +22,6 @@ public sealed class MongoDbContainerTests
         Assert.Equal("root", definition.RootUsername);
         Assert.Equal("root", definition.Environment.GetValue("MONGO_INITDB_ROOT_USERNAME"));
         Assert.Equal(password, definition.Environment.GetValue("MONGO_INITDB_ROOT_PASSWORD"));
-        Assert.False(definition.EnableJournaling);
         Assert.Equal(24, password.Length);
         Assert.Contains(password, static c => char.IsUpper(c));
         Assert.Contains(password, static c => char.IsLower(c));
@@ -58,13 +57,10 @@ public sealed class MongoDbContainerTests
     {
         SkipOnNonCompatibleEnvironments();
 
-        var definition = ContainerDefinition.CreateMongoDb();
-        definition.EnableJournaling = true;
-
-        await using var container = definition.CreateContainer();
+        await using var container = ContainerDefinition.CreateMongoDb().CreateContainer();
         await container.StartAsync(XunitCancellationToken);
 
-        Assert.Contains("j=true", container.GetConnectionString());
+        Assert.Contains("j=true", container.GetConnectionString(enableJournaling: true));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/SqlServerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/SqlServerContainerTests.cs
@@ -1,0 +1,110 @@
+using Meziantou.Xunit;
+using Microsoft.Data.SqlClient;
+
+namespace Meziantou.Framework.TemporaryContainers.Tests;
+
+public sealed class SqlServerContainerTests
+{
+    private static void SkipOnNonCompatibleEnvironments()
+    {
+        if (!OperatingSystem.IsLinux() && TestEnvironment.IsOnGitHubActions())
+            global::Xunit.Assert.Skip("Only runs on Linux.");
+    }
+
+    [Fact]
+    public void CreateSqlServer_ConfiguresDefinition()
+    {
+        var definition = ContainerDefinition.CreateSqlServer();
+        var password = definition.SaPassword;
+
+        Assert.StartsWith("mcr.microsoft.com/mssql/server:", ((RegistryImage)definition.Image).Name);
+        Assert.Equal("Y", definition.Environment.GetValue("ACCEPT_EULA"));
+        Assert.Equal(password, definition.Environment.GetValue("MSSQL_SA_PASSWORD"));
+        Assert.Equal(password, definition.Environment.GetValue("SA_PASSWORD"));
+        Assert.Equal(24, password.Length);
+        Assert.Contains(password, static c => char.IsUpper(c));
+        Assert.Contains(password, static c => char.IsLower(c));
+        Assert.Contains(password, static c => char.IsDigit(c));
+        Assert.Contains(password, static c => !char.IsLetterOrDigit(c));
+        Assert.Equal(1, definition.Ports.Count);
+        Assert.Equal(3, definition.WaitStrategies.Count);
+    }
+
+    [Fact]
+    public void CreateSqlServer_SaPassword_UpdatesEnvironmentVariables()
+    {
+        var definition = ContainerDefinition.CreateSqlServer();
+        definition.SaPassword = "Abcdef1!Abcdef1!";
+
+        Assert.Equal("Abcdef1!Abcdef1!", definition.Environment.GetValue("MSSQL_SA_PASSWORD"));
+        Assert.Equal("Abcdef1!Abcdef1!", definition.Environment.GetValue("SA_PASSWORD"));
+    }
+
+    [Fact]
+    public void CreateSqlServer_WithImage_UsesProvidedImage()
+    {
+        var definition = ContainerDefinition.CreateSqlServer(new RegistryImage("mcr.microsoft.com/mssql/server:2022-latest"));
+
+        Assert.Equal("mcr.microsoft.com/mssql/server:2022-latest", ((RegistryImage)definition.Image).Name);
+    }
+
+    [Fact]
+    public async Task CreateContainer_ReturnsSqlServerContainer()
+    {
+        SkipOnNonCompatibleEnvironments();
+        await using var container = ContainerDefinition.CreateSqlServer().CreateContainer();
+        Assert.IsType<SqlServerContainer>(container);
+    }
+
+    [Fact]
+    public async Task StartAsync_ConnectionStringWorks()
+    {
+        SkipOnNonCompatibleEnvironments();
+
+        await using var container = await StartWithRetryAsync(ContainerDefinition.CreateSqlServer());
+
+        await using var connection = await OpenConnectionWithRetryAsync(container.GetConnectionString());
+
+        await using var command = new SqlCommand("SELECT 1", connection);
+        var result = await command.ExecuteScalarAsync(XunitCancellationToken);
+        Assert.Equal(1, Convert.ToInt32(result, CultureInfo.InvariantCulture));
+    }
+
+    private static async Task<SqlServerContainer> StartWithRetryAsync(SqlServerContainerDefinition definition)
+    {
+        const int MaxRetries = 3;
+        for (var i = 0; ; i++)
+        {
+            var container = definition.CreateContainer();
+            try
+            {
+                await container.StartAsync(XunitCancellationToken);
+                return container;
+            }
+            catch when (i < MaxRetries)
+            {
+                await container.DisposeAsync();
+                await Task.Delay(1000, XunitCancellationToken);
+            }
+        }
+    }
+
+    private static async Task<SqlConnection> OpenConnectionWithRetryAsync(string connectionString)
+    {
+        const int MaxRetries = 5;
+        for (var i = 0; ; i++)
+        {
+            var connection = new SqlConnection(connectionString);
+            try
+            {
+                await connection.OpenAsync(XunitCancellationToken);
+                return connection;
+            }
+            catch (SqlException) when (i < MaxRetries)
+            {
+                await connection.DisposeAsync();
+                await Task.Delay(1000, XunitCancellationToken);
+            }
+        }
+    }
+}

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/SqlServerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/SqlServerContainerTests.cs
@@ -1,5 +1,6 @@
 using Meziantou.Xunit;
 using Microsoft.Data.SqlClient;
+using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.TemporaryContainers.Tests;
 
@@ -9,6 +10,12 @@ public sealed class SqlServerContainerTests
     {
         if (!OperatingSystem.IsLinux() && TestEnvironment.IsOnGitHubActions())
             global::Xunit.Assert.Skip("Only runs on Linux.");
+
+        if (TestEnvironment.IsGlobalizationInvariant())
+            global::Xunit.Assert.Skip("SQL Server tests require full globalization support.");
+
+        if (OperatingSystem.IsLinux() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64 && TestEnvironment.IsOnGitHubActions())
+            global::Xunit.Assert.Skip("The default SQL Server image is not supported on ARM64 GitHub Actions runners.");
     }
 
     [Fact]


### PR DESCRIPTION
This adds first-class MongoDB and SQL Server helpers to `Meziantou.Framework.TemporaryContainers` so integration tests can spin these databases up with the same API style as Redis/PostgreSQL.

## What changed
- Added new helper families:
  - `CreateMongoDb()` / `CreateMongoDb(ImageSource)`
  - `CreateSqlServer()` / `CreateSqlServer(ImageSource)`
- Added typed container definitions and container wrappers for both databases.
- Added connection string helpers on `MongoDbContainer` and `SqlServerContainer`.
- Added `ContainerCredentialGenerator` to share strong random password generation.
- Added definition-level credential properties:
  - `MongoDbContainerDefinition.RootUsername` / `RootPassword`
  - `SqlServerContainerDefinition.SaPassword`
  These properties synchronize the corresponding runtime environment variables while keeping credentials configurable from the definition API.
- Updated SQL Server readiness strategy to wait for both connection-ready and recovery-complete log messages.
- Updated docs and generated public API (`ref/Meziantou.Framework.TemporaryContainers.cs`).

## Tests
- Added `MongoDbContainerTests` and `SqlServerContainerTests`.
- Added package references needed by the new integration tests (`MongoDB.Driver`, `Microsoft.Data.SqlClient`).
- Covered:
  - default definition configuration
  - custom image overloads
  - container type creation
  - credential property behavior
  - live connectivity (`SELECT 1` for SQL Server, insert/count for MongoDB).