### PR TITLE
Cache the BufferWriterTextWriter instance per thread

### DIFF
--- a/src/Meziantou.Framework.Yaml/Serialization/BufferWriterTextWriter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/BufferWriterTextWriter.cs
@@ -1,10 +1,11 @@
 using System.Buffers;
+using System.Diagnostics;
 
 namespace Meziantou.Framework.Yaml.Serialization;
 
 internal sealed class BufferWriterTextWriter : TextWriter
 {
-    private readonly IBufferWriter<char> _destination;
+    private IBufferWriter<char>? _destination;
 
     public BufferWriterTextWriter(IBufferWriter<char> destination)
     {
@@ -12,13 +13,52 @@ internal sealed class BufferWriterTextWriter : TextWriter
         _destination = destination;
     }
 
+    private BufferWriterTextWriter()
+    {
+    }
+
     public override Encoding Encoding => Encoding.UTF8;
+
+    private IBufferWriter<char> Destination
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_destination is null, this);
+            return _destination;
+        }
+    }
+
+    /// <summary>
+    /// Resets the writer to write to a new destination, so the instance can be reused in pooling scenarios.
+    /// </summary>
+    /// <param name="destination">The new destination buffer writer.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="destination"/> is <see langword="null"/>.</exception>
+    public void Reset(IBufferWriter<char> destination)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+        _destination = destination;
+    }
+
+    internal static BufferWriterTextWriter CreateEmptyInstanceForCaching() => new();
+
+    internal void ConfigureForCacheReuse(IBufferWriter<char> destination)
+    {
+        Debug.Assert(_destination is null);
+        Reset(destination);
+    }
+
+    internal void ResetAllStateForCacheReuse()
+    {
+        // Release the reference to the caller's buffer writer so the cached instance doesn't keep it alive.
+        _destination = null;
+    }
 
     public override void Write(char value)
     {
-        var span = _destination.GetSpan(1);
+        var destination = Destination;
+        var span = destination.GetSpan(1);
         span[0] = value;
-        _destination.Advance(1);
+        destination.Advance(1);
     }
 
     public override void Write(char[] buffer, int index, int count)
@@ -52,7 +92,8 @@ internal sealed class BufferWriterTextWriter : TextWriter
             return;
         }
 
