### PR TITLE
Add rolling, formatters, and DI support to Meziantou.Extensions.Logging.FileLogger

### DIFF
--- a/ref/Meziantou.Extensions.Logging.FileLogger.cs
+++ b/ref/Meziantou.Extensions.Logging.FileLogger.cs
@@ -91,9 +91,16 @@ namespace Meziantou.Extensions.Logging
 
     public enum LogFileCompression
     {
+        #if NET10_0
         None = 0,
         GZip = 1,
         Brotli = 2
+        #elif NET11_0
+        None = 0,
+        GZip = 1,
+        Brotli = 2,
+        Zstandard = 3
+        #endif
     }
 
     public enum LogFileCompressionMode

--- a/ref/Meziantou.Extensions.Logging.FileLogger.cs
+++ b/ref/Meziantou.Extensions.Logging.FileLogger.cs
@@ -4,13 +4,101 @@
 
 namespace Meziantou.Extensions.Logging
 {
-    public sealed class FileLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, System.IDisposable
+    public abstract class FileFormatter
     {
-        public string LogFilePath { get => throw null; }
+        public string Name { get => throw null; }
+        protected FileFormatter(string name) { }
+        public abstract void Write<TState>(in Microsoft.Extensions.Logging.Abstractions.LogEntry<TState> logEntry, System.DateTimeOffset timestamp, Meziantou.Extensions.Logging.FileLoggerOptions options, Microsoft.Extensions.Logging.IExternalScopeProvider? scopeProvider, System.IO.TextWriter textWriter);
+        protected static string GetLogLevelString(Microsoft.Extensions.Logging.LogLevel logLevel) => throw null;
+    }
+
+    public static class FileFormatterNames
+    {
+        public const string Simple = "simple";
+        public const string Json = "json";
+    }
+
+    public static class FileLoggerBuilderExtensions
+    {
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(Meziantou.Extensions.Logging.FileLoggerOptions))]
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access", Justification = "The members of FileLoggerOptions used by the configuration binder are preserved by the DynamicDependency attribute")]
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddFile(this Microsoft.Extensions.Logging.ILoggingBuilder builder) => throw null;
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddFile(this Microsoft.Extensions.Logging.ILoggingBuilder builder, string logsDirectory) => throw null;
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddFile(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<Meziantou.Extensions.Logging.FileLoggerOptions> configure) => throw null;
+        public static Microsoft.Extensions.Logging.ILoggingBuilder AddFile(this Microsoft.Extensions.Logging.ILoggingBuilder builder, string logsDirectory, System.Action<Meziantou.Extensions.Logging.FileLoggerOptions> configure) => throw null;
+    }
+
+    public sealed class FileLoggerOptions
+    {
+        public string? Directory { get => throw null; set { } }
+        public string FileNamePrefix { get => throw null; set { } }
+        public string FileNameExtension { get => throw null; set { } }
+        public bool IncludeProcessIdInFileName { get => throw null; set { } }
+        public bool Append { get => throw null; set { } }
+        public Meziantou.Extensions.Logging.RollInterval RollInterval { get => throw null; set { } }
+        public long? MaxFileSizeInBytes { get => throw null; set { } }
+        public int? MaxRetainedFiles { get => throw null; set { } }
+        public bool CompressRolledFiles { get => throw null; set { } }
+        public Microsoft.Extensions.Logging.LogLevel MinLevel { get => throw null; set { } }
+        public bool IncludeScopes { get => throw null; set { } }
+        public bool IncludeCategory { get => throw null; set { } }
+        public bool IncludeLogLevel { get => throw null; set { } }
+        public bool IncludeEventId { get => throw null; set { } }
+        public bool IncludeThreadId { get => throw null; set { } }
+        public bool IncludeActivityTracking { get => throw null; set { } }
+        public bool UseShortCategoryName { get => throw null; set { } }
+        [System.Diagnostics.CodeAnalysis.StringSyntax("DateTimeFormat")]
+        public string? TimestampFormat { get => throw null; set { } }
+        public bool UseUtcTimestamp { get => throw null; set { } }
+        public int MaxQueueLength { get => throw null; set { } }
+        public Meziantou.Extensions.Logging.FileLoggerQueueFullMode QueueFullMode { get => throw null; set { } }
+        public System.TimeSpan FlushInterval { get => throw null; set { } }
+        public string FormatterName { get => throw null; set { } }
+        public Meziantou.Extensions.Logging.FileFormatter? Formatter { get => throw null; set { } }
+    }
+
+    public sealed class FileLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, Microsoft.Extensions.Logging.ISupportExternalScope, System.IAsyncDisposable, System.IDisposable
+    {
+        public string? LogFilePath { get => throw null; }
         public FileLoggerProvider(string logsDirectory) { }
         public FileLoggerProvider(string logsDirectory, System.TimeProvider timeProvider) { }
+        public FileLoggerProvider(Meziantou.Extensions.Logging.FileLoggerOptions options) { }
+        public FileLoggerProvider(Meziantou.Extensions.Logging.FileLoggerOptions options, System.TimeProvider timeProvider) { }
+        public FileLoggerProvider(Microsoft.Extensions.Options.IOptionsMonitor<Meziantou.Extensions.Logging.FileLoggerOptions> options) { }
+        public FileLoggerProvider(Microsoft.Extensions.Options.IOptionsMonitor<Meziantou.Extensions.Logging.FileLoggerOptions> options, System.TimeProvider timeProvider) { }
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName) => throw null;
+        public void SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
         public System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public void Dispose() { }
+        public System.Threading.Tasks.ValueTask DisposeAsync() => throw null;
+    }
+
+    public enum FileLoggerQueueFullMode
+    {
+        Wait = 0,
+        DropWrite = 1,
+        DropOldest = 2
+    }
+
+    public sealed class JsonFileFormatter : Meziantou.Extensions.Logging.FileFormatter
+    {
+        public static Meziantou.Extensions.Logging.JsonFileFormatter Instance { get => throw null; }
+        public JsonFileFormatter() : base(default(string)) { }
+        public override void Write<TState>(in Microsoft.Extensions.Logging.Abstractions.LogEntry<TState> logEntry, System.DateTimeOffset timestamp, Meziantou.Extensions.Logging.FileLoggerOptions options, Microsoft.Extensions.Logging.IExternalScopeProvider? scopeProvider, System.IO.TextWriter textWriter) { }
+    }
+
+    public enum RollInterval
+    {
+        None = 0,
+        Hourly = 1,
+        Daily = 2,
+        Monthly = 3
+    }
+
+    public sealed class SimpleFileFormatter : Meziantou.Extensions.Logging.FileFormatter
+    {
+        public static Meziantou.Extensions.Logging.SimpleFileFormatter Instance { get => throw null; }
+        public SimpleFileFormatter() : base(default(string)) { }
+        public override void Write<TState>(in Microsoft.Extensions.Logging.Abstractions.LogEntry<TState> logEntry, System.DateTimeOffset timestamp, Meziantou.Extensions.Logging.FileLoggerOptions options, Microsoft.Extensions.Logging.IExternalScopeProvider? scopeProvider, System.IO.TextWriter textWriter) { }
     }
 }

--- a/ref/Meziantou.Extensions.Logging.FileLogger.cs
+++ b/ref/Meziantou.Extensions.Logging.FileLogger.cs
@@ -38,7 +38,9 @@ namespace Meziantou.Extensions.Logging
         public Meziantou.Extensions.Logging.RollInterval RollInterval { get => throw null; set { } }
         public long? MaxFileSizeInBytes { get => throw null; set { } }
         public int? MaxRetainedFiles { get => throw null; set { } }
-        public bool CompressRolledFiles { get => throw null; set { } }
+        public Meziantou.Extensions.Logging.LogFileCompression Compression { get => throw null; set { } }
+        public Meziantou.Extensions.Logging.LogFileCompressionMode CompressionMode { get => throw null; set { } }
+        public System.IO.Compression.CompressionLevel CompressionLevel { get => throw null; set { } }
         public Microsoft.Extensions.Logging.LogLevel MinLevel { get => throw null; set { } }
         public bool IncludeScopes { get => throw null; set { } }
         public bool IncludeCategory { get => throw null; set { } }
@@ -85,6 +87,19 @@ namespace Meziantou.Extensions.Logging
         public static Meziantou.Extensions.Logging.JsonFileFormatter Instance { get => throw null; }
         public JsonFileFormatter() : base(default(string)) { }
         public override void Write<TState>(in Microsoft.Extensions.Logging.Abstractions.LogEntry<TState> logEntry, System.DateTimeOffset timestamp, Meziantou.Extensions.Logging.FileLoggerOptions options, Microsoft.Extensions.Logging.IExternalScopeProvider? scopeProvider, System.IO.TextWriter textWriter) { }
+    }
+
+    public enum LogFileCompression
+    {
+        None = 0,
+        GZip = 1,
+        Brotli = 2
+    }
+
+    public enum LogFileCompressionMode
+    {
+        Continuous = 0,
+        OnRoll = 1
     }
 
     public enum RollInterval

--- a/src/Meziantou.Extensions.Logging.FileLogger/FileFormatter.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileFormatter.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meziantou.Extensions.Logging;
+
+/// <summary>Allows custom log messages formatting for the <see cref="FileLoggerProvider"/>.</summary>
+/// <example>
+/// <code>
+/// internal sealed class CsvFileFormatter() : FileFormatter("csv")
+/// {
+///     public override void Write&lt;TState&gt;(in LogEntry&lt;TState&gt; logEntry, DateTimeOffset timestamp, FileLoggerOptions options, IExternalScopeProvider? scopeProvider, TextWriter textWriter)
+///     {
+///         textWriter.Write(logEntry.LogLevel);
+///         textWriter.Write(',');
+///         textWriter.Write(logEntry.Formatter(logEntry.State, logEntry.Exception));
+///     }
+/// }
+/// </code>
+/// </example>
+public abstract class FileFormatter
+{
+    /// <summary>Initializes a new instance of the <see cref="FileFormatter"/> class.</summary>
+    /// <param name="name">The name of the formatter.</param>
+    protected FileFormatter(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        Name = name;
+    }
+
+    /// <summary>Gets the name of the formatter.</summary>
+    public string Name { get; }
+
+    /// <summary>Writes the log message to the specified <see cref="TextWriter"/>. The line terminator is written by the provider.</summary>
+    /// <typeparam name="TState">The type of the log entry state.</typeparam>
+    /// <param name="logEntry">The log entry to write.</param>
+    /// <param name="timestamp">The date and time at which the message was logged, in the timezone configured by <see cref="FileLoggerOptions.UseUtcTimestamp"/>.</param>
+    /// <param name="options">The options of the provider that created the log entry.</param>
+    /// <param name="scopeProvider">The provider of scope data, or <see langword="null" /> when the scopes must not be written.</param>
+    /// <param name="textWriter">The writer the message must be written to.</param>
+    /// <remarks>The method is called on the thread that logs the message, so the ambient state such as <see cref="System.Diagnostics.Activity.Current"/> can be read.</remarks>
+    public abstract void Write<TState>(in LogEntry<TState> logEntry, DateTimeOffset timestamp, FileLoggerOptions options, IExternalScopeProvider? scopeProvider, TextWriter textWriter);
+
+    /// <summary>Gets the four-letter representation of the specified log level.</summary>
+    /// <param name="logLevel">The log level to format.</param>
+    /// <returns>The four-letter representation of <paramref name="logLevel"/>.</returns>
+    protected static string GetLogLevelString(LogLevel logLevel) => logLevel switch
+    {
+        LogLevel.Trace => "TRCE",
+        LogLevel.Debug => "DBUG",
+        LogLevel.Information => "INFO",
+        LogLevel.Warning => "WARN",
+        LogLevel.Error => "FAIL",
+        LogLevel.Critical => "CRIT",
+        _ => logLevel.ToString().ToUpperInvariant(),
+    };
+}

--- a/src/Meziantou.Extensions.Logging.FileLogger/FileFormatterNames.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileFormatterNames.cs
@@ -1,0 +1,11 @@
+namespace Meziantou.Extensions.Logging;
+
+/// <summary>Contains the names of the built-in <see cref="FileFormatter"/> implementations.</summary>
+public static class FileFormatterNames
+{
+    /// <summary>The name of the <see cref="SimpleFileFormatter"/>, which writes one human-readable line per log entry.</summary>
+    public const string Simple = "simple";
+
+    /// <summary>The name of the <see cref="JsonFileFormatter"/>, which writes one JSON object per log entry.</summary>
+    public const string Json = "json";
+}

