### PR TITLE
Add FullPath redundancy rules

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/DirectoryGetParentWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/DirectoryGetParentWithFullPathAnalyzer.cs
@@ -1,0 +1,52 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+/// <summary>
+/// Reports <c>Directory.GetParent</c> applied to a <c>FullPath</c>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class DirectoryGetParentWithFullPathAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: FullPathAnalyzerCommon.DirectoryGetParentWithFullPathDiagnosticId,
+        title: "Use FullPath.Parent instead of Directory.GetParent",
+        messageFormat: "Use FullPath.Parent instead of calling Directory.GetParent",
+        category: "FullPath",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var analyzerContext = new FullPathContext(context.Compilation);
+            if (!analyzerContext.IsValid || analyzerContext.DirectoryType is null)
+                return;
+
+            context.RegisterOperationAction(context => Analyze(context, analyzerContext), OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, FullPathContext analyzerContext)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "GetParent" } targetMethod)
+            return;
+
+        if (!SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, analyzerContext.DirectoryType))
+            return;
+
+        if (invocationOperation.Arguments.Length != 1 || !analyzerContext.IsFullPathType(invocationOperation.Arguments[0].Value))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation()));
+    }
+}

--- a/src/Meziantou.Framework.FullPath.Analyzer/FromPathWithFileSystemInfoAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FromPathWithFileSystemInfoAnalyzer.cs
@@ -1,0 +1,55 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+/// <summary>
+/// Reports <c>FullPath.FromPath(fileSystemInfo.FullName)</c>, for which a dedicated factory exists.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class FromPathWithFileSystemInfoAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: FullPathAnalyzerCommon.FromPathWithFileSystemInfoDiagnosticId,
+        title: "Use FullPath.FromFileSystemInfo instead of FullPath.FromPath",
+        messageFormat: "Use FullPath.FromFileSystemInfo instead of passing FullName to FullPath.FromPath",
+        category: "FullPath",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var analyzerContext = new FullPathContext(context.Compilation);
+            if (!analyzerContext.IsValid || analyzerContext.FileSystemInfoType is null)
+                return;
+
+            context.RegisterOperationAction(context => Analyze(context, analyzerContext), OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, FullPathContext analyzerContext)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        if (invocationOperation.TargetMethod is not { Name: "FromPath" } targetMethod || !analyzerContext.IsFullPathMember(targetMethod))
+            return;
+
+        if (invocationOperation.Arguments.Length != 1)
+            return;
+
+        if (invocationOperation.Arguments[0].Value is not IPropertyReferenceOperation { Property.Name: "FullName", Instance: not null } propertyReference)
+            return;
+
+        if (!analyzerContext.IsFileSystemInfo(propertyReference.Instance.Type))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation()));
+    }
+}

--- a/src/Meziantou.Framework.FullPath.Analyzer/FullPathAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FullPathAnalyzerCommon.cs
@@ -21,6 +21,12 @@ internal static class FullPathAnalyzerCommon
     internal const string ParameterShouldBeFullPathDiagnosticId = "MFFP0014";
     internal const string CompareFullPathAsStringDiagnosticId = "MFFP0015";
     internal const string FullPathEqualsStringDiagnosticId = "MFFP0016";
+    internal const string RedundantPathPredicateDiagnosticId = "MFFP0018";
+    internal const string RedundantFromPathDiagnosticId = "MFFP0019";
+    internal const string FromPathWithFileSystemInfoDiagnosticId = "MFFP0020";
+    internal const string UseIsEmptyDiagnosticId = "MFFP0021";
+    internal const string UseCreateParentDirectoryDiagnosticId = "MFFP0022";
+    internal const string DirectoryGetParentWithFullPathDiagnosticId = "MFFP0023";
 
     /// <summary>
     /// Returns the underlying <c>FullPath</c> operation of an expression that produces its string representation,

--- a/src/Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs
@@ -7,6 +7,24 @@ internal sealed class FullPathContext(Compilation compilation)
 {
     public INamedTypeSymbol? FullPathType { get; } = compilation.GetTypeByMetadataName("Meziantou.Framework.FullPath");
     public INamedTypeSymbol? PathType { get; } = compilation.GetTypeByMetadataName("System.IO.Path");
+    public INamedTypeSymbol? DirectoryType { get; } = compilation.GetTypeByMetadataName("System.IO.Directory");
+    public INamedTypeSymbol? FileSystemInfoType { get; } = compilation.GetTypeByMetadataName("System.IO.FileSystemInfo");
+
+    public bool IsFullPathMember(IMethodSymbol methodSymbol)
+    {
+        return methodSymbol.IsStatic && SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, FullPathType);
+    }
+
+    public bool IsFileSystemInfo(ITypeSymbol? typeSymbol)
+    {
+        for (var current = typeSymbol; current is not null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, FileSystemInfoType))
+                return true;
+        }
+
+        return false;
+    }
 
     [MemberNotNullWhen(true, nameof(FullPathType))]
     public bool IsValid => FullPathType is not null;

--- a/src/Meziantou.Framework.FullPath.Analyzer/RedundantFromPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/RedundantFromPathAnalyzer.cs
@@ -1,0 +1,74 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+/// <summary>
+/// Reports <c>FullPath.FromPath</c> calls whose argument already did the work.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RedundantFromPathAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: FullPathAnalyzerCommon.RedundantFromPathDiagnosticId,
+        title: "Simplify the FullPath.FromPath call",
+        messageFormat: "Use {0} instead",
+        category: "FullPath",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var analyzerContext = new FullPathContext(context.Compilation);
+            if (!analyzerContext.IsValid)
+                return;
+
+            context.RegisterOperationAction(context => Analyze(context, analyzerContext), OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, FullPathContext analyzerContext)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        if (invocationOperation.TargetMethod is not { Name: "FromPath" } targetMethod || !analyzerContext.IsFullPathMember(targetMethod))
+            return;
+
+        if (invocationOperation.Arguments.Length != 1)
+            return;
+
+        var argument = invocationOperation.Arguments[0].Value;
+
+        // FullPath.FromPath(fullPath) round-trips through string
+        if (analyzerContext.IsFullPathType(argument))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation(), "the FullPath value directly"));
+            return;
+        }
+
+        if (analyzerContext.UnwrapToFullPath(argument) is not IInvocationOperation { TargetMethod: { IsStatic: true } innerMethod } innerInvocation)
+            return;
+
+        if (!SymbolEqualityComparer.Default.Equals(innerMethod.ContainingType, analyzerContext.PathType))
+            return;
+
+        // FullPath.FromPath already calls Path.GetFullPath
+        if (innerMethod.Name is "GetFullPath" && innerInvocation.Arguments.Length == 1)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation(), "FullPath.FromPath with the original path"));
+            return;
+        }
+
+        if (innerMethod.Name is "Combine" or "Join")
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation(), "FullPath.Combine"));
+        }
+    }
+}

