### PR TITLE
Split glob dialects from matching options

### DIFF
--- a/benchmarks/GlobbingBenchmarks/EnumerateFilesBenchmark.cs
+++ b/benchmarks/GlobbingBenchmarks/EnumerateFilesBenchmark.cs
@@ -100,14 +100,14 @@ public class EnumerateFilesBenchmark
     [Benchmark]
     public int Meziantou_Globbing()
     {
-        var glob = Glob.Parse(Pattern, GlobOptions.None);
+        var glob = Glob.Parse(Pattern, GlobDialect.Standard);
         return glob.EnumerateFiles(GetPath()).Count();
     }
 
     [Benchmark]
     public int Meziantou_Globbing_IgnoreCase()
     {
-        var glob = Glob.Parse(Pattern, GlobOptions.IgnoreCase);
+        var glob = Glob.Parse(Pattern, GlobDialect.Standard, GlobOptions.IgnoreCase);
         return glob.EnumerateFiles(GetPath()).Count();
     }
 }

--- a/benchmarks/GlobbingBenchmarks/GlobIsMatchBenchmark.cs
+++ b/benchmarks/GlobbingBenchmarks/GlobIsMatchBenchmark.cs
@@ -32,7 +32,7 @@ public class GlobIsMatchBenchmark
     [GlobalSetup]
     public void Initialize()
     {
-        _meziantouGlob = Glob.Parse(Pattern, GlobOptions.None);
+        _meziantouGlob = Glob.Parse(Pattern, GlobDialect.Standard);
     }
 
     [Benchmark]

--- a/ref/Meziantou.Framework.Globbing.cs
+++ b/ref/Meziantou.Framework.Globbing.cs
@@ -7,10 +7,10 @@ namespace Meziantou.Framework.Globbing
     public sealed class Glob : Meziantou.Framework.Globbing.IGlobEvaluatable
     {
         public Meziantou.Framework.Globbing.GlobMode Mode { get => throw null; }
-        public static Meziantou.Framework.Globbing.Glob Parse(string pattern, Meziantou.Framework.Globbing.GlobOptions options) => throw null;
-        public static Meziantou.Framework.Globbing.Glob Parse(System.ReadOnlySpan<char> pattern, Meziantou.Framework.Globbing.GlobOptions options) => throw null;
-        public static bool TryParse(string pattern, Meziantou.Framework.Globbing.GlobOptions options, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Globbing.Glob? result) => throw null;
-        public static bool TryParse(System.ReadOnlySpan<char> pattern, Meziantou.Framework.Globbing.GlobOptions options, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Globbing.Glob? result) => throw null;
+        public static Meziantou.Framework.Globbing.Glob Parse(string pattern, Meziantou.Framework.Globbing.GlobDialect dialect, Meziantou.Framework.Globbing.GlobOptions options = 0) => throw null;
+        public static Meziantou.Framework.Globbing.Glob Parse(System.ReadOnlySpan<char> pattern, Meziantou.Framework.Globbing.GlobDialect dialect, Meziantou.Framework.Globbing.GlobOptions options = 0) => throw null;
+        public static bool TryParse(string pattern, Meziantou.Framework.Globbing.GlobDialect dialect, Meziantou.Framework.Globbing.GlobOptions options, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Globbing.Glob? result) => throw null;
+        public static bool TryParse(System.ReadOnlySpan<char> pattern, Meziantou.Framework.Globbing.GlobDialect dialect, Meziantou.Framework.Globbing.GlobOptions options, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Globbing.Glob? result) => throw null;
         public bool IsMatch(System.ReadOnlySpan<char> directory, System.ReadOnlySpan<char> filename, Meziantou.Framework.Globbing.PathItemType? itemType) => throw null;
         public bool IsPartialMatch(System.ReadOnlySpan<char> folderPath, System.ReadOnlySpan<char> filename) => throw null;
         public override string ToString() => throw null;
@@ -31,6 +31,15 @@ namespace Meziantou.Framework.Globbing
         public bool IsPartialMatch(System.ReadOnlySpan<char> folderPath, System.ReadOnlySpan<char> filename) => throw null;
         public System.Collections.Generic.IEnumerator<Meziantou.Framework.Globbing.IGlobEvaluatable> GetEnumerator() => throw null;
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
+    }
+
+    public enum GlobDialect
+    {
+        Standard = 0,
+        Git = 1,
+        MSBuild = 2,
+        Posix = 3,
+        PosixPath = 4
     }
 
     public static class GlobExtensions
@@ -72,7 +81,7 @@ namespace Meziantou.Framework.Globbing
     {
         None = 0,
         IgnoreCase = 1,
-        Git = 2
+        MatchLeadingDot = 2
     }
 
     public interface IGlobEvaluatable

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
@@ -329,9 +329,9 @@ internal static class Program
         if (patterns is null || patterns.Length is 0)
         {
             return new GlobCollection(
-                Glob.Parse("**/*", GlobOptions.None),
-                Glob.Parse("!**/node_modules/**/*", GlobOptions.None),
-                Glob.Parse("!**/.playwright/package/**/*", GlobOptions.None));
+                Glob.Parse("**/*", GlobDialect.Standard),
+                Glob.Parse("!**/node_modules/**/*", GlobDialect.Standard),
+                Glob.Parse("!**/.playwright/package/**/*", GlobDialect.Standard));
         }
 
         var parsedPatterns = new List<IGlobEvaluatable>(patterns.Length);
@@ -340,7 +340,7 @@ internal static class Program
             if (string.IsNullOrWhiteSpace(pattern))
                 continue;
 
