### PR TITLE
Add union type classifiers and fix union case selection

### DIFF
--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -1073,7 +1073,8 @@ namespace Meziantou.Framework.Yaml.Serialization
 
     public enum YamlTypeClassifierKind
     {
-        Union = 0
+        None = 0,
+        Union = 1
     }
 
     public sealed class YamlUnionCaseInfo

--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -1055,6 +1055,12 @@ namespace Meziantou.Framework.Yaml.Serialization
         Alias = 10
     }
 
+    public static class YamlTypeClassification
+    {
+        public static System.Type? Classify(Meziantou.Framework.Yaml.Serialization.YamlReader reader, Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext context, out string? bufferedNode) => throw null;
+        public static System.Type? ClassifyBufferedNode(Meziantou.Framework.Yaml.Serialization.YamlReader reader, string bufferedNode, Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext context) => throw null;
+    }
+
     public delegate System.Type? YamlTypeClassifier(Meziantou.Framework.Yaml.Serialization.YamlReader reader);
 
     public sealed class YamlTypeClassifierContext
@@ -1062,7 +1068,10 @@ namespace Meziantou.Framework.Yaml.Serialization
         public System.Type DeclaringType { get => throw null; }
         public Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierKind Kind { get => throw null; }
         public System.Collections.ObjectModel.ReadOnlyCollection<Meziantou.Framework.Yaml.Serialization.YamlUnionCaseInfo> UnionCases { get => throw null; }
-        public YamlTypeClassifierContext(System.Type declaringType, Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierKind kind, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Yaml.Serialization.YamlUnionCaseInfo> unionCases) { }
+        public System.Collections.ObjectModel.ReadOnlyCollection<Meziantou.Framework.Yaml.YamlDerivedType> DerivedTypes { get => throw null; }
+        public string? TypeDiscriminatorPropertyName { get => throw null; }
+        public static Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext CreateForUnion(System.Type declaringType, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Yaml.Serialization.YamlUnionCaseInfo> unionCases) => throw null;
+        public static Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext CreateForPolymorphicType(System.Type declaringType, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Yaml.YamlDerivedType> derivedTypes, string? typeDiscriminatorPropertyName) => throw null;
     }
 
     public abstract class YamlTypeClassifierFactory
@@ -1074,7 +1083,8 @@ namespace Meziantou.Framework.Yaml.Serialization
     public enum YamlTypeClassifierKind
     {
         None = 0,
-        Union = 1
+        Union = 1,
+        PolymorphicType = 2
     }
 
     public sealed class YamlUnionCaseInfo
@@ -1102,11 +1112,6 @@ namespace Meziantou.Framework.Yaml.Serialization
         Sequence = 3,
         Mapping = 4,
         Any = 5
-    }
-
-    public static class YamlUnionClassification
-    {
-        public static System.Type? Classify(Meziantou.Framework.Yaml.Serialization.YamlReader reader, Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext context, out string? bufferedNode) => throw null;
     }
 
     public sealed class YamlUnionTypeStructuralClassifier : Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierFactory

--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -334,6 +334,7 @@ namespace Meziantou.Framework.Yaml
     {
         public static Meziantou.Framework.Yaml.YamlSerializerOptions Default { get => throw null; }
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Yaml.Serialization.YamlConverter> Converters { get => throw null; init { } }
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierFactory> TypeClassifiers { get => throw null; init { } }
         public Meziantou.Framework.Yaml.YamlNamingPolicy? PropertyNamingPolicy { get => throw null; init { } }
         public string? SourceName { get => throw null; init { } }
         public Meziantou.Framework.Yaml.YamlNamingPolicy? DictionaryKeyPolicy { get => throw null; init { } }
@@ -1052,6 +1053,65 @@ namespace Meziantou.Framework.Yaml.Serialization
         EndSequence = 8,
         Scalar = 9,
         Alias = 10
+    }
+
+    public delegate System.Type? YamlTypeClassifier(Meziantou.Framework.Yaml.Serialization.YamlReader reader);
+
+    public sealed class YamlTypeClassifierContext
+    {
+        public System.Type DeclaringType { get => throw null; }
+        public Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierKind Kind { get => throw null; }
+        public System.Collections.ObjectModel.ReadOnlyCollection<Meziantou.Framework.Yaml.Serialization.YamlUnionCaseInfo> UnionCases { get => throw null; }
+        public YamlTypeClassifierContext(System.Type declaringType, Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierKind kind, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Yaml.Serialization.YamlUnionCaseInfo> unionCases) { }
+    }
+
+    public abstract class YamlTypeClassifierFactory
+    {
+        public abstract bool CanClassify(Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext context);
+        public abstract Meziantou.Framework.Yaml.Serialization.YamlTypeClassifier CreateYamlClassifier(Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext context, Meziantou.Framework.Yaml.YamlSerializerOptions options);
+    }
+
+    public enum YamlTypeClassifierKind
+    {
+        Union = 0
+    }
+
+    public sealed class YamlUnionCaseInfo
+    {
+        public System.Type CaseType { get => throw null; }
+        public Meziantou.Framework.Yaml.Serialization.YamlUnionCaseShape Shape { get => throw null; }
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Yaml.Serialization.YamlUnionCaseProperty> Properties { get => throw null; }
+        public bool HasObjectProperties { get => throw null; }
+        public bool DisallowUnmappedProperties { get => throw null; }
+        public YamlUnionCaseInfo(System.Type caseType, Meziantou.Framework.Yaml.Serialization.YamlUnionCaseShape shape, System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Yaml.Serialization.YamlUnionCaseProperty>? properties = null, bool disallowUnmappedProperties = false) { }
+    }
+
+    public sealed class YamlUnionCaseProperty
+    {
+        public string Name { get => throw null; }
+        public bool IsRequired { get => throw null; }
+        public YamlUnionCaseProperty(string name, bool isRequired) { }
+    }
+
+    public enum YamlUnionCaseShape
+    {
+        Boolean = 0,
+        Number = 1,
+        Text = 2,
+        Sequence = 3,
+        Mapping = 4,
+        Any = 5
+    }
+
+    public static class YamlUnionClassification
+    {
+        public static System.Type? Classify(Meziantou.Framework.Yaml.Serialization.YamlReader reader, Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext context, out string? bufferedNode) => throw null;
+    }
+
+    public sealed class YamlUnionTypeStructuralClassifier : Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierFactory
+    {
+        public override bool CanClassify(Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext context) => throw null;
+        public override Meziantou.Framework.Yaml.Serialization.YamlTypeClassifier CreateYamlClassifier(Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext context, Meziantou.Framework.Yaml.YamlSerializerOptions options) => throw null;
     }
 
     [System.AttributeUsage(System.AttributeTargets.Struct | System.AttributeTargets.Class, AllowMultiple = false)]

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
@@ -39,6 +39,7 @@ public sealed partial class YamlSerializerContextGenerator
         Dictionary<ITypeSymbol, int> indexByType)
     {
         var builder = new StringBuilder();
+        var pendingMembers = new StringBuilder();
         var accessors = new UnsafeAccessorRegistry(compilation, model.ContextSymbol);
         var propertyNamingPolicy = ResolveNamingPolicy(model.SourceGenerationOptions.PropertyNamingPolicy);
         var runtimeCustomConverterTypes = CollectRuntimeCustomConverterTypes(types);
@@ -185,10 +186,11 @@ public sealed partial class YamlSerializerContextGenerator
             var typeName = types[index].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
             EmitWriteValue(builder, index, types[index], typeName, derivedTypeMappings, indexByType, propertyNamingPolicy, model.SourceGenerationOptions, accessors);
             builder.AppendLine();
-            EmitReadValue(builder, index, types[index], typeName, derivedTypeMappings, indexByType, propertyNamingPolicy, model.SourceGenerationOptions, accessors);
+            EmitReadValue(builder, index, types[index], typeName, derivedTypeMappings, indexByType, propertyNamingPolicy, model.SourceGenerationOptions, accessors, pendingMembers);
             builder.AppendLine();
         }
 
+        builder.Append(pendingMembers);
         accessors.Emit(builder);
         builder.AppendLine("}");
         return builder.ToString();
@@ -866,8 +868,97 @@ public sealed partial class YamlSerializerContextGenerator
         }
     }
 
+    /// <summary>
+    /// Emits the dispatch selecting a derived type through a registered <c>YamlTypeClassifierFactory</c>, along with the
+    /// classifier context it needs.
+    /// </summary>
+    /// <remarks>
+    /// A classifier never overrides an explicit discriminator or tag, so this runs only once those have failed to
+    /// resolve a type.
+    /// </remarks>
+    private static void EmitReadPolymorphicClassifierDispatch(
+        StringBuilder builder,
+        StringBuilder pendingMembers,
+        int index,
+        string typeName,
+        PolymorphismInfoModel polymorphism,
+        Dictionary<ITypeSymbol, int> indexByType)
+    {
+        var derivedIndexes = new List<(ITypeSymbol DerivedType, string? Discriminator, string? Tag, int Index)>();
+        for (var i = 0; i < polymorphism.DerivedTypes.Length; i++)
+        {
+            var derived = polymorphism.DerivedTypes[i];
+            if (indexByType.TryGetValue(derived.DerivedType, out var derivedIndex))
+            {
+                derivedIndexes.Add((derived.DerivedType, derived.Discriminator, derived.Tag, derivedIndex));
+            }
+        }
+
+        if (derivedIndexes.Count == 0)
+        {
+            return;
+        }
+
+        var contextMethodName = "GetPolymorphicClassifierContext" + index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var contextFieldName = "s_polymorphicClassifierContext" + index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        builder.Append("        var classifiedType = global::Meziantou.Framework.Yaml.Serialization.YamlTypeClassification.ClassifyBufferedNode(reader, buffered, ").Append(contextMethodName).AppendLine("(discriminatorPropertyName));");
+        builder.AppendLine("        if (classifiedType is not null)");
+        builder.AppendLine("        {");
+        foreach (var derived in derivedIndexes)
+        {
+            builder.Append("            if (classifiedType == typeof(").Append(derived.DerivedType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)).AppendLine("))");
+            builder.AppendLine("            {");
+            builder.Append("                return (").Append(typeName).Append(")ReadValue").Append(derived.Index).AppendLine("(bufferedReader, runtimeConverters)!;");
+            builder.AppendLine("            }");
+        }
+
+        builder.AppendLine("        }");
+        builder.AppendLine();
+
+        // The discriminator name can come from the options, so the cached context is reused only while it matches.
+        pendingMembers.Append("    private static global::Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext? ").Append(contextFieldName).AppendLine(";");
+        pendingMembers.AppendLine();
+        pendingMembers.Append("    private static global::Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext ").Append(contextMethodName).AppendLine("(string? discriminatorPropertyName)");
+        pendingMembers.AppendLine("    {");
+        pendingMembers.Append("        var context = ").Append(contextFieldName).AppendLine(";");
+        pendingMembers.AppendLine("        if (context is not null && global::System.String.Equals(context.TypeDiscriminatorPropertyName, discriminatorPropertyName, global::System.StringComparison.Ordinal))");
+        pendingMembers.AppendLine("        {");
+        pendingMembers.AppendLine("            return context;");
+        pendingMembers.AppendLine("        }");
+        pendingMembers.AppendLine();
+        pendingMembers.AppendLine("        context = global::Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext.CreateForPolymorphicType(");
+        pendingMembers.Append("            typeof(").Append(typeName).AppendLine("),");
+        pendingMembers.AppendLine("            new global::Meziantou.Framework.Yaml.YamlDerivedType[]");
+        pendingMembers.AppendLine("            {");
+        foreach (var derived in derivedIndexes)
+        {
+            pendingMembers.Append("                new(typeof(").Append(derived.DerivedType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)).Append(')');
+            if (derived.Discriminator is not null)
+            {
+                pendingMembers.Append(", ").Append(ToLiteral(derived.Discriminator));
+            }
+
+            pendingMembers.Append(')');
+            if (derived.Tag is not null)
+            {
+                pendingMembers.Append(" { Tag = ").Append(ToLiteral(derived.Tag)).Append(" }");
+            }
+
+            pendingMembers.AppendLine(",");
+        }
+
+        pendingMembers.AppendLine("            },");
+        pendingMembers.AppendLine("            discriminatorPropertyName);");
+        pendingMembers.Append("        ").Append(contextFieldName).AppendLine(" = context;");
+        pendingMembers.AppendLine("        return context;");
+        pendingMembers.AppendLine("    }");
+        pendingMembers.AppendLine();
+    }
+
     private static void EmitReadPolymorphicDispatch(
         StringBuilder builder,
+        StringBuilder pendingMembers,
         int index,
         string typeName,
         PolymorphismInfoModel polymorphism,
@@ -987,6 +1078,8 @@ public sealed partial class YamlSerializerContextGenerator
 
             builder.AppendLine("        }");
         }
