### PR TITLE
Support IReadOnlyDictionary as YamlExtensionData

### DIFF
--- a/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/ExtensionDataKind.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/ExtensionDataKind.cs
@@ -3,5 +3,6 @@ namespace Meziantou.Framework.Yaml.SourceGeneration;
 internal enum ExtensionDataKind
 {
     Dictionary,
+    ReadOnlyDictionary,
     Mapping,
 }

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
@@ -1001,6 +1001,61 @@ public sealed partial class YamlSerializerContextGenerator
         }
     }
 
+    /// <summary>
+    /// Emits the code acquiring the mutable <c>container</c> dictionary backing an extension data member.
+    /// </summary>
+    /// <remarks>
+    /// A read-only dictionary member cannot be mutated through its declared type, so a mutable dictionary is created,
+    /// the existing entries are copied into it, and it is assigned back to the member.
+    /// </remarks>
+    private static void EmitExtensionDataContainerAcquisition(
+        StringBuilder builder,
+        ExtensionDataMemberModel extensionData,
+        string indent,
+        string valueTypeName,
+        string propertyNameComparerExpression,
+        string readExpression,
+        Func<string, string>? assignExpression)
+    {
+        var dictionaryTypeName = "global::System.Collections.Generic.Dictionary<string, " + valueTypeName + ">";
+        var isReadOnly = extensionData.Kind == ExtensionDataKind.ReadOnlyDictionary;
+
+        builder.Append(indent).Append("var container = ").Append(readExpression);
+        if (isReadOnly)
+        {
+            builder.Append(" as ").Append(dictionaryTypeName);
+        }
+
+        builder.AppendLine(";");
+        builder.Append(indent).AppendLine("if (container is null)");
+        builder.Append(indent).AppendLine("{");
+        builder.Append(indent).Append("    container = new ").Append(dictionaryTypeName).Append('(').Append(propertyNameComparerExpression).AppendLine(");");
+
+        if (isReadOnly)
+        {
+            builder.Append(indent).Append("    var existingContainer = ").Append(readExpression).AppendLine(";");
+            builder.Append(indent).AppendLine("    if (existingContainer is not null)");
+            builder.Append(indent).AppendLine("    {");
+            builder.Append(indent).AppendLine("        foreach (var existingPair in existingContainer)");
+            builder.Append(indent).AppendLine("        {");
+            builder.Append(indent).AppendLine("            container[existingPair.Key] = existingPair.Value;");
+            builder.Append(indent).AppendLine("        }");
+            builder.Append(indent).AppendLine("    }");
+        }
+
+        if (assignExpression is not null)
+        {
+            builder.Append(indent).Append("    ").Append(assignExpression("container")).AppendLine(";");
+        }
+        else
+        {
+            builder.Append(indent).Append("    throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowNotSupported(reader, \"Extension data member '")
+                .Append(extensionData.Symbol.Name).AppendLine("' could not be assigned.\");");
+        }
+
+        builder.Append(indent).AppendLine("}");
+    }
+
     private static void EmitWriteMembersMethod(StringBuilder builder, int index, string typeName, ImmutableArray<MemberModel> members, ExtensionDataMemberModel? extensionData, Dictionary<ITypeSymbol, int> indexByType, SourceGenerationOptionsModel sourceGenerationOptions)
     {
         builder.Append("    private static void WriteMembers").Append(index)
@@ -1032,7 +1087,7 @@ public sealed partial class YamlSerializerContextGenerator
             builder.AppendLine("        if (extensionData is not null)");
             builder.AppendLine("        {");
 
-            if (extensionData.Kind == ExtensionDataKind.Dictionary)
+            if (extensionData.Kind is ExtensionDataKind.Dictionary or ExtensionDataKind.ReadOnlyDictionary)
             {
                 var dictionaryValueType = extensionData.DictionaryValueType ?? throw new InvalidOperationException("Extension data dictionary value type is missing.");
                 var valueTypeName = GetGeneratedTypeName(dictionaryValueType);
@@ -1468,28 +1523,21 @@ public sealed partial class YamlSerializerContextGenerator
 
         if (extensionData is not null)
         {
-            if (extensionData.Kind == ExtensionDataKind.Dictionary)
+            if (extensionData.Kind is ExtensionDataKind.Dictionary or ExtensionDataKind.ReadOnlyDictionary)
             {
                 var dictionaryValueType = extensionData.DictionaryValueType ?? throw new InvalidOperationException("Extension data dictionary value type is missing.");
                 var valueTypeName = GetGeneratedTypeName(dictionaryValueType);
                 var valueTypeOfName = dictionaryValueType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
                 builder.AppendLine("        void ReadAndStoreExtensionData(string extensionKey)");
                 builder.AppendLine("        {");
-                builder.Append("            var container = ").Append(extensionData.AccessExpression("instance")).AppendLine(";");
-                builder.AppendLine("            if (container is null)");
-                builder.AppendLine("            {");
-                builder.Append("                container = new global::System.Collections.Generic.Dictionary<string, ").Append(valueTypeName)
-                    .Append(">(").Append(propertyNameComparerExpression).AppendLine(");");
-                if (extensionData.CanAssign)
-                {
-                    builder.Append("                ").Append(extensionData.AssignExpression!("container")).AppendLine(";");
-                }
-                else
-                {
-                    builder.Append("                throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowNotSupported(reader, \"Extension data member '")
-                        .Append(extensionData.Symbol.Name).Append("' could not be assigned.\");").AppendLine();
-                }
-                builder.AppendLine("            }");
+                EmitExtensionDataContainerAcquisition(
+                    builder,
+                    extensionData,
+                    "            ",
+                    valueTypeName,
+                    propertyNameComparerExpression,
+                    extensionData.AccessExpression("instance"),
+                    extensionData.CanAssign ? extensionData.AssignExpression : null);
                 builder.Append("            var converter = reader.GetConverter(typeof(").Append(valueTypeOfName).AppendLine("));");
                 builder.Append("            var extensionValue = (").Append(valueTypeName).Append(")converter.Read(reader, typeof(").Append(valueTypeOfName).AppendLine("));");
                 builder.AppendLine("            container[extensionKey] = extensionValue;");
@@ -1885,7 +1933,7 @@ public sealed partial class YamlSerializerContextGenerator
         {
             builder.AppendLine();
 
-            if (extensionData.Kind == ExtensionDataKind.Dictionary)
+            if (extensionData.Kind is ExtensionDataKind.Dictionary or ExtensionDataKind.ReadOnlyDictionary)
             {
                 var dictionaryValueType = extensionData.DictionaryValueType ?? throw new InvalidOperationException("Extension data dictionary value type is missing.");
                 var valueTypeName = GetGeneratedTypeName(dictionaryValueType);
@@ -2363,18 +2411,19 @@ public sealed partial class YamlSerializerContextGenerator
                     .Append(initOnlyExtensionData.AccessExpression("__defaults" + index.ToString(System.Globalization.CultureInfo.InvariantCulture) + (typeSymbol.IsReferenceType ? "!" : string.Empty))).AppendLine(";");
                 builder.AppendLine("        if (extensionEntries is not null && extensionEntries.Count != 0)");
                 builder.AppendLine("        {");
-                if (initOnlyExtensionData.Kind == ExtensionDataKind.Dictionary)
+                if (initOnlyExtensionData.Kind is ExtensionDataKind.Dictionary or ExtensionDataKind.ReadOnlyDictionary)
                 {
                     var dictionaryValueType = initOnlyExtensionData.DictionaryValueType ?? throw new InvalidOperationException("Extension data dictionary value type is missing.");
                     var valueTypeName = GetGeneratedTypeName(dictionaryValueType);
 
-                    builder.Append("            var container = ").Append(initOnlyExtensionDataValueVarName).AppendLine(";");
-                    builder.AppendLine("            if (container is null)");
-                    builder.AppendLine("            {");
-                    builder.Append("                container = new global::System.Collections.Generic.Dictionary<string, ").Append(valueTypeName)
-                        .Append(">(").Append(propertyNameComparerExpression).AppendLine(");");
-                    builder.Append("                ").Append(initOnlyExtensionDataValueVarName).AppendLine(" = container;");
-                    builder.AppendLine("            }");
+                    EmitExtensionDataContainerAcquisition(
+                        builder,
+                        initOnlyExtensionData,
+                        "            ",
+                        valueTypeName,
+                        propertyNameComparerExpression,
+                        initOnlyExtensionDataValueVarName!,
+                        container => initOnlyExtensionDataValueVarName + " = " + container);
                     builder.AppendLine("            for (var i = 0; i < extensionEntries.Count; i++)");
                     builder.AppendLine("            {");
                     builder.AppendLine("                var entry = extensionEntries[i];");
@@ -2505,26 +2554,19 @@ public sealed partial class YamlSerializerContextGenerator
             builder.AppendLine();
             builder.AppendLine("        if (extensionEntries is not null)");
             builder.AppendLine("        {");
-            if (extensionData.Kind == ExtensionDataKind.Dictionary)
+            if (extensionData.Kind is ExtensionDataKind.Dictionary or ExtensionDataKind.ReadOnlyDictionary)
             {
                 var dictionaryValueType = extensionData.DictionaryValueType ?? throw new InvalidOperationException("Extension data dictionary value type is missing.");
                 var valueTypeName = GetGeneratedTypeName(dictionaryValueType);
 
-                builder.Append("            var container = ").Append(extensionData.AccessExpression("instance")).AppendLine(";");
-                builder.AppendLine("            if (container is null)");
-                builder.AppendLine("            {");
-                builder.Append("                container = new global::System.Collections.Generic.Dictionary<string, ").Append(valueTypeName)
-                    .Append(">(").Append(propertyNameComparerExpression).AppendLine(");");
-                if (extensionData.CanAssign)
-                {
-                    builder.Append("                ").Append(extensionData.AssignExpression!("container")).AppendLine(";");
-                }
-                else
-                {
-                    builder.Append("                throw global::Meziantou.Framework.Yaml.Serialization.YamlThrowHelper.ThrowNotSupported(reader, \"Extension data member '")
-                        .Append(extensionData.Symbol.Name).Append("' could not be assigned.\");").AppendLine();
-                }
-                builder.AppendLine("            }");
+                EmitExtensionDataContainerAcquisition(
+                    builder,
+                    extensionData,
+                    "            ",
+                    valueTypeName,
+                    propertyNameComparerExpression,
+                    extensionData.AccessExpression("instance"),
+                    extensionData.CanAssign ? extensionData.AssignExpression : null);
                 builder.AppendLine("            for (var i = 0; i < extensionEntries.Count; i++)");
                 builder.AppendLine("            {");
                 builder.AppendLine("                var entry = extensionEntries[i];");

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -40,7 +40,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
     private static readonly DiagnosticDescriptor UnsupportedExtensionDataMember = new(
         id: "MFY003",
         title: "Unsupported extension data member",
-        messageFormat: "Type '{0}' contains extension data member '{1}' of unsupported type '{2}'. Extension data members must be 'IDictionary<string, object>', 'IDictionary<string, Meziantou.Framework.Yaml.Model.YamlNode>', or 'Meziantou.Framework.Yaml.Model.YamlMapping'.",
+        messageFormat: "Type '{0}' contains extension data member '{1}' of unsupported type '{2}'. Extension data members must be 'Dictionary<string, TValue>', 'IDictionary<string, TValue>', 'IReadOnlyDictionary<string, TValue>' where TValue is 'object' or 'Meziantou.Framework.Yaml.Model.YamlNode', or 'Meziantou.Framework.Yaml.Model.YamlMapping'.",
         category: "Meziantou.Framework.Yaml.SourceGeneration",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
@@ -1047,19 +1047,31 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         return true;
     }
 
-    private static bool TryGetDictionaryValueType(ITypeSymbol type, out ITypeSymbol valueType)
+    private static bool TryGetDictionaryValueType(ITypeSymbol type, out ITypeSymbol valueType, out bool isReadOnly)
     {
         if (type is INamedTypeSymbol named
             && named.IsGenericType
-            && string.Equals(named.ConstructedFrom.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), "global::System.Collections.Generic.Dictionary<TKey, TValue>", StringComparison.Ordinal)
             && named.TypeArguments.Length == 2
             && named.TypeArguments[0].SpecialType == SpecialType.System_String)
         {
-            valueType = named.TypeArguments[1];
-            return true;
+            var definition = named.ConstructedFrom.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            switch (definition)
+            {
+                case "global::System.Collections.Generic.Dictionary<TKey, TValue>":
+                case "global::System.Collections.Generic.IDictionary<TKey, TValue>":
+                    valueType = named.TypeArguments[1];
+                    isReadOnly = false;
+                    return true;
+
+                case "global::System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>":
+                    valueType = named.TypeArguments[1];
+                    isReadOnly = true;
+                    return true;
+            }
         }
 
         valueType = null!;
+        isReadOnly = false;
         return false;
     }
 
@@ -2434,7 +2446,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
             return true;
         }
 
-        if (TryGetDictionaryValueType(type, out var valueType))
+        if (TryGetDictionaryValueType(type, out var valueType, out _))
         {
             if (valueType.SpecialType == SpecialType.System_Object)
             {
@@ -2486,8 +2498,8 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         }
         else
         {
-            kind = ExtensionDataKind.Dictionary;
-            _ = TryGetDictionaryValueType(memberType, out dictionaryValueType);
+            _ = TryGetDictionaryValueType(memberType, out dictionaryValueType, out var isReadOnly);
+            kind = isReadOnly ? ExtensionDataKind.ReadOnlyDictionary : ExtensionDataKind.Dictionary;
         }
 
         var (accessExpression, assign, usesAccessorForWrite) = CreateMemberAccessExpressions(symbol, type, accessors);

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
@@ -1799,17 +1799,20 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
     private enum ExtensionDataKind
     {
         Dictionary,
+        ReadOnlyDictionary,
         Mapping,
     }
 
     private sealed class ExtensionDataInfo
     {
-        private ExtensionDataInfo(Member member, ExtensionDataKind kind, Type? dictionaryValueType, Func<object> createContainer)
+        private ExtensionDataInfo(Member member, ExtensionDataKind kind, Type? dictionaryValueType, Func<object> createContainer, Type? containerType = null, Func<object, IEnumerable<KeyValuePair<string, object?>>>? enumerateEntries = null)
         {
             Member = member;
             Kind = kind;
             DictionaryValueType = dictionaryValueType;
             CreateContainer = createContainer;
+            ContainerType = containerType;
+            EnumerateEntries = enumerateEntries;
         }
 
         public Member Member { get; }
@@ -1819,6 +1822,16 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
         public Type? DictionaryValueType { get; }
 
         public Func<object> CreateContainer { get; }
+
+        /// <summary>
+        /// Type of the mutable container created by <see cref="CreateContainer"/>. Only set for <see cref="ExtensionDataKind.ReadOnlyDictionary"/>.
+        /// </summary>
+        public Type? ContainerType { get; }
+
+        /// <summary>
+        /// Enumerates the entries of a read-only dictionary container. Only set for <see cref="ExtensionDataKind.ReadOnlyDictionary"/>.
+        /// </summary>
+        public Func<object, IEnumerable<KeyValuePair<string, object?>>>? EnumerateEntries { get; }
 
         [UnconditionalSuppressMessage(
             "AOT",
@@ -1855,9 +1868,15 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
                 return new ExtensionDataInfo(member, ExtensionDataKind.Mapping, dictionaryValueType: null, CreateMapping);
             }
 
-            if (!TryGetExtensionDataDictionaryValueType(memberType, out var valueType))
+            var kind = ExtensionDataKind.Dictionary;
+            if (!TryGetExtensionDataDictionaryValueType(memberType, typeof(IDictionary<,>), out var valueType))
             {
-                throw new NotSupportedException($"Extension data member '{member.Name}' on '{declaringType}' must be a '{typeof(YamlMapping)}' or implement 'IDictionary<string, object>' or 'IDictionary<string, YamlNode>'.");
+                if (!TryGetExtensionDataDictionaryValueType(memberType, typeof(IReadOnlyDictionary<,>), out valueType))
+                {
+                    throw new NotSupportedException($"Extension data member '{member.Name}' on '{declaringType}' must be a '{typeof(YamlMapping)}' or implement 'IDictionary<string, object>', 'IDictionary<string, YamlNode>', 'IReadOnlyDictionary<string, object>', or 'IReadOnlyDictionary<string, YamlNode>'.");
+                }
+
+                kind = ExtensionDataKind.ReadOnlyDictionary;
             }
 
             Type createType;
@@ -1885,14 +1904,36 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
                        ?? throw new NotSupportedException($"Extension data member '{member.Name}' on '{declaringType}' could not be instantiated.");
             }
 
-            return new ExtensionDataInfo(member, ExtensionDataKind.Dictionary, valueType, CreateDictionary);
+            if (kind == ExtensionDataKind.ReadOnlyDictionary)
+            {
+                return new ExtensionDataInfo(member, kind, valueType, CreateDictionary, createType, CreateReadOnlyDictionaryEnumerator(valueType));
+            }
+
+            return new ExtensionDataInfo(member, kind, valueType, CreateDictionary);
         }
 
-        private static bool TryGetExtensionDataDictionaryValueType(Type type, out Type valueType)
+        [UnconditionalSuppressMessage(
+            "AOT",
+            "IL3050",
+            Justification = "Extension-data enumeration uses reflection and is only exercised by reflection-based serialization. NativeAOT scenarios should use source-generated metadata.")]
+        [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2060",
+            Justification = "Extension-data enumeration uses reflection and is only exercised by reflection-based serialization. NativeAOT/trimming scenarios should use source-generated metadata.")]
+        private static Func<object, IEnumerable<KeyValuePair<string, object?>>> CreateReadOnlyDictionaryEnumerator(Type valueType)
+        {
+            var method = typeof(YamlObjectConverter<T>)
+                .GetMethod(nameof(EnumerateReadOnlyDictionary), BindingFlags.NonPublic | BindingFlags.Static)!
+                .MakeGenericMethod(valueType);
+
+            return method.CreateDelegate<Func<object, IEnumerable<KeyValuePair<string, object?>>>>();
+        }
+
+        private static bool TryGetExtensionDataDictionaryValueType(Type type, Type dictionaryDefinition, out Type valueType)
         {
             valueType = null!;
 
-            if (TryGetDictionaryInterface(type, out var dictionaryInterface))
+            if (TryGetDictionaryInterface(type, dictionaryDefinition, out var dictionaryInterface))
             {
                 valueType = dictionaryInterface.GetGenericArguments()[1];
                 if (valueType == typeof(object))
@@ -1913,14 +1954,14 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
             "Trimming",
             "IL2070",
             Justification = "Extension-data dictionary detection uses reflection and is only exercised by reflection-based serialization. NativeAOT/trimming scenarios should use source-generated metadata.")]
-        private static bool TryGetDictionaryInterface(Type type, out Type dictionaryInterface)
+        private static bool TryGetDictionaryInterface(Type type, Type dictionaryDefinition, out Type dictionaryInterface)
         {
             dictionaryInterface = null!;
 
             if (type.IsGenericType)
             {
                 var definition = type.GetGenericTypeDefinition();
-                if (definition == typeof(IDictionary<,>) && type.GetGenericArguments()[0] == typeof(string))
+                if (definition == dictionaryDefinition && type.GetGenericArguments()[0] == typeof(string))
                 {
                     dictionaryInterface = type;
                     return true;
@@ -1937,7 +1978,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
                 }
 
                 var definition = candidate.GetGenericTypeDefinition();
-                if (definition == typeof(IDictionary<,>) && candidate.GetGenericArguments()[0] == typeof(string))
+                if (definition == dictionaryDefinition && candidate.GetGenericArguments()[0] == typeof(string))
                 {
                     dictionaryInterface = candidate;
                     return true;
@@ -2497,6 +2538,7 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
         switch (extensionData.Kind)
         {
             case ExtensionDataKind.Dictionary:
+            case ExtensionDataKind.ReadOnlyDictionary:
             {
                 var valueType = extensionData.DictionaryValueType ?? typeof(object);
                 var converter = reader.GetConverter(valueType);
@@ -2522,22 +2564,34 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
 
         var member = extensionData.Member;
         var container = member.GetValue(instance);
-        if (container is null)
+
+        // A read-only dictionary member cannot be mutated through its declared type: create a mutable dictionary,
+        // copy the existing entries into it, and assign it back to the member.
+        if (extensionData.Kind == ExtensionDataKind.ReadOnlyDictionary && !extensionData.ContainerType!.IsInstanceOfType(container))
+        {
+            var mutableContainer = extensionData.CreateContainer();
+            if (container is not null)
+            {
+                var mutableDictionary = (IDictionary)mutableContainer;
+                foreach (var entry in extensionData.EnumerateEntries!(container))
+                {
+                    mutableDictionary[entry.Key] = entry.Value;
+                }
+            }
+
+            container = mutableContainer;
+            AssignExtensionDataContainer(instance, member, container);
+        }
+        else if (container is null)
         {
             container = extensionData.CreateContainer();
-            try
-            {
-                member.SetValue(instance, container);
-            }
-            catch (Exception exception)
-            {
-                throw new NotSupportedException($"Extension data member '{member.Name}' could not be assigned on '{instance.GetType()}'.", exception);
-            }
+            AssignExtensionDataContainer(instance, member, container);
         }
 
         switch (extensionData.Kind)
         {
             case ExtensionDataKind.Dictionary:
+            case ExtensionDataKind.ReadOnlyDictionary:
             {
                 if (container is not IDictionary dictionary)
                 {
@@ -2585,6 +2639,26 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
         }
     }
 
+    private static void AssignExtensionDataContainer(object instance, Member member, object container)
+    {
+        try
+        {
+            member.SetValue(instance, container);
+        }
+        catch (Exception exception)
+        {
+            throw new NotSupportedException($"Extension data member '{member.Name}' could not be assigned on '{instance.GetType()}'.", exception);
+        }
+    }
+
+    private static IEnumerable<KeyValuePair<string, object?>> EnumerateReadOnlyDictionary<TValue>(object container)
+    {
+        foreach (var pair in (IReadOnlyDictionary<string, TValue>)container)
+        {
+            yield return new KeyValuePair<string, object?>(pair.Key, pair.Value);
+        }
+    }
+
     private static void WriteExtensionData(YamlWriter writer, object instance, Contract contract)
     {
         ArgumentNullException.ThrowIfNull(writer);
@@ -2608,6 +2682,10 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
         {
             case ExtensionDataKind.Dictionary:
                 WriteExtensionDictionary(writer, container, extensionData.DictionaryValueType ?? typeof(object));
+                return;
+
+            case ExtensionDataKind.ReadOnlyDictionary:
+                WriteExtensionEntries(writer, extensionData.EnumerateEntries!(container), extensionData.DictionaryValueType ?? typeof(object));
                 return;
 
             case ExtensionDataKind.Mapping:
@@ -2661,6 +2739,26 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
             }
 
             WriteExtensionEntry(writer, key, entry.Value, valueType);
+        }
+    }
+
+    private static void WriteExtensionEntries(YamlWriter writer, IEnumerable<KeyValuePair<string, object?>> entries, Type valueType)
+    {
+        if (writer.Options.MappingOrder == YamlMappingOrderPolicy.Sorted)
+        {
+            var items = new List<KeyValuePair<string, object?>>(entries);
+            items.Sort(static (x, y) => string.CompareOrdinal(x.Key, y.Key));
+            for (var i = 0; i < items.Count; i++)
+            {
+                WriteExtensionEntry(writer, items[i].Key, items[i].Value, valueType);
+            }
+
+            return;
+        }
+
+        foreach (var entry in entries)
+        {
+            WriteExtensionEntry(writer, entry.Key, entry.Value, valueType);
         }
     }
 

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlExtensionDataAttribute.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlExtensionDataAttribute.cs
@@ -4,6 +4,11 @@ namespace Meziantou.Framework.Yaml.Serialization;
 /// <remarks>
 /// This behaves similarly to <c>System.Text.Json</c> extension data. The extension data member is not emitted as a
 /// regular mapping key; instead its contents are merged into the surrounding mapping during serialization.
+/// <para>
+/// The member must be a <see cref="Model.YamlMapping"/>, or a <see cref="Dictionary{TKey, TValue}"/>,
+/// <see cref="IDictionary{TKey, TValue}"/>, or <see cref="IReadOnlyDictionary{TKey, TValue}"/> whose keys are
+/// <see cref="string"/> and whose values are <see cref="object"/> or <see cref="Model.YamlNode"/>.
+/// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public sealed class YamlExtensionDataAttribute : YamlAttribute

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -159,6 +159,20 @@ internal sealed class Product
 }
 ```
 
+`YamlExtensionDataAttribute` collects the mapping keys that don't match any member. The annotated member must be a `YamlMapping`, or a dictionary whose keys are `string` and whose values are `object` or `YamlNode`:
+
+```csharp
+internal sealed class Product
+{
+    public int Id { get; set; }
+
+    [YamlExtensionData]
+    public IReadOnlyDictionary<string, object?>? Extra { get; set; }
+}
+```
+
+The supported dictionary types are `Dictionary<string, TValue>`, `IDictionary<string, TValue>`, and `IReadOnlyDictionary<string, TValue>`. A read-only dictionary cannot be mutated through its declared type, so the deserializer creates a `Dictionary<string, TValue>`, copies the entries of the current value into it, and assigns it to the member. The member must be settable, unless its value is already a `Dictionary<string, TValue>` which is then updated in place.
+
 Custom converters derive from `YamlConverter<T>` and can be registered through `YamlSerializerOptions.Converters` or `YamlSourceGenerationOptionsAttribute.Converters`.
 
 `YamlConverterAttribute` also accepts an open generic converter type when the annotated type, or the type of the annotated member, is a generic type with the same number of generic parameters. The converter is closed over the type arguments of the target type.

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlExtensionDataTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlExtensionDataTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Meziantou.Framework.Yaml.Model;
 using Meziantou.Framework.Yaml.Serialization;
 
@@ -109,6 +110,96 @@ public sealed class YamlExtensionDataTests
         Assert.Contains("2", yaml);
     }
 
+    [Fact]
+    public void Deserialize_CapturesUnknownKeysIntoReadOnlyDictionary()
+    {
+        var value = YamlSerializer.Deserialize<ReadOnlyDictionaryExtensionDataModel>("A: 1\nB: 2\nC: test\n")!;
+
+        Assert.Equal(1, value.A);
+        Assert.NotNull(value.Extra);
+        Assert.Equal(2L, value.Extra["B"]);
+        Assert.Equal("test", value.Extra["C"]);
+    }
+
+    [Fact]
+    public void Deserialize_LeavesReadOnlyDictionaryUntouchedWhenNoExtraKeys()
+    {
+        var value = YamlSerializer.Deserialize<ReadOnlyDictionaryExtensionDataModel>("A: 1\n")!;
+
+        Assert.Equal(1, value.A);
+        Assert.Null(value.Extra);
+    }
+
+    [Fact]
+    public void Deserialize_CopiesExistingEntriesIntoReadOnlyDictionary()
+    {
+        var value = YamlSerializer.Deserialize<PrePopulatedReadOnlyDictionaryExtensionDataModel>("A: 1\nB: 2\n")!;
+
+        Assert.Equal(1, value.A);
+        Assert.Equal("kept", value.Extra["Existing"]);
+        Assert.Equal(2L, value.Extra["B"]);
+    }
+
+    [Fact]
+    public void Serialize_EmitsReadOnlyDictionaryExtensionDataEntries()
+    {
+        var value = new ReadOnlyDictionaryExtensionDataModel
+        {
+            A = 1,
+            Extra = new Dictionary<string, object?>(StringComparer.Ordinal) { ["B"] = 2, ["C"] = "test" },
+        };
+
+        var yaml = YamlSerializer.Serialize(value);
+
+        Assert.Contains("A: 1", yaml);
+        Assert.Contains("B: 2", yaml);
+        Assert.Contains("C: test", yaml);
+    }
+
+    [Fact]
+    public void Serialize_EmitsReadOnlyDictionaryExtensionDataEntriesFromImmutableDictionary()
+    {
+        var value = new ReadOnlyDictionaryExtensionDataModel
+        {
+            A = 1,
+            Extra = ImmutableDictionary<string, object?>.Empty.Add("B", 2),
+        };
+
+        var yaml = YamlSerializer.Serialize(value);
+
+        Assert.Contains("A: 1", yaml);
+        Assert.Contains("B: 2", yaml);
+    }
+
+    [Fact]
+    public void Deserialize_CapturesUnknownKeysIntoReadOnlyDictionaryOfYamlNode()
+    {
+        var value = YamlSerializer.Deserialize<ReadOnlyNodeDictionaryExtensionDataModel>("A: 1\nB: 2\n")!;
+
+        Assert.Equal(1, value.A);
+        Assert.NotNull(value.Extra);
+        Assert.Equal("2", Assert.IsType<YamlValue>(value.Extra["B"]).Value);
+    }
+
+    [Fact]
+    public void Deserialize_SetsReadOnlyDictionaryOnInitOnlyMember()
+    {
+        var value = YamlSerializer.Deserialize<InitOnlyReadOnlyDictionaryExtensionDataModel>("A: 1\nB: 2\n")!;
+
+        Assert.Equal(1, value.A);
+        Assert.NotNull(value.Extra);
+        Assert.Equal(2L, value.Extra["B"]);
+    }
+
+    [Fact]
+    public void Deserialize_ThrowsWhenReadOnlyDictionaryMemberCannotBeAssigned()
+    {
+        var exception = Assert.ThrowsAny<Exception>(() => YamlSerializer.Deserialize<GetOnlyReadOnlyDictionaryExtensionDataModel>("A: 1\nB: 2\n"));
+
+        var message = exception.Message + exception.InnerException?.Message;
+        Assert.Contains("Extra", message);
+    }
+
     private sealed class DictionaryExtensionDataModel
     {
         public int A { get; set; }
@@ -139,5 +230,47 @@ public sealed class YamlExtensionDataTests
 
         [YamlExtensionData]
         public YamlMapping Extra { get; set; } = new();
+    }
+
+    private sealed class ReadOnlyDictionaryExtensionDataModel
+    {
+        public int A { get; set; }
+
+        [YamlExtensionData]
+        public IReadOnlyDictionary<string, object?>? Extra { get; set; }
+    }
+
+#pragma warning disable CA1859 // The declared type must stay 'IReadOnlyDictionary<,>' as this is what the test covers
+    private sealed class PrePopulatedReadOnlyDictionaryExtensionDataModel
+    {
+        public int A { get; set; }
+
+        [YamlExtensionData]
+        public IReadOnlyDictionary<string, object?> Extra { get; set; } = ImmutableDictionary<string, object?>.Empty.Add("Existing", "kept");
+    }
+#pragma warning restore CA1859
+
+    private sealed class ReadOnlyNodeDictionaryExtensionDataModel
+    {
+        public int A { get; set; }
+
+        [YamlExtensionData]
+        public IReadOnlyDictionary<string, YamlNode>? Extra { get; set; }
+    }
+
+    private sealed class InitOnlyReadOnlyDictionaryExtensionDataModel
+    {
+        public int A { get; init; }
+
+        [YamlExtensionData]
+        public IReadOnlyDictionary<string, object?>? Extra { get; init; }
+    }
+
+    private sealed class GetOnlyReadOnlyDictionaryExtensionDataModel
+    {
+        public int A { get; set; }
+
+        [YamlExtensionData]
+        public IReadOnlyDictionary<string, object?>? Extra { get; }
     }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
@@ -625,6 +625,63 @@ public class YamlSerializerContextGeneratorDiagnosticTests
     }
 
     [Fact]
+    public void AnalyzerReportsErrorForUnsupportedReadOnlyDictionaryExtensionDataMember()
+    {
+        const string Source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Yaml.Serialization;
+
+            public sealed class Model
+            {
+                [YamlExtensionData]
+                public IReadOnlyDictionary<string, int>? Extra { get; set; }
+            }
+
+            [YamlSerializable(typeof(Model))]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(Source)
+            .Where(static diagnostic => diagnostic.Id == "MFY003")
+            .ToArray();
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("Extra", diagnostic.GetMessage());
+    }
+
+    [Theory]
+    [InlineData("IDictionary<string, object?>")]
+    [InlineData("IReadOnlyDictionary<string, object?>")]
+    [InlineData("IReadOnlyDictionary<string, Meziantou.Framework.Yaml.Model.YamlNode>")]
+    public void AnalyzerAcceptsDictionaryInterfaceExtensionDataMember(string memberType)
+    {
+        var source = """
+            using System.Collections.Generic;
+            using Meziantou.Framework.Yaml.Serialization;
+
+            public sealed class Model
+            {
+                [YamlExtensionData]
+                public MEMBER_TYPE? Extra { get; set; }
+            }
+
+            [YamlSerializable(typeof(Model))]
+            internal partial class TestContext : YamlSerializerContext
+            {
+            }
+            """.Replace("MEMBER_TYPE", memberType, StringComparison.Ordinal);
+
+        var diagnostics = RunAnalyzer(source)
+            .Where(static diagnostic => diagnostic.Id == "MFY003")
+            .ToArray();
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public void AnalyzerReportsErrorForMultipleExtensionDataMembers()
     {
         const string Source = """

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerSourceGenerationTests.cs
@@ -502,6 +502,51 @@ internal sealed class GeneratedExtensionDataMappingPayload
     public YamlMapping? Extra { get; set; }
 }
 
+internal sealed class GeneratedInterfaceExtensionDataDictionaryPayload
+{
+    public int Known { get; set; }
+
+    [YamlExtensionData]
+    public IDictionary<string, object?>? Extra { get; set; }
+}
+
+internal sealed class GeneratedReadOnlyExtensionDataDictionaryPayload
+{
+    public int Known { get; set; }
+
+    [YamlExtensionData]
+    public IReadOnlyDictionary<string, object?>? Extra { get; set; }
+}
+
+internal sealed class GeneratedPrePopulatedReadOnlyExtensionDataDictionaryPayload
+{
+    public int Known { get; set; }
+
+    [YamlExtensionData]
+    public IReadOnlyDictionary<string, object?> Extra { get; set; } = ImmutableDictionary<string, object?>.Empty.Add("existing", "kept");
+}
+
+internal sealed class GeneratedConstructorReadOnlyExtensionDataDictionaryPayload
+{
+    public GeneratedConstructorReadOnlyExtensionDataDictionaryPayload(int known)
+    {
+        Known = known;
+    }
+
+    public int Known { get; }
+
+    [YamlExtensionData]
+    public IReadOnlyDictionary<string, object?>? Extra { get; set; }
+}
+
+internal sealed class GeneratedInitOnlyReadOnlyExtensionDataDictionaryPayload
+{
+    public int Known { get; set; }
+
+    [YamlExtensionData]
+    public IReadOnlyDictionary<string, object?> Extra { get; init; } = ImmutableDictionary<string, object?>.Empty.Add("existing", "kept");
+}
+
 internal sealed class GeneratedInitOnlyExtensionDataDictionaryPayload
 {
     public int Known { get; set; }
@@ -1130,6 +1175,11 @@ internal sealed class GeneratedYamlIgnoreConditions
 [YamlSerializable(typeof(GeneratedNullableInitOnlyPayload))]
 [YamlSerializable(typeof(GeneratedExtensionDataDictionaryPayload))]
 [YamlSerializable(typeof(GeneratedExtensionDataMappingPayload))]
+[YamlSerializable(typeof(GeneratedInterfaceExtensionDataDictionaryPayload))]
+[YamlSerializable(typeof(GeneratedReadOnlyExtensionDataDictionaryPayload))]
+[YamlSerializable(typeof(GeneratedPrePopulatedReadOnlyExtensionDataDictionaryPayload))]
+[YamlSerializable(typeof(GeneratedConstructorReadOnlyExtensionDataDictionaryPayload))]
+[YamlSerializable(typeof(GeneratedInitOnlyReadOnlyExtensionDataDictionaryPayload))]
 [YamlSerializable(typeof(GeneratedInitOnlyExtensionDataDictionaryPayload))]
 [YamlSerializable(typeof(GeneratedInitOnlyExtensionDataMappingPayload))]
 [YamlSerializable(typeof(GeneratedAttributedUnmappedPayload))]
@@ -2944,6 +2994,100 @@ extra_list:
             typeInfo);
         Assert.Contains("Known: 3", serialized);
         Assert.Contains("x: 5", serialized);
+    }
+
+    [Fact]
+    public void GeneratedContextSupportsYamlExtensionDataInterfaceDictionary()
+    {
+        var context = new TestYamlSerializerContext();
+        var typeInfo = context.GeneratedInterfaceExtensionDataDictionaryPayload;
+
+        var roundtripped = YamlSerializer.Deserialize("Known: 2\nextra_int: 1\n", typeInfo);
+        Assert.NotNull(roundtripped);
+        Assert.Equal(2, roundtripped.Known);
+        Assert.NotNull(roundtripped.Extra);
+        Assert.Equal(1L, roundtripped.Extra["extra_int"]);
+
+        var serialized = YamlSerializer.Serialize(
+            new GeneratedInterfaceExtensionDataDictionaryPayload
+            {
+                Known = 3,
+                Extra = new Dictionary<string, object?>(StringComparer.Ordinal) { ["x"] = 5 },
+            },
+            typeInfo);
+        Assert.Contains("Known: 3", serialized);
+        Assert.Contains("x: 5", serialized);
+    }
+
+    [Fact]
+    public void GeneratedContextSupportsYamlExtensionDataReadOnlyDictionary()
+    {
+        var context = new TestYamlSerializerContext();
+        var typeInfo = context.GeneratedReadOnlyExtensionDataDictionaryPayload;
+
+        var roundtripped = YamlSerializer.Deserialize("Known: 2\nextra_int: 1\nextra_text: a\n", typeInfo);
+        Assert.NotNull(roundtripped);
+        Assert.Equal(2, roundtripped.Known);
+        Assert.NotNull(roundtripped.Extra);
+        Assert.Equal(1L, roundtripped.Extra["extra_int"]);
+        Assert.Equal("a", roundtripped.Extra["extra_text"]);
+
+        var withoutExtras = YamlSerializer.Deserialize("Known: 3\n", typeInfo);
+        Assert.NotNull(withoutExtras);
+        Assert.Null(withoutExtras.Extra);
+
+        var serialized = YamlSerializer.Serialize(
+            new GeneratedReadOnlyExtensionDataDictionaryPayload
+            {
+                Known = 3,
+                Extra = ImmutableDictionary<string, object?>.Empty.Add("x", 5),
+            },
+            typeInfo);
+        Assert.Contains("Known: 3", serialized);
+        Assert.Contains("x: 5", serialized);
+    }
+
+    [Fact]
+    public void GeneratedContextCopiesExistingEntriesIntoYamlExtensionDataReadOnlyDictionary()
+    {
+        var context = new TestYamlSerializerContext();
+        var typeInfo = context.GeneratedPrePopulatedReadOnlyExtensionDataDictionaryPayload;
+
+        var roundtripped = YamlSerializer.Deserialize("Known: 2\nextra_int: 1\n", typeInfo);
+        Assert.NotNull(roundtripped);
+        Assert.Equal("kept", roundtripped.Extra["existing"]);
+        Assert.Equal(1L, roundtripped.Extra["extra_int"]);
+    }
+
+    [Fact]
+    public void GeneratedContextSupportsConstructorYamlExtensionDataReadOnlyDictionary()
+    {
+        var context = new TestYamlSerializerContext();
+        var typeInfo = context.GeneratedConstructorReadOnlyExtensionDataDictionaryPayload;
+
+        var roundtripped = YamlSerializer.Deserialize("Known: 2\nextra_int: 1\nextra_text: a\n", typeInfo);
+        Assert.NotNull(roundtripped);
+        Assert.Equal(2, roundtripped.Known);
+        Assert.NotNull(roundtripped.Extra);
+        Assert.Equal(1L, roundtripped.Extra["extra_int"]);
+        Assert.Equal("a", roundtripped.Extra["extra_text"]);
+    }
+
+    [Fact]
+    public void GeneratedContextSupportsInitOnlyYamlExtensionDataReadOnlyDictionary()
+    {
+        var context = new TestYamlSerializerContext();
+        var typeInfo = context.GeneratedInitOnlyReadOnlyExtensionDataDictionaryPayload;
+
+        var roundtripped = YamlSerializer.Deserialize("Known: 2\nextra_int: 1\n", typeInfo);
+        Assert.NotNull(roundtripped);
+        Assert.Equal(2, roundtripped.Known);
+        Assert.Equal("kept", roundtripped.Extra["existing"]);
+        Assert.Equal(1L, roundtripped.Extra["extra_int"]);
+
+        var withoutExtras = YamlSerializer.Deserialize("Known: 3\n", typeInfo);
+        Assert.NotNull(withoutExtras);
+        Assert.Equal("kept", withoutExtras.Extra["existing"]);
     }
 
     [Fact]


### PR DESCRIPTION
## What

Allow `IReadOnlyDictionary<string, object>` and `IReadOnlyDictionary<string, YamlNode>` members annotated with `[YamlExtensionData]`, in both the reflection-based and source-generated paths.

## Why

`[YamlExtensionData]` only accepted `YamlMapping` or a mutable dictionary, so a type exposing its extra keys as a read-only dictionary had to expose a mutable one instead.

## How

### Runtime (`YamlObjectConverter`)

- New `ExtensionDataKind.ReadOnlyDictionary`, used when the member implements `IReadOnlyDictionary<string, TValue>` but not `IDictionary<string, TValue>`. Immutable implementations (e.g. `ImmutableDictionary<string, object>` as the declared type) still fail the pre-existing "must be assignable from `Dictionary<…>`" check, as in the `System.Text.Json` change.
- Deserialization creates a `Dictionary<string, TValue>`, copies the entries of the current value into it (so a pre-populated read-only dictionary is preserved), and assigns it back to the member. If the current value is already a `Dictionary<string, TValue>`, it is updated in place, which matches the existing `IDictionary` behavior and keeps get-only members working.
- Serialization enumerates the container through `IReadOnlyDictionary<string, TValue>` instead of requiring the non-generic `IDictionary`, so values such as `ImmutableDictionary` are written correctly, including with `YamlMappingOrderPolicy.Sorted`.

### Source generator

- The three code paths that acquire the extension data container (direct read, buffered constructor entries, init-only members) now share a single emit helper. For read-only members it emits `access as Dictionary<…>`, then create + copy + assign.
- The generator also accepts `IDictionary<string, TValue>`, which it previously rejected with `MFY003` even though the diagnostic message listed it as supported. The `MFY003` message now lists the accepted types accurately.

### Docs

Readme section and `YamlExtensionDataAttribute` remarks describing the supported member types.

## Notes for reviewers

- No public API change (`ref/` is unchanged).
- Behavior difference vs `System.Text.Json`: when the member value is already a mutable `Dictionary<string, TValue>`, it is mutated in place instead of being copied. This keeps read-only members consistent with the existing `IDictionary` handling in this serializer and avoids a copy per extension entry.

## Testing

- 8 reflection tests and 5 source-generation tests (plain, pre-populated, constructor-buffered, init-only, plus the `IDictionary` interface case), and 2 analyzer tests.
- `dotnet build /p:TreatWarningsAsErrors=true` for the library, the generator, and the dependent projects (AotSmoke, FeatureSwitchSmoke, Yamlish.Tests, DependencyScanning).
- `dotnet run ./eng/update-all.cs` — no resulting file changes.
- Full `Meziantou.Framework.Yaml.Tests` suite: 1664 tests passed, 0 failed (net10.0 and net11.0).