### PR TITLE
Support merge keys whose value is an alias when binding to typed objects

### DIFF
--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
@@ -809,6 +809,12 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             reader.Read();
             while (reader.TokenType != YamlTokenType.EndSequence)
             {
+                if (reader.TokenType == YamlTokenType.Alias)
+                {
+                    ApplyMergeAliasToInstance(reader, instance, contract, explicitKeys, requiredSeen);
+                    continue;
+                }
+
                 if (reader.TokenType != YamlTokenType.StartMapping)
                 {
                     throw new YamlException(reader.SourceName, reader.Start, reader.End, "Merge sequence entries must be mappings.");
@@ -823,27 +829,8 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
 
         if (reader.TokenType == YamlTokenType.Alias)
         {
-            // Merge requires reading mapping entries; alias expansion is only supported when ReferenceHandling is Preserve
-            // and the alias resolves to a mapping-like value. For other cases, report a clear error.
-            if (reader.TryReadAlias(out var aliasValue) && aliasValue is Dictionary<string, object?> mergedDict)
-            {
-                foreach (var pair in mergedDict)
-                {
-                    if (explicitKeys.Contains(pair.Key))
-                    {
-                        continue;
-                    }
-
-                    if (contract.TryGetMember(pair.Key, out var member) && member.CanWrite)
-                    {
-                        member.SetValue(instance, pair.Value);
-                    }
-                }
-
-                return;
-            }
-
-            throw new YamlException(reader.SourceName, reader.Start, reader.End, "Merge alias values are not supported unless they resolve to a mapping.");
+            ApplyMergeAliasToInstance(reader, instance, contract, explicitKeys, requiredSeen);
+            return;
         }
 
         throw new YamlException(reader.SourceName, reader.Start, reader.End, "Merge key value must be a mapping or a sequence of mappings.");
@@ -935,6 +922,12 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             reader.Read();
             while (reader.TokenType != YamlTokenType.EndSequence)
             {
+                if (reader.TokenType == YamlTokenType.Alias)
+                {
+                    ApplyMergeAliasToInstance(reader, instance, contract, explicitKeys, requiredSeen);
+                    continue;
+                }
+
                 if (reader.TokenType != YamlTokenType.StartMapping)
                 {
                     throw new YamlException(reader.SourceName, reader.Start, reader.End, "Merge sequence entries must be mappings.");
@@ -949,7 +942,8 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
 
         if (reader.TokenType == YamlTokenType.Alias)
         {
-            throw new YamlException(reader.SourceName, reader.Start, reader.End, "Merge alias values are not supported unless they resolve to a mapping.");
+            ApplyMergeAliasToInstance(reader, instance, contract, explicitKeys, requiredSeen);
+            return;
         }
 
         throw new YamlException(reader.SourceName, reader.Start, reader.End, "Merge key value must be a mapping or a sequence of mappings.");
@@ -1205,6 +1199,12 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             reader.Read();
             while (reader.TokenType != YamlTokenType.EndSequence)
             {
+                if (reader.TokenType == YamlTokenType.Alias)
+                {
+                    ApplyMergeAliasToConstructorBuffers(reader, contract, constructor, args, paramSeen, memberValues, extensionEntries, explicitKeys, requiredSeen);
+                    continue;
+                }
+
                 if (reader.TokenType != YamlTokenType.StartMapping)
                 {
                     throw new YamlException(reader.SourceName, reader.Start, reader.End, "Merge sequence entries must be mappings.");
@@ -1214,6 +1214,12 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             }
 
             reader.Read();
+            return;
+        }
+
+        if (reader.TokenType == YamlTokenType.Alias)
+        {
+            ApplyMergeAliasToConstructorBuffers(reader, contract, constructor, args, paramSeen, memberValues, extensionEntries, explicitKeys, requiredSeen);
             return;
         }
 
@@ -1341,6 +1347,262 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
         }
 
         reader.Read();
+    }
+
+    private static void ApplyMergeAliasToInstance(YamlReader reader, object instance, Contract contract, HashSet<string> explicitKeys, bool[]? requiredSeen)
+    {
+        var aliasStart = reader.Start;
+        var aliasEnd = reader.End;
+        var entries = ReadMergeAliasEntries(reader, contract, aliasStart, aliasEnd);
+        if (entries is null)
+        {
+            return;
+        }
+
+        foreach (var (key, value) in entries)
+        {
+            if (explicitKeys.Contains(key))
+            {
+                continue;
+            }
+
+            if (contract.TryGetMember(key, out var member))
+            {
+                if (requiredSeen is not null && member.RequiredIndex >= 0)
+                {
+                    requiredSeen[member.RequiredIndex] = true;
+                }
+
+                if (member.ShouldIgnoreOnRead || !member.CanWrite)
+                {
+                    continue;
+                }
+
+                var memberValue = ConvertMergedValue(reader, contract, key, value, member.MemberType, aliasStart, aliasEnd);
+                ThrowIfNullForNonNullableMember(reader, contract, member, memberValue);
+                member.SetValue(instance, memberValue);
+                continue;
+            }
+
+            if (contract.ExtensionData is not null)
+            {
+                try
+                {
+                    AddExtensionDataValue(instance, contract.ExtensionData, key, value);
+                }
+                catch (YamlException)
+                {
+                    throw;
+                }
+                catch (Exception exception)
+                {
+                    throw new YamlException(reader.SourceName, aliasStart, aliasEnd, exception.Message, exception);
+                }
+
+                continue;
+            }
+
+            ThrowIfUnmappedMemberDisallowed(reader, contract, key);
+        }
+    }
+
+    private static void ApplyMergeAliasToConstructorBuffers(
+        YamlReader reader,
+        Contract contract,
+        ConstructorModel constructor,
+        object?[] args,
+        bool[] paramSeen,
+        Dictionary<Member, BufferedMemberAssignment> memberValues,
+        List<BufferedExtensionEntry>? extensionEntries,
+        HashSet<string> explicitKeys,
+        bool[]? requiredSeen)
+    {
+        var aliasStart = reader.Start;
+        var aliasEnd = reader.End;
+        var entries = ReadMergeAliasEntries(reader, contract, aliasStart, aliasEnd);
+        if (entries is null)
+        {
+            return;
+        }
+
+        foreach (var (key, value) in entries)
+        {
+            if (explicitKeys.Contains(key))
+            {
+                continue;
+            }
+
+            if (requiredSeen is not null && contract.TryGetMember(key, out var requiredCandidate) && requiredCandidate.RequiredIndex >= 0)
+            {
+                requiredSeen[requiredCandidate.RequiredIndex] = true;
+            }
+
+            if (constructor.TryGetParameterIndex(key, out var parameterIndex))
+            {
+                var parameterValue = ConvertMergedValue(reader, contract, key, value, constructor.GetParameterType(parameterIndex), aliasStart, aliasEnd);
+                ThrowIfNullForNonNullableConstructorParameter(reader, contract, constructor, parameterIndex, parameterValue);
+                args[parameterIndex] = parameterValue;
+                paramSeen[parameterIndex] = true;
+                continue;
+            }
+
+            if (contract.TryGetMember(key, out var member))
+            {
+                if (member.ShouldIgnoreOnRead)
+                {
+                    continue;
+                }
+
+                if (member.CanWrite)
+                {
+                    var memberValue = ConvertMergedValue(reader, contract, key, value, member.MemberType, aliasStart, aliasEnd);
+                    ThrowIfNullForNonNullableMember(reader, contract, member, memberValue);
+                    memberValues[member] = new BufferedMemberAssignment(member, memberValue, aliasStart, aliasEnd);
+                    continue;
+                }
+
+                if (extensionEntries is not null)
+                {
+                    extensionEntries.Add(new BufferedExtensionEntry(key, value, aliasStart, aliasEnd));
+                }
+
+                continue;
+            }
+
+            if (extensionEntries is not null)
+            {
+                extensionEntries.Add(new BufferedExtensionEntry(key, value, aliasStart, aliasEnd));
+                continue;
+            }
+
+            ThrowIfUnmappedMemberDisallowed(reader, contract, key);
+        }
+    }
+
+    /// <summary>Resolves the merge alias the reader is positioned on into the key/value pairs of its anchored mapping.</summary>
+    /// <returns><see langword="null"/> when the alias resolves to a null value; otherwise the entries to merge.</returns>
+    private static List<KeyValuePair<string, object?>>? ReadMergeAliasEntries(YamlReader reader, Contract contract, Mark aliasStart, Mark aliasEnd)
+    {
+        if (!reader.TryReadAlias(out var aliasValue))
+        {
+            throw new YamlException(reader.SourceName, aliasStart, aliasEnd, $"Aliases are not supported when deserializing into '{contract.DeclaringType}' unless ReferenceHandling is Preserve.");
+        }
+
+        switch (aliasValue)
+        {
+            case null:
+                return null;
+
+            case IDictionary dictionary:
+            {
+                var entries = new List<KeyValuePair<string, object?>>(dictionary.Count);
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    entries.Add(new KeyValuePair<string, object?>(entry.Key as string ?? YamlDictionaryConverterHelper.FormatNonStringKey(entry.Key), entry.Value));
+                }
+
+                return entries;
+            }
+
+            case YamlMapping mapping:
+            {
+                var entries = new List<KeyValuePair<string, object?>>(mapping.Count);
+                foreach (var entry in mapping)
+                {
+                    if (entry.Key is not YamlValue key)
+                    {
+                        throw new YamlException(reader.SourceName, aliasStart, aliasEnd, "Merge alias values must resolve to a mapping with scalar keys.");
+                    }
+
+                    entries.Add(new KeyValuePair<string, object?>(key.Value ?? string.Empty, entry.Value));
+                }
+
+                return entries;
+            }
+
+            default:
+                return GetMergeAliasObjectEntries(reader, aliasValue, aliasStart, aliasEnd);
+        }
+    }
+
+    private static List<KeyValuePair<string, object?>> GetMergeAliasObjectEntries(YamlReader reader, object aliasValue, Mark aliasStart, Mark aliasEnd)
+    {
+        // Only objects can expose their entries as members; scalars and sequences have no keys to merge.
+        if (aliasValue is IEnumerable || Type.GetTypeCode(aliasValue.GetType()) is not TypeCode.Object)
+        {
+            throw new YamlException(reader.SourceName, aliasStart, aliasEnd, "Merge alias values must resolve to a mapping.");
+        }
+
+        Contract sourceContract;
+        try
+        {
+            sourceContract = Contract.Create(aliasValue.GetType(), reader);
+        }
+        catch (YamlException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            throw new YamlException(reader.SourceName, aliasStart, aliasEnd, exception.Message, exception);
+        }
+
+        // The anchored node was already materialized, so the keys it declared are no longer known: every readable
+        // member of the anchored object is merged, including the ones left at their default value.
+        var members = sourceContract.MembersDeclaration;
+        var entries = new List<KeyValuePair<string, object?>>(members.Length);
+        foreach (var member in members)
+        {
+            if (!member.CanRead)
+            {
+                continue;
+            }
+
+            entries.Add(new KeyValuePair<string, object?>(member.Name, member.GetValue(aliasValue)));
+        }
+
+        return entries;
+    }
+
+    private static object? ConvertMergedValue(YamlReader reader, Contract contract, string key, object? value, Type targetType, Mark aliasStart, Mark aliasEnd)
+    {
+        if (value is null || targetType.IsInstanceOfType(value))
+        {
+            return value;
+        }
+
+        var underlyingType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        try
+        {
+            if (underlyingType.IsEnum)
+            {
+                return value is string enumText
+                    ? Enum.Parse(underlyingType, enumText, ignoreCase: true)
+                    : Enum.ToObject(underlyingType, value);
+            }
+
+            if (value is IConvertible)
+            {
+                return Convert.ChangeType(value, underlyingType, CultureInfo.InvariantCulture);
+            }
+        }
+        catch (Exception exception) when (exception is ArgumentException or FormatException or InvalidCastException or OverflowException)
+        {
+            throw MergedValueCannotBeAssigned(reader, contract, key, value, targetType, aliasStart, aliasEnd, exception);
+        }
+
+        throw MergedValueCannotBeAssigned(reader, contract, key, value, targetType, aliasStart, aliasEnd, innerException: null);
+    }
+
+    private static YamlException MergedValueCannotBeAssigned(YamlReader reader, Contract contract, string key, object value, Type targetType, Mark aliasStart, Mark aliasEnd, Exception? innerException)
+        => new(reader.SourceName, aliasStart, aliasEnd, $"The merged value for '{key}' of type '{value.GetType()}' cannot be assigned to '{targetType}' on '{contract.DeclaringType}'.", innerException);
+
+    private static void ThrowIfUnmappedMemberDisallowed(YamlReader reader, Contract contract, string key)
+    {
+        if (contract.UnmappedMemberHandling == YamlUnmappedMemberHandling.Disallow)
+        {
+            throw YamlThrowHelper.ThrowUnmappedMember(reader, contract.DeclaringType, key);
+        }
     }
 
     private static void WriteObjectCore(YamlWriter writer, object value, Contract contract)

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -248,6 +248,29 @@ internal sealed partial class ShapeYamlContext : YamlSerializerContext
 }
 ```
 
+## Merge keys
+
+A merge key (`<<`) copies the entries of another mapping into the current one. Its value can be an inline mapping, an alias to an anchored mapping, or a sequence mixing both. Keys written in the mapping itself always win over merged keys, and in a merge sequence the last entry wins:
+
+```yaml
+defaults: &defaults
+  timeout: 30
+  retries: 2
+
+prod:
+  <<: *defaults
+  timeout: 60   # wins over the merged value
+```
+
+Merge keys are part of the `Core` and `Extended` schemas; they are plain keys for `YamlSchemaKind.Json`. An alias as the merge value requires `ReferenceHandling = YamlReferenceHandling.Preserve`, as aliases are only resolved in that mode:
+
+```csharp
+var options = new YamlSerializerOptions { ReferenceHandling = YamlReferenceHandling.Preserve };
+var config = YamlSerializer.Deserialize<Config>(yaml, options);
+```
+
+An alias resolves to the value the anchored node was deserialized into. When that value is an object, every readable member takes part in the merge, including the members the anchored mapping left out. Source-generated deserialization does not support aliases as merge values.
+
 ## C# unions
 
 A C# union is serialized as its selected case, without a wrapper:

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlMergeKeyTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlMergeKeyTests.cs
@@ -1,3 +1,5 @@
+using Meziantou.Framework.Yaml.Serialization;
+
 namespace Meziantou.Framework.Yaml.Tests.Serialization;
 public sealed class YamlMergeKeyTests
 {
@@ -60,11 +62,186 @@ public sealed class YamlMergeKeyTests
         Assert.Equal(3, result.B);
     }
 
+    [Fact]
+    public void Deserialize_Object_ShouldApplyMergeAlias()
+    {
+        var yaml =
+            "Defaults: &d\n" +
+            "  Timeout: 30\n" +
+            "  Retries: 2\n" +
+            "Prod:\n" +
+            "  <<: *d\n" +
+            "  Timeout: 60\n";
+
+        var result = YamlSerializer.Deserialize<Config>(yaml, PreserveOptions);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Defaults);
+        Assert.Equal(30, result.Defaults.Timeout);
+        Assert.Equal(2, result.Defaults.Retries);
+        Assert.NotNull(result.Prod);
+        Assert.Equal(60, result.Prod.Timeout);
+        Assert.Equal(2, result.Prod.Retries);
+        Assert.NotSame(result.Defaults, result.Prod);
+    }
+
+    [Fact]
+    public void Deserialize_Object_ShouldApplyMergeAlias_WhenLocalKeyIsBeforeMergeKey()
+    {
+        var yaml =
+            "Defaults: &d\n" +
+            "  Timeout: 30\n" +
+            "  Retries: 2\n" +
+            "Prod:\n" +
+            "  Timeout: 60\n" +
+            "  <<: *d\n";
+
+        var result = YamlSerializer.Deserialize<Config>(yaml, PreserveOptions);
+
+        Assert.NotNull(result?.Prod);
+        Assert.Equal(60, result.Prod.Timeout);
+        Assert.Equal(2, result.Prod.Retries);
+    }
+
+    [Fact]
+    public void Deserialize_Object_ShouldApplyMergeSequenceMixingAliasesAndMappings()
+    {
+        var yaml =
+            "Defaults: &d\n" +
+            "  Timeout: 30\n" +
+            "  Retries: 2\n" +
+            "  Name: from-alias\n" +
+            "Prod:\n" +
+            "  <<:\n" +
+            "    - *d\n" +
+            "    - { Retries: 5 }\n" +
+            "  Timeout: 60\n";
+
+        var result = YamlSerializer.Deserialize<Config>(yaml, PreserveOptions);
+
+        Assert.NotNull(result?.Prod);
+        Assert.Equal(60, result.Prod.Timeout);
+        Assert.Equal(5, result.Prod.Retries);
+        Assert.Equal("from-alias", result.Prod.Name);
+    }
+
+    [Fact]
+    public void Deserialize_ObjectWithConstructor_ShouldApplyMergeAlias()
+    {
+        var yaml =
+            "Defaults: &d\n" +
+            "  Timeout: 30\n" +
+            "  Retries: 2\n" +
+            "Prod:\n" +
+            "  <<: *d\n" +
+            "  Timeout: 60\n";
+
+        var result = YamlSerializer.Deserialize<RecordConfig>(yaml, PreserveOptions);
+
+        Assert.NotNull(result?.Prod);
+        Assert.Equal(60, result.Prod.Timeout);
+        Assert.Equal(2, result.Prod.Retries);
+    }
+
+    [Fact]
+    public void Deserialize_Object_ShouldApplyMergeAliasFromDictionaryAnchor()
+    {
+        var yaml =
+            "Defaults: &d\n" +
+            "  Timeout: 30\n" +
+            "  Retries: 2\n" +
+            "Prod:\n" +
+            "  <<: *d\n" +
+            "  Timeout: 60\n";
+
+        var result = YamlSerializer.Deserialize<DictionaryDefaultsConfig>(yaml, PreserveOptions);
+
+        Assert.NotNull(result?.Prod);
+        Assert.Equal(60, result.Prod.Timeout);
+        Assert.Equal(2, result.Prod.Retries);
+    }
+
+    [Fact]
+    public void Deserialize_PopulatedObject_ShouldApplyMergeAlias()
+    {
+        var yaml =
+            "Defaults: &d\n" +
+            "  Timeout: 30\n" +
+            "  Retries: 2\n" +
+            "  Name: from-alias\n" +
+            "Prod:\n" +
+            "  <<: *d\n" +
+            "  Timeout: 60\n";
+
+        var result = YamlSerializer.Deserialize<PopulateConfig>(yaml, PreserveOptions);
+
+        Assert.NotNull(result);
+        Assert.Equal(60, result.Prod.Timeout);
+        Assert.Equal(2, result.Prod.Retries);
+        Assert.Equal("from-alias", result.Prod.Name);
+    }
+
+    [Fact]
+    public void Deserialize_Object_ShouldThrowForMergeAliasWhenReferenceHandlingIsNotPreserve()
+    {
+        var yaml =
+            "Defaults: &d\n" +
+            "  Timeout: 30\n" +
+            "Prod:\n" +
+            "  <<: *d\n";
+
+        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<Config>(yaml));
+
+        Assert.Contains("ReferenceHandling", exception.Message);
+    }
+
+    private static YamlSerializerOptions PreserveOptions => new() { ReferenceHandling = YamlReferenceHandling.Preserve };
+
     private sealed class MergePayload
     {
         public int A { get; set; }
 
         public int B { get; set; }
+    }
+
+    private sealed class Config
+    {
+        public Section? Defaults { get; set; }
+
+        public Section? Prod { get; set; }
+    }
+
+    private sealed class Section
+    {
+        public int Timeout { get; set; }
+
+        public int Retries { get; set; }
+
+        public string? Name { get; set; }
+    }
+
+    private sealed class RecordConfig
+    {
+        public SectionRecord? Defaults { get; set; }
+
+        public SectionRecord? Prod { get; set; }
+    }
+
+    private sealed record SectionRecord(int Timeout, int Retries);
+
+    private sealed class PopulateConfig
+    {
+        public Section? Defaults { get; set; }
+
+        [YamlObjectCreationHandling(YamlObjectCreationHandling.Populate)]
+        public Section Prod { get; } = new() { Name = "initial" };
+    }
+
+    private sealed class DictionaryDefaultsConfig
+    {
+        public Dictionary<string, int>? Defaults { get; set; }
+
+        public Section? Prod { get; set; }
     }
 }
 


### PR DESCRIPTION
## What

A merge key whose value is an alias (`<<: *anchor`, the canonical YAML idiom) worked when deserializing into a dictionary but failed on typed objects:

```yaml
Defaults: &d
  Timeout: 30
  Retries: 2