+
+        EmitReadPolymorphicClassifierDispatch(builder, pendingMembers, index, typeName, polymorphism, indexByType);
 
         if (polymorphism.DefaultDerivedType is not null && indexByType.TryGetValue(polymorphism.DefaultDerivedType, out var defaultIndex))
         {
@@ -2719,7 +2812,8 @@ public sealed partial class YamlSerializerContextGenerator
         Dictionary<ITypeSymbol, int> indexByType,
         YamlNamingPolicy? propertyNamingPolicy,
         SourceGenerationOptionsModel sourceGenerationOptions,
-        UnsafeAccessorRegistry accessors)
+        UnsafeAccessorRegistry accessors,
+        StringBuilder pendingMembers)
     {
         var attributeConverterTypeName = GetYamlConverterAttributeTypeName(typeSymbol, typeSymbol);
 
@@ -3408,6 +3502,7 @@ public sealed partial class YamlSerializerContextGenerator
 
             EmitReadPolymorphicDispatch(
                 builder,
+                pendingMembers,
                 index,
                 typeName,
                 interfacePolymorphism,
@@ -3565,6 +3660,8 @@ public sealed partial class YamlSerializerContextGenerator
 
                     builder.AppendLine("        }");
                 }
+                EmitReadPolymorphicClassifierDispatch(builder, pendingMembers, index, typeName, polymorphism, indexByType);
+
                 // Fallback: use default derived type if available
                 if (polymorphism.DefaultDerivedType is not null && indexByType.TryGetValue(polymorphism.DefaultDerivedType, out var defaultIndex))
                 {
@@ -5989,7 +6086,7 @@ public sealed partial class YamlSerializerContextGenerator
         var contextFieldName = GetCSharpUnionClassifierContextFieldName(index);
         builder.Append(indent).AppendLine("{");
         var innerIndent = indent + "    ";
-        builder.Append(innerIndent).Append("var classifiedCase = global::Meziantou.Framework.Yaml.Serialization.YamlUnionClassification.Classify(reader, ").Append(contextFieldName).AppendLine(", out var classifiedNode);");
+        builder.Append(innerIndent).Append("var classifiedCase = global::Meziantou.Framework.Yaml.Serialization.YamlTypeClassification.Classify(reader, ").Append(contextFieldName).AppendLine(", out var classifiedNode);");
         builder.Append(innerIndent).AppendLine("if (classifiedCase is not null)");
         builder.Append(innerIndent).AppendLine("{");
         var caseIndent = innerIndent + "    ";
@@ -6476,7 +6573,7 @@ public sealed partial class YamlSerializerContextGenerator
 
             emitted = true;
             builder.Append("    private static readonly global::Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext ").Append(GetCSharpUnionClassifierContextFieldName(index)).AppendLine(" =");
-            builder.Append("        new(typeof(").Append(unionType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)).AppendLine("), global::Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierKind.Union, new global::Meziantou.Framework.Yaml.Serialization.YamlUnionCaseInfo[]");
+            builder.Append("        global::Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext.CreateForUnion(typeof(").Append(unionType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)).AppendLine("), new global::Meziantou.Framework.Yaml.Serialization.YamlUnionCaseInfo[]");
             builder.AppendLine("        {");
             foreach (var unionCase in readCases)
             {

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
@@ -60,6 +60,7 @@ public sealed partial class YamlSerializerContextGenerator
         builder.Append("partial class ").Append(model.TypeName).AppendLine();
         builder.AppendLine("{");
         EmitSourceGenerationConverterFields(builder, model.SourceGenerationOptions);
+        EmitCSharpUnionClassifierContextFields(builder, types, propertyNamingPolicy, accessors, model.SourceGenerationOptions);
         EmitRuntimeCustomConverterHelpers(builder, model.SourceGenerationOptions, runtimeCustomConverterTypes);
         builder.AppendLine();
         builder.Append("    public static ").Append(model.TypeName).AppendLine(" Default { get; } = new(CreateDefaultOptions(), isDefault: true);");
@@ -2758,7 +2759,7 @@ public sealed partial class YamlSerializerContextGenerator
 
         if (typeSymbol is INamedTypeSymbol unionType && TryGetCSharpUnionCases(unionType, out var unionCases))
         {
-            EmitReadCSharpUnionValue(builder, typeName, unionCases, indexByType, sourceGenerationOptions);
+            EmitReadCSharpUnionValue(builder, index, typeName, unionCases, indexByType, sourceGenerationOptions);
             builder.AppendLine("    }");
             return;
         }
@@ -5770,7 +5771,7 @@ public sealed partial class YamlSerializerContextGenerator
         builder.AppendLine("        }");
         builder.AppendLine();
 
-        var writeCases = SortCSharpUnionCasesForWriting(unionCases);
+        var writeCases = SortCSharpUnionCasesForWriting(CollapseCSharpUnionNullableOverloads(unionCases));
         for (var i = 0; i < writeCases.Length; i++)
         {
             var unionCase = writeCases[i];
@@ -5788,11 +5789,14 @@ public sealed partial class YamlSerializerContextGenerator
 
     private static void EmitReadCSharpUnionValue(
         StringBuilder builder,
+        int index,
         string unionTypeName,
         ImmutableArray<CSharpUnionCaseModel> unionCases,
         Dictionary<ITypeSymbol, int> indexByType,
         SourceGenerationOptionsModel sourceGenerationOptions)
     {
+        var readCases = CollapseCSharpUnionNullableOverloads(unionCases);
+
         builder.AppendLine("        if (reader.TryReadAlias(out var rootAliasValue))");
         builder.AppendLine("        {");
         builder.AppendLine("            if (rootAliasValue is null)");
@@ -5806,10 +5810,10 @@ public sealed partial class YamlSerializerContextGenerator
         builder.AppendLine("            }");
         builder.AppendLine();
 
-        var writeCases = SortCSharpUnionCasesForWriting(unionCases);
-        for (var i = 0; i < writeCases.Length; i++)
+        var aliasCases = SortCSharpUnionCasesForWriting(readCases);
+        for (var i = 0; i < aliasCases.Length; i++)
         {
-            var unionCase = writeCases[i];
+            var unionCase = aliasCases[i];
             var runtimeTypeName = unionCase.RuntimeType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
             builder.Append("            if (rootAliasValue is ").Append(runtimeTypeName).Append(" aliasCaseValue").Append(i).AppendLine(")");
             builder.AppendLine("            {");
@@ -5833,27 +5837,27 @@ public sealed partial class YamlSerializerContextGenerator
         builder.AppendLine("            var scalarValue = global::Meziantou.Framework.Yaml.Serialization.YamlScalar.ResolveObject(reader);");
         builder.AppendLine("            if (scalarValue is bool)");
         builder.AppendLine("            {");
-        EmitReadCSharpUnionKind(builder, unionTypeName, unionCases, CSharpUnionCaseKind.Boolean, indexByType, "                ", sourceGenerationOptions);
+        EmitReadCSharpUnionKind(builder, index, unionTypeName, readCases, CSharpUnionCaseKind.Boolean, indexByType, "                ", sourceGenerationOptions);
         builder.AppendLine("            }");
         builder.AppendLine();
         builder.AppendLine("            if (scalarValue is sbyte or byte or short or ushort or int or uint or long or ulong or nint or nuint or float or double or decimal or global::System.Half or global::System.Int128 or global::System.UInt128)");
         builder.AppendLine("            {");
-        EmitReadCSharpUnionKind(builder, unionTypeName, unionCases, CSharpUnionCaseKind.Number, indexByType, "                ", sourceGenerationOptions);
+        EmitReadCSharpUnionKind(builder, index, unionTypeName, readCases, CSharpUnionCaseKind.Number, indexByType, "                ", sourceGenerationOptions);
         builder.AppendLine("            }");
         builder.AppendLine();
-        EmitReadCSharpUnionKind(builder, unionTypeName, unionCases, CSharpUnionCaseKind.String, indexByType, "            ", sourceGenerationOptions);
+        EmitReadCSharpUnionKind(builder, index, unionTypeName, readCases, CSharpUnionCaseKind.String, indexByType, "            ", sourceGenerationOptions);
         builder.AppendLine("        }");
         builder.AppendLine();
 
         builder.AppendLine("        if (reader.TokenType == global::Meziantou.Framework.Yaml.Serialization.YamlTokenType.StartSequence)");
         builder.AppendLine("        {");
-        EmitReadCSharpUnionKind(builder, unionTypeName, unionCases, CSharpUnionCaseKind.Sequence, indexByType, "            ", sourceGenerationOptions);
+        EmitReadCSharpUnionKind(builder, index, unionTypeName, readCases, CSharpUnionCaseKind.Sequence, indexByType, "            ", sourceGenerationOptions);
         builder.AppendLine("        }");
         builder.AppendLine();
 
         builder.AppendLine("        if (reader.TokenType == global::Meziantou.Framework.Yaml.Serialization.YamlTokenType.StartMapping)");
         builder.AppendLine("        {");
-        EmitReadCSharpUnionKind(builder, unionTypeName, unionCases, CSharpUnionCaseKind.Mapping, indexByType, "            ", sourceGenerationOptions);
+        EmitReadCSharpUnionKind(builder, index, unionTypeName, readCases, CSharpUnionCaseKind.Mapping, indexByType, "            ", sourceGenerationOptions);
         builder.AppendLine("        }");
         builder.AppendLine();
 
@@ -5868,15 +5872,18 @@ public sealed partial class YamlSerializerContextGenerator
         bool consumeReader)
     {
         var nullableCase = GetFirstNullableCSharpUnionCase(unionCases);
-        if (nullableCase is null)
-        {
-            builder.Append(indent).Append("throw new global::Meziantou.Framework.Yaml.YamlException(reader.SourceName, reader.Start, reader.End, \"Union type '").Append(unionTypeName).AppendLine("' does not define a nullable case.\");");
-            return;
-        }
 
         if (consumeReader)
         {
             builder.Append(indent).AppendLine("reader.Read();");
+        }
+
+        // A union with no nullable case still has a null state: 'default(TUnion)' selects no case and exposes a null
+        // value. Returning the default value makes 'default(TUnion)' round-trip through a null scalar.
+        if (nullableCase is null)
+        {
+            builder.Append(indent).Append("return default(").Append(unionTypeName).AppendLine(");");
+            return;
         }
 
         var caseTypeName = nullableCase.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
@@ -5885,6 +5892,7 @@ public sealed partial class YamlSerializerContextGenerator
 
     private static void EmitReadCSharpUnionKind(
         StringBuilder builder,
+        int index,
         string unionTypeName,
         ImmutableArray<CSharpUnionCaseModel> unionCases,
         CSharpUnionCaseKind kind,
@@ -5895,7 +5903,7 @@ public sealed partial class YamlSerializerContextGenerator
         var unionCase = GetSingleCSharpUnionCase(unionCases, kind, out var ambiguous);
         if (ambiguous)
         {
-            builder.Append(indent).Append("throw new global::Meziantou.Framework.Yaml.YamlException(reader.SourceName, reader.Start, reader.End, \"Cannot deserialize union type '").Append(unionTypeName).Append("' because multiple cases match YAML ").Append(GetCSharpUnionKindDescription(kind)).AppendLine(" values.\");");
+            EmitReadClassifiedCSharpUnionCase(builder, index, unionTypeName, unionCases, kind, indexByType, indent, sourceGenerationOptions);
             return;
         }
 
@@ -5906,8 +5914,8 @@ public sealed partial class YamlSerializerContextGenerator
         }
 
         builder.Append(indent).AppendLine("{");
-        EmitReadKnownType(builder, sourceGenerationOptions, unionCase.Type, indexByType, "unionCaseValue", indent + "    ");
-        builder.Append(indent).Append("    return new ").Append(unionTypeName).Append('(').Append(GetNonNullableValueExpression(unionCase.Type, "unionCaseValue")).AppendLine(");");
+        EmitReadKnownType(builder, sourceGenerationOptions, unionCase.RuntimeType, indexByType, "unionCaseValue", indent + "    ");
+        builder.Append(indent).Append("    return new ").Append(unionTypeName).Append('(').Append(GetNonNullableValueExpression(unionCase.RuntimeType, "unionCaseValue")).AppendLine(");");
         builder.Append(indent).AppendLine("}");
     }
 
@@ -5967,6 +5975,59 @@ public sealed partial class YamlSerializerContextGenerator
         builder.Append(innerIndent).AppendLine("}");
         builder.Append(indent).AppendLine("}");
     }
+
+    private static void EmitReadClassifiedCSharpUnionCase(
+        StringBuilder builder,
+        int index,
+        string unionTypeName,
+        ImmutableArray<CSharpUnionCaseModel> unionCases,
+        CSharpUnionCaseKind kind,
+        Dictionary<ITypeSymbol, int> indexByType,
+        string indent,
+        SourceGenerationOptionsModel sourceGenerationOptions)
+    {
+        var contextFieldName = GetCSharpUnionClassifierContextFieldName(index);
+        builder.Append(indent).AppendLine("{");
+        var innerIndent = indent + "    ";
+        builder.Append(innerIndent).Append("var classifiedCase = global::Meziantou.Framework.Yaml.Serialization.YamlUnionClassification.Classify(reader, ").Append(contextFieldName).AppendLine(", out var classifiedNode);");
+        builder.Append(innerIndent).AppendLine("if (classifiedCase is not null)");
+        builder.Append(innerIndent).AppendLine("{");
+        var caseIndent = innerIndent + "    ";
+
+        // Classification consumed the value, so the case is deserialized from the buffered copy.
+        builder.Append(caseIndent).AppendLine("reader = reader.CreateReader(classifiedNode!);");
+        builder.Append(caseIndent).AppendLine("if (!reader.Read())");
+        builder.Append(caseIndent).AppendLine("{");
+        builder.Append(caseIndent).AppendLine("    return default;");
+        builder.Append(caseIndent).AppendLine("}");
+        builder.AppendLine();
+
+        for (var i = 0; i < unionCases.Length; i++)
+        {
+            var unionCase = unionCases[i];
+            if (unionCase.Kind != kind && unionCase.Kind != CSharpUnionCaseKind.Any)
+            {
+                continue;
+            }
+
+            var runtimeTypeName = unionCase.RuntimeType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            builder.Append(caseIndent).Append("if (classifiedCase == typeof(").Append(runtimeTypeName).AppendLine("))");
+            builder.Append(caseIndent).AppendLine("{");
+            EmitReadKnownType(builder, sourceGenerationOptions, unionCase.RuntimeType, indexByType, "classifiedValue" + i.ToString(System.Globalization.CultureInfo.InvariantCulture), caseIndent + "    ");
+            builder.Append(caseIndent).Append("    return new ").Append(unionTypeName).Append("(classifiedValue").Append(i).AppendLine(");");
+            builder.Append(caseIndent).AppendLine("}");
+            builder.AppendLine();
+        }
+
+        builder.Append(caseIndent).Append("throw new global::Meziantou.Framework.Yaml.YamlException(reader.SourceName, reader.Start, reader.End, \"Union type '").Append(unionTypeName).Append("' does not define a case that matches YAML ").Append(GetCSharpUnionKindDescription(kind)).AppendLine(" values.\");");
+        builder.Append(innerIndent).AppendLine("}");
+        builder.AppendLine();
+        builder.Append(innerIndent).Append("throw new global::Meziantou.Framework.Yaml.YamlException(reader.SourceName, reader.Start, reader.End, \"Cannot deserialize union type '").Append(unionTypeName).Append("' because multiple cases match YAML ").Append(GetCSharpUnionKindDescription(kind)).AppendLine(" values.\");");
+        builder.Append(indent).AppendLine("}");
+    }
+
+    private static string GetCSharpUnionClassifierContextFieldName(int index)
+        => "s_unionClassifierContext" + index.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
     private static void EmitReadKnownType(StringBuilder builder, SourceGenerationOptionsModel sourceGenerationOptions, ITypeSymbol typeSymbol, Dictionary<ITypeSymbol, int> indexByType, string valueVarName, string indent)
     {
@@ -6376,6 +6437,109 @@ public sealed partial class YamlSerializerContextGenerator
             builder.AppendLine("            },");
         }
     }
+
+    private static void EmitCSharpUnionClassifierContextFields(
+        StringBuilder builder,
+        ImmutableArray<ITypeSymbol> types,
+        YamlNamingPolicy? propertyNamingPolicy,
+        UnsafeAccessorRegistry accessors,
+        SourceGenerationOptionsModel sourceGenerationOptions)
+    {
+        var emitted = false;
+        for (var index = 0; index < types.Length; index++)
+        {
+            if (types[index] is not INamedTypeSymbol unionType ||
+                !TryGetCSharpUnionCases(unionType, out var unionCases))
+            {
+                continue;
+            }
+
+            var readCases = CollapseCSharpUnionNullableOverloads(unionCases);
+
+            // A classifier is only consulted when several cases share a YAML shape; every other union is resolved by
+            // shape alone and needs no metadata.
+            var hasAmbiguousKind = false;
+            foreach (var kind in new[] { CSharpUnionCaseKind.Boolean, CSharpUnionCaseKind.Number, CSharpUnionCaseKind.String, CSharpUnionCaseKind.Sequence, CSharpUnionCaseKind.Mapping })
+            {
+                GetSingleCSharpUnionCase(readCases, kind, out var ambiguous);
+                if (ambiguous)
+                {
+                    hasAmbiguousKind = true;
+                    break;
+                }
+            }
+
+            if (!hasAmbiguousKind)
+            {
+                continue;
+            }
+
+            emitted = true;
+            builder.Append("    private static readonly global::Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext ").Append(GetCSharpUnionClassifierContextFieldName(index)).AppendLine(" =");
+            builder.Append("        new(typeof(").Append(unionType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)).AppendLine("), global::Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierKind.Union, new global::Meziantou.Framework.Yaml.Serialization.YamlUnionCaseInfo[]");
+            builder.AppendLine("        {");
+            foreach (var unionCase in readCases)
+            {
+                builder.Append("            new(typeof(").Append(unionCase.RuntimeType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)).Append("), global::Meziantou.Framework.Yaml.Serialization.YamlUnionCaseShape.").Append(GetCSharpUnionCaseShapeName(unionCase.Kind)).Append(", ");
+                AppendCSharpUnionCaseProperties(builder, unionCase, propertyNamingPolicy, accessors, sourceGenerationOptions);
+                builder.AppendLine("),");
+            }
+
+            builder.AppendLine("        });");
+        }
+
+        if (emitted)
+        {
+            builder.AppendLine();
+        }
+    }
+
+    private static void AppendCSharpUnionCaseProperties(
+        StringBuilder builder,
+        CSharpUnionCaseModel unionCase,
+        YamlNamingPolicy? propertyNamingPolicy,
+        UnsafeAccessorRegistry accessors,
+        SourceGenerationOptionsModel sourceGenerationOptions)
+    {
+        if (unionCase.Kind is not CSharpUnionCaseKind.Mapping ||
+            unionCase.RuntimeType is not INamedTypeSymbol named ||
+            named.TypeKind is TypeKind.Interface ||
+            TryGetDictionaryTypes(named, out _, out _, out _))
+        {
+            builder.Append("null, false");
+            return;
+        }
+
+        var extensionData = TryCreateExtensionDataMemberModel(named, accessors);
+        builder.Append("new global::Meziantou.Framework.Yaml.Serialization.YamlUnionCaseProperty[] { ");
+        foreach (var member in GetSerializableMembers(named))
+        {
+            if (extensionData is not null && SymbolEqualityComparer.Default.Equals(member, extensionData.Symbol))
+            {
+                continue;
+            }
+
+            var model = CreateMemberModel(member, named, propertyNamingPolicy, accessors);
+            builder.Append("new(").Append(model.SerializedNameExpressionForRead).Append(", ").Append(model.IsRequired ? "true" : "false").Append("), ");
+        }
+
+        builder.Append("}, ");
+
+        // An extension data member accepts any key, so the type never rejects unmapped keys.
+        var unmappedMemberHandling = TryGetUnmappedMemberHandlingOverride(named) ?? GetUnmappedMemberHandling(sourceGenerationOptions);
+        builder.Append(extensionData is null && string.Equals(unmappedMemberHandling, "Disallow", StringComparison.Ordinal) ? "true" : "false");
+    }
+
+    private static string GetCSharpUnionCaseShapeName(CSharpUnionCaseKind kind)
+        => kind switch
+        {
+            CSharpUnionCaseKind.Boolean => "Boolean",
+            CSharpUnionCaseKind.Number => "Number",
+            CSharpUnionCaseKind.String => "Text",
+            CSharpUnionCaseKind.Sequence => "Sequence",
+            CSharpUnionCaseKind.Mapping => "Mapping",
+            _ => "Any",
+        };
 
     private static void EmitSourceGenerationConverterFields(StringBuilder builder, SourceGenerationOptionsModel options)
     {

--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -888,15 +888,17 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
             {
                 foreach (var unionCase in unionCases)
                 {
-                    if (IsKnownScalar(unionCase.Type) || IsYamlNodeType(unionCase.Type))
+                    // A 'T?' case is read and written through the metadata of 'T': the union already carries its own
+                    // null state, so there is no separate contract to generate for the nullable wrapper.
+                    if (IsKnownScalar(unionCase.RuntimeType) || IsYamlNodeType(unionCase.RuntimeType) || IsUntypedObject(unionCase.RuntimeType))
                     {
                         continue;
                     }
 
-                    if (seen.Add(unionCase.Type))
+                    if (seen.Add(unionCase.RuntimeType))
                     {
-                        builder.Add(unionCase.Type);
-                        queue.Enqueue(unionCase.Type);
+                        builder.Add(unionCase.RuntimeType);
+                        queue.Enqueue(unionCase.RuntimeType);
                     }
                 }
             }
@@ -1496,6 +1498,40 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
             string.Equals(systemType.Name, "TimeSpan", StringComparison.Ordinal) ||
             string.Equals(systemType.Name, "DateOnly", StringComparison.Ordinal) ||
             string.Equals(systemType.Name, "TimeOnly", StringComparison.Ordinal));
