### PR TITLE
Support open generics in Meziantou.Framework.Yaml converters and polymorphism

### DIFF
--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
@@ -204,7 +204,7 @@ public sealed partial class YamlSerializerContextGenerator
         SourceGenerationOptionsModel sourceGenerationOptions,
         UnsafeAccessorRegistry accessors)
     {
-        var attributeConverterTypeName = GetYamlConverterAttributeTypeName((ISymbol)typeSymbol);
+        var attributeConverterTypeName = GetYamlConverterAttributeTypeName(typeSymbol, typeSymbol);
 
         builder.Append("    private static void WriteValue").Append(index)
             .Append("(global::Meziantou.Framework.Yaml.Serialization.YamlWriter writer, ").Append(typeName).Append(typeSymbol.IsReferenceType ? "?" : string.Empty).AppendLine(" value, RuntimeCustomConverterCache runtimeConverters)");
@@ -2678,7 +2678,7 @@ public sealed partial class YamlSerializerContextGenerator
         SourceGenerationOptionsModel sourceGenerationOptions,
         UnsafeAccessorRegistry accessors)
     {
-        var attributeConverterTypeName = GetYamlConverterAttributeTypeName((ISymbol)typeSymbol);
+        var attributeConverterTypeName = GetYamlConverterAttributeTypeName(typeSymbol, typeSymbol);
 
         builder.Append("    private static ").Append(typeName).Append(typeSymbol.IsReferenceType ? "?" : string.Empty).Append(" ReadValue").Append(index)
             .AppendLine("(global::Meziantou.Framework.Yaml.Serialization.YamlReader reader, RuntimeCustomConverterCache runtimeConverters)");

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -85,6 +85,14 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
+    private static readonly DiagnosticDescriptor UnresolvedOpenGenericDerivedType = new(
+        id: "MFY022",
+        title: "Open generic derived type cannot be resolved",
+        messageFormat: "Open generic derived type '{0}' cannot be resolved for base type '{1}' and is ignored. Ensure the type arguments of the derived type can be inferred from the base type.",
+        category: "Meziantou.Framework.Yaml.SourceGeneration",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
     internal static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticDescriptors = ImmutableArray.Create(
         ContextMustBePartial,
         UnsupportedMemberType,
@@ -93,7 +101,8 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         InvalidSourceGenerationOption,
         InvalidConverterType,
         InvalidDerivedTypeMapping,
-        MissingYamlPolymorphicOnDerivedTypeMappingBase);
+        MissingYamlPolymorphicOnDerivedTypeMappingBase,
+        UnresolvedOpenGenericDerivedType);
 
     internal sealed class ContextValidationResult
     {
@@ -357,6 +366,9 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                 continue;
             }
 
+            ValidateYamlConverterAttribute(diagnostics, named, named);
+            ValidateDerivedTypeAttributes(diagnostics, named);
+
             if (IsYamlNodeType(named))
             {
                 continue;
@@ -404,13 +416,15 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                     continue;
                 }
 
+                ValidateYamlConverterAttribute(diagnostics, member, memberType);
+
                 if (IsKnownScalar(memberType) || IsYamlNodeType(memberType) || IsUntypedObject(memberType))
                 {
                     continue;
                 }
 
                 // Skip if the member itself has [YamlConverter(typeof(...))] — the converter handles serialization.
-                if (GetYamlConverterAttributeTypeName(member) is not null)
+                if (HasYamlConverterAttribute(member))
                 {
                     continue;
                 }
@@ -480,6 +494,66 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         }
 
         return new ContextValidationResult(diagnostics.ToImmutable(), derivedTypeMappings, resolvedTypes, indexByType);
