### PR TITLE
Add emptiness assertion rules (MFAS0028-MFAS0030)

### DIFF
--- a/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
@@ -29,4 +29,7 @@ internal static class RuleIdentifiers
     internal const string UseCollectionAnyDoesNotContainDiagnosticId = "MFAS0025";
     internal const string UseCollectionAllDiagnosticId = "MFAS0026";
     internal const string UseCollectionDoesNotAllDiagnosticId = "MFAS0027";
+    internal const string UseNotEmptyForAnyDiagnosticId = "MFAS0028";
+    internal const string UseEmptyForAnyDiagnosticId = "MFAS0029";
+    internal const string UseEmptinessAssertionDiagnosticId = "MFAS0030";
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/CollectionAnyWithoutPredicateAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/CollectionAnyWithoutPredicateAnalyzer.cs
@@ -1,0 +1,57 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class CollectionAnyWithoutPredicateAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor UseNotEmptyDescriptor = new(
+        id: RuleIdentifiers.UseNotEmptyForAnyDiagnosticId,
+        title: "Use Assert.NotEmpty instead of Assert.True(collection.Any())",
+        messageFormat: "Use Assert.NotEmpty(actual) for readability",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseEmptyDescriptor = new(
+        id: RuleIdentifiers.UseEmptyForAnyDiagnosticId,
+        title: "Use Assert.Empty instead of Assert.False(collection.Any())",
+        messageFormat: "Use Assert.Empty(actual) for readability",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [UseNotEmptyDescriptor, UseEmptyDescriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var assertType = context.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+            if (assertType is null || !TrueFalseConditionMethodSelectionAnalyzerCommon.TryCreateSymbols(context.Compilation, out var symbols))
+                return;
+
+            context.RegisterOperationAction(
+                context => Analyze(context, assertType, symbols.Value),
+                OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, INamedTypeSymbol assertType, TrueFalseConditionMethodSelectionAnalyzerCommon.Symbols symbols)
+    {
+        var assertInvocation = (IInvocationOperation)context.Operation;
+        if (!TrueFalseConditionMethodSelectionAnalyzerCommon.TryGetAssertInnerInvocation(assertInvocation, assertType, out var innerInvocation, out var conditionExpectedToBeFalse))
+            return;
+
+        if (!TrueFalseConditionMethodSelectionAnalyzerCommon.TryGetCollectionAnyWithoutPredicateMatch(innerInvocation, symbols, conditionExpectedToBeFalse, out var match))
+            return;
+
+        var descriptor = conditionExpectedToBeFalse ? UseEmptyDescriptor : UseNotEmptyDescriptor;
+        context.ReportDiagnostic(Diagnostic.Create(descriptor, match.InnerInvocation.Syntax.GetLocation()));
+    }
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/EmptinessAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/EmptinessAssertionAnalyzer.cs
@@ -1,0 +1,43 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class EmptinessAssertionAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: RuleIdentifiers.UseEmptinessAssertionDiagnosticId,
+        title: "Use Assert.Empty or Assert.NotEmpty instead of a count assertion",
+        messageFormat: "Use Assert.{0} instead of a count assertion against zero",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var assertType = context.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+            if (assertType is null)
+                return;
+
+            context.RegisterOperationAction(context => Analyze(context, assertType), OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, INamedTypeSymbol assertType)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        if (!EmptinessAssertionAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, out var match))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation(), match.AssertionMethodName));
+    }
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/EmptinessAssertionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/EmptinessAssertionAnalyzerCommon.cs
@@ -1,0 +1,60 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+/// <summary>
+/// Detects count assertions that are equivalent to <c>Assert.Empty</c> or <c>Assert.NotEmpty</c>,
+/// such as <c>Assert.HasCount(0, actual)</c> or <c>Assert.HasCountGreaterThan(0, actual)</c>.
+/// </summary>
+internal static class EmptinessAssertionAnalyzerCommon
+{
+    private const string EmptyAssertionMethodName = "Empty";
+    private const string NotEmptyAssertionMethodName = "NotEmpty";
+
+    internal static bool TryGetAssertionMatch(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, out EmptinessMatch match)
+    {
+        if (invocationOperation.TargetMethod is not { IsStatic: true } targetMethod ||
+            !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, assertType))
+        {
+            match = default;
+            return false;
+        }
+
+        var expectedCountArgument = invocationOperation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "expectedCount");
+        if (expectedCountArgument is null)
+        {
+            match = default;
+            return false;
+        }
+
+        var expectedCountOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(expectedCountArgument.Value);
+        if (expectedCountOperation.ConstantValue is not { HasValue: true, Value: int expectedCount })
+        {
+            match = default;
+            return false;
+        }
+
+        var assertionMethodName = (targetMethod.Name, expectedCount) switch
+        {
+            ("HasCount", 0) => EmptyAssertionMethodName,
+            ("HasCountLessThan", 1) => EmptyAssertionMethodName,
+            ("HasCountLessThanOrEqual", 0) => EmptyAssertionMethodName,
+            ("DoesNotHaveCount", 0) => NotEmptyAssertionMethodName,
+            ("HasCountGreaterThan", 0) => NotEmptyAssertionMethodName,
+            ("HasCountGreaterThanOrEqual", 1) => NotEmptyAssertionMethodName,
+            _ => null,
+        };
+
+        if (assertionMethodName is null)
+        {
+            match = default;
+            return false;
+        }
+
+        match = new EmptinessMatch(expectedCountArgument, assertionMethodName);
+        return true;
+    }
+
+    internal readonly record struct EmptinessMatch(IArgumentOperation ExpectedCountArgument, string AssertionMethodName);
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/TrueFalseConditionMethodSelectionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/TrueFalseConditionMethodSelectionAnalyzerCommon.cs
@@ -66,6 +66,12 @@ internal static class TrueFalseConditionMethodSelectionAnalyzerCommon
             .Select(m => m.OriginalDefinition)
             .ToImmutableArray();
 
