### PR TITLE
Base MFY006 converter validation on real accessibility

### DIFF
--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -559,13 +559,14 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                 continue;
             }
 
-            if (named.DeclaredAccessibility is Accessibility.Private or Accessibility.Protected or Accessibility.ProtectedAndInternal)
+            // The generated code lives in the context type, so a nested converter can be private and still usable.
+            if (!compilation.IsSymbolAccessibleWithin(named, model.ContextSymbol))
             {
                 diagnostics.Add(Diagnostic.Create(
                     InvalidConverterType,
                     location,
                     named.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                    "Converter types must be accessible to the generated context (public or internal)."));
+                    "Converter types must be accessible from the generated context."));
                 continue;
             }
 
@@ -579,13 +580,13 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                 continue;
             }
 
-            if (!named.InstanceConstructors.Any(static ctor => ctor.Parameters.Length == 0 && ctor.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal))
+            if (!named.InstanceConstructors.Any(ctor => ctor.Parameters.Length == 0 && compilation.IsSymbolAccessibleWithin(ctor, model.ContextSymbol)))
             {
                 diagnostics.Add(Diagnostic.Create(
                     InvalidConverterType,
                     location,
                     named.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                    "Converter types must provide a public or internal parameterless constructor."));
+                    "Converter types must provide a parameterless constructor accessible from the generated context."));
             }
         }
     }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
@@ -705,6 +705,153 @@ public class YamlSerializerContextGeneratorDiagnosticTests
         Assert.Contains("derive", diagnostic.GetMessage());
     }
 
