### PR TITLE
Add converters for the .NET 11 IEEE 754 numeric types

### DIFF
--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -969,6 +969,9 @@ namespace Meziantou.Framework.Yaml.Serialization
         public static bool TryParseDecimal(System.ReadOnlySpan<char> value, out System.Decimal result) => throw null;
         public static bool TryParseInt64(System.ReadOnlySpan<char> value, out long result) => throw null;
         public static bool TryParseDouble(System.ReadOnlySpan<char> value, out double result) => throw null;
+        #if NET11_0
+        public static bool TryParseIeee754<T>(System.ReadOnlySpan<char> value, out T result) where T : struct, System.Numerics.IFloatingPointIeee754<T> => throw null;
+        #endif
         public static bool IsNull(Meziantou.Framework.Yaml.Serialization.YamlReader reader) => throw null;
         public static bool TryParseBool(Meziantou.Framework.Yaml.Serialization.YamlReader reader, out bool result) => throw null;
         public static bool TryParseInt32(Meziantou.Framework.Yaml.Serialization.YamlReader reader, out int result) => throw null;
@@ -977,6 +980,9 @@ namespace Meziantou.Framework.Yaml.Serialization
         public static bool TryParseInt64(Meziantou.Framework.Yaml.Serialization.YamlReader reader, out long result) => throw null;
         public static bool TryParseDouble(Meziantou.Framework.Yaml.Serialization.YamlReader reader, out double result) => throw null;
         public static bool TryParseDecimal(Meziantou.Framework.Yaml.Serialization.YamlReader reader, out System.Decimal result) => throw null;
+        #if NET11_0
+        public static bool TryParseIeee754<T>(Meziantou.Framework.Yaml.Serialization.YamlReader reader, out T result) where T : struct, System.Numerics.IFloatingPointIeee754<T> => throw null;
+        #endif
         public static object? ResolveObject(Meziantou.Framework.Yaml.Serialization.YamlReader reader) => throw null;
     }
 
@@ -1093,6 +1099,12 @@ namespace Meziantou.Framework.Yaml.Serialization
         public void WriteScalar(System.Half value) { }
         public void WriteScalar(System.Int128 value) { }
         public void WriteScalar(System.UInt128 value) { }
+        #if NET11_0
+        public void WriteScalar(System.Numerics.BFloat16 value) { }
+        public void WriteScalar(System.Numerics.Decimal32 value) { }
+        public void WriteScalar(System.Numerics.Decimal64 value) { }
+        public void WriteScalar(System.Numerics.Decimal128 value) { }
+        #endif
         public void WriteScalar<T>(T value) where T : System.IFormattable { }
         public void WriteNullValue() { }
         public readonly struct BlockSequenceItemStyleScope : System.IDisposable

--- a/src/Meziantou.Framework.HumanReadableSerializer/Converters/BFloat16Converter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Converters/BFloat16Converter.cs
@@ -1,0 +1,13 @@
+#if NET11_0_OR_GREATER
+using System.Numerics;
+
+namespace Meziantou.Framework.HumanReadable.Converters;
+
+internal sealed class BFloat16Converter : HumanReadableConverter<BFloat16>
+{
+    protected override void WriteValue(HumanReadableTextWriter writer, BFloat16 value, HumanReadableSerializerOptions options)
+    {
+        writer.WriteValue(value.ToString(CultureInfo.InvariantCulture));
+    }
+}
+#endif

--- a/src/Meziantou.Framework.HumanReadableSerializer/Converters/Decimal128Converter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Converters/Decimal128Converter.cs
@@ -1,0 +1,13 @@
+#if NET11_0_OR_GREATER
+using System.Numerics;
+
+namespace Meziantou.Framework.HumanReadable.Converters;
+
+internal sealed class Decimal128Converter : HumanReadableConverter<Decimal128>
+{
+    protected override void WriteValue(HumanReadableTextWriter writer, Decimal128 value, HumanReadableSerializerOptions options)
+    {
+        writer.WriteValue(value.ToString(CultureInfo.InvariantCulture));
+    }
+}
+#endif

--- a/src/Meziantou.Framework.HumanReadableSerializer/Converters/Decimal32Converter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Converters/Decimal32Converter.cs
@@ -1,0 +1,13 @@
+#if NET11_0_OR_GREATER
+using System.Numerics;
+
+namespace Meziantou.Framework.HumanReadable.Converters;
+
+internal sealed class Decimal32Converter : HumanReadableConverter<Decimal32>
+{
+    protected override void WriteValue(HumanReadableTextWriter writer, Decimal32 value, HumanReadableSerializerOptions options)
+    {
+        writer.WriteValue(value.ToString(CultureInfo.InvariantCulture));
+    }
+}
+#endif

--- a/src/Meziantou.Framework.HumanReadableSerializer/Converters/Decimal64Converter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Converters/Decimal64Converter.cs
@@ -1,0 +1,13 @@
+#if NET11_0_OR_GREATER
+using System.Numerics;
+
+namespace Meziantou.Framework.HumanReadable.Converters;
+
+internal sealed class Decimal64Converter : HumanReadableConverter<Decimal64>
+{
+    protected override void WriteValue(HumanReadableTextWriter writer, Decimal64 value, HumanReadableSerializerOptions options)
+    {
+        writer.WriteValue(value.ToString(CultureInfo.InvariantCulture));
+    }
+}
+#endif

