### PR TITLE
Remove the per-rune string allocation in Slug.Create

### DIFF
--- a/src/Meziantou.Framework.Slug/Slug.cs
+++ b/src/Meziantou.Framework.Slug/Slug.cs
@@ -11,6 +11,9 @@ namespace Meziantou.Framework;
 /// </summary>
 public static class Slug
 {
+    /// <summary>The number of UTF-16 characters needed to encode any single rune.</summary>
+    private const int MaxUtf16CharsPerRune = 2;
+
     /// <summary>Creates a slug from the specified text using default options.</summary>
     /// <param name="text">The text to convert to a slug.</param>
     /// <returns>A slug generated from the input text, or <see langword="null"/> if <paramref name="text"/> is <see langword="null"/>.</returns>
@@ -37,13 +40,27 @@ public static class Slug
         var maximumLength = options.MaximumLength > 0 ? options.MaximumLength : int.MaxValue;
 
         var sb = new StringBuilder(Math.Min(text.Length, maximumLength));
+        var usesDefaultReplace = options.UsesDefaultReplace;
+        Span<char> transformed = stackalloc char[MaxUtf16CharsPerRune];
+
         foreach (var rune in text.EnumerateRunes())
         {
             if (options.IsAllowed(rune))
             {
                 // Append the replacement atomically, so the maximum length can never split a
                 // surrogate pair or a multi-character replacement.
-                var replacement = options.Replace(rune);
+                scoped ReadOnlySpan<char> replacement;
+                if (usesDefaultReplace)
+                {
+                    // Replace allocates a string for every rune of the input. Its default implementation
+                    // is just a casing transformation, so write the result straight into the buffer instead.
+                    replacement = transformed[..options.Transform(rune).EncodeToUtf16(transformed)];
+                }
+                else
+                {
+                    replacement = options.Replace(rune);
+                }
+
                 if (sb.Length + replacement.Length > maximumLength)
                     break;
 

--- a/src/Meziantou.Framework.Slug/SlugOptions.cs
+++ b/src/Meziantou.Framework.Slug/SlugOptions.cs
@@ -102,15 +102,26 @@ public class SlugOptions
     /// <returns>The transformed string representation of the rune.</returns>
     public virtual string Replace(Rune rune)
     {
-        if (CasingTransformation == CasingTransformation.ToLowerCase)
-        {
-            rune = Culture is null ? Rune.ToLowerInvariant(rune) : Rune.ToLower(rune, Culture);
-        }
-        else if (CasingTransformation == CasingTransformation.ToUpperCase)
-        {
-            rune = Culture is null ? Rune.ToUpperInvariant(rune) : Rune.ToUpper(rune, Culture);
-        }
-
-        return rune.ToString();
+        return Transform(rune).ToString();
     }
+
+    /// <summary>
+    /// Applies <see cref="CasingTransformation"/> to a rune without allocating the string <see cref="Replace(Rune)"/> returns.
+    /// Only used when <see cref="Replace(Rune)"/> is known not to be overridden.
+    /// </summary>
+    internal Rune Transform(Rune rune)
+    {
+        return CasingTransformation switch
+        {
+            CasingTransformation.ToLowerCase => Culture is null ? Rune.ToLowerInvariant(rune) : Rune.ToLower(rune, Culture),
+            CasingTransformation.ToUpperCase => Culture is null ? Rune.ToUpperInvariant(rune) : Rune.ToUpper(rune, Culture),
+            _ => rune,
+        };
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="Replace(Rune)"/> still has its default implementation, in which case
+    /// <see cref="Transform(Rune)"/> produces the same result without allocating a string for every rune.
+    /// </summary>
+    internal bool UsesDefaultReplace => GetType() == typeof(SlugOptions);
 }

--- a/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
+++ b/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
@@ -131,4 +131,71 @@ public class SlugTests
     {
         Assert.Null(Slug.Create(text: null));
     }
+
+    [Fact]
+    public void Slug_OverriddenReplace_IsUsed()
+    {
+        var options = new UpperCaseVowelSlugOptions();
+        var slug = Slug.Create("hello world", options);
+        Assert.Equal("hEllO-wOrld", slug);
+    }
+
+    [Fact]
+    public void Slug_OverriddenReplace_IsUsedWhenItReturnsMultipleCharacters()
+    {
+        var options = new ExpandingSlugOptions();
+        var slug = Slug.Create("ab c", options);
+        Assert.Equal("aabb-cc", slug);
+    }
+
+    [Fact]
+    public void Slug_OverriddenIsAllowed_IsUsed()
+    {
+        var options = new NoVowelSlugOptions();
+        var slug = Slug.Create("hello world", options);
+        Assert.Equal("h-ll-w-rld", slug);
+    }
+
+    [Fact]
+    public void Slug_Culture_IsUsedForCasing()
+    {
+        var options = new SlugOptions
+        {
+            CasingTransformation = CasingTransformation.ToLowerCase,
+            Culture = CultureInfo.GetCultureInfo("tr-TR"),
+        };
+        var slug = Slug.Create("II", options);
+        Assert.Equal("\u0131\u0131", slug);
+    }
+
+    [Fact]
+    public void Slug_Replace_DefaultImplementationAppliesCasing()
+    {
+        var options = new SlugOptions { CasingTransformation = CasingTransformation.ToUpperCase };
+        Assert.Equal("A", options.Replace(new Rune('a')));
+    }
+
+    private sealed class UpperCaseVowelSlugOptions : SlugOptions
+    {
+        public override string Replace(Rune rune)
+        {
+            return "aeiou".Contains(rune.ToString(), StringComparison.Ordinal) ? rune.ToString().ToUpperInvariant() : base.Replace(rune);
+        }
+    }
+
+    private sealed class ExpandingSlugOptions : SlugOptions
+    {
+        public override string Replace(Rune rune)
+        {
+            return new string((char)rune.Value, count: 2);
+        }
+    }
+
+    private sealed class NoVowelSlugOptions : SlugOptions
+    {
+        public override bool IsAllowed(Rune character)
+        {
+            return base.IsAllowed(character) && !"aeiou".Contains(character.ToString(), StringComparison.Ordinal);
+        }
+    }
 }


### PR DESCRIPTION
> Stacked on #1907 — review that one first. This PR's base is `feature/meziantou-slug-analysis-e248bb`, so the diff shown here is only this change.

`SlugOptions.Replace` returns a `string`, so `Slug.Create` allocated **one string for every rune of the input**. It was the largest remaining allocation after #1907 (~1,296 of 1,400 bytes).

The default implementation is only a casing transformation, so that work moves into an internal `Transform` returning a `Rune`, and `Create` encodes it straight into a `stackalloc` buffer.

## Why the fast path is conditional

`Replace` is `public virtual` and is the documented extension point, so it cannot simply be bypassed. The fast path is taken only when `options.GetType() == typeof(SlugOptions)`, which proves `Replace` was not overridden. A subclass keeps going through `Replace`, and the default `Replace` now delegates to `Transform`, so the two paths cannot drift apart.

A subclass that overrides only `IsAllowed` loses the fast path even though it would be safe. That is deliberate — the alternative is reflecting over the method table, which is both slower and fragile under trimming (`IsTrimmable` is set on this project).

## Result

54-char ASCII input, 10,000 calls, `GC.GetAllocatedBytesForCurrentThread`:

| | bytes / `Create` |
|---|---|
| before #1907 | 5,720 |
| after #1907 | 1,400 |
| **after this PR** | **320** |

**−94% overall.** What remains is the `StringBuilder` and the result string itself.

## Tests

The risk in this change is the fast path silently skipping a customization, so the new tests target exactly that:

- a subclass overriding `Replace`
- a subclass whose `Replace` returns **more than one character** per rune (also exercises the atomic-append limit check from #1907)
- a subclass overriding `IsAllowed`
- culture-aware casing (`tr-TR`, `"II"` → `"ıı"`), locking in that `Transform` matches the old `Replace` behaviour
- `Replace` called directly, confirming the public method still applies casing

## Verification

- Debug and Release clean with `/p:TreatsWarningsAsErrors=true`, 0 warnings.
- **88/88 tests pass** across net10.0 and net11.0 in both configurations.
- `dotnet run ./eng/update-all.cs` exit 0, no generated-file changes. `ref/Meziantou.Framework.Slug.cs` unchanged — `Transform` and `UsesDefaultReplace` are `internal`, so the public API is identical.