### PR TITLE
Allow configuring generated .resx format parameter names and types

### DIFF
--- a/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
+++ b/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
@@ -331,7 +331,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
         /// " + formatComment + @"
         public static string? Format" + ToCSharpNameIdentifier(entry.Name) + "(global::System.Globalization.CultureInfo? provider, " + inParams + @")
         {
-            return GetString(provider, """ + entry.Name + "\", " + callParams + @");
+            return GetString(culture: provider, name: """ + entry.Name + @""", args: new object?[] { " + callParams + @" });
         }
 ");
 
@@ -339,7 +339,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
         /// " + formatComment + @"
         public static string? Format" + ToCSharpNameIdentifier(entry.Name) + "(" + inParams + @")
         {
-            return GetString(""" + entry.Name + "\", " + callParams + @");
+            return GetString(name: """ + entry.Name + @""", args: new object?[] { " + callParams + @" });
         }
 ");
                         }

--- a/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
+++ b/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
@@ -13,6 +13,8 @@ namespace Meziantou.Framework.ResxSourceGenerator;
 [Generator]
 public sealed partial class ResxGenerator : IIncrementalGenerator
 {
+    private const string ResxGeneratorNamespace = "https://meziantou.net/meziantou.framework/resxgenerator";
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var compilationProvider = context.CompilationProvider.Select(static (compilation, cancellationToken) =>
@@ -320,11 +322,13 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
 
                         if (args >= 0)
                         {
-                            var inParams = string.Join(", ", Enumerable.Range(0, args + 1).Select(arg => "object? arg" + arg.ToString(CultureInfo.InvariantCulture)));
-                            var callParams = string.Join(", ", Enumerable.Range(0, args + 1).Select(arg => "arg" + arg.ToString(CultureInfo.InvariantCulture)));
+                            var parameters = GetFormatParameters(entry, args);
+                            var inParams = string.Join(", ", parameters.Select(parameter => parameter.TypeName + " " + EscapeCSharpIdentifier(parameter.Name)));
+                            var callParams = string.Join(", ", parameters.Select(parameter => EscapeCSharpIdentifier(parameter.Name)));
+                            var formatComment = CreateFormatComment(comment, parameters);
 
                             sb.AppendLine(@"
-        /// " + comment + @"
+        /// " + formatComment + @"
         public static string? Format" + ToCSharpNameIdentifier(entry.Name) + "(global::System.Globalization.CultureInfo? provider, " + inParams + @")
         {
             return GetString(provider, """ + entry.Name + "\", " + callParams + @");
@@ -332,7 +336,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
 ");
 
                             sb.AppendLine(@"
-        /// " + comment + @"
+        /// " + formatComment + @"
         public static string? Format" + ToCSharpNameIdentifier(entry.Name) + "(" + inParams + @")
         {
             return GetString(""" + entry.Name + "\", " + callParams + @");
@@ -408,15 +412,27 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
                     var type = element.Attribute("type")?.Value;
                     var comment = element.Attribute("comment")?.Value;
                     var value = element.Element("value")?.Value;
+                    var parameters = element.Elements(XName.Get("parameter", ResxGeneratorNamespace))
+                        .Select(parameter => new ResxParameter
+                        {
+                            Name = parameter.Attribute("name")?.Value,
+                            TypeName = parameter.Attribute("typename")?.Value,
+                            Comment = parameter.Attribute("comment")?.Value,
+                        })
+                        .ToList();
 
                     var existingEntry = entries.Find(e => e.Name == name);
                     if (existingEntry is not null)
                     {
                         existingEntry.Comment ??= comment;
+                        if (existingEntry.Parameters.Count == 0)
+                        {
+                            existingEntry.Parameters.AddRange(parameters);
+                        }
                     }
                     else
                     {
-                        entries.Add(new ResxEntry { Name = name, Value = value, Comment = comment, Type = type });
+                        entries.Add(new ResxEntry { Name = name, Value = value, Comment = comment, Type = type, Parameters = parameters });
                     }
                 }
             }
@@ -427,6 +443,168 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
         }
 
         return entries;
+    }
+
+    private static List<FormatParameter> GetFormatParameters(ResxEntry entry, int maxArgumentIndex)
+    {
+        const string DefaultTypeName = "object?";
+        var parameters = new List<FormatParameter>();
+        var usedNames = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "provider",
+        };
+
+        for (var index = 0; index <= maxArgumentIndex; index++)
+        {
+            var fallbackName = GetUniqueFallbackName(index, usedNames);
+            var name = fallbackName;
+            var typeName = DefaultTypeName;
+            var comment = (string?)null;
+            if (index < entry.Parameters.Count)
+            {
+                var parameter = entry.Parameters[index];
+                comment = parameter.Comment;
+                if (!string.IsNullOrWhiteSpace(parameter.TypeName))
+                {
+                    typeName = parameter.TypeName.Trim();
+                }
+
+                if (!string.IsNullOrWhiteSpace(parameter.Name))
+                {
+                    var csharpName = ToCSharpNameIdentifier(parameter.Name);
+                    if (!string.IsNullOrEmpty(csharpName) && usedNames.Add(csharpName))
+                    {
+                        name = csharpName;
+                    }
+                }
+            }
+
+            if (name == fallbackName)
+            {
+                _ = usedNames.Add(name);
+            }
+
+            parameters.Add(new FormatParameter(name, typeName, comment));
+        }
+
+        return parameters;
+    }
+
+    private static string GetUniqueFallbackName(int index, HashSet<string> usedNames)
+    {
+        var name = "arg" + index.ToString(CultureInfo.InvariantCulture);
+        while (usedNames.Contains(name))
+        {
+            name += "_";
+        }
+
+        return name;
+    }
+
+    private static string CreateFormatComment(string comment, List<FormatParameter> parameters)
+    {
+        var elements = new List<string>
+        {
+            comment,
+        };
+
+        foreach (var parameter in parameters)
+        {
+            if (string.IsNullOrWhiteSpace(parameter.Comment))
+                continue;
+
+            var element = new XElement("param", new XAttribute("name", parameter.Name), parameter.Comment);
+            elements.Add(element.ToString().Replace(Environment.NewLine, Environment.NewLine + "       /// ", StringComparison.Ordinal));
+        }
+
+        return string.Join(Environment.NewLine + "        /// ", elements);
+    }
+
+    private static string EscapeCSharpIdentifier(string name)
+    {
+        return IsCSharpKeyword(name) ? "@" + name : name;
+    }
+
+    private static bool IsCSharpKeyword(string name)
+    {
+        return name is
+            "abstract" or
+            "as" or
+            "base" or
+            "bool" or
+            "break" or
+            "byte" or
+            "case" or
+            "catch" or
+            "char" or
+            "checked" or
+            "class" or
+            "const" or
+            "continue" or
+            "decimal" or
+            "default" or
+            "delegate" or
+            "do" or
+            "double" or
+            "else" or
+            "enum" or
+            "event" or
+            "explicit" or
+            "extern" or
+            "false" or
+            "finally" or
+            "fixed" or
+            "float" or
+            "for" or
+            "foreach" or
+            "goto" or
+            "if" or
+            "implicit" or
+            "in" or
+            "int" or
+            "interface" or
+            "internal" or
+            "is" or
+            "lock" or
+            "long" or
+            "namespace" or
+            "new" or
+            "null" or
+            "object" or
+            "operator" or
+            "out" or
+            "override" or
+            "params" or
+            "private" or
+            "protected" or
+            "public" or
+            "readonly" or
+            "ref" or
+            "return" or
+            "sbyte" or
+            "sealed" or
+            "short" or
+            "sizeof" or
+            "stackalloc" or
+            "static" or
+            "string" or
+            "struct" or
+            "switch" or
+            "this" or
+            "throw" or
+            "true" or
+            "try" or
+            "typeof" or
+            "uint" or
+            "ulong" or
+            "unchecked" or
+            "unsafe" or
+            "ushort" or
+            "using" or
+            "virtual" or
+            "void" or
+            "volatile" or
+            "while";
     }
 
 
@@ -475,6 +653,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
         public string? Value { get; set; }
         public string? Comment { get; set; }
         public string? Type { get; set; }
+        public List<ResxParameter> Parameters { get; set; } = [];
 
         public bool IsText
         {
@@ -521,4 +700,13 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
 
         public bool IsFileRef => Type is not null && Type.StartsWith("System.Resources.ResXFileRef,", StringComparison.Ordinal);
     }
+
+    private sealed class ResxParameter
+    {
+        public string? Name { get; set; }
+        public string? TypeName { get; set; }
+        public string? Comment { get; set; }
+    }
+
+    private sealed record FormatParameter(string Name, string TypeName, string? Comment);
 }

