### PR TITLE
Fix HTTP caching correctness bugs in the request path

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/HttpCache.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCache.cs
@@ -16,9 +16,12 @@ internal sealed class HttpCache
         _options = options;
     }
 
-    private static string ComputePrimaryKey(Uri? uri)
+    // RFC 9111 Section 2: the primary cache key is composed of the request method and the target URI.
+    // GET and HEAD must not share a key, otherwise a stored HEAD response (which has no body) could be
+    // served for a subsequent GET.
+    private static string ComputePrimaryKey(HttpMethod method, Uri? uri)
     {
-        return uri?.GetLeftPart(UriPartial.Query) ?? string.Empty;
+        return method.Method + " " + (uri?.GetLeftPart(UriPartial.Query) ?? string.Empty);
     }
 
     public async ValueTask<CacheEntry?> TryGetAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -26,7 +29,7 @@ internal sealed class HttpCache
         if (request.RequestUri == null)
             return null;
 
-        var primaryKey = ComputePrimaryKey(request.RequestUri);
+        var primaryKey = ComputePrimaryKey(request.Method, request.RequestUri);
         var persistedEntries = await _persistenceProvider.GetEntriesAsync(primaryKey, cancellationToken).ConfigureAwait(false);
         if (persistedEntries.Count is 0)
             return null;
@@ -77,7 +80,7 @@ internal sealed class HttpCache
         if (_options.ShouldCacheResponse is not null && !_options.ShouldCacheResponse(response))
             return;
 
-        var primaryKey = ComputePrimaryKey(request.RequestUri);
+        var primaryKey = ComputePrimaryKey(request.Method, request.RequestUri);
         var entry = await CacheEntry.CreateAsync(request, response, requestTime, responseTime, cancellationToken).ConfigureAwait(false);
 
         // Check response size limit if configured
@@ -93,22 +96,23 @@ internal sealed class HttpCache
         await _persistenceProvider.SetEntryAsync(primaryKey, entry.ToPersistenceEntry(), cancellationToken).ConfigureAwait(false);
     }
 
-    public ValueTask PersistEntryAsync(Uri? uri, CacheEntry entry, CancellationToken cancellationToken)
+    public ValueTask PersistEntryAsync(HttpMethod method, Uri? uri, CacheEntry entry, CancellationToken cancellationToken)
     {
-        if (uri == null)
+        if (uri is null)
             return ValueTask.CompletedTask;
 
-        var primaryKey = ComputePrimaryKey(uri);
+        var primaryKey = ComputePrimaryKey(method, uri);
         return _persistenceProvider.SetEntryAsync(primaryKey, entry.ToPersistenceEntry(), cancellationToken);
     }
 
-    public ValueTask InvalidateAsync(Uri? uri, CancellationToken cancellationToken)
+    public async ValueTask InvalidateAsync(Uri? uri, CancellationToken cancellationToken)
     {
-        if (uri == null)
-            return ValueTask.CompletedTask;
+        if (uri is null)
+            return;
 
-        var primaryKey = ComputePrimaryKey(uri);
-        return _persistenceProvider.RemoveEntriesAsync(primaryKey, cancellationToken);
+        // The primary key includes the request method, so every cacheable method must be invalidated.
+        await _persistenceProvider.RemoveEntriesAsync(ComputePrimaryKey(HttpMethod.Get, uri), cancellationToken).ConfigureAwait(false);
+        await _persistenceProvider.RemoveEntriesAsync(ComputePrimaryKey(HttpMethod.Head, uri), cancellationToken).ConfigureAwait(false);
     }
 
     private static bool IsCacheable(HttpRequestMessage request, HttpResponseMessage response)

--- a/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
@@ -71,6 +71,17 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
             return rangeResponse;
         }
 
+        // RFC 9111 Section 4.3.2: the caller is performing its own validation. Evaluating the precondition
+        // against the stored response would turn a conditional request into an unconditional 200, and adding
+        // our own validators on top of the caller's would send conflicting preconditions. Forward to origin
+        // so the caller gets the 304 or 200 it asked for.
+        if (HasConditionalHeaders(request.Headers))
+        {
+            var conditionalPassthroughResponse = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            conditionalPassthroughResponse.RequestMessage ??= request;
+            return conditionalPassthroughResponse;
+        }
+
         // Check request-level cache directives
         var requestCacheControl = request.Headers.CacheControl;
         var hasPragmaNoCache = HasPragmaNoCache(request.Headers);
