### PR TITLE
Fix FullPath.IsChildOf and MakePathRelativeTo edge cases

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -186,7 +186,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
 
     /// <summary>Creates a relative path from this path to the specified root path.</summary>
     /// <param name="rootPath">The root path to make this path relative to.</param>
-    /// <returns>A relative path string.</returns>
+    /// <returns>A relative path string, or <c>"."</c> when both paths are equal.</returns>
     public string MakePathRelativeTo(FullPath rootPath)
     {
         if (IsEmpty)
@@ -195,56 +195,13 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         if (rootPath.IsEmpty)
             return _value;
 
-        if (rootPath == this)
-            return ".";
-
-        return PathDifference(rootPath._value, _value, compareCase: FullPathComparer.Default.IsCaseSensitive);
-    }
-
-    private static string PathDifference(string path1, string path2, bool compareCase)
-    {
-        var directorySeparator = Path.DirectorySeparatorChar;
-
-        int i;
-        var si = -1;
-        for (i = 0; (i <= path1.Length) && (i < path2.Length); ++i)
-        {
-            var c1 = i == path1.Length ? directorySeparator : path1[i];
-            var c2 = path2[i];
-
-            if ((c1 != c2) && (compareCase || (char.ToUpperInvariant(c1) != char.ToUpperInvariant(c2))))
-                break;
-
-            if (c1 == directorySeparator)
-            {
-                si = i;
-            }
-        }
-
-        if (i == 0)
-            return path2;
-
-        if ((i == path1.Length + 1) && (i == path2.Length))
-            return "";
-
-        var relPath = new StringBuilder();
-        // Walk down several dirs
-        for (; i <= path1.Length; ++i)
-        {
-            var c = i == path1.Length ? directorySeparator : path1[i];
-            if (c == directorySeparator)
-            {
-                relPath.Append("..");
-                relPath.Append(directorySeparator);
-            }
-        }
-
-        return relPath.Append(path2.AsSpan(si + 1)).ToString();
+        return Path.GetRelativePath(rootPath._value, _value);
     }
 
     /// <summary>Determines whether this path is a child of the specified root path.</summary>
     /// <param name="rootPath">The root path to check against.</param>
     /// <returns><see langword="true"/> if this path is a child of the root path; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>The comparison uses the same case sensitivity as <see cref="FullPathComparer.Default"/>.</remarks>
     public bool IsChildOf(FullPath rootPath)
     {
         if (IsEmpty)
@@ -252,20 +209,25 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         if (rootPath.IsEmpty)
             throw new ArgumentException("Root path is empty", nameof(rootPath));
 
-        if (_value.Length <= rootPath._value.Length)
+        var root = rootPath._value;
+        if (_value.Length <= root.Length)
             return false;
 
-        if (!_value.StartsWith(rootPath._value, StringComparison.Ordinal))
+        var comparison = FullPathComparer.Default.IsCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        if (!_value.StartsWith(root, comparison))
             return false;
+
+        // Root directories such as "/" or "C:\" keep their trailing separator, so the child does not have an extra one
+        // rootpath: /
+        // current:  /a    => true
+        if (root[^1] == Path.DirectorySeparatorChar)
+            return true;
 
         // rootpath: /a/b
         // current:  /a/b/c => true
         // current:  /a/b/  => false
         // current:  /a/bc  => false
-        if (_value[rootPath._value.Length] == Path.DirectorySeparatorChar && _value.Length > rootPath._value.Length + 1)
-            return true;
-
-        return false;
+        return _value[root.Length] == Path.DirectorySeparatorChar && _value.Length > root.Length + 1;
     }
 
     /// <summary>Creates the parent directory of this path if it doesn't exist.</summary>

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -109,11 +109,23 @@ public sealed class FullPathTests
     [InlineData("a/", "a")]
     [InlineData("a/../b", "b")]
     [InlineData(".", ".")]
