### PR TITLE
Add 8 languages to RelativeDate

### DIFF
--- a/src/Meziantou.Framework.RelativeDate/ILocalizationProvider.cs
+++ b/src/Meziantou.Framework.RelativeDate/ILocalizationProvider.cs
@@ -3,7 +3,7 @@ namespace Meziantou.Framework;
 /// <summary>Provides an interface for retrieving localized strings for relative date formatting.</summary>
 /// <remarks>
 /// Implement this interface to provide custom localization for <see cref="RelativeDate"/>.
-/// The default implementation uses embedded resource files for English and French translations.
+/// The default implementation uses embedded resource files for Dutch, English, French, German, Italian, Japanese, Korean, Portuguese, Simplified Chinese, Spanish and Turkish translations.
 /// </remarks>
 public interface ILocalizationProvider
 {

--- a/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
@@ -25,7 +25,7 @@ namespace Meziantou.Framework;
 /// </code>
 /// </example>
 /// <remarks>
-/// This type provides localized relative date/time strings for multiple languages including English and French.
+/// This type provides localized relative date/time strings for multiple languages: Dutch, English, French, German, Italian, Japanese, Korean, Portuguese, Simplified Chinese, Spanish and Turkish.
 /// The default localization can be customized by setting <see cref="LocalizationProvider.Current"/>.
 /// </remarks>
 [StructLayout(LayoutKind.Auto)]

--- a/src/Meziantou.Framework.RelativeDate/RelativeDates.de.resx
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDates.de.resx
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AMinuteAgo" xml:space="preserve">
+    <value>vor einer Minute</value>
+  </data>
+  <data name="AnHourAgo" xml:space="preserve">
+    <value>vor einer Stunde</value>
+  </data>
+  <data name="InAMinute" xml:space="preserve">
+    <value>in einer Minute</value>
+  </data>
+  <data name="InAnHour" xml:space="preserve">
+    <value>in einer Stunde</value>
+  </data>
+  <data name="InManyDays" xml:space="preserve">
+    <value>in {0} Tagen</value>
+  </data>
+  <data name="InManyHours" xml:space="preserve">
+    <value>in {0} Stunden</value>
+  </data>
+  <data name="InManyMinutes" xml:space="preserve">
+    <value>in {0} Minuten</value>
+  </data>
+  <data name="InManyMonths" xml:space="preserve">
+    <value>in {0} Monaten</value>
+  </data>
+  <data name="InManySeconds" xml:space="preserve">
+    <value>in {0} Sekunden</value>
+  </data>
+  <data name="InManyYears" xml:space="preserve">
+    <value>in {0} Jahren</value>
+  </data>
+  <data name="InOneMonth" xml:space="preserve">
+    <value>in einem Monat</value>
+  </data>
+  <data name="InOneSecond" xml:space="preserve">
+    <value>in einer Sekunde</value>
+  </data>
+  <data name="InOneYear" xml:space="preserve">
+    <value>in einem Jahr</value>
+  </data>
+  <data name="ManyDaysAgo" xml:space="preserve">
+    <value>vor {0} Tagen</value>
+  </data>
+  <data name="ManyHoursAgo" xml:space="preserve">
+    <value>vor {0} Stunden</value>
+  </data>
+  <data name="ManyMinutesAgo" xml:space="preserve">
+    <value>vor {0} Minuten</value>
+  </data>
+  <data name="ManyMonthsAgo" xml:space="preserve">
+    <value>vor {0} Monaten</value>
+  </data>
+  <data name="ManySecondsAgo" xml:space="preserve">
+    <value>vor {0} Sekunden</value>
+  </data>
+  <data name="ManyYearsAgo" xml:space="preserve">
+    <value>vor {0} Jahren</value>
+  </data>
+  <data name="Now" xml:space="preserve">
+    <value>jetzt</value>
+  </data>
+  <data name="OneMonthAgo" xml:space="preserve">
+    <value>vor einem Monat</value>
+  </data>
+  <data name="OneSecondAgo" xml:space="preserve">
+    <value>vor einer Sekunde</value>
+  </data>
+  <data name="OneYearAgo" xml:space="preserve">
+    <value>vor einem Jahr</value>
+  </data>
+  <data name="Tomorrow" xml:space="preserve">
+    <value>morgen</value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value>gestern</value>
+  </data>
+</root>

--- a/src/Meziantou.Framework.RelativeDate/RelativeDates.it.resx
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDates.it.resx
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AMinuteAgo" xml:space="preserve">
+    <value>un minuto fa</value>
+  </data>
+  <data name="AnHourAgo" xml:space="preserve">
+    <value>un'ora fa</value>
+  </data>
+  <data name="InAMinute" xml:space="preserve">
+    <value>tra un minuto</value>
+  </data>
+  <data name="InAnHour" xml:space="preserve">
+    <value>tra un'ora</value>
+  </data>
+  <data name="InManyDays" xml:space="preserve">
+    <value>tra {0} giorni</value>
+  </data>
+  <data name="InManyHours" xml:space="preserve">
+    <value>tra {0} ore</value>
+  </data>
+  <data name="InManyMinutes" xml:space="preserve">
+    <value>tra {0} minuti</value>
+  </data>
+  <data name="InManyMonths" xml:space="preserve">
+    <value>tra {0} mesi</value>
+  </data>
+  <data name="InManySeconds" xml:space="preserve">
+    <value>tra {0} secondi</value>
+  </data>
+  <data name="InManyYears" xml:space="preserve">
+    <value>tra {0} anni</value>
+  </data>
+  <data name="InOneMonth" xml:space="preserve">
+    <value>tra un mese</value>
+  </data>
+  <data name="InOneSecond" xml:space="preserve">
+    <value>tra un secondo</value>
+  </data>
+  <data name="InOneYear" xml:space="preserve">
+    <value>tra un anno</value>
+  </data>
+  <data name="ManyDaysAgo" xml:space="preserve">
+    <value>{0} giorni fa</value>
+  </data>
+  <data name="ManyHoursAgo" xml:space="preserve">
+    <value>{0} ore fa</value>
+  </data>
+  <data name="ManyMinutesAgo" xml:space="preserve">
+    <value>{0} minuti fa</value>
+  </data>
+  <data name="ManyMonthsAgo" xml:space="preserve">
+    <value>{0} mesi fa</value>
+  </data>
+  <data name="ManySecondsAgo" xml:space="preserve">
+    <value>{0} secondi fa</value>
+  </data>
+  <data name="ManyYearsAgo" xml:space="preserve">
+    <value>{0} anni fa</value>
+  </data>
+  <data name="Now" xml:space="preserve">
+    <value>adesso</value>
+  </data>
+  <data name="OneMonthAgo" xml:space="preserve">
+    <value>un mese fa</value>
+  </data>
+  <data name="OneSecondAgo" xml:space="preserve">
+    <value>un secondo fa</value>
+  </data>
+  <data name="OneYearAgo" xml:space="preserve">
+    <value>un anno fa</value>
+  </data>
+  <data name="Tomorrow" xml:space="preserve">
+    <value>domani</value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value>ieri</value>
+  </data>
+</root>

--- a/src/Meziantou.Framework.RelativeDate/RelativeDates.ja.resx
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDates.ja.resx
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AMinuteAgo" xml:space="preserve">
+    <value>1分前</value>
+  </data>
+  <data name="AnHourAgo" xml:space="preserve">
+    <value>1時間前</value>
+  </data>
+  <data name="InAMinute" xml:space="preserve">
+    <value>1分後</value>
+  </data>
+  <data name="InAnHour" xml:space="preserve">
+    <value>1時間後</value>
+  </data>
+  <data name="InManyDays" xml:space="preserve">
+    <value>{0}日後</value>
+  </data>
+  <data name="InManyHours" xml:space="preserve">
+    <value>{0}時間後</value>
+  </data>
+  <data name="InManyMinutes" xml:space="preserve">
+    <value>{0}分後</value>
+  </data>
+  <data name="InManyMonths" xml:space="preserve">
+    <value>{0}か月後</value>
+  </data>
+  <data name="InManySeconds" xml:space="preserve">
+    <value>{0}秒後</value>
+  </data>
+  <data name="InManyYears" xml:space="preserve">
+    <value>{0}年後</value>
+  </data>
+  <data name="InOneMonth" xml:space="preserve">
+    <value>1か月後</value>
+  </data>
+  <data name="InOneSecond" xml:space="preserve">
+    <value>1秒後</value>
+  </data>
+  <data name="InOneYear" xml:space="preserve">
+    <value>1年後</value>
+  </data>
+  <data name="ManyDaysAgo" xml:space="preserve">
+    <value>{0}日前</value>
+  </data>
+  <data name="ManyHoursAgo" xml:space="preserve">
+    <value>{0}時間前</value>
+  </data>
+  <data name="ManyMinutesAgo" xml:space="preserve">
+    <value>{0}分前</value>
+  </data>
+  <data name="ManyMonthsAgo" xml:space="preserve">
+    <value>{0}か月前</value>
+  </data>
+  <data name="ManySecondsAgo" xml:space="preserve">
+    <value>{0}秒前</value>
+  </data>
+  <data name="ManyYearsAgo" xml:space="preserve">
+    <value>{0}年前</value>
+  </data>
+  <data name="Now" xml:space="preserve">
+    <value>今</value>
+  </data>
+  <data name="OneMonthAgo" xml:space="preserve">
+    <value>1か月前</value>
+  </data>
+  <data name="OneSecondAgo" xml:space="preserve">
+    <value>1秒前</value>
+  </data>
+  <data name="OneYearAgo" xml:space="preserve">
+    <value>1年前</value>
+  </data>
+  <data name="Tomorrow" xml:space="preserve">
+    <value>明日</value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value>昨日</value>
+  </data>
+</root>

--- a/src/Meziantou.Framework.RelativeDate/RelativeDates.ko.resx
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDates.ko.resx
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AMinuteAgo" xml:space="preserve">
+    <value>1분 전</value>
+  </data>
+  <data name="AnHourAgo" xml:space="preserve">
+    <value>1시간 전</value>
+  </data>
+  <data name="InAMinute" xml:space="preserve">
+    <value>1분 후</value>
+  </data>
+  <data name="InAnHour" xml:space="preserve">
+    <value>1시간 후</value>
+  </data>
+  <data name="InManyDays" xml:space="preserve">
+    <value>{0}일 후</value>
+  </data>
+  <data name="InManyHours" xml:space="preserve">
+    <value>{0}시간 후</value>
+  </data>
+  <data name="InManyMinutes" xml:space="preserve">
+    <value>{0}분 후</value>
+  </data>
+  <data name="InManyMonths" xml:space="preserve">
+    <value>{0}개월 후</value>
+  </data>
+  <data name="InManySeconds" xml:space="preserve">
+    <value>{0}초 후</value>
+  </data>
+  <data name="InManyYears" xml:space="preserve">
+    <value>{0}년 후</value>
+  </data>
+  <data name="InOneMonth" xml:space="preserve">
+    <value>1개월 후</value>
+  </data>
+  <data name="InOneSecond" xml:space="preserve">
+    <value>1초 후</value>
+  </data>
+  <data name="InOneYear" xml:space="preserve">
+    <value>1년 후</value>
+  </data>
+  <data name="ManyDaysAgo" xml:space="preserve">
+    <value>{0}일 전</value>
+  </data>
+  <data name="ManyHoursAgo" xml:space="preserve">
+    <value>{0}시간 전</value>
+  </data>
+  <data name="ManyMinutesAgo" xml:space="preserve">
+    <value>{0}분 전</value>
+  </data>
+  <data name="ManyMonthsAgo" xml:space="preserve">
+    <value>{0}개월 전</value>
+  </data>
+  <data name="ManySecondsAgo" xml:space="preserve">
+    <value>{0}초 전</value>
+  </data>
+  <data name="ManyYearsAgo" xml:space="preserve">
+    <value>{0}년 전</value>
+  </data>
+  <data name="Now" xml:space="preserve">
+    <value>지금</value>
+  </data>
+  <data name="OneMonthAgo" xml:space="preserve">
+    <value>1개월 전</value>
+  </data>
+  <data name="OneSecondAgo" xml:space="preserve">
+    <value>1초 전</value>
+  </data>
+  <data name="OneYearAgo" xml:space="preserve">
+    <value>1년 전</value>
+  </data>
+  <data name="Tomorrow" xml:space="preserve">
+    <value>내일</value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value>어제</value>
+  </data>
+</root>

--- a/src/Meziantou.Framework.RelativeDate/RelativeDates.nl.resx
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDates.nl.resx
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AMinuteAgo" xml:space="preserve">
+    <value>een minuut geleden</value>
+  </data>
+  <data name="AnHourAgo" xml:space="preserve">
+    <value>een uur geleden</value>
+  </data>
+  <data name="InAMinute" xml:space="preserve">
+    <value>over een minuut</value>
+  </data>
+  <data name="InAnHour" xml:space="preserve">
+    <value>over een uur</value>
+  </data>
+  <data name="InManyDays" xml:space="preserve">
+    <value>over {0} dagen</value>
+  </data>
+  <data name="InManyHours" xml:space="preserve">
+    <value>over {0} uur</value>
+  </data>
+  <data name="InManyMinutes" xml:space="preserve">
+    <value>over {0} minuten</value>
+  </data>
+  <data name="InManyMonths" xml:space="preserve">
+    <value>over {0} maanden</value>
+  </data>
+  <data name="InManySeconds" xml:space="preserve">
+    <value>over {0} seconden</value>
+  </data>
+  <data name="InManyYears" xml:space="preserve">
+    <value>over {0} jaar</value>
+  </data>
+  <data name="InOneMonth" xml:space="preserve">
+    <value>over een maand</value>
+  </data>
+  <data name="InOneSecond" xml:space="preserve">
+    <value>over een seconde</value>
+  </data>
+  <data name="InOneYear" xml:space="preserve">
+    <value>over een jaar</value>
+  </data>
+  <data name="ManyDaysAgo" xml:space="preserve">
+    <value>{0} dagen geleden</value>
+  </data>
+  <data name="ManyHoursAgo" xml:space="preserve">
+    <value>{0} uur geleden</value>
+  </data>
+  <data name="ManyMinutesAgo" xml:space="preserve">
+    <value>{0} minuten geleden</value>
+  </data>
+  <data name="ManyMonthsAgo" xml:space="preserve">
+    <value>{0} maanden geleden</value>
+  </data>
+  <data name="ManySecondsAgo" xml:space="preserve">
+    <value>{0} seconden geleden</value>
+  </data>
+  <data name="ManyYearsAgo" xml:space="preserve">
+    <value>{0} jaar geleden</value>
+  </data>
+  <data name="Now" xml:space="preserve">
+    <value>nu</value>
+  </data>
+  <data name="OneMonthAgo" xml:space="preserve">
+    <value>een maand geleden</value>
+  </data>
+  <data name="OneSecondAgo" xml:space="preserve">
+    <value>een seconde geleden</value>
+  </data>
+  <data name="OneYearAgo" xml:space="preserve">
+    <value>een jaar geleden</value>
+  </data>
+  <data name="Tomorrow" xml:space="preserve">
+    <value>morgen</value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value>gisteren</value>
+  </data>
+</root>

--- a/src/Meziantou.Framework.RelativeDate/RelativeDates.pt.resx
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDates.pt.resx
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AMinuteAgo" xml:space="preserve">
+    <value>há um minuto</value>
+  </data>
+  <data name="AnHourAgo" xml:space="preserve">
+    <value>há uma hora</value>
+  </data>
+  <data name="InAMinute" xml:space="preserve">
+    <value>em um minuto</value>
+  </data>
+  <data name="InAnHour" xml:space="preserve">
+    <value>em uma hora</value>
+  </data>
+  <data name="InManyDays" xml:space="preserve">
+    <value>em {0} dias</value>
+  </data>
+  <data name="InManyHours" xml:space="preserve">
+    <value>em {0} horas</value>
+  </data>
+  <data name="InManyMinutes" xml:space="preserve">
+    <value>em {0} minutos</value>
+  </data>
+  <data name="InManyMonths" xml:space="preserve">
+    <value>em {0} meses</value>
+  </data>
+  <data name="InManySeconds" xml:space="preserve">
+    <value>em {0} segundos</value>
+  </data>
+  <data name="InManyYears" xml:space="preserve">
+    <value>em {0} anos</value>
+  </data>
+  <data name="InOneMonth" xml:space="preserve">
+    <value>em um mês</value>
+  </data>
+  <data name="InOneSecond" xml:space="preserve">
+    <value>em um segundo</value>
+  </data>
+  <data name="InOneYear" xml:space="preserve">
+    <value>em um ano</value>
+  </data>
+  <data name="ManyDaysAgo" xml:space="preserve">
+    <value>há {0} dias</value>
+  </data>
+  <data name="ManyHoursAgo" xml:space="preserve">
+    <value>há {0} horas</value>
+  </data>
+  <data name="ManyMinutesAgo" xml:space="preserve">
+    <value>há {0} minutos</value>
+  </data>
+  <data name="ManyMonthsAgo" xml:space="preserve">
+    <value>há {0} meses</value>
+  </data>
+  <data name="ManySecondsAgo" xml:space="preserve">
+    <value>há {0} segundos</value>
+  </data>
+  <data name="ManyYearsAgo" xml:space="preserve">
+    <value>há {0} anos</value>
+  </data>
+  <data name="Now" xml:space="preserve">
+    <value>agora</value>
+  </data>
+  <data name="OneMonthAgo" xml:space="preserve">
+    <value>há um mês</value>
+  </data>
+  <data name="OneSecondAgo" xml:space="preserve">
+    <value>há um segundo</value>
+  </data>
+  <data name="OneYearAgo" xml:space="preserve">
+    <value>há um ano</value>
+  </data>
+  <data name="Tomorrow" xml:space="preserve">
+    <value>amanhã</value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value>ontem</value>
+  </data>
+</root>

--- a/src/Meziantou.Framework.RelativeDate/RelativeDates.tr.resx
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDates.tr.resx
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AMinuteAgo" xml:space="preserve">
+    <value>bir dakika önce</value>
+  </data>
+  <data name="AnHourAgo" xml:space="preserve">
+    <value>bir saat önce</value>
+  </data>
+  <data name="InAMinute" xml:space="preserve">
+    <value>bir dakika sonra</value>
+  </data>
+  <data name="InAnHour" xml:space="preserve">
+    <value>bir saat sonra</value>
+  </data>
+  <data name="InManyDays" xml:space="preserve">
+    <value>{0} gün sonra</value>
+  </data>
+  <data name="InManyHours" xml:space="preserve">
+    <value>{0} saat sonra</value>
+  </data>
+  <data name="InManyMinutes" xml:space="preserve">
+    <value>{0} dakika sonra</value>
+  </data>
+  <data name="InManyMonths" xml:space="preserve">
+    <value>{0} ay sonra</value>
+  </data>
+  <data name="InManySeconds" xml:space="preserve">
+    <value>{0} saniye sonra</value>
+  </data>
+  <data name="InManyYears" xml:space="preserve">
+    <value>{0} yıl sonra</value>
+  </data>
+  <data name="InOneMonth" xml:space="preserve">
+    <value>bir ay sonra</value>
+  </data>
+  <data name="InOneSecond" xml:space="preserve">
+    <value>bir saniye sonra</value>
+  </data>
+  <data name="InOneYear" xml:space="preserve">
+    <value>bir yıl sonra</value>
+  </data>
+  <data name="ManyDaysAgo" xml:space="preserve">
+    <value>{0} gün önce</value>
+  </data>
+  <data name="ManyHoursAgo" xml:space="preserve">
+    <value>{0} saat önce</value>
+  </data>
+  <data name="ManyMinutesAgo" xml:space="preserve">
+    <value>{0} dakika önce</value>
+  </data>
+  <data name="ManyMonthsAgo" xml:space="preserve">
+    <value>{0} ay önce</value>
+  </data>
+  <data name="ManySecondsAgo" xml:space="preserve">
+    <value>{0} saniye önce</value>
+  </data>
+  <data name="ManyYearsAgo" xml:space="preserve">
+    <value>{0} yıl önce</value>
+  </data>
+  <data name="Now" xml:space="preserve">
+    <value>şimdi</value>
+  </data>
+  <data name="OneMonthAgo" xml:space="preserve">
+    <value>bir ay önce</value>
+  </data>
+  <data name="OneSecondAgo" xml:space="preserve">
+    <value>bir saniye önce</value>
+  </data>
+  <data name="OneYearAgo" xml:space="preserve">
+    <value>bir yıl önce</value>
+  </data>
+  <data name="Tomorrow" xml:space="preserve">
+    <value>yarın</value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value>dün</value>
+  </data>
+</root>

--- a/src/Meziantou.Framework.RelativeDate/RelativeDates.zh-Hans.resx
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDates.zh-Hans.resx
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AMinuteAgo" xml:space="preserve">
+    <value>1分钟前</value>
+  </data>
+  <data name="AnHourAgo" xml:space="preserve">
+    <value>1小时前</value>
+  </data>
+  <data name="InAMinute" xml:space="preserve">
+    <value>1分钟后</value>
+  </data>
+  <data name="InAnHour" xml:space="preserve">
+    <value>1小时后</value>
+  </data>
+  <data name="InManyDays" xml:space="preserve">
+    <value>{0}天后</value>
+  </data>
+  <data name="InManyHours" xml:space="preserve">
+    <value>{0}小时后</value>
+  </data>
+  <data name="InManyMinutes" xml:space="preserve">
+    <value>{0}分钟后</value>
+  </data>
+  <data name="InManyMonths" xml:space="preserve">
+    <value>{0}个月后</value>
+  </data>
+  <data name="InManySeconds" xml:space="preserve">
+    <value>{0}秒后</value>
+  </data>
+  <data name="InManyYears" xml:space="preserve">
+    <value>{0}年后</value>
+  </data>
+  <data name="InOneMonth" xml:space="preserve">
+    <value>1个月后</value>
+  </data>
+  <data name="InOneSecond" xml:space="preserve">
+    <value>1秒后</value>
+  </data>
+  <data name="InOneYear" xml:space="preserve">
+    <value>1年后</value>
+  </data>
+  <data name="ManyDaysAgo" xml:space="preserve">
+    <value>{0}天前</value>
+  </data>
+  <data name="ManyHoursAgo" xml:space="preserve">
+    <value>{0}小时前</value>
+  </data>
+  <data name="ManyMinutesAgo" xml:space="preserve">
+    <value>{0}分钟前</value>
+  </data>
+  <data name="ManyMonthsAgo" xml:space="preserve">
+    <value>{0}个月前</value>
+  </data>
+  <data name="ManySecondsAgo" xml:space="preserve">
+    <value>{0}秒前</value>
+  </data>
+  <data name="ManyYearsAgo" xml:space="preserve">
+    <value>{0}年前</value>
+  </data>
+  <data name="Now" xml:space="preserve">
+    <value>现在</value>
+  </data>
+  <data name="OneMonthAgo" xml:space="preserve">
+    <value>1个月前</value>
+  </data>
+  <data name="OneSecondAgo" xml:space="preserve">
+    <value>1秒前</value>
+  </data>
+  <data name="OneYearAgo" xml:space="preserve">
+    <value>1年前</value>
+  </data>
+  <data name="Tomorrow" xml:space="preserve">
+    <value>明天</value>
+  </data>
+  <data name="Yesterday" xml:space="preserve">
+    <value>昨天</value>
+  </data>
+</root>

--- a/src/Meziantou.Framework.RelativeDate/ResxLocalizationProvider.cs
+++ b/src/Meziantou.Framework.RelativeDate/ResxLocalizationProvider.cs
@@ -5,7 +5,7 @@ namespace Meziantou.Framework;
 /// <summary>Provides localization using embedded resource files (.resx) for relative date formatting.</summary>
 /// <remarks>
 /// This is the default localization provider for <see cref="RelativeDate"/>.
-/// It includes translations for English, French and Spanish.
+/// It includes translations for Dutch, English, French, German, Italian, Japanese, Korean, Portuguese, Simplified Chinese, Spanish and Turkish.
 /// </remarks>
 internal sealed class ResxLocalizationProvider : ILocalizationProvider
 {

--- a/src/Meziantou.Framework.RelativeDate/readme.md
+++ b/src/Meziantou.Framework.RelativeDate/readme.md
@@ -1,6 +1,6 @@
 # Meziantou.Framework.RelativeDate
 
-`Meziantou.Framework.RelativeDate` allows to get a relative date similar to "5 minutes ago". It supports both local and UTC dates as well as dates with offset (DateTimeOffset). Also, culture to use can be specified explicitly. If it is not, current thread's current UI culture is used. It supports English and French.
+`Meziantou.Framework.RelativeDate` allows to get a relative date similar to "5 minutes ago". It supports both local and UTC dates as well as dates with offset (DateTimeOffset). Also, culture to use can be specified explicitly. If it is not, current thread's current UI culture is used. It supports Dutch, English, French, German, Italian, Japanese, Korean, Portuguese, Simplified Chinese, Spanish and Turkish.
 
 ````c#
 using Meziantou.Framework;

--- a/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
+++ b/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
@@ -1,4 +1,6 @@
-#pragma warning disable MA0011 // IFormatProvider is missing
+﻿#pragma warning disable MA0011 // IFormatProvider is missing
+using System.Collections;
+using System.Resources;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Meziantou.Framework.Tests;
@@ -28,8 +30,9 @@ public class RelativeDateTests
         Assert.NotEmpty(expectedValueFr);
 
 #if !INVARIANT_GLOBALIZATION_MODE_ENABLED
-        var resultDe = relativeDate.ToString(format: null, CultureInfo.GetCultureInfo("de"));
-        Assert.Equal(expectedValueEn, resultDe);
+        // Swedish is not translated, so it falls back to the neutral (English) resources
+        var resultSv = relativeDate.ToString(format: null, CultureInfo.GetCultureInfo("sv"));
+        Assert.Equal(expectedValueEn, resultSv);
 
         var resultFr = relativeDate.ToString(format: null, CultureInfo.GetCultureInfo("fr"));
         Assert.Equal(expectedValueFr, resultFr);
@@ -69,4 +72,85 @@ public class RelativeDateTests
             yield return new object[] { "2021/01/01 00:00:00Z", "2018/01/01 00:00:00Z", "in 3 years", "dans 3 ans" };
         }
     }