-        buffer.CopyTo(_destination.GetSpan(buffer.Length));
-        _destination.Advance(buffer.Length);
+        var destination = Destination;
+        buffer.CopyTo(destination.GetSpan(buffer.Length));
+        destination.Advance(buffer.Length);
     }
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/BufferWriterTextWriterCache.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/BufferWriterTextWriterCache.cs
@@ -9,11 +9,11 @@ namespace Meziantou.Framework.Yaml.Serialization;
 internal static class BufferWriterTextWriterCache
 {
     [ThreadStatic]
-    private static ThreadLocalState? t_threadLocalState;
+    private static ThreadLocalState? s_threadLocalState;
 
     public static BufferWriterTextWriter RentWriter(IBufferWriter<char> destination)
     {
-        var state = t_threadLocalState ??= new ThreadLocalState();
+        var state = s_threadLocalState ??= new ThreadLocalState();
         BufferWriterTextWriter writer;
 
         if (state.RentedWriters++ == 0)
@@ -33,7 +33,7 @@ internal static class BufferWriterTextWriterCache
 
     public static void ReturnWriter(BufferWriterTextWriter writer)
     {
-        var state = t_threadLocalState;
+        var state = s_threadLocalState;
         Debug.Assert(state is not null);
 
         writer.ResetAllStateForCacheReuse();

--- a/src/Meziantou.Framework.Yaml/Serialization/BufferWriterTextWriterCache.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/BufferWriterTextWriterCache.cs
@@ -1,0 +1,50 @@
+using System.Buffers;
+using System.Diagnostics;
+
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>
+/// Defines a thread-local cache for <see cref="YamlSerializer"/> to store reusable <see cref="BufferWriterTextWriter"/> instances.
+/// </summary>
+internal static class BufferWriterTextWriterCache
+{
+    [ThreadStatic]
+    private static ThreadLocalState? t_threadLocalState;
+
+    public static BufferWriterTextWriter RentWriter(IBufferWriter<char> destination)
+    {
+        var state = t_threadLocalState ??= new ThreadLocalState();
+        BufferWriterTextWriter writer;
+
+        if (state.RentedWriters++ == 0)
+        {
+            // First YamlSerializer call in the stack -- initialize & return the cached instance.
+            writer = state.Writer;
+            writer.ConfigureForCacheReuse(destination);
+        }
+        else
+        {
+            // We're in a recursive YamlSerializer call -- return a fresh instance.
+            writer = new BufferWriterTextWriter(destination);
+        }
+
+        return writer;
+    }
+
+    public static void ReturnWriter(BufferWriterTextWriter writer)
+    {
+        var state = t_threadLocalState;
+        Debug.Assert(state is not null);
+
+        writer.ResetAllStateForCacheReuse();
+
+        var rentedWriters = --state.RentedWriters;
+        Debug.Assert((rentedWriters == 0) == ReferenceEquals(state.Writer, writer));
+    }
+
+    private sealed class ThreadLocalState
+    {
+        public readonly BufferWriterTextWriter Writer = BufferWriterTextWriter.CreateEmptyInstanceForCaching();
+        public int RentedWriters;
+    }
+}

--- a/src/Meziantou.Framework.Yaml/YamlSerializer.cs
+++ b/src/Meziantou.Framework.Yaml/YamlSerializer.cs
@@ -927,8 +927,15 @@ public static class YamlSerializer
     {
         ArgumentNullException.ThrowIfNull(destination);
 
-        var writer = new BufferWriterTextWriter(destination);
-        Serialize(writer, value, options);
+        var writer = BufferWriterTextWriterCache.RentWriter(destination);
+        try
+        {
+            Serialize(writer, value, options);
+        }
+        finally
+        {
+            BufferWriterTextWriterCache.ReturnWriter(writer);
+        }
     }
 
     /// <summary>
@@ -944,8 +951,15 @@ public static class YamlSerializer
         ArgumentNullException.ThrowIfNull(destination);
         ArgumentNullException.ThrowIfNull(context);
 
-        var writer = new BufferWriterTextWriter(destination);
-        Serialize(writer, value, context);
+        var writer = BufferWriterTextWriterCache.RentWriter(destination);
+        try
+        {
+            Serialize(writer, value, context);
+        }
+        finally
+        {
+            BufferWriterTextWriterCache.ReturnWriter(writer);
+        }
     }
 
     /// <summary>
@@ -961,8 +975,15 @@ public static class YamlSerializer
         ArgumentNullException.ThrowIfNull(destination);
         ArgumentNullException.ThrowIfNull(inputType);
 
-        var writer = new BufferWriterTextWriter(destination);
-        Serialize(writer, value, inputType, options);
+        var writer = BufferWriterTextWriterCache.RentWriter(destination);
+        try
+        {
+            Serialize(writer, value, inputType, options);
+        }
+        finally
+        {
+            BufferWriterTextWriterCache.ReturnWriter(writer);
+        }
     }
 
     /// <summary>
@@ -979,8 +1000,15 @@ public static class YamlSerializer
         ArgumentNullException.ThrowIfNull(inputType);
         ArgumentNullException.ThrowIfNull(context);
 
-        var writer = new BufferWriterTextWriter(destination);
-        Serialize(writer, value, inputType, context);
+        var writer = BufferWriterTextWriterCache.RentWriter(destination);
+        try
+        {
+            Serialize(writer, value, inputType, context);
+        }
+        finally
+        {
+            BufferWriterTextWriterCache.ReturnWriter(writer);
+        }
     }
 
     private static void SerializeCore(YamlTypeInfo typeInfo, object? value, TextWriter writer)

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerBufferWriterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerBufferWriterTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using Meziantou.Framework.Yaml.Serialization;
 
 namespace Meziantou.Framework.Yaml.Tests.Serialization;
 public sealed class YamlSerializerBufferWriterTests
@@ -27,5 +28,115 @@ public sealed class YamlSerializerBufferWriterTests
         Assert.Contains("first_name", yaml);
         Assert.Contains("Bob", yaml);
         Assert.Contains("Age", yaml);
