### PR TITLE
Highlight the first difference in equality assertion failures

### DIFF
--- a/src/Meziantou.Framework.Assertions/Assert.Equal.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Equal.cs
@@ -47,7 +47,7 @@ public partial class Assert
 
         if (!ValuesEqual(expected, actual))
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<object?, object?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<object?, object?>(expected, actual, GetStringFirstDifferenceIndex(expected, actual, StringComparison.Ordinal), message, actualExpression, expectedExpression)));
         }
     }
 
@@ -62,7 +62,7 @@ public partial class Assert
 
         if (!ValuesEqual(expected, actual))
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<T, T>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<T, T>(expected, actual, GetStringFirstDifferenceIndex(expected, actual, StringComparison.Ordinal), message, actualExpression, expectedExpression)));
         }
     }
 
@@ -75,7 +75,7 @@ public partial class Assert
         if (string.Equals(expectedValue, actualValue, comparison))
             return;
 
-        throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<string?, string?>(expectedValue, actualValue, message, actualExpression, expectedExpression)));
+        throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<string?, string?>(expectedValue, actualValue, GetStringFirstDifferenceIndex(expectedValue, actualValue, comparison), message, actualExpression, expectedExpression)));
     }
 
     public static void Equal<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(expected))] string? expectedExpression = null)
@@ -113,7 +113,7 @@ public partial class Assert
     {
         if (expected.Length != actual.Length)
         {
-            throw new AssertionException(ErrorFormatter.Format(new ReadOnlySpanLengthAssertionError<TExpected, TActual>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new ReadOnlySpanLengthAssertionError<TExpected, TActual>(expected, actual, Math.Min(expected.Length, actual.Length), message, actualExpression, expectedExpression)));
         }
 
         for (var i = 0; i < expected.Length; i++)
@@ -129,7 +129,7 @@ public partial class Assert
     {
         if (actual is null)
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<T>, IEnumerable<T>?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<T>, IEnumerable<T>?>(expected, actual, null, message, actualExpression, expectedExpression)));
         }
 
         EqualCollections<T>(expected, actual, EqualityComparer<T>.Default, message, actualExpression, expectedExpression);
@@ -139,7 +139,7 @@ public partial class Assert
     {
         if (actual is null)
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<T>, IEnumerable<T>?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<T>, IEnumerable<T>?>(expected, actual, null, message, actualExpression, expectedExpression)));
         }
 
         EqualCollections<T>(expected, actual, comparer, message, actualExpression, expectedExpression);
@@ -150,7 +150,7 @@ public partial class Assert
     {
         if (actual is null)
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<TExpected>, IEnumerable<TActual>?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<TExpected>, IEnumerable<TActual>?>(expected, actual, null, message, actualExpression, expectedExpression)));
         }
 
         EqualCollections(expected, actual, comparer: (System.Collections.IEqualityComparer?)null, message, actualExpression, expectedExpression);
@@ -219,7 +219,7 @@ public partial class Assert
         {
             await using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
             await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<T>, IAsyncEnumerable<T>?>(expectedSnapshot.Items, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<T>, IAsyncEnumerable<T>?>(expectedSnapshot.Items, actual, null, message, actualExpression, expectedExpression)));
         }
 
         await EqualAsyncCollections<T>(expected, actual, EqualityComparer<T>.Default, message, actualExpression, expectedExpression).ConfigureAwait(false);
@@ -231,7 +231,7 @@ public partial class Assert
         {
             await using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
             await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<T>, IAsyncEnumerable<T>?>(expectedSnapshot.Items, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<T>, IAsyncEnumerable<T>?>(expectedSnapshot.Items, actual, null, message, actualExpression, expectedExpression)));
         }
 
         await EqualAsyncCollections<T>(expected, actual, comparer, message, actualExpression, expectedExpression).ConfigureAwait(false);
@@ -244,7 +244,7 @@ public partial class Assert
         {
             await using var expectedSnapshot = CollectionSnapshot.Create<TExpected>(expected);
             await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<TExpected>, IAsyncEnumerable<TActual>?>(expectedSnapshot.Items, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<TExpected>, IAsyncEnumerable<TActual>?>(expectedSnapshot.Items, actual, null, message, actualExpression, expectedExpression)));
         }
 
         await EqualAsyncCollections(expected, actual, comparer: (System.Collections.IEqualityComparer?)null, message, actualExpression, expectedExpression).ConfigureAwait(false);
@@ -254,7 +254,7 @@ public partial class Assert
     {
         if (actual is null)
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<T>, IAsyncEnumerable<T>?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IEnumerable<T>, IAsyncEnumerable<T>?>(expected, actual, null, message, actualExpression, expectedExpression)));
         }
 
         var actualList = new List<T>();
@@ -272,7 +272,7 @@ public partial class Assert
         {
             await using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
             await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<T>, IEnumerable<T>?>(expectedSnapshot.Items, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<IReadOnlyList<T>, IEnumerable<T>?>(expectedSnapshot.Items, actual, null, message, actualExpression, expectedExpression)));
         }
 
         var expectedList = new List<T>();
