### PR TITLE
Follow RFC 6797 for ports, IP hosts, duplicate headers, and max-age=0

### DIFF
--- a/ref/Meziantou.Framework.Http.Hsts.cs
+++ b/ref/Meziantou.Framework.Http.Hsts.cs
@@ -16,6 +16,7 @@ namespace Meziantou.Framework.Http
         public string Host { get => throw null; }
         public System.DateTimeOffset ExpiresAt { get => throw null; }
         public bool IncludeSubdomains { get => throw null; }
+        public bool IsPreloaded { get => throw null; }
         public override string ToString() => throw null;
     }
 
@@ -26,6 +27,7 @@ namespace Meziantou.Framework.Http
         public HstsDomainPolicyCollection(System.TimeProvider? timeProvider, bool includePreloadDomains = true) { }
         public void Add(string host, System.TimeSpan maxAge, bool includeSubdomains) { }
         public void Add(string host, System.DateTimeOffset expiresAt, bool includeSubdomains) { }
+        public bool Remove(string host) => throw null;
         public bool MustUpgradeRequest(string host) => throw null;
         public bool MustUpgradeRequest(System.ReadOnlySpan<char> host) => throw null;
         public System.Collections.Generic.IEnumerator<Meziantou.Framework.Http.HstsDomainPolicy> GetEnumerator() => throw null;

--- a/src/Meziantou.Framework.Http.Hsts/HstsClientHandler.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsClientHandler.cs
@@ -6,8 +6,8 @@ namespace Meziantou.Framework.Http;
 /// var policies = new HstsDomainPolicyCollection(includePreloadDomains: true);
 /// using var client = new HttpClient(new HstsClientHandler(new SocketsHttpHandler(), policies), disposeHandler: true);
 ///
-/// // Automatically upgrade to HTTPS as google.com is in the HSTS preload list
-/// using var response = await client.GetAsync("http://google.com");
+/// // Automatically upgrade to HTTPS as github.com is in the HSTS preload list
+/// using var response = await client.GetAsync("http://github.com");
 /// </code>
 /// </example>
 public sealed class HstsClientHandler : DelegatingHandler
@@ -29,6 +29,8 @@ public sealed class HstsClientHandler : DelegatingHandler
     public HstsClientHandler(HttpMessageHandler innerHandler, HstsDomainPolicyCollection configuration)
         : base(innerHandler)
     {
+        ArgumentNullException.ThrowIfNull(configuration);
+
         _configuration = configuration;
     }
 
@@ -38,16 +40,18 @@ public sealed class HstsClientHandler : DelegatingHandler
     /// <returns>The HTTP response message.</returns>
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        if (request.RequestUri?.Scheme == Uri.UriSchemeHttp && request.RequestUri.Port == 80)
+        // Use IdnHost: the preload list stores internationalized domains in their Punycode form
+        if (request.RequestUri?.Scheme == Uri.UriSchemeHttp && _configuration.MustUpgradeRequest(request.RequestUri.IdnHost))
         {
-            // Use IdnHost: the preload list stores internationalized domains in their Punycode form
-            if (_configuration.MustUpgradeRequest(request.RequestUri.IdnHost))
+            // https://datatracker.ietf.org/doc/html/rfc6797#section-8.3
+            // The default port becomes 443; an explicit port is kept as is.
+            var builder = new UriBuilder(request.RequestUri)
             {
-                var builder = new UriBuilder(request.RequestUri) { Scheme = Uri.UriSchemeHttps };
-                builder.Port = 443;
-                builder.Scheme = Uri.UriSchemeHttps;
-                request.RequestUri = builder.Uri;
-            }
+                Scheme = Uri.UriSchemeHttps,
+                Port = request.RequestUri.IsDefaultPort ? 443 : request.RequestUri.Port,
+            };
+
+            request.RequestUri = builder.Uri;
         }
 
         var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
@@ -56,27 +60,32 @@ public sealed class HstsClientHandler : DelegatingHandler
         // Note: The Strict-Transport-Security header is ignored by the browser when your site has only been accessed using HTTP.
         // Once your site is accessed over HTTPS with no certificate errors, the browser knows your site is HTTPS-capable and
         // will honor the Strict-Transport-Security header.
