### PR TITLE
Avoid copying the PNG image data three times while decoding

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/Images/PngImageLoader.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/PngImageLoader.cs
@@ -213,11 +213,14 @@ internal static class PngImageLoader
             throw new InvalidDataException("The PNG data has trailing bytes.");
 
         var bitsPerPixel = checked(GetPngChannelCount(colorType) * bitDepth);
-        var decompressedData = DecompressPngIdatData(idatData.GetBuffer().AsSpan(0, checked((int)idatData.Length)));
         var expectedImageDataLength = GetExpectedPngImageDataLength(width, height, bitsPerPixel, interlaceMethod);
-        if (decompressedData.Length != expectedImageDataLength)
+
+        idatData.Position = 0;
+        using var decompressedStream = DecompressPngIdatData(idatData, expectedImageDataLength);
+        if (decompressedStream.Length != expectedImageDataLength)
             throw new InvalidDataException("The PNG decompressed image data size is invalid.");
 
+        var decompressedData = decompressedStream.GetBuffer().AsSpan(0, expectedImageDataLength);
         var pixels = new Argb[checked(width * height)];
         if (interlaceMethod == 0)
         {
@@ -261,14 +264,19 @@ internal static class PngImageLoader
         return Image.Create(width, height, pixels);
     }
 
-    private static byte[] DecompressPngIdatData(ReadOnlySpan<byte> compressedData)
+    /// <summary>Inflates the concatenated IDAT chunks.</summary>
+    /// <param name="compressedStream">The concatenated IDAT chunks, positioned at the first byte.</param>
+    /// <param name="expectedLength">
+    /// The image data size computed from the header, used to size the output buffer. A malformed image may
+    /// inflate to a different size, in which case the stream simply grows as usual.
+    /// </param>
+    private static MemoryStream DecompressPngIdatData(Stream compressedStream, int expectedLength)
     {
-        using var compressedStream = new MemoryStream(compressedData.ToArray());
-        using var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress);
-        using var output = new MemoryStream();
+        using var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress, leaveOpen: true);
+        var output = new MemoryStream(expectedLength);
         zlibStream.CopyTo(output);
 
-        return output.ToArray();
+        return output;
     }
 
     private static void DecodePngRows(


### PR DESCRIPTION
Decoding a PNG copied the image data three times more than it needed to:

1. The concatenated IDAT bytes were copied out of the accumulating `MemoryStream` into a fresh array (`GetBuffer().AsSpan(...)` -> `ToArray()`) purely to wrap that array in *another* `MemoryStream`.
2. The inflated output went into a `MemoryStream` with no initial capacity, so it grew by repeated doubling — reallocating and copying the whole image several times.
3. That stream was then copied a third time by `ToArray()`.

Now the IDAT stream is inflated in place (`leaveOpen: true`), the output buffer is sized up front from the image data length the IHDR implies, and the decoder reads the inflated bytes straight out of that buffer via a span.

The expected-length check moved above the decompression so it can size the buffer. It still compares against the same value and throws the same `InvalidDataException`; a malformed image that inflates to a different size just grows the stream as before.

### Results

`PngImageLoaderBenchmark`, net10.0:

| `Image.Load` | Before | After |
| --- | --- | --- |
| 64x64 | 83.39 us, 76.79 KB | 84.48 us, **46.88 KB** |
| 512x512 | 3,580.16 us, 6.76 MB | **3,400.56 us, 2.44 MB** |

The time difference is small (5% at 512x512, within noise at 64x64). The allocation difference is not — a 512x512 decode drops from 6.76 MB to 2.44 MB, which is what shows up as the Gen2 collections in the benchmark.

Full test suite (288 tests, net10.0 + net11.0) passes, including the PNG loader tests that cover interlaced, indexed, grayscale and 16-bit images. The benchmark used above is added in #1934.