### PR TITLE
Use a per-instance lock to build templates

### DIFF
--- a/src/Meziantou.Framework.Templating/Template.cs
+++ b/src/Meziantou.Framework.Templating/Template.cs
@@ -22,7 +22,7 @@ public class Template
     private const string DefaultRunMethodName = "Run";
     private const string DefaultWriterParameterName = "__output__";
 
-    private static readonly Lock BuildLock = new();
+    private readonly Lock _buildLock = new();
 
     private MethodInfo? _runMethodInfo;
 
@@ -470,7 +470,7 @@ public class Template
         if (IsBuilt)
             return;
 
-        lock (BuildLock)
+        lock (_buildLock)
         {
             if (IsBuilt)
                 return;

--- a/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
@@ -639,6 +639,43 @@ public class TemplateTest
         Assert.Contains("public class Template : BaseClass, IFoo, IBar", template.SourceCode);
     }
 
+    [Fact]
+    public async Task Template_DifferentInstances_CanBuildConcurrently()
+    {
+        const int TemplateCount = 8;
+
+        var templates = new Template[TemplateCount];
+        for (var i = 0; i < templates.Length; i++)
+        {
+            var template = new Template();
+            template.Load($"value: <%= {i} %>");
+            templates[i] = template;
+        }
+
+        var results = await Task.WhenAll(templates.Select(template => Task.Run(() =>
+        {
+            template.Build(CancellationToken.None);
+            return template.Run();
+        })));
+
+        for (var i = 0; i < results.Length; i++)
+        {
+            Assert.Equal($"value: {i}", results[i]);
+        }
+    }
+
+    [Fact]
+    public async Task Template_SameInstance_BuiltOnceWhenRunConcurrently()
+    {
+        var template = new Template();
+        template.Load("Hello <%= 1 + 1 %>");
+
+        var results = await Task.WhenAll(Enumerable.Range(0, 8).Select(_ => Task.Run(() => template.Run())));
+
+        Assert.All(results, result => Assert.Equal("Hello 2", result));
+        Assert.True(template.IsBuilt);
+    }
+
     private sealed class TemplateWithoutCompilation : Template
     {
         protected override void Compile(string source, CancellationToken cancellationToken)


### PR DESCRIPTION
`BuildLock` was `static`, so compiling any template blocked compilation of every other template in the process, even though the instances share no state and Roslyn compilation is thread-safe.

### Measured

Building 8 independent templates concurrently (15-core machine, Release, arm64), first round discarded as JIT warmup:

| | before | after |
|---|---|---|
| 8 concurrent builds | ~76-80 ms | ~25-38 ms |

### Tests

Two new tests: independent templates build concurrently and each produces its own output, and concurrent first-`Run` on a single instance still builds exactly once.

All templating tests pass on net10.0 and net11.0.