-        if (response.RequestMessage?.RequestUri?.Scheme == Uri.UriSchemeHttps && response.Headers.TryGetValues("Strict-Transport-Security", out var headers))
+        var responseUri = response.RequestMessage?.RequestUri;
+        if (responseUri?.Scheme == Uri.UriSchemeHttps && !IsIPAddress(responseUri) && response.Headers.TryGetValues("Strict-Transport-Security", out var headers))
         {
-            TimeSpan maxAge = default;
-            var includeSubdomains = false;
-            foreach (var header in headers)
+            // https://datatracker.ietf.org/doc/html/rfc6797#section-8.1
+            // Only the first header field is processed when the response contains more than one
+            var header = headers.FirstOrDefault();
+            if (header is not null && TryParsePolicy(header, out var maxAge, out var includeSubdomains))
             {
-                if (TryParsePolicy(header, out var headerMaxAge, out var headerIncludeSubdomains))
+                if (maxAge > TimeSpan.Zero)
                 {
-                    maxAge = headerMaxAge;
-                    includeSubdomains = headerIncludeSubdomains;
+                    _configuration.Add(responseUri.IdnHost, maxAge, includeSubdomains);
                 }
-            }
-
-            if (maxAge > TimeSpan.Zero)
-            {
-                _configuration.Add(response.RequestMessage.RequestUri.IdnHost, maxAge, includeSubdomains);
+                else
+                {
+                    // max-age=0 signals the host is no longer a Known HSTS Host
+                    _configuration.RemoveLearnedPolicy(responseUri.IdnHost);
+                }
             }
         }
 
         return response;
     }
+
+    // https://datatracker.ietf.org/doc/html/rfc6797#section-8.1
+    // An IP address must not be noted as a Known HSTS Host
+    private static bool IsIPAddress(Uri uri) => uri.HostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6;
 
     // https://datatracker.ietf.org/doc/html/rfc6797#section-6.1
     // A malformed header must be ignored instead of failing the request, as the response is otherwise valid.

