### PR TITLE
Share freshness computations between the cache and the stores

### DIFF
--- a/ref/Meziantou.Framework.Http.Caching.cs
+++ b/ref/Meziantou.Framework.Http.Caching.cs
@@ -26,7 +26,13 @@ namespace Meziantou.Framework.Http.Caching
         public string? ETag { get => throw null; set { } }
         public System.DateTimeOffset? LastModified { get => throw null; set { } }
         public System.ReadOnlyMemory<byte> SerializedResponse { get => throw null; set { } }
+        public bool IsUnusableWhenStale { get => throw null; }
         public Meziantou.Framework.Http.Caching.HttpCachePersistenceEntry Clone() => throw null;
+        public System.TimeSpan GetFreshnessLifetime() => throw null;
+        public System.TimeSpan GetCurrentAge(System.DateTimeOffset now) => throw null;
+        public System.DateTimeOffset GetStaleTime() => throw null;
+        public bool IsObsolete(System.DateTimeOffset now) => throw null;
+        public string ComputeSecondaryKeyHash() => throw null;
         public static bool HasSameSecondaryKey(Meziantou.Framework.Http.Caching.HttpCachePersistenceEntry left, Meziantou.Framework.Http.Caching.HttpCachePersistenceEntry right) => throw null;
     }
 

--- a/src/Meziantou.Framework.Http.Caching.InMemory/InMemoryHttpCacheStore.cs
+++ b/src/Meziantou.Framework.Http.Caching.InMemory/InMemoryHttpCacheStore.cs
@@ -177,7 +177,7 @@ public sealed class InMemoryHttpCacheStore : IHttpCacheStore
 
                 foreach (var entry in bag)
                 {
-                    if (ShouldDelete(entry, now))
+                    if (entry.IsObsolete(now))
                     {
                         deletedEntriesForKey++;
                     }
@@ -209,74 +209,5 @@ public sealed class InMemoryHttpCacheStore : IHttpCacheStore
         }
 
         return ValueTask.CompletedTask;
-    }
-
-    private static bool ShouldDelete(HttpCachePersistenceEntry entry, DateTimeOffset now)
-    {
-        return IsExpired(entry, now) && ShouldDeleteWhenExpired(entry);
-    }
-
-    private static bool ShouldDeleteWhenExpired(HttpCachePersistenceEntry entry)
-    {
-        var cannotBeUsedStale = entry.MustRevalidate || entry.ProxyRevalidate || entry.ResponseNoCache;
-        if (!cannotBeUsedStale)
-            return false;
-
-        return string.IsNullOrEmpty(entry.ETag) && entry.LastModified is null;
-    }
-
-    private static bool IsExpired(HttpCachePersistenceEntry entry, DateTimeOffset now)
-    {
-        var freshnessLifetime = GetFreshnessLifetime(entry);
-        var currentAge = CalculateCurrentAge(entry, now);
-        return currentAge >= freshnessLifetime;
-    }
-
-    private static TimeSpan GetFreshnessLifetime(HttpCachePersistenceEntry entry)
-    {
-        if (entry.SharedMaxAge.HasValue)
-            return entry.SharedMaxAge.Value;
-
-        if (entry.MaxAge.HasValue)
-            return entry.MaxAge.Value;
-
-        if (entry.Expires.HasValue)
-        {
-            var expiresTime = entry.Expires.Value;
-            if (expiresTime == DateTimeOffset.MinValue)
-                return TimeSpan.Zero;
-
-            var freshness = expiresTime - entry.ResponseDate;
-            return freshness > TimeSpan.Zero ? freshness : TimeSpan.Zero;
-        }
-
-        if (entry.LastModified.HasValue)
-        {
-            var age = entry.ResponseDate - entry.LastModified.Value;
-            if (age > TimeSpan.Zero)
-            {
-                return TimeSpan.FromSeconds(age.TotalSeconds * 0.1);
-            }
-        }
-
-        return TimeSpan.Zero;
-    }
-
-    private static TimeSpan CalculateCurrentAge(HttpCachePersistenceEntry entry, DateTimeOffset now)
-    {
-        var correctedInitialAge = CalculateCorrectedInitialAge(entry);
-        var residentTime = now - entry.ResponseTime;
-        return correctedInitialAge + residentTime;
-    }
-
-    private static TimeSpan CalculateCorrectedInitialAge(HttpCachePersistenceEntry entry)
-    {
-        var apparentAge = entry.ResponseTime - entry.ResponseDate;
-        if (apparentAge < TimeSpan.Zero)
-            apparentAge = TimeSpan.Zero;
-
-        var responseDelay = entry.ResponseTime - entry.RequestTime;
-        var correctedAgeValue = entry.AgeValue + responseDelay;
-        return apparentAge > correctedAgeValue ? apparentAge : correctedAgeValue;
     }
 }