+
+    private static ImmutableArray<CSharpUnionCaseModel> CollapseCSharpUnionNullableOverloads(ImmutableArray<CSharpUnionCaseModel> cases)
+    {
+        var builder = ImmutableArray.CreateBuilder<CSharpUnionCaseModel>(cases.Length);
+        foreach (var unionCase in cases)
+        {
+            var replaced = false;
+            for (var i = 0; i < builder.Count; i++)
+            {
+                if (!SymbolEqualityComparer.Default.Equals(builder[i].RuntimeType, unionCase.RuntimeType))
+                {
+                    continue;
+                }
+
+                // 'union Foo(int, int?)' declares two cases for the same underlying type. They are indistinguishable
+                // when reading a non-null value, so keep the non-nullable overload as the canonical one. The nullable
+                // overload is still used when reading a null scalar.
+                if (builder[i].Type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T })
+                {
+                    builder[i] = unionCase;
+                }
+
+                replaced = true;
+                break;
+            }
+
+            if (!replaced)
+            {
+                builder.Add(unionCase);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
 
     private static ImmutableArray<CSharpUnionCaseModel> SortCSharpUnionCasesForWriting(ImmutableArray<CSharpUnionCaseModel> cases)
     {

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/IYamlUnionCaseShapeProvider.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/IYamlUnionCaseShapeProvider.cs
@@ -1,0 +1,8 @@
+namespace Meziantou.Framework.Yaml.Serialization.Converters;
+
+/// <summary>Exposes the mapping keys of a type so a union case can be classified structurally.</summary>
+internal interface IYamlUnionCaseShapeProvider
+{
+    /// <summary>Gets the mapping keys declared by the converted type, or <see langword="null"/> when they are unknown.</summary>
+    IReadOnlyList<YamlUnionCaseProperty>? GetUnionCaseProperties(YamlReaderWriterBase readerWriter, out bool disallowUnmappedProperties);
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlCSharpUnionConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlCSharpUnionConverter.cs
@@ -13,8 +13,11 @@ internal sealed class YamlCSharpUnionConverter<T> : YamlConverter<T?>
     private readonly Type _unionType = typeof(T);
     private readonly PropertyInfo _valueProperty;
     private readonly ImmutableArray<UnionCase> _cases;
+    private readonly ImmutableArray<UnionCase> _readCases;
     private readonly ImmutableArray<UnionCase> _writeCases;
     private readonly UnionCase? _nullableCase;
+    private YamlSerializerOptions? _classifierContextOptions;
+    private YamlTypeClassifierContext? _classifierContext;
 
     [UnconditionalSuppressMessage(
         "Trimming",
@@ -31,6 +34,7 @@ internal sealed class YamlCSharpUnionConverter<T> : YamlConverter<T?>
             throw new InvalidOperationException($"Type '{_unionType}' is not a supported C# union type.");
         }
 
+        _readCases = CollapseNullableOverloads(_cases);
         _writeCases = SortCasesForWriting(_cases);
         _nullableCase = FindNullableCase(_cases);
     }
@@ -81,10 +85,19 @@ internal sealed class YamlCSharpUnionConverter<T> : YamlConverter<T?>
         }
 
         var kind = GetCurrentKind(reader);
-        var unionCase = GetCaseForKind(kind, reader);
-        var converter = reader.GetConverter(unionCase.Type);
-        var caseValue = converter.Read(reader, unionCase.Type);
-        return CreateValue(reader, unionCase, caseValue);
+        if (TryGetSingleCaseForKind(kind, out var unionCase, out var ambiguous))
+        {
+            var converter = reader.GetConverter(unionCase.Type);
+            var caseValue = converter.Read(reader, unionCase.Type);
+            return CreateValue(reader, unionCase, caseValue);
+        }
+
+        if (!ambiguous)
+        {
+            throw CreateNoMatchingCaseException(reader, kind);
+        }
+
+        return ReadClassifiedValue(reader, kind);
     }
 
     public override void Write(YamlWriter writer, T? value)
@@ -197,6 +210,40 @@ internal sealed class YamlCSharpUnionConverter<T> : YamlConverter<T?>
 
         var nullabilityInfo = context.Create(parameter);
         return nullabilityInfo.ReadState != NullabilityState.NotNull;
+    }
+
+    private static ImmutableArray<UnionCase> CollapseNullableOverloads(ImmutableArray<UnionCase> cases)
+    {
+        var builder = ImmutableArray.CreateBuilder<UnionCase>(cases.Length);
+        foreach (var unionCase in cases)
+        {
+            var replaced = false;
+            for (var i = 0; i < builder.Count; i++)
+            {
+                if (builder[i].RuntimeType != unionCase.RuntimeType)
+                {
+                    continue;
+                }
+
+                // 'union Foo(int, int?)' declares two cases for the same underlying type. They are indistinguishable
+                // when reading a non-null value, so keep the non-nullable overload as the canonical one. The nullable
+                // overload is still used when reading a null scalar.
+                if (Nullable.GetUnderlyingType(builder[i].Type) is not null)
+                {
+                    builder[i] = unionCase;
+                }
+
+                replaced = true;
+                break;
+            }
+
+            if (!replaced)
+            {
+                builder.Add(unionCase);
+            }
+        }
+
+        return builder.ToImmutable();
     }
 
     private static ImmutableArray<UnionCase> SortCasesForWriting(ImmutableArray<UnionCase> cases)
@@ -361,38 +408,100 @@ internal sealed class YamlCSharpUnionConverter<T> : YamlConverter<T?>
         return null;
     }
 
