### PR TITLE
Extend the existing assertion rules to cases they missed

### DIFF
--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AssertionMethodSelectionAnalyzerCommon.cs
@@ -16,29 +16,28 @@ internal static class AssertionMethodSelectionAnalyzerCommon
 
     internal static bool TryGetNullCheckMatch(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, out NullCheckMatch match)
     {
-        if (!IsAssertInvocation(invocationOperation, assertType, "True"))
+        if (!TryGetAssertCondition(invocationOperation, assertType, out var conditionOperation, out var conditionExpectedToBeFalse))
         {
             match = default;
             return false;
         }
 
-        var conditionArgument = invocationOperation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "condition");
-        if (conditionArgument is null)
+        if (TryGetNullCheckMatchFromBinaryOperation(conditionOperation, out match) ||
+            TryGetNullCheckMatchFromPattern(conditionOperation, out match) ||
+            TryGetNullCheckMatchFromHasValue(conditionOperation, out match))
         {
-            match = default;
-            return false;
+            if (conditionExpectedToBeFalse)
+                match = match with { AssertionMethodName = NegateNullAssertionMethodName(match.AssertionMethodName) };
+
+            return true;
         }
-
-        var conditionOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(conditionArgument.Value);
-        if (TryGetNullCheckMatchFromBinaryOperation(conditionOperation, out match))
-            return true;
-
-        if (TryGetNullCheckMatchFromPattern(conditionOperation, out match))
-            return true;
 
         match = default;
         return false;
     }
+
+    private static string NegateNullAssertionMethodName(string assertionMethodName)
+        => assertionMethodName == NullAssertionMethodName ? NotNullAssertionMethodName : NullAssertionMethodName;
 
     internal static bool TryGetNullNotNullValueTypeMatch(
         IInvocationOperation invocationOperation,
@@ -234,6 +233,19 @@ internal static class AssertionMethodSelectionAnalyzerCommon
         if (IsNotNullPattern(isPatternOperation.Pattern))
         {
             match = new NullCheckMatch(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(isPatternOperation.Value), NotNullAssertionMethodName);
+            return true;
+        }
+
+        match = default;
+        return false;
+    }
+
+    private static bool TryGetNullCheckMatchFromHasValue(IOperation conditionOperation, out NullCheckMatch match)
+    {
+        if (conditionOperation is IPropertyReferenceOperation { Property.Name: "HasValue", Instance: { } instance } &&
+            instance.Type?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+        {
+            match = new NullCheckMatch(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(instance), NotNullAssertionMethodName);
             return true;
         }
 

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzer.cs
@@ -10,8 +10,8 @@ public sealed class CountAssertionAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor UseEmptyDescriptor = new(
         id: RuleIdentifiers.UseEmptyAssertionDiagnosticId,
-        title: "Use Assert.Empty for zero count checks",
-        messageFormat: "Use Assert.Empty for count checks equal to zero",
+        title: "Use Assert.Empty or Assert.NotEmpty for zero count checks",
+        messageFormat: "Use Assert.{0} for count checks against zero",
         category: "Assertions",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
@@ -46,6 +46,9 @@ public sealed class CountAssertionAnalyzer : DiagnosticAnalyzer
         if (!CountAssertionAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, symbols, out var match))
             return;
 
-        context.ReportDiagnostic(Diagnostic.Create(match.UseEmptyAssertion ? UseEmptyDescriptor : UseHasCountDescriptor, match.CountOperation.Syntax.GetLocation()));
+        var diagnostic = match.UseEmptyAssertion
+            ? Diagnostic.Create(UseEmptyDescriptor, match.CountOperation.Syntax.GetLocation(), match.AssertionMethodName)
+            : Diagnostic.Create(UseHasCountDescriptor, match.CountOperation.Syntax.GetLocation());
+        context.ReportDiagnostic(diagnostic);
     }
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzerCommon.cs
@@ -7,6 +7,7 @@ namespace Meziantou.Framework.Analyzers.Assertions;
 internal static class CountAssertionAnalyzerCommon
 {
     private const string EmptyAssertionMethodName = "Empty";
+    private const string NotEmptyAssertionMethodName = "NotEmpty";
     private const string HasCountAssertionMethodName = "HasCount";
     private const string DoesNotHaveCountAssertionMethodName = "DoesNotHaveCount";
     private const string HasCountLessThanAssertionMethodName = "HasCountLessThan";
@@ -45,7 +46,15 @@ internal static class CountAssertionAnalyzerCommon
             return false;
         }
 
-        symbols = new Symbols(arrayType, nonGenericICollectionCountProperty, genericICollectionCountPropertyDefinition, enumerableCountMethodDefinitions);
+        // Types that expose the item count through a 'Length' property instead of 'Count'
+        var lengthTypeDefinitions = new[]
+        {
+            compilation.GetTypeByMetadataName("System.Collections.Immutable.ImmutableArray`1"),
+            compilation.GetTypeByMetadataName("System.ReadOnlySpan`1"),
+            compilation.GetTypeByMetadataName("System.Span`1"),
+        }.Where(type => type is not null).Select(type => type!).ToImmutableArray();
+
+        symbols = new Symbols(arrayType, nonGenericICollectionCountProperty, genericICollectionCountPropertyDefinition, enumerableCountMethodDefinitions, lengthTypeDefinitions);
         return true;
     }
 
