### PR TITLE
Reduce allocations in Meziantou.Extensions.Logging.InMemory

### DIFF
--- a/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogEntry.cs
+++ b/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogEntry.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
@@ -132,7 +133,20 @@ public sealed class InMemoryLogEntry
             return false;
         }
 
-        if (owner is IEnumerable<KeyValuePair<string, object?>> stateDictionary)
+        // Most states and scopes (such as FormattedLogValues) are indexable, so avoid allocating an enumerator
+        if (owner is IReadOnlyList<KeyValuePair<string, object?>> stateList)
+        {
+            for (var i = 0; i < stateList.Count; i++)
+            {
+                var item = stateList[i];
+                if (string.Equals(name, item.Key, StringComparison.Ordinal))
+                {
+                    result = item.Value;
+                    return true;
+                }
+            }
+        }
+        else if (owner is IEnumerable<KeyValuePair<string, object?>> stateDictionary)
         {
             foreach (var item in stateDictionary)
             {
@@ -144,7 +158,7 @@ public sealed class InMemoryLogEntry
             }
         }
 
-        var property = owner.GetType().GetProperty(name, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+        var property = owner.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
         if (property is not null)
         {
             result = property.GetValue(owner);

--- a/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogger.cs
+++ b/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogger.cs
@@ -16,6 +16,9 @@ namespace Meziantou.Extensions.Logging.InMemory;
 /// </example>
 public class InMemoryLogger : IInMemoryLogger
 {
+    [ThreadStatic]
+    private static List<object?>? s_scopeBuffer;
+
     private readonly string? _category;
     private readonly IExternalScopeProvider _scopeProvider;
     private readonly TimeProvider _timeProvider;
@@ -69,8 +72,23 @@ public class InMemoryLogger : IInMemoryLogger
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
         var now = _timeProvider.GetUtcNow();
-        var scopes = new List<object?>();
-        _scopeProvider.ForEachScope((current, scopes) => scopes.Add(current), scopes);
+        var scopes = GetScopes();
         Logs.Add(new InMemoryLogEntry(now, _category, logLevel, eventId, scopes, state, exception, formatter(state, exception)));
+    }
+
+    private object?[] GetScopes()
+    {
+        // Collect the scopes in a thread-local buffer, so no allocation occurs when there is no scope,
+        // and a single right-sized array is allocated otherwise.
+        var buffer = s_scopeBuffer ??= [];
+        try
+        {
+            _scopeProvider.ForEachScope((current, scopes) => scopes.Add(current), buffer);
+            return buffer.Count is 0 ? [] : buffer.ToArray();
+        }
+        finally
+        {
+            buffer.Clear();
+        }
     }
 }

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
@@ -120,6 +120,49 @@ public sealed partial class InMemoryLoggerTests
         Assert.Equal(["test", "John"], log.GetAllParameterValues("Name"));
     }
 
+    [Fact]
+    public void TryGetParameterValue_DictionaryScope()
+    {
+        using var provider = new InMemoryLoggerProvider(new LoggerExternalScopeProvider());
+        var logger = provider.CreateLogger("my_category");
+        using (logger.BeginScope(new Dictionary<string, object?>(StringComparer.Ordinal) { ["Age"] = 52, ["Name"] = "John" }))
+        {
+            logger.LogInformation("Test {Number}", 1);
+        }
+
+        var log = provider.Logs.Informations.Single();
+        Assert.True(log.TryGetParameterValue("Number", out var number));
+        Assert.Equal(1, number);
+        Assert.True(log.TryGetParameterValue("Name", out var name));
+        Assert.Equal("John", name);
+        Assert.True(log.TryGetParameterValue("Age", out var age));
+        Assert.Equal(52, age);
+        Assert.False(log.TryGetParameterValue("Unknown", out var unknown));
+        Assert.Null(unknown);
+    }
+
+    [Fact]
+    public void WithScope_Parallel()
+    {
+        using var provider = new InMemoryLoggerProvider(new LoggerExternalScopeProvider());
+        var logger = provider.CreateLogger("my_category");
+        Parallel.For(0, 10_000, i =>
+        {
+            using (logger.BeginScope(new Dictionary<string, object?>(StringComparer.Ordinal) { ["Index"] = i }))
+            {
+                logger.LogInformation("Test {Number}", i);
+            }
+        });
+
+        Assert.HasCount(10_000, provider.Logs);
+        foreach (var log in provider.Logs)
+        {
+            var scope = Assert.Single(log.Scopes);
+            Assert.True(log.TryGetParameterValue("Number", out var number));
+            Assert.Equal(number, Assert.IsType<Dictionary<string, object?>>(scope)["Index"]);
+        }
+    }
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Value is {value}")]
     private static partial void Log(ILogger logger, int value);
 


