### PR TITLE
Add FullPath factory rule (MFFP0024)

### DIFF
--- a/ref/Meziantou.Framework.FullPath.cs
+++ b/ref/Meziantou.Framework.FullPath.cs
@@ -48,6 +48,7 @@ namespace Meziantou.Framework
         public static Meziantou.Framework.FullPath CreateTempFile(string? prefix, string? suffix = ".tmp") => throw null;
         public static Meziantou.Framework.FullPath CreateTempFile(Meziantou.Framework.FullPath? folder, string? prefix, string? suffix = ".tmp") => throw null;
         public static Meziantou.Framework.FullPath GetFolderPath(SpecialFolder folder) => throw null;
+        public static Meziantou.Framework.FullPath GetFolderPath(SpecialFolder folder, SpecialFolderOption option) => throw null;
         [System.Runtime.Versioning.SupportedOSPlatform("windows6.0.6000")]
         public static Meziantou.Framework.FullPath GetKnownFolderPath(Meziantou.Framework.KnownFolder knownFolder) => throw null;
         public static Meziantou.Framework.FullPath CurrentDirectory() => throw null;

--- a/src/Meziantou.Framework.FullPath.Analyzer/FullPathAnalyzerCommon.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FullPathAnalyzerCommon.cs
@@ -27,6 +27,7 @@ internal static class FullPathAnalyzerCommon
     internal const string UseIsEmptyDiagnosticId = "MFFP0021";
     internal const string UseCreateParentDirectoryDiagnosticId = "MFFP0022";
     internal const string DirectoryGetParentWithFullPathDiagnosticId = "MFFP0023";
+    internal const string UseFullPathFactoryDiagnosticId = "MFFP0024";
 
     /// <summary>
     /// Returns the underlying <c>FullPath</c> operation of an expression that produces its string representation,

--- a/src/Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs
@@ -30,9 +30,8 @@ internal sealed class FullPathContext(Compilation compilation)
             // Path.GetTempPath() => FullPath.GetTempPath()
             { Name: "GetTempPath", Parameters.IsEmpty: true } when SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, PathType) => "Path",
 
-            // Environment.GetFolderPath(SpecialFolder) => FullPath.GetFolderPath(SpecialFolder)
-            // The (SpecialFolder, SpecialFolderOption) overload has no FullPath equivalent
-            { Name: "GetFolderPath", Parameters.Length: 1 } when SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, EnvironmentType) => "Environment",
+            // Environment.GetFolderPath(SpecialFolder[, SpecialFolderOption]) => FullPath.GetFolderPath(SpecialFolder[, SpecialFolderOption])
+            { Name: "GetFolderPath", Parameters.Length: 1 or 2 } when SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, EnvironmentType) => "Environment",
 
             _ => null,
         };

--- a/src/Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs
@@ -9,10 +9,33 @@ internal sealed class FullPathContext(Compilation compilation)
     public INamedTypeSymbol? PathType { get; } = compilation.GetTypeByMetadataName("System.IO.Path");
     public INamedTypeSymbol? DirectoryType { get; } = compilation.GetTypeByMetadataName("System.IO.Directory");
     public INamedTypeSymbol? FileSystemInfoType { get; } = compilation.GetTypeByMetadataName("System.IO.FileSystemInfo");
+    public INamedTypeSymbol? EnvironmentType { get; } = compilation.GetTypeByMetadataName("System.Environment");
 
     public bool IsFullPathMember(IMethodSymbol methodSymbol)
     {
         return methodSymbol.IsStatic && SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, FullPathType);
+    }
+
+    /// <summary>
+    /// Returns the name of the type declaring <paramref name="methodSymbol"/> when <c>FullPath</c> exposes a factory
+    /// method with the same name and the same parameters, or <see langword="null"/> when there is no equivalent.
+    /// </summary>
+    public string? GetFullPathFactoryEquivalentTypeName(IMethodSymbol methodSymbol)
+    {
+        if (!methodSymbol.IsStatic)
+            return null;
+
+        return methodSymbol switch
+        {
+            // Path.GetTempPath() => FullPath.GetTempPath()
+            { Name: "GetTempPath", Parameters.IsEmpty: true } when SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, PathType) => "Path",
+
+            // Environment.GetFolderPath(SpecialFolder) => FullPath.GetFolderPath(SpecialFolder)
+            // The (SpecialFolder, SpecialFolderOption) overload has no FullPath equivalent
+            { Name: "GetFolderPath", Parameters.Length: 1 } when SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, EnvironmentType) => "Environment",
+
+            _ => null,
+        };
     }
 
     public bool IsFileSystemInfo(ITypeSymbol? typeSymbol)

