### PR TITLE
Improve Assert.Equal string diff messages

### DIFF
--- a/src/Meziantou.Framework.Assertions/Assert.Equal.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Equal.cs
@@ -47,7 +47,7 @@ public partial class Assert
 
         if (!ValuesEqual(expected, actual))
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<object?, object?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<object?, object?>(expected, actual, firstDifferenceIndex: null, message, actualExpression, expectedExpression)));
         }
     }
 
@@ -62,7 +62,7 @@ public partial class Assert
 
         if (!ValuesEqual(expected, actual))
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<T, T>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<T, T>(expected, actual, firstDifferenceIndex: null, message, actualExpression, expectedExpression)));
         }
     }
 
@@ -75,7 +75,7 @@ public partial class Assert
         if (string.Equals(expectedValue, actualValue, comparison))
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<string?, string?>(expectedValue, actualValue, message, actualExpression, expectedExpression)));
+        throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<string?, string?>(expectedValue, actualValue, GetFirstDifferenceIndex(expectedValue, actualValue, comparison), message, actualExpression, expectedExpression)));
     }
 
     public static void Equal<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
@@ -129,7 +129,7 @@ public partial class Assert
     {
         if (actual is null)
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<T>, IEnumerable<T>?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<T>, IEnumerable<T>?>(expected, actual, firstDifferenceIndex: null, message, actualExpression, expectedExpression)));
         }
 
         EqualCollections<T>(expected, actual, EqualityComparer<T>.Default, message, actualExpression, expectedExpression);
@@ -139,7 +139,7 @@ public partial class Assert
     {
         if (actual is null)
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<T>, IEnumerable<T>?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<T>, IEnumerable<T>?>(expected, actual, firstDifferenceIndex: null, message, actualExpression, expectedExpression)));
         }
 
         EqualCollections<T>(expected, actual, comparer, message, actualExpression, expectedExpression);
@@ -150,7 +150,7 @@ public partial class Assert
     {
         if (actual is null)
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<TExpected>, IEnumerable<TActual>?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<TExpected>, IEnumerable<TActual>?>(expected, actual, firstDifferenceIndex: null, message, actualExpression, expectedExpression)));
         }
 
         EqualCollections(expected, actual, comparer: (System.Collections.IEqualityComparer?)null, message, actualExpression, expectedExpression);
@@ -219,7 +219,7 @@ public partial class Assert
         {
             await using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
             await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<T>, IAsyncEnumerable<T>?>(expectedSnapshot.Items, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<T>, IAsyncEnumerable<T>?>(expectedSnapshot.Items, actual, firstDifferenceIndex: null, message, actualExpression, expectedExpression)));
         }
 
         await EqualAsyncCollections<T>(expected, actual, EqualityComparer<T>.Default, message, actualExpression, expectedExpression).ConfigureAwait(false);
@@ -231,7 +231,7 @@ public partial class Assert
         {
             await using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
             await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<T>, IAsyncEnumerable<T>?>(expectedSnapshot.Items, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<T>, IAsyncEnumerable<T>?>(expectedSnapshot.Items, actual, firstDifferenceIndex: null, message, actualExpression, expectedExpression)));
         }
 
         await EqualAsyncCollections<T>(expected, actual, comparer, message, actualExpression, expectedExpression).ConfigureAwait(false);
@@ -244,7 +244,7 @@ public partial class Assert
         {
             await using var expectedSnapshot = CollectionSnapshot.Create<TExpected>(expected);
             await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<TExpected>, IAsyncEnumerable<TActual>?>(expectedSnapshot.Items, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<TExpected>, IAsyncEnumerable<TActual>?>(expectedSnapshot.Items, actual, firstDifferenceIndex: null, message, actualExpression, expectedExpression)));
         }
 
         await EqualAsyncCollections(expected, actual, comparer: (System.Collections.IEqualityComparer?)null, message, actualExpression, expectedExpression).ConfigureAwait(false);
@@ -254,7 +254,7 @@ public partial class Assert
     {
         if (actual is null)
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<T>, IAsyncEnumerable<T>?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<T>, IAsyncEnumerable<T>?>(expected, actual, firstDifferenceIndex: null, message, actualExpression, expectedExpression)));
         }
 
         var actualList = new List<T>();
@@ -272,7 +272,7 @@ public partial class Assert
         {
             await using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
             await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<T>, IEnumerable<T>?>(expectedSnapshot.Items, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<T>, IEnumerable<T>?>(expectedSnapshot.Items, actual, firstDifferenceIndex: null, message, actualExpression, expectedExpression)));
         }
 
         var expectedList = new List<T>();
