### PR TITLE
Write template output without going through string.Format

### DIFF
--- a/ref/Meziantou.Framework.Templating.Html.cs
+++ b/ref/Meziantou.Framework.Templating.Html.cs
@@ -28,6 +28,8 @@ namespace Meziantou.Framework.Templating
         public const string TitleSectionName = "title";
         public System.Collections.Generic.IList<string> ContentIdentifiers { get => throw null; }
         public HtmlEmailOutput(Meziantou.Framework.Templating.Template template, System.IO.TextWriter writer) { }
+        public override void Write(string? value) { }
+        public override void Write(object? value) { }
         public override void Write(string format, params object?[] args) { }
         public virtual void WriteHtmlEncode(object? value) { }
         public virtual void WriteHtmlEncode(string? value) { }

--- a/src/Meziantou.Framework.Templating.Html/HtmlEmailOutput.cs
+++ b/src/Meziantou.Framework.Templating.Html/HtmlEmailOutput.cs
@@ -25,6 +25,26 @@ public class HtmlEmailOutput(Template template, TextWriter writer) : Output(temp
     /// <summary>Gets the list of content identifiers (CIDs) referenced in the template.</summary>
     public IList<string> ContentIdentifiers { get; } = new List<string>();
 
+    public override void Write(string? value)
+    {
+        foreach (var currentSection in _currentSections)
+        {
+            currentSection.Writer.Write(value);
+        }
+
+        base.Write(value);
+    }
+
+    public override void Write(object? value)
+    {
+        foreach (var currentSection in _currentSections)
+        {
+            currentSection.Writer.Write(value);
+        }
+
+        base.Write(value);
+    }
+
     public override void Write(string format, params object?[] args)
     {
         foreach (var currentSection in _currentSections)

--- a/src/Meziantou.Framework.Templating/CodeBlock.cs
+++ b/src/Meziantou.Framework.Templating/CodeBlock.cs
@@ -13,7 +13,7 @@ public class CodeBlock(Template template, string text, int index, bool isExpress
     {
         if (IsExpression)
         {
-            return Template.OutputParameterName + ".Write(\"{0}\", " + Text + ");";
+            return Template.OutputParameterName + ".Write(" + Text + ");";
         }
 
         return Text;

--- a/src/Meziantou.Framework.Templating/Output.cs
+++ b/src/Meziantou.Framework.Templating/Output.cs
@@ -22,14 +22,14 @@ public class Output
     /// <param name="value">The object to write.</param>
     public virtual void Write(object? value)
     {
-        Write("{0}", value);
+        Writer.Write(value);
     }
 
     /// <summary>Writes a string to the output.</summary>
     /// <param name="value">The string to write.</param>
     public virtual void Write(string? value)
     {
-        Write("{0}", value);
+        Writer.Write(value);
     }
 
     /// <summary>Writes a formatted string to the output.</summary>

--- a/tests/Meziantou.Framework.Templating.Html.Tests/EmailTemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Html.Tests/EmailTemplateTest.cs
@@ -94,4 +94,28 @@ public class EmailTemplateTest
              item => Assert.Equal("test1.png", item),
              item => Assert.Equal("test2.png", item));
     }
+    [Fact]
+    public void EmailTemplate_Section_CapturesPlainText()
+    {
+        var template = new HtmlEmailTemplate();
+        template.Load("Hello {{@begin_section title}}Plain text{{@end_section}}!");
+
+        var result = template.Run(out var metadata);
+        Assert.Equal("Hello Plain text!", result);
+        Assert.NotNull(metadata);
+        Assert.Equal("Plain text", metadata.Title);
+    }
+
+    [Fact]
+    public void EmailTemplate_Section_CapturesExpressionValue()
+    {
+        var template = new HtmlEmailTemplate();
+        template.Load("Hello {{@begin_section title}}{{= 42 }}{{@end_section}}!");
+
+        var result = template.Run(out var metadata);
+        Assert.Equal("Hello 42!", result);
+        Assert.NotNull(metadata);
+        Assert.Equal("42", metadata.Title);
+    }
+
 }

--- a/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
@@ -449,7 +449,7 @@ public class TemplateTest
 
         template.Build(CancellationToken.None);
 
-        Assert.Contains("#line (1, 4) - (1, 11) 32 \"template.cs\"", template.SourceCode);
+        Assert.Contains("#line (1, 4) - (1, 11) 25 \"template.cs\"", template.SourceCode);
         Assert.Contains("#line (1, 16) - (1, 36) 4 \"template.cs\"", template.SourceCode);
     }
 
@@ -645,4 +645,32 @@ public class TemplateTest
         {
         }
     }
+    [Fact]
+    public void Template_ExpressionBlock_WritesNullAsEmptyString()
+    {
+        var template = new Template();
+        template.Load("a<%= null %>b");
+
+        Assert.Equal("ab", template.Run());
+    }
+
+    [Fact]
+    public void Template_ExpressionBlock_FormatsFormattableValueUsingWriterFormatProvider()
+    {
+        var template = new Template();
+        template.Load("<%= 1.5 %>|<%= 42 %>|<%= new DateTime(2020, 1, 2, 0, 0, 0, DateTimeKind.Utc) %>");
+
+        var expected = string.Create(CultureInfo.CurrentCulture, $"{1.5}|{42}|{new DateTime(2020, 1, 2, 0, 0, 0, DateTimeKind.Utc)}");
+        Assert.Equal(expected, template.Run());
+    }
+
+    [Fact]
+    public void Template_ExpressionBlock_WritesArrayValueWithoutTreatingItAsFormatArguments()
+    {
+        var template = new Template();
+        template.Load("<%= new object[] { 1, 2 } %>");
+
+        Assert.Equal(new object[] { 1, 2 }.ToString(), template.Run());
+    }
+
 }


### PR DESCRIPTION
`Output.Write(string)` and `Output.Write(object)` both delegated to `Write("{0}", value)`, so **every** static text chunk and every expression block paid a params-array allocation, boxing, and a format-string parse.

`TextWriter.Write(object)` already applies the same `IFormattable` / `FormatProvider` semantics as `"{0}"`, so writing directly is equivalent. Expression blocks now emit `__output__.Write(expr)` instead of `__output__.Write("{0}", expr)`.

### Measured

22KB template, 200 text + 400 expression blocks, Release, arm64:

| | before | after | |
|---|---|---|---|
| `Run` | 64 us / 181 KB | 19 us / 99 KB | **3.4x faster, 46% fewer allocations** |

### Also fixed

An expression evaluating to `object[]` used to be splatted as format arguments instead of printed.

### Breaking change for derived `Output` types

`HtmlEmailOutput` mirrored output into sections by overriding only `Write(string, params object?[])`. Once text blocks stop routing through that overload, plain text inside `{{@begin_section}}` is silently dropped — verified: the new `EmailTemplate_Section_CapturesPlainText` test fails without the added overrides. `HtmlEmailOutput` is updated here; `Output` subclasses outside this repo need the same treatment.

### Tests

`Template_ExpressionAndClassMemberBlocks_EmitLineDirectivesWithFileName` asserts a hard-coded `#line` column offset, which correctly moves from 32 to 25 because the emitted prefix shrinks from `__output__.Write("{0}", ` to `__output__.Write(`. New tests cover null, formattable values, arrays, and section capture.

All templating and templating.html tests pass on net10.0 and net11.0.