### PR TITLE
Fix HSTS policy matching, header parsing, and thread safety

### DIFF
--- a/src/Meziantou.Framework.Http.Hsts/HstsClientHandler.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsClientHandler.cs
@@ -12,6 +12,8 @@ namespace Meziantou.Framework.Http;
 /// </example>
 public sealed class HstsClientHandler : DelegatingHandler
 {
+    private const long MaxMaxAgeInSeconds = 100L * 365 * 24 * 60 * 60;
+
     private readonly HstsDomainPolicyCollection _configuration;
 
     /// <summary>Initializes a new instance of the <see cref="HstsClientHandler"/> class with the default HSTS policy collection.</summary>
@@ -38,7 +40,8 @@ public sealed class HstsClientHandler : DelegatingHandler
     {
         if (request.RequestUri?.Scheme == Uri.UriSchemeHttp && request.RequestUri.Port == 80)
         {
-            if (_configuration.MustUpgradeRequest(request.RequestUri.Host))
+            // Use IdnHost: the preload list stores internationalized domains in their Punycode form
+            if (_configuration.MustUpgradeRequest(request.RequestUri.IdnHost))
             {
                 var builder = new UriBuilder(request.RequestUri) { Scheme = Uri.UriSchemeHttps };
                 builder.Port = 443;
@@ -59,28 +62,57 @@ public sealed class HstsClientHandler : DelegatingHandler
             var includeSubdomains = false;
             foreach (var header in headers)
             {
-                var headerSpan = header.AsSpan();
-                foreach (var part in headerSpan.Split(';'))
+                if (TryParsePolicy(header, out var headerMaxAge, out var headerIncludeSubdomains))
                 {
-                    var trimmed = headerSpan[part].Trim();
-                    if (trimmed.StartsWith("max-age=", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var maxAgeValue = int.Parse(trimmed[8..], NumberStyles.None, CultureInfo.InvariantCulture);
-                        maxAge = TimeSpan.FromSeconds(maxAgeValue);
-                    }
-                    else if (trimmed.Equals("includeSubDomains", StringComparison.OrdinalIgnoreCase))
-                    {
-                        includeSubdomains = true;
-                    }
+                    maxAge = headerMaxAge;
+                    includeSubdomains = headerIncludeSubdomains;
                 }
             }
 
             if (maxAge > TimeSpan.Zero)
             {
-                _configuration.Add(response.RequestMessage.RequestUri.Host, maxAge, includeSubdomains);
+                _configuration.Add(response.RequestMessage.RequestUri.IdnHost, maxAge, includeSubdomains);
             }
         }
 
         return response;
+    }
+
+    // https://datatracker.ietf.org/doc/html/rfc6797#section-6.1
+    // A malformed header must be ignored instead of failing the request, as the response is otherwise valid.
+    private static bool TryParsePolicy(ReadOnlySpan<char> header, out TimeSpan maxAge, out bool includeSubdomains)
+    {
+        maxAge = default;
+        includeSubdomains = false;
+        var hasMaxAge = false;
+
+        foreach (var part in header.Split(';'))
+        {
+            var directive = header[part].Trim();
+            if (directive.StartsWith("max-age=", StringComparison.OrdinalIgnoreCase))
+            {
+                var value = directive["max-age=".Length..].Trim();
+
+                // The directive value may be a quoted-string
+                if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+                {
+                    value = value[1..^1].Trim();
+                }
+
+                if (!long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var seconds))
+                    return false;
+
+                // Clamp so computing the expiration date cannot overflow
+                maxAge = TimeSpan.FromSeconds(Math.Min(seconds, MaxMaxAgeInSeconds));
+                hasMaxAge = true;
+            }
+            else if (directive.Equals("includeSubDomains", StringComparison.OrdinalIgnoreCase))
+            {
+                includeSubdomains = true;
+            }
+        }
+
+        // The max-age directive is required; without it the header is ignored
+        return hasMaxAge;
     }
 }

--- a/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
@@ -24,8 +24,12 @@ namespace Meziantou.Framework.Http;
 /// </example>
 public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainPolicy>
 {
-    private readonly List<ConcurrentDictionary<string, HstsDomainPolicy>> _policies = new(capacity: 8);
+    private readonly Lock _lock = new();
     private readonly TimeProvider _timeProvider;
+
+    // Copy-on-write: the array is never mutated once published, so readers can take a
+    // snapshot and index into it without locking. Writers build a new array under _lock.
+    private volatile ConcurrentDictionary<string, HstsDomainPolicy>[] _policies = [];
 
     // Avoid recomputing the value during initialization
     private readonly DateTimeOffset _expires18weeks;
@@ -95,14 +99,23 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
 
         var partCount = CountSegments(host);
         ConcurrentDictionary<string, HstsDomainPolicy> dictionary;
-        lock (_policies)
+        lock (_lock)
         {
-            for (var i = _policies.Count; i < partCount; i++)
+            var policies = _policies;
+            if (policies.Length < partCount)
             {
-                _policies.Add(new ConcurrentDictionary<string, HstsDomainPolicy>(StringComparer.OrdinalIgnoreCase));
+                var newPolicies = new ConcurrentDictionary<string, HstsDomainPolicy>[partCount];
+                Array.Copy(policies, newPolicies, policies.Length);
+                for (var i = policies.Length; i < partCount; i++)
+                {
+                    newPolicies[i] = new ConcurrentDictionary<string, HstsDomainPolicy>(StringComparer.OrdinalIgnoreCase);
+                }
+
+                // Publish the fully-initialized array; the volatile write makes the element stores visible first
+                _policies = policies = newPolicies;
             }
 
-            dictionary = _policies[partCount - 1];
+            dictionary = policies[partCount - 1];
         }
 
         dictionary.AddOrUpdate(host,
@@ -125,23 +138,28 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
     /// <returns><see langword="true"/> if the request should be upgraded to HTTPS; otherwise, <see langword="false"/>.</returns>
     public bool MustUpgradeRequest(ReadOnlySpan<char> host)
     {
+        var policies = _policies;
+        var now = _timeProvider.GetUtcNow();
+
+        // Walk the suffixes from the least to the most specific. A suffix that does not apply does not
+        // rule out a match: a more specific entry (down to the host itself) may still require an upgrade.
         var enumerator = new DomainSplitReverseEnumerator(host);
-        for (var i = 0; i < _policies.Count && enumerator.MoveNext(); i++)
+        for (var i = 0; i < policies.Length && enumerator.MoveNext(); i++)
         {
-            var dictionary = _policies[i];
+            var dictionary = policies[i];
             var lastSegments = host[enumerator.Current..];
 
             var lookup = dictionary.GetAlternateLookup<ReadOnlySpan<char>>();
             if (lookup.TryGetValue(lastSegments, out var hsts))
             {
-                if (hsts.ExpiresAt < _timeProvider.GetUtcNow())
+                if (hsts.ExpiresAt < now)
                 {
-                    return false;
+                    continue;
                 }
 
                 if (!hsts.IncludeSubdomains && enumerator.Current != 0)
                 {
-                    return false;
+                    continue;
                 }
 
                 return true;
@@ -169,12 +187,10 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
 
     public IEnumerator<HstsDomainPolicy> GetEnumerator()
     {
-        for (var i = 0; i < _policies.Count; i++)
+        var policies = _policies;
+        for (var i = 0; i < policies.Length; i++)
         {
-            var dictionary = _policies[i];
-            if (dictionary is null)
-                continue;
-
+            var dictionary = policies[i];
             foreach (var kvp in dictionary)
             {
                 yield return kvp.Value;

--- a/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.g.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.g.cs
@@ -2,7 +2,6 @@
 #nullable enable
 
 using System.Collections.Concurrent;
-using System.Runtime.InteropServices;
 
 namespace Meziantou.Framework.Http;
 
@@ -12,22 +11,24 @@ partial class HstsDomainPolicyCollection
     {
         // HSTS preload data source: https://raw.githubusercontent.com/chromium/chromium/7be0edc636b0e7b0143e2700ecf5c8af750d09ec/net/http/transport_security_state_static.json
         // Commit date: 2026-07-28T19:44:48.0000000+00:00
-        CollectionsMarshal.SetCount(_policies, 4);
+        var policies = new ConcurrentDictionary<string, HstsDomainPolicy>[4];
 
         var dict1 = new ConcurrentDictionary<string, HstsDomainPolicy>(concurrencyLevel: -1, capacity: 61, comparer: StringComparer.OrdinalIgnoreCase);
-        _policies[0] = dict1;
+        policies[0] = dict1;
         Load(dict1, 51, "preload_1.bin");
 
         var dict2 = new ConcurrentDictionary<string, HstsDomainPolicy>(concurrencyLevel: -1, capacity: 86296, comparer: StringComparer.OrdinalIgnoreCase);
-        _policies[1] = dict2;
+        policies[1] = dict2;
         Load(dict2, 86286, "preload_2.bin");
 
         var dict3 = new ConcurrentDictionary<string, HstsDomainPolicy>(concurrencyLevel: -1, capacity: 8152, comparer: StringComparer.OrdinalIgnoreCase);
-        _policies[2] = dict3;
+        policies[2] = dict3;
         Load(dict3, 8142, "preload_3.bin");
 
         var dict4 = new ConcurrentDictionary<string, HstsDomainPolicy>(concurrencyLevel: -1, capacity: 159, comparer: StringComparer.OrdinalIgnoreCase);
-        _policies[3] = dict4;
+        policies[3] = dict4;
         Load(dict4, 149, "preload_4.bin");
+
+        _policies = policies;
     }
 }

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/HstsClientHandlerTests.cs
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/HstsClientHandlerTests.cs
@@ -38,6 +38,55 @@ public sealed class HstsClientHandlerTests
         Assert.Equal(Uri.UriSchemeHttps, response2.RequestMessage!.RequestUri!.Scheme);
     }
 
+    [Fact]
+    public async Task UpgradeRequest_InternationalizedDomain()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: true);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler(headerResponse: null), hsts), disposeHandler: true);
+
+        // 跳.jp (xn--vt3a.jp) is in the HSTS preload list, which stores Punycode names
+        using var response = await client.GetAsync("http://跳.jp", XunitCancellationToken);
+        Assert.Equal(Uri.UriSchemeHttps, response.RequestMessage!.RequestUri!.Scheme);
+    }
+
+    [Theory]
+    [InlineData("max-age=abc")]
+    [InlineData("max-age=")]
+    [InlineData("max-age=-1")]
+    [InlineData("max-age=99999999999999999999999")]
+    [InlineData("includeSubDomains")]
+    [InlineData("")]
+    public async Task MalformedHeader_IsIgnored(string headerResponse)
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler(headerResponse), hsts), disposeHandler: true);
+
+        using var response = await client.GetAsync("https://example.com", XunitCancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.False(hsts.MustUpgradeRequest("example.com"));
+    }
+
+    [Fact]
+    public async Task QuotedMaxAge_IsSupported()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler("max-age=\"31536000\"; includeSubDomains"), hsts), disposeHandler: true);
+
+        using var response = await client.GetAsync("https://example.com", XunitCancellationToken);
+        Assert.True(hsts.MustUpgradeRequest("example.com"));
+        Assert.True(hsts.MustUpgradeRequest("foo.example.com"));
+    }
+
+    [Fact]
+    public async Task VeryLargeMaxAge_IsClamped()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler("max-age=9999999999"), hsts), disposeHandler: true);
+
+        using var response = await client.GetAsync("https://example.com", XunitCancellationToken);
+        Assert.True(hsts.MustUpgradeRequest("example.com"));
+    }
+
     private sealed class MockHttpMessageHandler(string? headerResponse) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -49,7 +98,7 @@ public sealed class HstsClientHandlerTests
 
             if (headerResponse is not null)
             {
-                response.Headers.Add("Strict-Transport-Security", headerResponse);
+                response.Headers.TryAddWithoutValidation("Strict-Transport-Security", headerResponse);
             }
 
             return Task.FromResult(response);

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Time.Testing;
+
 namespace Meziantou.Framework.Http.Hsts.Tests;
 public sealed class HstsDomainPolicyCollectionTests
 {
@@ -34,6 +36,90 @@ public sealed class HstsDomainPolicyCollectionTests
         Assert.True(hsts.MustUpgradeRequest("google.com"));
         Assert.False(hsts.MustUpgradeRequest("dummy.google.com"));
         Assert.False(hsts.MustUpgradeRequest("example.com"));
+    }
+
+    [Fact]
+    public void HstsCollection_Match_MoreSpecificPolicy_IsNotShadowedByParent()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("example.com", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: false);
+        hsts.Add("foo.example.com", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: false);
+
+        Assert.True(hsts.MustUpgradeRequest("foo.example.com"));
+        Assert.True(hsts.MustUpgradeRequest("example.com"));
+        Assert.False(hsts.MustUpgradeRequest("bar.example.com"));
+        Assert.False(hsts.MustUpgradeRequest("sub.foo.example.com"));
+    }
+
+    [Fact]
+    public void HstsCollection_Match_MoreSpecificPolicy_IsNotShadowedByExpiredParent()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("example.com", DateTimeOffset.UtcNow.AddYears(-1), includeSubdomains: true);
+        hsts.Add("foo.example.com", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: true);
+
+        Assert.True(hsts.MustUpgradeRequest("foo.example.com"));
+        Assert.True(hsts.MustUpgradeRequest("sub.foo.example.com"));
+        Assert.False(hsts.MustUpgradeRequest("example.com"));
+        Assert.False(hsts.MustUpgradeRequest("bar.example.com"));
+    }
+
+    [Fact]
+    public void HstsCollection_Match_ExpiredPolicy()
+    {
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.Parse("2024-01-01T00:00:00Z", CultureInfo.InvariantCulture));
+        var hsts = new HstsDomainPolicyCollection(timeProvider, includePreloadDomains: false);
+        hsts.Add("example.com", TimeSpan.FromDays(30), includeSubdomains: true);
+
+        Assert.True(hsts.MustUpgradeRequest("example.com"));
+        Assert.True(hsts.MustUpgradeRequest("foo.example.com"));
+
+        timeProvider.Advance(TimeSpan.FromDays(31));
+
+        Assert.False(hsts.MustUpgradeRequest("example.com"));
+        Assert.False(hsts.MustUpgradeRequest("foo.example.com"));
+    }
+
+    [Fact]
+    public void HstsCollection_Match_PreloadedInternationalizedDomain()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: true);
+
+        // The preload list stores internationalized domains in their Punycode form,
+        // which is what Uri.IdnHost returns (Uri.Host returns the Unicode form)
+        Assert.True(hsts.MustUpgradeRequest("xn--vt3a.jp"));
+        Assert.True(hsts.MustUpgradeRequest(new Uri("http://跳.jp").IdnHost));
+        Assert.True(hsts.MustUpgradeRequest(new Uri("http://sub.αβ.net").IdnHost));
+    }
+
+    [Fact]
+    public async Task HstsCollection_ConcurrentAddAndLookup()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        using var barrier = new Barrier(2);
+
+        // The writer grows the bucket list while the reader indexes into it
+        var writer = Task.Run(() =>
+        {
+            barrier.SignalAndWait();
+            for (var i = 1; i <= 64; i++)
+            {
+                hsts.Add(string.Join('.', Enumerable.Repeat("a", i)), DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: false);
+            }
+        });
+
+        var reader = Task.Run(() =>
+        {
+            var host = string.Join('.', Enumerable.Repeat("b", 64));
+            barrier.SignalAndWait();
+            for (var i = 0; i < 500_000; i++)
+            {
+                Assert.False(hsts.MustUpgradeRequest(host));
+            }
+        });
+
+        await Task.WhenAll(writer, reader);
+        Assert.True(hsts.MustUpgradeRequest(string.Join('.', Enumerable.Repeat("a", 64))));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/Meziantou.Framework.Http.Hsts.Tests.csproj
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/Meziantou.Framework.Http.Hsts.Tests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../../src/Meziantou.Framework.Http.Hsts/Meziantou.Framework.Http.Hsts.csproj" />
   </ItemGroup>
 

