### PR TITLE
Apply repository conventions and correct the caching readme

### DIFF
--- a/src/Meziantou.Framework.Http.Caching.InMemory/Meziantou.Framework.Http.Caching.InMemory.csproj
+++ b/src/Meziantou.Framework.Http.Caching.InMemory/Meziantou.Framework.Http.Caching.InMemory.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
     <Description>Provide In-memory persistence provider for Meziantou.Framework.Http.Caching</Description>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Http.Caching.Redis/Meziantou.Framework.Http.Caching.Redis.csproj
+++ b/src/Meziantou.Framework.Http.Caching.Redis/Meziantou.Framework.Http.Caching.Redis.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.0.4</Version>
     <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
     <Description>Provide Redis persistence provider for Meziantou.Framework.Http.Caching</Description>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Http.Caching.Sqlite/Meziantou.Framework.Http.Caching.Sqlite.csproj
+++ b/src/Meziantou.Framework.Http.Caching.Sqlite/Meziantou.Framework.Http.Caching.Sqlite.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
     <Description>Provide SQLite persistence provider for Meziantou.Framework.Http.Caching</Description>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Http.Caching/HttpCache.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCache.cs
@@ -27,7 +27,7 @@ internal sealed class HttpCache
 
     public async ValueTask<CacheEntry?> TryGetAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        if (request.RequestUri == null)
+        if (request.RequestUri is null)
             return null;
 
         var primaryKey = ComputePrimaryKey(request.Method, request.RequestUri);
@@ -71,7 +71,7 @@ internal sealed class HttpCache
 
     public async ValueTask StoreAsync(HttpRequestMessage request, HttpResponseMessage response, DateTimeOffset requestTime, DateTimeOffset responseTime, CancellationToken cancellationToken)
     {
-        if (request.RequestUri == null)
+        if (request.RequestUri is null)
             return;
 
         // RFC 7234 Section 3: Determine if response is cacheable
@@ -149,13 +149,13 @@ internal sealed class HttpCache
 
             if (!responseCacheControl.MustRevalidate &&
                 !responseCacheControl.Public &&
-                responseCacheControl.SharedMaxAge == null)
+                responseCacheControl.SharedMaxAge is null)
                 return false;
         }
 
         // Check if response has explicit freshness information or is cacheable by default
-        var hasExplicitFreshness = responseCacheControl?.MaxAge != null ||
-                                   responseCacheControl?.SharedMaxAge != null ||
+        var hasExplicitFreshness = responseCacheControl?.MaxAge is not null ||
+                                   responseCacheControl?.SharedMaxAge is not null ||
                                    responseCacheControl?.Public is true;
 
         // Validate Expires header if present and no Cache-Control freshness

--- a/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCachingDelegateHandler.cs
@@ -50,7 +50,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
             var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             // RFC 7234 Section 4.4: Invalidation on unsafe methods
-            if (!IsMethodSafe(request.Method) && IsSuccessStatusCode(response.StatusCode))
+            if (!IsMethodSafe(request.Method) && IsNonErrorStatusCode(response.StatusCode))
             {
                 await _cache.InvalidateAsync(request.RequestUri, cancellationToken).ConfigureAwait(false);
                 await InvalidateLocationHeadersAsync(response, cancellationToken).ConfigureAwait(false);
@@ -114,7 +114,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
                                       (hasPragmaNoCache && requestCacheControl is null));
 
             // RFC 7234 Section 5.2.1.1: max-age request directive
-            if (requestCacheControl?.MaxAge != null)
+            if (requestCacheControl?.MaxAge is not null)
             {
                 var maxAgeSeconds = requestCacheControl.MaxAge.Value.TotalSeconds;
                 if (currentAge.TotalSeconds >= maxAgeSeconds)
@@ -124,7 +124,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
             }
 
             // RFC 7234 Section 5.2.1.3: min-fresh request directive
