### PR TITLE
Forward the cancellation token to TryToMergeAsync

### DIFF
--- a/ref/Meziantou.Framework.UndoRedo.cs
+++ b/ref/Meziantou.Framework.UndoRedo.cs
@@ -9,7 +9,7 @@ namespace Meziantou.Framework.UndoRedo
         bool AllowToMergeWithPrevious { get; }
         System.Threading.Tasks.ValueTask ExecuteAsync(System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.ValueTask UnExecuteAsync(System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.ValueTask<bool> TryToMergeAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction followingAction);
+        System.Threading.Tasks.ValueTask<bool> TryToMergeAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction followingAction, System.Threading.CancellationToken cancellationToken = null);
     }
 
     public abstract class UndoRedoActionBase : Meziantou.Framework.UndoRedo.IUndoRedoAction
@@ -20,7 +20,7 @@ namespace Meziantou.Framework.UndoRedo
         protected abstract System.Threading.Tasks.ValueTask ExecuteCoreAsync(System.Threading.CancellationToken cancellationToken);
         public System.Threading.Tasks.ValueTask UnExecuteAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         protected abstract System.Threading.Tasks.ValueTask UnExecuteCoreAsync(System.Threading.CancellationToken cancellationToken);
-        public virtual System.Threading.Tasks.ValueTask<bool> TryToMergeAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction followingAction) => throw null;
+        public virtual System.Threading.Tasks.ValueTask<bool> TryToMergeAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction followingAction, System.Threading.CancellationToken cancellationToken = null) => throw null;
     }
 
     public sealed class UndoRedoDelegateAction : Meziantou.Framework.UndoRedo.UndoRedoActionBase
@@ -59,7 +59,7 @@ namespace Meziantou.Framework.UndoRedo
         public bool AllowToMergeWithPrevious { get => throw null; set { } }
         System.Threading.Tasks.ValueTask Meziantou.Framework.UndoRedo.IUndoRedoAction.ExecuteAsync(System.Threading.CancellationToken cancellationToken) => throw null;
         System.Threading.Tasks.ValueTask Meziantou.Framework.UndoRedo.IUndoRedoAction.UnExecuteAsync(System.Threading.CancellationToken cancellationToken) => throw null;
-        System.Threading.Tasks.ValueTask<bool> Meziantou.Framework.UndoRedo.IUndoRedoAction.TryToMergeAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction followingAction) => throw null;
+        System.Threading.Tasks.ValueTask<bool> Meziantou.Framework.UndoRedo.IUndoRedoAction.TryToMergeAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction followingAction, System.Threading.CancellationToken cancellationToken) => throw null;
         public System.Threading.Tasks.ValueTask CommitAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public System.Threading.Tasks.ValueTask RollbackAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public System.Threading.Tasks.ValueTask DisposeAsync() => throw null;

--- a/src/Meziantou.Framework.UndoRedo/ActionHistory.cs
+++ b/src/Meziantou.Framework.UndoRedo/ActionHistory.cs
@@ -16,9 +16,9 @@ internal sealed class ActionHistory
     /// Records a new action. When the action allows merging and the most recent undoable action absorbs it,
     /// no new entry is added. The redo buffer is cleared either way as the history moved forward.
     /// </summary>
-    public async ValueTask RecordAsync(IUndoRedoAction action)
+    public async ValueTask RecordAsync(IUndoRedoAction action, CancellationToken cancellationToken)
     {
-        if (!action.AllowToMergeWithPrevious || PeekUndo() is not { } previous || !await previous.TryToMergeAsync(action).ConfigureAwait(false))
+        if (!action.AllowToMergeWithPrevious || PeekUndo() is not { } previous || !await previous.TryToMergeAsync(action, cancellationToken).ConfigureAwait(false))
         {
             _undo.Push(action);
         }

--- a/src/Meziantou.Framework.UndoRedo/IUndoRedoAction.cs
+++ b/src/Meziantou.Framework.UndoRedo/IUndoRedoAction.cs
@@ -17,8 +17,9 @@ public interface IUndoRedoAction
     /// step. Useful for long chains of consecutive operations of the same kind (e.g. dragging or typing).
     /// </summary>
     /// <param name="followingAction">The action recorded right after this one.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns><see langword="true"/> if <paramref name="followingAction"/> was merged into this action; otherwise <see langword="false"/>.</returns>
-    ValueTask<bool> TryToMergeAsync(IUndoRedoAction followingAction);
+    ValueTask<bool> TryToMergeAsync(IUndoRedoAction followingAction, CancellationToken cancellationToken = default);
 
     /// <summary>Gets a value indicating whether this action may be merged with the previous action in the undo buffer.</summary>
     bool AllowToMergeWithPrevious { get; }

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoActionBase.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoActionBase.cs
@@ -40,5 +40,5 @@ public abstract class UndoRedoActionBase : IUndoRedoAction
     protected abstract ValueTask UnExecuteCoreAsync(CancellationToken cancellationToken);
 
     /// <inheritdoc />
-    public virtual ValueTask<bool> TryToMergeAsync(IUndoRedoAction followingAction) => new(false);
+    public virtual ValueTask<bool> TryToMergeAsync(IUndoRedoAction followingAction, CancellationToken cancellationToken = default) => new(false);
 }

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoManager.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoManager.cs
@@ -297,7 +297,7 @@ public sealed class UndoRedoManager
         if (execute)
             await ExecuteAsync(action, cancellationToken).ConfigureAwait(false);
 
