### PR TITLE
Expose .NET 11 process lifecycle features

### DIFF
--- a/ref/Meziantou.Framework.ProcessWrapper.cs
+++ b/ref/Meziantou.Framework.ProcessWrapper.cs
@@ -136,6 +136,12 @@ namespace Meziantou.Framework
         public System.Runtime.CompilerServices.ConfiguredTaskAwaitable<Meziantou.Framework.ProcessResult> ConfigureAwait(bool continueOnCapturedContext) => throw null;
         public System.Runtime.CompilerServices.ConfiguredTaskAwaitable<Meziantou.Framework.ProcessResult> ConfigureAwait(System.Threading.Tasks.ConfigureAwaitOptions options) => throw null;
         public void Kill(bool entireProcessTree = true) { }
+        #if NET11_0
+        [System.Runtime.Versioning.UnsupportedOSPlatform("ios")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
+        [System.Runtime.Versioning.SupportedOSPlatform("maccatalyst")]
+        public bool Signal(System.Runtime.InteropServices.PosixSignal signal) => throw null;
+        #endif
     }
 
     public sealed class ProcessLimits
@@ -232,6 +238,16 @@ namespace Meziantou.Framework
         public Meziantou.Framework.ProcessWrapper WithCredentials(string userName, System.Security.SecureString password, string? domain = null) => throw null;
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
         public Meziantou.Framework.ProcessWrapper WithUseCredentialsForNetworkingOnly(bool useCredentialsForNetworkingOnly = true) => throw null;
+        #if NET11_0
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        [System.Runtime.Versioning.SupportedOSPlatform("linux")]
+        [System.Runtime.Versioning.SupportedOSPlatform("android")]
+        public Meziantou.Framework.ProcessWrapper WithKillOnParentExit(bool killOnParentExit = true) => throw null;
+        public Meziantou.Framework.ProcessWrapper WithStartDetached(bool startDetached = true) => throw null;
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        [System.Runtime.Versioning.SupportedOSPlatform("macos")]
+        public Meziantou.Framework.ProcessWrapper WithStartSuspended(bool startSuspended = true) => throw null;
+        #endif
         public Meziantou.Framework.ProcessWrapper WithEnvironmentVariables(System.Action<Meziantou.Framework.ProcessWrapperEnvironmentVariables> configure) => throw null;
         public Meziantou.Framework.ProcessWrapper WithEnvironmentVariables(System.Collections.Generic.IReadOnlyDictionary<string, string?> variables) => throw null;
         public Meziantou.Framework.ProcessWrapper WithValidation(Meziantou.Framework.ProcessValidationMode mode) => throw null;
@@ -252,6 +268,12 @@ namespace Meziantou.Framework
         public Meziantou.Framework.ProcessWrapper WithInputStream(Meziantou.Framework.InputSource source) => throw null;
         public Meziantou.Framework.ProcessInstance ExecuteAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public Meziantou.Framework.BufferedProcessInstance ExecuteBufferedAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
+        #if NET11_0
+        [System.Runtime.Versioning.UnsupportedOSPlatform("ios")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
+        [System.Runtime.Versioning.SupportedOSPlatform("maccatalyst")]
+        public int StartAndForget() => throw null;
+        #endif
     }
 
     public sealed class ProcessWrapperEnvironmentVariables

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessInstance.cs
@@ -1,6 +1,10 @@
 using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Runtime.CompilerServices;
+#if NET11_0_OR_GREATER
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+#endif
 using Microsoft.Win32.SafeHandles;
 
 namespace Meziantou.Framework;
@@ -85,6 +89,21 @@ public class ProcessInstance
 
         KillProcess(process, entireProcessTree);
     }