--- a/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicy.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicy.cs
@@ -3,21 +3,26 @@ namespace Meziantou.Framework.Http;
 /// <summary>Represents an HSTS (HTTP Strict Transport Security) policy for a specific domain.</summary>
 public sealed class HstsDomainPolicy
 {
-    internal HstsDomainPolicy(string host, DateTimeOffset expiresAt, bool includeSubdomains)
+    internal HstsDomainPolicy(string host, DateTimeOffset expiresAt, bool includeSubdomains, bool isPreloaded)
     {
         Host = host;
         ExpiresAt = expiresAt;
         IncludeSubdomains = includeSubdomains;
+        IsPreloaded = isPreloaded;
     }
 
     /// <summary>Gets the domain host name for this HSTS policy.</summary>
     public string Host { get; }
 
     /// <summary>Gets the date and time when this HSTS policy expires.</summary>
-    public DateTimeOffset ExpiresAt { get; private set; }
+    public DateTimeOffset ExpiresAt { get; }
 
     /// <summary>Gets a value indicating whether the HSTS policy applies to subdomains of the host.</summary>
-    public bool IncludeSubdomains { get; private set; }
+    public bool IncludeSubdomains { get; }
+
+    /// <summary>Gets a value indicating whether the policy comes from the built-in HSTS preload list.</summary>
+    /// <remarks>A preloaded policy never expires and is not removed by a <c>max-age=0</c> response header.</remarks>
+    public bool IsPreloaded { get; }
 
     public override string ToString()
     {

--- a/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Runtime.InteropServices;
 using System.IO.Compression;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Meziantou.Framework.Http;
 
@@ -31,10 +32,6 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
     // snapshot and index into it without locking. Writers build a new array under _lock.
     private volatile ConcurrentDictionary<string, HstsDomainPolicy>[] _policies = [];
 
-    // Avoid recomputing the value during initialization
-    private readonly DateTimeOffset _expires18weeks;
-    private readonly DateTimeOffset _expires1year;
-
     /// <summary>Gets the default HSTS policy collection that includes preloaded domains from the Chromium HSTS preload list.</summary>
     public static HstsDomainPolicyCollection Default { get; } = new();
 
@@ -53,13 +50,11 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
         _timeProvider = timeProvider ?? TimeProvider.System;
         if (includePreloadDomains)
         {
-            _expires18weeks = _timeProvider.GetUtcNow().Add(TimeSpan.FromDays(18 * 7));
-            _expires1year = _timeProvider.GetUtcNow().Add(TimeSpan.FromDays(365));
             LoadPreloadDomains();
         }
     }
 
-    private void Load(ConcurrentDictionary<string, HstsDomainPolicy> dictionary, int entryCount, string resourceName)
+    private static void Load(ConcurrentDictionary<string, HstsDomainPolicy> dictionary, int entryCount, string resourceName)
     {
         using var stream = typeof(HstsDomainPolicyCollection).Assembly.GetManifestResourceStream(resourceName);
         Debug.Assert(stream is not null);
@@ -69,14 +64,12 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
         {
             var name = reader.ReadString();
             var includeSubdomains = reader.ReadBoolean();
-            var expiresIn = reader.ReadInt32();
-            var expiresAt = expiresIn switch
-            {
-                18 * 7 * 24 * 60 * 60 => _expires18weeks,
-                365 * 24 * 60 * 60 => _expires1year,
-                _ => _timeProvider.GetUtcNow().AddSeconds(expiresIn),
-            };
-            dictionary.TryAdd(name, new(name, expiresAt, includeSubdomains));
+
+            // The duration in the source data is the max-age the domain must serve to qualify for the
+            // preload list, not a lifetime for the entry itself. The list is compiled into the assembly,
+            // so its entries stay valid until the package is updated.
+            _ = reader.ReadInt32();
+            dictionary.TryAdd(name, new(name, DateTimeOffset.MaxValue, includeSubdomains, isPreloaded: true));
         }
     }
 
@@ -97,6 +90,7 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
     {
         ArgumentNullException.ThrowIfNull(host);
 
+        host = NormalizeHost(host);
         var partCount = CountSegments(host);
         ConcurrentDictionary<string, HstsDomainPolicy> dictionary;
         lock (_lock)
@@ -119,9 +113,56 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
         }
 
         dictionary.AddOrUpdate(host,
-            (key, arg) => new HstsDomainPolicy(key, arg.expiresAt, arg.includeSubdomains),
-            (key, value, arg) => new HstsDomainPolicy(key, arg.expiresAt, arg.includeSubdomains),
+            (key, arg) => new HstsDomainPolicy(key, arg.expiresAt, arg.includeSubdomains, isPreloaded: false),
+            // A host stays preloaded once it is on the built-in list, whatever policy replaces it
+            (key, value, arg) => new HstsDomainPolicy(key, arg.expiresAt, arg.includeSubdomains, value.IsPreloaded),
             factoryArgument: (expiresAt, includeSubdomains));
+    }
+
+    /// <summary>Removes the HSTS policy for the specified host, including a policy from the preload list.</summary>
+    /// <param name="host">The domain host name.</param>
+    /// <returns><see langword="true"/> if a policy was removed; otherwise, <see langword="false"/>.</returns>
+    public bool Remove(string host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+
+        return TryGetDictionary(host, out var dictionary, out var key) && dictionary.TryRemove(key, out _);
+    }
+
+    // Removes a policy learned from a Strict-Transport-Security header. Preloaded entries are kept: like
+    // browsers, the built-in list cannot be turned off by a response header.
+    internal bool RemoveLearnedPolicy(string host)
+    {
+        if (!TryGetDictionary(host, out var dictionary, out var key))
+            return false;
+
+        if (!dictionary.TryGetValue(key, out var policy) || policy.IsPreloaded)
+            return false;
+
+        return dictionary.TryRemove(new KeyValuePair<string, HstsDomainPolicy>(key, policy));
+    }
+
+    private bool TryGetDictionary(string host, [NotNullWhen(true)] out ConcurrentDictionary<string, HstsDomainPolicy>? dictionary, [NotNullWhen(true)] out string? key)
+    {
+        key = NormalizeHost(host);
+        var partCount = CountSegments(key);
+        var policies = _policies;
+        if (partCount > policies.Length)
+        {
+            dictionary = null;
+            key = null;
+            return false;
+        }
+
+        dictionary = policies[partCount - 1];
+        return true;
+    }
+
+    // A fully-qualified domain name may end with a dot; it designates the same host
+    private static string NormalizeHost(string host)
+    {
+        var trimmed = host.AsSpan().TrimEnd('.');
+        return trimmed.Length == host.Length ? host : trimmed.ToString();
     }
 
     /// <summary>Determines whether an HTTP request to the specified host should be upgraded to HTTPS based on HSTS policies.</summary>