--- a/src/Meziantou.Framework.Http.Caching.Redis/RedisHttpCacheStore.cs
+++ b/src/Meziantou.Framework.Http.Caching.Redis/RedisHttpCacheStore.cs
@@ -1,5 +1,4 @@
 using System.Buffers.Text;
-using System.Security.Cryptography;
 using System.Text.Json;
 using StackExchange.Redis;
 
@@ -68,7 +67,7 @@ public sealed class RedisHttpCacheStore : IHttpCacheStore
 
         var storageKey = GetPrimaryStorageKey(primaryKey);
         var storageKeyValue = storageKey.ToString();
-        var secondaryKey = ComputeSecondaryKey(entry);
+        var secondaryKey = entry.ComputeSecondaryKeyHash();
         var payload = JsonSerializer.SerializeToUtf8Bytes(entry, RedisSerializationContext.Default.HttpCachePersistenceEntry);
 
         var indexTask = _database.SetAddAsync(_primaryKeysSetKey, storageKeyValue);
@@ -132,7 +131,7 @@ public sealed class RedisHttpCacheStore : IHttpCacheStore
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var entry = TryDeserializeEntry(hashEntry.Value);
-                if (entry is null || ShouldDelete(entry, now))
+                if (entry is null || entry.IsObsolete(now))
                 {
                     fieldsToDelete ??= new List<RedisValue>();
                     fieldsToDelete.Add(hashEntry.Name);
@@ -184,97 +183,5 @@ public sealed class RedisHttpCacheStore : IHttpCacheStore
     {
         var bytes = Encoding.UTF8.GetBytes(primaryKey);
         return Base64Url.EncodeToString(bytes);
-    }
-
-    private static string ComputeSecondaryKey(HttpCachePersistenceEntry entry)
-    {
-        var stringBuilder = new StringBuilder();
-        stringBuilder.Append(entry.SecondaryKeyMatchNone ? '1' : '0');
-
-        var headers = entry.SecondaryKeyHeaders;
-        if (headers is not null)
-        {
-            foreach (var (key, value) in headers.OrderBy(static item => item.Key, StringComparer.OrdinalIgnoreCase))
-            {
-                stringBuilder.Append('\u001f');
-                stringBuilder.Append(key);
-                stringBuilder.Append('\u001e');
-                stringBuilder.Append(value);
-            }
-        }
-
-        var bytes = Encoding.UTF8.GetBytes(stringBuilder.ToString());
-        Span<byte> hash = stackalloc byte[32];
-        SHA256.HashData(bytes, hash);
-        return Convert.ToHexString(hash);
-    }
-
-    private static bool ShouldDelete(HttpCachePersistenceEntry entry, DateTimeOffset now)
-    {
-        return IsExpired(entry, now) && ShouldDeleteWhenExpired(entry);
-    }
-
-    private static bool ShouldDeleteWhenExpired(HttpCachePersistenceEntry entry)
-    {
-        var cannotBeUsedStale = entry.MustRevalidate || entry.ProxyRevalidate || entry.ResponseNoCache;
-        if (!cannotBeUsedStale)
-            return false;
-
-        return string.IsNullOrEmpty(entry.ETag) && entry.LastModified is null;
-    }
-
-    private static bool IsExpired(HttpCachePersistenceEntry entry, DateTimeOffset now)
-    {
-        var freshnessLifetime = GetFreshnessLifetime(entry);
-        var currentAge = CalculateCurrentAge(entry, now);
-        return currentAge >= freshnessLifetime;
-    }
-
-    private static TimeSpan GetFreshnessLifetime(HttpCachePersistenceEntry entry)
-    {
-        if (entry.SharedMaxAge.HasValue)
-            return entry.SharedMaxAge.Value;
-
-        if (entry.MaxAge.HasValue)
-            return entry.MaxAge.Value;
-
-        if (entry.Expires.HasValue)
-        {
-            var expiresTime = entry.Expires.Value;
-            if (expiresTime == DateTimeOffset.MinValue)
-                return TimeSpan.Zero;
-
-            var freshness = expiresTime - entry.ResponseDate;
-            return freshness > TimeSpan.Zero ? freshness : TimeSpan.Zero;
-        }
-
-        if (entry.LastModified.HasValue)
-        {
-            var age = entry.ResponseDate - entry.LastModified.Value;
-            if (age > TimeSpan.Zero)
-            {
-                return TimeSpan.FromSeconds(age.TotalSeconds * 0.1);
-            }
-        }
-
-        return TimeSpan.Zero;
-    }
-
-    private static TimeSpan CalculateCurrentAge(HttpCachePersistenceEntry entry, DateTimeOffset now)
-    {
-        var correctedInitialAge = CalculateCorrectedInitialAge(entry);
-        var residentTime = now - entry.ResponseTime;
-        return correctedInitialAge + residentTime;
-    }
-
-    private static TimeSpan CalculateCorrectedInitialAge(HttpCachePersistenceEntry entry)
-    {
-        var apparentAge = entry.ResponseTime - entry.ResponseDate;
-        if (apparentAge < TimeSpan.Zero)
-            apparentAge = TimeSpan.Zero;
-
-        var responseDelay = entry.ResponseTime - entry.RequestTime;
-        var correctedAgeValue = entry.AgeValue + responseDelay;
-        return apparentAge > correctedAgeValue ? apparentAge : correctedAgeValue;
     }
 }

