### PR TITLE
Replace the quadratic scans in EqualUnordered and Distinct

### DIFF
--- a/src/Meziantou.Framework.Assertions/Assert.Distinct.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Distinct.cs
@@ -12,9 +12,24 @@ public partial class Assert
     {
         comparer ??= EqualityComparer<T>.Default;
 
-        for (var duplicateIndex = 1; duplicateIndex < actual.Length; duplicateIndex++)
+        if (actual.Length <= LinearDuplicateSearchThreshold)
         {
-            var firstIndex = IndexOf(actual[..duplicateIndex], actual[duplicateIndex], comparer);
+            for (var duplicateIndex = 1; duplicateIndex < actual.Length; duplicateIndex++)
+            {
+                var firstIndex = IndexOf(actual[..duplicateIndex], actual[duplicateIndex], comparer);
+                if (firstIndex >= 0)
+                {
+                    throw new AssertionException(ErrorFormatter.Format(new ReadOnlySpanDistinctAssertionError<T>(actual, duplicateIndex, firstIndex, actualExpression, message)));
+                }
+            }
+
+            return;
+        }
+
+        var firstIndexes = new FirstIndexLookup<T>(comparer, actual.Length);
+        for (var duplicateIndex = 0; duplicateIndex < actual.Length; duplicateIndex++)
+        {
+            var firstIndex = firstIndexes.Add(actual[duplicateIndex], duplicateIndex);
             if (firstIndex >= 0)
             {
                 throw new AssertionException(ErrorFormatter.Format(new ReadOnlySpanDistinctAssertionError<T>(actual, duplicateIndex, firstIndex, actualExpression, message)));
@@ -39,9 +54,20 @@ public partial class Assert
         comparer ??= EqualityComparer<T>.Default;
         using var actualSnapshot = CollectionSnapshot.Create<T>(actual);
 
+        FirstIndexLookup<T>? firstIndexes = null;
         for (var duplicateIndex = 0; actualSnapshot.TryGetItem(duplicateIndex, out var item); duplicateIndex++)
         {
-            var firstIndex = IndexOf(actualSnapshot.Items, duplicateIndex, item, comparer);
+            int firstIndex;
+            if (duplicateIndex < LinearDuplicateSearchThreshold)
+            {
+                firstIndex = IndexOf(actualSnapshot.Items, duplicateIndex, item, comparer);
+            }
+            else
+            {
+                firstIndexes ??= FirstIndexLookup<T>.Create(actualSnapshot.Items, duplicateIndex, comparer);
+                firstIndex = firstIndexes.Add(item, duplicateIndex);
+            }
+
             if (firstIndex >= 0)
             {
                 throw new AssertionException(ErrorFormatter.Format(new CollectionDistinctAssertionError<T>(actualSnapshot, duplicateIndex, firstIndex, actualExpression, message)));
@@ -76,9 +102,20 @@ public partial class Assert
         comparer ??= EqualityComparer<T>.Default;
         await using var actualSnapshot = CollectionSnapshot.Create<T>(actual);
 
+        FirstIndexLookup<T>? firstIndexes = null;
         for (var duplicateIndex = 0; await actualSnapshot.TryGetItem(duplicateIndex).ConfigureAwait(false) is (true, var item); duplicateIndex++)
         {
-            var firstIndex = IndexOf(actualSnapshot.Items, duplicateIndex, item, comparer);
+            int firstIndex;
+            if (duplicateIndex < LinearDuplicateSearchThreshold)
+            {
+                firstIndex = IndexOf(actualSnapshot.Items, duplicateIndex, item, comparer);
+            }
+            else
+            {
+                firstIndexes ??= FirstIndexLookup<T>.Create(actualSnapshot.Items, duplicateIndex, comparer);
+                firstIndex = firstIndexes.Add(item, duplicateIndex);
+            }
+
             if (firstIndex >= 0)
             {
                 throw new AssertionException(await ErrorFormatter.FormatAsync(new AsyncCollectionDistinctAssertionError<T>(actualSnapshot, duplicateIndex, firstIndex, actualExpression, message)).ConfigureAwait(false));
@@ -117,5 +154,44 @@ public partial class Assert
         }
 
         return -1;
+    }
+
+    /// <summary>
+    /// Number of leading items compared with a linear scan before switching to a hash lookup. Small collections are
+    /// the common case in assertions and the scan allocates nothing for them; the quadratic work stays bounded by
+    /// the square of this value. Around this size the hash lookup starts winning despite the dictionary it allocates.
+    /// </summary>
+    private const int LinearDuplicateSearchThreshold = 64;
+
+    /// <summary>Maps each item to the index where it was first seen.</summary>
+    private sealed class FirstIndexLookup<T>
+    {
+        private readonly Dictionary<NullableKey<T>, int> _indexes;
+
+        public FirstIndexLookup(IEqualityComparer<T> comparer, int capacity)
+        {
+            _indexes = new Dictionary<NullableKey<T>, int>(capacity, NullableKeyComparer<T>.Create(comparer));
+        }
+
+        public static FirstIndexLookup<T> Create(IReadOnlyList<T> items, int count, IEqualityComparer<T> comparer)
+        {
+            var lookup = new FirstIndexLookup<T>(comparer, count);
+            for (var index = 0; index < count; index++)
+            {
+                lookup.Add(items[index], index);
+            }
+
+            return lookup;
+        }
+
+        /// <summary>Records <paramref name="item"/> and returns -1, or returns the index where it was first seen.</summary>
+        public int Add(T item, int index)
+        {
+            var key = new NullableKey<T>(item);
+            if (_indexes.TryAdd(key, index))
+                return -1;
+
+            return _indexes[key];
+        }
     }
 }

--- a/src/Meziantou.Framework.Assertions/Assert.EqualUnordered.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.EqualUnordered.cs
@@ -49,9 +49,10 @@ public partial class Assert
         expectedSnapshot.EnsureComplete();
         comparer ??= EqualityComparer<T>.Default;
 
-        if (comparer == EqualityComparer<T>.Default && EqualUnorderedUsingDefaultComparer(expectedSnapshot.Items, actualSnapshot.Items))
+        if (EqualUnorderedUsingComparer(expectedSnapshot.Items, actualSnapshot.Items, comparer))
             return;
 
+        // Only the failure path pays for the quadratic scan, which locates the indexes shown in the message.
         var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer);
         if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
         {
@@ -124,9 +125,10 @@ public partial class Assert
         await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
         comparer ??= EqualityComparer<T>.Default;
 
-        if (comparer == EqualityComparer<T>.Default && EqualUnorderedUsingDefaultComparer(expectedSnapshot.Items, actualSnapshot.Items))
+        if (EqualUnorderedUsingComparer(expectedSnapshot.Items, actualSnapshot.Items, comparer))
             return;
 
+        // Only the failure path pays for the quadratic scan, which locates the indexes shown in the message.
         var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer);
         if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
         {
@@ -168,22 +170,25 @@ public partial class Assert
         EqualUnorderedCollections(EnumerateObjects(expected), EnumerateObjects(actual), comparer, message, actualExpression, expectedExpression);
     }
 
-    private static bool EqualUnorderedUsingDefaultComparer<T>(IReadOnlyList<T> expected, IReadOnlyList<T> actual)
+    /// <summary>
+    /// Compares two collections as multisets in O(n) using <paramref name="comparer"/> for both hashing and equality.
+    /// </summary>
+    private static bool EqualUnorderedUsingComparer<T>(IReadOnlyList<T> expected, IReadOnlyList<T> actual, IEqualityComparer<T> comparer)
     {
         if (expected.Count != actual.Count)
             return false;
 
-        var counts = new Dictionary<DefaultComparerKey<T>, int>(expected.Count);
+        var counts = new Dictionary<NullableKey<T>, int>(expected.Count, NullableKeyComparer<T>.Create(comparer));
         for (var index = 0; index < expected.Count; index++)
         {
-            var key = new DefaultComparerKey<T>(expected[index]);
+            var key = new NullableKey<T>(expected[index]);
             counts.TryGetValue(key, out var count);
             counts[key] = count + 1;
         }
 
         for (var index = 0; index < actual.Count; index++)
         {
-            var key = new DefaultComparerKey<T>(actual[index]);
+            var key = new NullableKey<T>(actual[index]);
             if (!counts.TryGetValue(key, out var count))
                 return false;
 
@@ -238,26 +243,6 @@ public partial class Assert
         }
 
         return (missingExpectedIndex, unexpectedActualIndex);
-    }
-
-    private readonly struct DefaultComparerKey<T>(T value) : IEquatable<DefaultComparerKey<T>>
-    {
-        private T Value { get; } = value;
-
-        public bool Equals(DefaultComparerKey<T> other)
-        {
-            return EqualityComparer<T>.Default.Equals(Value, other.Value);
-        }
-
-        public override bool Equals([NotNullWhen(true)] object? obj)
-        {
-            return obj is DefaultComparerKey<T> other && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            return Value is null ? 0 : EqualityComparer<T>.Default.GetHashCode(Value);
-        }
     }
 
     private static (int? MissingExpectedIndex, int? UnexpectedActualIndex) GetEqualUnorderedMismatch<TExpected, TActual>(IReadOnlyList<TExpected> expected, IReadOnlyList<TActual> actual, System.Collections.IEqualityComparer? comparer)

--- a/src/Meziantou.Framework.Assertions/Assert.NotEqualUnordered.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.NotEqualUnordered.cs
@@ -13,7 +13,7 @@ public partial class Assert
         using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
         actualSnapshot.EnsureComplete();
         expectedSnapshot.EnsureComplete();
-        if (!EqualUnorderedUsingDefaultComparer(expectedSnapshot.Items, actualSnapshot.Items))
+        if (!EqualUnorderedUsingComparer(expectedSnapshot.Items, actualSnapshot.Items, EqualityComparer<T>.Default))
             return;
 
         throw new AssertionException(ErrorFormatter.Format(new NotEqualUnorderedAssertionError<IEnumerable<T>, IEnumerable<T>>("Not expected", expected, actual, actualExpression, expectedExpression, message)));
@@ -30,13 +30,12 @@ public partial class Assert
         expectedSnapshot.EnsureComplete();
         if (comparer is null)
         {
-            if (!EqualUnorderedUsingDefaultComparer(expectedSnapshot.Items, actualSnapshot.Items))
+            if (!EqualUnorderedUsingComparer(expectedSnapshot.Items, actualSnapshot.Items, EqualityComparer<T>.Default))
                 return;
         }
         else
         {
-            var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer);
-            if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
+            if (!EqualUnorderedUsingComparer(expectedSnapshot.Items, actualSnapshot.Items, comparer))
                 return;
         }
 
@@ -69,7 +68,7 @@ public partial class Assert
         await using var expectedSnapshot = CollectionSnapshot.Create<T>(expected);
         await actualSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
         await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-        if (!EqualUnorderedUsingDefaultComparer(expectedSnapshot.Items, actualSnapshot.Items))
+        if (!EqualUnorderedUsingComparer(expectedSnapshot.Items, actualSnapshot.Items, EqualityComparer<T>.Default))
             return;
 
         throw new AssertionException(ErrorFormatter.Format(new NotEqualUnorderedAssertionError<IReadOnlyList<T>, IReadOnlyList<T>>("Not expected", expectedSnapshot.Items, actualSnapshot.Items, actualExpression, expectedExpression, message)));
@@ -86,13 +85,12 @@ public partial class Assert
         await expectedSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
         if (comparer is null)
         {
-            if (!EqualUnorderedUsingDefaultComparer(expectedSnapshot.Items, actualSnapshot.Items))
+            if (!EqualUnorderedUsingComparer(expectedSnapshot.Items, actualSnapshot.Items, EqualityComparer<T>.Default))
                 return;
         }
         else
         {
-            var (missingExpectedIndex, unexpectedActualIndex) = GetEqualUnorderedMismatch(expectedSnapshot.Items, actualSnapshot.Items, comparer);
-            if (missingExpectedIndex is not null || unexpectedActualIndex is not null)
+            if (!EqualUnorderedUsingComparer(expectedSnapshot.Items, actualSnapshot.Items, comparer))
                 return;
         }
 

--- a/src/Meziantou.Framework.Assertions/Utils/NullableKey.cs
+++ b/src/Meziantou.Framework.Assertions/Utils/NullableKey.cs
@@ -1,0 +1,21 @@
+namespace Meziantou.Framework.Assertions;
+
+/// <summary>
+/// Wraps a value so it can be used as a <see cref="Dictionary{TKey, TValue}"/> key even when the value is null,
+/// which <see cref="Dictionary{TKey, TValue}"/> does not allow.
+/// </summary>
+/// <remarks>
+/// The <see cref="IEquatable{T}"/> implementation uses <see cref="EqualityComparer{T}.Default"/> so a dictionary
+/// built without an explicit comparer stays on the devirtualized path. Use <see cref="NullableKeyComparer{T}"/>
+/// to compare with a caller-supplied comparer instead.
+/// </remarks>
+internal readonly struct NullableKey<T>(T value) : IEquatable<NullableKey<T>>
+{
+    public T Value { get; } = value;
+
+    public bool Equals(NullableKey<T> other) => EqualityComparer<T>.Default.Equals(Value, other.Value);
+
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is NullableKey<T> other && Equals(other);
+
+    public override int GetHashCode() => Value is null ? 0 : EqualityComparer<T>.Default.GetHashCode(Value);
+}

--- a/src/Meziantou.Framework.Assertions/Utils/NullableKeyComparer.cs
+++ b/src/Meziantou.Framework.Assertions/Utils/NullableKeyComparer.cs
@@ -1,0 +1,19 @@
+namespace Meziantou.Framework.Assertions;
+
+/// <summary>Compares <see cref="NullableKey{T}"/> instances using the comparer supplied by the caller.</summary>
+internal sealed class NullableKeyComparer<T>(IEqualityComparer<T> comparer) : IEqualityComparer<NullableKey<T>>
+{
+    /// <summary>
+    /// Returns the comparer to pass to a dictionary of <see cref="NullableKey{T}"/>, or <see langword="null"/> when
+    /// <paramref name="comparer"/> is the default one. A null comparer lets the dictionary use
+    /// <see cref="EqualityComparer{T}.Default"/>, which the JIT devirtualizes.
+    /// </summary>
+    public static IEqualityComparer<NullableKey<T>>? Create(IEqualityComparer<T> comparer)
+    {
+        return ReferenceEquals(comparer, EqualityComparer<T>.Default) ? null : new NullableKeyComparer<T>(comparer);
+    }
+
+    public bool Equals(NullableKey<T> x, NullableKey<T> y) => comparer.Equals(x.Value, y.Value);
+
+    public int GetHashCode(NullableKey<T> obj) => obj.Value is null ? 0 : comparer.GetHashCode(obj.Value);
+}

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertDistinctTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertDistinctTests.cs
@@ -111,6 +111,75 @@ public sealed class AssertDistinctTests
     }
 
     [Fact]
+    public void LargeSpan_Success()
+    {
+        AssertionsAssert.Distinct<int>(Enumerable.Range(0, 100).ToArray());
+    }
+
+    [Fact]
+    public void LargeEnumerable_Success()
+    {
+        AssertionsAssert.Distinct(Enumerable.Range(0, 100));
+    }
+
+    [Fact]
+    public void LargeEnumerableWithNulls_Success()
+    {
+        var actual = new string?[100];
+        for (var i = 0; i < actual.Length; i++)
+        {
+            actual[i] = i.ToString(CultureInfo.InvariantCulture);
+        }
+
+        actual[50] = null;
+
+        AssertionsAssert.Distinct<string?>(actual);
+    }
+
+    [Fact]
+    public void LargeEnumerableWithDuplicateBeyondThreshold_Fails()
+    {
+        // Beyond the linear-search threshold the duplicate is found through the hash lookup.
+        var actual = Enumerable.Range(0, 100).ToList();
+        actual[99] = 20;
+
+        var exception = AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.Distinct(actual));
+
+        AssertionsAssert.Contains("Duplicate item found at index 99", exception.Message);
+        AssertionsAssert.Contains("First index:     20", exception.Message);
+    }
+
+    [Fact]
+    public void LargeEnumerableWithDuplicateNullBeyondThreshold_Fails()
+    {
+        var actual = new string?[100];
+        for (var i = 0; i < actual.Length; i++)
+        {
+            actual[i] = i.ToString(CultureInfo.InvariantCulture);
+        }
+
+        actual[5] = null;
+        actual[99] = null;
+
+        var exception = AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.Distinct<string?>(actual));
+
+        AssertionsAssert.Contains("Duplicate item found at index 99", exception.Message);
+        AssertionsAssert.Contains("First index:     5", exception.Message);
+    }
+
+    [Fact]
+    public void LargeEnumerableComparer_Fails()
+    {
+        var actual = Enumerable.Range(0, 100).Select(i => i.ToString(CultureInfo.InvariantCulture)).ToList();
+        actual[99] = "20";
+
+        var exception = AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.Distinct(actual, StringComparer.OrdinalIgnoreCase));
+
+        AssertionsAssert.Contains("Duplicate item found at index 99", exception.Message);
+        AssertionsAssert.Contains("First index:     20", exception.Message);
+    }
+
+    [Fact]
     public void NonGenericEnumerable_Fails()
     {
         System.Collections.IEnumerable actual = new object?[] { 1, 2, 1 };


### PR DESCRIPTION
**Stack 3/6** — base: `perf/assertions-2-span-equal` (#1937)

`EqualUnordered` already had an O(n) multiset check, but only used it for the default comparer; passing a comparer fell back to greedy O(n²) matching. `Distinct` was O(n²) unconditionally, rescanning every preceding item for each item.

- `EqualUnorderedUsingComparer` now handles any comparer. The quadratic matching runs only on the **failure** path, where it locates the indexes the message reports.
- `Distinct` switches to a hash lookup once a collection grows past `LinearDuplicateSearchThreshold` (64), so small collections still allocate nothing and large ones stop being quadratic.

Both now rely on the comparer's `GetHashCode` being consistent with its `Equals`, which the `IEqualityComparer<T>` contract requires. The cross-type overloads taking a non-generic `IEqualityComparer` keep the quadratic scan: they compare through `ValuesEqual`, which coerces between types, and that has no matching hash.

`NullableKey<T>` is the former `DefaultComparerKey<T>`, renamed and shared between the two call sites. It keeps its `IEquatable` implementation so dictionaries built without an explicit comparer stay on the devirtualized path — dropping that regressed the default-comparer path by ~60% in an earlier revision.

| | before | after |
|---|---|---|
| `EqualUnordered(int[5000], comparer)` | 3242 µs | 152 µs |
| `Distinct(int[5000])` | 3128 µs | 113 µs |
| `EqualUnordered(int[5000])` | 38 µs | 42 µs |

Trade-off worth noting: above the threshold `Distinct` allocates a dictionary (`int[100]`: 24 B → 4912 B) in exchange for dropping ~5000 comparisons. Below it, nothing changes.

Six tests added covering collections either side of the threshold, nulls beyond it, and duplicate reporting through the hash path.