@@ -138,6 +179,7 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
     /// <returns><see langword="true"/> if the request should be upgraded to HTTPS; otherwise, <see langword="false"/>.</returns>
     public bool MustUpgradeRequest(ReadOnlySpan<char> host)
     {
+        host = host.TrimEnd('.');
         var policies = _policies;
         var now = _timeProvider.GetUtcNow();
 
@@ -170,19 +212,10 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
     }
 
     // internal for tests
-    internal static int CountSegments(string host)
+    internal static int CountSegments(ReadOnlySpan<char> host)
     {
         // foo.bar.com -> 3
-        var count = 1;
-
-        var index = -1;
-        while (host.IndexOf('.', index + 1, StringComparison.Ordinal) is >= 0 and var newIndex)
-        {
-            index = newIndex;
-            count++;
-        }
-
-        return count;
+        return host.Count('.') + 1;
     }
 
     public IEnumerator<HstsDomainPolicy> GetEnumerator()

--- a/src/Meziantou.Framework.Http.Hsts/Meziantou.Framework.Http.Hsts.csproj
+++ b/src/Meziantou.Framework.Http.Hsts/Meziantou.Framework.Http.Hsts.csproj
@@ -6,7 +6,6 @@
     <Version>2.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Provide an HttpClientHandler to upgrade request from http to https if an HSTS policy is set for the domain</Description>
-    <DefineConstants Condition="'$(IsOfficialBuild)' == 'true'">$(DefineConstants);HSTS_PRELOAD_FULL</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.Http.Hsts/readme.md
+++ b/src/Meziantou.Framework.Http.Hsts/readme.md
@@ -6,6 +6,10 @@ This package provides an `HttpClientHandler` that automatically upgrades HTTP re
 var policies = new HstsDomainPolicyCollection(includePreloadDomains: true);
 using var client = new HttpClient(new HstsClientHandler(new SocketsHttpHandler(), policies), disposeHandler: true);
 
