### PR TITLE
Rename Roslyn source helpers for clarity

### DIFF
--- a/src/Meziantou.Framework.Roslyn/LanguageVersionExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/LanguageVersionExtensions.cs
@@ -44,42 +44,42 @@ internal static partial class LanguageVersionExtensions
         return LanguageVersion.Default;
     }
 
-    public static bool IsCSharp8OrAbove(this LanguageVersion languageVersion)
+    public static bool IsCSharp8OrGreater(this LanguageVersion languageVersion)
     {
         return languageVersion >= (LanguageVersion)800;
     }
 
-    public static bool IsCSharp9OrAbove(this LanguageVersion languageVersion)
+    public static bool IsCSharp9OrGreater(this LanguageVersion languageVersion)
     {
         return languageVersion >= (LanguageVersion)900;
     }
 
-    public static bool IsCSharp10OrAbove(this LanguageVersion languageVersion)
+    public static bool IsCSharp10OrGreater(this LanguageVersion languageVersion)
     {
         return languageVersion >= (LanguageVersion)1000;
     }
 
-    public static bool IsCSharp11OrAbove(this LanguageVersion languageVersion)
+    public static bool IsCSharp11OrGreater(this LanguageVersion languageVersion)
     {
         return languageVersion >= (LanguageVersion)1100;
     }
 
-    public static bool IsCSharp12OrAbove(this LanguageVersion languageVersion)
+    public static bool IsCSharp12OrGreater(this LanguageVersion languageVersion)
     {
         return languageVersion >= (LanguageVersion)1200;
     }
 
-    public static bool IsCSharp13OrAbove(this LanguageVersion languageVersion)
+    public static bool IsCSharp13OrGreater(this LanguageVersion languageVersion)
     {
         return languageVersion >= (LanguageVersion)1300;
     }
 
-    public static bool IsCSharp14OrAbove(this LanguageVersion languageVersion)
+    public static bool IsCSharp14OrGreater(this LanguageVersion languageVersion)
     {
         return languageVersion >= (LanguageVersion)1400;
     }
 