-    private UnionCase GetCaseForKind(UnionCaseKind kind, YamlReader reader)
+    private bool TryGetSingleCaseForKind(UnionCaseKind kind, out UnionCase unionCase, out bool ambiguous)
     {
         UnionCase? match = null;
         var matchCount = 0;
-        for (var i = 0; i < _cases.Length; i++)
+        for (var i = 0; i < _readCases.Length; i++)
         {
-            var unionCase = _cases[i];
-            if (unionCase.Kind == kind || unionCase.Kind == UnionCaseKind.Any)
+            var candidate = _readCases[i];
+            if (candidate.Kind == kind || candidate.Kind == UnionCaseKind.Any)
             {
-                match ??= unionCase;
+                match ??= candidate;
                 matchCount++;
             }
         }
 
-        if (matchCount == 1 && match is not null)
-        {
-            return match.Value;
-        }
+        ambiguous = matchCount > 1;
+        unionCase = match.GetValueOrDefault();
+        return matchCount == 1;
+    }
 
-        if (matchCount > 1)
+    private T? ReadClassifiedValue(YamlReader reader, UnionCaseKind kind)
+    {
+        var classified = YamlUnionClassification.Classify(reader, GetClassifierContext(reader), out var bufferedNode);
+        if (classified is null)
         {
             throw new YamlException(reader.SourceName, reader.Start, reader.End, $"Cannot deserialize union type '{_unionType}' because multiple cases match YAML {GetKindDescription(kind)} values.");
+        }
+
+        for (var i = 0; i < _readCases.Length; i++)
+        {
+            var unionCase = _readCases[i];
+            if (unionCase.RuntimeType != classified)
+            {
+                continue;
+            }
+
+            // Classification consumed the value, so the case is deserialized from the buffered copy.
+            var caseReader = reader.CreateReader(bufferedNode!);
+            if (!caseReader.Read())
+            {
+                return default;
+            }
+
+            var converter = caseReader.GetConverter(unionCase.Type);
+            return CreateValue(reader, unionCase, converter.Read(caseReader, unionCase.Type));
         }
 
         throw CreateNoMatchingCaseException(reader, kind);
     }
 
+    private YamlTypeClassifierContext GetClassifierContext(YamlReader reader)
+    {
+        if (_classifierContext is not null && ReferenceEquals(_classifierContextOptions, reader.Options))
+        {
+            return _classifierContext;
+        }
+
+        var cases = new YamlUnionCaseInfo[_readCases.Length];
+        for (var i = 0; i < _readCases.Length; i++)
+        {
+            var unionCase = _readCases[i];
+            IReadOnlyList<YamlUnionCaseProperty>? properties = null;
+            var disallowUnmappedProperties = false;
+            if (unionCase.Kind is UnionCaseKind.Mapping && reader.GetConverter(unionCase.RuntimeType) is IYamlUnionCaseShapeProvider provider)
+            {
+                properties = provider.GetUnionCaseProperties(reader, out disallowUnmappedProperties);
+            }
+
+            cases[i] = new YamlUnionCaseInfo(unionCase.RuntimeType, GetShape(unionCase.Kind), properties, disallowUnmappedProperties);
+        }
+
+        var context = new YamlTypeClassifierContext(_unionType, YamlTypeClassifierKind.Union, cases);
+        _classifierContextOptions = reader.Options;
+        _classifierContext = context;
+        return context;
+    }
+
+    private static YamlUnionCaseShape GetShape(UnionCaseKind kind)
+        => kind switch
+        {
+            UnionCaseKind.Boolean => YamlUnionCaseShape.Boolean,
+            UnionCaseKind.Number => YamlUnionCaseShape.Number,
+            UnionCaseKind.String => YamlUnionCaseShape.Text,
+            UnionCaseKind.Sequence => YamlUnionCaseShape.Sequence,
+            UnionCaseKind.Mapping => YamlUnionCaseShape.Mapping,
+            _ => YamlUnionCaseShape.Any,
+        };
+
     private T? CreateNullValue(YamlReader reader)
     {
+        // A union with no nullable case still has a null state: 'default(TUnion)' selects no case and exposes a null
+        // value. Returning the default value makes 'default(TUnion)' round-trip through a null scalar.
         if (_nullableCase is null)
         {
-            throw new YamlException(reader.SourceName, reader.Start, reader.End, $"Union type '{_unionType}' does not define a nullable case.");
+            return default;
         }
 
         return CreateValue(reader, _nullableCase.Value, null);

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlCSharpUnionConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlCSharpUnionConverter.cs
@@ -429,7 +429,7 @@ internal sealed class YamlCSharpUnionConverter<T> : YamlConverter<T?>
 
     private T? ReadClassifiedValue(YamlReader reader, UnionCaseKind kind)
     {
-        var classified = YamlUnionClassification.Classify(reader, GetClassifierContext(reader), out var bufferedNode);
+        var classified = YamlTypeClassification.Classify(reader, GetClassifierContext(reader), out var bufferedNode);
         if (classified is null)
         {
             throw new YamlException(reader.SourceName, reader.Start, reader.End, $"Cannot deserialize union type '{_unionType}' because multiple cases match YAML {GetKindDescription(kind)} values.");
@@ -478,7 +478,7 @@ internal sealed class YamlCSharpUnionConverter<T> : YamlConverter<T?>
             cases[i] = new YamlUnionCaseInfo(unionCase.RuntimeType, GetShape(unionCase.Kind), properties, disallowUnmappedProperties);
         }
 
-        var context = new YamlTypeClassifierContext(_unionType, YamlTypeClassifierKind.Union, cases);
+        var context = YamlTypeClassifierContext.CreateForUnion(_unionType, cases);
         _classifierContextOptions = reader.Options;
         _classifierContext = context;
         return context;

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
@@ -4,9 +4,34 @@ using Meziantou.Framework.Yaml.Model;
 
 namespace Meziantou.Framework.Yaml.Serialization.Converters;
 
-internal sealed class YamlObjectConverter<T> : YamlConverter<T?>
+internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCaseShapeProvider
 {
     private Contract? _contract;
+
+    IReadOnlyList<YamlUnionCaseProperty>? IYamlUnionCaseShapeProvider.GetUnionCaseProperties(YamlReaderWriterBase readerWriter, out bool disallowUnmappedProperties)
+    {
+        disallowUnmappedProperties = false;
+
+        var contract = _contract ??= Contract.Create(typeof(T), readerWriter);
+
+        // A polymorphic type is deserialized through its discriminator, so its own members do not describe the payload.
+        if (contract.Polymorphism is not null)
+        {
+            return null;
+        }
+
+        // An extension data member accepts any key, so the type never rejects unmapped keys.
+        disallowUnmappedProperties = contract.ExtensionData is null && contract.UnmappedMemberHandling is YamlUnmappedMemberHandling.Disallow;
+
+        var members = contract.MembersDeclaration;
+        var properties = new YamlUnionCaseProperty[members.Length];
+        for (var i = 0; i < members.Length; i++)
+        {
+            properties[i] = new YamlUnionCaseProperty(members[i].Name, members[i].IsRequired);
+        }
+
+        return properties;
+    }
 
     public override bool CanPopulate(Type typeToConvert) => typeToConvert == typeof(T);
 

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
@@ -1401,6 +1401,14 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
         }
     }
 
+    private YamlTypeClassifierContext? _classifierContext;
+
+    private YamlTypeClassifierContext GetClassifierContext(PolymorphismModel polymorphism)
+        => _classifierContext ??= YamlTypeClassifierContext.CreateForPolymorphicType(
+            typeof(T),
+            polymorphism.DerivedTypes,
+            polymorphism.AcceptsPropertyDiscriminator ? polymorphism.DiscriminatorPropertyName : null);
+
     private T? ReadPolymorphic(YamlReader reader, Contract contract)
     {
         var polymorphism = contract.Polymorphism!;
@@ -1440,6 +1448,10 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
                 throw YamlThrowHelper.ThrowUnknownTypeTag(reader, rootTag, typeof(T));
             }
         }
+
+        // A registered classifier selects a derived type from the payload itself. It never overrides an explicit
+        // discriminator or tag, so it only runs once those have failed to resolve a type.
+        targetType ??= YamlTypeClassification.ClassifyBufferedNode(reader, buffered, GetClassifierContext(polymorphism));
 
         targetType ??= polymorphism.DefaultDerivedType ?? typeof(T);
 
@@ -2147,6 +2159,32 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
 
         public bool TryGetDerivedTypeInfo(Type derivedType, out DerivedTypeInfo info)
             => _typeToDerived.TryGetValue(derivedType, out info);