--- a/src/Meziantou.Framework.HumanReadableSerializer/HumanReadableSerializerOptions.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/HumanReadableSerializerOptions.cs
@@ -479,6 +479,9 @@ public sealed record HumanReadableSerializerOptions
     {
         internal static readonly HumanReadableConverter[] DefaultConverters =
         [
+#if NET11_0_OR_GREATER
+            new BFloat16Converter(),
+#endif
             new BigIntegerConverter(),
             new BitArrayConverter(),
             new BitVector32Converter(),
@@ -494,6 +497,11 @@ public sealed record HumanReadableSerializerOptions
             new DateTimeOffsetConverter(),
             new DBNullConverter(),
             new DecimalConverter(),
+#if NET11_0_OR_GREATER
+            new Decimal32Converter(),
+            new Decimal64Converter(),
+            new Decimal128Converter(),
+#endif
             new DoubleConverter(),
             new ExpressionConverter(),
             new HalfConverter(),

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
@@ -4158,6 +4158,21 @@ public sealed partial class YamlSerializerContextGenerator
             return;
         }
 
+        if (GetIeee754TypeName(member.Type) is { } ieee754MemberType)
+        {
+            builder.AppendLine("                if (reader.TokenType != global::Meziantou.Framework.Yaml.Serialization.YamlTokenType.Scalar)");
+            builder.AppendLine("                {");
+            builder.AppendLine("                    throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowExpectedScalar(reader);");
+            builder.AppendLine("                }");
+            builder.Append("                if (!global::Meziantou.Framework.Yaml.Serialization.YamlScalar.TryParseIeee754<global::System.Numerics.").Append(ieee754MemberType).Append(">(reader, out var parsed").Append(ieee754MemberType).AppendLine("))");
+            builder.AppendLine("                {");
+            builder.Append("                    throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowInvalid").Append(ieee754MemberType).AppendLine("Scalar(reader);");
+            builder.AppendLine("                }");
+            builder.Append("                ").Append(member.AssignExpression("parsed" + ieee754MemberType)).AppendLine(";");
+            builder.AppendLine("                reader.Read();");
+            return;
+        }
+
         if (member.Type is INamedTypeSymbol systemType &&
             string.Equals(systemType.ContainingNamespace?.ToDisplayString(), "System", StringComparison.Ordinal))
         {
@@ -5062,6 +5077,12 @@ public sealed partial class YamlSerializerContextGenerator
             return true;
         }
 
+        if (GetIeee754TypeName(typeSymbol) is not null)
+        {
+            builder.Append(indent).Append("writer.WriteScalar(").Append(valueExpression).AppendLine(");");
+            return true;
+        }
+
         if (typeSymbol is INamedTypeSymbol systemType &&
             string.Equals(systemType.ContainingNamespace?.ToDisplayString(), "System", StringComparison.Ordinal))
         {
@@ -5265,6 +5286,16 @@ public sealed partial class YamlSerializerContextGenerator
             builder.Append(indent).Append("var textChar = ").Append(textExpression).AppendLine(" ?? string.Empty;");
             builder.Append(indent).AppendLine("if (textChar.Length != 1) { throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowInvalidCharScalar(reader, textChar); }");
             builder.Append(indent).Append("var ").Append(valueVarName).AppendLine(" = textChar[0];");
+            return;
+        }
+
+        if (GetIeee754TypeName(typeSymbol) is { } ieee754Type)
+        {
+            builder.Append(indent).Append("if (!global::Meziantou.Framework.Yaml.Serialization.YamlScalar.TryParseIeee754<global::System.Numerics.").Append(ieee754Type).Append(">(").Append(spanExpression).Append(", out var parsed").Append(ieee754Type).AppendLine("))");
+            builder.Append(indent).AppendLine("{");
+            builder.Append(indent).Append("    throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowInvalid").Append(ieee754Type).AppendLine("Scalar(reader);");
+            builder.Append(indent).AppendLine("}");
+            builder.Append(indent).Append("var ").Append(valueVarName).Append(" = parsed").Append(ieee754Type).AppendLine(";");
             return;
         }
 
@@ -5541,6 +5572,16 @@ public sealed partial class YamlSerializerContextGenerator
             builder.Append(indent).Append("var textChar = ").Append(textExpression).AppendLine(" ?? string.Empty;");
             builder.Append(indent).AppendLine("if (textChar.Length != 1) { throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowInvalidCharScalar(reader, textChar); }");
             builder.Append(indent).Append(targetExpression).AppendLine(" = textChar[0];");
+            return;
+        }
+
+        if (GetIeee754TypeName(typeSymbol) is { } ieee754Type)
+        {
+            builder.Append(indent).Append("if (!global::Meziantou.Framework.Yaml.Serialization.YamlScalar.TryParseIeee754<global::System.Numerics.").Append(ieee754Type).Append(">(").Append(spanExpression).Append(", out var parsed").Append(ieee754Type).AppendLine("))");
+            builder.Append(indent).AppendLine("{");
+            builder.Append(indent).Append("    throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowInvalid").Append(ieee754Type).AppendLine("Scalar(reader);");
+            builder.Append(indent).AppendLine("}");
+            builder.Append(indent).Append(targetExpression).Append(" = parsed").Append(ieee754Type).AppendLine(";");
             return;
         }
 

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -1280,6 +1280,17 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         return CSharpUnionCaseKind.Mapping;
     }
 