--- a/src/Meziantou.Extensions.Logging.FileLogger/FileLogger.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileLogger.cs
@@ -1,59 +1,66 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Meziantou.Extensions.Logging;
 
 /// <summary>A logger that writes to a file via the FileLoggerProvider.</summary>
 internal sealed class FileLogger(FileLoggerProvider provider, string categoryName) : ILogger
 {
+    // Keep the cached writer small, so a single big message doesn't retain a big buffer for the lifetime of the thread
+    private const int MaxCachedCapacity = 4 * 1024;
+
+    [ThreadStatic]
+    private static StringWriter? s_stringWriter;
+
     private readonly string _shortCategoryName = GetShortCategoryName(categoryName);
 
-    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+    public bool IsEnabled(LogLevel logLevel) => logLevel is not LogLevel.None && logLevel >= provider.CurrentOptions.MinLevel;
 
-    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => provider.ScopeProvider.Push(state);
 
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The StringWriter is cached in a thread static field and holds no unmanaged resource")]
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
-        if (!IsEnabled(logLevel))
-        {
+        var options = provider.CurrentOptions;
+        if (logLevel is LogLevel.None || logLevel < options.MinLevel)
             return;
-        }
 
-        var message = formatter(state, exception);
-        if (string.IsNullOrEmpty(message) && exception is null)
+        var timestamp = options.UseUtcTimestamp ? provider.TimeProvider.GetUtcNow() : provider.TimeProvider.GetLocalNow();
+        var category = options.UseShortCategoryName ? _shortCategoryName : categoryName;
+        var logEntry = new LogEntry<TState>(logLevel, category, eventId, state, exception, formatter);
+
+        // The message is formatted on the current thread, so the formatters can use the ambient state such as Activity.Current
+        var writer = s_stringWriter;
+        if (writer is null)
         {
-            return;
+            writer = new StringWriter(CultureInfo.InvariantCulture);
         }
-
-        var timestamp = provider.TimeProvider.GetUtcNow().ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture);
-        var level = GetLogLevelString(logLevel);
-        var logMessageBuilder = new StringBuilder(message.Length + _shortCategoryName.Length + 40);
-        logMessageBuilder.Append('[');
-        logMessageBuilder.Append(timestamp);
-        logMessageBuilder.Append("] [");
-        logMessageBuilder.Append(level);
-        logMessageBuilder.Append("] [");
-        logMessageBuilder.Append(_shortCategoryName);
-        logMessageBuilder.Append("] ");
-        logMessageBuilder.Append(message);
-        if (exception is not null)
+        else
         {
-            logMessageBuilder.AppendLine();
-            logMessageBuilder.Append(exception);
+            // Detach the cached writer in case a formatter logs a message
+            s_stringWriter = null;
         }
 
-        provider.WriteLog(logMessageBuilder.ToString());
+        try
+        {
+            var builder = writer.GetStringBuilder();
+            options.GetFormatter().Write(in logEntry, timestamp, options, options.IncludeScopes ? provider.ScopeProvider : null, writer);
+            if (builder.Length is 0)
+                return;
+
+            provider.WriteLog(builder.ToString());
+        }
+        finally
+        {
+            var builder = writer.GetStringBuilder();
+            var canReuse = builder.Capacity <= MaxCachedCapacity;
+            builder.Clear();
+            if (canReuse)
+            {
+                s_stringWriter = writer;
+            }
+        }
     }
-
-    private static string GetLogLevelString(LogLevel logLevel) => logLevel switch
-    {
-        LogLevel.Trace => "TRCE",
-        LogLevel.Debug => "DBUG",
-        LogLevel.Information => "INFO",
-        LogLevel.Warning => "WARN",
-        LogLevel.Error => "FAIL",
-        LogLevel.Critical => "CRIT",
-        _ => logLevel.ToString().ToUpperInvariant()
-    };
 
     private static string GetShortCategoryName(string categoryName)
     {

--- a/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerBuilderExtensions.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerBuilderExtensions.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Meziantou.Extensions.Logging;
+
+/// <summary>Provides extension methods for <see cref="ILoggingBuilder"/> to add file logging support.</summary>
+/// <example>
+/// <code>
+/// var builder = Host.CreateApplicationBuilder(args);
+/// builder.Logging.AddFile(options =>
+/// {
+///     options.Directory = "logs";
+///     options.RollInterval = RollInterval.Daily;
+///     options.MaxRetainedFiles = 7;
+/// });
+/// </code>
+/// </example>
+public static class FileLoggerBuilderExtensions
+{
+    /// <summary>Adds a file logger provider to the logging builder. The options are read from the <c>Logging:File</c> configuration section.</summary>
+    /// <param name="builder">The <see cref="ILoggingBuilder"/> to add the provider to.</param>
+    /// <returns>The <see cref="ILoggingBuilder"/> so that additional calls can be chained.</returns>
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(FileLoggerOptions))]
+    [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access", Justification = "The members of FileLoggerOptions used by the configuration binder are preserved by the DynamicDependency attribute")]
+    public static ILoggingBuilder AddFile(this ILoggingBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.AddConfiguration();
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, FileLoggerProvider>(CreateProvider));
+        LoggerProviderOptions.RegisterProviderOptions<FileLoggerOptions, FileLoggerProvider>(builder.Services);
+        return builder;
+
+        static FileLoggerProvider CreateProvider(IServiceProvider serviceProvider)
+        {
+            var options = serviceProvider.GetRequiredService<IOptionsMonitor<FileLoggerOptions>>();
+            return new FileLoggerProvider(options, serviceProvider.GetService<TimeProvider>() ?? TimeProvider.System);
+        }
+    }
+
+    /// <summary>Adds a file logger provider that writes to the specified directory.</summary>
+    /// <param name="builder">The <see cref="ILoggingBuilder"/> to add the provider to.</param>
+    /// <param name="logsDirectory">The directory where log files will be written.</param>
+    /// <returns>The <see cref="ILoggingBuilder"/> so that additional calls can be chained.</returns>
+    public static ILoggingBuilder AddFile(this ILoggingBuilder builder, string logsDirectory)
+    {
+        return builder.AddFile(options => options.Directory = logsDirectory);
+    }
+
+    /// <summary>Adds a file logger provider configured by the specified delegate.</summary>
+    /// <param name="builder">The <see cref="ILoggingBuilder"/> to add the provider to.</param>
+    /// <param name="configure">A delegate to configure the options of the provider.</param>
+    /// <returns>The <see cref="ILoggingBuilder"/> so that additional calls can be chained.</returns>
+    public static ILoggingBuilder AddFile(this ILoggingBuilder builder, Action<FileLoggerOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        builder.AddFile();
+        builder.Services.Configure(configure);
+        return builder;
+    }
+
+    /// <summary>Adds a file logger provider that writes to the specified directory and is configured by the specified delegate.</summary>
+    /// <param name="builder">The <see cref="ILoggingBuilder"/> to add the provider to.</param>
+    /// <param name="logsDirectory">The directory where log files will be written.</param>
+    /// <param name="configure">A delegate to configure the options of the provider.</param>
+    /// <returns>The <see cref="ILoggingBuilder"/> so that additional calls can be chained.</returns>
+    public static ILoggingBuilder AddFile(this ILoggingBuilder builder, string logsDirectory, Action<FileLoggerOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        return builder.AddFile(options =>
+        {
+            options.Directory = logsDirectory;
+            configure(options);
+        });
+    }
+}

--- a/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerOptions.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerOptions.cs
@@ -1,0 +1,166 @@
+using Microsoft.Extensions.Logging;
+
+namespace Meziantou.Extensions.Logging;
+
+/// <summary>Options for the <see cref="FileLoggerProvider"/>.</summary>
+public sealed class FileLoggerOptions
+{
+    private int _maxQueueLength = 1024;
+    private long? _maxFileSizeInBytes;
+    private int? _maxRetainedFiles;
+    private TimeSpan _flushInterval = TimeSpan.FromSeconds(1);
+    private string _fileNameExtension = ".log";
+    private string _fileNamePrefix = "";
+    private string _formatterName = FileFormatterNames.Simple;
+
+    /// <summary>Gets or sets the directory where log files are written. This value is required.</summary>
+    public string? Directory { get; set; }
+
+    /// <summary>Gets or sets the prefix added at the beginning of the log file names. Defaults to an empty string.</summary>
+    public string FileNamePrefix
+    {
+        get => _fileNamePrefix;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            _fileNamePrefix = value;
+        }
+    }
+
+    /// <summary>Gets or sets the extension of the log file names, including the leading dot. Defaults to <c>.log</c>.</summary>
+    public string FileNameExtension
+    {
+        get => _fileNameExtension;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            _fileNameExtension = value;
+        }
+    }
+
+    /// <summary>Gets or sets a value indicating whether the identifier of the current process is part of the log file names. Defaults to <see langword="true" />.</summary>
+    public bool IncludeProcessIdInFileName { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an existing log file is reused instead of creating a new one. Defaults to <see langword="false" />.
+    /// When a matching file is already in use by another process, a new file is created.
+    /// </summary>
+    public bool Append { get; set; }
+
+    /// <summary>Gets or sets how often a new log file is created based on time. Defaults to <see cref="RollInterval.None" />.</summary>
+    public RollInterval RollInterval { get; set; }
+
+    /// <summary>Gets or sets the maximum size of a log file, in bytes, after which a new file is created. Defaults to <see langword="null" /> (no limit).</summary>
+    public long? MaxFileSizeInBytes
+    {
+        get => _maxFileSizeInBytes;
+        set
+        {
+            if (value is not null)
+            {
+                ArgumentOutOfRangeException.ThrowIfLessThan(value.GetValueOrDefault(), 1, nameof(value));
+            }
+
+            _maxFileSizeInBytes = value;
+        }
+    }
+
+    /// <summary>Gets or sets the maximum number of log files to keep in the directory. Older files are deleted when a new file is created. Defaults to <see langword="null" /> (no limit).</summary>
+    public int? MaxRetainedFiles
+    {
+        get => _maxRetainedFiles;
+        set
+        {
+            if (value is not null)
+            {
+                ArgumentOutOfRangeException.ThrowIfLessThan(value.GetValueOrDefault(), 1, nameof(value));
+            }
+
+            _maxRetainedFiles = value;
+        }
+    }
+
+    /// <summary>Gets or sets a value indicating whether log files are compressed using gzip once they are rolled. Defaults to <see langword="false" />.</summary>
+    public bool CompressRolledFiles { get; set; }
+
+    /// <summary>Gets or sets the minimum level of the messages written to the file. Defaults to <see cref="LogLevel.Trace" />.</summary>
+    public LogLevel MinLevel { get; set; } = LogLevel.Trace;
+
+    /// <summary>Gets or sets a value indicating whether scopes are included in the log messages. Defaults to <see langword="false" />.</summary>
+    public bool IncludeScopes { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the category is included in the log messages. Defaults to <see langword="true" />.</summary>
+    public bool IncludeCategory { get; set; } = true;
+
+    /// <summary>Gets or sets a value indicating whether the log level is included in the log messages. Defaults to <see langword="true" />.</summary>
+    public bool IncludeLogLevel { get; set; } = true;
+
+    /// <summary>Gets or sets a value indicating whether the event id is included in the log messages. Defaults to <see langword="false" />.</summary>
+    public bool IncludeEventId { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the identifier of the thread that logged the message is included in the log messages. Defaults to <see langword="false" />.</summary>
+    public bool IncludeThreadId { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the trace id and the span id of the current <see cref="System.Diagnostics.Activity" /> are included in the log messages. Defaults to <see langword="false" />.</summary>
+    public bool IncludeActivityTracking { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether only the last segment of the category is written, for instance <c>Program</c> instead of <c>Sample.Program</c>. Defaults to <see langword="false" />.</summary>
+    public bool UseShortCategoryName { get; set; }
+
+    /// <summary>Gets or sets the format string used to format the timestamp of the log messages. Set it to <see langword="null" /> to omit the timestamp.</summary>
+    [StringSyntax(StringSyntaxAttribute.DateTimeFormat)]
+    public string? TimestampFormat { get; set; } = "yyyy-MM-dd HH:mm:ss.fff";
+
+    /// <summary>Gets or sets a value indicating whether the UTC timezone is used to format the timestamps. Defaults to <see langword="true" />.</summary>
+    public bool UseUtcTimestamp { get; set; } = true;
+
+    /// <summary>Gets or sets the maximum number of messages that can be queued before <see cref="QueueFullMode" /> applies. Defaults to <c>1024</c>.</summary>
+    public int MaxQueueLength
+    {
+        get => _maxQueueLength;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            _maxQueueLength = value;
+        }
+    }
+
+    /// <summary>Gets or sets the behavior when the message queue is full. Defaults to <see cref="FileLoggerQueueFullMode.Wait" />.</summary>
+    public FileLoggerQueueFullMode QueueFullMode { get; set; }
+
+    /// <summary>Gets or sets the maximum duration between two flushes when messages are logged continuously. Defaults to 1 second.</summary>
+    /// <remarks>The pending messages are always flushed as soon as the queue is empty, so this value only matters when the logger cannot keep up with the messages.</remarks>
+    public TimeSpan FlushInterval
+    {
+        get => _flushInterval;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(value, TimeSpan.Zero);
+            _flushInterval = value;
+        }
+    }
+
+    /// <summary>Gets or sets the name of the formatter to use. Supported values are <see cref="FileFormatterNames.Simple" /> and <see cref="FileFormatterNames.Json" />. This value is ignored when <see cref="Formatter" /> is set.</summary>
+    public string FormatterName
+    {
+        get => _formatterName;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            _formatterName = value;
+        }
+    }
+
+    /// <summary>Gets or sets the formatter used to write the log entries. When <see langword="null" />, the formatter is resolved from <see cref="FormatterName" />.</summary>
+    public FileFormatter? Formatter { get; set; }
+
+    internal FileFormatter GetFormatter()
+    {
+        if (Formatter is not null)
+            return Formatter;
+
+        return FormatterName.Equals(FileFormatterNames.Json, StringComparison.OrdinalIgnoreCase)
+            ? JsonFileFormatter.Instance
+            : SimpleFileFormatter.Instance;
+    }
+}

--- a/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerOptions.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerOptions.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using Microsoft.Extensions.Logging;
 
 namespace Meziantou.Extensions.Logging;
@@ -80,8 +81,15 @@ public sealed class FileLoggerOptions
         }
     }
 