@@ -345,7 +345,7 @@ public partial class Assert
     {
         if (actual is null)
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable?>(expected, actual, firstDifferenceIndex: null, message, actualExpression, expectedExpression)));
         }
 
         Equal(expected, actual, comparer: null, message, actualExpression, expectedExpression);
@@ -355,7 +355,7 @@ public partial class Assert
     {
         if (actual is null)
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable?>(expected, actual, firstDifferenceIndex: null, message, actualExpression, expectedExpression)));
         }
 
         using var actualSnapshot = CollectionSnapshot.Create(actual);
@@ -426,5 +426,19 @@ public partial class Assert
     private static StringComparison GetStringComparison(bool ignoreCase)
     {
         return ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+    }
+
+    private static int? GetFirstDifferenceIndex(string? expected, string? actual, StringComparison comparison)
+    {
+        if (expected is null || actual is null)
+            return null;
+
+        for (var i = 0; i < expected.Length; i++)
+        {
+            if (i >= actual.Length || !actual.AsSpan(i, 1).Equals(expected.AsSpan(i, 1), comparison))
+                return i;
+        }
+
+        return expected.Length < actual.Length ? expected.Length : null;
     }
 }

--- a/src/Meziantou.Framework.Assertions/Assert.NotEqual.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.NotEqual.cs
@@ -40,7 +40,7 @@ public partial class Assert
     {
         if (ValuesEqual(expected, actual))
         {
-            throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<T, T?>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
+            throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<T, T?>("Not expected", expected, actual, firstDifferenceIndex: null, actualExpression, expectedExpression, message)));
         }
     }
 
@@ -49,8 +49,17 @@ public partial class Assert
     {
         if (ValuesEqual(expected, actual))
         {
-            throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<TExpected, TActual?>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
+            throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<TExpected, TActual?>("Not expected", expected, actual, firstDifferenceIndex: null, actualExpression, expectedExpression, message)));
         }
+    }
+
+    public static void NotEqual(string expected, string? actual, bool ignoreCase = false, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
+    {
+        var comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        if (actual is null || !expected.Equals(actual, comparison))
+            return;
+
+        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<string, string?>("Not expected", expected, actual, GetFirstDifferenceIndex(expected, actual, comparison), actualExpression, expectedExpression, message)));
     }
 
     public static void NotEqual<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
@@ -75,7 +84,7 @@ public partial class Assert
         if (!SpansEqual(expected.Span, actual.Span))
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<ReadOnlyMemory<TExpected>, ReadOnlyMemory<TActual>>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<ReadOnlyMemory<TExpected>, ReadOnlyMemory<TActual>>("Not expected", expected, actual, firstDifferenceIndex: null, actualExpression, expectedExpression, message)));
     }
 
     public static void NotEqual<T>(IEnumerable<T> expected, IEnumerable<T>? actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
@@ -86,7 +95,7 @@ public partial class Assert
         if (!CollectionsEqual(expected, actual, (IEqualityComparer<T>)EqualityComparer<T>.Default))
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<IEnumerable<T>, IEnumerable<T>?>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<IEnumerable<T>, IEnumerable<T>?>("Not expected", expected, actual, firstDifferenceIndex: null, actualExpression, expectedExpression, message)));
     }
 
     public static void NotEqual<T>(IEnumerable<T> expected, IEnumerable<T>? actual, IEqualityComparer<T>? comparer, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
@@ -97,7 +106,7 @@ public partial class Assert
         if (!CollectionsEqual(expected, actual, comparer))
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<IEnumerable<T>, IEnumerable<T>?>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<IEnumerable<T>, IEnumerable<T>?>("Not expected", expected, actual, firstDifferenceIndex: null, actualExpression, expectedExpression, message)));
     }
 
     [OverloadResolutionPriority(-1)]
