### PR TITLE
Emit flow style when WriteIndented is disabled, and fix block indentation

### DIFF
--- a/src/Meziantou.Framework.Yaml/Serialization/YamlSourceGenerationOptionsAttribute.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlSourceGenerationOptionsAttribute.cs
@@ -18,6 +18,10 @@ namespace Meziantou.Framework.Yaml.Serialization;
 public sealed class YamlSourceGenerationOptionsAttribute : YamlAttribute
 {
     /// <summary>Gets or sets a value indicating whether emitted YAML should be indented.</summary>
+    /// <remarks>
+    /// When disabled, nested block collections still use the smallest indentation that keeps the nesting unambiguous.
+    /// See <see cref="YamlSerializerOptions.WriteIndented"/>.
+    /// </remarks>
     public bool WriteIndented { get; set; }
 
     /// <summary>

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlSourceGenerationOptionsAttribute.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlSourceGenerationOptionsAttribute.cs
@@ -19,7 +19,7 @@ public sealed class YamlSourceGenerationOptionsAttribute : YamlAttribute
 {
     /// <summary>Gets or sets a value indicating whether emitted YAML should be indented.</summary>
     /// <remarks>
-    /// When disabled, nested block collections still use the smallest indentation that keeps the nesting unambiguous.
+    /// When disabled, collections are written using the flow style, which keeps the whole document on a single line.
     /// See <see cref="YamlSerializerOptions.WriteIndented"/>.
     /// </remarks>
     public bool WriteIndented { get; set; }

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
@@ -62,6 +62,11 @@ public sealed class YamlWriter : YamlReaderWriterBase
 
     internal bool EndsWithNewLine => _hasWrittenChar && _lastWrittenChar == '\n';
 
+    /// <summary>
+    /// Gets a value indicating whether collections are written using the flow style, which keeps the document on a single line.
+    /// </summary>
+    private bool IsFlow => !Options.WriteIndented;
+
     /// <summary>Temporarily overrides how nested block collections are emitted when they appear as items in block sequences.</summary>
     /// <param name="mappingStyle">The mapping style override, or <see cref="YamlSequenceItemStyle.Default"/> to keep the current mapping style.</param>
     /// <param name="sequenceStyle">The sequence style override, or <see cref="YamlSequenceItemStyle.Default"/> to keep the current sequence style.</param>
@@ -175,7 +180,11 @@ public sealed class YamlWriter : YamlReaderWriterBase
     public void WriteEndMapping()
     {
         var frame = PopFrame(ContainerKind.Mapping);
-        if (!frame.HasContent)
+        if (IsFlow)
+        {
+            Write('}');
+        }
+        else if (!frame.HasContent)
         {
             WriteEmptyContainerInline(ContainerKind.Mapping, frame.PendingStart);
         }
@@ -194,7 +203,11 @@ public sealed class YamlWriter : YamlReaderWriterBase
     public void WriteEndSequence()
     {
         var frame = PopFrame(ContainerKind.Sequence);
-        if (!frame.HasContent)
+        if (IsFlow)
+        {
+            Write(']');
+        }
+        else if (!frame.HasContent)
         {
             WriteEmptyContainerInline(ContainerKind.Sequence, frame.PendingStart);
         }
@@ -217,6 +230,21 @@ public sealed class YamlWriter : YamlReaderWriterBase
         if (!frame.ExpectingKey)
         {
             throw new InvalidOperationException("A property name cannot be written when a value is expected.");
+        }
+
+        if (IsFlow)
+        {
+            if (frame.HasContent)
+            {
+                Write(", ");
+            }
+
+            WriteScalarCore(name, isKey: true);
+            Write(':');
+
+            frame.HasContent = true;
+            frame.ExpectingKey = false;
+            return;
         }
 
         var startedCompact = EnsureContainerStarted(ref frame);
@@ -570,6 +598,12 @@ public sealed class YamlWriter : YamlReaderWriterBase
         }
 
         ref var frame = ref _frames[_depth - 1];
+        if (IsFlow)
+        {
+            WriteFlowValuePrefix(ref frame, "A scalar value cannot be written when a key is expected.");
+            return;
+        }
+
         var startedCompact = EnsureContainerStarted(ref frame);
 
         if (frame.Kind == ContainerKind.Mapping)
@@ -604,6 +638,12 @@ public sealed class YamlWriter : YamlReaderWriterBase
         }
 
         ref var frame = ref _frames[_depth - 1];
+        if (IsFlow)
+        {
+            WriteFlowValuePrefix(ref frame, "An alias value cannot be written when a key is expected.");
+            return;
+        }
+
         var startedCompact = EnsureContainerStarted(ref frame);
 
         if (frame.Kind == ContainerKind.Mapping)
@@ -627,6 +667,31 @@ public sealed class YamlWriter : YamlReaderWriterBase
             WriteIndent(frame.Indent);
         }
         Write("- ");
+        frame.HasContent = true;
+    }
+
+    /// <summary>Writes the separator that precedes a value in a flow collection.</summary>
+    /// <param name="frame">The collection the value belongs to.</param>
+    /// <param name="keyExpectedError">The error message used when the collection is a mapping that expects a key.</param>
+    /// <exception cref="InvalidOperationException">The collection is a mapping and a key is expected.</exception>
+    private void WriteFlowValuePrefix(ref ContainerFrame frame, string keyExpectedError)
+    {
+        if (frame.Kind == ContainerKind.Mapping)
+        {
+            if (frame.ExpectingKey)
+            {
+                throw new InvalidOperationException(keyExpectedError);
+            }
+
+            Write(' ');
+            return;
+        }
+
+        if (frame.HasContent)
+        {
+            Write(", ");
+        }
+
         frame.HasContent = true;
     }
 