--- a/tools/Meziantou.Framework.Http.Hsts.Generator/Program.cs
+++ b/tools/Meziantou.Framework.Http.Hsts.Generator/Program.cs
@@ -28,12 +28,12 @@ var entriesThreshold = 10;
 var maxSegments = entries.Max(e => e.SegmentCount);
 
 var sb = new StringBuilder();
-sb.Append($"        CollectionsMarshal.SetCount(_policies, {maxSegments.ToString(CultureInfo.InvariantCulture)});\n\n");
+sb.Append($"        var policies = new ConcurrentDictionary<string, HstsDomainPolicy>[{maxSegments.ToString(CultureInfo.InvariantCulture)}];\n\n");
 for (var i = 1; i <= maxSegments; i++)
 {
     var count = entries.Count(e => e.SegmentCount == i);
     sb.Append($"        var dict{i.ToString(CultureInfo.InvariantCulture)} = new ConcurrentDictionary<string, HstsDomainPolicy>(concurrencyLevel: -1, capacity: {(count + 10).ToString(CultureInfo.InvariantCulture)}, comparer: StringComparer.OrdinalIgnoreCase);\n");
-    sb.Append($"        _policies[{(i - 1).ToString(CultureInfo.InvariantCulture)}] = dict{i.ToString(CultureInfo.InvariantCulture)};\n");
+    sb.Append($"        policies[{(i - 1).ToString(CultureInfo.InvariantCulture)}] = dict{i.ToString(CultureInfo.InvariantCulture)};\n");
 
     if (count < entriesThreshold)
     {
@@ -54,6 +54,9 @@ for (var i = 1; i <= maxSegments; i++)
     }
     sb.Append('\n');
 }
