### PR TITLE
Fix deadlock when cancellation races with AsyncLock/AsyncAutoResetEvent

### DIFF
--- a/src/Meziantou.Framework.Threading/Threading/AsyncAutoResetEvent.cs
+++ b/src/Meziantou.Framework.Threading/Threading/AsyncAutoResetEvent.cs
@@ -55,6 +55,8 @@ public sealed class AsyncAutoResetEvent
         if (cancellationToken.IsCancellationRequested)
             return Task.FromCanceled(cancellationToken);
 
+        WaiterCompletionSource waiter;
+        bool canceled;
         lock (_signalAwaiters)
         {
             if (_signaled)
@@ -62,22 +64,26 @@ public sealed class AsyncAutoResetEvent
                 _signaled = false;
                 return Task.CompletedTask;
             }
-            else
-            {
-                var waiter = new WaiterCompletionSource(this, _allowInliningAwaiters, cancellationToken);
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    waiter.TrySetCanceled(cancellationToken);
-                    waiter.Registration.Dispose();
-                }
-                else
-                {
-                    _signalAwaiters.Enqueue(waiter);
-                }
 
-                return waiter.Task;
+            waiter = new WaiterCompletionSource(this, _allowInliningAwaiters, cancellationToken);
+            canceled = cancellationToken.IsCancellationRequested;
+            if (!canceled)
+            {
+                _signalAwaiters.Enqueue(waiter);
             }
         }
+
+        // The token was canceled between the registration and this check, so the waiter was never
+        // queued and must be completed here. This has to happen outside the lock: TrySetCanceled can
+        // inline continuations, and Registration.Dispose blocks until a callback running on another
+        // thread completes. That callback is OnCancellationRequest, which takes this same lock.
+        if (canceled)
+        {
+            waiter.TrySetCanceled(cancellationToken);
+            waiter.Registration.Dispose();
+        }
+
+        return waiter.Task;
     }
 
     /// <summary>Sets the state of the event to signaled, allowing one waiting task to proceed.</summary>

--- a/src/Meziantou.Framework.Threading/Threading/AsyncLock.cs
+++ b/src/Meziantou.Framework.Threading/Threading/AsyncLock.cs
@@ -55,6 +55,8 @@ public sealed class AsyncLock
         if (cancellationToken.IsCancellationRequested)
             return ValueTask.FromCanceled<AsyncLockLease>(cancellationToken);
 
+        WaiterCompletionSource waiter;
+        bool canceled;
         lock (_signalAwaiters)
         {
             if (_signaled)
@@ -62,22 +64,26 @@ public sealed class AsyncLock
                 _signaled = false;
                 return new ValueTask<AsyncLockLease>(new AsyncLockLease(this));
             }
-            else
-            {
-                var waiter = new WaiterCompletionSource(this, _allowInliningAwaiters, cancellationToken);
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    waiter.TrySetCanceled(cancellationToken);
-                    waiter.Registration.Dispose();
-                }
-                else
-                {
-                    _signalAwaiters.Enqueue(waiter);
-                }
 
-                return new ValueTask<AsyncLockLease>(waiter.Task);
+            waiter = new WaiterCompletionSource(this, _allowInliningAwaiters, cancellationToken);
+            canceled = cancellationToken.IsCancellationRequested;
+            if (!canceled)
+            {
+                _signalAwaiters.Enqueue(waiter);
             }
         }
+
+        // The token was canceled between the registration and this check, so the waiter was never
+        // queued and must be completed here. This has to happen outside the lock: TrySetCanceled can
+        // inline continuations, and Registration.Dispose blocks until a callback running on another
+        // thread completes. That callback is OnCancellationRequest, which takes this same lock.
+        if (canceled)
+        {
+            waiter.TrySetCanceled(cancellationToken);
+            waiter.Registration.Dispose();
+        }
+
+        return new ValueTask<AsyncLockLease>(waiter.Task);
     }
 
     /// <summary>Attempts to acquire the lock synchronously without blocking.</summary>