+
+#if !INVARIANT_GLOBALIZATION_MODE_ENABLED
+    private static readonly string[] LocalizedCultures = ["de", "es", "fr", "it", "ja", "ko", "nl", "pt", "tr", "zh-Hans"];
+
+    /// <summary>Offsets from "now" reaching every branch of <see cref="RelativeDate.ToString(string, IFormatProvider)"/>, in both directions.</summary>
+    private static readonly TimeSpan[] AllBranchOffsets =
+    [
+        TimeSpan.Zero,
+        TimeSpan.FromSeconds(-1), TimeSpan.FromSeconds(-25), TimeSpan.FromSeconds(-90),
+        TimeSpan.FromMinutes(-10), TimeSpan.FromMinutes(-60), TimeSpan.FromHours(-2),
+        TimeSpan.FromHours(-30), TimeSpan.FromDays(-3), TimeSpan.FromDays(-31),
+        TimeSpan.FromDays(-90), TimeSpan.FromDays(-365), TimeSpan.FromDays(-1095),
+        TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(25), TimeSpan.FromSeconds(90),
+        TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(60), TimeSpan.FromHours(2),
+        TimeSpan.FromHours(30), TimeSpan.FromDays(3), TimeSpan.FromDays(31),
+        TimeSpan.FromDays(90), TimeSpan.FromDays(365), TimeSpan.FromDays(1095),
+    ];
+
+    public static TheoryData<string> LocalizedCulturesData => new(LocalizedCultures);
+
+    [Theory]
+    [MemberData(nameof(LocalizedCulturesData))]
+    public void RelativeDate_ToString_UsesLocalizedResources(string cultureName)
+    {
+        var culture = CultureInfo.GetCultureInfo(cultureName);
+        var now = new DateTimeOffset(2018, 1, 10, 0, 0, 0, TimeSpan.Zero);
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(now);
+
+        var seen = new Dictionary<string, TimeSpan>(StringComparer.Ordinal);
+        foreach (var offset in AllBranchOffsets)
+        {
+            var relativeDate = RelativeDate.Get(now + offset, timeProvider);
+            var neutral = relativeDate.ToString(format: null, CultureInfo.InvariantCulture);
+            var localized = relativeDate.ToString(format: null, culture);
+
+            Assert.NotEmpty(localized);
+
+            // A resource missing from the culture silently falls back to the neutral (English) value
+            Assert.NotEqual(neutral, localized);
+
+            // The count must survive the translation
+            var count = GetDigits(neutral);
+            if (count.Length > 0)
+                Assert.Contains(count, localized);
+
+            // Two branches producing the same text means a value was copied to the wrong key
+            // (e.g. "yesterday" translated with the word for "tomorrow")
+            Assert.False(seen.TryGetValue(localized, out var previousOffset), $"'{localized}' is produced by both {previousOffset} and {offset}");
+            seen.Add(localized, offset);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LocalizedCulturesData))]
+    public void AllResourcesAreLocalized(string cultureName)
+    {
+        var resourceManager = new ResourceManager("Meziantou.Framework.RelativeDates", typeof(RelativeDate).Assembly);
+        var neutralResources = resourceManager.GetResourceSet(CultureInfo.InvariantCulture, createIfNotExists: true, tryParents: false);
+        Assert.NotNull(neutralResources);
+
+        var localizedResources = resourceManager.GetResourceSet(CultureInfo.GetCultureInfo(cultureName), createIfNotExists: true, tryParents: false);
+        Assert.NotNull(localizedResources);
+
+        foreach (DictionaryEntry entry in neutralResources)
+        {
+            var name = (string)entry.Key;
+            var neutralValue = (string?)entry.Value;
+            Assert.NotNull(neutralValue);
+
+            var localizedValue = localizedResources.GetString(name);
+            Assert.NotNull(localizedValue);
+            Assert.NotEmpty(localizedValue);
+
+            // A resource that formats a count must keep its placeholder
+            Assert.Equal(neutralValue.Contains("{0}", StringComparison.Ordinal), localizedValue.Contains("{0}", StringComparison.Ordinal));
+        }
+    }
+
+    private static string GetDigits(string value) => string.Concat(value.Where(char.IsAsciiDigit));
+#endif
 }