@@ -187,55 +198,65 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
             // Attempt conditional validation
             if (cacheResult.ETag is not null || cacheResult.LastModified != null)
             {
-                using var conditionalRequest = CloneRequest(request);
-
-                // RFC 7232 Section 3.2: If-None-Match
-                if (cacheResult.ETag is not null)
+                var conditionalRequest = CloneRequest(request);
+                try
                 {
-                    conditionalRequest.Headers.TryAddWithoutValidation("If-None-Match", cacheResult.ETag);
-                }
-
-                // RFC 7232 Section 3.3: If-Modified-Since
-                if (cacheResult.LastModified != null)
-                {
-                    conditionalRequest.Headers.IfModifiedSince = cacheResult.LastModified;
-                }
-
-                var validationRequestTime = _timeProvider.GetUtcNow();
-                var conditionalResponse = await base.SendAsync(conditionalRequest, cancellationToken).ConfigureAwait(false);
-                var responseTime = _timeProvider.GetUtcNow();
-
-                // RFC 7234 Section 4.3.3: Handle 304 Not Modified
-                if (conditionalResponse.StatusCode is HttpStatusCode.NotModified)
-                {
-                    // Update cached entry with new headers from 304 response
-                    await cacheResult.UpdateFromValidationResponse(conditionalResponse, validationRequestTime, responseTime, cancellationToken).ConfigureAwait(false);
-                    await _cache.PersistEntryAsync(request.RequestUri, cacheResult, cancellationToken).ConfigureAwait(false);
-
-                    conditionalResponse.Dispose();
-
-                    var newAge = cacheResult.CalculateCurrentAge(_timeProvider.GetUtcNow());
-                    return CreateCachedResponse(request, cacheResult, newAge);
-                }
-
-                // RFC 5861: Handle error responses with stale-if-error
-                if (cacheResult.StaleIfError is not null && !conditionalResponse.IsSuccessStatusCode)
-                {
-                    var staleness = currentAge - freshnessLifetime;
-                    if (staleness <= cacheResult.StaleIfError.Value)
+                    // RFC 7232 Section 3.2: If-None-Match
+                    if (cacheResult.ETag is not null)
                     {
+                        conditionalRequest.Headers.TryAddWithoutValidation("If-None-Match", cacheResult.ETag);
+                    }
+
+                    // RFC 7232 Section 3.3: If-Modified-Since
+                    if (cacheResult.LastModified is not null)
+                    {
+                        conditionalRequest.Headers.IfModifiedSince = cacheResult.LastModified;
+                    }
+
+                    var validationRequestTime = _timeProvider.GetUtcNow();
+                    var conditionalResponse = await base.SendAsync(conditionalRequest, cancellationToken).ConfigureAwait(false);
+                    var responseTime = _timeProvider.GetUtcNow();
+
+                    // RFC 7234 Section 4.3.3: Handle 304 Not Modified
+                    if (conditionalResponse.StatusCode is HttpStatusCode.NotModified)
+                    {
+                        // Update cached entry with new headers from 304 response
+                        await cacheResult.UpdateFromValidationResponse(conditionalResponse, validationRequestTime, responseTime, cancellationToken).ConfigureAwait(false);
+                        await _cache.PersistEntryAsync(request.Method, request.RequestUri, cacheResult, cancellationToken).ConfigureAwait(false);
+
                         conditionalResponse.Dispose();
 
-                        // RFC 7234 Section 5.5: Add Warning headers
-                        var warnings = "110 - \"Response is Stale\", 111 - \"Revalidation Failed\"";
-                        return CreateCachedResponse(request, cacheResult, currentAge, warnings);
+                        var newAge = cacheResult.CalculateCurrentAge(_timeProvider.GetUtcNow());
+                        return CreateCachedResponse(request, cacheResult, newAge);
                     }
-                }
 
-                // Use fresh response and cache it
-                await _cache.StoreAsync(request, conditionalResponse, requestTime, responseTime, cancellationToken).ConfigureAwait(false);
-                conditionalResponse.RequestMessage ??= request;
-                return conditionalResponse;
+                    // RFC 5861: Handle error responses with stale-if-error
+                    if (cacheResult.StaleIfError is not null && !conditionalResponse.IsSuccessStatusCode)
+                    {
+                        var staleness = currentAge - freshnessLifetime;
+                        if (staleness <= cacheResult.StaleIfError.Value)
+                        {
+                            conditionalResponse.Dispose();
+
+                            // RFC 7234 Section 5.5: Add Warning headers
+                            var warnings = "110 - \"Response is Stale\", 111 - \"Revalidation Failed\"";
+                            return CreateCachedResponse(request, cacheResult, currentAge, warnings);
+                        }
+                    }
+
+                    // Use fresh response and cache it. The timing of the validation request is used so the
+                    // stored entry is not aged by the time the previous entry spent in the cache.
+                    await _cache.StoreAsync(request, conditionalResponse, validationRequestTime, responseTime, cancellationToken).ConfigureAwait(false);
+                    conditionalResponse.RequestMessage ??= request;
+                    return conditionalResponse;
+                }
+                finally
+                {
+                    // The clone shares the caller's content. Detach it so disposing the clone does not
+                    // dispose content that the caller still owns.
+                    conditionalRequest.Content = null;
+                    conditionalRequest.Dispose();
+                }
             }
         }
 