@@ -109,7 +118,7 @@ public partial class Assert
         if (!CollectionsEqual(expected, actual, (System.Collections.IEqualityComparer?)null))
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<IEnumerable<TExpected>, IEnumerable<TActual>?>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<IEnumerable<TExpected>, IEnumerable<TActual>?>("Not expected", expected, actual, firstDifferenceIndex: null, actualExpression, expectedExpression, message)));
     }
 
     public static async Task NotEqual<T>(IAsyncEnumerable<T> expected, IAsyncEnumerable<T>? actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
@@ -122,7 +131,7 @@ public partial class Assert
         if (!await AsyncCollectionsEqual(expectedSnapshot, actualSnapshot, (IEqualityComparer<T>)EqualityComparer<T>.Default).ConfigureAwait(false))
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<IReadOnlyList<T>, IReadOnlyList<T>>("Not expected", expectedSnapshot.Items, actualSnapshot.Items, actualExpression, expectedExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<IReadOnlyList<T>, IReadOnlyList<T>>("Not expected", expectedSnapshot.Items, actualSnapshot.Items, firstDifferenceIndex: null, actualExpression, expectedExpression, message)));
     }
 
     public static async Task NotEqual<T>(IAsyncEnumerable<T> expected, IAsyncEnumerable<T>? actual, IEqualityComparer<T>? comparer, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
@@ -135,7 +144,7 @@ public partial class Assert
         if (!await AsyncCollectionsEqual(expectedSnapshot, actualSnapshot, comparer).ConfigureAwait(false))
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<IReadOnlyList<T>, IReadOnlyList<T>>("Not expected", expectedSnapshot.Items, actualSnapshot.Items, actualExpression, expectedExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<IReadOnlyList<T>, IReadOnlyList<T>>("Not expected", expectedSnapshot.Items, actualSnapshot.Items, firstDifferenceIndex: null, actualExpression, expectedExpression, message)));
     }
 
     [OverloadResolutionPriority(-1)]
@@ -149,7 +158,7 @@ public partial class Assert
         if (!await AsyncCollectionsEqual(expectedSnapshot, actualSnapshot, (System.Collections.IEqualityComparer?)null).ConfigureAwait(false))
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<IReadOnlyList<TExpected>, IReadOnlyList<TActual>>("Not expected", expectedSnapshot.Items, actualSnapshot.Items, actualExpression, expectedExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<IReadOnlyList<TExpected>, IReadOnlyList<TActual>>("Not expected", expectedSnapshot.Items, actualSnapshot.Items, firstDifferenceIndex: null, actualExpression, expectedExpression, message)));
     }
 
     public static void NotEqual(System.Collections.IEnumerable expected, System.Collections.IEnumerable? actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
@@ -160,7 +169,7 @@ public partial class Assert
         if (!CollectionsEqual(EnumerateObjects(expected), EnumerateObjects(actual), (System.Collections.IEqualityComparer?)null))
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable?>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable?>("Not expected", expected, actual, firstDifferenceIndex: null, actualExpression, expectedExpression, message)));
     }
 
     public static void NotEqual(System.Collections.IEnumerable expected, System.Collections.IEnumerable? actual, System.Collections.IEqualityComparer? comparer, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
@@ -171,7 +180,7 @@ public partial class Assert
         if (!CollectionsEqual(EnumerateObjects(expected), EnumerateObjects(actual), comparer))
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable?>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
+        throw new AssertionException(ErrorFormatter.Format(new NotEqualAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable?>("Not expected", expected, actual, firstDifferenceIndex: null, actualExpression, expectedExpression, message)));
     }
 
     private static bool SpansEqual<TExpected, TActual>(ReadOnlySpan<TExpected> expected, ReadOnlySpan<TActual> actual)
@@ -183,6 +192,17 @@ public partial class Assert
         {
             if (!ValuesEqual(expected[i], actual[i]))
                 return false;
+        }
+
+        private static int GetFirstDifferenceIndex(string expected, string actual, StringComparison comparison)
+        {
+            for (var i = 0; i < expected.Length; i++)
+            {
+                if (!actual.AsSpan(i, 1).Equals(expected.AsSpan(i, 1), comparison))
+                    return i;
+            }
+
+            return expected.Length;
         }
 
         return true;

--- a/src/Meziantou.Framework.Assertions/Assert.NotEqual.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.NotEqual.cs
@@ -194,7 +194,7 @@ public partial class Assert
                 return false;
         }
 