--- a/tests/Meziantou.Framework.Threading.Tests/AsyncAutoResetEventTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/AsyncAutoResetEventTests.cs
@@ -1,0 +1,107 @@
+namespace Meziantou.Framework.Threading.Tests;
+
+public class AsyncAutoResetEventTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public async Task WaitAsync_InitiallySignaled_CompletesImmediatelyOnce()
+    {
+        var e = new AsyncAutoResetEvent(initialState: true);
+
+        await e.WaitAsync().WaitAsync(Timeout);
+
+        var second = e.WaitAsync();
+        Assert.False(second.IsCompleted);
+
+        e.Set();
+        await second.WaitAsync(Timeout);
+    }
+
+    [Fact]
+    public async Task Set_ReleasesASingleWaiter()
+    {
+        var e = new AsyncAutoResetEvent(initialState: false);
+        var first = e.WaitAsync();
+        var second = e.WaitAsync();
+
+        e.Set();
+        await first.WaitAsync(Timeout);
+        Assert.False(second.IsCompleted);
+
+        e.Set();
+        await second.WaitAsync(Timeout);
+    }
+
+    [Fact]
+    public async Task WaitAsync_AlreadyCanceledToken_Throws()
+    {
+        var e = new AsyncAutoResetEvent(initialState: false);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => e.WaitAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task WaitAsync_CancelWhileWaiting_DoesNotConsumeTheSignal()
+    {
+        var e = new AsyncAutoResetEvent(initialState: false);
+        using var cts = new CancellationTokenSource();
+        var canceled = e.WaitAsync(cts.Token);
+        var other = e.WaitAsync();
+
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceled);
+
+        // The signal must go to the remaining waiter, not to the canceled one.
+        e.Set();
+        await other.WaitAsync(Timeout);
+    }
+
+    [Fact]
+    public async Task WaitAsync_CancellationRacingWithWait_DoesNotDeadlock()
+    {
+        // Regression test: WaitAsync used to complete a canceled waiter while still holding the
+        // internal lock. CancellationTokenRegistration.Dispose blocks until a callback running on
+        // another thread completes, and that callback (OnCancellationRequest) takes the same lock,
+        // so the two threads deadlocked. WaitAsync blocks synchronously in that case, hence the
+        // Task.Run: it lets the timeout fail the test instead of hanging the whole run.
+        await Task.Run(RaceCancellationAgainstWaitAsync).WaitAsync(Timeout);
+
+        static async Task RaceCancellationAgainstWaitAsync()
+        {
+            for (var i = 0; i < 20_000; i++)
+            {
+                var e = new AsyncAutoResetEvent(initialState: false);
+                using var cts = new CancellationTokenSource();
+                using var barrier = new Barrier(2);
+
+                var canceling = Task.Run(() =>
+                {
+                    barrier.SignalAndWait();
+
+                    // Sweep the cancellation across the window between the token registration and
+                    // the IsCancellationRequested check inside WaitAsync.
+                    Thread.SpinWait(i % 64);
+                    cts.Cancel();
+                });
+
+                barrier.SignalAndWait();
+                var waiting = e.WaitAsync(cts.Token);
+
+                await canceling;
+
+                // Whichever side won, the waiter must reach a terminal state.
+                e.Set();
+                try
+                {
+                    await waiting;
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            }
+        }
+    }
+}

--- a/tests/Meziantou.Framework.Threading.Tests/AsyncLockTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/AsyncLockTests.cs
@@ -110,6 +110,56 @@ public class AsyncLockTests
     }
 
     [Fact]