+    /// <summary>
+    /// Gets the name of the IEEE 754 floating-point type introduced in .NET 11 (<c>System.Numerics.BFloat16</c>,
+    /// <c>Decimal32</c>, <c>Decimal64</c>, or <c>Decimal128</c>), or <see langword="null"/> when the type is not one of them.
+    /// </summary>
+    private static string? GetIeee754TypeName(ITypeSymbol type)
+        => type is INamedTypeSymbol namedType &&
+           string.Equals(namedType.ContainingNamespace?.ToDisplayString(), "System.Numerics", StringComparison.Ordinal) &&
+           namedType.Name is "BFloat16" or "Decimal32" or "Decimal64" or "Decimal128"
+            ? namedType.Name
+            : null;
+
     private static bool IsCSharpUnionNumericCase(ITypeSymbol type)
     {
         if (type.SpecialType is SpecialType.System_Byte
@@ -1295,6 +1306,11 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
             or SpecialType.System_Single
             or SpecialType.System_Double
             or SpecialType.System_Decimal)
+        {
+            return true;
+        }
+
+        if (GetIeee754TypeName(type) is not null)
         {
             return true;
         }
@@ -1395,6 +1411,11 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         }
 
         if (type is INamedTypeSymbol named && named.TypeKind == TypeKind.Enum)
+        {
+            return true;
+        }
+
+        if (GetIeee754TypeName(type) is not null)
         {
             return true;
         }

--- a/src/Meziantou.Framework.Yaml/Meziantou.Framework.Yaml.csproj
+++ b/src/Meziantou.Framework.Yaml/Meziantou.Framework.Yaml.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="System.Numerics" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../Meziantou.Framework.Yaml.SourceGenerator/Meziantou.Framework.Yaml.SourceGenerator.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlBFloat16Converter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlBFloat16Converter.cs
@@ -1,0 +1,16 @@
+#if NET11_0_OR_GREATER
+namespace Meziantou.Framework.Yaml.Serialization.Converters;
+
+internal sealed class YamlBFloat16Converter : YamlIeee754Converter<BFloat16>
+{
+    public static YamlBFloat16Converter Instance { get; } = new();
+
+    public override void Write(YamlWriter writer, BFloat16 value)
+    {
+        writer.WriteScalar(value);
+    }
+
+    protected override YamlException CreateInvalidScalarException(YamlReader reader)
+        => YamlThrowHelper.ThrowInvalidBFloat16Scalar(reader);
+}
+#endif

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlCSharpUnionConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlCSharpUnionConverter.cs
@@ -311,6 +311,12 @@ internal sealed class YamlCSharpUnionConverter<T> : YamlConverter<T?>
            type == typeof(decimal) ||
            type == typeof(Half) ||
            type == typeof(Int128) ||
