### PR TITLE
Allocate Hunt-Szymanski candidate nodes only when they are kept

### DIFF
--- a/src/Meziantou.Framework.TextDiff/HuntSzymanskiDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/HuntSzymanskiDiff.cs
@@ -53,18 +53,18 @@ internal static class HuntSzymanskiDiff
             {
                 var rightIndex = matches[i];
                 var position = DiffAlgorithmHelpers.LowerBound(thresholds, rightIndex);
-                var previous = position > 0 ? links[position - 1] : null;
-                var node = new MatchNode(leftIndex, rightIndex, previous);
 
+                // The node is only allocated once the candidate is known to improve the threshold list.
+                // On input with many duplicate chunks half of the candidates were allocated and dropped.
                 if (position == thresholds.Count)
                 {
                     thresholds.Add(rightIndex);
-                    links.Add(node);
+                    links.Add(new MatchNode(leftIndex, rightIndex, position > 0 ? links[position - 1] : null));
                 }
                 else if (rightIndex < thresholds[position])
                 {
                     thresholds[position] = rightIndex;
-                    links[position] = node;
+                    links[position] = new MatchNode(leftIndex, rightIndex, position > 0 ? links[position - 1] : null);
                 }
             }
         }


### PR DESCRIPTION
Stack 4/8 — base: `perf/textdiff-3-histogram-allocations` (#1925)

`BuildCandidateLinks` allocated a `MatchNode` for every candidate pair *before* checking whether it improves the threshold list.

The number of candidate pairs is quadratic in the number of duplicate chunks. Counting the threshold updates shows exactly half the nodes are dropped immediately:

| n (4 distinct lines) | nodes allocated | nodes kept | wasted |
|---|---|---|---|
| 2 000 | 1 000 000 | 501 000 | 49.9% |
| 20 000 | 100 000 000 | 50 010 000 | 50.0% |

On mostly-unique input the waste is 0%, so this is specific to duplicate-heavy input.

### Fix

Move the allocation into the two branches that keep the node.

On 8k repetitive lines with one inserted line: **489 MB -> 245 MB** allocated.

### Verification

The candidate that is chosen is unchanged. Fuzzed against the previous implementation over **300k random inputs** with both `Ordinal` and `OrdinalIgnoreCase` comparers: **0 mismatches**.

### Note

This halves a quadratic term without removing it. The candidate explosion itself is what PR 8 addresses (for the common case) — and bounding the candidate set for the genuinely pathological case is still open.

`dotnet test`: 192 passed.
---

### The stack

| | PR | change | output |
|---|---|---|---|
| 1 | #1921 | Myers: quadratic run sliding in `Optimize` | identical |
| 2 | #1923 | Histogram: stack overflow (crash fix) | identical |
| 3 | #1925 | Histogram: anchor-search allocations | identical |
| 4 | #1928 | Hunt-Szymanski: defer node allocation | identical |
| 5 | #1929 | Patience: anchors in order, drop the sort | identical |
| 6 | #1931 | helpers: redundant clears, span binary searches | identical |
| 7 | #1932 | hierarchy: block ranges instead of copies | identical |
| 8 | #1933 | Hunt-Szymanski: trim prefix/suffix | **changes Hunt-Szymanski** |

Review bottom-up; each PR targets the one above it.
