### PR TITLE
Hide the transaction's IUndoRedoAction members

### DIFF
--- a/ref/Meziantou.Framework.UndoRedo.cs
+++ b/ref/Meziantou.Framework.UndoRedo.cs
@@ -57,9 +57,9 @@ namespace Meziantou.Framework.UndoRedo
     public sealed class UndoRedoTransaction : Meziantou.Framework.UndoRedo.IUndoRedoAction, System.IAsyncDisposable
     {
         public bool AllowToMergeWithPrevious { get => throw null; set { } }
-        public System.Threading.Tasks.ValueTask ExecuteAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
-        public System.Threading.Tasks.ValueTask UnExecuteAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
-        public System.Threading.Tasks.ValueTask<bool> TryToMergeAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction followingAction) => throw null;
+        System.Threading.Tasks.ValueTask Meziantou.Framework.UndoRedo.IUndoRedoAction.ExecuteAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+        System.Threading.Tasks.ValueTask Meziantou.Framework.UndoRedo.IUndoRedoAction.UnExecuteAsync(System.Threading.CancellationToken cancellationToken) => throw null;
+        System.Threading.Tasks.ValueTask<bool> Meziantou.Framework.UndoRedo.IUndoRedoAction.TryToMergeAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction followingAction) => throw null;
         public System.Threading.Tasks.ValueTask CommitAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public System.Threading.Tasks.ValueTask RollbackAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public System.Threading.Tasks.ValueTask DisposeAsync() => throw null;

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoManager.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoManager.cs
@@ -270,7 +270,7 @@ public sealed class UndoRedoManager
         ActionIsExecuting = true;
         try
         {
-            await transaction.UnExecuteAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.UnExecuteCoreAsync(cancellationToken).ConfigureAwait(false);
         }
         finally
         {

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoTransaction.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoTransaction.cs
@@ -48,11 +48,20 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
     internal void MarkCompleted() => _completed = true;
 
     /// <inheritdoc />
-    /// <remarks>
-    /// The transaction is all-or-nothing: when an action fails, the actions that already ran are reverted before
-    /// the failure is propagated. An <see cref="AggregateException"/> is thrown if reverting them also fails.
-    /// </remarks>
-    public async ValueTask ExecuteAsync(CancellationToken cancellationToken = default)
+    ValueTask IUndoRedoAction.ExecuteAsync(CancellationToken cancellationToken) => ExecuteCoreAsync(cancellationToken);
+
+    /// <inheritdoc />
+    ValueTask IUndoRedoAction.UnExecuteAsync(CancellationToken cancellationToken) => UnExecuteCoreAsync(cancellationToken);
+
+    /// <inheritdoc />
+    ValueTask<bool> IUndoRedoAction.TryToMergeAsync(IUndoRedoAction followingAction) => new(false);
+
+    /// <summary>
+    /// Applies every action of the transaction. All-or-nothing: when an action fails, the actions that already ran
+    /// are reverted before the failure is propagated. An <see cref="AggregateException"/> is thrown if reverting
+    /// them also fails.
+    /// </summary>
+    internal async ValueTask ExecuteCoreAsync(CancellationToken cancellationToken)
     {
         if (_executed)
             return;
@@ -73,13 +82,12 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
         _executed = true;
     }
 
-    /// <inheritdoc />
-    /// <remarks>
-    /// The transaction is all-or-nothing: when an action fails to revert, the actions that were already reverted
-    /// are re-applied before the failure is propagated. An <see cref="AggregateException"/> is thrown if
-    /// re-applying them also fails.
-    /// </remarks>
-    public async ValueTask UnExecuteAsync(CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Reverts every action of the transaction. All-or-nothing: when an action fails to revert, the actions that
+    /// were already reverted are re-applied before the failure is propagated. An <see cref="AggregateException"/>
+    /// is thrown if re-applying them also fails.
+    /// </summary>
+    internal async ValueTask UnExecuteCoreAsync(CancellationToken cancellationToken)
     {
         if (!_executed)
             return;
@@ -130,9 +138,6 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
             await _actions[i].ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
         }
     }
-
-    /// <inheritdoc />
-    public ValueTask<bool> TryToMergeAsync(IUndoRedoAction followingAction) => new(false);
 
     /// <summary>Commits the transaction, recording it as a single undo step.</summary>
     /// <param name="cancellationToken">A token to cancel the operation.</param>


### PR DESCRIPTION
**Stack 4/7** — base #1914. Breaking.

`UndoRedoTransaction` implemented `IUndoRedoAction` publicly, and callers hold this object. So `transaction.ExecuteAsync()` was callable directly, corrupting the `_executed` flag the manager relies on to decide whether a non-delayed transaction still needs executing at commit.

`ExecuteAsync`, `UnExecuteAsync` and `TryToMergeAsync` become explicit interface implementations, forwarding to internal entry points the manager uses. `CommitAsync`, `RollbackAsync`, `DisposeAsync` and `AllowToMergeWithPrevious` stay public — those are the transaction's real surface.

**Breaking:** reaching those three members now requires a cast to `IUndoRedoAction`.

### Verification
- `dotnet build` / `dotnet test` with `/p:TreatsWarningsAsErrors=true` — 48/48, clean build
- `ref/` regenerated and committed; it is the assertion for this change, which is a compile-time guarantee rather than something a runtime test can meaningfully check