### PR TITLE
Clarify and complete SynchronizedList<T> synchronization contract

### DIFF
--- a/ref/Meziantou.Framework.Threading.cs
+++ b/ref/Meziantou.Framework.Threading.cs
@@ -38,13 +38,15 @@ namespace Meziantou.Framework.Collections.Concurrent
         }
     }
 
-    public sealed class SynchronizedList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+    public sealed class SynchronizedList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable
     {
         public int Count { get => throw null; }
         public T this[int index] { get => throw null; set { } }
         public SynchronizedList(int capacity) { }
         public SynchronizedList(System.Collections.Generic.IEnumerable<T>? items = null) { }
         public SynchronizedList(System.ReadOnlySpan<T> items) { }
+        public void Execute(System.Action<System.Collections.Generic.List<T>> action) { }
+        public TResult Execute<TResult>(System.Func<System.Collections.Generic.List<T>, TResult> func) => throw null;
         public System.Collections.Generic.IEnumerator<T> GetEnumerator() => throw null;
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
         public int EnsureCapacity(int capacity) => throw null;
@@ -56,7 +58,7 @@ namespace Meziantou.Framework.Collections.Concurrent
         public int IndexOf(T item) => throw null;
         public void Insert(int index, T item) { }
         public void RemoveAt(int index) { }
-        public void CopyTo(System.Array array, int index) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
     }
 }
 namespace Meziantou.Framework.Threading

--- a/src/Meziantou.Framework.Threading/Collections/Concurrent/SynchronizedList.cs
+++ b/src/Meziantou.Framework.Threading/Collections/Concurrent/SynchronizedList.cs
@@ -4,6 +4,12 @@ namespace Meziantou.Framework.Collections.Concurrent;
 
 /// <summary>Represents a thread-safe list that can be accessed by multiple threads concurrently.</summary>
 /// <typeparam name="T">The type of elements in the list.</typeparam>
+/// <remarks>
+/// Each member is individually atomic, but a sequence of members is not. For instance,
+/// <c>if (!list.Contains(item)) list.Add(item);</c> can add the same item twice, and <c>list[list.Count - 1]</c>
+/// can throw when another thread removes an element in between. Use <see cref="Execute(Action{List{T}})"/> or
+/// <see cref="Execute{TResult}(Func{List{T}, TResult})"/> to run several operations as a single atomic unit.
+/// </remarks>
 /// <example>
 /// <code><![CDATA[
 /// var list = new SynchronizedList<int>();
@@ -13,9 +19,18 @@ namespace Meziantou.Framework.Collections.Concurrent;
 /// {
 ///     Console.WriteLine(item);
 /// }
+///
+/// // Multiple operations as a single atomic unit
+/// list.Execute(items =>
+/// {
+///     if (!items.Contains(3))
+///     {
+///         items.Add(3);
+///     }
+/// });
 /// ]]></code>
 /// </example>
-public sealed class SynchronizedList<T> : IList<T>, IReadOnlyList<T>
+public sealed class SynchronizedList<T> : IList<T>, IReadOnlyList<T>, ICollection
 {
     private readonly List<T> _list;
 
@@ -57,16 +72,11 @@ public sealed class SynchronizedList<T> : IList<T>, IReadOnlyList<T>
         }
     }
 