-            if (requestCacheControl?.MinFresh != null && isFresh)
+            if (requestCacheControl?.MinFresh is not null && isFresh)
             {
                 var minFresh = requestCacheControl.MinFresh.Value;
                 var remainingFreshness = freshnessLifetime - currentAge;
@@ -152,7 +152,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
             var allowStale = false;
             if ((requestCacheControl?.MaxStale) is true && !cacheResult.MustRevalidate && !cacheResult.ProxyRevalidate)
             {
-                if (requestCacheControl.MaxStaleLimit != null)
+                if (requestCacheControl.MaxStaleLimit is not null)
                 {
                     var staleness = currentAge - freshnessLifetime;
                     if (staleness <= requestCacheControl.MaxStaleLimit.Value)
@@ -196,7 +196,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
             }
 
             // Attempt conditional validation
-            if (cacheResult.ETag is not null || cacheResult.LastModified != null)
+            if (cacheResult.ETag is not null || cacheResult.LastModified is not null)
             {
                 var conditionalRequest = CloneRequest(request);
                 try
@@ -308,8 +308,9 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
                method == HttpMethod.Trace;
     }
 
-    private static bool IsSuccessStatusCode(HttpStatusCode statusCode)
+    private static bool IsNonErrorStatusCode(HttpStatusCode statusCode)
     {
+        // RFC 9111 Section 4.4: invalidation happens on a non-error response, which includes redirections.
         var code = (int)statusCode;
         return code >= 200 && code < 400;
     }
@@ -331,19 +332,19 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
     private async ValueTask InvalidateLocationHeadersAsync(HttpResponseMessage response, CancellationToken cancellationToken)
     {
         // RFC 7234 Section 4.4: Invalidate Location and Content-Location URIs
-        if (response.Headers.Location != null)
+        if (response.Headers.Location is not null)
         {
             var locationUri = GetAbsoluteUri(response.RequestMessage?.RequestUri, response.Headers.Location);
-            if (locationUri != null && IsSameHost(response.RequestMessage?.RequestUri, locationUri))
+            if (locationUri is not null && IsSameHost(response.RequestMessage?.RequestUri, locationUri))
             {
                 await _cache.InvalidateAsync(locationUri, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        if (response.Content.Headers.ContentLocation != null)
+        if (response.Content.Headers.ContentLocation is not null)
         {
             var contentLocationUri = GetAbsoluteUri(response.RequestMessage?.RequestUri, response.Content.Headers.ContentLocation);
-            if (contentLocationUri != null && IsSameHost(response.RequestMessage?.RequestUri, contentLocationUri))
+            if (contentLocationUri is not null && IsSameHost(response.RequestMessage?.RequestUri, contentLocationUri))
             {
                 await _cache.InvalidateAsync(contentLocationUri, cancellationToken).ConfigureAwait(false);
             }
@@ -355,7 +356,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
         if (relativeOrAbsolute.IsAbsoluteUri)
             return relativeOrAbsolute;
 
-        if (baseUri == null)
+        if (baseUri is null)
             return null;
 
         return new Uri(baseUri, relativeOrAbsolute);
@@ -363,7 +364,7 @@ public sealed class HttpCachingDelegateHandler : DelegatingHandler
 
     private static bool IsSameHost(Uri? uri1, Uri? uri2)
     {
-        if (uri1 == null || uri2 == null)
+        if (uri1 is null || uri2 is null)
             return false;
 
         return string.Equals(uri1.Host, uri2.Host, StringComparison.OrdinalIgnoreCase);

--- a/src/Meziantou.Framework.Http.Caching/Meziantou.Framework.Http.Caching.csproj
+++ b/src/Meziantou.Framework.Http.Caching/Meziantou.Framework.Http.Caching.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
     <Description>Provide types to cache http response as described in RFC 7234</Description>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.Http.Caching/SerializationContext.cs
+++ b/src/Meziantou.Framework.Http.Caching/SerializationContext.cs
@@ -6,5 +6,4 @@ namespace Meziantou.Framework.Http.Caching;
 [JsonSourceGenerationOptions(WriteIndented = false, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault, PropertyNameCaseInsensitive = false)]
 internal sealed partial class SerializationContext : JsonSerializerContext
 {
-
 }

--- a/src/Meziantou.Framework.Http.Caching/readme.md
+++ b/src/Meziantou.Framework.Http.Caching/readme.md
@@ -1,6 +1,8 @@
 # Meziantou.Framework.Http.Caching
 
-An HTTP caching implementation for `HttpClient` that follows [RFC 7234 (HTTP Caching)](https://www.rfc-editor.org/rfc/rfc7234.html) and [RFC 8246 (Immutable directive)](https://www.rfc-editor.org/rfc/rfc8246.html) specifications.
+An HTTP caching implementation for `HttpClient` that follows [RFC 7234 (HTTP Caching)](https://www.rfc-editor.org/rfc/rfc7234.html), since obsoleted by [RFC 9111](https://www.rfc-editor.org/rfc/rfc9111.html), together with [RFC 8246 (Immutable directive)](https://www.rfc-editor.org/rfc/rfc8246.html) and [RFC 5861 (stale-if-error)](https://www.rfc-editor.org/rfc/rfc5861.html).
+
+This is a **private** cache: it is attached to a single `HttpClient` and its entries are not shared between users.
 
 ## What is it?
 
@@ -18,6 +20,7 @@ An HTTP caching implementation for `HttpClient` that follows [RFC 7234 (HTTP Cac
 - ✅ **Thread-Safe**: Designed for concurrent access across multiple threads
 - ✅ **Testable**: Supports custom `TimeProvider` for deterministic testing
 - ✅ **Pluggable Persistence**: Supports in-memory persistence and custom stores
+- ✅ **Bounded**: Responses whose `Content-Length` exceeds `MaximumResponseSize` are never buffered
 
 ## Installation
 
@@ -154,7 +157,9 @@ var response2 = await httpClient.GetAsync("https://api.example.com/data");
 
 The handler follows these rules when processing requests:
 
-1. **Only GET and HEAD requests are cached** (per RFC 7234 Section 4)
+1. **Only GET and HEAD requests are cached** (per RFC 7234 Section 4), each under its own cache key, so a stored `HEAD` response is never served for a `GET`
+1. **Requests that carry their own validators** (`If-None-Match`, `If-Modified-Since`, `If-Match`, `If-Unmodified-Since`, `If-Range`) are forwarded to the origin unchanged, so the caller receives the `304` or `200` it asked for
+1. **Range requests are forwarded to the origin** and `206 Partial Content` responses are never stored, since the cache cannot serve partial content
 2. **Checks request directives** like `no-store`, `no-cache`, `max-age`, `min-fresh`, `max-stale`, `only-if-cached`
 3. **Evaluates cache freshness** using `Cache-Control: max-age` and `Expires` headers
 4. **Validates stale entries** using conditional requests with `If-None-Match` (ETag) or `If-Modified-Since`
@@ -234,12 +239,15 @@ This is particularly useful for versioned resources (e.g., `/assets/script.v123.
 | `Expires` | `<date>` | Expiration date (fallback if `max-age` not present) |
 | `ETag` | `<value>` | Entity tag for conditional requests |
 | `Last-Modified` | `<date>` | Last modification date for conditional requests |
+| | `stale-if-error=<seconds>` | Serve the stale response when revalidation fails or the origin cannot be reached (RFC 5861) |
 | `Vary` | `<headers>` | Headers that affect response variant |
 | `Age` | `<seconds>` | Age of cached response (added when serving from cache) |
 
 ## Thread Safety
 
-The `HttpCachingDelegateHandler` is thread-safe and can be used concurrently across multiple threads. The internal cache implementation ensures that concurrent requests to the same URL are properly coordinated.
+The `HttpCachingDelegateHandler` is thread-safe and can be used concurrently across multiple threads.
+
+There is no request coalescing: concurrent misses for the same URL each result in a request to the origin, and each stores its own response. The last one written wins. If you need a single origin request per URL, coordinate that above the handler.
 
 ## Examples
 


### PR DESCRIPTION
**Stack 6/6** — base `http-caching/5-sqlite-schema-migration` (#1927)

Polish. No behaviour change.

### Conventions

- AGENTS.md requires `is null` / `is not null`; **15 occurrences** of `== null` and `!= null` converted.
- `IsSuccessStatusCode` returned true for 3xx. That is correct for invalidation, which RFC 9111 §4.4 performs on any non-error response, but the name said otherwise — renamed `IsNonErrorStatusCode`.
- `IsAotCompatible` enabled on all four packages. They are already trimmable and serialize through a source generator, and **all four build clean with the trim and AOT analyzers on**.

### Readme

The thread-safety section claimed:

> The internal cache implementation ensures that concurrent requests to the same URL are properly coordinated.

There is no request coalescing anywhere in the handler — concurrent misses each reach the origin and each stores its own response. The section now says so.

Also documented, since the behaviour either changed in this stack or was never written down:

- GET and HEAD are keyed separately
- requests carrying their own validators are forwarded unchanged
- `206` is never stored
- `stale-if-error`, which was implemented but entirely undocumented
- RFC 9111 as the successor to RFC 7234, and that this is a **private** cache

### Verification

Full suite **356 passed, 0 failed, 6 skipped**. `dotnet run ./eng/update-all.cs` produced no further changes.