### PR TITLE
Speed up snapshot caller context resolution

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotCallerContext.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -17,9 +18,18 @@ internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, st
         "TestMethodAttribute",
     };
 
+    /// <summary>
+    /// Caches everything the stack walk needs to know about a method. Resolving the state machine,
+    /// reading the attributes and normalizing the names are pure functions of the method, and the same
+    /// methods show up on the stack of every single assertion.
+    /// </summary>
+    private static readonly ConcurrentDictionary<MethodBase, StackFrameMethod> StackFrameMethods = new();
+
     public static SnapshotCallerContext Create(string? filePath, int lineNumber, string? memberName)
     {
-        var stackTrace = new StackTrace(fNeedFileInfo: true);
+        // Resolving the file name of every frame forces the PDBs to be loaded and the sequence points to
+        // be decoded. It is only needed when the caller did not provide a file path.
+        var stackTrace = new StackTrace(fNeedFileInfo: filePath is null);
         var stackAnalysisStartIndex = GetStackAnalysisStartIndex(stackTrace);
         string? discoveredMethodName = null;
         string? discoveredContainingTypeName = null;
@@ -31,17 +41,17 @@ internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, st
             if (method is null)
                 continue;
 
-            method = CallerContextUtilities.ResolveActualMethod(method);
+            var stackFrameMethod = GetStackFrameMethod(method);
 
-            if (HasTestAttribute(method))
+            if (stackFrameMethod.IsTestMethod)
             {
-                discoveredMethodName = NormalizeMethodName(method.Name);
-                discoveredContainingTypeName = NormalizeTypeName(method.DeclaringType);
+                discoveredMethodName = stackFrameMethod.NormalizedMethodName;
+                discoveredContainingTypeName = stackFrameMethod.NormalizedTypeName;
                 break;
             }
 
-            discoveredMethodName ??= NormalizeMethodName(method.Name);
-            discoveredContainingTypeName ??= NormalizeTypeName(method.DeclaringType);
+            discoveredMethodName ??= stackFrameMethod.NormalizedMethodName;
+            discoveredContainingTypeName ??= stackFrameMethod.NormalizedTypeName;
         }
 
         var sourceFilePath = filePath;
@@ -68,19 +78,29 @@ internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, st
 
     private static int GetStackAnalysisStartIndex(StackTrace stackTrace)
     {
-        for (var i = stackTrace.FrameCount - 1; i >= 0; i--)
+        // The methods decorated with [SnapshotAssertion] form a contiguous run at the innermost end of the
+        // stack: the attribute is internal and is only applied to the Snapshot.Validate overloads, which
+        // forward to each other. Walking outwards and stopping right after that run avoids reflecting over
+        // the whole stack, which is mostly test framework frames.
+        var startIndex = 0;
+        for (var i = 0; i < stackTrace.FrameCount; i++)
         {
             var frame = stackTrace.GetFrame(i);
             var method = frame?.GetMethod();
             if (method is null)
                 continue;
 
-            method = CallerContextUtilities.ResolveActualMethod(method);
-            if (method.GetCustomAttribute<SnapshotAssertionAttribute>(inherit: false) is not null)
-                return i + 1;
+            if (GetStackFrameMethod(method).IsSnapshotAssertion)
+            {
+                startIndex = i + 1;
+            }
+            else if (startIndex > 0)
+            {
+                break;
+            }
         }
 
-        return 0;
+        return startIndex;
     }
 
     internal static FullPath ResolveSourceFilePath(string sourceFilePath)
@@ -91,6 +111,19 @@ internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, st
             return resolvedSourceFilePath;
 
         throw new SnapshotException($"Cannot find source file path '{sourceFilePath}'.");
+    }
+
+    private static StackFrameMethod GetStackFrameMethod(MethodBase method)
+    {
+        return StackFrameMethods.GetOrAdd(method, static method =>
+        {
+            var resolvedMethod = CallerContextUtilities.ResolveActualMethod(method);
+            return new StackFrameMethod(
+                IsSnapshotAssertion: resolvedMethod.GetCustomAttribute<SnapshotAssertionAttribute>(inherit: false) is not null,
+                IsTestMethod: HasTestAttribute(resolvedMethod),
+                NormalizedMethodName: NormalizeMethodName(resolvedMethod.Name),
+                NormalizedTypeName: NormalizeTypeName(resolvedMethod.DeclaringType));
+        });
     }
 
     private static bool HasTestAttribute(MethodBase method)
@@ -170,4 +203,6 @@ internal sealed partial record SnapshotCallerContext(FullPath SourceFilePath, st
     {
         return typeName.StartsWith("<", StringComparison.Ordinal);
     }
+
+    private sealed record StackFrameMethod(bool IsSnapshotAssertion, bool IsTestMethod, string NormalizedMethodName, string? NormalizedTypeName);
 }


### PR DESCRIPTION
Every snapshot assertion resolves the caller context before anything is serialized or compared, so this cost is paid by every passing test too. Three things made it more expensive than it needed to be.

**1. The stack trace was always captured with `fNeedFileInfo: true`.** That forces the PDBs to be loaded and the sequence points decoded for *every* frame. The frame file names are only ever read when the caller did not supply a file path (`SnapshotCallerContext.Create` falls back to the stack only when `filePath is null`), and `[CallerFilePath]` always supplies one for source-compiled calls. Measured in isolation, `new StackTrace(true)` costs 20.6 µs against 5.0 µs for `new StackTrace(false)` on a 30-frame stack.

**2. The search for the outermost `[SnapshotAssertion]` frame walked the entire stack.** It scanned from the outermost frame inwards, doing a reflection attribute lookup on all of them, to find something that always sits within the first few frames. `SnapshotAssertionAttribute` is `internal` and is only applied to the four `Snapshot.Validate` overloads, which forward to each other — so the attributed frames are always a contiguous run at the innermost end of the stack, and the walk can stop as soon as it leaves that run.

**3. Per-frame work was recomputed on every assertion.** Resolving the async state machine, reading the attributes and normalizing the method/type names (including a regex match) are pure functions of the method, and the same methods appear on the stack of every assertion. They are now computed once per method and cached.

### Results

`SnapshotCallerContextBenchmark`, net10.0:

| StackDepth | Before | After |
| --- | --- | --- |
| 1 | 10.52 us, 22.63 KB | **5.20 us, 5.48 KB** |
| 20 | 19.46 us, 53.30 KB | **5.91 us, 9.85 KB** |

The cost is now essentially flat with stack depth instead of growing with it, which matters because real test-framework stacks are deep.

### Notes

- No behavior change: the discovered method name, containing type name and source file path are all unchanged. The full test suite (288 tests, net10.0 + net11.0) passes.
- The benchmark used for the numbers above is added in #1934; this PR does not depend on it and can merge in either order.