### PR TITLE
Add assertion correctness rules (MFAS0048-MFAS0051)

### DIFF
--- a/src/Meziantou.Framework.Assertions.Analyzer/AssertionCodeFixHelpers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/AssertionCodeFixHelpers.cs
@@ -199,6 +199,102 @@ internal static class AssertionCodeFixHelpers
         return true;
     }
 
+    /// <summary>
+    /// Whether awaiting <paramref name="expression"/> is possible without changing a signature the caller relies on.
+    /// </summary>
+    internal static bool CanCreateAwaitFix(ExpressionSyntax expression)
+    {
+        var container = GetEnclosingFunction(expression);
+        return container switch
+        {
+            AnonymousFunctionExpressionSyntax anonymousFunction => anonymousFunction.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword),
+            LocalFunctionStatementSyntax localFunction => localFunction.Modifiers.Any(SyntaxKind.AsyncKeyword),
+            MethodDeclarationSyntax method => method.Modifiers.Any(SyntaxKind.AsyncKeyword) ||
+                                              method.ReturnType is PredefinedTypeSyntax { Keyword.RawKind: (int)SyntaxKind.VoidKeyword },
+            _ => false,
+        };
+    }
+
+    private static SyntaxNode? GetEnclosingFunction(ExpressionSyntax expression)
+        => expression.Ancestors().FirstOrDefault(node => node is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax or MemberDeclarationSyntax);
+
+    /// <summary>
+    /// Awaits <paramref name="expression"/>, turning the enclosing method into <c>async Task</c> when needed.
+    /// </summary>
+    internal static bool TryCreateAwaitFix(SyntaxNode root, SemanticModel semanticModel, ExpressionSyntax expression, out SyntaxNode newRoot)
+    {
+        var awaitExpression = SyntaxFactory
+            .AwaitExpression(expression.WithoutLeadingTrivia())
+            .WithLeadingTrivia(expression.GetLeadingTrivia());
+
+        // Await belongs to the closest enclosing function, which is not necessarily the method
+        var container = GetEnclosingFunction(expression);
+
+        // Turning a lambda or a local function into an async one would change the delegate or the signature
+        // it is bound to, so only an already-async one can be fixed
+        if (container is AnonymousFunctionExpressionSyntax anonymousFunction)
+        {
+            if (!anonymousFunction.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword))
+            {
+                newRoot = null!;
+                return false;
+            }
+
+            newRoot = root.ReplaceNode(expression, awaitExpression);
+            return true;
+        }
+
+        if (container is LocalFunctionStatementSyntax localFunction)
+        {
+            if (!localFunction.Modifiers.Any(SyntaxKind.AsyncKeyword))
+            {
+                newRoot = null!;
+                return false;
+            }
+
+            newRoot = root.ReplaceNode(expression, awaitExpression);
+            return true;
+        }
+
+        if (container is not MethodDeclarationSyntax enclosingMethod)
+        {
+            newRoot = null!;
+            return false;
+        }
+
+        if (enclosingMethod.Modifiers.Any(SyntaxKind.AsyncKeyword))
+        {
+            newRoot = root.ReplaceNode(expression, awaitExpression);
+            return true;
+        }
+
+        // Only a void-returning method can be turned into an async method without changing its contract
+        if (enclosingMethod.ReturnType is not PredefinedTypeSyntax { Keyword.RawKind: (int)SyntaxKind.VoidKeyword })
+        {
+            newRoot = null!;
+            return false;
+        }
+
+        var taskType = semanticModel.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task");
+        if (taskType is null)
+        {
+            newRoot = null!;
+            return false;
+        }
+
+        var taskTypeSyntax = SyntaxFactory
+            .ParseTypeName(taskType.ToMinimalDisplayString(semanticModel, enclosingMethod.ReturnType.SpanStart))
+            .WithTriviaFrom(enclosingMethod.ReturnType);
+
+        var newMethod = enclosingMethod
+            .ReplaceNode(expression, awaitExpression)
+            .WithReturnType(taskTypeSyntax)
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.AsyncKeyword).WithTrailingTrivia(SyntaxFactory.Space));
+
+        newRoot = root.ReplaceNode(enclosingMethod, newMethod);
+        return true;
+    }
+
     private static bool TryGetMessageArgument(InvocationExpressionSyntax invocation, out ArgumentSyntax messageArgument)
     {
         var positionalArgumentIndex = 0;

--- a/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
@@ -50,7 +50,6 @@ internal static class RuleIdentifiers
     internal const string UseIsTypeForRuntimeTypeDiagnosticId = "MFAS0046";
     internal const string UseIsNotTypeForRuntimeTypeDiagnosticId = "MFAS0047";
     internal const string AwaitAssertionDiagnosticId = "MFAS0048";
-    internal const string AwaitAssertionArgumentDiagnosticId = "MFAS0049";
-    internal const string ConstantAssertionDiagnosticId = "MFAS0050";
-    internal const string UseFailAssertionDiagnosticId = "MFAS0051";
+    internal const string ConstantAssertionDiagnosticId = "MFAS0049";
+    internal const string UseFailAssertionDiagnosticId = "MFAS0050";
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
@@ -49,4 +49,8 @@ internal static class RuleIdentifiers
     internal const string UseNegatedConditionAssertionDiagnosticId = "MFAS0045";
     internal const string UseIsTypeForRuntimeTypeDiagnosticId = "MFAS0046";
     internal const string UseIsNotTypeForRuntimeTypeDiagnosticId = "MFAS0047";
+    internal const string AwaitAssertionDiagnosticId = "MFAS0048";
+    internal const string AwaitAssertionArgumentDiagnosticId = "MFAS0049";
+    internal const string ConstantAssertionDiagnosticId = "MFAS0050";
+    internal const string UseFailAssertionDiagnosticId = "MFAS0051";
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzer.cs
@@ -1,0 +1,58 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class AwaitAssertionAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor AwaitAssertionDescriptor = new(
+        id: RuleIdentifiers.AwaitAssertionDiagnosticId,
+        title: "Await assertions that return a Task",
+        messageFormat: "The task returned by this assertion is never awaited, so the assertion never runs",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor AwaitArgumentDescriptor = new(
+        id: RuleIdentifiers.AwaitAssertionArgumentDiagnosticId,
+        title: "Await the task passed to an assertion",
+        messageFormat: "This assertion compares a task with a value, so it can never succeed",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [AwaitAssertionDescriptor, AwaitArgumentDescriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var assertType = context.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+            if (assertType is null || !AwaitAssertionAnalyzerCommon.TryCreateSymbols(context.Compilation, out var symbols))
+                return;
+
+            context.RegisterOperationAction(context => Analyze(context, assertType, symbols.Value), OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, INamedTypeSymbol assertType, AwaitAssertionAnalyzerCommon.Symbols symbols)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+
+        if (AwaitAssertionAnalyzerCommon.IsDiscardedTaskAssertion(invocationOperation, assertType, symbols))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(AwaitAssertionDescriptor, invocationOperation.Syntax.GetLocation()));
+            return;
+        }
+
+        if (AwaitAssertionAnalyzerCommon.TryGetTaskArgumentMatch(invocationOperation, assertType, symbols, out var taskArgument))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(AwaitArgumentDescriptor, taskArgument.Value.Syntax.GetLocation()));
+        }
+    }
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzer.cs
@@ -16,15 +16,7 @@ public sealed class AwaitAssertionAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
-    public static readonly DiagnosticDescriptor AwaitArgumentDescriptor = new(
-        id: RuleIdentifiers.AwaitAssertionArgumentDiagnosticId,
-        title: "Await the task passed to an assertion",
-        messageFormat: "This assertion compares a task with a value, so it can never succeed",
-        category: "Assertions",
-        defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
-
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [AwaitAssertionDescriptor, AwaitArgumentDescriptor];
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [AwaitAssertionDescriptor];
 
     public override void Initialize(AnalysisContext context)
     {
@@ -43,16 +35,9 @@ public sealed class AwaitAssertionAnalyzer : DiagnosticAnalyzer
     private static void Analyze(OperationAnalysisContext context, INamedTypeSymbol assertType, AwaitAssertionAnalyzerCommon.Symbols symbols)
     {
         var invocationOperation = (IInvocationOperation)context.Operation;
-
-        if (AwaitAssertionAnalyzerCommon.IsDiscardedTaskAssertion(invocationOperation, assertType, symbols))
-        {
-            context.ReportDiagnostic(Diagnostic.Create(AwaitAssertionDescriptor, invocationOperation.Syntax.GetLocation()));
+        if (!AwaitAssertionAnalyzerCommon.IsDiscardedTaskAssertion(invocationOperation, assertType, symbols))
             return;
-        }
 
-        if (AwaitAssertionAnalyzerCommon.TryGetTaskArgumentMatch(invocationOperation, assertType, symbols, out var taskArgument))
-        {
-            context.ReportDiagnostic(Diagnostic.Create(AwaitArgumentDescriptor, taskArgument.Value.Syntax.GetLocation()));
-        }
+        context.ReportDiagnostic(Diagnostic.Create(AwaitAssertionDescriptor, invocationOperation.Syntax.GetLocation()));
     }
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzerCommon.cs
@@ -36,7 +36,10 @@ internal static class AwaitAssertionAnalyzerCommon
             return false;
         }
 
-        if (!IsTaskLike(targetMethod.ReturnType, symbols))
+        // The original definition tells an assertion that completes asynchronously apart from one that merely
+        // returns a value which happens to be a task: Assert.Single<T> returns T, so Assert.Single(taskArray)
+        // returns a Task without the assertion itself being asynchronous.
+        if (!IsTaskLike(targetMethod.OriginalDefinition.ReturnType, symbols))
             return false;
 
         // Anything else (await, return, assignment, argument) consumes the task

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzerCommon.cs
@@ -4,8 +4,8 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Meziantou.Framework.Analyzers.Assertions;
 
 /// <summary>
-/// Detects assertions whose result is a <see cref="System.Threading.Tasks.Task"/> that is never awaited, and
-/// assertions comparing an un-awaited task with a plain value. Both make the assertion pass unconditionally.
+/// Detects assertions whose result is a <see cref="System.Threading.Tasks.Task"/> that is never awaited, which
+/// makes the assertion pass unconditionally.
 /// </summary>
 internal static class AwaitAssertionAnalyzerCommon
 {
@@ -44,54 +44,6 @@ internal static class AwaitAssertionAnalyzerCommon
 
         // Anything else (await, return, assignment, argument) consumes the task
         return invocationOperation.Parent is IExpressionStatementOperation;
-    }
-
-    /// <summary>
-    /// Matches a comparison assertion where exactly one of the compared values is an un-awaited task.
-    /// </summary>
-    internal static bool TryGetTaskArgumentMatch(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, Symbols symbols, out IArgumentOperation taskArgument)
-    {
-        if (invocationOperation.TargetMethod is not { IsStatic: true } targetMethod ||
-            !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, assertType) ||
-            targetMethod.Name is not ("Equal" or "NotEqual" or "Same" or "NotSame" or "Equivalent" or "NotEquivalent"))
-        {
-            taskArgument = null!;
-            return false;
-        }
-
-        IArgumentOperation? expectedArgument = null;
-        IArgumentOperation? actualArgument = null;
-        foreach (var argument in invocationOperation.Arguments)
-        {
-            switch (argument.Parameter?.Name)
-            {
-                case "expected":
-                    expectedArgument = argument;
-                    break;
-                case "actual":
-                    actualArgument = argument;
-                    break;
-            }
-        }
-
-        if (expectedArgument is null || actualArgument is null)
-        {
-            taskArgument = null!;
-            return false;
-        }
-
-        var expectedIsTask = IsTaskLike(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(expectedArgument.Value).Type, symbols);
-        var actualIsTask = IsTaskLike(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(actualArgument.Value).Type, symbols);
-
-        // Comparing two tasks may be intentional; comparing a task with a plain value never succeeds
-        if (expectedIsTask == actualIsTask)
-        {
-            taskArgument = null!;
-            return false;
-        }
-
-        taskArgument = expectedIsTask ? expectedArgument : actualArgument;
-        return true;
     }
 
     private static bool IsTaskLike(ITypeSymbol? type, Symbols symbols)

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/AwaitAssertionAnalyzerCommon.cs
@@ -1,0 +1,111 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+/// <summary>
+/// Detects assertions whose result is a <see cref="System.Threading.Tasks.Task"/> that is never awaited, and
+/// assertions comparing an un-awaited task with a plain value. Both make the assertion pass unconditionally.
+/// </summary>
+internal static class AwaitAssertionAnalyzerCommon
+{
+    internal static bool TryCreateSymbols(Compilation compilation, [NotNullWhen(true)] out Symbols? symbols)
+    {
+        var taskType = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task");
+        var genericTaskType = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+        var valueTaskType = compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask");
+        var genericValueTaskType = compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
+        if (taskType is null || genericTaskType is null)
+        {
+            symbols = null;
+            return false;
+        }
+
+        symbols = new Symbols(taskType, genericTaskType, valueTaskType, genericValueTaskType);
+        return true;
+    }
+
+    /// <summary>
+    /// Matches an assertion whose returned task is discarded, such as <c>Assert.ThrowsAsync&lt;T&gt;(...);</c>.
+    /// </summary>
+    internal static bool IsDiscardedTaskAssertion(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, Symbols symbols)
+    {
+        if (invocationOperation.TargetMethod is not { IsStatic: true } targetMethod ||
+            !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, assertType))
+        {
+            return false;
+        }
+
+        if (!IsTaskLike(targetMethod.ReturnType, symbols))
+            return false;
+
+        // Anything else (await, return, assignment, argument) consumes the task
+        return invocationOperation.Parent is IExpressionStatementOperation;
+    }
+
+    /// <summary>
+    /// Matches a comparison assertion where exactly one of the compared values is an un-awaited task.
+    /// </summary>
+    internal static bool TryGetTaskArgumentMatch(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, Symbols symbols, out IArgumentOperation taskArgument)
+    {
+        if (invocationOperation.TargetMethod is not { IsStatic: true } targetMethod ||
+            !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, assertType) ||
+            targetMethod.Name is not ("Equal" or "NotEqual" or "Same" or "NotSame" or "Equivalent" or "NotEquivalent"))
+        {
+            taskArgument = null!;
+            return false;
+        }
+
+        IArgumentOperation? expectedArgument = null;
+        IArgumentOperation? actualArgument = null;
+        foreach (var argument in invocationOperation.Arguments)
+        {
+            switch (argument.Parameter?.Name)
+            {
+                case "expected":
+                    expectedArgument = argument;
+                    break;
+                case "actual":
+                    actualArgument = argument;
+                    break;
+            }
+        }
+
+        if (expectedArgument is null || actualArgument is null)
+        {
+            taskArgument = null!;
+            return false;
+        }
+
+        var expectedIsTask = IsTaskLike(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(expectedArgument.Value).Type, symbols);
+        var actualIsTask = IsTaskLike(AssertionsAnalyzerHelpers.UnwrapImplicitConversion(actualArgument.Value).Type, symbols);
+
+        // Comparing two tasks may be intentional; comparing a task with a plain value never succeeds
+        if (expectedIsTask == actualIsTask)
+        {
+            taskArgument = null!;
+            return false;
+        }
+
+        taskArgument = expectedIsTask ? expectedArgument : actualArgument;
+        return true;
+    }
+
+    private static bool IsTaskLike(ITypeSymbol? type, Symbols symbols)
+    {
+        if (type is null)
+            return false;
+
+        var originalDefinition = type.OriginalDefinition;
+        return SymbolEqualityComparer.Default.Equals(originalDefinition, symbols.TaskType) ||
+               SymbolEqualityComparer.Default.Equals(originalDefinition, symbols.GenericTaskType) ||
+               (symbols.ValueTaskType is not null && SymbolEqualityComparer.Default.Equals(originalDefinition, symbols.ValueTaskType)) ||
+               (symbols.GenericValueTaskType is not null && SymbolEqualityComparer.Default.Equals(originalDefinition, symbols.GenericValueTaskType));
+    }
+
+    internal readonly record struct Symbols(
+        INamedTypeSymbol TaskType,
+        INamedTypeSymbol GenericTaskType,
+        INamedTypeSymbol? ValueTaskType,
+        INamedTypeSymbol? GenericValueTaskType);
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConstantAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConstantAssertionAnalyzer.cs
@@ -84,7 +84,10 @@ public sealed class ConstantAssertionAnalyzer : DiagnosticAnalyzer
 
     private static bool TryGetSelfComparisonMessage(IInvocationOperation invocationOperation, string methodName, out string message)
     {
-        if (methodName is not ("Equal" or "NotEqual" or "Same" or "NotSame" or "Equivalent" or "NotEquivalent" or "EqualUnordered" or "NotEqualUnordered"))
+        // Equal, NotEqual and the unordered variants compare through EqualityComparer<T>.Default and therefore run
+        // the type's own Equals, so comparing a value with itself is a reflexivity assertion rather than a constant.
+        // Same and NotSame compare references and Equivalent compares structurally, neither of which runs user code.
+        if (methodName is not ("Same" or "NotSame" or "Equivalent" or "NotEquivalent"))
         {
             message = null!;
             return false;
@@ -121,53 +124,9 @@ public sealed class ConstantAssertionAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        // Reference identity and structural comparison never run the type's Equals, but the equality assertions go
-        // through EqualityComparer<T>.Default and therefore do. Comparing a custom type with itself is then a
-        // reflexivity assertion that fails when that implementation is wrong, so it is not reported.
-        var comparesWithEquals = methodName is "Equal" or "NotEqual" or "EqualUnordered" or "NotEqualUnordered";
-        if (comparesWithEquals && !HasBuiltInEquality(expectedOperation.Type))
-        {
-            message = null!;
-            return false;
-        }
-
         var alwaysSucceeds = !methodName.StartsWith("Not", StringComparison.Ordinal);
         message = $"Assert.{methodName} compares a value with itself and always {(alwaysSucceeds ? "succeeds" : "fails")}";
         return true;
-    }
-
-    /// <summary>
-    /// Types whose equality is defined by the runtime rather than by user code, so that comparing a value of that
-    /// type with itself cannot fail.
-    /// </summary>
-    private static bool HasBuiltInEquality(ITypeSymbol? type)
-    {
-        if (type is null)
-            return false;
-
-        if (type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
-            return type is INamedTypeSymbol { TypeArguments: [var underlyingType] } && HasBuiltInEquality(underlyingType);
-
-        if (type.TypeKind == TypeKind.Enum)
-            return true;
-
-        return type.SpecialType is
-            SpecialType.System_Boolean or
-            SpecialType.System_Char or
-            SpecialType.System_SByte or
-            SpecialType.System_Byte or
-            SpecialType.System_Int16 or
-            SpecialType.System_UInt16 or
-            SpecialType.System_Int32 or
-            SpecialType.System_UInt32 or
-            SpecialType.System_Int64 or
-            SpecialType.System_UInt64 or
-            SpecialType.System_Single or
-            SpecialType.System_Double or
-            SpecialType.System_Decimal or
-            SpecialType.System_String or
-            SpecialType.System_IntPtr or
-            SpecialType.System_UIntPtr;
     }
 
     /// <summary>

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConstantAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConstantAssertionAnalyzer.cs
@@ -121,9 +121,53 @@ public sealed class ConstantAssertionAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
+        // Reference identity and structural comparison never run the type's Equals, but the equality assertions go
+        // through EqualityComparer<T>.Default and therefore do. Comparing a custom type with itself is then a
+        // reflexivity assertion that fails when that implementation is wrong, so it is not reported.
+        var comparesWithEquals = methodName is "Equal" or "NotEqual" or "EqualUnordered" or "NotEqualUnordered";
+        if (comparesWithEquals && !HasBuiltInEquality(expectedOperation.Type))
+        {
+            message = null!;
+            return false;
+        }
+
         var alwaysSucceeds = !methodName.StartsWith("Not", StringComparison.Ordinal);
         message = $"Assert.{methodName} compares a value with itself and always {(alwaysSucceeds ? "succeeds" : "fails")}";
         return true;
+    }
+
+    /// <summary>
+    /// Types whose equality is defined by the runtime rather than by user code, so that comparing a value of that
+    /// type with itself cannot fail.
+    /// </summary>
+    private static bool HasBuiltInEquality(ITypeSymbol? type)
+    {
+        if (type is null)
+            return false;
+
+        if (type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+            return type is INamedTypeSymbol { TypeArguments: [var underlyingType] } && HasBuiltInEquality(underlyingType);
+
+        if (type.TypeKind == TypeKind.Enum)
+            return true;
+
+        return type.SpecialType is
+            SpecialType.System_Boolean or
+            SpecialType.System_Char or
+            SpecialType.System_SByte or
+            SpecialType.System_Byte or
+            SpecialType.System_Int16 or
+            SpecialType.System_UInt16 or
+            SpecialType.System_Int32 or
+            SpecialType.System_UInt32 or
+            SpecialType.System_Int64 or
+            SpecialType.System_UInt64 or
+            SpecialType.System_Single or
+            SpecialType.System_Double or
+            SpecialType.System_Decimal or
+            SpecialType.System_String or
+            SpecialType.System_IntPtr or
+            SpecialType.System_UIntPtr;
     }
 
     /// <summary>

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConstantAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConstantAssertionAnalyzer.cs
@@ -1,0 +1,140 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ConstantAssertionAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: RuleIdentifiers.ConstantAssertionDiagnosticId,
+        title: "Assertion always produces the same result",
+        messageFormat: "{0}",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var assertType = context.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+            if (assertType is null)
+                return;
+
+            context.RegisterOperationAction(context => Analyze(context, assertType), OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, INamedTypeSymbol assertType)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        if (invocationOperation.TargetMethod is not { IsStatic: true } targetMethod ||
+            !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, assertType))
+        {
+            return;
+        }
+
+        if (TryGetConstantConditionMessage(invocationOperation, targetMethod.Name, out var conditionMessage))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation(), conditionMessage));
+            return;
+        }
+
+        if (TryGetSelfComparisonMessage(invocationOperation, targetMethod.Name, out var selfComparisonMessage))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation(), selfComparisonMessage));
+        }
+    }
+
+    private static bool TryGetConstantConditionMessage(IInvocationOperation invocationOperation, string methodName, out string message)
+    {
+        if (methodName is not ("True" or "False"))
+        {
+            message = null!;
+            return false;
+        }
+
+        var conditionArgument = invocationOperation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "condition");
+        if (conditionArgument is null ||
+            AssertionsAnalyzerHelpers.UnwrapImplicitConversion(conditionArgument.Value).ConstantValue is not { HasValue: true, Value: bool conditionValue })
+        {
+            message = null!;
+            return false;
+        }
+
+        // Assert.True(false) and Assert.False(true) are reported by MFAS0051, which suggests Assert.Fail
+        var alwaysSucceeds = methodName == "True" == conditionValue;
+        if (!alwaysSucceeds)
+        {
+            message = null!;
+            return false;
+        }
+
+        message = $"Assert.{methodName} is called with the constant '{(conditionValue ? "true" : "false")}' and always succeeds";
+        return true;
+    }
+
+    private static bool TryGetSelfComparisonMessage(IInvocationOperation invocationOperation, string methodName, out string message)
+    {
+        if (methodName is not ("Equal" or "NotEqual" or "Same" or "NotSame" or "Equivalent" or "NotEquivalent" or "EqualUnordered" or "NotEqualUnordered"))
+        {
+            message = null!;
+            return false;
+        }
+
+        IArgumentOperation? expectedArgument = null;
+        IArgumentOperation? actualArgument = null;
+        foreach (var argument in invocationOperation.Arguments)
+        {
+            switch (argument.Parameter?.Name)
+            {
+                case "expected":
+                    expectedArgument = argument;
+                    break;
+                case "actual":
+                    actualArgument = argument;
+                    break;
+            }
+        }
+
+        if (expectedArgument is null || actualArgument is null)
+        {
+            message = null!;
+            return false;
+        }
+
+        var expectedOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(expectedArgument.Value);
+        var actualOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(actualArgument.Value);
+        if (!IsSideEffectFreeReference(expectedOperation) ||
+            !IsSideEffectFreeReference(actualOperation) ||
+            !SyntaxFactory.AreEquivalent(expectedOperation.Syntax, actualOperation.Syntax))
+        {
+            message = null!;
+            return false;
+        }
+
+        var alwaysSucceeds = !methodName.StartsWith("Not", StringComparison.Ordinal);
+        message = $"Assert.{methodName} compares a value with itself and always {(alwaysSucceeds ? "succeeds" : "fails")}";
+        return true;
+    }
+
+    /// <summary>
+    /// Only simple references are considered, so that comparing two calls with side effects is never reported.
+    /// A field access is side-effect free only when the instance it is read from is itself side-effect free,
+    /// otherwise <c>Next().Value</c> would be treated as a comparison of a value with itself.
+    /// </summary>
+    private static bool IsSideEffectFreeReference(IOperation operation) => operation switch
+    {
+        ILocalReferenceOperation or IParameterReferenceOperation or IInstanceReferenceOperation => true,
+        IFieldReferenceOperation fieldReference => fieldReference.Instance is null || IsSideEffectFreeReference(fieldReference.Instance),
+        _ => false,
+    };
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConstantAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/ConstantAssertionAnalyzer.cs
@@ -70,7 +70,7 @@ public sealed class ConstantAssertionAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        // Assert.True(false) and Assert.False(true) are reported by MFAS0051, which suggests Assert.Fail
+        // Assert.True(false) and Assert.False(true) are reported by MFAS0050, which suggests Assert.Fail
         var alwaysSucceeds = methodName == "True" == conditionValue;
         if (!alwaysSucceeds)
         {

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/UseFailAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/UseFailAssertionAnalyzer.cs
@@ -1,0 +1,43 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseFailAssertionAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: RuleIdentifiers.UseFailAssertionDiagnosticId,
+        title: "Use Assert.Fail instead of an assertion that always fails",
+        messageFormat: "Use Assert.Fail to express an unconditional failure",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var assertType = context.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+            if (assertType is null)
+                return;
+
+            context.RegisterOperationAction(context => Analyze(context, assertType), OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, INamedTypeSymbol assertType)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        if (!UseFailAssertionAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, out _))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation()));
+    }
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/UseFailAssertionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/UseFailAssertionAnalyzerCommon.cs
@@ -1,0 +1,42 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+/// <summary>
+/// Detects <c>Assert.True(false)</c> and <c>Assert.False(true)</c>, which are unconditional failures.
+/// </summary>
+internal static class UseFailAssertionAnalyzerCommon
+{
+    internal static bool TryGetAssertionMatch(IInvocationOperation invocationOperation, INamedTypeSymbol assertType, out FailMatch match)
+    {
+        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "True" or "False" } targetMethod ||
+            !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, assertType))
+        {
+            match = default;
+            return false;
+        }
+
+        var conditionArgument = invocationOperation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "condition");
+        if (conditionArgument is null ||
+            AssertionsAnalyzerHelpers.UnwrapImplicitConversion(conditionArgument.Value).ConstantValue is not { HasValue: true, Value: bool conditionValue })
+        {
+            match = default;
+            return false;
+        }
+
+        if (targetMethod.Name == "True" == conditionValue)
+        {
+            match = default;
+            return false;
+        }
+
+        // An omitted optional argument is still present in Arguments, and its syntax is the whole invocation
+        var messageArgument = invocationOperation.Arguments.FirstOrDefault(argument =>
+            argument is { Parameter.Name: "message", ArgumentKind: ArgumentKind.Explicit });
+        match = new FailMatch(messageArgument);
+        return true;
+    }
+
+    internal readonly record struct FailMatch(IArgumentOperation? MessageArgument);
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Meziantou.Framework.Assertions.CodeFix.csproj
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Meziantou.Framework.Assertions.CodeFix.csproj
@@ -16,6 +16,7 @@
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/TrueFalseConditionMethodSelectionAnalyzerCommon.cs" Link="Rules/TrueFalseConditionMethodSelectionAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/EmptinessAssertionAnalyzerCommon.cs" Link="Rules/EmptinessAssertionAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/ConditionRewriteAnalyzerCommon.cs" Link="Rules/ConditionRewriteAnalyzerCommon.cs" />
+    <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/UseFailAssertionAnalyzerCommon.cs" Link="Rules/UseFailAssertionAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Internals/NumericHelpers.cs" Link="Internals/NumericHelpers.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/AssertionsAnalyzerHelpers.cs" Link="AssertionsAnalyzerHelpers.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/AssertionCodeFixHelpers.cs" Link="AssertionCodeFixHelpers.cs" />

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/AwaitAssertionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/AwaitAssertionCodeFixProvider.cs
@@ -1,0 +1,60 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AwaitAssertionCodeFixProvider))]
+public sealed class AwaitAssertionCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        [RuleIdentifiers.AwaitAssertionDiagnosticId, RuleIdentifiers.AwaitAssertionArgumentDiagnosticId];
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            if (root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true) is not ExpressionSyntax expression)
+                continue;
+
+            if (!AssertionCodeFixHelpers.CanCreateAwaitFix(expression))
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Await the assertion",
+                    createChangedDocument: ct => ApplyFixAsync(context.Document, diagnostic.Location.SourceSpan, ct),
+                    equivalenceKey: GetType().FullName),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, TextSpan span, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return document;
+
+        if (root.FindNode(span, getInnermostNodeForTie: true) is not ExpressionSyntax expression)
+            return document;
+
+        if (!AssertionCodeFixHelpers.TryCreateAwaitFix(root, semanticModel, expression, out var newRoot))
+            return document;
+
+        return document.WithSyntaxRoot(newRoot.WithAdditionalAnnotations(Formatter.Annotation));
+    }
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/AwaitAssertionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/AwaitAssertionCodeFixProvider.cs
@@ -11,8 +11,7 @@ namespace Meziantou.Framework.Analyzers.Assertions;
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AwaitAssertionCodeFixProvider))]
 public sealed class AwaitAssertionCodeFixProvider : CodeFixProvider
 {
-    public override ImmutableArray<string> FixableDiagnosticIds =>
-        [RuleIdentifiers.AwaitAssertionDiagnosticId, RuleIdentifiers.AwaitAssertionArgumentDiagnosticId];
+    public override ImmutableArray<string> FixableDiagnosticIds => [RuleIdentifiers.AwaitAssertionDiagnosticId];
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/UseFailAssertionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/UseFailAssertionCodeFixProvider.cs
@@ -1,0 +1,85 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseFailAssertionCodeFixProvider))]
+public sealed class UseFailAssertionCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => [RuleIdentifiers.UseFailAssertionDiagnosticId];
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var assertType = semanticModel.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+        if (assertType is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var invocationExpression = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true)
+                .FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (invocationExpression is null)
+                continue;
+
+            if (!AssertionCodeFixHelpers.TryGetInvocationOperation(semanticModel, invocationExpression, context.CancellationToken, out var invocationOperation) ||
+                !UseFailAssertionAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, out _))
+            {
+                continue;
+            }
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Use Assert.Fail",
+                    createChangedDocument: ct => ApplyFixAsync(context.Document, invocationExpression, assertType, ct),
+                    equivalenceKey: GetType().FullName),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocationExpression, INamedTypeSymbol assertType, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return document;
+
+        if (!AssertionCodeFixHelpers.TryGetInvocationOperation(semanticModel, invocationExpression, cancellationToken, out var invocationOperation) ||
+            !UseFailAssertionAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, out var match))
+        {
+            return document;
+        }
+
+        var arguments = new List<ArgumentSyntax>(1);
+        if (match.MessageArgument is { } messageArgument &&
+            AssertionCodeFixHelpers.TryGetExpressionSyntax(messageArgument.Value, out var messageExpression))
+        {
+            arguments.Add(SyntaxFactory.Argument(messageExpression.WithoutTrivia()));
+        }
+
+        var newInvocationExpression = invocationExpression
+            .WithExpression(AssertionCodeFixHelpers.ReplaceMethodName(invocationExpression.Expression, "Fail"))
+            .WithArgumentList(SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        var newRoot = root.ReplaceNode(invocationExpression, newInvocationExpression);
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/Meziantou.Framework.Assertions/readme.md
+++ b/src/Meziantou.Framework.Assertions/readme.md
@@ -131,4 +131,8 @@ The package ships analyzers and code fixes to help write clearer assertions.
 | `MFAS0045` | Assertions | Use Assert.False instead of Assert.True(!condition) | Warning | ✔️ |
 | `MFAS0046` | Assertions | Use Assert.IsType instead of Assert.True(x.GetType() == typeof(T)) | Warning | ✔️ |
 | `MFAS0047` | Assertions | Use Assert.IsNotType instead of Assert.False(x.GetType() == typeof(T)) | Warning | ✔️ |
+| `MFAS0048` | Assertions | Await assertions that return a Task | Error | ✔️ |
+| `MFAS0049` | Assertions | Await the task passed to an assertion | Error | ✔️ |
+| `MFAS0050` | Assertions | Assertion always produces the same result | Error | ✔️ |
+| `MFAS0051` | Assertions | Use Assert.Fail instead of an assertion that always fails | Warning | ✔️ |
 <!-- analyzer-rules -->

--- a/src/Meziantou.Framework.Assertions/readme.md
+++ b/src/Meziantou.Framework.Assertions/readme.md
@@ -132,7 +132,6 @@ The package ships analyzers and code fixes to help write clearer assertions.
 | `MFAS0046` | Assertions | Use Assert.IsType instead of Assert.True(x.GetType() == typeof(T)) | Warning | ✔️ |
 | `MFAS0047` | Assertions | Use Assert.IsNotType instead of Assert.False(x.GetType() == typeof(T)) | Warning | ✔️ |
 | `MFAS0048` | Assertions | Await assertions that return a Task | Error | ✔️ |
-| `MFAS0049` | Assertions | Await the task passed to an assertion | Error | ✔️ |
-| `MFAS0050` | Assertions | Assertion always produces the same result | Error | ✔️ |
-| `MFAS0051` | Assertions | Use Assert.Fail instead of an assertion that always fails | Warning | ✔️ |
+| `MFAS0049` | Assertions | Assertion always produces the same result | Error | ✔️ |
+| `MFAS0050` | Assertions | Use Assert.Fail instead of an assertion that always fails | Warning | ✔️ |
 <!-- analyzer-rules -->

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AwaitAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AwaitAssertionRuleTests.cs
@@ -231,6 +231,34 @@ public sealed class AwaitAssertionRuleTests : AssertionsAnalyzerTestBase
     }
 
     [Fact]
