### PR TITLE
Add YamlNamingPolicyAttribute to configure naming policy per type or member

### DIFF
--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -874,6 +874,13 @@ namespace Meziantou.Framework.Yaml.Serialization
     {
     }
 
+    [System.AttributeUsage(System.AttributeTargets.Interface | System.AttributeTargets.Field | System.AttributeTargets.Property | System.AttributeTargets.Struct | System.AttributeTargets.Class, AllowMultiple = false)]
+    public sealed class YamlNamingPolicyAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
+    {
+        public Meziantou.Framework.Yaml.YamlKnownNamingPolicy NamingPolicy { get => throw null; }
+        public YamlNamingPolicyAttribute(Meziantou.Framework.Yaml.YamlKnownNamingPolicy namingPolicy) { }
+    }
+
     [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property | System.AttributeTargets.Struct | System.AttributeTargets.Class, AllowMultiple = false)]
     public sealed class YamlNumberHandlingAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/Meziantou.Framework.Yaml.SourceGenerator.csproj
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/Meziantou.Framework.Yaml.SourceGenerator.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="../Meziantou.Framework.Yaml/YamlKnownNamingPolicy.cs" Link="YamlKnownNamingPolicy.cs" />
     <Compile Include="../Meziantou.Framework.Yaml/YamlNamingPolicy.cs" Link="YamlNamingPolicy.cs" />
     <Compile Include="../Meziantou.Framework.Yaml/YamlCamelCaseNamingPolicy.cs" Link="YamlCamelCaseNamingPolicy.cs" />
     <Compile Include="../Meziantou.Framework.Yaml/YamlKebabCaseLowerNamingPolicy.cs" Link="YamlKebabCaseLowerNamingPolicy.cs" />

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
@@ -694,7 +694,7 @@ public sealed partial class YamlSerializerContextGenerator
             var extensionData = TryCreateExtensionDataMemberModel(named);
             var members = GetSerializableMembers(named)
                 .Where(m => extensionData is null || !SymbolEqualityComparer.Default.Equals(m, extensionData.Symbol))
-                .Select(m => CreateMemberModel(m, propertyNamingPolicy))
+                .Select(m => CreateMemberModel(m, named, propertyNamingPolicy))
                 .ToImmutableArray();
             builder.Append("        WriteMembers").Append(index).AppendLine("(writer, value, discriminatorPropertyName: null, runtimeConverters);");
             builder.AppendLine("        writer.WriteEndMapping();");
@@ -1819,7 +1819,10 @@ public sealed partial class YamlSerializerContextGenerator
             }
             else
             {
-                parameterYamlNameExpressions[i] = ToLiteral(ApplyNamingPolicy(parameterName, propertyNamingPolicy));
+                var declaredPolicy = GetDeclaredNamingPolicy(typeSymbol);
+                parameterYamlNameExpressions[i] = ToLiteral(declaredPolicy is not null
+                    ? ApplyNamingPolicy(parameterName, YamlNamingPolicy.GetPolicy(declaredPolicy.Value))
+                    : ApplyNamingPolicy(parameterName, propertyNamingPolicy));
             }
 
             parameterValueVarNames[i] = $"__ctor{index}_{parameterName}";
@@ -3396,7 +3399,7 @@ public sealed partial class YamlSerializerContextGenerator
             var extensionData = TryCreateExtensionDataMemberModel(named);
             var members = GetSerializableMembers(named)
                 .Where(m => extensionData is null || !SymbolEqualityComparer.Default.Equals(m, extensionData.Symbol))
-                .Select(m => CreateMemberModel(m, propertyNamingPolicy))
+                .Select(m => CreateMemberModel(m, named, propertyNamingPolicy))
                 .ToImmutableArray();
 
             if (named.TypeKind == TypeKind.Class && TryGetPolymorphismInfo(named, derivedTypeMappings, out var polymorphism) && polymorphism.DerivedTypes.Length != 0)

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -1482,9 +1482,9 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         return Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture) ?? "default";
     }
 