-// Automatically upgrade to HTTPS as google.com is in the HSTS preload list
-using var response = await client.GetAsync("http://google.com");
+// Automatically upgrade to HTTPS as github.com is in the HSTS preload list
+using var response = await client.GetAsync("http://github.com");
 ```
+
+The handler reads the `Strict-Transport-Security` header of HTTPS responses and adds the host to the collection, so later requests to that host are upgraded. A `max-age=0` header removes the policy, unless the host comes from the preload list. Policies learned this way are kept in memory only, and are not removed when they expire; use `Remove` to drop the ones you no longer need.
+
+The `HstsClientHandler` constructor that takes no collection uses `HstsDomainPolicyCollection.Default`, a shared instance for the whole process. Every handler using it observes the policies learned by the others. Create a dedicated `HstsDomainPolicyCollection` to isolate a client from the rest of the application.

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/HstsClientHandlerTests.cs
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/HstsClientHandlerTests.cs
@@ -8,7 +8,7 @@ public sealed class HstsClientHandlerTests
     public async Task DoNotUpgradeRequest()
     {
         var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
-        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler(headerResponse: null), hsts), disposeHandler: true);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler(), hsts), disposeHandler: true);
 
         using var response = await client.GetAsync("http://google.com", XunitCancellationToken);
         Assert.Equal(Uri.UriSchemeHttp, response.RequestMessage!.RequestUri!.Scheme);
@@ -19,7 +19,7 @@ public sealed class HstsClientHandlerTests
     {
         var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
         hsts.Add("google.com", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: true);
-        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler(headerResponse: null), hsts), disposeHandler: true);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler(), hsts), disposeHandler: true);
 
         using var response = await client.GetAsync("http://sample.google.com", XunitCancellationToken);
         Assert.Equal(Uri.UriSchemeHttps, response.RequestMessage!.RequestUri!.Scheme);
@@ -29,7 +29,7 @@ public sealed class HstsClientHandlerTests
     public async Task UpgradeRequest_AfterReadingHeader()
     {
         var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
-        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler(headerResponse: "max-age=31536000; includeSubDomains; preload"), hsts), disposeHandler: true);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler("max-age=31536000; includeSubDomains; preload"), hsts), disposeHandler: true);
 
         using var response1 = await client.GetAsync("https://sample.google.com", XunitCancellationToken);
         Assert.Equal(Uri.UriSchemeHttps, response1.RequestMessage!.RequestUri!.Scheme);
@@ -42,7 +42,7 @@ public sealed class HstsClientHandlerTests
     public async Task UpgradeRequest_InternationalizedDomain()
     {
         var hsts = new HstsDomainPolicyCollection(includePreloadDomains: true);
-        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler(headerResponse: null), hsts), disposeHandler: true);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler(), hsts), disposeHandler: true);
 
         // 跳.jp (xn--vt3a.jp) is in the HSTS preload list, which stores Punycode names
         using var response = await client.GetAsync("http://跳.jp", XunitCancellationToken);
@@ -87,7 +87,89 @@ public sealed class HstsClientHandlerTests
         Assert.True(hsts.MustUpgradeRequest("example.com"));
     }
 
-    private sealed class MockHttpMessageHandler(string? headerResponse) : HttpMessageHandler
+    [Fact]
+    public async Task UpgradeRequest_PreservesExplicitPort()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("example.com", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: true);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler(), hsts), disposeHandler: true);
+
+        // https://datatracker.ietf.org/doc/html/rfc6797#section-8.3
+        using var response = await client.GetAsync("http://example.com:8080/path", XunitCancellationToken);
+        Assert.Equal(new Uri("https://example.com:8080/path"), response.RequestMessage!.RequestUri);
+    }
+
+    [Fact]
+    public async Task UpgradeRequest_DefaultPortBecomes443()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("example.com", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: true);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler(), hsts), disposeHandler: true);
+
+        using var response = await client.GetAsync("http://example.com:80/path", XunitCancellationToken);
+        Assert.Equal(new Uri("https://example.com/path"), response.RequestMessage!.RequestUri);
+    }
+
+    [Fact]
+    public async Task MaxAgeZero_RemovesLearnedPolicy()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("example.com", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: true);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler("max-age=0"), hsts), disposeHandler: true);
+
+        using var response = await client.GetAsync("https://example.com", XunitCancellationToken);
+        Assert.False(hsts.MustUpgradeRequest("example.com"));
+    }
+
+    [Fact]
+    public async Task MaxAgeZero_DoesNotRemovePreloadedPolicy()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: true);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler("max-age=0"), hsts), disposeHandler: true);
+
+        // Like browsers, the built-in preload list cannot be turned off by a response header
+        using var response = await client.GetAsync("https://github.com", XunitCancellationToken);
+        Assert.True(hsts.MustUpgradeRequest("github.com"));
+    }
+
+    [Fact]
+    public async Task Header_IsIgnoredForIPAddress()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler("max-age=31536000"), hsts), disposeHandler: true);
+
+        // https://datatracker.ietf.org/doc/html/rfc6797#section-8.1
+        using var response = await client.GetAsync("https://127.0.0.1", XunitCancellationToken);
+        Assert.False(hsts.MustUpgradeRequest("127.0.0.1"));
+    }
+
+    [Fact]
+    public async Task OnlyFirstHeaderIsProcessed()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler("max-age=31536000", "max-age=0"), hsts), disposeHandler: true);
+
+        using var response = await client.GetAsync("https://example.com", XunitCancellationToken);
+        Assert.True(hsts.MustUpgradeRequest("example.com"));
+    }
+
+    [Fact]
+    public async Task MalformedFirstHeader_DoesNotFallBackToTheNextOne()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler("max-age=abc", "max-age=31536000"), hsts), disposeHandler: true);
+
+        using var response = await client.GetAsync("https://example.com", XunitCancellationToken);
+        Assert.False(hsts.MustUpgradeRequest("example.com"));
+    }
+
+    [Fact]
+    public void Constructor_ThrowsWhenConfigurationIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new HstsClientHandler(new MockHttpMessageHandler(), configuration: null!));
+    }
+
+    private sealed class MockHttpMessageHandler(params string[] headerResponses) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -96,7 +178,7 @@ public sealed class HstsClientHandlerTests
                 RequestMessage = request,
             };
 
-            if (headerResponse is not null)
+            foreach (var headerResponse in headerResponses)
             {
                 response.Headers.TryAddWithoutValidation("Strict-Transport-Security", headerResponse);
             }

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
@@ -123,6 +123,71 @@ public sealed class HstsDomainPolicyCollectionTests
     }
 
     [Fact]
+    public void HstsCollection_PreloadedPolicies_DoNotExpire()
+    {
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.Parse("2024-01-01T00:00:00Z", CultureInfo.InvariantCulture));
+        var hsts = new HstsDomainPolicyCollection(timeProvider, includePreloadDomains: true);
+
+        Assert.True(hsts.MustUpgradeRequest("github.com"));
+
+        // The preload list is compiled into the assembly; its entries stay valid until the package is updated
+        timeProvider.Advance(TimeSpan.FromDays(365 * 100));
+
+        Assert.True(hsts.MustUpgradeRequest("github.com"));
+    }
+
+    [Fact]
+    public void HstsCollection_Match_TrailingDot()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("example.com", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: true);
+        hsts.Add("other.com.", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: false);
+
+        // A fully-qualified domain name may end with a dot; it designates the same host
+        Assert.True(hsts.MustUpgradeRequest("example.com."));
+        Assert.True(hsts.MustUpgradeRequest("foo.example.com."));
+        Assert.True(hsts.MustUpgradeRequest("other.com"));
+        Assert.True(hsts.MustUpgradeRequest("other.com."));
+    }
+
+    [Fact]
+    public void HstsCollection_Remove()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("example.com", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: true);
+
+        Assert.True(hsts.Remove("example.com"));
+        Assert.False(hsts.MustUpgradeRequest("example.com"));
+
+        Assert.False(hsts.Remove("example.com"));
+        Assert.False(hsts.Remove("never-added.com"));
+
+        // The bucket for that segment count does not exist
+        Assert.False(hsts.Remove("a.b.c.d.e.f.example.com"));
+    }
+
+    [Fact]
+    public void HstsCollection_Remove_PreloadedPolicy()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: true);
+
+        // Remove is explicit, so it drops preloaded entries too
+        Assert.True(hsts.Remove("github.com"));
+        Assert.False(hsts.MustUpgradeRequest("github.com"));
+    }
+
+    [Fact]
+    public void HstsCollection_Add_KeepsThePreloadedFlag()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: true);
+        hsts.Add("github.com", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: false);
+
+        var policy = hsts.Single(entry => entry.Host == "github.com");
+        Assert.True(policy.IsPreloaded);
+        Assert.False(policy.IncludeSubdomains);
+    }
+
+    [Fact]
     public void HstsCollection_Match_UsePreloadDomains()
     {
         var hsts = new HstsDomainPolicyCollection(includePreloadDomains: true);

--- a/tools/Meziantou.Framework.Http.Hsts.Generator/Program.cs
+++ b/tools/Meziantou.Framework.Http.Hsts.Generator/Program.cs
@@ -39,13 +39,8 @@ for (var i = 1; i <= maxSegments; i++)
     {
         foreach (var entry in entries.Where(e => e.SegmentCount == i).OrderBy(e => e.Name, StringComparer.Ordinal))
         {
-            var expiresIn = entry.Policy switch
-            {
-                "bulk-18-weeks" => "_expires18weeks",
-                "bulk-1-year" => "_expires1year",
-                _ => "_expires1year",
-            };
-            sb.Append($"        dict{i.ToString(CultureInfo.InvariantCulture)}.TryAdd(\"{entry.Name}\", new HstsDomainPolicy(\"{entry.Name}\", {expiresIn}, {entry.IncludeSubdomains.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()}));\n");
+            // Preloaded entries are compiled into the assembly and stay valid until the package is updated
+            sb.Append($"        dict{i.ToString(CultureInfo.InvariantCulture)}.TryAdd(\"{entry.Name}\", new HstsDomainPolicy(\"{entry.Name}\", DateTimeOffset.MaxValue, {entry.IncludeSubdomains.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()}, isPreloaded: true));\n");
         }
     }
     else


### PR DESCRIPTION
Stacked on #1909 — please merge that one first. The diff shown against `main` will include #1909's commit until then; review [the second commit](https://github.com/meziantou/Meziantou.Framework/pull/1911/commits) on its own.

Picks up the remaining issues from the review of this package, after the four confirmed bugs in #1909.

## RFC 6797 deviations

**An explicit non-default port skipped the upgrade entirely.** [§8.3](https://datatracker.ietf.org/doc/html/rfc6797#section-8.3) says the scheme becomes `https`, port 80 becomes 443, and any other explicit port is preserved. `http://example.com:8080` now upgrades to `https://example.com:8080` instead of being left on plaintext.

