### PR TITLE
Update Meziantou.NET.Sdk to 1.0.149

### DIFF
--- a/global.json
+++ b/global.json
@@ -8,11 +8,11 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.Traversal": "4.1.82",
-    "Meziantou.NET.Sdk": "1.0.148",
-    "Meziantou.NET.Sdk.BlazorWebAssembly": "1.0.148",
-    "Meziantou.NET.Sdk.Razor": "1.0.148",
-    "Meziantou.NET.Sdk.Test": "1.0.148",
-    "Meziantou.NET.Sdk.Web": "1.0.148",
-    "Meziantou.NET.Sdk.WindowsDesktop": "1.0.148"
+    "Meziantou.NET.Sdk": "1.0.149",
+    "Meziantou.NET.Sdk.BlazorWebAssembly": "1.0.149",
+    "Meziantou.NET.Sdk.Razor": "1.0.149",
+    "Meziantou.NET.Sdk.Test": "1.0.149",
+    "Meziantou.NET.Sdk.Web": "1.0.149",
+    "Meziantou.NET.Sdk.WindowsDesktop": "1.0.149"
   }
 }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,6 +3,8 @@
 
   <PropertyGroup>
     <EnableCodeCoverage>false</EnableCodeCoverage>
+    <!-- The assertions come from the project reference below, not from the package the SDK adds by default -->
+    <EnableMeziantouAssertions>false</EnableMeziantouAssertions>
     <!-- Platform-specific test projects skip all their tests on the other platforms -->
     <MinimumExpectedTests>0</MinimumExpectedTests>
     <IncludeDefaultTestReferences Condition="'$(IncludeDefaultTestReferences)' == ''">true</IncludeDefaultTestReferences>


### PR DESCRIPTION
Update `Meziantou.NET.Sdk` from 1.0.148 to 1.0.149.

1.0.149 uses [`Meziantou.Framework.Assertions`](https://www.nuget.org/packages/Meziantou.Framework.Assertions) as the default assertion library, so `Assert` now refers to `Meziantou.Framework.Assertions.Assert` in the test projects.

Files changed:
- global.json
- tests/Directory.Build.props