-    private static MemberModel CreateMemberModel(ISymbol member, YamlNamingPolicy? propertyNamingPolicy)
+    private static MemberModel CreateMemberModel(ISymbol member, INamedTypeSymbol declaringType, YamlNamingPolicy? propertyNamingPolicy)
     {
-        var (nameForRead, nameForWrite) = GetSerializedMemberNameExpressions(member, propertyNamingPolicy);
+        var (nameForRead, nameForWrite) = GetSerializedMemberNameExpressions(member, declaringType, propertyNamingPolicy);
         var type = GetMemberType(member) ?? throw new InvalidOperationException("Member type could not be determined.");
         var accessExpression = member is IPropertySymbol prop ? "value." + prop.Name : "value." + member.Name;
         Func<string, string> assign = member is IPropertySymbol propAssign
@@ -1508,7 +1508,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         return new MemberModel(member, type, nameForRead, nameForWrite, accessExpression, assign, memberIgnoreCondition, converterTypeName, objectCreationHandling, blockSequenceMappingStyle, blockSequenceSequenceStyle, isRequired, isIgnoredOnRead, isInitOnly, isRequiredKeyword, requiresIncludeFields, disallowNull, disallowNull, isReadOnlyProperty, isReadOnlyField, numberHandling, enumCustomNames);
     }
 
-    private static (string ForRead, string ForWrite) GetSerializedMemberNameExpressions(ISymbol member, YamlNamingPolicy? propertyNamingPolicy)
+    private static (string ForRead, string ForWrite) GetSerializedMemberNameExpressions(ISymbol member, INamedTypeSymbol declaringType, YamlNamingPolicy? propertyNamingPolicy)
     {
         foreach (var attribute in member.GetAttributes())
         {
@@ -1527,7 +1527,10 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
             }
         }
 
-        var name = ApplyNamingPolicy(member.Name, propertyNamingPolicy);
+        var declaredPolicy = TryGetDeclaredNamingPolicy(member.GetAttributes()) ?? GetDeclaredNamingPolicy(declaringType);
+        var name = declaredPolicy is not null
+            ? ApplyNamingPolicy(member.Name, YamlNamingPolicy.GetPolicy(declaredPolicy.Value))
+            : ApplyNamingPolicy(member.Name, propertyNamingPolicy);
         var resolvedLiteral = ToLiteral(name);
         return (resolvedLiteral, resolvedLiteral);
     }
@@ -1535,6 +1538,43 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
     private static string ApplyNamingPolicy(string name, YamlNamingPolicy? policy)
     {
         return policy?.ConvertName(name) ?? name;
+    }
+
+    private static YamlKnownNamingPolicy? GetDeclaredNamingPolicy(INamedTypeSymbol? type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            var policy = TryGetDeclaredNamingPolicy(current.GetAttributes());
+            if (policy is not null)
+            {
+                return policy;
+            }
+        }
+
+        return null;
+    }
+
+    private static YamlKnownNamingPolicy? TryGetDeclaredNamingPolicy(ImmutableArray<AttributeData> attributes)
+    {
+        foreach (var attribute in attributes)
+        {
+            if (attribute.AttributeClass is null)
+            {
+                continue;
+            }
+
+            if (!string.Equals(attribute.AttributeClass.ToDisplayString(), "Meziantou.Framework.Yaml.Serialization.YamlNamingPolicyAttribute", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (attribute.ConstructorArguments.Length == 1 && attribute.ConstructorArguments[0].Value is int value)
+            {
+                return (YamlKnownNamingPolicy)value;
+            }
+        }
+
+        return null;
     }
 
     private static YamlNamingPolicy? ResolveNamingPolicy(string? policyName)

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
@@ -1611,7 +1611,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
                     continue;
                 }
 
-                var name = GetMemberName(property, readerWriter);
+                var name = GetMemberName(property, type, readerWriter);
                 var order = GetMemberOrder(property);
                 var token = property.MetadataToken;
 
@@ -1677,7 +1677,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
                     continue;
                 }
 
-                var name = GetMemberName(field, readerWriter);
+                var name = GetMemberName(field, type, readerWriter);
                 var order = GetMemberOrder(field);
                 var token = field.MetadataToken;
 
@@ -1752,7 +1752,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
                 }
                 else
                 {
-                    constructorModel = new ConstructorModel(selectedConstructor, members, readerWriter, nullabilityContext);
+                    constructorModel = new ConstructorModel(selectedConstructor, type, members, readerWriter, nullabilityContext);
                     createInstance = () => throw new NotSupportedException($"Type '{type}' must be deserialized using a parameterized constructor.");
                 }
             }
@@ -1956,9 +1956,10 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
         private readonly bool[] _parametersDisallowNull;
         private readonly Dictionary<string, int> _parameterIndexByYamlName;
 
