### PR TITLE
Produce Patience diff anchors in order instead of sorting them

### DIFF
--- a/src/Meziantou.Framework.TextDiff/PatienceDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/PatienceDiff.cs
@@ -92,19 +92,28 @@ internal static class PatienceDiff
         var leftUnique = FindUniquePositions(left, leftStart, leftEnd, comparer);
         var rightUnique = FindUniquePositions(right, rightStart, rightEnd, comparer);
 
+        // Walking the range in order yields the anchors already sorted by left index, which is what the
+        // longest-increasing-subsequence pass needs. Enumerating the dictionary instead produced them in
+        // an arbitrary order and required a sort.
         var pairs = new List<Anchor>();
-        foreach (var entry in leftUnique)
+        for (var leftIndex = leftStart; leftIndex < leftEnd; leftIndex++)
         {
-            if (entry.Value >= 0 && rightUnique.TryGetValue(entry.Key, out var rightIndex) && rightIndex >= 0)
+            var chunk = left[leftIndex];
+
+            // FindUniquePositions stores the index of a chunk that appears once and -1 for a chunk that
+            // appears several times, so this only matches chunks that are unique in the range.
+            if (leftUnique[chunk] != leftIndex)
+                continue;
+
+            if (rightUnique.TryGetValue(chunk, out var rightIndex) && rightIndex >= 0)
             {
-                pairs.Add(new Anchor(entry.Value, rightIndex));
+                pairs.Add(new Anchor(leftIndex, rightIndex));
             }
         }
 
         if (pairs.Count == 0)
             return pairs;
 
-        pairs.Sort((a, b) => a.LeftIndex.CompareTo(b.LeftIndex));
         return LongestIncreasingSubsequenceByRight(pairs);
     }
 


### PR DESCRIPTION
Stack 5/8 — base: `perf/textdiff-4-huntszymanski` (#1928)

`FindAnchors` collected candidate anchors by enumerating the dictionary of unique left-hand chunks — which yields them in an arbitrary order — then sorted the result by left index before running the longest-increasing-subsequence pass.

### Fix

Walk the range in order instead. `FindUniquePositions` already stores the index of a chunk that appears exactly once and `-1` for a chunk that appears several times, so a chunk is unique when its stored index equals the position being visited. The anchors then come out sorted by construction, and the sort goes away along with its comparison delegate.

### Verification

The set of anchors is identical and left indices are distinct, so the order was already fully determined by the sort. Fuzzed against the previous implementation over **300k random inputs** with both `Ordinal` and `OrdinalIgnoreCase` comparers: **0 mismatches**.

On 40k unique lines with 80 edits: **6.3 ms -> 3.6 ms** (1.74x).

`dotnet test`: 192 passed.
---

### The stack

| | PR | change | output |
|---|---|---|---|
| 1 | #1921 | Myers: quadratic run sliding in `Optimize` | identical |
| 2 | #1923 | Histogram: stack overflow (crash fix) | identical |
| 3 | #1925 | Histogram: anchor-search allocations | identical |
| 4 | #1928 | Hunt-Szymanski: defer node allocation | identical |
| 5 | #1929 | Patience: anchors in order, drop the sort | identical |
| 6 | #1931 | helpers: redundant clears, span binary searches | identical |
| 7 | #1932 | hierarchy: block ranges instead of copies | identical |
| 8 | #1933 | Hunt-Szymanski: trim prefix/suffix | **changes Hunt-Szymanski** |

Review bottom-up; each PR targets the one above it.
