### PR TITLE
Respect user-defined New methods in StronglyTypedId generator

### DIFF
--- a/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.Members.cs
+++ b/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.Members.cs
@@ -125,7 +125,7 @@ public partial class StronglyTypedIdSourceGenerator
         }
 
         // if Guid => New
-        if (context.IdType is IdType.System_Guid)
+        if (context.IdType is IdType.System_Guid && !context.IsNewDefined)
         {
             WriteNewMember(
                  XmlSummary("Initializes a new instance of the ", XmlSeeCref(context.TypeName), " using a new ", XmlSeeCref("global::System.Guid"), "."),

--- a/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.cs
+++ b/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.cs
@@ -420,6 +420,10 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
                         IsOpGreaterThanOrEqualDefined = true;
                         break;
 
+                    case IMethodSymbol { IsStatic: true, Name: "New", Arity: 0, Parameters: [] }:
+                        IsNewDefined = true;
+                        break;
+
                     case IMethodSymbol { IsStatic: true, Name: "TryParse", ReturnType.SpecialType: SpecialType.System_Boolean, Parameters: [{ Type.SpecialType: SpecialType.System_String }, ..] }:
                         IsTryParseDefined_String = true;
                         break;
@@ -569,6 +573,7 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
         public bool IsSealed { get; }
         public bool IsReferenceType { get; }
         public bool IsCtorDefined { get; }
+        public bool IsNewDefined { get; }
         public bool IsFieldDefined { get; }
         public bool IsValueDefined { get; }
         public bool IsValueAsStringDefined { get; }
@@ -635,6 +640,7 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
                 && AddCodeGeneratedAttribute == other.AddCodeGeneratedAttribute
                 && IsSealed == other.IsSealed
                 && IsCtorDefined == other.IsCtorDefined
+                && IsNewDefined == other.IsNewDefined
                 && IsFieldDefined == other.IsFieldDefined
                 && IsValueDefined == other.IsValueDefined
                 && IsValueAsStringDefined == other.IsValueAsStringDefined
@@ -683,6 +689,7 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
             hashcode.Add(AddCodeGeneratedAttribute);
             hashcode.Add(IsSealed);
             hashcode.Add(IsCtorDefined);
+            hashcode.Add(IsNewDefined);
             hashcode.Add(IsFieldDefined);
             hashcode.Add(IsValueDefined);
             hashcode.Add(IsValueAsStringDefined);

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
@@ -248,6 +248,26 @@ public sealed class StronglyTypedIdSourceGeneratorTests
     }
 
     [Fact]
+    public async Task GenerateStruct_Guid_UserDefinedNew()
+    {
+        var sourceCode = """
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(System.Guid))]
+            public partial struct Test
+            {
+                public static Test New() => FromGuid(System.Guid.CreateVersion7());
+            }
+            """;
+
+        await TestGeneratedAssembly(sourceCode, type =>
+        {
+            var newMethod = (MethodInfo)type.GetMember("New").Single();
+            var newInstance = newMethod.Invoke(null, null);
+            var value = (Guid)type.GetProperty("Value")!.GetValue(newInstance)!;
+            Assert.Equal(7, value.Version);
+        });
+    }
+
+    [Fact]
     public async Task Generate_ExistingOperators()
     {
         var sourceCode = """


### PR DESCRIPTION
## Summary

- detect a user-defined static, parameterless, non-generic `New()` method
- skip generating the default Guid-backed `New()` method when such a method exists
- add a regression test using `Guid.CreateVersion7()` as a concrete customization example

## Motivation

Guid-backed strongly typed IDs currently always receive a generated `New()` method that calls `Guid.NewGuid()`. As a result, consumers cannot provide a method with the same signature, for example when their ID policy requires UUIDv7.

This change follows the generator’s existing approach for user-defined members: when the partial type already contains a matching `New()` method, the generator leaves it in place. Types without a custom method keep the existing behavior.

## Alternatives considered

I also considered adding a generator option that switches the generated implementation between `Guid.NewGuid()` and `Guid.CreateVersion7()`. However, that would add a framework-version-specific policy option to the public configuration surface. Respecting an existing user-defined member seemed like the smallest and least disruptive change, while also supporting other custom ID-generation policies.

The generator itself does not emit or depend on `Guid.CreateVersion7()` as part of this change; it is only used by the test as a representative customization.

## Validation

- `dotnet test tests/Meziantou.Framework.StronglyTypedId.Tests/Meziantou.Framework.StronglyTypedId.Tests.csproj --configuration Release --no-restore /p:TreatsWarningsAsErrors=true`
- `dotnet test tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/Meziantou.Framework.StronglyTypedId.GeneratorTests.csproj --configuration Release /p:TreatsWarningsAsErrors=true`
- `dotnet build src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj --configuration Release --no-restore /p:TreatsWarningsAsErrors=true`
- `dotnet run ./eng/update-all.cs /p:TreatsWarningsAsErrors=true`
- formatting style and analyzer verification for the changed files