### PR TITLE
Support YamlIgnoreAttribute on types to set the default ignore condition

### DIFF
--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -863,7 +863,7 @@ namespace Meziantou.Framework.Yaml.Serialization
     {
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple = false)]
+    [System.AttributeUsage(System.AttributeTargets.Interface | System.AttributeTargets.Field | System.AttributeTargets.Property | System.AttributeTargets.Struct | System.AttributeTargets.Class, AllowMultiple = false)]
     public sealed class YamlIgnoreAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
         public Meziantou.Framework.Yaml.YamlIgnoreCondition Condition { get => throw null; set { } }

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -1490,7 +1490,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         Func<string, string> assign = member is IPropertySymbol propAssign
             ? rhs => "instance." + propAssign.Name + " = " + rhs
             : rhs => "instance." + member.Name + " = " + rhs;
-        var memberIgnoreCondition = TryGetIgnoreCondition(member, out var rawCondition) ? rawCondition : (int?)null;
+        var memberIgnoreCondition = TryGetIgnoreCondition(member, out var rawCondition) ? rawCondition : GetDeclaredIgnoreCondition(declaringType);
         var converterTypeName = GetYamlConverterAttributeTypeName(member);
         var objectCreationHandling = GetObjectCreationHandling(member);
         var (blockSequenceMappingStyle, blockSequenceSequenceStyle) = GetBlockSequenceItemStyles(member);
@@ -1857,6 +1857,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
 
         // Include base members for parity with reflection/STJ behavior, but prefer the most-derived
         // member when a derived type hides/overrides a base member with the same CLR name.
+        var declaredIgnoreCondition = GetDeclaredIgnoreCondition(type);
         var members = new List<ISymbol>();
         var indexByClrName = new Dictionary<string, int>(StringComparer.Ordinal);
 
@@ -1890,7 +1891,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                         continue;
                     }
 
-                    if (IsIgnoredAlways(property))
+                    if (IsIgnoredAlways(property, declaredIgnoreCondition))
                     {
                         continue;
                     }
@@ -1917,7 +1918,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                         continue;
                     }
 
-                    if (IsIgnoredAlways(field))
+                    if (IsIgnoredAlways(field, declaredIgnoreCondition))
                     {
                         continue;
                     }
@@ -2143,8 +2144,21 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
     private const int UnknownDerivedTypeHandlingFail = 0;
     private const int UnknownDerivedTypeHandlingFallBackToBase = 1;
 
-    private static bool IsIgnoredAlways(ISymbol symbol)
-        => TryGetIgnoreCondition(symbol, out var condition) && condition == IgnoreAlways;
+    private static bool IsIgnoredAlways(ISymbol symbol, int? declaringTypeCondition)
+        => (TryGetIgnoreCondition(symbol, out var condition) ? condition : declaringTypeCondition) == IgnoreAlways;
+
+    private static int? GetDeclaredIgnoreCondition(INamedTypeSymbol? type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (TryGetIgnoreCondition(current, out var condition))
+            {
+                return condition;
+            }
+        }
+
+        return null;
+    }
 
     private static bool TryGetIgnoreCondition(ISymbol symbol, out int condition)
     {

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
@@ -1605,7 +1605,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
                     continue;
                 }
 
-                var ignoreCondition = GetIgnoreCondition(property);
+                var ignoreCondition = GetIgnoreCondition(property, type);
                 if (ignoreCondition == YamlIgnoreCondition.Always)
                 {
                     continue;
@@ -1671,7 +1671,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
                     continue;
                 }
 
-                var ignoreCondition = GetIgnoreCondition(field);
+                var ignoreCondition = GetIgnoreCondition(field, type);
                 if (ignoreCondition == YamlIgnoreCondition.Always)
                 {
                     continue;
@@ -2722,6 +2722,12 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
 
         return null;
     }
