### PR TITLE
Remove AllowMergeKeys from YamlSerializerOptions

### DIFF
--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -363,7 +363,6 @@ namespace Meziantou.Framework.Yaml
         public int MaxDepth { get => throw null; init { } }
         public bool AllowAnchors { get => throw null; init { } }
         public bool AllowAliases { get => throw null; init { } }
-        public bool AllowMergeKeys { get => throw null; init { } }
         public Meziantou.Framework.Yaml.IYamlTypeInfoResolver? TypeInfoResolver { get => throw null; init { } }
         public Meziantou.Framework.Yaml.YamlTypeInfo<T> GetTypeInfo<T>() => throw null;
         public bool TryGetTypeInfo<T>([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Meziantou.Framework.Yaml.YamlTypeInfo<T>? typeInfo) => throw null;

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDictionaryConverterHelper.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlDictionaryConverterHelper.cs
@@ -217,11 +217,6 @@ internal static class YamlDictionaryConverterHelper
 
             if (mergeEnabled && string.Equals(key, "<<", StringComparison.Ordinal))
             {
-                if (!options.AllowMergeKeys)
-                {
-                    throw new YamlException(reader.SourceName, reader.Start, reader.End, "YAML merge keys are not allowed.");
-                }
-
                 ReadAndApplyMerge<TDictionary, TValue>(reader, ref valueConverter, dictionary, explicitKeys, createDictionary, containerKind);
                 continue;
             }

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
@@ -774,14 +774,6 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
     private static bool IsMergeKeyEnabled(YamlSerializerOptions options)
         => options.Schema is YamlSchemaKind.Core or YamlSchemaKind.Extended;
 
-    private static void ThrowIfMergeKeysAreNotAllowed(YamlReader reader)
-    {
-        if (!reader.Options.AllowMergeKeys)
-        {
-            throw new YamlException(reader.SourceName, reader.Start, reader.End, "YAML merge keys are not allowed.");
-        }
-    }
-
     private static void SkipOrThrowUnmappedMember(YamlReader reader, Contract contract, string key)
     {
         if (contract.UnmappedMemberHandling == YamlUnmappedMemberHandling.Disallow)
@@ -799,8 +791,6 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             reader.Skip();
             return;
         }
-
-        ThrowIfMergeKeysAreNotAllowed(reader);
 
         if (reader.TokenType == YamlTokenType.Scalar && YamlScalar.IsNull(reader))
         {
@@ -914,8 +904,6 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             reader.Skip();
             return;
         }
-
-        ThrowIfMergeKeysAreNotAllowed(reader);
 
         if (reader.TokenType == YamlTokenType.Scalar && YamlScalar.IsNull(reader))
         {
@@ -1193,8 +1181,6 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
             reader.Skip();
             return;
         }
-
-        ThrowIfMergeKeysAreNotAllowed(reader);
 
         if (reader.TokenType == YamlTokenType.Scalar && YamlScalar.IsNull(reader))
         {

--- a/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
+++ b/src/Meziantou.Framework.Yaml/YamlSerializerOptions.cs
@@ -269,16 +269,6 @@ public sealed record YamlSerializerOptions
     public bool AllowAliases { get; init; } = true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether YAML merge keys (<c>&lt;&lt;</c>) are allowed during deserialization.
-    /// </summary>
-    /// <remarks>
-    /// Merge keys are only recognized when <see cref="Schema"/> is <see cref="YamlSchemaKind.Core"/> or
-    /// <see cref="YamlSchemaKind.Extended"/>. When this option is <see langword="false"/> and a merge key would
-    /// otherwise be applied, a <see cref="YamlException"/> is thrown.
-    /// </remarks>
-    public bool AllowMergeKeys { get; init; } = true;
-
-    /// <summary>
     /// Gets or sets a metadata resolver used to retrieve <see cref="YamlTypeInfo"/> instances.
     /// </summary>
     /// <remarks>

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -676,8 +676,7 @@ YamlSerializer.Deserialize<Section>("""
 
 Merge keys are only recognized under the `Core` and `Extended` schemas; the `Json` and `Failsafe` schemas treat `<<` as
 an ordinary key. A merge key whose value is an alias additionally requires `ReferenceHandling` to be `Preserve` or
-`PreserveMinimal`, and is currently supported when binding to dictionaries only. `AllowMergeKeys = false` rejects merge
-keys when binding to a dictionary.
+`PreserveMinimal`, and is currently supported when binding to dictionaries only.
 
 ## Schemas
 
@@ -886,7 +885,6 @@ Use `TryDeserialize` when a failure is expected and an exception is not wanted.
 | `MaxDepth` | `64` | Caps the nesting depth of mappings and sequences while reading and writing. `0` means the default. |
 | `AllowAnchors` | `true` | Rejects documents declaring anchors. |
 | `AllowAliases` | `true` | Rejects documents using aliases, which prevents alias-expansion amplification. |
-| `AllowMergeKeys` | `true` | Rejects merge keys. |
 | `DuplicateKeyHandling` | `Error` | Rejects mappings with duplicate keys. |
 | `UnsafeAllowDeserializeFromTagTypeName` | `false` | Allows a YAML tag to name a CLR type to instantiate. Enable it only for trusted input. |
 
@@ -896,7 +894,6 @@ var options = new YamlSerializerOptions
     MaxDepth = 32,
     AllowAnchors = false,
     AllowAliases = false,
-    AllowMergeKeys = false,
     UnmappedMemberHandling = YamlUnmappedMemberHandling.Disallow,
 };
 ```

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlFeatureRestrictionTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlFeatureRestrictionTests.cs
@@ -80,7 +80,7 @@ public sealed class YamlFeatureRestrictionTests
     }
 
     [Fact]
-    public void Deserialize_MergeKey_AllowedByDefault()
+    public void Deserialize_MergeKey_IsApplied()
     {
         var yaml =
             "<<: { a: 1, b: 2 }\n" +
@@ -91,19 +91,6 @@ public sealed class YamlFeatureRestrictionTests
         Assert.NotNull(result);
         Assert.Equal(1, result["a"]);
         Assert.Equal(5, result["b"]);
-    }
-
-    [Fact]
-    public void Deserialize_MergeKey_Disallowed_Throws()
-    {
-        var yaml =
-            "<<: { a: 1, b: 2 }\n" +
-            "b: 5\n";
-        var options = new YamlSerializerOptions { AllowMergeKeys = false };
-
-        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<Dictionary<string, int>>(yaml, options));
-
-        Assert.Contains("merge keys are not allowed", exception.Message);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlMergeKeyTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlMergeKeyTests.cs
@@ -195,115 +195,6 @@ public sealed class YamlMergeKeyTests
         Assert.Contains("ReferenceHandling", exception.Message);
     }
 
-    [Fact]
-    public void Deserialize_Object_MergeKey_Disallowed_Throws()
-    {
-        var yaml =
-            "<<: { A: 1, B: 2 }\n" +
-            "B: 3\n";
-        var options = new YamlSerializerOptions { AllowMergeKeys = false };
-
-        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<MergePayload>(yaml, options));
-
-        Assert.Contains("merge keys are not allowed", exception.Message);
-    }
-
-    [Fact]
-    public void Deserialize_Object_MergeSequence_Disallowed_Throws()
-    {
-        var yaml =
-            "<<:\n" +
-            "  - { A: 1 }\n" +
-            "  - { A: 2, B: 3 }\n" +
-            "B: 4\n";
-        var options = new YamlSerializerOptions { AllowMergeKeys = false };
-
-        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<MergePayload>(yaml, options));
-
-        Assert.Contains("merge keys are not allowed", exception.Message);
-    }
-
-    [Fact]
-    public void Deserialize_ObjectWithConstructor_MergeKey_Disallowed_Throws()
-    {
-        var yaml =
-            "<<: { A: 1, B: 2 }\n" +
-            "B: 3\n";
-        var options = new YamlSerializerOptions { AllowMergeKeys = false };
-
-        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<MergeConstructorPayload>(yaml, options));
-
-        Assert.Contains("merge keys are not allowed", exception.Message);
-    }
-
-    [Fact]
-    public void Deserialize_PopulatedObject_MergeKey_Disallowed_Throws()
-    {
-        var yaml =
-            "Child:\n" +
-            "  <<: { A: 1, B: 2 }\n" +
-            "  B: 3\n";
-        var options = new YamlSerializerOptions
-        {
-            AllowMergeKeys = false,
-            PreferredObjectCreationHandling = YamlObjectCreationHandling.Populate,
-        };
-
-        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<MergePopulateHolder>(yaml, options));
-
-        Assert.Contains("merge keys are not allowed", exception.Message);
-    }
-
-    [Fact]
-    public void Deserialize_Object_NestedMergeKey_Disallowed_Throws()
-    {
-        var yaml =
-            "<<:\n" +
-            "  <<: { A: 1 }\n" +
-            "  B: 2\n";
-        var options = new YamlSerializerOptions { AllowMergeKeys = false };
-
-        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<MergePayload>(yaml, options));
-
-        Assert.Contains("merge keys are not allowed", exception.Message);
-    }
-
-    [Fact]
-    public void Deserialize_Object_MergeKey_Disallowed_ShouldBeIgnoredForJsonSchema()
-    {
-        var yaml =
-            "<<: { A: 1, B: 2 }\n" +
-            "B: 3\n";
-        var options = new YamlSerializerOptions { Schema = YamlSchemaKind.Json, AllowMergeKeys = false };
-
-        var result = YamlSerializer.Deserialize<MergePayload>(yaml, options);
-
-        Assert.NotNull(result);
-        Assert.Equal(0, result.A);
-        Assert.Equal(3, result.B);
-    }
-
-    [Fact]
-    public void Deserialize_Object_MergeAlias_Disallowed_Throws()
-    {
-        var yaml =
-            "Defaults: &d\n" +
-            "  Timeout: 30\n" +
-            "  Retries: 2\n" +
-            "Prod:\n" +
-            "  <<: *d\n" +
-            "  Timeout: 60\n";
-        var options = new YamlSerializerOptions
-        {
-            ReferenceHandling = YamlReferenceHandling.Preserve,
-            AllowMergeKeys = false,
-        };
-
-        var exception = Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<Config>(yaml, options));
-
-        Assert.Contains("merge keys are not allowed", exception.Message);
-    }
-
     private static YamlSerializerOptions PreserveOptions => new() { ReferenceHandling = YamlReferenceHandling.Preserve };
 
     private sealed class MergePayload
@@ -351,18 +242,6 @@ public sealed class YamlMergeKeyTests
         public Dictionary<string, int>? Defaults { get; set; }
 
         public Section? Prod { get; set; }
-    }
-
-    private sealed class MergeConstructorPayload(int a, int b)
-    {
-        public int A { get; } = a;
-
-        public int B { get; } = b;
-    }
-
-    private sealed class MergePopulateHolder
-    {
-        public MergePayload Child { get; } = new();
     }
 }
 


### PR DESCRIPTION
Removes the `AllowMergeKeys` option from `YamlSerializerOptions`.

## What changed

- `YamlSerializerOptions.AllowMergeKeys` and its documentation are deleted.
- `YamlObjectConverter`: the `ThrowIfMergeKeysAreNotAllowed` helper and its three call sites are removed.
- `YamlDictionaryConverterHelper`: the throw on encountering `<<` is removed.
- `readme.md`: removed from the "Hardening untrusted input" table, from the accompanying sample, and from the merge-key paragraph.
- `ref/Meziantou.Framework.Yaml.cs` regenerated by the build.
- Tests: the eight `*_Disallowed_Throws` tests are removed, along with the two payload types (`MergeConstructorPayload`, `MergePopulateHolder`) that only those tests used. `Deserialize_MergeKey_AllowedByDefault` is renamed to `Deserialize_MergeKey_IsApplied`, since "by default" no longer refers to anything.

## Behavior

Merge keys are now always applied when the schema recognizes them. The schema gate is unchanged: `Core` and `Extended` apply `<<`, while `Json` and `Failsafe` still treat it as an ordinary key. That gate lives in `IsMergeKeyEnabled` (runtime) and `GetMergeEnabledExpression` (source generator) and never depended on the removed option — which is also why the source generator needs no change here.

## Breaking change

Code setting `AllowMergeKeys = false` no longer compiles. There is no direct replacement: rejecting `<<` now requires switching to the `Json` or `Failsafe` schema, which also changes scalar resolution. Reviewers may want to weigh that against the option's value for hardening untrusted input.

## Verification

- `dotnet build src/Meziantou.Framework.Yaml/Meziantou.Framework.Yaml.csproj /p:TreatsWarningsAsErrors=true` — succeeded, 0 warnings.
- `dotnet test tests/Meziantou.Framework.Yaml.Tests /p:TreatsWarningsAsErrors=true` — 1798/1798 passed (928 net11.0, 870 net10.0), 0 failed, 0 skipped.
- `dotnet run ./eng/update-all.cs` — ran, no further file changes.