### PR TITLE
Fix stack overflow in Histogram diff on inputs with many anchors

### DIFF
--- a/src/Meziantou.Framework.TextDiff/HistogramDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/HistogramDiff.cs
@@ -26,36 +26,44 @@ internal static class HistogramDiff
         bool[] leftModified,
         bool[] rightModified)
     {
-        while (leftStart < leftEnd && rightStart < rightEnd && comparer.Equals(left[leftStart], right[rightStart]))
+        // Each level consumes a single anchor, so recursing on both sides of it made the recursion
+        // depth proportional to the number of anchors. The region after the anchor is a tail call:
+        // iterate on it instead of recursing, which leaves only the region before the anchor on the
+        // stack. Recursing on both sides overflowed the stack on a few thousand changed chunks.
+        while (true)
         {
-            leftModified[leftStart] = false;
-            rightModified[rightStart] = false;
-            leftStart++;
-            rightStart++;
+            while (leftStart < leftEnd && rightStart < rightEnd && comparer.Equals(left[leftStart], right[rightStart]))
+            {
+                leftModified[leftStart] = false;
+                rightModified[rightStart] = false;
+                leftStart++;
+                rightStart++;
+            }
+
+            while (leftStart < leftEnd && rightStart < rightEnd && comparer.Equals(left[leftEnd - 1], right[rightEnd - 1]))
+            {
+                leftEnd--;
+                rightEnd--;
+                leftModified[leftEnd] = false;
+                rightModified[rightEnd] = false;
+            }
+
+            if (leftStart >= leftEnd || rightStart >= rightEnd)
+                return;
+
+            var anchor = FindBestAnchor(left, leftStart, leftEnd, right, rightStart, rightEnd, comparer);
+            if (anchor is null)
+            {
+                ApplyMyers(left, leftStart, leftEnd, right, rightStart, rightEnd, comparer, leftModified, rightModified);
+                return;
+            }
+
+            ComputeRange(left, leftStart, anchor.Value.LeftIndex, right, rightStart, anchor.Value.RightIndex, comparer, leftModified, rightModified);
+            leftModified[anchor.Value.LeftIndex] = false;
+            rightModified[anchor.Value.RightIndex] = false;
+            leftStart = anchor.Value.LeftIndex + 1;
+            rightStart = anchor.Value.RightIndex + 1;
         }
-
-        while (leftStart < leftEnd && rightStart < rightEnd && comparer.Equals(left[leftEnd - 1], right[rightEnd - 1]))
-        {
-            leftEnd--;
-            rightEnd--;
-            leftModified[leftEnd] = false;
-            rightModified[rightEnd] = false;
-        }
-
-        if (leftStart >= leftEnd || rightStart >= rightEnd)
-            return;
-
-        var anchor = FindBestAnchor(left, leftStart, leftEnd, right, rightStart, rightEnd, comparer);
-        if (anchor is null)
-        {
-            ApplyMyers(left, leftStart, leftEnd, right, rightStart, rightEnd, comparer, leftModified, rightModified);
-            return;
-        }
-
-        ComputeRange(left, leftStart, anchor.Value.LeftIndex, right, rightStart, anchor.Value.RightIndex, comparer, leftModified, rightModified);
-        leftModified[anchor.Value.LeftIndex] = false;
-        rightModified[anchor.Value.RightIndex] = false;
-        ComputeRange(left, anchor.Value.LeftIndex + 1, leftEnd, right, anchor.Value.RightIndex + 1, rightEnd, comparer, leftModified, rightModified);
     }
 
     private static void ApplyMyers(

--- a/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
+++ b/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
@@ -344,6 +344,37 @@ public sealed class TextDiffTests
     }
 
     [Fact]
+    public void ComputeDiff_Histogram_ManyAnchors_DoesNotOverflowTheStack()
+    {
+        // Every second line differs, so each level of the histogram recursion consumes a single anchor.
+        // Recursing on both sides of the anchor made the depth proportional to the number of anchors.
+        const int Count = 3_000;
+        var oldLines = new string[Count];
+        var newLines = new string[Count];
+        for (var i = 0; i < Count; i++)
+        {
+            var suffix = i.ToString(CultureInfo.InvariantCulture);
+            oldLines[i] = "u" + suffix;
+            newLines[i] = (i % 2 is 0 ? "u" : "v") + suffix;
+        }
+
+        var oldText = JoinLines(oldLines);
+        var newText = JoinLines(newLines);
+
+        // A dedicated thread with an explicit stack size keeps the guard meaningful whatever the test host uses.
+        TextDiffResult? result = null;
+        var thread = new Thread(
+            () => result = Diff.ComputeDiff(oldText, newText, new TextDiffOptions { Algorithm = TextDiffAlgorithm.Histogram }),
+            maxStackSize: 512 * 1024);
+        thread.Start();
+        thread.Join();
+
+        Assert.NotNull(result);
+        Assert.Equal(oldText, ReconstructOldText(result));
+        Assert.Equal(newText, ReconstructNewText(result));
+    }
+
+    [Fact]
     public void ComputeDiff_InsertLine()
     {
         var result = Diff.ComputeDiff("line1\nline3", "line1\nline2\nline3");


### PR DESCRIPTION
Stack 2/8 — base: `perf/textdiff-1-myers-optimize` (#1921)

`HistogramDiff.ComputeRange` picks a **single** anchor per level and recursed on both the region before and the region after it, so recursion depth grew with the number of anchors rather than with the nesting of the diff.

Input where every second chunk differs produces one anchor per level. On a 1 MB stack this reaches ~1600 frames and dies:

```
Histogram n=4000: OK 325 ms
Histogram n=5000: Stack overflow.   <- uncatchable, kills the process
```

Patience on the same input is flat, so this is specific to Histogram.

### Fix

The call for the region *after* the anchor is a tail call, so iterate on it instead of recursing. Only the region before the anchor stays on the stack. Anchor selection and the resulting diff are unchanged.

With this change `n=100000` completes instead of overflowing.

### Tests

`ComputeDiff_Histogram_ManyAnchors_DoesNotOverflowTheStack` runs the diff on a dedicated thread with an explicit 512 KB stack, so the guard does not depend on the test host's default stack size. Checked against the parent commit: the test run dies with `Stack overflow.` without this fix and passes with it.

### Note on what is *not* fixed here

This fixes the crash, not the asymptotics — the anchor search still rebuilds its index over the remaining range at each level, so the pass stays `O(n^2)` in time. PR 3 cuts the constant significantly. Removing the quadratic term needs a git-style density guard that falls back to Myers, which changes output; happy to do it as a follow-up if you want it.

`dotnet test`: 192 passed.
---

### The stack

| | PR | change | output |
|---|---|---|---|
| 1 | #1921 | Myers: quadratic run sliding in `Optimize` | identical |
| 2 | #1923 | Histogram: stack overflow (crash fix) | identical |
| 3 | #1925 | Histogram: anchor-search allocations | identical |
| 4 | #1928 | Hunt-Szymanski: defer node allocation | identical |
| 5 | #1929 | Patience: anchors in order, drop the sort | identical |
| 6 | #1931 | helpers: redundant clears, span binary searches | identical |
| 7 | #1932 | hierarchy: block ranges instead of copies | identical |
| 8 | #1933 | Hunt-Szymanski: trim prefix/suffix | **changes Hunt-Szymanski** |

Review bottom-up; each PR targets the one above it.
