### PR TITLE
Add assembly-level configuration to StronglyTypedId

### DIFF
--- a/src/Meziantou.Framework.StronglyTypedId.Annotations/StronglyTypedIdDefaultsAttribute.cs
+++ b/src/Meziantou.Framework.StronglyTypedId.Annotations/StronglyTypedIdDefaultsAttribute.cs
@@ -1,0 +1,47 @@
+namespace Meziantou.Framework.Annotations;
+
+/// <summary>
+/// Configures the default values used by the strongly-typed identifier source generator for all the types of the assembly.
+/// Options set on <see cref="StronglyTypedIdAttribute"/> or <c>StronglyTypedIdAttribute&lt;T&gt;</c> take precedence over the values defined by this attribute.
+/// </summary>
+/// <example>
+/// <code>
+/// [assembly: StronglyTypedIdDefaults(GuidGenerationStrategy = GuidGenerationStrategy.Version7, GenerateNewtonsoftJsonConverter = false)]
+///
+/// [StronglyTypedId&lt;Guid&gt;]
+/// public partial struct ProductId
+/// {
+/// }
+///
+/// // Usage:
+/// var productId = ProductId.New(); // Uses Guid.CreateVersion7()
+/// </code>
+/// </example>
+[System.Diagnostics.Conditional("StronglyTypedId_Attributes")]
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+public sealed class StronglyTypedIdDefaultsAttribute : Attribute
+{
+    /// <summary>Gets or sets the default value indicating whether a System.Text.Json.Serialization.JsonConverter is generated. When the property is not set, the converter is generated.</summary>
+    public bool GenerateSystemTextJsonConverter { get; set; }
+
+    /// <summary>Gets or sets the default value indicating whether a Newtonsoft.Json.JsonConverter is generated. When the property is not set, the converter is generated.</summary>
+    public bool GenerateNewtonsoftJsonConverter { get; set; }
+
+    /// <summary>Gets or sets the default value indicating whether a System.ComponentModel.TypeConverter is generated. When the property is not set, the converter is generated.</summary>
+    public bool GenerateSystemComponentModelTypeConverter { get; set; }
+
+    /// <summary>Gets or sets the default value indicating whether a MongoDB.Bson.Serialization.Serializers.SerializerBase{T} is generated. When the property is not set, the serializer is generated.</summary>
+    public bool GenerateMongoDBBsonSerialization { get; set; }
+
+    /// <summary>Gets or sets the default value indicating whether generated members are marked with <see cref="System.CodeDom.Compiler.GeneratedCodeAttribute"/>. When the property is not set, the attribute is added.</summary>
+    public bool AddCodeGeneratedAttribute { get; set; }
+
+    /// <summary>Gets or sets the default string comparison method to use when the underlying type is <see cref="string"/>. When the property is not set, <see cref="System.StringComparison.Ordinal"/> is used.</summary>
+    public StringComparison StringComparison { get; set; }
+
+    /// <summary>Gets or sets the default value indicating whether the ToString() method generates output in record format. When the property is not set, the record format is used.</summary>
+    public bool GenerateToStringAsRecord { get; set; }
+
+    /// <summary>Gets or sets the default strategy used by the generated <c>New()</c> method when the underlying type is <see cref="Guid"/>. When the property is not set, <see cref="GuidGenerationStrategy.Version4"/> is used.</summary>
+    public GuidGenerationStrategy GuidGenerationStrategy { get; set; }
+}

--- a/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdAnalyzer.cs
+++ b/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdAnalyzer.cs
@@ -43,13 +43,37 @@ public sealed class StronglyTypedIdAnalyzer : DiagnosticAnalyzer
 
     private static void InitializeCore(CompilationStartAnalysisContext context)
     {
-        var nonGenericAttribute = context.Compilation.GetTypeByMetadataName("Meziantou.Framework.Annotations.StronglyTypedIdAttribute");
-        var genericAttribute = context.Compilation.GetTypeByMetadataName("Meziantou.Framework.Annotations.StronglyTypedIdAttribute`1");
+        var nonGenericAttribute = context.Compilation.GetTypeByMetadataName(StronglyTypedIdSourceGenerator.StronglyTypedIdAttributeName);
+        var genericAttribute = context.Compilation.GetTypeByMetadataName(StronglyTypedIdSourceGenerator.StronglyTypedIdGenericAttributeName);
         if (nonGenericAttribute is null && genericAttribute is null)
             return;
 
         var supportGuidCreateVersion7 = context.Compilation.SupportGuidCreateVersion7();
+        if (!supportGuidCreateVersion7 && context.Compilation.GetTypeByMetadataName(StronglyTypedIdSourceGenerator.StronglyTypedIdDefaultsAttributeName) is { } defaultsAttribute)
+        {
+            context.RegisterCompilationEndAction(context => AnalyzeAssemblyDefaults(context, defaultsAttribute));
+        }
+
         context.RegisterSymbolAction(context => AnalyzeSymbol(context, nonGenericAttribute, genericAttribute, supportGuidCreateVersion7), SymbolKind.NamedType);
+    }
+
+    private static void AnalyzeAssemblyDefaults(CompilationAnalysisContext context, INamedTypeSymbol defaultsAttribute)
+    {
+        foreach (var attribute in context.Compilation.Assembly.GetAttributes())
+        {
+            if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, defaultsAttribute))
+                continue;
+
+            if (GetGuidGenerationStrategy(attribute) is not StronglyTypedIdSourceGenerator.GuidGenerationStrategy.Version7)
+                continue;
+
+            var location = GetNamedArgumentLocation(attribute, StronglyTypedIdSourceGenerator.GuidGenerationStrategyPropertyName, context.CancellationToken)
+                ?? attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken).GetLocation();
+            if (location is not null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(UnsupportedGuidGenerationStrategy, location));
+            }
+        }
     }
 
     private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol? nonGenericAttribute, INamedTypeSymbol? genericAttribute, bool supportGuidCreateVersion7)