--- a/src/Meziantou.Framework.Http.Caching.Sqlite/SqliteHttpCacheStore.cs
+++ b/src/Meziantou.Framework.Http.Caching.Sqlite/SqliteHttpCacheStore.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using System.Text.Json;
 using System.Runtime.InteropServices;
 using Microsoft.Data.Sqlite;
@@ -88,10 +87,10 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        var secondaryKey = ComputeSecondaryKey(entry);
+        var secondaryKey = entry.ComputeSecondaryKeyHash();
         var secondaryKeyHeadersJson = SerializeSecondaryKeyHeaders(entry.SecondaryKeyHeaders);
-        var staleAtUtcTicks = ComputeStaleAtUtcTicks(entry);
-        var deleteWhenExpired = ShouldDeleteWhenExpired(entry) ? 1 : 0;
+        var staleAtUtcTicks = entry.GetStaleTime().UtcDateTime.Ticks;
+        var deleteWhenExpired = entry.IsUnusableWhenStale ? 1 : 0;
 
         await using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var command = connection.CreateCommand();
@@ -236,8 +235,8 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
                     continue;
                 }
 
-                var staleAtUtcTicks = ComputeStaleAtUtcTicks(entry);
-                var deleteWhenExpired = ShouldDeleteWhenExpired(entry) ? 1 : 0;
+                var staleAtUtcTicks = entry.GetStaleTime().UtcDateTime.Ticks;
+                var deleteWhenExpired = entry.IsUnusableWhenStale ? 1 : 0;
                 if (deleteWhenExpired is 1 && staleAtUtcTicks <= nowUtcTicks)
                 {
                     rowsToDelete.Add(rowId);
@@ -562,29 +561,6 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
         return connection;
     }
 
