### PR TITLE
Remove SkipLocalsInit from Directory.Build.props

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <IsPackable>True</IsPackable>
-    <SkipLocalsInit>true</SkipLocalsInit>
     <EnablePackageValidation Condition="'$(EnablePackageValidation)' == ''">true</EnablePackageValidation>
 
     <PublicApiGeneratorGenerateOnBuild Condition="'$(GITHUB_ACTIONS)' == 'true' and '$(PublicApiGeneratorGenerateOnBuild)' == ''">false</PublicApiGeneratorGenerateOnBuild>


### PR DESCRIPTION
Removed SkipLocalsInit property from the build configuration.