### PR TITLE
Decode 8-bit PNG scanlines without re-deciding the layout per sample

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/Images/PngImageLoader.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/PngImageLoader.cs
@@ -410,6 +410,54 @@ internal static class PngImageLoader
         bool hasTransparentRgb,
         Span<Argb> destinationPixels)
     {
+        // The color type and bit depth are fixed for the whole image, so the common 8-bit layouts get a
+        // loop of their own instead of re-deciding how to read a sample for every channel of every pixel.
+        if (bitDepth == 8)
+        {
+            switch (colorType)
+            {
+                case 0 when !hasTransparentGray:
+                    for (var x = 0; x < pixelCount; x++)
+                    {
+                        var gray = rowData[x];
+                        destinationPixels[x] = new Argb(255, gray, gray, gray);
+                    }
+
+                    return;
+
+                case 2 when !hasTransparentRgb:
+                    for (var x = 0; x < pixelCount; x++)
+                    {
+                        var sample = rowData.Slice(x * 3, 3);
+                        destinationPixels[x] = new Argb(255, sample[0], sample[1], sample[2]);
+                    }
+
+                    return;
+
+                case 3 when palette is not null:
+                    DecodePngIndexedScanline(rowData, pixelCount, palette, paletteAlpha, destinationPixels);
+                    return;
+
+                case 4:
+                    for (var x = 0; x < pixelCount; x++)
+                    {
+                        var sample = rowData.Slice(x * 2, 2);
+                        destinationPixels[x] = new Argb(sample[1], sample[0], sample[0], sample[0]);
+                    }
+
+                    return;
+
+                case 6:
+                    for (var x = 0; x < pixelCount; x++)
+                    {
+                        var sample = rowData.Slice(x * 4, 4);
+                        destinationPixels[x] = new Argb(sample[3], sample[0], sample[1], sample[2]);
+                    }
+
+                    return;
+            }
+        }
+
         for (var x = 0; x < pixelCount; x++)
         {
             destinationPixels[x] = DecodePngPixel(
@@ -425,6 +473,21 @@ internal static class PngImageLoader
                 transparentGreen,
                 transparentBlue,
                 hasTransparentRgb);
+        }
+    }
+
+    private static void DecodePngIndexedScanline(ReadOnlySpan<byte> rowData, int pixelCount, byte[] palette, byte[]? paletteAlpha, Span<Argb> destinationPixels)
+    {
+        var paletteEntryCount = palette.Length / 3;
+        for (var x = 0; x < pixelCount; x++)
+        {
+            int paletteIndex = rowData[x];
+            if (paletteIndex >= paletteEntryCount)
+                throw new InvalidDataException("The PNG palette index is out of range.");
+
+            var entry = palette.AsSpan(paletteIndex * 3, 3);
+            var alpha = paletteAlpha is not null && paletteIndex < paletteAlpha.Length ? paletteAlpha[paletteIndex] : (byte)255;
+            destinationPixels[x] = new Argb(alpha, entry[0], entry[1], entry[2]);
         }
     }
 

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/ImageTestData.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/ImageTestData.cs
@@ -179,6 +179,74 @@ internal static class ImageTestData
         return stream.ToArray();
     }
 