@@ -724,6 +789,12 @@ public sealed class YamlWriter : YamlReaderWriterBase
             throw YamlDepthHelper.CreateMaxDepthExceededException(Options.EffectiveMaxDepth);
         }
 
+        if (IsFlow)
+        {
+            PushFlowContainer(kind);
+            return;
+        }
+
         PendingStartKind pendingStart;
         int indent;
 
@@ -803,6 +874,27 @@ public sealed class YamlWriter : YamlReaderWriterBase
         }
 
         _frames[_depth++] = new ContainerFrame(kind, pendingStart, indent);
+    }
+
+    /// <summary>Opens a collection written using the flow style.</summary>
+    /// <param name="kind">The kind of collection to open.</param>
+    private void PushFlowContainer(ContainerKind kind)
+    {
+        if (_depth > 0)
+        {
+            ref var parent = ref _frames[_depth - 1];
+            WriteFlowValuePrefix(ref parent, "A container value cannot be written when a key is expected.");
+        }
+
+        WriteNodeProperties(writeLeadingSpace: false, writeTrailingSpace: true);
+        Write(kind == ContainerKind.Mapping ? '{' : '[');
+
+        if (_depth == _frames.Length)
+        {
+            Array.Resize(ref _frames, _frames.Length * 2);
+        }
+
+        _frames[_depth++] = new ContainerFrame(kind, PendingStartKind.None, indent: 0);
     }
 
     private ContainerFrame PopFrame(ContainerKind expectedKind)

--- a/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/YamlWriter.cs
@@ -228,7 +228,7 @@ public sealed class YamlWriter : YamlReaderWriterBase
 
         if (!startedCompact)
         {
-            WriteIndent();
+            WriteIndent(frame.Indent);
         }
         WriteScalarCore(name, isKey: true);
         Write(':');
@@ -590,7 +590,7 @@ public sealed class YamlWriter : YamlReaderWriterBase
 
         if (!startedCompact)
         {
-            WriteIndent();
+            WriteIndent(frame.Indent);
         }
         Write("- ");
         frame.HasContent = true;
@@ -624,7 +624,7 @@ public sealed class YamlWriter : YamlReaderWriterBase
 
         if (!startedCompact)
         {
-            WriteIndent();
+            WriteIndent(frame.Indent);
         }
         Write("- ");
         frame.HasContent = true;
@@ -725,9 +725,11 @@ public sealed class YamlWriter : YamlReaderWriterBase
         }
 
         PendingStartKind pendingStart;
+        int indent;
 
         if (_depth == 0)
         {
+            indent = 0;
             if (_pendingAnchor is not null || _pendingTag is not null)
             {
                 // Root node properties must be followed by a newline before content.
@@ -752,6 +754,7 @@ public sealed class YamlWriter : YamlReaderWriterBase
                 }
 
                 pendingStart = PendingStartKind.MappingValue;
+                indent = parent.Indent + GetIndentStep(kind);
                 if (_pendingAnchor is not null || _pendingTag is not null)
                 {
                     WriteNodeProperties(writeLeadingSpace: true, writeTrailingSpace: false);
@@ -766,17 +769,31 @@ public sealed class YamlWriter : YamlReaderWriterBase
 
                 if (!parentStartedCompact)
                 {
-                    WriteIndent();
+                    WriteIndent(parent.Indent);
                 }
                 Write('-');
-                if (_pendingAnchor is not null || _pendingTag is not null)
+                var hasNodeProperties = _pendingAnchor is not null || _pendingTag is not null;
+                if (hasNodeProperties)
                 {
                     WriteNodeProperties(writeLeadingSpace: true, writeTrailingSpace: false);
                 }
                 parent.HasContent = true;
-                pendingStart = ShouldCompactSequenceItem(kind)
-                    ? PendingStartKind.SequenceItemCompact
-                    : PendingStartKind.SequenceItem;
+
+                // A node property between the "-" indicator and the collection rules out the compact form.
+                if (!hasNodeProperties && ShouldCompactSequenceItem(kind))
+                {
+                    pendingStart = PendingStartKind.SequenceItemCompact;
+
+                    // The content starts right after the "- " indicator, so the following lines must align with it.
+                    indent = parent.Indent + 2;
+                }
+                else
+                {
+                    pendingStart = PendingStartKind.SequenceItem;
+
+                    // The content starts on the next line and must be indented past the "-" indicator.
+                    indent = parent.Indent + Math.Max(1, GetIndentStep(kind));
+                }
             }
         }
 
