### PR TITLE
Close coverage gaps in the FullPath analyzers

### DIFF
--- a/eng/update-all.cs
+++ b/eng/update-all.cs
@@ -1211,6 +1211,7 @@ static IReadOnlyList<AnalyzerRule> GetAnalyzerRulesFromProjectDirectory(FullPath
             \s*category:\s*"(?<category>[^"]+)"\s*,
             \s*(?:defaultSeverity:\s*)?DiagnosticSeverity\.(?<severity>\w+)\s*,
             \s*isEnabledByDefault:\s*(?<enabled>true|false)\s*
+            (?:,\s*[^)]*)?
         \)
         """,
         RegexOptions.IgnorePatternWhitespace | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture,

--- a/src/Meziantou.Framework.FullPath.Analyzer/FullPathAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FullPathAnalyzerCommon.cs
@@ -1,3 +1,6 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
 namespace Meziantou.Framework.Analyzers.FullPath;
 
 internal static class FullPathAnalyzerCommon
@@ -13,5 +16,82 @@ internal static class FullPathAnalyzerCommon
     internal const string PathChangeExtensionWithFullPathDiagnosticId = "MFFP0009";
     internal const string PathGetRelativePathWithFullPathDiagnosticId = "MFFP0010";
     internal const string MethodShouldReturnFullPathDiagnosticId = "MFFP0011";
+    internal const string PropertyShouldReturnFullPathDiagnosticId = "MFFP0012";
+    internal const string VariableShouldBeFullPathDiagnosticId = "MFFP0013";
+    internal const string ParameterShouldBeFullPathDiagnosticId = "MFFP0014";
 
+    /// <summary>
+    /// Returns the underlying <c>FullPath</c> operation of an expression that produces its string representation,
+    /// or the operation itself when it is not such an expression.
+    /// </summary>
+    /// <remarks>
+    /// Handles the implicit conversion to <see cref="string"/>, the explicit cast, the <c>Value</c> and <c>RawValue</c>
+    /// properties, and <c>ToString()</c>, so that <c>fullPath</c>, <c>(string)fullPath</c>, <c>fullPath.Value</c>,
+    /// <c>fullPath.RawValue</c>, and <c>fullPath.ToString()</c> are all recognized.
+    /// </remarks>
+    internal static IOperation UnwrapToFullPath(IOperation operation, ITypeSymbol? fullPathType)
+    {
+        while (true)
+        {
+            switch (operation)
+            {
+                case IConversionOperation conversionOperation when conversionOperation.IsImplicit || IsFullPathType(conversionOperation.Operand.Type, fullPathType):
+                    operation = conversionOperation.Operand;
+                    break;
+
+                case IPropertyReferenceOperation { Instance: not null } propertyReferenceOperation
+                    when propertyReferenceOperation.Property.Name is "Value" or "RawValue" && IsFullPathType(propertyReferenceOperation.Instance.Type, fullPathType):
+                    operation = propertyReferenceOperation.Instance;
+                    break;
+
+                case IInvocationOperation { Instance: not null } invocationOperation
+                    when invocationOperation.TargetMethod is { Name: "ToString", Parameters.IsEmpty: true } && IsFullPathType(invocationOperation.Instance.Type, fullPathType):
+                    operation = invocationOperation.Instance;
+                    break;
+
+                default:
+                    return operation;
+            }
+        }
+    }
+
+    private static bool IsFullPathType(ITypeSymbol? typeSymbol, ITypeSymbol? fullPathType)
+    {
+        return SymbolEqualityComparer.Default.Equals(typeSymbol, fullPathType);
+    }
+
+    /// <summary>
+    /// Determines whether the declared type of a member can be changed without breaking a base type or an interface.
+    /// </summary>
+    internal static bool CanChangeDeclaredType(ISymbol symbol)
+    {
+        if (symbol.IsOverride || symbol.IsVirtual || symbol.IsAbstract)
+            return false;
+
+        var containingType = symbol.ContainingType;
+        if (containingType is null)
+            return true;
+
+        foreach (var interfaceType in containingType.AllInterfaces)
+        {
+            foreach (var interfaceMember in interfaceType.GetMembers())
+            {
+                if (SymbolEqualityComparer.Default.Equals(containingType.FindImplementationForInterfaceMember(interfaceMember), symbol))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    internal static Location? GetFirstSourceLocation(ISymbol symbol)
+    {
+        foreach (var candidateLocation in symbol.Locations)
+        {
+            if (candidateLocation.IsInSource)
+                return candidateLocation;
+        }
+
+        return null;
+    }
 }

--- a/src/Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs
@@ -18,16 +18,39 @@ internal sealed class FullPathContext(Compilation compilation)
 
     public bool IsFullPathType(IOperation operation)
     {
-        return IsFullPathType(UnwrapImplicitConversion(operation).Type);
+        return IsFullPathType(UnwrapToFullPath(operation).Type);
     }
 
-    private static IOperation UnwrapImplicitConversion(IOperation operation)
+    public IOperation UnwrapToFullPath(IOperation operation)
     {
-        while (operation is IConversionOperation conversionOperation && conversionOperation.IsImplicit)
+        return FullPathAnalyzerCommon.UnwrapToFullPath(operation, FullPathType);
+    }
+
+    /// <summary>
+    /// Walks <paramref name="operation"/> and reports whether it contains at least one <see langword="return"/> with a
+    /// value, and whether every such value is a <c>FullPath</c>. Nested local functions are not walked.
+    /// </summary>
+    public void AnalyzeReturnOperations(IOperation operation, ref bool hasReturnValue, ref bool allReturnsAreFullPath)
+    {
+        if (!allReturnsAreFullPath)
+            return;
+
+        if (operation is ILocalFunctionOperation)
+            return;
+
+        if (operation is IReturnOperation returnOperation && returnOperation.ReturnedValue is not null)
         {
-            operation = conversionOperation.Operand;
+            hasReturnValue = true;
+            if (!IsFullPathType(returnOperation.ReturnedValue))
+            {
+                allReturnsAreFullPath = false;
+                return;
+            }
         }
 
-        return operation;
+        foreach (var childOperation in operation.ChildOperations)
+        {
+            AnalyzeReturnOperations(childOperation, ref hasReturnValue, ref allReturnsAreFullPath);
+        }
     }
 }

--- a/src/Meziantou.Framework.FullPath.Analyzer/MethodShouldReturnFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/MethodShouldReturnFullPathAnalyzer.cs
@@ -41,13 +41,21 @@ public sealed class MethodShouldReturnFullPathAnalyzer : DiagnosticAnalyzer
         if (methodSymbol.MethodKind is MethodKind.LocalFunction)
             return;
 
+        // Accessors are reported by PropertyShouldReturnFullPathAnalyzer, which points at the property itself
+        if (methodSymbol.AssociatedSymbol is not null)
+            return;
+
         if (methodSymbol.ReturnType.SpecialType != SpecialType.System_String)
             return;
+
+        if (!FullPathAnalyzerCommon.CanChangeDeclaredType(methodSymbol))
+            return;
+
         var hasReturnValue = false;
         var allReturnsAreFullPath = true;
         foreach (var operationBlock in context.OperationBlocks)
         {
-            AnalyzeReturnOperations(operationBlock, analyzerContext, ref hasReturnValue, ref allReturnsAreFullPath);
+            analyzerContext.AnalyzeReturnOperations(operationBlock, ref hasReturnValue, ref allReturnsAreFullPath);
         }
 
         if (!hasReturnValue && context.OperationBlocks.Length == 1 && context.OperationBlocks[0] is not IBlockOperation)
@@ -72,7 +80,7 @@ public sealed class MethodShouldReturnFullPathAnalyzer : DiagnosticAnalyzer
         var allReturnsAreFullPath = true;
         if (localFunctionOperation.Body is not null)
         {
-            AnalyzeReturnOperations(localFunctionOperation.Body, analyzerContext, ref hasReturnValue, ref allReturnsAreFullPath);
+            analyzerContext.AnalyzeReturnOperations(localFunctionOperation.Body, ref hasReturnValue, ref allReturnsAreFullPath);
         }
 
         if (!hasReturnValue || !allReturnsAreFullPath)
@@ -81,42 +89,9 @@ public sealed class MethodShouldReturnFullPathAnalyzer : DiagnosticAnalyzer
         ReportDiagnostic(context.ReportDiagnostic, localFunctionOperation.Symbol);
     }
 
-    private static void AnalyzeReturnOperations(IOperation operation, FullPathContext analyzerContext, ref bool hasReturnValue, ref bool allReturnsAreFullPath)
-    {
-        if (!allReturnsAreFullPath)
-            return;
-
-        if (operation is ILocalFunctionOperation)
-            return;
-
-        if (operation is IReturnOperation returnOperation && returnOperation.ReturnedValue is not null)
-        {
-            hasReturnValue = true;
-            if (!analyzerContext.IsFullPathType(returnOperation.ReturnedValue))
-            {
-                allReturnsAreFullPath = false;
-                return;
-            }
-        }
-
-        foreach (var childOperation in operation.ChildOperations)
-        {
-            AnalyzeReturnOperations(childOperation, analyzerContext, ref hasReturnValue, ref allReturnsAreFullPath);
-        }
-    }
-
     private static void ReportDiagnostic(Action<Diagnostic> reportDiagnostic, IMethodSymbol methodSymbol)
     {
-        Location? location = null;
-        foreach (var candidateLocation in methodSymbol.Locations)
-        {
-            if (!candidateLocation.IsInSource)
-                continue;
-
-            location = candidateLocation;
-            break;
-        }
-
+        var location = FullPathAnalyzerCommon.GetFirstSourceLocation(methodSymbol);
         if (location is null)
             return;
 

--- a/src/Meziantou.Framework.FullPath.Analyzer/ParameterShouldBeFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/ParameterShouldBeFullPathAnalyzer.cs
@@ -1,0 +1,140 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+/// <summary>
+/// Reports parameters that are declared as <see cref="string"/> but only ever receive <c>FullPath</c> arguments.
+/// </summary>
+/// <remarks>
+/// Only private methods and local functions are considered, because every call site must be visible in the
+/// compilation for the conclusion to hold.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ParameterShouldBeFullPathAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: FullPathAnalyzerCommon.ParameterShouldBeFullPathDiagnosticId,
+        title: "Declare the parameter as FullPath instead of string",
+        messageFormat: "Parameter '{0}' only receives FullPath values and should be declared as FullPath instead of string",
+        category: "FullPath",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        customTags: [WellKnownDiagnosticTags.CompilationEnd]);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var analyzerContext = new FullPathContext(context.Compilation);
+            if (!analyzerContext.IsValid)
+                return;
+
+            var candidateCache = new ConcurrentDictionary<ISymbol, bool>(SymbolEqualityComparer.Default);
+            var arguments = new ConcurrentBag<ArgumentUsage>();
+            var excludedMethods = new ConcurrentBag<IMethodSymbol>();
+
+            context.RegisterOperationAction(context => AnalyzeInvocation(context, analyzerContext, candidateCache, arguments), OperationKind.Invocation);
+            context.RegisterOperationAction(context => excludedMethods.Add(((IMethodReferenceOperation)context.Operation).Method.OriginalDefinition), OperationKind.MethodReference);
+            context.RegisterCompilationEndAction(context => Report(context, arguments, excludedMethods));
+        });
+    }
+
+    private static void AnalyzeInvocation(
+        OperationAnalysisContext context,
+        FullPathContext analyzerContext,
+        ConcurrentDictionary<ISymbol, bool> candidateCache,
+        ConcurrentBag<ArgumentUsage> arguments)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        var targetMethod = invocationOperation.TargetMethod.OriginalDefinition;
+        if (!candidateCache.GetOrAdd(targetMethod, static (_, method) => IsCandidate(method), targetMethod))
+            return;
+
+        foreach (var argument in invocationOperation.Arguments)
+        {
+            if (argument.Parameter is not { } parameter || !IsCandidate(parameter))
+                continue;
+
+            arguments.Add(new ArgumentUsage(targetMethod, parameter.Ordinal, analyzerContext.IsFullPathType(argument.Value)));
+        }
+    }
+
+    private static void Report(CompilationAnalysisContext context, ConcurrentBag<ArgumentUsage> arguments, ConcurrentBag<IMethodSymbol> excludedMethods)
+    {
+        var excluded = new HashSet<ISymbol>(excludedMethods, SymbolEqualityComparer.Default);
+
+        // For each parameter: null when never seen, true while every argument was a FullPath, false otherwise
+        var states = new Dictionary<ISymbol, bool?[]>(SymbolEqualityComparer.Default);
+        foreach (var argument in arguments)
+        {
+            if (excluded.Contains(argument.Method))
+                continue;
+
+            if (!states.TryGetValue(argument.Method, out var parameterStates))
+            {
+                parameterStates = new bool?[argument.Method.Parameters.Length];
+                states.Add(argument.Method, parameterStates);
+            }
+
+            parameterStates[argument.Ordinal] = argument.IsFullPath && parameterStates[argument.Ordinal] is not false;
+        }
+
+        foreach (var state in states)
+        {
+            var method = (IMethodSymbol)state.Key;
+            var parameterStates = state.Value;
+            for (var i = 0; i < parameterStates.Length; i++)
+            {
+                if (parameterStates[i] is not true)
+                    continue;
+
+                var parameter = method.Parameters[i];
+                var location = FullPathAnalyzerCommon.GetFirstSourceLocation(parameter);
+                if (location is null)
+                    continue;
+
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, parameter.Name));
+            }
+        }
+    }
+
+    private static bool IsCandidate(IMethodSymbol methodSymbol)
+    {
+        if (methodSymbol.MethodKind is not (MethodKind.Ordinary or MethodKind.LocalFunction))
+            return false;
+
+        // Every call site must be visible in the compilation
+        if (methodSymbol.MethodKind is MethodKind.Ordinary && methodSymbol.DeclaredAccessibility is not Accessibility.Private)
+            return false;
+
+        if (!methodSymbol.ExplicitInterfaceImplementations.IsEmpty)
+            return false;
+
+        if (!FullPathAnalyzerCommon.CanChangeDeclaredType(methodSymbol))
+            return false;
+
+        return FullPathAnalyzerCommon.GetFirstSourceLocation(methodSymbol) is not null;
+    }
+
+    private static bool IsCandidate(IParameterSymbol parameterSymbol)
+    {
+        if (parameterSymbol.Type.SpecialType != SpecialType.System_String)
+            return false;
+
+        if (parameterSymbol.RefKind is not RefKind.None)
+            return false;
+
+        // A params array is bound positionally and an optional parameter has a string default value
+        return !parameterSymbol.IsParams && !parameterSymbol.IsOptional;
+    }
+
+    private readonly record struct ArgumentUsage(IMethodSymbol Method, int Ordinal, bool IsFullPath);
+}

--- a/src/Meziantou.Framework.FullPath.Analyzer/ParameterShouldBeFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/ParameterShouldBeFullPathAnalyzer.cs
@@ -10,8 +10,8 @@ namespace Meziantou.Framework.Analyzers.FullPath;
 /// Reports parameters that are declared as <see cref="string"/> but only ever receive <c>FullPath</c> arguments.
 /// </summary>
 /// <remarks>
-/// Only private methods and local functions are considered, because every call site must be visible in the
-/// compilation for the conclusion to hold.
+/// Only methods that are not visible outside of the assembly are considered, because every call site must be visible
+/// in the compilation for the conclusion to hold.
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class ParameterShouldBeFullPathAnalyzer : DiagnosticAnalyzer
@@ -112,7 +112,7 @@ public sealed class ParameterShouldBeFullPathAnalyzer : DiagnosticAnalyzer
             return false;
 
         // Every call site must be visible in the compilation
-        if (methodSymbol.MethodKind is MethodKind.Ordinary && methodSymbol.DeclaredAccessibility is not Accessibility.Private)
+        if (methodSymbol.IsVisibleOutsideOfAssembly())
             return false;
 
         if (!methodSymbol.ExplicitInterfaceImplementations.IsEmpty)
@@ -130,6 +130,10 @@ public sealed class ParameterShouldBeFullPathAnalyzer : DiagnosticAnalyzer
             return false;
 
         if (parameterSymbol.RefKind is not RefKind.None)
+            return false;
+
+        // FullPath is a struct and cannot represent null
+        if (parameterSymbol.NullableAnnotation is NullableAnnotation.Annotated)
             return false;
 
         // A params array is bound positionally and an optional parameter has a string default value

--- a/src/Meziantou.Framework.FullPath.Analyzer/PathCombineWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathCombineWithFullPathAnalyzer.cs
@@ -10,8 +10,8 @@ public sealed class PathCombineWithFullPathAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathCombineWithFullPathDiagnosticId,
-        title: "Use '/' operator instead of Path.Combine",
-        messageFormat: "Use FullPath '/' operations instead of calling Path.Combine",
+        title: "Use '/' operator instead of Path.Combine or Path.Join",
+        messageFormat: "Use FullPath '/' operations instead of calling Path.{0}",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: true);
@@ -35,7 +35,7 @@ public sealed class PathCombineWithFullPathAnalyzer : DiagnosticAnalyzer
     private static void Analyze(OperationAnalysisContext context, FullPathContext analyzerContext)
     {
         var invocationOperation = (IInvocationOperation)context.Operation;
-        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" } targetMethod)
+        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" or "Join" } targetMethod)
             return;
 
         if (!SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, analyzerContext.PathType))
@@ -46,7 +46,7 @@ public sealed class PathCombineWithFullPathAnalyzer : DiagnosticAnalyzer
             if (!analyzerContext.IsFullPathType(argument.Value))
                 continue;
 
-            context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation()));
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation(), targetMethod.Name));
             return;
         }
     }

--- a/src/Meziantou.Framework.FullPath.Analyzer/PropertyShouldReturnFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PropertyShouldReturnFullPathAnalyzer.cs
@@ -1,0 +1,76 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PropertyShouldReturnFullPathAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: FullPathAnalyzerCommon.PropertyShouldReturnFullPathDiagnosticId,
+        title: "Declare the property as FullPath instead of string",
+        messageFormat: "Property '{0}' returns FullPath values and should be declared as FullPath instead of string",
+        category: "FullPath",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var analyzerContext = new FullPathContext(context.Compilation);
+            if (!analyzerContext.IsValid)
+                return;
+
+            context.RegisterOperationBlockAction(context => AnalyzeOperationBlock(context, analyzerContext));
+        });
+    }
+
+    private static void AnalyzeOperationBlock(OperationBlockAnalysisContext context, FullPathContext analyzerContext)
+    {
+        if (context.OwningSymbol is not IMethodSymbol { MethodKind: MethodKind.PropertyGet, AssociatedSymbol: IPropertySymbol propertySymbol })
+            return;
+
+        if (propertySymbol.Type.SpecialType != SpecialType.System_String)
+            return;
+
+        // Changing the type of a property that has a setter also changes what callers are allowed to assign
+        if (propertySymbol.SetMethod is not null)
+            return;
+
+        if (propertySymbol.IsIndexer)
+            return;
+
+        if (!FullPathAnalyzerCommon.CanChangeDeclaredType(propertySymbol))
+            return;
+
+        var hasReturnValue = false;
+        var allReturnsAreFullPath = true;
+        foreach (var operationBlock in context.OperationBlocks)
+        {
+            analyzerContext.AnalyzeReturnOperations(operationBlock, ref hasReturnValue, ref allReturnsAreFullPath);
+        }
+
+        // Expression-bodied properties and expression-bodied getters have no return operation
+        if (!hasReturnValue && context.OperationBlocks.Length == 1 && context.OperationBlocks[0] is not IBlockOperation)
+        {
+            hasReturnValue = true;
+            allReturnsAreFullPath &= analyzerContext.IsFullPathType(context.OperationBlocks[0]);
+        }
+
+        if (!hasReturnValue || !allReturnsAreFullPath)
+            return;
+
+        var location = FullPathAnalyzerCommon.GetFirstSourceLocation(propertySymbol);
+        if (location is null)
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, propertySymbol.Name));
+    }
+}

--- a/src/Meziantou.Framework.FullPath.Analyzer/SymbolExtensions.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/SymbolExtensions.cs
@@ -1,0 +1,20 @@
+using Microsoft.CodeAnalysis;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+internal static class SymbolExtensions
+{
+    public static bool IsVisibleOutsideOfAssembly([NotNullWhen(true)] this ISymbol? symbol)
+    {
+        if (symbol is null)
+            return false;
+
+        if (symbol.DeclaredAccessibility is not Accessibility.Public and not Accessibility.Protected and not Accessibility.ProtectedOrInternal)
+            return false;
+
+        if (symbol.ContainingType is null)
+            return true;
+
+        return IsVisibleOutsideOfAssembly(symbol.ContainingType);
+    }
+}

--- a/src/Meziantou.Framework.FullPath.Analyzer/VariableShouldBeFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/VariableShouldBeFullPathAnalyzer.cs
@@ -1,0 +1,125 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class VariableShouldBeFullPathAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: FullPathAnalyzerCommon.VariableShouldBeFullPathDiagnosticId,
+        title: "Declare the variable as FullPath instead of string",
+        messageFormat: "Variable '{0}' only holds FullPath values and should be declared as FullPath instead of string",
+        category: "FullPath",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var analyzerContext = new FullPathContext(context.Compilation);
+            if (!analyzerContext.IsValid)
+                return;
+
+            context.RegisterOperationBlockAction(context => AnalyzeOperationBlock(context, analyzerContext));
+        });
+    }
+
+    private static void AnalyzeOperationBlock(OperationBlockAnalysisContext context, FullPathContext analyzerContext)
+    {
+        var candidates = new Dictionary<ISymbol, VariableState>(SymbolEqualityComparer.Default);
+        foreach (var operationBlock in context.OperationBlocks)
+        {
+            Visit(operationBlock, analyzerContext, candidates);
+        }
+
+        foreach (var candidate in candidates)
+        {
+            var state = candidate.Value;
+            if (!state.HasValue || !state.AllValuesAreFullPath || state.Location is null)
+                continue;
+
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, state.Location, candidate.Key.Name));
+        }
+    }
+
+    private static void Visit(IOperation operation, FullPathContext analyzerContext, Dictionary<ISymbol, VariableState> candidates)
+    {
+        switch (operation)
+        {
+            case IVariableDeclaratorOperation variableDeclaratorOperation:
+                AnalyzeDeclarator(variableDeclaratorOperation, analyzerContext, candidates);
+                break;
+
+            case ISimpleAssignmentOperation { Target: ILocalReferenceOperation localReferenceOperation } assignmentOperation:
+                if (candidates.TryGetValue(localReferenceOperation.Local, out var assignedState))
+                {
+                    assignedState.HasValue = true;
+                    assignedState.AllValuesAreFullPath &= analyzerContext.IsFullPathType(assignmentOperation.Value);
+                }
+
+                break;
+
+            // Any other kind of write means the variable is used as a string
+            case ICompoundAssignmentOperation { Target: ILocalReferenceOperation compoundTarget }:
+                Disqualify(candidates, compoundTarget.Local);
+                break;
+
+            case IArgumentOperation { Parameter.RefKind: not RefKind.None, Value: ILocalReferenceOperation argumentReference }:
+                Disqualify(candidates, argumentReference.Local);
+                break;
+        }
+
+        foreach (var childOperation in operation.ChildOperations)
+        {
+            Visit(childOperation, analyzerContext, candidates);
+        }
+    }
+
+    private static void AnalyzeDeclarator(IVariableDeclaratorOperation operation, FullPathContext analyzerContext, Dictionary<ISymbol, VariableState> candidates)
+    {
+        var local = operation.Symbol;
+        if (local.Type.SpecialType != SpecialType.System_String)
+            return;
+
+        if (local.IsRef)
+            return;
+
+        // 'var' declarations are left alone: the developer asked for whatever the initializer produces
+        if (operation.Syntax is not VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax { Type.IsVar: false } })
+            return;
+
+        var state = new VariableState { Location = FullPathAnalyzerCommon.GetFirstSourceLocation(local) };
+        var initializer = operation.Initializer ?? (operation.Parent as IVariableDeclarationOperation)?.Initializer;
+        if (initializer is not null)
+        {
+            state.HasValue = true;
+            state.AllValuesAreFullPath = analyzerContext.IsFullPathType(initializer.Value);
+        }
+
+        candidates[local] = state;
+    }
+
+    private static void Disqualify(Dictionary<ISymbol, VariableState> candidates, ILocalSymbol local)
+    {
+        if (candidates.TryGetValue(local, out var state))
+        {
+            state.AllValuesAreFullPath = false;
+        }
+    }
+
+    private sealed class VariableState
+    {
+        public bool HasValue { get; set; }
+        public bool AllValuesAreFullPath { get; set; } = true;
+        public Location? Location { get; set; }
+    }
+}

--- a/src/Meziantou.Framework.FullPath.CodeFix/FullPathDivisionWithFullPathRightCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/FullPathDivisionWithFullPathRightCodeFixProvider.cs
@@ -78,7 +78,7 @@ public sealed class FullPathDivisionWithFullPathRightCodeFixProvider : CodeFixPr
         if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is IBinaryOperation binaryOperation &&
             binaryOperation.OperatorKind == BinaryOperatorKind.Divide)
         {
-            var rightOperand = UnwrapImplicitConversion(binaryOperation.RightOperand);
+            var rightOperand = FullPathAnalyzerCommon.UnwrapToFullPath(binaryOperation.RightOperand, fullPathType);
             if (SymbolEqualityComparer.Default.Equals(rightOperand.Type, fullPathType) && rightOperand.Syntax is ExpressionSyntax rightExpression)
             {
                 replacementExpression = rightExpression;
@@ -88,15 +88,5 @@ public sealed class FullPathDivisionWithFullPathRightCodeFixProvider : CodeFixPr
 
         replacementExpression = null!;
         return false;
-    }
-
-    private static IOperation UnwrapImplicitConversion(IOperation operation)
-    {
-        while (operation is IConversionOperation conversionOperation && conversionOperation.IsImplicit)
-        {
-            operation = conversionOperation.Operand;
-        }
-
-        return operation;
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathChangeExtensionWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathChangeExtensionWithFullPathCodeFixProvider.cs
@@ -83,7 +83,7 @@ public sealed class PathChangeExtensionWithFullPathCodeFixProvider : CodeFixProv
             SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) &&
             invocationOperation.Arguments.Length == 2)
         {
-            var fullPathOperation = UnwrapImplicitConversion(invocationOperation.Arguments[0].Value);
+            var fullPathOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[0].Value, fullPathType);
             if (SymbolEqualityComparer.Default.Equals(fullPathOperation.Type, fullPathType) &&
                 fullPathOperation.Syntax is ExpressionSyntax fullPathExpression &&
                 invocationOperation.Arguments[1].Value.Syntax is ExpressionSyntax extensionExpression)
@@ -103,15 +103,5 @@ public sealed class PathChangeExtensionWithFullPathCodeFixProvider : CodeFixProv
 
         replacementExpression = null!;
         return false;
-    }
-
-    private static IOperation UnwrapImplicitConversion(IOperation operation)
-    {
-        while (operation is IConversionOperation conversionOperation && conversionOperation.IsImplicit)
-        {
-            operation = conversionOperation.Operand;
-        }
-
-        return operation;
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathCombineWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathCombineWithFullPathCodeFixProvider.cs
@@ -79,7 +79,7 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
         out ExpressionSyntax replacementExpression)
     {
         if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is not IInvocationOperation invocationOperation ||
-            invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" } targetMethod ||
+            invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" or "Join" } targetMethod ||
             !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) ||
             invocationOperation.Arguments.Length == 0)
         {
@@ -90,7 +90,7 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
         var fullPathIndex = -1;
         for (var i = 0; i < invocationOperation.Arguments.Length; i++)
         {
-            var argument = UnwrapImplicitConversion(invocationOperation.Arguments[i].Value);
+            var argument = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[i].Value, fullPathType);
             if (SymbolEqualityComparer.Default.Equals(argument.Type, fullPathType))
             {
                 fullPathIndex = i;
@@ -103,7 +103,7 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
             return false;
         }
 
-        var startOperation = UnwrapImplicitConversion(invocationOperation.Arguments[fullPathIndex].Value);
+        var startOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[fullPathIndex].Value, fullPathType);
         if (startOperation.Syntax is not ExpressionSyntax expression)
         {
             replacementExpression = null!;
@@ -113,7 +113,7 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
         replacementExpression = expression.WithoutTrivia();
         for (var i = fullPathIndex + 1; i < invocationOperation.Arguments.Length; i++)
         {
-            var nextOperation = UnwrapImplicitConversion(invocationOperation.Arguments[i].Value);
+            var nextOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[i].Value, fullPathType);
             if (nextOperation.Syntax is not ExpressionSyntax nextExpression)
             {
                 replacementExpression = null!;
@@ -124,15 +124,5 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
         }
 
         return true;
-    }
-
-    private static IOperation UnwrapImplicitConversion(IOperation operation)
-    {
-        while (operation is IConversionOperation conversionOperation && conversionOperation.IsImplicit)
-        {
-            operation = conversionOperation.Operand;
-        }
-
-        return operation;
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetDirectoryNameWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetDirectoryNameWithFullPathCodeFixProvider.cs
@@ -83,7 +83,7 @@ public sealed class PathGetDirectoryNameWithFullPathCodeFixProvider : CodeFixPro
             SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) &&
             invocationOperation.Arguments.Length == 1)
         {
-            var fullPathOperation = UnwrapImplicitConversion(invocationOperation.Arguments[0].Value);
+            var fullPathOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[0].Value, fullPathType);
             if (SymbolEqualityComparer.Default.Equals(fullPathOperation.Type, fullPathType) &&
                 fullPathOperation.Syntax is ExpressionSyntax fullPathExpression)
             {
@@ -97,15 +97,5 @@ public sealed class PathGetDirectoryNameWithFullPathCodeFixProvider : CodeFixPro
 
         replacementExpression = null!;
         return false;
-    }
-
-    private static IOperation UnwrapImplicitConversion(IOperation operation)
-    {
-        while (operation is IConversionOperation conversionOperation && conversionOperation.IsImplicit)
-        {
-            operation = conversionOperation.Operand;
-        }
-
-        return operation;
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetExtensionWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetExtensionWithFullPathCodeFixProvider.cs
@@ -83,7 +83,7 @@ public sealed class PathGetExtensionWithFullPathCodeFixProvider : CodeFixProvide
             SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) &&
             invocationOperation.Arguments.Length == 1)
         {
-            var fullPathOperation = UnwrapImplicitConversion(invocationOperation.Arguments[0].Value);
+            var fullPathOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[0].Value, fullPathType);
             if (SymbolEqualityComparer.Default.Equals(fullPathOperation.Type, fullPathType) &&
                 fullPathOperation.Syntax is ExpressionSyntax fullPathExpression)
             {
@@ -97,15 +97,5 @@ public sealed class PathGetExtensionWithFullPathCodeFixProvider : CodeFixProvide
 
         replacementExpression = null!;
         return false;
-    }
-
-    private static IOperation UnwrapImplicitConversion(IOperation operation)
-    {
-        while (operation is IConversionOperation conversionOperation && conversionOperation.IsImplicit)
-        {
-            operation = conversionOperation.Operand;
-        }
-
-        return operation;
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetFileNameWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetFileNameWithFullPathCodeFixProvider.cs
@@ -83,7 +83,7 @@ public sealed class PathGetFileNameWithFullPathCodeFixProvider : CodeFixProvider
             SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) &&
             invocationOperation.Arguments.Length == 1)
         {
-            var fullPathOperation = UnwrapImplicitConversion(invocationOperation.Arguments[0].Value);
+            var fullPathOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[0].Value, fullPathType);
             if (SymbolEqualityComparer.Default.Equals(fullPathOperation.Type, fullPathType) &&
                 fullPathOperation.Syntax is ExpressionSyntax fullPathExpression)
             {
@@ -97,15 +97,5 @@ public sealed class PathGetFileNameWithFullPathCodeFixProvider : CodeFixProvider
 
         replacementExpression = null!;
         return false;
-    }
-
-    private static IOperation UnwrapImplicitConversion(IOperation operation)
-    {
-        while (operation is IConversionOperation conversionOperation && conversionOperation.IsImplicit)
-        {
-            operation = conversionOperation.Operand;
-        }
-
-        return operation;
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetFileNameWithoutExtensionWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetFileNameWithoutExtensionWithFullPathCodeFixProvider.cs
@@ -83,7 +83,7 @@ public sealed class PathGetFileNameWithoutExtensionWithFullPathCodeFixProvider :
             SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) &&
             invocationOperation.Arguments.Length == 1)
         {
-            var fullPathOperation = UnwrapImplicitConversion(invocationOperation.Arguments[0].Value);
+            var fullPathOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[0].Value, fullPathType);
             if (SymbolEqualityComparer.Default.Equals(fullPathOperation.Type, fullPathType) &&
                 fullPathOperation.Syntax is ExpressionSyntax fullPathExpression)
             {
@@ -97,15 +97,5 @@ public sealed class PathGetFileNameWithoutExtensionWithFullPathCodeFixProvider :
 
         replacementExpression = null!;
         return false;
-    }
-
-    private static IOperation UnwrapImplicitConversion(IOperation operation)
-    {
-        while (operation is IConversionOperation conversionOperation && conversionOperation.IsImplicit)
-        {
-            operation = conversionOperation.Operand;
-        }
-
-        return operation;
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetFullPathOnFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetFullPathOnFullPathCodeFixProvider.cs
@@ -83,7 +83,7 @@ public sealed class PathGetFullPathOnFullPathCodeFixProvider : CodeFixProvider
             invocationOperation.Arguments.Length >= 1)
         {
             var argument = invocationOperation.Arguments[0].Value;
-            if (SymbolEqualityComparer.Default.Equals(UnwrapImplicitConversion(argument).Type, fullPathType) &&
+            if (SymbolEqualityComparer.Default.Equals(FullPathAnalyzerCommon.UnwrapToFullPath(argument, fullPathType).Type, fullPathType) &&
                 argument.Syntax is ExpressionSyntax fullPathExpression)
             {
                 replacementExpression = fullPathExpression;
@@ -93,15 +93,5 @@ public sealed class PathGetFullPathOnFullPathCodeFixProvider : CodeFixProvider
 
         replacementExpression = null!;
         return false;
-    }
-
-    private static IOperation UnwrapImplicitConversion(IOperation operation)
-    {
-        while (operation is IConversionOperation conversionOperation && conversionOperation.IsImplicit)
-        {
-            operation = conversionOperation.Operand;
-        }
-
-        return operation;
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetFullPathWithFullPathBaseCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetFullPathWithFullPathBaseCodeFixProvider.cs
@@ -107,8 +107,8 @@ public sealed class PathGetFullPathWithFullPathBaseCodeFixProvider : CodeFixProv
             return false;
         }
 
-        var normalizedPathValue = UnwrapImplicitConversion(pathArgument.Value);
-        var normalizedBasePathValue = UnwrapImplicitConversion(basePathArgument.Value);
+        var normalizedPathValue = FullPathAnalyzerCommon.UnwrapToFullPath(pathArgument.Value, fullPathType);
+        var normalizedBasePathValue = FullPathAnalyzerCommon.UnwrapToFullPath(basePathArgument.Value, fullPathType);
         if (SymbolEqualityComparer.Default.Equals(normalizedPathValue.Type, fullPathType) ||
             !SymbolEqualityComparer.Default.Equals(normalizedBasePathValue.Type, fullPathType) ||
             normalizedPathValue.Syntax is not ExpressionSyntax pathExpression ||
@@ -124,15 +124,5 @@ public sealed class PathGetFullPathWithFullPathBaseCodeFixProvider : CodeFixProv
             pathExpression.WithoutTrivia());
 
         return true;
-    }
-
-    private static IOperation UnwrapImplicitConversion(IOperation operation)
-    {
-        while (operation is IConversionOperation conversionOperation && conversionOperation.IsImplicit)
-        {
-            operation = conversionOperation.Operand;
-        }
-
-        return operation;
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetRelativePathWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetRelativePathWithFullPathCodeFixProvider.cs
@@ -83,8 +83,8 @@ public sealed class PathGetRelativePathWithFullPathCodeFixProvider : CodeFixProv
             SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) &&
             invocationOperation.Arguments.Length == 2)
         {
-            var rootOperation = UnwrapImplicitConversion(invocationOperation.Arguments[0].Value);
-            var valueOperation = UnwrapImplicitConversion(invocationOperation.Arguments[1].Value);
+            var rootOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[0].Value, fullPathType);
+            var valueOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[1].Value, fullPathType);
             if (SymbolEqualityComparer.Default.Equals(rootOperation.Type, fullPathType) &&
                 SymbolEqualityComparer.Default.Equals(valueOperation.Type, fullPathType) &&
                 rootOperation.Syntax is ExpressionSyntax rootExpression &&
@@ -105,15 +105,5 @@ public sealed class PathGetRelativePathWithFullPathCodeFixProvider : CodeFixProv
 
         replacementExpression = null!;
         return false;
-    }
-
-    private static IOperation UnwrapImplicitConversion(IOperation operation)
-    {
-        while (operation is IConversionOperation conversionOperation && conversionOperation.IsImplicit)
-        {
-            operation = conversionOperation.Operand;
-        }
-
-        return operation;
     }
 }

--- a/src/Meziantou.Framework.FullPath/readme.md
+++ b/src/Meziantou.Framework.FullPath/readme.md
@@ -55,7 +55,7 @@ System.IO.File.WriteAllText(filePath, content);
 | `MFFP0001` | FullPath | Use FullPath directly instead of Path.GetFullPath | Info | ✔️ |
 | `MFFP0002` | FullPath | Use the right FullPath operand directly | Info | ✔️ |
 | `MFFP0003` | FullPath | Use '/' with a FullPath base instead of Path.GetFullPath | Info | ✔️ |
-| `MFFP0004` | FullPath | Use '/' operator instead of Path.Combine | Info | ✔️ |
+| `MFFP0004` | FullPath | Use '/' operator instead of Path.Combine or Path.Join | Info | ✔️ |
 | `MFFP0005` | FullPath | Use FullPath.Name instead of Path.GetFileName | Info | ✔️ |
 | `MFFP0006` | FullPath | Use FullPath.NameWithoutExtension instead of Path.GetFileNameWithoutExtension | Info | ✔️ |
 | `MFFP0007` | FullPath | Use FullPath.Extension instead of Path.GetExtension | Info | ✔️ |
@@ -63,6 +63,9 @@ System.IO.File.WriteAllText(filePath, content);
 | `MFFP0009` | FullPath | Use FullPath.ChangeExtension instead of Path.ChangeExtension | Info | ✔️ |
 | `MFFP0010` | FullPath | Use FullPath.MakePathRelativeTo instead of Path.GetRelativePath | Info | ✔️ |
 | `MFFP0011` | FullPath | Return FullPath instead of string | Info | ✔️ |
+| `MFFP0012` | FullPath | Declare the property as FullPath instead of string | Info | ✔️ |
+| `MFFP0013` | FullPath | Declare the variable as FullPath instead of string | Info | ✔️ |
+| `MFFP0014` | FullPath | Declare the parameter as FullPath instead of string | Info | ✔️ |
 <!-- analyzer-rules -->
 
 # Additional resources

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/ParameterShouldBeFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/ParameterShouldBeFullPathRuleTests.cs
@@ -82,7 +82,60 @@ public sealed class ParameterShouldBeFullPathRuleTests : FullPathAnalyzerTestBas
     }
 
     [Fact]
-    public async Task Analyzer_DoesNotReportDiagnostic_ForNonPrivateMethod()
+    public async Task Analyzer_ReportDiagnostic_ForInternalMethod()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static void M(FullPath fullPath)
+                    {
+                        Process(fullPath);
+                    }
+
+                    internal static void Process(string {|MFFP0014:path|})
+                    {
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForPublicMethodOfATypeThatIsNotVisibleOutsideOfTheAssembly()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                internal static class Helper
+                {
+                    public static void Process(string {|MFFP0014:path|})
+                    {
+                    }
+                }
+
+                public static class TestClass
+                {
+                    public static void M(FullPath fullPath)
+                    {
+                        Helper.Process(fullPath);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForMethodVisibleOutsideOfTheAssembly()
     {
         var source = """
             using Meziantou.Framework;
