### PR TITLE
Rewrite range, set, negation and type conditions (MFAS0039-MFAS0047)

### DIFF
--- a/src/Meziantou.Framework.Assertions.Analyzer/AssertionCodeFixHelpers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/AssertionCodeFixHelpers.cs
@@ -153,6 +153,7 @@ internal static class AssertionCodeFixHelpers
     /// Builds the replacement for an <c>Assert.True</c>/<c>Assert.False</c> call rewritten into a dedicated assertion.
     /// </summary>
     internal static bool TryCreateConditionRewriteFix(
+        SemanticModel semanticModel,
         InvocationExpressionSyntax assertInvocation,
         ConditionRewriteAnalyzerCommon.ConditionRewriteMatch match,
         out InvocationExpressionSyntax fixedInvocation)
@@ -185,8 +186,15 @@ internal static class AssertionCodeFixHelpers
                 messageArgument.Expression.WithoutTrivia()));
         }
 
+        var expression = match.TypeArgument is null
+            ? ReplaceMethodName(assertInvocation.Expression, match.AssertionMethodName)
+            : ReplaceMethodNameWithTypeArgument(
+                assertInvocation.Expression,
+                match.AssertionMethodName,
+                SyntaxFactory.ParseTypeName(match.TypeArgument.ToMinimalDisplayString(semanticModel, assertInvocation.SpanStart)));
+
         fixedInvocation = assertInvocation
-            .WithExpression(ReplaceMethodName(assertInvocation.Expression, match.AssertionMethodName))
+            .WithExpression(expression)
             .WithArgumentList(SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)));
         return true;
     }

--- a/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
@@ -40,4 +40,13 @@ internal static class RuleIdentifiers
     internal const string UseNotEqualForSequenceEqualDiagnosticId = "MFAS0036";
     internal const string UseSameForReferenceEqualsDiagnosticId = "MFAS0037";
     internal const string UseNotSameForReferenceEqualsDiagnosticId = "MFAS0038";
+    internal const string UseInRangeDiagnosticId = "MFAS0039";
+    internal const string UseNotInRangeDiagnosticId = "MFAS0040";
+    internal const string UseProperSubsetDiagnosticId = "MFAS0041";
+    internal const string UseNotProperSubsetDiagnosticId = "MFAS0042";
+    internal const string UseProperSupersetDiagnosticId = "MFAS0043";
+    internal const string UseNotProperSupersetDiagnosticId = "MFAS0044";
+    internal const string UseNegatedConditionAssertionDiagnosticId = "MFAS0045";
+    internal const string UseIsTypeForRuntimeTypeDiagnosticId = "MFAS0046";
+    internal const string UseIsNotTypeForRuntimeTypeDiagnosticId = "MFAS0047";
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConditionRewriteAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConditionRewriteAnalyzerCommon.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Framework.Analyzers.Assertions;
@@ -15,12 +16,24 @@ internal static class ConditionRewriteAnalyzerCommon
     private const string NotEqualAssertionMethodName = "NotEqual";
     private const string SameAssertionMethodName = "Same";
     private const string NotSameAssertionMethodName = "NotSame";
+    private const string InRangeAssertionMethodName = "InRange";
+    private const string NotInRangeAssertionMethodName = "NotInRange";
+    private const string ProperSubsetAssertionMethodName = "ProperSubset";
+    private const string NotProperSubsetAssertionMethodName = "NotProperSubset";
+    private const string ProperSupersetAssertionMethodName = "ProperSuperset";
+    private const string NotProperSupersetAssertionMethodName = "NotProperSuperset";
+    private const string IsTypeAssertionMethodName = "IsType";
+    private const string IsNotTypeAssertionMethodName = "IsNotType";
+    private const string TrueAssertionMethodName = "True";
+    private const string FalseAssertionMethodName = "False";
 
     internal static bool TryCreateSymbols(Compilation compilation, [NotNullWhen(true)] out Symbols? symbols)
     {
         var enumerableType = compilation.GetTypeByMetadataName("System.Linq.Enumerable");
+        var setType = compilation.GetTypeByMetadataName("System.Collections.Generic.ISet`1");
         var nonGenericEnumerableType = compilation.GetTypeByMetadataName("System.Collections.IEnumerable");
-        if (enumerableType is null || nonGenericEnumerableType is null)
+        var comparableType = compilation.GetTypeByMetadataName("System.IComparable`1");
+        if (enumerableType is null || setType is null || nonGenericEnumerableType is null || comparableType is null)
         {
             symbols = null;
             return false;
@@ -49,12 +62,20 @@ internal static class ConditionRewriteAnalyzerCommon
             .OfType<IMethodSymbol>()
             .FirstOrDefault(m => m is { IsStatic: true, Parameters.Length: 2 });
 
+        var objectGetTypeMethod = objectType.GetMembers("GetType")
+            .OfType<IMethodSymbol>()
+            .FirstOrDefault(m => m is { IsStatic: false, Parameters.Length: 0 });
+
         var stringStaticEqualsMethods = stringType.GetMembers("Equals")
             .OfType<IMethodSymbol>()
             .Where(m => m.IsStatic && m.Parameters.Length is 2 or 3)
             .ToImmutableArray();
 
-        if (objectReferenceEqualsMethod is null || objectStaticEqualsMethod is null)
+        var setProperSubsetMethod = setType.GetMembers("IsProperSubsetOf").OfType<IMethodSymbol>().FirstOrDefault();
+        var setProperSupersetMethod = setType.GetMembers("IsProperSupersetOf").OfType<IMethodSymbol>().FirstOrDefault();
+
+        if (objectReferenceEqualsMethod is null || objectStaticEqualsMethod is null || objectGetTypeMethod is null ||
+            setProperSubsetMethod is null || setProperSupersetMethod is null)
         {
             symbols = null;
             return false;
@@ -65,8 +86,12 @@ internal static class ConditionRewriteAnalyzerCommon
             sequenceEqualMethods,
             objectReferenceEqualsMethod,
             objectStaticEqualsMethod,
+            objectGetTypeMethod,
             stringStaticEqualsMethods,
-            nonGenericEnumerableType);
+            setProperSubsetMethod,
+            setProperSupersetMethod,
+            nonGenericEnumerableType,
+            comparableType);
         return true;
     }
 
