### PR TITLE
Validate Roslyn source warnings for all tested Roslyn versions

### DIFF
--- a/tests/Meziantou.Framework.Roslyn.Tests/Directory.Build.props
+++ b/tests/Meziantou.Framework.Roslyn.Tests/Directory.Build.props
@@ -4,6 +4,9 @@
   <PropertyGroup>
     <TargetFramework></TargetFramework>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+
+    <!-- The sources are shipped as content files, so warnings are disabled by default. Enable them here to validate the sources. -->
+    <DefineConstants>$(DefineConstants);MEZIANTOU_FRAMEWORK_ROSLYN_ENABLE_WARNINGS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Roslyn.Tests/Meziantou.Framework.Roslyn.Tests.Roslyn5_6.csproj
+++ b/tests/Meziantou.Framework.Roslyn.Tests/Meziantou.Framework.Roslyn.Tests.Roslyn5_6.csproj
@@ -1,10 +1,5 @@
 <Project Sdk="Meziantou.NET.Sdk.Test">
 
-  <PropertyGroup>
-    <!-- The sources are shipped as content files, so warnings are disabled by default. Enable them here to validate the sources. -->
-    <DefineConstants>$(DefineConstants);MEZIANTOU_FRAMEWORK_ROSLYN_ENABLE_WARNINGS</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
   </ItemGroup>


### PR DESCRIPTION
## What

Move the `MEZIANTOU_FRAMEWORK_ROSLYN_ENABLE_WARNINGS` constant from `Meziantou.Framework.Roslyn.Tests.Roslyn5_6.csproj` to the shared `tests/Meziantou.Framework.Roslyn.Tests/Directory.Build.props`.

## Why

The `Meziantou.Framework.Roslyn` sources ship as content files, so they suppress all compiler warnings by default to avoid polluting the consuming project's build. The test projects link those sources and are meant to validate them, but the opt-in constant was only defined for Roslyn 5.6 — the Roslyn 4.8, 5.0 and 5.3 test projects compiled the same sources with every warning suppressed, so a warning that only shows up on an older Roslyn version would have gone unnoticed.

## Notes for reviewers

- The other `MEZIANTOU_FRAMEWORK_ROSLYN_*` constants (`DISABLE_EMBEDDEDATTRIBUTE`, `DISABLE_EMBEDDEDATTRIBUTE_DECLARATION`) are consumer opt-outs rather than warning validation and are already covered by `Meziantou.Framework.Roslyn.PackageTests`, so they are left unchanged.
- No source changes were needed: all four projects already build warning-free.

## Verification

- `dotnet build` with `/p:TreatWarningsAsErrors=true` for the Roslyn 4.8, 5.0, 5.3 and 5.6 test projects: 0 warnings, 0 errors.
- `dotnet test` for the same four projects: 132 passed / 0 failed each (66 tests x net10.0 + net11.0), 528 total.
- `dotnet run ./eng/update-all.cs` produced no further file changes.