### PR DESCRIPTION
Adds German, Italian, Dutch, Portuguese, Turkish, Japanese, Korean and Simplified Chinese to `Meziantou.Framework.RelativeDate`, bringing the supported set from 3 to 11 languages.

## Translations

| Culture | "2 hours ago" | "in 3 days" |
|---|---|---|
| `de` German | vor 2 Stunden | in 3 Tagen |
| `it` Italian | 2 ore fa | tra 3 giorni |
| `nl` Dutch | 2 uur geleden | over 3 dagen |
| `pt` Portuguese | há 2 horas | em 3 dias |
| `tr` Turkish | 2 saat önce | 3 gün sonra |
| `ja` Japanese | 2時間前 | 3日後 |
| `ko` Korean | 2시간 전 | 3일 후 |
| `zh-Hans` Simplified Chinese | 2小时前 | 3天后 |

Each file defines all 25 keys and matches the existing resx files (UTF-8 BOM, LF, 2-space indent).

### Languages deliberately left out

Russian, Polish, Arabic and similar languages are **not** included. The current design uses one format string per key, which cannot express their plural categories — Russian needs different forms for "3 дня" and "5 дней", so any single string would be grammatically wrong for most counts. Supporting them properly requires plural-rule support in `ILocalizationProvider`, which felt out of scope here.