### PR DESCRIPTION
## What

Two allocation reductions in `Meziantou.Extensions.Logging.InMemory`, no public API change (`ref/` is unchanged).

**`InMemoryLogger.Log`** allocated a `List<object?>` on every log call to collect the ambient scopes, even when there was no scope at all. Scopes are now gathered into a `[ThreadStatic]` buffer and copied into a right-sized `object?[]`: nothing is allocated when there is no scope, and a single exact-size array is allocated otherwise, instead of a `List` plus its doubling backing array.

**`InMemoryLogEntry.TryGetValue`** enumerated the state and each scope through `IEnumerable<KeyValuePair<string, object?>>`, which allocates a boxed enumerator per inspected object. `FormattedLogValues` and the states generated by `LoggerMessage` implement `IReadOnlyList<KeyValuePair<string, object?>>`, so an indexed fast path is used when available; other states (e.g. a `Dictionary<string, object?>` scope) keep the existing enumeration path.

## Why

Measured on 200k operations (net10.0, Release, arm64):

| Scenario | Before | After |
|---|---|---|
| `LogInformation`, no scope | 283 ns / 304 B | 278 ns / 272 B |
| `LogInformation`, 2 scopes | 348 ns / 360 B | 311 ns / 312 B |
| `TryGetParameterValue` (found) | 30 ns / 72 B | **13 ns / 0 B** |
| `TryGetParameterValue` (miss) | 97 ns / 168 B | 91 ns / 88 B |

The allocation savings matter more than the byte counts suggest: the collection retains every entry, so those bytes survive to gen1/gen2 instead of dying in gen0. Of the remaining ~272 B per entry, about 104 B comes from `Microsoft.Extensions.Logging` itself (the `params object[]` and the boxed `FormattedLogValues`) and cannot be avoided while `State` is exposed.

## Tests

Two tests added to `InMemoryLoggerTests`:
- `TryGetParameterValue_DictionaryScope` covers the non-indexable branch (a `Dictionary<string, object?>` scope) and a missing parameter name.
- `WithScope_Parallel` logs 10k entries in parallel with a per-iteration scope and asserts each entry captured its own scope, exercising the reused thread-local buffer.

`Meziantou.Extensions.Logging.InMemory.Tests` (22), `Meziantou.Framework.HttpClientMock.Tests` (26) and `Meziantou.Framework.Http.ServerSideRequestForgery.Tests` (50) pass, built with `/p:TreatsWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` produces no changes.

## Notes for the reviewer

Two things I measured and deliberately did **not** do:

- Caching `Type.GetProperty` results in a `ConcurrentDictionary`: `GetProperty` is already ~11 ns and allocation-free on .NET 10, while `GetOrAdd` costs ~23 ns, so the cache made the lookup slower.
- Packing `InMemoryLogEntry` (storing a `DateTime` instead of a `DateTimeOffset`, splitting `EventId`) would save ~16 B per entry, but it would discard the offset a custom `TimeProvider` may return (e.g. `FakeTimeProvider.SetUtcNow` with a non-zero offset).

Unrelated pre-existing issue spotted while reading the code: `Find`, `GetByLogLevel`, `ToString` and `Enumerator` read `_firstChunk`/`Count` outside the lock, and `Add` links a new chunk before writing the entry into it, so enumerating while another thread logs can observe a chunk whose `Count` is still 0. Not addressed here.