@@ -61,7 +70,10 @@ internal static class CountAssertionAnalyzerCommon
         switch (targetMethod.Name)
         {
             case "Equal":
-                return TryGetAssertEqualAssertionMatch(invocationOperation, symbols, out match);
+                return TryGetAssertEqualAssertionMatch(invocationOperation, symbols, negate: false, out match);
+
+            case "NotEqual":
+                return TryGetAssertEqualAssertionMatch(invocationOperation, symbols, negate: true, out match);
 
             case "True":
                 return TryGetAssertBooleanAssertionMatch(invocationOperation, symbols, conditionExpectedToBeFalse: false, out match);
@@ -74,7 +86,7 @@ internal static class CountAssertionAnalyzerCommon
         return false;
     }
 
-    private static bool TryGetAssertEqualAssertionMatch(IInvocationOperation invocationOperation, Symbols symbols, out AssertionMatch match)
+    private static bool TryGetAssertEqualAssertionMatch(IInvocationOperation invocationOperation, Symbols symbols, bool negate, out AssertionMatch match)
     {
         IArgumentOperation? expectedArgument = null;
         IArgumentOperation? actualArgument = null;
@@ -103,7 +115,7 @@ internal static class CountAssertionAnalyzerCommon
             return false;
         }
 
-        if (!TryGetAssertionMethodForEquality(expectedArgument.Value, out var expectedOperation, out var assertionMethodName))
+        if (!TryGetAssertionMethodForEquality(expectedArgument.Value, negate, out var expectedOperation, out var assertionMethodName))
         {
             match = default;
             return false;
@@ -188,18 +200,18 @@ internal static class CountAssertionAnalyzerCommon
         return false;
     }
 
-    private static bool TryGetAssertionMethodForEquality(IOperation operation, out IOperation expectedOperation, out string assertionMethodName)
+    private static bool TryGetAssertionMethodForEquality(IOperation operation, bool negate, out IOperation expectedOperation, out string assertionMethodName)
     {
         expectedOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(operation);
         if (NumericHelpers.IsZero(expectedOperation.ConstantValue))
         {
-            assertionMethodName = EmptyAssertionMethodName;
+            assertionMethodName = negate ? NotEmptyAssertionMethodName : EmptyAssertionMethodName;
             return true;
         }
 
         if (expectedOperation.Type?.SpecialType == SpecialType.System_Int32)
         {
-            assertionMethodName = HasCountAssertionMethodName;
+            assertionMethodName = negate ? DoesNotHaveCountAssertionMethodName : HasCountAssertionMethodName;
             return true;
         }
 
@@ -213,8 +225,8 @@ internal static class CountAssertionAnalyzerCommon
         if (conditionExpectedToBeFalse)
             comparisonOperator = NegateComparisonOperator(comparisonOperator);
 
-        if (comparisonOperator == BinaryOperatorKind.Equals)
-            return TryGetAssertionMethodForEquality(expectedOperation, out unwrappedExpectedOperation, out assertionMethodName);
+        if (comparisonOperator is BinaryOperatorKind.Equals or BinaryOperatorKind.NotEquals)
+            return TryGetAssertionMethodForEquality(expectedOperation, comparisonOperator == BinaryOperatorKind.NotEquals, out unwrappedExpectedOperation, out assertionMethodName);
 
         if (!TryGetIntExpectedOperation(expectedOperation, out unwrappedExpectedOperation))
         {
@@ -223,7 +235,27 @@ internal static class CountAssertionAnalyzerCommon
         }
 
         assertionMethodName = GetAssertionMethodName(comparisonOperator, collectionOperationOnLeftSide);
+        assertionMethodName = NormalizeToEmptinessAssertion(assertionMethodName, unwrappedExpectedOperation);
         return true;
+    }
+
+    /// <summary>
+    /// Rewrites count comparisons that are equivalent to an emptiness check, so that <c>list.Count &gt; 0</c>
+    /// maps to <c>Assert.NotEmpty</c> rather than <c>Assert.HasCountGreaterThan(0, ...)</c>.
+    /// </summary>
+    private static string NormalizeToEmptinessAssertion(string assertionMethodName, IOperation expectedOperation)
+    {
+        if (expectedOperation.ConstantValue is not { HasValue: true, Value: int expectedCount })
+            return assertionMethodName;
+
+        return (assertionMethodName, expectedCount) switch
+        {
+            (HasCountGreaterThanAssertionMethodName, 0) => NotEmptyAssertionMethodName,
+            (HasCountGreaterThanOrEqualAssertionMethodName, 1) => NotEmptyAssertionMethodName,
+            (HasCountLessThanAssertionMethodName, 1) => EmptyAssertionMethodName,
+            (HasCountLessThanOrEqualAssertionMethodName, 0) => EmptyAssertionMethodName,
+            _ => assertionMethodName,
+        };
     }
 
     private static bool TryGetIntExpectedOperation(IOperation operation, out IOperation expectedOperation)
