### PR TITLE
Fix symbolic link resolution defects in FullPath

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -549,6 +549,14 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         return FromPath(fsi.FullName);
     }
 
+    // Matches the number of levels the operating systems themselves are willing to follow (MAXSYMLINKS on Linux)
+    private const int MaxSymbolicLinkDepth = 40;
+
+    private static IOException CreateTooManyLevelsOfSymbolicLinksException()
+    {
+        return new IOException($"Too many levels of symbolic links (more than {MaxSymbolicLinkDepth.ToString(CultureInfo.InvariantCulture)})");
+    }
+
     /// <summary>Determines whether this path represents a symbolic link.</summary>
     public bool IsSymbolicLink()
     {
@@ -649,6 +657,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
     /// <param name="resolutionMode">The mode to use when resolving symbolic links.</param>
     /// <param name="result">The target path if this is a symbolic link; otherwise, <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if this is a symbolic link; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="IOException">A symbolic link chain is too deep to resolve, which usually means the links form a cycle.</exception>
     public bool TryGetSymbolicLinkTarget(SymbolicLinkResolutionMode resolutionMode, [NotNullWhen(true)] out FullPath? result)
     {
         if (!IsEmpty)
@@ -666,8 +675,12 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
 
                 case SymbolicLinkResolutionMode.FinalTarget:
                     var value = _value;
+                    var depth = 0;
                     while (Symlink.TryGetSymLinkTarget(value, out path))
                     {
+                        if (++depth > MaxSymbolicLinkDepth)
+                            throw CreateTooManyLevelsOfSymbolicLinksException();
+
                         value = path;
                     }
 
@@ -683,16 +696,20 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
                     string? resultPath = null;
                     var current = this;
                     var hasSymLink = false;
+                    var componentDepth = 0;
                     while (!current.IsEmpty)
                     {
                         if (Symlink.TryGetSymLinkTarget(current._value, out path))
                         {
+                            if (++componentDepth > MaxSymbolicLinkDepth)
+                                throw CreateTooManyLevelsOfSymbolicLinksException();
+
                             current = FromPath(path);
                             hasSymLink = true;
                         }
                         else
                         {
-                            var name = current.Name is "" ? current._value : current.Name!;
+                            var name = current.Name is "" ? current._value : current.Name;
                             if (resultPath is null)
                             {
                                 resultPath = name;
@@ -703,6 +720,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
                             }
 
                             current = current.Parent;
+                            componentDepth = 0;
                         }
                     }
 

--- a/src/Meziantou.Framework.FullPath/Interop/Windows.cs
+++ b/src/Meziantou.Framework.FullPath/Interop/Windows.cs
@@ -84,6 +84,7 @@ namespace Meziantou.Framework
 
             internal const uint FSCTL_GET_REPARSE_POINT = 0x000900a8;
             internal const uint SYMLINK_FLAG_RELATIVE = 1;
+            internal const uint IO_REPARSE_TAG_SYMLINK = 0xA000000C;
 
             [StructLayout(LayoutKind.Sequential)]
             internal struct REPARSE_DATA_BUFFER_SYMLINK

--- a/src/Meziantou.Framework.FullPath/Symlink.cs
+++ b/src/Meziantou.Framework.FullPath/Symlink.cs
@@ -125,8 +125,10 @@ internal static partial class Symlink
             using var handle = Interop.Kernel32.FindFirstFile(path, ref findData);
             if (!handle.IsInvalid)
             {
+                // dwReserved0 holds the reparse tag, so it must be compared for equality.
+                // A bitwise test would also match other reparse points such as junctions (IO_REPARSE_TAG_MOUNT_POINT).
                 return ((FileAttributes)findData.dwFileAttributes).HasFlag(FileAttributes.ReparsePoint) &&
-                    (findData.dwReserved0 & 0xA000000C) != 0;  // IO_REPARSE_TAG_SYMLINK
+                    findData.dwReserved0 == Interop.Kernel32.IO_REPARSE_TAG_SYMLINK;
             }
 
             return false;
@@ -144,8 +146,6 @@ internal static partial class Symlink
                                                                                // https://docs.microsoft.com/en-us/windows-hardware/drivers/ifs/fsctl-get-reparse-point
 
             var sizeHeader = Marshal.SizeOf<Interop.Kernel32.REPARSE_DATA_BUFFER_SYMLINK>();
-            uint bytesRead = 0;
-            ReadOnlySpan<byte> validBuffer;
             var bufferSize = sizeHeader + Interop.Kernel32.MAX_PATH;
 
             while (true)
@@ -153,7 +153,7 @@ internal static partial class Symlink
                 var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
                 try
                 {
-                    var result = Interop.Kernel32.DeviceIoControl(handle, Interop.Kernel32.FSCTL_GET_REPARSE_POINT, inBuffer: null, cbInBuffer: 0, buffer, (uint)buffer.Length, out bytesRead, overlapped: IntPtr.Zero) ?
+                    var result = Interop.Kernel32.DeviceIoControl(handle, Interop.Kernel32.FSCTL_GET_REPARSE_POINT, inBuffer: null, cbInBuffer: 0, buffer, (uint)buffer.Length, out var bytesRead, overlapped: IntPtr.Zero) ?
                         0 : Marshal.GetLastWin32Error();
 
                     if (result is not Interop.Errors.ERROR_SUCCESS and not Interop.Errors.ERROR_INSUFFICIENT_BUFFER and not Interop.Errors.ERROR_MORE_DATA)
@@ -161,7 +161,7 @@ internal static partial class Symlink
                         throw new Win32Exception(result);
                     }
 
-                    validBuffer = buffer.AsSpan()[..(int)bytesRead];
+                    ReadOnlySpan<byte> validBuffer = buffer.AsSpan()[..(int)bytesRead];
 
                     if (!MemoryMarshal.TryRead<Interop.Kernel32.REPARSE_DATA_BUFFER_SYMLINK>(validBuffer, out var header))
                     {
@@ -172,7 +172,7 @@ internal static partial class Symlink
                         }
 
                         // can't read header, guess at buffer length
-                        buffer = new byte[buffer.Length + Interop.Kernel32.MAX_PATH];
+                        bufferSize = checked(buffer.Length + Interop.Kernel32.MAX_PATH);
                         continue;
                     }
 

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -297,6 +297,23 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public async Task ResolveSymlink_Cycle()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var a = temp.GetFullPath("a");
+        var b = temp.GetFullPath("b");
+        CreateSymlink(a, "b", isDirectory: false);
+        CreateSymlink(b, "a", isDirectory: false);
+
+        Assert.True(a.IsSymbolicLink());
+        Assert.True(a.TryGetSymbolicLinkTarget(SymbolicLinkResolutionMode.Immediate, out var immediate));
+        Assert.Equal(b, immediate);
+
+        Assert.Throws<IOException>(() => { a.TryGetSymbolicLinkTarget(SymbolicLinkResolutionMode.FinalTarget, out _); });
+        Assert.Throws<IOException>(() => { a.TryGetSymbolicLinkTarget(SymbolicLinkResolutionMode.AllSymbolicLinks, out _); });
+    }
+
+    [Fact]
     public async Task ResolveSymlink_ResolveAllSymbolicLinks()
     {
         await using var temp = TemporaryDirectory.Create();


### PR DESCRIPTION
Three unrelated defects in the symbolic link code.

## 1. A symbolic link cycle hangs forever

`TryGetSymbolicLinkTarget` follows links in an unbounded loop in both `FinalTarget` and `AllSymbolicLinks` modes. With `a -> b` and `b -> a` the call never returns — reproduced on macOS by running it on a background thread and observing that a 3s join times out.

Both loops now stop after 40 levels (`MAXSYMLINKS` on Linux) and throw `IOException`, which is what `FileSystemInfo.ResolveLinkTarget(returnFinalTarget: true)` does for the same condition. `AllSymbolicLinks` counts consecutive hops per path component and resets when it moves to the parent, so a path made of many symlinked directories is not affected.

Returning `false` was the alternative, but `false` already means "this is not a symbolic link", and a cycle is a genuine filesystem error rather than an absence of a link.

## 2. Junctions were reported as symbolic links (Windows)

```csharp
(findData.dwReserved0 & 0xA000000C) != 0  // IO_REPARSE_TAG_SYMLINK
```

`dwReserved0` holds the reparse *tag*, so it needs an equality comparison. A bitwise test also matches `IO_REPARSE_TAG_MOUNT_POINT` (`0xA0000003` → `0xA0000000`), dedup stubs, cloud-storage placeholders and AppExecLinks. The .NET runtime compares the tag for equality; this now does the same.

## 3. Unrecoverable retry path in `GetSingleSymbolicLinkTarget` (Windows)

When the reparse buffer was too small to even hold the header, the retry path did:

```csharp
buffer = new byte[buffer.Length + Interop.Kernel32.MAX_PATH];
continue;
```

`bufferSize` was never updated, so the next iteration rented the *same* size again and the loop could not make progress. The `finally` also returned the freshly allocated array to `ArrayPool` while leaking the rented one. It now grows `bufferSize` and leaves `buffer` alone.

## Tests

Added `ResolveSymlink_Cycle`, which builds `a -> b -> a` and asserts `Immediate` still resolves one hop while `FinalTarget` and `AllSymbolicLinks` throw. On main this test hangs the run.

Verified locally on macOS (net10.0 + net11.0): 144 passed, 0 failed, 40 skipped (Windows-only). Items 2 and 3 are Windows-only and are covered by the existing symlink tests there, but I could not execute them on this machine.