### PR TITLE
Honor AllowMergeKeys when deserializing into a typed object

### DIFF
--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
@@ -774,6 +774,14 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
     private static bool IsMergeKeyEnabled(YamlSerializerOptions options)
         => options.Schema is YamlSchemaKind.Core or YamlSchemaKind.Extended;
 
+    private static void ThrowIfMergeKeysAreNotAllowed(YamlReader reader)
+    {
+        if (!reader.Options.AllowMergeKeys)
+        {
+            throw new YamlException(reader.SourceName, reader.Start, reader.End, "YAML merge keys are not allowed.");
+        }
+    }
+
     private static void SkipOrThrowUnmappedMember(YamlReader reader, Contract contract, string key)
     {
         if (contract.UnmappedMemberHandling == YamlUnmappedMemberHandling.Disallow)
@@ -791,6 +799,8 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             reader.Skip();
             return;
         }
+
+        ThrowIfMergeKeysAreNotAllowed(reader);
 
         if (reader.TokenType == YamlTokenType.Scalar && YamlScalar.IsNull(reader))
         {
@@ -904,6 +914,8 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             reader.Skip();
             return;
         }
+
+        ThrowIfMergeKeysAreNotAllowed(reader);
 
         if (reader.TokenType == YamlTokenType.Scalar && YamlScalar.IsNull(reader))
         {
@@ -1181,6 +1193,8 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             reader.Skip();
             return;
         }
+
+        ThrowIfMergeKeysAreNotAllowed(reader);
 
         if (reader.TokenType == YamlTokenType.Scalar && YamlScalar.IsNull(reader))
         {

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlMergeKeyTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlMergeKeyTests.cs
@@ -195,6 +195,115 @@ public sealed class YamlMergeKeyTests
         Assert.Contains("ReferenceHandling", exception.Message);
     }
 
+    [Fact]
+    public void Deserialize_Object_MergeKey_Disallowed_Throws()
+    {
+        var yaml =
+            "<<: { A: 1, B: 2 }\n" +
+            "B: 3\n";
+        var options = new YamlSerializerOptions { AllowMergeKeys = false };
+
+        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<MergePayload>(yaml, options));
+
+        Assert.Contains("merge keys are not allowed", exception.Message);
+    }
+
+    [Fact]
+    public void Deserialize_Object_MergeSequence_Disallowed_Throws()
+    {
+        var yaml =
+            "<<:\n" +
+            "  - { A: 1 }\n" +
+            "  - { A: 2, B: 3 }\n" +
+            "B: 4\n";
+        var options = new YamlSerializerOptions { AllowMergeKeys = false };
+
+        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<MergePayload>(yaml, options));
+
+        Assert.Contains("merge keys are not allowed", exception.Message);
+    }
+
+    [Fact]
+    public void Deserialize_ObjectWithConstructor_MergeKey_Disallowed_Throws()
+    {
+        var yaml =
+            "<<: { A: 1, B: 2 }\n" +
+            "B: 3\n";
+        var options = new YamlSerializerOptions { AllowMergeKeys = false };
+
+        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<MergeConstructorPayload>(yaml, options));
+
+        Assert.Contains("merge keys are not allowed", exception.Message);
+    }
+
+    [Fact]
+    public void Deserialize_PopulatedObject_MergeKey_Disallowed_Throws()
+    {
+        var yaml =
+            "Child:\n" +
+            "  <<: { A: 1, B: 2 }\n" +
+            "  B: 3\n";
+        var options = new YamlSerializerOptions
+        {
+            AllowMergeKeys = false,
+            PreferredObjectCreationHandling = YamlObjectCreationHandling.Populate,
+        };
+
+        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<MergePopulateHolder>(yaml, options));
+
+        Assert.Contains("merge keys are not allowed", exception.Message);
+    }
+
+    [Fact]
+    public void Deserialize_Object_NestedMergeKey_Disallowed_Throws()
+    {
+        var yaml =
+            "<<:\n" +
+            "  <<: { A: 1 }\n" +
+            "  B: 2\n";
+        var options = new YamlSerializerOptions { AllowMergeKeys = false };
+
+        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<MergePayload>(yaml, options));
+
+        Assert.Contains("merge keys are not allowed", exception.Message);
+    }
+
+    [Fact]
+    public void Deserialize_Object_MergeKey_Disallowed_ShouldBeIgnoredForJsonSchema()
+    {
+        var yaml =
+            "<<: { A: 1, B: 2 }\n" +
+            "B: 3\n";
+        var options = new YamlSerializerOptions { Schema = YamlSchemaKind.Json, AllowMergeKeys = false };
+
+        var result = YamlSerializer.Deserialize<MergePayload>(yaml, options);
+
+        Assert.NotNull(result);
+        Assert.Equal(0, result.A);
+        Assert.Equal(3, result.B);
+    }
+
+    [Fact]
+    public void Deserialize_Object_MergeAlias_Disallowed_Throws()
+    {
+        var yaml =
+            "Defaults: &d\n" +
+            "  Timeout: 30\n" +
+            "  Retries: 2\n" +
+            "Prod:\n" +
+            "  <<: *d\n" +
+            "  Timeout: 60\n";
+        var options = new YamlSerializerOptions
+        {
+            ReferenceHandling = YamlReferenceHandling.Preserve,
+            AllowMergeKeys = false,
+        };
+
+        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<Config>(yaml, options));
+
+        Assert.Contains("merge keys are not allowed", exception.Message);
+    }
+
     private static YamlSerializerOptions PreserveOptions => new() { ReferenceHandling = YamlReferenceHandling.Preserve };
 
     private sealed class MergePayload