-        await _history.RecordAsync(action).ConfigureAwait(false);
+        await _history.RecordAsync(action, cancellationToken).ConfigureAwait(false);
         OnCollectionChanged();
     }
 

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoTransaction.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoTransaction.cs
@@ -54,7 +54,7 @@ public sealed class UndoRedoTransaction : IUndoRedoAction, IAsyncDisposable
     ValueTask IUndoRedoAction.UnExecuteAsync(CancellationToken cancellationToken) => UnExecuteCoreAsync(cancellationToken);
 
     /// <inheritdoc />
-    ValueTask<bool> IUndoRedoAction.TryToMergeAsync(IUndoRedoAction followingAction) => new(false);
+    ValueTask<bool> IUndoRedoAction.TryToMergeAsync(IUndoRedoAction followingAction, CancellationToken cancellationToken) => new(false);
 
     /// <summary>
     /// Applies every action of the transaction. All-or-nothing: when an action fails, the actions that already ran

--- a/tests/Meziantou.Framework.UndoRedo.Tests/UndoRedoManagerTests.cs
+++ b/tests/Meziantou.Framework.UndoRedo.Tests/UndoRedoManagerTests.cs
@@ -446,6 +446,21 @@ public sealed class UndoRedoManagerTests
         Assert.False(manager.CanUndo);
     }
 
+    [Fact]
+    public async Task Merge_ForwardsCancellationToken()
+    {
+        var manager = new UndoRedoManager();
+        var sum = 0;
+        using var cts = new CancellationTokenSource();
+
+        await manager.RecordActionAsync(new AddAction(v => sum += v, v => sum -= v, value: 1), cts.Token);
+
+        await cts.CancelAsync();
+        var second = new AddAction(v => sum += v, v => sum -= v, value: 2) { AllowToMergeWithPrevious = true };
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await manager.RecordActionAsync(second, cts.Token));
+    }
+
     private sealed class AddAction(Action<int> add, Action<int> subtract, int value) : UndoRedoActionBase
     {
         // The total amount this action is responsible for; grows when following actions are merged in.
@@ -463,8 +478,10 @@ public sealed class UndoRedoManagerTests
             return ValueTask.CompletedTask;
         }
 
-        public override ValueTask<bool> TryToMergeAsync(IUndoRedoAction followingAction)
+        public override ValueTask<bool> TryToMergeAsync(IUndoRedoAction followingAction, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             // The following action already executed its own effect; absorb its value so a single
             // UnExecute reverts both actions.
             if (followingAction is AddAction other)


### PR DESCRIPTION
**Stack 5/7** — base #1915. Breaking.

`TryToMergeAsync` was the only asynchronous member of `IUndoRedoAction` without a `CancellationToken`, and the manager called it without one even though `RecordActionAsync` had a token in hand. The token now flows `RecordActionAsync` -> `ActionHistory.RecordAsync` -> `TryToMergeAsync`.

**Breaking:** implementations of `IUndoRedoAction.TryToMergeAsync` and overrides of `UndoRedoActionBase.TryToMergeAsync` need the extra parameter.

### Verification
- `dotnet build` / `dotnet test` with `/p:TreatsWarningsAsErrors=true` — 50/50 (25 x 2 TFMs), clean build
- `ref/` regenerated and committed