### PR TITLE
Implement non-generic IComparable on FullPath

### DIFF
--- a/ref/Meziantou.Framework.FullPath.cs
+++ b/ref/Meziantou.Framework.FullPath.cs
@@ -5,7 +5,7 @@
 namespace Meziantou.Framework
 {
     [System.Text.Json.Serialization.JsonConverter(typeof(Meziantou.Framework.FullPathJsonConverter))]
-    public readonly struct FullPath : System.IComparable<Meziantou.Framework.FullPath>, System.IEquatable<Meziantou.Framework.FullPath>
+    public readonly struct FullPath : System.IComparable, System.IComparable<Meziantou.Framework.FullPath>, System.IEquatable<Meziantou.Framework.FullPath>
     {
         public static Meziantou.Framework.FullPath Empty { get => throw null; }
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, "_value")]
@@ -27,6 +27,7 @@ namespace Meziantou.Framework
         public static Meziantou.Framework.FullPath operator +(Meziantou.Framework.FullPath rootPath, string suffix) => throw null;
         public int CompareTo(Meziantou.Framework.FullPath other) => throw null;
         public int CompareTo(Meziantou.Framework.FullPath other, bool ignoreCase) => throw null;
+        int System.IComparable.CompareTo(object? obj) => throw null;
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) => throw null;
         public bool Equals(Meziantou.Framework.FullPath other) => throw null;
         public bool Equals(Meziantou.Framework.FullPath other, bool ignoreCase) => throw null;

--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -22,7 +22,7 @@ namespace Meziantou.Framework;
 /// </code>
 /// </example>
 [JsonConverter(typeof(FullPathJsonConverter))]
-public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<FullPath>
+public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<FullPath>, IComparable
 {
     internal readonly string? _value;
 
@@ -170,6 +170,17 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
 
     /// <summary>Compares this path to another with optional case-insensitive comparison.</summary>
     public int CompareTo(FullPath other, bool ignoreCase) => FullPathComparer.GetComparer(ignoreCase).Compare(this, other);
+
+    int IComparable.CompareTo(object? obj)
+    {
+        if (obj is null)
+            return 1;
+
+        if (obj is FullPath other)
+            return CompareTo(other);
+
+        throw new ArgumentException($"Object must be of type {nameof(FullPath)}", nameof(obj));
+    }
 
     public override bool Equals([NotNullWhen(true)] object? obj) => obj is FullPath path && Equals(path);
     public bool Equals(FullPath other) => FullPathComparer.Default.Equals(this, other);

--- a/src/Meziantou.Framework.FullPath/FullPathJsonConverter.cs
+++ b/src/Meziantou.Framework.FullPath/FullPathJsonConverter.cs
@@ -17,6 +17,6 @@ public sealed class FullPathJsonConverter : JsonConverter<FullPath>
 
     public override void Write(Utf8JsonWriter writer, FullPath value, JsonSerializerOptions options)
     {
-        writer.WriteStringValue(value);
+        writer.WriteStringValue(value.Value);
     }
 }

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -214,6 +214,17 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public void IComparable_CompareTo()
+    {
+        IComparable path = FullPath.FromPath("test") / "a";
+
+        Assert.Equal(0, path.CompareTo(FullPath.FromPath("test") / "a"));
+        Assert.True(path.CompareTo(FullPath.FromPath("test") / "b") < 0);
+        Assert.True(path.CompareTo(null) > 0);
+        Assert.Throws<ArgumentException>(() => path.CompareTo("test"));
+    }
+
+    [Fact]
     public async Task ResolveSymlink_FileAbsolutePath()
     {
         await using var temp = TemporaryDirectory.Create();


### PR DESCRIPTION
## Non-generic `IComparable`

`FullPath` implements `IComparable<FullPath>` but not the non-generic `IComparable`. Non-generic collections and `Array.Sort(object[])` fall back to the non-generic interface, so they throw rather than sort:

```csharp
object[] paths = [FullPath.FromPath("b"), FullPath.FromPath("a")];
Array.Sort(paths); // InvalidOperationException: Failed to compare two elements in the array
```

The implementation is explicit and delegates to `CompareTo(FullPath)`. `null` sorts first and a non-`FullPath` argument throws `ArgumentException`, which is the convention the BCL value types follow.

`ref/Meziantou.Framework.FullPath.cs` is regenerated. The package version is left at `3.0.1`.

## `FullPathJsonConverter.Write`

Passes `value.Value` instead of relying on the implicit `FullPath`-to-`string` conversion. Identical output — the conversion calls `ToString()`, which returns `Value` — just without the indirection. Covered by the existing `JsonSerialize_*` tests.

## Tests

`IComparable_CompareTo` covers equal, greater, `null`, and wrong-type arguments.

Verified locally on macOS (net10.0 + net11.0): 144 passed, 0 failed, 40 skipped (Windows-only).

---

*Revised from the original version of this PR, which also added `IParsable`/`ISpanParsable`, `ISpanFormattable`/`IUtf8SpanFormattable`, and JSON dictionary-key support. Those were dropped at the author's request.*