### PR TITLE
Apply MaximumLength to the composed slug

### DIFF
--- a/src/Meziantou.Framework.Slug/Slug.cs
+++ b/src/Meziantou.Framework.Slug/Slug.cs
@@ -40,11 +40,52 @@ public static class Slug
         var maximumLength = options.MaximumLength > 0 ? options.MaximumLength : int.MaxValue;
 
         var sb = new StringBuilder(Math.Min(text.Length, maximumLength));
+        var budget = maximumLength;
+        string slug;
+        while (true)
+        {
+            var completed = AppendSlug(sb, text, options, separator, budget);
+            slug = sb.ToString().Normalize(NormalizationForm.FormC);
+            if (completed)
+                break;
+
+            // The slug is built decomposed but returned composed, and composing it merges each combining
+            // mark back into the character it follows. The buffer can therefore be full while the composed
+            // slug is still under the limit. Grant back exactly the characters composition recovered and
+            // rebuild: the limit stays an upper bound on the composed slug, but it is actually filled.
+            var recovered = sb.Length - slug.Length;
+            if (recovered == 0 || maximumLength > int.MaxValue - recovered)
+                break;
+
+            var extendedBudget = maximumLength + recovered;
+            if (extendedBudget <= budget)
+                break;
+
+            budget = extendedBudget;
+        }
+
+        // Trimmed on the decomposed buffer, so a separator that is itself decomposed is still recognized.
+        if (!options.CanEndWithSeparator && separator.Length > 0 && EndsWith(sb, separator))
+        {
+            sb.Length -= separator.Length;
+            slug = sb.ToString().Normalize(NormalizationForm.FormC);
+        }
+
+        return slug;
+    }
+
+    /// <summary>Rebuilds the slug into <paramref name="sb"/>, using at most <paramref name="budget"/> characters.</summary>
+    /// <returns><see langword="true"/> if the whole text was consumed; otherwise, <see langword="false"/>.</returns>
+    private static bool AppendSlug(StringBuilder sb, string text, SlugOptions options, string separator, int budget)
+    {
+        sb.Clear();
         var usesDefaultReplace = options.UsesDefaultReplace;
         Span<char> transformed = stackalloc char[MaxUtf16CharsPerRune];
+        var characterStart = 0;
 
         foreach (var rune in text.EnumerateRunes())
         {
+            var isCombiningMark = Rune.GetUnicodeCategory(rune) is UnicodeCategory.NonSpacingMark or UnicodeCategory.SpacingCombiningMark or UnicodeCategory.EnclosingMark;
             if (options.IsAllowed(rune))
             {
                 // Append the replacement atomically, so the maximum length can never split a
@@ -61,32 +102,39 @@ public static class Slug
                     replacement = options.Replace(rune);
                 }
 
-                if (sb.Length + replacement.Length > maximumLength)
-                    break;
+                // A combining mark belongs to the character before it, so only a rune that is not one
+                // starts a new character.
+                if (!isCombiningMark)
+                    characterStart = sb.Length;
+
+                if (sb.Length + replacement.Length > budget)
+                {
+                    // Keeping a base character while dropping the mark that follows it would silently
+                    // strip the accent off the last character of the slug. Drop the character instead.
+                    if (isCombiningMark)
+                        sb.Length = characterStart;
+
+                    return false;
+                }
 
                 sb.Append(replacement);
             }
-            else if (Rune.GetUnicodeCategory(rune) is not (UnicodeCategory.NonSpacingMark or UnicodeCategory.SpacingCombiningMark or UnicodeCategory.EnclosingMark))
+            else if (!isCombiningMark)
             {
                 // Combining marks attached to a disallowed character are dropped silently instead of
                 // producing a separator. A slug never starts with a separator, and separators are never repeated.
                 if (sb.Length == 0 || EndsWith(sb, separator))
                     continue;
 
-                if (sb.Length + separator.Length > maximumLength)
-                    break;
+                if (sb.Length + separator.Length > budget)
+                    return false;
 
                 sb.Append(separator);
+                characterStart = sb.Length;
             }
         }
 