+#if NET11_0_OR_GREATER
+           type == typeof(System.Numerics.BFloat16) ||
+           type == typeof(System.Numerics.Decimal32) ||
+           type == typeof(System.Numerics.Decimal64) ||
+           type == typeof(System.Numerics.Decimal128) ||
+#endif
            type == typeof(UInt128);
 
     [UnconditionalSuppressMessage(

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDecimal128Converter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDecimal128Converter.cs
@@ -1,0 +1,16 @@
+#if NET11_0_OR_GREATER
+namespace Meziantou.Framework.Yaml.Serialization.Converters;
+
+internal sealed class YamlDecimal128Converter : YamlIeee754Converter<Decimal128>
+{
+    public static YamlDecimal128Converter Instance { get; } = new();
+
+    public override void Write(YamlWriter writer, Decimal128 value)
+    {
+        writer.WriteScalar(value);
+    }
+
+    protected override YamlException CreateInvalidScalarException(YamlReader reader)
+        => YamlThrowHelper.ThrowInvalidDecimal128Scalar(reader);
+}
+#endif

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDecimal32Converter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDecimal32Converter.cs
@@ -1,0 +1,16 @@
+#if NET11_0_OR_GREATER
+namespace Meziantou.Framework.Yaml.Serialization.Converters;
+
+internal sealed class YamlDecimal32Converter : YamlIeee754Converter<Decimal32>
+{
+    public static YamlDecimal32Converter Instance { get; } = new();
+
+    public override void Write(YamlWriter writer, Decimal32 value)
+    {
+        writer.WriteScalar(value);
+    }
+
+    protected override YamlException CreateInvalidScalarException(YamlReader reader)
+        => YamlThrowHelper.ThrowInvalidDecimal32Scalar(reader);
+}
+#endif

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDecimal64Converter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDecimal64Converter.cs
@@ -1,0 +1,16 @@
+#if NET11_0_OR_GREATER
+namespace Meziantou.Framework.Yaml.Serialization.Converters;
+
+internal sealed class YamlDecimal64Converter : YamlIeee754Converter<Decimal64>
+{
+    public static YamlDecimal64Converter Instance { get; } = new();
+
+    public override void Write(YamlWriter writer, Decimal64 value)
+    {
+        writer.WriteScalar(value);
+    }
+
+    protected override YamlException CreateInvalidScalarException(YamlReader reader)
+        => YamlThrowHelper.ThrowInvalidDecimal64Scalar(reader);
+}
+#endif

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlIeee754Converter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlIeee754Converter.cs
@@ -1,0 +1,29 @@
+#if NET11_0_OR_GREATER
+namespace Meziantou.Framework.Yaml.Serialization.Converters;
+
+/// <summary>
+/// Base converter for IEEE 754 floating-point types that share the same YAML scalar representation,
+/// including the <c>.inf</c>, <c>-.inf</c>, and <c>.nan</c> literals of the YAML core schema.
+/// </summary>
+internal abstract class YamlIeee754Converter<T> : YamlConverter<T>
+    where T : struct, IFloatingPointIeee754<T>
+{
+    public override T Read(YamlReader reader)
+    {
+        if (reader.TokenType != YamlTokenType.Scalar)
+        {
+            throw YamlThrowHelper.ThrowExpectedScalar(reader);
+        }
+
+        if (!YamlScalar.TryParseIeee754<T>(reader, out var result))
+        {
+            throw CreateInvalidScalarException(reader);
+        }
+
+        reader.Read();
+        return result;
+    }
+
+    protected abstract YamlException CreateInvalidScalarException(YamlReader reader);
+}
+#endif

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlBuiltInTypeInfoResolver.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlBuiltInTypeInfoResolver.cs
@@ -141,6 +141,28 @@ internal static class YamlBuiltInTypeInfoResolver
             return YamlUInt128Converter.Instance;
         }
 
+#if NET11_0_OR_GREATER
+        if (type == typeof(BFloat16))
+        {
+            return YamlBFloat16Converter.Instance;
+        }
+
+        if (type == typeof(Decimal32))
+        {
+            return YamlDecimal32Converter.Instance;
+        }
+
+        if (type == typeof(Decimal64))
+        {
+            return YamlDecimal64Converter.Instance;
+        }
+
+        if (type == typeof(Decimal128))
+        {
+            return YamlDecimal128Converter.Instance;
+        }
+#endif
+
         if (type == typeof(object))
         {
             return YamlUntypedObjectConverter.Instance;
@@ -190,6 +212,12 @@ internal static class YamlBuiltInTypeInfoResolver
         if (type == typeof(Half?)) return YamlNullableConverter<Half>.Instance;
         if (type == typeof(Int128?)) return YamlNullableConverter<Int128>.Instance;
         if (type == typeof(UInt128?)) return YamlNullableConverter<UInt128>.Instance;
+#if NET11_0_OR_GREATER
+        if (type == typeof(BFloat16?)) return YamlNullableConverter<BFloat16>.Instance;
+        if (type == typeof(Decimal32?)) return YamlNullableConverter<Decimal32>.Instance;
+        if (type == typeof(Decimal64?)) return YamlNullableConverter<Decimal64>.Instance;
+        if (type == typeof(Decimal128?)) return YamlNullableConverter<Decimal128>.Instance;
+#endif
 
         return null;
     }

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlReaderWriterBase.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlReaderWriterBase.cs
@@ -364,6 +364,28 @@ public abstract class YamlReaderWriterBase
                 return YamlUInt128Converter.Instance;
             }
 