--- a/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.cs
+++ b/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection;
 using System.Xml.Linq;
@@ -18,26 +19,36 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
     private const string PropertyAsStringName = "ValueAsString";
 
     internal const string GuidGenerationStrategyPropertyName = "GuidGenerationStrategy";
+    internal const string StronglyTypedIdAttributeName = "Meziantou.Framework.Annotations.StronglyTypedIdAttribute";
+    internal const string StronglyTypedIdGenericAttributeName = "Meziantou.Framework.Annotations.StronglyTypedIdAttribute`1";
+    internal const string StronglyTypedIdDefaultsAttributeName = "Meziantou.Framework.Annotations.StronglyTypedIdDefaultsAttribute";
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var nonGenericTypes = context.SyntaxProvider
             .ForAttributeWithMetadataName(
-                "Meziantou.Framework.Annotations.StronglyTypedIdAttribute",
+                StronglyTypedIdAttributeName,
                 predicate: static (syntax, cancellationToken) => IsSyntaxTargetForGeneration(syntax),
                 transform: static (ctx, cancellationToken) => GetNonGenericSemanticTargetForGeneration(ctx, cancellationToken))
             .Where(static m => m is not null)
             .WithTrackingName("Syntax");
         var genericTypes = context.SyntaxProvider
             .ForAttributeWithMetadataName(
-                "Meziantou.Framework.Annotations.StronglyTypedIdAttribute`1",
+                StronglyTypedIdGenericAttributeName,
                 predicate: static (syntax, _) => IsSyntaxTargetForGeneration(syntax),
                 transform: static (ctx, cancellationToken) => GetGenericSemanticTargetForGeneration(ctx, cancellationToken))
             .Where(static m => m is not null)
             .WithTrackingName("Syntax");
+        var assemblyDefaults = context.SyntaxProvider
+            .ForAttributeWithMetadataName(
+                StronglyTypedIdDefaultsAttributeName,
+                predicate: static (_, _) => true,
+                transform: static (ctx, _) => GetAssemblyDefaults(ctx))
+            .Collect()
+            .Select(static (options, _) => options.FirstOrDefault() ?? StronglyTypedIdOptions.Empty);
 
