### PR TITLE
Expose the history as read-only snapshots

### DIFF
--- a/ref/Meziantou.Framework.UndoRedo.cs
+++ b/ref/Meziantou.Framework.UndoRedo.cs
@@ -38,8 +38,8 @@ namespace Meziantou.Framework.UndoRedo
         public bool ActionIsExecuting { get => throw null; }
         public bool CanUndo { get => throw null; }
         public bool CanRedo { get => throw null; }
-        public System.Collections.Generic.IEnumerable<Meziantou.Framework.UndoRedo.IUndoRedoAction> UndoableActions { get => throw null; }
-        public System.Collections.Generic.IEnumerable<Meziantou.Framework.UndoRedo.IUndoRedoAction> RedoableActions { get => throw null; }
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.UndoRedo.IUndoRedoAction> UndoableActions { get => throw null; }
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.UndoRedo.IUndoRedoAction> RedoableActions { get => throw null; }
         public event System.EventHandler? CollectionChanged;
         public System.Threading.Tasks.ValueTask RecordActionAsync(Meziantou.Framework.UndoRedo.IUndoRedoAction action, System.Threading.CancellationToken cancellationToken = null) => throw null;
         public System.Threading.Tasks.ValueTask RecordActionAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> execute, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask> unexecute, System.Threading.CancellationToken cancellationToken = null) => throw null;

--- a/src/Meziantou.Framework.UndoRedo/ActionHistory.cs
+++ b/src/Meziantou.Framework.UndoRedo/ActionHistory.cs
@@ -42,7 +42,7 @@ internal sealed class ActionHistory
         _redo.Clear();
     }
 
-    public IEnumerable<IUndoRedoAction> UndoableActions => _undo;
+    public IReadOnlyList<IUndoRedoAction> UndoableActions => _undo.ToArray();
 
-    public IEnumerable<IUndoRedoAction> RedoableActions => _redo;
+    public IReadOnlyList<IUndoRedoAction> RedoableActions => _redo.ToArray();
 }

--- a/src/Meziantou.Framework.UndoRedo/UndoRedoManager.cs
+++ b/src/Meziantou.Framework.UndoRedo/UndoRedoManager.cs
@@ -168,11 +168,13 @@ public sealed class UndoRedoManager
         OnCollectionChanged();
     }
 
-    /// <summary>Gets the actions that can be undone, most recent first.</summary>
-    public IEnumerable<IUndoRedoAction> UndoableActions => _history.UndoableActions;
+    /// <summary>Gets a snapshot of the actions that can be undone, most recent first.</summary>
+    /// <remarks>Each access allocates a new snapshot, so it stays stable while the history changes.</remarks>
+    public IReadOnlyList<IUndoRedoAction> UndoableActions => _history.UndoableActions;
 
-    /// <summary>Gets the actions that can be redone, most recent first.</summary>
-    public IEnumerable<IUndoRedoAction> RedoableActions => _history.RedoableActions;
+    /// <summary>Gets a snapshot of the actions that can be redone, most recent first.</summary>
+    /// <remarks>Each access allocates a new snapshot, so it stays stable while the history changes.</remarks>
+    public IReadOnlyList<IUndoRedoAction> RedoableActions => _history.RedoableActions;
 
     /// <summary>Begins a transaction that groups subsequent recorded actions into a single undo step.</summary>
     /// <param name="isDelayed">

--- a/tests/Meziantou.Framework.UndoRedo.Tests/UndoRedoManagerTests.cs
+++ b/tests/Meziantou.Framework.UndoRedo.Tests/UndoRedoManagerTests.cs
@@ -461,6 +461,29 @@ public sealed class UndoRedoManagerTests
         await Assert.ThrowsAsync<OperationCanceledException>(async () => await manager.RecordActionAsync(second, cts.Token));
     }
 
+    [Fact]
+    public async Task UndoableActions_IsASnapshotOrderedFromMostRecent()
+    {
+        var manager = new UndoRedoManager();
+        var (first, _) = CreateLoggingAction("a");
+        var (second, _) = CreateLoggingAction("b");
+
+        await manager.RecordActionAsync(first, CancellationToken);
+        await manager.RecordActionAsync(second, CancellationToken);
+
+        var snapshot = manager.UndoableActions;
+        Assert.Equal([second, first], snapshot);
+
+        // Recording more actions must not change a snapshot taken earlier.
+        await manager.RecordActionAsync(CreateLoggingAction("c").Action, CancellationToken);
+        Assert.Equal([second, first], snapshot);
+        Assert.Equal(3, manager.UndoableActions.Count);
+
+        await manager.UndoAsync(CancellationToken);
+        Assert.Equal(2, manager.UndoableActions.Count);
+        Assert.Single(manager.RedoableActions);
+    }
+
     private sealed class AddAction(Action<int> add, Action<int> subtract, int value) : UndoRedoActionBase
     {
         // The total amount this action is responsible for; grows when following actions are merged in.


### PR DESCRIPTION
**Stack 6/7** — base #1916. Breaking.

`UndoableActions` and `RedoableActions` returned the live `Stack<IUndoRedoAction>` behind an `IEnumerable<T>`. A caller could cast it back and mutate the history directly, and enumerating it while an action was recorded threw `InvalidOperationException` from the collection's version check — awkward for the UI history lists these properties exist to feed.

Both now return an `IReadOnlyList<IUndoRedoAction>` snapshot, still ordered most recent first. Each access allocates, which is documented on the properties; that is the cost of a view that stays stable while the history changes underneath it.

**Breaking:** the property type changed from `IEnumerable<T>` to `IReadOnlyList<T>`.

### Verification
- `dotnet build` / `dotnet test` with `/p:TreatsWarningsAsErrors=true` — 52/52 (26 x 2 TFMs), clean build
- `ref/` regenerated and committed