### PR TITLE
Embed the Roslyn source package types

### DIFF
--- a/src/Meziantou.Framework.Roslyn/CompilationExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/CompilationExtensions.cs
@@ -7,6 +7,9 @@ using Microsoft.CodeAnalysis;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 internal static partial class CompilationExtensions
 {
     public static bool IsNet9OrGreater(this Compilation compilation)

--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.cs
@@ -13,6 +13,9 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 internal static partial class ContextExtensions
 {
     private static Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, Location? location, ImmutableDictionary<string, string?>? properties, object?[]? messageArgs)

--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticFieldReportOptions.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticFieldReportOptions.cs
@@ -6,6 +6,9 @@ using System;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 [Flags]
 internal enum DiagnosticFieldReportOptions
 {

--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticInvocationReportOptions.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticInvocationReportOptions.cs
@@ -6,6 +6,9 @@ using System;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 [Flags]
 internal enum DiagnosticInvocationReportOptions
 {

--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticMethodReportOptions.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticMethodReportOptions.cs
@@ -6,6 +6,9 @@ using System;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 [Flags]
 internal enum DiagnosticMethodReportOptions
 {

--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticParameterReportOptions.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticParameterReportOptions.cs
@@ -6,6 +6,9 @@ using System;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 [Flags]
 internal enum DiagnosticParameterReportOptions
 {

--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticPropertyReportOptions.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticPropertyReportOptions.cs
@@ -6,6 +6,9 @@ using System;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 [Flags]
 internal enum DiagnosticPropertyReportOptions
 {

--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticReporter.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/DiagnosticReporter.cs
@@ -9,6 +9,9 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 internal readonly struct DiagnosticReporter
 {
     private readonly Action<Diagnostic> _reportDiagnostic;

--- a/src/Meziantou.Framework.Roslyn/EmbeddedAttribute.cs
+++ b/src/Meziantou.Framework.Roslyn/EmbeddedAttribute.cs
@@ -1,0 +1,14 @@
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_ENABLE_WARNINGS
+#pragma warning disable
+#endif
+#nullable enable
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE && !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE_DECLARATION
+// The compiler only matches the attribute by its full name, so the usages don't need to be restricted
+#pragma warning disable CA1018 // Mark attributes with AttributeUsageAttribute
+namespace Microsoft.CodeAnalysis;
+
+// The type is partial and has no attribute, so it can be merged with the declarations emitted by other source generators or packages
+internal sealed partial class EmbeddedAttribute : global::System.Attribute
+{
+}
+#endif

--- a/src/Meziantou.Framework.Roslyn/LanguageVersionExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/LanguageVersionExtensions.cs
@@ -9,6 +9,9 @@ using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 internal static partial class LanguageVersionExtensions
 {
     public static LanguageVersion GetCSharpLanguageVersion(this IOperation operation)

--- a/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
+++ b/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
@@ -13,6 +13,9 @@ using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 internal static partial class LocalDataFlowAnalysis
 {
     public static ITypeSymbol? GetActualType(this IOperation operation, CancellationToken cancellationToken)

--- a/src/Meziantou.Framework.Roslyn/LocationExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/LocationExtensions.cs
@@ -7,6 +7,9 @@ using Microsoft.CodeAnalysis;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 internal static partial class LocationExtensions
 {
     /// <summary>

--- a/src/Meziantou.Framework.Roslyn/MethodSymbolExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/MethodSymbolExtensions.cs
@@ -10,6 +10,9 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 internal static partial class MethodSymbolExtensions
 {
     public static bool IsPrimaryConstructor(this IMethodSymbol? methodSymbol, CancellationToken cancellationToken, bool includeRecordDeclarations = false)

--- a/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
+++ b/src/Meziantou.Framework.Roslyn/Meziantou.Framework.Roslyn.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFramework);netstandard2.0</TargetFrameworks>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <Description>Source helpers for Roslyn analyzers and source generators</Description>
 
     <developmentDependency>true</developmentDependency>

--- a/src/Meziantou.Framework.Roslyn/NamespaceSymbolExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/NamespaceSymbolExtensions.cs
@@ -7,6 +7,9 @@ using Microsoft.CodeAnalysis;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 internal static partial class NamespaceSymbolExtensions
 {
     public static bool MatchesNamespace(this INamespaceSymbol namespaceSymbol, ReadOnlySpan<string> namespaceParts)

--- a/src/Meziantou.Framework.Roslyn/OperationExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/OperationExtensions.cs
@@ -10,6 +10,9 @@ using Microsoft.CodeAnalysis.Operations;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 internal static partial class OperationExtensions
 {
     public static IEnumerable<IOperation> Ancestors(this IOperation operation)

--- a/src/Meziantou.Framework.Roslyn/SuppressorHelpers.cs
+++ b/src/Meziantou.Framework.Roslyn/SuppressorHelpers.cs
@@ -7,6 +7,9 @@ using Microsoft.CodeAnalysis;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 internal static partial class SuppressorHelpers
 {
     public static SyntaxNode? FindNode(this Diagnostic diagnostic, CancellationToken cancellationToken)

--- a/src/Meziantou.Framework.Roslyn/SymbolAttributeExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/SymbolAttributeExtensions.cs
@@ -8,6 +8,9 @@ using Microsoft.CodeAnalysis;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 internal static partial class SymbolAttributeExtensions
 {
     public static IEnumerable<AttributeData> GetAttributes(this ISymbol symbol, ITypeSymbol? attributeType, bool inherits = true)

--- a/src/Meziantou.Framework.Roslyn/SymbolExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/SymbolExtensions.cs
@@ -9,6 +9,9 @@ using Microsoft.CodeAnalysis;
 
 namespace Meziantou.Framework.Roslyn;
 
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 internal static partial class SymbolExtensions
 {
     public static bool IsVisibleOutsideOfAssembly([NotNullWhen(true)] this ISymbol? symbol)

--- a/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
@@ -10,6 +10,9 @@ using Microsoft.CodeAnalysis;
 namespace Meziantou.Framework.Roslyn;
 
 // http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Shared/Extensions/ITypeSymbolExtensions.cs,190b4ed0932458fd,references
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
 internal static partial class TypeSymbolExtensions
 {
     public static IList<INamedTypeSymbol> GetAllInterfacesIncludingSelf(this ITypeSymbol type)

--- a/src/Meziantou.Framework.Roslyn/readme.md
+++ b/src/Meziantou.Framework.Roslyn/readme.md
@@ -39,6 +39,28 @@ using Meziantou.Framework.Roslyn;
 
 The package also defines Roslyn and C# feature constants before compilation based on the referenced `Microsoft.CodeAnalysis.*` package version, such as `ROSLYN_4_8_OR_GREATER` and `CSHARP12_OR_GREATER`.
 
+## Type embedding
+
+All types are decorated with `[Microsoft.CodeAnalysis.Embedded]`, so the compiler hides them from other assemblies. This means the helpers don't conflict when an assembly that uses this package exposes its internals with `[InternalsVisibleTo]` to another assembly that also uses it (`warning CS0436`).
+
+The package declares `Microsoft.CodeAnalysis.EmbeddedAttribute` as an `internal sealed partial class` without any attribute on it, so it can be merged with the declarations emitted by other source generators or packages.
+
+Define the `MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE` constant to opt out of both the attribute usages and the attribute declaration:
+
+````xml
+<PropertyGroup>
+  <DefineConstants>$(DefineConstants);MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE</DefineConstants>
+</PropertyGroup>
+````
+
+If the attribute is already declared in the project in a way that conflicts with this declaration, define `MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE_DECLARATION` instead. The types are still marked as embedded, but the attribute must be provided by the project:
+
+````xml
+<PropertyGroup>
+  <DefineConstants>$(DefineConstants);MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE_DECLARATION</DefineConstants>
+</PropertyGroup>
+````
+
 ## Compiler warnings
 
 The helper files suppress all compiler warnings so they don't pollute the consuming project's build. Define the `MEZIANTOU_FRAMEWORK_ROSLYN_ENABLE_WARNINGS` constant to report them:

--- a/tests/Meziantou.Framework.Roslyn.PackageTests/RoslynPackageTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.PackageTests/RoslynPackageTests.cs
@@ -14,6 +14,7 @@ public sealed class RoslynPackageTests(RoslynPackageFixture fixture) : IClassFix
         Assert.Contains("ReportDiagnostic", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/ContextExtensions.cs")));
         Assert.Contains("SyntaxNodeAnalysisContext", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/ContextExtensions.g.cs")));
         Assert.Contains("DiagnosticReporter", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/DiagnosticReporter.cs")));
+        Assert.Contains("class EmbeddedAttribute", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/EmbeddedAttribute.cs")));
         Assert.Contains("IsInterfaceImplementation", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/MethodSymbolExtensions.cs")));
         Assert.Contains("MatchesNamespace", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/NamespaceSymbolExtensions.cs")));
         Assert.Contains("UnwrapImplicitConversions", ReadEntryText(AssertEntry(package, "contentFiles/cs/any/Meziantou.Framework.Roslyn/OperationExtensions.cs")));
@@ -44,6 +45,21 @@ public sealed class RoslynPackageTests(RoslynPackageFixture fixture) : IClassFix
             .ToArray();
 
         Assert.Empty(entriesWithoutGuard);
+    }
+
+    [Fact]
+    public void Package_SourceFilesMarkTypesAsEmbeddedUnlessOptedOut()
+    {
+        using var package = ZipFile.OpenRead(fixture.PackagePath);
+
+        var entriesWithoutEmbeddedAttribute = package.Entries
+            .Where(entry => entry.FullName.StartsWith(SourceEntryPrefix, StringComparison.Ordinal) && entry.FullName.EndsWith(".cs", StringComparison.Ordinal))
+            .Where(entry => !SourceFileNamesWithoutEmbeddedAttribute.Contains(entry.FullName[SourceEntryPrefix.Length..], StringComparer.Ordinal))
+            .Where(entry => !ReadEntryText(entry).ReplaceLineEndings("\n").Contains(EmbeddedAttributeGuard, StringComparison.Ordinal))
+            .Select(entry => entry.FullName)
+            .ToArray();
+
+        Assert.Empty(entriesWithoutEmbeddedAttribute);
     }
 
     [Fact]
@@ -117,6 +133,75 @@ public sealed class RoslynPackageTests(RoslynPackageFixture fixture) : IClassFix
 
         await RunDotNetCommand(projectDirectory, ["restore", "--disable-build-servers"], expectedExitCode: 0);
         await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 0);
+    }
+
+    [Fact]
+    public async Task Package_EmbedsTypesSoTheyDoNotConflictWithInternalsVisibleTo()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var rootDirectory = CreateInternalsVisibleToProjects(temporaryDirectory, "consumer-ivt", additionalProperties: "");
+
+        await RunDotNetCommand(rootDirectory / "Consumer", ["restore", "--disable-build-servers"], expectedExitCode: 0);
+        var result = await RunDotNetCommand(rootDirectory / "Consumer", ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 0);
+
+        var output = string.Join('\n', result.Output);
+        Assert.DoesNotContain("CS0436", output);
+    }
+
+    [Fact]
+    public async Task Package_DoesNotEmbedTypesWhenOptedOut()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var rootDirectory = CreateInternalsVisibleToProjects(temporaryDirectory, "consumer-ivt-optout", additionalProperties: "<DefineConstants>$(DefineConstants);MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE</DefineConstants>");
+
+        await RunDotNetCommand(rootDirectory / "Consumer", ["restore", "--disable-build-servers"], expectedExitCode: 0);
+        var result = await RunDotNetCommand(rootDirectory / "Consumer", ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 1);
+
+        var output = string.Join('\n', result.Output);
+        Assert.Contains("CS0436", output);
+    }
+
+    private FullPath CreateInternalsVisibleToProjects(TemporaryDirectory temporaryDirectory, string directoryName, string additionalProperties)
+    {
+        var rootDirectory = temporaryDirectory.CreateDirectory(directoryName);
+        CreateGlobalJson(rootDirectory, fixture.DotnetSdkVersion);
+        CreateNuGetConfig(rootDirectory, fixture.PackagesDirectory);
+
+        temporaryDirectory.CreateTextFile($"{directoryName}/Directory.Build.props", $$"""
+            <Project>
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+                <TreatsWarningsAsErrors>true</TreatsWarningsAsErrors>
+                <NoWarn>nullable</NoWarn>
+                {{additionalProperties}}
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="{{RoslynPackageFixture.PackageName}}" Version="{{fixture.PackageVersion}}" PrivateAssets="all" />
+                <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" PrivateAssets="all" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        temporaryDirectory.CreateTextFile($"{directoryName}/Library/Library.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk" />
+            """);
+        temporaryDirectory.CreateTextFile($"{directoryName}/Library/AssemblyInfo.cs", """
+            [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Consumer")]
+            """);
+        temporaryDirectory.CreateTextFile($"{directoryName}/Library/Library.cs", CreateConsumerSourceWithConstantChecks([]));
+
+        temporaryDirectory.CreateTextFile($"{directoryName}/Consumer/Consumer.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <ProjectReference Include="../Library/Library.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        temporaryDirectory.CreateTextFile($"{directoryName}/Consumer/Consumer.cs", CreateConsumerSourceWithConstantChecks([]));
+
+        return rootDirectory;
     }
 
     private static ZipArchiveEntry AssertEntry(ZipArchive archive, string entryName)
@@ -291,6 +376,21 @@ public sealed class RoslynPackageTests(RoslynPackageFixture fixture) : IClassFix
 
         """;
 
+    private const string EmbeddedAttributeGuard = """
+        #if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+        [Microsoft.CodeAnalysis.Embedded]
+        #endif
+        """;
+
+    /// <summary>
+    /// <c>EmbeddedAttribute.cs</c> declares the attribute itself, and <c>ContextExtensions.g.cs</c> is another part of a type already marked in <c>ContextExtensions.cs</c>.
+    /// </summary>
+    private static readonly string[] SourceFileNamesWithoutEmbeddedAttribute =
+    [
+        "ContextExtensions.g.cs",
+        "EmbeddedAttribute.cs",
+    ];
+
     private static readonly string[] SourceFileNames =
     [
         "CompilationExtensions.cs",
@@ -302,6 +402,7 @@ public sealed class RoslynPackageTests(RoslynPackageFixture fixture) : IClassFix
         "DiagnosticParameterReportOptions.cs",
         "DiagnosticPropertyReportOptions.cs",
         "DiagnosticReporter.cs",
+        "EmbeddedAttribute.cs",
         "LanguageVersionExtensions.cs",
         "LocalDataFlowAnalysis.cs",
         "LocationExtensions.cs",


### PR DESCRIPTION
Every type shipped by `Meziantou.Framework.Roslyn` is now decorated with `[Microsoft.CodeAnalysis.Embedded]`, so the compiler hides them from other assemblies.

## Why

The package compiles its helpers into the consuming project. When an analyzer assembly that uses the package exposes its internals with `[InternalsVisibleTo]` to another assembly that also uses it (an analyzer and its code fix, an assembly and its test project…), the second compilation sees both its own copy and the imported one and reports `warning CS0436` for every helper. Marking the types as embedded makes the compiler skip them when importing the referenced assembly.

## What changed

- All 18 types are decorated with `[Microsoft.CodeAnalysis.Embedded]`. The attribute is applied to a single part of the partial `ContextExtensions`, as a duplicated non-`AllowMultiple` attribute across parts is `CS0579`.
- New `EmbeddedAttribute.cs` declaring `Microsoft.CodeAnalysis.EmbeddedAttribute`. The compiler never synthesizes it (verified from `LangVersion` 8 to `preview`: without a source declaration, applying the attribute is `CS0234`), so the package has to ship it. It is declared as an attribute-free `internal sealed partial class`, like the ones emitted by the source generators of this repository, so it merges with the declarations coming from other generators or packages instead of conflicting with them.
- Opt-out constants:
  - `MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE` removes both the usages and the declaration.
  - `MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE_DECLARATION` removes only the declaration, for projects where the attribute already exists in a way that conflicts with this one. The types stay embedded and the project provides the attribute.
- Package version `1.0.2` → `1.0.3` and readme updated.

## Notes for the reviewer

- `EmbeddedAttribute.cs` carries a `#pragma warning disable CA1018`. With `MEZIANTOU_FRAMEWORK_ROSLYN_ENABLE_WARNINGS`, the analyzer asks for an `[AttributeUsage]`, but adding one would break the merge with the parts declared by other generators. The compiler matches this attribute by its full name only, so restricting the targets brings nothing.
- The two new end-to-end tests build a `Library` + `Consumer` pair linked by `[InternalsVisibleTo]` with `TreatWarningsAsErrors`. The default build succeeds without `CS0436`; the same setup with the opt-out constant fails **with** `CS0436`. The second test is what proves the conflict is real and that the attribute is what removes it.
- A third test asserts every packed source file contains the attribute, so a new helper file can't silently miss it.

## Validation

All commands run with `/p:TreatsWarningsAsErrors=true`:

| | |
|---|---|
| `Meziantou.Framework.Roslyn.PackageTests` | 14 passed (7 methods × 2 TFM) |
| `Meziantou.Framework.Roslyn.Tests` (Roslyn 4.8 / 5.0 / 5.3 / 5.6) | build clean, 132 passed on 5.6 |
| `Meziantou.Framework.FullPath.Analyzer.Tests` | 105 passed |
| `Meziantou.Framework.Assertions.Analyzer.Tests` | 203 passed |
| `Meziantou.Framework.FastEnumGenerator.GeneratorTests` | 86 passed |
| `Meziantou.Framework.StronglyTypedId.GeneratorTests` | 172 passed |
| `Meziantou.Framework.Yaml.Tests` | 1674 passed |

The 7 in-repo projects that compile these sources all build clean. `dotnet run ./eng/update-all.cs` reports no change.