-    /// <summary>Gets or sets a value indicating whether log files are compressed using gzip once they are rolled. Defaults to <see langword="false" />.</summary>
-    public bool CompressRolledFiles { get; set; }
+    /// <summary>Gets or sets the algorithm used to compress the log files. Defaults to <see cref="LogFileCompression.None" />.</summary>
+    public LogFileCompression Compression { get; set; }
+
+    /// <summary>Gets or sets when the log files are compressed. Defaults to <see cref="LogFileCompressionMode.Continuous" />. This value is ignored when <see cref="Compression" /> is <see cref="LogFileCompression.None" />.</summary>
+    /// <remarks><see cref="Append" /> is ignored when the messages are compressed continuously, as appending to a compressed file would produce a file that most tools cannot read.</remarks>
+    public LogFileCompressionMode CompressionMode { get; set; }
+
+    /// <summary>Gets or sets the compression level. Defaults to <see cref="System.IO.Compression.CompressionLevel.Optimal" />. This value is ignored when <see cref="Compression" /> is <see cref="LogFileCompression.None" />.</summary>
+    public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Optimal;
 
     /// <summary>Gets or sets the minimum level of the messages written to the file. Defaults to <see cref="LogLevel.Trace" />.</summary>
     public LogLevel MinLevel { get; set; } = LogLevel.Trace;

--- a/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerProvider.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerProvider.cs
@@ -1,125 +1,182 @@
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Meziantou.Extensions.Logging;
 
 /// <summary>
 /// A logger provider that writes all log messages to a file on disk.
 /// </summary>
-public sealed class FileLoggerProvider : ILoggerProvider
+/// <example>
+/// <code>
+/// using var provider = new FileLoggerProvider(new FileLoggerOptions
+/// {
+///     Directory = "logs",
+///     RollInterval = RollInterval.Daily,
+///     MaxRetainedFiles = 7,
+/// });
+///
+/// using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(provider));
+/// </code>
+/// </example>
+[ProviderAlias("File")]
+public sealed class FileLoggerProvider : ILoggerProvider, ISupportExternalScope, IAsyncDisposable
 {
-    private const int MaxQueuedMessages = 1024;
-
-    private readonly string _logFilePath;
-    private readonly StreamWriter? _writer;
-    private readonly Channel<string>? _channel;
+    private readonly IDisposable? _optionsReloadToken;
+    private readonly LogFileWriter? _fileWriter;
+    private readonly Channel<LogMessage>? _channel;
     private readonly Task? _writerTask;
-    private bool _disposed;
 
-    /// <summary>Gets the path to the log file.</summary>
-    public string LogFilePath => _logFilePath;
+    private FileLoggerOptions _options;
+    private IExternalScopeProvider _scopeProvider = new LoggerExternalScopeProvider();
+    private int _disposed;
+
+    /// <summary>Gets the path of the file the messages are currently written to, or <see langword="null" /> when the log file could not be created.</summary>
+    /// <remarks>The value changes when the log file is rolled.</remarks>
+    public string? LogFilePath => _fileWriter?.CurrentFilePath;
 
     internal TimeProvider TimeProvider { get; }
 
+    internal FileLoggerOptions CurrentOptions => Volatile.Read(ref _options);
+
+    internal IExternalScopeProvider ScopeProvider => Volatile.Read(ref _scopeProvider);
+
+    /// <summary>Initializes a new instance of the <see cref="FileLoggerProvider"/> class that writes to the specified directory.</summary>
+    /// <param name="logsDirectory">The directory where log files will be written.</param>
     public FileLoggerProvider(string logsDirectory)
-            : this(logsDirectory, TimeProvider.System)
+        : this(logsDirectory, TimeProvider.System)
     {
     }
 
-    /// <summary>Creates a new FileLoggerProvider that writes to the specified directory.</summary>
+    /// <summary>Initializes a new instance of the <see cref="FileLoggerProvider"/> class that writes to the specified directory.</summary>
     /// <param name="logsDirectory">The directory where log files will be written.</param>
-    /// <param name="timeProvider">The time provider for timestamp generation.</param>
+    /// <param name="timeProvider">The time provider used to generate the timestamps.</param>
     public FileLoggerProvider(string logsDirectory, TimeProvider timeProvider)
+        : this(new FileLoggerOptions { Directory = logsDirectory }, timeProvider)
     {
-        TimeProvider = timeProvider;
+    }
 
-        var pid = Environment.ProcessId;
-        var timestamp = timeProvider.GetUtcNow().ToString("yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture);
-        // Timestamp first so files sort chronologically by name
-        _logFilePath = Path.Combine(logsDirectory, $"{timestamp}-{pid}.log");
+    /// <summary>Initializes a new instance of the <see cref="FileLoggerProvider"/> class with the specified options.</summary>
+    /// <param name="options">The options of the provider.</param>
+    public FileLoggerProvider(FileLoggerOptions options)
+        : this(options, TimeProvider.System)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="FileLoggerProvider"/> class with the specified options.</summary>
+    /// <param name="options">The options of the provider.</param>
+    /// <param name="timeProvider">The time provider used to generate the timestamps.</param>
+    public FileLoggerProvider(FileLoggerOptions options, TimeProvider timeProvider)
+        : this(options, optionsMonitor: null, timeProvider)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="FileLoggerProvider"/> class with the specified options.</summary>
+    /// <param name="options">The options of the provider.</param>
+    public FileLoggerProvider(IOptionsMonitor<FileLoggerOptions> options)
+        : this(options, TimeProvider.System)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="FileLoggerProvider"/> class with the specified options.</summary>
+    /// <param name="options">The options of the provider.</param>
+    /// <param name="timeProvider">The time provider used to generate the timestamps.</param>
+    public FileLoggerProvider(IOptionsMonitor<FileLoggerOptions> options, TimeProvider timeProvider)
+        : this(GetCurrentValue(options), options, timeProvider)
+    {
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "The application must keep running when the log file cannot be created")]
+    private FileLoggerProvider(FileLoggerOptions options, IOptionsMonitor<FileLoggerOptions>? optionsMonitor, TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        if (string.IsNullOrEmpty(options.Directory))
+            throw new InvalidOperationException($"The '{nameof(FileLoggerOptions)}.{nameof(FileLoggerOptions.Directory)}' option must be set");
+
+        _options = options;
+        TimeProvider = timeProvider;
+        _optionsReloadToken = optionsMonitor?.OnChange(UpdateOptions);
 
         try
         {
-            Directory.CreateDirectory(logsDirectory);
-            _writer = new StreamWriter(_logFilePath, append: false, Encoding.UTF8)
-            {
-                AutoFlush = true
-            };
-
-            // Create bounded channel - blocks producers when full to provide backpressure
-            _channel = Channel.CreateBounded<string>(new BoundedChannelOptions(MaxQueuedMessages)
-            {
-                FullMode = BoundedChannelFullMode.Wait,
-                SingleReader = true,
-                SingleWriter = false
-            });
-
-            // Start background writer task
-            _writerTask = Task.Run(ProcessLogQueueAsync);
+            _fileWriter = new LogFileWriter(options.Directory, options, timeProvider);
         }
-        catch (IOException ex)
+        catch (Exception ex)
         {
             // If we can't create the log file, warn on stderr and continue without file logging
-            Console.Error.WriteLine($"Warning: Could not create log file at {_logFilePath}: {ex.Message}");
-            _writer = null;
-            _channel = null;
-        }
-    }
-
-    private async Task ProcessLogQueueAsync()
-    {
-        if (_channel is null || _writer is null)
-        {
+            Console.Error.WriteLine($"Warning: Could not create a log file in '{options.Directory}': {ex.Message}");
             return;
         }
 
-        try
-        {
-            await foreach (var message in _channel.Reader.ReadAllAsync())
+        // Bounded channel, the behavior when it is full is defined by FileLoggerOptions.QueueFullMode
+        _channel = Channel.CreateBounded<LogMessage>(
+            new BoundedChannelOptions(options.MaxQueueLength)
             {
-                await _writer.WriteLineAsync(message).ConfigureAwait(false);
-            }
-        }
-        catch (ChannelClosedException)
-        {
-            // Expected when channel is completed during disposal
-        }
+                FullMode = options.QueueFullMode switch
+                {
+                    FileLoggerQueueFullMode.DropWrite => BoundedChannelFullMode.DropWrite,
+                    FileLoggerQueueFullMode.DropOldest => BoundedChannelFullMode.DropOldest,
+                    _ => BoundedChannelFullMode.Wait,
+                },
+                SingleReader = true,
+                SingleWriter = false,
+            }, OnMessageDropped);
+
+        // The messages are written synchronously, so use a dedicated thread instead of a thread pool thread
+        _writerTask = Task.Factory.StartNew(ProcessLogQueueAsync, CancellationToken.None, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default).Unwrap();
     }
 
+    private static FileLoggerOptions GetCurrentValue(IOptionsMonitor<FileLoggerOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        return options.CurrentValue;
+    }
+
+    private void UpdateOptions(FileLoggerOptions options)
+    {
+        // The options related to the file itself (directory, file name, rolling) are only read when the provider is created
+        Volatile.Write(ref _options, options);
+    }
+
+    private static void OnMessageDropped(LogMessage message)
+    {
+        // Do not let a FlushAsync call wait forever for a message that was dropped
+        message.FlushCompletion?.TrySetResult();
+    }
+
+    /// <inheritdoc/>
     public ILogger CreateLogger(string categoryName)
     {
         return new FileLogger(this, categoryName);
     }
 
+    /// <inheritdoc/>
+    public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+    {
+        Volatile.Write(ref _scopeProvider, scopeProvider ?? new LoggerExternalScopeProvider());
+    }
+
     internal void WriteLog(string message)
     {
-        if (_channel is null)
-        {
+        var channel = _channel;
+        if (channel is null)
             return;
-        }
 
         // Try to write to the channel - this will succeed as long as there's space
         // and the channel hasn't been completed yet
-        if (_channel.Writer.TryWrite(message))
-        {
+        if (channel.Writer.TryWrite(new LogMessage(message, flushCompletion: null)))
             return;
-        }
 
-        // TryWrite failed - either channel is full (need backpressure) or completed (disposal)
-        // Try async write which will wait for space or throw if completed
+        // TryWrite failed - the channel is full (need backpressure) or completed (disposal)
         try
         {
             // WaitToWriteAsync returns false if the channel is completed
             // This is cheaper than catching ChannelClosedException from WriteAsync
-            if (!_channel.Writer.WaitToWriteAsync().AsTask().GetAwaiter().GetResult())
-            {
-                // Channel is completed - disposal is happening, message won't be written
-                // This is the only case where we drop a message
+            if (!channel.Writer.WaitToWriteAsync().AsTask().GetAwaiter().GetResult())
                 return;
-            }
 
-            // Space is available, write the message
-            _channel.Writer.TryWrite(message);
+            channel.Writer.TryWrite(new LogMessage(message, flushCompletion: null));
         }
         catch (ChannelClosedException)
         {
@@ -127,33 +184,152 @@ public sealed class FileLoggerProvider : ILoggerProvider
         }
     }
 
-    /// <summary>Flushes any pending writes to the log file.</summary>
-    public async Task FlushAsync(CancellationToken cancellationToken = default)
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "The application must keep running when the log file cannot be written")]
+    private async Task ProcessLogQueueAsync()
     {
-        if (_writer is null || _disposed)
+        var channel = _channel!;
+        var fileWriter = _fileWriter!;
+        var lastFlush = TimeProvider.GetTimestamp();
+        var pendingFlush = false;
+
+        try
         {
-            return;
+            while (await channel.Reader.WaitToReadAsync().ConfigureAwait(false))
+            {
+                while (channel.Reader.TryRead(out var message))
+                {
+                    if (message.FlushCompletion is not null)
+                    {
+                        Flush();
+                        message.FlushCompletion.TrySetResult();
+                    }
+                    else
+                    {
+                        fileWriter.WriteLine(message.Message!);
+                        pendingFlush = true;
+
+                        // Ensure the messages reach the disk even when the queue is never empty
+                        if (TimeProvider.GetElapsedTime(lastFlush) >= CurrentOptions.FlushInterval)
+                        {
+                            Flush();
+                        }
+                    }
+                }
+
+                // The queue is empty, make the messages visible to the other processes
+                if (pendingFlush)
+                {
+                    Flush();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // Complete the channel, so the loggers stop waiting for room in a queue that is never drained again
+            channel.Writer.TryComplete();
+            Console.Error.WriteLine($"Warning: Stopped writing to the log file '{fileWriter.CurrentFilePath}': {ex.Message}");
+        }
+        finally
+        {
+            // Release the pending FlushAsync calls
+            while (channel.Reader.TryRead(out var message))
+            {
+                message.FlushCompletion?.TrySetResult();
+            }
         }
 
-        await _writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+        void Flush()
+        {
+            fileWriter.Flush();
+            pendingFlush = false;
+            lastFlush = TimeProvider.GetTimestamp();
+        }
     }
 
-    public void Dispose()
+    /// <summary>Waits for the pending messages to be written to the log file.</summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    public async Task FlushAsync(CancellationToken cancellationToken = default)
     {
-        if (_disposed)
-        {
+        var channel = _channel;
+        if (channel is null)
             return;
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var message = new LogMessage(message: null, completion);
+        if (!channel.Writer.TryWrite(message))
+        {
+            try
+            {
+                if (!await channel.Writer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false))
+                    return;
+
+                if (!channel.Writer.TryWrite(message))
+                    return;
+            }
+            catch (ChannelClosedException)
+            {
+                return;
+            }
         }
 
-        _disposed = true;
+        await completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
 
-        // Complete the channel to signal the writer task to finish
-        // Any messages already in the channel will be drained by the writer task
+    /// <inheritdoc/>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Disposing the provider must not throw because of a log message")]
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) is 1)
+            return;
+
+        _optionsReloadToken?.Dispose();
+
+        // Complete the channel to signal the writer task to finish.
+        // Any message already in the channel will be drained by the writer task
         _channel?.Writer.TryComplete();
 
-        // Wait for the writer task to finish processing ALL remaining messages
-        _writerTask?.GetAwaiter().GetResult();
+        try
+        {
+            // Wait for the writer task to finish processing ALL remaining messages
+            _writerTask?.GetAwaiter().GetResult();
+        }
+        catch (Exception)
+        {
+            // The error is already reported by the writer task
+        }
 
-        _writer?.Dispose();
+        _fileWriter?.Dispose();
+    }
+
+    /// <inheritdoc/>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Disposing the provider must not throw because of a log message")]
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) is 1)
+            return;
+
+        _optionsReloadToken?.Dispose();
+        _channel?.Writer.TryComplete();
+
+        if (_writerTask is not null)
+        {
+            try
+            {
+                await _writerTask.ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // The error is already reported by the writer task
+            }
+        }
+
+        _fileWriter?.Dispose();
+    }
+
+    private readonly struct LogMessage(string? message, TaskCompletionSource? flushCompletion)
+    {
+        public string? Message { get; } = message;
+
+        public TaskCompletionSource? FlushCompletion { get; } = flushCompletion;
     }
 }