-        var slug = sb.ToString();
-        if (!options.CanEndWithSeparator && separator.Length > 0 && slug.EndsWith(separator, StringComparison.Ordinal))
-        {
-            slug = slug[..^separator.Length];
-        }
-
-        return slug.Normalize(NormalizationForm.FormC);
+        return true;
     }
 
     private static bool EndsWith(StringBuilder stringBuilder, string suffix)

--- a/src/Meziantou.Framework.Slug/SlugOptions.cs
+++ b/src/Meziantou.Framework.Slug/SlugOptions.cs
@@ -32,10 +32,9 @@ public class SlugOptions
     /// Gets or sets the maximum length of the generated slug. Default is 80. A value less than or equal to zero means the slug is not truncated.
     /// </summary>
     /// <remarks>
-    /// The limit is never exceeded, and the slug is only cut between characters, so a truncated slug never ends with an
-    /// incomplete surrogate pair or a partial <see cref="Separator"/>. The limit is applied to the decomposed form of the
-    /// text; when <see cref="AllowedRanges"/> allows combining marks, those marks are recomposed with the character they
-    /// follow, so the returned slug can be shorter than <see cref="MaximumLength"/>.
+    /// The limit applies to the returned slug and is never exceeded. A slug is only cut between characters, so it never
+    /// ends with an incomplete surrogate pair, a partial <see cref="Separator"/>, or a character stripped of the combining
+    /// marks that follow it. Because those units are kept whole, a slug can end up slightly shorter than the limit.
     /// </remarks>
     public int MaximumLength { get; set; }
 

--- a/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
+++ b/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
@@ -198,4 +198,90 @@ public class SlugTests
             return base.IsAllowed(character) && !"aeiou".Contains(character.ToString(), StringComparison.Ordinal);
         }
     }