-    public static bool IsCSharp15OrAbove(this LanguageVersion languageVersion)
+    public static bool IsCSharp15OrGreater(this LanguageVersion languageVersion)
     {
 #if ROSLYN_5_6_OR_GREATER
         return languageVersion >= (LanguageVersion)1500 || languageVersion is LanguageVersion.Preview;

--- a/src/Meziantou.Framework.Roslyn/MethodSymbolExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/MethodSymbolExtensions.cs
@@ -53,34 +53,34 @@ internal static partial class MethodSymbolExtensions
 
     private static bool IsInterfaceImplementation(this ISymbol symbol)
     {
-        return GetImplementingInterfaceSymbol(symbol) is not null;
+        return GetImplementedInterfaceMember(symbol) is not null;
     }
 
-    public static IPropertySymbol? GetImplementingInterfaceSymbol(this IPropertySymbol symbol)
+    public static IPropertySymbol? GetImplementedInterfaceMember(this IPropertySymbol symbol)
     {
         if (symbol.ExplicitInterfaceImplementations.Length > 0)
             return symbol.ExplicitInterfaceImplementations[0];
 
-        return (IPropertySymbol?)GetImplementingInterfaceSymbol((ISymbol)symbol);
+        return (IPropertySymbol?)GetImplementedInterfaceMember((ISymbol)symbol);
     }
 
-    public static IEventSymbol? GetImplementingInterfaceSymbol(this IEventSymbol symbol)
+    public static IEventSymbol? GetImplementedInterfaceMember(this IEventSymbol symbol)
     {
         if (symbol.ExplicitInterfaceImplementations.Length > 0)
             return symbol.ExplicitInterfaceImplementations[0];
 
-        return (IEventSymbol?)GetImplementingInterfaceSymbol((ISymbol)symbol);
+        return (IEventSymbol?)GetImplementedInterfaceMember((ISymbol)symbol);
     }
 
-    public static IMethodSymbol? GetImplementingInterfaceSymbol(this IMethodSymbol symbol)
+    public static IMethodSymbol? GetImplementedInterfaceMember(this IMethodSymbol symbol)
     {
         if (symbol.ExplicitInterfaceImplementations.Length > 0)
             return symbol.ExplicitInterfaceImplementations[0];
 
-        return (IMethodSymbol?)GetImplementingInterfaceSymbol((ISymbol)symbol);
+        return (IMethodSymbol?)GetImplementedInterfaceMember((ISymbol)symbol);
     }
 
-    private static ISymbol? GetImplementingInterfaceSymbol(this ISymbol symbol)
+    private static ISymbol? GetImplementedInterfaceMember(this ISymbol symbol)
     {
         if (symbol.ContainingType is null)
             return null;
@@ -90,7 +90,7 @@ internal static partial class MethodSymbolExtensions
             .FirstOrDefault(interfaceMember => SymbolEqualityComparer.Default.Equals(symbol, symbol.ContainingType.FindImplementationForInterfaceMember(interfaceMember)));
     }
 
-    public static bool IsOrOverrideMethod(this IMethodSymbol? symbol, IMethodSymbol? baseMethod)
+    public static bool IsOrOverrides(this IMethodSymbol? symbol, IMethodSymbol? baseMethod)
     {
         if (symbol is null || baseMethod is null)
             return false;
@@ -109,7 +109,7 @@ internal static partial class MethodSymbolExtensions
         return false;
     }
 
-    public static bool Override(this IMethodSymbol? symbol, ISymbol? baseSymbol)
+    public static bool Overrides(this IMethodSymbol? symbol, ISymbol? baseSymbol)
     {
         if (baseSymbol is null)
             return false;
@@ -141,7 +141,7 @@ internal static partial class MethodSymbolExtensions
 
             if (inherits)
             {
-                if (attribute.AttributeClass.IsOrInheritFrom(attributeType))
+                if (attribute.AttributeClass.IsOrInheritsFrom(attributeType))
                     return attribute;
             }
             else

--- a/src/Meziantou.Framework.Roslyn/NamespaceSymbolExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/NamespaceSymbolExtensions.cs
@@ -9,7 +9,7 @@ namespace Meziantou.Framework.Roslyn;
 
 internal static partial class NamespaceSymbolExtensions
 {
-    public static bool IsNamespace(this INamespaceSymbol namespaceSymbol, ReadOnlySpan<string> namespaceParts)
+    public static bool MatchesNamespace(this INamespaceSymbol namespaceSymbol, ReadOnlySpan<string> namespaceParts)
     {
         for (var i = namespaceParts.Length - 1; i >= 0; i--)
         {

--- a/src/Meziantou.Framework.Roslyn/SuppressorHelpers.cs
+++ b/src/Meziantou.Framework.Roslyn/SuppressorHelpers.cs
@@ -9,12 +9,12 @@ namespace Meziantou.Framework.Roslyn;
 
 internal static partial class SuppressorHelpers
 {
-    public static SyntaxNode? TryFindNode(this Diagnostic diagnostic, CancellationToken cancellationToken)
+    public static SyntaxNode? FindNode(this Diagnostic diagnostic, CancellationToken cancellationToken)
     {
-        return TryFindNode(diagnostic.Location, cancellationToken);
+        return FindNode(diagnostic.Location, cancellationToken);
     }
 
-    private static SyntaxNode? TryFindNode(Location? location, CancellationToken cancellationToken)
+    private static SyntaxNode? FindNode(Location? location, CancellationToken cancellationToken)
     {
         if (location is null)
             return null;

--- a/src/Meziantou.Framework.Roslyn/SymbolAttributeExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/SymbolAttributeExtensions.cs
@@ -27,7 +27,7 @@ internal static partial class SymbolAttributeExtensions
 
             if (inherits)
             {
-                if (attribute.AttributeClass.IsOrInheritFrom(attributeType))
+                if (attribute.AttributeClass.IsOrInheritsFrom(attributeType))
                     yield return attribute;
             }
             else
@@ -53,7 +53,7 @@ internal static partial class SymbolAttributeExtensions
 
             if (inherits)
             {
-                if (attribute.AttributeClass.IsOrInheritFrom(attributeType))
+                if (attribute.AttributeClass.IsOrInheritsFrom(attributeType))
                     return attribute;
             }
             else

--- a/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
@@ -12,7 +12,7 @@ namespace Meziantou.Framework.Roslyn;
 // http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Shared/Extensions/ITypeSymbolExtensions.cs,190b4ed0932458fd,references
 internal static partial class TypeSymbolExtensions
 {
-    public static IList<INamedTypeSymbol> GetAllInterfacesIncludingThis(this ITypeSymbol type)
+    public static IList<INamedTypeSymbol> GetAllInterfacesIncludingSelf(this ITypeSymbol type)
     {
         var allInterfaces = type.AllInterfaces;
         if (type is INamedTypeSymbol namedType && namedType.TypeKind == TypeKind.Interface && !allInterfaces.Contains(namedType))
@@ -140,12 +140,12 @@ internal static partial class TypeSymbolExtensions
         return SymbolEquals(symbol, interfaceType) || symbol.Implements(interfaceType);
     }
 
-    public static bool IsOrInheritFrom(this ITypeSymbol symbol, [NotNullWhen(true)] ITypeSymbol? expectedType)
+    public static bool IsOrInheritsFrom(this ITypeSymbol symbol, [NotNullWhen(true)] ITypeSymbol? expectedType)
     {
-        return IsOrInheritFrom(symbol, expectedType, visitedTypeParameters: null);
+        return IsOrInheritsFrom(symbol, expectedType, visitedTypeParameters: null);
     }
 
-    private static bool IsOrInheritFrom(this ITypeSymbol symbol, [NotNullWhen(true)] ITypeSymbol? expectedType, HashSet<ITypeParameterSymbol>? visitedTypeParameters)
+    private static bool IsOrInheritsFrom(this ITypeSymbol symbol, [NotNullWhen(true)] ITypeSymbol? expectedType, HashSet<ITypeParameterSymbol>? visitedTypeParameters)
     {
         if (expectedType is null)
             return false;
@@ -157,7 +157,7 @@ internal static partial class TypeSymbolExtensions
         {
             return AnyConstraintTypeMatches(typeParameter, visitedTypeParameters, (constraintType, visitedTypeParameters) =>
             {
-                return constraintType.IsOrInheritFrom(expectedType, visitedTypeParameters);
+                return constraintType.IsOrInheritsFrom(expectedType, visitedTypeParameters);
             });
         }
 
@@ -285,7 +285,7 @@ internal static partial class TypeSymbolExtensions
 
     public static bool IsEnum([NotNullWhen(returnValue: true)] this ITypeSymbol? symbol)
     {
-        return symbol is not null && GetEnumType(symbol) is not null;
+        return symbol is not null && GetEnumUnderlyingType(symbol) is not null;
     }
 
     private static bool SymbolEquals(ISymbol? symbol, ISymbol? expectedSymbol)
@@ -293,7 +293,7 @@ internal static partial class TypeSymbolExtensions
         return symbol is not null && expectedSymbol is not null && SymbolEqualityComparer.Default.Equals(symbol, expectedSymbol);
     }
 
-    public static INamedTypeSymbol? GetEnumType(this ITypeSymbol? symbol)
+    public static INamedTypeSymbol? GetEnumUnderlyingType(this ITypeSymbol? symbol)
     {
         return (symbol as INamedTypeSymbol)?.EnumUnderlyingType;
     }

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -569,7 +569,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                 continue;
             }
 
-            if (!named.IsOrInheritFrom(yamlConverterSymbol))
+            if (!named.IsOrInheritsFrom(yamlConverterSymbol))
             {
                 diagnostics.Add(Diagnostic.Create(
                     InvalidConverterType,

--- a/tests/Meziantou.Framework.Roslyn.PackageTests/RoslynPackageTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.PackageTests/RoslynPackageTests.cs
@@ -15,9 +15,9 @@ public sealed class RoslynPackageTests(RoslynPackageFixture fixture) : IClassFix
         Assert.Contains("SyntaxNodeAnalysisContext", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/ContextExtensions.g.cs")));
         Assert.Contains("DiagnosticReporter", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/DiagnosticReporter.cs")));
         Assert.Contains("IsInterfaceImplementation", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/MethodSymbolExtensions.cs")));
-        Assert.Contains("IsNamespace", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/NamespaceSymbolExtensions.cs")));
+        Assert.Contains("MatchesNamespace", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/NamespaceSymbolExtensions.cs")));
         Assert.Contains("UnwrapImplicitConversions", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/OperationExtensions.cs")));
-        Assert.Contains("TryFindNode", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/SuppressorHelpers.cs")));
+        Assert.Contains("FindNode(this Diagnostic", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/SuppressorHelpers.cs")));
         Assert.Contains("IsVisibleOutsideOfAssembly", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/SymbolExtensions.cs")));
         Assert.Contains("GetFirstAttribute", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/SymbolAttributeExtensions.cs")));
         Assert.Contains("GetUnderlyingNullableTypeOrSelf", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs")));
@@ -156,13 +156,13 @@ public sealed class RoslynPackageTests(RoslynPackageFixture fixture) : IClassFix
                 public static bool HasAttribute(ISymbol symbol, ITypeSymbol attributeType) => symbol.HasAttribute(attributeType);
                 public static bool IsVisible(ISymbol? symbol) => symbol.IsVisibleOutsideOfAssembly();
                 public static bool IsInterfaceImplementation(IMethodSymbol symbol) => symbol.IsInterfaceImplementation();
-                public static bool IsNamespace(INamespaceSymbol namespaceSymbol) => namespaceSymbol.IsNamespace(["System"]);
+                public static bool MatchesNamespace(INamespaceSymbol namespaceSymbol) => namespaceSymbol.MatchesNamespace(["System"]);
                 public static IOperation Unwrap(IOperation operation) => operation.UnwrapImplicitConversions();
                 public static IOperation UnwrapOperations(IOperation operation) => operation.UnwrapConversions();
                 public static LanguageVersion GetOperationLanguageVersion(IOperation operation) => operation.GetCSharpLanguageVersion();
-                public static SyntaxNode? TryFindNode(Diagnostic diagnostic, CancellationToken cancellationToken) => diagnostic.TryFindNode(cancellationToken);
+                public static SyntaxNode? FindNode(Diagnostic diagnostic, CancellationToken cancellationToken) => diagnostic.FindNode(cancellationToken);
                 public static int? GetNodeLine(SyntaxNode node, CancellationToken cancellationToken) => node.GetLine(cancellationToken);
-                public static bool IsCSharp12(LanguageVersion languageVersion) => languageVersion.IsCSharp12OrAbove();
+                public static bool IsCSharp12(LanguageVersion languageVersion) => languageVersion.IsCSharp12OrGreater();
                 public static ITypeSymbol? GetFlowType(IOperation operation, CancellationToken cancellationToken) => LocalDataFlowAnalysis.GetActualType(operation, cancellationToken);
                 public static string ReporterName => typeof(DiagnosticReporter).Name;
                 public static DiagnosticInvocationReportOptions InvocationReportOptions => DiagnosticInvocationReportOptions.ReportOnMember | DiagnosticInvocationReportOptions.ReportOnArguments;

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -114,61 +114,61 @@ public sealed class RoslynHelperTests
     }
 
     [Fact]
-    public void IsCSharp8OrAbove_ReturnsTrueOnlyForCSharp8AndLater()
+    public void IsCSharp8OrGreater_ReturnsTrueOnlyForCSharp8AndLater()
     {
-        Assert.False(LanguageVersion.CSharp7_3.IsCSharp8OrAbove());
-        Assert.True(LanguageVersion.CSharp8.IsCSharp8OrAbove());
+        Assert.False(LanguageVersion.CSharp7_3.IsCSharp8OrGreater());
+        Assert.True(LanguageVersion.CSharp8.IsCSharp8OrGreater());
     }
 
     [Fact]
-    public void IsCSharp9OrAbove_ReturnsTrueOnlyForCSharp9AndLater()
+    public void IsCSharp9OrGreater_ReturnsTrueOnlyForCSharp9AndLater()
     {
-        Assert.False(LanguageVersion.CSharp8.IsCSharp9OrAbove());
-        Assert.True(LanguageVersion.CSharp9.IsCSharp9OrAbove());
+        Assert.False(LanguageVersion.CSharp8.IsCSharp9OrGreater());
+        Assert.True(LanguageVersion.CSharp9.IsCSharp9OrGreater());
     }
 
     [Fact]
-    public void IsCSharp10OrAbove_ReturnsTrueOnlyForCSharp10AndLater()
+    public void IsCSharp10OrGreater_ReturnsTrueOnlyForCSharp10AndLater()
     {
-        Assert.False(LanguageVersion.CSharp9.IsCSharp10OrAbove());
-        Assert.True(LanguageVersion.CSharp10.IsCSharp10OrAbove());
+        Assert.False(LanguageVersion.CSharp9.IsCSharp10OrGreater());
+        Assert.True(LanguageVersion.CSharp10.IsCSharp10OrGreater());
     }
 
     [Fact]
-    public void IsCSharp11OrAbove_ReturnsTrueOnlyForCSharp11AndLater()
+    public void IsCSharp11OrGreater_ReturnsTrueOnlyForCSharp11AndLater()
     {
-        Assert.False(LanguageVersion.CSharp10.IsCSharp11OrAbove());
-        Assert.True(LanguageVersion.CSharp11.IsCSharp11OrAbove());
+        Assert.False(LanguageVersion.CSharp10.IsCSharp11OrGreater());
+        Assert.True(LanguageVersion.CSharp11.IsCSharp11OrGreater());
     }
 
     [Fact]
-    public void IsCSharp12OrAbove_ReturnsTrueOnlyForCSharp12AndLater()
+    public void IsCSharp12OrGreater_ReturnsTrueOnlyForCSharp12AndLater()
     {
-        Assert.False(LanguageVersion.CSharp11.IsCSharp12OrAbove());
-        Assert.True(LanguageVersion.CSharp12.IsCSharp12OrAbove());
+        Assert.False(LanguageVersion.CSharp11.IsCSharp12OrGreater());
+        Assert.True(LanguageVersion.CSharp12.IsCSharp12OrGreater());
     }
 
     [Fact]
-    public void IsCSharp13OrAbove_ReturnsTrueOnlyForCSharp13AndLater()
+    public void IsCSharp13OrGreater_ReturnsTrueOnlyForCSharp13AndLater()
     {
-        Assert.False(LanguageVersion.CSharp12.IsCSharp13OrAbove());
-        Assert.True(((LanguageVersion)1300).IsCSharp13OrAbove());
+        Assert.False(LanguageVersion.CSharp12.IsCSharp13OrGreater());
+        Assert.True(((LanguageVersion)1300).IsCSharp13OrGreater());
     }
 
     [Fact]
-    public void IsCSharp14OrAbove_ReturnsTrueOnlyForCSharp14AndLater()
+    public void IsCSharp14OrGreater_ReturnsTrueOnlyForCSharp14AndLater()
     {
-        Assert.False(((LanguageVersion)1300).IsCSharp14OrAbove());
-        Assert.True(((LanguageVersion)1400).IsCSharp14OrAbove());
+        Assert.False(((LanguageVersion)1300).IsCSharp14OrGreater());
+        Assert.True(((LanguageVersion)1400).IsCSharp14OrGreater());
     }
 
     [Fact]
-    public void IsCSharp15OrAbove_ReturnsValueBasedOnAvailableRoslynConstants()
+    public void IsCSharp15OrGreater_ReturnsValueBasedOnAvailableRoslynConstants()
     {
 #if ROSLYN_5_6_OR_GREATER
-        Assert.True(LanguageVersion.Preview.IsCSharp15OrAbove());
+        Assert.True(LanguageVersion.Preview.IsCSharp15OrGreater());
 #else
-        Assert.False(LanguageVersion.Preview.IsCSharp15OrAbove());
+        Assert.False(LanguageVersion.Preview.IsCSharp15OrGreater());
 #endif
     }
 
@@ -182,8 +182,8 @@ public sealed class RoslynHelperTests
             """);
         var type = GetRequiredType(compilation, "Demo.Inner.Sample");
 
-        Assert.True(type.ContainingNamespace.IsNamespace(["Demo", "Inner"]));
-        Assert.False(type.ContainingNamespace.IsNamespace(["Inner"]));
+        Assert.True(type.ContainingNamespace.MatchesNamespace(["Demo", "Inner"]));
+        Assert.False(type.ContainingNamespace.MatchesNamespace(["Inner"]));
     }
 
     [Fact]
@@ -202,7 +202,7 @@ public sealed class RoslynHelperTests
         var descriptor = CreateDescriptor();
         var diagnostic = Diagnostic.Create(descriptor, parameter.GetLocation());
 
-        Assert.Same(parameter, diagnostic.TryFindNode(default));
+        Assert.Same(parameter, diagnostic.FindNode(default));
     }
 
     [Fact]
@@ -335,9 +335,9 @@ public sealed class RoslynHelperTests
         var property = type.GetMembers().OfType<IPropertySymbol>().Single(symbol => symbol.ExplicitInterfaceImplementations.Length == 1);
         var @event = type.GetMembers().OfType<IEventSymbol>().Single(symbol => symbol.ExplicitInterfaceImplementations.Length == 1);
 
-        Assert.Equal("M", method.GetImplementingInterfaceSymbol()?.Name);
-        Assert.Equal("Property", property.GetImplementingInterfaceSymbol()?.Name);
-        Assert.Equal("Changed", @event.GetImplementingInterfaceSymbol()?.Name);
+        Assert.Equal("M", method.GetImplementedInterfaceMember()?.Name);
+        Assert.Equal("Property", property.GetImplementedInterfaceMember()?.Name);
+        Assert.Equal("Changed", @event.GetImplementedInterfaceMember()?.Name);
     }
 
     [Fact]
@@ -361,9 +361,9 @@ public sealed class RoslynHelperTests
         var derivedMethod = GetRequiredMethod(derivedType, "M");
         var other = GetRequiredMethod(baseType, "Other");
 
-        Assert.True(derivedMethod.IsOrOverrideMethod(baseMethod));
-        Assert.True(baseMethod.IsOrOverrideMethod(baseMethod));
-        Assert.False(other.IsOrOverrideMethod(baseMethod));
+        Assert.True(derivedMethod.IsOrOverrides(baseMethod));
+        Assert.True(baseMethod.IsOrOverrides(baseMethod));
+        Assert.False(other.IsOrOverrides(baseMethod));
     }
 
     [Fact]
@@ -387,8 +387,8 @@ public sealed class RoslynHelperTests
         var derivedMethod = GetRequiredMethod(derivedType, "M");
         var other = GetRequiredMethod(baseType, "Other");
 
-        Assert.True(derivedMethod.Override(baseMethod));
-        Assert.False(other.Override(baseMethod));
+        Assert.True(derivedMethod.Overrides(baseMethod));
+        Assert.False(other.Overrides(baseMethod));
     }
 
     [Fact]
@@ -721,7 +721,7 @@ public sealed class RoslynHelperTests
             """);
         var type = GetRequiredType(compilation, "ISample");
 
-        Assert.Contains(type, type.GetAllInterfacesIncludingThis());
+        Assert.Contains(type, type.GetAllInterfacesIncludingSelf());
     }
 
     [Fact]
@@ -842,9 +842,9 @@ public sealed class RoslynHelperTests
         var baseType = GetRequiredType(compilation, "Base");
         var sampleType = GetRequiredType(compilation, "Sample");
 
-        Assert.True(baseType.IsOrInheritFrom(baseType));
-        Assert.True(sampleType.IsOrInheritFrom(baseType));
-        Assert.False(baseType.IsOrInheritFrom(sampleType));
+        Assert.True(baseType.IsOrInheritsFrom(baseType));
+        Assert.True(sampleType.IsOrInheritsFrom(baseType));
+        Assert.False(baseType.IsOrInheritsFrom(sampleType));
     }
 
     [Fact]
@@ -966,8 +966,8 @@ public sealed class RoslynHelperTests
         var enumType = GetRequiredType(compilation, "Sample");
         var otherType = GetRequiredType(compilation, "Other");
 
-        Assert.Equal(SpecialType.System_Int32, enumType.GetEnumType()?.SpecialType);
-        Assert.Null(otherType.GetEnumType());
+        Assert.Equal(SpecialType.System_Int32, enumType.GetEnumUnderlyingType()?.SpecialType);
+        Assert.Null(otherType.GetEnumUnderlyingType());
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #1863. Renames a few helpers in `Meziantou.Framework.Roslyn` whose names were misleading, ungrammatical, or inconsistent with their neighbours. No behavior change.

| Before | After | Why |
|---|---|---|
| `GetEnumType` | `GetEnumUnderlyingType` | Returns `EnumUnderlyingType` (`int`, `byte`…), not the enum type |
| `GetImplementingInterfaceSymbol` | `GetImplementedInterfaceMember` | Returns the interface member being implemented, so the direction was reversed |
| `Override` | `Overrides` | A `bool` predicate named with a bare verb reads as a command |
| `IsOrOverrideMethod` | `IsOrOverrides` | Grammar; `Method` is redundant when both parameters are `IMethodSymbol` |
| `IsOrInheritFrom` | `IsOrInheritsFrom` | Grammar; sits beside `InheritsFrom`, which conjugates correctly |
| `TryFindNode` | `FindNode` | Not the Try pattern: no `bool` return, no `out`. Matches `SyntaxNode.FindNode` |
| `IsNamespace` | `MatchesNamespace` | `ns.IsNamespace(["System"])` read as "is this a namespace", which is always true |
| `IsCSharp8OrAbove` … `IsCSharp15OrAbove` | `IsCSharp8OrGreater` … | Matches `IsNet9OrGreater` and the generated `CSHARP8_OR_GREATER` constants |
| `GetAllInterfacesIncludingThis` | `GetAllInterfacesIncludingSelf` | Matches `GetUnderlyingNullableTypeOrSelf` in the same file |

Doing this now, before the package ships: the helpers compile into the consumer's assembly, so renames break call sites on upgrade.

One caller outside the package was updated (`YamlSerializerContextGenerator` used `IsOrInheritFrom`). The identically named but unrelated `InputEnumSelect.GetEnumType()` and `HtmlAttribute.IsNamespace` were deliberately left alone.

Also tightened one package assertion: `Assert.Contains("TryFindNode", …)` became `Assert.Contains("FindNode(this Diagnostic", …)`, since a bare `"FindNode"` would now match the `root.FindNode(...)` call in the same file and pass even if the extension method were removed.

### Verification

Release builds clean for the package and all seven consuming projects. Tests: 128 per Roslyn version (4.8/5.0/5.3/5.6), 8 package tests, Yaml 1496, Assertions.Analyzer 203, FullPath.Analyzer 105, FastEnumGenerator 86, StronglyTypedId 172 — 0 failures. `dotnet run ./eng/update-all.cs` exits 0 with nothing to regenerate.