### PR TITLE
Reorder container runtime candidates

### DIFF
--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AutoContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AutoContainerRuntime.cs
@@ -28,10 +28,7 @@ internal sealed class AutoContainerRuntime : ContainerRuntime
             if (_resolvedRuntime is { } resolved)
                 return resolved;
 
-            if (_dockerApiRuntime.IsSupported())
-                return _resolvedRuntime = _dockerApiRuntime;
-
-            foreach (var candidate in GetCliCandidates())
+            foreach (var candidate in GetAllCandidates())
             {
                 if (candidate.IsSupported())
                     return _resolvedRuntime = candidate;
@@ -46,16 +43,17 @@ internal sealed class AutoContainerRuntime : ContainerRuntime
         return GetResolvedRuntimeOrNull() ?? throw CreateUnavailableRuntimeException(this);
     }
 
-    private static IEnumerable<ContainerRuntime> GetCliCandidates()
+    private IEnumerable<ContainerRuntime> GetAllCandidates()
     {
-        yield return Docker;
-        yield return Podman;
+        if (OperatingSystem.IsWindows())
+            yield return Wslc;
 
         if (OperatingSystem.IsMacOS())
             yield return AppleContainer;
 
-        if (OperatingSystem.IsWindows())
-            yield return Wslc;
+        yield return _dockerApiRuntime;
+        yield return Docker;
+        yield return Podman;
     }
 
     internal override bool SupportsPause => GetResolvedRuntimeOrThrow().SupportsPause;


### PR DESCRIPTION
Adjusts the priority order in which container runtimes are selected when using the auto-detection mode. The new order prioritizes:

1. WSL container (Windows only)
2. Apple container (macOS only)
3. Docker API runtime
4. Docker CLI
5. Podman CLI

This change consolidates the runtime selection logic into a single `GetAllCandidates()` method and ensures the Docker API runtime is checked before CLI tools, providing a more consistent experience across platforms.