@@ -240,9 +272,6 @@ internal static class CountAssertionAnalyzerCommon
 
     private static string GetAssertionMethodName(BinaryOperatorKind comparisonOperator, bool collectionOperationOnLeftSide)
     {
-        if (comparisonOperator == BinaryOperatorKind.NotEquals)
-            return DoesNotHaveCountAssertionMethodName;
-
         return (comparisonOperator, collectionOperationOnLeftSide) switch
         {
             (BinaryOperatorKind.LessThan, true) => HasCountLessThanAssertionMethodName,
@@ -278,7 +307,7 @@ internal static class CountAssertionAnalyzerCommon
         switch (operation)
         {
             case IPropertyReferenceOperation { Instance: { } instance } propertyReferenceOperation
-                when IsArrayLengthProperty(propertyReferenceOperation.Property, symbols) ||
+                when IsLengthProperty(propertyReferenceOperation.Property, symbols) ||
                      IsCollectionCountProperty(propertyReferenceOperation.Property, symbols):
                 collectionOperation = instance;
                 countOperation = propertyReferenceOperation;
@@ -306,10 +335,25 @@ internal static class CountAssertionAnalyzerCommon
         return false;
     }
 
-    private static bool IsArrayLengthProperty(IPropertySymbol property, Symbols symbols)
+    private static bool IsLengthProperty(IPropertySymbol property, Symbols symbols)
     {
-        return property is { Name: "Length" } &&
-               SymbolEqualityComparer.Default.Equals(property.ContainingType, symbols.ArrayType);
+        if (property.Name != "Length")
+            return false;
+
+        var containingType = property.ContainingType;
+        if (containingType.SpecialType == SpecialType.System_String ||
+            SymbolEqualityComparer.Default.Equals(containingType, symbols.ArrayType))
+        {
+            return true;
+        }
+
+        foreach (var lengthTypeDefinition in symbols.LengthTypeDefinitions)
+        {
+            if (SymbolEqualityComparer.Default.Equals(containingType.OriginalDefinition, lengthTypeDefinition))
+                return true;
+        }
+
+        return false;
     }
 
     private static bool IsCollectionCountProperty(IPropertySymbol property, Symbols symbols)
@@ -363,12 +407,16 @@ internal static class CountAssertionAnalyzerCommon
         IOperation CountOperation,
         string AssertionMethodName)
     {
-        internal bool UseEmptyAssertion => AssertionMethodName == EmptyAssertionMethodName;
+        /// <summary>
+        /// <c>Assert.Empty</c> and <c>Assert.NotEmpty</c> take only the collection, so the expected count is dropped.
+        /// </summary>
+        internal bool UseEmptyAssertion => AssertionMethodName is EmptyAssertionMethodName or NotEmptyAssertionMethodName;
     }
 
     internal readonly record struct Symbols(
         INamedTypeSymbol ArrayType,
         IPropertySymbol NonGenericICollectionCountProperty,
         IPropertySymbol GenericICollectionCountPropertyDefinition,
-        ImmutableArray<IMethodSymbol> EnumerableCountMethodDefinitions);
+        ImmutableArray<IMethodSymbol> EnumerableCountMethodDefinitions,
+        ImmutableArray<INamedTypeSymbol> LengthTypeDefinitions);
 }

