### PR TITLE
Stop enumerating in count assertions once the answer is known

### DIFF
--- a/src/Meziantou.Framework.Assertions/Assert.Count.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Count.cs
@@ -22,32 +22,22 @@ public partial class Assert
 
     public static void HasCount<T>(int expectedCount, IEnumerable<T> actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {
-        using var actualSnapshot = CollectionSnapshot.Create<T>(actual);
-        actualSnapshot.EnsureComplete();
-        if (actualSnapshot.Items.Count == expectedCount)
-            return;
-
-        throw new AssertionException(ErrorFormatter.Format(new CollectionCountAssertionError<T>(nameof(HasCount), expectedCount.ToString(CultureInfo.InvariantCulture), actualSnapshot.Items.Count, actualSnapshot, actualExpression, message)));
+        AssertCount(expectedCount, actual, CountComparison.Equal, nameof(HasCount), expectedCount.ToString(CultureInfo.InvariantCulture), message, actualExpression);
     }
 
     public static void HasCount(int expectedCount, System.Collections.IEnumerable actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {
         using var actualSnapshot = CollectionSnapshot.Create(actual);
-        actualSnapshot.EnsureComplete();
-        if (actualSnapshot.Items.Count == expectedCount)
+        if (CountSatisfies(actualSnapshot, expectedCount, CountComparison.Equal))
             return;
 
+        actualSnapshot.EnsureComplete();
         throw new AssertionException(ErrorFormatter.Format(new CollectionCountAssertionError<object?>(nameof(HasCount), expectedCount.ToString(CultureInfo.InvariantCulture), actualSnapshot.Items.Count, actualSnapshot, actualExpression, message)));
     }
 
-    public static async Task HasCount<T>(int expectedCount, IAsyncEnumerable<T> actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
+    public static Task HasCount<T>(int expectedCount, IAsyncEnumerable<T> actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {
-        await using var actualSnapshot = CollectionSnapshot.Create<T>(actual);
-        await actualSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-        if (actualSnapshot.Items.Count == expectedCount)
-            return;
-
-        throw new AssertionException(await ErrorFormatter.FormatAsync(new AsyncCollectionCountAssertionError<T>(nameof(HasCount), expectedCount.ToString(CultureInfo.InvariantCulture), actualSnapshot.Items.Count, actualSnapshot, actualExpression, message)).ConfigureAwait(false));
+        return AssertCountAsync(expectedCount, actual, CountComparison.Equal, nameof(HasCount), expectedCount.ToString(CultureInfo.InvariantCulture), message, actualExpression);
     }
 
     public static void HasCountGreaterThan<T>(int expectedCount, ReadOnlySpan<T> actual, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
@@ -176,22 +166,93 @@ public partial class Assert
 
     private static void AssertCount<T>(int expectedCount, IEnumerable<T> actual, CountComparison comparison, string assertionName, string expectedCountText, string? message, string? actualExpression)
     {
-        using var actualSnapshot = CollectionSnapshot.Create<T>(actual);
-        actualSnapshot.EnsureComplete();
-        if (CompareCount(actualSnapshot.Items.Count, expectedCount, comparison))
+        if (TryGetKnownCount(actual, out var knownCount) && CompareCount(knownCount, expectedCount, comparison))
             return;
 
+        using var actualSnapshot = CollectionSnapshot.Create<T>(actual);
+        if (CountSatisfies(actualSnapshot, expectedCount, comparison))
+            return;
+
+        actualSnapshot.EnsureComplete();
         throw new AssertionException(ErrorFormatter.Format(new CollectionCountAssertionError<T>(assertionName, expectedCountText, actualSnapshot.Items.Count, actualSnapshot, actualExpression, message)));
     }
 
     private static async Task AssertCountAsync<T>(int expectedCount, IAsyncEnumerable<T> actual, CountComparison comparison, string assertionName, string expectedCountText, string? message, string? actualExpression)
     {
         await using var actualSnapshot = CollectionSnapshot.Create<T>(actual);
-        await actualSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
-        if (CompareCount(actualSnapshot.Items.Count, expectedCount, comparison))
+        if (await CountSatisfiesAsync(actualSnapshot, expectedCount, comparison).ConfigureAwait(false))
             return;
 
+        await actualSnapshot.EnsureCompleteAsync().ConfigureAwait(false);
         throw new AssertionException(await ErrorFormatter.FormatAsync(new AsyncCollectionCountAssertionError<T>(assertionName, expectedCountText, actualSnapshot.Items.Count, actualSnapshot, actualExpression, message)).ConfigureAwait(false));
+    }
+
+    /// <summary>Gets the number of items in <paramref name="source"/> when it is known without enumerating.</summary>
+    private static bool TryGetKnownCount<T>(IEnumerable<T> source, out int count)
+    {
+        // Covers ICollection<T>, the non-generic ICollection and several LINQ operators.
+        if (Enumerable.TryGetNonEnumeratedCount(source, out count))
+            return true;
+
+        if (source is IReadOnlyCollection<T> readOnlyCollection)
+        {
+            count = readOnlyCollection.Count;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Evaluates the comparison by observing at most <paramref name="expectedCount"/> + 1 items, so a sequence is
+    /// never enumerated further than the answer requires.
+    /// </summary>
+    private static bool CountSatisfies<T>(CollectionSnapshot<T> snapshot, int expectedCount, CountComparison comparison)
+    {
+        return comparison switch
+        {
+            CountComparison.Equal => HasAtLeast(snapshot, expectedCount) && !HasAtLeast(snapshot, expectedCount + 1L),
+            CountComparison.GreaterThan => HasAtLeast(snapshot, expectedCount + 1L),
+            CountComparison.GreaterThanOrEqual => HasAtLeast(snapshot, expectedCount),
+            CountComparison.LessThan => !HasAtLeast(snapshot, expectedCount),
+            CountComparison.LessThanOrEqual => !HasAtLeast(snapshot, expectedCount + 1L),
+            _ => throw new ArgumentOutOfRangeException(nameof(comparison)),
+        };
+
+        static bool HasAtLeast(CollectionSnapshot<T> snapshot, long count)
+        {
+            if (count <= 0)
+                return true;
+
+            if (count > int.MaxValue)
+                return false;
+
+            return snapshot.TryGetItem((int)(count - 1), out _);
+        }
+    }
+
+    private static async Task<bool> CountSatisfiesAsync<T>(AsyncCollectionSnapshot<T> snapshot, int expectedCount, CountComparison comparison)
+    {
+        return comparison switch
+        {
+            CountComparison.Equal => await HasAtLeastAsync(snapshot, expectedCount).ConfigureAwait(false) && !await HasAtLeastAsync(snapshot, expectedCount + 1L).ConfigureAwait(false),
+            CountComparison.GreaterThan => await HasAtLeastAsync(snapshot, expectedCount + 1L).ConfigureAwait(false),
+            CountComparison.GreaterThanOrEqual => await HasAtLeastAsync(snapshot, expectedCount).ConfigureAwait(false),
+            CountComparison.LessThan => !await HasAtLeastAsync(snapshot, expectedCount).ConfigureAwait(false),
+            CountComparison.LessThanOrEqual => !await HasAtLeastAsync(snapshot, expectedCount + 1L).ConfigureAwait(false),
+            _ => throw new ArgumentOutOfRangeException(nameof(comparison)),
+        };
+
+        static async Task<bool> HasAtLeastAsync(AsyncCollectionSnapshot<T> snapshot, long count)
+        {
+            if (count <= 0)
+                return true;
+
+            if (count > int.MaxValue)
+                return false;
+
+            return await snapshot.TryGetItem((int)(count - 1)).ConfigureAwait(false) is (true, _);
+        }
     }
 
     private static bool CompareCount(int actualCount, int expectedCount, CountComparison comparison)

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertCountTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertCountTests.cs
@@ -188,4 +188,75 @@ public sealed class AssertCountTests
             Actual: [1, 2, 3]
             """);
     }
+
+    [Fact]
+    public void HasCountGreaterThan_DoesNotEnumerateInfiniteSequence()
+    {
+        AssertionsAssert.HasCountGreaterThan(3, InfiniteSequence());
+    }
+
+    [Fact]
+    public void HasCountGreaterThanOrEqual_StopsEnumeratingAtExpectedCount()
+    {
+        var enumerated = 0;
+
+        AssertionsAssert.HasCountGreaterThanOrEqual(3, CountingSequence(10, () => enumerated++));
+
+        AssertionsAssert.Equal(3, enumerated);
+    }
+
+    [Fact]
+    public void HasCount_UsesCountOfReadOnlyCollectionWithoutEnumerating()
+    {
+        var enumerated = 0;
+        var actual = new CountingCollection(3, () => enumerated++);
+
+        AssertionsAssert.HasCount(3, actual);
+
+        AssertionsAssert.Equal(0, enumerated);
+    }
+
+    [Fact]
+    public void HasCount_UsesCountOfCollectionWithoutEnumerating()
+    {
+        // A HashSet<T> is an ICollection<T> but not an IList<T>, so it used to be copied item by item.
+        IEnumerable<int> actual = new HashSet<int> { 1, 2, 3 };
+
+        AssertionsAssert.HasCount(3, actual);
+        AssertionsAssert.HasCountGreaterThan(2, actual);
+        AssertionsAssert.HasCountLessThan(4, actual);
+    }
+
+    private static IEnumerable<int> InfiniteSequence()
+    {
+        for (var i = 0; ; i++)
+        {
+            yield return i;
+        }
+    }
+
+    private static IEnumerable<int> CountingSequence(int count, Action onItem)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            onItem();
+            yield return i;
+        }
+    }
+
+    private sealed class CountingCollection(int count, Action onItem) : IReadOnlyCollection<int>
+    {
+        public int Count => count;
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            for (var i = 0; i < count; i++)
+            {
+                onItem();
+                yield return i;
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 }


### PR DESCRIPTION
**Stack 4/6** — base: `perf/assertions-3-unordered-distinct` (#1938)

Every count assertion called `EnsureComplete` first, materializing the whole sequence before comparing. Two consequences: a collection that already knows its count was copied item by item, and a comparison needing only a few items drained the sequence anyway — so `HasCountGreaterThan(3, infiniteSequence)` never returned.

The count now comes from `ICollection<T>`, `IReadOnlyCollection<T>` or the LINQ operators that track it when available (`TryGetNonEnumeratedCount` covers the first and third; `IReadOnlyCollection<T>` needed an explicit check). Otherwise the comparison is decided by observing at most `expectedCount + 1` items.

The **failure** path still completes the sequence, because the message reports the exact count. So an infinite sequence still hangs on a failing assertion — unchanged from before, and not something this PR sets out to fix.

| | before | after |
|---|---|---|
| `HasCount(100, HashSet<int>)` | 544 B | 0 B |

Four tests added: `HasCountGreaterThan` over an infinite sequence, enumeration counting for `HasCountGreaterThanOrEqual`, and the two no-enumeration collection paths.