+#if NET11_0_OR_GREATER
+            if (typeToConvert == typeof(BFloat16))
+            {
+                return YamlBFloat16Converter.Instance;
+            }
+
+            if (typeToConvert == typeof(Decimal32))
+            {
+                return YamlDecimal32Converter.Instance;
+            }
+
+            if (typeToConvert == typeof(Decimal64))
+            {
+                return YamlDecimal64Converter.Instance;
+            }
+
+            if (typeToConvert == typeof(Decimal128))
+            {
+                return YamlDecimal128Converter.Instance;
+            }
+#endif
+
             if (typeToConvert == typeof(nint))
             {
                 return YamlIntPtrConverter.Instance;

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlScalar.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlScalar.cs
@@ -326,6 +326,56 @@ public static class YamlScalar
         return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
     }
 
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// Parses a YAML floating-point scalar into an IEEE 754 floating-point type, including <c>.inf</c> and <c>.nan</c>.
+    /// </summary>
+    /// <typeparam name="T">The IEEE 754 floating-point type to parse.</typeparam>
+    /// <param name="value">The scalar text to parse.</param>
+    /// <param name="result">The parsed floating-point value.</param>
+    public static bool TryParseIeee754<T>(ReadOnlySpan<char> value, out T result)
+        where T : struct, IFloatingPointIeee754<T>
+    {
+        value = Trim(value);
+
+        if (value.Equals(".inf", StringComparison.OrdinalIgnoreCase) || value.Equals("+.inf", StringComparison.OrdinalIgnoreCase))
+        {
+            result = T.PositiveInfinity;
+            return true;
+        }
+
+        if (value.Equals("-.inf", StringComparison.OrdinalIgnoreCase))
+        {
+            result = T.NegativeInfinity;
+            return true;
+        }
+
+        if (value.Equals(".nan", StringComparison.OrdinalIgnoreCase))
+        {
+            result = T.NaN;
+            return true;
+        }
+
+        if (ContainsChar(value, '_'))
+        {
+            var buffer = new char[value.Length];
+            var written = 0;
+            for (var i = 0; i < value.Length; i++)
+            {
+                var c = value[i];
+                if (c != '_')
+                {
+                    buffer[written++] = c;
+                }
+            }
+
+            return T.TryParse(buffer.AsSpan(0, written), NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+        }
+
+        return T.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+    }
+#endif
+
     /// <summary>
     /// Determines whether the current scalar token represents YAML null while honoring scalar style and <see cref="YamlSerializerOptions.UseSchema"/>.
     /// </summary>
@@ -519,6 +569,35 @@ public static class YamlScalar
 
         return TryParseDecimal(reader.ScalarValue.AsSpan(), out result);
     }
+
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// Parses the current scalar token as an IEEE 754 floating-point value while honoring scalar style and <see cref="YamlSerializerOptions.UseSchema"/>.
+    /// </summary>
+    /// <typeparam name="T">The IEEE 754 floating-point type to parse.</typeparam>
+    /// <param name="reader">The reader positioned on a scalar token.</param>
+    /// <param name="result">The parsed floating-point value.</param>
+    public static bool TryParseIeee754<T>(YamlReader reader, out T result)
+        where T : struct, IFloatingPointIeee754<T>
+    {
+        if (reader.Options.UseSchema)
+        {
+            // The schema resolves scalars to double or decimal, which cannot represent every value of the
+            // wider IEEE 754 types. Only the resolved tag is used, the text is parsed by the target type.
+            if (TryResolveSchemaScalar(reader, out var defaultTag, out _) &&
+                (string.Equals(defaultTag, JsonSchema.FloatShortTag, StringComparison.Ordinal) ||
+                 string.Equals(defaultTag, JsonSchema.IntShortTag, StringComparison.Ordinal)))
+            {
+                return TryParseIeee754(reader.ScalarValue.AsSpan(), out result);
+            }
+
+            result = default;
+            return false;
+        }
+
+        return TryParseIeee754(reader.ScalarValue.AsSpan(), out result);
+    }
+#endif
 
     /// <summary>Resolves the current scalar token to the CLR value implied by the scalar style, tag, and schema options.</summary>
     /// <param name="reader">The reader positioned on a scalar token.</param>

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlThrowHelper.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlThrowHelper.cs
@@ -151,6 +151,24 @@ internal static class YamlThrowHelper
     public static YamlException ThrowInvalidUInt128Scalar(YamlReader reader)
         => ThrowInvalidScalar(reader, $"Invalid UInt128 scalar '{reader.ScalarValue}'.");
 
+#if NET11_0_OR_GREATER
+    /// <summary>Throws an exception for invalid <see cref="System.Numerics.BFloat16"/> Scalar.</summary>
+    public static YamlException ThrowInvalidBFloat16Scalar(YamlReader reader)
+        => ThrowInvalidScalar(reader, $"Invalid BFloat16 scalar '{reader.ScalarValue}'.");
+
+    /// <summary>Throws an exception for invalid <see cref="System.Numerics.Decimal32"/> Scalar.</summary>
+    public static YamlException ThrowInvalidDecimal32Scalar(YamlReader reader)
+        => ThrowInvalidScalar(reader, $"Invalid Decimal32 scalar '{reader.ScalarValue}'.");
+
+    /// <summary>Throws an exception for invalid <see cref="System.Numerics.Decimal64"/> Scalar.</summary>
+    public static YamlException ThrowInvalidDecimal64Scalar(YamlReader reader)
+        => ThrowInvalidScalar(reader, $"Invalid Decimal64 scalar '{reader.ScalarValue}'.");
+
+    /// <summary>Throws an exception for invalid <see cref="System.Numerics.Decimal128"/> Scalar.</summary>
+    public static YamlException ThrowInvalidDecimal128Scalar(YamlReader reader)
+        => ThrowInvalidScalar(reader, $"Invalid Decimal128 scalar '{reader.ScalarValue}'.");
+#endif
+
     /// <summary>Throws an exception for alias Missing Value.</summary>
     public static YamlException ThrowAliasMissingValue(YamlReader reader)
         => new(reader.SourceName, reader.Start, reader.End, "Alias token did not provide an alias value.");

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
@@ -494,6 +494,62 @@ public sealed class YamlWriter : YamlReaderWriterBase
         WritePlainScalar(value.ToString(CultureInfo.InvariantCulture));
     }
 
