### PR TITLE
Use System.IO.Hashing.Crc32 for PNG chunk checksums

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/Images/PngImageEncoder.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/PngImageEncoder.cs
@@ -1,5 +1,6 @@
 using System.Buffers.Binary;
 using System.IO.Compression;
+using System.IO.Hashing;
 
 namespace Meziantou.Framework.SnapshotTesting;
 
@@ -74,23 +75,10 @@ internal static class PngImageEncoder
 
     private static uint ComputeCrc32(ReadOnlySpan<byte> type, ReadOnlySpan<byte> data)
     {
-        var crc = uint.MaxValue;
-        crc = UpdateCrc32(crc, type);
-        crc = UpdateCrc32(crc, data);
-        return ~crc;
-    }
-
-    private static uint UpdateCrc32(uint crc, ReadOnlySpan<byte> data)
-    {
-        foreach (var value in data)
-        {
-            crc ^= value;
-            for (var bit = 0; bit < 8; bit++)
-            {
-                crc = (crc & 1) == 0 ? crc >> 1 : 0xEDB88320u ^ (crc >> 1);
-            }
-        }
-
-        return crc;
+        // PNG uses CRC-32/ISO-HDLC, which is what System.IO.Hashing.Crc32 computes.
+        var crc = new Crc32();
+        crc.Append(type);
+        crc.Append(data);
+        return crc.GetCurrentHashAsUInt32();
     }
 }

--- a/src/Meziantou.Framework.SnapshotTesting/Images/PngImageLoader.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/PngImageLoader.cs
@@ -1,5 +1,6 @@
 using System.Buffers.Binary;
 using System.IO.Compression;
+using System.IO.Hashing;
 
 namespace Meziantou.Framework.SnapshotTesting;
 
@@ -10,7 +11,6 @@ internal static class PngImageLoader
     private static readonly int[] Adam7YStarts = [0, 0, 4, 0, 2, 0, 1];
     private static readonly int[] Adam7XSteps = [8, 8, 4, 4, 2, 2, 1];
     private static readonly int[] Adam7YSteps = [8, 8, 8, 4, 4, 2, 2];
-    private static readonly uint[] PngCrc32Table = InitializePngCrc32Table();
 
     internal static bool IsPng(ReadOnlySpan<byte> data)
     {
@@ -699,37 +699,11 @@ internal static class PngImageLoader
 
     private static uint ComputePngCrc32(ReadOnlySpan<byte> chunkType, ReadOnlySpan<byte> chunkData)
     {
-        var crc = uint.MaxValue;
-        crc = UpdatePngCrc32(crc, chunkType);
-        crc = UpdatePngCrc32(crc, chunkData);
-        return ~crc;
-    }
-
-    private static uint UpdatePngCrc32(uint crc, ReadOnlySpan<byte> data)
-    {
-        foreach (var value in data)
-        {
-            crc = PngCrc32Table[(int)((crc ^ value) & 0xFF)] ^ (crc >> 8);
-        }
-
-        return crc;
-    }
-
-    private static uint[] InitializePngCrc32Table()
-    {
-        var table = new uint[256];
-        for (uint index = 0; index < table.Length; index++)
-        {
-            var crc = index;
-            for (var bit = 0; bit < 8; bit++)
-            {
-                crc = (crc & 1) == 0 ? crc >> 1 : 0xEDB88320u ^ (crc >> 1);
-            }
-
-            table[index] = crc;
-        }
-
-        return table;
+        // PNG uses CRC-32/ISO-HDLC, which is what System.IO.Hashing.Crc32 computes.
+        var crc = new Crc32();
+        crc.Append(chunkType);
+        crc.Append(chunkData);
+        return crc.GetCurrentHashAsUInt32();
     }
 
     private static uint ReadUInt32BigEndian(ReadOnlySpan<byte> data, int offset)

--- a/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.IO.Hashing" Version="10.0.10" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.298">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
> **Stacked on #1949** — it touches the same file. Review/merge that one first; the base retargets to `main` automatically once it lands.

PNG validates every chunk with CRC-32/ISO-HDLC, which is exactly what `System.IO.Hashing.Crc32` computes. The loader used a byte-at-a-time table lookup and the encoder an even slower bit-at-a-time loop, while `System.IO.Hashing` uses the hardware CRC instructions.

Measured in isolation over 4 MB, the loader's table-driven version takes **7.97 ms** against **0.13 ms** — 60x — and I verified the two produce bit-identical results before making the change.

### Results

`PngImageLoaderBenchmark`, net10.0, measured on top of #1949:

| `Image.Load` | Before | After |
| --- | --- | --- |
| 64x64 | 84.48 us | **55.11 us** |
| 512x512 | 3,400.56 us | **2,537.17 us** |

35% and 25%. Combined with #1949, against `main`: 83.39 us -> 55.11 us and 3,580.16 us -> 2,537.17 us, with 512x512 allocation down from 6.76 MB to 2.44 MB.

### The trade-off, so you can say no

This adds a `System.IO.Hashing` package reference to `Meziantou.Framework.SnapshotTesting`. It is a Microsoft-shipped, trimmable, AOT-friendly package with no transitive dependencies, and the repository already ships it in `Meziantou.Framework.Avatar` and `Meziantou.Framework.BloomFilters` — but it is still a new dependency on the *core* snapshot testing package, which is a judgement call that is yours rather than mine.

If you would rather not take it, the dependency-free alternative is a slicing-by-8 table in `PngImageLoader` (an 8 KB static table, ~30 lines), which gets most of the win. Say the word and I will swap it in.

Worth noting: after #1948, PNGs are only decoded when images actually differ or when a similarity/hash threshold is configured, so this matters most for threshold-based image comparisons and for failing tests.

Full test suite (288 tests, net10.0 + net11.0) passes — including the loader tests that validate CRCs of real PNG files, and the encoder tests that round-trip through the loader, so the checksums are verified unchanged.