+    public async Task LockAsync_CancellationRacingWithAcquisition_DoesNotDeadlock()
+    {
+        // Regression test: LockAsync used to complete a canceled waiter while still holding the
+        // internal lock. CancellationTokenRegistration.Dispose blocks until a callback running on
+        // another thread completes, and that callback (OnCancellationRequest) takes the same lock,
+        // so the two threads deadlocked. LockAsync blocks synchronously in that case, hence the
+        // Task.Run: it lets the timeout fail the test instead of hanging the whole run.
+        await Task.Run(RaceCancellationAgainstLockAsync).WaitAsync(Timeout);
+
+        static async Task RaceCancellationAgainstLockAsync()
+        {
+            for (var i = 0; i < 20_000; i++)
+            {
+                var asyncLock = new AsyncLock();
+
+                // Hold the lock so the acquisition below has to go through the waiter queue.
+                var held = await asyncLock.LockAsync();
+
+                using var cts = new CancellationTokenSource();
+                using var barrier = new Barrier(2);
+
+                var canceling = Task.Run(() =>
+                {
+                    barrier.SignalAndWait();
+
+                    // Sweep the cancellation across the window between the token registration and
+                    // the IsCancellationRequested check inside LockAsync.
+                    Thread.SpinWait(i % 64);
+                    cts.Cancel();
+                });
+
+                barrier.SignalAndWait();
+                var waiting = asyncLock.LockAsync(cts.Token);
+
+                await canceling;
+
+                // Whichever side won, the waiter must reach a terminal state.
+                held.Dispose();
+                try
+                {
+                    (await waiting).Dispose();
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            }
+        }
+    }
+
+    [Fact]
     public void DefaultLease_DisposeIsNoop()
     {
         default(AsyncLock.AsyncLockLease).Dispose();


### PR DESCRIPTION
## What

`AsyncLock.LockAsync` and `AsyncAutoResetEvent.WaitAsync` completed a canceled waiter while still holding the internal `_signalAwaiters` lock:

```csharp
lock (_signalAwaiters)
{
    var waiter = new WaiterCompletionSource(...); // registers OnCancellationRequest
    if (cancellationToken.IsCancellationRequested)
    {
        waiter.TrySetCanceled(cancellationToken);
        waiter.Registration.Dispose();            // blocks
    }
    ...
}
```

`CancellationTokenRegistration.Dispose` blocks until a callback running on another thread completes, and that callback is `OnCancellationRequest`, whose first act is to take the same lock.

The race: the token is not yet canceled when `Register` runs (so the callback is not invoked inline), then fires on another thread before the `IsCancellationRequested` check. That thread enters `OnCancellationRequest` and blocks on the lock we hold; we then call `Registration.Dispose()` and block waiting for it. Both threads hang, and the lock's internal state is stuck for good.

## Fix

Complete the canceled waiter after leaving the lock, matching the pattern `Release`/`Set` already use — dequeue under the lock, complete outside it:

```csharp
WaiterCompletionSource waiter;
bool canceled;
lock (_signalAwaiters)
{
    if (_signaled) { _signaled = false; return /* fast path */; }

    waiter = new WaiterCompletionSource(this, _allowInliningAwaiters, cancellationToken);
    canceled = cancellationToken.IsCancellationRequested;
    if (!canceled)
        _signalAwaiters.Enqueue(waiter);
}

if (canceled)
{
    waiter.TrySetCanceled(cancellationToken);
    waiter.Registration.Dispose();
}

return waiter.Task;
```

This also fixes a second problem on the same lines: with `allowInliningAwaiters: true`, `TrySetCanceled` ran arbitrary user continuations while holding the internal lock. Both calls are now outside it.

No public API change, so `ref/Meziantou.Framework.Threading.cs` is unchanged.

## Tests

- `AsyncLockTests.LockAsync_CancellationRacingWithAcquisition_DoesNotDeadlock`
- new `AsyncAutoResetEventTests` (the type had no test file at all) with the matching race test plus basic set/wait/cancel coverage

The race tests run 20k iterations, syncing the canceling thread against the acquiring thread with a `Barrier` and sweeping `Thread.SpinWait(i % 64)` to walk the cancellation across the narrow window between the token registration and the `IsCancellationRequested` check. The work runs under `Task.Run(...).WaitAsync(timeout)` because the deadlock is synchronous — otherwise it would hang the run instead of failing it.

I checked the tests actually catch the bug rather than just passing: with the fix reverted, both fail with `TimeoutException` after 30s; with the fix, both pass in ~0.4s.

## Verification

- `dotnet build` clean with `/p:TreatsWarningsAsErrors=true`
- 168/168 tests pass across net10.0 and net11.0 (84 each, up from 78); confirmed via the TRX that all 6 new tests ran on both frameworks
- `dotnet run ./eng/update-all.cs` succeeded with no further changes

## Note for the reviewer

This came out of a review of `Meziantou.Framework.Threading` that turned up other issues — non-idempotent `Dispose` on `DelayedCancellationTokenSource` / `ResettableCancellationTokenSource`, a cancellation token passed to `ContinueWith` in `MixedConsumerProducer`, `SuppressThrowing` not suppressing for `Task<T>` tuples, and `MonoThreadedTaskScheduler.MaximumConcurrencyLevel` not being overridden. This PR is scoped to the deadlock only.