Prod:
  <<: *d
  Timeout: 60
```

```csharp
YamlSerializer.Deserialize<Dictionary<string, Dictionary<string, int>>>(yaml, preserveOptions); // OK
YamlSerializer.Deserialize<Config>(yaml, preserveOptions); // YamlException: Merge alias values are not supported unless they resolve to a mapping.
```

Merge keys with an inline mapping or a sequence of inline mappings already worked on typed objects; only the alias form failed.

## Why it failed

The object converter has three merge-key paths, and each mishandled an alias:

- `ReadAndApplyMergeToInstance` only accepted an alias resolving to a literal `Dictionary<string, object?>`. In the repro above, `&d` sits on the `Defaults` member, which is deserialized as a `Section`, so the resolved value was a `Section` and the code fell through to the "not supported" throw.
- `ReadAndApplyMergeToPopulatedInstance` (members with `ObjectCreationHandling.Populate`) threw unconditionally on an alias.
- `ReadAndApplyMergeToConstructorBuffers` (records / primary-constructor types) had no alias branch at all, so it reported "Merge key value must be a mapping or a sequence of mappings."

None of them accepted an alias *inside* a merge sequence either.

## What changed

All three paths now resolve the alias through `TryReadAlias` and feed the anchored value into a shared `ReadMergeAliasEntries`, which yields key/value pairs from an `IDictionary`, a `YamlMapping`, or a typed object via its `Contract` members. Entries are applied with the same precedence as an inline mapping: keys written in the mapping win, later merge-sequence entries win over earlier ones, required members are marked seen, and unmapped keys go to extension data or trip `UnmappedMemberHandling.Disallow`. Values are converted when the anchored type doesn't match the target member (for example a `Dictionary<string, int>` anchor merged into typed members), with a clear `YamlException` when they can't be. Without `ReferenceHandling.Preserve`, the error now matches the one the dictionary converter reports and names `ReferenceHandling`.

## Reviewer notes

- **Inherent limitation, commented in the code and documented in the readme:** an alias resolves to the *already-materialized* value, so the set of keys the anchored mapping actually declared is gone. Merging from an object therefore contributes every readable member, including ones left at their default value. Merging from a dictionary anchor is unaffected. Preserving key-level fidelity would mean buffering the raw node for every anchored mapping, which is a much larger change.
- `readme.md` had no "Merge keys" section and documented no limitation, only a passing mention in the feature list. This PR adds one covering the supported forms, the `Preserve` requirement, precedence, and the object-anchor caveat.
- **Out of scope:** `AllowMergeKeys = false` is still honored when binding to a dictionary but ignored when binding to a typed object. That is tracked as a separate task; it is a small addition at each of the three `"<<"` checks in `ReadObjectCore`, `Populate`, and `ReadObjectCoreWithConstructor` if it should be folded in here instead.

## Tests

Seven new tests in `YamlMergeKeyTests`: the repro above, merge key after the local key, a sequence mixing `*alias` and an inline mapping, a record (constructor path), a `Populate` member (populated path), a dictionary-typed anchor, and the non-`Preserve` error.

All 1778 tests in `Meziantou.Framework.Yaml.Tests` pass on net10.0 and net11.0 with `/p:TreatWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` produced no file changes.