### PR TITLE
Remove global MinimumExpectedTests property

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,8 +5,6 @@
     <EnableCodeCoverage>false</EnableCodeCoverage>
     <!-- The assertions come from the project reference below, not from the package the SDK adds by default -->
     <EnableMeziantouAssertions>false</EnableMeziantouAssertions>
-    <!-- Platform-specific test projects skip all their tests on the other platforms -->
-    <MinimumExpectedTests>0</MinimumExpectedTests>
     <IncludeDefaultTestReferences Condition="'$(IncludeDefaultTestReferences)' == ''">true</IncludeDefaultTestReferences>
     <DefineConstants Condition="'$(GITHUB_ACTIONS)' == 'true'">$(DefineConstants);GITHUB_ACTIONS</DefineConstants>
     <TestTfmsInParallel Condition="'$(GITHUB_ACTIONS)' == 'true' AND $([MSBuild]::IsOsPlatform('Windows'))">false</TestTfmsInParallel>

--- a/tests/Meziantou.Framework.NtpClient.Tests/Meziantou.Framework.NtpClient.Tests.csproj
+++ b/tests/Meziantou.Framework.NtpClient.Tests/Meziantou.Framework.NtpClient.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- All the tests are skipped on macOS when running on GitHub Actions -->
+    <MinimumExpectedTests>0</MinimumExpectedTests>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.PostgreSqlServer.Tests/Meziantou.Framework.PostgreSqlServer.Tests.csproj
+++ b/tests/Meziantou.Framework.PostgreSqlServer.Tests/Meziantou.Framework.PostgreSqlServer.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- All the tests are skipped when globalization is invariant -->
+    <MinimumExpectedTests>0</MinimumExpectedTests>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.TdsServer.Tests/Meziantou.Framework.TdsServer.Tests.csproj
+++ b/tests/Meziantou.Framework.TdsServer.Tests/Meziantou.Framework.TdsServer.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- All the tests are skipped when globalization is invariant -->
+    <MinimumExpectedTests>0</MinimumExpectedTests>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.Unix.ControlGroups.Tests/Meziantou.Framework.Unix.ControlGroups.Tests.csproj
+++ b/tests/Meziantou.Framework.Unix.ControlGroups.Tests/Meziantou.Framework.Unix.ControlGroups.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- All the tests are skipped when not running on Linux, when cgroup v2 is unavailable, or when running on GitHub Actions -->
+    <MinimumExpectedTests>0</MinimumExpectedTests>
     <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
     <RootNamespace>Meziantou.Framework.Tests</RootNamespace>
   </PropertyGroup>

--- a/tests/Meziantou.Framework.Win32.AccessToken.Tests/Meziantou.Framework.Win32.AccessToken.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.AccessToken.Tests/Meziantou.Framework.Win32.AccessToken.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- All the tests are skipped on non-Windows operating systems -->
+    <MinimumExpectedTests>0</MinimumExpectedTests>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/tests/Meziantou.Framework.Win32.AmsiTests/Meziantou.Framework.Win32.AmsiTests.csproj
+++ b/tests/Meziantou.Framework.Win32.AmsiTests/Meziantou.Framework.Win32.AmsiTests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- All the tests are skipped when running on GitHub Actions -->
+    <MinimumExpectedTests>0</MinimumExpectedTests>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/Meziantou.Framework.Win32.CredentialManager.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/Meziantou.Framework.Win32.CredentialManager.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- All the tests are skipped on non-Windows operating systems -->
+    <MinimumExpectedTests>0</MinimumExpectedTests>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/tests/Meziantou.Framework.Win32.Jobs.Tests/Meziantou.Framework.Win32.Jobs.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.Jobs.Tests/Meziantou.Framework.Win32.Jobs.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- All the tests are skipped on non-Windows operating systems -->
+    <MinimumExpectedTests>0</MinimumExpectedTests>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/tests/Meziantou.Framework.Win32.Lsa.Tests/Meziantou.Framework.Win32.Lsa.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.Lsa.Tests/Meziantou.Framework.Win32.Lsa.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- All the tests are skipped on non-Windows operating systems -->
+    <MinimumExpectedTests>0</MinimumExpectedTests>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- All the tests are skipped on non-Windows operating systems -->
+    <MinimumExpectedTests>0</MinimumExpectedTests>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/tests/Meziantou.Framework.Win32.PerceivedType.Tests/Meziantou.Framework.Win32.PerceivedType.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.PerceivedType.Tests/Meziantou.Framework.Win32.PerceivedType.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- All the tests are skipped on non-Windows operating systems -->
+    <MinimumExpectedTests>0</MinimumExpectedTests>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/tests/Meziantou.Framework.Win32.RestartManager.Tests/Meziantou.Framework.Win32.RestartManager.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.RestartManager.Tests/Meziantou.Framework.Win32.RestartManager.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- All the tests are skipped on non-Windows operating systems -->
+    <MinimumExpectedTests>0</MinimumExpectedTests>
     <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
Removes the repo-wide `<MinimumExpectedTests>0</MinimumExpectedTests>` from `tests/Directory.Build.props` so that a test project running zero tests is reported as a failure by default.

CI is used to identify the projects that legitimately run zero tests on some platforms/configurations; the property will then be set on those projects only.