### PR TITLE
Add snapshot testing performance benchmarks

### DIFF
--- a/benchmarks/SnapshotTestingBenchmarks/ImageBenchmarkData.cs
+++ b/benchmarks/SnapshotTestingBenchmarks/ImageBenchmarkData.cs
@@ -1,0 +1,23 @@
+using Meziantou.Framework.SnapshotTesting;
+
+namespace SnapshotTestingBenchmarks;
+
+internal static class ImageBenchmarkData
+{
+    public static Image CreateImage(int width, int height, int seed)
+    {
+        var pixels = new Argb[checked(width * height)];
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var red = (byte)((x * 17 + y * 31 + seed) % 256);
+                var green = (byte)((x * 7 + y * 13 + seed) % 256);
+                var blue = (byte)((x * 3 + y * 5 + seed) % 256);
+                pixels[y * width + x] = new Argb(255, red, green, blue);
+            }
+        }
+
+        return Image.Create(width, height, pixels);
+    }
+}

--- a/benchmarks/SnapshotTestingBenchmarks/ImageComparerBenchmark.cs
+++ b/benchmarks/SnapshotTestingBenchmarks/ImageComparerBenchmark.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using Meziantou.Framework.SnapshotTesting;
+
+namespace SnapshotTestingBenchmarks;
+
+/// <summary>
+/// Measures <see cref="ImageComparer"/> on byte-identical images (every passing image snapshot test)
+/// and on images that actually differ.
+/// </summary>
+[MemoryDiagnoser]
+public class ImageComparerBenchmark
+{
+    private readonly ImageComparer _comparer = new();
+    private SnapshotData _expected = null!;
+    private SnapshotData _identical = null!;
+    private SnapshotData _different = null!;
+
+    [Params(64, 512)]
+    public int Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var expected = PngImageEncoder.Encode(ImageBenchmarkData.CreateImage(Size, Size, seed: 0));
+        _expected = new SnapshotData("png", expected);
+        _identical = new SnapshotData("png", [.. expected]);
+        _different = new SnapshotData("png", PngImageEncoder.Encode(ImageBenchmarkData.CreateImage(Size, Size, seed: 1)));
+    }
+
+    [Benchmark]
+    public bool IdenticalBytes() => _comparer.Equals(_expected, _identical);
+
+    [Benchmark]
+    public bool DifferentBytes() => _comparer.Equals(_expected, _different);
+}

--- a/benchmarks/SnapshotTestingBenchmarks/ImageHashBenchmark.cs
+++ b/benchmarks/SnapshotTestingBenchmarks/ImageHashBenchmark.cs
@@ -15,19 +15,7 @@ public class ImageHashBenchmark
     public void Setup()
     {
         var height = Width == 32 ? 32 : 1080;
-        var pixels = new Argb[checked(Width * height)];
-        for (var y = 0; y < height; y++)
-        {
-            for (var x = 0; x < Width; x++)
-            {
-                var red = (byte)((x * 17 + y * 31) % 256);
-                var green = (byte)((x * 7 + y * 13) % 256);
-                var blue = (byte)((x * 3 + y * 5) % 256);
-                pixels[y * Width + x] = new Argb(255, red, green, blue);
-            }
-        }
-
-        _image = Image.Create(Width, height, pixels);
+        _image = ImageBenchmarkData.CreateImage(Width, height, seed: 0);
     }
 
     [Benchmark]

--- a/benchmarks/SnapshotTestingBenchmarks/PngImageLoaderBenchmark.cs
+++ b/benchmarks/SnapshotTestingBenchmarks/PngImageLoaderBenchmark.cs
@@ -1,0 +1,20 @@
+using BenchmarkDotNet.Attributes;
+using Meziantou.Framework.SnapshotTesting;
+
+namespace SnapshotTestingBenchmarks;
+
+/// <summary>Measures PNG decoding, which dominates image snapshot comparisons that are not byte-identical.</summary>
+[MemoryDiagnoser]
+public class PngImageLoaderBenchmark
+{
+    private byte[] _png = null!;
+
+    [Params(64, 512)]
+    public int Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _png = PngImageEncoder.Encode(ImageBenchmarkData.CreateImage(Size, Size, seed: 0));
+
+    [Benchmark]
+    public int Load() => Image.Load(_png).Width;
+}