+    [InlineData("..", "..")]
+    [InlineData("../..", "../..")]
+    [InlineData("../sibling", "../sibling")]
     public void MakeRelativeTo(string childPath, string expected)
     {
         var rootPath = FullPath.FromPath("test");
         var path1 = FullPath.Combine("test", childPath);
-        Assert.Equal(expected, path1.MakePathRelativeTo(rootPath));
+        Assert.Equal(expected.Replace('/', Path.DirectorySeparatorChar), path1.MakePathRelativeTo(rootPath));
+    }
+
+    [Fact]
+    public void MakeRelativeTo_RootDirectory()
+    {
+        var rootPath = GetRootDirectory();
+        var path = rootPath / "a";
+
+        Assert.Equal("a", path.MakePathRelativeTo(rootPath));
     }
 
     [Theory]
@@ -140,6 +152,25 @@ public sealed class FullPathTests
         var rootPath = FullPath.FromPath(root);
         var childPath = FullPath.FromPath(path);
         Assert.False(childPath.IsChildOf(rootPath));
+    }
+
+    [Fact]
+    public void IsChildOf_RootDirectory()
+    {
+        var rootPath = GetRootDirectory();
+
+        Assert.True((rootPath / "a").IsChildOf(rootPath));
+        Assert.True((rootPath / "a" / "b.txt").IsChildOf(rootPath));
+        Assert.False(rootPath.IsChildOf(rootPath));
+    }
+
+    [Fact]
+    public void IsChildOf_UsesTheSameCaseSensitivityAsTheDefaultComparer()
+    {
+        var rootPath = FullPath.FromPath("test");
+        var childPath = FullPath.FromPath("TEST") / "a.txt";
+
+        Assert.Equal(childPath.Parent == rootPath, childPath.IsChildOf(rootPath));
     }
 
     [Theory]
@@ -613,6 +644,11 @@ public sealed class FullPathTests
         var extended = path.ToWindowsExtendedPath();
         Assert.StartsWith(@"\\?\", extended);
         Assert.Contains(longSegment, extended);
+    }
+
+    private static FullPath GetRootDirectory()
+    {
+        return FullPath.FromPath(Path.GetPathRoot(FullPath.CurrentDirectory().Value)!);
     }
 
     private static void CreateSymlink(FullPath source, string target, bool isDirectory)


### PR DESCRIPTION
## `IsChildOf`

Two defects, both reproduced on macOS:

**Children of a root directory were never detected.** `FromPath` keeps the trailing separator of a root (`/` or `C:\`) because `Path.TrimEndingDirectorySeparator` deliberately does not trim roots. The check for a separator at `rootPath.Length` therefore read the first character of the child name:

```
/a    IsChildOf /  => False   (expected True)
/a/b  IsChildOf /  => False   (expected True)
```

**The prefix comparison was ordinal**, while `==`, `Equals` and `Parent` all go through `FullPathComparer.Default`, which is case-insensitive on Windows and macOS. That made the type contradict itself:

```
/tmp/abc/d.txt IsChildOf /tmp/Abc  => False
(/tmp/abc/d.txt).Parent == /tmp/Abc => True
```

It also made `IsChildOf` unusable as a containment check on Windows, since a differently-cased path escapes it.

## `MakePathRelativeTo`

Two non-canonical results:

| path | root | before | after / `Path.GetRelativePath` |
|---|---|---|---|
| `/a` | `/` | `../a` | `a` |
| `/a` | `/a/b` | `../../a` | `..` |

Both resolved to the right location, but neither is the answer a caller expects. The hand-rolled `PathDifference` predates `Path.GetRelativePath` (.NET Core 2.0), which handles both cases and applies the per-OS case sensitivity, so this delegates to it and drops `PathDifference`.

## Tests

Added `IsChildOf_RootDirectory`, `IsChildOf_UsesTheSameCaseSensitivityAsTheDefaultComparer`, `MakeRelativeTo_RootDirectory`, and three `MakeRelativeTo` cases covering ancestors and siblings. The existing `MakeRelativeTo` theory now normalizes the expected separator so the new cases run on Windows too.

Verified locally on macOS (net10.0 + net11.0): 154 passed, 0 failed, 40 skipped (Windows-only).