+    public async Task Analyzer_ReportsDiagnostic_OnlyForAnExpressionStatement()
+    {
+        // Discarding the task or assigning it observes the result, so the assertion is not lost
+        var source = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static Task M(IAsyncEnumerable<int> actual)
+                {
+                    _ = Assert.Empty(actual);
+                    var task = Assert.Empty(actual);
+
+                    {|MFAS0048:Assert.Empty(actual)|};
+
+                    return task;
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<AwaitAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
     public async Task Analyzer_DoesNotReportDiagnostic_WhenTaskIsConsumed()
     {
         var source = """

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AwaitAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AwaitAssertionRuleTests.cs
@@ -245,6 +245,32 @@ public sealed class AwaitAssertionRuleTests : AssertionsAnalyzerTestBase
     }
 
     [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenTheAssertionReturnsAValueThatIsATask()
+    {
+        // Assert.Single<T> returns T, so these return a Task without the assertion being asynchronous
+        var source = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(Dictionary<string, Task> tasksByName)
+                {
+                    Task[] items = [];
+                    Assert.Single(items);
+                    Assert.Single(items, item => item is not null);
+                    Assert.Contains("a", tasksByName);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<AwaitAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
     public async Task Analyzer_DoesNotReportDiagnostic_WhenTaskIsConsumed()
     {
         var source = """

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AwaitAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AwaitAssertionRuleTests.cs
@@ -1,0 +1,286 @@
+using AwaitAssertionAnalyzerType = Meziantou.Framework.Analyzers.Assertions.AwaitAssertionAnalyzer;
+using AwaitAssertionCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.AwaitAssertionCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class AwaitAssertionRuleTests : AssertionsAnalyzerTestBase
+{
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForDiscardedTaskInSyncMethod()
+    {
+        var source = """
+            using System;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(Func<Task> action)
+                {
+                    {|MFAS0048:Assert.ThrowsAsync<InvalidOperationException>(action)|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static async Task M(Func<Task> action)
+                {
+                    await Assert.ThrowsAsync<InvalidOperationException>(action);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<AwaitAssertionAnalyzerType, AwaitAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForDiscardedTaskInAsyncMethod()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static async Task M(IAsyncEnumerable<int> actual)
+                {
+                    {|MFAS0048:Assert.Empty(actual)|};
+                    await Task.Yield();
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static async Task M(IAsyncEnumerable<int> actual)
+                {
+                    await Assert.Empty(actual);
+                    await Task.Yield();
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<AwaitAssertionAnalyzerType, AwaitAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForTaskArgument()
+    {
+        var source = """
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M()
+                {
+                    Assert.Equal(42, {|MFAS0049:GetValueAsync()|});
+                }
+
+                private static Task<int> GetValueAsync() => Task.FromResult(42);
+            }
+            """;
+
+        var fixedSource = """
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static async Task M()
+                {
+                    Assert.Equal(42, await GetValueAsync());
+                }
+
+                private static Task<int> GetValueAsync() => Task.FromResult(42);
+            }
+            """;
+
+        await CreateCodeFixTest<AwaitAssertionAnalyzerType, AwaitAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForExpressionBodiedMethod()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IAsyncEnumerable<int> actual) => {|MFAS0048:Assert.Empty(actual)|};
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static async Task M(IAsyncEnumerable<int> actual) => await Assert.Empty(actual);
+            }
+            """;
+
+        await CreateCodeFixTest<AwaitAssertionAnalyzerType, AwaitAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_InsideAsyncLambda()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IAsyncEnumerable<int> actual)
+                {
+                    Func<Task> f = async () => {|MFAS0048:Assert.Empty(actual)|};
+                    _ = f;
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IAsyncEnumerable<int> actual)
+                {
+                    Func<Task> f = async () => await Assert.Empty(actual);
+                    _ = f;
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<AwaitAssertionAnalyzerType, AwaitAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportsDiagnostic_ButOffersNoFix_InsideNonAsyncLambda()
+    {
+        // Adding async to the lambda would change the delegate type it is bound to, so no fix is offered
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IAsyncEnumerable<int> actual)
+                {
+                    Action a = () => {|MFAS0048:Assert.Empty(actual)|};
+                    a();
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<AwaitAssertionAnalyzerType, AwaitAssertionCodeFixProviderType>(source, source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportsDiagnostic_ButOffersNoFix_InsideNonAsyncLocalFunction()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(IAsyncEnumerable<int> actual)
+                {
+                    Local();
+
+                    void Local() => {|MFAS0048:Assert.Empty(actual)|};
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<AwaitAssertionAnalyzerType, AwaitAssertionCodeFixProviderType>(source, source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenTaskIsConsumed()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static async Task Awaited(IAsyncEnumerable<int> actual)
+                {
+                    await Assert.Empty(actual);
+                }
+
+                public static Task Returned(IAsyncEnumerable<int> actual)
+                {
+                    return Assert.Empty(actual);
+                }
+
+                public static void Synchronous(List<int> actual, int value)
+                {
+                    // These overloads do not return a task
+                    Assert.Empty(actual);
+                    Assert.Equal(42, value);
+                }
+
+                public static void ComparingTwoTasks(Task<int> a, Task<int> b)
+                {
+                    Assert.Equal(a, b);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<AwaitAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AwaitAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/AwaitAssertionRuleTests.cs
@@ -84,46 +84,6 @@ public sealed class AwaitAssertionRuleTests : AssertionsAnalyzerTestBase
     }
 
     [Fact]
-    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForTaskArgument()
-    {
-        var source = """
-            using System.Threading.Tasks;
-            using Meziantou.Framework.Assertions;
-
-            namespace Sample;
-
-            public static class TestClass
-            {
-                public static void M()
-                {
-                    Assert.Equal(42, {|MFAS0049:GetValueAsync()|});
-                }
-
-                private static Task<int> GetValueAsync() => Task.FromResult(42);
-            }
-            """;
-
-        var fixedSource = """
-            using System.Threading.Tasks;
-            using Meziantou.Framework.Assertions;
-
-            namespace Sample;
-
-            public static class TestClass
-            {
-                public static async Task M()
-                {
-                    Assert.Equal(42, await GetValueAsync());
-                }
-
-                private static Task<int> GetValueAsync() => Task.FromResult(42);
-            }
-            """;
-
-        await CreateCodeFixTest<AwaitAssertionAnalyzerType, AwaitAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
-    }
-
-    [Fact]
     public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForExpressionBodiedMethod()
     {
         var source = """
@@ -300,9 +260,11 @@ public sealed class AwaitAssertionRuleTests : AssertionsAnalyzerTestBase
                     Assert.Equal(42, value);
                 }
 
-                public static void ComparingTwoTasks(Task<int> a, Task<int> b)
+                public static void TaskPassedAsAnArgument(Task<int> a, Task<int> b)
                 {
+                    // The rule looks at what the assertion returns, not at the code passed to it
                     Assert.Equal(a, b);
+                    Assert.Equal(42, a);
                 }
             }
             """;

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/ConstantAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/ConstantAssertionRuleTests.cs
@@ -66,6 +66,39 @@ public sealed class ConstantAssertionRuleTests : AssertionsAnalyzerTestBase
     }
 
     [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForReflexivityAssertionOnCustomType()
+    {
+        // Assert.Equal goes through EqualityComparer<T>.Default and therefore runs Version.Equals, so this is a
+        // reflexivity assertion that fails when that implementation is wrong. Assert.Same never runs user code.
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public sealed class Version
+            {
+                public override bool Equals(object? obj) => obj is Version;
+                public override int GetHashCode() => 0;
+            }
+
+            public static class TestClass
+            {
+                public static void M(Version left, int number)
+                {
+                    Assert.Equal(left, left);
+                    Assert.NotEqual(left, left);
+
+                    {|MFAS0050:Assert.Equivalent(left, left)|};
+                    {|MFAS0050:Assert.Same(left, left)|};
+                    {|MFAS0050:Assert.Equal(number, number)|};
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ConstantAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
     public async Task Analyzer_DoesNotReportDiagnostic_WhenTheInstanceMayHaveSideEffects()
     {
         var source = """

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/ConstantAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/ConstantAssertionRuleTests.cs
@@ -7,8 +7,6 @@ public sealed class ConstantAssertionRuleTests : AssertionsAnalyzerTestBase
     [Theory]
     [InlineData("Assert.True(true)")]
     [InlineData("Assert.False(false)")]
-    [InlineData("Assert.Equal(value, value)")]
-    [InlineData("Assert.NotEqual(value, value)")]
     [InlineData("Assert.Same(reference, reference)")]
     [InlineData("Assert.NotSame(reference, reference)")]
     [InlineData("Assert.Equivalent(reference, reference)")]
@@ -50,6 +48,11 @@ public sealed class ConstantAssertionRuleTests : AssertionsAnalyzerTestBase
                     Assert.Equal(value, other);
                     Assert.Same(reference, otherReference);
 
+                    // Equal and NotEqual compare through the type's own Equals, so comparing a value with
+                    // itself is a reflexivity assertion rather than a constant
+                    Assert.Equal(value, value);
+                    Assert.NotEqual(value, value);
+
                     // Assert.True(false) is reported by MFAS0051 instead
                     Assert.True(false);
                     Assert.False(true);
@@ -66,10 +69,10 @@ public sealed class ConstantAssertionRuleTests : AssertionsAnalyzerTestBase
     }
 
     [Fact]
-    public async Task Analyzer_DoesNotReportDiagnostic_ForReflexivityAssertionOnCustomType()
+    public async Task Analyzer_DoesNotReportDiagnostic_ForReflexivityAssertion()
     {
-        // Assert.Equal goes through EqualityComparer<T>.Default and therefore runs Version.Equals, so this is a
-        // reflexivity assertion that fails when that implementation is wrong. Assert.Same never runs user code.
+        // Equal and NotEqual go through EqualityComparer<T>.Default and therefore run the type's own Equals,
+        // so these assert reflexivity. Same compares references and Equivalent compares structurally.
         var source = """
             using Meziantou.Framework.Assertions;
 
@@ -87,10 +90,11 @@ public sealed class ConstantAssertionRuleTests : AssertionsAnalyzerTestBase
                 {
                     Assert.Equal(left, left);
                     Assert.NotEqual(left, left);
+                    Assert.Equal(number, number);
+                    Assert.NotEqual(number, number);
 
                     {|MFAS0050:Assert.Equivalent(left, left)|};
                     {|MFAS0050:Assert.Same(left, left)|};
-                    {|MFAS0050:Assert.Equal(number, number)|};
                 }
             }
             """;
@@ -108,7 +112,7 @@ public sealed class ConstantAssertionRuleTests : AssertionsAnalyzerTestBase
 
             public sealed class Box
             {
-                public int Value;
+                public object Value = new();
             }
 
             public static class TestClass
@@ -118,7 +122,7 @@ public sealed class ConstantAssertionRuleTests : AssertionsAnalyzerTestBase
                 public static void M()
                 {
                     // Each call returns a different box, so this is not a comparison of a value with itself
-                    Assert.Equal(Next().Value, Next().Value);
+                    Assert.Same(Next().Value, Next().Value);
                 }
 
                 private static Box Next() => new Box { Value = Counter++ };
@@ -138,13 +142,13 @@ public sealed class ConstantAssertionRuleTests : AssertionsAnalyzerTestBase
 
             public sealed class Box
             {
-                public int Value;
+                public object Value = new();
 
                 public void M(Box other)
                 {
-                    {|MFAS0050:Assert.Equal(this.Value, this.Value)|};
-                    {|MFAS0050:Assert.Equal(other.Value, other.Value)|};
-                    Assert.Equal(this.Value, other.Value);
+                    {|MFAS0050:Assert.Same(this.Value, this.Value)|};
+                    {|MFAS0050:Assert.Same(other.Value, other.Value)|};
+                    Assert.Same(this.Value, other.Value);
                 }
             }
             """;

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/ConstantAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/ConstantAssertionRuleTests.cs
@@ -21,7 +21,7 @@ public sealed class ConstantAssertionRuleTests : AssertionsAnalyzerTestBase
             {
                 public static void M(int value, object reference)
                 {
-                    {|MFAS0050:{{assertion}}|};
+                    {|MFAS0049:{{assertion}}|};
                 }
             }
             """;
@@ -53,7 +53,7 @@ public sealed class ConstantAssertionRuleTests : AssertionsAnalyzerTestBase
                     Assert.Equal(value, value);
                     Assert.NotEqual(value, value);
 
-                    // Assert.True(false) is reported by MFAS0051 instead
+                    // Assert.True(false) is reported by MFAS0050 instead
                     Assert.True(false);
                     Assert.False(true);
 
@@ -93,8 +93,8 @@ public sealed class ConstantAssertionRuleTests : AssertionsAnalyzerTestBase
                     Assert.Equal(number, number);
                     Assert.NotEqual(number, number);
 
-                    {|MFAS0050:Assert.Equivalent(left, left)|};
-                    {|MFAS0050:Assert.Same(left, left)|};
+                    {|MFAS0049:Assert.Equivalent(left, left)|};
+                    {|MFAS0049:Assert.Same(left, left)|};
                 }
             }
             """;
@@ -146,8 +146,8 @@ public sealed class ConstantAssertionRuleTests : AssertionsAnalyzerTestBase
 
                 public void M(Box other)
                 {
-                    {|MFAS0050:Assert.Same(this.Value, this.Value)|};
-                    {|MFAS0050:Assert.Same(other.Value, other.Value)|};
+                    {|MFAS0049:Assert.Same(this.Value, this.Value)|};
+                    {|MFAS0049:Assert.Same(other.Value, other.Value)|};
                     Assert.Same(this.Value, other.Value);
                 }
             }

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/ConstantAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/ConstantAssertionRuleTests.cs
@@ -1,0 +1,121 @@
+using ConstantAssertionAnalyzerType = Meziantou.Framework.Analyzers.Assertions.ConstantAssertionAnalyzer;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class ConstantAssertionRuleTests : AssertionsAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("Assert.True(true)")]
+    [InlineData("Assert.False(false)")]
+    [InlineData("Assert.Equal(value, value)")]
+    [InlineData("Assert.NotEqual(value, value)")]
+    [InlineData("Assert.Same(reference, reference)")]
+    [InlineData("Assert.NotSame(reference, reference)")]
+    [InlineData("Assert.Equivalent(reference, reference)")]
+    public async Task Analyzer_ReportDiagnostic_ForAssertionWithConstantResult(string assertion)
+    {
+        var source = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(int value, object reference)
+                {
+                    {|MFAS0050:{{assertion}}|};
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ConstantAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForMeaningfulAssertions()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                private static int Counter;
+
+                public static void M(int value, int other, object reference, object otherReference, bool condition)
+                {
+                    Assert.True(condition);
+                    Assert.False(condition);
+                    Assert.Equal(value, other);
+                    Assert.Same(reference, otherReference);
+
+                    // Assert.True(false) is reported by MFAS0051 instead
+                    Assert.True(false);
+                    Assert.False(true);
+
+                    // Calls may have side effects, so comparing two of them is not necessarily pointless
+                    Assert.Equal(Next(), Next());
+                }
+
+                private static int Next() => Counter++;
+            }
+            """;
+
+        await CreateAnalyzerTest<ConstantAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenTheInstanceMayHaveSideEffects()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public sealed class Box
+            {
+                public int Value;
+            }
+
+            public static class TestClass
+            {
+                private static int Counter;
+
+                public static void M()
+                {
+                    // Each call returns a different box, so this is not a comparison of a value with itself
+                    Assert.Equal(Next().Value, Next().Value);
+                }
+
+                private static Box Next() => new Box { Value = Counter++ };
+            }
+            """;
+
+        await CreateAnalyzerTest<ConstantAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForFieldReachedThroughSideEffectFreeInstance()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public sealed class Box
+            {
+                public int Value;
+
+                public void M(Box other)
+                {
+                    {|MFAS0050:Assert.Equal(this.Value, this.Value)|};
+                    {|MFAS0050:Assert.Equal(other.Value, other.Value)|};
+                    Assert.Equal(this.Value, other.Value);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ConstantAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/UseFailAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/UseFailAssertionRuleTests.cs
@@ -1,0 +1,69 @@
+using UseFailAssertionAnalyzerType = Meziantou.Framework.Analyzers.Assertions.UseFailAssertionAnalyzer;
+using UseFailAssertionCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.UseFailAssertionCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class UseFailAssertionRuleTests : AssertionsAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("{|MFAS0051:Assert.True(false)|};", "Assert.Fail();")]
+    [InlineData("{|MFAS0051:Assert.False(true)|};", "Assert.Fail();")]
+    [InlineData("""{|MFAS0051:Assert.True(false, "unreachable")|};""", """Assert.Fail("unreachable");""")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForUnconditionalFailure(string assertion, string fixedAssertion)
+    {
+        var source = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M()
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var fixedSource = $$"""
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M()
+                {
+                    {{fixedAssertion}}
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<UseFailAssertionAnalyzerType, UseFailAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForAssertionsThatCanSucceed()
+    {
+        var source = """
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(bool condition)
+                {
+                    Assert.True(condition);
+                    Assert.False(condition);
+
+                    // Always succeeds, reported by MFAS0050 instead
+                    Assert.True(true);
+                    Assert.False(false);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseFailAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/UseFailAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/UseFailAssertionRuleTests.cs
@@ -6,9 +6,9 @@ namespace Meziantou.Framework.Tests;
 public sealed class UseFailAssertionRuleTests : AssertionsAnalyzerTestBase
 {
     [Theory]
-    [InlineData("{|MFAS0051:Assert.True(false)|};", "Assert.Fail();")]
-    [InlineData("{|MFAS0051:Assert.False(true)|};", "Assert.Fail();")]
-    [InlineData("""{|MFAS0051:Assert.True(false, "unreachable")|};""", """Assert.Fail("unreachable");""")]
+    [InlineData("{|MFAS0050:Assert.True(false)|};", "Assert.Fail();")]
+    [InlineData("{|MFAS0050:Assert.False(true)|};", "Assert.Fail();")]
+    [InlineData("""{|MFAS0050:Assert.True(false, "unreachable")|};""", """Assert.Fail("unreachable");""")]
     public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForUnconditionalFailure(string assertion, string fixedAssertion)
     {
         var source = $$"""
@@ -57,7 +57,7 @@ public sealed class UseFailAssertionRuleTests : AssertionsAnalyzerTestBase
                     Assert.True(condition);
                     Assert.False(condition);
 
-                    // Always succeeds, reported by MFAS0050 instead
+                    // Always succeeds, reported by MFAS0049 instead
                     Assert.True(true);
                     Assert.False(false);
                 }

--- a/tests/Meziantou.Framework.Assertions.Tests/.editorconfig
+++ b/tests/Meziantou.Framework.Assertions.Tests/.editorconfig
@@ -1,0 +1,7 @@
+root = false
+
+[*.cs]
+# This project tests the assertion methods themselves, so it must call assertions whose
+# result is known in advance, such as Assert.True(true) or Assert.Equal(value, value).
+dotnet_diagnostic.MFAS0050.severity = none
+dotnet_diagnostic.MFAS0051.severity = none

--- a/tests/Meziantou.Framework.Assertions.Tests/.editorconfig
+++ b/tests/Meziantou.Framework.Assertions.Tests/.editorconfig
@@ -2,6 +2,6 @@ root = false
 
 [*.cs]
 # This project tests the assertion methods themselves, so it must call assertions whose
-# result is known in advance, such as Assert.True(true) or Assert.Equal(value, value).
+# result is known in advance, such as Assert.True(true) or Assert.Same(value, value).
+dotnet_diagnostic.MFAS0049.severity = none
 dotnet_diagnostic.MFAS0050.severity = none
-dotnet_diagnostic.MFAS0051.severity = none


### PR DESCRIPTION
**5 of 5**. Based on #1848. These are the highest-value rules in the stack: each catches a test that passes while asserting nothing.

| Id | Severity | Detects |
| -- | -- | -- |
| `MFAS0048` | Error | The `Task` returned by an assertion is discarded |
| `MFAS0049` | Error | A comparison assertion where exactly one side is an un-awaited task |
| `MFAS0050` | Error | An assertion whose result is known in advance |
| `MFAS0051` | Warning | `Assert.True(false)` → `Assert.Fail` |

`MFAS0048` is the one I would prioritise. `CS4014` only fires inside an `async` method, so this got **no diagnostic at all** while silently never running:

```csharp
[Fact]
public void Test()
{
    Assert.ThrowsAsync<InvalidOperationException>(() => FooAsync()); // never checked anything
}
```

It covers `ThrowsAsync`, `ThrowsAnyAsync`, `Throws(Func<Task>)`, `DoesNotThrow(Func<Task>)` and every `IAsyncEnumerable<T>` overload of `Equal`, `All`, `Empty`, `Single`, `Contains`, `HasCount*` and friends.

`MFAS0049` covers `Assert.Equal(42, GetValueAsync())`, which compiles through the `Equal<TExpected, TActual>` overload (`OverloadResolutionPriority(-1)`) and can never succeed. Comparing two tasks is left alone, since that may be intentional.

### Notes

- **The await fix targets the closest enclosing function**, not the method. It turns a `void` method into `async Task`, but offers **no fix** inside a non-async lambda or local function, where adding `async` would change the delegate type or a signature the caller relies on. Without this it produced `Action a = () => await ...`, which does not compile.
- **`MFAS0050` only considers simple references**, so `Assert.Equal(Next().Value, Next().Value)` is not reported — the instance a field is read from must itself be side-effect free.
- **`tests/Meziantou.Framework.Assertions.Tests/.editorconfig` disables `MFAS0050`/`MFAS0051`.** They produced 44 errors in the library's own test suite, all genuine hits on code like `AssertionsAssert.True(false)` that those tests must write in order to verify the assertions. This follows the existing `tests/.editorconfig` precedent, but it is the file to revisit if you would rather narrow the rules.

One bug the tests caught: Roslyn includes omitted optional arguments in `IInvocationOperation.Arguments`, and their `Syntax` is the *whole invocation*, so the `Assert.Fail` fix initially produced `Assert.Fail(Assert.Fail(Assert.True(false)))`. It now filters on `ArgumentKind.Explicit`.

### Verification

Analyzer tests 187 passed (from 78 at the start of the stack), library tests 786 passed, `/p:TreatWarningsAsErrors=true` clean, `eng/update-all.cs` run and idempotent.
