### PR TITLE
Remove NuGetAuditSuppress entry

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,8 +47,4 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Removed NuGetAuditSuppress for GHSA-2m69-gcr7-jv3q.