### PR TITLE
Fix cancellation, throttling, and scheduler handling in MixedConsumerProducer

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/MixedConsumerProducer.cs
+++ b/src/Meziantou.Framework.Threading/Threading/MixedConsumerProducer.cs
@@ -8,9 +8,11 @@ public static class MixedConsumerProducer
     /// <summary>Processes items in parallel, where each processing action can enqueue additional items to be processed.</summary>
     /// <typeparam name="T">The type of items to process.</typeparam>
     /// <param name="initialItems">The initial collection of items to process.</param>
-    /// <param name="options">Options that configure the parallel processing.</param>
+    /// <param name="options">Options that configure the parallel processing. <see cref="ParallelOptions.MaxDegreeOfParallelism"/>, <see cref="ParallelOptions.CancellationToken"/>, and <see cref="ParallelOptions.TaskScheduler"/> are honored.</param>
     /// <param name="action">The action to perform on each item. The action receives a context to enqueue new items, the current item, and a cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <exception cref="AggregateException">One or more invocations of <paramref name="action"/> threw an exception. Remaining items are still processed, and all exceptions are reported once processing completes.</exception>
+    /// <exception cref="OperationCanceledException"><see cref="ParallelOptions.CancellationToken"/> was canceled.</exception>
     /// <example>
     /// <code><![CDATA[
     /// var initialUrls = new[] { "https://example.com" };
@@ -29,7 +31,23 @@ public static class MixedConsumerProducer
     /// </example>
     public static async Task Process<T>(IEnumerable<T> initialItems, ParallelOptions options, Func<MixedConsumerProducerContext<T>, T, CancellationToken, ValueTask> action)
     {
+        ArgumentNullException.ThrowIfNull(initialItems);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(action);
+
         if (Enumerable.TryGetNonEnumeratedCount(initialItems, out var count) && count == 0)
+            return;
+
+        var pendingItems = Channel.CreateUnbounded<T>();
+        var context = new MixedConsumerProducerContext<T>(pendingItems.Writer);
+        var hasItem = false;
+        foreach (var item in initialItems)
+        {
+            context.Enqueue(item);
+            hasItem = true;
+        }
+
+        if (!hasItem)
             return;
 
         var degreeOfParallelism = options.MaxDegreeOfParallelism;
@@ -38,93 +56,57 @@ public static class MixedConsumerProducer
             degreeOfParallelism = Environment.ProcessorCount;
         }
 
-        var pendingItems = Channel.CreateUnbounded<T>();
-        var hasItem = false;
-        foreach (var item in initialItems)
-        {
-            _ = pendingItems.Writer.TryWrite(item);
-            hasItem = true;
-        }
+        var cancellationToken = options.CancellationToken;
+        // ParallelOptions treats a null scheduler as "the current one", so mirror that behavior.
+        var scheduler = options.TaskScheduler ?? TaskScheduler.Current;
 
-        if (!hasItem)
-            return;
-
-        var context = new MixedConsumerProducerContext<T>(pendingItems.Writer);
-        var tasks = new List<Task>(degreeOfParallelism);
-        var remainingConcurrency = degreeOfParallelism;
+        var exceptionsLock = new Lock();
         List<Exception>? exceptions = null;
-        while (await pendingItems.Reader.WaitToReadAsync(options.CancellationToken).ConfigureAwait(false))
+
+        // Consumers are long-lived: each one drains the channel until it is completed, which happens
+        // once no item is pending. This bounds the concurrency to degreeOfParallelism without having
+        // to throttle the loop that dispatches the items.
+        var consume = ConsumeAsync;
+        var consumers = new Task[degreeOfParallelism];
+        for (var i = 0; i < consumers.Length; i++)
         {
-            while (TryGetItem(out var item))
-            {
-                // If we reach the maximum number of concurrent tasks, wait for one to finish
-                while (Volatile.Read(ref remainingConcurrency) < 0)
-                {
-                    // The tasks collection can change while Task.WhenAny enumerates the collection
-                    // so, we need to clone the collection to avoid issues
-                    Task[]? clone = null;
-                    lock (tasks)
-                    {
-                        if (tasks.Count > 0)
-                            clone = tasks.ToArray();
-                    }
-
-                    if (clone is not null)
-                        await Task.WhenAny(clone).ConfigureAwait(false);
-                }
-
-                var task = Task.Run(async () => await action(context, item, options.CancellationToken).ConfigureAwait(false), options.CancellationToken);
-
-                lock (tasks)
-                {
-                    tasks.Add(task);
-                    _ = task.ContinueWith(task => OnTaskCompleted(task), options.CancellationToken, TaskContinuationOptions.None, TaskScheduler.Default);
-                }
-            }
-
-            bool TryGetItem([MaybeNullWhen(false)] out T result)
-            {
-                lock (tasks)
-                {
-                    if (pendingItems.Reader.TryRead(out var item))
-                    {
-                        remainingConcurrency--;
-                        result = item;
-                        return true;
-                    }
-
-                    result = default;
-                    return false;
-                }
-            }
-
-            void OnTaskCompleted(Task completedTask)
-            {
-                lock (tasks)
-                {
-                    if (!tasks.Remove(completedTask))
-                        throw new InvalidOperationException("An unexpected error occurred");
-
-                    // Observe the task's exception so it doesn't resurface as an UnobservedTaskException,
-                    // and record it so it can be reported to the caller once processing completes.
-                    if (completedTask.Exception is { } exception)
-                    {
-                        exceptions ??= [];
-                        exceptions.AddRange(exception.InnerExceptions);
-                    }
-
-                    remainingConcurrency++;
-
-                    // There is no active tasks, so we are sure we are at the end
-                    if (degreeOfParallelism == remainingConcurrency && !pendingItems.Reader.TryPeek(out _))
-                        pendingItems.Writer.Complete();
-                }
-            }
+            consumers[i] = Task.Factory.StartNew(consume, cancellationToken, TaskCreationOptions.DenyChildAttach, scheduler).Unwrap();
         }
 