+#if NET11_0_OR_GREATER
+    /// <summary>Writes a bfloat16 floating-point scalar value.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteScalar(BFloat16 value)
+    {
+        WriteIeee754Scalar(value);
+    }
+
+    /// <summary>Writes a 32-bit IEEE 754 decimal floating-point scalar value.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteScalar(Decimal32 value)
+    {
+        WriteIeee754Scalar(value);
+    }
+
+    /// <summary>Writes a 64-bit IEEE 754 decimal floating-point scalar value.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteScalar(Decimal64 value)
+    {
+        WriteIeee754Scalar(value);
+    }
+
+    /// <summary>Writes a 128-bit IEEE 754 decimal floating-point scalar value.</summary>
+    /// <param name="value">The value to write.</param>
+    public void WriteScalar(Decimal128 value)
+    {
+        WriteIeee754Scalar(value);
+    }
+
+    // The decimal types can format to thousands of characters, so the fixed-size buffer used by
+    // WriteFormattableScalar is not usable here.
+    private void WriteIeee754Scalar<T>(T value)
+        where T : struct, IFloatingPointIeee754<T>
+    {
+        if (T.IsPositiveInfinity(value))
+        {
+            WritePlainScalar(".inf");
+            return;
+        }
+
+        if (T.IsNegativeInfinity(value))
+        {
+            WritePlainScalar("-.inf");
+            return;
+        }
+
+        if (T.IsNaN(value))
+        {
+            WritePlainScalar(".nan");
+            return;
+        }
+
+        WritePlainScalar(value.ToString(format: null, CultureInfo.InvariantCulture));
+    }
+#endif
+
     /// <summary>Writes a scalar value for a span-formattable type using invariant culture formatting.</summary>
     /// <typeparam name="T">The value type to write.</typeparam>
     /// <param name="value">The value to write.</param>

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -937,6 +937,35 @@ public sealed partial class SerializerTests : SerializerTestsBase
     [Fact]
     public void Half() => AssertSerialization((Half)0.5, "0.5");
 
+#if NET11_0_OR_GREATER
+    [Fact]
+    public void BFloat16() => AssertSerialization((BFloat16)0.5, "0.5");
+
+    [Fact]
+    public void BFloat16_NaN() => AssertSerialization(System.Numerics.BFloat16.NaN, "NaN");
+
+    [Fact]
+    public void BFloat16_PositiveInfinity() => AssertSerialization(System.Numerics.BFloat16.PositiveInfinity, "Infinity");
+
+    [Fact]
+    public void BFloat16_NegativeInfinity() => AssertSerialization(System.Numerics.BFloat16.NegativeInfinity, "-Infinity");
+
+    [Fact]
+    public void Decimal32() => AssertSerialization(System.Numerics.Decimal32.Parse("-5.30", CultureInfo.InvariantCulture), "-5.30");
+
+    [Fact]
+    public void Decimal32_NaN() => AssertSerialization(System.Numerics.Decimal32.NaN, "NaN");
+
+    [Fact]
+    public void Decimal64() => AssertSerialization(System.Numerics.Decimal64.Parse("123.456", CultureInfo.InvariantCulture), "123.456");
+
+    [Fact]
+    public void Decimal128() => AssertSerialization(System.Numerics.Decimal128.Pi, "3.141592653589793238462643383279503");
+
+    [Fact]
+    public void Decimal128_NegativeInfinity() => AssertSerialization(System.Numerics.Decimal128.NegativeInfinity, "-Infinity");
+#endif
+
     [Fact]
     public void Single() => AssertSerialization(-5.30f, "-5.3");
 

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -1,4 +1,7 @@
 #pragma warning disable MA0048 // File name must match type name
+#if NET11_0_OR_GREATER
+using System.Numerics;
+#endif
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
@@ -180,6 +183,13 @@ internal sealed class GeneratedModernScalars
     public Half Ratio { get; set; }
     public Int128 Big { get; set; }
     public UInt128 UBig { get; set; }
+#if NET11_0_OR_GREATER
+    public System.Numerics.BFloat16 Brain { get; set; }
+    public System.Numerics.Decimal32 Small { get; set; }
+    public System.Numerics.Decimal64 Medium { get; set; }
+    public System.Numerics.Decimal128 Large { get; set; }
+    public System.Numerics.Decimal64? OptionalMedium { get; set; }
+#endif
 }
 
 internal sealed class GeneratedCollections
@@ -1691,6 +1701,45 @@ public class YamlSerializerSourceGenerationTests
         Assert.Equal(payload.Big, roundTrip.Big);
         Assert.Equal(payload.UBig, roundTrip.UBig);
     }