--- a/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerQueueFullMode.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/FileLoggerQueueFullMode.cs
@@ -1,0 +1,14 @@
+namespace Meziantou.Extensions.Logging;
+
+/// <summary>Determines the behavior of the file logger when the message queue is full.</summary>
+public enum FileLoggerQueueFullMode
+{
+    /// <summary>Blocks the thread that logs the message until the queue has room for it.</summary>
+    Wait,
+
+    /// <summary>Drops the new message when the queue is full.</summary>
+    DropWrite,
+
+    /// <summary>Drops the oldest queued message to make room for the new one.</summary>
+    DropOldest,
+}

--- a/src/Meziantou.Extensions.Logging.FileLogger/JsonFileFormatter.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/JsonFileFormatter.cs
@@ -1,0 +1,164 @@
+using System.Buffers;
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meziantou.Extensions.Logging;
+
+/// <summary>A <see cref="FileFormatter"/> that writes one JSON object per log entry.</summary>
+public sealed class JsonFileFormatter : FileFormatter
+{
+    /// <summary>Gets a shared instance of the <see cref="JsonFileFormatter"/> class.</summary>
+    public static JsonFileFormatter Instance { get; } = new();
+
+    /// <summary>Initializes a new instance of the <see cref="JsonFileFormatter"/> class.</summary>
+    public JsonFileFormatter()
+        : base(FileFormatterNames.Json)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override void Write<TState>(in LogEntry<TState> logEntry, DateTimeOffset timestamp, FileLoggerOptions options, IExternalScopeProvider? scopeProvider, TextWriter textWriter)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(textWriter);
+
+        var message = logEntry.Formatter(logEntry.State, logEntry.Exception);
+        if (string.IsNullOrEmpty(message) && logEntry.Exception is null)
+            return;
+
+        var buffer = new ArrayBufferWriter<byte>(256);
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("Timestamp", timestamp.ToString(options.TimestampFormat ?? "o", CultureInfo.InvariantCulture));
+
+            if (options.IncludeLogLevel)
+            {
+                writer.WriteString("LogLevel", GetLogLevelString(logEntry.LogLevel));
+            }
+
+            if (options.IncludeCategory)
+            {
+                writer.WriteString("Category", logEntry.Category);
+            }
+
+            if (options.IncludeEventId)
+            {
+                writer.WriteNumber("EventId", logEntry.EventId.Id);
+                if (logEntry.EventId.Name is not null)
+                {
+                    writer.WriteString("EventName", logEntry.EventId.Name);
+                }
+            }
+
+            if (options.IncludeThreadId)
+            {
+                writer.WriteNumber("ThreadId", Environment.CurrentManagedThreadId);
+            }
+
+            if (options.IncludeActivityTracking && Activity.Current is { } activity)
+            {
+                writer.WriteString("TraceId", activity.TraceId.ToHexString());
+                writer.WriteString("SpanId", activity.SpanId.ToHexString());
+            }
+
+            writer.WriteString("Message", message);
+
+            if (logEntry.Exception is not null)
+            {
+                writer.WriteString("Exception", logEntry.Exception.ToString());
+            }
+
+            if (logEntry.State is IReadOnlyList<KeyValuePair<string, object?>> state)
+            {
+                writer.WriteStartObject("State");
+                foreach (var item in state)
+                {
+                    WriteProperty(writer, item.Key, item.Value);
+                }
+
+                writer.WriteEndObject();
+            }
+
+            if (scopeProvider is not null)
+            {
+                writer.WriteStartArray("Scopes");
+                scopeProvider.ForEachScope(
+                    (scope, jsonWriter) =>
+                    {
+                        if (scope is IEnumerable<KeyValuePair<string, object?>> scopeItems)
+                        {
+                            jsonWriter.WriteStartObject();
+                            jsonWriter.WriteString("Message", Convert.ToString(scope, CultureInfo.InvariantCulture));
+                            foreach (var item in scopeItems)
+                            {
+                                WriteProperty(jsonWriter, item.Key, item.Value);
+                            }
+
+                            jsonWriter.WriteEndObject();
+                        }
+                        else
+                        {
+                            jsonWriter.WriteStringValue(Convert.ToString(scope, CultureInfo.InvariantCulture));
+                        }
+                    }, writer);
+                writer.WriteEndArray();
+            }
+
+            writer.WriteEndObject();
+        }
+
+        textWriter.Write(Encoding.UTF8.GetString(buffer.WrittenSpan));
+    }
+
+    private static void WriteProperty(Utf8JsonWriter writer, string name, object? value)
+    {
+        switch (value)
+        {
+            case null:
+                writer.WriteNull(name);
+                break;
+            case string stringValue:
+                writer.WriteString(name, stringValue);
+                break;
+            case bool boolValue:
+                writer.WriteBoolean(name, boolValue);
+                break;
+            case byte or sbyte or short or ushort or int:
+                writer.WriteNumber(name, Convert.ToInt32(value, CultureInfo.InvariantCulture));
+                break;
+            case uint uintValue:
+                writer.WriteNumber(name, uintValue);
+                break;
+            case long longValue:
+                writer.WriteNumber(name, longValue);
+                break;
+            case ulong ulongValue:
+                writer.WriteNumber(name, ulongValue);
+                break;
+            case float floatValue:
+                writer.WriteNumber(name, floatValue);
+                break;
+            case double doubleValue:
+                writer.WriteNumber(name, doubleValue);
+                break;
+            case decimal decimalValue:
+                writer.WriteNumber(name, decimalValue);
+                break;
+            case DateTime dateTimeValue:
+                writer.WriteString(name, dateTimeValue);
+                break;
+            case DateTimeOffset dateTimeOffsetValue:
+                writer.WriteString(name, dateTimeOffsetValue);
+                break;
+            case Guid guidValue:
+                writer.WriteString(name, guidValue);
+                break;
+            default:
+                writer.WriteString(name, Convert.ToString(value, CultureInfo.InvariantCulture));
+                break;
+        }
+    }
+}

--- a/src/Meziantou.Extensions.Logging.FileLogger/LogFileCompression.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/LogFileCompression.cs
@@ -11,4 +11,9 @@ public enum LogFileCompression
 
     /// <summary>The log files are compressed using Brotli, and the <c>.br</c> extension is added to their name.</summary>
     Brotli,
+
+#if NET11_0_OR_GREATER
+    /// <summary>The log files are compressed using Zstandard, and the <c>.zst</c> extension is added to their name.</summary>
+    Zstandard,
+#endif
 }

--- a/src/Meziantou.Extensions.Logging.FileLogger/LogFileCompression.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/LogFileCompression.cs
@@ -1,0 +1,14 @@
+namespace Meziantou.Extensions.Logging;
+
+/// <summary>Specifies the algorithm used to compress the log files.</summary>
+public enum LogFileCompression
+{
+    /// <summary>The log files are not compressed.</summary>
+    None,
+
+    /// <summary>The log files are compressed using gzip, and the <c>.gz</c> extension is added to their name.</summary>
+    GZip,
+
+    /// <summary>The log files are compressed using Brotli, and the <c>.br</c> extension is added to their name.</summary>
+    Brotli,
+}

--- a/src/Meziantou.Extensions.Logging.FileLogger/LogFileCompressionMode.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/LogFileCompressionMode.cs
@@ -1,0 +1,17 @@
+namespace Meziantou.Extensions.Logging;
+
+/// <summary>Specifies when the log files are compressed.</summary>
+public enum LogFileCompressionMode
+{
+    /// <summary>
+    /// The messages are compressed as they are written, so the log file is never written uncompressed.
+    /// The compressed stream is finalized when the file is rolled or when the provider is disposed, so the current log file may not be readable by all the tools while the application is running.
+    /// </summary>
+    Continuous,
+
+    /// <summary>
+    /// The log file is compressed once it is rolled, so the current log file is a plain text file.
+    /// The compression happens on the thread that writes the messages, so rolling a big file delays the messages.
+    /// </summary>
+    OnRoll,
+}

--- a/src/Meziantou.Extensions.Logging.FileLogger/LogFileWriter.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/LogFileWriter.cs
@@ -5,7 +5,6 @@ namespace Meziantou.Extensions.Logging;
 /// <summary>Writes the log messages to a file and handles the log file rolling and retention.</summary>
 internal sealed class LogFileWriter : IDisposable
 {
-    private const string GZipExtension = ".gz";
     private const int MaxFileNameAttempts = 1000;
 
     private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
@@ -15,6 +14,11 @@ internal sealed class LogFileWriter : IDisposable
     private readonly string _directory;
     private readonly int _newLineByteCount;
 
+    // When the messages are compressed as they are written, the compression extension is part of the file name
+    private readonly bool _compressWhileWriting;
+    private readonly string _fileNameSuffix;
+
+    private FileStream _fileStream;
     private StreamWriter _writer;
     private bool _canAppend;
     private string? _currentFilePath;
@@ -30,7 +34,11 @@ internal sealed class LogFileWriter : IDisposable
         _options = options;
         _timeProvider = timeProvider;
         _newLineByteCount = Environment.NewLine.Length;
-        _canAppend = options.Append;
+        _compressWhileWriting = options.Compression is not LogFileCompression.None && options.CompressionMode is LogFileCompressionMode.Continuous;
+        _fileNameSuffix = _compressWhileWriting ? GetCompressionExtension(options.Compression) : "";
+
+        // Appending to a compressed file would create a file that most tools cannot read entirely
+        _canAppend = options.Append && !_compressWhileWriting;
         Open(timeProvider.GetUtcNow());
     }
 
@@ -39,15 +47,23 @@ internal sealed class LogFileWriter : IDisposable
         var byteCount = Utf8NoBom.GetByteCount(message) + _newLineByteCount;
         RollIfNeeded(_timeProvider.GetUtcNow(), byteCount);
         _writer.WriteLine(message);
+
+        // When the messages are compressed, this is an upper bound of the size of the file. The exact size is known when the data is flushed
         _currentFileSize += byteCount;
     }
 
-    public void Flush() => _writer.Flush();
+    public void Flush()
+    {
+        _writer.Flush();
+        _currentFileSize = _fileStream.Position;
+    }
 
     public void Dispose()
     {
-        // Keep CurrentFilePath, so the path of the last log file can be read after the provider is disposed
+        // Keep CurrentFilePath, so the path of the last log file can be read after the provider is disposed.
+        // Disposing the writer also finalizes the compressed stream and disposes the file stream
         _writer.Dispose();
+        _fileStream.Dispose();
     }
 
     private void RollIfNeeded(DateTimeOffset now, int byteCount)
@@ -64,7 +80,7 @@ internal sealed class LogFileWriter : IDisposable
         _writer.Dispose();
         Open(now);
 
-        if (_options.CompressRolledFiles && previousFilePath is not null)
+        if (_options.Compression is not LogFileCompression.None && _options.CompressionMode is LogFileCompressionMode.OnRoll && previousFilePath is not null)
         {
             Compress(previousFilePath);
         }
@@ -72,7 +88,7 @@ internal sealed class LogFileWriter : IDisposable
         ApplyRetentionPolicy();
     }
 
-    [MemberNotNull(nameof(_writer))]
+    [MemberNotNull(nameof(_writer), nameof(_fileStream))]
     private void Open(DateTimeOffset now)
     {
         Directory.CreateDirectory(_directory);
@@ -87,13 +103,15 @@ internal sealed class LogFileWriter : IDisposable
             if (append && _options.MaxFileSizeInBytes is { } maxSize && File.Exists(path) && new FileInfo(path).Length >= maxSize)
                 continue;
 
+            FileStream? stream = null;
             try
             {
                 // Opening the file with FileShare.Read allows other processes to read the log file while it is being written,
                 // and prevents 2 providers from writing to the same file
-                var stream = new FileStream(path, append ? FileMode.Append : FileMode.CreateNew, FileAccess.Write, FileShare.Read | FileShare.Delete);
+                stream = new FileStream(path, append ? FileMode.Append : FileMode.CreateNew, FileAccess.Write, FileShare.Read | FileShare.Delete);
+                _writer = new StreamWriter(_compressWhileWriting ? CreateCompressionStream(stream) : stream, Utf8NoBom) { AutoFlush = false };
+                _fileStream = stream;
                 _currentFileSize = stream.Length;
-                _writer = new StreamWriter(stream, Utf8NoBom) { AutoFlush = false };
                 _currentPeriod = Truncate(now);
                 _canAppend = false;
                 Volatile.Write(ref _currentFilePath, path);
@@ -102,12 +120,27 @@ internal sealed class LogFileWriter : IDisposable
             catch (IOException ex)
             {
                 // The file already exists or is used by another process, try the next name
+                stream?.Dispose();
                 lastException = ex;
             }
         }
 
         throw lastException ?? new IOException("Cannot create a log file in " + _directory);
     }