-        // All work has completed (the writer is only completed once no task is running and the
-        // channel is empty), so no continuation can still be mutating the list at this point.
+        await Task.WhenAll(consumers).ConfigureAwait(false);
+
+        // All consumers have completed, so nothing can be mutating the list anymore.
         if (exceptions is not null)
             throw new AggregateException(exceptions);
+
+        async Task ConsumeAsync()
+        {
+            var reader = pendingItems.Reader;
+            while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (!cancellationToken.IsCancellationRequested && reader.TryRead(out var item))
+                {
+                    try
+                    {
+                        await action(context, item, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Record the exception and keep processing the remaining items. Letting it
+                        // escape would take a consumer down and leave the item accounted for as
+                        // pending, which would prevent the channel from ever being completed.
+                        lock (exceptionsLock)
+                        {
+                            exceptions ??= [];
+                            exceptions.Add(ex);
+                        }
+                    }
+                    finally
+                    {
+                        context.OnItemProcessed();
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/Meziantou.Framework.Threading/Threading/MixedConsumerProducerContext.cs
+++ b/src/Meziantou.Framework.Threading/Threading/MixedConsumerProducerContext.cs
@@ -8,6 +8,11 @@ public sealed class MixedConsumerProducerContext<T>
 {
     private readonly ChannelWriter<T> _writer;
 
+    // Number of items that have been written to the channel but not fully processed yet. Reaching 0
+    // means no item is pending and no running action can produce a new one, so the channel can be
+    // completed to let the consumers stop.
+    private int _pendingItems;
+
     internal MixedConsumerProducerContext(ChannelWriter<T> writer)
     {
         _writer = writer;
@@ -17,7 +22,21 @@ public sealed class MixedConsumerProducerContext<T>
     /// <param name="item">The item to enqueue.</param>
     public void Enqueue(T item)
     {
+        // Count the item before writing it, so the count cannot transiently reach 0 while the item
+        // is in flight. The caller is processing an item of its own, so the count is at least 1 here.
+        Interlocked.Increment(ref _pendingItems);
         if (!_writer.TryWrite(item))
+        {
+            Interlocked.Decrement(ref _pendingItems);
             throw new InvalidOperationException("Item cannot be enqueued");
+        }
+    }
+
+    internal void OnItemProcessed()
+    {
+        if (Interlocked.Decrement(ref _pendingItems) == 0)
+        {
+            _writer.Complete();
+        }
     }
 }

--- a/src/Meziantou.Framework.Threading/Threading/SemaphoreSlimExtensions.cs
+++ b/src/Meziantou.Framework.Threading/Threading/SemaphoreSlimExtensions.cs
@@ -67,7 +67,8 @@ public static class SemaphoreSlimExtensions
     [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "<Pending>")]
     public readonly struct SemaphoreDisposer : IDisposable
     {
-        private readonly SemaphoreSlim _semaphore;
+        // Nullable so the default instance, which never acquired a semaphore, disposes without throwing.
+        private readonly SemaphoreSlim? _semaphore;
 
         public SemaphoreDisposer(SemaphoreSlim semaphore)
         {
@@ -76,7 +77,7 @@ public static class SemaphoreSlimExtensions
 
         public void Dispose()
         {
-            _semaphore.Release();
+            _semaphore?.Release();
         }
     }
 }

--- a/tests/Meziantou.Framework.Threading.Tests/MixedConsumerProducerTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/MixedConsumerProducerTests.cs
@@ -1,4 +1,6 @@
 ﻿#pragma warning disable CA1861 // Avoid constant arrays as arguments
+using System.Collections.Concurrent;
+
 namespace Meziantou.Framework.Threading.Tests;
 public sealed class MixedConsumerProducerTests
 {
@@ -113,5 +115,109 @@ public sealed class MixedConsumerProducerTests
         });
 
         Assert.Equal(1, processed);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(4)]
+    public async Task Process_NeverExceedsMaxDegreeOfParallelism(int maxDegreeOfParallelism)
+    {
+        var current = 0;
+        var observedConcurrency = new ConcurrentBag<int>();
+
+        await MixedConsumerProducer.Process(Enumerable.Range(0, 20), new ParallelOptions() { MaxDegreeOfParallelism = maxDegreeOfParallelism }, async (context, item, cancellationToken) =>
+        {
+            observedConcurrency.Add(Interlocked.Increment(ref current));
+            if (item < 100)
+            {
+                context.Enqueue(item + 20);
+            }
+
+            await Task.Yield();
+            Interlocked.Decrement(ref current);
+        });
+
+        Assert.HasCount(120, observedConcurrency);
+        Assert.True(observedConcurrency.Max() <= maxDegreeOfParallelism, $"Observed {observedConcurrency.Max()} concurrent actions for a max degree of parallelism of {maxDegreeOfParallelism}");
+    }
+
+    [Fact]
+    public async Task Process_CancellationDuringProcessing_WaitsForRunningActions()
+    {
+        using var cts = new CancellationTokenSource();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var running = 0;
+        var options = new ParallelOptions() { MaxDegreeOfParallelism = 4, CancellationToken = cts.Token };
+
+        var task = MixedConsumerProducer.Process(Enumerable.Range(0, 100), options, async (context, item, cancellationToken) =>
+        {
+            Interlocked.Increment(ref running);
+            try
+            {
+                started.TrySetResult();
+                await Task.Delay(TimeSpan.FromMilliseconds(50), CancellationToken.None);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref running);
+            }
+        });
+
+        await started.Task;
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+        Assert.Equal(0, running);
+    }
+
+    [Fact]
+    public async Task Process_UsesTaskSchedulerFromOptions()
+    {
+        var scheduler = new CountingTaskScheduler();
+        var options = new ParallelOptions() { MaxDegreeOfParallelism = 2, TaskScheduler = scheduler };
+        var observedSchedulers = new ConcurrentBag<TaskScheduler>();
+
+        await MixedConsumerProducer.Process([1, 2, 3, 4], options, (context, item, cancellationToken) =>
+        {
+            observedSchedulers.Add(TaskScheduler.Current);
+            return ValueTask.CompletedTask;
+        });
+
+        Assert.HasCount(4, observedSchedulers);
+        Assert.All(observedSchedulers, current => Assert.Same(scheduler, current));
+        Assert.True(scheduler.QueuedTaskCount > 0);
+    }
+
+    [Fact]
+    public async Task Process_NullArguments()
+    {
+        var options = new ParallelOptions();
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => MixedConsumerProducer.Process<int>(initialItems: null!, options, (context, item, cancellationToken) => ValueTask.CompletedTask));
+        Assert.Equal("initialItems", exception.ParamName);
+
+        exception = await Assert.ThrowsAsync<ArgumentNullException>(() => MixedConsumerProducer.Process([1], options: null!, (context, item, cancellationToken) => ValueTask.CompletedTask));
+        Assert.Equal("options", exception.ParamName);
+
+        exception = await Assert.ThrowsAsync<ArgumentNullException>(() => MixedConsumerProducer.Process([1], options, action: null!));
+        Assert.Equal("action", exception.ParamName);
+    }
+
+    private sealed class CountingTaskScheduler : TaskScheduler
+    {
+        private int _queuedTaskCount;
+
+        public int QueuedTaskCount => Volatile.Read(ref _queuedTaskCount);
+
+        protected override IEnumerable<Task> GetScheduledTasks() => [];
+
+        protected override void QueueTask(Task task)
+        {
+            Interlocked.Increment(ref _queuedTaskCount);
+            _ = Task.Run(() => TryExecuteTask(task));
+        }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
     }
 }