+        var enumerableAnyMethods = enumerableType.GetMembers("Any")
+            .OfType<IMethodSymbol>()
+            .Where(m => m is { IsStatic: true, IsExtensionMethod: true, Parameters.Length: 1 })
+            .Select(m => m.OriginalDefinition)
+            .ToImmutableArray();
+
         var enumerableAllMethods = enumerableType.GetMembers("All")
             .OfType<IMethodSymbol>()
             .Where(m => m is { IsStatic: true, IsExtensionMethod: true, Parameters.Length: 2 })
@@ -93,6 +99,7 @@ internal static class TrueFalseConditionMethodSelectionAnalyzerCommon
             genericReadOnlyDictionaryContainsKeyDefinition,
             enumerableContainsMethods,
             enumerableAnyWithPredicateMethods,
+            enumerableAnyMethods,
             enumerableAllMethods,
             cultureInfoType);
         return true;
@@ -121,7 +128,7 @@ internal static class TrueFalseConditionMethodSelectionAnalyzerCommon
         return true;
     }
 
-    private static bool TryGetAssertCondition(
+    internal static bool TryGetAssertCondition(
         IInvocationOperation invocationOperation,
         INamedTypeSymbol assertType,
         [NotNullWhen(true)] out IOperation? conditionOperation,
@@ -575,6 +582,46 @@ internal static class TrueFalseConditionMethodSelectionAnalyzerCommon
         return true;
     }
 
+    internal static bool TryGetCollectionAnyWithoutPredicateMatch(
+        IInvocationOperation innerInvocation,
+        Symbols symbols,
+        bool conditionExpectedToBeFalse,
+        out TrueFalseConditionMatch match)
+    {
+        if (innerInvocation.TargetMethod.Name != "Any" ||
+            symbols.EnumerableAnyMethods.IsDefaultOrEmpty)
+        {
+            match = default;
+            return false;
+        }
+
+        var originalDef = (innerInvocation.TargetMethod.ReducedFrom ?? innerInvocation.TargetMethod).OriginalDefinition;
+        if (!symbols.EnumerableAnyMethods.Contains(originalDef, SymbolEqualityComparer.Default))
+        {
+            match = default;
+            return false;
+        }
+
+        IOperation collectionOperation;
+        if (innerInvocation.Instance is not null)
+        {
+            collectionOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(innerInvocation.Instance);
+        }
+        else if (innerInvocation.Arguments.FirstOrDefault(a => a.Parameter?.Name == "source") is { } sourceArgument)
+        {
+            collectionOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(sourceArgument.Value);
+        }
+        else
+        {
+            match = default;
+            return false;
+        }
+
+        var assertionMethodName = conditionExpectedToBeFalse ? "Empty" : "NotEmpty";
+        match = new TrueFalseConditionMatch(innerInvocation, assertionMethodName, [collectionOperation]);
+        return true;
+    }
+
     internal static bool TryGetCollectionAllMatch(
         IInvocationOperation innerInvocation,
         Symbols symbols,
@@ -633,6 +680,7 @@ internal static class TrueFalseConditionMethodSelectionAnalyzerCommon
         IMethodSymbol GenericReadOnlyDictionaryContainsKeyDefinition,
         ImmutableArray<IMethodSymbol> EnumerableContainsMethods,
         ImmutableArray<IMethodSymbol> EnumerableAnyWithPredicateMethods,
+        ImmutableArray<IMethodSymbol> EnumerableAnyMethods,
         ImmutableArray<IMethodSymbol> EnumerableAllMethods,
         INamedTypeSymbol? CultureInfoType);
 

--- a/src/Meziantou.Framework.Assertions.CodeFix/Meziantou.Framework.Assertions.CodeFix.csproj
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Meziantou.Framework.Assertions.CodeFix.csproj
@@ -14,6 +14,7 @@
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/AssertionArgumentOrderAnalyzerCommon.cs" Link="Rules/AssertionArgumentOrderAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzerCommon.cs" Link="Rules/CountAssertionAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/TrueFalseConditionMethodSelectionAnalyzerCommon.cs" Link="Rules/TrueFalseConditionMethodSelectionAnalyzerCommon.cs" />
+    <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/EmptinessAssertionAnalyzerCommon.cs" Link="Rules/EmptinessAssertionAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Internals/NumericHelpers.cs" Link="Internals/NumericHelpers.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/AssertionsAnalyzerHelpers.cs" Link="AssertionsAnalyzerHelpers.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/AssertionCodeFixHelpers.cs" Link="AssertionCodeFixHelpers.cs" />

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/CollectionAnyWithoutPredicateCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/CollectionAnyWithoutPredicateCodeFixProvider.cs
@@ -1,0 +1,64 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CollectionAnyWithoutPredicateCodeFixProvider))]
+public sealed class CollectionAnyWithoutPredicateCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        [RuleIdentifiers.UseNotEmptyForAnyDiagnosticId, RuleIdentifiers.UseEmptyForAnyDiagnosticId];
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var assertType = semanticModel.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+        if (assertType is null || !TrueFalseConditionMethodSelectionAnalyzerCommon.TryCreateSymbols(semanticModel.Compilation, out var symbols))
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var innerNode = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var outerInvocation = AssertionCodeFixHelpers.TryFindOuterAssertInvocation(innerNode);
+            if (outerInvocation is null)
+                continue;
+
+            if (!AssertionCodeFixHelpers.TryGetInvocationOperation(semanticModel, outerInvocation, context.CancellationToken, out var outerOp))
+                continue;
+
+            if (!TrueFalseConditionMethodSelectionAnalyzerCommon.TryGetAssertInnerInvocation(outerOp, assertType, out var innerInvocation, out var conditionExpectedToBeFalse))
+                continue;
+
+            if (!TrueFalseConditionMethodSelectionAnalyzerCommon.TryGetCollectionAnyWithoutPredicateMatch(innerInvocation, symbols.Value, conditionExpectedToBeFalse, out var match))
+                continue;
+
+            context.RegisterCodeFix(CodeAction.Create(title: "Use Assert." + match.AssertionMethodName, createChangedDocument: ct => ApplyFixAsync(context.Document, outerInvocation, match, ct), equivalenceKey: GetType().FullName), diagnostic);
+        }
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax outerInvocation, TrueFalseConditionMethodSelectionAnalyzerCommon.TrueFalseConditionMatch match, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        if (!AssertionCodeFixHelpers.TryCreateTrueFalseConditionFix(outerInvocation, match, out var fixedInvocation))
+            return document;
+
+        var newRoot = root.ReplaceNode(outerInvocation, fixedInvocation.WithAdditionalAnnotations(Formatter.Annotation));
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/EmptinessAssertionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/EmptinessAssertionCodeFixProvider.cs
@@ -1,0 +1,84 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(EmptinessAssertionCodeFixProvider))]
+public sealed class EmptinessAssertionCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => [RuleIdentifiers.UseEmptinessAssertionDiagnosticId];
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var assertType = semanticModel.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+        if (assertType is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var invocationExpression = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true)
+                .FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (invocationExpression is null)
+                continue;
+
+            if (!AssertionCodeFixHelpers.TryGetInvocationOperation(semanticModel, invocationExpression, context.CancellationToken, out var invocationOperation))
+                continue;
+
+            if (!EmptinessAssertionAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, out var match))
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Use Assert." + match.AssertionMethodName,
+                    createChangedDocument: ct => ApplyFixAsync(context.Document, invocationExpression, assertType, ct),
+                    equivalenceKey: GetType().FullName),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocationExpression, INamedTypeSymbol assertType, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return document;
+
+        if (!AssertionCodeFixHelpers.TryGetInvocationOperation(semanticModel, invocationExpression, cancellationToken, out var invocationOperation))
+            return document;
+
+        if (!EmptinessAssertionAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, out var match))
+            return document;
+
+        // Dropping the expected count keeps the remaining arguments aligned with Assert.Empty/Assert.NotEmpty
+        var expectedCountSyntax = match.ExpectedCountArgument.Syntax;
+        var remainingArguments = invocationExpression.ArgumentList.Arguments
+            .Where(argument => argument != expectedCountSyntax)
+            .Select(argument => argument.WithoutTrivia());
+
+        var newInvocationExpression = invocationExpression
+            .WithExpression(AssertionCodeFixHelpers.ReplaceMethodName(invocationExpression.Expression, match.AssertionMethodName))
+            .WithArgumentList(SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(remainingArguments)))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        var newRoot = root.ReplaceNode(invocationExpression, newInvocationExpression);
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/Meziantou.Framework.Assertions/readme.md
+++ b/src/Meziantou.Framework.Assertions/readme.md
@@ -111,4 +111,7 @@ The package ships analyzers and code fixes to help write clearer assertions.
 | `MFAS0025` | Assertions | Use Assert.DoesNotContain instead of Assert.False(collection.Any(...)) | Warning | ✔️ |
 | `MFAS0026` | Assertions | Use Assert.All instead of Assert.True(collection.All(...)) | Warning | ✔️ |
 | `MFAS0027` | Assertions | Use Assert.DoesNotAll instead of Assert.False(collection.All(...)) | Warning | ✔️ |