-        public ConstructorModel(ConstructorInfo constructor, IReadOnlyList<Member> members, YamlReaderWriterBase readerWriter, NullabilityInfoContext? nullabilityContext)
+        public ConstructorModel(ConstructorInfo constructor, Type declaringType, IReadOnlyList<Member> members, YamlReaderWriterBase readerWriter, NullabilityInfoContext? nullabilityContext)
         {
             ArgumentNullException.ThrowIfNull(constructor);
+            ArgumentNullException.ThrowIfNull(declaringType);
             ArgumentNullException.ThrowIfNull(members);
             ArgumentNullException.ThrowIfNull(readerWriter);
 
@@ -1977,6 +1978,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
                 }
             }
 
+            var declaredPolicy = GetDeclaredNamingPolicy(declaringType);
             _parameterIndexByYamlName = new Dictionary<string, int>(readerWriter.PropertyNameComparer);
             for (var i = 0; i < _parameters.Length; i++)
             {
@@ -1985,7 +1987,9 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
 
                 var yamlName = clrNameToSerialized.TryGetValue(parameterName, out var memberName)
                     ? memberName
-                    : readerWriter.ConvertName(parameterName);
+                    : declaredPolicy is not null
+                        ? ApplyNamingPolicy(parameterName, declaredPolicy.GetValueOrDefault())
+                        : readerWriter.ConvertName(parameterName);
 
                 if (_parameterIndexByYamlName.ContainsKey(yamlName))
                 {
@@ -2938,7 +2942,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
         throw new NotSupportedException($"Type '{type}' defines multiple public constructors. Use '{typeof(YamlConstructorAttribute)}' to select the constructor to use for deserialization.");
     }
 
-    private static string GetMemberName(MemberInfo member, YamlReaderWriterBase readerWriter)
+    private static string GetMemberName(MemberInfo member, Type declaringType, YamlReaderWriterBase readerWriter)
     {
         var yamlName = member.GetCustomAttribute<YamlPropertyNameAttribute>(inherit: true);
         if (yamlName is not null)
@@ -2947,7 +2951,25 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
         }
 
         var name = member.Name;
+        var declaredPolicy = member.GetCustomAttribute<YamlNamingPolicyAttribute>(inherit: true)?.NamingPolicy
+            ?? GetDeclaredNamingPolicy(declaringType);
+        if (declaredPolicy is not null)
+        {
+            return ApplyNamingPolicy(name, declaredPolicy.GetValueOrDefault());
+        }
+
         return readerWriter.ConvertName(name);
+    }
+
+    private static YamlKnownNamingPolicy? GetDeclaredNamingPolicy(Type type)
+    {
+        return type.GetCustomAttribute<YamlNamingPolicyAttribute>(inherit: true)?.NamingPolicy;
+    }
+
+    private static string ApplyNamingPolicy(string name, YamlKnownNamingPolicy namingPolicy)
+    {
+        var policy = YamlNamingPolicy.GetPolicy(namingPolicy);
+        return policy is null ? name : policy.ConvertName(name);
     }
 
     private static int GetMemberOrder(MemberInfo member)

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlNamingPolicyAttribute.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlNamingPolicyAttribute.cs
@@ -1,0 +1,26 @@
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>Specifies the naming policy used to convert the names of the annotated member or of all members of the annotated type.</summary>
+/// <remarks>
+/// When applied to a type, it sets the naming policy for all members declared on that type.
+/// When applied to a member, it overrides the type-level and serializer-level naming policy for that member.
+/// <see cref="YamlPropertyNameAttribute"/> takes precedence over this attribute.
+/// </remarks>
+[AttributeUsage(
+    AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface |
+    AttributeTargets.Property | AttributeTargets.Field,
+    AllowMultiple = false)]
+public sealed class YamlNamingPolicyAttribute : YamlAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="YamlNamingPolicyAttribute"/> class.
+    /// </summary>
+    /// <param name="namingPolicy">The naming policy to apply. Use <see cref="YamlKnownNamingPolicy.Unspecified"/> to use the CLR names as-is.</param>
+    public YamlNamingPolicyAttribute(YamlKnownNamingPolicy namingPolicy)
+    {
+        NamingPolicy = namingPolicy;
+    }
+
+    /// <summary>Gets the naming policy to apply.</summary>
+    public YamlKnownNamingPolicy NamingPolicy { get; }
+}