+    }
+
+    /// <summary>
+    /// Reports a diagnostic when <c>[YamlConverter]</c> declares an open generic converter type that cannot be closed
+    /// over the generic arguments of the annotated type or member type.
+    /// </summary>
+    private static void ValidateYamlConverterAttribute(ImmutableArray<Diagnostic>.Builder diagnostics, ISymbol symbol, ITypeSymbol typeToConvert)
+    {
+        var converterType = GetYamlConverterAttributeType(symbol);
+        if (converterType is not INamedTypeSymbol namedConverterType || !IsOpenGenericConverterType(namedConverterType))
+        {
+            return;
+        }
+
+        if (!TryConstructOpenGenericConverterType(namedConverterType, typeToConvert, out _))
+        {
+            diagnostics.Add(Diagnostic.Create(
+                InvalidConverterType,
+                symbol.Locations.FirstOrDefault(),
+                namedConverterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                $"the open generic converter type is not compatible with type '{typeToConvert.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}'. Ensure that the total number of generic type parameters on the converter matches the number on the target type."));
+        }
+    }
+
+    /// <summary>
+    /// Reports a diagnostic for each <c>[YamlDerivedType]</c> declaring an open generic derived type that cannot be
+    /// closed over the type arguments of the base type.
+    /// </summary>
+    private static void ValidateDerivedTypeAttributes(ImmutableArray<Diagnostic>.Builder diagnostics, INamedTypeSymbol baseType)
+    {
+        foreach (var attribute in baseType.GetAttributes())
+        {
+            if (!string.Equals(attribute.AttributeClass?.ToDisplayString(), "Meziantou.Framework.Yaml.Serialization.YamlDerivedTypeAttribute", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (attribute.ConstructorArguments.Length < 1)
+            {
+                continue;
+            }
+
+            var derivedArgument = attribute.ConstructorArguments[0];
+            if (derivedArgument.Kind != TypedConstantKind.Type ||
+                derivedArgument.Value is not INamedTypeSymbol derivedType ||
+                GetAllTypeParameters(derivedType).Length == 0 ||
+                !IsOpenGenericType(derivedType))
+            {
+                continue;
+            }
+
+            if (!TryResolveDerivedType(baseType, derivedType, out _))
+            {
+                diagnostics.Add(Diagnostic.Create(
+                    UnresolvedOpenGenericDerivedType,
+                    attribute.ApplicationSyntaxReference?.GetSyntax().GetLocation() ?? baseType.Locations.FirstOrDefault(),
+                    derivedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                    baseType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+            }
+        }
     }
 
     private static void ValidateSourceGenerationOptions(ImmutableArray<Diagnostic>.Builder diagnostics, Compilation compilation, ContextModel model)
@@ -730,7 +804,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                 continue;
             }
 
-            if (GetYamlConverterAttributeTypeName(member) is not null)
+            if (HasYamlConverterAttribute(member))
             {
                 continue;
             }
@@ -1475,7 +1549,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         var type = GetMemberType(member) ?? throw new InvalidOperationException("Member type could not be determined.");
         var (accessExpression, assign, usesAccessorForWrite) = CreateMemberAccessExpressions(member, declaringType, accessors);
         var memberIgnoreCondition = TryGetIgnoreCondition(member, out var rawCondition) ? rawCondition : GetDeclaredIgnoreCondition(declaringType);
-        var converterTypeName = GetYamlConverterAttributeTypeName(member);
+        var converterTypeName = GetYamlConverterAttributeTypeName(member, type);
         var objectCreationHandling = GetObjectCreationHandling(member);
         var (blockSequenceMappingStyle, blockSequenceSequenceStyle) = GetBlockSequenceItemStyles(member);
         var isRequiredKeyword = member is IPropertySymbol { IsRequired: true } or IFieldSymbol { IsRequired: true };
@@ -1807,7 +1881,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         builder.Append(indent).AppendLine("}");
     }
 
-    private static string? GetYamlConverterAttributeTypeName(ISymbol member)
+    private static ITypeSymbol? GetYamlConverterAttributeType(ISymbol member)
     {
         foreach (var attribute in member.GetAttributes())
         {
@@ -1832,10 +1906,344 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                 continue;
             }
 
-            return converterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return converterType;
         }
 
         return null;
+    }
+
+    private static bool HasYamlConverterAttribute(ISymbol member)
+        => GetYamlConverterAttributeType(member) is not null;
+
+    /// <summary>
+    /// Gets the fully qualified name of the converter declared by <c>[YamlConverter]</c> on <paramref name="member"/>.
+    /// An open generic converter type is closed over the generic arguments of <paramref name="typeToConvert"/>;
+    /// <see langword="null"/> is returned when the converter cannot be constructed for that type.
+    /// </summary>
+    private static string? GetYamlConverterAttributeTypeName(ISymbol member, ITypeSymbol typeToConvert)
+    {
+        var converterType = GetYamlConverterAttributeType(member);
+        if (converterType is null)
+        {
+            return null;
+        }
+
+        if (!IsOpenGenericConverterType(converterType))
+        {
+            return converterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        }
+
+        return TryConstructOpenGenericConverterType((INamedTypeSymbol)converterType, typeToConvert, out var constructed)
+            ? constructed.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+            : null;
+    }
+
+    private static bool IsOpenGenericConverterType(ITypeSymbol converterType)
+        => converterType is INamedTypeSymbol named && GetAllTypeParameters(named).Length > 0 && IsOpenGenericType(named);
+
+    /// <summary>
+    /// Closes an open generic converter type over the generic arguments of <paramref name="typeToConvert"/>.
+    /// Both arities count the type parameters of the containing types, so nested converters such as
+    /// <c>Outer&lt;&gt;.Inner&lt;&gt;</c> are supported.
+    /// </summary>
+    private static bool TryConstructOpenGenericConverterType(INamedTypeSymbol converterType, ITypeSymbol typeToConvert, [NotNullWhen(true)] out INamedTypeSymbol? constructedConverterType)
+    {
+        constructedConverterType = null;
+        if (typeToConvert is not INamedTypeSymbol namedTypeToConvert)
+        {
+            return false;
+        }
+
+        var typeArguments = GetAllTypeArguments(namedTypeToConvert);
+        if (typeArguments.Length == 0 || typeArguments.Any(static argument => argument.TypeKind == TypeKind.TypeParameter))
+        {
+            return false;
+        }
+
+        if (GetAllTypeParameters(converterType).Length != typeArguments.Length)
+        {
+            return false;
+        }
+
+        return TryConstructGenericType(converterType, typeArguments, out constructedConverterType);
+    }
+
+    /// <summary>
+    /// Constructs a closed generic type from its definition and the type arguments of the whole nesting hierarchy,
+    /// outermost first.
+    /// </summary>
+    private static bool TryConstructGenericType(INamedTypeSymbol definition, IReadOnlyList<ITypeSymbol> typeArguments, [NotNullWhen(true)] out INamedTypeSymbol? constructedType)
+    {
+        constructedType = null;
+
+        var definitions = new List<INamedTypeSymbol>();
+        for (var current = definition.OriginalDefinition; current is not null; current = current.ContainingType)
+        {
+            definitions.Add(current);
+        }
+
+        definitions.Reverse();
+
+        INamedTypeSymbol? constructed = null;
+        var index = 0;
+        foreach (var currentDefinition in definitions)
+        {
+            var arity = currentDefinition.TypeParameters.Length;
+            var candidate = constructed is null
+                ? currentDefinition
+                : constructed.GetTypeMembers(currentDefinition.Name, arity).FirstOrDefault();
+            if (candidate is null)
+            {
+                return false;
+            }
+
+            if (arity > 0)
+            {
+                if (index + arity > typeArguments.Count)
+                {
+                    return false;
+                }
+
+                candidate = candidate.Construct(typeArguments.Skip(index).Take(arity).ToArray());
+                index += arity;
+            }
+
+            constructed = candidate;
+        }
+
+        if (constructed is null || index != typeArguments.Count)
+        {
+            return false;
+        }
+
+        constructedType = constructed;
+        return true;
+    }
+
+    /// <summary>Gets the type parameters of a type definition, including the ones of its containing types, outermost first.</summary>
+    private static ImmutableArray<ITypeParameterSymbol> GetAllTypeParameters(INamedTypeSymbol definition)
+    {
+        var builder = ImmutableArray.CreateBuilder<ITypeParameterSymbol>();
+        AppendTypeParameters(definition.OriginalDefinition, builder);
+        return builder.ToImmutable();
+
+        static void AppendTypeParameters(INamedTypeSymbol definition, ImmutableArray<ITypeParameterSymbol>.Builder builder)
+        {
+            if (definition.ContainingType is not null)
+            {
+                AppendTypeParameters(definition.ContainingType, builder);
+            }
+
+            builder.AddRange(definition.TypeParameters);
+        }
+    }
+
+    /// <summary>
+    /// Closes an open generic derived type over the type arguments of <paramref name="baseType"/> by unifying the base
+    /// type specification declared by the derived type with the closed base type. Types that are already closed are
+    /// returned unchanged.
+    /// </summary>
+    private static bool TryResolveDerivedType(ITypeSymbol baseType, ITypeSymbol derivedType, [NotNullWhen(true)] out ITypeSymbol? resolvedDerivedType)
+    {
+        if (derivedType is not INamedTypeSymbol namedDerivedType || GetAllTypeParameters(namedDerivedType).Length == 0 || !IsOpenGenericType(namedDerivedType))
+        {
+            resolvedDerivedType = derivedType;
+            return true;
+        }
+
+        var definition = namedDerivedType.OriginalDefinition;
+        var parameters = GetAllTypeParameters(definition);
+
+        INamedTypeSymbol? resolved = null;
+        foreach (var candidate in EnumerateBaseTypes(definition))
+        {
+            var substitution = new Dictionary<ITypeParameterSymbol, ITypeSymbol>(SymbolEqualityComparer.Default);
+            if (!TryUnify(candidate, baseType, substitution))
+            {
+                continue;
+            }
+
+            var arguments = new ITypeSymbol[parameters.Length];
+            var isComplete = true;
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                if (!substitution.TryGetValue(parameters[i], out var argument))
+                {
+                    isComplete = false;
+                    break;
+                }
+
+                arguments[i] = argument;
+            }
+
+            if (!isComplete || !SatisfiesConstraints(parameters, arguments) || !TryConstructGenericType(definition, arguments, out var constructed))
+            {
+                continue;
+            }
+
+            if (!IsAssignableTo(constructed, baseType))
+            {
+                continue;
+            }
+
+            if (resolved is null)
+            {
+                resolved = constructed;
+            }
+            else if (!SymbolEqualityComparer.Default.Equals(resolved, constructed))
+            {
+                // The derived type can be constructed in more than one way for that base type.
+                resolvedDerivedType = null;
+                return false;
+            }
+        }
+
+        resolvedDerivedType = resolved;
+        return resolved is not null;
+    }
+
+    private static bool IsOpenGenericType(INamedTypeSymbol type)
+        => type.IsUnboundGenericType || GetAllTypeArguments(type).Any(static argument => argument.TypeKind == TypeKind.TypeParameter);
+
+    private static IEnumerable<ITypeSymbol> EnumerateBaseTypes(INamedTypeSymbol type)
+    {
+        for (var current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            yield return current;
+        }
+
+        foreach (var interfaceType in type.AllInterfaces)
+        {
+            yield return interfaceType;
+        }
+    }
+
+    /// <summary>
+    /// Matches a base type specification declared by an open generic derived type (such as <c>Base&lt;List&lt;T&gt;&gt;</c>)
+    /// against the closed base type, recording the type arguments bound to each type parameter.
+    /// </summary>
+    private static bool TryUnify(ITypeSymbol specification, ITypeSymbol actual, Dictionary<ITypeParameterSymbol, ITypeSymbol> substitution)
+    {
+        if (specification is ITypeParameterSymbol parameter)
+        {
+            if (substitution.TryGetValue(parameter, out var existing))
+            {
+                return SymbolEqualityComparer.Default.Equals(existing, actual);
+            }
+
+            substitution[parameter] = actual;
+            return true;
+        }
+
+        if (specification is IArrayTypeSymbol specificationArray)
+        {
+            return actual is IArrayTypeSymbol actualArray
+                && specificationArray.Rank == actualArray.Rank
+                && TryUnify(specificationArray.ElementType, actualArray.ElementType, substitution);
+        }
+
+        if (specification is INamedTypeSymbol { IsGenericType: true } specificationType)
+        {
+            if (actual is not INamedTypeSymbol { IsGenericType: true } actualType ||
+                !SymbolEqualityComparer.Default.Equals(specificationType.OriginalDefinition, actualType.OriginalDefinition))
+            {
+                return false;
+            }
+
+            var specificationArguments = GetAllTypeArguments(specificationType);
+            var actualArguments = GetAllTypeArguments(actualType);
+            if (specificationArguments.Length != actualArguments.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < specificationArguments.Length; i++)
+            {
+                if (!TryUnify(specificationArguments[i], actualArguments[i], substitution))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return SymbolEqualityComparer.Default.Equals(specification, actual);
+    }
+
+    private static bool SatisfiesConstraints(ImmutableArray<ITypeParameterSymbol> parameters, ITypeSymbol[] arguments)
+    {
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var parameter = parameters[i];
+            var argument = arguments[i];
+
+            if (parameter.HasReferenceTypeConstraint && !argument.IsReferenceType)
+            {
+                return false;
+            }
+
+            if ((parameter.HasValueTypeConstraint || parameter.HasUnmanagedTypeConstraint) && !argument.IsValueType)
+            {
+                return false;
+            }
+
+            if (parameter.HasConstructorConstraint && argument is INamedTypeSymbol { TypeKind: TypeKind.Class } argumentClass &&
+                !argumentClass.InstanceConstructors.Any(static constructor => constructor.Parameters.Length == 0 && constructor.DeclaredAccessibility == Accessibility.Public))
+            {
+                return false;
+            }
+
+            foreach (var constraintType in parameter.ConstraintTypes)
+            {
+                var substituted = SubstituteTypeParameters(constraintType, parameters, arguments);
+                if (!IsAssignableTo(argument, substituted))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static ITypeSymbol SubstituteTypeParameters(ITypeSymbol type, ImmutableArray<ITypeParameterSymbol> parameters, ITypeSymbol[] arguments)
+    {
+        if (type is ITypeParameterSymbol parameter)
+        {
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                if (SymbolEqualityComparer.Default.Equals(parameters[i], parameter))
+                {
+                    return arguments[i];
+                }
+            }
+        }
+
+        return type;
+    }
+
+    /// <summary>Gets the type arguments of a type, including the ones of its containing types, outermost first.</summary>
+    private static ImmutableArray<ITypeSymbol> GetAllTypeArguments(INamedTypeSymbol type)
+    {
+        if (type.ContainingType is null)
+        {
+            return type.TypeArguments;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<ITypeSymbol>();
+        AppendTypeArguments(type, builder);
+        return builder.ToImmutable();
+
+        static void AppendTypeArguments(INamedTypeSymbol type, ImmutableArray<ITypeSymbol>.Builder builder)
+        {
+            if (type.ContainingType is not null)
+            {
+                AppendTypeArguments(type.ContainingType, builder);
+            }
+
+            builder.AddRange(type.TypeArguments);
+        }
     }
 
     /// <summary>
@@ -1856,7 +2264,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         }
 
         // Check if the type itself has [YamlConverter(typeof(...))].
-        if (GetYamlConverterAttributeTypeName(unwrappedType) is not null)
+        if (HasYamlConverterAttribute(unwrappedType))
         {
             return true;
         }
@@ -2366,7 +2774,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
             var baseType = mapping.BaseType;
             var derivedType = mapping.DerivedType;
 
-            if (!IsAssignableTo(derivedType, baseType))
+            if (!TryResolveDerivedType(baseType, derivedType, out var resolvedDerivedType) || !IsAssignableTo(resolvedDerivedType, baseType))
             {
                 diagnostics.Add(Diagnostic.Create(
                     InvalidDerivedTypeMapping,
@@ -2522,7 +2930,12 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
             }
 
             var derivedArg = attribute.ConstructorArguments[0];
-            if (derivedArg.Kind != TypedConstantKind.Type || derivedArg.Value is not ITypeSymbol derivedType)
+            if (derivedArg.Kind != TypedConstantKind.Type || derivedArg.Value is not ITypeSymbol declaredDerivedType)
+            {
+                continue;
+            }
+
+            if (!TryResolveDerivedType(baseType, declaredDerivedType, out var derivedType))
             {
                 continue;
             }
@@ -2575,9 +2988,14 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                 continue;
             }
 
+            if (!TryResolveDerivedType(baseType, mapping.DerivedType, out var mappedDerivedType))
+            {
+                continue;
+            }
+
             var isDefaultMapping = mapping.Discriminator is null && mapping.Tag is null;
             if (!CanAddLowerPrecedenceMapping(
-                mapping.DerivedType,
+                mappedDerivedType,
                 mapping.Discriminator,
                 mapping.Tag,
                 isDefaultMapping,
@@ -2591,10 +3009,10 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
 
             if (isDefaultMapping)
             {
-                defaultDerivedType ??= mapping.DerivedType;
+                defaultDerivedType ??= mappedDerivedType;
             }
 
-            derivedTypes.Add(new DerivedTypeInfoModel(mapping.DerivedType, mapping.Discriminator, mapping.Tag));
+            derivedTypes.Add(new DerivedTypeInfoModel(mappedDerivedType, mapping.Discriminator, mapping.Tag));
             if (mapping.Discriminator is not null)
             {
                 seenDiscriminators.Add(mapping.Discriminator);

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
@@ -2120,29 +2120,30 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
 
             foreach (YamlDerivedTypeAttribute attribute in yamlDerived)
             {
-                if (!type.IsAssignableFrom(attribute.DerivedType))
+                var derivedType = YamlDerivedTypeHelper.ResolveDerivedType(type, attribute.DerivedType);
+                if (!type.IsAssignableFrom(derivedType))
                 {
-                    throw new InvalidOperationException($"Derived type '{attribute.DerivedType}' is not assignable to '{type}'.");
+                    throw new InvalidOperationException($"Derived type '{derivedType}' is not assignable to '{type}'.");
                 }
 
                 if (attribute.Discriminator is null)
                 {
                     if (attribute.Tag is null)
                     {
-                        defaultDerivedType = attribute.DerivedType;
+                        defaultDerivedType = derivedType;
                     }
 
-                    typeToDerived[attribute.DerivedType] = new DerivedTypeInfo(null, attribute.Tag);
+                    typeToDerived[derivedType] = new DerivedTypeInfo(null, attribute.Tag);
                 }
                 else
                 {
-                    discriminatorToType.Add(attribute.Discriminator, attribute.DerivedType);
-                    typeToDerived[attribute.DerivedType] = new DerivedTypeInfo(attribute.Discriminator, attribute.Tag);
+                    discriminatorToType.Add(attribute.Discriminator, derivedType);
+                    typeToDerived[derivedType] = new DerivedTypeInfo(attribute.Discriminator, attribute.Tag);
                 }
 
                 if (attribute.Tag is not null)
                 {
-                    tagToType.Add(attribute.Tag, attribute.DerivedType);
+                    tagToType.Add(attribute.Tag, derivedType);
                 }
             }
 
@@ -2150,16 +2151,17 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
             {
                 foreach (var entry in runtimeDerived!)
                 {
-                    if (!type.IsAssignableFrom(entry.DerivedType))
+                    var derivedType = YamlDerivedTypeHelper.ResolveDerivedType(type, entry.DerivedType);
+                    if (!type.IsAssignableFrom(derivedType))
                     {
-                        throw new InvalidOperationException($"Derived type '{entry.DerivedType}' is not assignable to '{type}'.");
+                        throw new InvalidOperationException($"Derived type '{derivedType}' is not assignable to '{type}'.");
                     }
 
                     if (entry.Discriminator is null)
                     {
                         var isDefaultMapping = entry.Tag is null;
                         if (ShouldAddLowerPrecedenceMapping(
-                            entry.DerivedType,
+                            derivedType,
                             discriminator: null,
                             entry.Tag,
                             isDefaultMapping,
@@ -2170,20 +2172,20 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
                         {
                             if (isDefaultMapping)
                             {
-                                defaultDerivedType ??= entry.DerivedType;
+                                defaultDerivedType ??= derivedType;
                             }
 
-                            typeToDerived.Add(entry.DerivedType, new DerivedTypeInfo(null, entry.Tag));
+                            typeToDerived.Add(derivedType, new DerivedTypeInfo(null, entry.Tag));
                             if (entry.Tag is not null)
                             {
-                                tagToType.Add(entry.Tag, entry.DerivedType);
+                                tagToType.Add(entry.Tag, derivedType);
                             }
                         }
                     }
                     else
                     {
                         if (ShouldAddLowerPrecedenceMapping(
-                            entry.DerivedType,
+                            derivedType,
                             entry.Discriminator,
                             entry.Tag,
                             isDefaultMapping: false,
@@ -2192,11 +2194,11 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
                             tagToType,
                             typeToDerived))
                         {
-                            discriminatorToType.Add(entry.Discriminator, entry.DerivedType);
-                            typeToDerived.Add(entry.DerivedType, new DerivedTypeInfo(entry.Discriminator, entry.Tag));
+                            discriminatorToType.Add(entry.Discriminator, derivedType);
+                            typeToDerived.Add(derivedType, new DerivedTypeInfo(entry.Discriminator, entry.Tag));
                             if (entry.Tag is not null)
                             {
-                                tagToType.Add(entry.Tag, entry.DerivedType);
+                                tagToType.Add(entry.Tag, derivedType);
                             }
                         }
                     }
@@ -2863,12 +2865,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
             return null;
         }
 
-        var converterType = attribute.ConverterType;
-        if (converterType.IsGenericTypeDefinition)
-        {
-            throw new NotSupportedException($"Converter type '{converterType}' cannot be an open generic type.");
-        }
-
+        var converterType = YamlConverterAttributeHelper.ResolveConverterType(attribute.ConverterType, memberType);
         if (!typeof(YamlConverter).IsAssignableFrom(converterType))
         {
             throw new NotSupportedException($"Converter type '{converterType}' must derive from '{typeof(YamlConverter)}'.");

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlConverterAttributeHelper.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlConverterAttributeHelper.cs
@@ -1,0 +1,51 @@
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>
+/// Helpers shared by the type-level and member-level <see cref="YamlConverterAttribute"/> resolution paths.
+/// </summary>
+internal static class YamlConverterAttributeHelper
+{
+    /// <summary>
+    /// Resolves the converter type declared by a <see cref="YamlConverterAttribute"/>. An open generic converter type
+    /// is closed over the generic arguments of <paramref name="typeToConvert"/> when both have the same arity.
+    /// </summary>
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "This code path is only used by reflection-based serialization. NativeAOT/trimming scenarios should use source-generated metadata.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2055",
+        Justification = "This code path is only used by reflection-based serialization. NativeAOT/trimming scenarios should use source-generated metadata.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2068",
+        Justification = "This code path is only used by reflection-based serialization. NativeAOT/trimming scenarios should use source-generated metadata.")]
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public static Type ResolveConverterType(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type converterType,
+        Type typeToConvert)
+    {
+        if (!converterType.IsGenericTypeDefinition)
+        {
+            return converterType;
+        }
+
+        // An open generic converter is supported when the target type is a closed generic type with the same
+        // total number of generic parameters (nested types include the parameters of their containing types).
+        if (!typeToConvert.IsGenericType || typeToConvert.ContainsGenericParameters ||
+            converterType.GetGenericArguments().Length != typeToConvert.GetGenericArguments().Length)
+        {
+            throw new NotSupportedException($"The open generic converter type '{converterType}' is not compatible with type '{typeToConvert}'. Ensure that the total number of generic type parameters on the converter matches the number on the target type.");
+        }
+
+        try
+        {
+            return converterType.MakeGenericType(typeToConvert.GetGenericArguments());
+        }
+        catch (ArgumentException exception)
+        {
+            throw new NotSupportedException($"The open generic converter type '{converterType}' cannot be constructed for type '{typeToConvert}' because the generic constraints are not satisfied.", exception);
+        }
+    }
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlDerivedTypeHelper.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlDerivedTypeHelper.cs
@@ -1,0 +1,167 @@
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>
+/// Resolves derived types registered for polymorphic serialization. An open generic derived type is closed by
+/// unifying the base type specification it declares with the closed base type currently being serialized.
+/// </summary>
+internal static class YamlDerivedTypeHelper
+{
+    /// <summary>
+    /// Returns the closed derived type to register for <paramref name="baseType"/>.
+    /// Types that are already closed are returned unchanged.
+    /// </summary>
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "This code path is only used by reflection-based serialization. NativeAOT/trimming scenarios should use source-generated metadata.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2055",
+        Justification = "This code path is only used by reflection-based serialization. NativeAOT/trimming scenarios should use source-generated metadata.")]
+    public static Type ResolveDerivedType(Type baseType, Type derivedType)
+    {
+        if (!derivedType.ContainsGenericParameters)
+        {
+            return derivedType;
+        }
+
+        if (!derivedType.IsGenericTypeDefinition)
+        {
+            throw new InvalidOperationException($"Derived type '{derivedType}' cannot be resolved for base type '{baseType}' because it is a partially constructed generic type.");
+        }
+
+        Type? resolved = null;
+        foreach (var candidate in EnumerateBaseTypes(derivedType))
+        {
+            var substitution = new Dictionary<Type, Type>();
+            if (!TryUnify(candidate, baseType, substitution))
+            {
+                continue;
+            }
+
+            var parameters = derivedType.GetGenericArguments();
+            var arguments = new Type[parameters.Length];
+            var isComplete = true;
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                if (!substitution.TryGetValue(parameters[i], out var argument))
+                {
+                    isComplete = false;
+                    break;
+                }
+
+                arguments[i] = argument;
+            }
+
+            if (!isComplete)
+            {
+                continue;
+            }
+
+            Type constructed;
+            try
+            {
+                constructed = derivedType.MakeGenericType(arguments);
+            }
+            catch (ArgumentException)
+            {
+                // The generic constraints of the derived type are not satisfied by the base type arguments.
+                continue;
+            }
+
+            if (!baseType.IsAssignableFrom(constructed))
+            {
+                continue;
+            }
+
+            if (resolved is null)
+            {
+                resolved = constructed;
+            }
+            else if (resolved != constructed)
+            {
+                throw new InvalidOperationException($"Derived type '{derivedType}' is ambiguous for base type '{baseType}' because it can be constructed in more than one way.");
+            }
+        }
+
+        return resolved ?? throw new InvalidOperationException($"Derived type '{derivedType}' cannot be resolved for base type '{baseType}'. Ensure the type arguments of the open generic derived type can be inferred from the base type.");
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2070",
+        Justification = "This code path is only used by reflection-based serialization. NativeAOT/trimming scenarios should use source-generated metadata.")]
+    private static IEnumerable<Type> EnumerateBaseTypes(Type derivedType)
+    {
+        for (var current = derivedType.BaseType; current is not null; current = current.BaseType)
+        {
+            yield return current;
+        }
+
+        foreach (var interfaceType in derivedType.GetInterfaces())
+        {
+            yield return interfaceType;
+        }
+    }
+
+    /// <summary>
+    /// Matches a base type specification declared by an open generic derived type (such as <c>Base&lt;List&lt;T&gt;&gt;</c>)
+    /// against the closed base type, recording the type arguments bound to each generic parameter.
+    /// </summary>
+    private static bool TryUnify(Type specification, Type actual, Dictionary<Type, Type> substitution)
+    {
+        if (specification.IsGenericParameter)
+        {
+            if (substitution.TryGetValue(specification, out var existing))
+            {
+                return existing == actual;
+            }
+
+            substitution[specification] = actual;
+            return true;
+        }
+
+        if (specification.IsArray)
+        {
+            if (!actual.IsArray || specification.GetArrayRank() != actual.GetArrayRank())
+            {
+                return false;
+            }
+
+            // int[] and int[*] have the same rank but are distinct types.
+            if (specification.IsSZArray != actual.IsSZArray)
+            {
+                return false;
+            }
+
+            return TryUnify(specification.GetElementType()!, actual.GetElementType()!, substitution);
+        }
+
+        if (specification.IsGenericType)
+        {
+            if (!actual.IsGenericType || specification.GetGenericTypeDefinition() != actual.GetGenericTypeDefinition())
+            {
+                return false;
+            }
+
+            var specificationArguments = specification.GetGenericArguments();
+            var actualArguments = actual.GetGenericArguments();
+            if (specificationArguments.Length != actualArguments.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < specificationArguments.Length; i++)
+            {
+                if (!TryUnify(specificationArguments[i], actualArguments[i], substitution))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return specification == actual;
+    }
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlReaderWriterBase.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlReaderWriterBase.cs
@@ -137,12 +137,7 @@ public abstract class YamlReaderWriterBase
             return null;
         }
 
-        var converterType = attribute.ConverterType;
-        if (converterType.IsGenericTypeDefinition)
-        {
-            throw new NotSupportedException($"Converter type '{converterType}' cannot be an open generic type.");
-        }
-
+        var converterType = YamlConverterAttributeHelper.ResolveConverterType(attribute.ConverterType, typeToConvert);
         if (!typeof(YamlConverter).IsAssignableFrom(converterType))
         {
             throw new NotSupportedException($"Converter type '{converterType}' must derive from '{typeof(YamlConverter)}'.");

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -161,6 +161,34 @@ internal sealed class Product
 
 Custom converters derive from `YamlConverter<T>` and can be registered through `YamlSerializerOptions.Converters` or `YamlSourceGenerationOptionsAttribute.Converters`.
 
+`YamlConverterAttribute` also accepts an open generic converter type when the annotated type, or the type of the annotated member, is a generic type with the same number of generic parameters. The converter is closed over the type arguments of the target type.
+
+```csharp
+[YamlConverter(typeof(BoxConverter<>))]
+internal sealed class Box<T>
+{
+    public T? Value { get; set; }
+}
+
+internal sealed class BoxConverter<T> : YamlConverter<Box<T>>  // used for Box<int>, Box<string>, ...
+{
+}
+```
+
+`YamlDerivedTypeAttribute` accepts an open generic derived type on a generic base type. The derived type is closed for each instantiation of the base type by matching the base type it declares, so a single attribute covers every instantiation.
+
+```csharp
+[YamlPolymorphic]
+[YamlDerivedType(typeof(Dog<>), "dog")]
+internal abstract class Animal<T>
+{
+}
+
+internal sealed class Dog<T> : Animal<T>  // Animal<string> uses Dog<string>, Animal<int> uses Dog<int>
+{
+}
+```
+
 ## Feature switches
 
 Reflection-based serialization can be disabled for applications that only use source-generated metadata. Set the `MeziantouFrameworkYamlIsReflectionEnabledByDefault` MSBuild property to `false` in the project file:

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlConverterAttributeTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlConverterAttributeTests.cs
@@ -92,4 +92,216 @@ public sealed class YamlConverterAttributeTests
             writer.WriteScalar(value.Text);
         }
     }
+
+    [Fact]
+    public void Serialize_UsesOpenGenericTypeLevelConverter()
+    {
+        var yaml = YamlSerializer.Serialize(new BoxContainer { Number = new Box<int>(42), Text = new Box<string>("hello") });
+
+        Assert.Contains("Number: 42", yaml);
+        Assert.Contains("Text: hello", yaml);
+    }
+
+    [Fact]
+    public void Deserialize_UsesOpenGenericTypeLevelConverter()
+    {
+        var value = YamlSerializer.Deserialize<BoxContainer>("Number: 42\nText: hello\n")!;
+
+        Assert.Equal(42, value.Number!.Value);
+        Assert.Equal("hello", value.Text!.Value);
+    }
+
+    [Fact]
+    public void RoundTrip_UsesOpenGenericConverterAtRoot()
+    {
+        var yaml = YamlSerializer.Serialize(new Box<int>(1));
+        var value = YamlSerializer.Deserialize<Box<int>>(yaml)!;
+
+        Assert.Equal(1, value.Value);
+    }
+
+    [Fact]
+    public void RoundTrip_UsesOpenGenericPropertyConverterWithMultipleTypeParameters()
+    {
+        var yaml = YamlSerializer.Serialize(new PairModel { Pair = new Pair<int, string> { First = 1, Second = "two" } });
+        Assert.Contains("Pair: \"1|two\"", yaml);
+
+        var value = YamlSerializer.Deserialize<PairModel>(yaml)!;
+        Assert.Equal(1, value.Pair!.First);
+        Assert.Equal("two", value.Pair.Second);
+    }
+
+    [Fact]
+    public void RoundTrip_UsesNestedOpenGenericPropertyConverter()
+    {
+        var yaml = YamlSerializer.Serialize(new NestedConverterPairModel { Pair = new Pair<int, string> { First = 3, Second = "four" } });
+        Assert.Contains("Pair: \"3|four\"", yaml);
+
+        var value = YamlSerializer.Deserialize<NestedConverterPairModel>(yaml)!;
+        Assert.Equal(3, value.Pair!.First);
+        Assert.Equal("four", value.Pair.Second);
+    }
+
+    [Fact]
+    public void Serialize_OpenGenericConverterOnNonGenericType_Throws()
+    {
+        var exception = Assert.Throws<NotSupportedException>(() => YamlSerializer.Serialize(new NonGenericWithOpenGenericConverter()));
+
+        Assert.Contains("open generic converter type", exception.Message);
+    }
+
+    [Fact]
+    public void Serialize_OpenGenericConverterWithMismatchedArity_Throws()
+    {
+        var exception = Assert.Throws<NotSupportedException>(() => YamlSerializer.Serialize(new ArityMismatchModel { Value = new Cell<int>() }));
+
+        Assert.Contains("open generic converter type", exception.Message);
+    }
+
+    [Fact]
+    public void Serialize_OpenGenericConverterWithUnsatisfiedConstraint_Throws()
+    {
+        var exception = Assert.Throws<NotSupportedException>(() => YamlSerializer.Serialize(new ConstraintViolationModel { Value = new Cell<int>() }));
+
+        Assert.Contains("generic constraints are not satisfied", exception.Message);
+    }
+
+    private sealed class BoxContainer
+    {
+        public Box<int>? Number { get; set; }
+
+        public Box<string>? Text { get; set; }
+    }
+
+    [YamlConverter(typeof(BoxConverter<>))]
+    private sealed class Box<T>
+    {
+        public Box(T? value) => Value = value;
+
+        public T? Value { get; }
+    }
+
+    private sealed class BoxConverter<T> : YamlConverter<Box<T>?>
+    {
+        public override Box<T>? Read(YamlReader reader)
+        {
+            if (reader.TokenType is YamlTokenType.Scalar && YamlScalar.IsNull(reader.ScalarValue.AsSpan()))
+            {
+                reader.Read();
+                return null;
+            }
+
+            var scalar = reader.GetScalarValue();
+            reader.Read();
+            return new Box<T>((T)Convert.ChangeType(scalar, typeof(T), CultureInfo.InvariantCulture));
+        }
+
+        public override void Write(YamlWriter writer, Box<T>? value)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteScalar(Convert.ToString(value.Value, CultureInfo.InvariantCulture));
+        }
+    }
+
+    private sealed class Pair<TFirst, TSecond>
+    {
+        public TFirst? First { get; set; }
+
+        public TSecond? Second { get; set; }
+    }
+
+    private sealed class PairModel
+    {
+        [YamlConverter(typeof(PairConverter<,>))]
+        public Pair<int, string>? Pair { get; set; }
+    }
+
+    private sealed class NestedConverterPairModel
+    {
+        [YamlConverter(typeof(ConverterHost<>.NestedPairConverter<>))]
+        public Pair<int, string>? Pair { get; set; }
+    }
+
+    private sealed class PairConverter<TFirst, TSecond> : YamlConverter<Pair<TFirst, TSecond>?>
+    {
+        public override Pair<TFirst, TSecond>? Read(YamlReader reader) => ReadPair<TFirst, TSecond>(reader);
+
+        public override void Write(YamlWriter writer, Pair<TFirst, TSecond>? value) => WritePair(writer, value);
+    }
+
+    private sealed class ConverterHost<TFirst>
+    {
+        internal sealed class NestedPairConverter<TSecond> : YamlConverter<Pair<TFirst, TSecond>?>
+        {
+            public override Pair<TFirst, TSecond>? Read(YamlReader reader) => ReadPair<TFirst, TSecond>(reader);
+
+            public override void Write(YamlWriter writer, Pair<TFirst, TSecond>? value) => WritePair(writer, value);
+        }
+    }
+
+    private static Pair<TFirst, TSecond>? ReadPair<TFirst, TSecond>(YamlReader reader)
+    {
+        if (reader.TokenType is YamlTokenType.Scalar && YamlScalar.IsNull(reader.ScalarValue.AsSpan()))
+        {
+            reader.Read();
+            return null;
+        }
+
+        var scalar = reader.GetScalarValue();
+        reader.Read();
+
+        var parts = scalar.Split('|');
+        return new Pair<TFirst, TSecond>
+        {
+            First = (TFirst)Convert.ChangeType(parts[0], typeof(TFirst), CultureInfo.InvariantCulture),
+            Second = (TSecond)Convert.ChangeType(parts[1], typeof(TSecond), CultureInfo.InvariantCulture),
+        };
+    }
+
+    private static void WritePair<TFirst, TSecond>(YamlWriter writer, Pair<TFirst, TSecond>? value)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        writer.WriteScalar(Convert.ToString(value.First, CultureInfo.InvariantCulture) + "|" + Convert.ToString(value.Second, CultureInfo.InvariantCulture));
+    }
+
+    [YamlConverter(typeof(BoxConverter<>))]
+    private sealed class NonGenericWithOpenGenericConverter
+    {
+        public int Value { get; set; }
+    }
+
+    private sealed class Cell<T>
+    {
+        public T? Value { get; set; }
+    }
+
+    private sealed class ArityMismatchModel
+    {
+        [YamlConverter(typeof(PairConverter<,>))]
+        public Cell<int>? Value { get; set; }
+    }
+
+    private sealed class ConstraintViolationModel
+    {
+        [YamlConverter(typeof(ReferenceCellConverter<>))]
+        public Cell<int>? Value { get; set; }
+    }
+
+    private sealed class ReferenceCellConverter<T> : YamlConverter<Cell<T>?>
+        where T : class
+    {
+        public override Cell<T>? Read(YamlReader reader) => throw new NotSupportedException();
+
+        public override void Write(YamlWriter writer, Cell<T>? value) => throw new NotSupportedException();
+    }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlPolymorphismTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlPolymorphismTests.cs
@@ -428,4 +428,231 @@ public class YamlPolymorphismTests
         Assert.IsType<JsonFallbackShape>(value);
         Assert.Equal("Base", value.Name);
     }
+
+    [YamlPolymorphic]
+    [YamlDerivedType(typeof(GenericDog<>), "dog")]
+    private abstract class GenericAnimal<T>
+    {
+        public T? Name { get; set; }
+    }
+
+    private sealed class GenericDog<T> : GenericAnimal<T>
+    {
+        public int BarkVolume { get; set; }
+    }
+
+    [YamlPolymorphic]
+    [YamlDerivedType(typeof(SwappedPair<,>), "swapped")]
+    private abstract class PairBase<TFirst, TSecond>
+    {
+    }
+
+    private sealed class SwappedPair<TSecond, TFirst> : PairBase<TFirst, TSecond>
+    {
+        public TFirst? First { get; set; }
+
+        public TSecond? Second { get; set; }
+    }
+
+    [YamlPolymorphic]
+    [YamlDerivedType(typeof(PartiallyClosed<>), "partial")]
+    private abstract class PartiallyClosedBase<TFirst, TSecond>
+    {
+    }
+
+    private sealed class PartiallyClosed<T> : PartiallyClosedBase<T, int>
+    {
+        public T? Value { get; set; }
+    }
+
+    private sealed class PartiallyClosedNonMatching : PartiallyClosedBase<string, bool>
+    {
+    }
+
+    [YamlPolymorphic]
+    [YamlDerivedType(typeof(WrappedList<>), "wrapped")]
+    private abstract class WrapperBase<T>
+    {
+    }
+
+    private sealed class WrappedList<T> : WrapperBase<List<T>>
+    {
+        public int Count { get; set; }
+    }
+
+    [YamlPolymorphic]
+    [YamlDerivedType(typeof(WrappedArray<>), "array")]
+    private abstract class ArrayWrapperBase<T>
+    {
+    }
+
+    private sealed class WrappedArray<T> : ArrayWrapperBase<T[]>
+    {
+        public int Length { get; set; }
+    }
+
+    [YamlPolymorphic]
+    [YamlDerivedType(typeof(NodeImplementation<>), "impl")]
+    private interface INode<T>
+    {
+    }
+
+    private sealed class NodeImplementation<T> : INode<T>
+    {
+        public T? Value { get; set; }
+    }
+
+    [YamlPolymorphic]
+    [YamlDerivedType(typeof(NestingOuter<>.Leaf<>), "leaf")]
+    private abstract class NestedBase<T>
+    {
+    }
+
+    private static class NestingOuter<TOuter>
+    {
+        internal sealed class Leaf<TInner> : NestedBase<KeyValuePair<TOuter, TInner>>
+        {
+            public string Label { get; set; } = string.Empty;
+        }
+    }
+
+    [YamlPolymorphic]
+    [YamlDerivedType(typeof(AmbiguousDerived<>), "ambiguous")]
+    private interface IAmbiguousBase<T>
+    {
+    }
+
+    private sealed class AmbiguousDerived<T> : IAmbiguousBase<T>, IAmbiguousBase<List<T>>
+    {
+    }
+
+    [YamlPolymorphic]
+    [YamlDerivedType(typeof(UnboundDerived<,>), "unbound")]
+    private abstract class UnboundBase<T>
+    {
+    }
+
+    private sealed class UnboundDerived<TFirst, TSecond> : UnboundBase<TFirst>
+    {
+    }
+
+    [Fact]
+    public void OpenGenericDerivedTypeUsesMatchingArity()
+    {
+        GenericAnimal<string> animal = new GenericDog<string> { Name = "Rex", BarkVolume = 3 };
+        var yaml = YamlSerializer.Serialize(animal, typeof(GenericAnimal<string>));
+
+        Assert.Contains("$type: dog", yaml);
+        Assert.Contains("BarkVolume: 3", yaml);
+
+        var value = YamlSerializer.Deserialize<GenericAnimal<string>>(yaml);
+
+        Assert.NotNull(value);
+        Assert.IsType<GenericDog<string>>(value);
+        Assert.Equal("Rex", value.Name);
+    }
+
+    [Fact]
+    public void OpenGenericDerivedTypeIsResolvedForEachBaseInstantiation()
+    {
+        GenericAnimal<int> animal = new GenericDog<int> { Name = 1, BarkVolume = 4 };
+        var yaml = YamlSerializer.Serialize(animal, typeof(GenericAnimal<int>));
+
+        Assert.Contains("$type: dog", yaml);
+
+        var value = YamlSerializer.Deserialize<GenericAnimal<int>>(yaml);
+
+        Assert.NotNull(value);
+        Assert.IsType<GenericDog<int>>(value);
+        Assert.Equal(1, value.Name);
+    }
+
+    [Fact]
+    public void OpenGenericDerivedTypeSupportsReorderedTypeParameters()
+    {
+        PairBase<int, string> pair = new SwappedPair<string, int> { First = 1, Second = "two" };
+        var yaml = YamlSerializer.Serialize(pair, typeof(PairBase<int, string>));
+
+        Assert.Contains("$type: swapped", yaml);
+
+        var value = YamlSerializer.Deserialize<PairBase<int, string>>(yaml);
+
+        Assert.IsType<SwappedPair<string, int>>(value);
+    }
+
+    [Fact]
+    public void OpenGenericDerivedTypeSupportsPartiallyClosedBase()
+    {
+        PartiallyClosedBase<string, int> value = new PartiallyClosed<string> { Value = "text" };
+        var yaml = YamlSerializer.Serialize(value, typeof(PartiallyClosedBase<string, int>));
+
+        Assert.Contains("$type: partial", yaml);
+        Assert.IsType<PartiallyClosed<string>>(YamlSerializer.Deserialize<PartiallyClosedBase<string, int>>(yaml));
+    }
+
+    [Fact]
+    public void OpenGenericDerivedTypeIsRejectedWhenGroundArgumentDoesNotMatch()
+    {
+        PartiallyClosedBase<string, bool> value = new PartiallyClosedNonMatching();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => YamlSerializer.Serialize(value, typeof(PartiallyClosedBase<string, bool>)));
+
+        Assert.Contains("cannot be resolved", exception.Message);
+    }
+
+    [Fact]
+    public void OpenGenericDerivedTypeSupportsWrappedTypeArguments()
+    {
+        WrapperBase<List<int>> value = new WrappedList<int> { Count = 2 };
+        var yaml = YamlSerializer.Serialize(value, typeof(WrapperBase<List<int>>));
+
+        Assert.Contains("$type: wrapped", yaml);
+        Assert.IsType<WrappedList<int>>(YamlSerializer.Deserialize<WrapperBase<List<int>>>(yaml));
+    }
+
+    [Fact]
+    public void OpenGenericDerivedTypeSupportsArrayTypeArguments()
+    {
+        ArrayWrapperBase<int[]> value = new WrappedArray<int> { Length = 3 };
+        var yaml = YamlSerializer.Serialize(value, typeof(ArrayWrapperBase<int[]>));
+
+        Assert.Contains("$type: array", yaml);
+        Assert.IsType<WrappedArray<int>>(YamlSerializer.Deserialize<ArrayWrapperBase<int[]>>(yaml));
+    }
+
+    [Fact]
+    public void OpenGenericDerivedTypeSupportsInterfaceBase()
+    {
+        INode<int> value = new NodeImplementation<int> { Value = 7 };
+        var yaml = YamlSerializer.Serialize(value, typeof(INode<int>));
+
+        Assert.Contains("$type: impl", yaml);
+        Assert.IsType<NodeImplementation<int>>(YamlSerializer.Deserialize<INode<int>>(yaml));
+    }
+
+    [Fact]
+    public void OpenGenericDerivedTypeSupportsTypeParametersFromEnclosingTypes()
+    {
+        NestedBase<KeyValuePair<string, int>> value = new NestingOuter<string>.Leaf<int> { Label = "leaf" };
+        var yaml = YamlSerializer.Serialize(value, typeof(NestedBase<KeyValuePair<string, int>>));
+
+        Assert.Contains("$type: leaf", yaml);
+        Assert.IsType<NestingOuter<string>.Leaf<int>>(YamlSerializer.Deserialize<NestedBase<KeyValuePair<string, int>>>(yaml));
+    }
+
+    [Fact]
+    public void OpenGenericDerivedTypeThrowsWhenAmbiguous()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => YamlSerializer.Serialize(new AmbiguousDerived<List<int>>(), typeof(IAmbiguousBase<List<List<int>>>)));
+
+        Assert.Contains("ambiguous", exception.Message);
+    }
+
+    [Fact]
+    public void OpenGenericDerivedTypeThrowsWhenTypeArgumentCannotBeInferred()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => YamlSerializer.Serialize(new UnboundDerived<int, string>(), typeof(UnboundBase<int>)));
+
+        Assert.Contains("cannot be resolved", exception.Message);
+    }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
@@ -852,6 +852,172 @@ public class YamlSerializerContextGeneratorDiagnosticTests
         Assert.Contains("parameterless constructor", diagnostic.GetMessage());
     }
 
