### PR TITLE
Fix readme drift and remove dead code in Meziantou.Framework.FullPath

### DIFF
--- a/src/Meziantou.Framework.FullPath/CanonicalPath.cs
+++ b/src/Meziantou.Framework.FullPath/CanonicalPath.cs
@@ -74,8 +74,7 @@ internal static partial class CanonicalPath
     {
         public static bool TryGetCanonicalPath(string path, [NotNullWhen(true)] out string? canonicalPath)
         {
-            var utf8Path = Encoding.UTF8.GetBytes(path + '\0');
-            var pointer = Interop.RealPath(utf8Path, IntPtr.Zero);
+            var pointer = Interop.RealPath(path, IntPtr.Zero);
             if (pointer == IntPtr.Zero)
             {
                 canonicalPath = null;
@@ -95,23 +94,13 @@ internal static partial class CanonicalPath
 
         private static partial class Interop
         {
-            [LibraryImport("libc", EntryPoint = "realpath", SetLastError = true)]
+            [LibraryImport("libc", EntryPoint = "realpath", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-            private static partial IntPtr RealPathCore(byte[] path, IntPtr resolvedPath);
+            internal static partial IntPtr RealPath(string path, IntPtr resolvedPath);
 
             [LibraryImport("libc", EntryPoint = "free", SetLastError = false)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-            private static partial void FreeCore(IntPtr pointer);
-
-            internal static IntPtr RealPath(byte[] path, IntPtr resolvedPath)
-            {
-                return RealPathCore(path, resolvedPath);
-            }
-
-            internal static void Free(IntPtr pointer)
-            {
-                FreeCore(pointer);
-            }
+            internal static partial void Free(IntPtr pointer);
         }
     }
 }

--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -468,16 +468,11 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         }
 
         var fullPath = Path.GetFullPath(path);
-        var fullPathWithoutTrailingDirectorySeparator = TrimEndingDirectorySeparator(fullPath);
+        var fullPathWithoutTrailingDirectorySeparator = Path.TrimEndingDirectorySeparator(fullPath);
         if (string.IsNullOrEmpty(fullPathWithoutTrailingDirectorySeparator))
             return Empty;
 
         return new FullPath(fullPathWithoutTrailingDirectorySeparator);
-    }
-
-    private static string TrimEndingDirectorySeparator(string path)
-    {
-        return Path.TrimEndingDirectorySeparator(path);
     }
 
     /// <summary>Combines two path strings into a full path.</summary>

--- a/src/Meziantou.Framework.FullPath/Interop/Windows.cs
+++ b/src/Meziantou.Framework.FullPath/Interop/Windows.cs
@@ -51,23 +51,12 @@ namespace Meziantou.Framework
                     dwLowDateTime = (uint)fileTime;
                     dwHighDateTime = (uint)(fileTime >> 32);
                 }
-
-                internal readonly long ToTicks() => ((long)dwHighDateTime << 32) + dwLowDateTime;
-                internal readonly DateTime ToDateTimeUtc() => DateTime.FromFileTimeUtc(ToTicks());
-                internal readonly DateTimeOffset ToDateTimeOffset() => DateTimeOffset.FromFileTime(ToTicks());
             }
 
             internal static partial class FileOperations
             {
-                internal const int OPEN_EXISTING = 3;
-                internal const int COPY_FILE_FAIL_IF_EXISTS = 0x00000001;
-
                 internal const int FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
                 internal const int FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000;
-                internal const int FILE_FLAG_FIRST_PIPE_INSTANCE = 0x00080000;
-                internal const int FILE_FLAG_OVERLAPPED = 0x40000000;
-
-                internal const int FILE_LIST_DIRECTORY = 0x0001;
             }
 
             [SupportedOSPlatform("windows5.1.2600")]

--- a/src/Meziantou.Framework.FullPath/KnownFolder.cs
+++ b/src/Meziantou.Framework.FullPath/KnownFolder.cs
@@ -19,6 +19,7 @@ public sealed class KnownFolder
         FolderId = knownFolderId;
         DefaultPath = defaultPath;
     }
+
     /// <summary>Gets the display name of the known folder.</summary>
     public string Name { get; }
 