--- a/src/Meziantou.Framework.FullPath.Analyzer/RedundantPathPredicateAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/RedundantPathPredicateAnalyzer.cs
@@ -1,0 +1,53 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+/// <summary>
+/// Reports <c>Path.IsPathRooted</c> and <c>Path.IsPathFullyQualified</c> applied to a <c>FullPath</c>, which hold by
+/// construction for any non-empty value.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class RedundantPathPredicateAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: FullPathAnalyzerCommon.RedundantPathPredicateDiagnosticId,
+        title: "Path.IsPathRooted and Path.IsPathFullyQualified are redundant on a FullPath",
+        messageFormat: "Path.{0} is true for any non-empty FullPath; use IsEmpty if the intent is to check for an empty path",
+        category: "FullPath",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var analyzerContext = new FullPathContext(context.Compilation);
+            if (!analyzerContext.IsValid || analyzerContext.PathType is null)
+                return;
+
+            context.RegisterOperationAction(context => Analyze(context, analyzerContext), OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, FullPathContext analyzerContext)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "IsPathRooted" or "IsPathFullyQualified" } targetMethod)
+            return;
+
+        if (!SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, analyzerContext.PathType))
+            return;
+
+        if (invocationOperation.Arguments.Length != 1 || !analyzerContext.IsFullPathType(invocationOperation.Arguments[0].Value))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation(), targetMethod.Name));
+    }
+}

--- a/src/Meziantou.Framework.FullPath.Analyzer/UseCreateParentDirectoryAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/UseCreateParentDirectoryAnalyzer.cs
@@ -47,6 +47,10 @@ public sealed class UseCreateParentDirectoryAnalyzer : DiagnosticAnalyzer
         if (invocationOperation.Arguments.Length == 0)
             return;
 
+        // CreateParentDirectory returns void, so the DirectoryInfo must not be used
+        if (invocationOperation.Parent is not IExpressionStatementOperation)
+            return;
+
         if (analyzerContext.UnwrapToFullPath(invocationOperation.Arguments[0].Value) is not IPropertyReferenceOperation { Property.Name: "Parent", Instance: { } instance } property)
             return;
 

--- a/src/Meziantou.Framework.FullPath.Analyzer/UseCreateParentDirectoryAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/UseCreateParentDirectoryAnalyzer.cs
@@ -1,0 +1,58 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+/// <summary>
+/// Reports <c>Directory.CreateDirectory(fullPath.Parent)</c>, for which a dedicated method exists.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseCreateParentDirectoryAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: FullPathAnalyzerCommon.UseCreateParentDirectoryDiagnosticId,
+        title: "Use FullPath.CreateParentDirectory instead of Directory.CreateDirectory",
+        messageFormat: "Use FullPath.CreateParentDirectory instead of calling Directory.CreateDirectory with the parent path",
+        category: "FullPath",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var analyzerContext = new FullPathContext(context.Compilation);
+            if (!analyzerContext.IsValid || analyzerContext.DirectoryType is null)
+                return;
+
+            context.RegisterOperationAction(context => Analyze(context, analyzerContext), OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, FullPathContext analyzerContext)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "CreateDirectory" } targetMethod)
+            return;
+
+        if (!SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, analyzerContext.DirectoryType))
+            return;
+
+        if (invocationOperation.Arguments.Length == 0)
+            return;
+
+        if (analyzerContext.UnwrapToFullPath(invocationOperation.Arguments[0].Value) is not IPropertyReferenceOperation { Property.Name: "Parent", Instance: { } instance } property)
+            return;
+
+        if (!analyzerContext.IsFullPathType(property.Property.ContainingType) || !analyzerContext.IsFullPathType(instance.Type))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation()));
+    }
+}

--- a/src/Meziantou.Framework.FullPath.Analyzer/UseIsEmptyAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/UseIsEmptyAnalyzer.cs
@@ -1,0 +1,86 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+/// <summary>
+/// Reports emptiness checks written against the string representation of a <c>FullPath</c> or against
+/// <c>FullPath.Empty</c>.
+/// </summary>
+/// <remarks>
+/// <c>IsEmpty</c> carries a <see cref="MemberNotNullWhenAttribute"/>, which the alternatives do not.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseIsEmptyAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: FullPathAnalyzerCommon.UseIsEmptyDiagnosticId,
+        title: "Use FullPath.IsEmpty",
+        messageFormat: "Use FullPath.IsEmpty to check whether a path is empty",
+        category: "FullPath",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var analyzerContext = new FullPathContext(context.Compilation);
+            if (!analyzerContext.IsValid)
+                return;
+
+            context.RegisterOperationAction(context => AnalyzeInvocation(context, analyzerContext), OperationKind.Invocation);
+            context.RegisterOperationAction(context => AnalyzeBinaryOperation(context, analyzerContext), OperationKind.Binary);
+        });
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context, FullPathContext analyzerContext)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "IsNullOrEmpty" or "IsNullOrWhiteSpace" } targetMethod)
+            return;
+
+        if (targetMethod.ContainingType?.SpecialType != SpecialType.System_String)
+            return;
+
+        if (invocationOperation.Arguments.Length != 1 || !analyzerContext.IsFullPathType(invocationOperation.Arguments[0].Value))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation()));
+    }
+
+    private static void AnalyzeBinaryOperation(OperationAnalysisContext context, FullPathContext analyzerContext)
+    {
+        var binaryOperation = (IBinaryOperation)context.Operation;
+        if (binaryOperation.OperatorKind is not (BinaryOperatorKind.Equals or BinaryOperatorKind.NotEquals))
+            return;
+
+        if (IsComparisonWithEmpty(binaryOperation.LeftOperand, binaryOperation.RightOperand, analyzerContext) ||
+            IsComparisonWithEmpty(binaryOperation.RightOperand, binaryOperation.LeftOperand, analyzerContext))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, binaryOperation.Syntax.GetLocation()));
+        }
+    }
+
+    private static bool IsComparisonWithEmpty(IOperation operand, IOperation otherOperand, FullPathContext analyzerContext)
+    {
+        // fullPath == FullPath.Empty
+        if (operand is IPropertyReferenceOperation { Property: { IsStatic: true, Name: "Empty" } property } &&
+            analyzerContext.IsFullPathType(property.ContainingType) &&
+            analyzerContext.IsFullPathType(otherOperand))
+        {
+            return true;
+        }
+
+        // fullPath.Value.Length == 0
+        return operand is ILiteralOperation { ConstantValue: { HasValue: true, Value: 0 } } &&
+            otherOperand is IPropertyReferenceOperation { Property.Name: "Length", Instance: { } instance } &&
+            analyzerContext.IsFullPathType(instance);
+    }
+}

