### PR TITLE
Add PascalCase naming policy to Meziantou.Framework.Yaml

### DIFF
--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -190,7 +190,8 @@ namespace Meziantou.Framework.Yaml
         SnakeCaseLower = 2,
         SnakeCaseUpper = 3,
         KebabCaseLower = 4,
-        KebabCaseUpper = 5
+        KebabCaseUpper = 5,
+        PascalCase = 6
     }
 
     public enum YamlMappingOrderPolicy
@@ -206,6 +207,7 @@ namespace Meziantou.Framework.Yaml
         public static Meziantou.Framework.Yaml.YamlNamingPolicy SnakeCaseUpper { get => throw null; }
         public static Meziantou.Framework.Yaml.YamlNamingPolicy KebabCaseLower { get => throw null; }
         public static Meziantou.Framework.Yaml.YamlNamingPolicy KebabCaseUpper { get => throw null; }
+        public static Meziantou.Framework.Yaml.YamlNamingPolicy PascalCase { get => throw null; }
         public abstract string ConvertName(string name);
     }
 

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/Meziantou.Framework.Yaml.SourceGenerator.csproj
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/Meziantou.Framework.Yaml.SourceGenerator.csproj
@@ -21,6 +21,7 @@
     <Compile Include="../Meziantou.Framework.Yaml/YamlCamelCaseNamingPolicy.cs" Link="YamlCamelCaseNamingPolicy.cs" />
     <Compile Include="../Meziantou.Framework.Yaml/YamlKebabCaseLowerNamingPolicy.cs" Link="YamlKebabCaseLowerNamingPolicy.cs" />
     <Compile Include="../Meziantou.Framework.Yaml/YamlKebabCaseUpperNamingPolicy.cs" Link="YamlKebabCaseUpperNamingPolicy.cs" />
+    <Compile Include="../Meziantou.Framework.Yaml/YamlPascalCaseNamingPolicy.cs" Link="YamlPascalCaseNamingPolicy.cs" />
     <Compile Include="../Meziantou.Framework.Yaml/YamlSeparatorNamingPolicy.cs" Link="YamlSeparatorNamingPolicy.cs" />
     <Compile Include="../Meziantou.Framework.Yaml/YamlSnakeCaseLowerNamingPolicy.cs" Link="YamlSnakeCaseLowerNamingPolicy.cs" />
     <Compile Include="../Meziantou.Framework.Yaml/YamlSnakeCaseUpperNamingPolicy.cs" Link="YamlSnakeCaseUpperNamingPolicy.cs" />

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -1580,6 +1580,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
             "SnakeCaseUpper" => YamlNamingPolicy.SnakeCaseUpper,
             "KebabCaseLower" => YamlNamingPolicy.KebabCaseLower,
             "KebabCaseUpper" => YamlNamingPolicy.KebabCaseUpper,
+            "PascalCase" => YamlNamingPolicy.PascalCase,
             _ => null,
         };
     }

--- a/src/Meziantou.Framework.Yaml/YamlKnownNamingPolicy.cs
+++ b/src/Meziantou.Framework.Yaml/YamlKnownNamingPolicy.cs
@@ -37,4 +37,9 @@ enum YamlKnownNamingPolicy
     /// KEBAB-CASE (uppercase). See <see cref="YamlNamingPolicy.KebabCaseUpper"/>.
     /// </summary>
     KebabCaseUpper = 5,
+
+    /// <summary>
+    /// PascalCase. See <see cref="YamlNamingPolicy.PascalCase"/>.
+    /// </summary>
+    PascalCase = 6,
 }

--- a/src/Meziantou.Framework.Yaml/YamlNamingPolicy.cs
+++ b/src/Meziantou.Framework.Yaml/YamlNamingPolicy.cs
@@ -30,6 +30,9 @@ abstract class YamlNamingPolicy
     /// <summary>Gets the naming policy for KEBAB-CASE (uppercase).</summary>
     public static YamlNamingPolicy KebabCaseUpper { get; } = new YamlKebabCaseUpperNamingPolicy();
 