@@ -345,7 +345,7 @@ public partial class Assert
     {
         if (actual is null)
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable?>(expected, actual, null, message, actualExpression, expectedExpression)));
         }
 
         Equal(expected, actual, comparer: null, message, actualExpression, expectedExpression);
@@ -355,7 +355,7 @@ public partial class Assert
     {
         if (actual is null)
         {
-            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable?>(expected, actual, message, actualExpression, expectedExpression)));
+            throw new AssertionException(ErrorFormatter.Format(new EqualAssertionError<System.Collections.IEnumerable, System.Collections.IEnumerable?>(expected, actual, null, message, actualExpression, expectedExpression)));
         }
 
         using var actualSnapshot = CollectionSnapshot.Create(actual);
@@ -426,5 +426,31 @@ public partial class Assert
     private static StringComparison GetStringComparison(bool ignoreCase)
     {
         return ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+    }
+
+    private static int? GetStringFirstDifferenceIndex(object? expected, object? actual, StringComparison comparison)
+    {
+        if (expected is not string expectedString || actual is not string actualString)
+            return null;
+
+        return GetStringFirstDifferenceIndex(expectedString, actualString, comparison);
+    }
+
+    private static int? GetStringFirstDifferenceIndex(string? expected, string? actual, StringComparison comparison)
+    {
+        if (expected is null || actual is null)
+            return null;
+
+        var minLength = Math.Min(expected.Length, actual.Length);
+        for (var i = 0; i < minLength; i++)
+        {
+            if (!actual.AsSpan(i, 1).Equals(expected.AsSpan(i, 1), comparison))
+                return i;
+        }
+
+        if (expected.Length == actual.Length)
+            return null;
+
+        return minLength;
     }
 }

--- a/src/Meziantou.Framework.Assertions/AssertionFormatter.cs
+++ b/src/Meziantou.Framework.Assertions/AssertionFormatter.cs
@@ -397,13 +397,20 @@ internal class AssertionFormatter
 
     public virtual string Format<TExpected, TActual>(EqualAssertionError<TExpected, TActual> error)
     {
-        return CreateMessage("Assert.Equal() assertion failed.", error.Message)
+        var builder = CreateMessage("Assert.Equal() assertion failed.", error.Message)
             .AppendGroup(
                 ("Expected expression", error.ExpectedExpression),
-                ("Actual expression", error.ActualExpression))
+                ("Actual expression", error.ActualExpression));
+
+        if (error.FirstDifferenceIndex is not null)
+        {
+            builder.Append("Index of first difference", error.FirstDifferenceIndex.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        return builder
             .AppendGroup(
-                ("Expected", FormatValue(error.ExpectedValue)),
-                ("Actual", FormatValue(error.ActualValue)))
+                ("Expected", FormatValue(error.ExpectedValue, error.FirstDifferenceIndex)),
+                ("Actual", FormatValue(error.ActualValue, error.FirstDifferenceIndex)))
             .ToString();
     }
 
@@ -456,9 +463,10 @@ internal class AssertionFormatter
             .AppendGroup(
                 ("Expected length", error.ExpectedValue.Length.ToString(CultureInfo.InvariantCulture)),
                 ("Actual length", error.ActualValue.Length.ToString(CultureInfo.InvariantCulture)))
+            .Append("Index of first difference", error.FirstDifferenceIndex.ToString(CultureInfo.InvariantCulture))
             .AppendGroup(
-                ("Expected", FormatReadOnlySpanValue(error.ExpectedValue)),
-                ("Actual", FormatReadOnlySpanValue(error.ActualValue)))
+                ("Expected", FormatReadOnlySpanValue(error.ExpectedValue, error.FirstDifferenceIndex < error.ExpectedValue.Length ? error.FirstDifferenceIndex : null)),
+                ("Actual", FormatReadOnlySpanValue(error.ActualValue, error.FirstDifferenceIndex < error.ActualValue.Length ? error.FirstDifferenceIndex : null)))
             .ToString();
     }
 

--- a/src/Meziantou.Framework.Assertions/Errors/EqualAssertionError.cs
+++ b/src/Meziantou.Framework.Assertions/Errors/EqualAssertionError.cs
@@ -1,10 +1,11 @@
 namespace Meziantou.Framework.Assertions;
 
-internal readonly ref struct EqualAssertionError<TExpected, TActual>(TExpected? expectedValue, TActual? actualValue, string? message, string? actualExpression, string? expectedExpression)
+internal readonly ref struct EqualAssertionError<TExpected, TActual>(TExpected? expectedValue, TActual? actualValue, int? firstDifferenceIndex, string? message, string? actualExpression, string? expectedExpression)
 {
     public string? Message { get; } = message;
     public string? ExpectedExpression { get; } = expectedExpression;
     public string? ActualExpression { get; } = actualExpression;
     public TExpected? ExpectedValue { get; } = expectedValue;
     public TActual? ActualValue { get; } = actualValue;
+    public int? FirstDifferenceIndex { get; } = firstDifferenceIndex;
 }

