### PR TITLE
Remove redundant work in diff helpers

### DIFF
--- a/src/Meziantou.Framework.TextDiff/DiffAlgorithmHelpers.cs
+++ b/src/Meziantou.Framework.TextDiff/DiffAlgorithmHelpers.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Meziantou.Framework;
 
 internal static class DiffAlgorithmHelpers
@@ -10,12 +12,13 @@ internal static class DiffAlgorithmHelpers
 
     internal static int LowerBound(List<int> values, int value)
     {
+        var span = CollectionsMarshal.AsSpan(values);
         var low = 0;
-        var high = values.Count;
+        var high = span.Length;
         while (low < high)
         {
             var middle = low + ((high - low) / 2);
-            if (values[middle] < value)
+            if (span[middle] < value)
             {
                 low = middle + 1;
             }

--- a/src/Meziantou.Framework.TextDiff/MyersDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/MyersDiff.cs
@@ -18,9 +18,8 @@ internal static class MyersDiff
         var rightCodesBuffer = right.Length <= StackAllocationThreshold ? stackalloc int[StackAllocationThreshold] : new int[right.Length];
         var leftCodes = leftCodesBuffer[..left.Length];
         var rightCodes = rightCodesBuffer[..right.Length];
-        leftCodes.Clear();
-        rightCodes.Clear();
 
+        // No need to clear the code buffers: DiffCodes assigns every element.
         DiffCodes(left, h, leftCodes);
         DiffCodes(right, h, rightCodes);
 

--- a/src/Meziantou.Framework.TextDiff/PatienceDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/PatienceDiff.cs
@@ -143,9 +143,10 @@ internal static class PatienceDiff
         previous.Fill(-1);
         var length = 0;
 
+        var pairsSpan = CollectionsMarshal.AsSpan(pairs);
         for (var i = 0; i < count; i++)
         {
-            var position = LowerBoundByRight(pairs, tails, length, pairs[i].RightIndex);
+            var position = LowerBoundByRight(pairsSpan, tails, length, pairsSpan[i].RightIndex);
             if (position > 0)
             {
                 previous[i] = tails[position - 1];
@@ -162,7 +163,7 @@ internal static class PatienceDiff
         var index = tails[length - 1];
         while (index >= 0)
         {
-            result.Add(pairs[index]);
+            result.Add(pairsSpan[index]);
             index = previous[index];
         }
 
@@ -170,7 +171,7 @@ internal static class PatienceDiff
         return result;
     }
 
-    private static int LowerBoundByRight(List<Anchor> pairs, ReadOnlySpan<int> tails, int length, int rightIndex)
+    private static int LowerBoundByRight(ReadOnlySpan<Anchor> pairs, ReadOnlySpan<int> tails, int length, int rightIndex)
     {
         var low = 0;
         var high = length;


### PR DESCRIPTION
Stack 6/8 — base: `perf/textdiff-5-patience-anchor-order` (#1929)

Three small changes with no behavioral effect:

- `MyersDiff` cleared the two code buffers before filling them, but `DiffCodes` assigns every element — the clear was dead work on every call.
- `DiffAlgorithmHelpers.LowerBound` and `PatienceDiff.LowerBoundByRight` indexed a `List<T>` inside their binary search loops. Taking a span over the list once drops the per-access bounds check and indirection from the loop body.

I deliberately left the `downVector` / `upVector` clears alone: they are redundant only on the heap path, and separating the two paths costs more readability than it buys.

### Verification

Covered by the whole-series equivalence run described in #1933 — 300k comparisons against `main` across all four algorithms, the three chunkers, every combination of the ignore options, and the hierarchy API: **0 mismatches**.

`dotnet test`: 192 passed.
---

### The stack

| | PR | change | output |
|---|---|---|---|
| 1 | #1921 | Myers: quadratic run sliding in `Optimize` | identical |
| 2 | #1923 | Histogram: stack overflow (crash fix) | identical |
| 3 | #1925 | Histogram: anchor-search allocations | identical |
| 4 | #1928 | Hunt-Szymanski: defer node allocation | identical |
| 5 | #1929 | Patience: anchors in order, drop the sort | identical |
| 6 | #1931 | helpers: redundant clears, span binary searches | identical |
| 7 | #1932 | hierarchy: block ranges instead of copies | identical |
| 8 | #1933 | Hunt-Szymanski: trim prefix/suffix | **changes Hunt-Szymanski** |

Review bottom-up; each PR targets the one above it.