-        context.RegisterSourceOutput(nonGenericTypes, (context, attribute) => Execute(context, attribute!));
-        context.RegisterSourceOutput(genericTypes, (context, attribute) => Execute(context, attribute!));
+        context.RegisterSourceOutput(nonGenericTypes.Combine(assemblyDefaults), (context, item) => Execute(context, item.Left!.ApplyDefaults(item.Right)));
+        context.RegisterSourceOutput(genericTypes.Combine(assemblyDefaults), (context, item) => Execute(context, item.Left!.ApplyDefaults(item.Right)));
 
         static bool IsSyntaxTargetForGeneration(SyntaxNode syntax)
         {
@@ -108,48 +119,6 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
 
             foreach (var attribute in ctx.Attributes)
             {
-                var converters = StronglyTypedIdConverters.None;
-                AddConverter(arguments[0], StronglyTypedIdConverters.System_Text_Json);
-                AddConverter(arguments[1], StronglyTypedIdConverters.Newtonsoft_Json);
-                AddConverter(arguments[2], StronglyTypedIdConverters.System_ComponentModel_TypeConverter);
-                AddConverter(arguments[3], StronglyTypedIdConverters.MongoDB_Bson_Serialization);
-                void AddConverter(TypedConstant value, StronglyTypedIdConverters converterValue)
-                {
-                    if (value.Value is bool argumentValue && argumentValue)
-                    {
-                        converters |= converterValue;
-                    }
-                }
-
-                var addCodeGeneratedAttribute = false;
-                if (arguments[4].Value is bool addCodeGeneratedAttributeValue)
-                {
-                    addCodeGeneratedAttribute = addCodeGeneratedAttributeValue;
-                }
-
-                T GetNamedProperty<T>(string name, T defaultValue)
-                {
-                    foreach (var arg in attribute.NamedArguments)
-                    {
-                        if (arg.Key == name)
-                        {
-                            if (arg.Value.Value is T result)
-                                return result;
-
-                            if (typeof(T).IsEnum && arg.Value.Value is int i && Enum.IsDefined(typeof(T), i))
-                                return (T)Enum.ToObject(typeof(T), i);
-
-                            break;
-                        }
-                    }
-
-                    return defaultValue;
-                }
-
-                var stringComparison = GetNamedProperty("StringComparison", defaultValue: StringComparison.Ordinal);
-                var generateToStringAsRecord = GetNamedProperty("GenerateToStringAsRecord", defaultValue: true);
-                var guidGenerationStrategy = GetNamedProperty(GuidGenerationStrategyPropertyName, defaultValue: GuidGenerationStrategy.Version4);
-
                 var attributeSyntax = attribute.ApplicationSyntaxReference!.GetSyntax(cancellationToken);
                 var idType = GetIdType(semanticModel.Compilation, type);
 
@@ -158,21 +127,108 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
                     return null;
                 }
 
+                var explicitConstructorArguments = GetExplicitConstructorArguments(attribute, attributeSyntax);
+                var options = new StronglyTypedIdOptions(
+                    GetConstructorArgument("generateSystemTextJsonConverter", arguments[0]),
+                    GetConstructorArgument("generateNewtonsoftJsonConverter", arguments[1]),
+                    GetConstructorArgument("generateSystemComponentModelTypeConverter", arguments[2]),
+                    GetConstructorArgument("generateMongoDBBsonSerialization", arguments[3]),
+                    GetConstructorArgument("addCodeGeneratedAttribute", arguments[4]),
+                    GetNamedProperty<StringComparison>(attribute, "StringComparison"),
+                    GetNamedProperty<bool>(attribute, "GenerateToStringAsRecord"),
+                    GetNamedProperty<GuidGenerationStrategy>(attribute, GuidGenerationStrategyPropertyName));
+
+                bool? GetConstructorArgument(string parameterName, TypedConstant value)
+                {
+                    if (!explicitConstructorArguments.Contains(parameterName))
+                        return null;
+
+                    return value.Value is bool result ? result : null;
+                }
+
                 return new AttributeInfo(
                     semanticModel.Compilation,
                     attributeSyntax,
                     (INamedTypeSymbol)ctx.TargetSymbol,
                     idType,
                     type,
-                    converters,
-                    addCodeGeneratedAttribute,
-                    stringComparison,
-                    generateToStringAsRecord,
-                    guidGenerationStrategy);
+                    options);
             }
 
             return null;
         }
