### PR TITLE
Fix quadratic run sliding in Myers diff post-processing

### DIFF
--- a/src/Meziantou.Framework.TextDiff/MyersDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/MyersDiff.cs
@@ -72,21 +72,36 @@ internal static class MyersDiff
                 startPos++;
             }
 
-            var endPos = startPos;
-            while (endPos < modified.Length && modified[endPos])
-            {
-                endPos++;
-            }
+            if (startPos >= modified.Length)
+                break;
 
-            if (endPos < modified.Length && data[startPos] == data[endPos])
+            // Slide the run of modified chunks forward while the chunk following the run is identical
+            // to the first chunk of the run. endPos only ever moves forward, so sliding a run of length L
+            // over a uniform region of length S costs O(L + S) instead of O(L * S).
+            var endPos = startPos;
+            while (true)
             {
+                while (endPos < modified.Length && modified[endPos])
+                {
+                    endPos++;
+                }
+
+                if (endPos >= modified.Length || data[startPos] != data[endPos])
+                    break;
+
                 modified[startPos] = false;
                 modified[endPos] = true;
+                startPos++;
+                endPos++;
+
+                // Sliding over a single unmodified chunk merges the run with the one that follows it.
+                while (startPos < endPos && !modified[startPos])
+                {
+                    startPos++;
+                }
             }
-            else
-            {
-                startPos = endPos;
-            }
+
+            startPos = endPos;
         }
     }
 

--- a/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
+++ b/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
@@ -305,6 +305,44 @@ public sealed class TextDiffTests
         Assert.Contains(result.Entries, e => e.Operation == TextDiffOperation.Insert && e.Text.Equals("The door of all subtleties!", StringComparison.Ordinal));
     }
 
+    [Theory]
+    [MemberData(nameof(AllAlgorithms))]
+    [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Generating test inputs, and the fixed seed keeps the cases reproducible.")]
+    public void ComputeDiff_AllAlgorithms_RandomizedInputs_ReconstructsOldAndNewText(TextDiffAlgorithm algorithm)
+    {
+        var random = new Random(20250820);
+        var options = new TextDiffOptions { Algorithm = algorithm };
+
+        for (var iteration = 0; iteration < 200; iteration++)
+        {
+            var alphabet = random.Next(1, 6);
+            var oldText = JoinLines(CreateRandomLines(random, alphabet));
+            var newText = JoinLines(CreateRandomLines(random, alphabet));
+
+            var result = Diff.ComputeDiff(oldText, newText, options);
+
+            Assert.Equal(oldText, ReconstructOldText(result));
+            Assert.Equal(newText, ReconstructNewText(result));
+            Assert.Equal(!string.Equals(oldText, newText, StringComparison.Ordinal), result.HasDifferences);
+        }
+    }
+
+    [Fact]
+    public void ComputeDiff_Myers_ModifiedRunSlidingOverUniformRegion_ReconstructsOldAndNewText()
+    {
+        // A run of modified chunks sliding across a long uniform region used to be re-scanned from its
+        // start on every step, which made the post-processing pass quadratic in the size of the region.
+        const int Count = 20_000;
+        var oldText = JoinLines([.. Enumerable.Repeat("a", Count).Prepend("HEAD")]);
+        var newText = JoinLines([.. Enumerable.Repeat("a", Count + (Count / 2))]);
+
+        var result = Diff.ComputeDiff(oldText, newText, new TextDiffOptions { Algorithm = TextDiffAlgorithm.Myers });
+
+        Assert.True(result.HasDifferences);
+        Assert.Equal(oldText, ReconstructOldText(result));
+        Assert.Equal(newText, ReconstructNewText(result));
+    }
+
     [Fact]
     public void ComputeDiff_InsertLine()
     {
@@ -747,6 +785,18 @@ public sealed class TextDiffTests
     }
 
     private static string JoinLines(params string[] lines) => string.Join('\n', lines);
+
+    [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Generating test inputs, and the fixed seed keeps the cases reproducible.")]
+    private static string[] CreateRandomLines(Random random, int alphabet)
+    {
+        var lines = new string[random.Next(0, 40)];
+        for (var i = 0; i < lines.Length; i++)
+        {
+            lines[i] = "line" + random.Next(alphabet).ToString(CultureInfo.InvariantCulture);
+        }
+
+        return lines;
+    }
 
     private sealed record DiffCorpusCase(string Name, string OldText, string NewText, bool HasDifferences);
     private sealed record AlgorithmCase(string Name, TextDiffAlgorithm Algorithm, string OldText, string NewText, TextDiffEntry[] ExpectedEntries);


### PR DESCRIPTION
Stack 1/8 — base: `main`

`MyersDiff.Optimize` slides a run of modified chunks forward while the chunk following the run equals the first chunk of the run. It restarted the scan from the beginning of the run after every single-position shift, so sliding a run of length `L` across a uniform region of length `S` cost `O(L * S)`.

Instrumenting the inner scan shows exactly `0.5 * n^2` steps on a leading inserted run over a uniform region. A randomized search over small alphabets never exceeded `0.4 * n` steps, so ordinary input does not hit this — it is a worst case, not a common case.

### Fix

Track the end of the run incrementally. `endPos` only ever moves forward, which makes the pass linear. Sliding over a single unmodified chunk still merges the run with the one that follows it.

### Verification

The old and new implementations were fuzzed against each other over 500k random `(data, modified)` pairs: **0 mismatches**.

| n | before | after |
|---|--------|-------|
| 16 000 | 15.21 ms | 0.015 ms |
| 64 000 | 242.34 ms | 0.051 ms |

### Tests

- `ComputeDiff_Myers_ModifiedRunSlidingOverUniformRegion_ReconstructsOldAndNewText` covers the crafted worst case.
- `ComputeDiff_AllAlgorithms_RandomizedInputs_ReconstructsOldAndNewText` is a randomized reconstruction property test over all four algorithms. It lands here because it guards every later PR in this series.

`dotnet test` on `Meziantou.Framework.TextDiff.Tests`: 192 passed.
---

### The stack

| | PR | change | output |
|---|---|---|---|
| 1 | #1921 | Myers: quadratic run sliding in `Optimize` | identical |
| 2 | #1923 | Histogram: stack overflow (crash fix) | identical |
| 3 | #1925 | Histogram: anchor-search allocations | identical |
| 4 | #1928 | Hunt-Szymanski: defer node allocation | identical |
| 5 | #1929 | Patience: anchors in order, drop the sort | identical |
| 6 | #1931 | helpers: redundant clears, span binary searches | identical |
| 7 | #1932 | hierarchy: block ranges instead of copies | identical |
| 8 | #1933 | Hunt-Szymanski: trim prefix/suffix | **changes Hunt-Szymanski** |

Review bottom-up; each PR targets the one above it.