+
+    private static YamlIgnoreCondition? GetIgnoreCondition(MemberInfo member, Type declaringType)
+        => GetIgnoreCondition(member) ?? GetDeclaredIgnoreCondition(declaringType);
+
+    private static YamlIgnoreCondition? GetDeclaredIgnoreCondition(Type type)
+        => type.GetCustomAttribute<YamlIgnoreAttribute>(inherit: true)?.Condition;
 
     private static bool IsRequired(MemberInfo member)
     {

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlIgnoreAttribute.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlIgnoreAttribute.cs
@@ -1,7 +1,14 @@
 namespace Meziantou.Framework.Yaml.Serialization;
 
 /// <summary>Instructs the <see cref="YamlSerializer"/> when to ignore the public field or public read/write property value.</summary>
-[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
+/// <remarks>
+/// When applied to a type, it sets the default ignore condition for all its properties and fields.
+/// When applied to a member, it overrides the type-level condition and <see cref="YamlSerializerOptions.DefaultIgnoreCondition"/> for that member.
+/// </remarks>
+[AttributeUsage(
+    AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface |
+    AttributeTargets.Field | AttributeTargets.Property,
+    AllowMultiple = false)]
 public sealed class YamlIgnoreAttribute : YamlAttribute
 {
     /// <summary>

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -140,6 +140,22 @@ internal sealed class Product
 }
 ```
 
+`YamlIgnoreAttribute` overrides `YamlSerializerOptions.DefaultIgnoreCondition`. When applied to a type, it sets the default ignore condition for all its properties and fields; when applied to a member, it only applies to that member.
+
+```csharp
+[YamlIgnore(Condition = YamlIgnoreCondition.WhenWritingNull)]
+internal sealed class Product
+{
+    public string? Name { get; set; }                 // omitted when null
+
+    [YamlIgnore(Condition = YamlIgnoreCondition.Never)]
+    public string? Description { get; set; }          // always written
+
+    [YamlIgnore]
+    public string? Secret { get; set; }               // never serialized nor deserialized
+}
+```
+
 Custom converters derive from `YamlConverter<T>` and can be registered through `YamlSerializerOptions.Converters` or `YamlSourceGenerationOptionsAttribute.Converters`.
 
 ## Feature switches

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlIgnoreAttributeTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlIgnoreAttributeTests.cs
@@ -1,0 +1,216 @@
+using Meziantou.Framework.Yaml.Serialization;
+
+namespace Meziantou.Framework.Yaml.Tests.Serialization;
+public sealed class YamlIgnoreAttributeTests
+{
+    [Fact]
+    public void TypeLevel_AppliesConditionToAllMembers()
+    {
+        var yaml = YamlSerializer.Serialize(new TypeIgnoreModel { FirstValue = null, SecondValue = "b" });
+        Assert.DoesNotContain("FirstValue", yaml);
+        Assert.Contains("SecondValue: b", yaml);
+    }
+
+    [Fact]
+    public void MemberLevel_OverridesTypeLevel()
+    {
+        var yaml = YamlSerializer.Serialize(new TypeAndMemberIgnoreModel { FirstValue = null, SecondValue = null });
+        Assert.Contains("FirstValue:", yaml);
+        Assert.DoesNotContain("SecondValue", yaml);
+    }
+
+    [Fact]
+    public void TypeLevel_OverridesSerializerOptions()
+    {
+        var options = new YamlSerializerOptions { DefaultIgnoreCondition = YamlIgnoreCondition.WhenWritingDefault };
+        var yaml = YamlSerializer.Serialize(new TypeNeverIgnoreModel { FirstValue = 0 }, options);
+        Assert.Contains("FirstValue: 0", yaml);
+    }
+
+    [Fact]
+    public void TypeLevel_Always_IgnoresAllMembers()
+    {
+        var yaml = YamlSerializer.Serialize(new TypeAlwaysIgnoreModel { FirstValue = 1, SecondValue = 2 });
+        Assert.DoesNotContain("FirstValue", yaml);
+        Assert.Contains("SecondValue: 2", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<TypeAlwaysIgnoreModel>("FirstValue: 1\nSecondValue: 2\n")!;
+        Assert.Equal(0, roundTrip.FirstValue);
+        Assert.Equal(2, roundTrip.SecondValue);
+    }
+
+    [Fact]
+    public void TypeLevel_AppliesToFields()
+    {
+        var options = new YamlSerializerOptions { IncludeFields = true };
+        var yaml = YamlSerializer.Serialize(new TypeIgnoreFieldModel { FirstValue = null, SecondValue = "b" }, options);
+        Assert.DoesNotContain("FirstValue", yaml);
+        Assert.Contains("SecondValue: b", yaml);
+    }
+
+    [Fact]
+    public void TypeLevel_AppliesToInheritedMembers()
+    {
+        var yaml = YamlSerializer.Serialize(new DerivedIgnoreModel { BaseValue = null, DerivedValue = null });
+        Assert.Equal("{}", yaml.Trim(), ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void TypeLevel_WhenReading_IsIgnoredOnDeserialization()
+    {
+        var yaml = YamlSerializer.Serialize(new TypeWhenReadingIgnoreModel { FirstValue = 1 });
+        Assert.Contains("FirstValue: 1", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<TypeWhenReadingIgnoreModel>("FirstValue: 42\n")!;
+        Assert.Equal(0, roundTrip.FirstValue);
+    }
+
+    [Fact]
+    public void TypeLevel_DoesNotIgnoreExtensionData()
+    {
+        var yaml = YamlSerializer.Serialize(new TypeAlwaysIgnoreExtensionDataModel
+        {
+            FirstValue = 1,
+            ExtensionData = new Dictionary<string, object?>(StringComparer.Ordinal) { ["extra"] = "value" },
+        });
+
+        Assert.DoesNotContain("FirstValue", yaml);
+        Assert.Contains("extra: value", yaml);
+    }
+
+    [Fact]
+    public void SourceGenerated_TypeLevel_AppliesConditionToAllMembers()
+    {
+        var yaml = YamlSerializer.Serialize(new TypeIgnoreModel { FirstValue = null, SecondValue = "b" }, IgnoreConditionContext.Default);
+        Assert.DoesNotContain("FirstValue", yaml);
+        Assert.Contains("SecondValue: b", yaml);
+    }
+
+    [Fact]
+    public void SourceGenerated_MemberLevel_OverridesTypeLevel()
+    {
+        var yaml = YamlSerializer.Serialize(new TypeAndMemberIgnoreModel { FirstValue = null, SecondValue = null }, IgnoreConditionContext.Default);
+        Assert.Contains("FirstValue:", yaml);
+        Assert.DoesNotContain("SecondValue", yaml);
+    }
+
+    [Fact]
+    public void SourceGenerated_TypeLevel_OverridesSerializerOptions()
+    {
+        var context = new IgnoreConditionContext(new YamlSerializerOptions { DefaultIgnoreCondition = YamlIgnoreCondition.WhenWritingDefault });
+        var yaml = YamlSerializer.Serialize(new TypeNeverIgnoreModel { FirstValue = 0 }, context.TypeNeverIgnoreModel);
+        Assert.Contains("FirstValue: 0", yaml);
+    }
+
+    [Fact]
+    public void SourceGenerated_TypeLevel_Always_IgnoresAllMembers()
+    {
+        var yaml = YamlSerializer.Serialize(new TypeAlwaysIgnoreModel { FirstValue = 1, SecondValue = 2 }, IgnoreConditionContext.Default);
+        Assert.DoesNotContain("FirstValue", yaml);
+        Assert.Contains("SecondValue: 2", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize("FirstValue: 1\nSecondValue: 2\n", IgnoreConditionContext.Default.TypeAlwaysIgnoreModel)!;
+        Assert.Equal(0, roundTrip.FirstValue);
+        Assert.Equal(2, roundTrip.SecondValue);
+    }
+
+    [Fact]
+    public void SourceGenerated_TypeLevel_AppliesToInheritedMembers()
+    {
+        var yaml = YamlSerializer.Serialize(new DerivedIgnoreModel { BaseValue = null, DerivedValue = null }, IgnoreConditionContext.Default);
+        Assert.Equal("{}", yaml.Trim(), ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void SourceGenerated_TypeLevel_WhenReading_IsIgnoredOnDeserialization()
+    {
+        var yaml = YamlSerializer.Serialize(new TypeWhenReadingIgnoreModel { FirstValue = 1 }, IgnoreConditionContext.Default);
+        Assert.Contains("FirstValue: 1", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize("FirstValue: 42\n", IgnoreConditionContext.Default.TypeWhenReadingIgnoreModel)!;
+        Assert.Equal(0, roundTrip.FirstValue);
+    }
+}
+
+#pragma warning disable MA0048 // File name must match type name
+[YamlIgnore(Condition = YamlIgnoreCondition.WhenWritingNull)]
+internal sealed class TypeIgnoreModel
+{
+    public string? FirstValue { get; set; }
+    public string? SecondValue { get; set; }
+}
+
+[YamlIgnore(Condition = YamlIgnoreCondition.WhenWritingNull)]
+internal sealed class TypeAndMemberIgnoreModel
+{
+    [YamlIgnore(Condition = YamlIgnoreCondition.Never)]
+    public string? FirstValue { get; set; }
+
+    public string? SecondValue { get; set; }
+}
+
+[YamlIgnore(Condition = YamlIgnoreCondition.Never)]
+internal sealed class TypeNeverIgnoreModel
+{
+    public int FirstValue { get; set; }
+}
+
+[YamlIgnore]
+internal sealed class TypeAlwaysIgnoreModel
+{
+    public int FirstValue { get; set; }
+
+    [YamlIgnore(Condition = YamlIgnoreCondition.Never)]
+    public int SecondValue { get; set; }
+}
+
+[YamlIgnore(Condition = YamlIgnoreCondition.WhenWritingNull)]
+internal sealed class TypeIgnoreFieldModel
+{
+    public string? FirstValue;
+    public string? SecondValue;
+}
+
+[YamlIgnore(Condition = YamlIgnoreCondition.WhenWritingNull)]
+internal class BaseIgnoreModel
+{
+    public string? BaseValue { get; set; }
+}
+
+internal sealed class DerivedIgnoreModel : BaseIgnoreModel
+{
+    public string? DerivedValue { get; set; }
+}
+
+[YamlIgnore(Condition = YamlIgnoreCondition.WhenReading)]
+internal sealed class TypeWhenReadingIgnoreModel
+{
+    public int FirstValue { get; set; }
+}
+
+[YamlIgnore]
+internal sealed class TypeAlwaysIgnoreExtensionDataModel
+{
+    public int FirstValue { get; set; }
+
+    [YamlExtensionData]
+    public Dictionary<string, object?>? ExtensionData { get; set; }
+}
+
+[YamlSerializable(typeof(TypeIgnoreModel))]
+[YamlSerializable(typeof(TypeAndMemberIgnoreModel))]
+[YamlSerializable(typeof(TypeNeverIgnoreModel))]
+[YamlSerializable(typeof(TypeAlwaysIgnoreModel))]
+[YamlSerializable(typeof(DerivedIgnoreModel))]
+[YamlSerializable(typeof(TypeWhenReadingIgnoreModel))]
+internal sealed partial class IgnoreConditionContext : YamlSerializerContext
+{
+    public IgnoreConditionContext()
+    {
+    }
+
+    public IgnoreConditionContext(YamlSerializerOptions options)
+        : base(options)
+    {
+    }
+}


### PR DESCRIPTION
Adds support for `[YamlIgnore(Condition = ...)]` on a class, struct, or interface to set the default ignore condition for its properties and fields, so the condition no longer has to be repeated on every member.

```csharp
[YamlIgnore(Condition = YamlIgnoreCondition.WhenWritingNull)]
internal sealed class Product
{
    public string? Name { get; set; }                 // omitted when null

    [YamlIgnore(Condition = YamlIgnoreCondition.Never)]
    public string? Description { get; set; }          // always written

    [YamlIgnore]
    public string? Secret { get; set; }               // never serialized nor deserialized
}
```

## Resolution order

Member attribute → type attribute (walking the base type chain) → `YamlSerializerOptions.DefaultIgnoreCondition`. This mirrors the design of `YamlNamingPolicyAttribute` added in #1866, including how the type-level attribute flows to derived types.

## Changes

- `YamlIgnoreAttribute`: `AttributeUsage` extended with `Class | Struct | Interface`.
- `YamlObjectConverter`: new `GetIgnoreCondition(member, declaringType)` overload falling back to the type-level attribute, resolved with `inherit: true`.
- `YamlSerializerContextGenerator`: new `GetDeclaredIgnoreCondition` walking the base type chain, used by `CreateMemberModel` and by the `Always` filter in `GetSerializableMembers`, so the source-generated and reflection paths agree.
- `readme.md` documents the behavior; `ref/Meziantou.Framework.Yaml.cs` regenerated by the build.

## Notes for reviewers

- A type-level `Always` condition drops every member but leaves `[YamlExtensionData]` members intact — the extension-data validation still consults only member-level attributes, so annotating a type does not accidentally break extension data.
- `[YamlIgnore]` with no `Condition` on a type means `Always` (the property's existing default), which ignores all of the type's members. There is no back-compat concern since the attribute could not target types before.
- Interfaces are accepted for parity with `YamlNamingPolicyAttribute`; like that attribute, lookup walks base types and not implemented interfaces.

## Testing

- New `YamlIgnoreAttributeTests.cs`: 14 tests covering type-level conditions, member override, options override, `Always`, fields, inheritance, `WhenReading`, and extension data — each reflection case mirrored against a source-generated context. 28/28 pass across net10.0 and net11.0.
- Full Yaml suite: 1496/1496 pass, 0 warnings with `/p:TreatsWarningsAsErrors=true`.
- `dotnet run ./eng/update-all.cs` ran clean; `Meziantou.Framework.DependencyScanning`, `Meziantou.Framework.Yamlish.Tests`, and `Meziantou.Framework.Yaml.AotSmoke` all build warning-free.