@@ -242,6 +351,18 @@ public sealed class YamlMergeKeyTests
         public Dictionary<string, int>? Defaults { get; set; }
 
         public Section? Prod { get; set; }
+    }
+
+    private sealed class MergeConstructorPayload(int a, int b)
+    {
+        public int A { get; } = a;
+
+        public int B { get; } = b;
+    }
+
+    private sealed class MergePopulateHolder
+    {
+        public MergePayload Child { get; } = new();
     }
 }
 


### PR DESCRIPTION
## What

`YamlSerializerOptions.AllowMergeKeys = false` was not honored when deserializing into a typed object. The merge key was applied instead of throwing:

```csharp
internal sealed class Section { public int Timeout { get; set; } public int Retries { get; set; } }

var options = new YamlSerializerOptions { AllowMergeKeys = false };

// Dictionary: correctly throws "YAML merge keys are not allowed."
YamlSerializer.Deserialize<Dictionary<string, int>>("<<: { a: 1 }\nb: 2\n", options);

// Typed object (before this change): no exception, merge still applied
YamlSerializer.Deserialize<Section>("<<: { Timeout: 30 }\nRetries: 1\n", options).Timeout; // 30
```

## Why

The XML doc on `AllowMergeKeys` states that a `YamlException` is thrown when a merge key would otherwise be applied, so the typed-object path was not matching its contract. The option is documented as a hardening switch for untrusted input (see the "Hardening untrusted input" section of `src/Meziantou.Framework.Yaml/readme.md`), which makes the gap worth closing.

## How

`YamlObjectConverter` has three merge-key entry points — `ReadAndApplyMergeToInstance`, `ReadAndApplyMergeToPopulatedInstance` and `ReadAndApplyMergeToConstructorBuffers` — and each consulted only `IsMergeKeyEnabled`, which is a `Schema` check alone. Added a `ThrowIfMergeKeysAreNotAllowed` helper and called it from all three. The source-side diff is just those three call sites plus the helper.

Two notes for reviewers:

- The check is placed **after** the existing schema check, so merge keys remain silently ignored under `YamlSchemaKind.Json` — unchanged behavior, covered by a regression test.
- Nested `<<` inside a merge mapping routes back through these same three methods, so it is covered without extra call sites.

The exception message matches the dictionary converter verbatim: `"YAML merge keys are not allowed."`

## Relationship to #1890

This branch has been rebased onto `main` on top of #1890 (merge keys whose value is an alias). The two changes touch the same three methods, so they conflicted textually, but they compose cleanly: all six of the `ApplyMergeAlias*` call sites #1890 introduced sit **downstream** of the new guards, so alias-valued merge keys are now blocked by `AllowMergeKeys = false` as well. Added `Deserialize_Object_MergeAlias_Disallowed_Throws` to pin that interaction, since it only exists once both changes are present.

The diff against `main` is purely additive (135 insertions, 0 deletions) — no part of #1890 was altered in the conflict resolution.

## Tests

Seven tests added to `YamlMergeKeyTests.cs`, on top of the ones #1890 added:

| Test | Path covered |
|---|---|
| `Deserialize_Object_MergeKey_Disallowed_Throws` | inline mapping → `…ToInstance` |
| `Deserialize_Object_MergeSequence_Disallowed_Throws` | merge sequence → `…ToInstance` |
| `Deserialize_ObjectWithConstructor_MergeKey_Disallowed_Throws` | `…ToConstructorBuffers` |
| `Deserialize_PopulatedObject_MergeKey_Disallowed_Throws` | `…ToPopulatedInstance` |
| `Deserialize_Object_NestedMergeKey_Disallowed_Throws` | nested `<<` |
| `Deserialize_Object_MergeAlias_Disallowed_Throws` | alias-valued `<<` (interaction with #1890) |
| `Deserialize_Object_MergeKey_Disallowed_ShouldBeIgnoredForJsonSchema` | Json-schema regression guard |

I checked the tests are not vacuous: with the fix temporarily reverted, all the "throws" tests fail across both TFMs, and the Json-schema guard still passes.

## Verification

Re-run after the rebase:

- Builds clean with `/p:TreatsWarningsAsErrors=true`, 0 warnings.
- `Meziantou.Framework.Yaml.Tests`: 1792/1792 pass. `Meziantou.Framework.Yamlish.Tests`: 385/385 pass.
- `dotnet run ./eng/update-all.cs` exits 0 with no files left modified.
- No `ref/` changes — the new member is a private static helper, so public API is untouched.

## Out of scope — flagging for a follow-up

The same gap exists in two sibling converters that this PR deliberately does **not** touch, since they were outside the reported scope:

- `YamlUntypedObjectConverter.cs:72` — the `Deserialize<object>` path
- `YamlDictionaryObjectConverter.cs:67` and `:229` — the `Dictionary<string, object>` path

Both gate on the schema only and apply merges without checking `AllowMergeKeys`, so `YamlSerializer.Deserialize<object>("<<: { a: 1 }\nb: 2\n", options)` still silently merges. Given the hardening framing, these look like the same defect and are probably worth a follow-up.
