### PR TITLE
Make exec command settable

### DIFF
--- a/ref/Meziantou.Framework.TemporaryContainers.cs
+++ b/ref/Meziantou.Framework.TemporaryContainers.cs
@@ -209,7 +209,7 @@ namespace Meziantou.Framework.TemporaryContainers
 
     public sealed class ExecOptions
     {
-        public System.Collections.Generic.IList<string> Command { get => throw null; }
+        public System.Collections.Generic.IList<string> Command { get => throw null; set { } }
         public string? WorkingDirectory { get => throw null; set { } }
         public string? User { get => throw null; set { } }
         public System.Collections.Generic.IDictionary<string, string> Environment { get => throw null; }

--- a/src/Meziantou.Framework.TemporaryContainers/ExecOptions.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ExecOptions.cs
@@ -3,8 +3,8 @@ namespace Meziantou.Framework.TemporaryContainers;
 /// <summary>Options for a command executed inside a running container.</summary>
 public sealed class ExecOptions
 {
-    /// <summary>Gets the command and its arguments. The first element is the executable.</summary>
-    public IList<string> Command { get; } = [];
+    /// <summary>Gets or sets the command and its arguments. The first element is the executable.</summary>
+    public IList<string> Command { get; set; } = [];
 
     /// <summary>Gets or sets the working directory inside the container.</summary>
     public string? WorkingDirectory { get; set; }

--- a/src/Meziantou.Framework.TemporaryContainers/TemporaryContainer.Exec.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/TemporaryContainer.Exec.cs
@@ -14,6 +14,9 @@ public partial class TemporaryContainer
         var options = new ExecOptions();
         configure(options);
 
+        if (options.Command is null)
+            throw new InvalidOperationException("ExecOptions.Command must be set.");
+
         if (options.Command.Count == 0)
             throw new InvalidOperationException("ExecOptions.Command must contain at least one element.");
 


### PR DESCRIPTION
Exec options now need to support assigning the full command array directly, which matches the existing usage pattern for callers that want to replace the command in one shot.

This change makes `ExecOptions.Command` settable while keeping the default empty list, and adds a null guard in `ExecAsync` so the runtime still fails with a clear error if a caller omits the command entirely.

**Summary**
- Allow `ExecOptions.Command` to be assigned directly.
- Validate that `Command` is not null before checking for an empty command.
- Preserve the existing empty-command validation.

**Notes**
- `dotnet run ./eng/update-all.cs` was run as required.