+
+#if NET11_0_OR_GREATER
+    [Fact]
+    public void GeneratedContext_Ieee754ScalarTypes_RoundTrip()
+    {
+        var payload = new GeneratedModernScalars
+        {
+            Date = new DateOnly(2026, 03, 01),
+            Time = new TimeOnly(12, 34, 56),
+            Ratio = (Half)1.5f,
+            Big = Int128.Parse("123456789012345678901234567890", CultureInfo.InvariantCulture),
+            UBig = UInt128.Parse("123456789012345678901234567891", CultureInfo.InvariantCulture),
+            Brain = (BFloat16)1.5f,
+            Small = Decimal32.Parse("-5.30", CultureInfo.InvariantCulture),
+            Medium = Decimal64.NaN,
+            Large = Decimal128.Pi,
+            OptionalMedium = Decimal64.PositiveInfinity,
+        };
+
+        var context = TestYamlSerializerContext.Default;
+        var typeInfo = context.GeneratedModernScalars;
+
+        var yaml = YamlSerializer.Serialize(payload, typeInfo);
+        var roundTrip = YamlSerializer.Deserialize(yaml, typeInfo);
+
+        Assert.Contains("Brain: 1.5", yaml);
+        Assert.Contains("Small: -5.30", yaml);
+        Assert.Contains("Medium: .nan", yaml);
+        Assert.Contains("Large: 3.141592653589793238462643383279503", yaml);
+        Assert.Contains("OptionalMedium: .inf", yaml);
+
+        Assert.NotNull(roundTrip);
+        Assert.Equal(payload.Brain, roundTrip.Brain);
+        Assert.Equal(payload.Small, roundTrip.Small);
+        Assert.True(Decimal64.IsNaN(roundTrip.Medium));
+        Assert.Equal(payload.Large, roundTrip.Large);
+        Assert.Equal(payload.OptionalMedium, roundTrip.OptionalMedium);
+    }
+#endif
 
     [Fact]
     public void GeneratedContextExposesDefaultTypeInfoPropertyNames()

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWellKnownScalarConverterTests.cs
@@ -1,3 +1,7 @@
+#if NET11_0_OR_GREATER
+using System.Numerics;
+#endif
+
 namespace Meziantou.Framework.Yaml.Tests.Serialization;
 public sealed class YamlWellKnownScalarConverterTests
 {
@@ -17,6 +21,17 @@ public sealed class YamlWellKnownScalarConverterTests
         public Int128 Big { get; set; }
         public UInt128 UBig { get; set; }
     }
+
+#if NET11_0_OR_GREATER
+    private sealed class Ieee754Payload
+    {
+        public BFloat16 Brain { get; set; }
+        public Decimal32 Small { get; set; }
+        public Decimal64 Medium { get; set; }
+        public Decimal128 Large { get; set; }
+        public Decimal64? OptionalMedium { get; set; }
+    }
+#endif
 
     private sealed class NullablePayload
     {
@@ -86,6 +101,91 @@ public sealed class YamlWellKnownScalarConverterTests
         Assert.Contains("Lin:", ex.Message);
         Assert.Contains("Col:", ex.Message);
     }
