### PR TITLE
Fix extended path handling in FullPath

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -45,7 +45,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
 
     /// <summary>Gets the string representation of the path, or an empty string if the path is empty.</summary>
     /// <remarks>
-    /// <para>If the path contains a reserved device name (CON, PRN, AUX, NUL, COM1-COM9, LPT1-LPT9),
+    /// <para>If the path contains a reserved device name (CON, PRN, AUX, NUL, COM0-COM9, COM¹-COM³, LPT0-LPT9, LPT¹-LPT³),
     /// the extended path format (<c>\\?\</c>) is returned to bypass Win32 namespace restrictions.</para>
     /// <para>Use <see cref="RawValue"/> if you need the unmodified path without device name protection.</para>
     /// </remarks>
@@ -120,6 +120,9 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
                 !nameOnly[..3].Equals("LPT", StringComparison.OrdinalIgnoreCase))
                 return false;
 
+            // Windows documents COM1-COM9 and LPT1-LPT9, but COM0 and LPT0 are accepted here as well.
+            // Adding the extended prefix to a path that turns out not to be a device name is harmless,
+            // whereas omitting it for an actual device name is not.
             var lastChar = nameOnly[3];
             return lastChar is >= '0' and <= '9' or '\u00B9' or '\u00B2' or '\u00B3';
         }
@@ -292,7 +295,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         if (IsEmpty)
             return Empty;
 
-        return new FullPath(Path.ChangeExtension(Value, extension));
+        return new FullPath(Path.ChangeExtension(_value, extension));
     }
 
     /// <summary>Returns a new path with the specified file extension, optionally replacing all trailing extensions.</summary>
@@ -319,7 +322,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         if (IsEmpty)
             return Empty;
 
-        var current = Value;
+        var current = _value;
         var extensionsRemoved = 0;
         while (true)
         {
@@ -352,7 +355,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         if (IsEmpty)
             return Empty;
 
-        var parent = Path.GetDirectoryName(Value);
+        var parent = Path.GetDirectoryName(_value);
         if (parent is null)
             return new FullPath(name);
 
@@ -368,8 +371,8 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         if (IsEmpty)
             return Empty;
 
-        var parent = Path.GetDirectoryName(Value);
-        var extension = Path.GetExtension(Value);
+        var parent = Path.GetDirectoryName(_value);
+        var extension = Path.GetExtension(_value);
         var newName = nameWithoutExtension + extension;
         if (parent is null)
             return new FullPath(newName);
@@ -462,9 +465,10 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
     /// <param name="path">The path to convert. Can be relative or absolute.</param>
     public static FullPath FromPath(string path)
     {
-        if (PathInternal.IsExtended(path))
+        // '\' is a regular file name character on Unix, so a path such as @"\\?\a" is a relative file name there, not a device path
+        if (OperatingSystem.IsWindows() && PathInternal.IsExtended(path))
         {
-            path = path[4..];
+            path = path[PathInternal.DevicePrefixLength..];
         }
 
         var fullPath = Path.GetFullPath(path);

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -168,6 +168,24 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    [RunIf(TestOperatingSystems.Windows)]
+    public void FromPath_ExtendedPrefixIsRemovedOnWindows()
+    {
+        Assert.Equal(@"C:\temp\a.txt", FullPath.FromPath(@"\\?\C:\temp\a.txt").RawValue);
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Linux | TestOperatingSystems.MacOS)]
+    public void FromPath_ExtendedPrefixIsAFileNameOnUnix()
+    {
+        // '\' is a regular file name character on Unix, so this is a relative file name, not a device path
+        var expected = FullPath.CurrentDirectory() / @"\\?\a";
+
+        Assert.Equal(expected, FullPath.FromPath(@"\\?\a"));
+        Assert.Equal(@"\\?\a", FullPath.FromPath(@"\\?\a").Name);
+    }
+
+    [Fact]
     public void JsonSerialize_RoundTripEmpty()
     {
         var value = FullPath.Empty;

--- a/tests/Meziantou.Framework.FullPath.Tests/ReservedDeviceNameTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/ReservedDeviceNameTests.cs
@@ -37,4 +37,56 @@ public sealed class ReservedDeviceNameTests
 
         Assert.DoesNotStartWith(@"\\?\", value);
     }
+
+    [Theory]
+    [RunIf(TestOperatingSystems.Windows)]
+    [InlineData(@"C:\temp\CON")]
+    [InlineData(@"C:\temp\PRN.log")]
+    [InlineData(@"C:\folder\CON\file.txt")]
+    public void RawValue_ContainsReservedName_HasNoExtendedPrefix(string pathStr)
+    {
+        var path = FullPath.FromPath(pathStr);
+
+        Assert.Equal(pathStr, path.RawValue);
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Windows)]
+    public void WithExtension_ReservedName_DoesNotLeakTheExtendedPrefix()
+    {
+        var path = FullPath.FromPath(@"C:\temp\CON").WithExtension(".txt");
+
+        Assert.Equal(@"C:\temp\CON.txt", path.RawValue);
+        Assert.Equal(FullPath.FromPath(@"C:\temp\CON.txt"), path);
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Windows)]
+    public void WithExtension_MultipleExtensions_ReservedName_DoesNotLeakTheExtendedPrefix()
+    {
+        var path = FullPath.FromPath(@"C:\temp\CON.tar.gz").WithExtension(".zip", replaceAllTrailingExtensions: true);
+
+        Assert.Equal(@"C:\temp\CON.zip", path.RawValue);
+        Assert.Equal(FullPath.FromPath(@"C:\temp\CON.zip"), path);
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Windows)]
+    public void WithName_ReservedName_DoesNotLeakTheExtendedPrefix()
+    {
+        var path = FullPath.FromPath(@"C:\temp\CON\a.txt").WithName("b.txt");
+
+        Assert.Equal(@"C:\temp\CON\b.txt", path.RawValue);
+        Assert.Equal(FullPath.FromPath(@"C:\temp\CON\b.txt"), path);
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Windows)]
+    public void WithNameWithoutExtension_ReservedName_DoesNotLeakTheExtendedPrefix()
+    {
+        var path = FullPath.FromPath(@"C:\temp\CON\a.txt").WithNameWithoutExtension("b");
+
+        Assert.Equal(@"C:\temp\CON\b.txt", path.RawValue);
+        Assert.Equal(FullPath.FromPath(@"C:\temp\CON\b.txt"), path);
+    }
 }