--- a/src/Meziantou.Framework.FullPath.Analyzer/UseFullPathFactoryAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/UseFullPathFactoryAnalyzer.cs
@@ -1,0 +1,47 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+/// <summary>
+/// Reports path-producing BCL methods that have a <c>FullPath</c> equivalent.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseFullPathFactoryAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Descriptor = new(
+        id: FullPathAnalyzerCommon.UseFullPathFactoryDiagnosticId,
+        title: "Use the FullPath equivalent of Path.GetTempPath or Environment.GetFolderPath",
+        messageFormat: "Use FullPath.{0} instead of calling {1}.{0}",
+        category: "FullPath",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(context =>
+        {
+            var analyzerContext = new FullPathContext(context.Compilation);
+            if (!analyzerContext.IsValid)
+                return;
+
+            context.RegisterOperationAction(context => Analyze(context, analyzerContext), OperationKind.Invocation);
+        });
+    }
+
+    private static void Analyze(OperationAnalysisContext context, FullPathContext analyzerContext)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        var targetMethod = invocationOperation.TargetMethod;
+        if (analyzerContext.GetFullPathFactoryEquivalentTypeName(targetMethod) is not { } declaringTypeName)
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationOperation.Syntax.GetLocation(), targetMethod.Name, declaringTypeName));
+    }
+}

--- a/src/Meziantou.Framework.FullPath.CodeFix/UseFullPathFactoryCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/UseFullPathFactoryCodeFixProvider.cs
@@ -1,0 +1,46 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Simplification;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseFullPathFactoryCodeFixProvider))]
+public sealed class UseFullPathFactoryCodeFixProvider : FullPathCodeFixProviderBase
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => [FullPathAnalyzerCommon.UseFullPathFactoryDiagnosticId];
+
+    protected override string Title => "Use the FullPath equivalent";
+
+    private protected override bool TryGetReplacementExpression(
+        SemanticModel semanticModel,
+        ExpressionSyntax expressionSyntax,
+        FullPathContext analyzerContext,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax replacementExpression)
+    {
+        if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is IInvocationOperation { Syntax: InvocationExpressionSyntax invocationSyntax } invocationOperation &&
+            analyzerContext.GetFullPathFactoryEquivalentTypeName(invocationOperation.TargetMethod) is not null &&
+            analyzerContext.FullPathType is { } fullPathType)
+        {
+            // The name is simplified to 'FullPath' when the namespace is imported
+            var fullPathTypeName = SyntaxFactory
+                .ParseExpression(fullPathType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
+                .WithAdditionalAnnotations(Simplifier.Annotation);
+
+            replacementExpression = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    fullPathTypeName,
+                    SyntaxFactory.IdentifierName(invocationOperation.TargetMethod.Name)),
+                invocationSyntax.ArgumentList.WithoutTrivia());
+            return true;
+        }
+
+        replacementExpression = null!;
+        return false;
+    }
+}

--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -430,7 +430,13 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
     }
 
     /// <summary>Gets the path to the system special folder identified by the specified enumeration.</summary>
+    /// <param name="folder">The special folder to retrieve the path for.</param>
     public static FullPath GetFolderPath(Environment.SpecialFolder folder) => FromPath(Environment.GetFolderPath(folder));
+
+    /// <summary>Gets the path to the system special folder identified by the specified enumeration.</summary>
+    /// <param name="folder">The special folder to retrieve the path for.</param>
+    /// <param name="option">Specifies whether the folder must be verified or created.</param>
+    public static FullPath GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option) => FromPath(Environment.GetFolderPath(folder, option));
 
     /// <summary>Gets the path to a Windows known folder.</summary>
     /// <param name="knownFolder">The known folder to retrieve the path for.</param>

