### PR TITLE
Add IReadOnlySet<T> support to Meziantou.Framework.Yaml

### DIFF
--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -884,7 +884,8 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
             }
 
             if (string.Equals(constructed, "global::System.Collections.Generic.HashSet<T>", StringComparison.Ordinal) ||
-                string.Equals(constructed, "global::System.Collections.Generic.ISet<T>", StringComparison.Ordinal))
+                string.Equals(constructed, "global::System.Collections.Generic.ISet<T>", StringComparison.Ordinal) ||
+                string.Equals(constructed, "global::System.Collections.Generic.IReadOnlySet<T>", StringComparison.Ordinal))
             {
                 elementType = named.TypeArguments[0];
                 kind = SequenceKind.Set;

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlIReadOnlySetConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlIReadOnlySetConverter.cs
@@ -1,0 +1,54 @@
+namespace Meziantou.Framework.Yaml.Serialization.Converters;
+
+internal sealed class YamlIReadOnlySetConverter<TElement> : YamlConverter<IReadOnlySet<TElement>?>
+{
+    private YamlConverter? _elementConverter;
+
+    public override IReadOnlySet<TElement>? Read(YamlReader reader)
+    {
+        if (reader.TryReadAlias(out var rootAliasValue))
+        {
+            return (IReadOnlySet<TElement>)rootAliasValue!;
+        }
+
+        if (reader.TokenType == YamlTokenType.Alias)
+        {
+            throw new YamlException(reader.SourceName, reader.Start, reader.End, "Aliases are not supported when deserializing into a set unless ReferenceHandling is Preserve.");
+        }
+
+        if (reader.TokenType == YamlTokenType.Scalar && YamlScalar.IsNull(reader))
+        {
+            reader.Read();
+            return null;
+        }
+
+        if (reader.TokenType != YamlTokenType.StartSequence)
+        {
+            throw YamlThrowHelper.ThrowExpectedSequence(reader);
+        }
+
+        _elementConverter ??= reader.GetConverter(typeof(TElement));
+        var anchor = reader.Anchor;
+        reader.Read();
+
+        var set = new HashSet<TElement>();
+        if (reader.ReferenceReader is not null && anchor is not null)
+        {
+            reader.ReferenceReader.Register(anchor, set);
+        }
+
+        while (reader.TokenType != YamlTokenType.EndSequence)
+        {
+            var value = _elementConverter.Read(reader, typeof(TElement));
+            set.Add((TElement)value!);
+        }
+
+        reader.Read();
+        return set;
+    }
+
+    public override void Write(YamlWriter writer, IReadOnlySet<TElement>? value)
+    {
+        SequenceReadHelpers.WriteEnumerable(writer, value, ref _elementConverter);
+    }
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlReaderWriterBase.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlReaderWriterBase.cs
@@ -499,6 +499,12 @@ public abstract class YamlReaderWriterBase
                     return (YamlConverter)Activator.CreateInstance(converterType)!;
                 }
 
+                if (definition == typeof(IReadOnlySet<>))
+                {
+                    var converterType = typeof(YamlIReadOnlySetConverter<>).MakeGenericType(args[0]);
+                    return (YamlConverter)Activator.CreateInstance(converterType)!;
+                }
+
                 if (definition == typeof(IList<>))
                 {
                     var converterType = typeof(YamlIListConverter<>).MakeGenericType(args[0]);

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerCollectionSupportReflectionTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerCollectionSupportReflectionTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using Meziantou.Framework.Yaml.Serialization;
 
 namespace Meziantou.Framework.Yaml.Tests.Serialization;
 public sealed class YamlSerializerCollectionSupportReflectionTests
@@ -28,6 +29,79 @@ public sealed class YamlSerializerCollectionSupportReflectionTests
         Assert.HasCount(2, result);
         Assert.Contains("a", result);
         Assert.Contains("b", result);
+    }
+
+    [Fact]
+    public void Deserialize_IReadOnlySet_ShouldReturnHashSet()
+    {
+        var yaml = "- a\n- b\n- a\n";
+
+        var result = YamlSerializer.Deserialize<IReadOnlySet<string>>(yaml);
+
+        Assert.NotNull(result);
+        Assert.HasCount(2, result);
+        Assert.Contains("a", result);
+        Assert.Contains("b", result);
+    }
+
+    [Fact]
+    public void Serialize_IReadOnlySet_ShouldWriteSequence()
+    {
+        var value = (IReadOnlySet<int>)new HashSet<int> { 1, 2 };
+
+        var yaml = YamlSerializer.Serialize(value);
+
+        Assert.Equal("- 1\n- 2\n", yaml, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void RoundTrip_IReadOnlySetMember_ShouldPreserveValues()
+    {
+        var payload = new ReadOnlySetPayload
+        {
+            Tags = new HashSet<string>(StringComparer.Ordinal) { "a", "b" },
+        };
+
+        var yaml = YamlSerializer.Serialize(payload);
+        var result = YamlSerializer.Deserialize<ReadOnlySetPayload>(yaml);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Tags);
+        Assert.HasCount(2, result.Tags);
+        Assert.Contains("a", result.Tags);
+        Assert.Contains("b", result.Tags);
+    }
+
+    [Fact]
+    public void RoundTrip_IReadOnlySetMember_ShouldPreserveSharedReferences()
+    {
+        var shared = new HashSet<int> { 1, 2 };
+        var payload = new ReadOnlySetReferencePayload
+        {
+            Primary = shared,
+            Secondary = shared,
+        };
+
+        var options = new YamlSerializerOptions { ReferenceHandling = YamlReferenceHandling.Preserve };
+        var yaml = YamlSerializer.Serialize(payload, options);
+
+        var anchor = ExtractAnchor(yaml, "Primary: &");
+        Assert.Contains($"Secondary: *{anchor}", yaml);
+
+        var result = YamlSerializer.Deserialize<ReadOnlySetReferencePayload>(yaml, options);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Primary);
+        Assert.Same(result.Primary, result.Secondary);
+        Assert.HasCount(2, result.Primary);
+    }
+
+    [Fact]
+    public void Deserialize_IReadOnlySetMember_WithExplicitPopulate_ShouldThrow()
+    {
+        var yaml = "Tags:\n- a\n";
+
+        Assert.Throws<InvalidOperationException>(() => YamlSerializer.Deserialize<PopulateReadOnlySetPayload>(yaml));
     }
 
     [Fact]
@@ -205,6 +279,28 @@ public sealed class YamlSerializerCollectionSupportReflectionTests
     {
         Red = 1,
         Green = 2,
+    }
+
+    private sealed class ReadOnlySetPayload
+    {
+        [SuppressMessage("Performance", "CA1859: Use concrete types when possible for improved performance", Justification = "Test class")]
+        public IReadOnlySet<string>? Tags { get; set; }
+    }
+
+    private sealed class ReadOnlySetReferencePayload
+    {
+        [SuppressMessage("Performance", "CA1859: Use concrete types when possible for improved performance", Justification = "Test class")]
+        public IReadOnlySet<int>? Primary { get; set; }
+
+        [SuppressMessage("Performance", "CA1859: Use concrete types when possible for improved performance", Justification = "Test class")]
+        public IReadOnlySet<int>? Secondary { get; set; }
+    }
+
+    private sealed class PopulateReadOnlySetPayload
+    {
+        [SuppressMessage("Performance", "CA1859: Use concrete types when possible for improved performance", Justification = "Test class")]
+        [YamlObjectCreationHandling(YamlObjectCreationHandling.Populate)]
+        public IReadOnlySet<string> Tags { get; } = new HashSet<string>(StringComparer.Ordinal);
     }
 
     private sealed class ImmutableAnchorPayload

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -192,6 +192,8 @@ internal sealed class GeneratedMoreCollections
 
     public ISet<string>? Tags { get; set; }
 
+    public IReadOnlySet<string>? ReadOnlyTags { get; set; }
+
     public Dictionary<int, string> IntKeyMap { get; set; } = new();
 
     public IReadOnlyDictionary<GeneratedColor, int>? EnumKeyMap { get; set; }
@@ -807,6 +809,7 @@ internal sealed class GeneratedYamlIgnoreConditions
 [YamlSerializable(typeof(Dictionary<int, string>))]
 [YamlSerializable(typeof(IReadOnlyList<int>))]
 [YamlSerializable(typeof(ISet<string>))]
+[YamlSerializable(typeof(IReadOnlySet<string>))]
 [YamlSerializable(typeof(HashSet<int>))]
 [YamlSerializable(typeof(IReadOnlyDictionary<GeneratedColor, int>))]
 [YamlSerializable(typeof(ImmutableArray<int>))]
@@ -2036,6 +2039,13 @@ public class YamlSerializerSourceGenerationTests
         Assert.NotNull(roundSet);
         Assert.HasCount(2, roundSet);
 
+        var readOnlySetTypeInfo = context.IReadOnlySetString;
+        var yamlReadOnlySet = YamlSerializer.Serialize((IReadOnlySet<string>)new HashSet<string>(StringComparer.Ordinal) { "a", "b", "a" }, readOnlySetTypeInfo);
+        var roundReadOnlySet = YamlSerializer.Deserialize(yamlReadOnlySet, readOnlySetTypeInfo);
+        Assert.NotNull(roundReadOnlySet);
+        Assert.HasCount(2, roundReadOnlySet);
+        Assert.Contains("a", roundReadOnlySet);
+
         var dictTypeInfo = context.DictionaryInt32Int32;
         var yamlDict = YamlSerializer.Serialize(new Dictionary<int, int> { [1] = 2 }, dictTypeInfo);
         Assert.Contains("1:", yamlDict);
@@ -2068,6 +2078,7 @@ public class YamlSerializerSourceGenerationTests
         {
             ReadOnlyNumbers = new List<int> { 1, 2 },
             Tags = new HashSet<string>(StringComparer.Ordinal) { "a", "b", "a" },
+            ReadOnlyTags = new HashSet<string>(StringComparer.Ordinal) { "c", "d" },
             IntKeyMap = new Dictionary<int, string> { [1] = "one", [2] = "two" },
             EnumKeyMap = new Dictionary<GeneratedColor, int> { [GeneratedColor.Green] = 2 },
             ImmutableNumbers = ImmutableArray.Create(10, 20),
@@ -2085,6 +2096,11 @@ public class YamlSerializerSourceGenerationTests
         Assert.NotNull(roundtripped.Tags);
         Assert.HasCount(2, roundtripped.Tags);
         Assert.Contains("a", roundtripped.Tags);
+
+        Assert.NotNull(roundtripped.ReadOnlyTags);
+        Assert.HasCount(2, roundtripped.ReadOnlyTags);
+        Assert.Contains("c", roundtripped.ReadOnlyTags);
+        Assert.Contains("d", roundtripped.ReadOnlyTags);
 
         Assert.Equal("one", roundtripped.IntKeyMap[1]);
         Assert.NotNull(roundtripped.EnumKeyMap);


### PR DESCRIPTION
`System.Text.Json` supports `IReadOnlySet<T>`, but `YamlSerializer` did not: an `IReadOnlySet<T>` type or member fell through to the object converter and produced wrong output. This adds the equivalent support.

## What changed

- **`YamlIReadOnlySetConverter<T>`** (new) — deserializes a YAML sequence into a `HashSet<T>` and serializes as a sequence. Handles null scalars and anchors/aliases when `ReferenceHandling = Preserve`, mirroring `YamlISetConverter<T>`.
- **`YamlReaderWriterBase`** — resolves the new converter for `IReadOnlySet<>` in the reflection-based path.
- **`YamlSerializerContextGenerator`** — maps `IReadOnlySet<T>` to `SequenceKind.Set`, so generated contexts emit the same `HashSet<T>`-building code already used for `ISet<T>` / `HashSet<T>`.

## Notes for reviewers

- Populating is intentionally **not** supported: elements can't be added to an `IReadOnlySet<T>`, so `CanPopulate` stays `false`, consistent with the other read-only collection converters (`IReadOnlyList<T>`, `IReadOnlyCollection<T>`, `IReadOnlyDictionary<TKey, TValue>`). An explicit `[YamlObjectCreationHandling(Populate)]` on such a member throws the usual "doesn't support populating" error, and `PreferredObjectCreationHandling = Populate` falls back to replacing.
- The converter is `internal`, so there is no public API change and no `ref/` update.

## Tests

- 5 new tests in `YamlSerializerCollectionSupportReflectionTests`: root-level deserialize (including duplicate elimination), serialize, member round-trip, shared-reference preservation with `ReferenceHandling.Preserve`, and the explicit-populate failure.
- `YamlSerializerSourceGenerationTests`: `IReadOnlySet<string>` added both as a `[YamlSerializable]` root type and as a member of `GeneratedMoreCollections`.

## Verification

- `dotnet build /p:TreatsWarningsAsErrors=true` — succeeded, 0 warnings.
- `dotnet test tests/Meziantou.Framework.Yaml.Tests` — 1506 passed / 0 failed across net10.0 and net11.0; confirmed via the .trx that the new tests actually ran.
- `dotnet run ./eng/update-all.cs` — ran clean, no file changes produced.