@@ -785,7 +802,7 @@ public sealed class YamlWriter : YamlReaderWriterBase
             Array.Resize(ref _frames, _frames.Length * 2);
         }
 
-        _frames[_depth++] = new ContainerFrame(kind, pendingStart);
+        _frames[_depth++] = new ContainerFrame(kind, pendingStart, indent);
     }
 
     private ContainerFrame PopFrame(ContainerKind expectedKind)
@@ -816,20 +833,13 @@ public sealed class YamlWriter : YamlReaderWriterBase
         Write(kind == ContainerKind.Mapping ? "{}" : "[]");
     }
 
-    private void WriteIndent()
+    private void WriteIndent(int spaces)
     {
-        if (!Options.WriteIndented)
+        if (spaces == 0)
         {
             return;
         }
 
-        var indentLevel = Math.Max(0, _depth - 1);
-        if (indentLevel == 0)
-        {
-            return;
-        }
-
-        var spaces = Options.IndentSize * indentLevel;
         if (_indentBuilder.Length != spaces)
         {
             _indentBuilder.Clear();
@@ -837,6 +847,24 @@ public sealed class YamlWriter : YamlReaderWriterBase
         }
 
         Write(_indentBuilder);
+    }
+
+    /// <summary>
+    /// Gets the number of columns a nested block collection is indented by, relative to the collection that contains it.
+    /// </summary>
+    /// <remarks>
+    /// Block YAML expresses nesting through indentation, so a nested block mapping always needs at least one column.
+    /// A block sequence that is the value of a mapping key can be written at the indentation of its parent mapping,
+    /// which is the compact form used when <see cref="YamlSerializerOptions.WriteIndented"/> is disabled.
+    /// </remarks>
+    private int GetIndentStep(ContainerKind kind)
+    {
+        if (Options.WriteIndented)
+        {
+            return Options.IndentSize;
+        }
+
+        return kind == ContainerKind.Sequence ? 0 : 1;
     }
 
     private void WriteNewLine()
@@ -1197,17 +1225,21 @@ public sealed class YamlWriter : YamlReaderWriterBase
 
     private struct ContainerFrame
     {
-        public ContainerFrame(ContainerKind kind, PendingStartKind pendingStart)
+        public ContainerFrame(ContainerKind kind, PendingStartKind pendingStart, int indent)
         {
             Kind = kind;
             HasContent = false;
             ExpectingKey = kind == ContainerKind.Mapping;
             PendingStart = pendingStart;
+            Indent = indent;
         }
 
         public ContainerKind Kind;
         public bool HasContent;
         public bool ExpectingKey;
         public PendingStartKind PendingStart;
+
+        /// <summary>The number of columns each line of this collection's content is indented by.</summary>
+        public int Indent;
     }
 }

--- a/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
+++ b/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
@@ -130,6 +130,12 @@ public sealed record YamlSerializerOptions
     public YamlIgnoreCondition DefaultIgnoreCondition { get; init; }
 
     /// <summary>Gets or sets a value indicating whether output should be indented.</summary>
+    /// <remarks>
+    /// Block YAML expresses nesting through indentation, so nested collections are always indented enough to stay unambiguous.
+    /// When this property is <see langword="false"/>, the smallest valid indentation is used: a nested mapping is indented by
+    /// one column, and a block sequence is written at the indentation of the mapping that contains it.
+    /// <see cref="IndentSize"/> is only used when this property is <see langword="true"/>.
+    /// </remarks>
     public bool WriteIndented { get; init; } = true;
 
     /// <summary>

--- a/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
+++ b/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
@@ -131,10 +131,16 @@ public sealed record YamlSerializerOptions
 
     /// <summary>Gets or sets a value indicating whether output should be indented.</summary>
     /// <remarks>