--- a/src/Meziantou.Framework.FullPath.CodeFix/FromPathWithFileSystemInfoCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/FromPathWithFileSystemInfoCodeFixProvider.cs
@@ -1,0 +1,41 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(FromPathWithFileSystemInfoCodeFixProvider))]
+public sealed class FromPathWithFileSystemInfoCodeFixProvider : FullPathCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => [FullPathAnalyzerCommon.FromPathWithFileSystemInfoDiagnosticId];
+
+    protected override string Title => "Use FullPath.FromFileSystemInfo";
+
+    private protected override bool TryGetReplacementExpression(
+        SemanticModel semanticModel,
+        ExpressionSyntax expressionSyntax,
+        FullPathContext analyzerContext,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax replacementExpression)
+    {
+        if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is IInvocationOperation { Arguments.Length: 1 } invocationOperation &&
+            invocationOperation.TargetMethod is { Name: "FromPath" } targetMethod &&
+            analyzerContext.IsFullPathMember(targetMethod) &&
+            invocationOperation.Arguments[0].Value is IPropertyReferenceOperation { Property.Name: "FullName", Instance: { } instance } &&
+            analyzerContext.IsFileSystemInfo(instance.Type) &&
+            instance.Syntax is ExpressionSyntax instanceExpression &&
+            expressionSyntax is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax fromPathAccess })
+        {
+            replacementExpression = SyntaxFactory.InvocationExpression(
+                fromPathAccess.WithName(SyntaxFactory.IdentifierName("FromFileSystemInfo")).WithoutTrivia(),
+                SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(instanceExpression.WithoutTrivia()))));
+            return true;
+        }
+
+        replacementExpression = null!;
+        return false;
+    }
+}

--- a/src/Meziantou.Framework.FullPath.CodeFix/FullPathCodeFixProviderBase.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/FullPathCodeFixProviderBase.cs
@@ -1,0 +1,111 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+/// <summary>
+/// Replaces the expression a diagnostic was reported on with the expression returned by
+/// <see cref="TryGetReplacementExpression"/>.
+/// </summary>
+public abstract class FullPathCodeFixProviderBase : CodeFixProvider
+{
+    protected abstract string Title { get; }
+
+    public override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var analyzerContext = new FullPathContext(semanticModel.Compilation);
+        if (!analyzerContext.IsValid)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var expression = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true).FirstAncestorOrSelf<ExpressionSyntax>();
+            if (expression is null)
+                continue;
+
+            if (!TryGetReplacementExpression(semanticModel, expression, analyzerContext, context.CancellationToken, out _))
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: Title,
+                    createChangedDocument: cancellationToken => ApplyFixAsync(context.Document, expression, cancellationToken),
+                    equivalenceKey: GetType().FullName),
+                diagnostic);
+        }
+    }
+
+    private async Task<Document> ApplyFixAsync(Document document, ExpressionSyntax expressionSyntax, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return document;
+
+        var analyzerContext = new FullPathContext(semanticModel.Compilation);
+        if (!analyzerContext.IsValid)
+            return document;
+
+        if (!TryGetReplacementExpression(semanticModel, expressionSyntax, analyzerContext, cancellationToken, out var replacementExpression))
+            return document;
+
+        replacementExpression = replacementExpression.WithTriviaFrom(expressionSyntax).WithAdditionalAnnotations(Formatter.Annotation);
+        var newRoot = root.ReplaceNode(expressionSyntax, replacementExpression);
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private protected abstract bool TryGetReplacementExpression(
+        SemanticModel semanticModel,
+        ExpressionSyntax expressionSyntax,
+        FullPathContext analyzerContext,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax replacementExpression);
+
+    /// <summary>Builds <c>expression.IsEmpty</c> or <c>!expression.IsEmpty</c>.</summary>
+    private protected static ExpressionSyntax CreateIsEmptyExpression(ExpressionSyntax fullPathExpression, bool negate)
+    {
+        ExpressionSyntax result = SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            Parenthesize(fullPathExpression.WithoutTrivia()),
+            SyntaxFactory.IdentifierName("IsEmpty"));
+
+        if (negate)
+        {
+            result = SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, result);
+        }
+
+        return result;
+    }
+
+    /// <summary>Wraps the expression in parentheses unless it can already be used as the target of a member access.</summary>
+    private protected static ExpressionSyntax Parenthesize(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            IdentifierNameSyntax or MemberAccessExpressionSyntax or InvocationExpressionSyntax or ElementAccessExpressionSyntax
+                or ParenthesizedExpressionSyntax or ThisExpressionSyntax or BaseExpressionSyntax or LiteralExpressionSyntax
+                or PredefinedTypeSyntax or QualifiedNameSyntax => expression,
+            _ => SyntaxFactory.ParenthesizedExpression(expression),
+        };
+    }
+}