+
+#if NET11_0_OR_GREATER
+    [Fact]
+    public void RoundTrip_Ieee754ScalarTypes_ShouldSucceed()
+    {
+        var payload = new Ieee754Payload
+        {
+            Brain = (BFloat16)1.5f,
+            Small = Decimal32.Parse("-5.30", CultureInfo.InvariantCulture),
+            Medium = Decimal64.Parse("123.456", CultureInfo.InvariantCulture),
+            Large = Decimal128.Pi,
+            OptionalMedium = null,
+        };
+
+        var yaml = YamlSerializer.Serialize(payload);
+        var roundTrip = YamlSerializer.Deserialize<Ieee754Payload>(yaml);
+
+        Assert.Equal("""
+            Brain: 1.5
+            Small: -5.30
+            Medium: 123.456
+            Large: 3.141592653589793238462643383279503
+            OptionalMedium: null
+
+            """, yaml, ignoreLineEndingDifferences: true);
+
+        Assert.NotNull(roundTrip);
+        Assert.Equal(payload.Brain, roundTrip.Brain);
+        Assert.Equal(payload.Small, roundTrip.Small);
+        Assert.Equal(payload.Medium, roundTrip.Medium);
+        Assert.Equal(payload.Large, roundTrip.Large);
+        Assert.Null(roundTrip.OptionalMedium);
+    }
+
+    [Theory]
+    [InlineData(".inf")]
+    [InlineData("+.inf")]
+    [InlineData("-.inf")]
+    [InlineData(".nan")]
+    public void Deserialize_Ieee754NamedLiterals_ShouldSucceed(string scalar)
+    {
+        var expected = scalar switch
+        {
+            ".nan" => Decimal64.NaN,
+            "-.inf" => Decimal64.NegativeInfinity,
+            _ => Decimal64.PositiveInfinity,
+        };
+
+        var value = YamlSerializer.Deserialize<Decimal64>(scalar);
+
+        Assert.Equal(expected.ToString(null, CultureInfo.InvariantCulture), value.ToString(null, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void Serialize_Ieee754NonFiniteValues_ShouldUseYamlLiterals()
+    {
+        Assert.Equal(".inf\n", YamlSerializer.Serialize(BFloat16.PositiveInfinity), ignoreLineEndingDifferences: true);
+        Assert.Equal("-.inf\n", YamlSerializer.Serialize(Decimal32.NegativeInfinity), ignoreLineEndingDifferences: true);
+        Assert.Equal(".nan\n", YamlSerializer.Serialize(Decimal128.NaN), ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void Deserialize_Ieee754UnderscoreSeparators_ShouldSucceed()
+    {
+        var value = YamlSerializer.Deserialize<Decimal128>("1_000.5");
+
+        Assert.Equal(Decimal128.Parse("1000.5", CultureInfo.InvariantCulture), value);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidDecimal64_ShouldThrowYamlExceptionWithContext()
+    {
+        var ex = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<Decimal64>("not-a-decimal64"));
+        Assert.Contains("Decimal64", ex.Message);
+        Assert.Contains("Lin:", ex.Message);
+        Assert.Contains("Col:", ex.Message);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidBFloat16_ShouldThrowYamlExceptionWithContext()
+    {
+        var ex = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<BFloat16>("not-a-bfloat16"));
+        Assert.Contains("BFloat16", ex.Message);
+    }
+#endif
 
     [Fact]
     public void Serialize_NullableDateTimeOffsetAndBoolean_ShouldRemainPlain()


### PR DESCRIPTION
.NET 11 introduces four new IEEE 754 numeric types: `System.Numerics.BFloat16`, `Decimal32`, `Decimal64`, and `Decimal128`. This PR add support for them in `Meziantou.Framework.Yaml` and `Meziantou.Framework.HumanReadableSerializer`.

Everything is guarded by `#if NET11_0_OR_GREATER` since both projects also target `net10.0`.

## Meziantou.Framework.Yaml

- New `YamlIeee754Converter<T>` base plus `YamlBFloat16Converter` and `YamlDecimal32/64/128Converter`, registered in `YamlBuiltInTypeInfoResolver` (including `Nullable<T>`) and `YamlReaderWriterBase`.
- Values use the **YAML core-schema** float representation rather than the JSON one used by STJ: `.inf` / `-.inf` / `.nan` for non-finite values, matching the existing `double` and `float` converters. Reading also accepts `_` digit separators and honors `UseSchema`.
- New public API: `YamlScalar.TryParseIeee754<T>` and four `YamlWriter.WriteScalar` overloads. The existing generic `WriteScalar<T>` was not usable here — it formats into a 64-char stack buffer and throws otherwise, and `Decimal128.MaxValue` formats to 6145 characters — so the new overloads format via string.
- `ref/Meziantou.Framework.Yaml.cs` regenerated; the build emits the `#if NET11_0` guards itself.

### Source generator

This is the one part that goes beyond "add a converter", and it is required for the feature to be usable at all in AOT/source-generated contexts.

The generator did not recognise these types as scalars, so it fell back to POCO serialization and emitted code that **did not compile**:

```
error CS0176: Member 'Decimal64.One' cannot be accessed with an instance reference; qualify it with a type name instead
```

`Meziantou.Framework.Yaml.SourceGenerator` now classifies them as known scalars and emits calls to the same `YamlScalar.TryParseIeee754<T>` / `writer.WriteScalar(value)` helpers used by the reflection path, so both paths produce identical YAML. The generator ships inside the `Meziantou.Framework.Yaml` package as its analyzer.

The four types were also added to the C# discriminated-union numeric lists (runtime converter and generator), matching how `Half` is handled.

## Meziantou.Framework.HumanReadableSerializer

- `BFloat16Converter`, `Decimal32Converter`, `Decimal64Converter`, `Decimal128Converter`, registered in `HumanReadableSerializerOptions.DefaultConverters`.
- They format with the invariant culture like `HalfConverter`, so non-finite values render as `NaN` / `Infinity` / `-Infinity`, consistent with the existing `float`/`double` output.

## Notes for reviewers

- **Write format** is the default `ToString(null, InvariantCulture)`, not `"R"`. This round-trips for all four types and preserves the decimal quantum, so `Decimal32.Parse("1.50")` serializes back as `1.50` rather than `1.5`.
- **`UseSchema` reads** deliberately use the resolved tag only and then parse the raw scalar text with the target type. Routing through the schema-resolved object would go via `double`/`decimal` and lose precision for `Decimal128`.
- **Number handling** (`YamlNumberHandling`) was left untouched: it does not cover `Half`, `Int128`, or `UInt128` either, so the new types stay consistent with the existing behaviour.

## Verification

`dotnet run ./eng/update-all.cs` produced no further changes. All tests pass with `/p:TreatWarningsAsErrors=true` on both target frameworks:

| Suite | Result |
| --- | --- |
| `Meziantou.Framework.Yaml.Tests` | 1640 passed (836 net11.0 / 804 net10.0), 0 failed |
| `Meziantou.Framework.HumanReadableSerializer.Tests` | 532 passed (272 net11.0 / 260 net10.0), 0 failed |

19 new tests cover round-tripping, the `.inf` / `-.inf` / `.nan` literals, underscore separators, nullable members, error messages, and a source-generated round-trip asserting the exact emitted YAML.

`Meziantou.Framework.InlineSnapshotTesting` and `Meziantou.Framework.SnapshotTesting` (the downstream consumers of the human-readable serializer) still build clean.