+
+#if NET11_0_OR_GREATER
+    /// <summary>Sends a signal to the process.</summary>
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [SupportedOSPlatform("maccatalyst")]
+    public bool Signal(PosixSignal signal)
+    {
+        var processHandle = UnsafeGetProcessHandle();
+        if (processHandle is null)
+            throw new InvalidOperationException("Cannot signal the process because the process safe handle is not available.");
+
+        return processHandle.Signal(signal);
+    }
+#endif
 
     internal static void KillProcess(IProcessHandle process, bool entireProcessTree)
     {

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -33,6 +33,7 @@ public sealed class ProcessWrapper
     private ProcessLimits? _limits;
     private Action<JobObject>? _windowsJobObjectConfiguration;
     private Action<CGroup2>? _linuxControlGroupConfiguration;
+    private bool _validationModeConfigured;
 
     private ProcessWrapper(string fileName)
     {
@@ -59,6 +60,7 @@ public sealed class ProcessWrapper
         _limits = other._limits;
         _windowsJobObjectConfiguration = other._windowsJobObjectConfiguration;
         _linuxControlGroupConfiguration = other._linuxControlGroupConfiguration;
+        _validationModeConfigured = other._validationModeConfigured;
         _processFactory = other._processFactory;
         _processWrapperInterceptors = other._processWrapperInterceptors;
         _processStartInfoInterceptors = other._processStartInfoInterceptors;
@@ -136,6 +138,19 @@ public sealed class ProcessWrapper
         }
 
         CopyWindowsStartInfoCredentials(source, startInfo);
+#if NET11_0_OR_GREATER
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux() || OperatingSystem.IsAndroid())
+        {
+            startInfo.KillOnParentExit = source.KillOnParentExit;
+        }
+
+        startInfo.StartDetached = source.StartDetached;
+
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+        {
+            startInfo.StartSuspended = source.StartSuspended;
+        }
+#endif
 
         return startInfo;
     }
@@ -248,6 +263,34 @@ public sealed class ProcessWrapper
         return this;
     }
 
+#if NET11_0_OR_GREATER
+    /// <summary>Sets whether the child process should be killed when the parent process exits.</summary>
+    [SupportedOSPlatform("windows")]
+    [SupportedOSPlatform("linux")]
+    [SupportedOSPlatform("android")]
+    public ProcessWrapper WithKillOnParentExit(bool killOnParentExit = true)
+    {
+        _startInfo.KillOnParentExit = killOnParentExit;
+        return this;
+    }
+
+    /// <summary>Sets whether the child process should be detached from the parent process.</summary>
+    public ProcessWrapper WithStartDetached(bool startDetached = true)
+    {
+        _startInfo.StartDetached = startDetached;
+        return this;
+    }
+
+    /// <summary>Sets whether the child process should start in a suspended state.</summary>
+    [SupportedOSPlatform("windows")]
+    [SupportedOSPlatform("macos")]
+    public ProcessWrapper WithStartSuspended(bool startSuspended = true)
+    {
+        _startInfo.StartSuspended = startSuspended;
+        return this;
+    }
+#endif
+
     /// <summary>Configures environment variables using a callback. Accumulates with previous calls.</summary>
     public ProcessWrapper WithEnvironmentVariables(Action<ProcessWrapperEnvironmentVariables> configure)
     {
@@ -279,6 +322,7 @@ public sealed class ProcessWrapper
     public ProcessWrapper WithValidation(ProcessValidationMode mode)
     {
         _validationMode = mode;
+        _validationModeConfigured = true;
         return this;
     }
 
@@ -438,6 +482,38 @@ public sealed class ProcessWrapper
             cancellationToken);
     }
 