@@ -293,6 +318,260 @@ internal static class ConditionRewriteAnalyzerCommon
     }
 
     // ---------------------------------------------------------------------------------------------------------
+    // Assert.True(low <= x && x <= high) -> Assert.InRange(x, low, high)
+    // ---------------------------------------------------------------------------------------------------------
+    internal static bool TryGetRangeMatch(IInvocationOperation assertInvocation, INamedTypeSymbol assertType, Symbols symbols, out ConditionRewriteMatch match)
+    {
+        if (!TryGetCondition(assertInvocation, assertType, out var conditionOperation, out var conditionExpectedToBeFalse) ||
+            conditionOperation is not IBinaryOperation { OperatorKind: BinaryOperatorKind.ConditionalAnd } andOperation)
+        {
+            match = default;
+            return false;
+        }
+
+        if (!TryGetComparison(andOperation.LeftOperand, symbols, out var first) ||
+            !TryGetComparison(andOperation.RightOperand, symbols, out var second))
+        {
+            match = default;
+            return false;
+        }
+
+        // The value under test is the operand the two comparisons have in common, which works whether the bounds
+        // are constants or variables and whichever side of each comparison the value is written on
+        if (!TryGetSharedValue(first, second, out var value, out var lowOperand, out var highOperand))
+        {
+            match = default;
+            return false;
+        }
+
+        var assertionMethodName = conditionExpectedToBeFalse ? NotInRangeAssertionMethodName : InRangeAssertionMethodName;
+        match = new ConditionRewriteMatch(andOperation, assertionMethodName, [value, lowOperand, highOperand]);
+        return true;
+    }
+
+    private static bool TryGetComparison(IOperation operation, Symbols symbols, out Comparison comparison)
+    {
+        operation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(operation);
+
+        // Assert.InRange is inclusive on both ends, so strict comparisons are not equivalent
+        if (operation is IBinaryOperation binaryOperation &&
+            binaryOperation.OperatorKind is BinaryOperatorKind.GreaterThanOrEqual or BinaryOperatorKind.LessThanOrEqual &&
+            IsComparableWithDefaultComparer(binaryOperation, symbols))
+        {
+            comparison = new Comparison(
+                AssertionsAnalyzerHelpers.UnwrapImplicitConversion(binaryOperation.LeftOperand),
+                AssertionsAnalyzerHelpers.UnwrapImplicitConversion(binaryOperation.RightOperand),
+                binaryOperation.OperatorKind);
+            return true;
+        }
+
+        comparison = default;
+        return false;
+    }
+
+    private static bool TryGetSharedValue(Comparison first, Comparison second, out IOperation value, out IOperation lowOperand, out IOperation highOperand)
+    {
+        foreach (var valueOnFirstLeft in Booleans)
+        {
+            var candidate = valueOnFirstLeft ? first.Left : first.Right;
+            foreach (var valueOnSecondLeft in Booleans)
+            {
+                var other = valueOnSecondLeft ? second.Left : second.Right;
+                if (!SyntaxFactory.AreEquivalent(candidate.Syntax, other.Syntax))
+                    continue;
+
+                var firstIsLowerBound = IsLowerBound(first.OperatorKind, valueOnFirstLeft);
+                var secondIsLowerBound = IsLowerBound(second.OperatorKind, valueOnSecondLeft);
+
+                // One comparison must give the lower bound and the other the upper bound
+                if (firstIsLowerBound == secondIsLowerBound)
+                    continue;
+
+                var firstBound = valueOnFirstLeft ? first.Right : first.Left;
+                var secondBound = valueOnSecondLeft ? second.Right : second.Left;
+
+                value = candidate;
+                lowOperand = firstIsLowerBound ? firstBound : secondBound;
+                highOperand = firstIsLowerBound ? secondBound : firstBound;
+                return true;
+            }
+        }
+
+        value = null!;
+        lowOperand = null!;
+        highOperand = null!;
+        return false;
+    }
+
+    /// <summary>'value &gt;= bound' and 'bound &lt;= value' both express a lower bound.</summary>
+    private static bool IsLowerBound(BinaryOperatorKind operatorKind, bool valueOnLeft)
+        => valueOnLeft
+            ? operatorKind == BinaryOperatorKind.GreaterThanOrEqual
+            : operatorKind == BinaryOperatorKind.LessThanOrEqual;
+
+    private static readonly bool[] Booleans = [true, false];
+
+    private readonly record struct Comparison(IOperation Left, IOperation Right, BinaryOperatorKind OperatorKind);
+
+    private static bool IsComparableWithDefaultComparer(IBinaryOperation binaryOperation, Symbols symbols)
+    {
+        // Built-in relational operators always agree with Comparer<T>.Default
+        if (binaryOperation.OperatorMethod is null)
+            return true;
+
+        var type = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(binaryOperation.LeftOperand).Type;
+        if (type is null)
+            return false;
+
+        foreach (var interfaceType in type.AllInterfaces)
+        {
+            if (SymbolEqualityComparer.Default.Equals(interfaceType.OriginalDefinition, symbols.ComparableType) &&
+                interfaceType.TypeArguments is [var typeArgument] &&
+                SymbolEqualityComparer.Default.Equals(typeArgument, type))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+    // Assert.True(set.IsProperSubsetOf(other)) -> Assert.ProperSubset(set, other)
+    // ---------------------------------------------------------------------------------------------------------
+    internal static bool TryGetSetMatch(IInvocationOperation assertInvocation, INamedTypeSymbol assertType, Symbols symbols, out ConditionRewriteMatch match)
+    {
+        if (!TryGetCondition(assertInvocation, assertType, out var conditionOperation, out var conditionExpectedToBeFalse) ||
+            conditionOperation is not IInvocationOperation { Instance: { } instance, Arguments.Length: 1 } invocation)
+        {
+            match = default;
+            return false;
+        }
+
+        var isSubset = invocation.TargetMethod.Name == "IsProperSubsetOf";
+        var isSuperset = invocation.TargetMethod.Name == "IsProperSupersetOf";
+        if (!isSubset && !isSuperset)
+        {
+            match = default;
+            return false;
+        }
+
+        var interfaceMethod = isSubset ? symbols.SetProperSubsetMethod : symbols.SetProperSupersetMethod;
+        if (!ImplementsSetMethod(invocation.TargetMethod, interfaceMethod))
+        {
+            match = default;
+            return false;
+        }
+
+        // Assert.ProperSubset(expected, actual) asserts that 'expected' is a proper subset of 'actual',
+        // which matches the receiver/argument order of ISet<T>.IsProperSubsetOf
+        var assertionMethodName = (isSubset, conditionExpectedToBeFalse) switch
+        {
+            (true, false) => ProperSubsetAssertionMethodName,
+            (true, true) => NotProperSubsetAssertionMethodName,
+            (false, false) => ProperSupersetAssertionMethodName,
+            (false, true) => NotProperSupersetAssertionMethodName,
+        };
+
+        match = new ConditionRewriteMatch(
+            invocation,
+            assertionMethodName,
+            [AssertionsAnalyzerHelpers.UnwrapImplicitConversion(instance), AssertionsAnalyzerHelpers.UnwrapImplicitConversion(invocation.Arguments[0].Value)]);
+        return true;
+    }
+
+    private static bool ImplementsSetMethod(IMethodSymbol method, IMethodSymbol interfaceMethodDefinition)
+    {
+        if (SymbolEqualityComparer.Default.Equals(method.OriginalDefinition, interfaceMethodDefinition))
+            return true;
+
+        foreach (var interfaceType in method.ContainingType.AllInterfaces)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(interfaceType.OriginalDefinition, interfaceMethodDefinition.ContainingType))
+                continue;
+
+            var interfaceMethod = interfaceType.GetMembers(interfaceMethodDefinition.Name).OfType<IMethodSymbol>().FirstOrDefault();
+            if (interfaceMethod is null)
+                continue;
+
+            if (SymbolEqualityComparer.Default.Equals(method.ContainingType.FindImplementationForInterfaceMember(interfaceMethod), method))
+                return true;
+        }
+
+        return false;
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+    // Assert.True(!condition) -> Assert.False(condition)
+    // ---------------------------------------------------------------------------------------------------------
+    internal static bool TryGetNegatedConditionMatch(IInvocationOperation assertInvocation, INamedTypeSymbol assertType, Symbols symbols, out ConditionRewriteMatch match)
+    {
+        _ = symbols;
+        if (!TryGetCondition(assertInvocation, assertType, out var conditionOperation, out var conditionExpectedToBeFalse) ||
+            conditionOperation is not IUnaryOperation { OperatorKind: UnaryOperatorKind.Not, OperatorMethod: null } unaryOperation)
+        {
+            match = default;
+            return false;
+        }
+
+        var operand = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(unaryOperation.Operand);
+        if (operand.Type?.SpecialType != SpecialType.System_Boolean)
+        {
+            match = default;
+            return false;
+        }
+
+        var assertionMethodName = conditionExpectedToBeFalse ? TrueAssertionMethodName : FalseAssertionMethodName;
+        match = new ConditionRewriteMatch(unaryOperation, assertionMethodName, [operand]);
+        return true;
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+    // Assert.True(x.GetType() == typeof(T)) -> Assert.IsType<T>(x)
+    // ---------------------------------------------------------------------------------------------------------
+    internal static bool TryGetRuntimeTypeMatch(IInvocationOperation assertInvocation, INamedTypeSymbol assertType, Symbols symbols, out ConditionRewriteMatch match)
+    {
+        if (!TryGetCondition(assertInvocation, assertType, out var conditionOperation, out var conditionExpectedToBeFalse) ||
+            conditionOperation is not IBinaryOperation binaryOperation ||
+            binaryOperation.OperatorKind is not (BinaryOperatorKind.Equals or BinaryOperatorKind.NotEquals))
+        {
+            match = default;
+            return false;
+        }
+
+        var left = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(binaryOperation.LeftOperand);
+        var right = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(binaryOperation.RightOperand);
+
+        if (!TryGetGetTypeReceiverAndType(left, right, symbols, out var receiver, out var type) &&
+            !TryGetGetTypeReceiverAndType(right, left, symbols, out receiver, out type))
+        {
+            match = default;
+            return false;
+        }
+
+        var negated = binaryOperation.OperatorKind == BinaryOperatorKind.NotEquals ^ conditionExpectedToBeFalse;
+        var assertionMethodName = negated ? IsNotTypeAssertionMethodName : IsTypeAssertionMethodName;
+        match = new ConditionRewriteMatch(binaryOperation, assertionMethodName, [receiver], TypeArgument: type);
+        return true;
+    }
+
+    private static bool TryGetGetTypeReceiverAndType(IOperation getTypeCandidate, IOperation typeOfCandidate, Symbols symbols, out IOperation receiver, out ITypeSymbol type)
+    {
+        if (getTypeCandidate is IInvocationOperation { TargetMethod.Name: "GetType", Instance: { } instance } getTypeInvocation &&
+            SymbolEqualityComparer.Default.Equals(getTypeInvocation.TargetMethod.OriginalDefinition, symbols.ObjectGetTypeMethod) &&
+            typeOfCandidate is ITypeOfOperation { TypeOperand: { } typeOperand })
+        {
+            receiver = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(instance);
+            type = typeOperand;
+            return true;
+        }
+
+        receiver = null!;
+        type = null!;
+        return false;
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
 
     private static bool TryGetCondition(IInvocationOperation assertInvocation, INamedTypeSymbol assertType, out IOperation conditionOperation, out bool conditionExpectedToBeFalse)
     {
@@ -396,12 +675,17 @@ internal static class ConditionRewriteAnalyzerCommon
         ImmutableArray<IMethodSymbol> SequenceEqualMethods,
         IMethodSymbol ObjectReferenceEqualsMethod,
         IMethodSymbol ObjectStaticEqualsMethod,
+        IMethodSymbol ObjectGetTypeMethod,
         ImmutableArray<IMethodSymbol> StringStaticEqualsMethods,
-        INamedTypeSymbol NonGenericEnumerableType);
+        IMethodSymbol SetProperSubsetMethod,
+        IMethodSymbol SetProperSupersetMethod,
+        INamedTypeSymbol NonGenericEnumerableType,
+        INamedTypeSymbol ComparableType);
 
     internal readonly record struct ConditionRewriteMatch(
         IOperation ReportOperation,
         string AssertionMethodName,
         IOperation[] Arguments,
-        bool? IgnoreCaseValue = null);
+        bool? IgnoreCaseValue = null,
+        ITypeSymbol? TypeArgument = null);
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/NegatedConditionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/NegatedConditionAnalyzer.cs
@@ -1,0 +1,23 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NegatedConditionAnalyzer : ConditionRewriteAnalyzerBase
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: RuleIdentifiers.UseNegatedConditionAssertionDiagnosticId,
+        title: "Use Assert.False instead of Assert.True(!condition)",
+        messageFormat: "Use Assert.{0} and drop the negation",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetNegatedConditionMatch;
+
+    private protected override DiagnosticDescriptor GetDescriptor(string assertionMethodName) => Descriptor;
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/RangeConditionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/RangeConditionAnalyzer.cs
@@ -1,0 +1,32 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RangeConditionAnalyzer : ConditionRewriteAnalyzerBase
+{
+    public static readonly DiagnosticDescriptor UseInRangeDescriptor = new(
+        id: RuleIdentifiers.UseInRangeDiagnosticId,
+        title: "Use Assert.InRange instead of Assert.True(low <= x && x <= high)",
+        messageFormat: "Use Assert.InRange(actual, low, high) to report the value and the range",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseNotInRangeDescriptor = new(
+        id: RuleIdentifiers.UseNotInRangeDiagnosticId,
+        title: "Use Assert.NotInRange instead of Assert.False(low <= x && x <= high)",
+        messageFormat: "Use Assert.NotInRange(actual, low, high) to report the value and the range",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [UseInRangeDescriptor, UseNotInRangeDescriptor];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetRangeMatch;
+
+    private protected override DiagnosticDescriptor GetDescriptor(string assertionMethodName)
+        => assertionMethodName == "InRange" ? UseInRangeDescriptor : UseNotInRangeDescriptor;
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/RuntimeTypeConditionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/RuntimeTypeConditionAnalyzer.cs
@@ -1,0 +1,32 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RuntimeTypeConditionAnalyzer : ConditionRewriteAnalyzerBase
+{
+    public static readonly DiagnosticDescriptor UseIsTypeDescriptor = new(
+        id: RuleIdentifiers.UseIsTypeForRuntimeTypeDiagnosticId,
+        title: "Use Assert.IsType instead of Assert.True(x.GetType() == typeof(T))",
+        messageFormat: "Use Assert.IsType<T>(actual) to report the actual runtime type",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseIsNotTypeDescriptor = new(
+        id: RuleIdentifiers.UseIsNotTypeForRuntimeTypeDiagnosticId,
+        title: "Use Assert.IsNotType instead of Assert.False(x.GetType() == typeof(T))",
+        messageFormat: "Use Assert.IsNotType<T>(actual) to report the actual runtime type",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [UseIsTypeDescriptor, UseIsNotTypeDescriptor];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetRuntimeTypeMatch;
+
+    private protected override DiagnosticDescriptor GetDescriptor(string assertionMethodName)
+        => assertionMethodName == "IsType" ? UseIsTypeDescriptor : UseIsNotTypeDescriptor;
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/SetConditionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/SetConditionAnalyzer.cs
@@ -1,0 +1,54 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class SetConditionAnalyzer : ConditionRewriteAnalyzerBase
+{
+    public static readonly DiagnosticDescriptor UseProperSubsetDescriptor = new(
+        id: RuleIdentifiers.UseProperSubsetDiagnosticId,
+        title: "Use Assert.ProperSubset instead of Assert.True(set.IsProperSubsetOf(other))",
+        messageFormat: "Use Assert.ProperSubset(expected, actual) to report the compared sets",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseNotProperSubsetDescriptor = new(
+        id: RuleIdentifiers.UseNotProperSubsetDiagnosticId,
+        title: "Use Assert.NotProperSubset instead of Assert.False(set.IsProperSubsetOf(other))",
+        messageFormat: "Use Assert.NotProperSubset(expected, actual) to report the compared sets",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseProperSupersetDescriptor = new(
+        id: RuleIdentifiers.UseProperSupersetDiagnosticId,
+        title: "Use Assert.ProperSuperset instead of Assert.True(set.IsProperSupersetOf(other))",
+        messageFormat: "Use Assert.ProperSuperset(expected, actual) to report the compared sets",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseNotProperSupersetDescriptor = new(
+        id: RuleIdentifiers.UseNotProperSupersetDiagnosticId,
+        title: "Use Assert.NotProperSuperset instead of Assert.False(set.IsProperSupersetOf(other))",
+        messageFormat: "Use Assert.NotProperSuperset(expected, actual) to report the compared sets",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [UseProperSubsetDescriptor, UseNotProperSubsetDescriptor, UseProperSupersetDescriptor, UseNotProperSupersetDescriptor];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetSetMatch;
+
+    private protected override DiagnosticDescriptor GetDescriptor(string assertionMethodName) => assertionMethodName switch
+    {
+        "ProperSubset" => UseProperSubsetDescriptor,
+        "NotProperSubset" => UseNotProperSubsetDescriptor,
+        "ProperSuperset" => UseProperSupersetDescriptor,
+        _ => UseNotProperSupersetDescriptor,
+    };
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/ConditionRewriteCodeFixProviderBase.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/ConditionRewriteCodeFixProviderBase.cs
@@ -77,7 +77,7 @@ public abstract class ConditionRewriteCodeFixProviderBase : CodeFixProvider
         if (!Matcher(assertOperation, assertType, symbols.Value, out var match))
             return document;
 
-        if (!AssertionCodeFixHelpers.TryCreateConditionRewriteFix(assertInvocation, match, out var fixedInvocation))
+        if (!AssertionCodeFixHelpers.TryCreateConditionRewriteFix(semanticModel, assertInvocation, match, out var fixedInvocation))
             return document;
 
         var newRoot = root.ReplaceNode(assertInvocation, fixedInvocation.WithAdditionalAnnotations(Formatter.Annotation));

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/NegatedConditionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/NegatedConditionCodeFixProvider.cs
@@ -1,0 +1,16 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(NegatedConditionCodeFixProvider))]
+public sealed class NegatedConditionCodeFixProvider : ConditionRewriteCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+    [
+        RuleIdentifiers.UseNegatedConditionAssertionDiagnosticId,
+    ];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetNegatedConditionMatch;
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/RangeConditionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/RangeConditionCodeFixProvider.cs
@@ -1,0 +1,17 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RangeConditionCodeFixProvider))]
+public sealed class RangeConditionCodeFixProvider : ConditionRewriteCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+    [
+        RuleIdentifiers.UseInRangeDiagnosticId,
+        RuleIdentifiers.UseNotInRangeDiagnosticId,
+    ];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetRangeMatch;
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/RuntimeTypeConditionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/RuntimeTypeConditionCodeFixProvider.cs
@@ -1,0 +1,17 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RuntimeTypeConditionCodeFixProvider))]
+public sealed class RuntimeTypeConditionCodeFixProvider : ConditionRewriteCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+    [
+        RuleIdentifiers.UseIsTypeForRuntimeTypeDiagnosticId,
+        RuleIdentifiers.UseIsNotTypeForRuntimeTypeDiagnosticId,
+    ];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetRuntimeTypeMatch;
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/SetConditionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/SetConditionCodeFixProvider.cs
@@ -1,0 +1,19 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SetConditionCodeFixProvider))]
+public sealed class SetConditionCodeFixProvider : ConditionRewriteCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+    [
+        RuleIdentifiers.UseProperSubsetDiagnosticId,
+        RuleIdentifiers.UseNotProperSubsetDiagnosticId,
+        RuleIdentifiers.UseProperSupersetDiagnosticId,
+        RuleIdentifiers.UseNotProperSupersetDiagnosticId,
+    ];
+
+    private protected override TryGetMatch Matcher => ConditionRewriteAnalyzerCommon.TryGetSetMatch;
+}

