### PR TITLE
Collapse Where and equality predicates in collection assertions (MFAS0051-MFAS0055)

### DIFF
--- a/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/RuleIdentifiers.cs
@@ -52,4 +52,9 @@ internal static class RuleIdentifiers
     internal const string AwaitAssertionDiagnosticId = "MFAS0048";
     internal const string ConstantAssertionDiagnosticId = "MFAS0049";
     internal const string UseFailAssertionDiagnosticId = "MFAS0050";
+    internal const string UseContainsForWhereDiagnosticId = "MFAS0051";
+    internal const string UseDoesNotContainForWhereDiagnosticId = "MFAS0052";
+    internal const string UseSingleWithPredicateDiagnosticId = "MFAS0053";
+    internal const string UseContainsWithExpectedValueDiagnosticId = "MFAS0054";
+    internal const string UseDoesNotContainWithExpectedValueDiagnosticId = "MFAS0055";
 }

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/CollectionContainsPredicateAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/CollectionContainsPredicateAnalyzer.cs
@@ -1,0 +1,52 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class CollectionContainsPredicateAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor UseContainsWithExpectedValueDescriptor = new(
+        id: RuleIdentifiers.UseContainsWithExpectedValueDiagnosticId,
+        title: "Use Assert.Contains with the expected value instead of an equality predicate",
+        messageFormat: "Use Assert.Contains(expected, actual) so the expected value is reported",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseDoesNotContainWithExpectedValueDescriptor = new(
+        id: RuleIdentifiers.UseDoesNotContainWithExpectedValueDiagnosticId,
+        title: "Use Assert.DoesNotContain with the expected value instead of an equality predicate",
+        messageFormat: "Use Assert.DoesNotContain(expected, actual) so the expected value is reported",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [UseContainsWithExpectedValueDescriptor, UseDoesNotContainWithExpectedValueDescriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var assertType = context.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+            if (assertType is null)
+                return;
+
+            context.RegisterOperationAction(context => Analyze(context, assertType), OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, INamedTypeSymbol assertType)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        if (!CollectionContainsPredicateAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, out var match))
+            return;
+
+        var descriptor = match.AssertionMethodName == "Contains" ? UseContainsWithExpectedValueDescriptor : UseDoesNotContainWithExpectedValueDescriptor;
+        context.ReportDiagnostic(Diagnostic.Create(descriptor, invocationOperation.Syntax.GetLocation()));
+    }
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/CollectionContainsPredicateAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/CollectionContainsPredicateAnalyzerCommon.cs
@@ -1,0 +1,147 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+/// <summary>
+/// Detects <c>Assert.Contains(collection, item =&gt; item == expected)</c>, where the predicate only compares the item
+/// with a value, so the assertion can report the expected value instead of an opaque predicate.
+/// </summary>
+internal static class CollectionContainsPredicateAnalyzerCommon
+{
+    internal static bool TryGetAssertionMatch(
+        IInvocationOperation invocationOperation,
+        INamedTypeSymbol assertType,
+        out ContainsPredicateMatch match)
+    {
+        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "Contains" or "DoesNotContain" } targetMethod ||
+            !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, assertType))
+        {
+            match = default;
+            return false;
+        }
+
+        var actualArgument = invocationOperation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "actual");
+        var predicateArgument = invocationOperation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "predicate");
+        if (actualArgument is null || predicateArgument is null)
+        {
+            match = default;
+            return false;
+        }
+
+        var actualOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(actualArgument.Value);
+
+        // Assert.Contains(expected, actual) has dedicated string overloads with a different meaning
+        if (actualOperation.Type?.SpecialType == SpecialType.System_String)
+        {
+            match = default;
+            return false;
+        }
+
+        if (!TryGetComparedValue(predicateArgument.Value, out var expectedOperation))
+        {
+            match = default;
+            return false;
+        }
+
+        var messageArgument = invocationOperation.Arguments.FirstOrDefault(argument => argument is { ArgumentKind: ArgumentKind.Explicit, Parameter.Name: "message" });
+        match = new ContainsPredicateMatch(actualOperation, expectedOperation, messageArgument, targetMethod.Name);
+        return true;
+    }
+
+    private static bool TryGetComparedValue(IOperation predicateOperation, [NotNullWhen(true)] out IOperation? expectedOperation)
+    {
+        expectedOperation = null;
+
+        var operation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(predicateOperation);
+        if (operation is IDelegateCreationOperation delegateCreationOperation)
+        {
+            operation = delegateCreationOperation.Target;
+        }
+
+        if (operation is not IAnonymousFunctionOperation { Symbol.Parameters: [var lambdaParameter] } anonymousFunctionOperation ||
+            anonymousFunctionOperation.Body is not { Operations: [IReturnOperation { ReturnedValue: { } returnedValue }] })
+        {
+            return false;
+        }
+
+        if (AssertionsAnalyzerHelpers.UnwrapImplicitConversion(returnedValue) is not IBinaryOperation { OperatorKind: BinaryOperatorKind.Equals, OperatorMethod: null } binaryOperation)
+            return false;
+
+        // The default equality comparer used by the assertion must behave like the == operator
+        if (!HasDefaultEqualitySemantics(lambdaParameter.Type))
+            return false;
+
+        if (IsParameterReference(binaryOperation.LeftOperand, lambdaParameter))
+        {
+            expectedOperation = binaryOperation.RightOperand;
+        }
+        else if (IsParameterReference(binaryOperation.RightOperand, lambdaParameter))
+        {
+            expectedOperation = binaryOperation.LeftOperand;
+        }
+        else
+        {
+            return false;
+        }
+
+        // The value must be usable outside of the lambda
+        if (!SymbolEqualityComparer.Default.Equals(expectedOperation.Type, lambdaParameter.Type) ||
+            ReferencesParameter(expectedOperation, lambdaParameter))
+        {
+            expectedOperation = null;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsParameterReference(IOperation operation, IParameterSymbol parameter)
+    {
+        return AssertionsAnalyzerHelpers.UnwrapImplicitConversion(operation) is IParameterReferenceOperation parameterReferenceOperation &&
+            SymbolEqualityComparer.Default.Equals(parameterReferenceOperation.Parameter, parameter) &&
+            SymbolEqualityComparer.Default.Equals(operation.Type, parameter.Type);
+    }
+
+    private static bool ReferencesParameter(IOperation operation, IParameterSymbol parameter)
+    {
+        foreach (var descendant in operation.DescendantsAndSelf())
+        {
+            if (descendant is IParameterReferenceOperation parameterReferenceOperation &&
+                SymbolEqualityComparer.Default.Equals(parameterReferenceOperation.Parameter, parameter))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasDefaultEqualitySemantics(ITypeSymbol type)
+    {
+        if (type.TypeKind == TypeKind.Enum)
+            return true;
+
+        // Floating-point types are excluded as == and Equals disagree on NaN
+        return type.SpecialType is SpecialType.System_String or
+            SpecialType.System_Boolean or
+            SpecialType.System_Char or
+            SpecialType.System_SByte or
+            SpecialType.System_Byte or
+            SpecialType.System_Int16 or
+            SpecialType.System_UInt16 or
+            SpecialType.System_Int32 or
+            SpecialType.System_UInt32 or
+            SpecialType.System_Int64 or
+            SpecialType.System_UInt64 or
+            SpecialType.System_IntPtr or
+            SpecialType.System_UIntPtr or
+            SpecialType.System_Decimal;
+    }
+
+    internal readonly record struct ContainsPredicateMatch(
+        IOperation ActualOperation,
+        IOperation ExpectedOperation,
+        IArgumentOperation? MessageArgument,
+        string AssertionMethodName);
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/CollectionWhereAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/CollectionWhereAssertionAnalyzer.cs
@@ -1,0 +1,68 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class CollectionWhereAssertionAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor UseContainsForWhereDescriptor = new(
+        id: RuleIdentifiers.UseContainsForWhereDiagnosticId,
+        title: "Use Assert.Contains instead of Assert.NotEmpty(collection.Where(...))",
+        messageFormat: "Use Assert.Contains(actual, predicate) for readability",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseDoesNotContainForWhereDescriptor = new(
+        id: RuleIdentifiers.UseDoesNotContainForWhereDiagnosticId,
+        title: "Use Assert.DoesNotContain instead of Assert.Empty(collection.Where(...))",
+        messageFormat: "Use Assert.DoesNotContain(actual, predicate) for readability",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor UseSingleWithPredicateDescriptor = new(
+        id: RuleIdentifiers.UseSingleWithPredicateDiagnosticId,
+        title: "Use Assert.Single with a predicate instead of Assert.Single(collection.Where(...))",
+        messageFormat: "Use Assert.Single(actual, predicate) for readability",
+        category: "Assertions",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [UseContainsForWhereDescriptor, UseDoesNotContainForWhereDescriptor, UseSingleWithPredicateDescriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var assertType = context.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+            if (assertType is null || !CollectionWhereAssertionAnalyzerCommon.TryCreateSymbols(context.Compilation, out var symbols))
+                return;
+
+            context.RegisterOperationAction(
+                context => Analyze(context, assertType, symbols.Value),
+                OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, INamedTypeSymbol assertType, CollectionWhereAssertionAnalyzerCommon.Symbols symbols)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        if (!CollectionWhereAssertionAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, symbols, out var match))
+            return;
+
+        var descriptor = match.AssertionMethodName switch
+        {
+            "Contains" => UseContainsForWhereDescriptor,
+            "DoesNotContain" => UseDoesNotContainForWhereDescriptor,
+            _ => UseSingleWithPredicateDescriptor,
+        };
+
+        context.ReportDiagnostic(Diagnostic.Create(descriptor, invocationOperation.Syntax.GetLocation()));
+    }
+}

--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/CollectionWhereAssertionAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/CollectionWhereAssertionAnalyzerCommon.cs
@@ -1,0 +1,142 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+/// <summary>
+/// Detects assertions applied to a filtered sequence, such as <c>Assert.NotEmpty(collection.Where(predicate))</c>,
+/// which can be expressed with the predicate overload of the assertion.
+/// </summary>
+internal static class CollectionWhereAssertionAnalyzerCommon
+{
+    private const string ContainsAssertionMethodName = "Contains";
+    private const string DoesNotContainAssertionMethodName = "DoesNotContain";
+    private const string SingleAssertionMethodName = "Single";
+
+    internal static bool TryCreateSymbols(Compilation compilation, [NotNullWhen(true)] out Symbols? symbols)
+    {
+        var enumerableType = compilation.GetTypeByMetadataName("System.Linq.Enumerable");
+        if (enumerableType is null)
+        {
+            symbols = null;
+            return false;
+        }
+
+        // Only the Func<TSource, bool> overload can be moved to the assertion; the indexed one has no equivalent
+        var enumerableWhereMethods = enumerableType.GetMembers("Where")
+            .OfType<IMethodSymbol>()
+            .Where(method => method is { IsStatic: true, IsExtensionMethod: true, Parameters.Length: 2 } &&
+                             method.Parameters[1].Type is INamedTypeSymbol { TypeArguments.Length: 2 })
+            .Select(method => method.OriginalDefinition)
+            .ToImmutableArray();
+
+        if (enumerableWhereMethods.IsDefaultOrEmpty)
+        {
+            symbols = null;
+            return false;
+        }
+
+        symbols = new Symbols(enumerableWhereMethods);
+        return true;
+    }
+
+    internal static bool TryGetAssertionMatch(
+        IInvocationOperation invocationOperation,
+        INamedTypeSymbol assertType,
+        Symbols symbols,
+        out CollectionWhereMatch match)
+    {
+        if (invocationOperation.TargetMethod is not { IsStatic: true } targetMethod ||
+            !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, assertType))
+        {
+            match = default;
+            return false;
+        }
+
+        var assertionMethodName = targetMethod.Name switch
+        {
+            "NotEmpty" => ContainsAssertionMethodName,
+            "Empty" => DoesNotContainAssertionMethodName,
+            "Single" => SingleAssertionMethodName,
+            _ => null,
+        };
+
+        if (assertionMethodName is null)
+        {
+            match = default;
+            return false;
+        }
+
+        var actualArgument = invocationOperation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "actual");
+
+        // The overload that already takes a predicate is the expected result of the fix
+        if (actualArgument?.Parameter is not { } actualParameter ||
+            actualParameter.Type.OriginalDefinition.SpecialType != SpecialType.System_Collections_Generic_IEnumerable_T ||
+            targetMethod.Parameters.Any(parameter => parameter.Name == "predicate"))
+        {
+            match = default;
+            return false;
+        }
+
+        if (AssertionsAnalyzerHelpers.UnwrapImplicitConversion(actualArgument.Value) is not IInvocationOperation whereInvocation ||
+            !TryGetWhereArguments(whereInvocation, symbols, out var sourceOperation, out var predicateOperation))
+        {
+            match = default;
+            return false;
+        }
+
+        match = new CollectionWhereMatch(actualArgument, sourceOperation, predicateOperation, assertionMethodName);
+        return true;
+    }
+
+    private static bool TryGetWhereArguments(
+        IInvocationOperation whereInvocation,
+        Symbols symbols,
+        [NotNullWhen(true)] out IOperation? sourceOperation,
+        [NotNullWhen(true)] out IOperation? predicateOperation)
+    {
+        if (whereInvocation.TargetMethod.Name != "Where")
+        {
+            sourceOperation = null;
+            predicateOperation = null;
+            return false;
+        }
+
+        var originalDefinition = (whereInvocation.TargetMethod.ReducedFrom ?? whereInvocation.TargetMethod).OriginalDefinition;
+        if (!symbols.EnumerableWhereMethods.Contains(originalDefinition, SymbolEqualityComparer.Default))
+        {
+            sourceOperation = null;
+            predicateOperation = null;
+            return false;
+        }
+
+        if (whereInvocation.Instance is not null)
+        {
+            sourceOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(whereInvocation.Instance);
+            predicateOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(whereInvocation.Arguments[0].Value);
+            return true;
+        }
+
+        var sourceArgument = whereInvocation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "source");
+        var predicateArgument = whereInvocation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "predicate");
+        if (sourceArgument is null || predicateArgument is null)
+        {
+            sourceOperation = null;
+            predicateOperation = null;
+            return false;
+        }
+
+        sourceOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(sourceArgument.Value);
+        predicateOperation = AssertionsAnalyzerHelpers.UnwrapImplicitConversion(predicateArgument.Value);
+        return true;
+    }
+
+    internal readonly record struct Symbols(ImmutableArray<IMethodSymbol> EnumerableWhereMethods);
+
+    internal readonly record struct CollectionWhereMatch(
+        IArgumentOperation ActualArgument,
+        IOperation SourceOperation,
+        IOperation PredicateOperation,
+        string AssertionMethodName);
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Meziantou.Framework.Assertions.CodeFix.csproj
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Meziantou.Framework.Assertions.CodeFix.csproj
@@ -17,6 +17,8 @@
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/EmptinessAssertionAnalyzerCommon.cs" Link="Rules/EmptinessAssertionAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/ConditionRewriteAnalyzerCommon.cs" Link="Rules/ConditionRewriteAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/UseFailAssertionAnalyzerCommon.cs" Link="Rules/UseFailAssertionAnalyzerCommon.cs" />
+    <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/CollectionWhereAssertionAnalyzerCommon.cs" Link="Rules/CollectionWhereAssertionAnalyzerCommon.cs" />
+    <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Rules/CollectionContainsPredicateAnalyzerCommon.cs" Link="Rules/CollectionContainsPredicateAnalyzerCommon.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/Internals/NumericHelpers.cs" Link="Internals/NumericHelpers.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/AssertionsAnalyzerHelpers.cs" Link="AssertionsAnalyzerHelpers.cs" />
     <Compile Include="../Meziantou.Framework.Assertions.Analyzer/AssertionCodeFixHelpers.cs" Link="AssertionCodeFixHelpers.cs" />

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/CollectionContainsPredicateCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/CollectionContainsPredicateCodeFixProvider.cs
@@ -1,0 +1,100 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CollectionContainsPredicateCodeFixProvider))]
+public sealed class CollectionContainsPredicateCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        [RuleIdentifiers.UseContainsWithExpectedValueDiagnosticId, RuleIdentifiers.UseDoesNotContainWithExpectedValueDiagnosticId];
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var assertType = semanticModel.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+        if (assertType is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var invocationExpression = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true)
+                .FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (invocationExpression is null)
+                continue;
+
+            if (!AssertionCodeFixHelpers.TryGetInvocationOperation(semanticModel, invocationExpression, context.CancellationToken, out var invocationOperation))
+                continue;
+
+            if (!CollectionContainsPredicateAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, out var match))
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Use Assert." + match.AssertionMethodName + " with the expected value",
+                    createChangedDocument: ct => ApplyFixAsync(context.Document, invocationExpression, assertType, ct),
+                    equivalenceKey: GetType().FullName),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocationExpression, INamedTypeSymbol assertType, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return document;
+
+        if (!AssertionCodeFixHelpers.TryGetInvocationOperation(semanticModel, invocationExpression, cancellationToken, out var invocationOperation))
+            return document;
+
+        if (!CollectionContainsPredicateAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, out var match))
+            return document;
+
+        if (!AssertionCodeFixHelpers.TryGetExpressionSyntax(match.ExpectedOperation, out var expectedExpression) ||
+            !AssertionCodeFixHelpers.TryGetExpressionSyntax(match.ActualOperation, out var actualExpression))
+        {
+            return document;
+        }
+
+        var arguments = new List<ArgumentSyntax>(3)
+        {
+            SyntaxFactory.Argument(expectedExpression.WithoutTrivia()),
+            SyntaxFactory.Argument(actualExpression.WithoutTrivia()),
+        };
+
+        // The overload takes an optional comparer, so the message cannot stay positional
+        if (match.MessageArgument is not null &&
+            AssertionCodeFixHelpers.TryGetExpressionSyntax(match.MessageArgument.Value, out var messageExpression))
+        {
+            arguments.Add(SyntaxFactory.Argument(
+                SyntaxFactory.NameColon(SyntaxFactory.IdentifierName("message")),
+                refKindKeyword: default,
+                messageExpression.WithoutTrivia()));
+        }
+
+        var newInvocationExpression = invocationExpression
+            .WithArgumentList(SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        var newRoot = root.ReplaceNode(invocationExpression, newInvocationExpression);
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/Meziantou.Framework.Assertions.CodeFix/Rules/CollectionWhereAssertionCodeFixProvider.cs
+++ b/src/Meziantou.Framework.Assertions.CodeFix/Rules/CollectionWhereAssertionCodeFixProvider.cs
@@ -1,0 +1,109 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Meziantou.Framework.Analyzers.Assertions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CollectionWhereAssertionCodeFixProvider))]
+public sealed class CollectionWhereAssertionCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        [RuleIdentifiers.UseContainsForWhereDiagnosticId, RuleIdentifiers.UseDoesNotContainForWhereDiagnosticId, RuleIdentifiers.UseSingleWithPredicateDiagnosticId];
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return;
+
+        var assertType = semanticModel.Compilation.GetTypeByMetadataName(AssertionsAnalyzerHelpers.AssertMetadataName);
+        if (assertType is null || !CollectionWhereAssertionAnalyzerCommon.TryCreateSymbols(semanticModel.Compilation, out var symbols))
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var invocationExpression = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true)
+                .FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (invocationExpression is null)
+                continue;
+
+            if (!AssertionCodeFixHelpers.TryGetInvocationOperation(semanticModel, invocationExpression, context.CancellationToken, out var invocationOperation))
+                continue;
+
+            if (!CollectionWhereAssertionAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, symbols.Value, out var match))
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Use Assert." + match.AssertionMethodName + " with a predicate",
+                    createChangedDocument: ct => ApplyFixAsync(context.Document, invocationExpression, assertType, ct),
+                    equivalenceKey: GetType().FullName),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocationExpression, INamedTypeSymbol assertType, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return document;
+
+        if (!CollectionWhereAssertionAnalyzerCommon.TryCreateSymbols(semanticModel.Compilation, out var symbols))
+            return document;
+
+        if (!AssertionCodeFixHelpers.TryGetInvocationOperation(semanticModel, invocationExpression, cancellationToken, out var invocationOperation))
+            return document;
+
+        if (!CollectionWhereAssertionAnalyzerCommon.TryGetAssertionMatch(invocationOperation, assertType, symbols.Value, out var match))
+            return document;
+
+        if (!AssertionCodeFixHelpers.TryGetExpressionSyntax(match.SourceOperation, out var sourceExpression) ||
+            !AssertionCodeFixHelpers.TryGetExpressionSyntax(match.PredicateOperation, out var predicateExpression))
+        {
+            return document;
+        }
+
+        var arguments = new List<ArgumentSyntax>(invocationExpression.ArgumentList.Arguments.Count + 1);
+        foreach (var argument in invocationExpression.ArgumentList.Arguments)
+        {
+            if (argument != match.ActualArgument.Syntax)
+            {
+                arguments.Add(argument);
+                continue;
+            }
+
+            // The filtered sequence is replaced by the source, and the filter becomes the predicate of the assertion
+            arguments.Add(argument.WithExpression(sourceExpression.WithoutTrivia()));
+
+            var predicateArgument = SyntaxFactory.Argument(predicateExpression.WithoutTrivia());
+            if (argument.NameColon is not null)
+            {
+                predicateArgument = predicateArgument.WithNameColon(SyntaxFactory.NameColon("predicate"));
+            }
+
+            arguments.Add(predicateArgument);
+        }
+
+        var newInvocationExpression = invocationExpression
+            .WithExpression(AssertionCodeFixHelpers.ReplaceMethodName(invocationExpression.Expression, match.AssertionMethodName))
+            .WithArgumentList(SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        var newRoot = root.ReplaceNode(invocationExpression, newInvocationExpression);
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/Meziantou.Framework.Assertions/readme.md
+++ b/src/Meziantou.Framework.Assertions/readme.md
@@ -134,4 +134,9 @@ The package ships analyzers and code fixes to help write clearer assertions.
 | `MFAS0048` | Assertions | Await assertions that return a Task | Error | ✔️ |
 | `MFAS0049` | Assertions | Assertion always produces the same result | Error | ✔️ |
 | `MFAS0050` | Assertions | Use Assert.Fail instead of an assertion that always fails | Warning | ✔️ |
+| `MFAS0051` | Assertions | Use Assert.Contains instead of Assert.NotEmpty(collection.Where(...)) | Warning | ✔️ |
+| `MFAS0052` | Assertions | Use Assert.DoesNotContain instead of Assert.Empty(collection.Where(...)) | Warning | ✔️ |
+| `MFAS0053` | Assertions | Use Assert.Single with a predicate instead of Assert.Single(collection.Where(...)) | Warning | ✔️ |
+| `MFAS0054` | Assertions | Use Assert.Contains with the expected value instead of an equality predicate | Warning | ✔️ |
+| `MFAS0055` | Assertions | Use Assert.DoesNotContain with the expected value instead of an equality predicate | Warning | ✔️ |
 <!-- analyzer-rules -->

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CollectionContainsPredicateRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CollectionContainsPredicateRuleTests.cs
@@ -1,0 +1,246 @@
+using CollectionContainsPredicateAnalyzerType = Meziantou.Framework.Analyzers.Assertions.CollectionContainsPredicateAnalyzer;
+using CollectionContainsPredicateCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.CollectionContainsPredicateCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class CollectionContainsPredicateRuleTests : AssertionsAnalyzerTestBase
+{
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForContainsWithEqualityPredicate()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {|MFAS0054:Assert.Contains(collection, x => x == 1)|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.Contains(1, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CollectionContainsPredicateAnalyzerType, CollectionContainsPredicateCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForDoesNotContainWithEqualityPredicate()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<string> collection, string expected)
+                {
+                    {|MFAS0055:Assert.DoesNotContain(collection, x => expected == x)|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<string> collection, string expected)
+                {
+                    Assert.DoesNotContain(expected, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CollectionContainsPredicateAnalyzerType, CollectionContainsPredicateCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_KeepsMessageAsNamedArgument()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {|MFAS0054:Assert.Contains(collection, x => x == 1, "message")|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.Contains(1, collection, message: "message");
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CollectionContainsPredicateAnalyzerType, CollectionContainsPredicateCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForEnumValue()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public enum Sample1 { A, B }
+
+            public static class TestClass
+            {
+                public static void M(List<Sample1> collection)
+                {
+                    {|MFAS0054:Assert.Contains(collection, x => x == Sample1.B)|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public enum Sample1 { A, B }
+
+            public static class TestClass
+            {
+                public static void M(List<Sample1> collection)
+                {
+                    Assert.Contains(Sample1.B, collection);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CollectionContainsPredicateAnalyzerType, CollectionContainsPredicateCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForPredicateUsingTheItem()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.Contains(collection, x => x > 0);
+                    Assert.Contains(collection, x => x == x + 1);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<CollectionContainsPredicateAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForFloatingPointValue()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<double> collection)
+                {
+                    Assert.Contains(collection, x => x == 1d);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<CollectionContainsPredicateAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForCustomType()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public sealed class Item
+            {
+                public int Value { get; set; }
+            }
+
+            public static class TestClass
+            {
+                public static void M(List<Item> collection, Item expected)
+                {
+                    Assert.Contains(collection, x => x == expected);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<CollectionContainsPredicateAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForExpectedValueAssertion()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.Contains(1, collection);
+                    Assert.DoesNotContain(1, collection);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<CollectionContainsPredicateAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CollectionWhereAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CollectionWhereAssertionRuleTests.cs
@@ -1,0 +1,265 @@
+using CollectionWhereAssertionAnalyzerType = Meziantou.Framework.Analyzers.Assertions.CollectionWhereAssertionAnalyzer;
+using CollectionWhereAssertionCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.CollectionWhereAssertionCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class CollectionWhereAssertionRuleTests : AssertionsAnalyzerTestBase
+{
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForNotEmptyWithWhere()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {|MFAS0051:Assert.NotEmpty(collection.Where(x => x > 0))|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.Contains(collection, x => x > 0);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CollectionWhereAssertionAnalyzerType, CollectionWhereAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForEmptyWithWhere()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {|MFAS0052:Assert.Empty(collection.Where(x => x > 0))|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.DoesNotContain(collection, x => x > 0);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CollectionWhereAssertionAnalyzerType, CollectionWhereAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForSingleWithWhere()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static int M(List<int> collection)
+                {
+                    return {|MFAS0053:Assert.Single(collection.Where(x => x > 0))|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static int M(List<int> collection)
+                {
+                    return Assert.Single(collection, x => x > 0);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CollectionWhereAssertionAnalyzerType, CollectionWhereAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_KeepsMessage()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {|MFAS0051:Assert.NotEmpty(collection.Where(x => x > 0), "message")|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.Contains(collection, x => x > 0, "message");
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CollectionWhereAssertionAnalyzerType, CollectionWhereAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForNamedArgument()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {|MFAS0052:Assert.Empty(actual: collection.Where(x => x > 0))|};
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.DoesNotContain(actual: collection, predicate: x => x > 0);
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<CollectionWhereAssertionAnalyzerType, CollectionWhereAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForIndexedWhere()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.NotEmpty(collection.Where((x, i) => x > i));
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<CollectionWhereAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForCollection()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.NotEmpty(collection);
+                    Assert.Empty(collection);
+                    Assert.Single(collection);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<CollectionWhereAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForSingleWithPredicate()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    Assert.Single(collection, x => x > 0);
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<CollectionWhereAssertionAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.Assertions.Tests/.editorconfig
+++ b/tests/Meziantou.Framework.Assertions.Tests/.editorconfig
@@ -5,3 +5,8 @@ root = false
 # result is known in advance, such as Assert.True(true) or Assert.Same(value, value).
 dotnet_diagnostic.MFAS0049.severity = none
 dotnet_diagnostic.MFAS0050.severity = none
+
+# The predicate overloads of Assert.Contains and Assert.DoesNotContain are validated here,
+# so the predicate cannot be replaced by the expected value.
+dotnet_diagnostic.MFAS0054.severity = none
+dotnet_diagnostic.MFAS0055.severity = none

--- a/tests/Meziantou.Framework.Language.Json.Tests/JsonSyntaxTreeTests.cs
+++ b/tests/Meziantou.Framework.Language.Json.Tests/JsonSyntaxTreeTests.cs
@@ -108,7 +108,7 @@ public sealed class JsonSyntaxTreeTests
 """;
 
         var tree = JsonSyntaxTree.ParseText(Text);
-        var comment = Assert.Single(tree.Root.DescendantTrivia().Where(trivia => trivia.Kind == JsonSyntaxKind.SingleLineCommentTrivia));
+        var comment = Assert.Single(tree.Root.DescendantTrivia(), trivia => trivia.Kind == JsonSyntaxKind.SingleLineCommentTrivia);
         var property = Assert.IsType<JsonObjectSyntax>(tree.Root.Value).Members[0];
 
         Assert.Equal("// comment", comment.Text);
@@ -139,7 +139,7 @@ public sealed class JsonSyntaxTreeTests
 """;
 
         var tree = JsonSyntaxTree.ParseText(Text);
-        var comment = Assert.Single(tree.Root.DescendantTrivia().Where(trivia => trivia.Kind == JsonSyntaxKind.SingleLineCommentTrivia));
+        var comment = Assert.Single(tree.Root.DescendantTrivia(), trivia => trivia.Kind == JsonSyntaxKind.SingleLineCommentTrivia);
 
         var updated = tree.Root.ReplaceTrivia(comment, SyntaxFactory.Trivia(JsonSyntaxKind.MultiLineCommentTrivia, "/* new */"));
 


### PR DESCRIPTION
Follow-up to the `Assert.True(collection.Any(...))` family (MFAS0022-MFAS0029), covering the patterns that were still missing around `Contains`/`DoesNotContain` and `Any`/`All`.

| Id | Rewrite |
| -- | -- |
| `MFAS0051` | `Assert.NotEmpty(c.Where(p))` → `Assert.Contains(c, p)` |
| `MFAS0052` | `Assert.Empty(c.Where(p))` → `Assert.DoesNotContain(c, p)` |
| `MFAS0053` | `Assert.Single(c.Where(p))` → `Assert.Single(c, p)` |
| `MFAS0054` | `Assert.Contains(c, x => x == value)` → `Assert.Contains(value, c)` |
| `MFAS0055` | `Assert.DoesNotContain(c, x => x == value)` → `Assert.DoesNotContain(value, c)` |

Both analyzers ship a code fix.

## Notes for reviewers

- `MFAS0051`-`MFAS0053` only match the `Func<T, bool>` overload of `Where`; the indexed overload has no assertion equivalent. `Assert.Single` is skipped when a predicate is already passed. The fix keeps a `message` argument and preserves named arguments (adding `predicate:` when the sequence was passed as `actual:`).
- `MFAS0054`/`MFAS0055` only fire when `==` and `EqualityComparer<T>.Default` agree: string, bool, char, integral types, decimal and enums. Floating-point (NaN), nullable and user-defined types are excluded, as is a predicate whose other operand references the lambda parameter. The fix passes `message:` as a named argument because the target overload has an optional `comparer` in that position.
- The rules chain with the existing ones: `Assert.True(list.Any(x => x == "a"))` → `MFAS0024` → `Assert.Contains(list, x => x == "a")` → `MFAS0054` → `Assert.Contains("a", list)`.
- The new rules found two real occurrences in `JsonSyntaxTreeTests`, fixed here.
- `Meziantou.Framework.Assertions.Tests` deliberately exercises the predicate overloads (it asserts on their failure messages), so `MFAS0054`/`MFAS0055` are disabled in that project's `.editorconfig`, matching how `MFAS0049`/`MFAS0050` are handled there.

## Validation

- `dotnet build Meziantou.Framework.slnx -p:TreatWarningsAsErrors=true`: 0 warnings, 0 errors
- Analyzer tests: 203/203, assertions tests: 786/786, JSON tests: 44/44
- `dotnet run ./eng/update-all.cs` runs clean (it regenerated the rule table in the readme)