+| `MFAS0028` | Assertions | Use Assert.NotEmpty instead of Assert.True(collection.Any()) | Warning | ✔️ |
+| `MFAS0029` | Assertions | Use Assert.Empty instead of Assert.False(collection.Any()) | Warning | ✔️ |
+| `MFAS0030` | Assertions | Use Assert.Empty or Assert.NotEmpty instead of a count assertion | Warning | ✔️ |
 <!-- analyzer-rules -->

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CollectionAnyWithoutPredicateRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CollectionAnyWithoutPredicateRuleTests.cs
@@ -1,0 +1,133 @@
+using CollectionAnyWithoutPredicateAnalyzerType = Meziantou.Framework.Analyzers.Assertions.CollectionAnyWithoutPredicateAnalyzer;
+using CollectionAnyWithoutPredicateCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.CollectionAnyWithoutPredicateCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class CollectionAnyWithoutPredicateRuleTests : AssertionsAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("Assert.True({|MFAS0028:collection.Any()|});", "Assert.NotEmpty(collection);")]
+    [InlineData("Assert.False({|MFAS0029:collection.Any()|});", "Assert.Empty(collection);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForCollectionAny(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CollectionAnyWithoutPredicateAnalyzerType, CollectionAnyWithoutPredicateCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_PreservesMessage()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.True({|MFAS0028:collection.Any()|}, "custom message");
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.NotEmpty(collection, message: "custom message");
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CollectionAnyWithoutPredicateAnalyzerType, CollectionAnyWithoutPredicateCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForAnyWithPredicate()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.True(collection.Any(x => x > 0));
+                    Assert.False(collection.Any(x => x > 0));
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<CollectionAnyWithoutPredicateAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForCustomAnyMethod()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public sealed class CustomCollection
+            {
+                public bool Any() => true;
+            }
+
+            public static class TestClass
+            {
+                public static void M(CustomCollection collection)
+                {
+                    Assert.True(collection.Any());
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<CollectionAnyWithoutPredicateAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/EmptinessAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/EmptinessAssertionRuleTests.cs
@@ -1,0 +1,150 @@
+using EmptinessAssertionAnalyzerType = Meziantou.Framework.Analyzers.Assertions.EmptinessAssertionAnalyzer;
+using EmptinessAssertionCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.EmptinessAssertionCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class EmptinessAssertionRuleTests : AssertionsAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("{|MFAS0030:Assert.HasCount(0, collection)|};", "Assert.Empty(collection);")]
+    [InlineData("{|MFAS0030:Assert.HasCountLessThan(1, collection)|};", "Assert.Empty(collection);")]
+    [InlineData("{|MFAS0030:Assert.HasCountLessThanOrEqual(0, collection)|};", "Assert.Empty(collection);")]
+    [InlineData("{|MFAS0030:Assert.DoesNotHaveCount(0, collection)|};", "Assert.NotEmpty(collection);")]
+    [InlineData("{|MFAS0030:Assert.HasCountGreaterThan(0, collection)|};", "Assert.NotEmpty(collection);")]
+    [InlineData("{|MFAS0030:Assert.HasCountGreaterThanOrEqual(1, collection)|};", "Assert.NotEmpty(collection);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForCountAssertionAgainstZero(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<EmptinessAssertionAnalyzerType, EmptinessAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_PreservesMessage()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {|MFAS0030:Assert.HasCount(0, collection, "custom message")|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.Empty(collection, "custom message");
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<EmptinessAssertionAnalyzerType, EmptinessAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForNonZeroCounts()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection, int count)
+                {
+                    Assert.HasCount(1, collection);
+                    Assert.HasCount(count, collection);
+                    Assert.HasCountGreaterThan(1, collection);
+                    Assert.HasCountGreaterThanOrEqual(0, collection);
+                    Assert.HasCountLessThan(2, collection);
+                    Assert.HasCountLessThanOrEqual(1, collection);
+                    Assert.DoesNotHaveCount(1, collection);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<EmptinessAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Theory]
+    [InlineData("{|MFAS0030:Assert.HasCount(expectedCount: 0, actual: collection)|};", "Assert.Empty(actual: collection);")]
+    [InlineData("{|MFAS0030:Assert.HasCount(actual: collection, expectedCount: 0)|};", "Assert.Empty(actual: collection);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForNamedArguments(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<EmptinessAssertionAnalyzerType, EmptinessAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+}


### PR DESCRIPTION
**2 of 5**. Based on #1845.

| Id | Detects | Suggests |
| -- | -- | -- |
| `MFAS0028` | `Assert.True(collection.Any())` | `Assert.NotEmpty(collection)` |
| `MFAS0029` | `Assert.False(collection.Any())` | `Assert.Empty(collection)` |
| `MFAS0030` | `Assert.HasCount(0, x)`, `HasCountGreaterThan(0, x)`, `HasCountGreaterThanOrEqual(1, x)`, `HasCountLessThan(1, x)`, `HasCountLessThanOrEqual(0, x)`, `DoesNotHaveCount(0, x)` | `Assert.Empty` / `Assert.NotEmpty` |

`MFAS0024`/`MFAS0025` deliberately match only the two-parameter `Enumerable.Any(source, predicate)`, so the no-predicate overload had no rule at all.

`MFAS0030` extends to explicit `HasCount*` calls the preference `MFAS0004` already applies to count comparisons.

### Reviewer note

`Assert.HasCount(1, x)` → `Assert.Single(x)` is deliberately **not** proposed: `HasCount(1, …)` is already explicit, and unlike the zero case there is no established preference to extend. (This was your call on the original proposal; recording it here so the omission is not read as an oversight.)

### Verification

Analyzer tests 110 passed, `/p:TreatWarningsAsErrors=true` clean.