+#if NET11_0_OR_GREATER
+    /// <summary>Starts the process without tracking it and returns its process ID.</summary>
+    [UnsupportedOSPlatform("ios")]
+    [UnsupportedOSPlatform("tvos")]
+    [SupportedOSPlatform("maccatalyst")]
+    public int StartAndForget()
+    {
+        ApplyProcessWrapperInterceptors();
+
+        if (!_outputTargets.IsEmpty)
+            throw new InvalidOperationException("Output streams cannot be configured when starting a process without tracking it.");
+
+        if (!_errorTargets.IsEmpty)
+            throw new InvalidOperationException("Error streams cannot be configured when starting a process without tracking it.");
+
+        if (_inputSource is not null)
+            throw new InvalidOperationException("Input streams cannot be configured when starting a process without tracking it.");
+
+        if (_limits is not null || _windowsJobObjectConfiguration is not null || _linuxControlGroupConfiguration is not null)
+            throw new InvalidOperationException("Process limits cannot be configured when starting a process without tracking it.");
+
+        if (_validationModeConfigured && _validationMode != ProcessValidationMode.None)
+            throw new InvalidOperationException("Process validation cannot be configured when starting a process without tracking it.");
+
+        var startInfo = CloneStartInfo(_startInfo);
+        startInfo.FileName = ResolveFileName(startInfo.FileName, startInfo.WorkingDirectory);
+        ApplyProcessStartInfoInterceptors(startInfo);
+
+        return Process.StartAndForget(startInfo);
+    }
+#endif
+
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "ProcessInstance will dispose it")]
     private T StartProcess<T>(ImmutableArray<OutputTarget> outputTargets, ImmutableArray<OutputTarget> errorTargets, Func<IProcessHandle, Task, Task, CancellationTokenRegistration, IDisposable?, Func<bool>, Activity?, string, IReadOnlyList<string>, ProcessLogVerbosity, CancellationToken, T> factory, CancellationToken cancellationToken)
     {
@@ -462,7 +538,7 @@ public sealed class ProcessWrapper
         var processLimiter = CreateProcessLimiter();
 #if NET11_0_OR_GREATER
         var shouldResumeProcess = false;
-        if (processLimiter is not null && (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()))
+        if (processLimiter is not null && (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()) && !startInfo.StartSuspended)
         {
             startInfo.StartSuspended = true;
             shouldResumeProcess = true;

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -1214,7 +1214,182 @@ public class ProcessWrapperTests
         Assert.Same(command, command.WithLimits(limits => limits.CpuPercentage = 50));
         Assert.Same(command, command.WithWindowsJobObject(_ => { }));
         Assert.Same(command, command.WithLinuxControlGroup(_ => { }));
+#if NET11_0_OR_GREATER
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux() || OperatingSystem.IsAndroid())
+        {
+            Assert.Same(command, command.WithKillOnParentExit());
+        }
+
+        Assert.Same(command, command.WithStartDetached());
+
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+        {
+            Assert.Same(command, command.WithStartSuspended());
+        }
+#endif
     }
