### PR TITLE
Remove the remaining per-call allocations

### DIFF
--- a/src/Meziantou.Framework.Assertions/Assert.All.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.All.cs
@@ -69,7 +69,19 @@ public partial class Assert
     /// <param name="assertionExpression">The expression that produced the assertion.</param>
     public static void All<T>(IEnumerable<T> actual, Action<T> assertion, string? message = null, [CallerArgumentExpression(nameof(actual))] string? actualExpression = null, [CallerArgumentExpression(nameof(assertion))] string? assertionExpression = null)
     {
-        All(actual, (item, _) => assertion(item), message, actualExpression, assertionExpression);
+        using var actualSnapshot = CollectionSnapshot.Create<T>(actual);
+
+        for (var index = 0; actualSnapshot.TryGetItem(index, out var item); index++)
+        {
+            try
+            {
+                assertion(item);
+            }
+            catch (Exception exception)
+            {
+                throw new AssertionException(ErrorFormatter.Format(new CollectionAllAssertionError<T>(actualSnapshot, index, exception, actualExpression, assertionExpression, message)), exception);
+            }
+        }
     }
 
     /// <summary>Asserts that all items in an enumerable satisfy the specified assertion.</summary>

--- a/src/Meziantou.Framework.Assertions/Assert.Equal.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Equal.cs
@@ -453,6 +453,15 @@ public partial class Assert
         return false;
     }
 
+    private static string NormalizeLineEndings(string value)
+    {
+        // The span overload always copies. Most strings contain no '\r' at all, so return the instance unchanged.
+        if (!value.AsSpan().Contains('\r'))
+            return value;
+
+        return NormalizeLineEndings(value.AsSpan());
+    }
+
     private static string NormalizeLineEndings(ReadOnlySpan<char> value)
     {
         if (!value.Contains('\r'))
@@ -497,10 +506,22 @@ public partial class Assert
             return null;
 
         var minLength = Math.Min(expected.Length, actual.Length);
-        for (var i = 0; i < minLength; i++)
+
+        // An ordinal comparison is character by character, so the common prefix can be found with a single
+        // vectorized scan instead of one span comparison per character.
+        if (comparison is StringComparison.Ordinal)
         {
-            if (!actual.AsSpan(i, 1).Equals(expected.AsSpan(i, 1), comparison))
-                return i;
+            var commonLength = expected.AsSpan().CommonPrefixLength(actual.AsSpan());
+            if (commonLength < minLength)
+                return commonLength;
+        }
+        else
+        {
+            for (var i = 0; i < minLength; i++)
+            {
+                if (!actual.AsSpan(i, 1).Equals(expected.AsSpan(i, 1), comparison))
+                    return i;
+            }
         }
 
         if (expected.Length == actual.Length)

--- a/src/Meziantou.Framework.Assertions/Assert.Equality.cs
+++ b/src/Meziantou.Framework.Assertions/Assert.Equality.cs
@@ -24,8 +24,7 @@ public partial class Assert
     private static bool TryGetMemoryItems<T>(T value, [NotNullWhen(true)] out System.Collections.IEnumerable? items)
     {
         items = null;
-        var declaredType = typeof(T);
-        if (declaredType != typeof(object) && !declaredType.IsInterface && !declaredType.IsAbstract && !IsMemoryType(declaredType))
+        if (!MemoryCandidate<T>.IsPossible)
             return false;
 
         if (value is null)
@@ -38,6 +37,19 @@ public partial class Assert
 
         items = (System.Collections.IEnumerable?)toArrayMethod.Invoke(value, parameters: null);
         return items is not null;
+    }
+
+    private static class MemoryCandidate<T>
+    {
+        /// <summary>
+        /// Gets a value indicating whether a value declared as <typeparamref name="T"/> can be a Memory or
+        /// ReadOnlyMemory at runtime. Reading the type flags once per instantiation keeps them off the hot path.
+        /// </summary>
+        public static readonly bool IsPossible =
+            typeof(T) == typeof(object)
+            || typeof(T).IsInterface
+            || typeof(T).IsAbstract
+            || IsMemoryType(typeof(T));
     }
 
     private static bool IsMemoryType(Type type)

--- a/src/Meziantou.Framework.Assertions/AssertionMessageBuilder.cs
+++ b/src/Meziantou.Framework.Assertions/AssertionMessageBuilder.cs
@@ -19,7 +19,7 @@ internal readonly struct AssertionMessageBuilder
         return this;
     }
 
-    public AssertionMessageBuilder AppendGroup(params (string Label, string? Value)[] rows)
+    public AssertionMessageBuilder AppendGroup(params ReadOnlySpan<(string Label, string? Value)> rows)
     {
         var maxLabelLength = 0;
         foreach (var row in rows)

--- a/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Tests/AssertEqualTests.cs
@@ -309,6 +309,24 @@ public sealed class AssertEqualTests
     }
 
     [Fact]
+    public void IgnoreLineEndingDifferencesWithoutCarriageReturn_Success()
+    {
+        var expected = "line1\nline2";
+        var actual = "line1\nline2";
+
+        AssertionsAssert.Equal(expected, actual, ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void IgnoreLineEndingDifferencesWithoutCarriageReturn_Fails()
+    {
+        var expected = "line1\nline2";
+        var actual = "line1\nline3";
+
+        AssertionsAssert.Throws<AssertionException>(() => AssertionsAssert.Equal(expected, actual, ignoreLineEndingDifferences: true));
+    }
+
+    [Fact]
     public void String_IgnoreLineEndingDifferences_Success()
     {
         var expected = "line1\r\nline2\rline3";


### PR DESCRIPTION
**Stack 6/6** — base: `perf/assertions-5-equivalent-path` (#1940)

Five small independent cleanups, each contained to one method:

- `Equal(string, string, ignoreLineEndingDifferences: true)` normalized through the span overload, which always copies. Most strings contain no `\r`, so a `string` overload now returns the instance unchanged.
- `All(IEnumerable<T>, Action<T>)` adapted the delegate to `Action<T, int>` with a lambda, allocating a closure and a delegate per call. The loop is written out instead.
- `AppendGroup` took a params array, allocated on every failure message. `params ReadOnlySpan` lets the compiler stack-allocate it.
- `TryGetMemoryItems` read `IsInterface`/`IsAbstract`/`IsConstructedGenericType` on every comparison. The verdict is now computed once per instantiation.
- `GetStringFirstDifferenceIndex` compared one character at a time through a span comparison — slow on large strings, though only on the failure path. Ordinal comparisons use `CommonPrefixLength`; the case-insensitive path is unchanged.

| | before | after |
|---|---|---|
| `Equal(str, str, ignoreLineEndings: true)` | 64 B | 0 B |
| `All(int[100], Action<T>)` | 112 B | 24 B |

Two tests added for line-ending normalization of strings containing no `\r`.