--- a/src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj
+++ b/src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Compile Include="../Meziantou.Framework.FullPath.Analyzer/FullPathAnalyzerCommon.cs" Link="FullPathAnalyzerCommon.cs" />
+    <Compile Include="../Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs" Link="FullPathContext.cs" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Meziantou.Framework.FullPath.CodeFix/RedundantFromPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/RedundantFromPathCodeFixProvider.cs
@@ -1,0 +1,78 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RedundantFromPathCodeFixProvider))]
+public sealed class RedundantFromPathCodeFixProvider : FullPathCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => [FullPathAnalyzerCommon.RedundantFromPathDiagnosticId];
+
+    protected override string Title => "Simplify the FullPath.FromPath call";
+
+    private protected override bool TryGetReplacementExpression(
+        SemanticModel semanticModel,
+        ExpressionSyntax expressionSyntax,
+        FullPathContext analyzerContext,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax replacementExpression)
+    {
+        replacementExpression = null!;
+
+        if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is not IInvocationOperation { Arguments.Length: 1 } invocationOperation)
+            return false;
+
+        if (invocationOperation.TargetMethod is not { Name: "FromPath" } targetMethod || !analyzerContext.IsFullPathMember(targetMethod))
+            return false;
+
+        var argument = invocationOperation.Arguments[0].Value;
+
+        // FullPath.FromPath(fullPath) -> fullPath
+        if (analyzerContext.IsFullPathType(argument))
+        {
+            if (analyzerContext.UnwrapToFullPath(argument).Syntax is not ExpressionSyntax fullPathExpression)
+                return false;
+
+            replacementExpression = fullPathExpression.WithoutTrivia();
+            return true;
+        }
+
+        if (analyzerContext.UnwrapToFullPath(argument) is not IInvocationOperation { TargetMethod.IsStatic: true } innerInvocation ||
+            !SymbolEqualityComparer.Default.Equals(innerInvocation.TargetMethod.ContainingType, analyzerContext.PathType))
+        {
+            return false;
+        }
+
+        if (innerInvocation.Syntax is not InvocationExpressionSyntax innerSyntax)
+            return false;
+
+        // FullPath.FromPath(Path.GetFullPath(path)) -> FullPath.FromPath(path)
+        if (innerInvocation.TargetMethod.Name is "GetFullPath" && innerInvocation.Arguments.Length == 1)
+        {
+            if (innerInvocation.Arguments[0].Value.Syntax is not ExpressionSyntax innerArgument)
+                return false;
+
+            replacementExpression = ((InvocationExpressionSyntax)expressionSyntax)
+                .WithArgumentList(SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(innerArgument.WithoutTrivia()))));
+            return true;
+        }
+
+        // FullPath.FromPath(Path.Combine(path1, path2)) -> FullPath.Combine(path1, path2)
+        if (innerInvocation.TargetMethod.Name is "Combine" or "Join")
+        {
+            if (expressionSyntax is not InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax fromPathAccess })
+                return false;
+
+            replacementExpression = SyntaxFactory.InvocationExpression(
+                fromPathAccess.WithName(SyntaxFactory.IdentifierName("Combine")).WithoutTrivia(),
+                innerSyntax.ArgumentList.WithoutTrivia());
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Meziantou.Framework.FullPath.CodeFix/RedundantPathPredicateCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/RedundantPathPredicateCodeFixProvider.cs
@@ -1,0 +1,40 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RedundantPathPredicateCodeFixProvider))]
+public sealed class RedundantPathPredicateCodeFixProvider : FullPathCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => [FullPathAnalyzerCommon.RedundantPathPredicateDiagnosticId];
+
+    protected override string Title => "Use !FullPath.IsEmpty";
+
+    private protected override bool TryGetReplacementExpression(
+        SemanticModel semanticModel,
+        ExpressionSyntax expressionSyntax,
+        FullPathContext analyzerContext,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax replacementExpression)
+    {
+        // Path.IsPathRooted and Path.IsPathFullyQualified are true for every FullPath except the empty one,
+        // for which they are false. '!IsEmpty' is therefore an exact replacement.
+        if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is IInvocationOperation { Arguments.Length: 1 } invocationOperation &&
+            invocationOperation.TargetMethod is { IsStatic: true, Name: "IsPathRooted" or "IsPathFullyQualified" } targetMethod &&
+            SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, analyzerContext.PathType))
+        {
+            var fullPathOperation = analyzerContext.UnwrapToFullPath(invocationOperation.Arguments[0].Value);
+            if (analyzerContext.IsFullPathType(fullPathOperation.Type) && fullPathOperation.Syntax is ExpressionSyntax fullPathExpression)
+            {
+                replacementExpression = CreateIsEmptyExpression(fullPathExpression, negate: true);
+                return true;
+            }
+        }
+
+        replacementExpression = null!;
+        return false;
+    }
+}

--- a/src/Meziantou.Framework.FullPath.CodeFix/UseCreateParentDirectoryCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/UseCreateParentDirectoryCodeFixProvider.cs
@@ -1,0 +1,43 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseCreateParentDirectoryCodeFixProvider))]
+public sealed class UseCreateParentDirectoryCodeFixProvider : FullPathCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => [FullPathAnalyzerCommon.UseCreateParentDirectoryDiagnosticId];
+
+    protected override string Title => "Use FullPath.CreateParentDirectory";
+
+    private protected override bool TryGetReplacementExpression(
+        SemanticModel semanticModel,
+        ExpressionSyntax expressionSyntax,
+        FullPathContext analyzerContext,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax replacementExpression)
+    {
+        if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is IInvocationOperation { Arguments.Length: > 0 } invocationOperation &&
+            invocationOperation.TargetMethod is { IsStatic: true, Name: "CreateDirectory" } targetMethod &&
+            SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, analyzerContext.DirectoryType) &&
+            analyzerContext.UnwrapToFullPath(invocationOperation.Arguments[0].Value) is IPropertyReferenceOperation { Property.Name: "Parent", Instance: { } instance } property &&
+            analyzerContext.IsFullPathType(property.Property.ContainingType) &&
+            analyzerContext.IsFullPathType(instance.Type) &&
+            instance.Syntax is ExpressionSyntax instanceExpression)
+        {
+            replacementExpression = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    Parenthesize(instanceExpression.WithoutTrivia()),
+                    SyntaxFactory.IdentifierName("CreateParentDirectory")));
+            return true;
+        }
+
+        replacementExpression = null!;
+        return false;
+    }
+}