-    private static string ComputeSecondaryKey(HttpCachePersistenceEntry entry)
-    {
-        var stringBuilder = new StringBuilder();
-        stringBuilder.Append(entry.SecondaryKeyMatchNone ? '1' : '0');
-
-        var headers = entry.SecondaryKeyHeaders;
-        if (headers is not null)
-        {
-            foreach (var (key, value) in headers.OrderBy(static item => item.Key, StringComparer.OrdinalIgnoreCase))
-            {
-                stringBuilder.Append('\u001f');
-                stringBuilder.Append(key);
-                stringBuilder.Append('\u001e');
-                stringBuilder.Append(value);
-            }
-        }
-
-        var bytes = Encoding.UTF8.GetBytes(stringBuilder.ToString());
-        Span<byte> hash = stackalloc byte[32];
-        SHA256.HashData(bytes, hash);
-        return Convert.ToHexString(hash);
-    }
-
     private static string? SerializeSecondaryKeyHeaders(Dictionary<string, string>? headers)
     {
         if (headers is null || headers.Count is 0)
@@ -765,94 +741,6 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
 
             return -1;
         }
-    }
-
-    private static bool ShouldDeleteWhenExpired(HttpCachePersistenceEntry entry)
-    {
-        var cannotBeUsedStale = entry.MustRevalidate || entry.ProxyRevalidate || entry.ResponseNoCache;
-        if (!cannotBeUsedStale)
-            return false;
-
-        return string.IsNullOrEmpty(entry.ETag) && entry.LastModified is null;
-    }
-
-    private static long ComputeStaleAtUtcTicks(HttpCachePersistenceEntry entry)
-    {
-        var correctedInitialAge = CalculateCorrectedInitialAge(entry);
-        var freshnessLifetime = GetFreshnessLifetime(entry);
-
-        long ticks;
-        try
-        {
-            ticks = checked(entry.ResponseTime.UtcDateTime.Ticks + freshnessLifetime.Ticks - correctedInitialAge.Ticks);
-        }
-        catch (OverflowException)
-        {
-            ticks = freshnessLifetime >= correctedInitialAge ? DateTime.MaxValue.Ticks : DateTime.MinValue.Ticks;
-        }
-
-        if (ticks < DateTime.MinValue.Ticks)
-            return DateTime.MinValue.Ticks;
-
-        if (ticks > DateTime.MaxValue.Ticks)
-            return DateTime.MaxValue.Ticks;
-
-        return ticks;
-    }
-
-    private static bool IsExpired(HttpCachePersistenceEntry entry, DateTimeOffset now)
-    {
-        var freshnessLifetime = GetFreshnessLifetime(entry);
-        var currentAge = CalculateCurrentAge(entry, now);
-        return currentAge >= freshnessLifetime;
-    }
-
-    private static TimeSpan GetFreshnessLifetime(HttpCachePersistenceEntry entry)
-    {
-        if (entry.SharedMaxAge.HasValue)
-            return entry.SharedMaxAge.Value;
-
-        if (entry.MaxAge.HasValue)
-            return entry.MaxAge.Value;
-
-        if (entry.Expires.HasValue)
-        {
-            var expiresTime = entry.Expires.Value;
-            if (expiresTime == DateTimeOffset.MinValue)
-                return TimeSpan.Zero;
-
-            var freshness = expiresTime - entry.ResponseDate;
-            return freshness > TimeSpan.Zero ? freshness : TimeSpan.Zero;
-        }
-
-        if (entry.LastModified.HasValue)
-        {
-            var age = entry.ResponseDate - entry.LastModified.Value;
-            if (age > TimeSpan.Zero)
-            {
-                return TimeSpan.FromSeconds(age.TotalSeconds * 0.1);
-            }
-        }
-
-        return TimeSpan.Zero;
-    }
-
-    private static TimeSpan CalculateCurrentAge(HttpCachePersistenceEntry entry, DateTimeOffset now)
-    {
-        var correctedInitialAge = CalculateCorrectedInitialAge(entry);
-        var residentTime = now - entry.ResponseTime;
-        return correctedInitialAge + residentTime;
-    }
-
-    private static TimeSpan CalculateCorrectedInitialAge(HttpCachePersistenceEntry entry)
-    {
-        var apparentAge = entry.ResponseTime - entry.ResponseDate;
-        if (apparentAge < TimeSpan.Zero)
-            apparentAge = TimeSpan.Zero;
-
-        var responseDelay = entry.ResponseTime - entry.RequestTime;
-        var correctedAgeValue = entry.AgeValue + responseDelay;
-        return apparentAge > correctedAgeValue ? apparentAge : correctedAgeValue;
     }
 
     /// <inheritdoc />