+
+    [Theory]
+    [InlineData(1, "")]
+    [InlineData(2, "\u00E9")]
+    [InlineData(3, "\u00E9\u00E9")]
+    [InlineData(5, "\u00E9\u00E9\u00E9\u00E9")]
+    [InlineData(9, "\u00E9\u00E9\u00E9\u00E9")]
+    public void Slug_MaximumLength_AppliesToTheComposedSlug(int maximumLength, string expected)
+    {
+        var options = new SlugOptions { MaximumLength = maximumLength };
+        options.AllowedRanges.Clear();
+
+        var slug = Slug.Create("\u00E9\u00E9\u00E9\u00E9", options);
+
+        Assert.Equal(expected, slug);
+    }
+
+    [Fact]
+    public void Slug_MaximumLength_FillsTheLimitWhenComposingFreesRoom()
+    {
+        var options = new SlugOptions { MaximumLength = 17 };
+        options.AllowedRanges.Clear();
+
+        var slug = Slug.Create("caf\u00E9 cr\u00E8me br\u00FBl\u00E9e", options);
+
+        Assert.Equal("caf\u00E9 cr\u00E8me br\u00FBl\u00E9e", slug);
+        Assert.HasCount(17, slug);
+    }
+
+    [Fact]
+    public void Slug_MaximumLength_NeverStripsCombiningMarksFromTheLastCharacter()
+    {
+        var options = new SlugOptions { MaximumLength = 4 };
+        options.AllowedRanges.Clear();
+
+        var slug = Slug.Create("\u00E9\u00E9\u00E9\u00E9", options);
+
+        Assert.DoesNotContain('e', slug);
+        Assert.Equal("\u00E9\u00E9\u00E9", slug);
+    }
+
+    [Fact]
+    public void Slug_MaximumLength_IsNeverExceededOnComposingInput()
+    {
+        string[] inputs =
+        [
+            "\u00E9\u00E9\u00E9\u00E9",
+            "caf\u00E9 cr\u00E8me br\u00FBl\u00E9e",
+            "\uAC00\uAC01\uAC02",
+            "  \u00E9 \u00E9  ",
+            "\U0001F600\u00E9\U0001F600",
+        ];
+
+        foreach (var input in inputs)
+        {
+            for (var maximumLength = 1; maximumLength <= 24; maximumLength++)
+            {
+                foreach (var separator in new[] { "-", "__", "" })
+                {
+                    var options = new SlugOptions { MaximumLength = maximumLength, Separator = separator };
+                    options.AllowedRanges.Clear();
+
+                    var slug = Slug.Create(input, options);
+
+                    Assert.HasCountLessThanOrEqual(maximumLength, slug, $"[{input}] with limit {maximumLength} and separator '{separator}'");
+                    Assert.Equal(slug, slug.Normalize(NormalizationForm.FormC));
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void Slug_MaximumLength_RaisingTheLimitNeverShortensTheSlug()
+    {
+        var previousLength = 0;
+        for (var maximumLength = 1; maximumLength <= 24; maximumLength++)
+        {
+            var options = new SlugOptions { MaximumLength = maximumLength };
+            options.AllowedRanges.Clear();
+
+            var slug = Slug.Create("caf\u00E9 cr\u00E8me br\u00FBl\u00E9e", options);
+
+            Assert.HasCountGreaterThanOrEqual(previousLength, slug, $"limit {maximumLength} produced fewer characters than limit {maximumLength - 1}");
+            previousLength = slug.Length;
+        }
+    }
 }


### PR DESCRIPTION
> Stacked on #1910, which is stacked on #1907. Review those first — this PR's base is `feature/slug-replace-allocation`, so the diff shown here is only this change.

This is the last item from the original analysis, the one I deliberately left out of #1907.

## The problem

The slug is built from the **decomposed** (FormD) text but returned **composed** (FormC), and `MaximumLength` was charged against the decomposed buffer. Every combining mark that later merged back into the character before it had consumed a slot for nothing, so callers got much shorter slugs than they asked for:

| `MaximumLength` | `"café crème brûlée"` before | after |
|---|---|---|
| 6 | `café ` (5) | `café c` (6) |
| 10 | `café crè` (8) | `café crème` (10) |
| 17 | `café crème brû` (14) | `café crème brûlée` (17) |

## Two changes

**1. The limit is measured on the composed slug.** When composition recovers characters and the text is not exhausted, exactly those characters are granted back and the slug is rebuilt.

This is safe because the budget only ever grows by the number of characters composition *already* removed, and composition loss cannot decrease as the buffer grows — so the composed slug still cannot exceed `MaximumLength`. The loop stops as soon as a rebuild recovers nothing new. It converges geometrically rather than linearly, so adversarial input cannot turn it into a quadratic scan, and plain text completes on the first pass exactly as before.

**2. A base character and its combining marks are kept together.** The limit could previously fall *between* them, keeping the base and dropping the mark — silently stripping the accent off the last character. `MaximumLength = 5` over four `é` returned **`"éée"`**, with a bare `e` at the end. A character that does not fit whole is now left out entirely.

That second one is why `MaximumLength = 4` over four `é` returns `"ééé"` (3) rather than 4: the fourth character cannot be represented whole within the budget the iteration reaches, and 3 intact characters beat 4 with a corrupted one. The property is documented on `MaximumLength` — a slug can be slightly shorter than the limit because these units are kept whole.

## Verification

Beyond the unit tests, I fuzzed **5,616 combinations** of composing inputs (Latin diacritics, Hangul, stacked marks, astral-plane characters, Devanagari) × limits 1–24 × three separators × `CanEndWithSeparator` × all three casing modes:

- limit exceeded: **0**
- orphaned leading combining mark: **0**
- lone surrogate / invalid Unicode: **0**
- non-monotonic (raising the limit shortening the slug): **0**

Two of those invariants are locked in as tests.

## Cost

The trailing separator is still trimmed on the decomposed buffer, so a separator that is itself decomposed keeps being recognized. That costs one extra `ToString` when the slug ends with a separator — **456 bytes** per call instead of 320. Slugs that don't end with a separator stay at **320 bytes**, unchanged from #1910.

## Checks

- Debug and Release clean with `/p:TreatsWarningsAsErrors=true`, 0 warnings.
- **106/106 tests pass** across net10.0 and net11.0 in both configurations.
- `dotnet run ./eng/update-all.cs` exit 0, no generated-file changes; `ref/Meziantou.Framework.Slug.cs` unchanged.