--- a/tests/Meziantou.Framework.Threading.Tests/SemaphoreSlimExtensionsTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/SemaphoreSlimExtensionsTests.cs
@@ -1,0 +1,37 @@
+namespace Meziantou.Framework.Threading.Tests;
+
+public class SemaphoreSlimExtensionsTests
+{
+    [Fact]
+    public void SemaphoreDisposer_Default_DisposeDoesNothing()
+    {
+        var disposer = default(SemaphoreSlimExtensions.SemaphoreDisposer);
+        disposer.Dispose();
+    }
+
+    [Fact]
+    public void DisposableUnsafeWait_ReleasesOnDispose()
+    {
+        using var semaphore = new SemaphoreSlim(1, 1);
+
+        using (semaphore.DisposableUnsafeWait())
+        {
+            Assert.Equal(0, semaphore.CurrentCount);
+        }
+
+        Assert.Equal(1, semaphore.CurrentCount);
+    }
+
+    [Fact]
+    public async Task DisposableWaitUnsafeAsync_ReleasesOnDispose()
+    {
+        using var semaphore = new SemaphoreSlim(1, 1);
+
+        using (await semaphore.DisposableWaitUnsafeAsync())
+        {
+            Assert.Equal(0, semaphore.CurrentCount);
+        }
+
+        Assert.Equal(1, semaphore.CurrentCount);
+    }
+}


