### PR TITLE
Add GetTypeInfo<T>() and TryGetTypeInfo<T>() to YamlSerializerOptions

### DIFF
--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -361,6 +361,8 @@ namespace Meziantou.Framework.Yaml
         public bool AllowAliases { get => throw null; init { } }
         public bool AllowMergeKeys { get => throw null; init { } }
         public Meziantou.Framework.Yaml.IYamlTypeInfoResolver? TypeInfoResolver { get => throw null; init { } }
+        public Meziantou.Framework.Yaml.YamlTypeInfo<T> GetTypeInfo<T>() => throw null;
+        public bool TryGetTypeInfo<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Yaml.YamlTypeInfo<T>? typeInfo) => throw null;
         public override string ToString() => throw null;
         public static bool operator !=(Meziantou.Framework.Yaml.YamlSerializerOptions? left, Meziantou.Framework.Yaml.YamlSerializerOptions? right) => throw null;
         public static bool operator ==(Meziantou.Framework.Yaml.YamlSerializerOptions? left, Meziantou.Framework.Yaml.YamlSerializerOptions? right) => throw null;

--- a/src/Meziantou.Framework.Yaml/DelegatingYamlTypeInfo.cs
+++ b/src/Meziantou.Framework.Yaml/DelegatingYamlTypeInfo.cs
@@ -1,0 +1,27 @@
+using Meziantou.Framework.Yaml.Serialization;
+
+namespace Meziantou.Framework.Yaml;
+
+/// <summary>Adapts a non-generic <see cref="YamlTypeInfo"/> to the strongly typed <see cref="YamlTypeInfo{T}"/> contract.</summary>
+internal sealed class DelegatingYamlTypeInfo<T> : YamlTypeInfo<T>
+{
+    private readonly YamlTypeInfo _typeInfo;
+
+    public DelegatingYamlTypeInfo(YamlTypeInfo typeInfo) : base(typeInfo.Options)
+    {
+        _typeInfo = typeInfo;
+    }
+
+    public override void Write(YamlWriter writer, T value)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        _typeInfo.Write(writer, value);
+    }
+
+    public override T? Read(YamlReader reader)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        var value = _typeInfo.ReadAsObject(reader);
+        return value is null ? default : (T)value;
+    }
+}

--- a/src/Meziantou.Framework.Yaml/YamlSerializer.cs
+++ b/src/Meziantou.Framework.Yaml/YamlSerializer.cs
@@ -1170,19 +1170,36 @@ public static class YamlSerializer
         throw new InvalidOperationException($"No generated metadata is available for '{requestedType}' on context '{context.GetType()}'.");
     }
 
-    private static YamlTypeInfo ResolveTypeInfo(YamlSerializerOptions options, Type requestedType)
+    internal static YamlTypeInfo ResolveTypeInfo(YamlSerializerOptions options, Type requestedType)
+    {
+        var typeInfo = TryResolveTypeInfo(options, requestedType);
+        if (typeInfo is not null)
+        {
+            return typeInfo;
+        }
+
+        if (options.TypeInfoResolver is YamlSerializerContext context && !ReferenceEquals(options, context.Options))
+        {
+            throw new InvalidOperationException($"No generated metadata is available for '{requestedType}' on context '{context.GetType()}'.");
+        }
+
+        if (IsReflectionEnabledByDefault)
+        {
+            throw new InvalidOperationException($"No metadata is available for '{requestedType}'.");
+        }
+
+        throw new InvalidOperationException(
+            $"Reflection serialization is disabled and no metadata was found for '{requestedType}'. " +
+            $"Provide metadata via {nameof(YamlSerializerOptions)}.{nameof(YamlSerializerOptions.TypeInfoResolver)} or enable the '{ReflectionSwitchName}' AppContext switch.");
+    }
+
+    internal static YamlTypeInfo? TryResolveTypeInfo(YamlSerializerOptions options, Type requestedType)
     {
         if (options.TypeInfoResolver is YamlSerializerContext context && !ReferenceEquals(options, context.Options))
         {
             // Resolve type info from the context with the caller's options so generated contexts can
             // initialize any option-dependent metadata before serialization/deserialization starts.
-            var contextTypeInfo = context.GetTypeInfo(requestedType, options);
-            if (contextTypeInfo is not null)
-            {
-                return contextTypeInfo;
-            }
-
-            throw new InvalidOperationException($"No generated metadata is available for '{requestedType}' on context '{context.GetType()}'.");
+            return context.GetTypeInfo(requestedType, options);
         }
 
         var typeInfo = options.TypeInfoResolver?.GetTypeInfo(requestedType, options);
@@ -1199,17 +1216,9 @@ public static class YamlSerializer
 
         if (IsReflectionEnabledByDefault)
         {
-            typeInfo = ReflectionYamlTypeInfoResolver.Default.GetTypeInfo(requestedType, options);
-            if (typeInfo is null)
-            {
-                throw new InvalidOperationException($"No metadata is available for '{requestedType}'.");
-            }
-
-            return typeInfo;
+            return ReflectionYamlTypeInfoResolver.Default.GetTypeInfo(requestedType, options);
         }
 
-        throw new InvalidOperationException(
-            $"Reflection serialization is disabled and no metadata was found for '{requestedType}'. " +
-            $"Provide metadata via {nameof(YamlSerializerOptions)}.{nameof(YamlSerializerOptions.TypeInfoResolver)} or enable the '{ReflectionSwitchName}' AppContext switch.");
+        return null;
     }
 }