--- a/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
+++ b/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
@@ -104,7 +104,7 @@ internal sealed class CacheEntry
         return null;
     }
 
-    private static DateTimeOffset? ParseExpiresHeader(HttpResponseMessage response)
+    internal static DateTimeOffset? ParseExpiresHeader(HttpResponseMessage response)
     {
         if (!response.Content.Headers.TryGetValues("Expires", out var values))
         {
@@ -258,43 +258,7 @@ internal sealed class CacheEntry
     }
 
     /// <summary>Calculates the freshness lifetime per RFC 7234 Section 4.2.1.</summary>
-    public TimeSpan FreshnessLifetime
-    {
-        get
-        {
-            // 1. Use s-maxage if present (takes precedence for shared caches), otherwise max-age
-            if (SharedMaxAge.HasValue)
-                return SharedMaxAge.Value;
-
-            if (MaxAge.HasValue)
-                return MaxAge.Value;
-
-            // 2. Use Expires - Date if present
-            if (Expires.HasValue)
-            {
-                var expiresTime = Expires.Value;
-                if (expiresTime == DateTimeOffset.MinValue)
-                    return TimeSpan.Zero; // Already expired
-
-                var freshness = expiresTime - ResponseDate;
-                return freshness > TimeSpan.Zero ? freshness : TimeSpan.Zero;
-            }
-
-            // 3. Heuristic freshness (RFC 7234 Section 4.2.2)
-            // Use 10% of time since Last-Modified
-            if (LastModified.HasValue)
-            {
-                var age = ResponseDate - LastModified.Value;
-                if (age > TimeSpan.Zero)
-                {
-                    return TimeSpan.FromSeconds(age.TotalSeconds * 0.1);
-                }
-            }
-
-            // No explicit expiration and no heuristic available
-            return TimeSpan.Zero;
-        }
-    }
+    public TimeSpan FreshnessLifetime => CacheFreshness.GetFreshnessLifetime(SharedMaxAge, MaxAge, Expires, ResponseDate, LastModified);
 
     /// <summary>Gets whether heuristic expiration was used to calculate the freshness lifetime.</summary>
     public bool UsesHeuristicExpiration
@@ -310,25 +274,7 @@ internal sealed class CacheEntry
     /// <summary>Calculates the current age per RFC 7234 Section 4.2.3.</summary>
     public TimeSpan CalculateCurrentAge(DateTimeOffset now)
     {
-        // apparent_age = max(0, response_time - date_value)
-        var apparentAge = ResponseTime - ResponseDate;
-        if (apparentAge < TimeSpan.Zero)
-            apparentAge = TimeSpan.Zero;
-
-        // response_delay = response_time - request_time
-        var responseDelay = ResponseTime - RequestTime;
-
-        // corrected_age_value = age_value + response_delay
-        var correctedAgeValue = AgeValue + responseDelay;
-
-        // corrected_initial_age = max(apparent_age, corrected_age_value)
-        var correctedInitialAge = apparentAge > correctedAgeValue ? apparentAge : correctedAgeValue;
-
-        // resident_time = now - response_time
-        var residentTime = now - ResponseTime;
-
-        // current_age = corrected_initial_age + resident_time
-        return correctedInitialAge + residentTime;
+        return CacheFreshness.GetCurrentAge(RequestTime, ResponseTime, ResponseDate, AgeValue, now);
     }
 
     /// <summary>Updates this cache entry from a 304 Not Modified validation response.</summary>

--- a/src/Meziantou.Framework.Http.Caching/CacheFreshness.cs
+++ b/src/Meziantou.Framework.Http.Caching/CacheFreshness.cs
@@ -1,0 +1,60 @@
+namespace Meziantou.Framework.Http.Caching;
+
+/// <summary>Freshness and age computations shared by the cache and the cache stores.</summary>
+internal static class CacheFreshness
+{
+    /// <summary>Computes the freshness lifetime per RFC 7234 Section 4.2.1.</summary>
+    public static TimeSpan GetFreshnessLifetime(TimeSpan? sharedMaxAge, TimeSpan? maxAge, DateTimeOffset? expires, DateTimeOffset responseDate, DateTimeOffset? lastModified)
+    {
+        // 1. Use s-maxage if present (takes precedence for shared caches), otherwise max-age
+        if (sharedMaxAge.HasValue)
+            return sharedMaxAge.Value;
+
+        if (maxAge.HasValue)
+            return maxAge.Value;
+
+        // 2. Use Expires - Date if present
+        if (expires.HasValue)
+        {
+            if (expires.Value == DateTimeOffset.MinValue)
+                return TimeSpan.Zero; // Already expired
+
+            var freshness = expires.Value - responseDate;
+            return freshness > TimeSpan.Zero ? freshness : TimeSpan.Zero;
+        }
+
+        // 3. Heuristic freshness (RFC 7234 Section 4.2.2)
+        // Use 10% of time since Last-Modified
+        if (lastModified.HasValue)
+        {
+            var age = responseDate - lastModified.Value;
+            if (age > TimeSpan.Zero)
+                return TimeSpan.FromSeconds(age.TotalSeconds * 0.1);
+        }
+
+        // No explicit expiration and no heuristic available
+        return TimeSpan.Zero;
+    }
+
+    /// <summary>Computes the corrected initial age per RFC 7234 Section 4.2.3.</summary>
+    public static TimeSpan GetCorrectedInitialAge(DateTimeOffset requestTime, DateTimeOffset responseTime, DateTimeOffset responseDate, TimeSpan ageValue)
+    {
+        // apparent_age = max(0, response_time - date_value)
+        var apparentAge = responseTime - responseDate;
+        if (apparentAge < TimeSpan.Zero)
+            apparentAge = TimeSpan.Zero;
+
+        // corrected_age_value = age_value + response_delay
+        var correctedAgeValue = ageValue + (responseTime - requestTime);
+
+        // corrected_initial_age = max(apparent_age, corrected_age_value)
+        return apparentAge > correctedAgeValue ? apparentAge : correctedAgeValue;
+    }
+
+    /// <summary>Computes the current age per RFC 7234 Section 4.2.3.</summary>
+    public static TimeSpan GetCurrentAge(DateTimeOffset requestTime, DateTimeOffset responseTime, DateTimeOffset responseDate, TimeSpan ageValue, DateTimeOffset now)
+    {
+        // current_age = corrected_initial_age + resident_time
+        return GetCorrectedInitialAge(requestTime, responseTime, responseDate, ageValue) + (now - responseTime);
+    }
+}

--- a/src/Meziantou.Framework.Http.Caching/HttpCache.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCache.cs
@@ -159,7 +159,7 @@ internal sealed class HttpCache
         // Validate Expires header if present and no Cache-Control freshness
         if (!hasExplicitFreshness && HasExpiresHeader(response))
         {
-            var expires = ParseExpiresHeaderForValidation(response);
+            var expires = CacheEntry.ParseExpiresHeader(response);
             var date = response.Headers.Date ?? DateTimeOffset.UtcNow;
 
             // If Expires is valid and in the future, it counts as explicit freshness
@@ -223,50 +223,5 @@ internal sealed class HttpCache
         // Expires can be on content headers or response headers depending on how it was added
         return response.Content.Headers.TryGetValues("Expires", out _) ||
                response.Headers.TryGetValues("Expires", out _);
-    }
-
-    private static DateTimeOffset? ParseExpiresHeaderForValidation(HttpResponseMessage response)
-    {
-        if (!response.Content.Headers.TryGetValues("Expires", out var values))
-        {
-            if (!response.Headers.TryGetValues("Expires", out values))
-                return null;
-        }
-
-        var expiresValue = values.FirstOrDefault();
-        if (string.IsNullOrEmpty(expiresValue))
-            return null;
-
-        // RFC 7234 Section 5.3: Invalid dates (including "0") are treated as past
-        if (expiresValue is "0" or "-1")
-            return DateTimeOffset.MinValue;
-
-        // RFC 7231 Section 7.1.1.1: Try RFC 1123 format first (preferred)
-        if (DateTimeOffset.TryParseExact(expiresValue, "R", CultureInfo.InvariantCulture, DateTimeStyles.None, out var result))
-            return result;
-
-        // RFC 7231: Try RFC 850 format (obsolete but still used)
-        // Format: Sunday, 06-Nov-94 08:49:37 GMT
-        if (DateTimeOffset.TryParseExact(expiresValue, "dddd, dd-MMM-yy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out result))
-            return result;
-
-        // Try without GMT suffix in case it was already parsed
-        if (DateTimeOffset.TryParseExact(expiresValue, "dddd, dd-MMM-yy HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out result))
-            return result;
-
-        // RFC 7231: Try asctime format (obsolete but still used)
-        // Format: Sun Nov  6 08:49:37 1994
-        if (DateTimeOffset.TryParseExact(expiresValue, "ddd MMM  d HH:mm:ss yyyy", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out result))
-            return result;
-
-        // Also try single-digit day format for asctime
-        if (DateTimeOffset.TryParseExact(expiresValue, "ddd MMM d HH:mm:ss yyyy", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out result))
-            return result;
-
-        // Try general parsing as fallback
-        if (DateTimeOffset.TryParse(expiresValue, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out result))
-            return result;
-
-        return DateTimeOffset.MinValue; // Invalid date treated as expired
     }
 }

--- a/src/Meziantou.Framework.Http.Caching/HttpCachePersistenceEntry.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCachePersistenceEntry.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 namespace Meziantou.Framework.Http.Caching;
 
 /// <summary>Represents a persisted HTTP cache entry.</summary>
@@ -118,6 +120,96 @@ public sealed class HttpCachePersistenceEntry
         };
     }
 
+    /// <summary>Computes the freshness lifetime of the entry, as defined by RFC 7234 Section 4.2.1.</summary>
+    public TimeSpan GetFreshnessLifetime()
+    {
+        return CacheFreshness.GetFreshnessLifetime(SharedMaxAge, MaxAge, Expires, ResponseDate, LastModified);
+    }
+
+    /// <summary>Computes the age of the entry at the specified time, as defined by RFC 7234 Section 4.2.3.</summary>
+    /// <param name="now">The time at which the age is evaluated.</param>
+    public TimeSpan GetCurrentAge(DateTimeOffset now)
+    {
+        return CacheFreshness.GetCurrentAge(RequestTime, ResponseTime, ResponseDate, AgeValue, now);
+    }
+
+    /// <summary>Gets the time at which the entry becomes stale.</summary>
+    /// <remarks>
+    /// The result is clamped to the range of <see cref="DateTimeOffset"/>. Stores can index this value to
+    /// remove obsolete entries without deserializing them.
+    /// </remarks>
+    public DateTimeOffset GetStaleTime()
+    {
+        var correctedInitialAge = CacheFreshness.GetCorrectedInitialAge(RequestTime, ResponseTime, ResponseDate, AgeValue);
+        var freshnessLifetime = GetFreshnessLifetime();
+
+        long ticks;
+        try
+        {
+            ticks = checked(ResponseTime.UtcDateTime.Ticks + freshnessLifetime.Ticks - correctedInitialAge.Ticks);
+        }
+        catch (OverflowException)
+        {
+            ticks = freshnessLifetime >= correctedInitialAge ? DateTime.MaxValue.Ticks : DateTime.MinValue.Ticks;
+        }
+
+        if (ticks < DateTime.MinValue.Ticks)
+            return DateTimeOffset.MinValue;
+
+        if (ticks > DateTime.MaxValue.Ticks)
+            return DateTimeOffset.MaxValue;
+
+        return new DateTimeOffset(ticks, TimeSpan.Zero);
+    }
+
+    /// <summary>Gets a value indicating whether the entry becomes unusable as soon as it is stale.</summary>
+    /// <remarks>
+    /// An entry that may be served stale, or that carries a validator allowing it to be revalidated, remains
+    /// usable after it expires and must be kept.
+    /// </remarks>
+    public bool IsUnusableWhenStale
+    {
+        get
+        {
+            if (!MustRevalidate && !ProxyRevalidate && !ResponseNoCache)
+                return false;
+
+            return string.IsNullOrEmpty(ETag) && LastModified is null;
+        }
+    }
+
+    /// <summary>
+    /// Indicates whether the entry is stale and cannot be reused, and can therefore be removed by a store.
+    /// </summary>
+    /// <param name="now">The time at which staleness is evaluated.</param>
+    public bool IsObsolete(DateTimeOffset now)
+    {
+        return IsUnusableWhenStale && GetCurrentAge(now) >= GetFreshnessLifetime();
+    }
+
+    /// <summary>Computes a stable hash of the secondary key, suitable for use as a storage key.</summary>
+    public string ComputeSecondaryKeyHash()
+    {
+        var stringBuilder = new StringBuilder();
+        stringBuilder.Append(SecondaryKeyMatchNone ? '1' : '0');
+
+        if (SecondaryKeyHeaders is not null)
+        {
+            foreach (var (key, value) in SecondaryKeyHeaders.OrderBy(static item => item.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                stringBuilder.Append('\u001f');
+                stringBuilder.Append(key);
+                stringBuilder.Append('\u001e');
+                stringBuilder.Append(value);
+            }
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(stringBuilder.ToString());
+        Span<byte> hash = stackalloc byte[32];
+        SHA256.HashData(bytes, hash);
+        return Convert.ToHexString(hash);
+    }
+
     /// <summary>Indicates whether two entries share the same secondary key.</summary>
     public static bool HasSameSecondaryKey(HttpCachePersistenceEntry left, HttpCachePersistenceEntry right)
     {
@@ -149,5 +241,4 @@ public sealed class HttpCachePersistenceEntry
 
         return true;
     }
-
 }


### PR DESCRIPTION
**Stack 2/6** — base `http-caching/1-correctness-fixes` (#1920)

Pure refactor, no behaviour change.

### The duplication

`GetFreshnessLifetime`, `CalculateCurrentAge`, `CalculateCorrectedInitialAge`, `IsExpired` and `ShouldDeleteWhenExpired` were copy-pasted **verbatim** into the InMemory, Redis and SQLite stores, and the freshness/age logic existed a fourth time in `CacheEntry`. `ComputeSecondaryKey` was duplicated between Redis and SQLite. The `Expires` parser (~45 lines) was duplicated between `HttpCache` and `CacheEntry`.

Two consequences:

- A fix to freshness calculation had to land in four places.
- A third-party `IHttpCacheStore` **could not implement `PruneObsoleteEntriesAsync` correctly**, because the logic it needs was private to this assembly.

### The change

The single implementation lives in the new internal `CacheFreshness`. `HttpCachePersistenceEntry` exposes it through `GetFreshnessLifetime()`, `GetCurrentAge(now)`, `GetStaleTime()`, `IsObsolete(now)`, `IsUnusableWhenStale` and `ComputeSecondaryKeyHash()`, which the three stores call instead of their own copies.

### Compatibility

The public API change is **additive only** (see the `ref/` diff). The secondary key hash algorithm is byte-identical, so existing SQLite rows and Redis hash fields still match.

> This is the one PR in the stack that adds public API. It is the mechanism that lets the stores share the logic; if you would rather keep these members internal, the alternative is passing the values as parameters to an internal helper, at the cost of leaving third-party stores unable to prune correctly.

### Verification

All four packages build clean with `/p:TreatsWarningsAsErrors=true`; full suite **172 passed, 0 failed, 3 skipped**. `ref/` regenerated with a Release + `IsOfficialBuild` build.