### PR TITLE
Start Windows processes suspended before applying limits

### DIFF
--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -459,17 +459,17 @@ public sealed class ProcessWrapper
         var processFileName = startInfo.FileName;
         var arguments = (IReadOnlyList<string>)[.. startInfo.ArgumentList];
 
-        var processFactory = _processFactory ?? DefaultProcessFactory;
-        var processHandle = processFactory.Create(startInfo);
         var processLimiter = CreateProcessLimiter();
 #if NET11_0_OR_GREATER
         var shouldResumeProcess = false;
-        if (processLimiter is WindowsProcessLimiter && OperatingSystem.IsWindows())
+        if (processLimiter is not null && (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()))
         {
             startInfo.StartSuspended = true;
             shouldResumeProcess = true;
         }
 #endif
+        var processFactory = _processFactory ?? DefaultProcessFactory;
+        var processHandle = processFactory.Create(startInfo);
 
         var processStarted = false;
         try
@@ -482,7 +482,7 @@ public sealed class ProcessWrapper
             processStarted = true;
             processLimiter?.Apply(processHandle);
 #if NET11_0_OR_GREATER
-            if (shouldResumeProcess && OperatingSystem.IsWindows())
+            if (shouldResumeProcess && (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()))
             {
                 var safeProcessHandle = processHandle.SafeProcessHandle
                     ?? throw new InvalidOperationException("Cannot resume the process because the process safe handle is not available.");

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -462,6 +462,14 @@ public sealed class ProcessWrapper
         var processFactory = _processFactory ?? DefaultProcessFactory;
         var processHandle = processFactory.Create(startInfo);
         var processLimiter = CreateProcessLimiter();
+#if NET11_0_OR_GREATER
+        var shouldResumeProcess = false;
+        if (processLimiter is WindowsProcessLimiter && OperatingSystem.IsWindows())
+        {
+            startInfo.StartSuspended = true;
+            shouldResumeProcess = true;
+        }
+#endif
 
         var processStarted = false;
         try
@@ -473,6 +481,14 @@ public sealed class ProcessWrapper
 
             processStarted = true;
             processLimiter?.Apply(processHandle);
+#if NET11_0_OR_GREATER
+            if (shouldResumeProcess && OperatingSystem.IsWindows())
+            {
+                var safeProcessHandle = processHandle.SafeProcessHandle
+                    ?? throw new InvalidOperationException("Cannot resume the process because the process safe handle is not available.");
+                safeProcessHandle.Resume();
+            }
+#endif
         }
         catch
         {


### PR DESCRIPTION
## Summary

- Start Windows processes suspended when applying Windows process limits.
- Resume the process after limits are applied.
- Target the behavior to .NET 11 or later on Windows.

## Testing

- Not run (not requested)