### PR TITLE
Infer polymorphic derived types from closed hierarchies

### DIFF
--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -231,6 +231,7 @@ namespace Meziantou.Framework.Yaml
         public Meziantou.Framework.Yaml.YamlTypeDiscriminatorStyle DiscriminatorStyle { get => throw null; init { } }
         public string TypeDiscriminatorPropertyName { get => throw null; init { } }
         public Meziantou.Framework.Yaml.YamlUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get => throw null; init { } }
+        public bool InferClosedTypePolymorphism { get => throw null; init { } }
         public System.Collections.Generic.IDictionary<System.Type, System.Collections.Generic.IList<Meziantou.Framework.Yaml.YamlDerivedType>> DerivedTypeMappings { get => throw null; }
     }
 
@@ -905,6 +906,7 @@ namespace Meziantou.Framework.Yaml.Serialization
         public string? TypeDiscriminatorPropertyName { get => throw null; set { } }
         public Meziantou.Framework.Yaml.YamlTypeDiscriminatorStyle DiscriminatorStyle { get => throw null; set { } }
         public Meziantou.Framework.Yaml.YamlUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get => throw null; set { } }
+        public bool InferClosedTypePolymorphism { get => throw null; set { } }
     }
 
     [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
@@ -1033,6 +1035,7 @@ namespace Meziantou.Framework.Yaml.Serialization
         public Meziantou.Framework.Yaml.YamlTypeDiscriminatorStyle DiscriminatorStyle { get => throw null; set { } }
         public string? TypeDiscriminatorPropertyName { get => throw null; set { } }
         public Meziantou.Framework.Yaml.YamlUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get => throw null; set { } }
