### PR TITLE
Drop the InMemoryLogger scope buffer when it grows too large

### DIFF
--- a/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogger.cs
+++ b/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogger.cs
@@ -16,6 +16,10 @@ namespace Meziantou.Extensions.Logging.InMemory;
 /// </example>
 public class InMemoryLogger : IInMemoryLogger
 {
+    // Beyond this capacity, the thread-local buffer is dropped instead of being reused,
+    // so an unusually deep scope stack doesn't keep a large array alive on the thread forever.
+    private const int MaxScopeBufferCapacity = 64;
+
     [ThreadStatic]
     private static List<object?>? s_scopeBuffer;
 
@@ -88,7 +92,14 @@ public class InMemoryLogger : IInMemoryLogger
         }
         finally
         {
-            buffer.Clear();
+            if (buffer.Capacity > MaxScopeBufferCapacity)
+            {
+                s_scopeBuffer = null;
+            }
+            else
+            {
+                buffer.Clear();
+            }
         }
     }
 }

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
@@ -163,6 +163,45 @@ public sealed partial class InMemoryLoggerTests
         }
     }
 
+    [Fact]
+    public void WithDeepScopeStack_ThenShallowScope()
+    {
+        using var provider = new InMemoryLoggerProvider(new LoggerExternalScopeProvider());
+        var logger = provider.CreateLogger("my_category");
+
+        // Deep enough to grow the scope buffer past the capacity at which it is dropped instead of reused
+        var scopes = new List<IDisposable?>();
+        try
+        {
+            for (var i = 0; i < 200; i++)
+            {
+                scopes.Add(logger.BeginScope(new Dictionary<string, object?>(StringComparer.Ordinal) { ["Index"] = i }));
+            }
+
+            logger.LogInformation("Deep");
+        }
+        finally
+        {
+            for (var i = scopes.Count - 1; i >= 0; i--)
+            {
+                scopes[i]?.Dispose();
+            }
+        }
+
+        using (logger.BeginScope(new Dictionary<string, object?>(StringComparer.Ordinal) { ["Index"] = 42 }))
+        {
+            logger.LogInformation("Shallow");
+        }
+
+        var deep = provider.Logs.Informations.Single(log => log.Message is "Deep");
+        Assert.HasCount(200, deep.Scopes);
+        Assert.Equal(Enumerable.Range(0, 200).Cast<object?>(), deep.Scopes.Select(scope => Assert.IsType<Dictionary<string, object?>>(scope)["Index"]));
+
+        var shallow = provider.Logs.Informations.Single(log => log.Message is "Shallow");
+        var shallowScope = Assert.Single(shallow.Scopes);
+        Assert.Equal(42, Assert.IsType<Dictionary<string, object?>>(shallowScope)["Index"]);
+    }
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Value is {value}")]
     private static partial void Log(ILogger logger, int value);
 


### PR DESCRIPTION
## What changed

`InMemoryLogger.GetScopes` collects scopes into a `[ThreadStatic]` `List<object?>` and clears it afterwards. `Clear()` releases the scope objects but never shrinks the backing array, so a single unusually deep scope stack left an oversized `object?[]` attached to that thread for the process lifetime.

The buffer is now abandoned rather than cleared once its capacity passes 64:

```csharp
if (buffer.Capacity > MaxScopeBufferCapacity)
{
    s_scopeBuffer = null;
}
else
{
    buffer.Clear();
}
```

No `Clear()` is needed on that path — the list is unreachable garbage as soon as the local goes out of scope. Normal scope depths keep the existing zero-allocation reuse and pay nothing extra.

## Why not an `ObjectPool`

That was the first idea, and it's a worse trade here:

- It needs a `Microsoft.Extensions.ObjectPool` package reference in a library that currently depends only on `Logging.Abstractions`.
- `DefaultObjectPool` rent/return is an `Interlocked.CompareExchange` pair on the fast path plus a scan of the shared array under contention — strictly more work per `Log` call than a `[ThreadStatic]` field read.
- It doesn't fix the growth. The pool holds up to `maximumRetained` lists in a static field forever, and `DefaultPooledObjectPolicy<List<object?>>.Return` never trims capacity, so you'd trade one oversized array per logging thread for N retained globally — unless you write a custom policy that discards large instances, at which point that discard is the whole fix and the pool is scaffolding around it.

## Scale of the problem

Worth being honest that this is a small leak, not a large one: retained memory was `maxScopeDepthEverSeenOnThisThread * 8` bytes per thread that logged. At a typical depth of 2–5 that's ~40 bytes. This closes the pathological case rather than fixing a hot issue.

## Notes for reviewers

- The regression risk is buffer state leaking across calls, so `WithDeepScopeStack_ThenShallowScope` logs a 200-deep stack followed by a 1-deep one on the same thread and asserts both entries capture the right scopes.
- `GetScopes` is only reachable from `Log`, and `formatter(...)` runs after it returns, so there is no re-entrancy path that could observe a half-filled buffer. A future change that calls back into the logger from inside `ForEachScope` would break that assumption.
- 64 is a judgement call — comfortably above any realistic scope depth, low enough that the retained array stays small.

## Verification

- `dotnet build` on the test project with `/p:TreatsWarningsAsErrors=true`: clean, 0 warnings.
- `dotnet test`: 12 tests per TFM, 24 total, 0 failed (net10.0 and net11.0).
- New test confirmed to actually run via `--filter-method`: 2 passed, one per TFM.
- `dotnet run ./eng/update-all.cs`: produced no file changes.