### PR TITLE
Add Assert.XunitSkip to skip a test at runtime

### DIFF
--- a/ref/Meziantou.Framework.Assertions.cs
+++ b/ref/Meziantou.Framework.Assertions.cs
@@ -320,6 +320,8 @@ namespace Meziantou.Framework.Assertions
         public static object IsType(System.Type expectedType, object? actual, string? message = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) => throw null;
         public static T IsAssignableTo<T>(object? actual, string? message = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) => throw null;
         public static object IsAssignableTo(System.Type expectedType, object? actual, string? message = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) => throw null;
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void XunitSkip(string reason) { }
     }
 
     public sealed class AssertionException : System.Exception

--- a/src/Meziantou.Framework.Assertions/Assert.XunitSkip.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.XunitSkip.cs
@@ -1,0 +1,18 @@
+namespace Meziantou.Framework.Assertions;
+
+public partial class Assert
+{
+    // xunit considers an exception to be a skip request when its message starts with this token.
+    // Everything after the token is used as the skip reason.
+    private const string XunitDynamicSkipToken = "$XunitDynamicSkip$";
+
+    /// <summary>
+    /// Skips the currently running xunit test by throwing an <see cref="AssertionException"/> whose message uses the format expected by xunit for dynamically skipped tests.
+    /// </summary>
+    /// <param name="reason">The reason why the test is skipped.</param>
+    [DoesNotReturn]
+    public static void XunitSkip(string reason)
+    {
+        throw new AssertionException(XunitDynamicSkipToken + reason);
+    }
+}

--- a/src/Meziantou.Framework.Assertions/readme.md
+++ b/src/Meziantou.Framework.Assertions/readme.md
@@ -60,6 +60,7 @@ Assertion helpers for .NET tests.
 - `DoesNotRaise`: Asserts a specific event is not raised.
 - `DoesNotRaiseAny`: Asserts no compatible event is raised.
 - `Fail`: Fails the test with a custom message.
+- `XunitSkip`: Skips the running xunit test with the specified reason.
 
 ## Use as the default `Assert` class
 

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertApiTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertApiTests.cs
@@ -13,6 +13,7 @@ public sealed class AssertApiTests
         var methods = typeof(AssertionsAssert).GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
             .Where(method => !method.IsSpecialName)
             .Where(method => !IsObjectGuardMethod(method))
+            .Where(method => !IsSkipMethod(method))
             .OrderBy(method => method.Name, StringComparer.Ordinal)
             .ThenBy(method => string.Join(",", method.GetParameters().Select(parameter => parameter.ParameterType.FullName)), StringComparer.Ordinal);
 
@@ -45,5 +46,11 @@ public sealed class AssertApiTests
     {
         return string.Equals(method.Name, nameof(Equals), StringComparison.Ordinal) ||
                string.Equals(method.Name, nameof(ReferenceEquals), StringComparison.Ordinal);
+    }
+
+    // Skip methods do not report an assertion failure, so they take a skip reason instead of an additional message.
+    private static bool IsSkipMethod(MethodInfo method)
+    {
+        return string.Equals(method.Name, nameof(AssertionsAssert.XunitSkip), StringComparison.Ordinal);
     }
 }

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertFailTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertFailTests.cs
@@ -1,4 +1,5 @@
 using AssertionsAssert = Meziantou.Framework.Assertions.Assert;
+using XunitAssert = Xunit.Assert;
 
 namespace Meziantou.Framework.Assertions.Tests;
 
@@ -15,5 +16,29 @@ public sealed class AssertFailTests
             Assert.Fail() assertion failed.
             Message: custom message
             """);
+    }
+
+    [Fact]
+    public void XunitSkip_UsesTheFormatExpectedByXunit()
+    {
+        var exception = AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.XunitSkip("custom reason"));
+
+        AssertionsAssert.Equal("$XunitDynamicSkip$custom reason", exception.Message);
+        AssertionsAssert.Equal(GetXunitSkipMessage("custom reason"), exception.Message);
+    }
+
+    // xunit only exposes the skip contract through the exception thrown by Assert.Skip
+    private static string GetXunitSkipMessage(string reason)
+    {
+        try
+        {
+            XunitAssert.Skip(reason);
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+
+        throw new InvalidOperationException("Xunit.Assert.Skip did not throw");
     }
 }


### PR DESCRIPTION
Adds `Assert.XunitSkip(reason)` to `Meziantou.Framework.Assertions`.

## What

```csharp
if (!OperatingSystem.IsWindows())
    Assert.XunitSkip("Windows only");
```

The method throws an `AssertionException` whose message is `"$XunitDynamicSkip$" + reason`. That token is xunit's documented dynamic-skip contract: any exception whose message starts with it is reported as a *skipped* test rather than a failed one, and the text after the token becomes the skip reason. This lets a test decide at runtime that it should be skipped, without taking a dependency on `Xunit.Assert` from code that uses this assertion library.

It is marked `[DoesNotReturn]` so the compiler treats the code following the call as unreachable (useful for nullability and definite-assignment analysis after a guard).

## Notes for reviewers

- The test asserts both the literal message format *and* that it matches the message xunit's own `Assert.Skip` produces, so the test breaks if xunit ever changes the contract. `Xunit.Sdk.DynamicSkipToken` is internal, hence the round trip through `Assert.Skip` rather than referencing the constant.
- `AssertApiTests.PublicAssertionMethodsExposeNullableMessageParameter` requires every public `Assert` method to expose an optional nullable `message` parameter. `XunitSkip` takes a required `reason` instead — it does not report an assertion failure — so it is excluded there with a comment.
- `ref/Meziantou.Framework.Assertions.cs` regenerated, and the method added to the package readme.

## Validation

- `dotnet run ./eng/update-all.cs` — clean
- Build with `/p:TreatsWarningsAsErrors=true` — no warnings or errors
- `Meziantou.Framework.Assertions.Tests`: 388/388 pass on net10.0 and net11.0; confirmed the new test and both `AssertApiTests` tests actually ran