--- a/src/Meziantou.Framework.ResxSourceGenerator/readme.md
+++ b/src/Meziantou.Framework.ResxSourceGenerator/readme.md
@@ -19,6 +19,20 @@ _ = Sample.FormatHello("meziantou"); // Hello meziantou
 
 The generator also supports binary resources and expose them as `byte[]`.
 
+You can customize generated format method parameter names, types, and XML documentation comments by adding metadata in the `https://meziantou.net/meziantou.framework/resxgenerator` namespace:
+
+````xml
+<root xmlns:mfrg="https://meziantou.net/meziantou.framework/resxgenerator">
+  <data name="Location" xml:space="preserve">
+    <value>I live in country {0}, city {1}</value>
+    <mfrg:parameter name="country" comment="Country name." />
+    <mfrg:parameter name="city" typename="global::System.String" comment="City name." />
+  </data>
+</root>
+````
+
+The parameter elements are matched to composite format placeholders by their order in the `.resx` file. When `typename` is omitted, the generated parameter type is `object?`.
+
 ## How to configure the source generator
 
 Install the NuGet package `Meziantou.Framework.ResxSourceGenerator` ([NuGet](https://www.nuget.org/packages/Meziantou.Framework.ResxSourceGenerator/))

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Resource1.fr.resx
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Resource1.fr.resx
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<root>
+<root xmlns:mfrg="https://meziantou.net/meziantou.framework/resxgenerator">
   <!-- 
     Microsoft ResX Schema 
     
@@ -119,6 +119,7 @@
   </resheader>
   <data name="Hello" xml:space="preserve">
     <value>Bonjour {0}!</value>
+    <mfrg:parameter name="name" typename="global::System.String" comment="Name to greet." />
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Image1" type="System.Resources.ResXFileRef, System.Windows.Forms">

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Resource1.resx
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Resource1.resx
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<root>
+<root xmlns:mfrg="https://meziantou.net/meziantou.framework/resxgenerator">
   <!-- 
     Microsoft ResX Schema 
     
@@ -119,6 +119,7 @@
   </resheader>
   <data name="Hello" xml:space="preserve">
     <value>Hello {0}!</value>
+    <mfrg:parameter name="name" typename="global::System.String" comment="Name to greet." />
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Image1" type="System.Resources.ResXFileRef, System.Windows.Forms">

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/ResxGeneratorTests.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/ResxGeneratorTests.cs
@@ -17,6 +17,13 @@ public class ResxGeneratorTests
     }
 
     [Fact, RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    public void ResxWithCustomParameterElementsCanBeReadByResourceManager()
+    {
+        Assert.Equal("Hello {0}!", Resource1.ResourceManager.GetString("Hello", CultureInfo.GetCultureInfo("en-US")));
+        Assert.Equal("Bonjour {0}!", Resource1.ResourceManager.GetString("Hello", CultureInfo.GetCultureInfo("fr")));
+    }
+
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
     public void StringValue()
     {
         CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
@@ -123,6 +123,114 @@ public sealed class ResxGeneratorTest
     }
 
     [Fact]
+    public async Task GenerateProperties_WithFormatParameterMetadata()
+    {
+        XNamespace generatorNamespace = "https://meziantou.net/meziantou.framework/resxgenerator";
+        var element = new XElement("root",
+            new XAttribute(XNamespace.Xmlns + "mfrg", generatorNamespace),
+            new XElement("data",
+                new XAttribute("name", "HelloWorld"),
+                new XElement("value", "Hello {0} from {1}!"),
+                new XElement(generatorNamespace + "parameter", new XAttribute("name", "name"), new XAttribute("comment", "Name to greet.")),
+                new XElement(generatorNamespace + "parameter", new XAttribute("name", "country"), new XAttribute("typename", "global::System.String"), new XAttribute("comment", "Country name."))));
+
+        var result = await GenerateFiles([("test.resx", element.ToString())], new OptionProvider
+        {
+            Namespace = "test",
+            ResourceName = "test",
+        });
+
+        var fileContent = result.GeneratedFileRoot.ToFullString();
+        Assert.Contains("FormatHelloWorld(global::System.Globalization.CultureInfo? provider, object? name, global::System.String country)", fileContent);
+        Assert.Contains("FormatHelloWorld(object? name, global::System.String country)", fileContent);
+        Assert.Contains("<param name=\"name\">Name to greet.</param>", fileContent);
+        Assert.Contains("<param name=\"country\">Country name.</param>", fileContent);
+        Assert.DoesNotContain("object? arg0", fileContent);
+    }
+
+    [Fact]
+    public async Task GenerateProperties_WithMissingAndExtraFormatParameterMetadata()
+    {
+        XNamespace generatorNamespace = "https://meziantou.net/meziantou.framework/resxgenerator";
+        var element = new XElement("root",
+            new XAttribute(XNamespace.Xmlns + "mfrg", generatorNamespace),
+            new XElement("data",
+                new XAttribute("name", "HelloWorld"),
+                new XElement("value", "Hello {0} from {1}!"),
+                new XElement(generatorNamespace + "parameter", new XAttribute("name", "name"), new XAttribute("comment", "Name to greet.")),
+                new XElement(generatorNamespace + "parameter", new XAttribute("name", ""), new XAttribute("comment", "Fallback parameter.")),
+                new XElement(generatorNamespace + "parameter", new XAttribute("name", "unused"), new XAttribute("comment", "Ignored parameter."))));
+
+        var result = await GenerateFiles([("test.resx", element.ToString())], new OptionProvider
+        {
+            Namespace = "test",
+            ResourceName = "test",
+        });
+
+        var fileContent = result.GeneratedFileRoot.ToFullString();
+        Assert.Contains("FormatHelloWorld(object? name, object? arg1)", fileContent);
+        Assert.Contains("<param name=\"name\">Name to greet.</param>", fileContent);
+        Assert.Contains("<param name=\"arg1\">Fallback parameter.</param>", fileContent);
+        Assert.DoesNotContain("unused", fileContent);
+        Assert.DoesNotContain("Ignored parameter.", fileContent);
+    }
+
+    [Fact]
+    public async Task GenerateProperties_WithFallbackFormatParameterNameCollision()
+    {
+        XNamespace generatorNamespace = "https://meziantou.net/meziantou.framework/resxgenerator";
+        var element = new XElement("root",
+            new XAttribute(XNamespace.Xmlns + "mfrg", generatorNamespace),
+            new XElement("data",
+                new XAttribute("name", "HelloWorld"),
+                new XElement("value", "Hello {0} from {1}!"),
+                new XElement(generatorNamespace + "parameter", new XAttribute("name", "arg1")),
+                new XElement(generatorNamespace + "parameter", new XAttribute("name", ""))));
+
+        var result = await GenerateFiles([("test.resx", element.ToString())], new OptionProvider
+        {
+            Namespace = "test",
+            ResourceName = "test",
+        });
+
+        var fileContent = result.GeneratedFileRoot.ToFullString();
+        Assert.Contains("FormatHelloWorld(object? arg1, object? arg1_)", fileContent);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GenerateProperties_UsesFormatParameterMetadataFromAnyDuplicateEntry(bool parameterMetadataInFirstFile)
+    {
+        XNamespace generatorNamespace = "https://meziantou.net/meziantou.framework/resxgenerator";
+        var elementWithoutParameterMetadata = new XElement("root",
+            new XElement("data", new XAttribute("name", "HelloWorld"), new XElement("value", "Hello {0}!")));
+        var elementWithParameterMetadata = new XElement("root",
+            new XAttribute(XNamespace.Xmlns + "mfrg", generatorNamespace),
+            new XElement("data",
+                new XAttribute("name", "HelloWorld"),
+                new XElement("value", "Hello {0}!"),
+                new XElement(generatorNamespace + "parameter", new XAttribute("name", "name"), new XAttribute("typename", "global::System.String"), new XAttribute("comment", "Name to greet."))));
+
+        var firstElement = parameterMetadataInFirstFile ? elementWithParameterMetadata : elementWithoutParameterMetadata;
+        var secondElement = parameterMetadataInFirstFile ? elementWithoutParameterMetadata : elementWithParameterMetadata;
+
+        var result = await GenerateFiles(
+            [
+                ("test.en.resx", firstElement.ToString()),
+                ("test.resx", secondElement.ToString()),
+            ], new OptionProvider
+            {
+                Namespace = "test",
+                ResourceName = "test",
+            });
+
+        var fileContent = result.GeneratedFileRoot.ToFullString();
+        Assert.Contains("FormatHelloWorld(global::System.String name)", fileContent);
+        Assert.Contains("<param name=\"name\">Name to greet.</param>", fileContent);
+    }
+
+    [Fact]
     public async Task GeneratePropertiesFromMultipleResx()
     {
         var element1 = new XElement("root",


### PR DESCRIPTION
## Summary

- Support custom format parameter names, types, and XML documentation comments via `.resx` metadata.
- Handle duplicate resource entries, missing metadata, keyword escaping, and parameter name collisions.
- Document the new metadata namespace and behavior.
- Add generator and resource manager coverage.

## Testing

- Added unit tests covering custom metadata, fallbacks, collisions, duplicate entries, and localized resources.