+    /// <summary>Builds an uncompressed, non-interlaced PNG with an arbitrary color type and bit depth.</summary>
+    /// <param name="samples">The raw scanlines, without the per-row filter byte.</param>
+    public static byte[] CreatePng(int width, int height, byte bitDepth, byte colorType, byte[] samples, byte[]? palette = null, byte[]? transparency = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        ArgumentNullException.ThrowIfNull(samples);
+
+        var channelCount = colorType switch
+        {
+            0 or 3 => 1,
+            2 => 3,
+            4 => 2,
+            6 => 4,
+            _ => throw new ArgumentOutOfRangeException(nameof(colorType)),
+        };
+
+        var rowLength = (width * channelCount * bitDepth + 7) / 8;
+        if (samples.Length != checked(rowLength * height))
+            throw new ArgumentOutOfRangeException(nameof(samples));
+
+        var imageData = new byte[checked((rowLength + 1) * height)];
+        for (var y = 0; y < height; y++)
+        {
+            var rowOffset = y * (rowLength + 1);
+            imageData[rowOffset] = 0;
+            samples.AsSpan(y * rowLength, rowLength).CopyTo(imageData.AsSpan(rowOffset + 1));
+        }
+
+        byte[] compressedData;
+        using (var compressedStream = new MemoryStream())
+        {
+            using (var zlib = new ZLibStream(compressedStream, CompressionLevel.SmallestSize, leaveOpen: true))
+            {
+                zlib.Write(imageData);
+            }
+
+            compressedData = compressedStream.ToArray();
+        }
+
+        using var stream = new MemoryStream();
+        stream.Write([137, 80, 78, 71, 13, 10, 26, 10]);
+
+        Span<byte> ihdrData = stackalloc byte[13];
+        BinaryPrimitives.WriteUInt32BigEndian(ihdrData, (uint)width);
+        BinaryPrimitives.WriteUInt32BigEndian(ihdrData[4..], (uint)height);
+        ihdrData[8] = bitDepth;
+        ihdrData[9] = colorType;
+        ihdrData[10] = 0;
+        ihdrData[11] = 0;
+        ihdrData[12] = 0;
+        WritePngChunk(stream, "IHDR"u8, ihdrData);
+
+        if (palette is not null)
+        {
+            WritePngChunk(stream, "PLTE"u8, palette);
+        }
+
+        if (transparency is not null)
+        {
+            WritePngChunk(stream, "tRNS"u8, transparency);
+        }
+
+        WritePngChunk(stream, "IDAT"u8, compressedData);
+        WritePngChunk(stream, "IEND"u8, ReadOnlySpan<byte>.Empty);
+        return stream.ToArray();
+    }
+
     public static byte[] CreateIcoWithPngEntries(params byte[][] pngImages)
     {
         ArgumentNullException.ThrowIfNull(pngImages);

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/PngImageLoaderTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/PngImageLoaderTests.cs
@@ -25,4 +25,87 @@ public sealed class PngImageLoaderTests
             new Argb(0x800000FFu),
         ], image.Pixels.ToArray());
     }