--- a/src/Meziantou.Framework.Assertions/readme.md
+++ b/src/Meziantou.Framework.Assertions/readme.md
@@ -33,6 +33,7 @@ Assertion helpers for .NET tests.
 - `Matches`: Asserts text matches a regular expression.
 - `DoesNotMatch`: Asserts text does not match a regular expression.
 - `All`: Asserts all items in a collection satisfy an assertion.
+- `DoesNotAll`: Asserts at least one item in a collection does not satisfy a predicate.
 - `Collection`: Asserts collection items match a list of inspectors.
 - `Distinct`: Asserts all items in a sequence are distinct.
 - `NotDistinct`: Asserts a sequence contains duplicate items.
@@ -86,7 +87,7 @@ The package ships analyzers and code fixes to help write clearer assertions.
 | `MFAS0001` | Assertions | Pass the expected value before the actual value | Warning | ✔️ |
 | `MFAS0002` | Assertions | Use Assert.Same instead of Assert.ReferenceEquals | Error | ✔️ |
 | `MFAS0003` | Assertions | Do not use Assert.IsType with static or abstract types | Error | ✔️ |
-| `MFAS0004` | Assertions | Use Assert.Empty for zero count checks | Warning | ✔️ |
+| `MFAS0004` | Assertions | Use Assert.Empty or Assert.NotEmpty for zero count checks | Warning | ✔️ |
 | `MFAS0005` | Assertions | Use specialized count assertions | Warning | ✔️ |
 | `MFAS0006` | Assertions | Use Assert.Null for null comparisons | Warning | ✔️ |
 | `MFAS0007` | Assertions | Use Assert.NotNull for null comparisons | Warning | ✔️ |

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CountAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CountAssertionRuleTests.cs
@@ -633,7 +633,7 @@ public sealed class CountAssertionRuleTests : AssertionsAnalyzerTestBase
             {
                 public static void M(int[] collection)
                 {
-                    Assert.False({|MFAS0005:collection.Length|} == 0);
+                    Assert.False({|MFAS0004:collection.Length|} == 0);
                 }
             }
             """;
@@ -647,7 +647,7 @@ public sealed class CountAssertionRuleTests : AssertionsAnalyzerTestBase
             {
                 public static void M(int[] collection)
                 {
-                    Assert.DoesNotHaveCount(0, collection);
+                    Assert.NotEmpty(collection);
                 }
             }
             """;
@@ -1018,7 +1018,7 @@ public sealed class CountAssertionRuleTests : AssertionsAnalyzerTestBase
                     Assert.False(collection.Count() <= 10L);
                     Assert.False(collection.Count() > 10L);
                     Assert.False(collection.Count() >= 10L);
-                    Assert.NotEqual(10, collection.Count());
+                    Assert.NotEqual(10L, collection.Count());
                 }
             }
             """;
@@ -1061,5 +1061,157 @@ public sealed class CountAssertionRuleTests : AssertionsAnalyzerTestBase
             """;
 
         await CreateAnalyzerTest<CountAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Theory]