-    /// Block YAML expresses nesting through indentation, so nested collections are always indented enough to stay unambiguous.
-    /// When this property is <see langword="false"/>, the smallest valid indentation is used: a nested mapping is indented by
-    /// one column, and a block sequence is written at the indentation of the mapping that contains it.
-    /// <see cref="IndentSize"/> is only used when this property is <see langword="true"/>.
+    /// <para>
+    /// When <see langword="true"/>, collections are written using the block style and nested collections are indented by
+    /// <see cref="IndentSize"/> columns.
+    /// </para>
+    /// <para>
+    /// When <see langword="false"/>, collections are written using the flow style, which keeps the whole document on a single
+    /// line: <c>{a: {b: 1}, c: [2, 3]}</c>. Block YAML expresses nesting through indentation, so the flow style is what makes
+    /// unindented output possible. <see cref="IndentSize"/>, <see cref="BlockSequenceMappingStyle"/>, and
+    /// <see cref="BlockSequenceSequenceStyle"/> only apply to the block style and are ignored.
+    /// </para>
     /// </remarks>
     public bool WriteIndented { get; init; } = true;
 
@@ -162,7 +168,8 @@ public sealed record YamlSerializerOptions
     /// <summary>Gets or sets how mappings are emitted when they appear as items in block sequences.</summary>
     /// <remarks>
     /// The default is <see cref="YamlSequenceItemStyle.Compact"/>, which emits the first mapping key on the same
-    /// line as the sequence dash when possible.
+    /// line as the sequence dash when possible. This option is ignored when <see cref="WriteIndented"/> is disabled,
+    /// because the flow style has no sequence dash.
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Value is not a defined <see cref="YamlSequenceItemStyle"/>.</exception>
     public YamlSequenceItemStyle BlockSequenceMappingStyle
@@ -178,7 +185,8 @@ public sealed record YamlSerializerOptions
     /// <summary>Gets or sets how nested sequences are emitted when they appear as items in block sequences.</summary>
     /// <remarks>
     /// The default is <see cref="YamlSequenceItemStyle.Expanded"/>, which keeps nested sequence items on lines
-    /// following the parent sequence dash.
+    /// following the parent sequence dash. This option is ignored when <see cref="WriteIndented"/> is disabled,
+    /// because the flow style has no sequence dash.
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Value is not a defined <see cref="YamlSequenceItemStyle"/>.</exception>
     public YamlSequenceItemStyle BlockSequenceSequenceStyle

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -152,8 +152,8 @@ exposes the default instance.
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `WriteIndented` | `true` | Indents nested block collections. When disabled, the smallest indentation that keeps the nesting unambiguous is used. |
-| `IndentSize` | `2` | Number of spaces per indentation level. |
+| `WriteIndented` | `true` | Writes block collections indented by `IndentSize`. When disabled, collections use the flow style and the document stays on a single line. |
+| `IndentSize` | `2` | Number of spaces per indentation level. Ignored when `WriteIndented` is disabled. |
 | `MappingOrder` | `Declaration` | `Declaration` or `Sorted`. |
 | `BlockSequenceMappingStyle` | `Compact` | How a mapping inside a block sequence is emitted. |
 | `BlockSequenceSequenceStyle` | `Expanded` | How a nested sequence inside a block sequence is emitted. |
@@ -174,7 +174,7 @@ items:
     name: first
 ```
 
-Block YAML expresses nesting through indentation, so disabling `WriteIndented` does not remove all indentation: it uses the smallest indentation that keeps the nesting unambiguous. A nested mapping is indented by one column, and a block sequence is written at the indentation of the mapping that contains it:
+Block YAML expresses nesting through indentation, so `WriteIndented = false` switches collections to the flow style instead of writing block collections without indentation. The whole document stays on a single line, and `IndentSize`, `BlockSequenceMappingStyle`, and `BlockSequenceSequenceStyle` no longer apply:
 
 ```yaml
 # WriteIndented = true, IndentSize = 2
@@ -182,13 +182,14 @@ product:
   name: Table
   tags:
     - new