@@ -419,18 +440,38 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
 
     private static HttpRequestMessage CloneRequest(HttpRequestMessage original)
     {
-        var clone = new HttpRequestMessage(original.Method, original.RequestUri);
+        var clone = new HttpRequestMessage(original.Method, original.RequestUri)
+        {
+            Version = original.Version,
+            VersionPolicy = original.VersionPolicy,
+            // The content is shared with the original request. The caller owns it, so the clone must be
+            // detached from it before it is disposed.
+            Content = original.Content,
+        };
 
         foreach (var header in original.Headers)
         {
             clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
         }
 
-        if (original.Content is not null)
+        // Request options carry per-request state for the inner handlers (resilience policies,
+        // IHttpClientFactory metadata, ...) and must survive revalidation.
+        IDictionary<string, object?> cloneOptions = clone.Options;
+        foreach (var option in original.Options)
         {
-            clone.Content = original.Content;
+            cloneOptions[option.Key] = option.Value;
         }
 
         return clone;
+    }
+
+    private static bool HasConditionalHeaders(HttpRequestHeaders headers)
+    {
+        // RFC 9110 Section 13.1: preconditions issued by the caller
+        return headers.IfNoneMatch.Count > 0 ||
+               headers.IfMatch.Count > 0 ||
+               headers.IfModifiedSince is not null ||
+               headers.IfUnmodifiedSince is not null ||
+               headers.IfRange is not null;
     }
 }

--- a/tests/Meziantou.Framework.Http.Caching.Tests/ComprehensiveRFC7234Tests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/ComprehensiveRFC7234Tests.cs
@@ -69,6 +69,37 @@ public sealed class ComprehensiveRFC7234Tests
     }
 
     [Fact]