+    [InlineData("Assert.NotEqual(0, {|MFAS0004:collection.Count|});", "Assert.NotEmpty(collection);")]
+    [InlineData("Assert.NotEqual(3, {|MFAS0005:collection.Count|});", "Assert.DoesNotHaveCount(3, collection);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForAssertNotEqualCount(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Theory]
+    [InlineData("Assert.True({|MFAS0004:collection.Count|} > 0);", "Assert.NotEmpty(collection);")]
+    [InlineData("Assert.True({|MFAS0004:collection.Count|} >= 1);", "Assert.NotEmpty(collection);")]
+    [InlineData("Assert.True({|MFAS0004:collection.Count|} < 1);", "Assert.Empty(collection);")]
+    [InlineData("Assert.True({|MFAS0004:collection.Count|} <= 0);", "Assert.Empty(collection);")]
+    [InlineData("Assert.True({|MFAS0004:collection.Count|} != 0);", "Assert.NotEmpty(collection);")]
+    [InlineData("Assert.False({|MFAS0004:collection.Count|} > 0);", "Assert.Empty(collection);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForEmptinessEquivalentComparison(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForStringLength()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(string value)
+                {
+                    Assert.Equal(0, {|MFAS0004:value.Length|});
+                    Assert.Equal(3, {|MFAS0005:value.Length|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(string value)
+                {
+                    Assert.Empty(value);
+                    Assert.HasCount(3, value);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForImmutableArrayLength()
+    {
+        var source = """
+            using System.Collections.Immutable;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ImmutableArray<int> collection)
+                {
+                    Assert.Equal(0, {|MFAS0004:collection.Length|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Immutable;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(ImmutableArray<int> collection)
+                {
+                    Assert.Empty(collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
     }
 }

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/UseNullAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/UseNullAssertionRuleTests.cs
@@ -140,4 +140,104 @@ public sealed class UseNullAssertionRuleTests : AssertionsAnalyzerTestBase
 
         await CreateCodeFixTest<UseNullAssertionAnalyzerType, UseNullAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
     }
+
+    [Theory]
+    [InlineData("Assert.False({|MFAS0007:value|} == null);", "Assert.NotNull(value);")]
+    [InlineData("Assert.False({|MFAS0006:value|} != null);", "Assert.Null(value);")]
+    [InlineData("Assert.False({|MFAS0007:value|} is null);", "Assert.NotNull(value);")]
+    [InlineData("Assert.False({|MFAS0006:value|} is not null);", "Assert.Null(value);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForAssertFalseNullCheck(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(string? value)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(string? value)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<UseNullAssertionAnalyzerType, UseNullAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Theory]
+    [InlineData("Assert.True({|MFAS0007:value|}.HasValue);", "Assert.NotNull(value);")]
+    [InlineData("Assert.False({|MFAS0006:value|}.HasValue);", "Assert.Null(value);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForNullableHasValue(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int? value)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int? value)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<UseNullAssertionAnalyzerType, UseNullAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForHasValueOnCustomType()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public sealed class Option
+            {
+                public bool HasValue => true;
+            }
+
+            public static class TestClass
+            {
+                public static void M(Option value)
+                {
+                    Assert.True(value.HasValue);
+                    Assert.False(value.HasValue);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseNullAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
 }

--- a/tests/Meziantou.Framework.Avatar.Tests/AvatarGeneratorTests.cs
+++ b/tests/Meziantou.Framework.Avatar.Tests/AvatarGeneratorTests.cs
@@ -265,7 +265,7 @@ public class AvatarGeneratorTests
     private static double GetRelativeLuminance(string hexColor)
     {
         Assert.StartsWith("#", hexColor);
-        Assert.Equal(7, hexColor.Length);
+        Assert.HasCount(7, hexColor);
 
         var red = Convert.ToInt32(hexColor[1..3], fromBase: 16) / 255d;
         var green = Convert.ToInt32(hexColor[3..5], fromBase: 16) / 255d;

--- a/tests/Meziantou.Framework.FastEnumGenerator.Tests/FastEnumSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FastEnumGenerator.Tests/FastEnumSourceGeneratorTests.cs
@@ -29,7 +29,7 @@ public sealed class FastEnumSourceGeneratorTests
 
         var (runResult, _) = await GenerateFiles(sourceCode);
         Assert.Empty(runResult.Diagnostics);
-        Assert.Equal(3, runResult.GeneratedTrees.Length);
+        Assert.HasCount(3, runResult.GeneratedTrees);
         var generatedTree = Assert.Single(runResult.GeneratedTrees, static tree => tree.FilePath.EndsWith("FastEnumExtensions.g.cs", StringComparison.Ordinal));
         Assert.Contains(runResult.GeneratedTrees, static tree => tree.FilePath.EndsWith("Microsoft.CodeAnalysis.EmbeddedAttribute.g.cs", StringComparison.Ordinal));
         Assert.Contains(runResult.GeneratedTrees, static tree => tree.FilePath.EndsWith("Meziantou.Framework.Annotations.FastEnumAttribute.g.cs", StringComparison.Ordinal));

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
@@ -44,7 +44,7 @@ public sealed class FixedStringBuilderSourceGeneratorTests
         var (runResult, compilation) = await GenerateAsync(Source);
         Assert.Empty(runResult.Diagnostics);
         Assert.Single(runResult.Results);
-        Assert.Equal(3, runResult.Results[0].GeneratedSources.Length);
+        Assert.HasCount(3, runResult.Results[0].GeneratedSources);
 
         var allGeneratedSources = string.Join('\n', runResult.Results[0].GeneratedSources.Select(static source => source.SourceText.ToString()));
         Assert.Contains("internal partial class FixedStringBuilderAttribute", allGeneratedSources);

--- a/tests/Meziantou.Framework.FixedStringBuilder.Tests/FixedStringBuilderTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Tests/FixedStringBuilderTests.cs
@@ -53,7 +53,7 @@ public sealed class FixedStringBuilderTests
         var fixedString = (IFixedString)value;
         var span = fixedString.GetUnsafeFullSpan();
 
-        Assert.Equal(FixedStringBuilder8.MaxLength, span.Length);
+        Assert.HasCount(FixedStringBuilder8.MaxLength, span);
         Assert.Equal('a', span[0]);
         Assert.Equal('b', span[1]);
         Assert.Equal('c', span[2]);

--- a/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
@@ -89,7 +89,7 @@ public sealed class JsonPathEvaluateTests
 
         var value = doc.RootElement.EvaluateValue(path);
 
-        Assert.True(value.HasValue);
+        Assert.NotNull(value);
         Assert.Equal(JsonValueKind.Null, value.Value.ValueKind);
     }
 

--- a/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
@@ -102,7 +102,7 @@ public sealed class FlacTests
         var result = MediaFile.ReadTags(GetTestFilePath("long_values.flac"));
         Assert.True(result.IsSuccess);
         Assert.NotNull(result.Value.Title);
-        Assert.True(result.Value.Title.Length > 100);
+        Assert.HasCountGreaterThan(100, result.Value.Title);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.MediaTags.Tests/Mp3Id3v2Tests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Mp3Id3v2Tests.cs
@@ -73,7 +73,7 @@ public sealed class Mp3Id3v2Tests
 
         var tags = result.Value;
         Assert.NotNull(tags.Title);
-        Assert.True(tags.Title.Length > 100); // Should be very long
+        Assert.HasCountGreaterThan(100, tags.Title); // Should be very long
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
+++ b/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
@@ -279,7 +279,7 @@ public sealed class PooledMemoryStreamTests
         IBufferWriter<byte> writer = stream;
 
         var span = writer.GetSpan(20);
-        Assert.True(span.Length >= 20);
+        Assert.HasCountGreaterThanOrEqual(20, span);
         for (var i = 0; i < 20; i++)
             span[i] = (byte)i;
         writer.Advance(20);
@@ -288,7 +288,7 @@ public sealed class PooledMemoryStreamTests
         Assert.Equal(20, stream.Position);
 
         var span2 = writer.GetSpan(10);
-        Assert.True(span2.Length >= 10);
+        Assert.HasCountGreaterThanOrEqual(10, span2);
         for (var i = 0; i < 10; i++)
             span2[i] = (byte)(100 + i);
         writer.Advance(10);

--- a/tests/Meziantou.Framework.QRCode.Tests/QRCodeConsoleRendererTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/QRCodeConsoleRendererTests.cs
@@ -155,7 +155,7 @@ public class QRCodeConsoleRendererTests
         var withoutQuiet = qr.ToConsoleString(new QRCodeConsoleOptions { QuietZoneModules = 0, ModuleWidth = 2, ModuleHeight = 2 });
         var withQuiet = qr.ToConsoleString(new QRCodeConsoleOptions { QuietZoneModules = 2, ModuleWidth = 2, ModuleHeight = 2 });
 
-        Assert.True(withQuiet.Length > withoutQuiet.Length);
+        Assert.HasCountGreaterThan(withoutQuiet.Length, withQuiet);
     }
 
     [Theory]

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/ResxGeneratorTests.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/ResxGeneratorTests.cs
@@ -37,7 +37,7 @@ public class ResxGeneratorTests
     public void GetStringWithDefaultValue()
     {
         // Ensure the value is not nullable
-        Assert.Equal(3, Resource1.GetString("UnknownValue", defaultValue: "abc").Length);
+        Assert.HasCount(3, Resource1.GetString("UnknownValue", defaultValue: "abc"));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -113,7 +113,7 @@ public sealed partial class SnapshotTests
         var path = settings.SnapshotPathStrategy(context);
         Assert.Matches(SnapshotNameWithIndexRegex(), path.Name);
         Assert.DoesNotMatch(SnapshotNameHashWithIndexFragmentRegex(), path.Name);
-        Assert.True(path.Name.Length <= settings.MaxSnapshotFileNameLength);
+        Assert.HasCountLessThanOrEqual(settings.MaxSnapshotFileNameLength, path.Name);
     }
 
     [Fact]
@@ -135,7 +135,7 @@ public sealed partial class SnapshotTests
         var path = settings.SnapshotPathStrategy(context);
         Assert.Matches(SnapshotNameRegex(), path.Name);
         Assert.DoesNotContain("_0", path.Name);
-        Assert.True(path.Name.Length <= settings.MaxSnapshotFileNameLength);
+        Assert.HasCountLessThanOrEqual(settings.MaxSnapshotFileNameLength, path.Name);
     }
 
     [Fact]
@@ -291,7 +291,7 @@ public sealed partial class SnapshotTests
 
         var path = settings.SnapshotPathStrategy(context);
         Assert.Matches(SnapshotNameWithHashAndIndexRegex(), path.Name);
-        Assert.True(path.Name.Length <= settings.MaxSnapshotFileNameLength);
+        Assert.HasCountLessThanOrEqual(settings.MaxSnapshotFileNameLength, path.Name);
     }
 
     [Theory]
@@ -314,7 +314,7 @@ public sealed partial class SnapshotTests
 
         var path = settings.SnapshotPathStrategy(context);
         Assert.Matches(SnapshotNameWithHashAndIndexRegex(), path.Name);
-        Assert.True(path.Name.Length <= settings.MaxSnapshotFileNameLength);
+        Assert.HasCountLessThanOrEqual(settings.MaxSnapshotFileNameLength, path.Name);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
@@ -127,7 +127,9 @@ public sealed partial class StronglyTypedIdTests
     public void TestNullableClass()
     {
         IdClassInt32 value = IdClassInt32.FromInt32(42);
+#pragma warning disable MFAS0007 // Preserve the generated == operator validation
         Assert.False(value == null);
+#pragma warning restore MFAS0007
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/MongoDbContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/MongoDbContainerTests.cs
@@ -25,7 +25,7 @@ public sealed class MongoDbContainerTests
         Assert.Equal("root", definition.RootUsername);
         Assert.Equal("root", definition.Environment.GetValue("MONGO_INITDB_ROOT_USERNAME"));
         Assert.Equal(password, definition.Environment.GetValue("MONGO_INITDB_ROOT_PASSWORD"));
-        Assert.Equal(24, password.Length);
+        Assert.HasCount(24, password);
         Assert.Contains(password, static c => char.IsUpper(c));
         Assert.Contains(password, static c => char.IsLower(c));
         Assert.Contains(password, static c => char.IsDigit(c));

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/SqlServerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/SqlServerContainerTests.cs
@@ -31,7 +31,7 @@ public sealed class SqlServerContainerTests
         Assert.Equal("Y", definition.Environment.GetValue("ACCEPT_EULA"));
         Assert.Equal(password, definition.Environment.GetValue("MSSQL_SA_PASSWORD"));
         Assert.Equal(password, definition.Environment.GetValue("SA_PASSWORD"));
-        Assert.Equal(24, password.Length);
+        Assert.HasCount(24, password);
         Assert.Contains(password, static c => char.IsUpper(c));
         Assert.Contains(password, static c => char.IsLower(c));
         Assert.Contains(password, static c => char.IsDigit(c));

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableArrayTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableArrayTests.cs
@@ -91,9 +91,9 @@ public sealed class ImmutableEquatableArrayTests
         var array = ImmutableEquatableArray.Create(new[] { "a" });
 
         Assert.False(array.Equals(null));
+#pragma warning disable MFAS0007 // Preserve == and != operator validation
         Assert.False(array == null);
         Assert.False(null == array);
-#pragma warning disable MFAS0007 // Preserve == and != operator validation
         Assert.True(array != null);
         Assert.True(null != array);
 #pragma warning restore MFAS0007

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableDictionaryTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableDictionaryTests.cs
@@ -177,9 +177,9 @@ public sealed class ImmutableEquatableDictionaryTests
         var dict = new[] { ("a", 1) }.ToImmutableEquatableDictionary();
 
         Assert.False(dict.Equals(null));
+#pragma warning disable MFAS0007 // Preserve == and != operator validation
         Assert.False(dict == null);
         Assert.False(null == dict);
-#pragma warning disable MFAS0007 // Preserve == and != operator validation
         Assert.True(dict != null);
         Assert.True(null != dict);
 #pragma warning restore MFAS0007

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
@@ -87,9 +87,9 @@ public sealed class ImmutableEquatableSetTests
         var set = ImmutableEquatableSet.Create(new HashSet<string>(StringComparer.Ordinal) { "a" });
 
         Assert.False(set.Equals(null));
+#pragma warning disable MFAS0007 // Preserve == and != operator validation
         Assert.False(set == null);
         Assert.False(null == set);
-#pragma warning disable MFAS0007 // Preserve == and != operator validation
         Assert.True(set != null);
         Assert.True(null != set);
 #pragma warning restore MFAS0007

--- a/tests/Meziantou.Framework.Tests/Collections/SortedListTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/SortedListTests.cs
@@ -70,7 +70,7 @@ public sealed class SortedListTests
     public void AsSpan()
     {
         var list = new SortedList<int> { 1, 3, 2 };
-        Assert.Equal(3, list.UnsafeAsReadOnlySpan().Length);
+        Assert.HasCount(3, list.UnsafeAsReadOnlySpan());
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Tests/EncodingTests.cs
+++ b/tests/Meziantou.Framework.Tests/EncodingTests.cs
@@ -5,6 +5,6 @@ public sealed class EncodingTests
     public static void Utf8WithoutPreambleTest()
     {
         var encoding = Encoding.UTF8WithoutPreamble;
-        Assert.Equal(0, encoding.Preamble.Length);
+        Assert.Empty(encoding.Preamble);
     }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlReferenceHandlingTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlReferenceHandlingTests.cs
@@ -61,7 +61,7 @@ public class YamlReferenceHandlingTests
         Assert.True(anchorEnd > anchorStart, "Expected an anchor name after 'A: &'.");
 
         var anchor = yaml.Substring(anchorStart, anchorEnd - anchorStart).Trim();
-        Assert.True(anchor.Length > 0);
+        Assert.NotEmpty(anchor);
 
         Assert.Contains($"B: *{anchor}", yaml);
     }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerCollectionSupportReflectionTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerCollectionSupportReflectionTests.cs
@@ -133,7 +133,7 @@ public sealed class YamlSerializerCollectionSupportReflectionTests
 
         var result = YamlSerializer.Deserialize<ImmutableArray<int>>(yaml);
 
-        Assert.Equal(2, result.Length);
+        Assert.HasCount(2, result);
         Assert.Equal(10, result[0]);
         Assert.Equal(20, result[1]);
     }
@@ -195,8 +195,8 @@ public sealed class YamlSerializerCollectionSupportReflectionTests
         var result = YamlSerializer.Deserialize<ImmutableArrayAnchorPayload>(yaml, options);
 
         Assert.NotNull(result);
-        Assert.Equal(2, result.Values.Length);
-        Assert.Equal(2, result.Other.Length);
+        Assert.HasCount(2, result.Values);
+        Assert.HasCount(2, result.Other);
         Assert.Equal(result.Values[0], result.Other[0]);
         Assert.Equal(result.Values[1], result.Other[1]);
     }


### PR DESCRIPTION
**1 of 5** in a stack that adds analyzer rules to `Meziantou.Framework.Assertions`. Each PR builds and passes tests on its own; later PRs are based on this one.

No new diagnostic ids here — these are gaps in rules that already ship.

| Gap | Where |
| -- | -- |
| `MFAS0006`/`MFAS0007` only inspected `Assert.True`, so `Assert.False(x == null)` and `Assert.False(x is not null)` were missed | `TryGetNullCheckMatch` hardcoded the method name |
| `Nullable<T>.HasValue` was not recognised as a null check | same file |
| `Assert.Equal(0, s.Length)` on a **string** was missed, though `Assert.Empty(string)` exists | the count analyzer only knew `Array.Length` and `ICollection(<T>).Count` |
| `Assert.NotEqual(0, x.Count)` was not handled | the count analyzer handled `Equal`/`True`/`False` only |
| `x.Count > 0` mapped to `HasCountGreaterThan(0, x)` rather than `NotEmpty(x)` | comparisons equivalent to an emptiness check are now normalised |
| `readme.md` omitted `DoesNotAll`, which exists in the API and is `MFAS0027`'s target | readme |

`ImmutableArray<T>.Length` and `Span<T>.Length` are recognised alongside `string.Length`.

### Reviewer note

`MFAS0004` now covers `NotEmpty` too, so its title changed to "Use Assert.Empty or Assert.NotEmpty for zero count checks". Two existing tests shifted with it: `Assert.False(x.Length == 0)` now fixes to `Assert.NotEmpty(x)` instead of `Assert.DoesNotHaveCount(0, x)`. I updated those tests rather than preserving the old output — flagging in case you prefer the old mapping.

### Verification

Analyzer tests 95 passed (from 78), library tests 786 passed, `/p:TreatWarningsAsErrors=true` clean, `eng/update-all.cs` run and idempotent.