--- a/src/Meziantou.Framework.Yaml/YamlKnownNamingPolicy.cs
+++ b/src/Meziantou.Framework.Yaml/YamlKnownNamingPolicy.cs
@@ -3,7 +3,12 @@ namespace Meziantou.Framework.Yaml;
 /// <summary>
 /// Specifies a built-in <see cref="YamlNamingPolicy"/> for use with the source generator.
 /// </summary>
-public enum YamlKnownNamingPolicy
+#if MEZIANTOU_FRAMEWORK_YAML_SOURCE_GENERATOR
+internal
+#else
+public
+#endif
+enum YamlKnownNamingPolicy
 {
     /// <summary>No naming policy is applied; CLR member names are used as-is.</summary>
     Unspecified = 0,

--- a/src/Meziantou.Framework.Yaml/YamlNamingPolicy.cs
+++ b/src/Meziantou.Framework.Yaml/YamlNamingPolicy.cs
@@ -30,6 +30,22 @@ abstract class YamlNamingPolicy
     /// <summary>Gets the naming policy for KEBAB-CASE (uppercase).</summary>
     public static YamlNamingPolicy KebabCaseUpper { get; } = new YamlKebabCaseUpperNamingPolicy();
 
+    /// <summary>Gets the policy matching the specified <see cref="YamlKnownNamingPolicy"/> value.</summary>
+    /// <param name="namingPolicy">The naming policy to resolve.</param>
+    /// <returns>The matching policy, or <see langword="null"/> when no policy must be applied.</returns>
+    internal static YamlNamingPolicy? GetPolicy(YamlKnownNamingPolicy namingPolicy)
+    {
+        return namingPolicy switch
+        {
+            YamlKnownNamingPolicy.CamelCase => CamelCase,
+            YamlKnownNamingPolicy.SnakeCaseLower => SnakeCaseLower,
+            YamlKnownNamingPolicy.SnakeCaseUpper => SnakeCaseUpper,
+            YamlKnownNamingPolicy.KebabCaseLower => KebabCaseLower,
+            YamlKnownNamingPolicy.KebabCaseUpper => KebabCaseUpper,
+            _ => null,
+        };
+    }
+
     /// <summary>Converts the specified name according to the policy.</summary>
     /// <param name="name">The CLR member name.</param>
     /// <returns>The converted name.</returns>

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -114,6 +114,7 @@ var options = new YamlSerializerOptions
 Attributes can be used to configure individual types and members:
 
 - `YamlPropertyNameAttribute`
+- `YamlNamingPolicyAttribute`
 - `YamlIgnoreAttribute`
 - `YamlRequiredAttribute`
 - `YamlConstructorAttribute`
@@ -123,6 +124,21 @@ Attributes can be used to configure individual types and members:
 - `YamlDerivedTypeAttribute`
 - `YamlNumberHandlingAttribute`
 - `YamlObjectCreationHandlingAttribute`
+
+`YamlNamingPolicyAttribute` overrides `YamlSerializerOptions.PropertyNamingPolicy`. When applied to a type, it sets the naming policy for all its members; when applied to a member, it only applies to that member. `YamlPropertyNameAttribute` takes precedence over both.
+
+```csharp
+[YamlNamingPolicy(YamlKnownNamingPolicy.SnakeCaseLower)]
+internal sealed class Product
+{
+    public int Id { get; set; }                       // id
+
+    [YamlNamingPolicy(YamlKnownNamingPolicy.CamelCase)]
+    public string? DisplayName { get; set; }          // displayName
+
+    public DateTime CreationDate { get; set; }        // creation_date
+}
+```
 
 Custom converters derive from `YamlConverter<T>` and can be registered through `YamlSerializerOptions.Converters` or `YamlSourceGenerationOptionsAttribute.Converters`.
 

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlNamingPolicyAttributeTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlNamingPolicyAttributeTests.cs
@@ -1,0 +1,242 @@
+using Meziantou.Framework.Yaml.Serialization;
+
+namespace Meziantou.Framework.Yaml.Tests.Serialization;
+public sealed class YamlNamingPolicyAttributeTests
+{
+    [Fact]
+    public void MemberLevel_AppliesPolicyToAnnotatedMemberOnly()
+    {
+        var yaml = YamlSerializer.Serialize(new MemberPolicyModel { FirstValue = 1, SecondValue = 2 });
+        Assert.Contains("firstValue: 1", yaml);
+        Assert.Contains("SecondValue: 2", yaml);
+    }
+
+    [Fact]
+    public void MemberLevel_RoundTrips()
+    {
+        var roundTrip = YamlSerializer.Deserialize<MemberPolicyModel>("firstValue: 1\nSecondValue: 2\n")!;
+        Assert.Equal(1, roundTrip.FirstValue);
+        Assert.Equal(2, roundTrip.SecondValue);
+    }
+
+    [Fact]
+    public void TypeLevel_AppliesPolicyToAllMembers()
+    {
+        var yaml = YamlSerializer.Serialize(new TypePolicyModel { FirstValue = 1, SecondValue = 2 });
+        Assert.Contains("first_value: 1", yaml);
+        Assert.Contains("second_value: 2", yaml);
+    }
+
+    [Fact]
+    public void MemberLevel_OverridesTypeLevel()
+    {
+        var yaml = YamlSerializer.Serialize(new TypeAndMemberPolicyModel { FirstValue = 1, SecondValue = 2 });
+        Assert.Contains("first-value: 1", yaml);
+        Assert.Contains("second_value: 2", yaml);
+    }
+
+    [Fact]
+    public void PropertyNameAttribute_TakesPrecedence()
+    {
+        var yaml = YamlSerializer.Serialize(new ExplicitNameModel { FirstValue = 1 });
+        Assert.Contains("explicit: 1", yaml);
+    }
+
+    [Fact]
+    public void Attribute_OverridesSerializerOptions()
+    {
+        var options = new YamlSerializerOptions { PropertyNamingPolicy = YamlNamingPolicy.SnakeCaseUpper };
+        var yaml = YamlSerializer.Serialize(new TypePolicyModel { FirstValue = 1, SecondValue = 2 }, options);
+        Assert.Contains("first_value: 1", yaml);
+        Assert.Contains("second_value: 2", yaml);
+    }
+
+    [Fact]
+    public void Unspecified_OptsOutOfSerializerOptions()
+    {
+        var options = new YamlSerializerOptions { PropertyNamingPolicy = YamlNamingPolicy.SnakeCaseLower };
+        var yaml = YamlSerializer.Serialize(new UnspecifiedPolicyModel { FirstValue = 1, SecondValue = 2 }, options);
+        Assert.Contains("FirstValue: 1", yaml);
+        Assert.Contains("second_value: 2", yaml);
+    }
+
+    [Fact]
+    public void TypeLevel_AppliesToInheritedMembers()
+    {
+        var yaml = YamlSerializer.Serialize(new DerivedPolicyModel { BaseValue = 1, DerivedValue = 2 });
+        Assert.Contains("base_value: 1", yaml);
+        Assert.Contains("derived_value: 2", yaml);
+    }
+
+    [Fact]
+    public void TypeLevel_AppliesToConstructorParameters()
+    {
+        var roundTrip = YamlSerializer.Deserialize<ConstructorPolicyModel>("first_value: 1\nsecond_value: 2\n")!;
+        Assert.Equal(1, roundTrip.FirstValue);
+        Assert.Equal(2, roundTrip.SecondValue);
+    }
+
+    [Fact]
+    public void MemberLevel_Unspecified_OptsOutOfTypeLevel()
+    {
+        var yaml = YamlSerializer.Serialize(new TypeLevelOptOutModel { FirstValue = 1, SecondValue = 2 });
+        Assert.Contains("FirstValue: 1", yaml);
+        Assert.Contains("second_value: 2", yaml);
+    }
+
+    [Fact]
+    public void SourceGenerated_MemberLevel_Unspecified_OptsOutOfTypeLevel()
+    {
+        var yaml = YamlSerializer.Serialize(new TypeLevelOptOutModel { FirstValue = 1, SecondValue = 2 }, NamingPolicyContext.Default);
+        Assert.Contains("FirstValue: 1", yaml);
+        Assert.Contains("second_value: 2", yaml);
+    }
+
+    [Fact]
+    public void SourceGenerated_PropertyNameAttribute_TakesPrecedence()
+    {
+        var yaml = YamlSerializer.Serialize(new ExplicitNameModel { FirstValue = 1 }, NamingPolicyContext.Default);
+        Assert.Contains("explicit: 1", yaml);
+    }
+
+    [Fact]
+    public void SourceGenerated_MemberLevel_RoundTrips()
+    {
+        var yaml = YamlSerializer.Serialize(new MemberPolicyModel { FirstValue = 1, SecondValue = 2 }, NamingPolicyContext.Default);
+        Assert.Contains("firstValue: 1", yaml);
+        Assert.Contains("SecondValue: 2", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize("firstValue: 3\nSecondValue: 4\n", NamingPolicyContext.Default.MemberPolicyModel)!;
+        Assert.Equal(3, roundTrip.FirstValue);
+        Assert.Equal(4, roundTrip.SecondValue);
+    }
+
+    [Fact]
+    public void SourceGenerated_TypeLevel_RoundTrips()
+    {
+        var yaml = YamlSerializer.Serialize(new TypePolicyModel { FirstValue = 1, SecondValue = 2 }, NamingPolicyContext.Default);
+        Assert.Contains("first_value: 1", yaml);
+        Assert.Contains("second_value: 2", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize("first_value: 3\nsecond_value: 4\n", NamingPolicyContext.Default.TypePolicyModel)!;
+        Assert.Equal(3, roundTrip.FirstValue);
+        Assert.Equal(4, roundTrip.SecondValue);
+    }
+
+    [Fact]
+    public void SourceGenerated_MemberLevel_OverridesTypeLevel()
+    {
+        var yaml = YamlSerializer.Serialize(new TypeAndMemberPolicyModel { FirstValue = 1, SecondValue = 2 }, NamingPolicyContext.Default);
+        Assert.Contains("first-value: 1", yaml);
+        Assert.Contains("second_value: 2", yaml);
+    }
+
+    [Fact]
+    public void SourceGenerated_TypeLevel_AppliesToInheritedMembers()
+    {
+        var yaml = YamlSerializer.Serialize(new DerivedPolicyModel { BaseValue = 1, DerivedValue = 2 }, NamingPolicyContext.Default);
+        Assert.Contains("base_value: 1", yaml);
+        Assert.Contains("derived_value: 2", yaml);
+    }
+
+    [Fact]
+    public void SourceGenerated_TypeLevel_AppliesToConstructorParameters()
+    {
+        var roundTrip = YamlSerializer.Deserialize("first_value: 1\nsecond_value: 2\n", NamingPolicyContext.Default.ConstructorPolicyModel)!;
+        Assert.Equal(1, roundTrip.FirstValue);
+        Assert.Equal(2, roundTrip.SecondValue);
+    }
+}
+
+#pragma warning disable MA0048 // File name must match type name
+internal sealed class MemberPolicyModel
+{
+    [YamlNamingPolicy(YamlKnownNamingPolicy.CamelCase)]
+    public int FirstValue { get; set; }
+
+    public int SecondValue { get; set; }
+}
+
+[YamlNamingPolicy(YamlKnownNamingPolicy.SnakeCaseLower)]
+internal sealed class TypePolicyModel
+{
+    public int FirstValue { get; set; }
+    public int SecondValue { get; set; }
+}
+
+[YamlNamingPolicy(YamlKnownNamingPolicy.SnakeCaseLower)]
+internal sealed class TypeAndMemberPolicyModel
+{
+    [YamlNamingPolicy(YamlKnownNamingPolicy.KebabCaseLower)]
+    public int FirstValue { get; set; }
+
+    public int SecondValue { get; set; }
+}
+
+[YamlNamingPolicy(YamlKnownNamingPolicy.SnakeCaseLower)]
+internal sealed class ExplicitNameModel
+{
+    [YamlPropertyName("explicit")]
+    [YamlNamingPolicy(YamlKnownNamingPolicy.CamelCase)]
+    public int FirstValue { get; set; }
+}
+
+[YamlNamingPolicy(YamlKnownNamingPolicy.SnakeCaseLower)]
+internal sealed class TypeLevelOptOutModel
+{
+    [YamlNamingPolicy(YamlKnownNamingPolicy.Unspecified)]
+    public int FirstValue { get; set; }
+
+    public int SecondValue { get; set; }
+}
+
+internal sealed class UnspecifiedPolicyModel
+{
+    [YamlNamingPolicy(YamlKnownNamingPolicy.Unspecified)]
+    public int FirstValue { get; set; }
+
+    public int SecondValue { get; set; }
+}
+
+[YamlNamingPolicy(YamlKnownNamingPolicy.SnakeCaseLower)]
+internal class BasePolicyModel
+{
+    public int BaseValue { get; set; }
+}
+
+internal sealed class DerivedPolicyModel : BasePolicyModel
+{
+    public int DerivedValue { get; set; }
+}
+
+[YamlNamingPolicy(YamlKnownNamingPolicy.SnakeCaseLower)]
+internal sealed class ConstructorPolicyModel
+{
+    public ConstructorPolicyModel(int firstValue, int secondValue)
+    {
+        FirstValue = firstValue;
+        SecondValue = secondValue;
+    }
+
+    public int FirstValue { get; }
+    public int SecondValue { get; }
+}
+
+[YamlSerializable(typeof(MemberPolicyModel))]
+[YamlSerializable(typeof(TypePolicyModel))]
+[YamlSerializable(typeof(TypeAndMemberPolicyModel))]
+[YamlSerializable(typeof(TypeLevelOptOutModel))]
+[YamlSerializable(typeof(ExplicitNameModel))]
+[YamlSerializable(typeof(DerivedPolicyModel))]
+[YamlSerializable(typeof(ConstructorPolicyModel))]
+internal sealed partial class NamingPolicyContext : YamlSerializerContext
+{
+    public NamingPolicyContext()
+    {
+    }
+
+    public NamingPolicyContext(YamlSerializerOptions options)
+        : base(options)
+    {
+    }
+}


### PR DESCRIPTION
## What

Adds `YamlNamingPolicyAttribute`, so a naming policy can be applied to a type or to an individual member instead of only globally via `YamlSerializerOptions.PropertyNamingPolicy`.

```csharp
[YamlNamingPolicy(YamlKnownNamingPolicy.SnakeCaseLower)]
internal sealed class Product
{
    public int Id { get; set; }                       // id

    [YamlNamingPolicy(YamlKnownNamingPolicy.CamelCase)]
    public string? DisplayName { get; set; }          // displayName

    public DateTime CreationDate { get; set; }        // creation_date
}
```

`AttributeUsage` is `Class | Struct | Interface | Property | Field`, `AllowMultiple = false`. The attribute derives from `YamlAttribute` like the other serialization attributes.

## Precedence

Mirrors the layering already used by `YamlNumberHandlingAttribute`:

1. `YamlPropertyNameAttribute` — an explicit name always wins
2. member-level `[YamlNamingPolicy]`
3. type-level `[YamlNamingPolicy]` (inherited from base types)
4. `YamlSerializerOptions.PropertyNamingPolicy`

`YamlKnownNamingPolicy.Unspecified` is treated as an explicit value rather than "absent", so it opts a member or type out of a policy coming from a higher level.

## How

Both metadata paths handle the attribute:

- **Reflection** — `YamlObjectConverter.GetMemberName` now receives the serialized type so it can consult the type-level attribute, and `ConstructorModel` applies the type-level policy to constructor parameters that do not bind to a member.
- **Source generator** — `GetSerializedMemberNameExpressions` and the constructor-parameter naming in the emit phase resolve the attribute off the symbol, walking base types to match reflection's `inherit: true` semantics. Names are still emitted as literals, so there is no added runtime cost.

The enum-to-policy mapping lives in one place (`YamlNamingPolicy.GetPolicy`) and is shared by linking `YamlKnownNamingPolicy.cs` into the source generator project, using the same `#if MEZIANTOU_FRAMEWORK_YAML_SOURCE_GENERATOR` visibility guard as the other linked naming-policy files.

## Notes for reviewers

- `ref/Meziantou.Framework.Yaml.cs` was regenerated by the build; the only change is the new attribute.
- An out-of-range enum value (e.g. `(YamlKnownNamingPolicy)42`) is silently treated as "no policy" rather than throwing, which is consistent with the existing `ResolveNamingPolicy` behavior in the generator. A generator diagnostic for that could be a follow-up if preferred.
- Documented in `src/Meziantou.Framework.Yaml/readme.md`.

## Testing

- 17 new tests in `YamlNamingPolicyAttributeTests.cs` covering both the reflection and source-generated paths: member-level, type-level, member-overrides-type, `YamlPropertyName` precedence, overriding serializer options, `Unspecified` opt-out (both standalone and under a type-level policy), inherited members, and constructor parameters.
- Full `Meziantou.Framework.Yaml.Tests` suite: 1468/1468 passing across net10.0 and net11.0, none skipped.
- Built with `-p:TreatWarningsAsErrors=true`; both Yaml smoke projects build clean; `dotnet run ./eng/update-all.cs` produced no further changes.