+
+        static StronglyTypedIdOptions GetAssemblyDefaults(GeneratorAttributeSyntaxContext ctx)
+        {
+            var options = StronglyTypedIdOptions.Empty;
+            foreach (var attribute in ctx.Attributes)
+            {
+                options = options.Merge(new StronglyTypedIdOptions(
+                    GetNamedProperty<bool>(attribute, "GenerateSystemTextJsonConverter"),
+                    GetNamedProperty<bool>(attribute, "GenerateNewtonsoftJsonConverter"),
+                    GetNamedProperty<bool>(attribute, "GenerateSystemComponentModelTypeConverter"),
+                    GetNamedProperty<bool>(attribute, "GenerateMongoDBBsonSerialization"),
+                    GetNamedProperty<bool>(attribute, "AddCodeGeneratedAttribute"),
+                    GetNamedProperty<StringComparison>(attribute, "StringComparison"),
+                    GetNamedProperty<bool>(attribute, "GenerateToStringAsRecord"),
+                    GetNamedProperty<GuidGenerationStrategy>(attribute, GuidGenerationStrategyPropertyName)));
+            }
+
+            return options;
+        }
+    }
+
+    private static T? GetNamedProperty<T>(AttributeData attribute, string name) where T : struct
+    {
+        foreach (var arg in attribute.NamedArguments)
+        {
+            if (arg.Key == name)
+            {
+                if (arg.Value.Value is T result)
+                    return result;
+
+                if (typeof(T).IsEnum && arg.Value.Value is int i && Enum.IsDefined(typeof(T), i))
+                    return (T)Enum.ToObject(typeof(T), i);
+
+                break;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the names of the constructor parameters explicitly set in the source code, so optional parameters that are not set can fall back to the assembly-level defaults.
+    /// </summary>
+    private static HashSet<string> GetExplicitConstructorArguments(AttributeData attribute, SyntaxNode attributeSyntax)
+    {
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        if (attributeSyntax is not AttributeSyntax { ArgumentList: not null } syntax)
+            return result;
+
+        var parameters = attribute.AttributeConstructor?.Parameters ?? ImmutableArray<IParameterSymbol>.Empty;
+        var index = 0;
+        foreach (var argument in syntax.ArgumentList.Arguments)
+        {
+            if (argument.NameEquals is not null)
+                continue;
+
+            if (argument.NameColon is not null)
+            {
+                result.Add(argument.NameColon.Name.Identifier.ValueText);
+            }
+            else
+            {
+                if (index < parameters.Length)
+                {
+                    result.Add(parameters[index].Name);
+                }
+
+                index++;
+            }
+        }
+
+        return result;
     }
 
     private static void Execute(SourceProductionContext context, AttributeInfo attribute)
@@ -383,17 +439,14 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
 
     private sealed class AttributeInfo : IEquatable<AttributeInfo>
     {
-        public AttributeInfo(Compilation compilation, SyntaxNode attributeSyntax, INamedTypeSymbol typeSymbol, IdType idType, ITypeSymbol idTypeSymbol, StronglyTypedIdConverters converters, bool addCodeGeneratedAttribute, StringComparison stringComparison, bool generateToStringAsRecord, GuidGenerationStrategy guidGenerationStrategy)
+        public AttributeInfo(Compilation compilation, SyntaxNode attributeSyntax, INamedTypeSymbol typeSymbol, IdType idType, ITypeSymbol idTypeSymbol, StronglyTypedIdOptions options)
         {
             Debug.Assert(idType != IdType.Unknown);
 
             AttributeSyntax = attributeSyntax;
             IdType = idType;
-            Converters = converters;
-            AddCodeGeneratedAttribute = addCodeGeneratedAttribute;
-            StringComparison = stringComparison;
-            GenerateToStringAsRecord = generateToStringAsRecord;
-            GuidGenerationStrategy = guidGenerationStrategy;
+            Options = options;
+            ApplyOptions();
             TypeName = typeSymbol.Name;
             IsSealed = typeSymbol.IsSealed;
             IsReferenceType = typeSymbol.IsReferenceType;
@@ -574,11 +627,49 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
         // Info provided by the attribute
         public PartialTypeContext PartialTypeContext { get; }
         public IdType IdType { get; }
-        public StronglyTypedIdConverters Converters { get; }
-        public bool AddCodeGeneratedAttribute { get; }
-        public StringComparison StringComparison { get; }
-        public bool GenerateToStringAsRecord { get; }
-        public GuidGenerationStrategy GuidGenerationStrategy { get; }
+
+        /// <summary>Gets the options explicitly set on the attribute. Options that are not set fall back to the assembly-level defaults, then to the default values.</summary>
+        public StronglyTypedIdOptions Options { get; private set; }
+        public StronglyTypedIdConverters Converters { get; private set; }
+        public bool AddCodeGeneratedAttribute { get; private set; }
+        public StringComparison StringComparison { get; private set; }
+        public bool GenerateToStringAsRecord { get; private set; }
+        public GuidGenerationStrategy GuidGenerationStrategy { get; private set; }
+
+        /// <summary>Returns an instance where the options that are not explicitly set on the attribute use the assembly-level default values.</summary>
+        public AttributeInfo ApplyDefaults(StronglyTypedIdOptions defaults)
+        {
+            if (defaults == StronglyTypedIdOptions.Empty)
+                return this;
+
+            var result = (AttributeInfo)MemberwiseClone();
+            result.Options = Options.Merge(defaults);
+            result.ApplyOptions();
+            return result;
+        }
+
+        private void ApplyOptions()
+        {
+            var converters = StronglyTypedIdConverters.None;
+            AddConverter(Options.GenerateSystemTextJsonConverter, StronglyTypedIdConverters.System_Text_Json);
+            AddConverter(Options.GenerateNewtonsoftJsonConverter, StronglyTypedIdConverters.Newtonsoft_Json);
+            AddConverter(Options.GenerateSystemComponentModelTypeConverter, StronglyTypedIdConverters.System_ComponentModel_TypeConverter);
+            AddConverter(Options.GenerateMongoDBBsonSerialization, StronglyTypedIdConverters.MongoDB_Bson_Serialization);
+
+            Converters = converters;
+            AddCodeGeneratedAttribute = Options.AddCodeGeneratedAttribute ?? true;
+            StringComparison = Options.StringComparison ?? StringComparison.Ordinal;
+            GenerateToStringAsRecord = Options.GenerateToStringAsRecord ?? true;
+            GuidGenerationStrategy = Options.GuidGenerationStrategy ?? GuidGenerationStrategy.Version4;
+
+            void AddConverter(bool? value, StronglyTypedIdConverters converterValue)
+            {
+                if (value ?? true)
+                {
+                    converters |= converterValue;
+                }
+            }
+        }
 
         // Computed info
         public string TypeName { get; }
@@ -648,12 +739,8 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
                 && PartialTypeContext == other.PartialTypeContext
                 && IdType == other.IdType
                 && TypeName == other.TypeName
-                && StringComparison == other.StringComparison
-                && GenerateToStringAsRecord == other.GenerateToStringAsRecord
-                && GuidGenerationStrategy == other.GuidGenerationStrategy
+                && Options == other.Options
                 && SupportGuidCreateVersion7 == other.SupportGuidCreateVersion7
-                && Converters == other.Converters
-                && AddCodeGeneratedAttribute == other.AddCodeGeneratedAttribute
                 && IsSealed == other.IsSealed
                 && IsCtorDefined == other.IsCtorDefined
                 && IsNewDefined == other.IsNewDefined
@@ -699,12 +786,8 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
             hashcode.Add(PartialTypeContext);
             hashcode.Add(IdType);
             hashcode.Add(TypeName, StringComparer.Ordinal);
-            hashcode.Add(Converters);
-            hashcode.Add(StringComparison);
-            hashcode.Add(GenerateToStringAsRecord);
-            hashcode.Add(GuidGenerationStrategy);
+            hashcode.Add(Options);
             hashcode.Add(SupportGuidCreateVersion7);
-            hashcode.Add(AddCodeGeneratedAttribute);
             hashcode.Add(IsSealed);
             hashcode.Add(IsCtorDefined);
             hashcode.Add(IsNewDefined);
@@ -835,6 +918,36 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
                 IdType.MongoDB_Bson_ObjectId => "ObjectId",
                 _ => throw new ArgumentException($"Type '{type}' not supported", nameof(type)),
             };
+        }
+    }
+
+    /// <summary>
+    /// Options set on an attribute. A <see langword="null"/> value means the option is not set.
+    /// </summary>
+    internal sealed record StronglyTypedIdOptions(
+        bool? GenerateSystemTextJsonConverter,
+        bool? GenerateNewtonsoftJsonConverter,
+        bool? GenerateSystemComponentModelTypeConverter,
+        bool? GenerateMongoDBBsonSerialization,
+        bool? AddCodeGeneratedAttribute,
+        StringComparison? StringComparison,
+        bool? GenerateToStringAsRecord,
+        GuidGenerationStrategy? GuidGenerationStrategy)
+    {
+        public static StronglyTypedIdOptions Empty { get; } = new(null, null, null, null, null, null, null, null);
+
+        /// <summary>Returns the current options where the options that are not set use the values from <paramref name="defaults"/>.</summary>
+        public StronglyTypedIdOptions Merge(StronglyTypedIdOptions defaults)
+        {
+            return new StronglyTypedIdOptions(
+                GenerateSystemTextJsonConverter ?? defaults.GenerateSystemTextJsonConverter,
+                GenerateNewtonsoftJsonConverter ?? defaults.GenerateNewtonsoftJsonConverter,
+                GenerateSystemComponentModelTypeConverter ?? defaults.GenerateSystemComponentModelTypeConverter,
+                GenerateMongoDBBsonSerialization ?? defaults.GenerateMongoDBBsonSerialization,
+                AddCodeGeneratedAttribute ?? defaults.AddCodeGeneratedAttribute,
+                StringComparison ?? defaults.StringComparison,
+                GenerateToStringAsRecord ?? defaults.GenerateToStringAsRecord,
+                GuidGenerationStrategy ?? defaults.GuidGenerationStrategy);
         }
     }
 

--- a/src/Meziantou.Framework.StronglyTypedId/readme.md
+++ b/src/Meziantou.Framework.StronglyTypedId/readme.md
@@ -148,6 +148,25 @@ public partial struct ProjectId
 public partial struct ProjectId { } // No New() method is generated
 ````
 
+You can configure the default value of the options for all the types of an assembly using the `[assembly: StronglyTypedIdDefaults]` attribute. Options set on `[StronglyTypedId]` take precedence over the assembly-level defaults:
+
+````c#
+[assembly: StronglyTypedIdDefaults(GuidGenerationStrategy = GuidGenerationStrategy.Version7,
+                                   GenerateNewtonsoftJsonConverter = false,
+                                   GenerateMongoDBBsonSerialization = false,
+                                   GenerateSystemComponentModelTypeConverter = false,
+                                   GenerateSystemTextJsonConverter = true,
+                                   AddCodeGeneratedAttribute = true,
+                                   StringComparison = StringComparison.Ordinal,
+                                   GenerateToStringAsRecord = true)]
+
+[StronglyTypedId<Guid>]
+public partial struct ProjectId { } // New() uses Guid.CreateVersion7()
+
+[StronglyTypedId<Guid>(GuidGenerationStrategy = GuidGenerationStrategy.Version4)]
+public partial struct CustomerId { } // New() uses Guid.NewGuid()
+````
+
 You can generate `IComparable`, `IComparable<T>` and comparison operators by adding one interface:
 
 ````c#

--- a/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
@@ -11,6 +11,9 @@ using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 using Newtonsoft.Json;
 
+// Validate the assembly-level configuration is applied to all the types of the assembly
+[assembly: StronglyTypedIdDefaults(AddCodeGeneratedAttribute = false)]
+
 namespace Meziantou.Framework.StronglyTypedId.GeneratorTests;
 
 public sealed partial class StronglyTypedIdTests
@@ -143,6 +146,9 @@ public sealed partial class StronglyTypedIdTests
     {
         Assert.NotNull(typeof(IdInt32WithCodeGeneratedAttribute).GetMethod("FromInt32")!.GetCustomAttribute<System.CodeDom.Compiler.GeneratedCodeAttribute>());
         Assert.Null(typeof(IdInt32WithoutCodeGeneratedAttribute).GetMethod("FromInt32")!.GetCustomAttribute<System.CodeDom.Compiler.GeneratedCodeAttribute>());
+
+        // The assembly-level configuration sets AddCodeGeneratedAttribute to false
+        Assert.Null(typeof(IdInt32).GetMethod("FromInt32")!.GetCustomAttribute<System.CodeDom.Compiler.GeneratedCodeAttribute>());
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
@@ -433,6 +433,236 @@ public sealed class StronglyTypedIdSourceGeneratorTests
         Assert.Empty(diagnostics);
     }
 
+    [Fact]
+    public async Task AssemblyDefaults_GuidGenerationStrategy()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Framework.Annotations.StronglyTypedIdDefaults(GuidGenerationStrategy = Meziantou.Framework.Annotations.GuidGenerationStrategy.Version7)]
+
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(System.Guid))]
+            public partial struct Test {}
+            """;
+
+        await TestGeneratedAssembly(sourceCode, type =>
+        {
+            Assert.Equal(7, GetNewValue(type).Version);
+        });
+    }
+
+    [Fact]
+    public async Task AssemblyDefaults_GuidGenerationStrategy_GenericAttribute()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Framework.Annotations.StronglyTypedIdDefaults(GuidGenerationStrategy = Meziantou.Framework.Annotations.GuidGenerationStrategy.Version7)]
+
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute<System.Guid>]
+            public partial struct Test {}
+            """;
+
+        await TestGeneratedAssembly(sourceCode, type =>
+        {
+            Assert.Equal(7, GetNewValue(type).Version);
+        });
+    }
+
+    [Fact]
+    public async Task AssemblyDefaults_GuidGenerationStrategy_OverriddenByType()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Framework.Annotations.StronglyTypedIdDefaults(GuidGenerationStrategy = Meziantou.Framework.Annotations.GuidGenerationStrategy.Version7)]
+
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(System.Guid), GuidGenerationStrategy = Meziantou.Framework.Annotations.GuidGenerationStrategy.Version4)]
+            public partial struct Test {}
+            """;
+
+        await TestGeneratedAssembly(sourceCode, type =>
+        {
+            Assert.Equal(4, GetNewValue(type).Version);
+        });
+    }
+
+    [Fact]
+    public async Task AssemblyDefaults_StringComparison()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Framework.Annotations.StronglyTypedIdDefaults(StringComparison = System.StringComparison.OrdinalIgnoreCase)]
+
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(string))]
+            public partial struct Test {}
+            """;
+
+        await TestGeneratedAssembly(sourceCode, type =>
+        {
+            var from = (MethodInfo)type.GetMember("FromString").Single();
+            Assert.Equal(from.Invoke(null, ["TEST"]), from.Invoke(null, ["test"]));
+        });
+    }
+
+    [Fact]
+    public async Task AssemblyDefaults_GenerateToStringAsRecord()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Framework.Annotations.StronglyTypedIdDefaults(GenerateToStringAsRecord = false)]
+
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(int))]
+            public partial struct Test {}
+            """;
+
+        await TestGeneratedAssembly(sourceCode, type =>
+        {
+            var from = (MethodInfo)type.GetMember("FromInt32").Single();
+            Assert.Equal("42", from.Invoke(null, [42])!.ToString());
+        });
+    }
+
+    [Fact]
+    public async Task AssemblyDefaults_AddCodeGeneratedAttribute()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Framework.Annotations.StronglyTypedIdDefaults(AddCodeGeneratedAttribute = false)]
+
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(int))]
+            public partial struct Test {}
+            """;
+
+        var generatedCode = await GenerateSingleFile(sourceCode);
+        Assert.DoesNotContain("GeneratedCodeAttribute", generatedCode);
+    }
+
+    [Fact]
+    public async Task AssemblyDefaults_AddCodeGeneratedAttribute_OverriddenByType()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Framework.Annotations.StronglyTypedIdDefaults(AddCodeGeneratedAttribute = false)]
+
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(int), addCodeGeneratedAttribute: true)]
+            public partial struct Test {}
+            """;
+
+        var generatedCode = await GenerateSingleFile(sourceCode);
+        Assert.Contains("GeneratedCodeAttribute", generatedCode);
+    }
+
+    [Fact]
+    public async Task AssemblyDefaults_Converters()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Framework.Annotations.StronglyTypedIdDefaults(GenerateSystemTextJsonConverter = false, GenerateNewtonsoftJsonConverter = false, GenerateSystemComponentModelTypeConverter = false, GenerateMongoDBBsonSerialization = false)]
+
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(int))]
+            public partial struct Test {}
+            """;
+
+        var generatedCode = await GenerateSingleFile(sourceCode);
+        Assert.DoesNotContain("JsonConverterAttribute", generatedCode);
+        Assert.DoesNotContain("TypeConverterAttribute", generatedCode);
+    }
+
+    [Fact]
+    public async Task AssemblyDefaults_Converters_OverriddenByType()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Framework.Annotations.StronglyTypedIdDefaults(GenerateSystemTextJsonConverter = false, GenerateSystemComponentModelTypeConverter = false)]
+
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(int), generateSystemTextJsonConverter: true)]
+            public partial struct Test {}
+            """;
+
+        var generatedCode = await GenerateSingleFile(sourceCode);
+        Assert.Contains("System.Text.Json.Serialization.JsonConverterAttribute", generatedCode);
+        Assert.DoesNotContain("TypeConverterAttribute", generatedCode);
+    }
+
+    [Fact]
+    public async Task AssemblyDefaults_Converters_OverriddenByTypeUsingPositionalArgument()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Framework.Annotations.StronglyTypedIdDefaults(GenerateSystemTextJsonConverter = false, GenerateNewtonsoftJsonConverter = false)]
+
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(int), true)]
+            public partial struct Test {}
+            """;
+
+        var generatedCode = await GenerateSingleFile(sourceCode);
+        Assert.Contains("System.Text.Json.Serialization.JsonConverterAttribute", generatedCode);
+        Assert.DoesNotContain("Newtonsoft.Json.JsonConverterAttribute", generatedCode);
+    }
+
+    [Fact]
+    public async Task AssemblyDefaults_GuidGenerationStrategy_NotSupportedByTargetFramework()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Framework.Annotations.StronglyTypedIdDefaults(GuidGenerationStrategy = Meziantou.Framework.Annotations.GuidGenerationStrategy.Version7)]
+
+            """ + AttributeSourceCode + """
+
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(System.Guid))]
+            public partial struct Test {}
+            """;
+
+        var result = await GenerateFiles(sourceCode, netCoreVersion: "8.0.0", referenceAnnotations: false);
+        var generatedCode = (await Assert.Single(result.GeneratorResult.GeneratedTrees).GetRootAsync(XunitCancellationToken)).ToFullString();
+        Assert.Contains("global::System.Guid.NewGuid()", generatedCode);
+
+        var diagnostics = await Analyze(sourceCode, netCoreVersion: "8.0.0", referenceAnnotations: false);
+        Assert.Collection(diagnostics, diag => Assert.Equal("MFSTID0002", diag.Id));
+    }
+
+    [Fact]
+    public async Task AssemblyDefaults_GuidGenerationStrategy_OnNonGuidType_NotReported()
+    {
+        var sourceCode = """
+            [assembly: Meziantou.Framework.Annotations.StronglyTypedIdDefaults(GuidGenerationStrategy = Meziantou.Framework.Annotations.GuidGenerationStrategy.Version7)]
+
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(int))]
+            public partial struct Test {}
+            """;
+
+        var diagnostics = await Analyze(sourceCode);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task AssemblyDefaults_UpdatingTheAttributeRegeneratesTheCode()
+    {
+        var generator = InstantiateGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: [generator],
+            driverOptions: new GeneratorDriverOptions(default, trackIncrementalGeneratorSteps: true));
+
+        var compilation = await CreateCompilation("[Meziantou.Framework.Annotations.StronglyTypedId(typeof(System.Guid))] public partial struct Test { }",
+        [
+            new NuGetReference("Microsoft.NETCore.App.Ref", NetCoreVersion, "ref/"),
+        ]);
+
+        driver = driver.RunGenerators(compilation, XunitCancellationToken);
+        Assert.Contains("global::System.Guid.NewGuid()", await GetGeneratedCode());
+
+        // Add the assembly-level attribute in another syntax tree
+        var attributeTree = CSharpSyntaxTree.ParseText("[assembly: Meziantou.Framework.Annotations.StronglyTypedIdDefaults(GuidGenerationStrategy = Meziantou.Framework.Annotations.GuidGenerationStrategy.Version7)]");
+        compilation = compilation.AddSyntaxTrees(attributeTree);
+        driver = driver.RunGenerators(compilation, XunitCancellationToken);
+        Assert.Contains("global::System.Guid.CreateVersion7()", await GetGeneratedCode());
+
+        // Remove the assembly-level attribute
+        compilation = compilation.RemoveSyntaxTrees(attributeTree);
+        driver = driver.RunGenerators(compilation, XunitCancellationToken);
+        Assert.Contains("global::System.Guid.NewGuid()", await GetGeneratedCode());
+
+        async Task<string> GetGeneratedCode()
+        {
+            var result = driver.GetRunResult().Results.Single();
+            return (await Assert.Single(result.GeneratedSources).SyntaxTree.GetRootAsync(XunitCancellationToken)).ToFullString();
+        }
+    }
+
+    private static async Task<string> GenerateSingleFile([StringSyntax("c#-test")] string sourceCode)
+    {
+        var result = await GenerateFiles(sourceCode);
+        Assert.Empty(result.GeneratorResult.Diagnostics);
+        return (await Assert.Single(result.GeneratorResult.GeneratedTrees).GetRootAsync(XunitCancellationToken)).ToFullString();
+    }
+
     /// <summary>
     /// Declaration of the attribute, so the generator can run against reference assemblies that are older than the ones targeted by the annotations assembly.
     /// </summary>
@@ -453,6 +683,19 @@ public sealed class StronglyTypedIdSourceGeneratorTests
                 }
 
                 public System.Type IdType { get; }
+                public System.StringComparison StringComparison { get; set; }
+                public bool GenerateToStringAsRecord { get; set; }
+                public GuidGenerationStrategy GuidGenerationStrategy { get; set; }
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Assembly)]
+            public sealed class StronglyTypedIdDefaultsAttribute : System.Attribute
+            {
+                public bool GenerateSystemTextJsonConverter { get; set; }
+                public bool GenerateNewtonsoftJsonConverter { get; set; }
+                public bool GenerateSystemComponentModelTypeConverter { get; set; }
+                public bool GenerateMongoDBBsonSerialization { get; set; }
+                public bool AddCodeGeneratedAttribute { get; set; }
                 public System.StringComparison StringComparison { get; set; }
                 public bool GenerateToStringAsRecord { get; set; }
                 public GuidGenerationStrategy GuidGenerationStrategy { get; set; }


### PR DESCRIPTION
Adds a way to configure the source generator options for a whole assembly, so options such as the `Guid` generation strategy don't have to be repeated on every type.

```csharp
[assembly: StronglyTypedIdDefaults(GuidGenerationStrategy = GuidGenerationStrategy.Version7,
                                   GenerateNewtonsoftJsonConverter = false)]

[StronglyTypedId<Guid>]
public partial struct ProjectId { } // New() uses Guid.CreateVersion7()

[StronglyTypedId<Guid>(GuidGenerationStrategy = GuidGenerationStrategy.Version4)]
public partial struct CustomerId { } // New() uses Guid.NewGuid()
```

## What changed

- **`StronglyTypedIdDefaultsAttribute`** (new, `AttributeTargets.Assembly`) exposes every option supported by `[StronglyTypedId]`: `GenerateSystemTextJsonConverter`, `GenerateNewtonsoftJsonConverter`, `GenerateSystemComponentModelTypeConverter`, `GenerateMongoDBBsonSerialization`, `AddCodeGeneratedAttribute`, `StringComparison`, `GenerateToStringAsRecord`, `GuidGenerationStrategy`.
- **Precedence**: option set on the type → assembly-level default → built-in default.
- **Analyzer**: `MFSTID0002` is now also reported on the assembly-level attribute when the target framework has no `Guid.CreateVersion7()`. `MFSTID0003` is intentionally *not* reported there, since the option legitimately applies only to the `Guid` ids of the assembly.
- Documentation added to the package readme.

## Notes for reviewers

- The constructor parameters of `[StronglyTypedId]` are optional and default to `true`, so the resolved value alone can't tell "not set" from "explicitly true". The generator now inspects the attribute syntax to collect the arguments that are actually written (positional, `name:` and property initializers are all handled) and only those override the assembly-level defaults.
- The defaults are a dedicated `ForAttributeWithMetadataName` provider combined with the type providers, rather than being read from the compilation inside the per-type transform. Otherwise editing the assembly attribute would leave stale cached output for types declared in other files. `AssemblyDefaults_UpdatingTheAttributeRegeneratesTheCode` adds and removes the attribute across driver runs to cover this.
- The options set on the attribute are stored as a nullable record on `AttributeInfo` (used for the incremental equality), and the effective values are computed when the assembly defaults are applied.
- `Meziantou.Framework.StronglyTypedId.GeneratorTests` now carries a real `[assembly: StronglyTypedIdDefaults(AddCodeGeneratedAttribute = false)]`, so the feature is also exercised through an actual build; `CodeGeneratedAttribute` asserts both the inherited default and the per-type override.

## Validation

- Build with `/p:TreatsWarningsAsErrors=true`: clean.
- `Meziantou.Framework.StronglyTypedId.Tests`: 1456 passed (all TFMs), including 13 new `AssemblyDefaults_*` tests.
- `Meziantou.Framework.StronglyTypedId.GeneratorTests`: 172 passed (all TFMs).
- `dotnet run ./eng/update-all.cs`: no changes produced.