+
+#if NET11_0_OR_GREATER
+    [Fact]
+    public async Task ExecuteBufferedAsync_WithKillOnParentExit_PropagatesToProcessStartInfo()
+    {
+        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid())
+            return;
+
+        ProcessStartInfo? capturedStartInfo = null;
+        var fakeFactory = new FakeProcessFactory(startInfo =>
+        {
+            capturedStartInfo = startInfo;
+            return FakeProcess.Create(0, outputText: "", errorText: "");
+        });
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            _ = await ProcessWrapper.Create("dotnet")
+                .WithKillOnParentExit()
+                .ExecuteBufferedAsync();
+        });
+
+        Assert.NotNull(capturedStartInfo);
+        Assert.True(capturedStartInfo.KillOnParentExit);
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_WithStartDetached_PropagatesToProcessStartInfo()
+    {
+        ProcessStartInfo? capturedStartInfo = null;
+        var fakeFactory = new FakeProcessFactory(startInfo =>
+        {
+            capturedStartInfo = startInfo;
+            return FakeProcess.Create(0, outputText: "", errorText: "");
+        });
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            _ = await ProcessWrapper.Create("dotnet")
+                .WithStartDetached()
+                .ExecuteBufferedAsync();
+        });
+
+        Assert.NotNull(capturedStartInfo);
+        Assert.True(capturedStartInfo.StartDetached);
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_WithStartSuspended_PropagatesToProcessStartInfo()
+    {
+        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS())
+            return;
+
+        ProcessStartInfo? capturedStartInfo = null;
+        var fakeFactory = new FakeProcessFactory(startInfo =>
+        {
+            capturedStartInfo = startInfo;
+            return FakeProcess.Create(0, outputText: "", errorText: "");
+        });
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            _ = await ProcessWrapper.Create("dotnet")
+                .WithStartSuspended()
+                .ExecuteBufferedAsync();
+        });
+
+        Assert.NotNull(capturedStartInfo);
+        Assert.True(capturedStartInfo.StartSuspended);
+    }
+
+    [Fact]
+    public async Task ExecuteBufferedAsync_WithPipeOperator_PreservesNet11StartInfoOptions()
+    {
+        var capturedStartInfos = new List<ProcessStartInfo>();
+        var fakeFactory = new FakeProcessFactory(startInfo =>
+        {
+            capturedStartInfos.Add(startInfo);
+            return FakeProcess.Create(0, outputText: "", errorText: "");
+        });
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            _ = await (ProcessWrapper.Create("first").WithStartDetached() | ProcessWrapper.Create("second").WithStartDetached())
+                .ExecuteBufferedAsync();
+        });
+
+        Assert.Collection(
+            capturedStartInfos,
+            startInfo => Assert.True(startInfo.StartDetached),
+            startInfo => Assert.True(startInfo.StartDetached));
+    }
+
+    [Fact]
+    public async Task StartAndForget_AppliesConfigurationAndInterceptors()
+    {
+        using var temporaryDirectory = TemporaryDirectory.Create();
+        var temporaryDirectoryPath = temporaryDirectory.FullPath.Value;
+        var outputPath = Path.Combine(temporaryDirectoryPath, "start-and-forget-output.txt");
+
+        string executableName;
+        if (OperatingSystem.IsWindows())
+        {
+            executableName = "start-and-forget.cmd";
+            _ = temporaryDirectory.CreateTextFile(executableName, "@echo off\r\necho %TEST_VAR_52% %TEST_VAR_53% %1>\"%OUTPUT_FILE%\"\r\n");
+        }
+        else
+        {
+            executableName = "start-and-forget.sh";
+            var scriptPath = temporaryDirectory.CreateTextFile(executableName, "#!/bin/sh\nprintf '%s %s %s' \"$TEST_VAR_52\" \"$TEST_VAR_53\" \"$1\" > \"$OUTPUT_FILE\"\n");
+            File.SetUnixFileMode(scriptPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        using var processWrapperInterceptorRegistration = ProcessWrapper.AddInterceptor(new WrapperEnvironmentVariableInterceptor("TEST_VAR_52", "wrapper"));
+        using var processStartInfoInterceptorRegistration = ProcessWrapper.AddInterceptor(new StartInfoEnvironmentVariableInterceptor("TEST_VAR_53", "start-info"));
+
+        var processId = ProcessWrapper.Create(executableName)
+            .WithWorkingDirectory(temporaryDirectoryPath)
+            .WithArguments("argument")
+            .WithEnvironmentVariables(env => env.Set("OUTPUT_FILE", outputPath))
+            .StartAndForget();
+
+        Assert.True(processId > 0);
+
+        var output = await WaitForFileTextAsync(outputPath);
+        Assert.Equal("wrapper start-info argument", output.Trim());
+    }
+
+    [Fact]
+    public void StartAndForget_WithUnsupportedConfiguration_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() => ProcessWrapper.Create("dotnet").WithOutputStream(OutputTarget.ToTextDelegate(_ => { })).StartAndForget());
+        Assert.Throws<InvalidOperationException>(() => ProcessWrapper.Create("dotnet").WithErrorStream(OutputTarget.ToTextDelegate(_ => { })).StartAndForget());
+        Assert.Throws<InvalidOperationException>(() => ProcessWrapper.Create("dotnet").WithInputStream("stdin").StartAndForget());
+        Assert.Throws<InvalidOperationException>(() => ProcessWrapper.Create("dotnet").WithLimits(new ProcessLimits()).StartAndForget());
+        Assert.Throws<InvalidOperationException>(() => ProcessWrapper.Create("dotnet").WithWindowsJobObject(_ => { }).StartAndForget());
+        Assert.Throws<InvalidOperationException>(() => ProcessWrapper.Create("dotnet").WithLinuxControlGroup(_ => { }).StartAndForget());
+        Assert.Throws<InvalidOperationException>(() => ProcessWrapper.Create("dotnet").WithValidation(ProcessValidationMode.FailIfNonZeroExitCode).StartAndForget());
+
+        using var processWrapperInterceptorRegistration = ProcessWrapper.AddInterceptor(new ValidationProcessWrapperInterceptor(ProcessValidationMode.FailIfStdError));
+        Assert.Throws<InvalidOperationException>(() => ProcessWrapper.Create("dotnet").StartAndForget());
+    }
+
+    [Fact]
+    public async Task ProcessInstance_Signal_WhenSafeHandleIsUnavailable_Throws()
+    {
+        var fakeProcess = FakeProcess.CreatePending(0);
+        var fakeFactory = new FakeProcessFactory(fakeProcess);
+
+        await RunWithDefaultProcessFactoryAsync(fakeFactory, async () =>
+        {
+            var process = ProcessWrapper.Create("dotnet")
+                .WithValidation(ProcessValidationMode.None)
+                .ExecuteAsync();
+
+            _ = Assert.Throws<InvalidOperationException>(() => process.Signal(System.Runtime.InteropServices.PosixSignal.SIGTERM));
+
+            fakeProcess.Complete();
+            _ = await process;
+        });
+    }
+#endif
 
     [Fact]
     public void ProcessPipe_WithInvalidMaxBufferSize_Throws()