+
+    private Stream CreateCompressionStream(Stream stream) => _options.Compression switch
+    {
+        LogFileCompression.GZip => new GZipStream(stream, _options.CompressionLevel),
+        LogFileCompression.Brotli => new BrotliStream(stream, _options.CompressionLevel),
+        _ => stream,
+    };
+
+    private static string GetCompressionExtension(LogFileCompression compression) => compression switch
+    {
+        LogFileCompression.GZip => ".gz",
+        LogFileCompression.Brotli => ".br",
+        _ => "",
+    };
 
     private string GetFileName(DateTimeOffset now, int index)
     {
@@ -129,6 +162,7 @@ internal sealed class LogFileWriter : IDisposable
         }
 
         builder.Append(_options.FileNameExtension);
+        builder.Append(_fileNameSuffix);
         return builder.ToString();
     }
 
@@ -152,15 +186,15 @@ internal sealed class LogFileWriter : IDisposable
         };
     }
 
-    private static void Compress(string path)
+    private void Compress(string path)
     {
         try
         {
             using (var source = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
-            using (var destination = new FileStream(path + GZipExtension, FileMode.Create, FileAccess.Write, FileShare.None))
-            using (var gzip = new GZipStream(destination, CompressionLevel.Optimal))
+            using (var destination = new FileStream(path + GetCompressionExtension(_options.Compression), FileMode.Create, FileAccess.Write, FileShare.None))
+            using (var compressedStream = CreateCompressionStream(destination))
             {
-                source.CopyTo(gzip);
+                source.CopyTo(compressedStream);
             }
 
             File.Delete(path);
@@ -180,9 +214,12 @@ internal sealed class LogFileWriter : IDisposable
         {
             var directory = new DirectoryInfo(_directory);
             var pattern = _options.FileNamePrefix + "*" + _options.FileNameExtension;
-            // The file names start with the timestamp, so ordering them by name orders them chronologically
+
+            // The file names start with the timestamp, so ordering them by name orders them chronologically.
+            // The second pattern matches the compressed files, whatever the algorithm they were compressed with
             var files = directory.GetFiles(pattern)
-                .Concat(directory.GetFiles(pattern + GZipExtension))
+                .Concat(directory.GetFiles(pattern + ".*"))
+                .DistinctBy(file => file.FullName, StringComparer.Ordinal)
                 .OrderByDescending(file => file.Name, StringComparer.Ordinal)
                 .Skip(maxRetainedFiles);
 

--- a/src/Meziantou.Extensions.Logging.FileLogger/LogFileWriter.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/LogFileWriter.cs
@@ -132,6 +132,9 @@ internal sealed class LogFileWriter : IDisposable
     {
         LogFileCompression.GZip => new GZipStream(stream, _options.CompressionLevel),
         LogFileCompression.Brotli => new BrotliStream(stream, _options.CompressionLevel),
+#if NET11_0_OR_GREATER
+        LogFileCompression.Zstandard => new ZstandardStream(stream, _options.CompressionLevel),
+#endif
         _ => stream,
     };
 
@@ -139,6 +142,9 @@ internal sealed class LogFileWriter : IDisposable
     {
         LogFileCompression.GZip => ".gz",
         LogFileCompression.Brotli => ".br",
+#if NET11_0_OR_GREATER
+        LogFileCompression.Zstandard => ".zst",
+#endif
         _ => "",
     };
 

--- a/src/Meziantou.Extensions.Logging.FileLogger/LogFileWriter.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/LogFileWriter.cs
@@ -1,0 +1,208 @@
+using System.IO.Compression;
+
+namespace Meziantou.Extensions.Logging;
+
+/// <summary>Writes the log messages to a file and handles the log file rolling and retention.</summary>
+internal sealed class LogFileWriter : IDisposable
+{
+    private const string GZipExtension = ".gz";
+    private const int MaxFileNameAttempts = 1000;
+
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+
+    private readonly FileLoggerOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly string _directory;
+    private readonly int _newLineByteCount;
+
+    private StreamWriter _writer;
+    private bool _canAppend;
+    private string? _currentFilePath;
+    private long _currentFileSize;
+    private DateTimeOffset _currentPeriod;
+
+    /// <summary>Gets the path of the file the messages are currently written to.</summary>
+    public string? CurrentFilePath => Volatile.Read(ref _currentFilePath);
+
+    public LogFileWriter(string directory, FileLoggerOptions options, TimeProvider timeProvider)
+    {
+        _directory = directory;
+        _options = options;
+        _timeProvider = timeProvider;
+        _newLineByteCount = Environment.NewLine.Length;
+        _canAppend = options.Append;
+        Open(timeProvider.GetUtcNow());
+    }
+
+    public void WriteLine(string message)
+    {
+        var byteCount = Utf8NoBom.GetByteCount(message) + _newLineByteCount;
+        RollIfNeeded(_timeProvider.GetUtcNow(), byteCount);
+        _writer.WriteLine(message);
+        _currentFileSize += byteCount;
+    }
+
+    public void Flush() => _writer.Flush();
+
+    public void Dispose()
+    {
+        // Keep CurrentFilePath, so the path of the last log file can be read after the provider is disposed
+        _writer.Dispose();
+    }
+
+    private void RollIfNeeded(DateTimeOffset now, int byteCount)
+    {
+        var rollPeriod = _options.RollInterval is not RollInterval.None && Truncate(now) != _currentPeriod;
+
+        // Never roll on an empty file, otherwise a message bigger than the limit would roll indefinitely
+        var rollSize = _options.MaxFileSizeInBytes is { } maxSize && _currentFileSize > 0 && (_currentFileSize + byteCount) > maxSize;
+        if (!rollPeriod && !rollSize)
+            return;
+
+        var previousFilePath = _currentFilePath;
+        _writer.Flush();
+        _writer.Dispose();
+        Open(now);
+
+        if (_options.CompressRolledFiles && previousFilePath is not null)
+        {
+            Compress(previousFilePath);
+        }
+
+        ApplyRetentionPolicy();
+    }
+
+    [MemberNotNull(nameof(_writer))]
+    private void Open(DateTimeOffset now)
+    {
+        Directory.CreateDirectory(_directory);
+
+        IOException? lastException = null;
+        for (var index = 0; index < MaxFileNameAttempts; index++)
+        {
+            var path = Path.Combine(_directory, GetFileName(now, index));
+
+            // Only the first file can be appended to, the next ones are created by a roll and must be new
+            var append = _canAppend;
+            if (append && _options.MaxFileSizeInBytes is { } maxSize && File.Exists(path) && new FileInfo(path).Length >= maxSize)
+                continue;
+
+            try
+            {
+                // Opening the file with FileShare.Read allows other processes to read the log file while it is being written,
+                // and prevents 2 providers from writing to the same file
+                var stream = new FileStream(path, append ? FileMode.Append : FileMode.CreateNew, FileAccess.Write, FileShare.Read | FileShare.Delete);
+                _currentFileSize = stream.Length;
+                _writer = new StreamWriter(stream, Utf8NoBom) { AutoFlush = false };
+                _currentPeriod = Truncate(now);
+                _canAppend = false;
+                Volatile.Write(ref _currentFilePath, path);
+                return;
+            }
+            catch (IOException ex)
+            {
+                // The file already exists or is used by another process, try the next name
+                lastException = ex;
+            }
+        }
+
+        throw lastException ?? new IOException("Cannot create a log file in " + _directory);
+    }
+
+    private string GetFileName(DateTimeOffset now, int index)
+    {
+        var builder = new StringBuilder();
+        builder.Append(_options.FileNamePrefix);
+
+        // Timestamp first so the files sort chronologically by name
+        builder.Append(now.ToString(GetTimestampFormat(_options.RollInterval), CultureInfo.InvariantCulture));
+
+        if (_options.IncludeProcessIdInFileName)
+        {
+            builder.Append('-').Append(Environment.ProcessId);
+        }
+
+        if (index > 0)
+        {
+            // '_' sorts after '.', so the file names of a same period are ordered chronologically
+            builder.Append('_').Append(index.ToString("000", CultureInfo.InvariantCulture));
+        }
+
+        builder.Append(_options.FileNameExtension);
+        return builder.ToString();
+    }
+
+    private static string GetTimestampFormat(RollInterval rollInterval) => rollInterval switch
+    {
+        RollInterval.Hourly => "yyyy-MM-dd-HH",
+        RollInterval.Daily => "yyyy-MM-dd",
+        RollInterval.Monthly => "yyyy-MM",
+        _ => "yyyy-MM-dd-HH-mm-ss",
+    };
+
+    private DateTimeOffset Truncate(DateTimeOffset value)
+    {
+        var utc = value.UtcDateTime;
+        return _options.RollInterval switch
+        {
+            RollInterval.Hourly => new DateTimeOffset(utc.Year, utc.Month, utc.Day, utc.Hour, minute: 0, second: 0, TimeSpan.Zero),
+            RollInterval.Daily => new DateTimeOffset(utc.Year, utc.Month, utc.Day, hour: 0, minute: 0, second: 0, TimeSpan.Zero),
+            RollInterval.Monthly => new DateTimeOffset(utc.Year, utc.Month, day: 1, hour: 0, minute: 0, second: 0, TimeSpan.Zero),
+            _ => DateTimeOffset.MinValue,
+        };
+    }
+
+    private static void Compress(string path)
+    {
+        try
+        {
+            using (var source = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
+            using (var destination = new FileStream(path + GZipExtension, FileMode.Create, FileAccess.Write, FileShare.None))
+            using (var gzip = new GZipStream(destination, CompressionLevel.Optimal))
+            {
+                source.CopyTo(gzip);
+            }
+
+            File.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Keep the uncompressed file when it cannot be compressed
+        }
+    }
+
+    private void ApplyRetentionPolicy()
+    {
+        if (_options.MaxRetainedFiles is not { } maxRetainedFiles)
+            return;
+
+        try
+        {
+            var directory = new DirectoryInfo(_directory);
+            var pattern = _options.FileNamePrefix + "*" + _options.FileNameExtension;
+            // The file names start with the timestamp, so ordering them by name orders them chronologically
+            var files = directory.GetFiles(pattern)
+                .Concat(directory.GetFiles(pattern + GZipExtension))
+                .OrderByDescending(file => file.Name, StringComparer.Ordinal)
+                .Skip(maxRetainedFiles);
+
+            foreach (var file in files)
+            {
+                if (string.Equals(file.FullName, _currentFilePath, StringComparison.Ordinal))
+                    continue;
+
+                try
+                {
+                    file.Delete();
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    // The file is in use by another process
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or DirectoryNotFoundException)
+        {
+        }
+    }
+}

--- a/src/Meziantou.Extensions.Logging.FileLogger/Meziantou.Extensions.Logging.FileLogger.csproj
+++ b/src/Meziantou.Extensions.Logging.FileLogger/Meziantou.Extensions.Logging.FileLogger.csproj
@@ -2,16 +2,17 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <IsTrimmable>false</IsTrimmable>
+    <IsTrimmable>true</IsTrimmable>
 
-    <Description>Microsoft.Extension.Logging.ILogger implementation that writes to a file.</Description>
+    <Description>Microsoft.Extension.Logging.ILogger implementation that writes to a file. Supports rolling files, retention, gzip compression, scopes, and JSON output.</Description>
     <PackageTags>logger, file</PackageTags>
-    <Version>2.0.1</Version>
+    <Version>3.0.0</Version>
     <RootNamespace>Meziantou.Extensions.Logging</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Extensions.Logging.FileLogger/RollInterval.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/RollInterval.cs
@@ -1,0 +1,17 @@
+namespace Meziantou.Extensions.Logging;
+
+/// <summary>Specifies how often a new log file is created based on time.</summary>
+public enum RollInterval
+{
+    /// <summary>The log file is never rolled based on time.</summary>
+    None,
+
+    /// <summary>A new log file is created every hour.</summary>
+    Hourly,
+
+    /// <summary>A new log file is created every day.</summary>
+    Daily,
+
+    /// <summary>A new log file is created every month.</summary>
+    Monthly,
+}

--- a/src/Meziantou.Extensions.Logging.FileLogger/SimpleFileFormatter.cs
+++ b/src/Meziantou.Extensions.Logging.FileLogger/SimpleFileFormatter.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meziantou.Extensions.Logging;
+
+/// <summary>A <see cref="FileFormatter"/> that writes one human-readable line per log entry.</summary>
+public sealed class SimpleFileFormatter : FileFormatter
+{
+    /// <summary>Gets a shared instance of the <see cref="SimpleFileFormatter"/> class.</summary>
+    public static SimpleFileFormatter Instance { get; } = new();
+
+    /// <summary>Initializes a new instance of the <see cref="SimpleFileFormatter"/> class.</summary>
+    public SimpleFileFormatter()
+        : base(FileFormatterNames.Simple)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override void Write<TState>(in LogEntry<TState> logEntry, DateTimeOffset timestamp, FileLoggerOptions options, IExternalScopeProvider? scopeProvider, TextWriter textWriter)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(textWriter);
+
+        var message = logEntry.Formatter(logEntry.State, logEntry.Exception);
+        if (string.IsNullOrEmpty(message) && logEntry.Exception is null)
+            return;
+
+        if (options.TimestampFormat is not null)
+        {
+            WriteSegment(textWriter, timestamp.ToString(options.TimestampFormat, CultureInfo.InvariantCulture));
+        }
+
+        if (options.IncludeLogLevel)
+        {
+            WriteSegment(textWriter, GetLogLevelString(logEntry.LogLevel));
+        }
+
+        if (options.IncludeCategory)
+        {
+            WriteSegment(textWriter, logEntry.Category);
+        }
+
+        if (options.IncludeEventId)
+        {
+            textWriter.Write("[EventId:");
+            textWriter.Write(logEntry.EventId.Id.ToString(CultureInfo.InvariantCulture));
+            if (logEntry.EventId.Name is not null)
+            {
+                textWriter.Write(':');
+                textWriter.Write(logEntry.EventId.Name);
+            }
+
+            textWriter.Write("] ");
+        }
+
+        if (options.IncludeThreadId)
+        {
+            textWriter.Write("[ThreadId:");
+            textWriter.Write(Environment.CurrentManagedThreadId.ToString(CultureInfo.InvariantCulture));
+            textWriter.Write("] ");
+        }
+
+        if (options.IncludeActivityTracking && Activity.Current is { } activity)
+        {
+            textWriter.Write("[TraceId:");
+            textWriter.Write(activity.TraceId.ToHexString());
+            textWriter.Write(" SpanId:");
+            textWriter.Write(activity.SpanId.ToHexString());
+            textWriter.Write("] ");
+        }
+
+        scopeProvider?.ForEachScope(
+            (scope, writer) =>
+            {
+                writer.Write("=> ");
+                writer.Write(Convert.ToString(scope, CultureInfo.InvariantCulture));
+                writer.Write(' ');
+            }, textWriter);
+
+        textWriter.Write(message);
+
+        if (logEntry.Exception is not null)
+        {
+            textWriter.WriteLine();
+            textWriter.Write(logEntry.Exception.ToString());
+        }
+    }
+
+    private static void WriteSegment(TextWriter textWriter, string value)
+    {
+        textWriter.Write('[');
+        textWriter.Write(value);
+        textWriter.Write("] ");
+    }
+}

--- a/src/Meziantou.Extensions.Logging.FileLogger/readme.md
+++ b/src/Meziantou.Extensions.Logging.FileLogger/readme.md
@@ -63,7 +63,7 @@ Note that the options related to the log file itself (`Directory`, file name, `A
 | `RollInterval` | Creates a new file every hour / day / month |
 | `MaxFileSizeInBytes` | Creates a new file when the current one reaches the size limit |
 | `MaxRetainedFiles` | Deletes the oldest files when a new file is created |
-| `Compression` | Compresses the log files using gzip or Brotli |
+| `Compression` | Compresses the log files using gzip, Brotli, or Zstandard (.NET 11+) |
 | `Append` | Reuses an existing file instead of creating a new one at startup |
 
 The log files are named `{FileNamePrefix}{timestamp}-{processId}{FileNameExtension}`, so they are ordered chronologically by name. When the name is already used, a suffix is added (`_001`, `_002`, …).
@@ -71,7 +71,7 @@ The log files are named `{FileNamePrefix}{timestamp}-{processId}{FileNameExtensi
 ## Compression
 
 ```c#
-options.Compression = LogFileCompression.GZip;      // or LogFileCompression.Brotli
+options.Compression = LogFileCompression.GZip;      // GZip, Brotli, or Zstandard (.NET 11+)
 options.CompressionLevel = CompressionLevel.SmallestSize;
 options.CompressionMode = LogFileCompressionMode.Continuous;
 ```

--- a/src/Meziantou.Extensions.Logging.FileLogger/readme.md
+++ b/src/Meziantou.Extensions.Logging.FileLogger/readme.md
@@ -63,10 +63,29 @@ Note that the options related to the log file itself (`Directory`, file name, `A
 | `RollInterval` | Creates a new file every hour / day / month |
 | `MaxFileSizeInBytes` | Creates a new file when the current one reaches the size limit |
 | `MaxRetainedFiles` | Deletes the oldest files when a new file is created |
-| `CompressRolledFiles` | Compresses the files using gzip once they are rolled |
+| `Compression` | Compresses the log files using gzip or Brotli |
 | `Append` | Reuses an existing file instead of creating a new one at startup |
 
 The log files are named `{FileNamePrefix}{timestamp}-{processId}{FileNameExtension}`, so they are ordered chronologically by name. When the name is already used, a suffix is added (`_001`, `_002`, …).
+
+## Compression
+
+```c#
+options.Compression = LogFileCompression.GZip;      // or LogFileCompression.Brotli
+options.CompressionLevel = CompressionLevel.SmallestSize;
+options.CompressionMode = LogFileCompressionMode.Continuous;
+```
+
+| `CompressionMode` | Description |
+| --- | --- |
+| `Continuous` (default) | The messages are compressed as they are written, so the file is never written uncompressed. The extension of the compression algorithm is part of the file name (`2024-01-02-1234.log.gz`). |
+| `OnRoll` | The current log file is a plain text file, and it is compressed once it is rolled. |
+
+`Continuous` doesn't need any extra disk space and doesn't pause the logging to compress a big file, but the compressed stream is only finalized when the file is rolled or when the provider is disposed, so the current log file may not be readable by all the tools while the application is running. Use `OnRoll` when you need to read the current log file with the usual text tools.
+
+`Append` is ignored when the messages are compressed continuously, as appending to a compressed file would produce a file that most tools cannot read entirely.
+
+`MaxFileSizeInBytes` is compared to the size of the file on disk, so it accounts for the compression. As the compressed size is only known once the data is flushed, the file may be rolled slightly before the limit.
 
 ## Formatters
 

--- a/src/Meziantou.Extensions.Logging.FileLogger/readme.md
+++ b/src/Meziantou.Extensions.Logging.FileLogger/readme.md
@@ -1,5 +1,9 @@
 # Meziantou.Extensions.Logging.FileLogger
 
+An `ILogger` implementation that writes to a file. The messages are queued and written by a background thread, so logging doesn't block the application.
+
+## Usage
+
 ```c#
 using Microsoft.Extensions.Logging;
 
@@ -12,3 +16,96 @@ var logger = loggerFactory.CreateLogger("Sample");
 logger.LogInformation("Hello from file logger");
 Console.WriteLine($"Log file: {provider.LogFilePath}");
 ```
+
+## Dependency Injection
+
+```c#
+var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.AddFile(options =>
+{
+    options.Directory = "logs";
+    options.RollInterval = RollInterval.Daily;
+    options.MaxRetainedFiles = 7;
+    options.CompressRolledFiles = true;
+    options.IncludeScopes = true;
+});
+```
+
+The options can also be set from the configuration, using the `File` provider alias:
+
+```json
+{
+  "Logging": {
+    "File": {
+      "Directory": "logs",
+      "RollInterval": "Daily",
+      "MaxFileSizeInBytes": 10485760,
+      "MaxRetainedFiles": 7,
+      "FormatterName": "json",
+      "LogLevel": {
+        "Default": "Information"
+      }
+    }
+  }
+}
+```
+
+```c#
+builder.Logging.AddFile();
+```
+
+Note that the options related to the log file itself (`Directory`, file name, `Append`, rolling, `MaxQueueLength`, `QueueFullMode`) are read when the provider is created. The other options are re-read when the configuration changes.
+
+## Rolling and retention
+
+| Option | Description |
+| --- | --- |
+| `RollInterval` | Creates a new file every hour / day / month |
+| `MaxFileSizeInBytes` | Creates a new file when the current one reaches the size limit |
+| `MaxRetainedFiles` | Deletes the oldest files when a new file is created |
+| `CompressRolledFiles` | Compresses the files using gzip once they are rolled |
+| `Append` | Reuses an existing file instead of creating a new one at startup |
+
+The log files are named `{FileNamePrefix}{timestamp}-{processId}{FileNameExtension}`, so they are ordered chronologically by name. When the name is already used, a suffix is added (`_001`, `_002`, …).
+
+## Formatters
+
+`SimpleFileFormatter` (default) writes one human-readable line per entry:
+
+```
+[2024-01-02 03:04:05.006] [INFO] [Sample.Program] => Scope1 Hello world
+```
+
+`JsonFileFormatter` writes one JSON object per entry, including the message template and its named parameters:
+
+```c#
+builder.Logging.AddFile("logs", options => options.FormatterName = FileFormatterNames.Json);
+```
+
+```json
+{"Timestamp":"2024-01-02 03:04:05.006","LogLevel":"INFO","Category":"Sample.Program","Message":"Hello world","State":{"Name":"world","{OriginalFormat}":"Hello {Name}"},"Scopes":["Scope1"]}
+```
+
+You can also write a custom formatter by inheriting from `FileFormatter` and setting `FileLoggerOptions.Formatter`.
+
+## Content of the messages
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `MinLevel` | `Trace` | Minimum level of the messages written to the file |
+| `TimestampFormat` | `yyyy-MM-dd HH:mm:ss.fff` | Format of the timestamp, `null` to omit it |
+| `UseUtcTimestamp` | `true` | Use UTC instead of the local time |
+| `IncludeLogLevel` | `true` | Write the log level |
+| `IncludeCategory` | `true` | Write the category |
+| `UseShortCategoryName` | `false` | Write only the last segment of the category |
+| `IncludeScopes` | `false` | Write the scopes |
+| `IncludeEventId` | `false` | Write the event id |
+| `IncludeThreadId` | `false` | Write the id of the thread that logged the message |
+| `IncludeActivityTracking` | `false` | Write the trace id and the span id of `Activity.Current` |
+
+## Reliability
+
+- The messages are queued in a bounded queue. When it is full, `QueueFullMode` determines if the caller waits for room (default), or if the message is dropped.
+- The pending messages are flushed as soon as the queue is empty, and at most every `FlushInterval` when the logger cannot keep up.
+- `FlushAsync` waits for the pending messages to be written.
+- When the log file cannot be created or written, a warning is written on the standard error stream and the application keeps running.

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
@@ -1,5 +1,11 @@
+using System.Diagnostics;
+using System.Text.Json;
 using Meziantou.Framework;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 
 #pragma warning disable CA1848 // Use the LoggerMessage delegates
 
@@ -7,6 +13,8 @@ namespace Meziantou.Extensions.Logging.FileLogger.Tests;
 
 public sealed class FileLoggerProviderTests
 {
+    private static readonly DateTimeOffset StartDate = new(2024, 1, 2, 3, 4, 5, TimeSpan.Zero);
+
     [Fact]
     public async Task WritesLogToFile()
     {
@@ -26,11 +34,483 @@ public sealed class FileLoggerProviderTests
             var content = await File.ReadAllTextAsync(logFilePath);
             Assert.Contains("Hello from test", content);
             Assert.Contains("[INFO]", content);
-            Assert.Contains("[Category]", content);
+            Assert.Contains("[Test.Namespace.Category]", content);
         }
         finally
         {
             provider.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task WritesExceptionToFile()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(tempDirectory);
+        var logger = provider.CreateLogger("Test");
+
+        logger.LogError(new InvalidOperationException("Sample exception"), "Something failed");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        var content = await ReadLogFileAsync(provider.LogFilePath);
+        Assert.Contains("[FAIL]", content);
+        Assert.Contains("Something failed", content);
+        Assert.Contains(nameof(InvalidOperationException), content);
+        Assert.Contains("Sample exception", content);
+    }
+
+    [Fact]
+    public async Task UseShortCategoryName()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions { Directory = tempDirectory.FullPath, UseShortCategoryName = true });
+        provider.CreateLogger("Test.Namespace.Category").LogInformation("Hello");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        var content = await ReadLogFileAsync(provider.LogFilePath);
+        Assert.Contains("[Category]", content);
+        Assert.DoesNotContain("Test.Namespace", content);
+    }
+
+    [Fact]
+    public async Task MinLevelFiltersMessages()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions { Directory = tempDirectory.FullPath, MinLevel = LogLevel.Warning });
+        var logger = provider.CreateLogger("Test");
+
+        Assert.False(logger.IsEnabled(LogLevel.Information));
+        Assert.True(logger.IsEnabled(LogLevel.Warning));
+
+        logger.LogInformation("ignored message");
+        logger.LogWarning("kept message");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        var content = await ReadLogFileAsync(provider.LogFilePath);
+        Assert.DoesNotContain("ignored message", content);
+        Assert.Contains("kept message", content);
+    }
+
+    [Fact]
+    public async Task IncludeScopes()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions { Directory = tempDirectory.FullPath, IncludeScopes = true });
+        using var loggerFactory = LoggerFactory.Create(builder => builder.SetMinimumLevel(LogLevel.Trace).AddProvider(provider));
+        var logger = loggerFactory.CreateLogger("Test");
+
+        using (logger.BeginScope("OuterScope"))
+        using (logger.BeginScope("InnerScope"))
+        {
+            logger.LogInformation("Hello");
+        }
+
+        logger.LogInformation("Outside");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        var lines = (await ReadLogFileAsync(provider.LogFilePath)).Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Contains("=> OuterScope => InnerScope Hello", lines[0]);
+        Assert.DoesNotContain("=>", lines[1]);
+    }
+
+    [Fact]
+    public async Task IncludeEventIdThreadIdAndActivity()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            IncludeEventId = true,
+            IncludeThreadId = true,
+            IncludeActivityTracking = true,
+        });
+
+        using var activitySource = new ActivitySource("Test");
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name is "Test",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var activity = activitySource.StartActivity("Test");
+        Assert.NotNull(activity);
+
+        var threadId = Environment.CurrentManagedThreadId;
+        provider.CreateLogger("Test").LogInformation(new EventId(42, "SampleEvent"), "Hello");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        var content = await ReadLogFileAsync(provider.LogFilePath);
+        Assert.Contains("[EventId:42:SampleEvent]", content);
+        Assert.Contains($"[ThreadId:{threadId.ToString(CultureInfo.InvariantCulture)}]", content);
+        Assert.Contains($"[TraceId:{activity.TraceId.ToHexString()}", content);
+    }
+
+    [Fact]
+    public async Task JsonFormatter()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            FormatterName = FileFormatterNames.Json,
+            IncludeScopes = true,
+        });
+
+        using var loggerFactory = LoggerFactory.Create(builder => builder.SetMinimumLevel(LogLevel.Trace).AddProvider(provider));
+        var logger = loggerFactory.CreateLogger("Test.Category");
+
+        using (logger.BeginScope("Scope1"))
+        {
+            logger.LogWarning("Hello {Name}", "world");
+        }
+
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        var content = await ReadLogFileAsync(provider.LogFilePath);
+        using var document = JsonDocument.Parse(content);
+        var root = document.RootElement;
+        Assert.Equal("WARN", root.GetProperty("LogLevel").GetString());
+        Assert.Equal("Test.Category", root.GetProperty("Category").GetString());
+        Assert.Equal("Hello world", root.GetProperty("Message").GetString());
+        Assert.Equal("world", root.GetProperty("State").GetProperty("Name").GetString());
+        Assert.Equal("Hello {Name}", root.GetProperty("State").GetProperty("{OriginalFormat}").GetString());
+        Assert.Equal("Scope1", root.GetProperty("Scopes")[0].GetString());
+    }
+
+    [Fact]
+    public async Task CustomFormatter()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions { Directory = tempDirectory.FullPath, Formatter = new UppercaseFileFormatter() });
+        provider.CreateLogger("Test").LogInformation("Hello");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        var content = await ReadLogFileAsync(provider.LogFilePath);
+        Assert.Equal("HELLO", content.Trim());
+    }
+
+    [Fact]
+    public async Task RollFileOnMaxFileSize()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            MaxFileSizeInBytes = 200,
+            TimestampFormat = null,
+            IncludeCategory = false,
+            IncludeLogLevel = false,
+        });
+
+        var logger = provider.CreateLogger("Test");
+        for (var i = 0; i < 20; i++)
+        {
+            logger.LogInformation("Message {Index} ..........", i);
+        }
+
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        var files = Directory.GetFiles(tempDirectory.FullPath);
+        var fileCount = files.Length;
+        Assert.True(fileCount > 1, $"Expected multiple log files, got {fileCount}");
+        foreach (var file in files)
+        {
+            Assert.True(new FileInfo(file).Length <= 200, "A log file is bigger than the maximum size");
+        }
+    }
+
+    [Fact]
+    public async Task RollFileOnInterval()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new FakeTimeProvider(StartDate);
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions { Directory = tempDirectory.FullPath, RollInterval = RollInterval.Daily }, timeProvider);
+        var logger = provider.CreateLogger("Test");
+
+        logger.LogInformation("First day");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+        var firstFile = provider.LogFilePath;
+
+        timeProvider.Advance(TimeSpan.FromDays(1));
+        logger.LogInformation("Second day");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+        var secondFile = provider.LogFilePath;
+
+        Assert.NotEqual(firstFile, secondFile);
+        var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        Assert.Equal($"2024-01-02-{pid}.log", Path.GetFileName(firstFile));
+        Assert.Equal($"2024-01-03-{pid}.log", Path.GetFileName(secondFile));
+        Assert.Contains("First day", await ReadLogFileAsync(firstFile));
+        Assert.Contains("Second day", await ReadLogFileAsync(secondFile));
+    }
+
+    [Fact]
+    public async Task MaxRetainedFiles()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new FakeTimeProvider(StartDate);
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            RollInterval = RollInterval.Daily,
+            MaxRetainedFiles = 2,
+        }, timeProvider);
+
+        var logger = provider.CreateLogger("Test");
+        for (var i = 0; i < 5; i++)
+        {
+            logger.LogInformation("Day {Index}", i);
+            await provider.FlushAsync(TestContext.Current.CancellationToken);
+            timeProvider.Advance(TimeSpan.FromDays(1));
+        }
+
+        var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        Assert.Equal([$"2024-01-05-{pid}.log", $"2024-01-06-{pid}.log"], GetFileNames(tempDirectory));
+    }
+
+    [Fact]
+    public async Task CompressRolledFiles()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new FakeTimeProvider(StartDate);
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            RollInterval = RollInterval.Daily,
+            CompressRolledFiles = true,
+        }, timeProvider);
+
+        var logger = provider.CreateLogger("Test");
+        logger.LogInformation("First day");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        timeProvider.Advance(TimeSpan.FromDays(1));
+        logger.LogInformation("Second day");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        var files = GetFileNames(tempDirectory);
+        Assert.Equal([$"2024-01-02-{pid}.log.gz", $"2024-01-03-{pid}.log"], files);
+
+        await using var stream = File.OpenRead(Path.Combine(tempDirectory.FullPath, files[0]));
+        await using var gzip = new System.IO.Compression.GZipStream(stream, System.IO.Compression.CompressionMode.Decompress);
+        using var reader = new StreamReader(gzip);
+        Assert.Contains("First day", await reader.ReadToEndAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task TwoProvidersUseDifferentFiles()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new FakeTimeProvider(StartDate);
+        await using var provider1 = new FileLoggerProvider(tempDirectory.FullPath, timeProvider);
+        await using var provider2 = new FileLoggerProvider(tempDirectory.FullPath, timeProvider);
+
+        provider1.CreateLogger("Test").LogInformation("From first provider");
+        provider2.CreateLogger("Test").LogInformation("From second provider");
+        await provider1.FlushAsync(TestContext.Current.CancellationToken);
+        await provider2.FlushAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotEqual(provider1.LogFilePath, provider2.LogFilePath);
+        Assert.Contains("From first provider", await ReadLogFileAsync(provider1.LogFilePath));
+        Assert.Contains("From second provider", await ReadLogFileAsync(provider2.LogFilePath));
+    }
+
+    [Fact]
+    public async Task AppendToExistingFile()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new FakeTimeProvider(StartDate);
+        var options = new FileLoggerOptions { Directory = tempDirectory.FullPath, Append = true, RollInterval = RollInterval.Daily };
+
+        await using (var provider = new FileLoggerProvider(options, timeProvider))
+        {
+            provider.CreateLogger("Test").LogInformation("First run");
+        }
+
+        await using (var provider = new FileLoggerProvider(options, timeProvider))
+        {
+            provider.CreateLogger("Test").LogInformation("Second run");
+        }
+
+        var files = Directory.GetFiles(tempDirectory.FullPath);
+        var file = Assert.Single(files);
+        var content = await ReadLogFileAsync(file);
+        Assert.Contains("First run", content);
+        Assert.Contains("Second run", content);
+    }
+
+    [Fact]
+    public async Task AppendDoesNotReuseAFullFile()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new FakeTimeProvider(StartDate);
+        var options = new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            Append = true,
+            RollInterval = RollInterval.Daily,
+            MaxFileSizeInBytes = 100,
+            TimestampFormat = null,
+            IncludeCategory = false,
+            IncludeLogLevel = false,
+        };
+
+        for (var i = 0; i < 3; i++)
+        {
+            await using var provider = new FileLoggerProvider(options, timeProvider);
+            provider.CreateLogger("Test").LogInformation("Message .............................................................................");
+        }
+
+        var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        Assert.Equal([$"2024-01-02-{pid}.log", $"2024-01-02-{pid}_001.log", $"2024-01-02-{pid}_002.log"], GetFileNames(tempDirectory));
+    }
+
+    [Fact]
+    public async Task FlushAsyncWritesPendingMessages()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions { Directory = tempDirectory.FullPath, FlushInterval = TimeSpan.FromHours(1) });
+        provider.CreateLogger("Test").LogInformation("Hello");
+
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("Hello", await ReadLogFileAsync(provider.LogFilePath));
+    }
+
+    [Fact]
+    public async Task DropWriteDoesNotBlock()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            MaxQueueLength = 1,
+            QueueFullMode = FileLoggerQueueFullMode.DropWrite,
+        });
+
+        var logger = provider.CreateLogger("Test");
+        for (var i = 0; i < 10_000; i++)
+        {
+            logger.LogInformation("Message {Index}", i);
+        }
+
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+        Assert.True(File.Exists(provider.LogFilePath));
+    }
+
+    [Fact]
+    public async Task DisposeWritesAllPendingMessages()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var provider = new FileLoggerProvider(new FileLoggerOptions { Directory = tempDirectory.FullPath, FlushInterval = TimeSpan.FromHours(1) });
+        var logger = provider.CreateLogger("Test");
+        for (var i = 0; i < 1000; i++)
+        {
+            logger.LogInformation("Message {Index}", i);
+        }
+
+        await provider.DisposeAsync();
+        await provider.DisposeAsync();
+
+        var lines = await File.ReadAllLinesAsync(provider.LogFilePath!, TestContext.Current.CancellationToken);
+        Assert.HasCount(1000, lines);
+    }
+
+    [Fact]
+    public void MissingDirectoryThrows()
+    {
+        Assert.Throws<InvalidOperationException>(() => new FileLoggerProvider(new FileLoggerOptions()));
+    }
+
+    [Fact]
+    public async Task AddFileRegistersTheProvider()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Trace).AddFile(tempDirectory.FullPath, options => options.UseShortCategoryName = true));
+
+        await using (var serviceProvider = services.BuildServiceProvider())
+        {
+            var logger = serviceProvider.GetRequiredService<ILogger<FileLoggerProviderTests>>();
+            using (logger.BeginScope("Scope"))
+            {
+                logger.LogInformation("Hello from DI");
+            }
+        }
+
+        var file = Assert.Single(Directory.GetFiles(tempDirectory.FullPath));
+        var content = await File.ReadAllTextAsync(file, TestContext.Current.CancellationToken);
+        Assert.Contains("[FileLoggerProviderTests] Hello from DI", content);
+    }
+
+    [Fact]
+    public async Task AddFileReadsTheConfiguration()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["Logging:File:Directory"] = tempDirectory.FullPath,
+                ["Logging:File:IncludeEventId"] = "true",
+                ["Logging:File:LogLevel:Default"] = "Warning",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.AddConfiguration(configuration.GetSection("Logging"));
+            builder.AddFile();
+        });
+
+        await using (var serviceProvider = services.BuildServiceProvider())
+        {
+            var logger = serviceProvider.GetRequiredService<ILogger<FileLoggerProviderTests>>();
+            logger.LogInformation("Filtered out by the configuration");
+            logger.LogWarning(new EventId(42), "Kept by the configuration");
+        }
+
+        var file = Assert.Single(Directory.GetFiles(tempDirectory.FullPath));
+        var content = await File.ReadAllTextAsync(file, TestContext.Current.CancellationToken);
+        Assert.DoesNotContain("Filtered out", content);
+        Assert.Contains("[EventId:42] Kept by the configuration", content);
+    }
+
+    [Fact]
+    public async Task InvalidDirectoryDoesNotThrow()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var filePath = tempDirectory.CreateEmptyFile("file.txt");
+
+        // The directory cannot be created because a file with the same name already exists
+        await using var provider = new FileLoggerProvider(filePath.Value);
+        provider.CreateLogger("Test").LogInformation("Hello");
+        await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+        Assert.Null(provider.LogFilePath);
+    }
+
+    private static string[] GetFileNames(TemporaryDirectory directory)
+    {
+        return new DirectoryInfo(directory.FullPath).GetFiles().Select(file => file.Name).Order(StringComparer.Ordinal).ToArray();
+    }
+
+    private static async Task<string> ReadLogFileAsync(string? path)
+    {
+        Assert.NotNull(path);
+
+        // The file is still opened by the provider
+        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(stream);
+        return await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
+    }
+
+    private sealed class UppercaseFileFormatter() : FileFormatter("uppercase")
+    {
+        public override void Write<TState>(in LogEntry<TState> logEntry, DateTimeOffset timestamp, FileLoggerOptions options, IExternalScopeProvider? scopeProvider, TextWriter textWriter)
+        {
+            textWriter.Write(logEntry.Formatter(logEntry.State, logEntry.Exception).ToUpperInvariant());
         }
     }
 }

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO.Compression;
 using System.Text.Json;
 using Meziantou.Framework;
 using Microsoft.Extensions.Configuration;
@@ -270,7 +271,7 @@ public sealed class FileLoggerProviderTests
     }
 
     [Fact]
-    public async Task CompressRolledFiles()
+    public async Task CompressOnRoll()
     {
         using var tempDirectory = TemporaryDirectory.Create();
         var timeProvider = new FakeTimeProvider(StartDate);
@@ -278,7 +279,8 @@ public sealed class FileLoggerProviderTests
         {
             Directory = tempDirectory.FullPath,
             RollInterval = RollInterval.Daily,
-            CompressRolledFiles = true,
+            Compression = LogFileCompression.GZip,
+            CompressionMode = LogFileCompressionMode.OnRoll,
         }, timeProvider);
 
         var logger = provider.CreateLogger("Test");
@@ -293,10 +295,115 @@ public sealed class FileLoggerProviderTests
         var files = GetFileNames(tempDirectory);
         Assert.Equal([$"2024-01-02-{pid}.log.gz", $"2024-01-03-{pid}.log"], files);
 
-        await using var stream = File.OpenRead(Path.Combine(tempDirectory.FullPath, files[0]));
-        await using var gzip = new System.IO.Compression.GZipStream(stream, System.IO.Compression.CompressionMode.Decompress);
-        using var reader = new StreamReader(gzip);
-        Assert.Contains("First day", await reader.ReadToEndAsync(TestContext.Current.CancellationToken));
+        // The current file is not compressed
+        Assert.Contains("Second day", await ReadLogFileAsync(provider.LogFilePath));
+        Assert.Contains("First day", await ReadCompressedFileAsync(Path.Combine(tempDirectory.FullPath, files[0]), LogFileCompression.GZip));
+    }
+
+    [Theory]
+    [InlineData(LogFileCompression.GZip, ".gz")]
+    [InlineData(LogFileCompression.Brotli, ".br")]
+    public async Task CompressWhileWriting(LogFileCompression compression, string extension)
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new FakeTimeProvider(StartDate);
+        var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+
+        await using (var provider = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            RollInterval = RollInterval.Daily,
+            Compression = compression,
+        }, timeProvider))
+        {
+            var logger = provider.CreateLogger("Test");
+            logger.LogInformation("First day");
+            await provider.FlushAsync(TestContext.Current.CancellationToken);
+
+            timeProvider.Advance(TimeSpan.FromDays(1));
+            logger.LogInformation("Second day");
+        }
+
+        var files = GetFileNames(tempDirectory);
+        Assert.Equal([$"2024-01-02-{pid}.log{extension}", $"2024-01-03-{pid}.log{extension}"], files);
+        Assert.Contains("First day", await ReadCompressedFileAsync(Path.Combine(tempDirectory.FullPath, files[0]), compression));
+        Assert.Contains("Second day", await ReadCompressedFileAsync(Path.Combine(tempDirectory.FullPath, files[1]), compression));
+    }
+
+    [Fact]
+    public async Task CompressWhileWritingUsesTheCompressionLevel()
+    {
+        var uncompressedSize = await GetLogFileSizeAsync(CompressionLevel.NoCompression);
+        var compressedSize = await GetLogFileSizeAsync(CompressionLevel.SmallestSize);
+        Assert.True(compressedSize < uncompressedSize, $"The file compressed with SmallestSize ({compressedSize} bytes) is not smaller than the one written with NoCompression ({uncompressedSize} bytes)");
+
+        static async Task<long> GetLogFileSizeAsync(CompressionLevel level)
+        {
+            using var tempDirectory = TemporaryDirectory.Create();
+            await using (var provider = new FileLoggerProvider(new FileLoggerOptions
+            {
+                Directory = tempDirectory.FullPath,
+                Compression = LogFileCompression.GZip,
+                CompressionLevel = level,
+            }))
+            {
+                var logger = provider.CreateLogger("Test");
+                for (var i = 0; i < 200; i++)
+                {
+                    logger.LogInformation("A very repetitive message that should compress very well");
+                }
+            }
+
+            return new FileInfo(Directory.GetFiles(tempDirectory.FullPath).Single()).Length;
+        }
+    }
+
+    [Fact]
+    public async Task CompressWhileWritingIgnoresAppend()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new FakeTimeProvider(StartDate);
+        var options = new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            RollInterval = RollInterval.Daily,
+            Append = true,
+            Compression = LogFileCompression.GZip,
+        };
+
+        for (var i = 0; i < 2; i++)
+        {
+            await using var provider = new FileLoggerProvider(options, timeProvider);
+            provider.CreateLogger("Test").LogInformation("Run {Index}", i);
+        }
+
+        var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        Assert.Equal([$"2024-01-02-{pid}.log.gz", $"2024-01-02-{pid}_001.log.gz"], GetFileNames(tempDirectory));
+    }
+
+    [Fact]
+    public async Task CompressedFilesAreDeletedByTheRetentionPolicy()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeProvider = new FakeTimeProvider(StartDate);
+        await using var provider = new FileLoggerProvider(new FileLoggerOptions
+        {
+            Directory = tempDirectory.FullPath,
+            RollInterval = RollInterval.Daily,
+            Compression = LogFileCompression.GZip,
+            MaxRetainedFiles = 2,
+        }, timeProvider);
+
+        var logger = provider.CreateLogger("Test");
+        for (var i = 0; i < 5; i++)
+        {
+            logger.LogInformation("Day {Index}", i);
+            await provider.FlushAsync(TestContext.Current.CancellationToken);
+            timeProvider.Advance(TimeSpan.FromDays(1));
+        }
+
+        var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        Assert.Equal([$"2024-01-05-{pid}.log.gz", $"2024-01-06-{pid}.log.gz"], GetFileNames(tempDirectory));
     }
 
     [Fact]
@@ -494,6 +601,20 @@ public sealed class FileLoggerProviderTests
     private static string[] GetFileNames(TemporaryDirectory directory)
     {
         return new DirectoryInfo(directory.FullPath).GetFiles().Select(file => file.Name).Order(StringComparer.Ordinal).ToArray();
+    }
+
+    private static async Task<string> ReadCompressedFileAsync(string path, LogFileCompression compression)
+    {
+        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        await using Stream decompressedStream = compression switch
+        {
+            LogFileCompression.GZip => new GZipStream(stream, CompressionMode.Decompress),
+            LogFileCompression.Brotli => new BrotliStream(stream, CompressionMode.Decompress),
+            _ => throw new ArgumentOutOfRangeException(nameof(compression)),
+        };
+
+        using var reader = new StreamReader(decompressedStream);
+        return await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
     }
 
     private static async Task<string> ReadLogFileAsync(string? path)

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/FileLoggerProviderTests.cs
@@ -303,6 +303,9 @@ public sealed class FileLoggerProviderTests
     [Theory]
     [InlineData(LogFileCompression.GZip, ".gz")]
     [InlineData(LogFileCompression.Brotli, ".br")]
+#if NET11_0_OR_GREATER
+    [InlineData(LogFileCompression.Zstandard, ".zst")]
+#endif
     public async Task CompressWhileWriting(LogFileCompression compression, string extension)
     {
         using var tempDirectory = TemporaryDirectory.Create();
@@ -610,6 +613,9 @@ public sealed class FileLoggerProviderTests
         {
             LogFileCompression.GZip => new GZipStream(stream, CompressionMode.Decompress),
             LogFileCompression.Brotli => new BrotliStream(stream, CompressionMode.Decompress),
+#if NET11_0_OR_GREATER
+            LogFileCompression.Zstandard => new ZstandardStream(stream, CompressionMode.Decompress),
+#endif
             _ => throw new ArgumentOutOfRangeException(nameof(compression)),
         };
 

--- a/tests/Meziantou.Extensions.Logging.FileLogger.Tests/Meziantou.Extensions.Logging.FileLogger.Tests.csproj
+++ b/tests/Meziantou.Extensions.Logging.FileLogger.Tests/Meziantou.Extensions.Logging.FileLogger.Tests.csproj
@@ -5,6 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../../src/Meziantou.Extensions.Logging.FileLogger/Meziantou.Extensions.Logging.FileLogger.csproj" />
     <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
   </ItemGroup>

--- a/tests/Trimmable/Trimmable.csproj
+++ b/tests/Trimmable/Trimmable.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\src\Meziantou.AspNetCore\Meziantou.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.AspNetCore.Authentication.HttpBasic\Meziantou.AspNetCore.Authentication.HttpBasic.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.AspNetCore.Mvc\Meziantou.AspNetCore.Mvc.csproj" />
+    <ProjectReference Include="..\..\src\Meziantou.Extensions.Logging.FileLogger\Meziantou.Extensions.Logging.FileLogger.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.Framework\Meziantou.Framework.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.Framework.AnsiFormatting\Meziantou.Framework.AnsiFormatting.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.Framework.Avatar\Meziantou.Framework.Avatar.csproj" />
@@ -74,6 +75,7 @@
     <TrimmerRootAssembly Include="Meziantou.AspNetCore" />
     <TrimmerRootAssembly Include="Meziantou.AspNetCore.Authentication.HttpBasic" />
     <TrimmerRootAssembly Include="Meziantou.AspNetCore.Mvc" />
+    <TrimmerRootAssembly Include="Meziantou.Extensions.Logging.FileLogger" />
     <TrimmerRootAssembly Include="Meziantou.Framework" />
     <TrimmerRootAssembly Include="Meziantou.Framework.AnsiFormatting" />
     <TrimmerRootAssembly Include="Meziantou.Framework.Avatar" />


### PR DESCRIPTION
## Why

`Meziantou.Extensions.Logging.FileLogger` wrote every message to a single file for the lifetime of the process, which isn't usable for a long-running application, and the background writer had a few reliability issues.

## Reliability fixes

- **A write failure hung the whole application.** When `WriteLineAsync` threw (disk full, file deleted on a network share), the writer task ended without completing the channel. Once 1024 messages accumulated, every logger blocked forever in `WaitToWriteAsync`. The writer now completes the channel and reports the error on stderr, so logging degrades instead of deadlocking.
- **`FlushAsync` was racy.** It flushed the `StreamWriter` from the caller thread while the background task could be inside `WriteLineAsync` on the same instance. The flush is now queued as a marker and executed by the writer thread.
- **`AutoFlush` is disabled.** Messages are flushed when the queue drains, plus at most every `FlushInterval` under sustained load, instead of one syscall per line.
- The constructor catches every exception that can occur while creating the file, not only `IOException`.
- Log files are opened with `FileMode.CreateNew` and a numbered suffix (`_001`, `_002`), so two providers in the same process/second no longer collide and silently disable logging.
- `Dispose` is idempotent and `IAsyncDisposable` is implemented.

## Features

- **Rolling and retention**: `RollInterval` (Hourly/Daily/Monthly), `MaxFileSizeInBytes`, `MaxRetainedFiles`, `Append`, and file name customization.
- **Compression**: `Compression` (`None` / `GZip` / `Brotli`, plus `Zstandard` when targeting .NET 11), `CompressionLevel`, and `CompressionMode`:
  - `Continuous` (default) compresses the messages as they are written, so the file is never written uncompressed — no extra disk space, and no pause to compress a big file at roll time. The algorithm extension is part of the file name (`2024-01-02-1234.log.gz`).
  - `OnRoll` keeps the current file as plain text and compresses it once it is rolled, for when you need to read the current log file with the usual text tools.
- **DI and configuration**: `ILoggingBuilder.AddFile(...)`, `[ProviderAlias("File")]`, and `IOptionsMonitor` support, so options and per-category log levels can be set from the `Logging:File` configuration section.
- **Scopes**: the provider implements `ISupportExternalScope`; `BeginScope` no longer returns `null`.
- **`FileLoggerOptions`**: `MinLevel`, `QueueFullMode` (Wait/DropWrite/DropOldest), `MaxQueueLength`, `FlushInterval`, and the display options mirroring `XUnitLoggerOptions`.
- **Pluggable formatters**: abstract `FileFormatter` with `SimpleFileFormatter` (default) and `JsonFileFormatter`, which writes the message template and its named parameters.
- Optional `EventId`, thread id, and `Activity` trace id / span id. Messages are formatted on the calling thread, so ambient state is correct.

## Notes for the reviewer

- **Behavior change**: the category is now written in full (`Sample.Program` instead of `Program`), matching the other logger providers. `UseShortCategoryName` restores the previous output. The version is bumped to `3.0.0` for that reason — if you'd rather keep it source-and-output compatible, flipping that default is a one-line change.
- `LogFileCompression.Zstandard` is behind `#if NET11_0_OR_GREATER`, so the enum has one more value on `net11.0` than on `net10.0`. The generated `ref/` file shows the difference.
- With continuous compression, the compressed stream is finalized when the file is rolled or when the provider is disposed, so the current file may not be readable by all tools while the application runs. `Append` is ignored in that mode, since appending would produce a file most tools cannot read entirely. Both are documented in the readme.
- `MaxFileSizeInBytes` is compared to the size on disk, refreshed on every flush, so it accounts for the compression. Between two flushes the uncompressed byte count is used as an upper bound, so the file can be rolled slightly before the limit rather than after it.
- The log file uses UTF-8 **without** BOM now, and `LogFilePath` became `string?` (it is `null` when the file could not be created, and changes when the file is rolled).
- Options related to the file itself (directory, name, rolling, compression, queue) are read when the provider is created; the others are re-read on configuration change.
- `IsTrimmable` is now `true`. The config binder call is covered by a `DynamicDependency` on `FileLoggerOptions`; `dotnet publish tests/Trimmable` with `TrimMode=full` reports no warning.

## Validation

- `dotnet build` in Debug and Release with `/p:TreatWarningsAsErrors=true`: 0 warnings, 0 errors.
- `dotnet test`: 55/55 passing (27 tests on net10.0 + 28 on net11.0, the extra one being the Zstandard case), covering rolling by size and time, retention, both compression modes, all three algorithms, compression level, append, scopes, JSON, custom formatters, DI, configuration binding, drop modes, flush/dispose, and the unwritable-directory path.
- `dotnet publish tests/Trimmable -f net11.0` with full trimming: no trim warnings.
- `dotnet run ./eng/update-all.cs`: exit 0; `ref/` regenerated and committed.