### PR TITLE
Remove direct Microsoft.OpenApi references

### DIFF
--- a/src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj
+++ b/src/Meziantou.AspNetCore.ServiceDefaults/Meziantou.AspNetCore.ServiceDefaults.csproj
@@ -19,13 +19,9 @@
 
   <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
-    <!-- Force Microsoft.OpenApi to a non-vulnerable (transitive: Microsoft.AspNetCore.OpenApi) -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net11.0'">
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="11.0.0-preview.7.26381.103" />
-    <!-- Force Microsoft.OpenApi to a non-vulnerable (transitive: Microsoft.AspNetCore.OpenApi) -->
-    <PackageReference Include="Microsoft.OpenApi" Version="3.9.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Removed forced Microsoft.OpenApi package references for net10.0 and net11.0.