+    [Fact]
+    public void MFY006_IsReported_WhenOpenGenericConverterArityDoesNotMatch()
+    {
+        const string Source = """
+            using Meziantou.Framework.Yaml.Serialization;
+
+            [YamlConverter(typeof(BoxConverter<,>))]
+            public sealed class Box<T>
+            {
+                public T? Value { get; set; }
+            }
+
+            public sealed class BoxConverter<TFirst, TSecond> : YamlConverter<Box<TFirst>>
+            {
+                public override Box<TFirst>? Read(YamlReader reader) => null;
+
+                public override void Write(YamlWriter writer, Box<TFirst> value) => writer.WriteNullValue();
+            }
+
+            [YamlSerializable(typeof(Box<int>))]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(Source)
+            .Where(static diagnostic => diagnostic.Id == "MFY006")
+            .ToArray();
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("open generic converter type", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void MFY006_IsReported_WhenOpenGenericConverterIsUsedOnNonGenericType()
+    {
+        const string Source = """
+            using Meziantou.Framework.Yaml.Serialization;
+
+            public sealed class Box<T>
+            {
+                public T? Value { get; set; }
+            }
+
+            public sealed class BoxConverter<T> : YamlConverter<Box<T>>
+            {
+                public override Box<T>? Read(YamlReader reader) => null;
+
+                public override void Write(YamlWriter writer, Box<T> value) => writer.WriteNullValue();
+            }
+
+            public sealed class Model
+            {
+                [YamlConverter(typeof(BoxConverter<>))]
+                public string? Value { get; set; }
+            }
+
+            [YamlSerializable(typeof(Model))]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(Source)
+            .Where(static diagnostic => diagnostic.Id == "MFY006")
+            .ToArray();
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("open generic converter type", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void OpenGenericConverterIsClosedOverTheTargetTypeArguments()
+    {
+        const string Source = """
+            using Meziantou.Framework.Yaml.Serialization;
+
+            [YamlConverter(typeof(BoxConverter<>))]
+            public sealed class Box<T>
+            {
+                public T? Value { get; set; }
+            }
+
+            public sealed class BoxConverter<T> : YamlConverter<Box<T>>
+            {
+                public override Box<T>? Read(YamlReader reader) => null;
+
+                public override void Write(YamlWriter writer, Box<T> value) => writer.WriteNullValue();
+            }
+
+            [YamlSerializable(typeof(Box<int>))]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var result = RunGenerator(Source);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Contains("new global::BoxConverter<int>()", result.GeneratedSource);
+    }
+
+    [Fact]
+    public void MFY022_IsReported_WhenOpenGenericDerivedTypeCannotBeResolved()
+    {
+        const string Source = """
+            using Meziantou.Framework.Yaml.Serialization;
+
+            [YamlPolymorphic]
+            [YamlDerivedType(typeof(Derived<,>), "derived")]
+            public abstract class Base<T>
+            {
+                public T? Value { get; set; }
+            }
+
+            public sealed class Derived<TFirst, TSecond> : Base<TFirst>
+            {
+            }
+
+            [YamlSerializable(typeof(Base<int>))]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(Source)
+            .Where(static diagnostic => diagnostic.Id == "MFY022")
+            .ToArray();
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Contains("cannot be resolved", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void MFY022_IsNotReported_WhenOpenGenericDerivedTypeIsResolved()
+    {
+        const string Source = """
+            using Meziantou.Framework.Yaml.Serialization;
+
+            [YamlPolymorphic]
+            [YamlDerivedType(typeof(Derived<>), "derived")]
+            public abstract class Base<T>
+            {
+                public T? Value { get; set; }
+            }
+
+            public sealed class Derived<T> : Base<T>
+            {
+            }
+
+            [YamlSerializable(typeof(Base<int>))]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(Source)
+            .Where(static diagnostic => diagnostic.Id == "MFY022")
+            .ToArray();
+
+        Assert.Empty(diagnostics);
+    }
+
     private static Diagnostic[] RunAnalyzer([StringSyntax("c#-test")] string source)
     {
         var compilation = CreateCompilation(source);

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -558,6 +558,105 @@ internal sealed class GeneratedTypeConverter : YamlConverter<GeneratedTypeWithCo
         => writer.WriteScalar(value.Value);
 }
 
+[YamlConverter(typeof(GeneratedOpenGenericBoxConverter<>))]
+internal sealed class GeneratedOpenGenericBox<T>
+{
+    public GeneratedOpenGenericBox(T? value) => Value = value;
+
+    public T? Value { get; }
+}
+
+internal sealed class GeneratedOpenGenericBoxConverter<T> : YamlConverter<GeneratedOpenGenericBox<T>?>
+{
+    public override GeneratedOpenGenericBox<T>? Read(YamlReader reader)
+    {
+        if (reader.TokenType is YamlTokenType.Scalar && YamlScalar.IsNull(reader.ScalarValue.AsSpan()))
+        {
+            reader.Read();
+            return null;
+        }
+
+        var scalar = reader.GetScalarValue();
+        reader.Read();
+        return new GeneratedOpenGenericBox<T>((T)Convert.ChangeType(scalar, typeof(T), CultureInfo.InvariantCulture));
+    }
+
+    public override void Write(YamlWriter writer, GeneratedOpenGenericBox<T>? value)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        writer.WriteScalar(Convert.ToString(value.Value, CultureInfo.InvariantCulture));
+    }
+}
+
+internal sealed class GeneratedOpenGenericCell<T>
+{
+    public T? Value { get; set; }
+}
+
+internal sealed class GeneratedOpenGenericCellConverter<T> : YamlConverter<GeneratedOpenGenericCell<T>?>
+{
+    public override GeneratedOpenGenericCell<T>? Read(YamlReader reader)
+    {
+        if (reader.TokenType is YamlTokenType.Scalar && YamlScalar.IsNull(reader.ScalarValue.AsSpan()))
+        {
+            reader.Read();
+            return null;
+        }
+
+        var scalar = reader.GetScalarValue();
+        reader.Read();
+        return new GeneratedOpenGenericCell<T> { Value = (T)Convert.ChangeType(scalar, typeof(T), CultureInfo.InvariantCulture) };
+    }
+
+    public override void Write(YamlWriter writer, GeneratedOpenGenericCell<T>? value)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        writer.WriteScalar(Convert.ToString(value.Value, CultureInfo.InvariantCulture));
+    }
+}
+
+internal sealed class GeneratedOpenGenericConverterHolder
+{
+    public GeneratedOpenGenericBox<int>? Number { get; set; }
+
+    [YamlConverter(typeof(GeneratedOpenGenericCellConverter<>))]
+    public GeneratedOpenGenericCell<string>? Text { get; set; }
+}
+
+[YamlPolymorphic]
+[YamlDerivedType(typeof(GeneratedGenericDog<>), "dog")]
+internal abstract class GeneratedGenericAnimal<T>
+{
+    public T? Name { get; set; }
+}
+
+internal sealed class GeneratedGenericDog<T> : GeneratedGenericAnimal<T>
+{
+    public int BarkVolume { get; set; }
+}
+
+[YamlPolymorphic]
+[YamlDerivedType(typeof(GeneratedWrappedLeaf<>), "leaf")]
+internal abstract class GeneratedWrapperNode<T>
+{
+    public int Depth { get; set; }
+}
+
+internal sealed class GeneratedWrappedLeaf<T> : GeneratedWrapperNode<List<T>>
+{
+    public string Label { get; set; } = string.Empty;
+}
+
 internal sealed class GeneratedConvertedScalar
 {
     public GeneratedConvertedScalar(int value) => Value = value;
@@ -1037,6 +1136,10 @@ internal sealed class GeneratedYamlIgnoreConditions
 [YamlSerializable(typeof(GeneratedAttributedExtensionDataPayload))]
 [YamlSerializable(typeof(GeneratedMemberConverterPayload))]
 [YamlSerializable(typeof(GeneratedTypeWithConverter))]
+[YamlSerializable(typeof(GeneratedOpenGenericBox<int>))]
+[YamlSerializable(typeof(GeneratedOpenGenericConverterHolder))]
+[YamlSerializable(typeof(GeneratedGenericAnimal<string>))]
+[YamlSerializable(typeof(GeneratedWrapperNode<List<int>>))]
 [YamlSerializable(typeof(GeneratedRuntimeConverterHolder))]
 [YamlSerializable(typeof(GeneratedYamlCtorModel))]
 [YamlSerializable(typeof(GeneratedJsonCtorModel))]
@@ -3187,6 +3290,79 @@ extra_list:
 
         Assert.Equal(1.5, value.GetValue());
         Assert.Contains("_value: 1.5", YamlSerializer.Serialize(value, typeInfo));
+    }
+
+    [Fact]
+    public void GeneratedContextResolvesOpenGenericDerivedType()
+    {
+        var context = new TestYamlSerializerContext();
+        var typeInfo = context.GeneratedGenericAnimalString;
+        GeneratedGenericAnimal<string> animal = new GeneratedGenericDog<string> { Name = "Rex", BarkVolume = 3 };
+
+        var yaml = YamlSerializer.Serialize(animal, typeInfo);
+
+        Assert.Contains("$type: dog", yaml);
+        Assert.Contains("BarkVolume: 3", yaml);
+
+        var value = YamlSerializer.Deserialize(yaml, typeInfo);
+
+        Assert.NotNull(value);
+        Assert.IsType<GeneratedGenericDog<string>>(value);
+        Assert.Equal("Rex", value.Name);
+    }
+
+    [Fact]
+    public void GeneratedContextResolvesOpenGenericDerivedTypeWithWrappedTypeArgument()
+    {
+        var context = new TestYamlSerializerContext();
+        var typeInfo = context.GeneratedWrapperNodeListInt32;
+        GeneratedWrapperNode<List<int>> node = new GeneratedWrappedLeaf<int> { Depth = 2, Label = "leaf" };
+
+        var yaml = YamlSerializer.Serialize(node, typeInfo);
+
+        Assert.Contains("$type: leaf", yaml);
+        Assert.Contains("Label: leaf", yaml);
+
+        var value = YamlSerializer.Deserialize(yaml, typeInfo);
+
+        Assert.NotNull(value);
+        Assert.IsType<GeneratedWrappedLeaf<int>>(value);
+        Assert.Equal(2, value.Depth);
+    }
+
+    [Fact]
+    public void GeneratedContextUsesOpenGenericConverterDeclaredOnGenericType()
+    {
+        var context = new TestYamlSerializerContext();
+        var typeInfo = context.GeneratedOpenGenericBoxInt32;
+
+        var yaml = YamlSerializer.Serialize(new GeneratedOpenGenericBox<int>(7), typeInfo);
+
+        Assert.Equal("7\n", yaml);
+        Assert.Equal(7, YamlSerializer.Deserialize(yaml, typeInfo)!.Value);
+    }
+
+    [Fact]
+    public void GeneratedContextUsesOpenGenericConvertersOnMembers()
+    {
+        var context = new TestYamlSerializerContext();
+        var typeInfo = context.GeneratedOpenGenericConverterHolder;
+        var value = new GeneratedOpenGenericConverterHolder
+        {
+            Number = new GeneratedOpenGenericBox<int>(42),
+            Text = new GeneratedOpenGenericCell<string> { Value = "hello" },
+        };
+
+        var yaml = YamlSerializer.Serialize(value, typeInfo);
+
+        Assert.Contains("Number: 42", yaml);
+        Assert.Contains("Text: hello", yaml);
+
+        var deserialized = YamlSerializer.Deserialize(yaml, typeInfo);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal(42, deserialized.Number!.Value);
+        Assert.Equal("hello", deserialized.Text!.Value);
     }
 
     [Fact]


### PR DESCRIPTION
System.Text.Json recently added two open generic features that `Meziantou.Framework.Yaml` did not support. This adds both, in the reflection-based path and in the source generator.

## Open generic converters

`[YamlConverter(typeof(BoxConverter<>))]` on a generic type, or on a member whose type is generic, now closes the converter over the type arguments of the target type instead of throwing "Converter type cannot be an open generic type".

```csharp
[YamlConverter(typeof(BoxConverter<>))]
internal sealed class Box<T>
{
    public T? Value { get; set; }
}

internal sealed class BoxConverter<T> : YamlConverter<Box<T>>  // used for Box<int>, Box<string>, ...
{
}
```

The arity comparison counts the type parameters of the containing types, so nested converters such as `Outer<>.Inner<>` are supported. A converter whose arity does not match the target type, or whose constraints are not satisfied, produces a `NotSupportedException` with a contextual message (reflection) or a `MFY006` error (source generator).

## Open generics in polymorphic serialization 

`[YamlDerivedType(typeof(Derived<>), "d")]` on a generic base type is now resolved for each instantiation of the base, so a single attribute covers every closed form.

```csharp
[YamlPolymorphic]
[YamlDerivedType(typeof(Dog<>), "dog")]
internal abstract class Animal<T>
{
}

internal sealed class Dog<T> : Animal<T>  // Animal<string> uses Dog<string>, Animal<int> uses Dog<int>
{
}
```

Resolution unifies the base type declared by the derived type with the closed base type, which admits the same patterns as System.Text.Json:

- identity binding (`Derived<T> : Base<T>`)
- reordered parameters (`Derived<U, V> : Base<V, U>`)
- partial concretization (`Derived<T> : Base<T, int>`)
- wrapped and array type arguments (`Derived<T> : Base<List<T>>`, `Derived<T> : Base<T[]>`)
- generic interface bases
- type parameters coming from enclosing types (`Outer<T>.Leaf<U> : Base<KeyValuePair<T, U>>`)

Ground-position mismatches, type parameters that cannot be inferred, unsatisfied constraints, and ambiguous unifications are rejected. This applies to `[YamlDerivedType]`, `[YamlDerivedTypeMapping]`, and the runtime `YamlPolymorphismOptions.DerivedTypeMappings`.

## Notes for reviewers

- Error behavior follows System.Text.Json: the reflection resolver throws, while the source generator reports a diagnostic and skips the entry. `MFY022` (warning) is new and is the equivalent of `SYSLIB1229`.
- The source generator has to walk the nesting hierarchy by hand because Roslyn's `INamedTypeSymbol.TypeParameters` only exposes the parameters of the immediate type, unlike `Type.GetGenericArguments()`. It also validates generic constraints explicitly, since `INamedTypeSymbol.Construct` does not.
- No public API change, so `ref/` is unchanged. The two new helper types are internal.

## Validation

- `dotnet test tests/Meziantou.Framework.Yaml.Tests` with `/p:TreatsWarningsAsErrors=true`: 1630 tests pass on net10.0 and net11.0, including 28 new tests covering the converter cases, the six derived type patterns, the error cases, the source-generated equivalents, and the generator diagnostics.
- `dotnet run ./eng/update-all.cs` produced no changes.
- `Meziantou.Framework.Yaml.AotSmoke` and `Meziantou.Framework.Yaml.FeatureSwitchSmoke` build clean with the trimming and AOT analyzers enabled.