--- a/src/Meziantou.Framework.Assertions/Errors/ReadOnlySpanLengthAssertionError.cs
+++ b/src/Meziantou.Framework.Assertions/Errors/ReadOnlySpanLengthAssertionError.cs
@@ -1,10 +1,11 @@
 namespace Meziantou.Framework.Assertions;
 
-internal readonly ref struct ReadOnlySpanLengthAssertionError<TExpected, TActual>(ReadOnlySpan<TExpected> expectedValue, ReadOnlySpan<TActual> actualValue, string? message, string? actualExpression, string? expectedExpression)
+internal readonly ref struct ReadOnlySpanLengthAssertionError<TExpected, TActual>(ReadOnlySpan<TExpected> expectedValue, ReadOnlySpan<TActual> actualValue, int firstDifferenceIndex, string? message, string? actualExpression, string? expectedExpression)
 {
     public string? Message { get; } = message;
     public string? ExpectedExpression { get; } = expectedExpression;
     public string? ActualExpression { get; } = actualExpression;
     public ReadOnlySpan<TExpected> ExpectedValue { get; } = expectedValue;
     public ReadOnlySpan<TActual> ActualValue { get; } = actualValue;
+    public int FirstDifferenceIndex { get; } = firstDifferenceIndex;
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
@@ -195,8 +195,9 @@ public sealed class AssertEqualTests
             Assert.Equal() assertion failed.
             Expected expression: expected
             Actual expression:   actual
-            Expected: "Hello\n\"World\""
-            Actual:   "Hello\tWorld"
+            Index of first difference: 5
+            Expected: "Hello\̲n̲\"World\""
+            Actual:   "Hello\̲t̲World"
             """);
     }
 
@@ -233,7 +234,43 @@ public sealed class AssertEqualTests
     [Fact]
     public void String_IgnoreCase_FailsWhenDisabled()
     {
-        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.Equal("Hello", "hello"));
+        AssertionTestHelpers.Validate(() => AssertionsAssert.Equal("Hello", "hello"), """
+            Assert.Equal() assertion failed.
+            Expected expression: "Hello"
+            Actual expression:   "hello"
+            Index of first difference: 0
+            Expected: "H̲ello"
+            Actual:   "h̲ello"
+            """);
+    }
+
+    [Fact]
+    public void String_IgnoreCase_FailsAtFirstRelevantDifference()
+    {
+        AssertionTestHelpers.Validate(() => AssertionsAssert.Equal("HelloX", "helloY", ignoreCase: true), """
+            Assert.Equal() assertion failed.
+            Expected expression: "HelloX"
+            Actual expression:   "helloY"
+            Index of first difference: 5
+            Expected: "HelloX̲"
+            Actual:   "helloY̲"
+            """);
+    }
+
+    [Fact]
+    public void BoxedString_FailsWithFirstDifference()
+    {
+        object expected = "abc";
+        object actual = "axc";
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.Equal(expected, actual), """
+            Assert.Equal() assertion failed.
+            Expected expression: expected
+            Actual expression:   actual
+            Index of first difference: 1
+            Expected: "ab̲c"
+            Actual:   "ax̲c"
+            """);
     }
 
     [Fact]
@@ -605,6 +642,47 @@ public sealed class AssertEqualTests
 
             AssertionsAssert.Equal(expected, actual);
         }
+    }
+
+    [Fact]
+    public void HighlightsReadOnlySpanLengthDifference()
+    {
+        AssertionTestHelpers.Validate(Validate, """
+            Assert.Equal() assertion failed: Lengths differ.
+            Expected expression: expected
+            Actual expression:   actual
+            Expected length: 3
+            Actual length:   2
+            Index of first difference: 2
+            Expected: [1, 2, 3̲]
+            Actual:   [1, 2]
+            """);
+
+        static void Validate()
+        {
+            ReadOnlySpan<int> expected = [1, 2, 3];
+            ReadOnlySpan<int> actual = [1, 2];
+
+            AssertionsAssert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void HighlightsReadOnlyMemoryLengthDifference()
+    {
+        ReadOnlyMemory<int> expected = new[] { 1, 2 };
+        ReadOnlyMemory<int> actual = new[] { 1, 2, 3 };
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.Equal(expected, actual), """
+            Assert.Equal() assertion failed: Lengths differ.
+            Expected expression: expected
+            Actual expression:   actual
+            Expected length: 2
+            Actual length:   3
+            Index of first difference: 2
+            Expected: [1, 2]
+            Actual:   [1, 2, 3̲]
+            """);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add first-difference indexes to string, span, and memory equality assertion failures.
- Highlight the differing values in formatted expected and actual output.
- Support ordinal and case-insensitive string comparisons.
- Add coverage for boxed strings and length mismatches.

## Testing

- Added and updated unit tests in `AssertEqualTests` covering string differences, ignore-case comparisons, boxed strings, and span/memory length differences.