+
+// Publish the fully-initialized array (see the copy-on-write comment on _policies)
+sb.Append("        _policies = policies;\n");
 
 void AddPreloadData()
 {
@@ -94,7 +97,6 @@ var result = $$"""
     #nullable enable
 
     using System.Collections.Concurrent;
-    using System.Runtime.InteropServices;
 
     namespace Meziantou.Framework.Http;
 


### PR DESCRIPTION
Fixes four confirmed bugs in `Meziantou.Framework.Http.Hsts`, found while reviewing the package. Each one has a regression test that fails without the corresponding fix.

## What changed

### A parent policy shadowed a more specific child policy

`MustUpgradeRequest` walks host suffixes from the least to the most specific, but returned `false` as soon as it found an entry that did not apply — either expired, or `includeSubdomains: false` while matching a subdomain. A more specific entry, down to the host itself, may still require an upgrade, so those two cases now `continue` the walk instead.

```csharp
hsts.Add("example.com", oneYear, includeSubdomains: false);
hsts.Add("foo.example.com", oneYear, includeSubdomains: false);
hsts.MustUpgradeRequest("foo.example.com"); // was false, now true
```

This was reachable whenever a site and one of its subdomains each sent their own `Strict-Transport-Security` header, and equally when a parent policy had simply expired.

### A malformed `max-age` threw out of `HttpClient.SendAsync`

`int.Parse` was unguarded, so a bad response header failed an otherwise valid response. All of these threw: `max-age=abc`, `max-age=` (`FormatException`), `max-age=99999999999` (`OverflowException`), and `max-age="31536000"` — the quoted-string form that [RFC 6797 §6.1](https://datatracker.ietf.org/doc/html/rfc6797#section-6.1) explicitly permits. Any server could break every request to it.

Parsing moved into `TryParsePolicy`, which uses `long.TryParse`, accepts the quoted form, clamps the value so computing the expiration date cannot overflow, and ignores a header it cannot parse. The existing last-wins behavior across multiple header values is preserved.

### Data race on the policy buckets

`MustUpgradeRequest` and `GetEnumerator` read the bucket list with no synchronization while `Add` mutated it under `lock (_policies)`. `List<T>.Add` increments `_size` *before* storing the element, so a concurrent reader could observe the new count with a null slot. A stress test throws `NullReferenceException` within a handful of attempts.

The buckets are now a copy-on-write `volatile ConcurrentDictionary<...>[]`: writers build and publish a fully-initialized array under a dedicated `Lock`, readers take a single snapshot and index freely. The outer array grows at most once per distinct segment count, so the copy cost is negligible. This also makes nulls unrepresentable, so the `is null` guard in `GetEnumerator` is gone.

### Internationalized domains never matched the preload list

The preload data stores Punycode (`xn--…`), but the handler passed `Uri.Host`, which returns the Unicode form:

```
Host='ουτοπία.δπθ.gr'   IdnHost='xn--kxae4bafwg.xn--pxaix.gr'
```

Every IDN in the preload list (260 entries) was silently unreachable. The handler now uses `Uri.IdnHost` for both the lookup and the `Add`, so header-learned policies are keyed consistently. The collection itself stays a plain string store.

## Reviewer notes

**The generator template had to move with the code.** The copy-on-write change alters the shape of the generated `LoadPreloadDomains`. Without updating [`tools/Meziantou.Framework.Http.Hsts.Generator/Program.cs`](tools/Meziantou.Framework.Http.Hsts.Generator/Program.cs), the weekly `update-hsts-preload` workflow would regenerate `CollectionsMarshal.SetCount(_policies, …)` against an array and break `main`. I verified byte-for-byte that the checked-in `.g.cs` is exactly what the updated generator now emits, so the next scheduled run produces no spurious diff.

**No public API change**, so `ref/` is untouched. The package version is not bumped, matching how other fixes in this repo are handled.

The IDN tests use real preload entries (`xn--vt3a.jp` / 跳.jp, `xn--mxac.net` / αβ.net) verified against the embedded `.bin` payload rather than invented domains.

## Verification

- Library, generator, and test project build clean on `net10.0` and `net11.0` with `TreatWarningsAsErrors=true`.
- 50/50 tests pass (25 per TFM).
- `dotnet run ./eng/update-all.cs` exits 0 with no resulting file changes.
- Reverting only `src/` makes 10 of the new tests fail, confirming they are genuine regressions. Two added tests pass either way and are additive coverage: the expiry test uses a single policy, and the collection-level Punycode lookup was never the IDN bug.
- The concurrency test is stable across repeated Release runs; there is no unsynchronized access left for it to flake on.

## Follow-ups not in this PR

Remaining RFC 6797 deviations, which I can do next: `max-age=0` should delete the policy (needs a public `Remove` API), an explicit non-80 port should be preserved rather than skipping the upgrade entirely (§8.3), IP-address hosts should not be noted as HSTS hosts (§8.1), and only the first header instance should be processed. There are also cost items — the preload list retains ~28 MB for ~95k entries, and preload entries expire relative to process start, so a service running past 18 weeks silently stops upgrading them.