-            if (!Glob.TryParse(pattern, GlobOptions.IgnoreCase, out var parsedPattern))
+            if (!Glob.TryParse(pattern, GlobDialect.Standard, GlobOptions.IgnoreCase, out var parsedPattern))
             {
                 error.WriteLine($"Glob pattern '{pattern}' is invalid");
                 return null;

--- a/src/Meziantou.Framework.DependencyScanning/Scanners/RegexScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/RegexScanner.cs
@@ -10,7 +10,7 @@ namespace Meziantou.Framework.DependencyScanning.Scanners;
 /// <code><![CDATA[
 /// var scanner = new RegexScanner
 /// {
-///     FilePatterns = [Glob.Parse("**/*.custom", GlobOptions.IgnoreCase)],
+///     FilePatterns = [Glob.Parse("**/*.custom", GlobDialect.Standard, GlobOptions.IgnoreCase)],
 ///     DependencyType = DependencyType.DockerImage,
 ///     Regex = new Regex(@"image:\s*(?<name>[a-z/]+)(:(?<version>[0-9.]+))?", RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(10))
 /// };

--- a/src/Meziantou.Framework.DependencyScanning/readme.md
+++ b/src/Meziantou.Framework.DependencyScanning/readme.md
@@ -162,7 +162,7 @@ var options = new ScannerOptions
     [
         new RegexScanner
         {
-            FilePatterns = [Glob.Parse("**/*.custom", GlobOptions.IgnoreCase)],
+            FilePatterns = [Glob.Parse("**/*.custom", GlobDialect.Standard, GlobOptions.IgnoreCase)],
             DependencyType = DependencyType.DockerImage,
             Regex = new Regex(@"image:\s*(?<name>[a-z/]+)(:(?<version>[0-9.]+))?", RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(10))
         }

--- a/src/Meziantou.Framework.Globbing/Glob.cs
+++ b/src/Meziantou.Framework.Globbing/Glob.cs
@@ -181,7 +181,7 @@ public sealed class Glob : IGlobEvaluatable
         {
             var path = directory.IsEmpty
                 ? filename.ToString()
-                : directory.ToString() + Path.DirectorySeparatorChar + filename.ToString();
+                : directory.ToString() + '/' + filename.ToString();
             directory = path.AsSpan();
             filename = [];
         }

--- a/src/Meziantou.Framework.Globbing/Glob.cs
+++ b/src/Meziantou.Framework.Globbing/Glob.cs
@@ -177,10 +177,9 @@ public sealed class Glob : IGlobEvaluatable
 
     internal bool IsMatchCore(ReadOnlySpan<char> directory, ReadOnlySpan<char> filename, PathItemType? itemType)
     {
-        string? path = null;
         if (!_pathSeparatorAware && !filename.IsEmpty)
         {
-            path = directory.IsEmpty
+            var path = directory.IsEmpty
                 ? filename.ToString()
                 : directory.ToString() + Path.DirectorySeparatorChar + filename.ToString();
             directory = path.AsSpan();

--- a/src/Meziantou.Framework.Globbing/Glob.cs
+++ b/src/Meziantou.Framework.Globbing/Glob.cs
@@ -58,7 +58,7 @@ namespace Meziantou.Framework.Globbing;
 /// <example>
 /// Parse a glob pattern and check if a path matches:
 /// <code>
-/// var glob = Glob.Parse("src/**/*.txt", GlobOptions.None);
+/// var glob = Glob.Parse("src/**/*.txt", GlobDialect.Standard);
 /// if (glob.IsMatch("src/folder/file.txt"))
 /// {
 ///     Console.WriteLine("File matches!");
@@ -66,7 +66,7 @@ namespace Meziantou.Framework.Globbing;
 /// </code>
 /// Enumerate files that match a glob pattern:
 /// <code>
-/// var glob = Glob.Parse("**/*.cs", GlobOptions.IgnoreCase);
+/// var glob = Glob.Parse("**/*.cs", GlobDialect.Standard, GlobOptions.IgnoreCase);
 /// foreach (var file in glob.EnumerateFiles("C:/MyProject"))
 /// {
 ///     Console.WriteLine(file);
@@ -79,6 +79,8 @@ public sealed class Glob : IGlobEvaluatable
 {
     private readonly GlobMatchType _matchType;
     internal readonly Segment[] _segments;
+    private readonly bool[] _matchLeadingDot;
+    private readonly bool _pathSeparatorAware;
 
     // Anchors are precomputed once per pattern. Only segments that immediately follow a
     // RecursiveMatchAllSegment ('**') can be tested as an anchor during matching, so we only
@@ -87,14 +89,17 @@ public sealed class Glob : IGlobEvaluatable
 
     /// <summary>Gets the glob mode indicating whether this pattern includes or excludes matches.</summary>
     public GlobMode Mode { get; }
+    internal bool MatchLeadingDot => _matchLeadingDot.Contains(true);
 
     bool IGlobEvaluatable.CanMatchFiles => _matchType is GlobMatchType.File or GlobMatchType.Any;
     bool IGlobEvaluatable.CanMatchDirectories => _matchType is GlobMatchType.Directory or GlobMatchType.Any;
-    bool IGlobEvaluatable.TraverseDirectories => _segments.Length > 1 || ShouldRecurse(_segments[0]);
+    bool IGlobEvaluatable.TraverseDirectories => !_pathSeparatorAware || _segments.Length > 1 || ShouldRecurse(_segments[0]);
 
-    internal Glob(Segment[] segments, GlobMode mode, GlobMatchType matchType)
+    internal Glob(Segment[] segments, bool[] matchLeadingDot, bool pathSeparatorAware, GlobMode mode, GlobMatchType matchType)
     {
         _segments = segments;
+        _matchLeadingDot = matchLeadingDot;
+        _pathSeparatorAware = pathSeparatorAware;
         _matchType = matchType;
         Mode = mode;
 
@@ -110,22 +115,24 @@ public sealed class Glob : IGlobEvaluatable
 
     /// <summary>Parses a glob pattern string.</summary>
     /// <param name="pattern">The glob pattern to parse.</param>
+    /// <param name="dialect">The glob pattern dialect to use.</param>
     /// <param name="options">Options for controlling pattern parsing behavior.</param>
     /// <returns>A <see cref="Glob"/> object representing the parsed pattern.</returns>
     /// <exception cref="ArgumentException">The pattern is invalid.</exception>
-    public static Glob Parse(string pattern, GlobOptions options)
+    public static Glob Parse(string pattern, GlobDialect dialect, GlobOptions options = GlobOptions.None)
     {
-        return Parse(pattern.AsSpan(), options);
+        return Parse(pattern.AsSpan(), dialect, options);
     }
 
     /// <summary>Parses a glob pattern string.</summary>
     /// <param name="pattern">The glob pattern to parse.</param>
+    /// <param name="dialect">The glob pattern dialect to use.</param>
     /// <param name="options">Options for controlling pattern parsing behavior.</param>
     /// <returns>A <see cref="Glob"/> object representing the parsed pattern.</returns>
     /// <exception cref="ArgumentException">The pattern is invalid.</exception>
-    public static Glob Parse(ReadOnlySpan<char> pattern, GlobOptions options)
+    public static Glob Parse(ReadOnlySpan<char> pattern, GlobDialect dialect, GlobOptions options = GlobOptions.None)
     {
-        if (TryParse(pattern, options, out var result, out var errorMessage))
+        if (TryParse(pattern, dialect, options, out var result, out var errorMessage))
             return result;
 
         throw new ArgumentException($"The pattern '{pattern.ToString()}' is invalid: {errorMessage}", nameof(pattern));
@@ -133,27 +140,29 @@ public sealed class Glob : IGlobEvaluatable
 
     /// <summary>Attempts to parse a glob pattern string.</summary>
     /// <param name="pattern">The glob pattern to parse.</param>
+    /// <param name="dialect">The glob pattern dialect to use.</param>
     /// <param name="options">Options for controlling pattern parsing behavior.</param>
     /// <param name="result">When this method returns, contains the parsed <see cref="Glob"/> if parsing succeeded, or <see langword="null"/> if parsing failed.</param>
     /// <returns><see langword="true"/> if the pattern was parsed successfully; otherwise, <see langword="false"/>.</returns>
-    public static bool TryParse(string pattern, GlobOptions options, [NotNullWhen(true)] out Glob? result)
+    public static bool TryParse(string pattern, GlobDialect dialect, GlobOptions options, [NotNullWhen(true)] out Glob? result)
     {
-        return TryParse(pattern.AsSpan(), options, out result);
+        return TryParse(pattern.AsSpan(), dialect, options, out result);
     }
 
     /// <summary>Attempts to parse a glob pattern string.</summary>
     /// <param name="pattern">The glob pattern to parse.</param>
+    /// <param name="dialect">The glob pattern dialect to use.</param>
     /// <param name="options">Options for controlling pattern parsing behavior.</param>
     /// <param name="result">When this method returns, contains the parsed <see cref="Glob"/> if parsing succeeded, or <see langword="null"/> if parsing failed.</param>
     /// <returns><see langword="true"/> if the pattern was parsed successfully; otherwise, <see langword="false"/>.</returns>
-    public static bool TryParse(ReadOnlySpan<char> pattern, GlobOptions options, [NotNullWhen(true)] out Glob? result)
+    public static bool TryParse(ReadOnlySpan<char> pattern, GlobDialect dialect, GlobOptions options, [NotNullWhen(true)] out Glob? result)
     {
-        return TryParse(pattern, options, out result, out _);
+        return TryParse(pattern, dialect, options, out result, out _);
     }
 
-    private static bool TryParse(ReadOnlySpan<char> pattern, GlobOptions options, [NotNullWhen(true)] out Glob? result, [NotNullWhen(false)] out string? errorMessage)
+    private static bool TryParse(ReadOnlySpan<char> pattern, GlobDialect dialect, GlobOptions options, [NotNullWhen(true)] out Glob? result, [NotNullWhen(false)] out string? errorMessage)
     {
-        return GlobParser.TryParse(pattern, options, out result, out errorMessage);
+        return GlobParser.TryParse(pattern, dialect, options, out result, out errorMessage);
     }
 
     /// <summary>Determines whether the specified path matches this glob pattern.</summary>
@@ -168,7 +177,17 @@ public sealed class Glob : IGlobEvaluatable
 
     internal bool IsMatchCore(ReadOnlySpan<char> directory, ReadOnlySpan<char> filename, PathItemType? itemType)
     {
-        var pathReader = new PathReader(directory, filename, itemType);
+        string? path = null;
+        if (!_pathSeparatorAware && !filename.IsEmpty)
+        {
+            path = directory.IsEmpty
+                ? filename.ToString()
+                : directory.ToString() + Path.DirectorySeparatorChar + filename.ToString();
+            directory = path.AsSpan();
+            filename = [];
+        }
+
+        var pathReader = new PathReader(directory, filename, itemType, _pathSeparatorAware);
 
         if (_matchType is not GlobMatchType.Any)
         {
@@ -179,10 +198,10 @@ public sealed class Glob : IGlobEvaluatable
                 return false;
         }
 
-        return IsMatchCore(pathReader, _segments, _segmentAnchors);
+        return IsMatchCore(pathReader, _segments, _segmentAnchors, _matchLeadingDot);
     }
 
-    private static bool IsMatchCore(PathReader pathReader, ReadOnlySpan<Segment> patternSegments, ReadOnlySpan<SegmentAnchor?> anchors)
+    private static bool IsMatchCore(PathReader pathReader, ReadOnlySpan<Segment> patternSegments, ReadOnlySpan<SegmentAnchor?> anchors, ReadOnlySpan<bool> matchLeadingDot)
     {
         for (var i = 0; i < patternSegments.Length; i++)
         {
@@ -194,21 +213,31 @@ public sealed class Glob : IGlobEvaluatable
                     return false; // Match only files
 
                 var remainingAnchors = anchors[(i + 1)..];
-                if (IsMatchCore(pathReader, remainingPatternSegments, remainingAnchors))
+                var remainingMatchLeadingDot = matchLeadingDot[(i + 1)..];
+                if (IsMatchCore(pathReader, remainingPatternSegments, remainingAnchors, remainingMatchLeadingDot))
                     return true;
 
                 var segmentAnchor = remainingAnchors[0];
+                if (!CanMatchLeadingDot(pathReader, matchLeadingDot[i]))
+                    return false;
+
                 pathReader.ConsumeSegment();
                 while (!pathReader.IsEndOfPath)
                 {
                     if (segmentAnchor.HasValue && !segmentAnchor.GetValueOrDefault().Contains(pathReader.CurrentText))
                     {
+                        if (!CanMatchLeadingDot(pathReader, matchLeadingDot[i]))
+                            return false;
+
                         pathReader.ConsumeSegment();
                         continue;
                     }
 
-                    if (IsMatchCore(pathReader, remainingPatternSegments, remainingAnchors))
+                    if (IsMatchCore(pathReader, remainingPatternSegments, remainingAnchors, remainingMatchLeadingDot))
                         return true;
+
+                    if (!CanMatchLeadingDot(pathReader, matchLeadingDot[i]))
+                        return false;
 
                     pathReader.ConsumeSegment();
                 }
@@ -217,6 +246,9 @@ public sealed class Glob : IGlobEvaluatable
             }
 
             if (pathReader.IsEndOfPath)
+                return false;
+
+            if (!CanMatchLeadingDot(pathReader, matchLeadingDot[i]))
                 return false;
 
             if (!patternSegment.IsMatch(ref pathReader))
@@ -243,27 +275,43 @@ public sealed class Glob : IGlobEvaluatable
 
     internal bool IsPartialMatchCore(ReadOnlySpan<char> folderPath, ReadOnlySpan<char> filename)
     {
-        return IsPartialMatchCore(new PathReader(folderPath, filename, itemType: null), _segments);
+        if (!_pathSeparatorAware)
+            return true;
+
+        return IsPartialMatchCore(new PathReader(folderPath, filename, itemType: null), _segments, _matchLeadingDot);
     }
 
-    private static bool IsPartialMatchCore(PathReader pathReader, ReadOnlySpan<Segment> patternSegments)
+    private static bool IsPartialMatchCore(PathReader pathReader, ReadOnlySpan<Segment> patternSegments, ReadOnlySpan<bool> matchLeadingDot)
     {
-        foreach (var patternSegment in patternSegments)
+        for (var i = 0; i < patternSegments.Length; i++)
         {
+            var patternSegment = patternSegments[i];
             if (ShouldRecurse(patternSegment))
-                return true;
+            {
+                if (IsPartialMatchCore(pathReader, patternSegments[(i + 1)..], matchLeadingDot[(i + 1)..]))
+                    return true;
+
+                return pathReader.IsEndOfPath || CanMatchLeadingDot(pathReader, matchLeadingDot[i]);
+            }
 
             if (pathReader.IsEndOfPath)
                 return true;
+
+            if (!CanMatchLeadingDot(pathReader, matchLeadingDot[i]))
+                return false;
 
             if (!patternSegment.IsMatch(ref pathReader))
                 return false;
 
             pathReader.ConsumeSegment();
-            patternSegments = patternSegments[1..];
         }
 
         return true;
+    }
+
+    private static bool CanMatchLeadingDot(PathReader pathReader, bool matchLeadingDot)
+    {
+        return matchLeadingDot || pathReader.CurrentSegment.IsEmpty || pathReader.CurrentSegment[0] != '.';
     }
 
     private static bool ShouldRecurse(Segment patternSegment)

--- a/src/Meziantou.Framework.Globbing/GlobCollection.cs
+++ b/src/Meziantou.Framework.Globbing/GlobCollection.cs
@@ -8,8 +8,8 @@ namespace Meziantou.Framework.Globbing;
 /// Combine multiple glob patterns with include and exclude rules:
 /// <code>
 /// var globs = new GlobCollection(
-///     Glob.Parse("**/*.txt", GlobOptions.None),
-///     Glob.Parse("!temp/**/*", GlobOptions.None)
+///     Glob.Parse("**/*.txt", GlobDialect.Standard),
+///     Glob.Parse("!temp/**/*", GlobDialect.Standard)
 /// );
 ///
 /// foreach (var file in globs.EnumerateFiles("C:/MyProject"))
@@ -101,7 +101,7 @@ public sealed class GlobCollection : IReadOnlyList<IGlobEvaluatable>, IGlobEvalu
         if (line[0] == '#')
             return;
 
-        globs.Add(Glob.Parse(line, GlobOptions.Git));
+        globs.Add(Glob.Parse(line, GlobDialect.Git));
     }
 
     private static ReadOnlySpan<char> TrimGitIgnoreLineEnd(ReadOnlySpan<char> line)
@@ -134,6 +134,7 @@ public sealed class GlobCollection : IReadOnlyList<IGlobEvaluatable>, IGlobEvalu
     bool IGlobEvaluatable.CanMatchFiles => _globs.Any(g => g.Mode is GlobMode.Include && g.CanMatchFiles);
     bool IGlobEvaluatable.CanMatchDirectories => _globs.Any(g => g.Mode is GlobMode.Include && g.CanMatchDirectories);
     bool IGlobEvaluatable.TraverseDirectories => _globs.Any(g => g.Mode is GlobMode.Include && ((IGlobEvaluatable)g).TraverseDirectories);
+    internal bool MatchLeadingDot => _globs.Any(static g => g is Glob { MatchLeadingDot: true } or GlobCollection { MatchLeadingDot: true });
 
     /// <summary>Gets the number of glob patterns in the collection.</summary>
     public int Count => _globs.Length;

--- a/src/Meziantou.Framework.Globbing/GlobDialect.cs
+++ b/src/Meziantou.Framework.Globbing/GlobDialect.cs
@@ -1,0 +1,20 @@
+namespace Meziantou.Framework.Globbing;
+
+/// <summary>Specifies the glob pattern dialect to use when parsing a pattern.</summary>
+public enum GlobDialect
+{
+    /// <summary>Use the default glob pattern syntax.</summary>
+    Standard = 0,
+
+    /// <summary>Use gitignore pattern syntax.</summary>
+    Git = 1,
+
+    /// <summary>Use MSBuild glob pattern syntax.</summary>
+    MSBuild = 2,
+
+    /// <summary>Use POSIX fnmatch pattern syntax without path-separator awareness.</summary>
+    Posix = 3,
+
+    /// <summary>Use POSIX fnmatch pattern syntax where ordinary wildcards do not cross path separators.</summary>
+    PosixPath = 4,
+}

--- a/src/Meziantou.Framework.Globbing/GlobExtensions.cs
+++ b/src/Meziantou.Framework.Globbing/GlobExtensions.cs
@@ -5,7 +5,10 @@ namespace Meziantou.Framework.Globbing;
 /// <summary>Provides extension methods for working with glob patterns.</summary>
 public static class GlobExtensions
 {
-    private static readonly EnumerationOptions DefaultEnumerationOptions = new() { RecurseSubdirectories = true };
+    private static readonly EnumerationOptions DefaultEnumerationOptions = new();
+    private static readonly EnumerationOptions DefaultEnumerationOptionsIncludingHidden = new() { AttributesToSkip = default(FileAttributes) };
+    private static readonly EnumerationOptions DefaultRecursiveEnumerationOptions = new() { RecurseSubdirectories = true };
+    private static readonly EnumerationOptions DefaultRecursiveEnumerationOptionsIncludingHidden = new() { RecurseSubdirectories = true, AttributesToSkip = default(FileAttributes) };
 
     /// <summary>Determines whether the specified path matches the glob pattern.</summary>
     /// <param name="glob">The glob pattern to match against.</param>
@@ -75,10 +78,7 @@ public static class GlobExtensions
         if (!glob.CanMatchFiles)
             yield break;
 
-        if (options is null && glob.TraverseDirectories)
-        {
-            options = DefaultEnumerationOptions;
-        }
+        options ??= GetDefaultEnumerationOptions(glob);
 
         using var enumerator = new GlobFileSystemEnumerator(glob, directory, options);
         while (enumerator.MoveNext())
@@ -92,13 +92,26 @@ public static class GlobExtensions
     /// <returns>An enumerable collection of file system entry paths that match the glob pattern.</returns>
     public static IEnumerable<string> EnumerateFileSystemEntries(this IGlobEvaluatable glob, string directory, EnumerationOptions? options = null)
     {
-        if (options is null && glob.TraverseDirectories)
-        {
-            options = DefaultEnumerationOptions;
-        }
+        options ??= GetDefaultEnumerationOptions(glob);
 
         using var enumerator = new GlobFileSystemEnumerator(glob, directory, options);
         while (enumerator.MoveNext())
             yield return enumerator.Current;
+    }
+
+    private static EnumerationOptions GetDefaultEnumerationOptions(IGlobEvaluatable glob)
+    {
+        return (glob.TraverseDirectories, MatchLeadingDot(glob)) switch
+        {
+            (true, true) => DefaultRecursiveEnumerationOptionsIncludingHidden,
+            (true, false) => DefaultRecursiveEnumerationOptions,
+            (false, true) => DefaultEnumerationOptionsIncludingHidden,
+            (false, false) => DefaultEnumerationOptions,
+        };
+    }
+
+    private static bool MatchLeadingDot(IGlobEvaluatable glob)
+    {
+        return glob is Glob { MatchLeadingDot: true } or GlobCollection { MatchLeadingDot: true };
     }
 }

--- a/src/Meziantou.Framework.Globbing/GlobOptions.cs
+++ b/src/Meziantou.Framework.Globbing/GlobOptions.cs
@@ -10,6 +10,6 @@ public enum GlobOptions
     /// <summary>Perform case-insensitive matching. Only ASCII letters are supported for case-insensitive character ranges.</summary>
     IgnoreCase = 0x1,
 
-    /// <summary>Use gitignore patterns.</summary>
-    Git = 0x2,
+    /// <summary>Allow wildcard patterns to match path segments that start with a dot.</summary>
+    MatchLeadingDot = 0x2,
 }

--- a/src/Meziantou.Framework.Globbing/Internals/GlobParser.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/GlobParser.cs
@@ -8,7 +8,7 @@ internal static class GlobParser
 {
     private static readonly char[] DirectorySeparator = [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar];
 
-    public static bool TryParse(ReadOnlySpan<char> pattern, GlobOptions options, [NotNullWhen(true)] out Glob? result, [NotNullWhen(false)] out string? errorMessage)
+    public static bool TryParse(ReadOnlySpan<char> pattern, GlobDialect dialect, GlobOptions options, [NotNullWhen(true)] out Glob? result, [NotNullWhen(false)] out string? errorMessage)
     {
         result = null;
         if (pattern.IsEmpty)
@@ -17,22 +17,25 @@ internal static class GlobParser
             return false;
         }
 
-        var ignoreCase = options.HasFlag(GlobOptions.IgnoreCase);
+        var settings = new GlobParserSettings(dialect, options);
 
         var exclude = false;
         var segments = new List<Segment>();
+        var matchLeadingDot = new List<bool>();
         List<Segment>? subSegments = null;
         List<string>? setSubsegment = null;
         List<CharacterRange>? rangeSubsegment = null;
         char? rangeStart = null;
         var rangeInverse = false;
+        var currentSegmentMatchLeadingDot = settings.MatchLeadingDot;
 
-        if (options.HasFlag(GlobOptions.Git))
+        if (dialect is GlobDialect.Git)
         {
             // Check if there is a separator at start or middle of the string
             if (pattern[0..^1].IndexOf('/') < 0)
             {
                 segments.Add(RecursiveMatchAllSegment.Instance);
+                matchLeadingDot.Add(settings.MatchLeadingDot);
             }
         }
 
@@ -49,29 +52,37 @@ internal static class GlobParser
                 var c = pattern[i];
                 if (escape)
                 {
-                    currentLiteral.Append(c);
+                    AppendLiteral(ref currentLiteral, ref currentSegmentMatchLeadingDot, subSegments, c, settings.MatchLeadingDot);
                     escape = false;
                     continue;
                 }
 
-                if (c == '!' && i == 0)
+                if (c == '!' && i == 0 && settings.SupportsLeadingExclude)
                 {
                     exclude = true;
                     continue;
                 }
 
+                if (dialect is GlobDialect.MSBuild && TryDecodeMsBuildEscape(pattern, i, out var escapedCharacter))
+                {
+                    AppendLiteral(ref currentLiteral, ref currentSegmentMatchLeadingDot, subSegments, escapedCharacter, settings.MatchLeadingDot);
+                    i += 2;
+                    continue;
+                }
+
                 if (parserContext == GlobParserContext.Segment)
                 {
-                    if (c == '/')
+                    if (settings.IsPatternSeparator(c))
                     {
-                        FinishSegment(segments, ref subSegments, ref currentLiteral, ignoreCase);
+                        FinishSegment(segments, matchLeadingDot, ref subSegments, ref currentLiteral, settings.IgnoreCase, currentSegmentMatchLeadingDot, settings.PathSeparatorAware);
+                        currentSegmentMatchLeadingDot = settings.MatchLeadingDot;
                         continue;
                     }
                     else if (c == '.')
                     {
-                        if (subSegments is null && currentLiteral.Length == 0)
+                        if (settings.NormalizeDotSegments && subSegments is null && currentLiteral.Length == 0)
                         {
-                            if (EndOfSegmentEqual(pattern[i..], ".."))
+                            if (EndOfSegmentEqual(pattern[i..], "..", settings))
                             {
                                 if (segments.Count == 0)
                                 {
@@ -86,11 +97,12 @@ internal static class GlobParser
                                 }
 
                                 segments.RemoveAt(segments.Count - 1);
+                                matchLeadingDot.RemoveAt(matchLeadingDot.Count - 1);
                                 i += 2;
                                 continue;
                             }
 
-                            if (EndOfSegmentEqual(pattern[i..], "."))
+                            if (EndOfSegmentEqual(pattern[i..], ".", settings))
                             {
                                 i += 1;
                                 continue;
@@ -99,29 +111,40 @@ internal static class GlobParser
                     }
                     else if (c == '?')
                     {
-                        AddSubsegment(ref subSegments, ref currentLiteral, ignoreCase, MatchAnyCharacterSegment.Instance);
+                        AddSubsegment(ref subSegments, ref currentLiteral, settings.IgnoreCase, settings.AnyCharacterSegment);
                         continue;
                     }
                     else if (c == '*')
                     {
+                        if (dialect is GlobDialect.MSBuild && i + 1 < pattern.Length && pattern[i + 1] == '*' &&
+                            (subSegments is not null || currentLiteral.Length > 0 || !EndOfSegmentEqual(pattern[i..], "**", settings)))
+                        {
+                            errorMessage = "the recursive wildcard '**' must be its own path segment";
+                            return false;
+                        }
+
                         if (subSegments is null && currentLiteral.Length == 0)
                         {
-                            if (EndOfSegmentEqual(pattern[i..], "**"))
+                            if (settings.SupportsRecursiveWildcard && EndOfSegmentEqual(pattern[i..], "**", settings))
                             {
                                 // Merge two consecutive '**' (**/**)
                                 if (segments.Count == 0 || segments[^1] is not RecursiveMatchAllSegment)
                                 {
                                     segments.Add(RecursiveMatchAllSegment.Instance);
+                                    matchLeadingDot.Add(settings.MatchLeadingDot);
                                 }
 
                                 i += 2;
+                                currentSegmentMatchLeadingDot = settings.MatchLeadingDot;
                                 continue;
                             }
 
-                            if (EndOfSegmentEqual(pattern[i..], "*"))
+                            if (EndOfSegmentEqual(pattern[i..], "*", settings))
                             {
                                 segments.Add(MatchAllSegment.Instance);
+                                matchLeadingDot.Add(currentSegmentMatchLeadingDot);
                                 i += 1;
+                                currentSegmentMatchLeadingDot = settings.MatchLeadingDot;
                                 continue;
                             }
                         }
@@ -130,21 +153,21 @@ internal static class GlobParser
                         if (currentLiteral.Length == 0 && subSegments is not null && subSegments.Count > 0 && subSegments[^1] is MatchAllSubSegment)
                             continue;
 
-                        AddSubsegment(ref subSegments, ref currentLiteral, ignoreCase, MatchAllSubSegment.Instance);
+                        AddSubsegment(ref subSegments, ref currentLiteral, settings.IgnoreCase, MatchAllSubSegment.Instance);
                         continue;
                     }
-                    else if (c == '{') // Start LiteralSet
+                    else if (c == '{' && settings.SupportsLiteralSet) // Start LiteralSet
                     {
                         Debug.Assert(setSubsegment is null);
-                        AddSubsegment(ref subSegments, ref currentLiteral, ignoreCase, subSegment: null);
+                        AddSubsegment(ref subSegments, ref currentLiteral, settings.IgnoreCase, subSegment: null);
                         parserContext = GlobParserContext.LiteralSet;
                         setSubsegment = [];
                         continue;
                     }
-                    else if (c == '[') // Range
+                    else if (c == '[' && dialect is not GlobDialect.MSBuild) // Range
                     {
                         Debug.Assert(rangeSubsegment is null);
-                        AddSubsegment(ref subSegments, ref currentLiteral, ignoreCase, subSegment: null);
+                        AddSubsegment(ref subSegments, ref currentLiteral, settings.IgnoreCase, subSegment: null);
                         parserContext = GlobParserContext.Range;
                         rangeSubsegment = [];
                         rangeInverse = i + 1 < pattern.Length && pattern[i + 1] == '!';
@@ -170,13 +193,13 @@ internal static class GlobParser
                         setSubsegment.Add(currentLiteral.AsSpan().ToString());
                         currentLiteral.Clear();
 
-                        if (setSubsegment.Exists(s => s.IndexOfAny(DirectorySeparator) >= 0))
+                        if (settings.PathSeparatorAware && setSubsegment.Exists(s => s.IndexOfAny(DirectorySeparator) >= 0))
                         {
                             errorMessage = "set contains a path separator";
                             return false;
                         }
 
-                        AddSubsegment(ref subSegments, ref currentLiteral, ignoreCase, new LiteralSetSegment(setSubsegment.ToArray(), ignoreCase));
+                        AddSubsegment(ref subSegments, ref currentLiteral, settings.IgnoreCase, new LiteralSetSegment(setSubsegment.ToArray(), settings.IgnoreCase));
                         setSubsegment = null;
                         parserContext = GlobParserContext.Segment;
                         continue;
@@ -197,13 +220,13 @@ internal static class GlobParser
 
                         if (rangeSubsegment.Count > 0)
                         {
-                            if (rangeSubsegment.Exists(s => s.IsInRange(Path.DirectorySeparatorChar) || s.IsInRange(Path.AltDirectorySeparatorChar)))
+                            if (settings.PathSeparatorAware && rangeSubsegment.Exists(s => s.IsInRange(Path.DirectorySeparatorChar) || s.IsInRange(Path.AltDirectorySeparatorChar)))
                             {
                                 errorMessage = "range contains a path separator";
                                 return false;
                             }
 
-                            AddSubsegment(ref subSegments, ref currentLiteral, ignoreCase, CreateRangeSubsegment(rangeSubsegment, rangeInverse, ignoreCase));
+                            AddSubsegment(ref subSegments, ref currentLiteral, settings.IgnoreCase, CreateRangeSubsegment(rangeSubsegment, rangeInverse, settings.IgnoreCase));
                             rangeSubsegment = null;
                             parserContext = GlobParserContext.Segment;
                             continue;
@@ -241,11 +264,20 @@ internal static class GlobParser
                 switch (c)
                 {
                     case '\\': // Escape next character
-                        escape = true;
+                        if (dialect is GlobDialect.MSBuild)
+                        {
+                            FinishSegment(segments, matchLeadingDot, ref subSegments, ref currentLiteral, settings.IgnoreCase, currentSegmentMatchLeadingDot, settings.PathSeparatorAware);
+                            currentSegmentMatchLeadingDot = settings.MatchLeadingDot;
+                        }
+                        else
+                        {
+                            escape = true;
+                        }
+
                         break;
 
                     default:
-                        currentLiteral.Append(c);
+                        AppendLiteral(ref currentLiteral, ref currentSegmentMatchLeadingDot, subSegments, c, settings.MatchLeadingDot);
                         break;
                 }
             }
@@ -263,26 +295,28 @@ internal static class GlobParser
                 return false;
             }
 
-            FinishSegment(segments, ref subSegments, ref currentLiteral, ignoreCase);
+            FinishSegment(segments, matchLeadingDot, ref subSegments, ref currentLiteral, settings.IgnoreCase, currentSegmentMatchLeadingDot, settings.PathSeparatorAware);
 
-            if (options.HasFlag(GlobOptions.Git))
+            if (dialect is GlobDialect.Git)
             {
                 if (pattern[^1] == '/')
                 {
                     segments.Add(RecursiveMatchAllSegment.Instance);
+                    matchLeadingDot.Add(settings.MatchLeadingDot);
                     segments.Add(MatchAllSegment.Instance);
+                    matchLeadingDot.Add(settings.MatchLeadingDot);
                 }
             }
             else
             {
-                if (pattern[^1] == '/')
+                if (settings.PathSeparatorAware && settings.IsPatternSeparator(pattern[^1]))
                 {
                     matchType = GlobMatchType.Directory;
                 }
             }
 
             errorMessage = null;
-            result = CreateGlob(segments, exclude, ignoreCase, matchType);
+            result = CreateGlob(segments, matchLeadingDot, exclude, settings.IgnoreCase, matchType, settings.MatchLeadingDot, settings.PathSeparatorAware);
             return true;
         }
         finally
@@ -305,7 +339,7 @@ internal static class GlobParser
             }
         }
 
-        static void FinishSegment(List<Segment> segments, ref List<Segment>? subSegments, ref ValueStringBuilder currentLiteral, bool ignoreCase)
+        static void FinishSegment(List<Segment> segments, List<bool> matchLeadingDot, ref List<Segment>? subSegments, ref ValueStringBuilder currentLiteral, bool ignoreCase, bool currentSegmentMatchLeadingDot, bool pathSeparatorAware)
         {
             if (subSegments is not null)
             {
@@ -315,21 +349,23 @@ internal static class GlobParser
                     currentLiteral.Clear();
                 }
 
-                segments.Add(CreateSegment(subSegments, ignoreCase));
+                segments.Add(CreateSegment(subSegments, ignoreCase, pathSeparatorAware));
+                matchLeadingDot.Add(currentSegmentMatchLeadingDot);
                 subSegments = null;
             }
             else if (currentLiteral.Length > 0)
             {
                 segments.Add(new LiteralSegment(currentLiteral.AsSpan().ToString(), ignoreCase));
+                matchLeadingDot.Add(currentSegmentMatchLeadingDot);
                 currentLiteral.Clear();
             }
         }
     }
 
-    private static Glob CreateGlob(List<Segment> segments, bool exclude, bool ignoreCase, GlobMatchType matchType)
+    private static Glob CreateGlob(List<Segment> segments, List<bool> matchLeadingDot, bool exclude, bool ignoreCase, GlobMatchType matchType, bool optimizeRecursiveWildcards, bool pathSeparatorAware)
     {
         // Optimize segments
-        if (segments.Count >= 3)
+        if (optimizeRecursiveWildcards && segments.Count >= 3)
         {
             for (var i = segments.Count - 3; i >= 0; i--)
             {
@@ -358,47 +394,101 @@ internal static class GlobParser
                 if (isFixedSuffix)
                 {
                     segments.RemoveRange(i, suffixLength + 1);
+                    matchLeadingDot.RemoveRange(i, suffixLength + 1);
                     segments.Insert(i, new PathSuffixSegment([.. suffix], ignoreCase));
+                    matchLeadingDot.Insert(i, true);
                     break;
                 }
             }
         }
 
-        if (segments.Count >= 2)
+        if (optimizeRecursiveWildcards && segments.Count >= 2)
         {
             if (segments[^2] is RecursiveMatchAllSegment && segments[^1] is MatchAllSegment) // **/*
             {
                 var lastSegment = MatchNonEmptyTextSegment.Instance;
                 segments.RemoveRange(segments.Count - 2, 2);
+                matchLeadingDot.RemoveRange(matchLeadingDot.Count - 2, 2);
                 segments.Add(lastSegment);
+                matchLeadingDot.Add(true);
             }
             else if (segments[^2] is RecursiveMatchAllSegment && segments[^1] is EndsWithSegment endsWith) // **/*.txt
             {
                 var lastSegment = new MatchAllEndsWithSegment(endsWith.Value, ignoreCase);
                 segments.RemoveRange(segments.Count - 2, 2);
+                matchLeadingDot.RemoveRange(matchLeadingDot.Count - 2, 2);
                 segments.Add(lastSegment);
+                matchLeadingDot.Add(true);
             }
             else if (segments[^2] is RecursiveMatchAllSegment) // **/segment
             {
                 var lastSegment = new LastSegment(segments[^1]);
                 segments.RemoveRange(segments.Count - 2, 2);
+                matchLeadingDot.RemoveRange(matchLeadingDot.Count - 2, 2);
                 segments.Add(lastSegment);
+                matchLeadingDot.Add(true);
             }
         }
 
-        return new Glob([.. segments], exclude ? GlobMode.Exclude : GlobMode.Include, matchType);
+        return new Glob([.. segments], [.. matchLeadingDot], pathSeparatorAware, exclude ? GlobMode.Exclude : GlobMode.Include, matchType);
     }
 
-    private static bool EndOfSegmentEqual(ReadOnlySpan<char> rest, string expected)
+    private static bool EndOfSegmentEqual(ReadOnlySpan<char> rest, string expected, GlobParserSettings settings)
     {
         // Could be "{rest}/" or "{rest}"$
         if (rest.Length == expected.Length)
             return rest.SequenceEqual(expected.AsSpan());
 
         if (rest.Length > expected.Length)
-            return rest.StartsWith(expected.AsSpan(), StringComparison.Ordinal) && rest[expected.Length] == '/';
+            return rest.StartsWith(expected.AsSpan(), StringComparison.Ordinal) && settings.IsPatternSeparator(rest[expected.Length]);
 
         return false;
+    }
+
+    private static void AppendLiteral(ref ValueStringBuilder currentLiteral, ref bool currentSegmentMatchLeadingDot, List<Segment>? subSegments, char c, bool defaultMatchLeadingDot)
+    {
+        if (!defaultMatchLeadingDot && c == '.' && subSegments is null && currentLiteral.Length == 0)
+        {
+            currentSegmentMatchLeadingDot = true;
+        }
+
+        currentLiteral.Append(c);
+    }
+
+    private static bool TryDecodeMsBuildEscape(ReadOnlySpan<char> pattern, int index, out char c)
+    {
+        if (pattern[index] == '%' && index + 2 < pattern.Length && TryGetHexValue(pattern[index + 1], out var high) && TryGetHexValue(pattern[index + 2], out var low))
+        {
+            c = (char)((high * 16) + low);
+            return true;
+        }
+
+        c = '\0';
+        return false;
+
+        static bool TryGetHexValue(char c, out int result)
+        {
+            if (c is >= '0' and <= '9')
+            {
+                result = c - '0';
+                return true;
+            }
+
+            if (c is >= 'a' and <= 'f')
+            {
+                result = c - 'a' + 10;
+                return true;
+            }
+
+            if (c is >= 'A' and <= 'F')
+            {
+                result = c - 'A' + 10;
+                return true;
+            }
+
+            result = 0;
+            return false;
+        }
     }
 
     private static Segment CreateRangeSubsegment(List<CharacterRange> ranges, bool inverse, bool ignoreCase)
@@ -464,7 +554,7 @@ internal static class GlobParser
         };
     }
 
-    private static Segment CreateSegment(List<Segment> parts, bool ignoreCase)
+    private static Segment CreateSegment(List<Segment> parts, bool ignoreCase, bool pathSeparatorAware)
     {
         Debug.Assert(parts.Count > 0);
 
@@ -565,10 +655,13 @@ internal static class GlobParser
 
                     if (nextCharacters is not null)
                     {
-                        nextCharacters.Add(Path.DirectorySeparatorChar);
-                        if (Path.DirectorySeparatorChar != Path.AltDirectorySeparatorChar)
+                        if (pathSeparatorAware)
                         {
-                            nextCharacters.Add(Path.AltDirectorySeparatorChar);
+                            nextCharacters.Add(Path.DirectorySeparatorChar);
+                            if (Path.DirectorySeparatorChar != Path.AltDirectorySeparatorChar)
+                            {
+                                nextCharacters.Add(Path.AltDirectorySeparatorChar);
+                            }
                         }
 
                         parts.Insert(i, new ConsumeSegmentUntilSegment([.. nextCharacters], ignoreCase));
@@ -587,5 +680,36 @@ internal static class GlobParser
             return parts[0];
 
         return new RaggedSegment(parts.ToArray());
+    }
+
+    private readonly struct GlobParserSettings
+    {
+        private readonly GlobDialect _dialect;
+
+        public GlobParserSettings(GlobDialect dialect, GlobOptions options)
+        {
+            _dialect = dialect;
+            IgnoreCase = options.HasFlag(GlobOptions.IgnoreCase);
+            MatchLeadingDot = dialect is GlobDialect.Git or GlobDialect.Posix or GlobDialect.PosixPath || options.HasFlag(GlobOptions.MatchLeadingDot);
+        }
+
+        public bool IgnoreCase { get; }
+        public bool MatchLeadingDot { get; }
+        public bool NormalizeDotSegments => _dialect is not (GlobDialect.Posix or GlobDialect.PosixPath);
+        public bool PathSeparatorAware => _dialect is not GlobDialect.Posix;
+        public bool SupportsLeadingExclude => _dialect is GlobDialect.Standard or GlobDialect.Git;
+        public bool SupportsLiteralSet => _dialect is GlobDialect.Standard or GlobDialect.Git;
+        public bool SupportsRecursiveWildcard => _dialect is GlobDialect.Standard or GlobDialect.Git or GlobDialect.MSBuild;
+        public Segment AnyCharacterSegment => _dialect is GlobDialect.Posix ? MatchAnyTextCharacterSegment.Instance : MatchAnyCharacterSegment.Instance;
+
+        public bool IsPatternSeparator(char c)
+        {
+            return _dialect switch
+            {
+                GlobDialect.Posix => false,
+                GlobDialect.MSBuild => c is '/' or '\\',
+                _ => c == '/',
+            };
+        }
     }
 }

--- a/src/Meziantou.Framework.Globbing/Internals/PathReader.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/PathReader.cs
@@ -8,9 +8,11 @@ internal ref struct PathReader
 {
     private ReadOnlySpan<char> _filename;
     private int _currentSegmentLength;
+    private readonly bool _pathSeparatorAware;
 
-    public PathReader(ReadOnlySpan<char> path, ReadOnlySpan<char> filename, PathItemType? itemType)
+    public PathReader(ReadOnlySpan<char> path, ReadOnlySpan<char> filename, PathItemType? itemType, bool pathSeparatorAware = true)
     {
+        _pathSeparatorAware = pathSeparatorAware;
         if (path.IsEmpty)
         {
             CurrentText = filename;
@@ -65,7 +67,7 @@ internal ref struct PathReader
         {
             if (_currentSegmentLength == int.MinValue)
             {
-                _currentSegmentLength = CurrentText.IndexOfAny(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                _currentSegmentLength = _pathSeparatorAware ? CurrentText.IndexOfAny(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) : -1;
                 if (_currentSegmentLength == -1)
                 {
                     _currentSegmentLength = CurrentText.Length;
@@ -76,7 +78,7 @@ internal ref struct PathReader
         }
     }
 
-    public readonly bool IsEndOfCurrentSegment => CurrentText.IsEmpty || IsPathSeparator(CurrentText[0]);
+    public readonly bool IsEndOfCurrentSegment => CurrentText.IsEmpty || (_pathSeparatorAware && IsPathSeparator(CurrentText[0]));
 
     public readonly ReadOnlySpan<char> LastSegment
     {
@@ -109,6 +111,14 @@ internal ref struct PathReader
 
     public void ConsumeEndOfSegment()
     {
+        if (!_pathSeparatorAware)
+        {
+            CurrentText = _filename;
+            _filename = [];
+            _currentSegmentLength = CurrentText.Length;
+            return;
+        }
+
         if (CurrentText.IsEmpty)
         {
             CurrentText = _filename;
@@ -144,6 +154,14 @@ internal ref struct PathReader
 
     public void ConsumeSegment()
     {
+        if (!_pathSeparatorAware)
+        {
+            CurrentText = _filename;
+            _filename = [];
+            _currentSegmentLength = CurrentText.Length;
+            return;
+        }
+
         var endSegmentIndex = CurrentText.IndexOfAny(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         if (endSegmentIndex == -1)
         {
@@ -212,6 +230,9 @@ internal ref struct PathReader
 
     public readonly bool IsPathSeparator()
     {
+        if (!_pathSeparatorAware)
+            return false;
+
         var c = CurrentText[0];
         return c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
     }

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/MatchAllSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/MatchAllSegment.cs
@@ -10,7 +10,11 @@ internal sealed class MatchAllSegment : Segment
 
     public override bool IsMatch(ref PathReader pathReader)
     {
-        pathReader.ConsumeInSegment(pathReader.CurrentSegmentLength);
+        if (pathReader.CurrentSegmentLength > 0)
+        {
+            pathReader.ConsumeInSegment(pathReader.CurrentSegmentLength);
+        }
+
         return true;
     }
 

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/MatchAnyTextCharacterSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/MatchAnyTextCharacterSegment.cs
@@ -1,0 +1,24 @@
+namespace Meziantou.Framework.Globbing.Internals;
+
+internal sealed class MatchAnyTextCharacterSegment : Segment
+{
+    private MatchAnyTextCharacterSegment()
+    {
+    }
+
+    public static MatchAnyTextCharacterSegment Instance { get; } = new MatchAnyTextCharacterSegment();
+
+    public override bool IsMatch(ref PathReader pathReader)
+    {
+        if (pathReader.IsEndOfPath)
+            return false;
+
+        pathReader.ConsumeInSegment(1);
+        return true;
+    }
+
+    public override string ToString()
+    {
+        return "?";
+    }
+}

--- a/src/Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj
+++ b/src/Meziantou.Framework.Globbing/Meziantou.Framework.Globbing.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Description>A globbing library for .NET. Can be used to match any string or with System.IO.Enumeration.</Description>
-    <Version>4.0.0</Version>
+    <Version>5.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Globbing/readme.md
+++ b/src/Meziantou.Framework.Globbing/readme.md
@@ -22,7 +22,7 @@ dotnet package add Meziantou.Framework.Globbing
 - `IsMatch` tests whether a file matches the glob pattern
 
     ````csharp
-    Glob glob = Glob.Parse("src/**/*.txt", GlobOptions.IgnoreCase);
+    Glob glob = Glob.Parse("src/**/*.txt", GlobDialect.Standard, GlobOptions.IgnoreCase);
     glob.IsMatch("src/abc.txt");
     ````
 
@@ -30,7 +30,7 @@ dotnet package add Meziantou.Framework.Globbing
 
     ````csharp
     // Enumerate files that match the glob in the folder rootDirectory
-    Glob glob = Glob.Parse("src/**/*.txt", GlobOptions.None);
+    Glob glob = Glob.Parse("src/**/*.txt", GlobDialect.Standard);
     foreach(var file in glob.EnumerateFiles("rootDirectory"))
     {
         Console.WriteLine(file);

--- a/src/Meziantou.Framework.Html.Tool/Program.cs
+++ b/src/Meziantou.Framework.Html.Tool/Program.cs
@@ -66,7 +66,7 @@ internal static class Program
 
         if (!string.IsNullOrEmpty(globPattern))
         {
-            if (!Glob.TryParse(globPattern, GlobOptions.None, out var glob))
+            if (!Glob.TryParse(globPattern, GlobDialect.Standard, GlobOptions.None, out var glob))
             {
                 await Console.Error.WriteLineAsync($"Glob pattern '{globPattern}' is invalid");
                 return -1;
@@ -127,7 +127,7 @@ internal static class Program
 
             if (!string.IsNullOrEmpty(filePattern))
             {
-                if (!Glob.TryParse(filePattern, GlobOptions.None, out var glob))
+                if (!Glob.TryParse(filePattern, GlobDialect.Standard, GlobOptions.None, out var glob))
                 {
                     await Console.Error.WriteLineAsync($"Glob pattern '{filePattern}' is invalid".AsMemory(), cancellationToken);
                     return -1;
@@ -282,7 +282,7 @@ internal static class Program
 
             if (!string.IsNullOrEmpty(filePattern))
             {
-                if (!Glob.TryParse(filePattern, GlobOptions.None, out var glob))
+                if (!Glob.TryParse(filePattern, GlobDialect.Standard, GlobOptions.None, out var glob))
                 {
                     await Console.Error.WriteLineAsync($"Glob pattern '{filePattern}' is invalid".AsMemory(), cancellationToken);
                     return -1;

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
@@ -110,7 +110,7 @@ public sealed class DependencyScannerTests
         var file1 = directory.CreateEmptyFile($"packages.json");
         var file2 = directory.CreateEmptyFile($"node_modules/packages.json");
 
-        var globs = new GlobCollection(Glob.Parse("**/*", GlobOptions.None), Glob.Parse("!**/node_modules/**/*", GlobOptions.None));
+        var globs = new GlobCollection(Glob.Parse("**/*", GlobDialect.Standard), Glob.Parse("!**/node_modules/**/*", GlobDialect.Standard));
         var options = new ScannerOptions()
         {
             RecurseSubdirectories = true,

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -886,7 +886,7 @@ jobs:
         AddFile("custom/sample.yml", Original);
         var result = await GetDependencies<RegexScanner>([new RegexScanner()
         {
-            FilePatterns = new GlobCollection(Glob.Parse("**/*", GlobOptions.None)),
+            FilePatterns = new GlobCollection(Glob.Parse("**/*", GlobDialect.Standard)),
             DependencyType = DependencyType.DockerImage,
             Regex = DockerImageWithVersionRegex(),
         }]);
@@ -916,7 +916,7 @@ jobs:
         AddFile("custom/sample.yml", Original);
         var result = await GetDependencies<RegexScanner>([new RegexScanner()
         {
-            FilePatterns = new GlobCollection(Glob.Parse("**/*", GlobOptions.None)),
+            FilePatterns = new GlobCollection(Glob.Parse("**/*", GlobDialect.Standard)),
             DependencyType = DependencyType.DockerImage,
             Regex = DockerImageWithOptionalVersionRegex(),
         }]);

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobCollectionTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobCollectionTests.cs
@@ -4,8 +4,8 @@ public sealed class GlobCollectionTests
     [Fact]
     public void CanUseCollectionInitializer()
     {
-        var a = Glob.Parse("a", GlobOptions.None);
-        var b = Glob.Parse("b", GlobOptions.None);
+        var a = Glob.Parse("a", GlobDialect.Standard);
+        var b = Glob.Parse("b", GlobDialect.Standard);
 
         GlobCollection globs = [a, b];
         Assert.Collection(globs,

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
@@ -7,13 +7,13 @@ public class GlobParserTests
 {
     private static Segment[] GetSegments(string pattern)
     {
-        var glob = Glob.Parse(pattern, GlobOptions.None);
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
         return glob._segments;
     }
 
     private static Segment[] GetSubSegments(string pattern)
     {
-        var glob = Glob.Parse(pattern, GlobOptions.None);
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
         Assert.All(glob._segments, item => Assert.IsType<RaggedSegment>(item));
         return ((RaggedSegment)glob._segments[0])._segments;
     }
@@ -22,7 +22,7 @@ public class GlobParserTests
     [InlineData("*")]
     public void ValidPatterns(string content)
     {
-        Glob.Parse(content, GlobOptions.None);
+        Glob.Parse(content, GlobDialect.Standard);
     }
 
     [Theory]
@@ -30,7 +30,7 @@ public class GlobParserTests
     [InlineData("")]
     public void InvalidPatterns(string? content)
     {
-        Assert.Throws<ArgumentException>(() => Glob.Parse(content!, GlobOptions.None));
+        Assert.Throws<ArgumentException>(() => Glob.Parse(content!, GlobDialect.Standard));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
@@ -16,10 +16,10 @@ public class GlobTests
     [InlineData("a{a,/}b")] // literal contains '/'
     public void ParseInvalid(string pattern)
     {
-        Assert.False(Glob.TryParse(pattern, GlobOptions.None, out var result));
+        Assert.False(Glob.TryParse(pattern, GlobDialect.Standard, GlobOptions.None, out var result));
         Assert.Null(result);
 
-        Assert.Throws<ArgumentException>(() => Glob.Parse(pattern, GlobOptions.None));
+        Assert.Throws<ArgumentException>(() => Glob.Parse(pattern, GlobDialect.Standard));
     }
 
     [Theory]
@@ -33,8 +33,8 @@ public class GlobTests
     [InlineData("!test/**/a*.txt", "test/a/b/c/d")]
     public void ShouldRecurse(string pattern, string folderPath)
     {
-        var glob = Glob.Parse(pattern, GlobOptions.None);
-        var globi = Glob.Parse(pattern, GlobOptions.IgnoreCase);
+        var glob = Glob.Parse(pattern, GlobDialect.Standard);
+        var globi = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.IgnoreCase);
         Assert.True(glob.IsPartialMatch(folderPath));
         Assert.True(globi.IsPartialMatch(folderPath));
     }
@@ -45,8 +45,8 @@ public class GlobTests
     [InlineData("test/**/a*.txt", "titi/b/c/d")]
     public void ShouldNotRecurse(string pattern, string folderPath)
     {
-        var glob = Glob.Parse(pattern, GlobOptions.None);
-        var globi = Glob.Parse(pattern, GlobOptions.IgnoreCase);
+        var glob = Glob.Parse(pattern, GlobDialect.Standard);
+        var globi = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.IgnoreCase);
         Assert.False(glob.IsPartialMatch(folderPath));
         Assert.False(globi.IsPartialMatch(folderPath));
     }
@@ -55,7 +55,6 @@ public class GlobTests
     [InlineData("a/b", "a/b")]
     [InlineData("a?c", "abc")]
     [InlineData("a?c", "adc")]
-    [InlineData("*.txt", ".txt")]
     [InlineData("*.txt", "test.txt")]
     [InlineData(".*", ".gitignore")]
     [InlineData("*.*", "a.txt")]
@@ -166,8 +165,8 @@ public class GlobTests
         var fileName = Path.GetFileName(pathWithoutEndingSlash);
         var itemType = isDirectory ? PathItemType.Directory : PathItemType.File;
 
-        var glob = Glob.Parse(pattern, GlobOptions.None);
-        var globi = Glob.Parse(pattern, GlobOptions.IgnoreCase);
+        var glob = Glob.Parse(pattern, GlobDialect.Standard);
+        var globi = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.IgnoreCase);
         Assert.True(glob.IsMatch(path));
         Assert.True(glob.IsMatch(directoryName, fileName, itemType));
         Assert.True(globi.IsMatch(path));
@@ -185,7 +184,6 @@ public class GlobTests
     [Theory]
     [InlineData("a?c", "a?C")]
     [InlineData("a?c", "adC")]
-    [InlineData("*.txt", ".Txt")]
     [InlineData("*.txt", "test.Txt")]
     [InlineData(".*", ".GitIgnore")]
     [InlineData("!*.txt", "A.TXT")]
@@ -233,7 +231,44 @@ public class GlobTests
     [InlineData("*abc", "ZABC")]
     public void MatchIgnoreCase(string pattern, string path)
     {
-        var glob = Glob.Parse(pattern, GlobOptions.IgnoreCase);
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.IgnoreCase);
+        Assert.True(glob.IsMatch(path));
+        Assert.True(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
+    }
+
+    [Theory]
+    [InlineData("*", ".hidden")]
+    [InlineData("?", ".")]
+    [InlineData("[.]", ".")]
+    [InlineData("**/*.txt", ".hidden/test.txt")]
+    [InlineData("**/*.txt", "src/.hidden/test.txt")]
+    public void DoesNotMatchLeadingDotByDefault(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard);
+        Assert.False(glob.IsMatch(path));
+        Assert.False(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
+    }
+
+    [Theory]
+    [InlineData("*", ".hidden")]
+    [InlineData("?", ".")]
+    [InlineData("[.]", ".")]
+    [InlineData("**/*.txt", ".hidden/test.txt")]
+    [InlineData("**/*.txt", "src/.hidden/test.txt")]
+    public void MatchLeadingDotOption(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.True(glob.IsMatch(path));
+        Assert.True(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
+    }
+
+    [Theory]
+    [InlineData(".*", ".hidden")]
+    [InlineData("**/.hidden/*.txt", ".hidden/test.txt")]
+    [InlineData("**/.hidden/*.txt", "src/.hidden/test.txt")]
+    public void MatchExplicitLeadingDot(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard);
         Assert.True(glob.IsMatch(path));
         Assert.True(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
     }
@@ -294,8 +329,8 @@ public class GlobTests
         var fileName = Path.GetFileName(pathWithoutEndingSlash);
         var itemType = isDirectory ? PathItemType.Directory : PathItemType.File;
 
-        var glob = Glob.Parse(pattern, GlobOptions.None);
-        var globi = Glob.Parse(pattern, GlobOptions.IgnoreCase);
+        var glob = Glob.Parse(pattern, GlobDialect.Standard);
+        var globi = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.IgnoreCase);
         Assert.False(glob.IsMatch(path));
         Assert.False(glob.IsMatch(directoryName, fileName, itemType));
         Assert.False(globi.IsMatch(path));
@@ -323,7 +358,7 @@ public class GlobTests
         var fileName = Path.GetFileName(pathWithoutEndingSlash);
         var itemType = isDirectory ? PathItemType.Directory : PathItemType.File;
 
-        var glob = Glob.Parse(pattern, GlobOptions.None);
+        var glob = Glob.Parse(pattern, GlobDialect.Standard);
         Assert.True(glob.IsMatch(path));
         Assert.True(glob.IsMatch(directoryName, fileName, itemType));
     }
@@ -351,7 +386,7 @@ public class GlobTests
         var fileName = Path.GetFileName(pathWithoutEndingSlash);
         var itemType = isDirectory ? PathItemType.Directory : PathItemType.File;
 
-        var glob = Glob.Parse(pattern, GlobOptions.None);
+        var glob = Glob.Parse(pattern, GlobDialect.Standard);
         Assert.False(glob.IsMatch(path));
         Assert.False(glob.IsMatch(directoryName, fileName, itemType));
     }
@@ -367,7 +402,7 @@ public class GlobTests
     [InlineData("range/[a-b][C-D]", "range/BD")]
     public void DoesNotMatch_CaseSensitive(string pattern, string path)
     {
-        var glob = Glob.Parse(pattern, GlobOptions.None);
+        var glob = Glob.Parse(pattern, GlobDialect.Standard);
         Assert.False(glob.IsMatch(path));
         Assert.False(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
     }
@@ -383,7 +418,7 @@ public class GlobTests
         directory.CreateEmptyFile("d1/f3.txt");
         directory.CreateEmptyFile("d1/f3.png");
 
-        var glob = Glob.Parse("**/*.txt", options);
+        var glob = Glob.Parse("**/*.txt", GlobDialect.Standard, options);
 
         AssertEnumerateFiles(directory, glob, ["d1/d2/f1.txt", "d1/d2/f2.txt", "d1/f3.txt"]);
     }
@@ -398,7 +433,7 @@ public class GlobTests
         directory.CreateEmptyFile("d1/d2/f2.txt");
         directory.CreateEmptyFile("d1/f3.txt");
 
-        var glob = Glob.Parse("d1/*.txt", options);
+        var glob = Glob.Parse("d1/*.txt", GlobDialect.Standard, options);
         AssertEnumerateFiles(directory, glob, ["d1/f3.txt"]);
     }
 
@@ -412,7 +447,7 @@ public class GlobTests
         directory.CreateEmptyFile("d1/d2/f2.txt");
         directory.CreateEmptyFile("d1/f3.txt");
 
-        var glob = Glob.Parse("d1/*.txt", options);
+        var glob = Glob.Parse("d1/*.txt", GlobDialect.Standard, options);
         AssertEnumerateFileSystemEntries(directory, glob, ["d1/f3.txt"]);
     }
 
@@ -427,7 +462,7 @@ public class GlobTests
         directory.CreateEmptyFile("d1/d3/f2.txt");
         directory.CreateEmptyFile("d1/f3.txt");
 
-        var glob = Glob.Parse("d1/*/", options);
+        var glob = Glob.Parse("d1/*/", GlobDialect.Standard, options);
         AssertEnumerateFileSystemEntries(directory, glob, ["d1/d2", "d1/d3"]);
     }
 
@@ -443,8 +478,8 @@ public class GlobTests
         directory.CreateEmptyFile("d3/f4.txt");
 
         var glob = new GlobCollection(
-            Glob.Parse("**/*.txt", options),
-            Glob.Parse("!d1/*.txt", options));
+            Glob.Parse("**/*.txt", GlobDialect.Standard, options),
+            Glob.Parse("!d1/*.txt", GlobDialect.Standard, options));
 
         AssertEnumerateFiles(directory, glob,
         [
@@ -463,9 +498,9 @@ public class GlobTests
         directory.CreateEmptyFile("System Volume Information/f2.txt");
 
         var glob = new GlobCollection(
-            Glob.Parse("**/*.txt", GlobOptions.IgnoreCase),
-            Glob.Parse("!*/System Volume Information/", GlobOptions.IgnoreCase),
-            Glob.Parse("!*/System Volume Information/**/*", GlobOptions.IgnoreCase));
+            Glob.Parse("**/*.txt", GlobDialect.Standard, GlobOptions.IgnoreCase),
+            Glob.Parse("!*/System Volume Information/", GlobDialect.Standard, GlobOptions.IgnoreCase),
+            Glob.Parse("!*/System Volume Information/**/*", GlobDialect.Standard, GlobOptions.IgnoreCase));
 
         Assert.True(glob.IsMatch("System Volume Information/f1.txt"));
         AssertEnumerateFiles(directory, glob,
@@ -484,9 +519,9 @@ public class GlobTests
         directory.CreateEmptyFile("System Volume Information/f2.txt");
 
         var glob = new GlobCollection(
-            Glob.Parse("**/*.txt", GlobOptions.IgnoreCase),
-            Glob.Parse("!System Volume Information/", GlobOptions.IgnoreCase),
-            Glob.Parse("!System Volume Information/**/*", GlobOptions.IgnoreCase));
+            Glob.Parse("**/*.txt", GlobDialect.Standard, GlobOptions.IgnoreCase),
+            Glob.Parse("!System Volume Information/", GlobDialect.Standard, GlobOptions.IgnoreCase),
+            Glob.Parse("!System Volume Information/**/*", GlobDialect.Standard, GlobOptions.IgnoreCase));
 
         Assert.False(glob.IsMatch("System Volume Information/f1.txt"));
 
@@ -509,10 +544,10 @@ public class GlobTests
         directory.CreateEmptyFile("d3/f5.txt");
 
         var glob = new GlobCollection(
-            Glob.Parse("**/*", options),
-            Glob.Parse("**/*/", options),
-            Glob.Parse("!d1/*.txt", options),
-            Glob.Parse("!d1/d1.2/", options));
+            Glob.Parse("**/*", GlobDialect.Standard, options),
+            Glob.Parse("**/*/", GlobDialect.Standard, options),
+            Glob.Parse("!d1/*.txt", GlobDialect.Standard, options),
+            Glob.Parse("!d1/d1.2/", GlobDialect.Standard, options));
 
         AssertEnumerateFileSystemEntries(directory, glob,
         [
@@ -525,6 +560,18 @@ public class GlobTests
             "d3/f5.txt",
         ]);
     }
+
+    [Fact]
+    public void EnumerateFiles_LeadingDot()
+    {
+        using var directory = TemporaryDirectory.Create();
+        directory.CreateEmptyFile(".hidden/f1.txt");
+        directory.CreateEmptyFile("visible/f2.txt");
+
+        AssertEnumerateFiles(directory, Glob.Parse("**/*.txt", GlobDialect.Standard), ["visible/f2.txt"]);
+        AssertEnumerateFiles(directory, Glob.Parse("**/*.txt", GlobDialect.Standard, GlobOptions.MatchLeadingDot), [".hidden/f1.txt", "visible/f2.txt"]);
+    }
+
     [Theory]
     [InlineData("readme.md", "readme.md")]
     [InlineData("readme.md", "a/readme.md")]
@@ -539,8 +586,8 @@ public class GlobTests
     [InlineData("a/**/?.txt", "a/c/d/b.txt")]
     public void MatchGit(string pattern, string path)
     {
-        var glob = Glob.Parse(pattern, GlobOptions.Git);
-        var globi = Glob.Parse(pattern, GlobOptions.IgnoreCase | GlobOptions.Git);
+        var glob = Glob.Parse(pattern, GlobDialect.Git);
+        var globi = Glob.Parse(pattern, GlobDialect.Git, GlobOptions.IgnoreCase);
         Assert.True(glob.IsMatch(path));
         Assert.True(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
         Assert.True(globi.IsMatch(path));
@@ -556,6 +603,17 @@ public class GlobTests
     }
 
     [Theory]
+    [InlineData("*", ".hidden")]
+    [InlineData("**/*.txt", ".hidden/test.txt")]
+    [InlineData("**/*.txt", "src/.hidden/test.txt")]
+    public void MatchGitLeadingDot(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Git);
+        Assert.True(glob.IsMatch(path));
+        Assert.True(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
+    }
+
+    [Theory]
     [InlineData("**/.*", "foobar.")]
     [InlineData("a/", "sample")]
     [InlineData("a/", "b/a")]
@@ -565,8 +623,8 @@ public class GlobTests
     [InlineData("a/*", "a/b/c.txt")]
     public void DoesNotMatchGit(string pattern, string path)
     {
-        var glob = Glob.Parse(pattern, GlobOptions.Git);
-        var globi = Glob.Parse(pattern, GlobOptions.IgnoreCase | GlobOptions.Git);
+        var glob = Glob.Parse(pattern, GlobDialect.Git);
+        var globi = Glob.Parse(pattern, GlobDialect.Git, GlobOptions.IgnoreCase);
         Assert.False(glob.IsMatch(path));
         Assert.False(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
         Assert.False(globi.IsMatch(path));
@@ -591,7 +649,7 @@ public class GlobTests
         var fileName = Path.GetFileName(pathWithoutEndingSlash);
         var itemType = isDirectory ? PathItemType.Directory : PathItemType.File;
 
-        var glob = Glob.Parse(pattern, GlobOptions.Git);
+        var glob = Glob.Parse(pattern, GlobDialect.Git);
         Assert.True(glob.IsMatch(path));
         Assert.True(glob.IsMatch(directoryName, fileName, itemType));
     }
@@ -612,9 +670,86 @@ public class GlobTests
         var fileName = Path.GetFileName(pathWithoutEndingSlash);
         var itemType = isDirectory ? PathItemType.Directory : PathItemType.File;
 
-        var glob = Glob.Parse(pattern, GlobOptions.Git);
+        var glob = Glob.Parse(pattern, GlobDialect.Git);
         Assert.False(glob.IsMatch(path));
         Assert.False(glob.IsMatch(directoryName, fileName, itemType));
+    }
+
+    [Theory]
+    [InlineData("**/*.cs", "src/Program.cs")]
+    [InlineData(@"src\**\*.cs", "src/Generated/Program.cs")]
+    [InlineData(@"src\*.cs", "src/Program.cs")]
+    [InlineData("%2A.cs", "*.cs")]
+    [InlineData("%3F.cs", "?.cs")]
+    [InlineData("[abc].cs", "[abc].cs")]
+    [InlineData("{a,b}.cs", "{a,b}.cs")]
+    [InlineData("!file.cs", "!file.cs")]
+    public void MatchMSBuild(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.MSBuild);
+        Assert.True(glob.IsMatch(path));
+        Assert.True(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
+    }
+
+    [Theory]
+    [InlineData("a**")]
+    [InlineData("**a")]
+    [InlineData("a**b")]
+    public void MSBuildRecursiveWildcardMustBeAPathSegment(string pattern)
+    {
+        Assert.False(Glob.TryParse(pattern, GlobDialect.MSBuild, GlobOptions.None, out var result));
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("*", "src/Program.cs")]
+    [InlineData("a?b", "a/b")]
+    [InlineData("a[/]b", "a/b")]
+    [InlineData("**", "src/Program.cs")]
+    [InlineData("*.cs", "src/Program.cs")]
+    [InlineData("!file.cs", "!file.cs")]
+    [InlineData("{a,b}.cs", "{a,b}.cs")]
+    [InlineData("*", ".hidden")]
+    public void MatchPosix(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Posix);
+        Assert.True(glob.IsMatch(path));
+        Assert.True(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
+    }
+
+    [Theory]
+    [InlineData("*", "src/Program.cs")]
+    [InlineData("a?b", "a/b")]
+    [InlineData("**", "src/Program.cs")]
+    [InlineData("*.cs", "src/Program.cs")]
+    public void DoesNotMatchPosixPathAcrossPathSeparators(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.PosixPath);
+        Assert.False(glob.IsMatch(path));
+        Assert.False(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
+    }
+
+    [Theory]
+    [InlineData("src/*.cs", "src/Program.cs")]
+    [InlineData("src/?/Program.cs", "src/a/Program.cs")]
+    [InlineData("!file.cs", "!file.cs")]
+    [InlineData("{a,b}.cs", "{a,b}.cs")]
+    [InlineData("*", ".hidden")]
+    public void MatchPosixPath(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.PosixPath);
+        Assert.True(glob.IsMatch(path));
+        Assert.True(glob.IsMatch(Path.GetDirectoryName(path)!, Path.GetFileName(path)));
+    }
+
+    [Fact]
+    public void EnumerateFiles_PosixMatchesAcrossPathSeparators()
+    {
+        using var directory = TemporaryDirectory.Create();
+        directory.CreateEmptyFile("Program.cs");
+        directory.CreateEmptyFile("src/Program.cs");
+
+        AssertEnumerateFiles(directory, Glob.Parse("*.cs", GlobDialect.Posix), ["Program.cs", "src/Program.cs"]);
     }
 
     private static void AssertEnumerateFiles(TemporaryDirectory directory, IGlobEvaluatable glob, string[] expectedResult)


### PR DESCRIPTION
## Summary

- Separate glob syntax dialects from matching options
- Refine glob parsing and path matching behavior
- Update glob APIs, documentation, generated references, and dependent scanners/tools
- Expand glob and dependency-scanning test coverage

## Testing

Not run (not requested).