+    }
+
+    [Fact]
+    public void BufferWriterTextWriter_Reset_ShouldWriteToNewDestination()
+    {
+        var first = new ArrayBufferWriter<char>();
+        var second = new ArrayBufferWriter<char>();
+
+        using var writer = new BufferWriterTextWriter(first);
+        writer.Write("abc");
+
+        writer.Reset(second);
+        writer.Write("def");
+
+        Assert.Equal("abc", new string(first.WrittenSpan));
+        Assert.Equal("def", new string(second.WrittenSpan));
+    }
+
+    [Fact]
+    public void BufferWriterTextWriter_Reset_WithNullDestination_ShouldThrow()
+    {
+        using var writer = new BufferWriterTextWriter(new ArrayBufferWriter<char>());
+
+        Assert.Throws<ArgumentNullException>(() => writer.Reset(destination: null!));
+    }
+
+    [Fact]
+    public void BufferWriterTextWriter_UseAfterReturnedToCache_ShouldThrow()
+    {
+        var writer = BufferWriterTextWriterCache.RentWriter(new ArrayBufferWriter<char>());
+        BufferWriterTextWriterCache.ReturnWriter(writer);
+
+        Assert.Throws<ObjectDisposedException>(() => writer.Write('a'));
+        Assert.Throws<ObjectDisposedException>(() => writer.Write("abc"));
+    }
+
+    [Fact]
+    public void BufferWriterTextWriterCache_ShouldReuseTheSameInstance()
+    {
+        var first = BufferWriterTextWriterCache.RentWriter(new ArrayBufferWriter<char>());
+        BufferWriterTextWriterCache.ReturnWriter(first);
+
+        var second = BufferWriterTextWriterCache.RentWriter(new ArrayBufferWriter<char>());
+        BufferWriterTextWriterCache.ReturnWriter(second);
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void BufferWriterTextWriterCache_NestedRent_ShouldUseDistinctInstances()
+    {
+        var outerDestination = new ArrayBufferWriter<char>();
+        var innerDestination = new ArrayBufferWriter<char>();
+
+        var outer = BufferWriterTextWriterCache.RentWriter(outerDestination);
+        var inner = BufferWriterTextWriterCache.RentWriter(innerDestination);
+        try
+        {
+            Assert.NotSame(outer, inner);
+
+            outer.Write("outer");
+            inner.Write("inner");
+        }
+        finally
+        {
+            BufferWriterTextWriterCache.ReturnWriter(inner);
+            BufferWriterTextWriterCache.ReturnWriter(outer);
+        }
+
+        Assert.Equal("outer", new string(outerDestination.WrittenSpan));
+        Assert.Equal("inner", new string(innerDestination.WrittenSpan));
+
+        var reused = BufferWriterTextWriterCache.RentWriter(new ArrayBufferWriter<char>());
+        BufferWriterTextWriterCache.ReturnWriter(reused);
+        Assert.Same(outer, reused);
+    }
+
+    [Fact]
+    public void Serialize_IBufferWriter_ConsecutiveCalls_ShouldWriteToTheirOwnDestination()
+    {
+        var first = new ArrayBufferWriter<char>();
+        var second = new ArrayBufferWriter<char>();
+
+        YamlSerializer.Serialize(first, new Dictionary<string, int>(StringComparer.Ordinal) { ["a"] = 1 });
+        YamlSerializer.Serialize(second, new Dictionary<string, int>(StringComparer.Ordinal) { ["b"] = 2 });
+
+        Assert.Equal("a: 1\n", new string(first.WrittenSpan));
+        Assert.Equal("b: 2\n", new string(second.WrittenSpan));
+    }
+
+    [Fact]
+    public void Serialize_IBufferWriter_WhenSerializationThrows_ShouldReleaseTheCachedWriter()
+    {
+        var cached = BufferWriterTextWriterCache.RentWriter(new ArrayBufferWriter<char>());
+        BufferWriterTextWriterCache.ReturnWriter(cached);
+
+        var destination = new ArrayBufferWriter<char>();
+        Assert.ThrowsAny<Exception>(() => YamlSerializer.Serialize(destination, new ThrowingValue()));
+
+        var afterFailure = BufferWriterTextWriterCache.RentWriter(new ArrayBufferWriter<char>());
+        BufferWriterTextWriterCache.ReturnWriter(afterFailure);
+
+        Assert.Same(cached, afterFailure);
+    }
+
+    private sealed class ThrowingValue
+    {
+        public string Message { get; } = "boom";
+
+        public int Value => throw new InvalidOperationException(Message);
     }
 }


### PR DESCRIPTION
## What

Adds pooling support to `BufferWriterTextWriter` and uses it from the `YamlSerializer.Serialize(IBufferWriter<char>, ...)` overloads, following the [`Utf8JsonWriterCache`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriterCache.cs) pattern from `System.Text.Json` (and the `Reset` overloads added in dotnet/runtime#126578).

- `BufferWriterTextWriter.Reset(IBufferWriter<char>)` re-points an existing writer at a new destination.
- New `BufferWriterTextWriterCache`: a `[ThreadStatic]` state holding one cached writer plus a rent counter. The first serializer call on the stack gets the cached instance; a nested (recursive) call — e.g. a converter re-entering the serializer — gets a fresh one.
- The four `Serialize(IBufferWriter<char>, ...)` overloads rent from the cache and return it in a `finally`, so a serialization failure doesn't leak the rent count.

## Why

Each `Serialize(IBufferWriter<char>, ...)` call allocated a new `TextWriter`. Reusing one per thread removes that allocation from the buffer-writer serialization path.

## Notes for reviewers

- `_destination` is now nullable and is cleared when the writer is returned to the cache, so the cached instance doesn't keep the caller's `IBufferWriter<char>` alive. Writes go through a property using `ObjectDisposedException.ThrowIf`, so using a writer after it has been returned throws instead of writing into a stale buffer — same observable behavior as `Utf8JsonWriter` after `JsonSerializer` returns it to its cache.
- Two deliberate deviations from `System.Text.Json`, because this type is simpler: there are no writer options to reconfigure, so `ConfigureForCacheReuse` only takes a destination; and there is no buffer-pool half (`PooledByteBufferWriter` / `RentWriterAndBuffer`) since the caller owns the buffer.
- `Dispose` is left as the inherited no-op rather than adding disposal semantics to a type that never had them.
- All serialization paths here are synchronous, so the thread-static cache has no await-crossing concern.
- Both types are internal, so there is no `ref/` change.

## Testing

- Full `Meziantou.Framework.Yaml.Tests` suite with `/p:TreatWarningsAsErrors=true`: 1510 passed, 0 failed (net10.0 + net11.0).
- 7 new tests: instance reuse across rents, nested rents getting distinct instances, use-after-return throwing `ObjectDisposedException`, consecutive serializes writing to their own destinations, and the cached writer still being reused after a serialization throws.
- `dotnet run ./eng/update-all.cs` — no generated file changes.