+    [Fact]
+    public void MFY006_IsNotReported_WhenConverterIsPrivateNestedInsideContext()
+    {
+        const string Source = """
+            using Meziantou.Framework.Yaml.Serialization;
+
+            [YamlSerializable(typeof(int))]
+            [YamlSourceGenerationOptions(Converters = [typeof(TestContext.NestedConverter)])]
+            internal partial class TestContext : YamlSerializerContext
+            {
+                private sealed class NestedConverter : YamlConverter<int>
+                {
+                    public override int Read(YamlReader reader)
+                    {
+                        reader.Skip();
+                        return 123;
+                    }
+
+                    public override void Write(YamlWriter writer, int value)
+                        => writer.WriteScalar("123");
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(Source)
+            .Where(static diagnostic => diagnostic.Id == "MFY006")
+            .ToArray();
+
+        Assert.Empty(diagnostics);
+
+        var result = RunGenerator(Source);
+        Assert.Contains("NestedConverter", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void MFY006_IsNotReported_WhenConverterConstructorIsProtectedInternal()
+    {
+        const string Source = """
+            using Meziantou.Framework.Yaml.Serialization;
+
+            public class ProtectedInternalCtorConverter : YamlConverter<int>
+            {
+                protected internal ProtectedInternalCtorConverter()
+                {
+                }
+
+                public override int Read(YamlReader reader)
+                {
+                    reader.Skip();
+                    return 123;
+                }
+
+                public override void Write(YamlWriter writer, int value)
+                    => writer.WriteScalar("123");
+            }
+
+            [YamlSerializable(typeof(int))]
+            [YamlSourceGenerationOptions(Converters = [typeof(ProtectedInternalCtorConverter)])]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(Source)
+            .Where(static diagnostic => diagnostic.Id == "MFY006")
+            .ToArray();
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void MFY006_StillFires_WhenNestedConverterConstructorIsPrivate()
+    {
+        // A private constructor of a nested type is not reachable from the enclosing type.
+        const string Source = """
+            using Meziantou.Framework.Yaml.Serialization;
+
+            [YamlSerializable(typeof(int))]
+            [YamlSourceGenerationOptions(Converters = [typeof(TestContext.NestedConverter)])]
+            internal partial class TestContext : YamlSerializerContext
+            {
+                private sealed class NestedConverter : YamlConverter<int>
+                {
+                    private NestedConverter()
+                    {
+                    }
+
+                    public override int Read(YamlReader reader)
+                    {
+                        reader.Skip();
+                        return 123;
+                    }
+
+                    public override void Write(YamlWriter writer, int value)
+                        => writer.WriteScalar("123");
+                }
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(Source)
+            .Where(static diagnostic => diagnostic.Id == "MFY006")
+            .ToArray();
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("parameterless constructor", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void MFY006_StillFires_WhenConverterConstructorIsNotAccessibleFromContext()
+    {
+        const string Source = """
+            using Meziantou.Framework.Yaml.Serialization;
+
+            public sealed class PrivateCtorConverter : YamlConverter<int>
+            {
+                private PrivateCtorConverter()
+                {
+                }
+
+                public override int Read(YamlReader reader)
+                {
+                    reader.Skip();
+                    return 123;
+                }
+
+                public override void Write(YamlWriter writer, int value)
+                    => writer.WriteScalar("123");
+            }
+
+            [YamlSerializable(typeof(int))]
+            [YamlSourceGenerationOptions(Converters = [typeof(PrivateCtorConverter)])]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(Source)
+            .Where(static diagnostic => diagnostic.Id == "MFY006")
+            .ToArray();
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("PrivateCtorConverter", diagnostic.GetMessage());
+        Assert.Contains("parameterless constructor", diagnostic.GetMessage());
+    }
+
     private static Diagnostic[] RunAnalyzer([StringSyntax("c#-test")] string source)
     {
         var compilation = CreateCompilation(source);


### PR DESCRIPTION
## Summary

`MFY006` (`InvalidConverterType`) validated converter types with `DeclaredAccessibility`, which says how a symbol is declared, not whether the generated code can reach it:

```csharp
if (named.DeclaredAccessibility is Accessibility.Private or Accessibility.Protected or Accessibility.ProtectedAndInternal)
    // "Converter types must be accessible to the generated context (public or internal)."

if (!named.InstanceConstructors.Any(ctor => ctor.Parameters.Length == 0 && ctor.DeclaredAccessibility is Public or Internal))
    // "Converter types must provide a public or internal parameterless constructor."
```

The generated code lives in `partial class TheContext`, so a converter declared as a **private nested class inside the context itself** is perfectly usable — but was rejected. Worse, the generator reports no diagnostics of its own (`EmitContext` returns `false` and leaves reporting to `YamlSerializerContextAnalyzer`), so the only thing a command-line build showed was:

```
error CS0534: 'NestedContext' does not implement inherited abstract member 'YamlSerializerContext.GetTypeInfo(Type, YamlSerializerOptions)'
```

A `protected internal` parameterless constructor was rejected for the same reason, even though it is callable from anywhere in the assembly.

## Changes

Both checks now use `compilation.IsSymbolAccessibleWithin(symbol, model.ContextSymbol)`. The messages no longer enumerate modifiers, since the rule is about reachability from the context:

- *"Converter types must be accessible from the generated context."*
- *"Converter types must provide a parameterless constructor accessible from the generated context."*

## Note for reviewers

The **type** accessibility check is now close to unreachable from valid C#, and that is expected: `typeof(X)` in the attribute only binds if `X` is nameable at that location, which is inside the context's own accessibility domain. It is kept as a defensive check (it also catches error types). The **constructor** check remains reachable and is still enforced — a private constructor is genuinely not callable, including from the enclosing type when the converter is nested. I verified that last point against the compiler rather than assuming it:

```csharp
internal sealed class Outer
{
    private sealed class Inner { private Inner() { } }
    public static object Make() => new Inner();  // error CS0122
}
```

## Testing

Four tests added to `YamlSerializerContextGeneratorDiagnosticTests.cs`:

| Test | Asserts |
| --- | --- |
| `MFY006_IsNotReported_WhenConverterIsPrivateNestedInsideContext` | no diagnostic, and the generated source references the converter |
| `MFY006_IsNotReported_WhenConverterConstructorIsProtectedInternal` | no diagnostic |
| `MFY006_StillFires_WhenNestedConverterConstructorIsPrivate` | still an error |
| `MFY006_StillFires_WhenConverterConstructorIsNotAccessibleFromContext` | still an error |

I confirmed the two `IsNotReported` tests **fail against the previous code**, so they genuinely guard the fix rather than just passing by construction.

Also verified end-to-end at runtime that the private nested converter is actually used, not merely accepted — a context with a nested converter writing `999` and reading `123` produces `serialized: Value: 999` / `deserialized: 123`.

Full Yaml suite: **1504 passed / 0 failed** on net10.0 and net11.0, Debug and Release, with `/p:TreatWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` produces no changes.

## Out of scope

While reproducing this I found a separate, pre-existing issue worth its own change: **MFY006 never surfaces in a command-line build at all.** `EmitContext` discards `validationResult.Diagnostics` and relies solely on the analyzer. `MFY001` does appear in the same project, but `MFY002` and `MFY006` do not — the analyzer loads (no `CS8032`) and throws nothing (no `AD0001`), so I have a reproduction but not a root cause. Either way, users hitting an invalid converter today only see the downstream `CS0534`. Not addressed here.