+    public async Task WhenHeadResponseIsCachedThenGetRequestIsNotServedFromIt()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, ("Cache-Control", "max-age=3600"), ("Content-Length", "14"));
+        context.AddResponse(HttpStatusCode.OK, "cached-content", ("Cache-Control", "max-age=3600"));
+
+        await context.SnapshotResponse(HttpMethod.Head, "http://example.com/resource", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+            Content:
+              Headers:
+                Content-Length: 14
+              Value:
+            """);
+
+        // RFC 9111 Section 2: the method is part of the primary cache key, so the bodiless HEAD response
+        // must not be reused for a GET.
+        await context.SnapshotResponse("http://example.com/resource", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+            Content:
+              Headers:
+                Content-Length: 14
+                Content-Type: text/plain; charset=utf-8
+              Value: cached-content
+            """);
+    }
+
+    [Fact]
     public async Task WhenPostRequestThenNotCached()
     {
         await using var context = new HttpTestContext();

--- a/tests/Meziantou.Framework.Http.Caching.Tests/ConditionalRequestsAndRevalidationTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/ConditionalRequestsAndRevalidationTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Meziantou.Framework.Http.Caching.InMemory;
 
 namespace Meziantou.Framework.Http.Caching.Tests;
 
@@ -552,6 +553,124 @@ public sealed class ConditionalRequestsAndRevalidationTests
                 Content-Type: text/plain; charset=utf-8
               Value: cached
             """);
+    }
+
+    #endregion
+
+    #region Caller-issued conditional requests
+
+    [Fact]
+    public async Task WhenRequestAlreadyHasConditionalHeadersThenTheCacheIsBypassed()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "original", ("Cache-Control", "max-age=3600"), ("ETag", "\"v1\""));
+        context.AddResponse(HttpStatusCode.NotModified);
+
+        await context.SnapshotResponse("http://example.com/resource", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              ETag: "v1"
+            Content:
+              Headers:
+                Content-Length: 8
+                Content-Type: text/plain; charset=utf-8
+              Value: original
+            """);
+
+        // The caller performs its own validation. Even though a fresh entry is stored, the request must
+        // reach the origin so the caller receives the 304 it asked for instead of a cached 200.
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        request.Headers.TryAddWithoutValidation("If-None-Match", "\"v1\"");
+        await context.SnapshotResponse(request, """
+            StatusCode: 304 (NotModified)
+            Content:
+            """);
+    }
+
+    [Fact]
+    public async Task WhenRevalidatingThenRequestOptionsAndVersionArePreserved()
+    {
+        using var innerHandler = new RecordingHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "original", ("Cache-Control", "max-age=0"), ("ETag", "\"v1\"")));
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.NotModified));
+
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore());
+        using var client = new HttpClient(handler);
+
+        using var firstRequest = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        using var firstResponse = await client.SendAsync(firstRequest, CancellationToken.None);
+
+        var optionKey = new HttpRequestOptionsKey<string>("test-option");
+        using var secondRequest = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource")
+        {
+            Version = HttpVersion.Version20,
+            VersionPolicy = HttpVersionPolicy.RequestVersionExact,
+        };
+        secondRequest.Options.Set(optionKey, "option-value");
+        using var secondResponse = await client.SendAsync(secondRequest, CancellationToken.None);
+
+        var revalidationRequest = innerHandler.Requests[^1];
+        Assert.True(revalidationRequest.Options.TryGetValue(optionKey, out var optionValue));
+        Assert.Equal("option-value", optionValue);
+        Assert.Equal(HttpVersion.Version20, revalidationRequest.Version);
+        Assert.Equal(HttpVersionPolicy.RequestVersionExact, revalidationRequest.VersionPolicy);
+    }
+
+    [Fact]
+    public async Task WhenRevalidatingThenTheCallerRequestContentIsNotDisposed()
+    {
+        using var innerHandler = new RecordingHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "original", ("Cache-Control", "max-age=0"), ("ETag", "\"v1\"")));
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.NotModified));
+
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore());
+        using var client = new HttpClient(handler);
+
+        using var firstRequest = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        using var firstResponse = await client.SendAsync(firstRequest, CancellationToken.None);
+
+        using var content = new StringContent("payload");
+        using var secondRequest = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource") { Content = content };
+        using var secondResponse = await client.SendAsync(secondRequest, CancellationToken.None);
+
+        // The revalidation request shares the content of the caller request, so it must not dispose it.
+        Assert.Equal("payload", await content.ReadAsStringAsync(CancellationToken.None));
+    }
+
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to the caller")]
+    private static HttpResponseMessage CreateResponse(HttpStatusCode statusCode, string? content = null, params (string Name, string Value)[] headers)
+    {
+        var response = new HttpResponseMessage(statusCode);
+        foreach (var (name, value) in headers)
+        {
+            response.Headers.TryAddWithoutValidation(name, value);
+        }
+
+        if (content is not null)
+        {
+            response.Content = new StringContent(content);
+        }
+
+        return response;
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<Func<HttpResponseMessage>> _responses = new();
+
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        public void AddResponse(Func<HttpResponseMessage> responseFactory)
+        {
+            _responses.Enqueue(responseFactory);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(_responses.Dequeue()());
+        }
     }
 
     #endregion


### PR DESCRIPTION
**Stack 1/6** — base `main`

Five defects in `HttpCachingDelegateHandler`, each verified by a new test. Found while reviewing `Meziantou.Framework.Http.Caching`.

| # | Defect | Impact |
|---|---|---|
| 1 | GET and HEAD shared a primary cache key | A cached `HEAD`, which has no body, was served for a later `GET`: **empty body, original `Content-Length`** |
| 2 | The revalidation clone dropped `Options`, `Version`, `VersionPolicy` | Resilience policies and `IHttpClientFactory` metadata silently lost state, only on the revalidation path |
| 3 | The clone shared the caller's `Content` and was disposed with `using` | The caller's own content became `ObjectDisposedException` after the send |
| 4 | Caller-supplied `If-None-Match` / `If-Modified-Since` | Answered from cache with a `200`, and a duplicate validator was appended |
| 5 | Storing after a `200` revalidation used the original request time | The refreshed entry was born aged by the time the previous one spent in the cache |

### Notes

- **Bug 1** is the reason `InvalidateAsync` became `async`: with the method in the key, an unsafe method has to clear both the GET and the HEAD key.
- **Bug 4** is fixed by forwarding such requests to the origin (as Range requests already are), rather than trying to evaluate the precondition against the stored response.
- Bug 5 is a one-token change inside the block already being edited by bug 3.

### Compatibility

The primary cache key format changed, so **existing persisted caches will miss once** after upgrade. A miss is safe (it re-fetches), but the stale rows are not reclaimed by `PruneObsoleteEntriesAsync` since nothing looks them up.

### Verification

`dotnet build /p:TreatsWarningsAsErrors=true` clean; full suite **172 passed, 0 failed, 3 skipped** (the skipped ones are the Linux-gated Redis container tests).