+
+        private YamlDerivedType[]? _derivedTypes;
+
+        /// <summary>Gets the registered derived types, in the shape a <see cref="YamlTypeClassifierFactory"/> consumes.</summary>
+        public IReadOnlyList<YamlDerivedType> DerivedTypes
+        {
+            get
+            {
+                if (_derivedTypes is not null)
+                {
+                    return _derivedTypes;
+                }
+
+                var derivedTypes = new YamlDerivedType[_typeToDerived.Count];
+                var index = 0;
+                foreach (var entry in _typeToDerived)
+                {
+                    var info = entry.Value;
+                    derivedTypes[index++] = info.Discriminator is null
+                        ? new YamlDerivedType(entry.Key) { Tag = info.Tag }
+                        : new YamlDerivedType(entry.Key, info.Discriminator) { Tag = info.Tag };
+                }
+
+                return _derivedTypes = derivedTypes;
+            }
+        }
 
         public static PolymorphismModel? TryCreate(Type type, YamlSerializerOptions options)
         {

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassification.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassification.cs
@@ -3,24 +3,24 @@ using System.Runtime.CompilerServices;
 
 namespace Meziantou.Framework.Yaml.Serialization;
 
-/// <summary>Applies the <see cref="YamlSerializerOptions.TypeClassifiers"/> of a reader to a C# union payload.</summary>
+/// <summary>Applies the <see cref="YamlSerializerOptions.TypeClassifiers"/> of a reader to a YAML payload.</summary>
 /// <remarks>This type supports the serializer infrastructure and is not intended to be used directly from your code.</remarks>
-public static class YamlUnionClassification
+public static class YamlTypeClassification
 {
     private static readonly ConditionalWeakTable<YamlSerializerOptions, ConcurrentDictionary<Type, YamlTypeClassifier?>> Cache = new();
 
     /// <summary>
-    /// Selects the union case matching the value <paramref name="reader"/> is positioned on, when a classifier is
-    /// registered for the union type.
+    /// Selects the type matching the value <paramref name="reader"/> is positioned on, when a classifier is registered
+    /// for the type described by <paramref name="context"/>.
     /// </summary>
     /// <param name="reader">The reader positioned at the start of the value.</param>
-    /// <param name="context">The union type and the cases to select from.</param>
+    /// <param name="context">The type to classify and the candidates to select from.</param>
     /// <param name="bufferedNode">
     /// Receives the buffered YAML of the value when a classifier ran, or <see langword="null"/> when no classifier is
-    /// registered. Classification reads the value, so the caller must deserialize the selected case from a reader
-    /// created over the buffered YAML rather than from <paramref name="reader"/>.
+    /// registered. Classification reads the value, so the caller must deserialize from a reader created over the
+    /// buffered YAML rather than from <paramref name="reader"/>.
     /// </param>
-    /// <returns>The selected case type, or <see langword="null"/> when no classifier is registered or the value cannot be classified.</returns>
+    /// <returns>The selected type, or <see langword="null"/> when no classifier is registered or the value cannot be classified.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="reader"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
     public static Type? Classify(YamlReader reader, YamlTypeClassifierContext context, out string? bufferedNode)
     {
@@ -29,14 +29,37 @@ public static class YamlUnionClassification
 
         bufferedNode = null;
 
-        var classifier = GetClassifier(reader.Options, context);
-        if (classifier is null)
+        if (GetClassifier(reader.Options, context) is null)
         {
             return null;
         }
 
         // Classification reads the value, so it runs over a private copy and leaves the buffered YAML to the caller.
         bufferedNode = YamlReader.BufferCurrentNodeToString(reader);
+        return ClassifyBufferedNode(reader, bufferedNode, context);
+    }
+
+    /// <summary>
+    /// Selects the type matching an already buffered value, when a classifier is registered for the type described by
+    /// <paramref name="context"/>.
+    /// </summary>
+    /// <param name="reader">The reader the value was buffered from, used for its options.</param>
+    /// <param name="bufferedNode">The buffered YAML of the value to classify.</param>
+    /// <param name="context">The type to classify and the candidates to select from.</param>
+    /// <returns>The selected type, or <see langword="null"/> when no classifier is registered or the value cannot be classified.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="reader"/>, <paramref name="bufferedNode"/>, or <paramref name="context"/> is <see langword="null"/>.</exception>
+    public static Type? ClassifyBufferedNode(YamlReader reader, string bufferedNode, YamlTypeClassifierContext context)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(bufferedNode);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var classifier = GetClassifier(reader.Options, context);
+        if (classifier is null)
+        {
+            return null;
+        }
+
         var classifierReader = reader.CreateReader(bufferedNode);
         return classifierReader.Read() ? classifier(classifierReader) : null;
     }

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifier.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifier.cs
@@ -1,0 +1,9 @@
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>Selects the case type matching the YAML value <paramref name="reader"/> is positioned on.</summary>
+/// <param name="reader">
+/// A reader positioned at the start of the value to classify. The reader reads a private copy of the value, so a
+/// classifier may consume it; doing so does not affect the reader the value is deserialized from.
+/// </param>
+/// <returns>The selected case type, or <see langword="null"/> when the value cannot be classified.</returns>
+public delegate Type? YamlTypeClassifier(YamlReader reader);

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifierContext.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifierContext.cs
@@ -1,0 +1,39 @@
+using System.Collections.ObjectModel;
+
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>Describes the type a <see cref="YamlTypeClassifierFactory"/> is asked to classify.</summary>
+public sealed class YamlTypeClassifierContext
+{
+    /// <summary>Initializes a new instance of the <see cref="YamlTypeClassifierContext"/> class.</summary>
+    /// <param name="declaringType">The type being classified.</param>
+    /// <param name="kind">The kind of the type being classified.</param>
+    /// <param name="unionCases">The cases declared by <paramref name="declaringType"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="declaringType"/> or <paramref name="unionCases"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A case entry is <see langword="null"/>.</exception>
+    public YamlTypeClassifierContext(Type declaringType, YamlTypeClassifierKind kind, IReadOnlyList<YamlUnionCaseInfo> unionCases)
+    {
+        ArgumentNullException.ThrowIfNull(declaringType);
+        ArgumentNullException.ThrowIfNull(unionCases);
+
+        DeclaringType = declaringType;
+        Kind = kind;
+
+        var copy = new YamlUnionCaseInfo[unionCases.Count];
+        for (var i = 0; i < unionCases.Count; i++)
+        {
+            copy[i] = unionCases[i] ?? throw new ArgumentException("Union cases cannot contain null entries.", nameof(unionCases));
+        }
+
+        UnionCases = Array.AsReadOnly(copy);
+    }
+
+    /// <summary>Gets the type being classified.</summary>
+    public Type DeclaringType { get; }
+
+    /// <summary>Gets the kind of the type being classified.</summary>
+    public YamlTypeClassifierKind Kind { get; }
+
+    /// <summary>Gets the cases declared by <see cref="DeclaringType"/>.</summary>
+    public ReadOnlyCollection<YamlUnionCaseInfo> UnionCases { get; }
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifierContext.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifierContext.cs
@@ -5,27 +5,67 @@ namespace Meziantou.Framework.Yaml.Serialization;
 /// <summary>Describes the type a <see cref="YamlTypeClassifierFactory"/> is asked to classify.</summary>
 public sealed class YamlTypeClassifierContext
 {
-    /// <summary>Initializes a new instance of the <see cref="YamlTypeClassifierContext"/> class.</summary>
-    /// <param name="declaringType">The type being classified.</param>
-    /// <param name="kind">The kind of the type being classified.</param>
+    private static readonly ReadOnlyCollection<YamlUnionCaseInfo> EmptyUnionCases = Array.AsReadOnly(Array.Empty<YamlUnionCaseInfo>());
+    private static readonly ReadOnlyCollection<YamlDerivedType> EmptyDerivedTypes = Array.AsReadOnly(Array.Empty<YamlDerivedType>());
+
+    private YamlTypeClassifierContext(
+        Type declaringType,
+        YamlTypeClassifierKind kind,
+        ReadOnlyCollection<YamlUnionCaseInfo> unionCases,
+        ReadOnlyCollection<YamlDerivedType> derivedTypes,
+        string? typeDiscriminatorPropertyName)
+    {
+        DeclaringType = declaringType;
+        Kind = kind;
+        UnionCases = unionCases;
+        DerivedTypes = derivedTypes;
+        TypeDiscriminatorPropertyName = typeDiscriminatorPropertyName;
+    }
+
+    /// <summary>Creates a context describing a C# union type.</summary>
+    /// <param name="declaringType">The union type.</param>
     /// <param name="unionCases">The cases declared by <paramref name="declaringType"/>.</param>
+    /// <returns>The context to create a classifier from.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="declaringType"/> or <paramref name="unionCases"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">A case entry is <see langword="null"/>.</exception>
-    public YamlTypeClassifierContext(Type declaringType, YamlTypeClassifierKind kind, IReadOnlyList<YamlUnionCaseInfo> unionCases)
+    public static YamlTypeClassifierContext CreateForUnion(Type declaringType, IReadOnlyList<YamlUnionCaseInfo> unionCases)
     {
         ArgumentNullException.ThrowIfNull(declaringType);
         ArgumentNullException.ThrowIfNull(unionCases);
 
-        DeclaringType = declaringType;
-        Kind = kind;
+        return new(declaringType, YamlTypeClassifierKind.Union, Copy(unionCases, nameof(unionCases)), EmptyDerivedTypes, typeDiscriminatorPropertyName: null);
+    }
 
-        var copy = new YamlUnionCaseInfo[unionCases.Count];
-        for (var i = 0; i < unionCases.Count; i++)
+    /// <summary>Creates a context describing a polymorphic type.</summary>
+    /// <param name="declaringType">The base type.</param>
+    /// <param name="derivedTypes">The types derived from <paramref name="declaringType"/>.</param>
+    /// <param name="typeDiscriminatorPropertyName">The mapping key carrying the type discriminator, when the type uses one.</param>
+    /// <returns>The context to create a classifier from.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="declaringType"/> or <paramref name="derivedTypes"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A derived type entry is <see langword="null"/>.</exception>
+    public static YamlTypeClassifierContext CreateForPolymorphicType(Type declaringType, IReadOnlyList<YamlDerivedType> derivedTypes, string? typeDiscriminatorPropertyName)
+    {
+        ArgumentNullException.ThrowIfNull(declaringType);
+        ArgumentNullException.ThrowIfNull(derivedTypes);
+
+        return new(declaringType, YamlTypeClassifierKind.PolymorphicType, EmptyUnionCases, Copy(derivedTypes, nameof(derivedTypes)), typeDiscriminatorPropertyName);
+    }
+
+    private static ReadOnlyCollection<T> Copy<T>(IReadOnlyList<T> values, string paramName)
+        where T : class
+    {
+        if (values.Count == 0)
         {
-            copy[i] = unionCases[i] ?? throw new ArgumentException("Union cases cannot contain null entries.", nameof(unionCases));
+            return Array.AsReadOnly(Array.Empty<T>());
         }
 
-        UnionCases = Array.AsReadOnly(copy);
+        var copy = new T[values.Count];
+        for (var i = 0; i < values.Count; i++)
+        {
+            copy[i] = values[i] ?? throw new ArgumentException("The collection cannot contain null entries.", paramName);
+        }
+
+        return Array.AsReadOnly(copy);
     }
 
     /// <summary>Gets the type being classified.</summary>
@@ -34,6 +74,12 @@ public sealed class YamlTypeClassifierContext
     /// <summary>Gets the kind of the type being classified.</summary>
     public YamlTypeClassifierKind Kind { get; }
 
-    /// <summary>Gets the cases declared by <see cref="DeclaringType"/>.</summary>
+    /// <summary>Gets the cases declared by <see cref="DeclaringType"/>, when it is a union type.</summary>
     public ReadOnlyCollection<YamlUnionCaseInfo> UnionCases { get; }
+
+    /// <summary>Gets the types derived from <see cref="DeclaringType"/>, when it is a polymorphic type.</summary>
+    public ReadOnlyCollection<YamlDerivedType> DerivedTypes { get; }
+
+    /// <summary>Gets the mapping key carrying the type discriminator, when <see cref="DeclaringType"/> uses one.</summary>
+    public string? TypeDiscriminatorPropertyName { get; }
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifierFactory.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifierFactory.cs
@@ -1,0 +1,20 @@
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>Creates the <see cref="YamlTypeClassifier"/> used to select a union case from a YAML payload.</summary>
+/// <remarks>
+/// Register a factory through <see cref="YamlSerializerOptions.TypeClassifiers"/>. Without one, union cases are
+/// selected by YAML shape alone and a payload matching several cases fails to deserialize.
+/// </remarks>
+public abstract class YamlTypeClassifierFactory
+{
+    /// <summary>Determines whether this factory can classify the type described by <paramref name="context"/>.</summary>
+    /// <param name="context">The type being classified.</param>
+    /// <returns><see langword="true"/> when the factory can classify the type; otherwise <see langword="false"/>.</returns>
+    public abstract bool CanClassify(YamlTypeClassifierContext context);
+
+    /// <summary>Creates the classifier for the type described by <paramref name="context"/>.</summary>
+    /// <param name="context">The type being classified.</param>
+    /// <param name="options">The options the classifier is created for.</param>
+    /// <returns>The classifier to select a case with.</returns>
+    public abstract YamlTypeClassifier CreateYamlClassifier(YamlTypeClassifierContext context, YamlSerializerOptions options);
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifierKind.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifierKind.cs
@@ -3,6 +3,9 @@ namespace Meziantou.Framework.Yaml.Serialization;
 /// <summary>Describes the kind of type a <see cref="YamlTypeClassifierFactory"/> is asked to classify.</summary>
 public enum YamlTypeClassifierKind
 {
+    /// <summary>No kind is specified.</summary>
+    None = 0,
+
     /// <summary>The type is a C# union type.</summary>
-    Union,
+    Union = 1,
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifierKind.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifierKind.cs
@@ -1,0 +1,8 @@
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>Describes the kind of type a <see cref="YamlTypeClassifierFactory"/> is asked to classify.</summary>
+public enum YamlTypeClassifierKind
+{
+    /// <summary>The type is a C# union type.</summary>
+    Union,
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifierKind.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlTypeClassifierKind.cs
@@ -8,4 +8,7 @@ public enum YamlTypeClassifierKind
 
     /// <summary>The type is a C# union type.</summary>
     Union = 1,
+
+    /// <summary>The type is a polymorphic type.</summary>
+    PolymorphicType = 2,
 }

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlUnionCaseInfo.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlUnionCaseInfo.cs
@@ -1,0 +1,62 @@
+using System.Collections.ObjectModel;
+
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>Describes a single case of a C# union type to a <see cref="YamlTypeClassifierFactory"/>.</summary>
+public sealed class YamlUnionCaseInfo
+{
+    private static readonly ReadOnlyCollection<YamlUnionCaseProperty> EmptyProperties = Array.AsReadOnly(Array.Empty<YamlUnionCaseProperty>());
+
+    /// <summary>Initializes a new instance of the <see cref="YamlUnionCaseInfo"/> class.</summary>
+    /// <param name="caseType">The declared case type.</param>
+    /// <param name="shape">The YAML shape the case is represented by.</param>
+    /// <param name="properties">The mapping keys declared by the case, or <see langword="null"/> when the case does not serialize as an object mapping.</param>
+    /// <param name="disallowUnmappedProperties">Whether the case rejects mapping keys it does not declare.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="caseType"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A property entry is <see langword="null"/>.</exception>
+    public YamlUnionCaseInfo(
+        Type caseType,
+        YamlUnionCaseShape shape,
+        IReadOnlyList<YamlUnionCaseProperty>? properties = null,
+        bool disallowUnmappedProperties = false)
+    {
+        ArgumentNullException.ThrowIfNull(caseType);
+
+        CaseType = caseType;
+        Shape = shape;
+        DisallowUnmappedProperties = disallowUnmappedProperties;
+
+        if (properties is null)
+        {
+            Properties = EmptyProperties;
+            return;
+        }
+
+        HasObjectProperties = true;
+        var copy = new YamlUnionCaseProperty[properties.Count];
+        for (var i = 0; i < properties.Count; i++)
+        {
+            copy[i] = properties[i] ?? throw new ArgumentException("Properties cannot contain null entries.", nameof(properties));
+        }
+
+        Properties = Array.AsReadOnly(copy);
+    }
+
+    /// <summary>Gets the declared case type.</summary>
+    public Type CaseType { get; }
+
+    /// <summary>Gets the YAML shape the case is represented by.</summary>
+    public YamlUnionCaseShape Shape { get; }
+
+    /// <summary>Gets the mapping keys declared by the case.</summary>
+    public IReadOnlyList<YamlUnionCaseProperty> Properties { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the case serializes as an object mapping whose keys are known.
+    /// A mapping case backed by a dictionary has no declared keys and therefore reports <see langword="false"/>.
+    /// </summary>
+    public bool HasObjectProperties { get; }
+
+    /// <summary>Gets a value indicating whether the case rejects mapping keys it does not declare.</summary>
+    public bool DisallowUnmappedProperties { get; }
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlUnionCaseProperty.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlUnionCaseProperty.cs
@@ -1,0 +1,23 @@
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>Describes a mapping key declared by a union case that serializes as a YAML mapping.</summary>
+public sealed class YamlUnionCaseProperty
+{
+    /// <summary>Initializes a new instance of the <see cref="YamlUnionCaseProperty"/> class.</summary>
+    /// <param name="name">The mapping key, after the naming policy has been applied.</param>
+    /// <param name="isRequired">Whether the payload must contain the key.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
+    public YamlUnionCaseProperty(string name, bool isRequired)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        Name = name;
+        IsRequired = isRequired;
+    }
+
+    /// <summary>Gets the mapping key, after the naming policy has been applied.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets a value indicating whether the payload must contain the key.</summary>
+    public bool IsRequired { get; }
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlUnionCaseShape.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlUnionCaseShape.cs
@@ -1,0 +1,23 @@
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>Describes the YAML shape a union case is represented by.</summary>
+public enum YamlUnionCaseShape
+{
+    /// <summary>The case is represented by a boolean scalar.</summary>
+    Boolean,
+
+    /// <summary>The case is represented by a numeric scalar.</summary>
+    Number,
+
+    /// <summary>The case is represented by a text scalar.</summary>
+    Text,
+
+    /// <summary>The case is represented by a sequence.</summary>
+    Sequence,
+
+    /// <summary>The case is represented by a mapping.</summary>
+    Mapping,
+
+    /// <summary>The case can be represented by any YAML shape.</summary>
+    Any,
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlUnionClassification.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlUnionClassification.cs
@@ -1,0 +1,64 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>Applies the <see cref="YamlSerializerOptions.TypeClassifiers"/> of a reader to a C# union payload.</summary>
+/// <remarks>This type supports the serializer infrastructure and is not intended to be used directly from your code.</remarks>
+public static class YamlUnionClassification
+{
+    private static readonly ConditionalWeakTable<YamlSerializerOptions, ConcurrentDictionary<Type, YamlTypeClassifier?>> Cache = new();
+
+    /// <summary>
+    /// Selects the union case matching the value <paramref name="reader"/> is positioned on, when a classifier is
+    /// registered for the union type.
+    /// </summary>
+    /// <param name="reader">The reader positioned at the start of the value.</param>
+    /// <param name="context">The union type and the cases to select from.</param>
+    /// <param name="bufferedNode">
+    /// Receives the buffered YAML of the value when a classifier ran, or <see langword="null"/> when no classifier is
+    /// registered. Classification reads the value, so the caller must deserialize the selected case from a reader
+    /// created over the buffered YAML rather than from <paramref name="reader"/>.
+    /// </param>
+    /// <returns>The selected case type, or <see langword="null"/> when no classifier is registered or the value cannot be classified.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="reader"/> or <paramref name="context"/> is <see langword="null"/>.</exception>
+    public static Type? Classify(YamlReader reader, YamlTypeClassifierContext context, out string? bufferedNode)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(context);
+
+        bufferedNode = null;
+
+        var classifier = GetClassifier(reader.Options, context);
+        if (classifier is null)
+        {
+            return null;
+        }
+
+        // Classification reads the value, so it runs over a private copy and leaves the buffered YAML to the caller.
+        bufferedNode = YamlReader.BufferCurrentNodeToString(reader);
+        var classifierReader = reader.CreateReader(bufferedNode);
+        return classifierReader.Read() ? classifier(classifierReader) : null;
+    }
+
+    private static YamlTypeClassifier? GetClassifier(YamlSerializerOptions options, YamlTypeClassifierContext context)
+    {
+        var classifiersByType = Cache.GetValue(options, static _ => new ConcurrentDictionary<Type, YamlTypeClassifier?>());
+        if (classifiersByType.TryGetValue(context.DeclaringType, out var cached))
+        {
+            return cached;
+        }
+
+        YamlTypeClassifier? classifier = null;
+        foreach (var factory in options.TypeClassifiers)
+        {
+            if (factory.CanClassify(context))
+            {
+                classifier = factory.CreateYamlClassifier(context, options);
+                break;
+            }
+        }
+
+        return classifiersByType.GetOrAdd(context.DeclaringType, classifier);
+    }
+}

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlUnionTypeStructuralClassifier.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlUnionTypeStructuralClassifier.cs
@@ -1,0 +1,305 @@
+namespace Meziantou.Framework.Yaml.Serialization;
+
+/// <summary>
+/// Classifies YAML payloads into union case types by comparing their YAML shape and, for mappings, their keys.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The default union classification only distinguishes cases that use different YAML shapes, such as a scalar and a
+/// sequence. This classifier adds structural classification for cases that serialize as YAML mappings.
+/// </para>
+/// <para>
+/// To classify a mapping, the classifier starts with every object case as a candidate. For each key at the level of
+/// the current mapping, it eliminates candidates that do not declare a matching key. Values and nested content are
+/// not examined, and key order does not affect the result. Name matching honors
+/// <see cref="YamlSerializerOptions.PropertyNameCaseInsensitive"/>.
+/// </para>
+/// <para>
+/// After reading the mapping, candidates missing a required key are eliminated. Missing optional keys have no effect.
+/// A key that is not declared by any case eliminates only cases configured with
+/// <see cref="YamlUnmappedMemberHandling.Disallow"/>.
+/// </para>
+/// <para>
+/// The classifier selects the case when exactly one candidate remains. Classification fails when no candidates or
+/// several candidates remain. Configurations containing a case that can never be selected uniquely are rejected when
+/// the classifier is created.
+/// </para>
+/// </remarks>
+public sealed class YamlUnionTypeStructuralClassifier : YamlTypeClassifierFactory
+{
+    /// <inheritdoc/>
+    public override bool CanClassify(YamlTypeClassifierContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return context.Kind is YamlTypeClassifierKind.Union;
+    }
+
+    /// <inheritdoc/>
+    /// <exception cref="ArgumentNullException"><paramref name="context"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException"><paramref name="context"/> does not describe a union type.</exception>
+    /// <exception cref="NotSupportedException">The union declares cases that cannot be told apart.</exception>
+    public override YamlTypeClassifier CreateYamlClassifier(YamlTypeClassifierContext context, YamlSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (context.Kind is not YamlTypeClassifierKind.Union)
+        {
+            throw new InvalidOperationException($"'{nameof(YamlUnionTypeStructuralClassifier)}' can only classify union types, but '{context.DeclaringType}' is not one.");
+        }
+
+        var classifier = StructuralClassifier.Create(context, options.PropertyNameCaseInsensitive);
+        return classifier.Classify;
+    }
+
+    private sealed class StructuralClassifier
+    {
+        private readonly Dictionary<YamlUnionCaseShape, Type> _shapeCases;
+        private readonly ObjectCase[] _objectCases;
+        private readonly StringComparer _comparer;
+
+        private StructuralClassifier(Dictionary<YamlUnionCaseShape, Type> shapeCases, ObjectCase[] objectCases, StringComparer comparer)
+        {
+            _shapeCases = shapeCases;
+            _objectCases = objectCases;
+            _comparer = comparer;
+        }
+
+        public static StructuralClassifier Create(YamlTypeClassifierContext context, bool caseInsensitive)
+        {
+            var comparer = caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            var shapeCases = new Dictionary<YamlUnionCaseShape, Type>();
+            var objectCases = new List<ObjectCase>();
+
+            foreach (var unionCase in context.UnionCases)
+            {
+                if (unionCase is { Shape: YamlUnionCaseShape.Mapping, HasObjectProperties: true })
+                {
+                    objectCases.Add(new ObjectCase(unionCase, comparer));
+                    continue;
+                }
+
+                // A shape is the only discriminator for non-object cases, so at most one case can claim each shape.
+                if (!shapeCases.TryAdd(unionCase.Shape, unionCase.CaseType))
+                {
+                    throw CreateAmbiguousCasesException(context.DeclaringType, shapeCases[unionCase.Shape], unionCase.CaseType);
+                }
+            }
+
+            // A mapping case without declared keys, such as a dictionary, accepts every mapping, so it cannot coexist
+            // with object cases.
+            if (objectCases.Count > 0 && shapeCases.TryGetValue(YamlUnionCaseShape.Mapping, out var dictionaryCase))
+            {
+                throw CreateAmbiguousCasesException(context.DeclaringType, objectCases[0].CaseType, dictionaryCase);
+            }
+
+            // Reject a case when every mapping it accepts also satisfies another case, since it can never be selected
+            // uniquely. This quadratic check runs only once, and is bounded by the cases declared on the union.
+            for (var i = 0; i < objectCases.Count; i++)
+            {
+                for (var j = 0; j < objectCases.Count; j++)
+                {
+                    if (i != j && objectCases[i].IsShadowedBy(objectCases[j]))
+                    {
+                        throw new NotSupportedException($"Union type '{context.DeclaringType}' declares case '{objectCases[i].CaseType}', which cannot be told apart from case '{objectCases[j].CaseType}'.");
+                    }
+                }
+            }
+
+            return new StructuralClassifier(shapeCases, [.. objectCases], comparer);
+        }
+
+        private static NotSupportedException CreateAmbiguousCasesException(Type unionType, Type first, Type second)
+            => new($"Union type '{unionType}' declares cases '{first}' and '{second}', which are represented by the same YAML shape.");
+
+        public Type? Classify(YamlReader reader)
+        {
+            ArgumentNullException.ThrowIfNull(reader);
+
+            if (reader.TokenType is YamlTokenType.StartMapping && _objectCases.Length > 0)
+            {
+                return ClassifyMapping(reader) ?? GetCatchAllCase();
+            }
+
+            var shape = GetShape(reader);
+            if (shape is not null && _shapeCases.TryGetValue(shape.Value, out var caseType))
+            {
+                return caseType;
+            }
+
+            return GetCatchAllCase();
+        }
+
+        /// <summary>Gets the case accepting any YAML shape, which is selected when no other case matches.</summary>
+        private Type? GetCatchAllCase()
+            => _shapeCases.TryGetValue(YamlUnionCaseShape.Any, out var caseType) ? caseType : null;
+
+        private static YamlUnionCaseShape? GetShape(YamlReader reader)
+        {
+            if (reader.TokenType is YamlTokenType.StartMapping)
+            {
+                return YamlUnionCaseShape.Mapping;
+            }
+
+            if (reader.TokenType is YamlTokenType.StartSequence)
+            {
+                return YamlUnionCaseShape.Sequence;
+            }
+
+            if (reader.TokenType is not YamlTokenType.Scalar)
+            {
+                return null;
+            }
+
+            return YamlScalar.ResolveObject(reader) switch
+            {
+                null => null,
+                bool => YamlUnionCaseShape.Boolean,
+                sbyte or byte or short or ushort or int or uint or long or ulong or nint or nuint or float or double or decimal or Half or Int128 or UInt128 => YamlUnionCaseShape.Number,
+                _ => YamlUnionCaseShape.Text,
+            };
+        }
+
+        private Type? ClassifyMapping(YamlReader reader)
+        {
+            // Key order and duplicates do not affect the result, so collect the keys of the current mapping first and
+            // then evaluate every case against that set.
+            var keys = new HashSet<string>(_comparer);
+            reader.Read();
+            while (reader.TokenType is not YamlTokenType.EndMapping)
+            {
+                if (reader.TokenType is not YamlTokenType.Scalar)
+                {
+                    // A non-scalar key never matches a declared member, and the object converter rejects it anyway.
+                    reader.Skip();
+                    reader.Skip();
+                    continue;
+                }
+
+                var key = reader.ScalarValue ?? string.Empty;
+                reader.Read();
+                reader.Skip();
+
+                // A merge key carries the keys of another mapping rather than a member of the case.
+                if (!string.Equals(key, "<<", StringComparison.Ordinal))
+                {
+                    keys.Add(key);
+                }
+            }
+
+            // Begin with every object case as a candidate and eliminate cases using keys only.
+            var isCandidate = new bool[_objectCases.Length];
+            Array.Fill(isCandidate, value: true);
+
+            foreach (var key in keys)
+            {
+                var isKnownKey = false;
+                for (var i = 0; i < _objectCases.Length; i++)
+                {
+                    if (_objectCases[i].DeclaresProperty(key))
+                    {
+                        isKnownKey = true;
+                        break;
+                    }
+                }
+
+                for (var i = 0; i < _objectCases.Length; i++)
+                {
+                    // A key some case declares retains only the cases declaring it; an unknown key eliminates only the
+                    // cases that reject unmapped keys.
+                    isCandidate[i] &= isKnownKey
+                        ? _objectCases[i].DeclaresProperty(key)
+                        : !_objectCases[i].DisallowUnmappedProperties;
+                }
+            }
+
+            Type? selected = null;
+            for (var i = 0; i < _objectCases.Length; i++)
+            {
+                if (!isCandidate[i] || !_objectCases[i].HasAllRequiredProperties(keys))
+                {
+                    continue;
+                }
+
+                if (selected is not null)
+                {
+                    return null;
+                }
+
+                selected = _objectCases[i].CaseType;
+            }
+
+            return selected;
+        }
+    }
+
+    private sealed class ObjectCase
+    {
+        private readonly HashSet<string> _propertyNames;
+        private readonly HashSet<string> _requiredPropertyNames;
+
+        public ObjectCase(YamlUnionCaseInfo unionCase, StringComparer comparer)
+        {
+            CaseType = unionCase.CaseType;
+            DisallowUnmappedProperties = unionCase.DisallowUnmappedProperties;
+
+            _propertyNames = new HashSet<string>(comparer);
+            _requiredPropertyNames = new HashSet<string>(comparer);
+            foreach (var property in unionCase.Properties)
+            {
+                _propertyNames.Add(property.Name);
+                if (property.IsRequired)
+                {
+                    _requiredPropertyNames.Add(property.Name);
+                }
+            }
+        }
+
+        public Type CaseType { get; }
+        public bool DisallowUnmappedProperties { get; }
+
+        public bool DeclaresProperty(string name) => _propertyNames.Contains(name);
+
+        public bool HasAllRequiredProperties(HashSet<string> keys)
+        {
+            foreach (var name in _requiredPropertyNames)
+            {
+                if (!keys.Contains(name))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public bool IsShadowedBy(ObjectCase other)
+        {
+            // This case is shadowed when every mapping it accepts is also accepted by the other case: the other case
+            // must be at least as permissive about unknown keys, declare every key this case declares, and require no
+            // key that this case does not itself require.
+            if (!DisallowUnmappedProperties && other.DisallowUnmappedProperties)
+            {
+                return false;
+            }
+
+            foreach (var name in _propertyNames)
+            {
+                if (!other._propertyNames.Contains(name))
+                {
+                    return false;
+                }
+            }
+
+            foreach (var name in other._requiredPropertyNames)
+            {
+                if (!_requiredPropertyNames.Contains(name))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
+++ b/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
@@ -11,11 +11,13 @@ public sealed record YamlSerializerOptions
 {
     private static readonly YamlConverter[] EmptyConverters = [];
     private static readonly ReadOnlyCollection<YamlConverter> EmptyConvertersReadOnly = Array.AsReadOnly(EmptyConverters);
+    private static readonly ReadOnlyCollection<YamlTypeClassifierFactory> EmptyTypeClassifiersReadOnly = Array.AsReadOnly(Array.Empty<YamlTypeClassifierFactory>());
 
     /// <summary>Gets a default options instance.</summary>
     public static YamlSerializerOptions Default { get; } = new();
 
     private readonly ReadOnlyCollection<YamlConverter> _convertersReadOnly = EmptyConvertersReadOnly;
+    private readonly ReadOnlyCollection<YamlTypeClassifierFactory> _typeClassifiersReadOnly = EmptyTypeClassifiersReadOnly;
 
     /// <summary>Gets the custom converters.</summary>
     /// <remarks>Converters are evaluated in order and take precedence over built-in converters.</remarks>
@@ -46,6 +48,36 @@ public sealed record YamlSerializerOptions
             }
 
             _convertersReadOnly = Array.AsReadOnly(copy);
+        }
+    }
+
+    /// <summary>Gets the type classifier factories used to select a C# union case from a YAML payload.</summary>
+    /// <remarks>
+    /// Factories are evaluated in order, and the first one accepting a type classifies it. Without a factory, union
+    /// cases are selected by YAML shape alone and a payload matching several cases fails to deserialize. Register
+    /// <see cref="YamlUnionTypeStructuralClassifier"/> to also tell mapping cases apart by their keys.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Value is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">A factory entry is <see langword="null"/>.</exception>
+    public IReadOnlyList<YamlTypeClassifierFactory> TypeClassifiers
+    {
+        get => _typeClassifiersReadOnly;
+        init
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            if (value.Count == 0)
+            {
+                _typeClassifiersReadOnly = EmptyTypeClassifiersReadOnly;
+                return;
+            }
+
+            var copy = new YamlTypeClassifierFactory[value.Count];
+            for (var i = 0; i < value.Count; i++)
+            {
+                copy[i] = value[i] ?? throw new ArgumentException("Type classifiers cannot contain null entries.", nameof(value));
+            }
+
+            _typeClassifiersReadOnly = Array.AsReadOnly(copy);
         }
     }
 

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -277,6 +277,23 @@ The classifier starts with every mapping case as a candidate and eliminates the 
 
 Implement `YamlTypeClassifierFactory` to select cases with your own rules.
 
+## Classify polymorphic types
+
+A type classifier can also select a derived type from the payload itself, as an alternative to a discriminator. `CanClassify` receives a context whose `Kind` is `YamlTypeClassifierKind.PolymorphicType`, along with the registered derived types:
+
+```csharp
+internal sealed class ShapeClassifier : YamlTypeClassifierFactory
+{
+    public override bool CanClassify(YamlTypeClassifierContext context)
+        => context.Kind is YamlTypeClassifierKind.PolymorphicType && context.DeclaringType == typeof(Shape);
+
+    public override YamlTypeClassifier CreateYamlClassifier(YamlTypeClassifierContext context, YamlSerializerOptions options)
+        => reader => /* inspect the payload and return a type from context.DerivedTypes */;
+}
+```
+
+The classifier reads a private copy of the value, so it may consume the reader. It never overrides an explicit discriminator or tag: it runs only once those have failed to resolve a type, and returning `null` falls back to the default derived type or the usual failure.
+
 ## Feature switches
 
 Reflection-based serialization can be disabled for applications that only use source-generated metadata. Set the `MeziantouFrameworkYamlIsReflectionEnabledByDefault` MSBuild property to `false` in the project file:

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -248,6 +248,35 @@ internal sealed partial class ShapeYamlContext : YamlSerializerContext
 }
 ```
 
+## C# unions
+
+A C# union is serialized as its selected case, without a wrapper:
+
+```csharp
+internal union Setting(bool, int, string);
+
+YamlSerializer.Serialize(new Setting(42)); // 42
+```
+
+Cases are selected by YAML shape when deserializing, so a union whose cases use distinct shapes needs no configuration. A payload matching several cases &mdash; two cases that both serialize as a mapping, for instance &mdash; fails unless a type classifier is registered. `YamlUnionTypeStructuralClassifier` tells mapping cases apart by their keys:
+
+```csharp
+internal union Shape(Circle, Rectangle);
+internal sealed class Circle { public int Radius { get; set; } }
+internal sealed class Rectangle { public int Width { get; set; } public int Height { get; set; } }
+
+var options = new YamlSerializerOptions
+{
+    TypeClassifiers = [new YamlUnionTypeStructuralClassifier()],
+};
+
+YamlSerializer.Deserialize<Shape>("Radius: 3", options); // Circle
+```
+
+The classifier starts with every mapping case as a candidate and eliminates the cases that do not declare a key present in the payload. Keys no case declares eliminate only the cases that reject unmapped members, and a case missing a required key is eliminated once the mapping has been read. Deserialization succeeds when exactly one candidate remains. A union declaring cases that can never be told apart is rejected when the classifier is created.
+
+Implement `YamlTypeClassifierFactory` to select cases with your own rules.
+
 ## Feature switches
 
 Reflection-based serialization can be disabled for applications that only use source-generated metadata. Set the `MeziantouFrameworkYamlIsReflectionEnabledByDefault` MSBuild property to `false` in the project file:

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlCSharpUnionTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlCSharpUnionTests.cs
@@ -56,11 +56,74 @@ public sealed class YamlCSharpUnionTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public void NullWithoutNullableCaseThrows(bool useSourceGeneration)
+    public void NullWithoutNullableCaseReturnsDefault(bool useSourceGeneration)
     {
-        var exception = Assert.Throws<YamlException>(() => Deserialize<NonNullableUnion>("null\n", useSourceGeneration));
+        Assert.Null(Deserialize<NonNullableUnion>("null\n", useSourceGeneration).Value);
+    }
 
-        Assert.Contains("nullable case", exception.Message);
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DefaultUnionRoundTripsThroughNull(bool useSourceGeneration)
+    {
+        var yaml = Serialize(default(NonNullableUnion), useSourceGeneration);
+        var roundTrip = Deserialize<NonNullableUnion>(yaml, useSourceGeneration);
+
+        Assert.Equal("null\n", yaml);
+        Assert.Null(roundTrip.Value);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DefaultUnionRoundTripsInsideObject(bool useSourceGeneration)
+    {
+        var yaml = Serialize(new NonNullableUnionHolder(), useSourceGeneration);
+        var roundTrip = Deserialize<NonNullableUnionHolder>(yaml, useSourceGeneration);
+
+        Assert.Equal("Value: null\n", yaml);
+        Assert.NotNull(roundTrip);
+        Assert.Null(roundTrip.Value.Value);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NullableAndNonNullableOverloadsOfTheSameCaseAreNotAmbiguous(bool useSourceGeneration)
+    {
+        var number = Deserialize<NullableOverloadUnion>("42\n", useSourceGeneration);
+        var nullValue = Deserialize<NullableOverloadUnion>("null\n", useSourceGeneration);
+
+        Assert.NotNull(number);
+        Assert.Equal(42, number.Value);
+        Assert.NotNull(nullValue);
+        Assert.Null(nullValue.Value);
+        Assert.Equal("42\n", Serialize(new NullableOverloadUnion(42), useSourceGeneration));
+        Assert.Equal("42\n", Serialize(new NullableOverloadUnion((int?)42), useSourceGeneration));
+        Assert.Equal("null\n", Serialize(new NullableOverloadUnion((int?)null), useSourceGeneration));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RecursiveUnionCaseUsesThePayloadAndNotTheUnionInstance(bool useSourceGeneration)
+    {
+        var yaml = Serialize(new RecursiveUnion(new RecursiveUnion(true)), useSourceGeneration);
+        var roundTrip = Deserialize<RecursiveUnion>(yaml, useSourceGeneration);
+
+        Assert.Equal("true\n", yaml);
+        Assert.NotNull(roundTrip);
+        Assert.Equal(true, roundTrip.Value);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void UnionImplementingItsOwnCaseInterfaceUsesThePayload(bool useSourceGeneration)
+    {
+        var yaml = Serialize(new ShapeUnion(new UnionSquare { Size = 3 }), useSourceGeneration);
+
+        Assert.Equal("$type: square\nSize: 3\n", yaml);
     }
 
     [Theory]
@@ -130,6 +193,98 @@ public sealed class YamlCSharpUnionTests
         Assert.Equal("Name: Rex\n", yaml);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StructuralClassifierSelectsMappingCaseByKeys(bool useSourceGeneration)
+    {
+        var circle = Deserialize<ShapeOrCircleUnion>("Radius: 3\n", useSourceGeneration, StructuralOptions);
+        var rectangle = Deserialize<ShapeOrCircleUnion>("Width: 4\nHeight: 5\n", useSourceGeneration, StructuralOptions);
+
+        Assert.Equal(3, Assert.IsType<UnionCircle>(circle.Value).Radius);
+        var value = Assert.IsType<UnionRectangle>(rectangle.Value);
+        Assert.Equal(4, value.Width);
+        Assert.Equal(5, value.Height);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StructuralClassifierFailsWhenNoCaseMatchesTheKeys(bool useSourceGeneration)
+    {
+        var exception = Assert.Throws<YamlException>(() => Deserialize<ShapeOrCircleUnion>("Depth: 3\n", useSourceGeneration, StructuralOptions));
+
+        Assert.Contains("multiple cases", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StructuralClassifierIsNotUsedWhenNotRegistered(bool useSourceGeneration)
+    {
+        var exception = Assert.Throws<YamlException>(() => Deserialize<ShapeOrCircleUnion>("Radius: 3\n", useSourceGeneration));
+
+        Assert.Contains("multiple cases", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StructuralClassifierUsesRequiredKeysToTellCasesApart(bool useSourceGeneration)
+    {
+        var full = Deserialize<PointOrLabelUnion>("Name: a\nX: 1\n", useSourceGeneration, StructuralOptions);
+        var partial = Deserialize<PointOrLabelUnion>("Name: a\n", useSourceGeneration, StructuralOptions);
+
+        Assert.Equal(1, Assert.IsType<UnionPoint>(full.Value).X);
+        Assert.Equal("a", Assert.IsType<UnionLabel>(partial.Value).Name);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StructuralClassifierIgnoresKeysNoCaseDeclares(bool useSourceGeneration)
+    {
+        var value = Deserialize<ShapeOrCircleUnion>("Radius: 3\nExtra: 4\n", useSourceGeneration, StructuralOptions);
+
+        Assert.Equal(3, Assert.IsType<UnionCircle>(value.Value).Radius);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StructuralClassifierHonorsCaseInsensitivePropertyNames(bool useSourceGeneration)
+    {
+        var options = StructuralOptions with { PropertyNameCaseInsensitive = true };
+        var value = Deserialize<ShapeOrCircleUnion>("radius: 3\n", useSourceGeneration, options);
+
+        Assert.Equal(3, Assert.IsType<UnionCircle>(value.Value).Radius);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StructuralClassifierRejectsCasesThatCannotBeToldApart(bool useSourceGeneration)
+    {
+        var exception = Assert.Throws<NotSupportedException>(() => Deserialize<AmbiguousAnimalUnion>("Name: Rex\n", useSourceGeneration, StructuralOptions));
+
+        Assert.Contains("cannot be told apart", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StructuralClassifierFallsBackToTheCatchAllCase(bool useSourceGeneration)
+    {
+        var label = Deserialize<LabelOrAnyUnion>("Name: a\n", useSourceGeneration, StructuralOptions);
+        var other = Deserialize<LabelOrAnyUnion>("Depth: 3\n", useSourceGeneration, StructuralOptions);
+
+        Assert.Equal("a", Assert.IsType<UnionLabel>(label.Value).Name);
+        var mapping = Assert.IsAssignableTo<IDictionary<string, object?>>(other.Value);
+        Assert.Equal(3, mapping["Depth"]);
+    }
+
+    private static YamlSerializerOptions StructuralOptions { get; } = new() { TypeClassifiers = [new YamlUnionTypeStructuralClassifier()] };
+
     private static string Serialize<T>(T value, bool useSourceGeneration)
         => useSourceGeneration
             ? YamlSerializer.Serialize(value, CSharpUnionYamlContext.Default)
@@ -139,6 +294,11 @@ public sealed class YamlCSharpUnionTests
         => useSourceGeneration
             ? YamlSerializer.Deserialize<T>(yaml, CSharpUnionYamlContext.Default)
             : YamlSerializer.Deserialize<T>(yaml);
+
+    private static T? Deserialize<T>(string yaml, bool useSourceGeneration, YamlSerializerOptions options)
+        => useSourceGeneration
+            ? YamlSerializer.Deserialize<T>(yaml, new CSharpUnionYamlContext(options))
+            : YamlSerializer.Deserialize<T>(yaml, options);
 
     internal sealed class UnionDog
     {
@@ -162,6 +322,55 @@ public sealed class YamlCSharpUnionTests
     internal union CollectionOrDogUnion(List<int>, UnionDog);
     internal union AmbiguousAnimalUnion(UnionDog, UnionCat);
     internal union AmbiguousNumberUnion(int, double);
+    internal union NullableOverloadUnion(int, int?, string);
+    internal union ShapeOrCircleUnion(UnionCircle, UnionRectangle);
+    internal union PointOrLabelUnion(UnionPoint, UnionLabel);
+    internal union LabelOrAnyUnion(UnionLabel, object);
+
+    internal sealed class UnionPoint
+    {
+        public required string Name { get; set; }
+        public required int X { get; set; }
+    }
+
+    internal sealed class UnionLabel
+    {
+        public required string Name { get; set; }
+    }
+
+
+    internal sealed class UnionCircle
+    {
+        public int Radius { get; set; }
+    }
+
+    internal sealed class UnionRectangle
+    {
+        public int Width { get; set; }
+        public int Height { get; set; }
+    }
+
+    internal union RecursiveUnion(bool, RecursiveUnion?);
+    internal union ShapeUnion(int, IUnionShape) : IUnionShape
+    {
+        int IUnionShape.Size => -1;
+    }
+
+    [YamlDerivedType(typeof(UnionSquare), "square")]
+    internal interface IUnionShape
+    {
+        int Size { get; }
+    }
+
+    internal sealed class UnionSquare : IUnionShape
+    {
+        public int Size { get; set; }
+    }
+
+    internal sealed class NonNullableUnionHolder
+    {
+        public NonNullableUnion Value { get; set; }
+    }
 }
 
 [YamlSerializable(typeof(YamlCSharpUnionTests.ScalarUnion))]
@@ -172,7 +381,22 @@ public sealed class YamlCSharpUnionTests
 [YamlSerializable(typeof(YamlCSharpUnionTests.AmbiguousAnimalUnion))]
 [YamlSerializable(typeof(YamlCSharpUnionTests.AmbiguousNumberUnion))]
 [YamlSerializable(typeof(YamlCSharpUnionTests.UnionHolder))]
+[YamlSerializable(typeof(YamlCSharpUnionTests.NullableOverloadUnion))]
+[YamlSerializable(typeof(YamlCSharpUnionTests.RecursiveUnion))]
+[YamlSerializable(typeof(YamlCSharpUnionTests.ShapeUnion))]
+[YamlSerializable(typeof(YamlCSharpUnionTests.NonNullableUnionHolder))]
+[YamlSerializable(typeof(YamlCSharpUnionTests.ShapeOrCircleUnion))]
+[YamlSerializable(typeof(YamlCSharpUnionTests.PointOrLabelUnion))]
+[YamlSerializable(typeof(YamlCSharpUnionTests.LabelOrAnyUnion))]
 internal sealed partial class CSharpUnionYamlContext : YamlSerializerContext
 {
+    public CSharpUnionYamlContext()
+    {
+    }
+
+    public CSharpUnionYamlContext(YamlSerializerOptions options)
+        : base(options)
+    {
+    }
 }
 #endif

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlPolymorphicClassifierTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlPolymorphicClassifierTests.cs
@@ -1,0 +1,134 @@
+#pragma warning disable MA0048 // File name must match type name
+using Meziantou.Framework.Yaml.Serialization;
+
+namespace Meziantou.Framework.Yaml.Tests.Serialization;
+
+[YamlPolymorphic]
+[YamlDerivedType(typeof(ClassifiedCircle), "circle")]
+[YamlDerivedType(typeof(ClassifiedSquare), "square")]
+internal abstract class ClassifiedShape
+{
+}
+
+internal sealed class ClassifiedCircle : ClassifiedShape
+{
+    public int Radius { get; set; }
+}
+
+internal sealed class ClassifiedSquare : ClassifiedShape
+{
+    public int Size { get; set; }
+}
+
+[YamlSerializable(typeof(ClassifiedShape))]
+[YamlSerializable(typeof(ClassifiedCircle))]
+[YamlSerializable(typeof(ClassifiedSquare))]
+internal sealed partial class ClassifiedShapeYamlContext : YamlSerializerContext
+{
+    public ClassifiedShapeYamlContext()
+    {
+    }
+
+    public ClassifiedShapeYamlContext(YamlSerializerOptions options)
+        : base(options)
+    {
+    }
+}
+
+/// <summary>Selects a derived type from the first key of the mapping.</summary>
+internal sealed class ShapeByFirstKeyClassifier : YamlTypeClassifierFactory
+{
+    public static YamlTypeClassifierContext? LastContext { get; private set; }
+
+    public override bool CanClassify(YamlTypeClassifierContext context)
+        => context.Kind is YamlTypeClassifierKind.PolymorphicType && context.DeclaringType == typeof(ClassifiedShape);
+
+    public override YamlTypeClassifier CreateYamlClassifier(YamlTypeClassifierContext context, YamlSerializerOptions options)
+    {
+        LastContext = context;
+        return Classify;
+    }
+
+    private static Type? Classify(YamlReader reader)
+    {
+        if (reader.TokenType != YamlTokenType.StartMapping)
+        {
+            return null;
+        }
+
+        reader.Read();
+        return reader.TokenType == YamlTokenType.Scalar
+            ? reader.ScalarValue switch
+            {
+                "Radius" => typeof(ClassifiedCircle),
+                "Size" => typeof(ClassifiedSquare),
+                _ => null,
+            }
+            : null;
+    }
+}
+
+public sealed class YamlPolymorphicClassifierTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ClassifierSelectsDerivedTypeWithoutDiscriminator(bool useSourceGeneration)
+    {
+        var circle = Deserialize("Radius: 3\n", useSourceGeneration, ClassifierOptions);
+        var square = Deserialize("Size: 4\n", useSourceGeneration, ClassifierOptions);
+
+        Assert.Equal(3, Assert.IsType<ClassifiedCircle>(circle).Radius);
+        Assert.Equal(4, Assert.IsType<ClassifiedSquare>(square).Size);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DiscriminatorTakesPrecedenceOverTheClassifier(bool useSourceGeneration)
+    {
+        var value = Deserialize("$type: square\nRadius: 3\n", useSourceGeneration, ClassifierOptions);
+
+        Assert.IsType<ClassifiedSquare>(value);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ClassifierIsNotUsedWhenNotRegistered(bool useSourceGeneration)
+    {
+        Assert.Throws<YamlException>(() => Deserialize("Radius: 3\n", useSourceGeneration, new YamlSerializerOptions()));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ClassifierIsNotUsedWhenTheValueCannotBeClassified(bool useSourceGeneration)
+    {
+        Assert.Throws<YamlException>(() => Deserialize("Depth: 3\n", useSourceGeneration, ClassifierOptions));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ContextDescribesTheRegisteredDerivedTypes(bool useSourceGeneration)
+    {
+        _ = Deserialize("Radius: 3\n", useSourceGeneration, ClassifierOptions);
+
+        var context = ShapeByFirstKeyClassifier.LastContext;
+        Assert.NotNull(context);
+        Assert.Equal(YamlTypeClassifierKind.PolymorphicType, context.Kind);
+        Assert.Equal(typeof(ClassifiedShape), context.DeclaringType);
+        Assert.Equal("$type", context.TypeDiscriminatorPropertyName);
+        Assert.Equal(
+            ["circle", "square"],
+            context.DerivedTypes.Select(d => d.Discriminator).Order(StringComparer.Ordinal));
+    }
+
+    private static YamlSerializerOptions ClassifierOptions { get; } = new() { TypeClassifiers = [new ShapeByFirstKeyClassifier()] };
+
+    private static ClassifiedShape? Deserialize(string yaml, bool useSourceGeneration, YamlSerializerOptions options)
+        => useSourceGeneration
+            ? YamlSerializer.Deserialize<ClassifiedShape>(yaml, new ClassifiedShapeYamlContext(options))
+            : YamlSerializer.Deserialize<ClassifiedShape>(yaml, options);
+}


### PR DESCRIPTION
Union cases were selected by YAML shape alone, so a payload matching several cases — two cases that both serialize as a mapping, for instance — failed to deserialize. This adds an opt-in classifier API covering both unions and polymorphic types, and fixes three defects in the existing union support.

## Type classifiers

`YamlSerializerOptions.TypeClassifiers` accepts `YamlTypeClassifierFactory` instances. A factory is asked what it can handle through a `YamlTypeClassifierContext`, whose `Kind` is either `Union` or `PolymorphicType`.

### Unions

`YamlUnionTypeStructuralClassifier` tells mapping cases apart by their keys:

```csharp
internal union Shape(Circle, Rectangle);
internal sealed class Circle { public int Radius { get; set; } }
internal sealed class Rectangle { public int Width { get; set; } public int Height { get; set; } }

var options = new YamlSerializerOptions
{
    TypeClassifiers = [new YamlUnionTypeStructuralClassifier()],
};

YamlSerializer.Deserialize<Shape>("Radius: 3", options); // Circle
```

It starts with every mapping case as a candidate and eliminates the cases that do not declare a key present in the payload. Keys no case declares eliminate only the cases that reject unmapped members, and a case missing a required key is eliminated once the mapping has been read. Exactly one remaining candidate wins. A union declaring cases that can never be told apart is rejected when the classifier is created. A case accepting any shape (`object`, `YamlNode`) is selected when nothing else matches.

### Polymorphic types

A classifier can also select a derived type from the payload itself, as an alternative to a discriminator. The context carries the registered derived types and the discriminator key:

```csharp
internal sealed class ShapeClassifier : YamlTypeClassifierFactory
{
    public override bool CanClassify(YamlTypeClassifierContext context)
        => context.Kind is YamlTypeClassifierKind.PolymorphicType && context.DeclaringType == typeof(Shape);

    public override YamlTypeClassifier CreateYamlClassifier(YamlTypeClassifierContext context, YamlSerializerOptions options)
        => reader => /* inspect the payload and return a type from context.DerivedTypes */;
}
```

A classifier never overrides an explicit discriminator or tag: it runs only once those have failed to resolve a type, and returning `null` falls back to the default derived type or the usual failure.

Classification works the same under reflection and source generation, and in both cases only engages where deserialization previously threw, so no working configuration changes behavior. Classifiers read a private copy of the value and may consume the reader.

One design note. For unions, the case shapes — key names and required flags — are carried on the context by the converter or the generated code rather than resolved by the factory. `YamlTypeInfo` exposes no property metadata, and the source-generated path has none at runtime at all since it emits direct read/write code, so this is what lets a single classifier serve both resolvers. The alternative was exposing property metadata on `YamlTypeInfo`, a much larger change to both the reflection contract and the generator.

## Fixes

- `union Foo(int, int?)` reported that multiple cases matched a number. Cases sharing a runtime type now collapse to the non-nullable overload for values, keeping the nullable one for null.
- Unions are value types, so `default(U)` serializes as null, but reading null for a union without a nullable case threw. It now returns the default value, so `default(U)` round-trips — including as a member of a newly constructed object.
- `union Rec(bool, Rec?)` emitted generated code that did not compile, because metadata was generated for the nullable wrapper. Union cases are now resolved through their underlying type, which also makes an `object` case work.

## Tests

`YamlCSharpUnionTests` and `YamlPolymorphicClassifierTests` cover each of the above against both the reflection and source-generated resolvers. Union classifier semantics: required keys, unknown keys, case-insensitive matching, the catch-all fallback, and rejection of indistinguishable cases. Polymorphic classifier semantics: selection without a discriminator, discriminator precedence, and the fallback when the value cannot be classified. Tests also pin that a recursive union case and a union implementing an interface it declares as a case bind the payload rather than the union instance.

`dotnet run ./eng/update-all.cs` ran; `ref/Meziantou.Framework.Yaml.cs` is regenerated. All 1764 `Meziantou.Framework.Yaml.Tests` and 385 `Meziantou.Framework.Yamlish.Tests` pass, and every Yaml project builds clean with `/p:TreatsWarningsAsErrors=true`.
