### PR TITLE
Fix remaining HTTP caching correctness issues

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
+++ b/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
@@ -232,7 +232,10 @@ internal sealed class CacheEntry
     {
         ArgumentNullException.ThrowIfNull(entry);
 
-        var cacheEntry = new CacheEntry(entry.SerializedResponse.ToArray())
+        var serializedResponse = entry.SerializedResponse.ToArray();
+        ResponseSerializer.EnsureWellFormed(serializedResponse);
+
+        var cacheEntry = new CacheEntry(serializedResponse)
         {
             SecondaryKey = CacheEntrySecondaryKey.Create(entry.SecondaryKeyMatchNone, entry.SecondaryKeyHeaders),
             RequestTime = entry.RequestTime,

--- a/src/Meziantou.Framework.Http.Caching/CacheEntrySecondaryKey.cs
+++ b/src/Meziantou.Framework.Http.Caching/CacheEntrySecondaryKey.cs
@@ -4,7 +4,10 @@ namespace Meziantou.Framework.Http.Caching;
 
 internal readonly struct CacheEntrySecondaryKey : IEquatable<CacheEntrySecondaryKey>
 {
-    public static CacheEntrySecondaryKey MatchAll { get; } = new(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+    // A new instance is returned every time: the value is a struct wrapping a mutable dictionary, so a
+    // shared instance would let Add on any copy corrupt the key for the whole process. An empty
+    // Dictionary does not allocate its buckets, so this stays cheap.
+    public static CacheEntrySecondaryKey MatchAll => new();
     public static CacheEntrySecondaryKey MatchNone { get; }
 
     private readonly Dictionary<string, string>? _headers;

--- a/src/Meziantou.Framework.Http.Caching/HttpCache.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCache.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 
 namespace Meziantou.Framework.Http.Caching;
 
@@ -47,8 +48,9 @@ internal sealed class HttpCache
             {
                 entry = CacheEntry.FromPersistenceEntry(persistedEntry);
             }
-            catch
+            catch (JsonException)
             {
+                // The stored payload is corrupted: ignore the entry and treat it as a miss.
                 continue;
             }
 
@@ -180,12 +182,13 @@ internal sealed class HttpCache
     {
         // RFC 7234 Section 3: Cacheable status codes
         // RFC 7231 Section 6.1: These can be cached with explicit caching directives
+        // 206 is excluded: Range requests bypass the cache, so a stored partial response could only ever
+        // be replayed to a request that asked for the full representation.
         return status switch
         {
             HttpStatusCode.OK => true,
             HttpStatusCode.NonAuthoritativeInformation => true,
             HttpStatusCode.NoContent => true,
-            HttpStatusCode.PartialContent => true,
             HttpStatusCode.MultipleChoices => true,
             HttpStatusCode.MovedPermanently => true,
             HttpStatusCode.NotFound => true,
@@ -206,7 +209,6 @@ internal sealed class HttpCache
             HttpStatusCode.OK => true,
             HttpStatusCode.NonAuthoritativeInformation => true,
             HttpStatusCode.NoContent => true,
-            HttpStatusCode.PartialContent => true,
             HttpStatusCode.MultipleChoices => true,
             HttpStatusCode.MovedPermanently => true,
             HttpStatusCode.NotFound => true,

--- a/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
@@ -214,7 +214,18 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
                     }
 
                     var validationRequestTime = _timeProvider.GetUtcNow();
-                    var conditionalResponse = await base.SendAsync(conditionalRequest, cancellationToken).ConfigureAwait(false);
+                    HttpResponseMessage conditionalResponse;
+                    try
+                    {
+                        conditionalResponse = await base.SendAsync(conditionalRequest, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex) when (IsOriginUnreachable(ex, cancellationToken) && CanServeStaleOnError(cacheResult, currentAge, freshnessLifetime))
+                    {
+                        // RFC 5861: the origin could not be reached at all, which is the case stale-if-error
+                        // exists for. RFC 7234 Section 5.5: Add Warning headers
+                        return CreateCachedResponse(request, cacheResult, currentAge, "110 - \"Response is Stale\", 111 - \"Revalidation Failed\"");
+                    }
+
                     var responseTime = _timeProvider.GetUtcNow();
 
                     // RFC 7234 Section 4.3.3: Handle 304 Not Modified
@@ -231,17 +242,13 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
                     }
 
                     // RFC 5861: Handle error responses with stale-if-error
-                    if (cacheResult.StaleIfError is not null && !conditionalResponse.IsSuccessStatusCode)
+                    if (!conditionalResponse.IsSuccessStatusCode && CanServeStaleOnError(cacheResult, currentAge, freshnessLifetime))
                     {
-                        var staleness = currentAge - freshnessLifetime;
-                        if (staleness <= cacheResult.StaleIfError.Value)
-                        {
-                            conditionalResponse.Dispose();
+                        conditionalResponse.Dispose();
 
-                            // RFC 7234 Section 5.5: Add Warning headers
-                            var warnings = "110 - \"Response is Stale\", 111 - \"Revalidation Failed\"";
-                            return CreateCachedResponse(request, cacheResult, currentAge, warnings);
-                        }
+                        // RFC 7234 Section 5.5: Add Warning headers
+                        var warnings = "110 - \"Response is Stale\", 111 - \"Revalidation Failed\"";
+                        return CreateCachedResponse(request, cacheResult, currentAge, warnings);
                     }
 
                     // Use fresh response and cache it. The timing of the validation request is used so the
@@ -270,7 +277,20 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
         }
 
         // No suitable cached response, send request to origin
-        var freshResponse = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        HttpResponseMessage freshResponse;
+        try
+        {
+            freshResponse = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (cacheResult is not null &&
+                                   IsOriginUnreachable(ex, cancellationToken) &&
+                                   CanServeStaleOnError(cacheResult, cacheResult.CalculateCurrentAge(_timeProvider.GetUtcNow()), cacheResult.FreshnessLifetime))
+        {
+            // RFC 5861: serve the stale entry rather than propagating the transport failure.
+            var staleAge = cacheResult.CalculateCurrentAge(_timeProvider.GetUtcNow());
+            return CreateCachedResponse(request, cacheResult, staleAge, "110 - \"Response is Stale\", 111 - \"Revalidation Failed\"");
+        }
+
         var freshResponseTime = _timeProvider.GetUtcNow();
 
         await _cache.StoreAsync(request, freshResponse, requestTime, freshResponseTime, cancellationToken).ConfigureAwait(false);
@@ -463,6 +483,27 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
         }
 
         return clone;
+    }
+
+    private static bool CanServeStaleOnError(CacheEntry entry, TimeSpan currentAge, TimeSpan freshnessLifetime)
+    {
+        // RFC 5861: stale-if-error allows a stale response to be served for the given amount of time past
+        // the point at which it became stale.
+        if (entry.StaleIfError is null)
+            return false;
+
+        var staleness = currentAge - freshnessLifetime;
+        return staleness <= entry.StaleIfError.Value;
+    }
+
+    private static bool IsOriginUnreachable(Exception exception, CancellationToken cancellationToken)
+    {
+        // A cancellation requested by the caller is not an origin failure and must propagate. A
+        // TaskCanceledException without a cancellation request is an HttpClient timeout.
+        if (cancellationToken.IsCancellationRequested)
+            return false;
+
+        return exception is HttpRequestException or TaskCanceledException;
     }
 
     private static bool HasConditionalHeaders(HttpRequestHeaders headers)

--- a/src/Meziantou.Framework.Http.Caching/ResponseSerializer.cs
+++ b/src/Meziantou.Framework.Http.Caching/ResponseSerializer.cs
@@ -21,6 +21,23 @@ internal static class ResponseSerializer
         return JsonSerializer.SerializeToUtf8Bytes(serialized, SerializationContext.Default.SerializedResponseMessage);
     }
 
+    /// <summary>Throws when the payload is not well-formed JSON.</summary>
+    /// <remarks>
+    /// Entries come from an external store and can be truncated or corrupted. Validating on read keeps the
+    /// failure inside the cache lookup, where it is turned into a cache miss, instead of letting it escape
+    /// from the message handler once the response is being built.
+    /// </remarks>
+    public static void EnsureWellFormed(ReadOnlySpan<byte> data)
+    {
+        if (data.IsEmpty)
+            throw new JsonException("The serialized response is empty");
+
+        var reader = new Utf8JsonReader(data);
+        while (reader.Read())
+        {
+        }
+    }
+
     public static HttpResponseMessage Deserialize(byte[] data)
     {
         var serialized = JsonSerializer.Deserialize(data, SerializationContext.Default.SerializedResponseMessage);

--- a/tests/Meziantou.Framework.Http.Caching.Tests/ComprehensiveRFC7234Tests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/ComprehensiveRFC7234Tests.cs
@@ -271,9 +271,12 @@ public sealed class ComprehensiveRFC7234Tests
     }
 
     [Fact]
-    public async Task When206PartialContentThenCacheable()
+    public async Task When206PartialContentThenNotCached()
     {
         await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.PartialContent, "partial",
+            ("Cache-Control", "max-age=60"),
+            ("Content-Range", "bytes 0-6/100"));
         context.AddResponse(HttpStatusCode.PartialContent, "partial",
             ("Cache-Control", "max-age=60"),
             ("Content-Range", "bytes 0-6/100"));
@@ -290,10 +293,11 @@ public sealed class ComprehensiveRFC7234Tests
               Value: partial
             """);
 
+        // Range requests bypass the cache, so a stored 206 could only ever be replayed to a request that
+        // asked for the full representation. The second request must reach the origin.
         await context.SnapshotResponse("http://example.com/resource", """
             StatusCode: 206 (PartialContent)
             Headers:
-              Age: 0
               Cache-Control: max-age=60
             Content:
               Headers:

--- a/tests/Meziantou.Framework.Http.Caching.Tests/StaleResponseTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/StaleResponseTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using Meziantou.Framework.Http.Caching.InMemory;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Meziantou.Framework.Http.Caching.Tests;
 
@@ -194,5 +196,147 @@ public class StaleResponseTests
                 Content-Type: text/plain; charset=utf-8
               Value: fresh-content
             """);
+    }
+
+    [Fact]
+    public async Task WhenRevalidationThrowsAndStaleIfErrorAllowsItThenStaleResponseServed()
+    {
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "cached", ("Cache-Control", "max-age=2, stale-if-error=60"), ("ETag", "\"v1\"")));
+        innerHandler.AddThrow(static () => new HttpRequestException("origin unreachable"));
+
+        var timeProvider = new FakeTimeProvider();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { TimeProvider = timeProvider });
+        using var client = new HttpClient(handler);
+
+        using var firstResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        Assert.Equal("cached", await firstResponse.Content.ReadAsStringAsync(CancellationToken.None));
+
+        timeProvider.Advance(TimeSpan.FromSeconds(3));
+
+        // The origin cannot be reached at all, which is the case stale-if-error exists for.
+        using var secondResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+        Assert.Equal("cached", await secondResponse.Content.ReadAsStringAsync(CancellationToken.None));
+        Assert.Equal("110 - \"Response is Stale\", 111 - \"Revalidation Failed\"", string.Join(", ", secondResponse.Headers.GetValues("Warning")));
+    }
+
+    [Fact]
+    public async Task WhenEntryHasNoValidatorAndRequestThrowsAndStaleIfErrorAllowsItThenStaleResponseServed()
+    {
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "cached", ("Cache-Control", "max-age=2, stale-if-error=60")));
+        innerHandler.AddThrow(static () => new HttpRequestException("origin unreachable"));
+
+        var timeProvider = new FakeTimeProvider();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { TimeProvider = timeProvider });
+        using var client = new HttpClient(handler);
+
+        using var firstResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromSeconds(3));
+
+        // The entry carries no validator, so the request goes to the origin unconditionally.
+        using var secondResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+        Assert.Equal("cached", await secondResponse.Content.ReadAsStringAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenStaleIfErrorWindowHasPassedThenTransportFailureIsPropagated()
+    {
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "cached", ("Cache-Control", "max-age=2, stale-if-error=10"), ("ETag", "\"v1\"")));
+        innerHandler.AddThrow(static () => new HttpRequestException("origin unreachable"));
+
+        var timeProvider = new FakeTimeProvider();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { TimeProvider = timeProvider });
+        using var client = new HttpClient(handler);
+
+        using var firstResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromSeconds(60));
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync("http://example.com/resource", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenCallerCancelsThenStaleResponseIsNotServed()
+    {
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "cached", ("Cache-Control", "max-age=2, stale-if-error=60"), ("ETag", "\"v1\"")));
+        innerHandler.AddThrow(static () => new TaskCanceledException("canceled"));
+
+        var timeProvider = new FakeTimeProvider();
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), new HttpCachingOptions { TimeProvider = timeProvider });
+        using var client = new HttpClient(handler);
+
+        using var firstResponse = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromSeconds(3));
+
+        // A cancellation requested by the caller is not an origin failure and must propagate.
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.GetAsync("http://example.com/resource", cancellationTokenSource.Token));
+    }
+
+    [Fact]
+    public async Task WhenStoredPayloadIsCorruptedThenTheRequestGoesToTheOrigin()
+    {
+        var store = new InMemoryHttpCacheStore();
+        await store.SetEntryAsync("GET http://example.com/resource", new HttpCachePersistenceEntry
+        {
+            RequestTime = DateTimeOffset.UnixEpoch,
+            ResponseTime = DateTimeOffset.UnixEpoch,
+            ResponseDate = DateTimeOffset.UnixEpoch,
+            MaxAge = TimeSpan.FromHours(1),
+            SerializedResponse = "{ this is not valid json"u8.ToArray(),
+        }, CancellationToken.None);
+
+        using var innerHandler = new StubHandler();
+        innerHandler.AddResponse(static () => CreateResponse(HttpStatusCode.OK, "from-origin", ("Cache-Control", "max-age=3600")));
+
+        using var handler = new HttpCachingDelegateHandler(innerHandler, store);
+        using var client = new HttpClient(handler);
+
+        // A truncated or corrupted payload must be treated as a miss instead of throwing.
+        using var response = await client.GetAsync("http://example.com/resource", CancellationToken.None);
+        Assert.Equal("from-origin", await response.Content.ReadAsStringAsync(CancellationToken.None));
+    }
+
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to the caller")]
+    private static HttpResponseMessage CreateResponse(HttpStatusCode statusCode, string? content = null, params (string Name, string Value)[] headers)
+    {
+        var response = new HttpResponseMessage(statusCode);
+        foreach (var (name, value) in headers)
+        {
+            response.Headers.TryAddWithoutValidation(name, value);
+        }
+
+        if (content is not null)
+        {
+            response.Content = new StringContent(content);
+        }
+
+        return response;
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Queue<Func<HttpResponseMessage>> _responses = new();
+
+        public void AddResponse(Func<HttpResponseMessage> responseFactory)
+        {
+            _responses.Enqueue(responseFactory);
+        }
+
+        public void AddThrow(Func<Exception> exceptionFactory)
+        {
+            _responses.Enqueue(() => throw exceptionFactory());
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_responses.Dequeue()());
+        }
     }
 }


### PR DESCRIPTION
**Stack 3/6** — base `http-caching/2-shared-freshness-helpers` (#1922)

Four further correctness issues from the same review.

### `206 Partial Content` was stored and replayed

Range requests bypass the cache, so a stored `206` could only ever be served to a request that asked for the **full** representation. The caller received a fragment of the body plus a `Content-Range` header.

`When206PartialContentThenCacheable` asserted exactly this: a plain `GET` receiving 7 of 100 bytes from cache. The status is removed from both cacheable lists and that test now asserts the second request reaches the origin.

### `CacheEntrySecondaryKey.MatchAll` shared a mutable dictionary

It was a struct wrapping a single `static` mutable `Dictionary`. Nothing calls `Add` on a copy today, so this is latent, but one future call would corrupt the key for the whole process. It now returns a new instance; an empty `Dictionary` does not allocate its buckets, so this stays cheap.

### A corrupted payload threw out of `SendAsync`

The `catch` in `TryGetAsync` guarded `FromPersistenceEntry`, which does not parse the JSON — the parse happened later, unguarded, while building the response. A truncated Redis or SQLite blob therefore escaped the handler. Payloads are now validated when the entry is rehydrated, so corruption becomes a cache miss, and the bare `catch` is narrowed to `JsonException`.

### `stale-if-error` did not cover the case it exists for

It applied only when revalidation returned an error **status**. An origin that could not be reached at all was not covered, nor was the unconditional fetch made when an entry carries no validator. Both now fall back to the stale entry.

A cancellation requested by the caller is not an origin failure and still propagates — covered by a test.

### Verification

Full suite **354 passed, 0 failed, 6 skipped** across both TFMs. Five new tests.