### PR TITLE
Remove CanExecute/CanUnExecute from IUndoRedoAction

### DIFF
--- a/ref/Meziantou.Framework.UndoRedo.cs
+++ b/ref/Meziantou.Framework.UndoRedo.cs
@@ -9,8 +9,6 @@ namespace Meziantou.Framework.UndoRedo
         bool AllowToMergeWithPrevious { get; }
         System.Threading.Tasks.ValueTask ExecuteAsync(System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.ValueTask UnExecuteAsync(System.Threading.CancellationToken cancellationToken = null);
-        bool CanExecute();
-        bool CanUnExecute();
         System.Threading.Tasks.ValueTask<bool> TryToMergeAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction followingAction);
     }
 
@@ -22,8 +20,6 @@ namespace Meziantou.Framework.UndoRedo
         protected abstract System.Threading.Tasks.ValueTask ExecuteCoreAsync(System.Threading.CancellationToken cancellationToken);
         public System.Threading.Tasks.ValueTask UnExecuteAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         protected abstract System.Threading.Tasks.ValueTask UnExecuteCoreAsync(System.Threading.CancellationToken cancellationToken);
-        public bool CanExecute() => throw null;
-        public bool CanUnExecute() => throw null;
         public virtual System.Threading.Tasks.ValueTask<bool> TryToMergeAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction followingAction) => throw null;
     }
 
@@ -63,8 +59,6 @@ namespace Meziantou.Framework.UndoRedo
         public bool AllowToMergeWithPrevious { get => throw null; set { } }
         public System.Threading.Tasks.ValueTask ExecuteAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public System.Threading.Tasks.ValueTask UnExecuteAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
-        public bool CanExecute() => throw null;
-        public bool CanUnExecute() => throw null;
         public System.Threading.Tasks.ValueTask<bool> TryToMergeAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction followingAction) => throw null;
         public System.Threading.Tasks.ValueTask CommitAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public System.Threading.Tasks.ValueTask RollbackAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;

--- a/src/Meziantou.Framework.UndoRedo/IUndoRedoAction.cs
+++ b/src/Meziantou.Framework.UndoRedo/IUndoRedoAction.cs
@@ -12,12 +12,6 @@ public interface IUndoRedoAction
     /// <summary>Reverts the change previously applied by <see cref="ExecuteAsync"/>.</summary>
     ValueTask UnExecuteAsync(CancellationToken cancellationToken = default);
 
-    /// <summary>Gets a value indicating whether the action can currently be executed.</summary>
-    bool CanExecute();
-
-    /// <summary>Gets a value indicating whether the action can currently be reverted.</summary>
-    bool CanUnExecute();
-
     /// <summary>
     /// Attempts to merge a following action into this one instead of recording it as a separate
     /// step. Useful for long chains of consecutive operations of the same kind (e.g. dragging or typing).

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoActionBase.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoActionBase.cs
@@ -16,34 +16,28 @@ public abstract class UndoRedoActionBase : IUndoRedoAction
     /// <inheritdoc />
     public async ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        if (!CanExecute())
+        if (ExecuteCount > 0)
             return;
 
         await ExecuteCoreAsync(cancellationToken).ConfigureAwait(false);
         ExecuteCount++;
     }
 
-    /// <summary>Contains the logic that applies the change. Called by <see cref="ExecuteAsync"/> when <see cref="CanExecute"/> is <see langword="true"/>.</summary>
+    /// <summary>Contains the logic that applies the change. Called by <see cref="ExecuteAsync"/> unless the action is already executed.</summary>
     protected abstract ValueTask ExecuteCoreAsync(CancellationToken cancellationToken);
 
     /// <inheritdoc />
     public async ValueTask UnExecuteAsync(CancellationToken cancellationToken = default)
     {
-        if (!CanUnExecute())
+        if (ExecuteCount == 0)
             return;
 
         await UnExecuteCoreAsync(cancellationToken).ConfigureAwait(false);
         ExecuteCount--;
     }
 
-    /// <summary>Contains the logic that reverts the change. Called by <see cref="UnExecuteAsync"/> when <see cref="CanUnExecute"/> is <see langword="true"/>.</summary>
+    /// <summary>Contains the logic that reverts the change. Called by <see cref="UnExecuteAsync"/> unless the action is not currently executed.</summary>
     protected abstract ValueTask UnExecuteCoreAsync(CancellationToken cancellationToken);
-
-    /// <inheritdoc />
-    public bool CanExecute() => ExecuteCount == 0;
-
-    /// <inheritdoc />
-    public bool CanUnExecute() => !CanExecute();
 
     /// <inheritdoc />
     public virtual ValueTask<bool> TryToMergeAsync(IUndoRedoAction followingAction) => new(false);

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoTransaction.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoTransaction.cs
@@ -132,12 +132,6 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
     }
 
     /// <inheritdoc />
-    public bool CanExecute() => !_executed;
-
-    /// <inheritdoc />
-    public bool CanUnExecute() => _executed;
-
-    /// <inheritdoc />
     public ValueTask<bool> TryToMergeAsync(IUndoRedoAction followingAction) => new(false);
 
     /// <summary>Commits the transaction, recording it as a single undo step.</summary>


### PR DESCRIPTION
**Stack 3/7** — base #1913. Breaking.

`UndoRedoManager` never called either method. `UndoAsync` invoked `UnExecuteAsync` and moved the action to the redo buffer whether or not anything happened, so an action returning `false` was a silent no-op that still consumed an undo step. Confirmed by grep: the only references were the declarations and `UndoRedoActionBase`'s own internal use.

Two ways out: honor them in `UndoAsync`/`RedoAsync`, or drop them. Honoring adds a check that can never fire under the manager's own flow — an action in the undo stack has always been executed — so this drops them. Callers asking "is an operation available" use `UndoRedoManager.CanUndo`/`CanRedo`.

The execute-once guard stays; it is now expressed directly on `ExecuteCount` inside `UndoRedoActionBase` instead of round-tripping through public API.

**Breaking:** `IUndoRedoAction` implementations must drop the two members.

### Verification
- `dotnet build` / `dotnet test` with `/p:TreatsWarningsAsErrors=true` — 48/48, clean build
- `ref/` regenerated (6 lines removed) and committed