@@ -97,6 +150,31 @@ public sealed class ParameterShouldBeFullPathRuleTests : FullPathAnalyzerTestBas
                     }
 
                     public static void Process(string path)
+                    {
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForProtectedMethod()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public class TestClass
+                {
+                    public void M(FullPath fullPath)
+                    {
+                        Process(fullPath);
+                    }
+
+                    protected void Process(string path)
                     {
                     }
                 }
@@ -142,6 +220,32 @@ public sealed class ParameterShouldBeFullPathRuleTests : FullPathAnalyzerTestBas
                     }
 
                     private static void Process(string path)
+                    {
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForNullableParameter()
+    {
+        var source = """
+            #nullable enable
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static void M(FullPath fullPath)
+                    {
+                        Process(fullPath);
+                    }
+
+                    private static void Process(string? path)
                     {
                     }
                 }

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/ParameterShouldBeFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/ParameterShouldBeFullPathRuleTests.cs
@@ -1,0 +1,178 @@
+using ParameterShouldBeFullPathAnalyzerType = Meziantou.Framework.Analyzers.FullPath.ParameterShouldBeFullPathAnalyzer;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class ParameterShouldBeFullPathRuleTests : FullPathAnalyzerTestBase
+{
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_WhenEveryCallSitePassesAFullPath()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static void M(FullPath value1, FullPath value2)
+                    {
+                        Process(value1);
+                        Process(value2);
+                    }
+
+                    private static void Process(string {|MFFP0014:path|})
+                    {
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForLocalFunction()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static void M(FullPath fullPath)
+                    {
+                        Process(fullPath);
+
+                        static void Process(string {|MFFP0014:path|})
+                        {
+                        }
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenAnyCallSitePassesAString()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static void M(FullPath fullPath)
+                    {
+                        Process(fullPath);
+                        Process("text");
+                    }
+
+                    private static void Process(string path)
+                    {
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForNonPrivateMethod()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static void M(FullPath fullPath)
+                    {
+                        Process(fullPath);
+                    }
+
+                    public static void Process(string path)
+                    {
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenMethodIsNeverCalled()
+    {
+        var source = """
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    private static void Process(string path)
+                    {
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenMethodIsUsedAsADelegate()
+    {
+        var source = """
+            using System;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static Action<string> M(FullPath fullPath)
+                    {
+                        Process(fullPath);
+                        return Process;
+                    }
+
+                    private static void Process(string path)
+                    {
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForOptionalParameter()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static void M(FullPath fullPath)
+                    {
+                        Process(fullPath);
+                    }
+
+                    private static void Process(string path = "")
+                    {
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathCombineWithFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathCombineWithFullPathRuleTests.cs
@@ -120,6 +120,103 @@ public sealed class PathCombineWithFullPathRuleTests : FullPathAnalyzerTestBase
     }
 
     [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForPathJoinWithFullPath()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return {|MFFP0004:Path.Join(fullPath, "value1", "value2")|};
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return fullPath / "value1" / "value2";
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForPathCombineWithFullPathValue()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return {|MFFP0004:Path.Combine(fullPath.Value, "value")|};
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return fullPath / "value";
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForPathJoinWithStrings()
+    {
+        var source = """
+            using System.IO;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M()
+                    {
+                        return Path.Join("value1", "value2");
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<PathCombineWithFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
     public async Task Analyzer_DoesNotReportDiagnostic_ForPathCombineWithStrings()
     {
         var source = """

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathGetExtensionWithFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathGetExtensionWithFullPathRuleTests.cs
@@ -43,6 +43,48 @@ public sealed class PathGetExtensionWithFullPathRuleTests : FullPathAnalyzerTest
         await CreateCodeFixTest<PathGetExtensionWithFullPathAnalyzerType, PathGetExtensionWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
     }
 
+    [Theory]
+    [InlineData("fullPath.Value")]
+    [InlineData("fullPath.RawValue")]
+    [InlineData("fullPath.ToString()")]
+    [InlineData("(string)fullPath")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForPathGetExtensionOnFullPathStringRepresentation(string expression)
+    {
+        var source = $$"""
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return {|MFFP0007:Path.GetExtension({{expression}})|};
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return fullPath.Extension;
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathGetExtensionWithFullPathAnalyzerType, PathGetExtensionWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
     [Fact]
     public async Task Analyzer_DoesNotReportDiagnostic_ForPathGetExtensionOnString()
     {

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PropertyShouldReturnFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PropertyShouldReturnFullPathRuleTests.cs
@@ -1,0 +1,178 @@
+using PropertyShouldReturnFullPathAnalyzerType = Meziantou.Framework.Analyzers.FullPath.PropertyShouldReturnFullPathAnalyzer;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class PropertyShouldReturnFullPathRuleTests : FullPathAnalyzerTestBase
+{
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForExpressionBodiedProperty()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public sealed class TestClass
+                {
+                    private readonly FullPath _path;
+
+                    public string {|MFFP0012:Path|} => _path;
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<PropertyShouldReturnFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_WhenAllReturnsAreFullPathInGetter()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public sealed class TestClass
+                {
+                    private readonly FullPath _path;
+
+                    public string {|MFFP0012:Path|}
+                    {
+                        get
+                        {
+                            if (_path.IsEmpty)
+                                return FullPath.Empty;
+
+                            return _path;
+                        }
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<PropertyShouldReturnFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForFullPathValueAccess()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public sealed class TestClass
+                {
+                    private readonly FullPath _path;
+
+                    public string {|MFFP0012:Path|} => _path.Value;
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<PropertyShouldReturnFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenAnyReturnIsNotFullPath()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public sealed class TestClass
+                {
+                    private readonly FullPath _path;
+
+                    public string Path
+                    {
+                        get
+                        {
+                            if (_path.IsEmpty)
+                                return "";
+
+                            return _path;
+                        }
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<PropertyShouldReturnFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenPropertyHasSetter()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public sealed class TestClass
+                {
+                    private FullPath _path;
+
+                    public string Path
+                    {
+                        get => _path;
+                        set => _path = FullPath.FromPath(value);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<PropertyShouldReturnFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenPropertyImplementsAnInterface()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public interface IHasPath
+                {
+                    string Path { get; }
+                }
+
+                public sealed class TestClass : IHasPath
+                {
+                    private readonly FullPath _path;
+
+                    public string Path => _path;
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<PropertyShouldReturnFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenPropertyOverridesABaseMember()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public abstract class BaseClass
+                {
+                    public abstract string Path { get; }
+                }
+
+                public sealed class TestClass : BaseClass
+                {
+                    private readonly FullPath _path;
+
+                    public override string Path => _path;
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<PropertyShouldReturnFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/VariableShouldBeFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/VariableShouldBeFullPathRuleTests.cs
@@ -1,0 +1,171 @@
+using VariableShouldBeFullPathAnalyzerType = Meziantou.Framework.Analyzers.FullPath.VariableShouldBeFullPathAnalyzer;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class VariableShouldBeFullPathRuleTests : FullPathAnalyzerTestBase
+{
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForStringLocalInitializedWithFullPath()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        string {|MFFP0013:path|} = fullPath;
+                        return path;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_WhenEveryAssignmentIsFullPath()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(bool condition, FullPath value1, FullPath value2)
+                    {
+                        string {|MFFP0013:path|} = value1;
+                        if (condition)
+                            path = value2;
+
+                        return path;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenAnyAssignmentIsNotFullPath()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(bool condition, FullPath value)
+                    {
+                        string path = value;
+                        if (condition)
+                            path = "text";
+
+                        return path;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForVarDeclaration()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        var path = fullPath.Value;
+                        return path;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenVariableIsPassedByReference()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        string path = fullPath;
+                        Update(ref path);
+                        return path;
+                    }
+
+                    private static void Update(ref string value) => value = "text";
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenVariableIsAppendedTo()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        string path = fullPath;
+                        path += ".bak";
+                        return path;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForStringLocalWithoutValue()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        string path;
+                        path = "text";
+                        return path;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -601,7 +601,7 @@ public sealed class FullPathTests
         Assert.Contains(longSegment, extended);
     }
 
-    private static void CreateSymlink(string source, string target, bool isDirectory)
+    private static void CreateSymlink(FullPath source, string target, bool isDirectory)
     {
         if (isDirectory)
         {


### PR DESCRIPTION
First of three PRs adding rules to `Meziantou.Framework.FullPath.Analyzer`. This one closes gaps in the rules that already exist; the next two add correctness rules and redundancy rules on top of it.

## The `.Value` blind spot

Every `Path.*` rule (MFFP0001, MFFP0003-MFFP0010) recognized a `FullPath` only when it reached the argument through the *implicit* conversion to `string`. These all went unreported:

```csharp
Path.GetExtension(fullPath.Value)
Path.GetExtension(fullPath.ToString())
Path.GetExtension((string)fullPath)
```

The unwrapping now lives in `FullPathAnalyzerCommon`, which is already shared with the code fix project, so the fixers keep pace with the analyzers instead of reporting a diagnostic no fix is offered for. Each fixer's private copy of `UnwrapImplicitConversion` is gone.

## `Path.Join`

MFFP0004 matched `Combine` only. `Path.Join(fullPath, "x")` slipped through and is arguably worse than `Combine`, since it does no rooting.

## Three declaration-site rules

MFFP0011 infers "this should be a `FullPath`" from return statements. The same inference applies at three more declaration sites:

| Id | Reports |
| -- | -- |
| `MFFP0012` | a get-only `string` property whose getter only returns `FullPath` values |
| `MFFP0013` | a `string` local that only ever holds `FullPath` values |
| `MFFP0014` | a `string` parameter whose call sites all pass a `FullPath` |

MFFP0014 only considers private methods and local functions, since every call site has to be visible in the compilation for the conclusion to hold. It also skips `params`, optional and by-ref parameters, and any method used as a delegate. It reports at compilation end, so it is a build-time diagnostic rather than a live one.

MFFP0013 leaves `var` declarations alone — there the developer asked for whatever the initializer produces — and bails out on any write that isn't a plain assignment.

## Fixes to MFFP0011

Two false positives, both surfaced while writing MFFP0012:

- it fired on property accessors, reporting `get_Foo` at the accessor. Accessors are now MFFP0012's job, reported at the property itself.
- it fired on members that override a base member or implement an interface, where the return type can't be changed.

## Notes

- The readme table is generated, but its regex stopped matching a descriptor at `isEnabledByDefault`, so MFFP0014 (which needs a `CompilationEnd` custom tag) was silently dropped from the table. `eng/update-all.cs` now allows trailing descriptor arguments.
- Analyzer tests: 27 -> 55, all passing. `dotnet run ./eng/update-all.cs` is clean.
- Dogfooding check: the repo builds every project that references `Meziantou.Framework.FullPath` with these analyzers. With the new rules temporarily raised to warnings, the repo produces zero hits — verified against a probe file to confirm the analyzers were actually running.