+        public bool InferClosedTypePolymorphism { get => throw null; set { } }
         public System.Type[]? Converters { get => throw null; set { } }
     }
 

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/ClosedTypeSymbolHelper.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/ClosedTypeSymbolHelper.cs
@@ -1,0 +1,145 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Meziantou.Framework.Yaml.SourceGeneration;
+
+/// <summary>
+/// Describes a <c>closed</c> type hierarchy from the symbol model so derived type registrations can be inferred.
+/// </summary>
+/// <remarks>
+/// <c>ITypeSymbol.IsClosed</c> is unavailable in the Roslyn reference assemblies the generator compiles against, so
+/// it is used through reflection when the compiler running the generator provides it. Older compilers do not
+/// understand the <c>closed</c> modifier at all, so the fallback only has to recognize source declarations, which it
+/// does by looking for the modifier. The derived types are always reconstructed from the symbol model: the
+/// <c>closed</c> modifier restricts subtyping to the module declaring the base type, so the direct derived types are
+/// exactly the named types of that module whose base type shares the closed type's original definition.
+/// </remarks>
+internal static class ClosedTypeSymbolHelper
+{
+    private static readonly Func<ITypeSymbol, bool>? IsClosedAccessor = CreateIsClosedAccessor();
+
+    public static bool IsClosedType(INamedTypeSymbol type)
+    {
+        if (type is not { TypeKind: TypeKind.Class, IsAbstract: true })
+        {
+            return false;
+        }
+
+        if (IsClosedAccessor is not null)
+        {
+            return IsClosedAccessor(type);
+        }
+
+        foreach (var syntaxReference in type.DeclaringSyntaxReferences)
+        {
+            if (syntaxReference.GetSyntax() is not BaseTypeDeclarationSyntax declaration)
+            {
+                continue;
+            }
+
+            foreach (var modifier in declaration.Modifiers)
+            {
+                // The 'closed' contextual keyword has a dedicated SyntaxKind on compilers that understand it, but that
+                // enum member does not exist in the Roslyn version the generator compiles against. The token text is
+                // stable across compiler versions.
+                if (string.Equals(modifier.Text, "closed", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the direct derived types of a closed type. Generic derived types are returned in unbound form so callers
+    /// can unify them against the constructed base type.
+    /// </summary>
+    public static ImmutableArray<ITypeSymbol> GetClosedDerivedTypes(INamedTypeSymbol closedType)
+    {
+        var baseDefinition = closedType.OriginalDefinition;
+        var derivedTypes = ImmutableArray.CreateBuilder<ITypeSymbol>();
+
+        foreach (var candidate in EnumerateNamedTypes(closedType.ContainingModule.GlobalNamespace))
+        {
+            if (candidate.BaseType is { } candidateBase &&
+                SymbolEqualityComparer.Default.Equals(candidateBase.OriginalDefinition, baseDefinition))
+            {
+                derivedTypes.Add(candidate.IsGenericType ? candidate.ConstructUnboundGenericType() : candidate);
+            }
+        }
+
+        return derivedTypes.ToImmutable();
+    }
+
+    /// <summary>Gets the discriminator synthesized for an inferred derived type: its name without the generic arity suffix.</summary>
+    public static string GetInferredDiscriminator(ITypeSymbol type) => type.Name;
+
+    /// <summary>
+    /// Determines whether <paramref name="type"/> is at least as visible as <paramref name="other"/>, comparing the
+    /// effective visibility of each type, that is the most restrictive accessibility found on the type itself and on
+    /// every type it is nested in. An inferred derived type that is less visible than its base type cannot be
+    /// referenced from every place the base type can, so the generated context could not reference it.
+    /// </summary>
+    public static bool IsAtLeastAsVisibleAs(ITypeSymbol type, ITypeSymbol other)
+        => GetEffectiveVisibility(type) >= GetEffectiveVisibility(other);
+
+    private static Func<ITypeSymbol, bool>? CreateIsClosedAccessor()
+    {
+        var getter = typeof(ITypeSymbol).GetProperty("IsClosed")?.GetMethod;
+        return getter is null ? null : (Func<ITypeSymbol, bool>)getter.CreateDelegate(typeof(Func<ITypeSymbol, bool>));
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateNamedTypes(INamespaceSymbol namespaceSymbol)
+    {
+        foreach (var member in namespaceSymbol.GetMembers())
+        {
+            if (member is INamespaceSymbol childNamespace)
+            {
+                foreach (var namedType in EnumerateNamedTypes(childNamespace))
+                {
+                    yield return namedType;
+                }
+            }
+            else if (member is INamedTypeSymbol namedType)
+            {
+                yield return namedType;
+
+                foreach (var nestedType in EnumerateNestedTypes(namedType))
+                {
+                    yield return nestedType;
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateNestedTypes(INamedTypeSymbol type)
+    {
+        foreach (var nestedType in type.GetTypeMembers())
+        {
+            yield return nestedType;
+
+            foreach (var deeperType in EnumerateNestedTypes(nestedType))
+            {
+                yield return deeperType;
+            }
+        }
+    }
+
+    private static Accessibility GetEffectiveVisibility(ITypeSymbol type)
+    {
+        var visibility = Accessibility.Public;
+        for (ISymbol? current = type; current is INamedTypeSymbol; current = current.ContainingType)
+        {
+            if (current.DeclaredAccessibility < visibility)
+            {
+                visibility = current.DeclaredAccessibility;
+            }
+        }
+
+        return visibility;
+    }
+}

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/SourceGenerationOptionsModel.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/Internals/SourceGenerationOptionsModel.cs
@@ -33,6 +33,7 @@ internal sealed class SourceGenerationOptionsModel
     public string? DiscriminatorStyle { get; set; }
     public string? TypeDiscriminatorPropertyName { get; set; }
     public string? UnknownDerivedTypeHandling { get; set; }
+    public bool? InferClosedTypePolymorphism { get; set; }
     public ImmutableArray<ITypeSymbol> ConverterTypes { get; set; } = ImmutableArray<ITypeSymbol>.Empty;
 
     public void ApplyFrom(SourceGenerationOptionsModel other)
@@ -65,6 +66,7 @@ internal sealed class SourceGenerationOptionsModel
         if (!string.IsNullOrEmpty(other.DiscriminatorStyle)) DiscriminatorStyle = other.DiscriminatorStyle;
         if (other.TypeDiscriminatorPropertyName is not null) TypeDiscriminatorPropertyName = other.TypeDiscriminatorPropertyName;
         if (!string.IsNullOrEmpty(other.UnknownDerivedTypeHandling)) UnknownDerivedTypeHandling = other.UnknownDerivedTypeHandling;
+        if (other.InferClosedTypePolymorphism.HasValue) InferClosedTypePolymorphism = other.InferClosedTypePolymorphism;
         if (!other.ConverterTypes.IsDefaultOrEmpty) ConverterTypes = other.ConverterTypes;
     }
 }

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
@@ -521,7 +521,7 @@ public sealed partial class YamlSerializerContextGenerator
             builder.AppendLine();
             builder.AppendLine("        if (writer.TryWriteReference(value)) { return; }");
 
-            if (TryGetPolymorphismInfo(interfaceType, derivedTypeMappings, out var interfacePolymorphism) && interfacePolymorphism.DerivedTypes.Length != 0)
+            if (TryGetPolymorphismInfo(interfaceType, derivedTypeMappings, sourceGenerationOptions, out var interfacePolymorphism) && interfacePolymorphism.DerivedTypes.Length != 0)
             {
                 EmitWriteLifecycleCallbackHelpers(builder, typeName);
                 EmitWritePolymorphicDispatch(
@@ -598,7 +598,7 @@ public sealed partial class YamlSerializerContextGenerator
                 builder.AppendLine("        InvokeOnSerializing();");
             }
 
-            if (named.TypeKind == TypeKind.Class && TryGetPolymorphismInfo(named, derivedTypeMappings, out var polymorphism) && polymorphism.DerivedTypes.Length != 0)
+            if (named.TypeKind == TypeKind.Class && TryGetPolymorphismInfo(named, derivedTypeMappings, sourceGenerationOptions, out var polymorphism) && polymorphism.DerivedTypes.Length != 0)
             {
                 builder.AppendLine();
 
@@ -3388,7 +3388,7 @@ public sealed partial class YamlSerializerContextGenerator
 
         if (typeSymbol is INamedTypeSymbol interfaceType
             && interfaceType.TypeKind == TypeKind.Interface
-            && TryGetPolymorphismInfo(interfaceType, derivedTypeMappings, out var interfacePolymorphism)
+            && TryGetPolymorphismInfo(interfaceType, derivedTypeMappings, sourceGenerationOptions, out var interfacePolymorphism)
             && interfacePolymorphism.DerivedTypes.Length != 0)
         {
             builder.AppendLine("        if (reader.TryReadAlias(out var rootAliasValue))");
@@ -3443,7 +3443,7 @@ public sealed partial class YamlSerializerContextGenerator
                 .Select(m => CreateMemberModel(m, named, propertyNamingPolicy, accessors))
                 .ToImmutableArray();
 
-            if (named.TypeKind == TypeKind.Class && TryGetPolymorphismInfo(named, derivedTypeMappings, out var polymorphism) && polymorphism.DerivedTypes.Length != 0)
+            if (named.TypeKind == TypeKind.Class && TryGetPolymorphismInfo(named, derivedTypeMappings, sourceGenerationOptions, out var polymorphism) && polymorphism.DerivedTypes.Length != 0)
             {
                 builder.AppendLine("        var rootTag = reader.Tag;");
 
@@ -6329,7 +6329,8 @@ public sealed partial class YamlSerializerContextGenerator
 
         if (!string.IsNullOrEmpty(options.DiscriminatorStyle) ||
             options.TypeDiscriminatorPropertyName is not null ||
-            !string.IsNullOrEmpty(options.UnknownDerivedTypeHandling))
+            !string.IsNullOrEmpty(options.UnknownDerivedTypeHandling) ||
+            options.InferClosedTypePolymorphism.HasValue)
         {
             builder.AppendLine("            PolymorphismOptions = new global::Meziantou.Framework.Yaml.YamlPolymorphismOptions");
             builder.AppendLine("            {");
@@ -6351,6 +6352,13 @@ public sealed partial class YamlSerializerContextGenerator
             {
                 builder.Append("                UnknownDerivedTypeHandling = global::Meziantou.Framework.Yaml.YamlUnknownDerivedTypeHandling.")
                     .Append(options.UnknownDerivedTypeHandling)
+                    .AppendLine(",");
+            }
+
+            if (options.InferClosedTypePolymorphism.HasValue)
+            {
+                builder.Append("                InferClosedTypePolymorphism = ")
+                    .Append(options.InferClosedTypePolymorphism.Value ? "true" : "false")
                     .AppendLine(",");
             }
 

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -93,6 +93,30 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
+    private static readonly DiagnosticDescriptor InferClosedTypePolymorphismOnNonClosedType = new(
+        id: "MFY023",
+        title: "Closed type polymorphism inference requires a closed type",
+        messageFormat: "Type '{0}' enables [YamlPolymorphic(InferClosedTypePolymorphism = true)] but is not a closed type, so no derived type can be inferred. Declare the type 'closed' or register its derived types using [YamlDerivedType].",
+        category: "Meziantou.Framework.Yaml.SourceGeneration",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor InferClosedTypePolymorphismWithExplicitDerivedTypes = new(
+        id: "MFY024",
+        title: "Closed type polymorphism inference is replaced by explicit derived types",
+        messageFormat: "Type '{0}' enables [YamlPolymorphic(InferClosedTypePolymorphism = true)] but also declares [YamlDerivedType]. Explicit registrations replace inference, so only the derived types declared explicitly are serialized polymorphically.",
+        category: "Meziantou.Framework.Yaml.SourceGeneration",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor IgnoredInferredDerivedType = new(
+        id: "MFY025",
+        title: "Inferred derived type is ignored",
+        messageFormat: "Derived type '{0}' of the closed type '{1}' is ignored: {2}",
+        category: "Meziantou.Framework.Yaml.SourceGeneration",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
     internal static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticDescriptors = ImmutableArray.Create(
         ContextMustBePartial,
         UnsupportedMemberType,
@@ -102,7 +126,10 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         InvalidConverterType,
         InvalidDerivedTypeMapping,
         MissingYamlPolymorphicOnDerivedTypeMappingBase,
-        UnresolvedOpenGenericDerivedType);
+        UnresolvedOpenGenericDerivedType,
+        InferClosedTypePolymorphismOnNonClosedType,
+        InferClosedTypePolymorphismWithExplicitDerivedTypes,
+        IgnoredInferredDerivedType);
 
     internal sealed class ContextValidationResult
     {
@@ -368,6 +395,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
 
             ValidateYamlConverterAttribute(diagnostics, named, named);
             ValidateDerivedTypeAttributes(diagnostics, named);
+            ValidateClosedTypePolymorphism(diagnostics, named, derivedTypeMappings, model.SourceGenerationOptions);
 
             if (IsYamlNodeType(named))
             {
@@ -556,6 +584,131 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         }
     }
 
+    /// <summary>
+    /// Reports the misuses of <c>[YamlPolymorphic(InferClosedTypePolymorphism = true)]</c>: a type that is not
+    /// declared <c>closed</c>, from which nothing can ever be inferred, and a type that also declares explicit
+    /// registrations, which replace inference. When inference does apply, reports each derived type it has to ignore.
+    /// </summary>
+    private static void ValidateClosedTypePolymorphism(
+        ImmutableArray<Diagnostic>.Builder diagnostics,
+        INamedTypeSymbol baseType,
+        ImmutableArray<DerivedTypeMappingModel> contextMappings,
+        SourceGenerationOptionsModel sourceGenerationOptions)
+    {
+        AttributeData? polymorphicAttribute = null;
+        var hasExplicitRegistrations = false;
+        foreach (var attribute in baseType.GetAttributes())
+        {
+            var attributeName = attribute.AttributeClass?.ToDisplayString();
+            if (string.Equals(attributeName, "Meziantou.Framework.Yaml.Serialization.YamlPolymorphicAttribute", StringComparison.Ordinal))
+            {
+                polymorphicAttribute = attribute;
+            }
+            else if (string.Equals(attributeName, "Meziantou.Framework.Yaml.Serialization.YamlDerivedTypeAttribute", StringComparison.Ordinal))
+            {
+                hasExplicitRegistrations = true;
+            }
+        }
+
+        for (var i = 0; i < contextMappings.Length && !hasExplicitRegistrations; i++)
+        {
+            hasExplicitRegistrations = SymbolEqualityComparer.Default.Equals(contextMappings[i].BaseType, baseType);
+        }
+
+        bool? inferOverride = null;
+        if (polymorphicAttribute is not null)
+        {
+            foreach (var pair in polymorphicAttribute.NamedArguments)
+            {
+                if (string.Equals(pair.Key, "InferClosedTypePolymorphism", StringComparison.Ordinal) && pair.Value.Value is bool inferValue)
+                {
+                    inferOverride = inferValue;
+                }
+            }
+        }
+
+        if (inferOverride is true)
+        {
+            var location = polymorphicAttribute!.ApplicationSyntaxReference?.GetSyntax().GetLocation() ?? baseType.Locations.FirstOrDefault();
+            if (!ClosedTypeSymbolHelper.IsClosedType(baseType))
+            {
+                diagnostics.Add(Diagnostic.Create(
+                    InferClosedTypePolymorphismOnNonClosedType,
+                    location,
+                    baseType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+                return;
+            }
+
+            if (hasExplicitRegistrations)
+            {
+                diagnostics.Add(Diagnostic.Create(
+                    InferClosedTypePolymorphismWithExplicitDerivedTypes,
+                    location,
+                    baseType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+                return;
+            }
+        }
+
+        if (!hasExplicitRegistrations && InfersClosedTypePolymorphism(baseType, inferOverride, sourceGenerationOptions))
+        {
+            InferClosedTypeDerivedTypes(baseType, diagnostics);
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the derived types of <paramref name="baseType"/> are inferred from its closed hierarchy.
+    /// </summary>
+    private static bool InfersClosedTypePolymorphism(
+        INamedTypeSymbol baseType,
+        bool? declarationOverride,
+        SourceGenerationOptionsModel sourceGenerationOptions)
+        => (declarationOverride ?? sourceGenerationOptions.InferClosedTypePolymorphism ?? false) && ClosedTypeSymbolHelper.IsClosedType(baseType);
+
+    /// <summary>
+    /// Registers each direct derived type of a closed hierarchy, using its name, without the generic arity suffix, as
+    /// its discriminator. Derived types are ordered by discriminator so the generated metadata is deterministic.
+    /// </summary>
+    private static ImmutableArray<DerivedTypeInfoModel> InferClosedTypeDerivedTypes(
+        INamedTypeSymbol baseType,
+        ImmutableArray<Diagnostic>.Builder? diagnostics)
+    {
+        var derivedTypes = ImmutableArray.CreateBuilder<DerivedTypeInfoModel>();
+        var seenDiscriminators = new HashSet<string>(StringComparer.Ordinal);
+        var location = baseType.Locations.FirstOrDefault();
+
+        foreach (var closedDerivedType in ClosedTypeSymbolHelper.GetClosedDerivedTypes(baseType).OrderBy(static type => type.Name, StringComparer.Ordinal))
+        {
+            string? reason = null;
+            if (!TryResolveDerivedType(baseType, closedDerivedType, out var derivedType) || !IsAssignableTo(derivedType, baseType))
+            {
+                reason = $"it cannot be resolved for the base type '{baseType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)}'";
+            }
+            else if (!ClosedTypeSymbolHelper.IsAtLeastAsVisibleAs(derivedType, baseType))
+            {
+                reason = "it is less visible than the base type";
+            }
+            else if (!seenDiscriminators.Add(ClosedTypeSymbolHelper.GetInferredDiscriminator(derivedType)))
+            {
+                reason = $"another derived type already uses the discriminator '{ClosedTypeSymbolHelper.GetInferredDiscriminator(derivedType)}'";
+            }
+
+            if (reason is not null)
+            {
+                diagnostics?.Add(Diagnostic.Create(
+                    IgnoredInferredDerivedType,
+                    location,
+                    closedDerivedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                    baseType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                    reason));
+                continue;
+            }
+
+            derivedTypes.Add(new DerivedTypeInfoModel(derivedType!, ClosedTypeSymbolHelper.GetInferredDiscriminator(derivedType!), tag: null));
+        }
+
+        return derivedTypes.ToImmutable();
+    }
+
     private static void ValidateSourceGenerationOptions(ImmutableArray<Diagnostic>.Builder diagnostics, Compilation compilation, ContextModel model)
     {
         var location = model.ContextSymbol.Locations.FirstOrDefault();
@@ -722,7 +875,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                 continue;
             }
 
-            foreach (var derived in GetPolymorphicDerivedTypes(named, contextMappings))
+            foreach (var derived in GetPolymorphicDerivedTypes(named, contextMappings, sourceGenerationOptions))
             {
                 if (seen.Add(derived))
                 {
@@ -891,7 +1044,7 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
 
         if (named.TypeKind == TypeKind.Interface)
         {
-            return TryGetPolymorphismInfo(named, contextMappings, out var polymorphism) &&
+            return TryGetPolymorphismInfo(named, contextMappings, sourceGenerationOptions, out var polymorphism) &&
                 polymorphism.DerivedTypes.Length != 0;
         }
 
@@ -2893,9 +3046,10 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
 
     private static IEnumerable<ITypeSymbol> GetPolymorphicDerivedTypes(
         INamedTypeSymbol baseType,
-        ImmutableArray<DerivedTypeMappingModel> contextMappings)
+        ImmutableArray<DerivedTypeMappingModel> contextMappings,
+        SourceGenerationOptionsModel sourceGenerationOptions)
     {
-        if (TryGetPolymorphismInfo(baseType, contextMappings, out var info))
+        if (TryGetPolymorphismInfo(baseType, contextMappings, sourceGenerationOptions, out var info))
         {
             for (var i = 0; i < info.DerivedTypes.Length; i++)
             {
@@ -2907,12 +3061,14 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
     private static bool TryGetPolymorphismInfo(
         INamedTypeSymbol baseType,
         ImmutableArray<DerivedTypeMappingModel> contextMappings,
+        SourceGenerationOptionsModel sourceGenerationOptions,
         out PolymorphismInfoModel info)
     {
         string? discriminatorPropertyNameOverride = null;
         int? discriminatorStyleOverrideValue = null;
         int? unknownOverrideValue = null;
         int? yamlUnknownOverrideValue = null;
+        bool? inferClosedTypePolymorphismOverride = null;
 
         var derivedTypes = ImmutableArray.CreateBuilder<DerivedTypeInfoModel>();
         var seenDerived = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
@@ -2937,6 +3093,10 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                     else if (string.Equals(pair.Key, "UnknownDerivedTypeHandling", StringComparison.Ordinal) && pair.Value.Value is int unknownValue)
                     {
                         yamlUnknownOverrideValue = unknownValue;
+                    }
+                    else if (string.Equals(pair.Key, "InferClosedTypePolymorphism", StringComparison.Ordinal) && pair.Value.Value is bool inferValue)
+                    {
+                        inferClosedTypePolymorphismOverride = inferValue;
                     }
                 }
             }
@@ -3055,6 +3215,14 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
             {
                 seenTags.Add(mapping.Tag);
             }
+        }
+
+        // A value set on the declaration overrides the source-generation option; the option applies when unset.
+        // Explicit registrations replace inference, so the closed hierarchy is only enumerated when none was declared.
+        if (derivedTypes.Count == 0 &&
+            InfersClosedTypePolymorphism(baseType, inferClosedTypePolymorphismOverride, sourceGenerationOptions))
+        {
+            derivedTypes.AddRange(InferClosedTypeDerivedTypes(baseType, diagnostics: null));
         }
 
         if (derivedTypes.Count == 0 && discriminatorPropertyNameOverride is null && discriminatorStyleOverrideValue is null)
@@ -3334,6 +3502,9 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
                     break;
                 case "PreferQuotedForAmbiguousScalars":
                     model.PreferQuotedForAmbiguousScalars = argument.Value.Value as bool?;
+                    break;
+                case "InferClosedTypePolymorphism":
+                    model.InferClosedTypePolymorphism = argument.Value.Value as bool?;
                     break;
                 case "DiscriminatorStyle":
                     model.DiscriminatorStyle = NormalizeEnumName(argument.Value.ToCSharpString());

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
@@ -2130,12 +2130,35 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
             var hasRuntimeMappings = options.PolymorphismOptions.DerivedTypeMappings.TryGetValue(type, out var runtimeDerived)
                                      && runtimeDerived is { Count: > 0 };
 
-            if (yamlDerived.Length == 0 && !hasRuntimeMappings)
+            var yamlPolymorphic = type.GetCustomAttribute<YamlPolymorphicAttribute>(inherit: false);
+
+            // A value set on the declaration overrides the serializer-level setting; the serializer-level value applies when unset.
+            var inferOverride = yamlPolymorphic?.InferClosedTypePolymorphismOrNull;
+            var hasExplicitRegistrations = yamlDerived.Length != 0 || hasRuntimeMappings;
+            var infer = (inferOverride ?? options.PolymorphismOptions.InferClosedTypePolymorphism) && !hasExplicitRegistrations;
+
+            // The closed type metadata is only read when inference could apply, so ordinary type resolution does not
+            // pay for it: an explicit opt-in always needs the answer to be validated, while the serializer-level
+            // opt-in only matters when the declaration registers no derived type.
+            Type[]? inferredDerivedTypes = null;
+            if (inferOverride is true || infer)
+            {
+                var isClosedType = YamlClosedTypeHelper.IsClosedType(type, out var closedDerivedTypes);
+                if (inferOverride is true && !isClosedType)
+                {
+                    throw new InvalidOperationException($"Type '{type}' enables '{nameof(YamlPolymorphicAttribute)}.{nameof(YamlPolymorphicAttribute.InferClosedTypePolymorphism)}' but is not a closed type, so no derived type can be inferred. Declare the type 'closed' or register its derived types using '{nameof(YamlDerivedTypeAttribute)}'.");
+                }
+
+                if (infer)
+                {
+                    inferredDerivedTypes = closedDerivedTypes;
+                }
+            }
+
+            if (!hasExplicitRegistrations && inferredDerivedTypes is null)
             {
                 return null;
             }
-
-            var yamlPolymorphic = type.GetCustomAttribute<YamlPolymorphicAttribute>(inherit: false);
 
             var style = options.PolymorphismOptions.DiscriminatorStyle;
             if (yamlPolymorphic is not null && yamlPolymorphic.DiscriminatorStyle != YamlTypeDiscriminatorStyle.Unspecified)
@@ -2243,6 +2266,32 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
                             }
                         }
                     }
+                }
+            }
+
+            if (inferredDerivedTypes is not null)
+            {
+                foreach (var inferredDerivedType in inferredDerivedTypes)
+                {
+                    var derivedType = YamlDerivedTypeHelper.ResolveDerivedType(type, inferredDerivedType);
+                    if (!type.IsAssignableFrom(derivedType))
+                    {
+                        throw new InvalidOperationException($"Derived type '{derivedType}' is not assignable to '{type}'.");
+                    }
+
+                    if (!YamlClosedTypeHelper.IsAtLeastAsVisibleAs(derivedType, type))
+                    {
+                        throw new InvalidOperationException($"Derived type '{derivedType}' inferred for the closed type '{type}' is less visible than '{type}' and cannot be registered.");
+                    }
+
+                    var discriminator = YamlClosedTypeHelper.GetInferredDiscriminator(derivedType);
+                    if (discriminatorToType.ContainsKey(discriminator))
+                    {
+                        throw new InvalidOperationException($"Derived type '{derivedType}' inferred for the closed type '{type}' uses the discriminator '{discriminator}', which is already registered by another derived type.");
+                    }
+
+                    discriminatorToType.Add(discriminator, derivedType);
+                    typeToDerived[derivedType] = new DerivedTypeInfo(discriminator, tag: null);
                 }
             }
 

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlClosedTypeHelper.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlClosedTypeHelper.cs
@@ -1,0 +1,160 @@
+using System.Reflection;
+
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>
+/// Reads the compiler-emitted metadata describing a <c>closed</c> type hierarchy so derived type
+/// registrations can be inferred instead of being duplicated with <see cref="YamlDerivedTypeAttribute"/>.
+/// </summary>
+internal static class YamlClosedTypeHelper
+{
+    private const string IsClosedTypeAttributeFullName = "System.Runtime.CompilerServices.IsClosedTypeAttribute";
+
+    /// <summary>
+    /// Determines whether <paramref name="type"/> is declared <c>closed</c>, reporting the derived types the
+    /// compiler recorded for it in <paramref name="derivedTypes"/>.
+    /// </summary>
+    /// <remarks>
+    /// The two results are independent: a closed type declaring no derived type is still a closed type, so
+    /// <paramref name="derivedTypes"/> is <see langword="null"/> both for a type that is not closed and for a
+    /// closed type with an empty hierarchy. The marker attribute is matched by full name because the compiler
+    /// emits its own copy into assemblies targeting a runtime that does not provide the type.
+    /// </remarks>
+    public static bool IsClosedType(Type type, out Type[]? derivedTypes)
+    {
+        derivedTypes = null;
+
+        foreach (var attributeData in type.GetCustomAttributesData())
+        {
+            var attributeType = attributeData.AttributeType;
+            if (!string.Equals(attributeType.Name, "IsClosedTypeAttribute", StringComparison.Ordinal) ||
+                !string.Equals(attributeType.FullName, IsClosedTypeAttributeFullName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            derivedTypes = GetDeclaredDerivedTypes(attributeData);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Gets the discriminator synthesized for an inferred derived type: its name without the generic arity suffix.</summary>
+    public static string GetInferredDiscriminator(Type type)
+    {
+        var name = type.Name;
+        var arityIndex = name.IndexOf('`', StringComparison.Ordinal);
+        return arityIndex < 0 ? name : name[..arityIndex];
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="type"/> is at least as visible as <paramref name="other"/>.
+    /// </summary>
+    /// <remarks>
+    /// An inferred derived type must be at least as visible as the base type it is registered under; otherwise
+    /// there are call sites that can reference the base but not the derived type, and the source generator could
+    /// not emit a reference to it. The comparison uses the effective visibility of each type, that is the most
+    /// restrictive accessibility found on the type itself and on every type it is nested in.
+    /// </remarks>
+    public static bool IsAtLeastAsVisibleAs(Type type, Type other)
+        => GetEffectiveVisibility(type) >= GetEffectiveVisibility(other);
+
+    /// <summary>
+    /// Reads the derived type list from the compiler-emitted closed type marker. Returns <see langword="null"/>
+    /// when the hierarchy is empty or the attribute cannot be interpreted.
+    /// </summary>
+    private static Type[]? GetDeclaredDerivedTypes(CustomAttributeData attributeData)
+    {
+        foreach (var namedArgument in attributeData.NamedArguments)
+        {
+            if (!string.Equals(namedArgument.MemberName, "DerivedTypes", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Mono materializes array-valued named arguments directly, while CoreCLR wraps each element in a CustomAttributeTypedArgument.
+            if (namedArgument.TypedValue.Value is Type[] materializedDerivedTypes)
+            {
+                return Array.Exists(materializedDerivedTypes, derivedType => derivedType is null) ? null : materializedDerivedTypes;
+            }
+
+            if (namedArgument.TypedValue.Value is not IList<CustomAttributeTypedArgument> derivedTypeArguments)
+            {
+                return null;
+            }
+
+            var derivedTypes = new Type[derivedTypeArguments.Count];
+            for (var i = 0; i < derivedTypes.Length; i++)
+            {
+                if (derivedTypeArguments[i].Value is not Type derivedType)
+                {
+                    return null;
+                }
+
+                derivedTypes[i] = derivedType;
+            }
+
+            return derivedTypes;
+        }
+
+        // The closed type marker is present but carries no derived type.
+        return null;
+    }
+
+    private static Visibility GetEffectiveVisibility(Type type)
+    {
+        var visibility = Visibility.Public;
+        for (Type? current = type; current is not null; current = current.DeclaringType)
+        {
+            var declared = GetDeclaredVisibility(current);
+            if (declared < visibility)
+            {
+                visibility = declared;
+            }
+        }
+
+        return visibility;
+    }
+
+    private static Visibility GetDeclaredVisibility(Type type)
+    {
+        if (type.IsPublic || type.IsNestedPublic)
+        {
+            return Visibility.Public;
+        }
+
+        if (type.IsNestedFamORAssem)
+        {
+            return Visibility.ProtectedOrInternal;
+        }
+
+        if (type.IsNestedFamily)
+        {
+            return Visibility.Protected;
+        }
+
+        if (type.IsNestedFamANDAssem)
+        {
+            return Visibility.ProtectedAndInternal;
+        }
+
+        if (type.IsNestedPrivate)
+        {
+            return Visibility.Private;
+        }
+
+        // Top-level non-public types and nested assembly types are both internal.
+        return Visibility.Internal;
+    }
+
+    private enum Visibility
+    {
+        Private,
+        ProtectedAndInternal,
+        Protected,
+        Internal,
+        ProtectedOrInternal,
+        Public,
+    }
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlPolymorphicAttribute.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlPolymorphicAttribute.cs
@@ -17,4 +17,34 @@ public sealed class YamlPolymorphicAttribute : YamlAttribute
     /// and any value from <see cref="System.Text.Json.Serialization.JsonPolymorphicAttribute"/>.
     /// </remarks>
     public YamlUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get; set; } = YamlUnknownDerivedTypeHandling.Unspecified;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether derived type registrations are inferred from the compiler-provided
+    /// metadata of a <c>closed</c> type hierarchy.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Setting this property overrides <see cref="YamlPolymorphismOptions.InferClosedTypePolymorphism"/> for the
+    /// annotated type, so an explicit <see langword="false"/> suppresses inference even when it is enabled on the
+    /// serializer options. When the property is left unset the value from the options is used.
+    /// </para>
+    /// <para>
+    /// Inference is skipped for a type that declares explicit <see cref="YamlDerivedTypeAttribute"/> registrations.
+    /// Setting this property to <see langword="true"/> on a type that is not declared <c>closed</c> throws an
+    /// <see cref="InvalidOperationException"/>.
+    /// </para>
+    /// </remarks>
+    public bool InferClosedTypePolymorphism
+    {
+        get => _inferClosedTypePolymorphism ?? false;
+        set => _inferClosedTypePolymorphism = value;
+    }
+
+    /// <summary>
+    /// Gets the explicitly configured <see cref="InferClosedTypePolymorphism"/> value,
+    /// or <see langword="null"/> when the property has not been set.
+    /// </summary>
+    internal bool? InferClosedTypePolymorphismOrNull => _inferClosedTypePolymorphism;
+
+    private bool? _inferClosedTypePolymorphism;
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlSourceGenerationOptionsAttribute.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlSourceGenerationOptionsAttribute.cs
@@ -109,6 +109,17 @@ public sealed class YamlSourceGenerationOptionsAttribute : YamlAttribute
     /// <summary>Gets or sets behavior when an unknown derived type discriminator is encountered.</summary>
     public YamlUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether derived type registrations are inferred from the compiler-provided
+    /// metadata of a <c>closed</c> type hierarchy.
+    /// </summary>
+    /// <remarks>
+    /// This is the source-generation counterpart of <see cref="YamlPolymorphismOptions.InferClosedTypePolymorphism"/>.
+    /// <see cref="YamlPolymorphicAttribute.InferClosedTypePolymorphism"/> overrides this value for the type it is
+    /// applied to.
+    /// </remarks>
+    public bool InferClosedTypePolymorphism { get; set; }
+
     /// <summary>Gets or sets converter types to be instantiated and registered on the generated options instance.</summary>
     /// <remarks>
     /// Each converter type must derive from <see cref="YamlConverter"/> and expose a public parameterless constructor.

--- a/src/Meziantou.Framework.Yaml/YamlPolymorphismOptions.cs
+++ b/src/Meziantou.Framework.Yaml/YamlPolymorphismOptions.cs
@@ -51,6 +51,23 @@ public sealed class YamlPolymorphismOptions
         }
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether derived type registrations are inferred from the compiler-provided
+    /// metadata of a <c>closed</c> type hierarchy.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each inferred derived type uses its name, without the generic arity suffix, as its discriminator.
+    /// Inference is skipped for a type that declares explicit registrations, either with
+    /// <see cref="Serialization.YamlDerivedTypeAttribute"/> or in <see cref="DerivedTypeMappings"/>.
+    /// </para>
+    /// <para>
+    /// <see cref="Serialization.YamlPolymorphicAttribute.InferClosedTypePolymorphism"/> overrides this value
+    /// for the type it is applied to.
+    /// </para>
+    /// </remarks>
+    public bool InferClosedTypePolymorphism { get; init; }
+
     private YamlTypeDiscriminatorStyle _discriminatorStyle = YamlTypeDiscriminatorStyle.Property;
     private string _typeDiscriminatorPropertyName = "$type";
     private YamlUnknownDerivedTypeHandling _unknownDerivedTypeHandling = YamlUnknownDerivedTypeHandling.Fail;

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -203,6 +203,51 @@ internal sealed class Dog<T> : Animal<T>  // Animal<string> uses Dog<string>, An
 }
 ```
 
+### Closed hierarchies
+
+A `closed` class hierarchy already lists its derived types in metadata, so they do not need to be repeated with `YamlDerivedTypeAttribute`. Set `InferClosedTypePolymorphism` to register every direct derived type of a closed base type automatically, using the derived type name, without the generic arity suffix, as its discriminator.
+
+```csharp
+public closed class Shape
+{
+    public string Name { get; set; } = "";
+}
+
+public sealed class Circle : Shape { public double Radius { get; set; } }
+public sealed class Square : Shape { public double Side { get; set; } }
+
+var options = new YamlSerializerOptions
+{
+    PolymorphismOptions = new YamlPolymorphismOptions { InferClosedTypePolymorphism = true },
+};
+
+Shape shape = new Circle { Name = "circle", Radius = 3 };
+var yaml = YamlSerializer.Serialize(shape, options); // $type: Circle
+```
+
+Inference is opt-in. It can also be enabled for a single type with `YamlPolymorphicAttribute`, which takes precedence over the serializer options, so `InferClosedTypePolymorphism = false` excludes a type from a global opt-in:
+
+```csharp
+[YamlPolymorphic(InferClosedTypePolymorphism = true)]
+public closed class Shape
+{
+}
+```
+
+Explicit registrations replace inference: a type declaring `YamlDerivedTypeAttribute` or a runtime mapping registers only those derived types. Enabling `YamlPolymorphicAttribute.InferClosedTypePolymorphism` on a type that is not declared `closed` throws an `InvalidOperationException` and reports the `MFY023` diagnostic. Only the direct derived types of the closed base type are registered, as with explicit registrations: when a derived type is itself `closed`, its own derived types are registered under it and not under the root of the hierarchy.
+
+A derived type must be at least as visible as the base type it is registered under, and two derived types cannot share a name. Reflection-based serialization throws an `InvalidOperationException` in those cases, and the source generator skips the derived type and reports the `MFY025` diagnostic.
+
+Source generation exposes the same setting on `YamlSourceGenerationOptionsAttribute`:
+
+```csharp
+[YamlSourceGenerationOptions(InferClosedTypePolymorphism = true)]
+[YamlSerializable(typeof(Shape))]
+internal sealed partial class ShapeYamlContext : YamlSerializerContext
+{
+}
+```
+
 ## Feature switches
 
 Reflection-based serialization can be disabled for applications that only use source-generated metadata. Set the `MeziantouFrameworkYamlIsReflectionEnabledByDefault` MSBuild property to `false` in the project file:

--- a/tests/Meziantou.Framework.Yaml.Tests/Meziantou.Framework.Yaml.Tests.csproj
+++ b/tests/Meziantou.Framework.Yaml.Tests/Meziantou.Framework.Yaml.Tests.csproj
@@ -11,7 +11,7 @@
     <Compile Include="..\..\common\TargetFrameworkHelper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlPolymorphismTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlPolymorphismTests.cs
@@ -655,4 +655,289 @@ public class YamlPolymorphismTests
 
         Assert.Contains("cannot be resolved", exception.Message);
     }
+
+    private static YamlSerializerOptions InferClosedTypePolymorphismOptions { get; } = new()
+    {
+        PolymorphismOptions = new YamlPolymorphismOptions { InferClosedTypePolymorphism = true },
+    };
+
+    private closed class ClosedShape
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class ClosedCircle : ClosedShape
+    {
+        public double Radius { get; set; }
+    }
+
+    private sealed class ClosedSquare : ClosedShape
+    {
+        public double Side { get; set; }
+    }
+
+    private closed class ClosedEmptyBase;
+
+    private abstract class PlainAbstractBase
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class PlainAbstractDerived : PlainAbstractBase;
+
+    [YamlPolymorphic(TypeDiscriminatorPropertyName = "$kind")]
+    private closed class ClosedCustomDiscriminatorBase
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class ClosedCustomDiscriminatorDerived : ClosedCustomDiscriminatorBase
+    {
+        public int Value { get; set; }
+    }
+
+    [YamlPolymorphic]
+    [YamlDerivedType(typeof(ClosedExplicitDerived), "custom")]
+    private closed class ClosedExplicitBase
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class ClosedExplicitDerived : ClosedExplicitBase
+    {
+        public int Value { get; set; }
+    }
+
+    [YamlPolymorphic(InferClosedTypePolymorphism = true)]
+    private closed class ClosedOptInBase
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class ClosedOptInDerived : ClosedOptInBase
+    {
+        public int Value { get; set; }
+    }
+
+    [YamlPolymorphic(InferClosedTypePolymorphism = false)]
+    private closed class ClosedOptOutBase
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class ClosedOptOutDerived : ClosedOptOutBase
+    {
+        public int Value { get; set; }
+    }
+
+    [YamlPolymorphic(InferClosedTypePolymorphism = true)]
+    private abstract class NonClosedOptInBase
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class NonClosedOptInDerived : NonClosedOptInBase
+    {
+    }
+
+    private closed class ClosedContainer<T>
+    {
+        public T? BaseValue { get; set; }
+    }
+
+    private sealed class ClosedBox<T> : ClosedContainer<T>
+    {
+        public T? Value { get; set; }
+    }
+
+    private sealed class ClosedIntBag : ClosedContainer<int>
+    {
+        public int Count { get; set; }
+    }
+
+    internal closed class ClosedLessVisibleBase
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class ClosedLessVisibleDerived : ClosedLessVisibleBase
+    {
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceEmitsAndReadsDiscriminatorFromTypeName()
+    {
+        ClosedShape value = new ClosedCircle { Name = "circle", Radius = 3 };
+        var yaml = YamlSerializer.Serialize(value, typeof(ClosedShape), InferClosedTypePolymorphismOptions);
+
+        Assert.Contains("$type: ClosedCircle", yaml);
+
+        var roundtripped = YamlSerializer.Deserialize<ClosedShape>(yaml, InferClosedTypePolymorphismOptions);
+        var circle = Assert.IsType<ClosedCircle>(roundtripped);
+        Assert.Equal("circle", circle.Name);
+        Assert.Equal(3, circle.Radius);
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceRegistersEveryDerivedType()
+    {
+        ClosedShape value = new ClosedSquare { Name = "square", Side = 4 };
+        var yaml = YamlSerializer.Serialize(value, typeof(ClosedShape), InferClosedTypePolymorphismOptions);
+
+        Assert.Contains("$type: ClosedSquare", yaml);
+        Assert.IsType<ClosedSquare>(YamlSerializer.Deserialize<ClosedShape>(yaml, InferClosedTypePolymorphismOptions));
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceIsDisabledByDefault()
+    {
+        ClosedShape value = new ClosedCircle { Name = "circle", Radius = 3 };
+        var yaml = YamlSerializer.Serialize(value, typeof(ClosedShape));
+
+        Assert.DoesNotContain("$type", yaml);
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceIgnoresClosedTypeWithoutDerivedType()
+    {
+        var yaml = YamlSerializer.Serialize<ClosedEmptyBase?>(null, InferClosedTypePolymorphismOptions);
+
+        Assert.DoesNotContain("$type", yaml);
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceIsNotAppliedToPlainAbstractClass()
+    {
+        PlainAbstractBase value = new PlainAbstractDerived { Name = "plain" };
+        var yaml = YamlSerializer.Serialize(value, typeof(PlainAbstractBase), InferClosedTypePolymorphismOptions);
+
+        Assert.DoesNotContain("$type", yaml);
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceHonorsCustomDiscriminatorPropertyName()
+    {
+        ClosedCustomDiscriminatorBase value = new ClosedCustomDiscriminatorDerived { Name = "custom", Value = 42 };
+        var yaml = YamlSerializer.Serialize(value, typeof(ClosedCustomDiscriminatorBase), InferClosedTypePolymorphismOptions);
+
+        Assert.Contains("$kind: ClosedCustomDiscriminatorDerived", yaml);
+        Assert.IsType<ClosedCustomDiscriminatorDerived>(YamlSerializer.Deserialize<ClosedCustomDiscriminatorBase>(yaml, InferClosedTypePolymorphismOptions));
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceIsSuppressedByExplicitDerivedTypes()
+    {
+        ClosedExplicitBase value = new ClosedExplicitDerived { Name = "explicit", Value = 42 };
+        var yaml = YamlSerializer.Serialize(value, typeof(ClosedExplicitBase), InferClosedTypePolymorphismOptions);
+
+        Assert.Contains("$type: custom", yaml);
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceIsSuppressedByRuntimeDerivedTypeMappings()
+    {
+        var options = new YamlSerializerOptions
+        {
+            PolymorphismOptions = new YamlPolymorphismOptions
+            {
+                InferClosedTypePolymorphism = true,
+                DerivedTypeMappings =
+                {
+                    [typeof(ClosedShape)] = [new YamlDerivedType(typeof(ClosedCircle), "runtime-circle")],
+                },
+            },
+        };
+
+        ClosedShape value = new ClosedCircle { Name = "circle", Radius = 3 };
+        var yaml = YamlSerializer.Serialize(value, typeof(ClosedShape), options);
+
+        Assert.Contains("$type: runtime-circle", yaml);
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceCanBeEnabledPerType()
+    {
+        ClosedOptInBase value = new ClosedOptInDerived { Name = "opt-in", Value = 42 };
+        var yaml = YamlSerializer.Serialize(value, typeof(ClosedOptInBase));
+
+        Assert.Contains("$type: ClosedOptInDerived", yaml);
+        Assert.IsType<ClosedOptInDerived>(YamlSerializer.Deserialize<ClosedOptInBase>(yaml));
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceCanBeDisabledPerType()
+    {
+        ClosedOptOutBase value = new ClosedOptOutDerived { Name = "opt-out", Value = 42 };
+        var yaml = YamlSerializer.Serialize(value, typeof(ClosedOptOutBase), InferClosedTypePolymorphismOptions);
+
+        Assert.DoesNotContain("$type", yaml);
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceThrowsWhenEnabledOnNonClosedType()
+    {
+        NonClosedOptInBase value = new NonClosedOptInDerived { Name = "plain" };
+        var exception = Assert.Throws<InvalidOperationException>(() => YamlSerializer.Serialize(value, typeof(NonClosedOptInBase)));
+
+        Assert.Contains("is not a closed type", exception.Message);
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceThrowsWhenDerivedTypeIsLessVisibleThanBaseType()
+    {
+        ClosedLessVisibleBase value = new ClosedLessVisibleDerived { Name = "hidden" };
+        var exception = Assert.Throws<InvalidOperationException>(() => YamlSerializer.Serialize(value, typeof(ClosedLessVisibleBase), InferClosedTypePolymorphismOptions));
+
+        Assert.Contains("less visible", exception.Message);
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceResolvesGenericDerivedTypes()
+    {
+        ClosedContainer<int> value = new ClosedBox<int> { BaseValue = 7, Value = 42 };
+        var yaml = YamlSerializer.Serialize(value, typeof(ClosedContainer<int>), InferClosedTypePolymorphismOptions);
+
+        Assert.Contains("$type: ClosedBox", yaml);
+        Assert.IsType<ClosedBox<int>>(YamlSerializer.Deserialize<ClosedContainer<int>>(yaml, InferClosedTypePolymorphismOptions));
+
+        ClosedContainer<int> bag = new ClosedIntBag { BaseValue = 3, Count = 2 };
+        var bagYaml = YamlSerializer.Serialize(bag, typeof(ClosedContainer<int>), InferClosedTypePolymorphismOptions);
+
+        Assert.Contains("$type: ClosedIntBag", bagYaml);
+        Assert.IsType<ClosedIntBag>(YamlSerializer.Deserialize<ClosedContainer<int>>(bagYaml, InferClosedTypePolymorphismOptions));
+    }
+
+    private closed class ClosedNestedRoot
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private closed class ClosedNestedMiddle : ClosedNestedRoot
+    {
+        public int Level { get; set; }
+    }
+
+    private sealed class ClosedNestedLeaf : ClosedNestedMiddle
+    {
+        public string Detail { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceRegistersDirectDerivedTypesOnly()
+    {
+        ClosedNestedRoot value = new ClosedNestedLeaf { Name = "leaf", Level = 2, Detail = "detail" };
+
+        Assert.Throws<NotSupportedException>(() => YamlSerializer.Serialize(value, typeof(ClosedNestedRoot), InferClosedTypePolymorphismOptions));
+
+        ClosedNestedMiddle middleValue = new ClosedNestedLeaf { Name = "leaf", Level = 2, Detail = "detail" };
+        var yaml = YamlSerializer.Serialize(middleValue, typeof(ClosedNestedMiddle), InferClosedTypePolymorphismOptions);
+
+        Assert.Contains("$type: ClosedNestedLeaf", yaml);
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceFailsForUnknownDiscriminator()
+    {
+        Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<ClosedShape>("$type: Nonexistent\n", InferClosedTypePolymorphismOptions));
+    }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
@@ -1075,6 +1075,147 @@ public class YamlSerializerContextGeneratorDiagnosticTests
         Assert.Empty(diagnostics);
     }
 
+    [Fact]
+    public void AnalyzerReportsErrorForClosedTypePolymorphismInferenceOnNonClosedType()
+    {
+        const string Source = """
+            using Meziantou.Framework.Yaml.Serialization;
+
+            [YamlPolymorphic(InferClosedTypePolymorphism = true)]
+            public abstract class Animal
+            {
+            }
+
+            public sealed class Dog : Animal
+            {
+            }
+
+            [YamlSerializable(typeof(Animal))]
+            internal partial class NonClosedContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(Source)
+            .Where(static diagnostic => diagnostic.Id == "MFY023")
+            .ToArray();
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("Animal", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void AnalyzerReportsWarningWhenClosedTypePolymorphismInferenceIsReplacedByExplicitDerivedTypes()
+    {
+        const string Source = """
+            using Meziantou.Framework.Yaml.Serialization;
+
+            [YamlPolymorphic(InferClosedTypePolymorphism = true)]
+            [YamlDerivedType(typeof(Dog), "dog")]
+            public closed class Animal
+            {
+            }
+
+            public sealed class Dog : Animal
+            {
+            }
+
+            public sealed class Cat : Animal
+            {
+            }
+
+            [YamlSerializable(typeof(Animal))]
+            internal partial class ExplicitDerivedTypesContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(Source)
+            .Where(static diagnostic => diagnostic.Id == "MFY024")
+            .ToArray();
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Contains("Animal", diagnostic.GetMessage());
+
+        var result = RunGenerator(Source);
+        Assert.Contains("\"dog\"", result.GeneratedSource);
+        AssertGeneratedSourceDoesNotContain(result.GeneratedSource, "\"Cat\"");
+    }
+
+    [Fact]
+    public void AnalyzerReportsWarningForInferredDerivedTypeLessVisibleThanBaseType()
+    {
+        const string Source = """
+            using Meziantou.Framework.Yaml.Serialization;
+
+            public closed class Animal
+            {
+            }
+
+            public sealed class Dog : Animal
+            {
+            }
+
+            internal sealed class Cat : Animal
+            {
+            }
+
+            [YamlSourceGenerationOptions(InferClosedTypePolymorphism = true)]
+            [YamlSerializable(typeof(Animal))]
+            internal partial class LessVisibleDerivedTypeContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var diagnostics = RunAnalyzer(Source)
+            .Where(static diagnostic => diagnostic.Id == "MFY025")
+            .ToArray();
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Contains("Cat", diagnostic.GetMessage());
+        Assert.Contains("less visible", diagnostic.GetMessage());
+
+        var result = RunGenerator(Source);
+        Assert.Contains("\"Dog\"", result.GeneratedSource);
+        AssertGeneratedSourceDoesNotContain(result.GeneratedSource, "\"Cat\"");
+    }
+
+    [Fact]
+    public void GeneratorInfersDerivedTypesOfClosedHierarchy()
+    {
+        const string Source = """
+            using Meziantou.Framework.Yaml.Serialization;
+
+            public closed class Animal
+            {
+                public string Name { get; set; } = "";
+            }
+
+            public sealed class Dog : Animal
+            {
+            }
+
+            public sealed class Cat : Animal
+            {
+            }
+
+            [YamlSourceGenerationOptions(InferClosedTypePolymorphism = true)]
+            [YamlSerializable(typeof(Animal))]
+            internal partial class InferredClosedContext : YamlSerializerContext
+            {
+            }
+            """;
+
+        var result = RunGenerator(Source);
+
+        Assert.Empty(result.GeneratorDiagnostics);
+        Assert.Contains("\"Dog\"", result.GeneratedSource);
+        Assert.Contains("\"Cat\"", result.GeneratedSource);
+    }
+
     private static Diagnostic[] RunAnalyzer([StringSyntax("c#-test")] string source)
     {
         var compilation = CreateCompilation(source);

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSourceGeneratedDerivedTypeMappingTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSourceGeneratedDerivedTypeMappingTests.cs
@@ -47,6 +47,46 @@ namespace Meziantou.Framework.Yaml.Tests.Serialization.CrossProject.AttributePlu
     }
 }
 
+
+namespace Meziantou.Framework.Yaml.Tests.Serialization.ClosedHierarchy
+{
+    internal closed class Shape
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    internal sealed class Circle : Shape
+    {
+        public double Radius { get; set; }
+    }
+
+    internal sealed class Square : Shape
+    {
+        public double Side { get; set; }
+    }
+
+    [YamlPolymorphic(InferClosedTypePolymorphism = true, TypeDiscriminatorPropertyName = "$kind")]
+    internal closed class OptInShape
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    internal sealed class OptInTriangle : OptInShape
+    {
+        public double Height { get; set; }
+    }
+
+    internal sealed class ShapeHolder
+    {
+        public Shape? Shape { get; set; }
+    }
+
+    internal sealed class OptInShapeHolder
+    {
+        public OptInShape? Shape { get; set; }
+    }
+}
+
 namespace Meziantou.Framework.Yaml.Tests.Serialization
 {
     internal sealed class CrossProjectZoo
@@ -75,8 +115,79 @@ namespace Meziantou.Framework.Yaml.Tests.Serialization
         {
         }
     }
+    [YamlSourceGenerationOptions(InferClosedTypePolymorphism = true)]
+    [YamlSerializable(typeof(ClosedHierarchy.ShapeHolder))]
+    internal sealed partial class InferredClosedTypeYamlContext : YamlSerializerContext
+    {
+    }
+
+    [YamlSerializable(typeof(ClosedHierarchy.OptInShapeHolder))]
+    internal sealed partial class OptInClosedTypeYamlContext : YamlSerializerContext
+    {
+    }
+
     public class YamlSourceGeneratedDerivedTypeMappingTests
     {
+        [Fact]
+        public void GeneratedContextInfersClosedHierarchyDerivedTypes()
+        {
+            var context = new InferredClosedTypeYamlContext();
+            var typeInfo = context.ShapeHolder;
+
+            var yaml = YamlSerializer.Serialize(
+                new ClosedHierarchy.ShapeHolder
+                {
+                    Shape = new ClosedHierarchy.Circle { Name = "circle", Radius = 3 },
+                },
+                typeInfo);
+
+            Assert.Contains("$type: Circle", yaml);
+            Assert.Contains("Radius: 3", yaml);
+
+            var roundtripped = YamlSerializer.Deserialize(yaml, typeInfo);
+            var circle = Assert.IsType<ClosedHierarchy.Circle>(roundtripped?.Shape);
+            Assert.Equal("circle", circle.Name);
+            Assert.Equal(3, circle.Radius);
+        }
+
+        [Fact]
+        public void GeneratedContextInfersEveryClosedHierarchyDerivedType()
+        {
+            var context = new InferredClosedTypeYamlContext();
+            var typeInfo = context.ShapeHolder;
+
+            var yaml = YamlSerializer.Serialize(
+                new ClosedHierarchy.ShapeHolder
+                {
+                    Shape = new ClosedHierarchy.Square { Name = "square", Side = 4 },
+                },
+                typeInfo);
+
+            Assert.Contains("$type: Square", yaml);
+            Assert.IsType<ClosedHierarchy.Square>(YamlSerializer.Deserialize(yaml, typeInfo)?.Shape);
+        }
+
+        [Fact]
+        public void GeneratedContextInfersClosedHierarchyFromTypeLevelOptIn()
+        {
+            var context = new OptInClosedTypeYamlContext();
+            var typeInfo = context.OptInShapeHolder;
+
+            var yaml = YamlSerializer.Serialize(
+                new ClosedHierarchy.OptInShapeHolder
+                {
+                    Shape = new ClosedHierarchy.OptInTriangle { Name = "triangle", Height = 5 },
+                },
+                typeInfo);
+
+            Assert.Contains("$kind: OptInTriangle", yaml);
+
+            var roundtripped = YamlSerializer.Deserialize(yaml, typeInfo);
+            var triangle = Assert.IsType<ClosedHierarchy.OptInTriangle>(roundtripped?.Shape);
+            Assert.Equal("triangle", triangle.Name);
+            Assert.Equal(5, triangle.Height);
+        }
+
         [Fact]
         public void GeneratedContextSupportsCrossProjectPropertyDiscriminatorMappings()
         {


### PR DESCRIPTION
A `closed` class hierarchy already records its derived types in metadata, so they do not need to be repeated with `[YamlDerivedType]`. This adds an opt-in `InferClosedTypePolymorphism` setting that registers every direct derived type of a closed base type automatically, using the derived type name, without the generic arity suffix, as its discriminator.

```csharp
public closed class Shape
{
    public string Name { get; set; } = "";
}

public sealed class Circle : Shape { public double Radius { get; set; } }
public sealed class Square : Shape { public double Side { get; set; } }

var options = new YamlSerializerOptions
{
    PolymorphismOptions = new YamlPolymorphismOptions { InferClosedTypePolymorphism = true },
};

Shape shape = new Circle { Name = "circle", Radius = 3 };
var yaml = YamlSerializer.Serialize(shape, options); // $type: Circle
```

## API

| Member | Purpose |
| --- | --- |
| `YamlPolymorphismOptions.InferClosedTypePolymorphism` | serializer-wide opt-in, `false` by default |
| `YamlPolymorphicAttribute.InferClosedTypePolymorphism` | per-type override, so an explicit `false` excludes a type from a global opt-in |
| `YamlSourceGenerationOptionsAttribute.InferClosedTypePolymorphism` | source-generation counterpart |

Explicit registrations replace inference: a type declaring `[YamlDerivedType]` or a runtime mapping registers only those derived types. Open generic derived types are closed over the base type arguments through the existing unification logic, so a generic closed hierarchy works per instantiation.

## Implementation notes

- The reflection resolver matches the compiler-emitted `System.Runtime.CompilerServices.IsClosedTypeAttribute` by full name through `CustomAttributeData`, instead of a compile-time type reference. That way inference also works on `net10.0`, where the compiler emits its own copy of the attribute rather than using the one from the runtime.
- The source generator reads `ITypeSymbol.IsClosed` through reflection light-up and reconstructs the derived type set from the symbol model, because Roslyn filters the synthesized `[IsClosedType]` out of `GetAttributes()`. This keeps the generator's Roslyn floor at 5.6.0, so it still loads on the .NET 10 SDK. Only the test project moves to 5.9.0, because its in-process compiler has to parse the `closed` keyword.
- A derived type must be at least as visible as the base type it is registered under, otherwise the generated context could not reference it. The check compares effective visibility, that is the most restrictive accessibility on the type and on every type it is nested in.

## Diagnostics

| Id | Severity | Reported when |
| --- | --- | --- |
| `MFY023` | Error | `[YamlPolymorphic(InferClosedTypePolymorphism = true)]` on a type that is not declared `closed` |
| `MFY024` | Warning | inference is enabled but explicit registrations are declared, which replace it |
| `MFY025` | Warning | an inferred derived type is ignored, because it is less visible than the base type, its discriminator collides, or it cannot be resolved for the base type |

The reflection resolver throws an `InvalidOperationException` in the same situations.

## Behavior worth calling out

Only the direct derived types of a closed base type are registered, as with explicit registrations: when a derived type is itself `closed`, its own derived types are registered under it and not under the root of the hierarchy. Serializing a grand-derived instance through the root base still throws `NotSupportedException`, unchanged from the current behavior for explicit registrations. `ClosedTypeInferenceRegistersDirectDerivedTypesOnly` pins this down.

## Validation

- 1718 tests pass on `net10.0` and `net11.0`, 21 of them new, covering the reflection path, the generated contexts, and the generator diagnostics.
- `dotnet run ./eng/update-all.cs` was run, `ref/Meziantou.Framework.Yaml.cs` regenerated.
- `readme.md` documents the feature in a new "Closed hierarchies" section.