+
+    [Fact]
+    public void Load_Grayscale8_RepeatsTheSampleOnEveryChannel()
+    {
+        var image = Image.Load(ImageTestData.CreatePng(width: 2, height: 1, bitDepth: 8, colorType: 0, samples: [0x10, 0x20]));
+
+        Assert.Equal([new Argb(0xFF101010u), new Argb(0xFF202020u)], image.Pixels.ToArray());
+    }
+
+    [Fact]
+    public void Load_Grayscale8_WithTransparency_MarksTheTransparentSample()
+    {
+        var image = Image.Load(ImageTestData.CreatePng(width: 2, height: 1, bitDepth: 8, colorType: 0, samples: [0x10, 0x20], transparency: [0x00, 0x20]));
+
+        Assert.Equal([new Argb(0xFF101010u), new Argb(0x00202020u)], image.Pixels.ToArray());
+    }
+
+    [Fact]
+    public void Load_Rgb8_DecodesOpaquePixels()
+    {
+        var image = Image.Load(ImageTestData.CreatePng(width: 2, height: 1, bitDepth: 8, colorType: 2, samples: [0x10, 0x20, 0x30, 0x40, 0x50, 0x60]));
+
+        Assert.Equal([new Argb(0xFF102030u), new Argb(0xFF405060u)], image.Pixels.ToArray());
+    }
+
+    [Fact]
+    public void Load_Rgb8_WithTransparency_MarksTheTransparentColor()
+    {
+        var image = Image.Load(ImageTestData.CreatePng(
+            width: 2,
+            height: 1,
+            bitDepth: 8,
+            colorType: 2,
+            samples: [0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
+            transparency: [0x00, 0x10, 0x00, 0x20, 0x00, 0x30]));
+
+        Assert.Equal([new Argb(0x00102030u), new Argb(0xFF405060u)], image.Pixels.ToArray());
+    }
+
+    [Fact]
+    public void Load_Indexed8_ResolvesThePalette()
+    {
+        var image = Image.Load(ImageTestData.CreatePng(
+            width: 3,
+            height: 1,
+            bitDepth: 8,
+            colorType: 3,
+            samples: [0, 1, 2],
+            palette: [0xFF, 0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x00, 0xFF]));
+
+        Assert.Equal([new Argb(0xFFFF0000u), new Argb(0xFF00FF00u), new Argb(0xFF0000FFu)], image.Pixels.ToArray());
+    }
+
+    [Fact]
+    public void Load_Indexed8_WithTransparency_AppliesThePaletteAlpha()
+    {
+        var image = Image.Load(ImageTestData.CreatePng(
+            width: 3,
+            height: 1,
+            bitDepth: 8,
+            colorType: 3,
+            samples: [0, 1, 2],
+            palette: [0xFF, 0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x00, 0xFF],
+            transparency: [0x00, 0x80]));
+
+        Assert.Equal([new Argb(0x00FF0000u), new Argb(0x8000FF00u), new Argb(0xFF0000FFu)], image.Pixels.ToArray());
+    }
+
+    [Fact]
+    public void Load_Indexed8_ThrowsWhenThePaletteIndexIsOutOfRange()
+    {
+        var data = ImageTestData.CreatePng(width: 2, height: 1, bitDepth: 8, colorType: 3, samples: [0, 5], palette: [0xFF, 0x00, 0x00]);
+
+        Assert.Throws<InvalidDataException>(() => Image.Load(data));
+    }
+
+    [Fact]
+    public void Load_GrayscaleAlpha8_DecodesTheAlphaChannel()
+    {
+        var image = Image.Load(ImageTestData.CreatePng(width: 2, height: 1, bitDepth: 8, colorType: 4, samples: [0x10, 0xFF, 0x20, 0x80]));
+
+        Assert.Equal([new Argb(0xFF101010u), new Argb(0x80202020u)], image.Pixels.ToArray());
+    }
 }


### PR DESCRIPTION
> **Stacked on #1950** (which is stacked on #1949) — same file. The base retargets automatically as each lands.

Decoding a scanline called a generic per-pixel routine that switched on the color type, and that routine read each channel through a helper that branched again on the bit depth and did `checked` offset arithmetic. For a 1920x1080 RGBA image that is four branchy calls per pixel, all re-answering questions that are fixed for the entire image.

The five 8-bit layouts — grayscale, RGB, indexed, grayscale+alpha and RGBA — now have a tight loop each, selected once per scanline. Everything else still goes through the generic path completely unchanged: sub-8-bit and 16-bit depths, interlaced images, and the truecolor/grayscale `tRNS` variants (guarded with `when !hasTransparent...` so the specialized loops stay branch-free).

### Results

`PngImageLoaderBenchmark`, net10.0, on top of #1950:

| `Image.Load` | Before | After |
| --- | --- | --- |
| 64x64 | 55.11 us | **43.80 us** |
| 512x512 | 2,537.17 us | **1,865.10 us** |

21% and 26%. Across the three stacked PNG PRs, against `main`: **83.39 us -> 43.80 us** and **3,580.16 us -> 1,865.10 us** (1.9x both), with 512x512 allocation down from 6.76 MB to 2.44 MB.

### Tests

This is the most invasive of the performance changes, and the existing fixtures only exercised 8-bit grayscale, RGB and RGBA — the indexed and grayscale+alpha paths had no coverage at all. Added:

- grayscale-8, with and without `tRNS`
- RGB-8, with and without `tRNS`
- indexed-8, with and without `tRNS`, plus the out-of-range palette index error
- grayscale+alpha-8

Worth noting how these were validated: I wrote them against the **previous** decoder and confirmed all 18 (9 tests x 2 TFMs) pass on it unmodified before switching the implementation in. So they check that the two paths agree, rather than just restating what the new code happens to do.

Full suite is now 304 tests, all passing on net10.0 + net11.0.