### PR DESCRIPTION
Fixes found while reviewing `Meziantou.Framework.Threading`. Two independent fixes, one commit each.

## `MixedConsumerProducer`

`Process` dispatched one task per item and throttled the dispatch loop with a hand-rolled concurrency counter. Three defects came out of that design:

- **The bookkeeping continuation was cancelled along with the token.** It was registered as `ContinueWith(..., options.CancellationToken, ...)`, which cancels the *continuation itself* when the token fires. The completed task was then never removed, the concurrency slot never restored, and the channel never completed — so collected exceptions were silently dropped and in-flight tasks were abandoned unobserved.
- **The throttle loop spun.** The concurrency counter is restored by that continuation, which runs *after* the task completes, so `Task.WhenAny` returned immediately while the condition was still unsatisfied — re-cloning the task list and allocating a fresh `WhenAny` task for the whole scheduling delay.
- **`ParallelOptions.TaskScheduler` was ignored**; work was hardcoded to `Task.Run`.

The dispatch-and-throttle loop is replaced by a fixed pool of `MaxDegreeOfParallelism` long-lived consumers draining the channel. Concurrency is bounded by construction, so there is no counter, no spin, and no per-iteration allocation. Consumers start via `Task.Factory.StartNew` on `options.TaskScheduler ?? TaskScheduler.Current`, mirroring how `ParallelOptions` itself resolves a null scheduler. Cancellation is observed by `WaitToReadAsync`, and `Process` now awaits every consumer before propagating, so it no longer returns while actions are still running.

Termination moves into `MixedConsumerProducerContext`, which counts items written-but-not-yet-processed and completes the channel at zero. `Enqueue` counts an item *before* writing it, so the count cannot dip to zero while an item is in flight; the decrement runs in a `finally`, so an action that throws cannot strand an item and hang the remaining consumers.

Also adds the missing argument null checks and documents the exception contract and which `ParallelOptions` members are honored.

## `SemaphoreSlimExtensions`

`SemaphoreDisposer` is a struct, so `default(SemaphoreDisposer)` is reachable and its `Dispose` threw a `NullReferenceException` on the uninitialized field. The field is now nullable and releases through `?.`, matching how the other lease types in this assembly guard their default instance.

## Notes for the reviewer

- **Public API is unchanged** — the new context members are `internal`, and `ref/Meziantou.Framework.Threading.cs` needed no regeneration.
- **One behavior change worth knowing:** `Process` now eagerly creates `MaxDegreeOfParallelism` consumer tasks up front, where the old code created one task per item. With a large degree of parallelism and few items (say 1000 and 1) that is 1000 short-lived async tasks instead of 1. They hold no threads — each just awaits the channel — and this is the standard channel-worker-pool shape. Capping the pool to the initial item count would be wrong, since actions enqueue more work: a one-URL crawl that discovers 1000 links would go serial.
- New tests cover the concurrency bound (previously untested — `Process_NoParallelism` only counted items), cancellation mid-processing, the scheduler being honored, and the argument guards.

## Validation

- Clean rebuild (`--no-incremental`, `-p:TreatWarningsAsErrors=true`) on net10.0 and net11.0: 0 warnings, 0 errors.
- `Meziantou.Framework.Threading.Tests`: **174/174** passing (87 per TFM); verified via the `.trx` files that the new tests actually executed on both TFMs.
- 17 consecutive full-suite runs with zero failures, since these are concurrency changes.
- `dotnet run ./eng/update-all.cs`: exit 0, no generated file changes.

## Not addressed

Other findings from the same review are left for follow-ups — most notably a deadlock in `AsyncLock`/`AsyncAutoResetEvent` (disposing a `CancellationTokenRegistration` while holding the lock its callback takes), non-idempotent `Dispose` on `DelayedCancellationTokenSource` and `ResettableCancellationTokenSource`, `ConfigureAwaitOptions.SuppressThrowing` not suppressing for `Task<T>` tuples, and `MonoThreadedTaskScheduler` not overriding `MaximumConcurrencyLevel`.