-    bool ICollection<T>.IsReadOnly
-    {
-        get
-        {
-            lock (_list)
-            {
-                return ((ICollection<T>)_list).IsReadOnly;
-            }
-        }
-    }
+    bool ICollection<T>.IsReadOnly => false;
+
+    bool ICollection.IsSynchronized => true;
+
+    object ICollection.SyncRoot => throw new NotSupportedException("The SyncRoot property may not be used for the synchronization of concurrent collections. Use Execute to run several operations atomically.");
 
     public T this[int index]
     {
@@ -83,6 +93,34 @@ public sealed class SynchronizedList<T> : IList<T>, IReadOnlyList<T>
             {
                 _list[index] = value;
             }
+        }
+    }
+
+    /// <summary>Runs the specified action on the underlying list while holding the lock, so the operations it performs are atomic with respect to other members.</summary>
+    /// <param name="action">The action to execute. The list passed to the action must not be used after the action returns.</param>
+    /// <remarks>Keep the action short and avoid calling code that may block or acquire other locks, because all other members block while it runs.</remarks>
+    public void Execute(Action<List<T>> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        lock (_list)
+        {
+            action(_list);
+        }
+    }
+
+    /// <summary>Runs the specified function on the underlying list while holding the lock, so the operations it performs are atomic with respect to other members.</summary>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="func"/>.</typeparam>
+    /// <param name="func">The function to execute. The list passed to the function must not be used after the function returns.</param>
+    /// <returns>The value returned by <paramref name="func"/>.</returns>
+    /// <remarks>Keep the function short and avoid calling code that may block or acquire other locks, because all other members block while it runs.</remarks>
+    public TResult Execute<TResult>(Func<List<T>, TResult> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        lock (_list)
+        {
+            return func(_list);
         }
     }
 
@@ -176,7 +214,7 @@ public sealed class SynchronizedList<T> : IList<T>, IReadOnlyList<T>
         }
     }
 
