### PR TITLE
Publish the compiled run method with release/acquire semantics

### DIFF
--- a/src/Meziantou.Framework.Templating/Template.cs
+++ b/src/Meziantou.Framework.Templating/Template.cs
@@ -64,7 +64,7 @@ public class Template
     public BlockCollection Blocks { get; } = [];
 
     /// <summary>Gets a value indicating whether the template has been built.</summary>
-    public bool IsBuilt => _runMethodInfo != null;
+    public bool IsBuilt => Volatile.Read(ref _runMethodInfo) is not null;
 
     /// <summary>Gets the generated C# source code after building the template.</summary>
     public string? SourceCode { get; private set; }
@@ -783,11 +783,14 @@ public class Template
         pdbStream.Seek(0, SeekOrigin.Begin);
 
         var assembly = LoadAssembly(dllStream, pdbStream);
-        _runMethodInfo = FindMethod(assembly);
-        if (_runMethodInfo == null)
+        var runMethodInfo = FindMethod(assembly);
+        if (runMethodInfo is null)
         {
             throw new TemplateException("Run method not found in the generated assembly.");
         }
+
+        // Publish last: a thread observing IsBuilt must also observe everything written above.
+        Volatile.Write(ref _runMethodInfo, runMethodInfo);
     }
 
     /// <summary>Loads an assembly from memory streams.</summary>
@@ -900,7 +903,7 @@ public class Template
             Build(CancellationToken.None);
         }
 
-        var parameterInfos = _runMethodInfo!.GetParameters();
+        var parameterInfos = Volatile.Read(ref _runMethodInfo)!.GetParameters();
         var p = new object?[parameterInfos.Length];
         foreach (var pi in parameterInfos)
         {
@@ -929,6 +932,6 @@ public class Template
             Build(CancellationToken.None);
         }
 
-        _runMethodInfo!.Invoke(null, p);
+        Volatile.Read(ref _runMethodInfo)!.Invoke(null, p);
     }
 }


### PR DESCRIPTION
Previously stacked on #1943; that has merged, so this is now a standalone single-commit PR against `main`.

`IsBuilt` read the `_runMethodInfo` field without a barrier and `Compile` wrote it without one, while `Build`, `Run` and `InvokeRunMethod` all check `IsBuilt` outside the lock.

That is unsynchronized double-checked locking. On a weak memory model (arm64 — including the Apple silicon this repo is developed on) a thread can observe `IsBuilt` as `true` before the writes that precede it are visible, and then use a partially published template.

### Change

- publish the method info with `Volatile.Write` as the **last** step of a successful compile, so everything written before it is visible to any thread that observes it
- read it with `Volatile.Read` in `IsBuilt`, `CreateMethodParameters` and `InvokeRunMethod`

No behaviour change on x86/x64, where the store/load ordering happened to hold anyway.

### Tests

Memory-model races are not deterministically testable; the concurrency tests added in #1943 exercise the path. All templating and templating.html tests pass on net10.0 and net11.0.