### PR TITLE
Fix C# constant for Roslyn 5.9 and add data flow opt-out overloads

### DIFF
--- a/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
+++ b/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
@@ -17,16 +17,28 @@ internal static partial class LocalDataFlowAnalysis
 {
     public static ITypeSymbol? GetActualType(this IOperation operation, CancellationToken cancellationToken)
     {
+        return operation.GetActualType(useDataFlowAnalysis: true, cancellationToken);
+    }
+
+    public static ITypeSymbol? GetActualType(this IOperation operation, bool useDataFlowAnalysis, CancellationToken cancellationToken)
+    {
         operation = operation.UnwrapImplicitConversions();
+        if (!useDataFlowAnalysis)
+            return operation.Type;
 
         var value = GetFlowValue(operation, cancellationToken);
         if (value is not null && value != operation)
-            return GetActualType(value, cancellationToken);
+            return GetActualType(value, useDataFlowAnalysis, cancellationToken);
 
         return operation.Type;
     }
 
     public static bool TryGetConstantValue(this IOperation operation, out object? value, CancellationToken cancellationToken)
+    {
+        return operation.TryGetConstantValue(useDataFlowAnalysis: true, out value, cancellationToken);
+    }
+
+    public static bool TryGetConstantValue(this IOperation operation, bool useDataFlowAnalysis, out object? value, CancellationToken cancellationToken)
     {
         operation = operation.UnwrapImplicitConversions();
         if (operation.ConstantValue.HasValue)
@@ -35,9 +47,12 @@ internal static partial class LocalDataFlowAnalysis
             return true;
         }
 
-        var flowValue = GetFlowValue(operation, cancellationToken);
-        if (flowValue is not null && flowValue != operation)
-            return TryGetConstantValue(flowValue, out value, cancellationToken);
+        if (useDataFlowAnalysis)
+        {
+            var flowValue = GetFlowValue(operation, cancellationToken);
+            if (flowValue is not null && flowValue != operation)
+                return TryGetConstantValue(flowValue, useDataFlowAnalysis, out value, cancellationToken);
+        }
 
         value = null;
         return false;

--- a/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
+++ b/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Description>Source helpers for Roslyn analyzers and source generators</Description>
 
     <developmentDependency>true</developmentDependency>

--- a/src/Meziantou.Framework.Roslyn/buildTransitive/Meziantou.Framework.Roslyn.targets
+++ b/src/Meziantou.Framework.Roslyn/buildTransitive/Meziantou.Framework.Roslyn.targets
@@ -95,7 +95,6 @@
       <_MeziantouFrameworkRoslynConstant Include="CSHARP13_OR_GREATER" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_MeziantouFrameworkRoslynVersion)', '4.14.0'))" />
       <_MeziantouFrameworkRoslynConstant Include="CSHARP14_OR_GREATER" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_MeziantouFrameworkRoslynVersion)', '5.0.0'))" />
       <_MeziantouFrameworkRoslynConstant Include="CSHARP15_OR_GREATER" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_MeziantouFrameworkRoslynVersion)', '5.6.0'))" />
-      <_MeziantouFrameworkRoslynConstant Include="CSHARP16_OR_GREATER" Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(_MeziantouFrameworkRoslynVersion)', '5.9.0'))" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/tests/Meziantou.Framework.Roslyn.PackageTests/RoslynPackageTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.PackageTests/RoslynPackageTests.cs
@@ -164,6 +164,7 @@ public sealed class RoslynPackageTests(RoslynPackageFixture fixture) : IClassFix
                 public static int? GetNodeLine(SyntaxNode node, CancellationToken cancellationToken) => node.GetLine(cancellationToken);
                 public static bool IsCSharp12(LanguageVersion languageVersion) => languageVersion.IsCSharp12OrGreater();
                 public static ITypeSymbol? GetFlowType(IOperation operation, CancellationToken cancellationToken) => LocalDataFlowAnalysis.GetActualType(operation, cancellationToken);
+                public static ITypeSymbol? GetUnwrappedType(IOperation operation, CancellationToken cancellationToken) => LocalDataFlowAnalysis.GetActualType(operation, useDataFlowAnalysis: false, cancellationToken);
                 public static string ReporterName => typeof(DiagnosticReporter).Name;
                 public static DiagnosticInvocationReportOptions InvocationReportOptions => DiagnosticInvocationReportOptions.ReportOnMember | DiagnosticInvocationReportOptions.ReportOnArguments;
             }

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -266,6 +266,48 @@ public sealed class RoslynHelperTests
     }
 
     [Fact]
+    public void GetActualType_WithoutDataFlowAnalysis_OnlyUnwrapsConversions()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                public void M()
+                {
+                    object value = 42;
+                    object boxed = value;
+                }
+            }
+            """);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.Equal(SpecialType.System_Int32, boxed.GetActualType(useDataFlowAnalysis: true, default)?.SpecialType);
+        Assert.Equal(SpecialType.System_Object, boxed.GetActualType(useDataFlowAnalysis: false, default)?.SpecialType);
+    }
+
+    [Fact]
+    public void TryGetConstantValue_WithoutDataFlowAnalysis_OnlyUsesTheUnwrappedOperationValue()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                public void M()
+                {
+                    var value = 42;
+                    object boxed = value;
+                }
+            }
+            """);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.True(boxed.TryGetConstantValue(useDataFlowAnalysis: true, out var flowValue, default));
+        Assert.Equal(42, flowValue);
+        Assert.False(boxed.TryGetConstantValue(useDataFlowAnalysis: false, out var unwrappedValue, default));
+        Assert.Null(unwrappedValue);
+    }
+
+    [Fact]
     public void IsPrimaryConstructor_ReturnsTrueForPrimaryClassConstructor()
     {
         var compilation = CreateCompilation("""


### PR DESCRIPTION
## Roslyn 5.9 constants

`Meziantou.Framework.Roslyn.targets` defined `CSHARP16_OR_GREATER` for Roslyn 5.9. Enumerating `LanguageVersion` from `Microsoft.CodeAnalysis.CSharp` 5.9.0 shows it still tops out at `CSharp14 = 1400` (no `CSharp15` member), so `Preview` still means C# 15 — exactly what `CSHARP15_OR_GREATER` covers since Roslyn 5.6. The constant is removed; `ROSLYN_5_9_OR_GREATER` is unchanged.

Package version bumped to 1.0.2.

## LocalDataFlowAnalysis overloads

`GetActualType` and `TryGetConstantValue` now have overloads taking a `useDataFlowAnalysis` parameter, so a caller can ask for conversion unwrapping only, without walking local assignments and member initializers. The existing overloads keep their behavior (`useDataFlowAnalysis: true`).

## Validation

- `dotnet run ./eng/update-all.cs` — no changes
- `Meziantou.Framework.Roslyn.Tests` (Roslyn 4.8 / 5.0 / 5.3 / 5.6, net10.0 + net11.0): 132 passed per variant, 0 failed
- `Meziantou.Framework.Roslyn.PackageTests`: 8 passed, 0 failed (the consumer project built by those tests exercises the new overload)