+    /// <summary>Gets the naming policy for PascalCase.</summary>
+    public static YamlNamingPolicy PascalCase { get; } = new YamlPascalCaseNamingPolicy();
+
     /// <summary>Gets the policy matching the specified <see cref="YamlKnownNamingPolicy"/> value.</summary>
     /// <param name="namingPolicy">The naming policy to resolve.</param>
     /// <returns>The matching policy, or <see langword="null"/> when no policy must be applied.</returns>
@@ -42,6 +45,7 @@ abstract class YamlNamingPolicy
             YamlKnownNamingPolicy.SnakeCaseUpper => SnakeCaseUpper,
             YamlKnownNamingPolicy.KebabCaseLower => KebabCaseLower,
             YamlKnownNamingPolicy.KebabCaseUpper => KebabCaseUpper,
+            YamlKnownNamingPolicy.PascalCase => PascalCase,
             _ => null,
         };
     }

--- a/src/Meziantou.Framework.Yaml/YamlPascalCaseNamingPolicy.cs
+++ b/src/Meziantou.Framework.Yaml/YamlPascalCaseNamingPolicy.cs
@@ -1,0 +1,18 @@
+namespace Meziantou.Framework.Yaml;
+
+internal sealed class YamlPascalCaseNamingPolicy : YamlNamingPolicy
+{
+    public override string ConvertName(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        if (string.IsNullOrEmpty(name) || !char.IsLower(name[0]))
+        {
+            return name;
+        }
+
+        var chars = name.ToCharArray();
+        chars[0] = char.ToUpperInvariant(chars[0]);
+        return new string(chars);
+    }
+}

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlCollectionConverterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlCollectionConverterTests.cs
@@ -49,6 +49,23 @@ public sealed class YamlCollectionConverterTests
     }
 
     [Fact]