--- a/benchmarks/SnapshotTestingBenchmarks/SnapshotCallerContextBenchmark.cs
+++ b/benchmarks/SnapshotTestingBenchmarks/SnapshotCallerContextBenchmark.cs
@@ -1,0 +1,47 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using Meziantou.Framework.SnapshotTesting;
+
+namespace SnapshotTestingBenchmarks;
+
+/// <summary>
+/// Measures the cost of resolving the caller context, which every snapshot assertion pays before
+/// anything is serialized or compared.
+/// </summary>
+[MemoryDiagnoser]
+public class SnapshotCallerContextBenchmark
+{
+    private string _sourceFilePath = null!;
+
+    /// <summary>Number of frames between the assertion method and the benchmark entry point.</summary>
+    [Params(1, 20)]
+    public int StackDepth { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "SnapshotTestingBenchmarks", "CallerContext");
+        Directory.CreateDirectory(directory);
+        _sourceFilePath = Path.Combine(directory, "Source.cs");
+        File.WriteAllText(_sourceFilePath, "");
+    }
+
+    [Benchmark]
+    public string Create() => Recurse(StackDepth);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private string Recurse(int depth)
+    {
+        if (depth > 0)
+            return Recurse(depth - 1);
+
+        return CreateCallerContext();
+    }
+
+    [SnapshotAssertion]
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    private string CreateCallerContext()
+    {
+        return SnapshotCallerContext.Create(_sourceFilePath, lineNumber: 1, memberName: nameof(CreateCallerContext)).MethodName;
+    }
+}

--- a/benchmarks/SnapshotTestingBenchmarks/SnapshotValidateBenchmark.cs
+++ b/benchmarks/SnapshotTestingBenchmarks/SnapshotValidateBenchmark.cs
@@ -1,0 +1,57 @@
+using BenchmarkDotNet.Attributes;
+using Meziantou.Framework;
+using Meziantou.Framework.SnapshotTesting;
+
+namespace SnapshotTestingBenchmarks;
+
+/// <summary>
+/// Measures an end-to-end <see cref="Snapshot.Validate(object?, SnapshotType?, SnapshotSettings?, string?, int, string?)"/>
+/// call whose snapshot already matches. This is the path every passing snapshot test takes.
+/// </summary>
+[MemoryDiagnoser]
+public class SnapshotValidateBenchmark
+{
+    private readonly object _value = new { FirstName = "John", LastName = "Doe", Age = 42 };
+    private SnapshotSettings _settings = null!;
+    private string _sourceFilePath = null!;
+
+    /// <summary>Number of unrelated snapshots sitting in the same <c>__snapshots__</c> folder.</summary>
+    [Params(0, 100)]
+    public int SiblingSnapshotCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "SnapshotTestingBenchmarks", $"Validate{SiblingSnapshotCount}");
+        if (Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+
+        Directory.CreateDirectory(directory);
+        _sourceFilePath = Path.Combine(directory, "Source.cs");
+        File.WriteAllText(_sourceFilePath, "");
+
+        var snapshotDirectory = Path.Combine(directory, "__snapshots__");
+        Directory.CreateDirectory(snapshotDirectory);
+        for (var i = 0; i < SiblingSnapshotCount; i++)
+        {
+            File.WriteAllText(Path.Combine(snapshotDirectory, $"Sibling{i}.verified.txt"), "sibling");
+        }
+
+        var snapshotPath = FullPath.FromPath(Path.Combine(snapshotDirectory, "Benchmark.verified.txt"));
+        _settings = new SnapshotSettings
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotPathStrategy = _ => snapshotPath,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+        };
+
+        // Create the verified snapshot so the benchmark measures the matching path.
+        Validate();
+        _settings.SnapshotUpdateStrategy = SnapshotUpdateStrategy.Disallow;
+    }
+
+    [Benchmark]
+    public void Validate() => Snapshot.Validate(_value, type: null, _settings, _sourceFilePath, callerLineNumber: 1, callerMemberName: nameof(Validate));
+}


### PR DESCRIPTION
Adds benchmarks for the paths targeted by the follow-up performance PRs, so each change can be measured rather than assumed.

| Benchmark | Covers |
| --- | --- |
| `SnapshotCallerContextBenchmark` | Caller context resolution — the stack walk every assertion pays before anything is serialized or compared. Parameterized by stack depth. |
| `SnapshotValidateBenchmark` | End-to-end `Snapshot.Validate` on a snapshot that already matches. Parameterized by the number of sibling files in the `__snapshots__` folder, which is what makes the expected-file discovery scale badly. |
| `ImageComparerBenchmark` | `ImageComparer.Equals` on byte-identical images (every passing image test) and on images that actually differ. |
| `PngImageLoaderBenchmark` | PNG decoding. |

`ImageHashBenchmark` now builds its image through the shared `ImageBenchmarkData` helper instead of its own inline loop.

No product code is touched by this PR.