### PR TITLE
Rewrite equality and identity conditions into dedicated assertions (MFAS0031-MFAS0038)

### DIFF
--- a/src/Meziantou.Framework.Assertions.Analyzer/AssertionCodeFixHelpers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/AssertionCodeFixHelpers.cs
@@ -123,6 +123,74 @@ internal static class AssertionCodeFixHelpers
         return true;
     }
 
+    /// <summary>
+    /// Finds the <c>Assert.True</c>/<c>Assert.False</c> invocation that encloses <paramref name="diagnosticNode"/>.
+    /// The condition is not necessarily an invocation, so ancestors are matched semantically rather than by depth.
+    /// </summary>
+    internal static bool TryFindEnclosingAssertTrueFalseInvocation(
+        SemanticModel semanticModel,
+        SyntaxNode diagnosticNode,
+        INamedTypeSymbol assertType,
+        CancellationToken cancellationToken,
+        out InvocationExpressionSyntax assertInvocation)
+    {
+        foreach (var candidate in diagnosticNode.AncestorsAndSelf().OfType<InvocationExpressionSyntax>())
+        {
+            if (TryGetInvocationOperation(semanticModel, candidate, cancellationToken, out var operation) &&
+                operation.TargetMethod is { IsStatic: true, Name: "True" or "False" } targetMethod &&
+                SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, assertType))
+            {
+                assertInvocation = candidate;
+                return true;
+            }
+        }
+
+        assertInvocation = null!;
+        return false;
+    }
+
+    /// <summary>
+    /// Builds the replacement for an <c>Assert.True</c>/<c>Assert.False</c> call rewritten into a dedicated assertion.
+    /// </summary>
+    internal static bool TryCreateConditionRewriteFix(
+        InvocationExpressionSyntax assertInvocation,
+        ConditionRewriteAnalyzerCommon.ConditionRewriteMatch match,
+        out InvocationExpressionSyntax fixedInvocation)
+    {
+        var arguments = new List<ArgumentSyntax>(match.Arguments.Length + 2);
+        foreach (var argument in match.Arguments)
+        {
+            if (!TryGetExpressionSyntax(argument, out var argumentExpression))
+            {
+                fixedInvocation = null!;
+                return false;
+            }
+
+            arguments.Add(SyntaxFactory.Argument(argumentExpression.WithoutTrivia()));
+        }
+
+        if (match.IgnoreCaseValue == true)
+        {
+            arguments.Add(SyntaxFactory.Argument(
+                SyntaxFactory.NameColon(SyntaxFactory.IdentifierName("ignoreCase")),
+                refKindKeyword: default,
+                SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression)));
+        }
+
+        if (TryGetMessageArgument(assertInvocation, out var messageArgument))
+        {
+            arguments.Add(SyntaxFactory.Argument(
+                SyntaxFactory.NameColon(SyntaxFactory.IdentifierName("message")),
+                refKindKeyword: default,
+                messageArgument.Expression.WithoutTrivia()));
+        }
+
+        fixedInvocation = assertInvocation
+            .WithExpression(ReplaceMethodName(assertInvocation.Expression, match.AssertionMethodName))
+            .WithArgumentList(SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)));
+        return true;
+    }
+
     private static bool TryGetMessageArgument(InvocationExpressionSyntax invocation, out ArgumentSyntax messageArgument)
     {
         var positionalArgumentIndex = 0;

--- a/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
@@ -32,4 +32,12 @@ internal static class RuleIdentifiers
     internal const string UseNotEmptyForAnyDiagnosticId = "MFAS0028";
     internal const string UseEmptyForAnyDiagnosticId = "MFAS0029";
     internal const string UseEmptinessAssertionDiagnosticId = "MFAS0030";
+    internal const string UseEqualForEqualityOperatorDiagnosticId = "MFAS0031";
+    internal const string UseNotEqualForEqualityOperatorDiagnosticId = "MFAS0032";
+    internal const string UseEqualForEqualsMethodDiagnosticId = "MFAS0033";
+    internal const string UseNotEqualForEqualsMethodDiagnosticId = "MFAS0034";
+    internal const string UseEqualForSequenceEqualDiagnosticId = "MFAS0035";
+    internal const string UseNotEqualForSequenceEqualDiagnosticId = "MFAS0036";
+    internal const string UseSameForReferenceEqualsDiagnosticId = "MFAS0037";
+    internal const string UseNotSameForReferenceEqualsDiagnosticId = "MFAS0038";
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConditionRewriteAnalyzerBase.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConditionRewriteAnalyzerBase.cs
@@ -1,0 +1,45 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+/// <summary>
+/// Base class for the rules that rewrite <c>Assert.True(condition)</c> / <c>Assert.False(condition)</c> into a
+/// dedicated assertion. Derived types only provide the detection method and the descriptor to report.
+/// </summary>
+public abstract class ConditionRewriteAnalyzerBase : DiagnosticAnalyzer
+{
+    private protected delegate bool TryGetMatch(
+        IInvocationOperation assertInvocation,
+        INamedTypeSymbol assertType,
+        ConditionRewriteAnalyzerCommon.Symbols symbols,
+        out ConditionRewriteAnalyzerCommon.ConditionRewriteMatch match);
+
+    private protected abstract TryGetMatch Matcher { get; }
+
+    private protected abstract DiagnosticDescriptor GetDescriptor(string assertionMethodName);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var assertType = context.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+            if (assertType is null || !ConditionRewriteAnalyzerCommon.TryCreateSymbols(context.Compilation, out var symbols))
+                return;
+
+            context.RegisterOperationAction(context => Analyze(context, assertType, symbols.Value), OperationKind.Invocation);
+        });
+    }
+
+    private void Analyze(OperationAnalysisContext context, INamedTypeSymbol assertType, ConditionRewriteAnalyzerCommon.Symbols symbols)
+    {
+        var assertInvocation = (IInvocationOperation)context.Operation;
+        if (!Matcher(assertInvocation, assertType, symbols, out var match))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(GetDescriptor(match.AssertionMethodName), match.ReportOperation.Syntax.GetLocation(), match.AssertionMethodName));
+    }
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConditionRewriteAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConditionRewriteAnalyzerCommon.cs
@@ -1,0 +1,407 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+/// <summary>
+/// Detects <c>Assert.True(condition)</c> / <c>Assert.False(condition)</c> calls whose condition can be expressed
+/// with a dedicated assertion method. Unlike <see cref="TrueFalseConditionMethodSelectionAnalyzerCommon"/>, the
+/// condition is not required to be an invocation, so operators and patterns are supported too.
+/// </summary>
+internal static class ConditionRewriteAnalyzerCommon
+{
+    private const string EqualAssertionMethodName = "Equal";
+    private const string NotEqualAssertionMethodName = "NotEqual";
+    private const string SameAssertionMethodName = "Same";
+    private const string NotSameAssertionMethodName = "NotSame";
+
+    internal static bool TryCreateSymbols(Compilation compilation, [NotNullWhen(true)] out Symbols? symbols)
+    {
+        var enumerableType = compilation.GetTypeByMetadataName("System.Linq.Enumerable");
+        var nonGenericEnumerableType = compilation.GetTypeByMetadataName("System.Collections.IEnumerable");
+        if (enumerableType is null || nonGenericEnumerableType is null)
+        {
+            symbols = null;
+            return false;
+        }
+
+        if (!CountAssertionAnalyzerCommon.TryCreateSymbols(compilation, out var countSymbols))
+        {
+            symbols = null;
+            return false;
+        }
+
+        var objectType = compilation.GetSpecialType(SpecialType.System_Object);
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+
+        var sequenceEqualMethods = enumerableType.GetMembers("SequenceEqual")
+            .OfType<IMethodSymbol>()
+            .Where(m => m is { IsStatic: true, IsExtensionMethod: true, Parameters.Length: 2 })
+            .Select(m => m.OriginalDefinition)
+            .ToImmutableArray();
+
+        var objectReferenceEqualsMethod = objectType.GetMembers("ReferenceEquals")
+            .OfType<IMethodSymbol>()
+            .FirstOrDefault(m => m is { IsStatic: true, Parameters.Length: 2 });
+
+        var objectStaticEqualsMethod = objectType.GetMembers("Equals")
+            .OfType<IMethodSymbol>()
+            .FirstOrDefault(m => m is { IsStatic: true, Parameters.Length: 2 });
+
+        var stringStaticEqualsMethods = stringType.GetMembers("Equals")
+            .OfType<IMethodSymbol>()
+            .Where(m => m.IsStatic && m.Parameters.Length is 2 or 3)
+            .ToImmutableArray();
+
+        if (objectReferenceEqualsMethod is null || objectStaticEqualsMethod is null)
+        {
+            symbols = null;
+            return false;
+        }
+
+        symbols = new Symbols(
+            countSymbols,
+            sequenceEqualMethods,
+            objectReferenceEqualsMethod,
+            objectStaticEqualsMethod,
+            stringStaticEqualsMethods,
+            nonGenericEnumerableType);
+        return true;
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+    // Assert.True(a == b) -> Assert.Equal(b, a)
+    // ---------------------------------------------------------------------------------------------------------
+    internal static bool TryGetEqualityOperatorMatch(IInvocationOperation assertInvocation, INamedTypeSymbol assertType, Symbols symbols, out ConditionRewriteMatch match)
+    {
+        if (!TryGetCondition(assertInvocation, assertType, out var conditionOperation, out var conditionExpectedToBeFalse))
+        {
+            match = default;
+            return false;
+        }
+
+        if (conditionOperation is not IBinaryOperation { OperatorMethod: null } binaryOperation ||
+            binaryOperation.OperatorKind is not (BinaryOperatorKind.Equals or BinaryOperatorKind.NotEquals))
+        {
+            match = default;
+            return false;
+        }
+
+        // Count comparisons belong to the count assertion rules
+        if (CountAssertionAnalyzerCommon.TryGetAssertionMatch(assertInvocation, assertType, symbols.CountSymbols, out _))
+        {
+            match = default;
+            return false;
+        }
+
+        var left = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(binaryOperation.LeftOperand);
+        var right = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(binaryOperation.RightOperand);
+
+        // Null comparisons belong to the null assertion rules
+        if (IsNullConstant(left) || IsNullConstant(right))
+        {
+            match = default;
+            return false;
+        }
+
+        if (!HasValueEqualitySemantics(left.Type) || !HasValueEqualitySemantics(right.Type))
+        {
+            match = default;
+            return false;
+        }
+
+        var negated = binaryOperation.OperatorKind == BinaryOperatorKind.NotEquals ^ conditionExpectedToBeFalse;
+        var assertionMethodName = negated ? NotEqualAssertionMethodName : EqualAssertionMethodName;
+
+        // Assert.Equal takes the expected value first, so a constant operand becomes the expected value
+        var (expected, actual) = AssertionArgumentOrderAnalyzerCommon.IsConstantOrCollectionContainingConstant(right) &&
+                                 !AssertionArgumentOrderAnalyzerCommon.IsConstantOrCollectionContainingConstant(left)
+            ? (right, left)
+            : (left, right);
+
+        match = new ConditionRewriteMatch(binaryOperation, assertionMethodName, [expected, actual]);
+        return true;
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+    // Assert.True(a.Equals(b)) / object.Equals(a, b) / string.Equals(a, b, comparison) -> Assert.Equal
+    // ---------------------------------------------------------------------------------------------------------
+    internal static bool TryGetEqualsMethodMatch(IInvocationOperation assertInvocation, INamedTypeSymbol assertType, Symbols symbols, out ConditionRewriteMatch match)
+    {
+        if (!TryGetCondition(assertInvocation, assertType, out var conditionOperation, out var conditionExpectedToBeFalse) ||
+            conditionOperation is not IInvocationOperation { TargetMethod.Name: "Equals" } invocation)
+        {
+            match = default;
+            return false;
+        }
+
+        var assertionMethodName = conditionExpectedToBeFalse ? NotEqualAssertionMethodName : EqualAssertionMethodName;
+
+        // string.Equals(a, b) / string.Equals(a, b, StringComparison)
+        if (symbols.StringStaticEqualsMethods.Contains(invocation.TargetMethod, SymbolEqualityComparer.Default))
+        {
+            if (invocation.Arguments.Length < 2)
+            {
+                match = default;
+                return false;
+            }
+
+            var expectedOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(invocation.Arguments[0].Value);
+            var actualOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(invocation.Arguments[1].Value);
+            if (invocation.Arguments.Length == 2)
+            {
+                match = new ConditionRewriteMatch(invocation, assertionMethodName, [expectedOperand, actualOperand]);
+                return true;
+            }
+
+            if (!TryGetIgnoreCase(invocation.Arguments[2], out var stringIgnoreCase))
+            {
+                match = default;
+                return false;
+            }
+
+            match = new ConditionRewriteMatch(invocation, assertionMethodName, [expectedOperand, actualOperand], IgnoreCaseValue: stringIgnoreCase ? true : null);
+            return true;
+        }
+
+        // object.Equals(a, b)
+        if (SymbolEqualityComparer.Default.Equals(invocation.TargetMethod, symbols.ObjectStaticEqualsMethod) && invocation.Arguments.Length == 2)
+        {
+            var expectedOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(invocation.Arguments[0].Value);
+            var actualOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(invocation.Arguments[1].Value);
+            if (MayBeComparedAsSequence(expectedOperand.Type, symbols) || MayBeComparedAsSequence(actualOperand.Type, symbols))
+            {
+                match = default;
+                return false;
+            }
+
+            match = new ConditionRewriteMatch(invocation, assertionMethodName, [expectedOperand, actualOperand]);
+            return true;
+        }
+
+        // instance a.Equals(b) — the receiver is the actual value
+        if (invocation is { Instance: { } instance, Arguments.Length: 1 } && !invocation.TargetMethod.IsStatic)
+        {
+            var actualOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(instance);
+            var expectedOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(invocation.Arguments[0].Value);
+
+            // Assert.Equal compares sequences element by element, which Equals does not
+            if (MayBeComparedAsSequence(actualOperand.Type, symbols) || MayBeComparedAsSequence(expectedOperand.Type, symbols))
+            {
+                match = default;
+                return false;
+            }
+
+            match = new ConditionRewriteMatch(invocation, assertionMethodName, [expectedOperand, actualOperand]);
+            return true;
+        }
+
+        // instance a.Equals(b, StringComparison)
+        if (invocation is { Instance: { } stringInstance, Arguments.Length: 2 } &&
+            !invocation.TargetMethod.IsStatic &&
+            stringInstance.Type?.SpecialType == SpecialType.System_String)
+        {
+            if (!TryGetIgnoreCase(invocation.Arguments[1], out var ignoreCase))
+            {
+                match = default;
+                return false;
+            }
+
+            var actualOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(stringInstance);
+            var expectedOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(invocation.Arguments[0].Value);
+            match = new ConditionRewriteMatch(invocation, assertionMethodName, [expectedOperand, actualOperand], IgnoreCaseValue: ignoreCase ? true : null);
+            return true;
+        }
+
+        match = default;
+        return false;
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+    // Assert.True(actual.SequenceEqual(expected)) -> Assert.Equal(expected, actual)
+    // ---------------------------------------------------------------------------------------------------------
+    internal static bool TryGetSequenceEqualMatch(IInvocationOperation assertInvocation, INamedTypeSymbol assertType, Symbols symbols, out ConditionRewriteMatch match)
+    {
+        if (!TryGetCondition(assertInvocation, assertType, out var conditionOperation, out var conditionExpectedToBeFalse) ||
+            conditionOperation is not IInvocationOperation { TargetMethod.Name: "SequenceEqual" } invocation)
+        {
+            match = default;
+            return false;
+        }
+
+        var originalDefinition = (invocation.TargetMethod.ReducedFrom ?? invocation.TargetMethod).OriginalDefinition;
+        if (!symbols.SequenceEqualMethods.Contains(originalDefinition, SymbolEqualityComparer.Default))
+        {
+            match = default;
+            return false;
+        }
+
+        IOperation actualOperand;
+        IOperation expectedOperand;
+        if (invocation.Instance is not null)
+        {
+            actualOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(invocation.Instance);
+            expectedOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(invocation.Arguments[0].Value);
+        }
+        else
+        {
+            var firstArgument = invocation.Arguments.FirstOrDefault(a => a.Parameter?.Name == "first");
+            var secondArgument = invocation.Arguments.FirstOrDefault(a => a.Parameter?.Name == "second");
+            if (firstArgument is null || secondArgument is null)
+            {
+                match = default;
+                return false;
+            }
+
+            actualOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(firstArgument.Value);
+            expectedOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(secondArgument.Value);
+        }
+
+        var assertionMethodName = conditionExpectedToBeFalse ? NotEqualAssertionMethodName : EqualAssertionMethodName;
+        match = new ConditionRewriteMatch(invocation, assertionMethodName, [expectedOperand, actualOperand]);
+        return true;
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+    // Assert.True(ReferenceEquals(a, b)) -> Assert.Same(a, b)
+    // ---------------------------------------------------------------------------------------------------------
+    internal static bool TryGetReferenceEqualsMatch(IInvocationOperation assertInvocation, INamedTypeSymbol assertType, Symbols symbols, out ConditionRewriteMatch match)
+    {
+        if (!TryGetCondition(assertInvocation, assertType, out var conditionOperation, out var conditionExpectedToBeFalse) ||
+            conditionOperation is not IInvocationOperation { TargetMethod.Name: "ReferenceEquals" } invocation ||
+            !SymbolEqualityComparer.Default.Equals(invocation.TargetMethod, symbols.ObjectReferenceEqualsMethod) ||
+            invocation.Arguments.Length != 2)
+        {
+            match = default;
+            return false;
+        }
+
+        var expectedOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(invocation.Arguments[0].Value);
+        var actualOperand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(invocation.Arguments[1].Value);
+
+        // Assert.Same reports an error for value types (MFAS0010/MFAS0011)
+        if (AssertionsAnalyzerHelpers.IsValueType(expectedOperand.Type) || AssertionsAnalyzerHelpers.IsValueType(actualOperand.Type))
+        {
+            match = default;
+            return false;
+        }
+
+        var assertionMethodName = conditionExpectedToBeFalse ? NotSameAssertionMethodName : SameAssertionMethodName;
+        match = new ConditionRewriteMatch(invocation, assertionMethodName, [expectedOperand, actualOperand]);
+        return true;
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+
+    private static bool TryGetCondition(IInvocationOperation assertInvocation, INamedTypeSymbol assertType, out IOperation conditionOperation, out bool conditionExpectedToBeFalse)
+    {
+        if (TrueFalseConditionMethodSelectionAnalyzerCommon.TryGetAssertCondition(assertInvocation, assertType, out var operation, out conditionExpectedToBeFalse))
+        {
+            conditionOperation = operation;
+            return true;
+        }
+
+        conditionOperation = null!;
+        return false;
+    }
+
+    private static bool IsNullConstant(IOperation operation)
+        => operation.ConstantValue is { HasValue: true, Value: null };
+
+    private static bool TryGetIgnoreCase(IArgumentOperation argument, out bool ignoreCase)
+    {
+        var operation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(argument.Value);
+        if (argument.Parameter?.Type?.Name == "StringComparison" && operation.ConstantValue is { HasValue: true, Value: int comparisonValue })
+        {
+            if (comparisonValue == (int)StringComparison.Ordinal)
+            {
+                ignoreCase = false;
+                return true;
+            }
+
+            if (comparisonValue == (int)StringComparison.OrdinalIgnoreCase)
+            {
+                ignoreCase = true;
+                return true;
+            }
+        }
+
+        ignoreCase = false;
+        return false;
+    }
+
+    /// <summary>
+    /// <c>Assert.Equal</c> inspects its arguments at run time and compares sequences element by element, which
+    /// <c>Equals</c> never does. The rewrite is therefore only safe when the value provably cannot be a sequence:
+    /// a value type or a sealed type that does not implement <see cref="System.Collections.IEnumerable"/>. An
+    /// <c>object</c>, an interface or an open class could hold a collection at run time, and rewriting those can
+    /// turn a failing assertion into a passing one.
+    /// </summary>
+    private static bool MayBeComparedAsSequence(ITypeSymbol? type, Symbols symbols)
+    {
+        if (type is null)
+            return true;
+
+        // Assert.Equal compares strings as strings, never as sequences of characters
+        if (type.SpecialType == SpecialType.System_String)
+            return false;
+
+        if (SymbolEqualityComparer.Default.Equals(type, symbols.NonGenericEnumerableType))
+            return true;
+
+        foreach (var interfaceType in type.AllInterfaces)
+        {
+            if (SymbolEqualityComparer.Default.Equals(interfaceType, symbols.NonGenericEnumerableType))
+                return true;
+        }
+
+        return type is { IsValueType: false, IsSealed: false };
+    }
+
+    /// <summary>
+    /// Types whose <c>==</c> operator performs the same comparison as <c>Assert.Equal</c>. Floating point types are
+    /// excluded because <c>double.NaN == double.NaN</c> is false while <c>double.NaN.Equals(double.NaN)</c> is true.
+    /// </summary>
+    private static bool HasValueEqualitySemantics(ITypeSymbol? type)
+    {
+        if (type is null)
+            return false;
+
+        if (type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+            return type is INamedTypeSymbol { TypeArguments: [var underlyingType] } && HasValueEqualitySemantics(underlyingType);
+
+        if (type.TypeKind == TypeKind.Enum)
+            return true;
+
+        return type.SpecialType is
+            SpecialType.System_Boolean or
+            SpecialType.System_Char or
+            SpecialType.System_SByte or
+            SpecialType.System_Byte or
+            SpecialType.System_Int16 or
+            SpecialType.System_UInt16 or
+            SpecialType.System_Int32 or
+            SpecialType.System_UInt32 or
+            SpecialType.System_Int64 or
+            SpecialType.System_UInt64 or
+            SpecialType.System_Decimal or
+            SpecialType.System_String or
+            SpecialType.System_IntPtr or
+            SpecialType.System_UIntPtr;
+    }
+
+    internal readonly record struct Symbols(
+        CountAssertionAnalyzerCommon.Symbols CountSymbols,
+        ImmutableArray<IMethodSymbol> SequenceEqualMethods,
+        IMethodSymbol ObjectReferenceEqualsMethod,
+        IMethodSymbol ObjectStaticEqualsMethod,
+        ImmutableArray<IMethodSymbol> StringStaticEqualsMethods,
+        INamedTypeSymbol NonGenericEnumerableType);
+
+    internal readonly record struct ConditionRewriteMatch(
+        IOperation ReportOperation,
+        string AssertionMethodName,
+        IOperation[] Arguments,
+        bool? IgnoreCaseValue = null);
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/EqualityOperatorAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/EqualityOperatorAnalyzer.cs
@@ -1,0 +1,32 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class EqualityOperatorAnalyzer : ConditionRewriteAnalyzerBase
+{
+    public static readonly DiagnosticDescriptor UseEqualDescriptor = new(
+        id: RuleIdentifiers.UseEqualForEqualityOperatorDiagnosticId,
+        title: "Use Assert.Equal instead of Assert.True(a == b)",
+        messageFormat: "Use Assert.Equal(expected, actual) to report the compared values",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseNotEqualDescriptor = new(
+        id: RuleIdentifiers.UseNotEqualForEqualityOperatorDiagnosticId,
+        title: "Use Assert.NotEqual instead of Assert.True(a != b)",
+        messageFormat: "Use Assert.NotEqual(expected, actual) to report the compared values",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [UseEqualDescriptor, UseNotEqualDescriptor];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetEqualityOperatorMatch;
+
+    private protected override DiagnosticDescriptor GetDescriptor(string assertionMethodName)
+        => assertionMethodName == "Equal" ? UseEqualDescriptor : UseNotEqualDescriptor;
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/EqualsMethodAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/EqualsMethodAnalyzer.cs
@@ -1,0 +1,32 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class EqualsMethodAnalyzer : ConditionRewriteAnalyzerBase
+{
+    public static readonly DiagnosticDescriptor UseEqualDescriptor = new(
+        id: RuleIdentifiers.UseEqualForEqualsMethodDiagnosticId,
+        title: "Use Assert.Equal instead of Assert.True(a.Equals(b))",
+        messageFormat: "Use Assert.Equal(expected, actual) to report the compared values",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseNotEqualDescriptor = new(
+        id: RuleIdentifiers.UseNotEqualForEqualsMethodDiagnosticId,
+        title: "Use Assert.NotEqual instead of Assert.False(a.Equals(b))",
+        messageFormat: "Use Assert.NotEqual(expected, actual) to report the compared values",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [UseEqualDescriptor, UseNotEqualDescriptor];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetEqualsMethodMatch;
+
+    private protected override DiagnosticDescriptor GetDescriptor(string assertionMethodName)
+        => assertionMethodName == "Equal" ? UseEqualDescriptor : UseNotEqualDescriptor;
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/ReferenceEqualsConditionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/ReferenceEqualsConditionAnalyzer.cs
@@ -1,0 +1,32 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ReferenceEqualsConditionAnalyzer : ConditionRewriteAnalyzerBase
+{
+    public static readonly DiagnosticDescriptor UseSameDescriptor = new(
+        id: RuleIdentifiers.UseSameForReferenceEqualsDiagnosticId,
+        title: "Use Assert.Same instead of Assert.True(ReferenceEquals(a, b))",
+        messageFormat: "Use Assert.Same(expected, actual) to report the compared instances",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseNotSameDescriptor = new(
+        id: RuleIdentifiers.UseNotSameForReferenceEqualsDiagnosticId,
+        title: "Use Assert.NotSame instead of Assert.False(ReferenceEquals(a, b))",
+        messageFormat: "Use Assert.NotSame(expected, actual) to report the compared instances",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [UseSameDescriptor, UseNotSameDescriptor];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetReferenceEqualsMatch;
+
+    private protected override DiagnosticDescriptor GetDescriptor(string assertionMethodName)
+        => assertionMethodName == "Same" ? UseSameDescriptor : UseNotSameDescriptor;
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/SequenceEqualAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/SequenceEqualAnalyzer.cs
@@ -1,0 +1,32 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class SequenceEqualAnalyzer : ConditionRewriteAnalyzerBase
+{
+    public static readonly DiagnosticDescriptor UseEqualDescriptor = new(
+        id: RuleIdentifiers.UseEqualForSequenceEqualDiagnosticId,
+        title: "Use Assert.Equal instead of Assert.True(actual.SequenceEqual(expected))",
+        messageFormat: "Use Assert.Equal(expected, actual) to report the differing items",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseNotEqualDescriptor = new(
+        id: RuleIdentifiers.UseNotEqualForSequenceEqualDiagnosticId,
+        title: "Use Assert.NotEqual instead of Assert.False(actual.SequenceEqual(expected))",
+        messageFormat: "Use Assert.NotEqual(expected, actual) to report the compared sequences",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [UseEqualDescriptor, UseNotEqualDescriptor];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetSequenceEqualMatch;
+
+    private protected override DiagnosticDescriptor GetDescriptor(string assertionMethodName)
+        => assertionMethodName == "Equal" ? UseEqualDescriptor : UseNotEqualDescriptor;
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Meziantou.Framework.Assertions.CodeFix.csproj
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Meziantou.Framework.Assertions.CodeFix.csproj
@@ -15,6 +15,7 @@
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzerCommon.cs" Link="Rules/CountAssertionAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/TrueFalseConditionMethodSelectionAnalyzerCommon.cs" Link="Rules/TrueFalseConditionMethodSelectionAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/EmptinessAssertionAnalyzerCommon.cs" Link="Rules/EmptinessAssertionAnalyzerCommon.cs" />
+    <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/ConditionRewriteAnalyzerCommon.cs" Link="Rules/ConditionRewriteAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Internals/NumericHelpers.cs" Link="Internals/NumericHelpers.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/AssertionsAnalyzerHelpers.cs" Link="AssertionsAnalyzerHelpers.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/AssertionCodeFixHelpers.cs" Link="AssertionCodeFixHelpers.cs" />

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/ConditionRewriteCodeFixProviderBase.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/ConditionRewriteCodeFixProviderBase.cs
@@ -1,0 +1,86 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+/// <summary>
+/// Base class for the fixes that rewrite <c>Assert.True(condition)</c> / <c>Assert.False(condition)</c> into a
+/// dedicated assertion. Derived types only provide the detection method matching their analyzer.
+/// </summary>
+public abstract class ConditionRewriteCodeFixProviderBase : CodeFixProvider
+{
+    private protected delegate bool TryGetMatch(
+        IInvocationOperation assertInvocation,
+        INamedTypeSymbol assertType,
+        ConditionRewriteAnalyzerCommon.Symbols symbols,
+        out ConditionRewriteAnalyzerCommon.ConditionRewriteMatch match);
+
+    private protected abstract TryGetMatch Matcher { get; }
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var assertType = semanticModel.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+        if (assertType is null || !ConditionRewriteAnalyzerCommon.TryCreateSymbols(semanticModel.Compilation, out var symbols))
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var diagnosticNode = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            if (!AssertionCodeFixHelpers.TryFindEnclosingAssertTrueFalseInvocation(semanticModel, diagnosticNode, assertType, context.CancellationToken, out var assertInvocation))
+                continue;
+
+            if (!AssertionCodeFixHelpers.TryGetInvocationOperation(semanticModel, assertInvocation, context.CancellationToken, out var assertOperation))
+                continue;
+
+            if (!Matcher(assertOperation, assertType, symbols.Value, out var match))
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Use Assert." + match.AssertionMethodName,
+                    createChangedDocument: ct => ApplyFixAsync(context.Document, assertInvocation, assertType, ct),
+                    equivalenceKey: GetType().FullName),
+                diagnostic);
+        }
+    }
+
+    private async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax assertInvocation, INamedTypeSymbol assertType, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return document;
+
+        if (!ConditionRewriteAnalyzerCommon.TryCreateSymbols(semanticModel.Compilation, out var symbols))
+            return document;
+
+        if (!AssertionCodeFixHelpers.TryGetInvocationOperation(semanticModel, assertInvocation, cancellationToken, out var assertOperation))
+            return document;
+
+        if (!Matcher(assertOperation, assertType, symbols.Value, out var match))
+            return document;
+
+        if (!AssertionCodeFixHelpers.TryCreateConditionRewriteFix(assertInvocation, match, out var fixedInvocation))
+            return document;
+
+        var newRoot = root.ReplaceNode(assertInvocation, fixedInvocation.WithAdditionalAnnotations(Formatter.Annotation));
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/EqualityOperatorCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/EqualityOperatorCodeFixProvider.cs
@@ -1,0 +1,17 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(EqualityOperatorCodeFixProvider))]
+public sealed class EqualityOperatorCodeFixProvider : ConditionRewriteCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+    [
+        RuleIdentifiers.UseEqualForEqualityOperatorDiagnosticId,
+        RuleIdentifiers.UseNotEqualForEqualityOperatorDiagnosticId,
+    ];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetEqualityOperatorMatch;
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/EqualsMethodCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/EqualsMethodCodeFixProvider.cs
@@ -1,0 +1,17 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(EqualsMethodCodeFixProvider))]
+public sealed class EqualsMethodCodeFixProvider : ConditionRewriteCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+    [
+        RuleIdentifiers.UseEqualForEqualsMethodDiagnosticId,
+        RuleIdentifiers.UseNotEqualForEqualsMethodDiagnosticId,
+    ];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetEqualsMethodMatch;
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/ReferenceEqualsConditionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/ReferenceEqualsConditionCodeFixProvider.cs
@@ -1,0 +1,17 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ReferenceEqualsConditionCodeFixProvider))]
+public sealed class ReferenceEqualsConditionCodeFixProvider : ConditionRewriteCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+    [
+        RuleIdentifiers.UseSameForReferenceEqualsDiagnosticId,
+        RuleIdentifiers.UseNotSameForReferenceEqualsDiagnosticId,
+    ];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetReferenceEqualsMatch;
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/SequenceEqualCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/SequenceEqualCodeFixProvider.cs
@@ -1,0 +1,17 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SequenceEqualCodeFixProvider))]
+public sealed class SequenceEqualCodeFixProvider : ConditionRewriteCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+    [
+        RuleIdentifiers.UseEqualForSequenceEqualDiagnosticId,
+        RuleIdentifiers.UseNotEqualForSequenceEqualDiagnosticId,
+    ];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetSequenceEqualMatch;
+}

--- a/src/Meziantou.Framework.Assertions/readme.md
+++ b/src/Meziantou.Framework.Assertions/readme.md
@@ -114,4 +114,12 @@ The package ships analyzers and code fixes to help write clearer assertions.
 | `MFAS0028` | Assertions | Use Assert.NotEmpty instead of Assert.True(collection.Any()) | Warning | ✔️ |
 | `MFAS0029` | Assertions | Use Assert.Empty instead of Assert.False(collection.Any()) | Warning | ✔️ |
 | `MFAS0030` | Assertions | Use Assert.Empty or Assert.NotEmpty instead of a count assertion | Warning | ✔️ |
+| `MFAS0031` | Assertions | Use Assert.Equal instead of Assert.True(a == b) | Warning | ✔️ |
+| `MFAS0032` | Assertions | Use Assert.NotEqual instead of Assert.True(a != b) | Warning | ✔️ |
+| `MFAS0033` | Assertions | Use Assert.Equal instead of Assert.True(a.Equals(b)) | Warning | ✔️ |
+| `MFAS0034` | Assertions | Use Assert.NotEqual instead of Assert.False(a.Equals(b)) | Warning | ✔️ |
+| `MFAS0035` | Assertions | Use Assert.Equal instead of Assert.True(actual.SequenceEqual(expected)) | Warning | ✔️ |
+| `MFAS0036` | Assertions | Use Assert.NotEqual instead of Assert.False(actual.SequenceEqual(expected)) | Warning | ✔️ |
+| `MFAS0037` | Assertions | Use Assert.Same instead of Assert.True(ReferenceEquals(a, b)) | Warning | ✔️ |
+| `MFAS0038` | Assertions | Use Assert.NotSame instead of Assert.False(ReferenceEquals(a, b)) | Warning | ✔️ |
 <!-- analyzer-rules -->

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/EqualityOperatorRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/EqualityOperatorRuleTests.cs
@@ -1,0 +1,295 @@
+using EqualityOperatorAnalyzerType = Meziantou.Framework.Analyzers.Assertions.EqualityOperatorAnalyzer;
+using EqualityOperatorCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.EqualityOperatorCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class EqualityOperatorRuleTests : AssertionsAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("Assert.True({|MFAS0031:value == 42|});", "Assert.Equal(42, value);")]
+    [InlineData("Assert.True({|MFAS0031:42 == value|});", "Assert.Equal(42, value);")]
+    [InlineData("Assert.True({|MFAS0032:value != 42|});", "Assert.NotEqual(42, value);")]
+    [InlineData("Assert.False({|MFAS0032:value == 42|});", "Assert.NotEqual(42, value);")]
+    [InlineData("Assert.False({|MFAS0031:value != 42|});", "Assert.Equal(42, value);")]
+    [InlineData("Assert.True({|MFAS0031:value == other|});", "Assert.Equal(value, other);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForIntComparison(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value, int other)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value, int other)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<EqualityOperatorAnalyzerType, EqualityOperatorCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForStringComparison()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(string value)
+                {
+                    Assert.True({|MFAS0031:value == "expected"|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(string value)
+                {
+                    Assert.Equal("expected", value);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<EqualityOperatorAnalyzerType, EqualityOperatorCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForEnumComparison()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public enum Color { Red, Green }
+
+            public static class TestClass
+            {
+                public static void M(Color value)
+                {
+                    Assert.True({|MFAS0031:value == Color.Red|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public enum Color { Red, Green }
+
+            public static class TestClass
+            {
+                public static void M(Color value)
+                {
+                    Assert.Equal(Color.Red, value);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<EqualityOperatorAnalyzerType, EqualityOperatorCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_PreservesMessage()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value)
+                {
+                    Assert.True({|MFAS0031:value == 42|}, "custom message");
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value)
+                {
+                    Assert.Equal(42, value, message: "custom message");
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<EqualityOperatorAnalyzerType, EqualityOperatorCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForNullComparisonAndReferenceTypes()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public sealed class Sample
+            {
+                public static bool operator ==(Sample? a, Sample? b) => ReferenceEquals(a, b);
+                public static bool operator !=(Sample? a, Sample? b) => !ReferenceEquals(a, b);
+                public override bool Equals(object? obj) => true;
+                public override int GetHashCode() => 0;
+            }
+
+            public static class TestClass
+            {
+                public static void M(string? text, Sample? sample, List<int> collection, double number)
+                {
+                    // Null comparisons belong to MFAS0006/MFAS0007
+                    Assert.True(text == null);
+                    Assert.False(text != null);
+
+                    // User-defined operators may not agree with Assert.Equal
+                    Assert.True(sample == null);
+
+                    // Count comparisons belong to MFAS0004/MFAS0005
+                    Assert.True(collection.Count == 3);
+
+                    // double.NaN == double.NaN is false but double.NaN.Equals(double.NaN) is true
+                    Assert.True(number == 1.5);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<EqualityOperatorAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForNullableValue()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int? value)
+                {
+                    Assert.True({|MFAS0031:value == 42|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int? value)
+                {
+                    Assert.Equal(42, value);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<EqualityOperatorAnalyzerType, EqualityOperatorCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ThroughTypeAlias()
+    {
+        var source = """
+            using MyAssert = Meziantou.Framework.Assertions.Assert;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value)
+                {
+                    MyAssert.True({|MFAS0031:value == 42|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using MyAssert = Meziantou.Framework.Assertions.Assert;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value)
+                {
+                    MyAssert.Equal(42, value);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<EqualityOperatorAnalyzerType, EqualityOperatorCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ThroughUsingStatic()
+    {
+        var source = """
+            using static Meziantou.Framework.Assertions.Assert;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value)
+                {
+                    True({|MFAS0031:value == 42|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using static Meziantou.Framework.Assertions.Assert;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value)
+                {
+                    Equal(42, value);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<EqualityOperatorAnalyzerType, EqualityOperatorCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/EqualsMethodRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/EqualsMethodRuleTests.cs
@@ -1,0 +1,178 @@
+using EqualsMethodAnalyzerType = Meziantou.Framework.Analyzers.Assertions.EqualsMethodAnalyzer;
+using EqualsMethodCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.EqualsMethodCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class EqualsMethodRuleTests : AssertionsAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("Assert.True({|MFAS0033:value.Equals(other)|});", "Assert.Equal(other, value);")]
+    [InlineData("Assert.False({|MFAS0034:value.Equals(other)|});", "Assert.NotEqual(other, value);")]
+    [InlineData("Assert.True({|MFAS0033:object.Equals(value, other)|});", "Assert.Equal(value, other);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForEqualsMethod(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value, int other)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value, int other)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<EqualsMethodAnalyzerType, EqualsMethodCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Theory]
+    [InlineData("Assert.True({|MFAS0033:string.Equals(a, b, StringComparison.OrdinalIgnoreCase)|});", "Assert.Equal(a, b, ignoreCase: true);")]
+    [InlineData("Assert.True({|MFAS0033:string.Equals(a, b, StringComparison.Ordinal)|});", "Assert.Equal(a, b);")]
+    [InlineData("Assert.True({|MFAS0033:a.Equals(b, StringComparison.OrdinalIgnoreCase)|});", "Assert.Equal(b, a, ignoreCase: true);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForStringEquals(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using System;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(string a, string b)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using System;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(string a, string b)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<EqualsMethodAnalyzerType, EqualsMethodCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForSequenceTypesAndUnsupportedComparisons()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection, List<int> other, string a, string b)
+                {
+                    // Assert.Equal compares sequences element by element, Equals does not
+                    Assert.True(collection.Equals(other));
+                    Assert.True(object.Equals(collection, other));
+
+                    // Only Ordinal and OrdinalIgnoreCase map onto the ignoreCase parameter
+                    Assert.True(string.Equals(a, b, StringComparison.InvariantCulture));
+                    Assert.True(a.Equals(b, StringComparison.CurrentCulture));
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<EqualsMethodAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenTheValueMayBeASequenceAtRuntime()
+    {
+        // Assert.Equal inspects its arguments at run time and compares sequences element by element, which
+        // Equals never does. Rewriting these would turn a failing assertion into a passing one.
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public interface IValue;
+
+            public class OpenValue;
+
+            public static class TestClass
+            {
+                public static void M(object a, object b, IValue c, IValue d, OpenValue e, OpenValue f)
+                {
+                    Assert.True(a.Equals(b));
+                    Assert.True(object.Equals(a, b));
+                    Assert.True(c.Equals(d));
+                    Assert.True(e.Equals(f));
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<EqualsMethodAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForSealedTypeThatCannotBeASequence()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public sealed class SealedValue;
+
+            public static class TestClass
+            {
+                public static void M(SealedValue a, SealedValue b)
+                {
+                    Assert.True({|MFAS0033:a.Equals(b)|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public sealed class SealedValue;
+
+            public static class TestClass
+            {
+                public static void M(SealedValue a, SealedValue b)
+                {
+                    Assert.Equal(b, a);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<EqualsMethodAnalyzerType, EqualsMethodCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/ReferenceEqualsConditionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/ReferenceEqualsConditionRuleTests.cs
@@ -1,0 +1,64 @@
+using ReferenceEqualsConditionAnalyzerType = Meziantou.Framework.Analyzers.Assertions.ReferenceEqualsConditionAnalyzer;
+using ReferenceEqualsConditionCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.ReferenceEqualsConditionCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class ReferenceEqualsConditionRuleTests : AssertionsAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("Assert.True({|MFAS0037:object.ReferenceEquals(a, b)|});", "Assert.Same(a, b);")]
+    [InlineData("Assert.False({|MFAS0038:object.ReferenceEquals(a, b)|});", "Assert.NotSame(a, b);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForReferenceEquals(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object a, object b)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object a, object b)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<ReferenceEqualsConditionAnalyzerType, ReferenceEqualsConditionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForValueTypes()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int a, int b)
+                {
+                    // Assert.Same reports MFAS0010 for value types
+                    Assert.True(object.ReferenceEquals(a, b));
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ReferenceEqualsConditionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/SequenceEqualRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/SequenceEqualRuleTests.cs
@@ -1,0 +1,115 @@
+using SequenceEqualAnalyzerType = Meziantou.Framework.Analyzers.Assertions.SequenceEqualAnalyzer;
+using SequenceEqualCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.SequenceEqualCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class SequenceEqualRuleTests : AssertionsAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("Assert.True({|MFAS0035:actual.SequenceEqual(expected)|});", "Assert.Equal(expected, actual);")]
+    [InlineData("Assert.False({|MFAS0036:actual.SequenceEqual(expected)|});", "Assert.NotEqual(expected, actual);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForSequenceEqual(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> actual, List<int> expected)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> actual, List<int> expected)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<SequenceEqualAnalyzerType, SequenceEqualCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForCustomSequenceEqualAndComparerOverload()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public sealed class CustomCollection
+            {
+                public bool SequenceEqual(CustomCollection other) => true;
+            }
+
+            public static class TestClass
+            {
+                public static void M(CustomCollection a, CustomCollection b, List<int> actual, List<int> expected)
+                {
+                    Assert.True(a.SequenceEqual(b));
+
+                    // The comparer overload has no matching rewrite
+                    Assert.True(actual.SequenceEqual(expected, EqualityComparer<int>.Default));
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<SequenceEqualAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForStaticInvocationForm()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> actual, List<int> expected)
+                {
+                    Assert.True({|MFAS0035:Enumerable.SequenceEqual(actual, expected)|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> actual, List<int> expected)
+                {
+                    Assert.Equal(expected, actual);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<SequenceEqualAnalyzerType, SequenceEqualCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
@@ -141,9 +141,11 @@ public sealed class BencodeDocumentTests
         var equal = new BencodeInteger(42);
         var different = new BencodeInteger(-1);
 
+#pragma warning disable MFAS0033, MFAS0034 // Preserve the Equals overload validation
         Assert.True(left.Equals(equal));
         Assert.True(left.Equals((object)equal));
         Assert.False(left.Equals(different));
+#pragma warning restore MFAS0033, MFAS0034
         Assert.Equal(left.GetHashCode(), equal.GetHashCode());
         Assert.Equal("42", left.ToString());
         Assert.Equal("-1", different.ToString());

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotTests.cs
@@ -1380,9 +1380,7 @@ public sealed partial class InlineSnapshotTests(ITestOutputHelper testOutputHelp
         process.BeginErrorReadLine();
         await process.WaitForExitAsync(TestContext.Current.CancellationToken);
 
-        Assert.True(
-            expectedExitCode == process.ExitCode,
-            $"dotnet {string.Join(' ', arguments)} returned exit code {process.ExitCode} but {expectedExitCode} was expected.{Environment.NewLine}{output}");
+        Assert.Equal(expectedExitCode, process.ExitCode, message: $"dotnet {string.Join(' ', arguments)} returned exit code {process.ExitCode} but {expectedExitCode} was expected.{Environment.NewLine}{output}");
 
         static void AppendLine(StringBuilder builder, string? line)
         {

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -27,9 +27,11 @@ public class ProcessWrapperTests
         var exitCodeB = new ProcessExitCode(42);
         var exitCodeC = new ProcessExitCode(1);
 
+#pragma warning disable MFAS0033, MFAS0034 // Preserve the Equals overload validation
         Assert.True(exitCodeA.Equals(exitCodeB));
         Assert.True(exitCodeA.Equals((object)exitCodeB));
         Assert.False(exitCodeA.Equals(exitCodeC));
+#pragma warning restore MFAS0033, MFAS0034
         Assert.True(exitCodeA == exitCodeB);
         Assert.True(exitCodeA != exitCodeC);
         Assert.Equal(exitCodeA.GetHashCode(), exitCodeB.GetHashCode());

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -1439,9 +1439,7 @@ public sealed partial class SnapshotEndToEndTests
             }
         }
 
-        Assert.True(
-            result.ExitCode == expectedExitCode,
-            $"dotnet {string.Join(' ', arguments)} returned exit code {result.ExitCode} after {maxAttempts} attempts but {expectedExitCode} was expected.{Environment.NewLine}{output}");
+        Assert.Equal(expectedExitCode, result.ExitCode, message: $"dotnet {string.Join(' ', arguments)} returned exit code {result.ExitCode} after {maxAttempts} attempts but {expectedExitCode} was expected.{Environment.NewLine}{output}");
     }
 
     private static async Task<DotNetExecutionResult> ExecuteDotNet(FullPath workingDirectory, string dotnetPath, IReadOnlyList<string> arguments, int? expectedExitCode = null)

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlOrderedDictionaryConverterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlOrderedDictionaryConverterTests.cs
@@ -127,7 +127,7 @@ public sealed class YamlOrderedDictionaryConverterTests
         Assert.NotNull(result);
         Assert.NotNull(result.Primary);
         Assert.NotNull(result.Secondary);
-        Assert.True(ReferenceEquals(result.Primary, result.Secondary));
+        Assert.Same(result.Primary, result.Secondary);
 
         var keys = new List<string>(result.Primary.Keys);
         Assert.Equal(new[] { "zebra", "apple" }, keys);
@@ -159,7 +159,7 @@ public sealed class YamlOrderedDictionaryConverterTests
         Assert.NotNull(result);
         Assert.NotNull(result.Primary);
         Assert.NotNull(result.Secondary);
-        Assert.True(ReferenceEquals(result.Primary, result.Secondary));
+        Assert.Same(result.Primary, result.Secondary);
 
         var keys = new List<int>(result.Primary.Keys);
         Assert.Equal(new[] { 3, 1 }, keys);

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlReferenceHandlingTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlReferenceHandlingTests.cs
@@ -39,7 +39,7 @@ public class YamlReferenceHandlingTests
             new YamlSerializerOptions { ReferenceHandling = YamlReferenceHandling.Preserve });
 
         Assert.NotNull(node);
-        Assert.True(ReferenceEquals(node, node.Next));
+        Assert.Same(node, node.Next);
         Assert.Equal("root", node.Name);
     }
 
@@ -78,7 +78,7 @@ public class YamlReferenceHandlingTests
         Assert.NotNull(container);
         Assert.NotNull(container.A);
         Assert.NotNull(container.B);
-        Assert.True(ReferenceEquals(container.A, container.B));
+        Assert.Same(container.A, container.B);
         Assert.Equal("shared", container.A.Name);
     }
 
@@ -92,7 +92,7 @@ public class YamlReferenceHandlingTests
 
         Assert.NotNull(list);
         Assert.Single(list);
-        Assert.True(ReferenceEquals(list, list[0]));
+        Assert.Same(list, list[0]);
 
         var roundTrip = YamlSerializer.Serialize(list, options);
         Assert.Contains("&id001", roundTrip);
@@ -109,7 +109,7 @@ public class YamlReferenceHandlingTests
 
         Assert.NotNull(dict);
         Assert.True(dict.TryGetValue("self", out var self));
-        Assert.True(ReferenceEquals(dict, self));
+        Assert.Same(dict, self);
 
         var roundTrip = YamlSerializer.Serialize(dict, options);
         Assert.Contains("&id001", roundTrip);
@@ -131,7 +131,7 @@ public class YamlReferenceHandlingTests
 
         var roundTrip = YamlSerializer.Deserialize<Container>(yaml, options);
         Assert.NotNull(roundTrip);
-        Assert.True(ReferenceEquals(roundTrip.A, roundTrip.B));
+        Assert.Same(roundTrip.A, roundTrip.B);
     }
 
     [Fact]
@@ -148,6 +148,6 @@ public class YamlReferenceHandlingTests
 
         var roundTrip = YamlSerializer.Deserialize<Node>(yaml, options);
         Assert.NotNull(roundTrip);
-        Assert.True(ReferenceEquals(roundTrip, roundTrip.Next));
+        Assert.Same(roundTrip, roundTrip.Next);
     }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerCollectionSupportReflectionTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerCollectionSupportReflectionTests.cs
@@ -80,7 +80,7 @@ public sealed class YamlSerializerCollectionSupportReflectionTests
         Assert.NotNull(result);
         Assert.NotNull(result.Primary);
         Assert.NotNull(result.Secondary);
-        Assert.True(ReferenceEquals(result.Primary, result.Secondary));
+        Assert.Same(result.Primary, result.Secondary);
         Assert.Equal("one", result.Primary[1]);
         Assert.Equal("two", result.Primary[2]);
     }
@@ -111,7 +111,7 @@ public sealed class YamlSerializerCollectionSupportReflectionTests
         Assert.NotNull(result);
         Assert.NotNull(result.Primary);
         Assert.NotNull(result.Secondary);
-        Assert.True(ReferenceEquals(result.Primary, result.Secondary));
+        Assert.Same(result.Primary, result.Secondary);
         Assert.Equal(1, result.Primary[TestColor.Red]);
         Assert.Equal(2, result.Primary[TestColor.Green]);
     }
@@ -179,7 +179,7 @@ public sealed class YamlSerializerCollectionSupportReflectionTests
         Assert.NotNull(result);
         Assert.NotNull(result.Values);
         Assert.NotNull(result.Other);
-        Assert.True(ReferenceEquals(result.Values, result.Other));
+        Assert.Same(result.Values, result.Other);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -2171,7 +2171,7 @@ public class YamlSerializerSourceGenerationTests
         Assert.NotNull(roundtripped);
         Assert.NotNull(roundtripped.First);
         Assert.NotNull(roundtripped.Second);
-        Assert.True(ReferenceEquals(roundtripped.First, roundtripped.Second));
+        Assert.Same(roundtripped.First, roundtripped.Second);
         Assert.Equal("shared", roundtripped.First.Name);
     }
 
@@ -2195,7 +2195,7 @@ public class YamlSerializerSourceGenerationTests
         var roundtripped = YamlSerializer.Deserialize(yaml, typeInfo);
         Assert.NotNull(roundtripped);
         Assert.NotNull(roundtripped.Next);
-        Assert.True(ReferenceEquals(roundtripped, roundtripped.Next));
+        Assert.Same(roundtripped, roundtripped.Next);
     }
 
     [Fact]


### PR DESCRIPTION
**3 of 5**. Based on #1846.

Turns *"Assert.True() failed"* into a real value diff.

| Id | Detects | Suggests |
| -- | -- | -- |
| `MFAS0031`/`MFAS0032` | `Assert.True(a == b)` | `Assert.Equal` / `Assert.NotEqual` |
| `MFAS0033`/`MFAS0034` | `a.Equals(b)`, `object.Equals(a, b)`, `string.Equals(a, b, comparison)` | `Assert.Equal` / `Assert.NotEqual` |
| `MFAS0035`/`MFAS0036` | `actual.SequenceEqual(expected)` | `Assert.Equal` / `Assert.NotEqual` |
| `MFAS0037`/`MFAS0038` | `object.ReferenceEquals(a, b)` | `Assert.Same` / `Assert.NotSame` |

Also introduces the shared plumbing this and the next PR use: `ConditionRewriteAnalyzerCommon` holds detection, `ConditionRewriteAnalyzerBase` and `ConditionRewriteCodeFixProviderBase` hold the registration boilerplate, and `AssertionCodeFixHelpers` gains a builder that rewrites the call while re-attaching its `message` argument. Unlike the existing True/False engine the condition need not be an invocation, so operators are supported; the enclosing assertion is located semantically rather than by syntax depth.

### Where these rules deliberately hold back

This is the part most worth reviewing — each restriction exists because the naive rewrite changes behaviour:

- **`MFAS0031` excludes floating point.** `double.NaN == double.NaN` is false but `Assert.Equal` treats the two as equal. It is limited to primitives, `string`, enums and `Nullable<T>` of those, with no user-defined operator, so reference equality is never silently swapped for value equality.
- **`MFAS0033` only rewrites values that provably cannot be a sequence** — value types, sealed types and `string`. `Assert.Equal` inspects its arguments at run time and calls `TryEqualEnumerables`, which `Equals` never does. I verified this: for two equal `List<int>` held in `object` variables, `a.Equals(b)` is **false** while `Assert.Equal(b, a)` **passes** — the rewrite would turn a failing assertion into a passing one. `object`, interfaces and open classes are therefore excluded.
- **`MFAS0031` defers** to `MFAS0004`/`MFAS0005` on count comparisons and to `MFAS0006`/`MFAS0007` on null comparisons, so nothing is reported twice.
- **`MFAS0037`/`MFAS0038` skip value types**, which belong to `MFAS0010`/`MFAS0011`.

I also checked the enum case and it needs no guard: `Assert.Equal(0, enumValue)` agrees with `enumValue == 0` in both directions.

### Verification

Analyzer tests 139 passed, `/p:TreatWarningsAsErrors=true` clean. Coverage includes aliases, `using static`, message preservation, and a negative case per restriction above.