--- a/src/Meziantou.Framework.FullPath/readme.md
+++ b/src/Meziantou.Framework.FullPath/readme.md
@@ -74,6 +74,7 @@ System.IO.File.WriteAllText(filePath, content);
 | `MFFP0021` | FullPath | Use FullPath.IsEmpty | Info | ✔️ |
 | `MFFP0022` | FullPath | Use FullPath.CreateParentDirectory instead of Directory.CreateDirectory | Info | ✔️ |
 | `MFFP0023` | FullPath | Use FullPath.Parent instead of Directory.GetParent | Info | ✔️ |
+| `MFFP0024` | FullPath | Use the FullPath equivalent of Path.GetTempPath or Environment.GetFolderPath | Info | ✔️ |
 <!-- analyzer-rules -->
 
 # Additional resources

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseFullPathFactoryRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseFullPathFactoryRuleTests.cs
@@ -1,0 +1,183 @@
+using UseFullPathFactoryAnalyzerType = Meziantou.Framework.Analyzers.FullPath.UseFullPathFactoryAnalyzer;
+using UseFullPathFactoryCodeFixProviderType = Meziantou.Framework.Analyzers.FullPath.UseFullPathFactoryCodeFixProvider;
+
+namespace Meziantou.Framework.Tests;
+
+public sealed class UseFullPathFactoryRuleTests : FullPathAnalyzerTestBase
+{
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForPathGetTempPath()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M()
+                    {
+                        return FullPath.Combine({|MFFP0024:Path.GetTempPath()|}, "sample");
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M()
+                    {
+                        return FullPath.Combine(FullPath.GetTempPath(), "sample");
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<UseFullPathFactoryAnalyzerType, UseFullPathFactoryCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForPathGetTempPathAssignedToString()
+    {
+        var source = """
+            using System.IO;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M()
+                    {
+                        return {|MFFP0024:Path.GetTempPath()|};
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.IO;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M()
+                    {
+                        return Meziantou.Framework.FullPath.GetTempPath();
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<UseFullPathFactoryAnalyzerType, UseFullPathFactoryCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForEnvironmentGetFolderPath()
+    {
+        var source = """
+            using System;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M()
+                    {
+                        return FullPath.Combine({|MFFP0024:Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)|}, "sample");
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M()
+                    {
+                        return FullPath.Combine(FullPath.GetFolderPath(Environment.SpecialFolder.MyDocuments), "sample");
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<UseFullPathFactoryAnalyzerType, UseFullPathFactoryCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForEnvironmentGetFolderPathWithSpecialFolderOption()
+    {
+        var source = """
+            using System;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M()
+                    {
+                        return Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments, Environment.SpecialFolderOption.Create);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseFullPathFactoryAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForFullPathFactoryMethods()
+    {
+        var source = """
+            using System;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M()
+                    {
+                        return FullPath.Combine(FullPath.GetTempPath(), FullPath.GetFolderPath(Environment.SpecialFolder.MyDocuments).Name);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseFullPathFactoryAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForUnrelatedMethods()
+    {
+        var source = """
+            using System.IO;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M()
+                    {
+                        return Path.GetTempFileName();
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseFullPathFactoryAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+}

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseFullPathFactoryRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseFullPathFactoryRuleTests.cs
@@ -118,10 +118,11 @@ public sealed class UseFullPathFactoryRuleTests : FullPathAnalyzerTestBase
     }
 
     [Fact]
-    public async Task Analyzer_DoesNotReportDiagnostic_ForEnvironmentGetFolderPathWithSpecialFolderOption()
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForEnvironmentGetFolderPathWithSpecialFolderOption()
     {
         var source = """
             using System;
+            using Meziantou.Framework;
 
             namespace Sample
             {
@@ -129,13 +130,29 @@ public sealed class UseFullPathFactoryRuleTests : FullPathAnalyzerTestBase
                 {
                     public static string M()
                     {
-                        return Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments, Environment.SpecialFolderOption.Create);
+                        return {|MFFP0024:Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments, Environment.SpecialFolderOption.Create)|};
                     }
                 }
             }
             """;
 
-        await CreateAnalyzerTest<UseFullPathFactoryAnalyzerType>(source).RunAsync(XunitCancellationToken);
+        var fixedSource = """
+            using System;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M()
+                    {
+                        return FullPath.GetFolderPath(Environment.SpecialFolder.MyDocuments, Environment.SpecialFolderOption.Create);
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<UseFullPathFactoryAnalyzerType, UseFullPathFactoryCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -445,6 +445,20 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public void GetFolderPath()
+    {
+        var expected = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        Assert.Equal(FullPath.FromPath(expected), FullPath.GetFolderPath(Environment.SpecialFolder.UserProfile));
+    }
+
+    [Fact]
+    public void GetFolderPath_WithSpecialFolderOption()
+    {
+        var expected = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.DoNotVerify);
+        Assert.Equal(FullPath.FromPath(expected), FullPath.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.DoNotVerify));
+    }
+
+    [Fact]
     public async Task TryFindFirstAncestorOrSelf()
     {
         await using var tempDir = TemporaryDirectory.Create();


### PR DESCRIPTION
## What

New analyzer + code fix `MFFP0024` that suggests the `FullPath` equivalent of the path-producing BCL APIs:

| Reported | Fix |
| -- | -- |
| `Path.GetTempPath()` | `FullPath.GetTempPath()` |
| `Environment.GetFolderPath(folder)` | `FullPath.GetFolderPath(folder)` |
| `Environment.GetFolderPath(folder, option)` | `FullPath.GetFolderPath(folder, option)` |

Severity `Info`, enabled by default, consistent with the other `MFFP` rules.

This also adds the missing `FullPath.GetFolderPath(Environment.SpecialFolder, Environment.SpecialFolderOption)` overload so the rule can cover both `Environment.GetFolderPath` overloads. `ref/Meziantou.Framework.FullPath.cs` is updated accordingly.

## Why

```c#
FullPath.Combine(Path.GetTempPath(), "sample");
```

The rule nudges toward `FullPath.GetTempPath()` so the path stays a `FullPath` from the start instead of round-tripping through `string`.

## Notes for reviewers

- The mapping lives in `FullPathContext.GetFullPathFactoryEquivalentTypeName` and is shared by the analyzer and the code fix, so adding entries (for instance `Environment.CurrentDirectory` / `Directory.GetCurrentDirectory()` => `FullPath.CurrentDirectory()`) is a one-liner. I kept the scope to the APIs above.
- The code fix emits the fully qualified type name annotated with `Simplifier.Annotation`, so it collapses to `FullPath.X()` when `Meziantou.Framework` is imported and stays qualified otherwise. Both cases are covered by tests.
- Applying the fix to the snippet above yields `FullPath.Combine(FullPath.GetTempPath(), "sample")`. Going all the way to `FullPath.GetTempPath() / "sample"` would need a separate rule for `FullPath.Combine` with a `FullPath` root, which I did not add since the readme and the `use-fullpath` skill both present `FullPath.Combine` as an acceptable idiom.
- Known trade-off: the rule fires on every `Path.GetTempPath()` call, not only those already in a `FullPath` context. The fix changes the expression type from `string` to `FullPath`, so applying it on something like `Path.GetTempPath().TrimEnd('/')` produces code that does not compile. `MFFP0005`-`MFFP0010` have the same characteristic.
- `GetFolderPath` forwards to `FullPath.FromPath`, which calls `Path.GetFullPath` and therefore throws on the empty string. `Environment.GetFolderPath` returns an empty string for special folders that are not defined on the current platform, so both overloads can throw there. That behavior is pre-existing on the single-parameter overload and the new overload matches it rather than diverging; happy to change both if you would rather return `FullPath.Empty`.

## Validation

- `Meziantou.Framework.FullPath.Analyzer.Tests`: 105/105 passed (6 new)
- `Meziantou.Framework.FullPath.Tests`: 142 passed, 40 skipped (platform-gated), 2 new for `GetFolderPath`
- Build clean with `/p:TreatWarningsAsErrors=true`
- `dotnet run ./eng/update-all.cs` runs clean; the readme rule table is regenerated