### PR TITLE
Track hierarchy diff blocks as ranges instead of copying them

### DIFF
--- a/src/Meziantou.Framework.TextDiff/TextDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiff.cs
@@ -145,50 +145,56 @@ public static class TextDiff
 
             hasDifferences = true;
 
-            var deletedChunks = new List<string>();
+            // The deleted and inserted chunks of a block are contiguous, so track the ranges rather than
+            // copying the chunks into a list per block.
+            var deletedStart = left;
             while (left < leftLength && (right >= rightLength || leftModified[left]))
             {
-                deletedChunks.Add(oldChunks[left]);
                 left++;
             }
 
-            var insertedChunks = new List<string>();
+            var deletedCount = left - deletedStart;
+
+            var insertedStart = right;
             while (right < rightLength && (left >= leftLength || rightModified[right]))
             {
-                insertedChunks.Add(newChunks[right]);
                 right++;
             }
 
+            var insertedCount = right - insertedStart;
+
             if (!hasInnerLevel)
             {
-                for (var i = 0; i < deletedChunks.Count; i++)
+                for (var i = 0; i < deletedCount; i++)
                 {
-                    entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Delete, deletedChunks[i], null));
+                    entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Delete, oldChunks[deletedStart + i], null));
                 }
 
-                for (var i = 0; i < insertedChunks.Count; i++)
+                for (var i = 0; i < insertedCount; i++)
                 {
-                    entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Insert, null, insertedChunks[i]));
+                    entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Insert, null, newChunks[insertedStart + i]));
                 }
 
                 continue;
             }
 
-            var pairedCount = Math.Min(deletedChunks.Count, insertedChunks.Count);
+            var pairedCount = Math.Min(deletedCount, insertedCount);
             for (var i = 0; i < pairedCount; i++)
             {
-                var children = ComputeHierarchyDiffCore(deletedChunks[i], insertedChunks[i], chunkers, chunkerIndex + 1, options, comparer);
-                entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Replace, deletedChunks[i], insertedChunks[i], children.Entries));
+                var deleted = oldChunks[deletedStart + i];
+                var inserted = newChunks[insertedStart + i];
+                var children = ComputeHierarchyDiffCore(deleted, inserted, chunkers, chunkerIndex + 1, options, comparer);
+                entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Replace, deleted, inserted, children.Entries));
             }
 
-            for (var i = pairedCount; i < deletedChunks.Count; i++)
+            for (var i = pairedCount; i < deletedCount; i++)
             {
-                entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Delete, deletedChunks[i], null));
+                entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Delete, oldChunks[deletedStart + i], null));
             }
 
-            for (var i = pairedCount; i < insertedChunks.Count; i++)
+            for (var i = pairedCount; i < insertedCount; i++)
             {
-                entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Insert, null, insertedChunks[i]));
+                entries.Add(new TextDiffHierarchyEntry(TextDiffHierarchyOperation.Insert, null, newChunks[insertedStart + i]));
             }
         }
 


### PR DESCRIPTION
Stack 7/8 — base: `perf/textdiff-6-micro-cleanups` (#1931)

`BuildHierarchyResult` collected the deleted and the inserted chunks of every changed block into two freshly allocated `List<string>` before emitting entries from them. The chunks of a block are contiguous in the chunk arrays, so those lists were a copy of a range that was already there — allocated once per changed block.

### Fix

Track the start and count of each range and index the chunk arrays directly.

On a 4k line hierarchy diff (lines/words/characters), best-of-25 over 3 rounds: **12.2 ms -> 10.9 ms** and **10.8 MB -> 9.5 MB**.

### Something I tried and dropped

I also tried reserving `Math.Max(left, right)` instead of `left + right` for the entry list. It looks right — it is exact when the texts are identical — but it is exact *only* then: 50k lines with 100 edits needs 50 200 entries against a 50 000 reservation, so it triggers a growth step and ends up allocating **more** (16.8 MB -> 17.6 MB). Reverted; the original upper bound stays.

### Verification

Output unchanged — covered by the whole-series equivalence run described in #1933.

`dotnet test`: 192 passed.
---

### The stack

| | PR | change | output |
|---|---|---|---|
| 1 | #1921 | Myers: quadratic run sliding in `Optimize` | identical |
| 2 | #1923 | Histogram: stack overflow (crash fix) | identical |
| 3 | #1925 | Histogram: anchor-search allocations | identical |
| 4 | #1928 | Hunt-Szymanski: defer node allocation | identical |
| 5 | #1929 | Patience: anchors in order, drop the sort | identical |
| 6 | #1931 | helpers: redundant clears, span binary searches | identical |
| 7 | #1932 | hierarchy: block ranges instead of copies | identical |
| 8 | #1933 | Hunt-Szymanski: trim prefix/suffix | **changes Hunt-Szymanski** |

Review bottom-up; each PR targets the one above it.