--- a/src/Meziantou.Framework.FullPath/Symlink.cs
+++ b/src/Meziantou.Framework.FullPath/Symlink.cs
@@ -92,15 +92,9 @@ internal static partial class Symlink
 
         private static partial class Interop
         {
-            internal static nint ReadLink(string path, byte[] buffer, nuint bufferSize)
-            {
-                var utf8Path = Encoding.UTF8.GetBytes(path + '\0');
-                return ReadLinkCore(utf8Path, buffer, bufferSize);
-            }
-
-            [LibraryImport("libc", EntryPoint = "readlink", SetLastError = true)]
+            [LibraryImport("libc", EntryPoint = "readlink", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-            private static partial nint ReadLinkCore(byte[] path, byte[] buffer, nuint bufferSize);
+            internal static partial nint ReadLink(string path, byte[] buffer, nuint bufferSize);
         }
     }
 

--- a/src/Meziantou.Framework.FullPath/readme.md
+++ b/src/Meziantou.Framework.FullPath/readme.md
@@ -7,7 +7,7 @@
 FullPath rootPath = FullPath.FromPath("demo"); // It automatically calls Path.GetFullPath to resolve the path
 FullPath filePath = FullPath.Combine(rootPath, "temp", "meziantou.txt"); // Use Path.Combine to join paths (you can combine as many path as you needed)
 FullPath temp = FullPath.GetTempPath(); // equivalent of Path.GetTempPath()
-FullPath cwd = FullPath.GetCurrentDirectory(); // equivalent of Environment.CurrentDirectory
+FullPath cwd = FullPath.CurrentDirectory(); // equivalent of Environment.CurrentDirectory
 
 // Combine path: you can use the / operator to join path
 FullPath filePath1 = rootPath / "temp" / "meziantou.txt";
@@ -32,7 +32,7 @@ FullPath pathWithNewName = filePath.WithName("other.txt");
 FullPath pathWithNewNameWithoutExtension = filePath.WithNameWithoutExtension("other");
 
 // Make relative path
-string relativePath = filePath.MakeRelativeTo(rootPath); // temp\meziantou.txt
+string relativePath = filePath.MakePathRelativeTo(rootPath); // temp\meziantou.txt
 
 // Check if a path is under another path
 bool isChildOf = filePath.IsChildOf(rootPath);

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -282,6 +282,24 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public async Task ResolveSymlink_NonAsciiPath()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var path = temp.CreateEmptyFile("日本語.txt");
+
+        var symlink = temp.GetFullPath("リンク.txt");
+        CreateSymlink(symlink, "日本語.txt", isDirectory: false);
+
+        Assert.True(symlink.IsSymbolicLink());
+        Assert.True(symlink.TryGetSymbolicLinkTarget(out var target));
+        Assert.Equal(path, target);
+
+        Assert.True(path.TryGetCanonicalPath(out var expected));
+        Assert.True(symlink.TryGetCanonicalPath(out var actual));
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
     public async Task ResolveSymlink_Recursive()
     {
         await using var temp = TemporaryDirectory.Create();


### PR DESCRIPTION
## The readme sample did not compile

Two members had been renamed without the readme following:

| readme | actual |
|---|---|
| `FullPath.GetCurrentDirectory()` | `FullPath.CurrentDirectory()` |
| `filePath.MakeRelativeTo(rootPath)` | `filePath.MakePathRelativeTo(rootPath)` |

I pasted the corrected sample into a scratch project and ran it, so the whole block compiles and executes now.

## Dead interop declarations

Each of these appeared exactly once — at its own declaration:

- `OPEN_EXISTING`, `COPY_FILE_FAIL_IF_EXISTS`, `FILE_FLAG_FIRST_PIPE_INSTANCE`, `FILE_FLAG_OVERLAPPED`, `FILE_LIST_DIRECTORY`
- `FILE_TIME.ToTicks()`, `ToDateTimeUtc()`, `ToDateTimeOffset()` (the struct itself stays — `WIN32_FIND_DATA` needs it for layout)

## Declarative UTF-8 marshalling for `readlink` / `realpath`

Both built a null-terminated buffer by hand:

```csharp
var utf8Path = Encoding.UTF8.GetBytes(path + '\0');
```

which allocates a throwaway string *and* a byte array on every call. `StringMarshalling = StringMarshalling.Utf8` does the same job in the attribute, and the generated marshaller stack-allocates for short paths. That also made three pure pass-through wrappers redundant, so the P/Invokes are now declared directly.

This is the one change here that touches behavior, so it is covered by a new test: `ResolveSymlink_NonAsciiPath` creates a symlink with Japanese characters in both the link and target names and resolves it through `readlink` (`TryGetSymbolicLinkTarget`) and `realpath` (`TryGetCanonicalPath`). Kanji were chosen over accented Latin deliberately — they have no Unicode decomposition, so the assertion is not affected by macOS filesystem normalization.

## Small tidies

- Inlined the `TrimEndingDirectorySeparator` wrapper, which only forwarded to `Path.TrimEndingDirectorySeparator`
- Added the missing blank line before an XML doc comment in `KnownFolder` (the only violation of that AGENTS.md rule in the project)

## Not done

- **Caching the reserved-device-name scan.** `ToString()`/`Value` walks the whole path on every call on Windows, and that is the hot path for the implicit `string` conversion. Caching needs a second field, which grows the struct from 8 to 16 bytes — a real cost for a type that is passed around constantly. Storing the prefixed form as the single field instead does not work: `IsChildOf` and `MakePathRelativeTo` compare a prefixed child against a non-prefixed root. Your call whether the trade is worth it.
- **Replacing the hand-rolled `WIN32_FIND_DATA`** with the `WIN32_FIND_DATAW` CsWin32 already generates from `FindFirstFileExW`. It is a layout-sensitive change on the symlink detection path, and I cannot run the Windows tests on this machine.
- **`ArrayPool` in `CanonicalPath`/`GetFinalPathNameByHandle`.** I flagged the `char[]` allocation in my analysis, but it sits next to a `CreateFile` + `GetFinalPathNameByHandle` syscall pair — the allocation is noise, and pooling would add `try`/`finally` to code that is currently obviously correct.

Verified locally on macOS (net10.0 + net11.0): 144 passed, 0 failed, 40 skipped (Windows-only).