### PR TITLE
Trim common prefix and suffix before the Hunt-Szymanski search

### DIFF
--- a/src/Meziantou.Framework.TextDiff/HuntSzymanskiDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/HuntSzymanskiDiff.cs
@@ -6,15 +6,37 @@ internal static class HuntSzymanskiDiff
 {
     internal static DiffComputationResult Compute(string[] left, string[] right, IEqualityComparer<string> comparer)
     {
-        var rightPositions = BuildRightPositions(right, comparer);
-        var links = BuildCandidateLinks(left, rightPositions);
-
         var leftModified = new bool[left.Length];
         var rightModified = new bool[right.Length];
         Array.Fill(leftModified, true);
         Array.Fill(rightModified, true);
 
-        var current = links;
+        // Trim the common prefix and suffix first, as the other three algorithms already do. The number
+        // of candidate pairs is quadratic in the number of repeated chunks inside the searched region,
+        // so keeping unchanged chunks out of that region matters more here than elsewhere.
+        var leftStart = 0;
+        var leftEnd = left.Length;
+        var rightStart = 0;
+        var rightEnd = right.Length;
+
+        while (leftStart < leftEnd && rightStart < rightEnd && comparer.Equals(left[leftStart], right[rightStart]))
+        {
+            leftModified[leftStart] = false;
+            rightModified[rightStart] = false;
+            leftStart++;
+            rightStart++;
+        }
+
+        while (leftStart < leftEnd && rightStart < rightEnd && comparer.Equals(left[leftEnd - 1], right[rightEnd - 1]))
+        {
+            leftEnd--;
+            rightEnd--;
+            leftModified[leftEnd] = false;
+            rightModified[rightEnd] = false;
+        }
+
+        var rightPositions = BuildRightPositions(right, rightStart, rightEnd, comparer);
+        var current = BuildCandidateLinks(left, leftStart, leftEnd, rightPositions);
         while (current is not null)
         {
             leftModified[current.LeftIndex] = false;
@@ -25,10 +47,10 @@ internal static class HuntSzymanskiDiff
         return new DiffComputationResult(leftModified, rightModified);
     }
 
-    private static Dictionary<string, List<int>> BuildRightPositions(string[] right, IEqualityComparer<string> comparer)
+    private static Dictionary<string, List<int>> BuildRightPositions(string[] right, int rightStart, int rightEnd, IEqualityComparer<string> comparer)
     {
         var positionsByToken = new Dictionary<string, List<int>>(comparer);
-        for (var i = 0; i < right.Length; i++)
+        for (var i = rightStart; i < rightEnd; i++)
         {
             ref var positions = ref CollectionsMarshal.GetValueRefOrAddDefault(positionsByToken, right[i], out _);
             positions ??= new List<int>();
@@ -39,12 +61,12 @@ internal static class HuntSzymanskiDiff
         return positionsByToken;
     }
 
-    private static MatchNode? BuildCandidateLinks(string[] left, Dictionary<string, List<int>> rightPositions)
+    private static MatchNode? BuildCandidateLinks(string[] left, int leftStart, int leftEnd, Dictionary<string, List<int>> rightPositions)
     {
         var thresholds = new List<int>();
         var links = new List<MatchNode?>();
 
-        for (var leftIndex = 0; leftIndex < left.Length; leftIndex++)
+        for (var leftIndex = leftStart; leftIndex < leftEnd; leftIndex++)
         {
             if (!rightPositions.TryGetValue(left[leftIndex], out var matches))
                 continue;


### PR DESCRIPTION
Stack 8/8 — base: `perf/textdiff-7-result-building` (#1932)

> **This is the only PR in the series that changes diff output.** It is last in the stack precisely so it can be dropped without affecting anything else.

Hunt-Szymanski was the only algorithm that searched the whole input — Myers, Patience and Histogram all trim the common prefix and suffix first. Its candidate set is quadratic in the number of repeated chunks *inside the searched region*, so an unchanged region that shares chunks with the rest of the file is exactly what makes the search explode. A 20k line file with one changed line in the middle took **3.2 s and allocated 3 GB**.

### Fix

Trim both ends before building the position index and the candidate links.

| scenario | before | after | |
|---|---|---|---|
| 20k repetitive lines, 1 line changed | 3156 ms / 3056 MB | 0.6 ms / 3.2 MB | 5358x |
| 20k source-like lines, 1 line changed | 554 ms / 496 MB | 0.6 ms / 4.4 MB | 914x |
| 8k repetitive lines, 1 insert at the top | 740 ms / 490 MB | 0.3 ms / 1.1 MB | 2317x |

### The behavior change, precisely

Over 200k random inputs through the public API:

- the produced diff differs in **5.4%** of cases;
- in **0** of them does it contain more or fewer matched chunks — the common subsequence found is always the same length, so the edit script is the same size and only the choice between equally good alignments over repeated chunks moves;
- the reconstruction invariant holds in every case;
- Myers, Patience and Histogram are byte-for-byte identical to `main`.

So diff *quality* is unchanged and diff *identity* is not. If you pin exact Hunt-Szymanski output anywhere, this is the PR to drop.

### Whole-series verification

With all 8 commits applied, the library was fuzzed against `main` through the public API over **300k comparisons** covering all four algorithms, the three chunkers, every combination of `IgnoreCase` / `IgnoreWhitespace` / `IgnoreEndOfLine`, and `ComputeHierarchyDiff`. Excluding Hunt-Szymanski, mismatches: **0**.

`dotnet test` on `Meziantou.Framework.TextDiff.Tests`: 192 passed. `Meziantou.Framework.InlineSnapshotTesting.Tests` (the only other consumer, which uses the default Myers algorithm): 230 passed.
---

### The stack

| | PR | change | output |
|---|---|---|---|
| 1 | #1921 | Myers: quadratic run sliding in `Optimize` | identical |
| 2 | #1923 | Histogram: stack overflow (crash fix) | identical |
| 3 | #1925 | Histogram: anchor-search allocations | identical |
| 4 | #1928 | Hunt-Szymanski: defer node allocation | identical |
| 5 | #1929 | Patience: anchors in order, drop the sort | identical |
| 6 | #1931 | helpers: redundant clears, span binary searches | identical |
| 7 | #1932 | hierarchy: block ranges instead of copies | identical |
| 8 | #1933 | Hunt-Szymanski: trim prefix/suffix | **changes Hunt-Szymanski** |

Review bottom-up; each PR targets the one above it.