-    public void CopyTo(Array array, int index)
+    void ICollection.CopyTo(Array array, int index)
     {
         lock (_list)
         {

--- a/tests/Meziantou.Framework.Threading.Tests/SynchronizedListTests.cs
+++ b/tests/Meziantou.Framework.Threading.Tests/SynchronizedListTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Meziantou.Framework.Collections.Concurrent;
 
 namespace Meziantou.Framework.Tests.Collections.Concurrent;
@@ -150,12 +151,64 @@ public sealed class SynchronizedListTests
     }
 
     [Fact]
-    public void CopyToArray_ShouldCopyItems()
+    public void ICollectionCopyTo_ShouldCopyItems()
     {
         var list = new SynchronizedList<int>([1, 2, 3]);
         var array = new int[3];
-        list.CopyTo(array, 0);
+        ((ICollection)list).CopyTo(array, 0);
         Assert.Equal([1, 2, 3], array);
+    }
+
+    [Fact]
+    public void IsSynchronized_ShouldBeTrue()
+    {
+        var list = new SynchronizedList<int>();
+        Assert.True(((ICollection)list).IsSynchronized);
+    }
+
+    [Fact]
+    public void SyncRoot_ShouldThrow()
+    {
+        var list = new SynchronizedList<int>();
+        Assert.Throws<NotSupportedException>(() => _ = ((ICollection)list).SyncRoot);
+    }
+
+    [Fact]
+    public void Execute_ShouldRunActionOnUnderlyingList()
+    {
+        var list = new SynchronizedList<int>([1, 2, 3]);
+        list.Execute(items => items.RemoveAll(item => item % 2 is 1));
+        Assert.Equal([2], list);
+    }
+
+    [Fact]
+    public void Execute_ShouldReturnFunctionResult()
+    {
+        var list = new SynchronizedList<int>([1, 2, 3]);
+        Assert.Equal(6, list.Execute(items => items.Sum()));
+    }
+
+    [Fact]
+    public void Execute_NullCallback_ShouldThrow()
+    {
+        var list = new SynchronizedList<int>();
+        Assert.Throws<ArgumentNullException>(() => list.Execute(action: null!));
+        Assert.Throws<ArgumentNullException>(() => _ = list.Execute<int>(func: null!));
+    }
+
+    [Fact]
+    public async Task Execute_ShouldMakeCompositeOperationsAtomic()
+    {
+        var list = new SynchronizedList<int>();
+        var tasks = new List<Task>();
+
+        for (var i = 0; i < 100; i++)
+        {
+            tasks.Add(Task.Run(() => list.Execute(items => items.Add(items.Count))));
+        }
+
+        await Task.WhenAll(tasks);
+        Assert.Equal(Enumerable.Range(0, 100), list.Order());
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to a review of `Meziantou.Framework.Threading`. This PR addresses only the `SynchronizedList<T>` findings; the other issues turned up by that review (an `AsyncLock`/`AsyncAutoResetEvent` deadlock, non-idempotent `Dispose` on the two cancellation-token-source types, the `ContinueWith` cancellation token in `MixedConsumerProducer`, `SuppressThrowing` not suppressing for `Task<T>` tuples, and the missing `MonoThreadedTaskScheduler.MaximumConcurrencyLevel` override) are untouched and left for separate changes.

## What changed

**Composite operations can now be made atomic.** Each member of `SynchronizedList<T>` is individually atomic, but a sequence of members is not — `if (!list.Contains(x)) list.Add(x)` can add the same item twice, and `list[list.Count - 1]` can throw when another thread removes an element in between. There was no way for a caller to close that gap. Two new members run a callback while holding the lock:

```csharp
public void Execute(Action<List<T>> action)
public TResult Execute<TResult>(Func<List<T>, TResult> func)
```

They hand out the underlying `List<T>` rather than an `IList<T>`, so `RemoveAll`, `Sort`, `BinarySearch` and friends are reachable. Both null-check the callback and document that the list must not escape it.

**The type doc now states the real guarantee** instead of just "thread-safe list", with the two concrete traps above and a pointer to `Execute`.

**`ICollection<T>.IsReadOnly`** took the lock to read a constant. It now returns `false` directly.

**`CopyTo(Array, int)` was public on a type that did not implement non-generic `ICollection`.** The type now implements `System.Collections.ICollection` and `CopyTo` is an explicit implementation. `IsSynchronized` returns `true`; `SyncRoot` throws `NotSupportedException`, following `ConcurrentDictionary`'s precedent — exposing the internal lock object would both hand out the inner `List<T>` and let callers stall every other member, which is what `Execute` provides safely instead.

## Reviewer notes

**Public API change:** `CopyTo(Array, int)` is no longer callable without a cast to `ICollection`. It was unreferenced anywhere in the repo, and the test that appeared to cover it (`CopyToArray_ShouldCopyItems`) was actually binding to the generic `CopyTo(T[], int)` overload — a duplicate of the test directly above it. That test has been repurposed to exercise `ICollection.CopyTo` for real. `ref/Meziantou.Framework.Threading.cs` was regenerated by the build and reflects the change.

The alternative was deleting the method outright; the explicit-interface route was chosen so the behaviour stays available and the type works in non-generic scenarios.

## Tests

Six new tests in the existing `SynchronizedListTests.cs`:

- `ICollectionCopyTo_ShouldCopyItems`, `IsSynchronized_ShouldBeTrue`, `SyncRoot_ShouldThrow`
- `Execute_ShouldRunActionOnUnderlyingList`, `Execute_ShouldReturnFunctionResult`, `Execute_NullCallback_ShouldThrow`
- `Execute_ShouldMakeCompositeOperationsAtomic` — 100 concurrent `items.Add(items.Count)` calls asserting the result is exactly `0..99`. This fails unless the lock spans both the read and the write, so it actually exercises the new guarantee rather than just calling through it.

## Verification

- `dotnet build src/Meziantou.Framework.Threading/Meziantou.Framework.Threading.csproj /p:TreatsWarningsAsErrors=true` — succeeded, 0 warnings, `net10.0` and `net11.0`.
- `dotnet test tests/Meziantou.Framework.Threading.Tests /p:TreatsWarningsAsErrors=true` — 168 passed, 0 failed (84 per TFM; the `SynchronizedList` class went from 20 to 26 tests per TFM).
- `dotnet run ./eng/update-all.cs` — exit 0, no further file changes.