**A header returned for an IP address was noted as a policy.** [§8.1](https://datatracker.ietf.org/doc/html/rfc6797#section-8.1) forbids treating an IP address as a Known HSTS Host.

**Every header field was processed, last one winning.** §8.1 says process only the first. A later field can no longer override it, and a malformed first field no longer falls through to the next.

**`max-age=0` was ignored,** so a site could never turn HSTS off. It now removes the policy.

## The `max-age=0` design decision

This needed a removal API, and there is a judgement call in it worth flagging.

Removing on `max-age=0` means a response can disable HSTS for a host. For a host on the **preload list** that is strictly weaker than the current behavior, and browsers universally treat preloaded entries as not overridable by a header. Since this is a security feature, I did not want to introduce that downgrade path as a side effect of an RFC fix:

- `public bool Remove(string host)` — unconditional, for explicit callers. Also fills a real gap: the collection had `Add` and `IEnumerable` but no way to drop an entry.
- `internal bool RemoveLearnedPolicy(string host)` — what the handler calls for `max-age=0`; keeps preloaded entries.
- `HstsDomainPolicy.IsPreloaded` makes the distinction visible, and `Add` preserves the flag so a learned policy cannot silently un-preload a host.

Happy to collapse this to the literal RFC reading (remove unconditionally) if you would rather keep the model simpler — it is a small change.

## Preloaded entries no longer expire

The duration in the Chromium data is the max-age a domain must serve to *qualify* for the list (`bulk-1-year`, `bulk-18-weeks` are submission categories), not a lifetime for the entry. It was being applied relative to process start, so a service running past 18 weeks silently stopped upgrading a large part of the list.

The generator still writes the field and `Load` skips it, so **the embedded `.bin` files are unchanged** and stay byte-identical to what the generator produces. The generator's inline path — used when a bucket has fewer than 10 entries, which does not happen with the current data but would after a future refresh — was updated to match, so a regeneration cannot emit code referencing the removed fields.

## Also in passing

- **A trailing dot is now accepted.** `example.com.` designates the same host but matched nothing.
- **The documented example was wrong.** It claimed `google.com` is preloaded. It is not — the `google` TLD is, but `google.com` has no entry, so `MustUpgradeRequest("google.com")` returns `false` and the sample in the readme and XML docs did not do what it said. Verified against the embedded data and at runtime, and replaced with `github.com`, which is on the list.
- Documented that the parameterless handler constructor shares `HstsDomainPolicyCollection.Default` process-wide, and that learned policies are never evicted.
- Removed `HSTS_PRELOAD_FULL`, defined in the csproj but referenced nowhere.
- Null check on the collection passed to `HstsClientHandler`.
- `HstsDomainPolicy` properties are get-only; `CountSegments` takes a span.

## Public API

Additive only, reflected in `ref/`:

```csharp
public bool HstsDomainPolicyCollection.Remove(string host);
public bool HstsDomainPolicy.IsPreloaded { get; }
```

## Verification

- Builds clean on `net10.0` and `net11.0` with `TreatWarningsAsErrors=true`.
- 76/76 tests pass (38 per TFM), up from 50.
- `dotnet run ./eng/update-all.cs` exits 0; the only generated change is the additive `ref/` update.
- Restoring the previous handler makes 6 of the new tests fail, confirming they are genuine regressions. `MaxAgeZero_DoesNotRemovePreloadedPolicy` and `UpgradeRequest_DefaultPortBecomes443` pass either way by design — they guard behavior that must not change.

## Not included

The preload list retains ~28 MB for ~95k entries (measured: 94,628 entries, 36 ms load). Making the dictionary value a struct would save roughly 15% of that; a real win needs a different data structure entirely. That is an optimization rather than a correctness fix, it would touch the generator a third time, and it deserves benchmarks, so I left it out. Same for evicting expired learned policies, which needs a pruning policy decision — `Remove` at least makes it possible to do by hand now.