-        private static int GetFirstDifferenceIndex(string expected, string actual, StringComparison comparison)
+        static int GetFirstDifferenceIndex(string expected, string actual, StringComparison comparison)
         {
             for (var i = 0; i < expected.Length; i++)
             {

--- a/src/Meziantou.Framework.Assertions/Assert.StartsWith.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.StartsWith.cs
@@ -110,7 +110,7 @@ public partial class Assert
         if (actual.StartsWith(expected, comparison))
             return;
 
-        var firstDifferenceIndex = GetFirstDifferenceIndex(expected, actual, comparison);
+        var firstDifferenceIndex = GetFirstDifferenceIndex(expected.AsSpan(), actual.AsSpan(), comparison);
         throw new AssertionException(ErrorFormatter.Format(new ReadOnlySpanCharStartsWithAssertionError(expected, actual, firstDifferenceIndex, comparison, actualExpression, expectedExpression, message)));
     }
 

--- a/src/Meziantou.Framework.Assertions/AssertionFormatter.cs
+++ b/src/Meziantou.Framework.Assertions/AssertionFormatter.cs
@@ -397,14 +397,21 @@ internal class AssertionFormatter
 
     public virtual string Format<TExpected, TActual>(EqualAssertionError<TExpected, TActual> error)
     {
-        return CreateMessage("Assert.Equal() assertion failed.", error.Message)
+        var builder = CreateMessage("Assert.Equal() assertion failed.", error.Message)
             .AppendGroup(
                 ("Expected expression", error.ExpectedExpression),
-                ("Actual expression", error.ActualExpression))
-            .AppendGroup(
-                ("Expected", FormatValue(error.ExpectedValue)),
-                ("Actual", FormatValue(error.ActualValue)))
-            .ToString();
+                ("Actual expression", error.ActualExpression));
+
+        if (error.FirstDifferenceIndex is not null)
+        {
+            builder.Append("Index of first difference", error.FirstDifferenceIndex.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        return builder
+           .AppendGroup(
+               ("Expected", FormatValue(error.ExpectedValue, error.FirstDifferenceIndex)),
+               ("Actual", FormatValue(error.ActualValue, error.FirstDifferenceIndex)))
+           .ToString();
     }
 
     public virtual string Format<T>(EqualWithToleranceAssertionError<T> error)

--- a/src/Meziantou.Framework.Assertions/Errors/EqualAssertionError.cs
+++ b/src/Meziantou.Framework.Assertions/Errors/EqualAssertionError.cs
@@ -1,10 +1,11 @@
 namespace Meziantou.Framework.Assertions;
 
-internal readonly ref struct EqualAssertionError<TExpected, TActual>(TExpected? expectedValue, TActual? actualValue, string? message, string? actualExpression, string? expectedExpression)
+internal readonly ref struct EqualAssertionError<TExpected, TActual>(TExpected? expectedValue, TActual? actualValue, int? firstDifferenceIndex, string? message, string? actualExpression, string? expectedExpression)
 {
     public string? Message { get; } = message;
     public string? ExpectedExpression { get; } = expectedExpression;
     public string? ActualExpression { get; } = actualExpression;
     public TExpected? ExpectedValue { get; } = expectedValue;
     public TActual? ActualValue { get; } = actualValue;
+    public int? FirstDifferenceIndex { get; } = firstDifferenceIndex;
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
@@ -195,8 +195,9 @@ public sealed class AssertEqualTests
             Assert.Equal() assertion failed.
             Expected expression: expected
             Actual expression:   actual
-            Expected: "Hello\n\"World\""
-            Actual:   "Hello\tWorld"
+            Index of first difference: 5
+            Expected: "Hello\̲n̲\"World\""
+            Actual:   "Hello\̲t̲World"
             """);
     }
 
@@ -212,6 +213,22 @@ public sealed class AssertEqualTests
             Actual expression:   actual
             Expected: "Hello"
             Actual:   <null>
+            """);
+    }
+
+    [Fact]
+    public void String_ShowsDifferenceIndex_WhenActualHasAdditionalSuffix()
+    {
+        var expected = "Hello";
+        var actual = "Hello world";
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.Equal(expected, actual), """
+            Assert.Equal() assertion failed.
+            Expected expression: expected
+            Actual expression:   actual
+            Index of first difference: 5
+            Expected: "Hello"
+            Actual:   "Hello ̲world"
             """);
     }
 


### PR DESCRIPTION
## Summary
String `Assert.Equal` failures now report the first differing index, which makes long multi-line payload mismatches much easier to diagnose.

This reuses the existing highlighted-value formatting path so the differing character is underlined in both expected and actual output, including when the only difference is an additional suffix in the actual string. The formatter only emits the index when one is available, so non-string `Assert.Equal` failures keep their existing shape.

## Testing
- `dotnet run ./eng/update-all.cs`
- `dotnet test tests/Meziantou.Framework.Assertions.Tests/Meziantou.Framework.Assertions.Tests.csproj /p:TreatsWarningsAsErrors=true`