-
-# WriteIndented = false
-product:
- name: Table
- tags:
- - new
 ```
+
+```yaml
+# WriteIndented = false
+{product: {name: Table, tags: [new]}}
+```
+
+Flow output is read back by the deserializer like any other YAML, and scalars containing a flow indicator such as `,`, `:`, `[`, or `{` are quoted so the round-trip stays faithful.
 
 `PreferQuotedForAmbiguousScalars` keeps a round-trip faithful when a string looks like another type:
 

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -152,7 +152,7 @@ exposes the default instance.
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `WriteIndented` | `true` | Indents nested block collections. |
+| `WriteIndented` | `true` | Indents nested block collections. When disabled, the smallest indentation that keeps the nesting unambiguous is used. |
 | `IndentSize` | `2` | Number of spaces per indentation level. |
 | `MappingOrder` | `Declaration` | `Declaration` or `Sorted`. |
 | `BlockSequenceMappingStyle` | `Compact` | How a mapping inside a block sequence is emitted. |
@@ -172,6 +172,22 @@ items:
   -
     id: 1
     name: first
+```
+
+Block YAML expresses nesting through indentation, so disabling `WriteIndented` does not remove all indentation: it uses the smallest indentation that keeps the nesting unambiguous. A nested mapping is indented by one column, and a block sequence is written at the indentation of the mapping that contains it:
+
+```yaml
+# WriteIndented = true, IndentSize = 2
+product:
+  name: Table
+  tags:
+    - new
+
+# WriteIndented = false
+product:
+ name: Table
+ tags:
+ - new
 ```
 
 `PreferQuotedForAmbiguousScalars` keeps a round-trip faithful when a string looks like another type:

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWriterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWriterTests.cs
@@ -163,9 +163,153 @@ public sealed class YamlWriterTests
         Assert.Equal("- {}", buffer.ToString());
     }
 
+    [Fact]
+    public void NestedMapping_WithoutIndentation_KeepsMinimalIndentAndRoundTrips()
+    {
+        var options = new YamlSerializerOptions { WriteIndented = false };
+        var yaml = YamlSerializer.Serialize(new Outer { Child = new Inner { Value = 1 }, Count = 2 }, options);
+
+        Assert.Equal("Child:\n Value: 1\nCount: 2\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<Outer>(yaml, options);
+        Assert.NotNull(roundTrip);
+        Assert.NotNull(roundTrip.Child);
+        Assert.Equal(1, roundTrip.Child.Value);
+        Assert.Equal(2, roundTrip.Count);
+    }
+
+    [Fact]
+    public void DeeplyNestedMappings_WithoutIndentation_RoundTrip()
+    {
+        var options = new YamlSerializerOptions { WriteIndented = false };
+        var yaml = YamlSerializer.Serialize(new Level1 { Level2 = new Level2 { Level3 = new Inner { Value = 42 } } }, options);
+
+        Assert.Equal("Level2:\n Level3:\n  Value: 42\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<Level1>(yaml, options);
+        Assert.Equal(42, roundTrip?.Level2?.Level3?.Value);
+    }
+
+    [Fact]
+    public void SequenceOfMappings_WithoutIndentation_UsesIndentlessSequenceAndRoundTrips()
+    {
+        var options = new YamlSerializerOptions { WriteIndented = false };
+        var yaml = YamlSerializer.Serialize(
+            new ItemsContainer
+            {
+                Items = [new Item { A = 1, B = 2 }, new Item { A = 3, B = 4 }],
+            },
+            options);
+
+        Assert.Equal("Items:\n- A: 1\n  B: 2\n- A: 3\n  B: 4\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<ItemsContainer>(yaml, options);
+        Assert.NotNull(roundTrip?.Items);
+        Assert.HasCount(2, roundTrip.Items);
+        Assert.Equal((1, 2), (roundTrip.Items[0].A, roundTrip.Items[0].B));
+        Assert.Equal((3, 4), (roundTrip.Items[1].A, roundTrip.Items[1].B));
+    }
+
+    [Fact]
+    public void ExpandedSequenceOfMappings_WithoutIndentation_RoundTrips()
+    {
+        var options = new YamlSerializerOptions { WriteIndented = false, BlockSequenceMappingStyle = YamlSequenceItemStyle.Expanded };
+        var yaml = YamlSerializer.Serialize(new ItemsContainer { Items = [new Item { A = 1, B = 2 }] }, options);
+
+        Assert.Equal("Items:\n-\n A: 1\n B: 2\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<ItemsContainer>(yaml, options);
+        Assert.NotNull(roundTrip?.Items);
+        var item = Assert.Single(roundTrip.Items);
+        Assert.Equal((1, 2), (item.A, item.B));
+    }
+
+    [Fact]
+    public void SequenceOfSequences_WithoutIndentation_RoundTrips()
+    {
+        var options = new YamlSerializerOptions { WriteIndented = false };
+        var yaml = YamlSerializer.Serialize(new RowsContainer { Rows = [[1, 2], [3, 4]] }, options);
+
+        Assert.Equal("Rows:\n-\n - 1\n - 2\n-\n - 3\n - 4\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<RowsContainer>(yaml, options);
+        Assert.NotNull(roundTrip?.Rows);
+        Assert.Equal([1, 2], roundTrip.Rows[0]);
+        Assert.Equal([3, 4], roundTrip.Rows[1]);
+    }
+
+    [Fact]
+    public void SequenceOfMappings_WithIndentSizeGreaterThanTwo_AlignsCompactItemsAndRoundTrips()
+    {
+        var options = new YamlSerializerOptions { IndentSize = 4 };
+        var yaml = YamlSerializer.Serialize(new ItemsContainer { Items = [new Item { A = 1, B = 2 }] }, options);
+
+        Assert.Equal("Items:\n    - A: 1\n      B: 2\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<ItemsContainer>(yaml, options);
+        Assert.NotNull(roundTrip?.Items);
+        var item = Assert.Single(roundTrip.Items);
+        Assert.Equal((1, 2), (item.A, item.B));
+    }
+
+    [Fact]
+    public void AnchoredSequenceItem_UsesExpandedStyleAndRoundTrips()
+    {
+        var options = new YamlSerializerOptions { ReferenceHandling = YamlReferenceHandling.Preserve };
+        var shared = new Item { A = 1, B = 2 };
+        var yaml = YamlSerializer.Serialize(new ItemsContainer { Items = [shared, shared] }, options);
+
+        Assert.Matches("  - &\\w+\n    A: 1\n    B: 2\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<ItemsContainer>(yaml, options);
+        Assert.NotNull(roundTrip?.Items);
+        Assert.HasCount(2, roundTrip.Items);
+        Assert.Same(roundTrip.Items[0], roundTrip.Items[1]);
+        Assert.Equal((1, 2), (roundTrip.Items[0].A, roundTrip.Items[0].B));
+    }
+
     private static YamlWriter CreateWriter(YamlSerializerOptions options, out StringWriter buffer)
     {
         buffer = new StringWriter();
         return new YamlWriter(buffer, options);
+    }
+
+    private sealed class Outer
+    {
+        public Inner? Child { get; set; }
+
+        public int Count { get; set; }
+    }
+
+    private sealed class Inner
+    {
+        public int Value { get; set; }
+    }
+
+    private sealed class Level1
+    {
+        public Level2? Level2 { get; set; }
+    }
+
+    private sealed class Level2
+    {
+        public Inner? Level3 { get; set; }
+    }
+
+    private sealed class ItemsContainer
+    {
+        public List<Item>? Items { get; set; }
+    }
+
+    private sealed class Item
+    {
+        public int A { get; set; }
+
+        public int B { get; set; }
+    }
+
+    private sealed class RowsContainer
+    {
+        public List<List<int>>? Rows { get; set; }
     }
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWriterTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlWriterTests.cs
@@ -164,12 +164,12 @@ public sealed class YamlWriterTests
     }
 
     [Fact]
-    public void NestedMapping_WithoutIndentation_KeepsMinimalIndentAndRoundTrips()
+    public void NestedMapping_WithoutIndentation_UsesFlowStyleAndRoundTrips()
     {
         var options = new YamlSerializerOptions { WriteIndented = false };
         var yaml = YamlSerializer.Serialize(new Outer { Child = new Inner { Value = 1 }, Count = 2 }, options);
 
-        Assert.Equal("Child:\n Value: 1\nCount: 2\n", yaml);
+        Assert.Equal("{Child: {Value: 1}, Count: 2}\n", yaml);
 
         var roundTrip = YamlSerializer.Deserialize<Outer>(yaml, options);
         Assert.NotNull(roundTrip);
@@ -179,19 +179,19 @@ public sealed class YamlWriterTests
     }
 
     [Fact]
-    public void DeeplyNestedMappings_WithoutIndentation_RoundTrip()
+    public void DeeplyNestedMappings_WithoutIndentation_UseFlowStyleAndRoundTrip()
     {
         var options = new YamlSerializerOptions { WriteIndented = false };
         var yaml = YamlSerializer.Serialize(new Level1 { Level2 = new Level2 { Level3 = new Inner { Value = 42 } } }, options);
 
-        Assert.Equal("Level2:\n Level3:\n  Value: 42\n", yaml);
+        Assert.Equal("{Level2: {Level3: {Value: 42}}}\n", yaml);
 
         var roundTrip = YamlSerializer.Deserialize<Level1>(yaml, options);
         Assert.Equal(42, roundTrip?.Level2?.Level3?.Value);
     }
 
     [Fact]
-    public void SequenceOfMappings_WithoutIndentation_UsesIndentlessSequenceAndRoundTrips()
+    public void SequenceOfMappings_WithoutIndentation_UsesFlowStyleAndRoundTrips()
     {
         var options = new YamlSerializerOptions { WriteIndented = false };
         var yaml = YamlSerializer.Serialize(
@@ -201,7 +201,7 @@ public sealed class YamlWriterTests
             },
             options);
 
-        Assert.Equal("Items:\n- A: 1\n  B: 2\n- A: 3\n  B: 4\n", yaml);
+        Assert.Equal("{Items: [{A: 1, B: 2}, {A: 3, B: 4}]}\n", yaml);
 
         var roundTrip = YamlSerializer.Deserialize<ItemsContainer>(yaml, options);
         Assert.NotNull(roundTrip?.Items);
@@ -211,31 +211,81 @@ public sealed class YamlWriterTests
     }
 
     [Fact]
-    public void ExpandedSequenceOfMappings_WithoutIndentation_RoundTrips()
-    {
-        var options = new YamlSerializerOptions { WriteIndented = false, BlockSequenceMappingStyle = YamlSequenceItemStyle.Expanded };
-        var yaml = YamlSerializer.Serialize(new ItemsContainer { Items = [new Item { A = 1, B = 2 }] }, options);
-
-        Assert.Equal("Items:\n-\n A: 1\n B: 2\n", yaml);
-
-        var roundTrip = YamlSerializer.Deserialize<ItemsContainer>(yaml, options);
-        Assert.NotNull(roundTrip?.Items);
-        var item = Assert.Single(roundTrip.Items);
-        Assert.Equal((1, 2), (item.A, item.B));
-    }
-
-    [Fact]
-    public void SequenceOfSequences_WithoutIndentation_RoundTrips()
+    public void SequenceOfSequences_WithoutIndentation_UsesFlowStyleAndRoundTrips()
     {
         var options = new YamlSerializerOptions { WriteIndented = false };
         var yaml = YamlSerializer.Serialize(new RowsContainer { Rows = [[1, 2], [3, 4]] }, options);
 
-        Assert.Equal("Rows:\n-\n - 1\n - 2\n-\n - 3\n - 4\n", yaml);
+        Assert.Equal("{Rows: [[1, 2], [3, 4]]}\n", yaml);
 
         var roundTrip = YamlSerializer.Deserialize<RowsContainer>(yaml, options);
         Assert.NotNull(roundTrip?.Rows);
         Assert.Equal([1, 2], roundTrip.Rows[0]);
         Assert.Equal([3, 4], roundTrip.Rows[1]);
+    }
+
+    [Fact]
+    public void RootSequence_WithoutIndentation_UsesFlowStyleAndRoundTrips()
+    {
+        var options = new YamlSerializerOptions { WriteIndented = false };
+        var yaml = YamlSerializer.Serialize(new[] { 1, 2, 3 }, options);
+
+        Assert.Equal("[1, 2, 3]\n", yaml);
+        Assert.Equal([1, 2, 3], YamlSerializer.Deserialize<int[]>(yaml, options));
+    }
+
+    [Fact]
+    public void EmptyCollections_WithoutIndentation_UseFlowStyle()
+    {
+        var options = new YamlSerializerOptions { WriteIndented = false };
+        var yaml = YamlSerializer.Serialize(new MapsContainer { Map = [], List = [] }, options);
+
+        Assert.Equal("{Map: {}, List: []}\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<MapsContainer>(yaml, options);
+        Assert.NotNull(roundTrip?.Map);
+        Assert.Empty(roundTrip.Map);
+        Assert.NotNull(roundTrip.List);
+        Assert.Empty(roundTrip.List);
+    }
+
+    [Fact]
+    public void ScalarsWithFlowIndicators_WithoutIndentation_AreQuotedAndRoundTrip()
+    {
+        var options = new YamlSerializerOptions { WriteIndented = false };
+        var value = new TextContainer { Text = "a, b", Other = "x: y" };
+        var yaml = YamlSerializer.Serialize(value, options);
+
+        Assert.Equal("{Text: \"a, b\", Other: \"x: y\"}\n", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<TextContainer>(yaml, options);
+        Assert.Equal("a, b", roundTrip?.Text);
+        Assert.Equal("x: y", roundTrip?.Other);
+    }
+
+    [Fact]
+    public void BlockSequenceItemStyle_WithoutIndentation_IsIgnored()
+    {
+        var options = new YamlSerializerOptions { WriteIndented = false, BlockSequenceMappingStyle = YamlSequenceItemStyle.Expanded };
+        var yaml = YamlSerializer.Serialize(new ItemsContainer { Items = [new Item { A = 1, B = 2 }] }, options);
+
+        Assert.Equal("{Items: [{A: 1, B: 2}]}\n", yaml);
+    }
+
+    [Fact]
+    public void Anchors_WithoutIndentation_UseFlowStyleAndRoundTrip()
+    {
+        var options = new YamlSerializerOptions { WriteIndented = false, ReferenceHandling = YamlReferenceHandling.Preserve };
+        var shared = new Item { A = 1, B = 2 };
+        var yaml = YamlSerializer.Serialize(new ItemsContainer { Items = [shared, shared] }, options);
+
+        Assert.Matches(@"^&\w+ \{Items: &\w+ \[&\w+ \{A: 1, B: 2\}, \*\w+\]\}\n$", yaml);
+
+        var roundTrip = YamlSerializer.Deserialize<ItemsContainer>(yaml, options);
+        Assert.NotNull(roundTrip?.Items);
+        Assert.HasCount(2, roundTrip.Items);
+        Assert.Same(roundTrip.Items[0], roundTrip.Items[1]);
+        Assert.Equal((1, 2), (roundTrip.Items[0].A, roundTrip.Items[0].B));
     }
 
     [Fact]
@@ -311,5 +361,19 @@ public sealed class YamlWriterTests
     private sealed class RowsContainer
     {
         public List<List<int>>? Rows { get; set; }
+    }
+
+    private sealed class MapsContainer
+    {
+        public Dictionary<string, int>? Map { get; set; }
+
+        public List<int>? List { get; set; }
+    }
+
+    private sealed class TextContainer
+    {
+        public string? Text { get; set; }
+
+        public string? Other { get; set; }
     }
 }


### PR DESCRIPTION
Two commits: the first fixes block indentation, the second gives `WriteIndented = false` its System.Text.Json meaning.

## 1. Block collections could be emitted with invalid nesting

`YamlSerializer.Serialize(new Outer { A = new Inner { B = 1 }, C = 2 }, new YamlSerializerOptions { WriteIndented = false })` produced:

```yaml
A:
B: 1
C: 2
```

`B` landed at the same column as `A`, so it became a sibling key. Deserializing that back into `Outer` yielded `A == null` — silent data loss.

The cause: `YamlWriter` derived indentation from the nesting counter (`IndentSize * (depth - 1)`) rather than from where content actually starts. Indentation is now tracked as the **content column of each open container**, derived from the parent container. That also fixes two independent bugs of the same kind:

- **`IndentSize` other than 2 misaligned compact sequence items.** With `IndentSize = 4` the writer emitted `Items:\n    - A: 1\n        B: 2` — the content of `- ` starts two columns after the indicator regardless of the configured indent size. The compact item's content column is now `parent + 2`.
- **An anchored collection in a sequence item emitted `- &id003 A: 1`**, which is not valid compact notation; reading it back threw `Unknown YAML alias '*id003'`. Node properties now force the expanded form.

## 2. `WriteIndented = false` now emits flow style

The first commit made `WriteIndented = false` emit block collections at minimum valid indentation. That was correct YAML, but on a typical document it saved **2 characters** over `IndentSize = 1` (44 vs 46) — not enough for the option to earn its place, and not what the name suggests to anyone arriving from `JsonSerializerOptions`.

So `WriteIndented = false` now switches collections to the YAML flow style, keeping the document on a single line:

```yaml
# WriteIndented = true, IndentSize = 2
product:
  name: Table
  tags:
    - new
```

```yaml
# WriteIndented = false
{product: {name: Table, tags: [new]}}
```

Notes for review:

- **This changes existing output for flat mappings**, the one shape `WriteIndented = false` already handled correctly: `a: 1\nb: 2` becomes `{a: 1, b: 2}`.
- `IndentSize`, `BlockSequenceMappingStyle`, and `BlockSequenceSequenceStyle` describe block style only and are ignored in flow style. A test pins that.
- Scalar quoting needed no changes — `IsPlainSafe` already rejected the flow indicators `, { } [ ] :`, so plain scalars were flow-safe. Values like `"a, b"` and `"x: y"` are quoted.
- Anchors, aliases, and tags work in flow (`&id001 {x: &id002 {b: 7}, y: *id002}`, `{pet: !dog {name: Rex}}`).
- Block output is unchanged for the default options.
- The serializer still cannot emit flow style on request for a specific type or member. `YamlStyle { Any, Block, Flow }` exists and is honored by the low-level `Emitter` and the DOM, but nothing in `Serialization/` reads it — worth a follow-up if per-type or per-member flow style is wanted.

## Tests

`YamlWriterTests` gains round-trip coverage for flow output (nested mappings, sequences of mappings, sequences of sequences, root sequence, empty collections, flow-indicator quoting, anchors, and the ignored block-style options) plus the two block-indentation regressions.

- `dotnet test tests/Meziantou.Framework.Yaml.Tests /p:TreatsWarningsAsErrors=true` — 1800 passed, 0 failed
- `dotnet test tests/Meziantou.Framework.Yamlish.Tests` — 385 passed
- `dotnet run ./eng/update-all.cs` — clean, no file changes (no public API surface changed, so `ref/` is untouched)