### PR TITLE
Enforce MaximumResponseSize before buffering the response

### DIFF
--- a/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
+++ b/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
@@ -9,10 +9,14 @@ internal sealed class CacheEntry
         SerializedResponse = serializedResponse;
     }
 
-    public static async Task<CacheEntry> CreateAsync(HttpRequestMessage request, HttpResponseMessage response,
-        DateTimeOffset requestTime, DateTimeOffset responseTime, CancellationToken cancellationToken)
+    /// <summary>Creates an entry, or returns <see langword="null"/> when the response exceeds <paramref name="maximumSize"/>.</summary>
+    public static async Task<CacheEntry?> CreateAsync(HttpRequestMessage request, HttpResponseMessage response,
+        DateTimeOffset requestTime, DateTimeOffset responseTime, long? maximumSize, CancellationToken cancellationToken)
     {
-        var serializedResponse = await ResponseSerializer.SerializeAsync(response, cancellationToken).ConfigureAwait(false);
+        var serializedResponse = await ResponseSerializer.SerializeAsync(response, maximumSize, cancellationToken).ConfigureAwait(false);
+        if (serializedResponse is null)
+            return null;
+
         var entry = new CacheEntry(serializedResponse)
         {
             RequestTime = requestTime,

--- a/src/Meziantou.Framework.Http.Caching/HttpCache.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCache.cs
@@ -82,18 +82,18 @@ internal sealed class HttpCache
         if (_options.ShouldCacheResponse is not null && !_options.ShouldCacheResponse(response))
             return;
 
-        var primaryKey = ComputePrimaryKey(request.Method, request.RequestUri);
-        var entry = await CacheEntry.CreateAsync(request, response, requestTime, responseTime, cancellationToken).ConfigureAwait(false);
+        // Check the announced size before reading anything. Buffering a multi-gigabyte response only to
+        // discard it is a needless allocation, and serialization would grow it further.
+        var maximumResponseSize = _options.MaximumResponseSize;
+        if (maximumResponseSize is not null && response.Content?.Headers.ContentLength > maximumResponseSize.GetValueOrDefault())
+            return;
 
-        // Check response size limit if configured
-        // We check the serialized size which includes headers and metadata
-        if (_options.MaximumResponseSize is not null)
-        {
-            if (entry.SerializedResponse.Length > _options.MaximumResponseSize.Value)
-            {
-                return;
-            }
-        }
+        var primaryKey = ComputePrimaryKey(request.Method, request.RequestUri);
+
+        // The size limit applies to the serialized entry, which includes headers and metadata.
+        var entry = await CacheEntry.CreateAsync(request, response, requestTime, responseTime, maximumResponseSize, cancellationToken).ConfigureAwait(false);
+        if (entry is null)
+            return;
 
         await _persistenceProvider.SetEntryAsync(primaryKey, entry.ToPersistenceEntry(), cancellationToken).ConfigureAwait(false);
     }

--- a/src/Meziantou.Framework.Http.Caching/ResponseSerializer.cs
+++ b/src/Meziantou.Framework.Http.Caching/ResponseSerializer.cs
@@ -7,7 +7,22 @@ internal static class ResponseSerializer
 {
     public static async Task<byte[]> SerializeAsync(HttpResponseMessage response, CancellationToken cancellationToken)
     {
+        var serialized = await SerializeAsync(response, maximumSize: null, cancellationToken).ConfigureAwait(false);
+        return serialized!;
+    }
+
+    /// <summary>Serializes the response, or returns <see langword="null"/> when it exceeds <paramref name="maximumSize"/>.</summary>
+    /// <remarks>
+    /// The body is checked before it is serialized. JSON encoding only grows the payload, since the body is
+    /// Base64-encoded and the headers are added, so a body already over the limit can never fit and the
+    /// serialization is skipped entirely.
+    /// </remarks>
+    public static async Task<byte[]?> SerializeAsync(HttpResponseMessage response, long? maximumSize, CancellationToken cancellationToken)
+    {
         var content = response.Content is null ? null : await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+        if (maximumSize is not null && content is not null && content.Length > maximumSize.GetValueOrDefault())
+            return null;
+
         var serialized = new SerializedResponseMessage
         {
             HttpStatusCode = response.StatusCode,
@@ -18,7 +33,11 @@ internal static class ResponseSerializer
             Content = content,
         };
 
-        return JsonSerializer.SerializeToUtf8Bytes(serialized, SerializationContext.Default.SerializedResponseMessage);
+        var payload = JsonSerializer.SerializeToUtf8Bytes(serialized, SerializationContext.Default.SerializedResponseMessage);
+        if (maximumSize is not null && payload.Length > maximumSize.GetValueOrDefault())
+            return null;
+
+        return payload;
     }
 
     /// <summary>Throws when the payload is not well-formed JSON.</summary>

--- a/tests/Meziantou.Framework.Http.Caching.Tests/AdvancedCachingTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/AdvancedCachingTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Meziantou.Framework.Http.Caching.InMemory;
 
 namespace Meziantou.Framework.Http.Caching.Tests;
 
@@ -745,6 +746,54 @@ public sealed class AdvancedCachingTests
                 Content-Type: text/plain; charset=utf-8
               Value: {content}
             """);
+    }
+
+    [Fact]
+    public async Task WhenContentLengthExceedsLimitThenResponseIsNotBuffered()
+    {
+        // The body must not be read at all: the announced length is already over the limit.
+        var contentReadCount = 0;
+        using var innerHandler = new ContentReadCountingHandler(() => contentReadCount++);
+        var options = new HttpCachingOptions { MaximumResponseSize = 100 };
+        using var handler = new HttpCachingDelegateHandler(innerHandler, new InMemoryHttpCacheStore(), options);
+        using var client = new HttpClient(handler);
+
+        // ResponseHeadersRead so that HttpClient does not buffer the content itself.
+        using var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/resource");
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, CancellationToken.None);
+        Assert.Equal(0, contentReadCount);
+
+        // The caller still gets the untouched response.
+        Assert.Equal(new string('x', 500), await response.Content.ReadAsStringAsync(CancellationToken.None));
+        Assert.Equal(1, contentReadCount);
+    }
+
+    private sealed class ContentReadCountingHandler(Action onRead) : HttpMessageHandler
+    {
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership is transferred to the caller")]
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Headers.TryAddWithoutValidation("Cache-Control", "max-age=3600");
+            response.Content = new CountingContent(new string('x', 500), onRead);
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class CountingContent(string content, Action onRead) : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            onRead();
+            var bytes = Encoding.UTF8.GetBytes(content);
+            return stream.WriteAsync(bytes, 0, bytes.Length);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = Encoding.UTF8.GetByteCount(content);
+            return true;
+        }
     }
 
     [Fact]


### PR DESCRIPTION
**Stack 4/6** — base `http-caching/3-correctness-followups` (#1924)

`MaximumResponseSize` was checked **after** the whole body had been read into a `byte[]` and JSON-serialized with the body Base64-encoded. A response far over the limit was therefore fully materialized twice, at roughly 2.3x its size, before being discarded. With the 5 MB default, a 2 GB response allocated several GB on its way to being rejected.

### The change

Two short-circuits, both sound because serialization only ever grows the payload:

1. The announced `Content-Length` is checked **before anything is read**.
2. The buffered body is checked **before it is serialized**, skipping the JSON and Base64 step.

The final comparison still applies to the serialized entry, so the option keeps its current meaning — `WhenResponseOneByteLargerThanLimitThenNotCached` (400-byte body, 500-byte limit, rejected on serialized size) still passes unchanged.

### What is deliberately not changed

Responses whose length is **not** announced are still buffered in full. Deciding by reading would consume a stream the caller has not read yet: `LoadIntoBufferAsync(maxBufferSize)` leaves the content unusable when it throws, which would corrupt the response the caller receives. Content-Length is present for the large majority of real responses.

### Verification

New test drives a counting `HttpContent` through `ResponseHeadersRead` and asserts the body is **never read** when `Content-Length` exceeds the limit, and that the caller still receives the untouched response. Full suite **356 passed, 0 failed, 6 skipped**.