### PR TITLE
Avoid boxing in the value-equality fast path

### DIFF
--- a/src/Meziantou.Framework.Assertions/Assert.Equality.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Equality.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Meziantou.Framework.Assertions;
 
@@ -58,8 +59,26 @@ public partial class Assert
         if (comparer is not null)
             return comparer.Equals(expected, actual);
 
-        if (object.Equals(expected, actual))
+        // object.Equals boxes both operands. When both have the same static type, EqualityComparer<T>.Default gives
+        // the same answer without allocating, and the JIT devirtualizes it for value types.
+        var sameType = typeof(TExpected) == typeof(TActual);
+        if (sameType)
+        {
+            if (EqualityComparer<TExpected>.Default.Equals(expected, Unsafe.As<TActual, TExpected>(ref actual)))
+                return true;
+
+            if (typeof(TExpected).IsValueType)
+            {
+                // Numeric widening and user-defined implicit conversions can only make values of different runtime
+                // types compare equal, and a value type has no derived types. Only the structural comparison is left,
+                // which still matters for collection-like structs such as ImmutableArray<T>.
+                return TryCompareEnumerableValues(expected, actual, out var valueTypeResult) && valueTypeResult;
+            }
+        }
+        else if (object.Equals(expected, actual))
+        {
             return true;
+        }
 
         return (TryCompareNumericValues(expected, actual, out var result) && result)
             || (TryCompareEnumerableValues(expected, actual, out result) && result)

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
@@ -414,6 +414,40 @@ public sealed class AssertEqualTests
     }
 
     [Fact]
+    public void SameImmutableArrayTypes_Success()
+    {
+        var expected = ImmutableArray.Create(1, 2, 3);
+        var actual = ImmutableArray.Create(1, 2, 3);
+
+        AssertionsAssert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void NestedSameImmutableArrayTypes_Success()
+    {
+        ImmutableArray<int>[] expected = [ImmutableArray.Create(1, 2), ImmutableArray.Create(3)];
+        ImmutableArray<int>[] actual = [ImmutableArray.Create(1, 2), ImmutableArray.Create(3)];
+
+        AssertionsAssert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void NestedSameImmutableArrayTypes_Fails()
+    {
+        ImmutableArray<int>[] expected = [ImmutableArray.Create(1, 2)];
+        ImmutableArray<int>[] actual = [ImmutableArray.Create(1, 3)];
+
+        AssertionTestHelpers.Validate(() => AssertionsAssert.Equal(expected, actual), """
+            Assert.Equal() assertion failed: Item at index 0 differs.
+            Expected expression: expected
+            Actual expression:   actual
+            Index of first difference: 0
+            Expected item: [[̲1̲,̲ ̲2̲]̲]
+            Actual item:   [[̲1̲,̲ ̲3̲]̲]
+            """);
+    }
+
+    [Fact]
     public void DifferentListTypes_Success()
     {
         var expected = new List<int> { 1, 2, 3 };


### PR DESCRIPTION
**Stack 1/6** — base: `main`

`Assert.Equal`/`NotEqual` route every comparison through `ValuesEqual`, whose first step was `object.Equals(TExpected, TActual)`. With unconstrained type parameters that boxes both operands, so `Assert.Equal(1, 1)` allocated 48 bytes, and the `ReadOnlySpan` overload (which arrays bind to) paid it per element — 48 KB for a 1000-item `int[]`.

When both operands have the same static type, `EqualityComparer<T>.Default` gives the same answer without allocating and is devirtualized by the JIT for value types. For same-typed *value* types it is also authoritative: numeric widening and user-defined implicit conversions can only make values of different runtime types compare equal, and a value type has no derived types. Only the structural comparison is still needed, which matters for collection-like structs such as `ImmutableArray<T>`.

| | before | after |
|---|---|---|
| `Equal(int, int)` | 48 B | 0 B |
| `Equal(Guid, Guid)` | 64 B | 0 B |
| `NotEqual(int, int)` | 288 B | 0 B |
| `Equal(int[100])` | 4800 B | 0 B |
| `Equal(int[5000])` | 33.7 µs | 8.9 µs |

Three tests added for same-typed enumerable structs, the case the value-type shortcut has to keep working. No public API change (`ref/` unchanged).