--- a/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
+++ b/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using Meziantou.Framework.Yaml.Serialization;
 
 namespace Meziantou.Framework.Yaml;
@@ -241,6 +242,38 @@ public sealed record YamlSerializerOptions
     /// runtime converter set.
     /// </remarks>
     public IYamlTypeInfoResolver? TypeInfoResolver { get; init; }
+
+    /// <summary>Gets the <see cref="YamlTypeInfo{T}"/> contract metadata resolved by this options instance.</summary>
+    /// <typeparam name="T">The type to resolve metadata for.</typeparam>
+    /// <returns>The metadata resolved for <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidOperationException">No metadata is available for <typeparamref name="T"/>.</exception>
+    public YamlTypeInfo<T> GetTypeInfo<T>()
+    {
+        var typeInfo = YamlSerializer.ResolveTypeInfo(this, typeof(T));
+        return AsGenericTypeInfo<T>(typeInfo);
+    }
+
+    /// <summary>Attempts to get the <see cref="YamlTypeInfo{T}"/> contract metadata resolved by this options instance.</summary>
+    /// <typeparam name="T">The type to resolve metadata for.</typeparam>
+    /// <param name="typeInfo">The metadata resolved for <typeparamref name="T"/>, when available.</param>
+    /// <returns><see langword="true"/> when metadata is available for <typeparamref name="T"/>; otherwise <see langword="false"/>.</returns>
+    public bool TryGetTypeInfo<T>([NotNullWhen(returnValue: true)] out YamlTypeInfo<T>? typeInfo)
+    {
+        var resolved = YamlSerializer.TryResolveTypeInfo(this, typeof(T));
+        if (resolved is null)
+        {
+            typeInfo = null;
+            return false;
+        }
+
+        typeInfo = AsGenericTypeInfo<T>(resolved);
+        return true;
+    }
+
+    private static YamlTypeInfo<T> AsGenericTypeInfo<T>(YamlTypeInfo typeInfo)
+    {
+        return typeInfo as YamlTypeInfo<T> ?? new DelegatingYamlTypeInfo<T>(typeInfo);
+    }
 
     internal int EffectiveMaxDepth => YamlDepthHelper.GetEffectiveMaxDepth(MaxDepth);
 

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerApiTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerApiTests.cs
@@ -386,6 +386,72 @@ public class YamlSerializerApiTests
     }
 
     [Fact]
