### PR TITLE
Reject reentrant history changes while an action is executing

### DIFF
--- a/src/Meziantou.Framework.UndoRedo/Meziantou.Framework.UndoRedo.csproj
+++ b/src/Meziantou.Framework.UndoRedo/Meziantou.Framework.UndoRedo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>2.0.1</Version>
+    <Version>3.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
     <Description>Async-first undo/redo framework based on the command pattern, with transactions and action merging.</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoManager.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoManager.cs
@@ -30,6 +30,10 @@ public sealed class UndoRedoManager
     private readonly Stack<UndoRedoTransaction> _transactions = new();
 
     /// <summary>Gets a value indicating whether an action is currently being executed, undone, or redone.</summary>
+    /// <remarks>
+    /// While this is <see langword="true"/>, any operation that changes the history throws an
+    /// <see cref="InvalidOperationException"/>. An action must not record, undo, or redo anything itself.
+    /// </remarks>
     public bool ActionIsExecuting { get; private set; }
 
     /// <summary>Gets a value indicating whether there is at least one action that can be undone.</summary>
@@ -47,6 +51,7 @@ public sealed class UndoRedoManager
     public async ValueTask RecordActionAsync(IUndoRedoAction action, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(action);
+        EnsureNoActionIsExecuting();
 
         if (_transactions.Count > 0)
         {
@@ -103,6 +108,8 @@ public sealed class UndoRedoManager
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     public async ValueTask UndoAsync(CancellationToken cancellationToken = default)
     {
+        EnsureNoActionIsExecuting();
+
         if (_transactions.Count > 0)
             throw new InvalidOperationException("Cannot undo while a transaction is open.");
 
@@ -127,6 +134,8 @@ public sealed class UndoRedoManager
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     public async ValueTask RedoAsync(CancellationToken cancellationToken = default)
     {
+        EnsureNoActionIsExecuting();
+
         if (_transactions.Count > 0)
             throw new InvalidOperationException("Cannot redo while a transaction is open.");
 
@@ -150,6 +159,8 @@ public sealed class UndoRedoManager
     /// <summary>Empties both the undo and redo buffers.</summary>
     public void Clear()
     {
+        EnsureNoActionIsExecuting();
+
         if (_transactions.Count > 0)
             throw new InvalidOperationException("Cannot clear the history while a transaction is open.");
 
@@ -175,6 +186,8 @@ public sealed class UndoRedoManager
     /// </returns>
     public UndoRedoTransaction CreateTransaction(bool isDelayed = true)
     {
+        EnsureNoActionIsExecuting();
+
         var transaction = new UndoRedoTransaction(this, isDelayed);
         _transactions.Push(transaction);
         return transaction;
@@ -184,6 +197,8 @@ public sealed class UndoRedoManager
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     public ValueTask CommitTransactionAsync(CancellationToken cancellationToken = default)
     {
+        EnsureNoActionIsExecuting();
+
         if (_transactions.Count == 0)
             throw new InvalidOperationException("There is no transaction to commit.");
 
@@ -193,6 +208,7 @@ public sealed class UndoRedoManager
     /// <summary>Commits <paramref name="transaction"/>, which must be the innermost open transaction.</summary>
     internal ValueTask CommitTransactionAsync(UndoRedoTransaction transaction, CancellationToken cancellationToken)
     {
+        EnsureNoActionIsExecuting();
         EnsureIsInnermostTransaction(transaction, "commit");
 
         return CommitTransactionCoreAsync(cancellationToken);
@@ -229,6 +245,8 @@ public sealed class UndoRedoManager
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     public ValueTask RollbackTransactionAsync(CancellationToken cancellationToken = default)
     {
+        EnsureNoActionIsExecuting();
+
         if (_transactions.Count == 0)
             throw new InvalidOperationException("There is no transaction to roll back.");
 
@@ -238,6 +256,7 @@ public sealed class UndoRedoManager
     /// <summary>Rolls back <paramref name="transaction"/>, which must be the innermost open transaction.</summary>
     internal ValueTask RollbackTransactionAsync(UndoRedoTransaction transaction, CancellationToken cancellationToken)
     {
+        EnsureNoActionIsExecuting();
         EnsureIsInnermostTransaction(transaction, "roll back");
 
         return RollbackTransactionCoreAsync(cancellationToken);
@@ -257,6 +276,14 @@ public sealed class UndoRedoManager
         {
             ActionIsExecuting = false;
         }
+    }
+
+    private void EnsureNoActionIsExecuting()
+    {
+        // Reentrancy would clear ActionIsExecuting while the outer action is still running and would
+        // record the inner action as an unrelated undo step.
+        if (ActionIsExecuting)
+            throw new InvalidOperationException("Cannot change the undo/redo history while an action is executing.");
     }
 
     private void EnsureIsInnermostTransaction(UndoRedoTransaction transaction, string operation)

--- a/tests/Meziantou.Framework.UndoRedo.Tests/UndoRedoManagerTests.cs
+++ b/tests/Meziantou.Framework.UndoRedo.Tests/UndoRedoManagerTests.cs
@@ -406,6 +406,46 @@ public sealed class UndoRedoManagerTests
         Assert.Equal(["undo:c", "undo:b", "undo:a"], log);
     }
 
+    [Fact]
+    public async Task RecordAction_FromInsideAnExecutingAction_Throws()
+    {
+        var manager = new UndoRedoManager();
+        var log = new List<string>();
+
+        var action = new UndoRedoDelegateAction(
+            execute: async ct =>
+            {
+                Assert.True(manager.ActionIsExecuting);
+                await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.RecordActionAsync(() => log.Add("do:inner"), () => log.Add("undo:inner"), ct));
+                await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.UndoAsync(ct));
+                await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.RedoAsync(ct));
+                Assert.Throws<InvalidOperationException>(manager.Clear);
+                Assert.Throws<InvalidOperationException>(() => manager.CreateTransaction());
+                log.Add("do:outer");
+            },
+            unexecute: () => log.Add("undo:outer"));
+
+        await manager.RecordActionAsync(action, CancellationToken);
+
+        Assert.Equal(["do:outer"], log);
+        Assert.False(manager.ActionIsExecuting);
+        Assert.Single(manager.UndoableActions);
+    }
+
+    [Fact]
+    public async Task ActionIsExecuting_IsResetAfterAFailedAction()
+    {
+        var manager = new UndoRedoManager();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await manager.RecordActionAsync(
+            () => throw new InvalidOperationException("boom"),
+            () => { },
+            CancellationToken));
+
+        Assert.False(manager.ActionIsExecuting);
+        Assert.False(manager.CanUndo);
+    }
+
     private sealed class AddAction(Action<int> add, Action<int> subtract, int value) : UndoRedoActionBase
     {
         // The total amount this action is responsible for; grows when following actions are merged in.


### PR DESCRIPTION
**Stack 2/7** — base #1912. First breaking change of the stack, so it bumps the package to `3.0.0`; the following PRs stay on that version.

`ActionIsExecuting` was a plain `bool`. An action that recorded, undid, or redid something from inside its own execute delegate reset the flag while the outer action was still running:

```
outer-executing, ActionIsExecuting=True
do:inner
after inner, ActionIsExecuting=False   // outer is still running
undo count=2                            // inner became an unrelated undo step
```

Every operation that changes the history — `RecordActionAsync`, `UndoAsync`, `RedoAsync`, `Clear`, `CreateTransaction`, commit and rollback — now throws `InvalidOperationException` while an action is executing.

Reentrancy is essentially always a bug here, and rejecting it is what makes the `bool` accurate: with nesting impossible, no depth counter is needed. It also turns the "not thread-safe" remark in the docs into something that actually fails loudly when two flows interleave on the same manager.

### Verification
- `dotnet build` / `dotnet test` with `/p:TreatsWarningsAsErrors=true` — 48/48 (24 x 2 TFMs), clean build
- `ref/` unchanged: no signature change, only behavior