--- a/src/Meziantou.Framework.FullPath.CodeFix/UseIsEmptyCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/UseIsEmptyCodeFixProvider.cs
@@ -1,0 +1,81 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseIsEmptyCodeFixProvider))]
+public sealed class UseIsEmptyCodeFixProvider : FullPathCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => [FullPathAnalyzerCommon.UseIsEmptyDiagnosticId];
+
+    protected override string Title => "Use FullPath.IsEmpty";
+
+    private protected override bool TryGetReplacementExpression(
+        SemanticModel semanticModel,
+        ExpressionSyntax expressionSyntax,
+        FullPathContext analyzerContext,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax replacementExpression)
+    {
+        replacementExpression = null!;
+
+        switch (semanticModel.GetOperation(expressionSyntax, cancellationToken))
+        {
+            // string.IsNullOrEmpty(fullPath) / string.IsNullOrWhiteSpace(fullPath)
+            case IInvocationOperation { Arguments.Length: 1 } invocationOperation:
+                if (analyzerContext.UnwrapToFullPath(invocationOperation.Arguments[0].Value) is not { Syntax: ExpressionSyntax argumentExpression } argument ||
+                    !analyzerContext.IsFullPathType(argument.Type))
+                {
+                    return false;
+                }
+
+                replacementExpression = CreateIsEmptyExpression(argumentExpression, negate: false);
+                return true;
+
+            case IBinaryOperation binaryOperation:
+                var negate = binaryOperation.OperatorKind is BinaryOperatorKind.NotEquals;
+                if (TryGetFullPathExpression(binaryOperation.LeftOperand, binaryOperation.RightOperand, analyzerContext, out var fullPathExpression) ||
+                    TryGetFullPathExpression(binaryOperation.RightOperand, binaryOperation.LeftOperand, analyzerContext, out fullPathExpression))
+                {
+                    replacementExpression = CreateIsEmptyExpression(fullPathExpression, negate);
+                    return true;
+                }
+
+                return false;
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryGetFullPathExpression(IOperation operand, IOperation otherOperand, FullPathContext analyzerContext, out ExpressionSyntax fullPathExpression)
+    {
+        fullPathExpression = null!;
+
+        // fullPath == FullPath.Empty
+        if (operand is IPropertyReferenceOperation { Property: { IsStatic: true, Name: "Empty" } property } &&
+            analyzerContext.IsFullPathType(property.ContainingType))
+        {
+            if (analyzerContext.UnwrapToFullPath(otherOperand) is not { Syntax: ExpressionSyntax expression } unwrapped || !analyzerContext.IsFullPathType(unwrapped.Type))
+                return false;
+
+            fullPathExpression = expression;
+            return true;
+        }
+
+        // fullPath.Value.Length == 0
+        if (operand is ILiteralOperation { ConstantValue: { HasValue: true, Value: 0 } } &&
+            otherOperand is IPropertyReferenceOperation { Property.Name: "Length", Instance: { } instance } &&
+            analyzerContext.IsFullPathType(instance) &&
+            analyzerContext.UnwrapToFullPath(instance).Syntax is ExpressionSyntax instanceExpression)
+        {
+            fullPathExpression = instanceExpression;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Meziantou.Framework.FullPath/readme.md
+++ b/src/Meziantou.Framework.FullPath/readme.md
@@ -68,6 +68,12 @@ System.IO.File.WriteAllText(filePath, content);
 | `MFFP0014` | FullPath | Declare the parameter as FullPath instead of string | Info | ✔️ |
 | `MFFP0015` | FullPath | Compare FullPath values instead of their string representation | Warning | ✔️ |
 | `MFFP0016` | FullPath | FullPath.Equals with a string argument is always false | Warning | ✔️ |
+| `MFFP0018` | FullPath | Path.IsPathRooted and Path.IsPathFullyQualified are redundant on a FullPath | Info | ✔️ |
+| `MFFP0019` | FullPath | Simplify the FullPath.FromPath call | Info | ✔️ |
+| `MFFP0020` | FullPath | Use FullPath.FromFileSystemInfo instead of FullPath.FromPath | Info | ✔️ |
+| `MFFP0021` | FullPath | Use FullPath.IsEmpty | Info | ✔️ |
+| `MFFP0022` | FullPath | Use FullPath.CreateParentDirectory instead of Directory.CreateDirectory | Info | ✔️ |
+| `MFFP0023` | FullPath | Use FullPath.Parent instead of Directory.GetParent | Info | ✔️ |
 <!-- analyzer-rules -->
 
 # Additional resources

--- a/src/Meziantou.Framework.SnapshotTesting/common/CallerContextUtilities.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/common/CallerContextUtilities.cs
@@ -69,7 +69,7 @@ internal static partial class CallerContextUtilities
             return null;
 
         if (TryResolveSourceFilePath(sourceFilePath, out var resolvedPath))
-            return FullPath.FromPath(resolvedPath);
+            return resolvedPath;
 
         return fallbackToOriginalPath ? FullPath.FromPath(sourceFilePath) : null;
     }

--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryDirectory.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryDirectory.cs
@@ -94,7 +94,7 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     public FullPath CreateEmptyFile(string relativePath)
     {
         var path = GetFullPath(relativePath);
-        Directory.CreateDirectory(path.Parent);
+        path.CreateParentDirectory();
         using var stream = new FileStream(path, FileMode.Create, FileAccess.Write);
         return path;
     }
@@ -113,7 +113,7 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     public FullPath CreateTextFile(string relativePath, string content)
     {
         var path = GetFullPath(relativePath);
-        Directory.CreateDirectory(path.Parent);
+        path.CreateParentDirectory();
         File.WriteAllText(path, content);
         return path;
     }
@@ -133,7 +133,7 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     public async Task<FullPath> CreateTextFileAsync(string relativePath, string content, CancellationToken cancellationToken = default)
     {
         var path = GetFullPath(relativePath);
-        Directory.CreateDirectory(path.Parent);
+        path.CreateParentDirectory();
         await File.WriteAllTextAsync(path, content, cancellationToken).ConfigureAwait(false);
         return path;
     }

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/FromPathWithFileSystemInfoRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/FromPathWithFileSystemInfoRuleTests.cs
@@ -1,0 +1,78 @@
+using FromPathWithFileSystemInfoAnalyzerType = Meziantou.Framework.Analyzers.FullPath.FromPathWithFileSystemInfoAnalyzer;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class FromPathWithFileSystemInfoRuleTests : FullPathAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("FileInfo")]
+    [InlineData("DirectoryInfo")]
+    [InlineData("FileSystemInfo")]
+    public async Task Analyzer_ReportDiagnostic_ForFromPathWithFullName(string typeName)
+    {
+        var source = $$"""
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M({{typeName}} info)
+                    {
+                        return {|MFFP0020:FullPath.FromPath(info.FullName)|};
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<FromPathWithFileSystemInfoAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForFromPathWithString()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M(string path)
+                    {
+                        return FullPath.FromPath(path);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<FromPathWithFileSystemInfoAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForFullNameOfAnotherType()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public sealed class Descriptor
+                {
+                    public string FullName => "";
+                }
+
+                public static class TestClass
+                {
+                    public static FullPath M(Descriptor descriptor)
+                    {
+                        return FullPath.FromPath(descriptor.FullName);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<FromPathWithFileSystemInfoAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/FromPathWithFileSystemInfoRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/FromPathWithFileSystemInfoRuleTests.cs
@@ -1,4 +1,5 @@
 using FromPathWithFileSystemInfoAnalyzerType = Meziantou.Framework.Analyzers.FullPath.FromPathWithFileSystemInfoAnalyzer;
+using FromPathWithFileSystemInfoCodeFixProviderType = Meziantou.Framework.Analyzers.FullPath.FromPathWithFileSystemInfoCodeFixProvider;
 
 namespace Meziantou.Framework.Tests;
 
@@ -8,7 +9,7 @@ public sealed class FromPathWithFileSystemInfoRuleTests : FullPathAnalyzerTestBa
     [InlineData("FileInfo")]
     [InlineData("DirectoryInfo")]
     [InlineData("FileSystemInfo")]
-    public async Task Analyzer_ReportDiagnostic_ForFromPathWithFullName(string typeName)
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForFromPathWithFullName(string typeName)
     {
         var source = $$"""
             using System.IO;
@@ -26,7 +27,23 @@ public sealed class FromPathWithFileSystemInfoRuleTests : FullPathAnalyzerTestBa
             }
             """;
 
-        await CreateAnalyzerTest<FromPathWithFileSystemInfoAnalyzerType>(source).RunAsync(XunitCancellationToken);
+        var fixedSource = $$"""
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M({{typeName}} info)
+                    {
+                        return FullPath.FromFileSystemInfo(info);
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<FromPathWithFileSystemInfoAnalyzerType, FromPathWithFileSystemInfoCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/RedundantFromPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/RedundantFromPathRuleTests.cs
@@ -1,0 +1,92 @@
+using RedundantFromPathAnalyzerType = Meziantou.Framework.Analyzers.FullPath.RedundantFromPathAnalyzer;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class RedundantFromPathRuleTests : FullPathAnalyzerTestBase
+{
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForFromPathWithFullPath()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M(FullPath fullPath)
+                    {
+                        return {|MFFP0019:FullPath.FromPath(fullPath)|};
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<RedundantFromPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForFromPathWithPathGetFullPath()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M(string path)
+                    {
+                        return {|MFFP0019:FullPath.FromPath(Path.GetFullPath(path))|};
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<RedundantFromPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForFromPathWithPathCombine()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M(string path1, string path2)
+                    {
+                        return {|MFFP0019:FullPath.FromPath(Path.Combine(path1, path2))|};
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<RedundantFromPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForFromPathWithString()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M(string path)
+                    {
+                        return FullPath.FromPath(path);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<RedundantFromPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/RedundantFromPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/RedundantFromPathRuleTests.cs
@@ -1,11 +1,12 @@
 using RedundantFromPathAnalyzerType = Meziantou.Framework.Analyzers.FullPath.RedundantFromPathAnalyzer;
+using RedundantFromPathCodeFixProviderType = Meziantou.Framework.Analyzers.FullPath.RedundantFromPathCodeFixProvider;
 
 namespace Meziantou.Framework.Tests;
 
 public sealed class RedundantFromPathRuleTests : FullPathAnalyzerTestBase
 {
     [Fact]
-    public async Task Analyzer_ReportDiagnostic_ForFromPathWithFullPath()
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForFromPathWithFullPath()
     {
         var source = """
             using Meziantou.Framework;
@@ -22,11 +23,26 @@ public sealed class RedundantFromPathRuleTests : FullPathAnalyzerTestBase
             }
             """;
 
-        await CreateAnalyzerTest<RedundantFromPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+        var fixedSource = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M(FullPath fullPath)
+                    {
+                        return fullPath;
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<RedundantFromPathAnalyzerType, RedundantFromPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
     }
 
     [Fact]
-    public async Task Analyzer_ReportDiagnostic_ForFromPathWithPathGetFullPath()
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForFromPathWithPathGetFullPath()
     {
         var source = """
             using System.IO;
@@ -44,11 +60,27 @@ public sealed class RedundantFromPathRuleTests : FullPathAnalyzerTestBase
             }
             """;
 
-        await CreateAnalyzerTest<RedundantFromPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M(string path)
+                    {
+                        return FullPath.FromPath(path);
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<RedundantFromPathAnalyzerType, RedundantFromPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
     }
 
     [Fact]
-    public async Task Analyzer_ReportDiagnostic_ForFromPathWithPathCombine()
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForFromPathWithPathCombine()
     {
         var source = """
             using System.IO;
@@ -66,7 +98,23 @@ public sealed class RedundantFromPathRuleTests : FullPathAnalyzerTestBase
             }
             """;
 
-        await CreateAnalyzerTest<RedundantFromPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M(string path1, string path2)
+                    {
+                        return FullPath.Combine(path1, path2);
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<RedundantFromPathAnalyzerType, RedundantFromPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/RedundantPathPredicateRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/RedundantPathPredicateRuleTests.cs
@@ -1,4 +1,5 @@
 using RedundantPathPredicateAnalyzerType = Meziantou.Framework.Analyzers.FullPath.RedundantPathPredicateAnalyzer;
+using RedundantPathPredicateCodeFixProviderType = Meziantou.Framework.Analyzers.FullPath.RedundantPathPredicateCodeFixProvider;
 
 namespace Meziantou.Framework.Tests;
 
@@ -7,7 +8,7 @@ public sealed class RedundantPathPredicateRuleTests : FullPathAnalyzerTestBase
     [Theory]
     [InlineData("IsPathRooted")]
     [InlineData("IsPathFullyQualified")]
-    public async Task Analyzer_ReportDiagnostic_ForPredicateOnFullPath(string methodName)
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForPredicateOnFullPath(string methodName)
     {
         var source = $$"""
             using System.IO;
@@ -25,7 +26,23 @@ public sealed class RedundantPathPredicateRuleTests : FullPathAnalyzerTestBase
             }
             """;
 
-        await CreateAnalyzerTest<RedundantPathPredicateAnalyzerType>(source).RunAsync(XunitCancellationToken);
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(FullPath fullPath)
+                    {
+                        return !fullPath.IsEmpty;
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<RedundantPathPredicateAnalyzerType, RedundantPathPredicateCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/RedundantPathPredicateRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/RedundantPathPredicateRuleTests.cs
@@ -1,0 +1,51 @@
+using RedundantPathPredicateAnalyzerType = Meziantou.Framework.Analyzers.FullPath.RedundantPathPredicateAnalyzer;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class RedundantPathPredicateRuleTests : FullPathAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("IsPathRooted")]
+    [InlineData("IsPathFullyQualified")]
+    public async Task Analyzer_ReportDiagnostic_ForPredicateOnFullPath(string methodName)
+    {
+        var source = $$"""
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(FullPath fullPath)
+                    {
+                        return {|MFFP0018:Path.{{methodName}}(fullPath)|};
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<RedundantPathPredicateAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForPredicateOnString()
+    {
+        var source = """
+            using System.IO;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(string path)
+                    {
+                        return Path.IsPathRooted(path);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<RedundantPathPredicateAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseCreateParentDirectoryRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseCreateParentDirectoryRuleTests.cs
@@ -1,0 +1,94 @@
+using DirectoryGetParentWithFullPathAnalyzerType = Meziantou.Framework.Analyzers.FullPath.DirectoryGetParentWithFullPathAnalyzer;
+using UseCreateParentDirectoryAnalyzerType = Meziantou.Framework.Analyzers.FullPath.UseCreateParentDirectoryAnalyzer;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class UseCreateParentDirectoryRuleTests : FullPathAnalyzerTestBase
+{
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForCreateDirectoryWithParent()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static void M(FullPath fullPath)
+                    {
+                        {|MFFP0022:Directory.CreateDirectory(fullPath.Parent)|};
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseCreateParentDirectoryAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForCreateDirectoryWithFullPath()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static void M(FullPath fullPath)
+                    {
+                        Directory.CreateDirectory(fullPath);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseCreateParentDirectoryAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForDirectoryGetParentWithFullPath()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static DirectoryInfo M(FullPath fullPath)
+                    {
+                        return {|MFFP0023:Directory.GetParent(fullPath)|};
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<DirectoryGetParentWithFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForDirectoryGetParentWithString()
+    {
+        var source = """
+            using System.IO;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static DirectoryInfo M(string path)
+                    {
+                        return Directory.GetParent(path);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<DirectoryGetParentWithFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseCreateParentDirectoryRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseCreateParentDirectoryRuleTests.cs
@@ -1,12 +1,13 @@
 using DirectoryGetParentWithFullPathAnalyzerType = Meziantou.Framework.Analyzers.FullPath.DirectoryGetParentWithFullPathAnalyzer;
 using UseCreateParentDirectoryAnalyzerType = Meziantou.Framework.Analyzers.FullPath.UseCreateParentDirectoryAnalyzer;
+using UseCreateParentDirectoryCodeFixProviderType = Meziantou.Framework.Analyzers.FullPath.UseCreateParentDirectoryCodeFixProvider;
 
 namespace Meziantou.Framework.Tests;
 
 public sealed class UseCreateParentDirectoryRuleTests : FullPathAnalyzerTestBase
 {
     [Fact]
-    public async Task Analyzer_ReportDiagnostic_ForCreateDirectoryWithParent()
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForCreateDirectoryWithParent()
     {
         var source = """
             using System.IO;
@@ -24,7 +25,23 @@ public sealed class UseCreateParentDirectoryRuleTests : FullPathAnalyzerTestBase
             }
             """;
 
-        await CreateAnalyzerTest<UseCreateParentDirectoryAnalyzerType>(source).RunAsync(XunitCancellationToken);
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static void M(FullPath fullPath)
+                    {
+                        fullPath.CreateParentDirectory();
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<UseCreateParentDirectoryAnalyzerType, UseCreateParentDirectoryCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
     }
 
     [Fact]
@@ -41,6 +58,28 @@ public sealed class UseCreateParentDirectoryRuleTests : FullPathAnalyzerTestBase
                     public static void M(FullPath fullPath)
                     {
                         Directory.CreateDirectory(fullPath);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseCreateParentDirectoryAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenTheDirectoryInfoIsUsed()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static DirectoryInfo M(FullPath fullPath)
+                    {
+                        return Directory.CreateDirectory(fullPath.Parent);
                     }
                 }
             }

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseIsEmptyRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseIsEmptyRuleTests.cs
@@ -1,0 +1,94 @@
+using UseIsEmptyAnalyzerType = Meziantou.Framework.Analyzers.FullPath.UseIsEmptyAnalyzer;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class UseIsEmptyRuleTests : FullPathAnalyzerTestBase
+{
+    [Theory]
+    [InlineData("string.IsNullOrEmpty(fullPath)")]
+    [InlineData("string.IsNullOrWhiteSpace(fullPath)")]
+    [InlineData("fullPath == FullPath.Empty")]
+    [InlineData("fullPath != FullPath.Empty")]
+    [InlineData("FullPath.Empty == fullPath")]
+    [InlineData("fullPath.Value.Length == 0")]
+    public async Task Analyzer_ReportDiagnostic_ForEmptinessCheck(string expression)
+    {
+        var source = $$"""
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(FullPath fullPath)
+                    {
+                        return {|MFFP0021:{{expression}}|};
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseIsEmptyAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForIsEmpty()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(FullPath fullPath)
+                    {
+                        return fullPath.IsEmpty;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseIsEmptyAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForStringEmptinessCheck()
+    {
+        var source = """
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(string text)
+                    {
+                        return string.IsNullOrEmpty(text);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseIsEmptyAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForComparisonBetweenTwoFullPaths()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(FullPath fullPath, FullPath other)
+                    {
+                        return fullPath == other;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseIsEmptyAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseIsEmptyRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseIsEmptyRuleTests.cs
@@ -1,17 +1,18 @@
 using UseIsEmptyAnalyzerType = Meziantou.Framework.Analyzers.FullPath.UseIsEmptyAnalyzer;
+using UseIsEmptyCodeFixProviderType = Meziantou.Framework.Analyzers.FullPath.UseIsEmptyCodeFixProvider;
 
 namespace Meziantou.Framework.Tests;
 
 public sealed class UseIsEmptyRuleTests : FullPathAnalyzerTestBase
 {
     [Theory]
-    [InlineData("string.IsNullOrEmpty(fullPath)")]
-    [InlineData("string.IsNullOrWhiteSpace(fullPath)")]
-    [InlineData("fullPath == FullPath.Empty")]
-    [InlineData("fullPath != FullPath.Empty")]
-    [InlineData("FullPath.Empty == fullPath")]
-    [InlineData("fullPath.Value.Length == 0")]
-    public async Task Analyzer_ReportDiagnostic_ForEmptinessCheck(string expression)
+    [InlineData("string.IsNullOrEmpty(fullPath)", "fullPath.IsEmpty")]
+    [InlineData("string.IsNullOrWhiteSpace(fullPath)", "fullPath.IsEmpty")]
+    [InlineData("fullPath == FullPath.Empty", "fullPath.IsEmpty")]
+    [InlineData("fullPath != FullPath.Empty", "!fullPath.IsEmpty")]
+    [InlineData("FullPath.Empty == fullPath", "fullPath.IsEmpty")]
+    [InlineData("fullPath.Value.Length == 0", "fullPath.IsEmpty")]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForEmptinessCheck(string expression, string fixedExpression)
     {
         var source = $$"""
             using Meziantou.Framework;
@@ -28,7 +29,22 @@ public sealed class UseIsEmptyRuleTests : FullPathAnalyzerTestBase
             }
             """;
 
-        await CreateAnalyzerTest<UseIsEmptyAnalyzerType>(source).RunAsync(XunitCancellationToken);
+        var fixedSource = $$"""
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(FullPath fullPath)
+                    {
+                        return {{fixedExpression}};
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<UseIsEmptyAnalyzerType, UseIsEmptyCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
+++ b/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
@@ -119,7 +119,7 @@ public class TemporaryDirectoryTests
     [Fact]
     public void TemporaryFileCreateWithFullPath()
     {
-        var fullPath = FullPath.FromPath(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".tmp"));
+        var fullPath = FullPath.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".tmp");
         using var file = TemporaryFile.Create(fullPath);
         Assert.Equal(fullPath, file.FullPath);
         Assert.True(File.Exists(fullPath));


### PR DESCRIPTION
Last of three PRs adding rules to `Meziantou.Framework.FullPath.Analyzer`.

> **Stacked on #1851** (which is stacked on #1850) — the base branch is `claude/fullpath-analyzer-correctness-rules`, so the diff stays scoped to this group. Retarget to `main` as the earlier PRs merge.

Six suggestions for work the `FullPath` type already did, or already exposes a member for. All `Info`, matching the existing rules, and all but one ship with a code fix.

| Id | Reports | Code fix |
| -- | -- | -- |
| `MFFP0018` | `Path.IsPathRooted(fullPath)`, `Path.IsPathFullyQualified(fullPath)` | `!fullPath.IsEmpty` |
| `MFFP0019` | `FromPath(fullPath)`, `FromPath(Path.GetFullPath(x))`, `FromPath(Path.Combine(a, b))` | the value itself / `FromPath(x)` / `FullPath.Combine(a, b)` |
| `MFFP0020` | `FromPath(fsi.FullName)` | `FullPath.FromFileSystemInfo(fsi)` |
| `MFFP0021` | `string.IsNullOrEmpty(fullPath)`, `fullPath == FullPath.Empty`, `fullPath.Value.Length == 0` | `fullPath.IsEmpty` / `!fullPath.IsEmpty` |
| `MFFP0022` | `Directory.CreateDirectory(fullPath.Parent)` | `fullPath.CreateParentDirectory()` |
| `MFFP0023` | `Directory.GetParent(fullPath)` | none — see below |

A few notes on the choices:

- **MFFP0018's fix is exact, not a constant.** `Path.IsPathRooted` is true for every `FullPath` except the empty one, where it is false — so `!IsEmpty` preserves behaviour, which replacing with `true` would not.
- **MFFP0021** prefers `IsEmpty` partly because it carries `[MemberNotNullWhen]`, which the alternatives don't, so it flows nullability information the others lose.
- **MFFP0022** is a genuine improvement rather than a rename: `CreateParentDirectory` also handles the empty path and the root directory, where `Path.GetDirectoryName` returns null. The analyzer now only reports when the `DirectoryInfo` returned by `Directory.CreateDirectory` is discarded, since `CreateParentDirectory` returns `void` and the fix would not compile otherwise.
- **MFFP0023 has no fix.** `Directory.GetParent` returns `DirectoryInfo?` while `Parent` returns `FullPath`, so a mechanical replacement would fail to compile at most call sites. Happy to drop the rule if a diagnostic without a fix isn't worth it.

The five providers share a `FullPathCodeFixProviderBase` instead of repeating the `RegisterCodeFixes`/`ApplyFix` plumbing, and `FullPathContext` is now compiled into the code fix project so fixers resolve symbols exactly the way the analyzers do. The ten existing providers still have their own copies of that plumbing — happy to migrate them in a follow-up if you like the shape.

## Id numbering

MFFP0017 was dropped from #1851 at review request, so these rules still start at `MFFP0018` and `MFFP0017` is an unused id. I left the gap rather than renumbering a PR already under review — happy to shift these down to `MFFP0017`-`MFFP0022` if you'd rather the ids were contiguous, since nothing is released yet.

## Real hits in this repo

Unlike the first two PRs, these rules found existing occurrences, all fixed here:

- `src/Meziantou.Framework.SnapshotTesting/common/CallerContextUtilities.cs` — `FullPath.FromPath(resolvedPath)` where `resolvedPath` is already a `FullPath` `out` parameter, so it converted to `string` and re-ran `Path.GetFullPath` (MFFP0019).
- `tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs` — `FullPath.FromPath(Path.Combine(...))` (MFFP0019).
- `src/Meziantou.Framework.TemporaryDirectory/TemporaryDirectory.cs` — three `Directory.CreateDirectory(path.Parent)` calls (MFFP0022).

With all six rules temporarily raised to warnings across every project that references `Meziantou.Framework.FullPath`, the repo now reports zero hits and there were no false positives.

## Notes

- Analyzer tests: 73 -> 99, all passing. The positive tests are now code fix tests, so each one asserts the exact fixed output.
- `Meziantou.Framework.FullPath.Tests`, `TemporaryDirectory.Tests` and `InlineSnapshotTesting.Tests` pass with the source fixes. `dotnet run ./eng/update-all.cs` is clean.
- #1850 and #1851 still ship as diagnostics only. MFFP0012-MFFP0016 either infer a declaration type or flag a wrong comparison, where the correct edit depends on intent.