+    public void GetTypeInfo_ReturnsGenericMetadataFromResolver()
+    {
+        var typeInfo = new StringTypeInfo(new YamlSerializerOptions());
+        var options = new YamlSerializerOptions
+        {
+            TypeInfoResolver = new StringTypeInfoResolver(typeInfo),
+        };
+
+        Assert.Same(typeInfo, options.GetTypeInfo<string>());
+        Assert.True(options.TryGetTypeInfo<string>(out var resolved));
+        Assert.Same(typeInfo, resolved);
+    }
+
+    [Fact]
+    public void GetTypeInfo_AdaptsNonGenericMetadata()
+    {
+        var options = new YamlSerializerOptions();
+
+        var typeInfo = options.GetTypeInfo<Person>();
+
+        Assert.Equal(typeof(Person), typeInfo.Type);
+        Assert.Same(options, typeInfo.Options);
+
+        var yaml = YamlSerializer.Serialize(new Person { FirstName = "Ada", Age = 37 }, typeInfo);
+        var value = YamlSerializer.Deserialize(yaml, typeInfo);
+
+        Assert.NotNull(value);
+        Assert.Equal("Ada", value.FirstName);
+        Assert.Equal(37, value.Age);
+    }
+
+    [Fact]
+    public void GetTypeInfo_AdaptsNonGenericMetadataForValueTypes()
+    {
+        var typeInfo = YamlSerializerOptions.Default.GetTypeInfo<int>();
+
+        Assert.Equal(typeof(int), typeInfo.Type);
+        Assert.Equal(42, YamlSerializer.Deserialize("42", typeInfo));
+        Assert.Equal("42\n", YamlSerializer.Serialize(42, typeInfo));
+    }
+
+    [Fact]
+    public void TryGetTypeInfo_ReturnsFalseWhenContextHasNoMetadata()
+    {
+        var context = new EmptyContext();
+        var options = context.CreateOptions(o => o with { SourceName = "sample.yaml" });
+
+        Assert.False(options.TryGetTypeInfo<Person>(out var typeInfo));
+        Assert.Null(typeInfo);
+    }
+
+    [Fact]
+    public void GetTypeInfo_ThrowsWhenContextHasNoMetadata()
+    {
+        var context = new EmptyContext();
+        var options = context.CreateOptions(o => o with { SourceName = "sample.yaml" });
+
+        _ = Assert.Throws<InvalidOperationException>(() => options.GetTypeInfo<Person>());
+    }
+
+    private sealed class EmptyContext : YamlSerializerContext
+    {
+        public override YamlTypeInfo? GetTypeInfo(Type type, YamlSerializerOptions options) => null;
+    }
+
+    [Fact]
     public void JsonAttributesAreRespectedByReflectionSerializer()
     {
         var person = new JsonAnnotatedPerson


### PR DESCRIPTION
Ports the API `System.Text.Json` gained in [dotnet/runtime#123940](https://github.com/dotnet/runtime/pull/123940) to `Meziantou.Framework.Yaml`:

```csharp
public YamlTypeInfo<T> GetTypeInfo<T>();
public bool TryGetTypeInfo<T>([NotNullWhen(true)] out YamlTypeInfo<T>? typeInfo);
```

Callers can now get a strongly typed contract to pass to `YamlSerializer.Serialize<T>(value, typeInfo)` / `Deserialize<T>(yaml, typeInfo)` without the `(YamlTypeInfo<T>)options.GetTypeInfo(typeof(T))` cast pattern.

## Implementation note

One difference from `System.Text.Json` mattered here. In STJ every resolved contract is already a `JsonTypeInfo<T>`, so the generic overloads are a pure cast. In this library only source-generated metadata derives from `YamlTypeInfo<T>` — `YamlBuiltInTypeInfoResolver` and `ReflectionYamlTypeInfoResolver` return plain non-generic `YamlTypeInfo` instances. A straight cast would therefore have failed for the most common (reflection) case.

So an internal `DelegatingYamlTypeInfo<T>` adapter wraps a non-generic contract. When the resolved contract already is a `YamlTypeInfo<T>` it is returned as-is (reference-equal to what the resolver produced), so no wrapper is introduced on the source-generated path.

`YamlSerializer.ResolveTypeInfo(options, type)` is split into a non-throwing `TryResolveTypeInfo` core plus the throwing wrapper. All three existing exception messages are preserved unchanged.

## Files

- `src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs` — the two new methods and an `AsGenericTypeInfo<T>` helper.
- `src/Meziantou.Framework.Yaml/DelegatingYamlTypeInfo.cs` — new internal adapter.
- `src/Meziantou.Framework.Yaml/YamlSerializer.cs` — `TryResolveTypeInfo` split.
- `tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerApiTests.cs` — 5 tests: resolver-provided generic metadata returned unwrapped, reflection metadata round-trips through the adapter, value types (`int`) work through it, and the context-with-no-metadata case returns `false` / throws `InvalidOperationException`.
- `ref/Meziantou.Framework.Yaml.cs` — regenerated by the build.

## Not included

Non-generic `GetTypeInfo(Type)` / `TryGetTypeInfo(Type, out …)` are not added. Those predate the STJ PR; in this library they don't exist, and there is no `YamlSerializer` overload accepting a non-generic `YamlTypeInfo` sourced from options, so they'd have no consumer today. Happy to add them for parity if wanted.

## Validation

- `dotnet build` clean with `-p:TreatWarningsAsErrors=true`
- Full Yaml test suite passes: 1564 tests, net10.0 + net11.0, 0 failures
- `dotnet run ./eng/update-all.cs` ran with no further changes