### PR TITLE
Fix undo/redo history corruption bugs

### DIFF
--- a/src/Meziantou.Framework.UndoRedo/ActionHistory.cs
+++ b/src/Meziantou.Framework.UndoRedo/ActionHistory.cs
@@ -12,9 +12,17 @@ internal sealed class ActionHistory
     public bool CanUndo => _undo.Count > 0;
     public bool CanRedo => _redo.Count > 0;
 
-    public void Record(IUndoRedoAction action)
+    /// <summary>
+    /// Records a new action. When the action allows merging and the most recent undoable action absorbs it,
+    /// no new entry is added. The redo buffer is cleared either way as the history moved forward.
+    /// </summary>
+    public async ValueTask RecordAsync(IUndoRedoAction action)
     {
-        _undo.Push(action);
+        if (!action.AllowToMergeWithPrevious || PeekUndo() is not { } previous || !await previous.TryToMergeAsync(action).ConfigureAwait(false))
+        {
+            _undo.Push(action);
+        }
+
         _redo.Clear();
     }
 

--- a/src/Meziantou.Framework.UndoRedo/Meziantou.Framework.UndoRedo.csproj
+++ b/src/Meziantou.Framework.UndoRedo/Meziantou.Framework.UndoRedo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Async-first undo/redo framework based on the command pattern, with transactions and action merging.</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoManager.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoManager.cs
@@ -51,11 +51,18 @@ public sealed class UndoRedoManager
         if (_transactions.Count > 0)
         {
             var transaction = _transactions.Peek();
-            transaction.Add(action);
+
+            // An action that fails to execute must not become part of the transaction, otherwise it
+            // would be reverted on rollback and executed for the first time on redo.
             if (!transaction.IsDelayed)
             {
                 await ExecuteAsync(action, cancellationToken).ConfigureAwait(false);
+                transaction.Add(action);
                 transaction.MarkExecuted();
+            }
+            else
+            {
+                transaction.Add(action);
             }
 
             return;
@@ -161,7 +168,11 @@ public sealed class UndoRedoManager
     /// When <see langword="true"/> (the default), actions added to the transaction are executed only when the
     /// transaction is committed. When <see langword="false"/>, actions are executed as soon as they are recorded.
     /// </param>
-    /// <returns>A transaction that should be committed or rolled back. Disposing it commits the transaction unless it was rolled back.</returns>
+    /// <returns>
+    /// A transaction that should be committed or rolled back. Disposing it commits the transaction unless it was already
+    /// completed, including when the scope is left because of an exception. Nested transactions must be completed from
+    /// the innermost out.
+    /// </returns>
     public UndoRedoTransaction CreateTransaction(bool isDelayed = true)
     {
         var transaction = new UndoRedoTransaction(this, isDelayed);
@@ -171,11 +182,24 @@ public sealed class UndoRedoManager
 
     /// <summary>Commits the innermost open transaction, recording it as a single undo step (or merging it into its parent transaction).</summary>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    public async ValueTask CommitTransactionAsync(CancellationToken cancellationToken = default)
+    public ValueTask CommitTransactionAsync(CancellationToken cancellationToken = default)
     {
         if (_transactions.Count == 0)
             throw new InvalidOperationException("There is no transaction to commit.");
 
+        return CommitTransactionCoreAsync(cancellationToken);
+    }
+
+    /// <summary>Commits <paramref name="transaction"/>, which must be the innermost open transaction.</summary>
+    internal ValueTask CommitTransactionAsync(UndoRedoTransaction transaction, CancellationToken cancellationToken)
+    {
+        EnsureIsInnermostTransaction(transaction, "commit");
+
+        return CommitTransactionCoreAsync(cancellationToken);
+    }
+
+    private async ValueTask CommitTransactionCoreAsync(CancellationToken cancellationToken)
+    {
         var transaction = _transactions.Pop();
         transaction.MarkCompleted();
 
@@ -203,11 +227,24 @@ public sealed class UndoRedoManager
 
     /// <summary>Rolls back the innermost open transaction, reverting any actions that were already executed.</summary>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    public async ValueTask RollbackTransactionAsync(CancellationToken cancellationToken = default)
+    public ValueTask RollbackTransactionAsync(CancellationToken cancellationToken = default)
     {
         if (_transactions.Count == 0)
             throw new InvalidOperationException("There is no transaction to roll back.");
 
+        return RollbackTransactionCoreAsync(cancellationToken);
+    }
+
+    /// <summary>Rolls back <paramref name="transaction"/>, which must be the innermost open transaction.</summary>
+    internal ValueTask RollbackTransactionAsync(UndoRedoTransaction transaction, CancellationToken cancellationToken)
+    {
+        EnsureIsInnermostTransaction(transaction, "roll back");
+
+        return RollbackTransactionCoreAsync(cancellationToken);
+    }
+
+    private async ValueTask RollbackTransactionCoreAsync(CancellationToken cancellationToken)
+    {
         var transaction = _transactions.Pop();
         transaction.MarkCompleted();
 
@@ -222,18 +259,18 @@ public sealed class UndoRedoManager
         }
     }
 
+    private void EnsureIsInnermostTransaction(UndoRedoTransaction transaction, string operation)
+    {
+        if (_transactions.Count == 0 || _transactions.Peek() != transaction)
+            throw new InvalidOperationException($"Cannot {operation} this transaction because it is not the innermost open transaction. Complete the nested transactions first.");
+    }
+
     private async ValueTask RecordActionCoreAsync(IUndoRedoAction action, bool execute, CancellationToken cancellationToken)
     {
         if (execute)
             await ExecuteAsync(action, cancellationToken).ConfigureAwait(false);
 
-        if (action.AllowToMergeWithPrevious && _history.PeekUndo() is { } previous && await previous.TryToMergeAsync(action).ConfigureAwait(false))
-        {
-            OnCollectionChanged();
-            return;
-        }
-
-        _history.Record(action);
+        await _history.RecordAsync(action).ConfigureAwait(false);
         OnCollectionChanged();
     }
 

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoTransaction.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoTransaction.cs
@@ -3,8 +3,14 @@ namespace Meziantou.Framework.UndoRedo;
 /// <summary>
 /// Groups several actions into a single undoable/redoable unit. Create one with
 /// <see cref="UndoRedoManager.CreateTransaction"/> and commit it (explicitly or by disposal) to
-/// record it as a single step.
+/// record it as a single step. Committing is all-or-nothing: if one of the actions fails, the
+/// actions that already ran are reverted before the exception is propagated.
 /// </summary>
+/// <remarks>
+/// Disposal commits the transaction, including when the scope is left because of an exception. Call
+/// <see cref="RollbackAsync"/> explicitly to discard the actions recorded so far. Nested transactions
+/// must be completed from the innermost out.
+/// </remarks>
 /// <example>
 /// <code>
 /// await using (manager.CreateTransaction())
@@ -42,20 +48,37 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
     internal void MarkCompleted() => _completed = true;
 
     /// <inheritdoc />
+    /// <remarks>
+    /// The transaction is all-or-nothing: when an action fails, the actions that already ran are reverted before
+    /// the failure is propagated. An <see cref="AggregateException"/> is thrown if reverting them also fails.
+    /// </remarks>
     public async ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
     {
         if (_executed)
             return;
 
-        foreach (var action in _actions)
+        for (var i = 0; i < _actions.Count; i++)
         {
-            await action.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await _actions[i].ExecuteAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                await CompensateAsync(exception, () => RevertRangeAsync(0, i - 1)).ConfigureAwait(false);
+                throw;
+            }
         }
 
         _executed = true;
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// The transaction is all-or-nothing: when an action fails to revert, the actions that were already reverted
+    /// are re-applied before the failure is propagated. An <see cref="AggregateException"/> is thrown if
+    /// re-applying them also fails.
+    /// </remarks>
     public async ValueTask UnExecuteAsync(CancellationToken cancellationToken = default)
     {
         if (!_executed)
@@ -63,10 +86,49 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
 
         for (var i = _actions.Count - 1; i >= 0; i--)
         {
-            await _actions[i].UnExecuteAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await _actions[i].UnExecuteAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                await CompensateAsync(exception, () => ReapplyRangeAsync(i + 1, _actions.Count - 1)).ConfigureAwait(false);
+                throw;
+            }
         }
 
         _executed = false;
+    }
+
+    private static async ValueTask CompensateAsync(Exception exception, Func<ValueTask> compensate)
+    {
+        try
+        {
+            await compensate().ConfigureAwait(false);
+        }
+        catch (Exception compensationException)
+        {
+            throw new AggregateException(exception, compensationException);
+        }
+    }
+
+    /// <summary>Reverts the actions in <c>[firstIndex, lastIndex]</c>, most recent first.</summary>
+    private async ValueTask RevertRangeAsync(int firstIndex, int lastIndex)
+    {
+        for (var i = lastIndex; i >= firstIndex; i--)
+        {
+            // The compensation must run to completion even when the failure was a cancellation.
+            await _actions[i].UnExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Re-applies the actions in <c>[firstIndex, lastIndex]</c>, oldest first.</summary>
+    private async ValueTask ReapplyRangeAsync(int firstIndex, int lastIndex)
+    {
+        for (var i = firstIndex; i <= lastIndex; i++)
+        {
+            await _actions[i].ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc />
@@ -80,18 +142,40 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
 
     /// <summary>Commits the transaction, recording it as a single undo step.</summary>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    public ValueTask CommitAsync(CancellationToken cancellationToken = default) => _manager.CommitTransactionAsync(cancellationToken);
+    /// <exception cref="InvalidOperationException">The transaction is already completed, or it is not the innermost open transaction.</exception>
+    public ValueTask CommitAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureNotCompleted();
+
+        return _manager.CommitTransactionAsync(this, cancellationToken);
+    }
 
     /// <summary>Rolls back the transaction, reverting any actions that were already executed.</summary>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    public ValueTask RollbackAsync(CancellationToken cancellationToken = default) => _manager.RollbackTransactionAsync(cancellationToken);
+    /// <exception cref="InvalidOperationException">The transaction is already completed, or it is not the innermost open transaction.</exception>
+    public ValueTask RollbackAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureNotCompleted();
 
-    /// <summary>Commits the transaction if it has not already been committed or rolled back.</summary>
+        return _manager.RollbackTransactionAsync(this, cancellationToken);
+    }
+
+    /// <summary>
+    /// Commits the transaction if it has not already been committed or rolled back. Note that this commits even
+    /// when the scope is left because of an exception; call <see cref="RollbackAsync"/> explicitly to discard the
+    /// actions recorded so far.
+    /// </summary>
     public async ValueTask DisposeAsync()
     {
         if (_completed)
             return;
 
         await CommitAsync().ConfigureAwait(false);
+    }
+
+    private void EnsureNotCompleted()
+    {
+        if (_completed)
+            throw new InvalidOperationException("The transaction is already committed or rolled back.");
     }
 }

--- a/src/Meziantou.Framework.UndoRedo/readme.md
+++ b/src/Meziantou.Framework.UndoRedo/readme.md
@@ -70,6 +70,30 @@ await using (manager.CreateTransaction())
 await manager.UndoAsync();
 ````
 
+> **Disposing always commits**, including when the scope is left because of an exception. To discard the actions
+> recorded so far, call `RollbackAsync` explicitly:
+>
+> ````c#
+> var transaction = manager.CreateTransaction();
+> try
+> {
+>     await manager.RecordActionAsync(addFirst, removeFirst);
+>     await manager.RecordActionAsync(addSecond, removeSecond);
+>     await transaction.CommitAsync();
+> }
+> catch
+> {
+>     await transaction.RollbackAsync();
+>     throw;
+> }
+> ````
+
+Nested transactions must be completed from the innermost out; committing or rolling back a transaction while one of
+its nested transactions is still open throws an `InvalidOperationException`.
+
+Committing a transaction is all-or-nothing: if one of its actions fails, the actions that already ran are reverted
+before the exception is propagated.
+
 ## Merge consecutive actions
 
 When an action sets `AllowToMergeWithPrevious` and the previous action's `TryToMergeAsync` returns `true`, both collapse into a single undo step. This is useful for chains of similar operations such as typing or dragging.

--- a/tests/Meziantou.Framework.UndoRedo.Tests/UndoRedoManagerTests.cs
+++ b/tests/Meziantou.Framework.UndoRedo.Tests/UndoRedoManagerTests.cs
@@ -281,6 +281,131 @@ public sealed class UndoRedoManagerTests
         Assert.Equal(0, value);
     }
 
+    [Fact]
+    public async Task Merge_ClearsRedoBuffer()
+    {
+        var manager = new UndoRedoManager();
+        var sum = 0;
+
+        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 1), CancellationToken);
+        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 2), CancellationToken);
+        await manager.UndoAsync(CancellationToken);
+        Assert.True(manager.CanRedo);
+
+        // Recording moves the history forward, so the redo buffer must be dropped even when the action is merged.
+        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 4) { AllowToMergeWithPrevious = true }, CancellationToken);
+
+        Assert.False(manager.CanRedo);
+        Assert.Equal(5, sum);
+        Assert.Single(manager.UndoableActions);
+
+        await manager.UndoAsync(CancellationToken);
+        Assert.Equal(0, sum);
+    }
+
+    [Fact]
+    public async Task Transaction_ActionThatFailsToExecute_IsNotPartOfTheTransaction()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+
+        await using (manager.CreateTransaction(isDelayed: false))
+        {
+            await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.RecordActionAsync(
+                () => throw new InvalidOperationException("boom"),
+                () => log.Add("undo:b"),
+                CancellationToken));
+        }
+
+        Assert.Equal(["do:a"], log);
+
+        await manager.UndoAsync(CancellationToken);
+        await manager.RedoAsync(CancellationToken);
+
+        // The failed action must not run for the first time during redo.
+        Assert.Equal(["do:a", "undo:a", "do:a"], log);
+    }
+
+    [Fact]
+    public async Task Transaction_CommitOuterWhileInnerIsOpen_Throws()
+    {
+        var manager = new UndoRedoManager();
+        var outer = manager.CreateTransaction();
+        var inner = manager.CreateTransaction();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await outer.CommitAsync(CancellationToken));
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await outer.RollbackAsync(CancellationToken));
+
+        await inner.CommitAsync(CancellationToken);
+        await outer.CommitAsync(CancellationToken);
+    }
+
+    [Fact]
+    public async Task Transaction_CompletedTwice_Throws()
+    {
+        var manager = new UndoRedoManager();
+
+        var outer = manager.CreateTransaction();
+        var inner = manager.CreateTransaction();
+        await inner.CommitAsync(CancellationToken);
+
+        // Completing an already completed transaction must not silently complete the enclosing one.
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await inner.CommitAsync(CancellationToken));
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await inner.RollbackAsync(CancellationToken));
+
+        // Disposing an already completed transaction stays a no-op.
+        await inner.DisposeAsync();
+
+        await outer.CommitAsync(CancellationToken);
+    }
+
+    [Fact]
+    public async Task Transaction_CommitFailure_RevertsAlreadyExecutedActions()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+
+        var transaction = manager.CreateTransaction();
+        await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+        await manager.RecordActionAsync(() => throw new InvalidOperationException("boom"), () => log.Add("undo:b"), CancellationToken);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await transaction.CommitAsync(CancellationToken));
+
+        Assert.Equal(["do:a", "undo:a"], log);
+        Assert.False(manager.CanUndo);
+    }
+
+    [Fact]
+    public async Task Transaction_UndoFailure_ReappliesRevertedActions()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+        var failOnUndo = true;
+
+        await using (manager.CreateTransaction())
+        {
+            await manager.RecordActionAsync(() => log.Add("do:a"), () => log.Add("undo:a"), CancellationToken);
+            await manager.RecordActionAsync(
+                () => log.Add("do:b"),
+                () => { if (failOnUndo) throw new InvalidOperationException("boom"); log.Add("undo:b"); },
+                CancellationToken);
+            await manager.RecordActionAsync(() => log.Add("do:c"), () => log.Add("undo:c"), CancellationToken);
+        }
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.UndoAsync(CancellationToken));
+
+        // "b" failed to revert, so "c" is re-applied and the step stays fully executed and undoable.
+        Assert.Equal(["do:a", "do:b", "do:c", "undo:c", "do:c"], log);
+        Assert.True(manager.CanUndo);
+        Assert.False(manager.CanRedo);
+
+        failOnUndo = false;
+        log.Clear();
+        await manager.UndoAsync(CancellationToken);
+        Assert.Equal(["undo:c", "undo:b", "undo:a"], log);
+    }
+
     private sealed class AddAction(Action<int> add, Action<int> subtract, int value) : UndoRedoActionBase
     {
         // The total amount this action is responsible for; grows when following actions are merged in.


### PR DESCRIPTION
**Stack 1/7** — base `main`. Non-breaking, ships as `2.0.1`.

Four bugs found while reviewing `Meziantou.Framework.UndoRedo`. Each was reproduced against the pre-fix code before being fixed, and each new test was re-run on the stashed original source to confirm it fails there.

### Merging left a stale redo entry
`RecordActionCoreAsync` returned early on a successful merge, skipping the only `_redo.Clear()`. Recording after an undo left a redo entry that replayed onto diverged state:

```
record a, record b, undo  ->  do:a, do:b, undo:b
record c (merges into a)  ->  do:c        // CanRedo still true
redo                      ->  do:b        // replays b on top of a+c
```

The merge attempt now lives in `ActionHistory.RecordAsync`, so both paths clear the redo buffer and cannot drift apart again.

### A failed action stayed in its transaction and ran during redo
`transaction.Add(action)` happened before `ExecuteAsync`. When execute threw, the action stayed in `_actions` while `_executed` was already `true`, so commit skipped it and **redo executed it for the first time** — and threw. It is now added only after it executes.

### `CommitAsync`/`RollbackAsync` acted on the innermost transaction, not on `this`
Both forwarded to the manager, which blindly popped the stack. `outer.CommitAsync()` with an inner transaction open committed the *inner* one and left `outer` open forever, so every later `UndoAsync`/`RedoAsync`/`Clear` threw. Both now verify the transaction is the innermost one, and refuse a second completion.

### Partial failure stranded already-applied actions
Neither `ExecuteAsync` nor `UnExecuteAsync` tracked progress, so a failure at action 3 of 5 left the first two applied with no way back. Commit and undo are now all-or-nothing: the actions that ran are compensated before the exception propagates. Compensation runs with `CancellationToken.None` so it completes even when the trigger was a cancellation, and an `AggregateException` carries both causes if compensation itself fails.

### Also
Documents that disposing a transaction commits it **even when the scope is left because of an exception** — the opposite of `TransactionScope`. Behavior unchanged here; inverting it is breaking and deliberately left out of this PR.

### Verification
- `dotnet build /p:TreatsWarningsAsErrors=true` — clean, net10.0 + net11.0
- `dotnet test /p:TreatsWarningsAsErrors=true` — 44/44 (22 tests x 2 TFMs; 16 existing + 6 new)
- `ref/Meziantou.Framework.UndoRedo.cs` unchanged: no public API change
- `dotnet run ./eng/update-all.cs` — no changes