### PR TITLE
Harden MP4 and WAV parsing against truncated data

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Atom.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Atom.cs
@@ -42,6 +42,9 @@ internal sealed class Mp4Atom
                 size = endPosition - atomPosition;
             }
 
+            if (size < headerSize || atomPosition > endPosition - size)
+                break;
+
             var atom = new Mp4Atom
             {
                 Position = atomPosition,
@@ -57,6 +60,9 @@ internal sealed class Mp4Atom
                 // For 'meta' atom, skip 4-byte version/flags
                 if (type == "meta")
                 {
+                    if (dataSize < 4)
+                        break;
+
                     stream.Seek(4, SeekOrigin.Current);
                     atom.Children.AddRange(ReadAtoms(stream, atomEnd, recurse: true));
                 }
@@ -68,7 +74,8 @@ internal sealed class Mp4Atom
             else if (dataSize > 0 && dataSize <= 10 * 1024 * 1024) // Max 10MB for single atom data
             {
                 atom.Data = new byte[dataSize];
-                stream.ReadAtLeast(atom.Data, (int)dataSize, throwOnEndOfStream: false);
+                if (stream.ReadAtLeast(atom.Data, (int)dataSize, throwOnEndOfStream: false) < dataSize)
+                    break;
             }
 
             stream.Position = atomEnd;

--- a/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Writer.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Writer.cs
@@ -12,7 +12,8 @@ internal sealed class Mp4Writer : IMediaTagWriter
 
             // Read the entire file to get the atom structure
             var fileData = new byte[inputStream.Length];
-            inputStream.ReadAtLeast(fileData, fileData.Length, throwOnEndOfStream: false);
+            if (inputStream.ReadAtLeast(fileData, fileData.Length, throwOnEndOfStream: false) < fileData.Length)
+                return MediaTagResult.Failure(MediaTagError.CorruptFile, "File ended before all MP4 data could be read.");
 
             // Parse atoms
             inputStream.Position = 0;

--- a/src/Meziantou.Framework.MediaTags/Formats/Wav/RiffChunk.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Wav/RiffChunk.cs
@@ -23,6 +23,8 @@ internal sealed class RiffChunk
 
             var id = Encoding.ASCII.GetString(header[..4]);
             var size = BinaryPrimitives.ReadInt32LittleEndian(header[4..]);
+            if (size < 0)
+                break;
 
             var chunk = new RiffChunk
             {
@@ -31,25 +33,30 @@ internal sealed class RiffChunk
                 DataPosition = stream.Position,
             };
 
+            if (chunk.DataPosition > endPosition - size)
+                break;
+
+            var chunkEnd = chunk.DataPosition + size;
             if (id == "LIST")
             {
                 // LIST chunk has a 4-byte type followed by sub-chunks
                 if (size >= 4)
                 {
-                    stream.ReadAtLeast(listType, 4, throwOnEndOfStream: false);
+                    if (stream.ReadAtLeast(listType, 4, throwOnEndOfStream: false) < 4)
+                        break;
+
                     chunk.Id = "LIST-" + Encoding.ASCII.GetString(listType);
-                    chunk.SubChunks.AddRange(ReadChunks(stream, chunk.DataPosition + size));
+                    chunk.SubChunks.AddRange(ReadChunks(stream, chunkEnd));
                 }
             }
             else if (size > 0 && size <= 10 * 1024 * 1024)
             {
                 chunk.Data = new byte[size];
-                stream.ReadAtLeast(chunk.Data, size, throwOnEndOfStream: false);
+                if (stream.ReadAtLeast(chunk.Data, size, throwOnEndOfStream: false) < size)
+                    break;
             }
-            else
-            {
-                stream.Seek(size, SeekOrigin.Current);
-            }
+
+            stream.Position = chunkEnd;
 
             // Chunks are padded to even byte boundaries
             if (size % 2 != 0 && stream.Position < endPosition)

--- a/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
@@ -199,6 +199,29 @@ public sealed class Mp4Tests
     }
 
     [Fact]
+    public void ReadTags_TruncatedAtom_DoesNotReadZeroPaddedData()
+    {
+        var valueBytes = Encoding.UTF8.GetBytes("A");
+        var dataPayload = new byte[8 + valueBytes.Length];
+        BinaryPrimitives.WriteUInt32BigEndian(dataPayload, 1);
+        valueBytes.CopyTo(dataPayload, 8);
+
+        var titleAtomType = Encoding.Latin1.GetString([0xA9, (byte)'n', (byte)'a', (byte)'m']);
+        var titleAtom = CreateAtom(titleAtomType, CreateAtom("data", dataPayload));
+        var ilstAtom = CreateAtom("ilst", titleAtom);
+        var metaPayload = new byte[4 + ilstAtom.Length];
+        ilstAtom.CopyTo(metaPayload, 4);
+        var mp4 = CreateAtom("moov", CreateAtom("udta", CreateAtom("meta", metaPayload)));
+        BinaryPrimitives.WriteUInt32BigEndian(mp4, (uint)(mp4.Length + 4));
+
+        using var stream = new MemoryStream(mp4);
+        var result = MediaFile.ReadTags(stream, MediaFormat.Mp4);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Value.Title);
+    }
+
+    [Fact]
     public void ReadTags_FreeformReplayGain_NullTerminatedText()
     {
         using var stream = new MemoryStream(CreateMp4WithFreeformTags([

--- a/tests/Meziantou.Framework.MediaTags.Tests/WavTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/WavTests.cs
@@ -94,4 +94,19 @@ public sealed class WavTests
         var result = MediaFile.ReadTags(stream, MediaFormat.Wav);
         Assert.False(result.IsSuccess);
     }
+
+    [Fact]
+    public void ReadTags_TruncatedInfoChunk_DoesNotReadZeroPaddedData()
+    {
+        using var stream = new MemoryStream([
+            (byte)'R', (byte)'I', (byte)'F', (byte)'F', 25, 0, 0, 0, (byte)'W', (byte)'A', (byte)'V', (byte)'E',
+            (byte)'L', (byte)'I', (byte)'S', (byte)'T', 16, 0, 0, 0, (byte)'I', (byte)'N', (byte)'F', (byte)'O',
+            (byte)'I', (byte)'N', (byte)'A', (byte)'M', 4, 0, 0, 0, (byte)'A',
+        ]);
+
+        var result = MediaFile.ReadTags(stream, MediaFormat.Wav);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Value.Title);
+    }
 }


### PR DESCRIPTION
## Summary

- Prevent MP4 and WAV parsers from processing truncated or invalid atom/chunk data.
- Report MP4 writer failures when the input stream ends prematurely.
- Add regression tests ensuring truncated payloads are not interpreted as zero-padded data.

## Testing

- Not run (not requested).