### PR DESCRIPTION
## `FromPath` stripped `\\?\` on every platform

`PathInternal.IsExtended` is a pure string test with no OS guard, but `\` is a regular file name character on Unix. Reproduced on macOS:

```
FullPath.FromPath(@"\\?\x").RawValue  =>  <cwd>/x
```

The file actually named `\\?\x` is unreachable through `FullPath`. The prefix is now only removed on Windows, matching the guard the `Value` property already uses.

## `With*` leaked the extended prefix into `_value`

`WithExtension`, `WithName` and `WithNameWithoutExtension` read `Value` — which injects `\\?\` for reserved device names — and passed the result straight to the private constructor instead of going through `FromPath`, which is what strips the prefix. On Windows:

```csharp
FullPath.FromPath(@"C:\dir\CON").WithExtension(".txt")  // _value = @"\\?\C:\dir\CON.txt"
FullPath.FromPath(@"C:\dir\CON.txt")                    // _value = @"C:\dir\CON.txt"
```

Those two compare as **not equal** and expose different `RawValue`, even though they name the same file. It also breaks the invariant the private constructor asserts. They now read `_value`.

`CreateParentDirectory` and `operator +` keep using `Value`: the first passes the string to `Directory.CreateDirectory`, where the prefix is the point, and the second round-trips through `FromPath`, which strips it again.

## COM0 / LPT0

Windows documents `COM1`-`COM9` and `LPT1`-`LPT9`, but the code also treats `COM0`/`LPT0` as reserved, which contradicted the XML docs. I kept the code and corrected the docs instead: adding `\\?\` to a name that turns out not to be a device is harmless, while omitting it for one that is is not, so the over-approximation is the safe direction.

## Tests

- `FromPath_ExtendedPrefixIsAFileNameOnUnix` / `FromPath_ExtendedPrefixIsRemovedOnWindows`
- `RawValue_ContainsReservedName_HasNoExtendedPrefix` and four `With*` round-trip tests in `ReservedDeviceNameTests`

Verified locally on macOS (net10.0 + net11.0): 144 passed, 0 failed. The 8 new reserved-device-name tests are Windows-only and are skipped here — they run on the `windows-2025-vs2026` leg of CI, so the `With*` fix is not verified on this machine.