### PR TITLE
Reduce allocations in Histogram diff anchor search

### DIFF
--- a/src/Meziantou.Framework.TextDiff/HistogramDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/HistogramDiff.cs
@@ -87,64 +87,56 @@ internal static class HistogramDiff
 
     private static Anchor? FindBestAnchor(string[] left, int leftStart, int leftEnd, string[] right, int rightStart, int rightEnd, IEqualityComparer<string> comparer)
     {
-        var leftFrequency = CountOccurrences(left, leftStart, leftEnd, comparer);
-        var rightPositions = BuildPositions(right, rightStart, rightEnd, comparer);
+        // A single map holds the occurrence counts on both sides and the first right-hand position of
+        // each token. This replaces a second dictionary and the List<int> that used to be allocated per
+        // distinct token, which dominated the allocations of this pass.
+        var stats = new Dictionary<string, TokenStats>(comparer);
+        for (var i = leftStart; i < leftEnd; i++)
+        {
+            ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(stats, left[i], out _);
+            entry.LeftCount++;
+        }
+
+        // Walking backwards leaves the smallest index of each token in FirstRightIndex.
+        for (var i = rightEnd - 1; i >= rightStart; i--)
+        {
+            ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(stats, right[i], out _);
+            entry.RightCount++;
+            entry.FirstRightIndex = i;
+        }
 
         Anchor? best = null;
         var bestScore = int.MaxValue;
         for (var leftIndex = leftStart; leftIndex < leftEnd; leftIndex++)
         {
-            var token = left[leftIndex];
-            if (!rightPositions.TryGetValue(token, out var positions))
+            var entry = stats[left[leftIndex]];
+            if (entry.RightCount is 0)
                 continue;
 
-            // positions is sorted ascending, so positions[0] is the only candidate that can win the
-            // tie-break for this leftIndex (smaller rightIndex wins). The right occurrence count equals
-            // positions.Count, so there is no need for a separate frequency dictionary.
-            var score = leftFrequency[token] + positions.Count;
-            var rightIndex = positions[0];
-            if (best is null || score < bestScore || (score == bestScore && IsBetterTieBreak(leftIndex, rightIndex, best.Value)))
-            {
-                best = new Anchor(leftIndex, rightIndex);
-                bestScore = score;
-            }
+            // leftIndex only increases and ties are won by the smallest leftIndex, so an anchor found
+            // later can only replace the current best with a strictly lower score.
+            var score = entry.LeftCount + entry.RightCount;
+            if (score >= bestScore)
+                continue;
+
+            best = new Anchor(leftIndex, entry.FirstRightIndex);
+            bestScore = score;
+
+            // 2 is the lowest reachable score: the token occurs exactly once on each side. Nothing
+            // later in the range can beat it, so stop scanning.
+            if (score is 2)
+                break;
         }
 
         return best;
     }
 
-    private static bool IsBetterTieBreak(int leftIndex, int rightIndex, Anchor current)
+    [StructLayout(LayoutKind.Auto)]
+    private struct TokenStats
     {
-        if (leftIndex != current.LeftIndex)
-            return leftIndex < current.LeftIndex;
-
-        return rightIndex < current.RightIndex;
-    }
-
-    private static Dictionary<string, int> CountOccurrences(string[] values, int start, int end, IEqualityComparer<string> comparer)
-    {
-        var result = new Dictionary<string, int>(comparer);
-        for (var i = start; i < end; i++)
-        {
-            ref var count = ref CollectionsMarshal.GetValueRefOrAddDefault(result, values[i], out var exists);
-            count = exists ? count + 1 : 1;
-        }
-
-        return result;
-    }
-
-    private static Dictionary<string, List<int>> BuildPositions(string[] values, int start, int end, IEqualityComparer<string> comparer)
-    {
-        var result = new Dictionary<string, List<int>>(comparer);
-        for (var i = start; i < end; i++)
-        {
-            ref var positions = ref CollectionsMarshal.GetValueRefOrAddDefault(result, values[i], out _);
-            positions ??= new List<int>();
-
-            positions.Add(i);
-        }
-
-        return result;
+        public int LeftCount;
+        public int RightCount;
+        public int FirstRightIndex;
     }
 
     [StructLayout(LayoutKind.Auto)]


### PR DESCRIPTION
Stack 3/8 — base: `perf/textdiff-2-histogram-stack-overflow` (#1923)

`FindBestAnchor` built two dictionaries per range:

- occurrence counts for the left range, and
- `Dictionary<string, List<int>>` holding **every** position of every token in the right range.

Only `positions[0]` was ever read, so the per-token `List<int>` was pure overhead. Scoring a candidate then needed a second dictionary lookup (`leftFrequency[token]` after `rightPositions.TryGetValue`). The scan also ran to the end of the range even after finding an anchor with the lowest reachable score.

### Fix

- One map holding both counts and the first right-hand position.
- Stop the scan at score 2 (the token occurs exactly once on each side).
- The tie-break was unreachable — `leftIndex` only increases and ties are won by the smallest `leftIndex`, so an anchor found later can only win with a strictly lower score — and is removed.

### Verification

Anchor selection is unchanged. Fuzzed against the previous implementation over **300k random inputs** with both `Ordinal` and `OrdinalIgnoreCase` comparers: **0 mismatches**.

| scenario | before | after | |
|---|---|---|---|
| 20k unique lines, 40 scattered edits | 61.5 ms / 85.4 MB | 16.9 ms / 38.9 MB | 3.64x time, 2.19x alloc |
| 6k lines, 30-word vocabulary | 39.8 ms / 8.2 MB | 23.5 ms / 2.0 MB | 1.69x time, 4.02x alloc |
| 3k lines, every second line changed | 293.5 ms / 502.6 MB | 94.3 ms / 324.9 MB | 3.11x time, 1.55x alloc |
| 4k lines, 8-token vocabulary | 27.1 ms / 10.3 MB | 13.4 ms / 1.5 MB | 2.02x time, 7.08x alloc |

Best-of-10 per configuration; single-shot numbers on this workload are too noisy to compare.

`dotnet test`: 192 passed.
---

### The stack

| | PR | change | output |
|---|---|---|---|
| 1 | #1921 | Myers: quadratic run sliding in `Optimize` | identical |
| 2 | #1923 | Histogram: stack overflow (crash fix) | identical |
| 3 | #1925 | Histogram: anchor-search allocations | identical |
| 4 | #1928 | Hunt-Szymanski: defer node allocation | identical |
| 5 | #1929 | Patience: anchors in order, drop the sort | identical |
| 6 | #1931 | helpers: redundant clears, span binary searches | identical |
| 7 | #1932 | hierarchy: block ranges instead of copies | identical |
| 8 | #1933 | Hunt-Szymanski: trim prefix/suffix | **changes Hunt-Szymanski** |

Review bottom-up; each PR targets the one above it.
