### PR TITLE
Balance CI test shards using measured test durations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,10 +173,33 @@ jobs:
           test-projects-only: "true"
           shard: ${{ matrix.shard }}
           total-shards: 2
+          # DeltaBuild balances shards by project count, which is a poor proxy for duration:
+          # a handful of suites account for most of the test time. The projects below are
+          # assigned round-robin in declaration order (1st -> shard 1, 2nd -> shard 2, ...),
+          # so the list is sorted to alternate the expensive suites between shards.
+          # Approximate test duration per project, summed over TFMs (win/linux-x64/linux-arm64/macOS, in seconds):
+          #   SnapshotTesting           2769 / 3237 / 1869 / 2446
+          #   TemporaryContainers       1247 /  609 /  545 /    7
+          #   InlineSnapshotTesting     1060 /  921 /  843 /  790
+          #   PublicApiGenerator.MSBuild 801 /  951 /  557 /  632
+          #   StronglyTypedId            652 /  284 /  188 /  375
+          #   EmbeddedConstantsGenerator 297 /  200 /  170 /  141
+          #   CommandLine                285 /  132 /   98 /   99
+          #   Yaml                       255 /  284 /  164 /  174
+          #   ResxSourceGenerator         88 /   47 /   34 /   53
+          #   DependencyScanning          82 /   12 /    9 /   19
+          # Paths must point to the project file: directory paths are silently ignored.
           shard-separate: |
-            tests/Meziantou.Framework.InlineSnapshotTesting.Tests
-            tests/Meziantou.Framework.PublicApiGenerator.Tests
-            tests/Meziantou.Framework.SnapshotTesting.Tests/
+            tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj
+            tests/Meziantou.Framework.TemporaryContainers.Tests/Meziantou.Framework.TemporaryContainers.Tests.csproj
+            tests/Meziantou.Framework.StronglyTypedId.Tests/Meziantou.Framework.StronglyTypedId.Tests.csproj
+            tests/Meziantou.Framework.InlineSnapshotTesting.Tests/Meziantou.Framework.InlineSnapshotTesting.Tests.csproj
+            tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests.csproj
+            tests/Meziantou.Framework.PublicApiGenerator.MSBuild.Tests/Meziantou.Framework.PublicApiGenerator.MSBuild.Tests.csproj
+            tests/Meziantou.Framework.ResxSourceGenerator.Tests/Meziantou.Framework.ResxSourceGenerator.Tests.csproj
+            tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj
+            tests/Meziantou.Framework.DependencyScanning.Tests/Meziantou.Framework.DependencyScanning.Tests.csproj
+            tests/Meziantou.Framework.Yaml.Tests/Meziantou.Framework.Yaml.Tests.csproj
           full-rebuild-triggers: |
             .github/workflows/ci.yml
             eng/**/*.proj


### PR DESCRIPTION
## Problem

Shard 1 and shard 2 of `build_and_test` are wildly unbalanced. In run [31981487749](https://github.com/meziantou/Meziantou.Framework/actions/runs/31981487749), the Windows Release jobs were 15m36s (shard 1) vs 32m10s (shard 2), and the same 2–3x ratio shows on every runner.

Two causes, both in the `shard-separate` input:

1. **The entries never matched anything.** DeltaBuild expects project *file* paths, but the list contained directory paths (`tests/Meziantou.Framework.SnapshotTesting.Tests/`). Running the tool locally with the old list produces exactly the same assignment as passing no `--shard-separate` at all. So the split fell back to DeltaBuild's default: sort the affected test projects by path, cut in half **by count**. That is A–`MediaTags` in shard 1, `NtpClient`–Z in shard 2 — and the four most expensive suites are all in the second half.
2. **The wrong project was named.** `PublicApiGenerator.Tests` takes ~5s; the expensive one is `PublicApiGenerator.**MSBuild**.Tests` at ~13 min.

## Data

Per-assembly durations parsed out of 8 job logs from run 31981487749 (Release, all four runners, both shards), summed per project over TFMs. Five suites account for 92% of the imbalance:

| project | win | linux-x64 | linux-arm64 | macOS |
|---|---|---|---|---|
| SnapshotTesting | 2769s | 3237s | 1869s | 2446s |
| TemporaryContainers | 1247s | 609s | 545s | 7s |
| InlineSnapshotTesting | 1060s | 921s | 843s | 790s |
| PublicApiGenerator.MSBuild | 801s | 951s | 557s | 632s |
| StronglyTypedId | 652s | 284s | 188s | 375s |

## Change

`--shard-separate` assigns listed projects round-robin in declaration order, so the list order *is* the shard assignment. This points the entries at the `.csproj` files and orders the ten heaviest suites so the expensive ones alternate. The durations and the path gotcha are recorded in a comment, since the ordering is otherwise inscrutable.

## Result

Worst shard, summing per-assembly test durations:

| | win | linux-x64 | linux-arm64 | macOS |
|---|---|---|---|---|
| before | 112.9m | 103.5m | 64.3m | 69.9m |
| after | **76.4m** | **73.2m** | **45.3m** | **57.9m** |

−32% on the critical path (Windows), within 0.3m of the theoretical optimum for two shards.

These are summed assembly durations, not wall clock — assemblies run in parallel within a job, so expect the Windows shard-2 job to land around 20–22 min rather than 32.

## Notes for the reviewer

- The "after" numbers are not a simulation: I ran DeltaBuild locally for both shards with the new list and scored the resulting project lists against the measured durations.
- **Two shards is now essentially maxed out.** `SnapshotTesting.Tests` alone is 46–54 min, which is the floor for whichever shard holds it. Going to 3 shards only brings the worst shard to ~60m (linux is bound by that single project) in exchange for 50% more jobs, so it does not look worth it. The real lever is splitting or speeding up `SnapshotTesting.Tests`.
- **The tail is balanced by alphabetical accident.** The ~100 remaining projects (~44 min total) are still split by count, so adding test projects will slowly drift the balance. Worth re-deriving the list from a fresh run's logs occasionally.
- `dotnet run ./eng/update-all.cs` runs clean and produces no further changes. No build or test run — the change is workflow YAML only, and it parses.