## Tests

The existing `RelativeDate_ToString` used `de` as the untranslated culture that falls back to English. German now breaks that, so Swedish takes over the role.

Two new theories cover every supported culture:

- **`RelativeDate_ToString_UsesLocalizedResources`** walks all 25 branches of `ToString` and asserts *properties* rather than copied strings:
  - the output differs from the neutral English value — a missing key silently falls back, so this catches an untranslated or absent resource
  - the count from the English rendering survives the translation — catches a lost `{0}`
  - no two branches produce the same text — catches a value pasted under the wrong key

  It contains no hardcoded translations and extends itself when a language or a resource key is added.
- **`AllResourcesAreLocalized`** checks that each culture defines every key of the neutral resource set and preserves the `{0}` placeholder.

Both are guarded by `INVARIANT_GLOBALIZATION_MODE_ENABLED`: in that mode every culture resolves to invariant and satellite lookup returns English, which would make the assertions meaningless. That CI leg therefore has no coverage of the new languages — inherent to the mode rather than something the tests can work around.

### Mutation check

I broke the resources six ways to confirm the tests actually bite. An earlier draft used a hardcoded `InlineData` table, which covered only 3 of the 25 keys and missed the last row; the property-based version catches all six.

| Mutation | Hardcoded draft | Merged version |
|---|---|---|
| key dropped from `de.resx` | ✅ | ✅ |
| `{0}` stripped from `it.resx` | ✅ | ✅ |
| `nl.resx` deleted | ✅ | ✅ |
| `ja` 昨日 → 明日 | ✅ | ✅ |
| `tr` Yesterday left in English | ✅ | ✅ |
| `tr` ManyMonthsAgo left in English | ❌ | ✅ |

## Verification

- `dotnet test /p:TreatsWarningsAsErrors=true` — 92/92 pass, 0 warnings
- `dotnet test /p:TreatsWarningsAsErrors=true /p:InvariantGlobalization=true` — 52/52 pass
- `dotnet run ./eng/update-all.cs` — exits 0, no file changes

## Note for reviewers

The translations are mine and have not been checked by native speakers. The tests verify structure (keys present, placeholders intact, no duplicated or untranslated values) but cannot verify that a translation is *semantically* right — that part needs human eyes. `pt` uses Brazilian phrasing ("em 3 dias"); European Portuguese would prefer "daqui a 3 dias".