@@ -1751,6 +1926,30 @@ public class ProcessWrapperTests
         return path;
     }
 
+#if NET11_0_OR_GREATER
+    private static async Task<string> WaitForFileTextAsync(string path)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed <= TimeSpan.FromSeconds(10))
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    return await File.ReadAllTextAsync(path);
+                }
+            }
+            catch (IOException)
+            {
+            }
+
+            await Task.Delay(50);
+        }
+
+        throw new TimeoutException($"The file '{path}' was not created.");
+    }
+#endif
+
     private sealed class WrapperEnvironmentVariableInterceptor(string variableName, string variableValue) : IProcessWrapperInterceptor
     {
         public void Intercept(ProcessWrapper processWrapper)
@@ -1778,6 +1977,17 @@ public class ProcessWrapperTests
             events.Add(eventName);
         }
     }
+
+#if NET11_0_OR_GREATER
+    private sealed class ValidationProcessWrapperInterceptor(ProcessValidationMode validationMode) : IProcessWrapperInterceptor
+    {
+        public void Intercept(ProcessWrapper processWrapper)
+        {
+            ArgumentNullException.ThrowIfNull(processWrapper);
+            processWrapper.WithValidation(validationMode);
+        }
+    }
+#endif
 
     private sealed class RecordingProcessStartInfoInterceptor(List<string> events, string eventName) : IProcessStartInfoInterceptor
     {


### PR DESCRIPTION
## Summary

- Add .NET 11 APIs for process signaling and detached, suspended, and parent-exit-aware startup.
- Add `StartAndForget` support with validation for unsupported configurations.
- Preserve new start options when cloning and composing process wrappers.
- Add coverage for option propagation, interceptors, validation, and unavailable process handles.

## Testing

- Tests added for the new process lifecycle APIs.
- Full build and test validation not run (not requested).