### PR TITLE
Mark Assert.Fail as [DoesNotReturn]

### DIFF
--- a/ref/Meziantou.Framework.Assertions.cs
+++ b/ref/Meziantou.Framework.Assertions.cs
@@ -87,6 +87,7 @@ namespace Meziantou.Framework.Assertions
         public static bool Equals(object? a, object? b) => throw null;
         [System.Obsolete("This is an override of Object.ReferenceEquals(). Use Assert.Same() instead.", true)]
         public static bool ReferenceEquals(object? a, object? b) => throw null;
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
         public static void Fail(string? message = null) { }
         public static void Distinct<T>(System.ReadOnlySpan<T> actual, System.Collections.Generic.IEqualityComparer<T>? comparer = null, string? message = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         public static void Distinct(string actual, string? message = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }

--- a/src/Meziantou.Framework.Assertions/Assert.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.cs
@@ -28,6 +28,7 @@ public static partial class Assert
 
     /// <summary>Fails the assertion with the specified message.</summary>
     /// <param name="message">The message that describes the failure.</param>
+    [DoesNotReturn]
     public static void Fail(string? message = null)
     {
         throw new AssertionException(ErrorFormatter.Format(new FailAssertionError(message)));

--- a/src/Meziantou.Framework.Assertions/Meziantou.Framework.Assertions.csproj
+++ b/src/Meziantou.Framework.Assertions/Meziantou.Framework.Assertions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Assertions</RootNamespace>
-    <Version>2.0.3</Version>
+    <Version>2.0.4</Version>
     <Description>Assertion helpers for .NET tests</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
## What

Adds `[DoesNotReturn]` to `Assert.Fail` in `Meziantou.Framework.Assertions`, and bumps the package version `2.0.3` → `2.0.4`.

## Why

`Assert.Fail` unconditionally throws an `AssertionException`, but it was not annotated, so the compiler did not treat a call to it as terminating a code path. Callers had to add a redundant `return`/`throw` afterwards to satisfy definite-assignment and nullability analysis:

```csharp
if (value is null)
{
    Assert.Fail("value should not be null");
    return; // no longer needed
}

Use(value); // previously warned about a possible null dereference
```

The neighbouring `Assert.XunitSkip` was already annotated this way, so this makes the two consistent.

## Notes for reviewers

- The change is source- and binary-compatible. `[DoesNotReturn]` only feeds the compiler's nullable flow analysis; it does not affect classic reachability rules (`CS0162`/`CS0161`), so it cannot introduce new unreachable-code or missing-return diagnostics at existing call sites.
- `ref/Meziantou.Framework.Assertions.cs` is regenerated by the build and is included in the commit, as required.
- Version bump is a patch, matching the convention used in 23ef00b91.

## Verification

- `dotnet build` on the library with `/p:TreatsWarningsAsErrors=true` — succeeded, 0 warnings.
- `dotnet test` on `Meziantou.Framework.Assertions.Tests` — 776/776 passed across net10.0 and net11.0.
- `dotnet run ./eng/update-all.cs` — ran clean, no further file changes.
- Because the attribute affects flow analysis at call sites, also rebuilt the four other test projects that call `Assert.Fail` (JsonPath, InlineSnapshotTesting, Threading, Yaml) with warnings-as-errors — all succeeded with no new warnings.