### PR TITLE
Disable Renovate CodeAnalysis updates for Meziantou.Framework.Roslyn

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -29,6 +29,7 @@
         "src/Meziantou.Framework.FullPath.Analyzer/Meziantou.Framework.FullPath.Analyzer.csproj",
         "src/Meziantou.Framework.FullPath.CodeFix/Meziantou.Framework.FullPath.CodeFix.csproj",
         "src/Meziantou.Framework.ResxSourceGenerator/Meziantou.Framework.ResxSourceGenerator.csproj",
+        "src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj",
         "src/Meziantou.Framework.StronglyTypedId/Meziantou.Framework.StronglyTypedId.csproj",
         "src/Meziantou.Framework.Yaml.SourceGenerator/Meziantou.Framework.Yaml.SourceGenerator.csproj",
         "tests/Meziantou.Framework.Roslyn.Tests/Meziantou.Framework.Roslyn.Tests.Roslyn4_8.csproj",


### PR DESCRIPTION
## What

Adds `src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj` to the existing disabled `roslyn-analyzers` package rule in `renovate.json5`.

## Why

`Meziantou.Framework.Roslyn` targets `netstandard2.0` and pins `Microsoft.CodeAnalysis.CSharp` 4.8.0 as its analyzer baseline. Bumping that reference would raise the minimum Roslyn version consumers need, so it should be excluded from automated updates like the other analyzer and source generator projects already listed in that rule.

## Notes for reviewers

- Config-only change; no code or tests are affected.
- The project is inserted in alphabetical order within the existing `matchFileNames` list, reusing the rule that already matches the `Microsoft.CodeAnalysis*` packages.