+    public void DictionaryKeyPolicy_PascalCase_AppliesToSerializedKeys()
+    {
+        var options = new YamlSerializerOptions { DictionaryKeyPolicy = YamlNamingPolicy.PascalCase };
+        var yaml = YamlSerializer.Serialize(
+            new Dictionary<string, int>(StringComparer.Ordinal)
+            {
+                ["myKey"] = 1,
+                ["OtherKey"] = 2,
+            },
+            options);
+
+        Assert.Contains("MyKey: 1", yaml);
+        Assert.Contains("OtherKey: 2", yaml);
+        Assert.DoesNotContain("myKey:", yaml);
+    }
+
+    [Fact]
     public void Indentation_RespectsIndentSize()
     {
         var yaml = YamlSerializer.Serialize(

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlNamingPolicyAttributeTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlNamingPolicyAttributeTests.cs
@@ -85,6 +85,30 @@ public sealed class YamlNamingPolicyAttributeTests
     }
 
     [Fact]
+    public void TypeLevel_PascalCase_UppercasesFirstCharacter()
+    {
+        var yaml = YamlSerializer.Serialize(new PascalCasePolicyModel { firstValue = 1, secondValue = 2 });
+        Assert.Contains("FirstValue: 1", yaml);
+        Assert.Contains("SecondValue: 2", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<PascalCasePolicyModel>("FirstValue: 3\nSecondValue: 4\n")!;
+        Assert.Equal(3, roundTrip.firstValue);
+        Assert.Equal(4, roundTrip.secondValue);
+    }
+
+    [Fact]
+    public void SourceGenerated_TypeLevel_PascalCase_UppercasesFirstCharacter()
+    {
+        var yaml = YamlSerializer.Serialize(new PascalCasePolicyModel { firstValue = 1, secondValue = 2 }, NamingPolicyContext.Default);
+        Assert.Contains("FirstValue: 1", yaml);
+        Assert.Contains("SecondValue: 2", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize("FirstValue: 3\nSecondValue: 4\n", NamingPolicyContext.Default.PascalCasePolicyModel)!;
+        Assert.Equal(3, roundTrip.firstValue);
+        Assert.Equal(4, roundTrip.secondValue);
+    }
+
+    [Fact]
     public void SourceGenerated_MemberLevel_Unspecified_OptsOutOfTypeLevel()
     {
         var yaml = YamlSerializer.Serialize(new TypeLevelOptOutModel { FirstValue = 1, SecondValue = 2 }, NamingPolicyContext.Default);
@@ -198,6 +222,13 @@ internal sealed class UnspecifiedPolicyModel
     public int SecondValue { get; set; }
 }
 
+[YamlNamingPolicy(YamlKnownNamingPolicy.PascalCase)]
+internal sealed class PascalCasePolicyModel
+{
+    public int firstValue { get; set; }
+    public int secondValue { get; set; }
+}
+
 [YamlNamingPolicy(YamlKnownNamingPolicy.SnakeCaseLower)]
 internal class BasePolicyModel
 {
@@ -229,6 +260,7 @@ internal sealed class ConstructorPolicyModel
 [YamlSerializable(typeof(ExplicitNameModel))]
 [YamlSerializable(typeof(DerivedPolicyModel))]
 [YamlSerializable(typeof(ConstructorPolicyModel))]
+[YamlSerializable(typeof(PascalCasePolicyModel))]
 internal sealed partial class NamingPolicyContext : YamlSerializerContext
 {
     public NamingPolicyContext()

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlNamingPolicyAttributeTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlNamingPolicyAttributeTests.cs
@@ -222,12 +222,14 @@ internal sealed class UnspecifiedPolicyModel
     public int SecondValue { get; set; }
 }
 
+#pragma warning disable IDE1006 // Naming Styles - the members must start with a lowercase character for the PascalCase policy to have an effect
 [YamlNamingPolicy(YamlKnownNamingPolicy.PascalCase)]
 internal sealed class PascalCasePolicyModel
 {
     public int firstValue { get; set; }
     public int secondValue { get; set; }
 }
+#pragma warning restore IDE1006 // Naming Styles
 
 [YamlNamingPolicy(YamlKnownNamingPolicy.SnakeCaseLower)]
 internal class BasePolicyModel

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlOptionsValidationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlOptionsValidationTests.cs
@@ -76,6 +76,16 @@ public sealed class YamlOptionsValidationTests
     }
 
     [Fact]
+    public void NamingPolicy_PascalCase_ConvertsOnlyWhenLeadingLowercase()
+    {
+        Assert.Equal(string.Empty, YamlNamingPolicy.PascalCase.ConvertName(string.Empty));
+        Assert.Equal("Already", YamlNamingPolicy.PascalCase.ConvertName("Already"));
+        Assert.Equal("Hello", YamlNamingPolicy.PascalCase.ConvertName("hello"));
+        Assert.Equal("FirstValue", YamlNamingPolicy.PascalCase.ConvertName("firstValue"));
+        Assert.Equal("_value", YamlNamingPolicy.PascalCase.ConvertName("_value"));
+    }
+
+    [Fact]
     public void PolymorphismOptions_ValidateDiscriminatorStyle()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => new YamlPolymorphismOptions

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -52,6 +52,13 @@ internal sealed class GeneratedWithDefaultOptions
     public string? Optional { get; set; }
 }
 
+internal sealed class GeneratedWithPascalCaseOptions
+{
+    public string displayName { get; set; } = string.Empty;
+
+    public Dictionary<string, int>? values { get; set; }
+}
+
 internal sealed class GeneratedOptionsPayload
 {
     public int Value;
@@ -933,6 +940,14 @@ internal sealed partial class TestYamlSerializerContextWithSchema : YamlSerializ
 }
 
 [YamlSourceGenerationOptions(
+    PropertyNamingPolicy = YamlKnownNamingPolicy.PascalCase,
+    DictionaryKeyPolicy = YamlKnownNamingPolicy.PascalCase)]
+[YamlSerializable(typeof(GeneratedWithPascalCaseOptions))]
+internal sealed partial class TestYamlSerializerContextWithPascalCase : YamlSerializerContext
+{
+}
+
+[YamlSourceGenerationOptions(
     UnmappedMemberHandling = YamlUnmappedMemberHandling.Disallow)]
 [YamlSerializable(typeof(GeneratedWithDefaultOptions))]
 internal sealed partial class TestYamlSerializerContextWithStrictUnmappedMembers : YamlSerializerContext
@@ -1533,6 +1548,29 @@ public class YamlSerializerSourceGenerationTests
 
         Assert.Contains("displayName: Ada", yaml);
         Assert.DoesNotContain("optional:", yaml);
+    }
+
+    [Fact]
+    public void GeneratedContextAppliesPascalCaseNamingPolicies()
+    {
+        var context = TestYamlSerializerContextWithPascalCase.Default;
+        var options = context.GeneratedWithPascalCaseOptions.Options;
+
+        Assert.Same(YamlNamingPolicy.PascalCase, options.DictionaryKeyPolicy);
+
+        var yaml = YamlSerializer.Serialize(
+            new GeneratedWithPascalCaseOptions
+            {
+                displayName = "Ada",
+                values = new Dictionary<string, int>(StringComparer.Ordinal) { ["firstKey"] = 1 },
+            },
+            context.GeneratedWithPascalCaseOptions);
+
+        Assert.Contains("DisplayName: Ada", yaml);
+        Assert.Contains("FirstKey: 1", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize(yaml, context.GeneratedWithPascalCaseOptions)!;
+        Assert.Equal("Ada", roundTrip.displayName);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -52,12 +52,14 @@ internal sealed class GeneratedWithDefaultOptions
     public string? Optional { get; set; }
 }
 
+#pragma warning disable IDE1006 // Naming Styles - the members must start with a lowercase character for the PascalCase policy to have an effect
 internal sealed class GeneratedWithPascalCaseOptions
 {
     public string displayName { get; set; } = string.Empty;
 
     public Dictionary<string, int>? values { get; set; }
 }
+#pragma warning restore IDE1006 // Naming Styles
 
 internal sealed class GeneratedOptionsPayload
 {


### PR DESCRIPTION
## What

Adds a PascalCase naming policy to `Meziantou.Framework.Yaml`:

- `YamlKnownNamingPolicy.PascalCase = 6` (appended, so existing values keep their numbers)
- `YamlNamingPolicy.PascalCase`, backed by the new internal `YamlPascalCaseNamingPolicy`
- Mapping in `YamlNamingPolicy.GetPolicy` (reflection path and the generator's `[YamlNamingPolicy]` resolution)
- `"PascalCase"` in the generator's name-based lookup used by `[YamlSourceGenerationOptions(PropertyNamingPolicy = ...)]`
- Regenerated `ref/Meziantou.Framework.Yaml.cs`

The policy uppercases the first character and leaves the rest of the name as-is, returning the name unchanged when it is empty or does not start with a lowercase letter. This matches the existing `YamlishNamingPolicy.PascalCase` behavior in the sibling project.

## Notes for reviewers

- The source generator compiles the naming policy files via explicit `<Compile Include>` items, so `YamlPascalCaseNamingPolicy.cs` also had to be linked in `Meziantou.Framework.Yaml.SourceGenerator.csproj`; without it the generator project fails to build.
- The new test models deliberately use lowercase-leading property names, since the policy is a no-op on names that are already Pascal-cased.
- The readme documents naming policies by example rather than enumerating them, so it was left unchanged.

## Tests

5 new tests added to existing files, covering `ConvertName` edge cases, `DictionaryKeyPolicy` at runtime, and `[YamlNamingPolicy(PascalCase)]` / `[YamlSourceGenerationOptions(...)]` through both the reflection and source-generated paths.

- `dotnet build` with `/p:TreatWarningsAsErrors=true`: 0 warnings, 0 errors
- `Meziantou.Framework.Yaml.Tests`: 1530 passed / 0 failed (net10.0 + net11.0)
- `dotnet run ./eng/update-all.cs`: clean, no further file changes