--- a/src/Meziantou.Framework.Assertions/readme.md
+++ b/src/Meziantou.Framework.Assertions/readme.md
@@ -122,4 +122,13 @@ The package ships analyzers and code fixes to help write clearer assertions.
 | `MFAS0036` | Assertions | Use Assert.NotEqual instead of Assert.False(actual.SequenceEqual(expected)) | Warning | ✔️ |
 | `MFAS0037` | Assertions | Use Assert.Same instead of Assert.True(ReferenceEquals(a, b)) | Warning | ✔️ |
 | `MFAS0038` | Assertions | Use Assert.NotSame instead of Assert.False(ReferenceEquals(a, b)) | Warning | ✔️ |
+| `MFAS0039` | Assertions | Use Assert.InRange instead of Assert.True(low <= x && x <= high) | Warning | ✔️ |
+| `MFAS0040` | Assertions | Use Assert.NotInRange instead of Assert.False(low <= x && x <= high) | Warning | ✔️ |
+| `MFAS0041` | Assertions | Use Assert.ProperSubset instead of Assert.True(set.IsProperSubsetOf(other)) | Warning | ✔️ |
+| `MFAS0042` | Assertions | Use Assert.NotProperSubset instead of Assert.False(set.IsProperSubsetOf(other)) | Warning | ✔️ |
+| `MFAS0043` | Assertions | Use Assert.ProperSuperset instead of Assert.True(set.IsProperSupersetOf(other)) | Warning | ✔️ |
+| `MFAS0044` | Assertions | Use Assert.NotProperSuperset instead of Assert.False(set.IsProperSupersetOf(other)) | Warning | ✔️ |
+| `MFAS0045` | Assertions | Use Assert.False instead of Assert.True(!condition) | Warning | ✔️ |
+| `MFAS0046` | Assertions | Use Assert.IsType instead of Assert.True(x.GetType() == typeof(T)) | Warning | ✔️ |
+| `MFAS0047` | Assertions | Use Assert.IsNotType instead of Assert.False(x.GetType() == typeof(T)) | Warning | ✔️ |
 <!-- analyzer-rules -->

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/NegatedConditionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/NegatedConditionRuleTests.cs
@@ -1,0 +1,75 @@
+using NegatedConditionAnalyzerType = Meziantou.Framework.Analyzers.Assertions.NegatedConditionAnalyzer;
+using NegatedConditionCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.NegatedConditionCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class NegatedConditionRuleTests : AssertionsAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("Assert.True({|MFAS0045:!condition|});", "Assert.False(condition);")]
+    [InlineData("Assert.False({|MFAS0045:!condition|});", "Assert.True(condition);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForNegatedCondition(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(bool condition)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(bool condition)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<NegatedConditionAnalyzerType, NegatedConditionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForNonNegatedCondition()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(bool condition, int value)
+                {
+                    Assert.True(condition);
+                    Assert.False(condition);
+                    Assert.True(~value == 0);
+                }
+            }
+
+            public static class NullableTestClass
+            {
+                public static void M(bool? condition)
+                {
+                    // '!condition' on a nullable bool is a lifted operator that yields null when condition is null,
+                    // so Assert.False(condition) is not equivalent
+                    Assert.True(!condition);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<NegatedConditionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/RangeConditionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/RangeConditionRuleTests.cs
@@ -1,0 +1,192 @@
+using RangeConditionAnalyzerType = Meziantou.Framework.Analyzers.Assertions.RangeConditionAnalyzer;
+using RangeConditionCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.RangeConditionCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class RangeConditionRuleTests : AssertionsAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("Assert.True({|MFAS0039:value >= 0 && value <= 10|});", "Assert.InRange(value, 0, 10);")]
+    [InlineData("Assert.True({|MFAS0039:0 <= value && value <= 10|});", "Assert.InRange(value, 0, 10);")]
+    [InlineData("Assert.True({|MFAS0039:value <= 10 && value >= 0|});", "Assert.InRange(value, 0, 10);")]
+    [InlineData("Assert.True({|MFAS0039:value >= 0 && 10 >= value|});", "Assert.InRange(value, 0, 10);")]
+    [InlineData("Assert.False({|MFAS0040:value >= 0 && value <= 10|});", "Assert.NotInRange(value, 0, 10);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForRangeCheck(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<RangeConditionAnalyzerType, RangeConditionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForComparableType()
+    {
+        var source = """
+            using System;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(DateTime value, DateTime low, DateTime high)
+                {
+                    Assert.True({|MFAS0039:value >= low && value <= high|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(DateTime value, DateTime low, DateTime high)
+                {
+                    Assert.InRange(value, low, high);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<RangeConditionAnalyzerType, RangeConditionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Theory]
+    [InlineData("Assert.True({|MFAS0039:low <= value && value <= high|});", "Assert.InRange(value, low, high);")]
+    [InlineData("Assert.True({|MFAS0039:value >= low && value <= high|});", "Assert.InRange(value, low, high);")]
+    [InlineData("Assert.True({|MFAS0039:value <= high && low <= value|});", "Assert.InRange(value, low, high);")]
+    [InlineData("Assert.True({|MFAS0039:high >= value && low <= value|});", "Assert.InRange(value, low, high);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForVariableBounds(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value, int low, int high)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value, int low, int high)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<RangeConditionAnalyzerType, RangeConditionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForMemberAccessValue()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public sealed class Box
+            {
+                public int Value { get; set; }
+            }
+
+            public static class TestClass
+            {
+                public static void M(Box box, int low, int high)
+                {
+                    Assert.True({|MFAS0039:low <= box.Value && box.Value <= high|});
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public sealed class Box
+            {
+                public int Value { get; set; }
+            }
+
+            public static class TestClass
+            {
+                public static void M(Box box, int low, int high)
+                {
+                    Assert.InRange(box.Value, low, high);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<RangeConditionAnalyzerType, RangeConditionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForExclusiveBoundsOrDifferentValues()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value, int other)
+                {
+                    // Assert.InRange is inclusive on both ends
+                    Assert.True(value > 0 && value <= 10);
+                    Assert.True(value >= 0 && value < 10);
+
+                    // Two different values are not a range check
+                    Assert.True(value >= 0 && other <= 10);
+
+                    // Two lower bounds are not a range check
+                    Assert.True(value >= 0 && value >= 10);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<RangeConditionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/RuntimeTypeConditionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/RuntimeTypeConditionRuleTests.cs
@@ -1,0 +1,68 @@
+using RuntimeTypeConditionAnalyzerType = Meziantou.Framework.Analyzers.Assertions.RuntimeTypeConditionAnalyzer;
+using RuntimeTypeConditionCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.RuntimeTypeConditionCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class RuntimeTypeConditionRuleTests : AssertionsAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("Assert.True({|MFAS0046:value.GetType() == typeof(string)|});", "Assert.IsType<string>(value);")]
+    [InlineData("Assert.True({|MFAS0046:typeof(string) == value.GetType()|});", "Assert.IsType<string>(value);")]
+    [InlineData("Assert.True({|MFAS0047:value.GetType() != typeof(string)|});", "Assert.IsNotType<string>(value);")]
+    [InlineData("Assert.False({|MFAS0047:value.GetType() == typeof(string)|});", "Assert.IsNotType<string>(value);")]
+    [InlineData("Assert.False({|MFAS0046:value.GetType() != typeof(string)|});", "Assert.IsType<string>(value);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForRuntimeTypeComparison(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object value)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object value)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<RuntimeTypeConditionAnalyzerType, RuntimeTypeConditionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForOtherTypeComparisons()
+    {
+        var source = """
+            using System;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(object value, Type type)
+                {
+                    Assert.True(value.GetType() == type);
+                    Assert.True(type == typeof(string));
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<RuntimeTypeConditionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/SetConditionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/SetConditionRuleTests.cs
@@ -1,0 +1,74 @@
+using SetConditionAnalyzerType = Meziantou.Framework.Analyzers.Assertions.SetConditionAnalyzer;
+using SetConditionCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.SetConditionCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class SetConditionRuleTests : AssertionsAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("Assert.True({|MFAS0041:set.IsProperSubsetOf(other)|});", "Assert.ProperSubset(set, other);")]
+    [InlineData("Assert.False({|MFAS0042:set.IsProperSubsetOf(other)|});", "Assert.NotProperSubset(set, other);")]
+    [InlineData("Assert.True({|MFAS0043:set.IsProperSupersetOf(other)|});", "Assert.ProperSuperset(set, other);")]
+    [InlineData("Assert.False({|MFAS0044:set.IsProperSupersetOf(other)|});", "Assert.NotProperSuperset(set, other);")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForSetOperations(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(HashSet<int> set, HashSet<int> other)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(HashSet<int> set, HashSet<int> other)
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<SetConditionAnalyzerType, SetConditionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForCustomSetLikeType()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public sealed class CustomSet
+            {
+                public bool IsProperSubsetOf(CustomSet other) => true;
+                public bool IsProperSupersetOf(CustomSet other) => true;
+            }
+
+            public static class TestClass
+            {
+                public static void M(CustomSet set, CustomSet other)
+                {
+                    Assert.True(set.IsProperSubsetOf(other));
+                    Assert.True(set.IsProperSupersetOf(other));
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<SetConditionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
+++ b/tests/Meziantou.Framework.Tests/Collections/ImmutableEquatableSetTests.cs
@@ -225,9 +225,11 @@ public sealed class ImmutableEquatableSetTests
         var set = ImmutableEquatableSet.Create(new HashSet<string>(StringComparer.Ordinal) { "a", "b" });
         var iset = (ISet<string>)set;
 
+#pragma warning disable MFAS0041, MFAS0042 // The test validates IsProperSubsetOf itself
         Assert.True(iset.IsProperSubsetOf(new[] { "a", "b", "c" }));
         Assert.False(iset.IsProperSubsetOf(new[] { "a", "b" }));
         Assert.False(iset.IsProperSubsetOf(new[] { "a" }));
+#pragma warning restore MFAS0041, MFAS0042
     }
 
     [Fact]
@@ -236,9 +238,11 @@ public sealed class ImmutableEquatableSetTests
         var set = ImmutableEquatableSet.Create(new HashSet<string>(StringComparer.Ordinal) { "a", "b", "c" });
         var iset = (ISet<string>)set;
 
+#pragma warning disable MFAS0043, MFAS0044 // The test validates IsProperSupersetOf itself
         Assert.True(iset.IsProperSupersetOf(new[] { "a", "b" }));
         Assert.False(iset.IsProperSupersetOf(new[] { "a", "b", "c" }));
         Assert.False(iset.IsProperSupersetOf(new[] { "a", "b", "c", "d" }));
+#pragma warning restore MFAS0043, MFAS0044
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Threading.Tests/ConcurrentHashSetTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/ConcurrentHashSetTests.cs
@@ -80,10 +80,12 @@ public class ConcurrentHashSetTests
         var set = new ConcurrentHashSet<string>(StringComparer.OrdinalIgnoreCase);
         set.AddRange("a", "b");
 
+#pragma warning disable MFAS0041, MFAS0043 // The test validates the set comparison methods themselves
         Assert.True(set.IsSubsetOf(["A", "B", "C"]));
         Assert.True(set.IsProperSubsetOf(["A", "B", "C"]));
         Assert.True(set.IsSupersetOf(["A"]));
         Assert.True(set.IsProperSupersetOf(["A"]));
+#pragma warning restore MFAS0041, MFAS0043
         Assert.True(set.Overlaps(["A", "C"]));
         Assert.True(set.SetEquals(["A", "B"]));
     }


### PR DESCRIPTION
**4 of 5**. Based on #1847.

| Id | Detects | Suggests |
| -- | -- | -- |
| `MFAS0039`/`MFAS0040` | `low <= x && x <= high` | `Assert.InRange` / `Assert.NotInRange` |
| `MFAS0041`–`MFAS0044` | `ISet<T>.IsProperSubsetOf` / `IsProperSupersetOf` | `Assert.ProperSubset` / `ProperSuperset` / `NotProperSubset` / `NotProperSuperset` |
| `MFAS0045` | `Assert.True(!condition)` | `Assert.False(condition)` and the mirror |
| `MFAS0046`/`MFAS0047` | `x.GetType() == typeof(T)` | `Assert.IsType<T>(x)` / `Assert.IsNotType<T>(x)` |

Seven assertion methods that previously had **no** rule pointing at them now do: `InRange`, `NotInRange`, `IsNotType`, and the four proper subset/superset methods.

### Notes

- **Range matching** finds the value under test as the operand the two comparisons have in common, so any combination of operand order and bound kind is recognised (`low <= x && x <= high`, `x >= low && high >= x`, …). Only inclusive comparisons match, because `Assert.InRange` is inclusive on both ends, and only operands whose relational operator agrees with `Comparer<T>.Default`: built-in operators, or a type implementing `IComparable<T>` (so `DateTime` works).
- **Argument order for the set rules**: `Assert.ProperSubset(expected, actual)` asserts that its *first* argument is a proper subset of its second, which matches the receiver/argument order of the `ISet<T>` methods — so `set.IsProperSubsetOf(other)` becomes `Assert.ProperSubset(set, other)`. Worth a second pair of eyes since it reads backwards from the usual expected/actual convention.
- **`MFAS0045` skips lifted operators** on `bool?`, where `!condition` yields null rather than a negated value.
- **`MFAS0046`/`MFAS0047` are distinct from `MFAS0012`/`MFAS0013`**, which map `x is T` onto the *assignable* assertions; these map exact runtime type checks.

### Verification

Analyzer tests 165 passed, `/p:TreatWarningsAsErrors=true` clean.
