### PR TITLE
Compare byte-identical images without decoding them

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting.ImageSharp/ImageSharpSnapshotComparer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting.ImageSharp/ImageSharpSnapshotComparer.cs
@@ -8,6 +8,12 @@ internal sealed class ImageSharpSnapshotComparer(ImageComparisonSettings? settin
 {
     public bool Equals(SnapshotData expected, SnapshotData actual)
     {
+        // Identical bytes decode to identical pixels, so an exact comparison matches, SSIM is 1.0 and both
+        // hash distances are 0 - every configured threshold is satisfied. This is the case for every passing
+        // image snapshot test, and it avoids decoding both images.
+        if (expected.Data.AsSpan().SequenceEqual(actual.Data))
+            return true;
+
         using var expectedImage = Image.Load<Rgba32>(expected.Data);
         using var actualImage = Image.Load<Rgba32>(actual.Data);
 

--- a/src/Meziantou.Framework.SnapshotTesting.SkiaSharp/SkiaSharpSnapshotComparer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting.SkiaSharp/SkiaSharpSnapshotComparer.cs
@@ -7,6 +7,12 @@ internal sealed class SkiaSharpSnapshotComparer(ImageComparisonSettings? setting
 {
     public bool Equals(SnapshotData expected, SnapshotData actual)
     {
+        // Identical bytes decode to identical pixels, so an exact comparison matches, SSIM is 1.0 and both
+        // hash distances are 0 - every configured threshold is satisfied. This is the case for every passing
+        // image snapshot test, and it avoids decoding both images.
+        if (expected.Data.AsSpan().SequenceEqual(actual.Data))
+            return true;
+
         using var expectedImage = Decode(expected.Data);
         using var actualImage = Decode(actual.Data);
         if (expectedImage is null || actualImage is null)

--- a/src/Meziantou.Framework.SnapshotTesting/Images/ImageComparer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/ImageComparer.cs
@@ -14,6 +14,12 @@ public sealed class ImageComparer(ImageComparisonSettings? settings = null) : IS
         ArgumentNullException.ThrowIfNull(expected);
         ArgumentNullException.ThrowIfNull(actual);
 
+        // Identical bytes decode to identical pixels, so an exact comparison matches, SSIM is 1.0 and both
+        // hash distances are 0 - every configured threshold is satisfied. This is the case for every passing
+        // image snapshot test, and it avoids decoding both images.
+        if (expected.Data.AsSpan().SequenceEqual(actual.Data))
+            return true;
+
         try
         {
             var expectedImage = Image.Load(expected.Data);


### PR DESCRIPTION
The image comparers decoded **both** images before comparing, even when the two files were byte for byte the same — which is exactly what every *passing* image snapshot test looks like.

Identical bytes decode to identical pixels, so the exact comparison matches, SSIM is 1.0 and both hash distances are 0. Every threshold in the documented ranges (`SimilarityThreshold` 0.0–1.0, `DHashThreshold`/`PHashThreshold` 0–64) is therefore satisfied, so the fast path is safe for every configuration.

Applied to the built-in `ImageComparer` and to the ImageSharp and SkiaSharp comparers.

### Results

`ImageComparerBenchmark`, net10.0:

| | Before | After |
| --- | --- | --- |
| identical 64x64 | 162.4 us, 153.58 KB | **240.8 ns, 0 B** |
| identical 512x512 | 7,001.9 us, 13.5 MB | **6.81 us, 0 B** |

Roughly 670x and 1000x, and the allocation goes away entirely — a 512x512 comparison was allocating 13.5 MB.

Images that genuinely differ take exactly the same path as before, and measure the same (161.3 us -> 161.3 us, and 6,917.7 us -> 7,009.2 us, both within run-to-run noise).

### Behavior change

Two byte-identical files that *cannot be decoded* now compare as equal instead of unequal. Previously the decode threw and the comparer returned `false`, so a snapshot that had not changed still failed. Returning "equal" for an unchanged snapshot is the better answer, but it is a change and worth being aware of. In practice `ImageComparer` is only registered for BMP/PNG/JPEG/TIFF, so this only affects genuinely corrupt files.

Full test suite (288 tests, net10.0 + net11.0) passes. The benchmark used above is added in #1934; this PR does not depend on it.