### PR TITLE
Resolve the LLM context once per process

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettings.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/InlineSnapshotSettings.cs
@@ -145,7 +145,7 @@ public sealed record InlineSnapshotSettings
         IsRunningOnContinuousIntegration = {IsRunningOnContinuousIntegration()}
         BuildServerDetector = {BuildServerDetector.Detected}
         ContinuousTestingDetector = {ContinuousTestingDetector.Detected}
-        LLMContextDetector = {LLMContextDetector.IsLLMContext()}
+        LLMContextDetector = {LLMEnvironmentDetector.Detected}
         """;
 
     public InlineSnapshotSettings()
@@ -177,7 +177,7 @@ public sealed record InlineSnapshotSettings
         }
     }
 
-    internal static bool IsRunningOnContinuousIntegration() => BuildServerDetector.Detected || ContinuousTestingDetector.Detected || LLMContextDetector.IsLLMContext();
+    internal static bool IsRunningOnContinuousIntegration() => BuildServerDetector.Detected || ContinuousTestingDetector.Detected || LLMEnvironmentDetector.Detected;
 
     [DoesNotReturn]
     internal void AssertSnapshot(string? expected, string? actual)

--- a/src/Meziantou.Framework.InlineSnapshotTesting/MergeTool.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/MergeTool.cs
@@ -55,7 +55,7 @@ public abstract class MergeTool
         return string.Equals(variable, "true", StringComparison.OrdinalIgnoreCase) ||
                BuildServerDetector.Detected ||
                ContinuousTestingDetector.Detected ||
-               LLMContextDetector.IsLLMContext();
+               LLMEnvironmentDetector.Detected;
     }
 
     internal static MergeToolResult? Launch(IEnumerable<MergeTool?>? mergeTools, string currentFilePath, string newFilePath)

--- a/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj
@@ -13,6 +13,7 @@
     <Compile Include="../Meziantou.Framework/ExecutableFinder.cs" Link="Utils/ExecutableFinder.cs" />
     <Compile Include="../Meziantou.Framework.SnapshotTesting/common/BuildServerDetector.cs" Link="Utils/BuildServerDetector.cs" />
     <Compile Include="../Meziantou.Framework.SnapshotTesting/common/ContinuousTestingDetector.cs" Link="Utils/ContinuousTestingDetector.cs" />
+    <Compile Include="../Meziantou.Framework.SnapshotTesting/common/LLMEnvironmentDetector.cs" Link="Utils/LLMEnvironmentDetector.cs" />
     <Compile Include="../Meziantou.Framework.SnapshotTesting/common/CallerContextUtilities.cs" Link="Utils/CallerContextUtilities.cs" />
     <Compile Include="../Meziantou.Framework.SnapshotTesting/common/MergeTools/GitTool.cs" Link="MergeTools/GitTool.cs" />
     <Compile Include="../Meziantou.Framework.SnapshotTesting/common/Utils/FileInfoExtensions.cs" Link="Utils/FileInfoExtensions.cs" />

--- a/src/Meziantou.Framework.SnapshotTesting/MergeTool.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/MergeTool.cs
@@ -55,7 +55,7 @@ public abstract class MergeTool
         return string.Equals(variable, "true", StringComparison.OrdinalIgnoreCase) ||
                BuildServerDetector.Detected ||
                ContinuousTestingDetector.Detected ||
-               LLMContextDetector.IsLLMContext();
+               LLMEnvironmentDetector.Detected;
     }
 
     internal static MergeToolResult? Launch(IEnumerable<MergeTool?>? mergeTools, string currentFilePath, string newFilePath)

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotSettings.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotSettings.cs
@@ -133,7 +133,7 @@ public sealed record SnapshotSettings
         MergeTools = options.MergeTools is null ? null : [.. options.MergeTools];
     }
 
-    internal static bool IsRunningOnContinuousIntegration() => BuildServerDetector.Detected || ContinuousTestingDetector.Detected || LLMContextDetector.IsLLMContext();
+    internal static bool IsRunningOnContinuousIntegration() => BuildServerDetector.Detected || ContinuousTestingDetector.Detected || LLMEnvironmentDetector.Detected;
 
     private static FullPath DefaultSnapshotPath(SnapshotPathContext context)
     {

--- a/src/Meziantou.Framework.SnapshotTesting/common/LLMEnvironmentDetector.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/common/LLMEnvironmentDetector.cs
@@ -1,0 +1,14 @@
+using Meziantou.Framework.LLMContext;
+
+namespace Meziantou.Framework;
+
+/// <summary>
+/// Caches whether the process runs in a known LLM or agentic context. <see cref="LLMContextDetector.IsLLMContext" />
+/// reads about thirty environment variables and allocates on every call, and it sits next to
+/// <see cref="BuildServerDetector" /> and <see cref="ContinuousTestingDetector" />, which are both resolved
+/// once for the lifetime of the process.
+/// </summary>
+internal static class LLMEnvironmentDetector
+{
+    public static bool Detected { get; } = LLMContextDetector.IsLLMContext();
+}


### PR DESCRIPTION
`IsRunningOnContinuousIntegration()` and `MergeTool.IsDisable()` both read:

```csharp
BuildServerDetector.Detected || ContinuousTestingDetector.Detected || LLMContextDetector.IsLLMContext()
```

The first two are resolved once for the lifetime of the process. The third reads about thirty environment variables and allocates a `List<LLMContextKind>` on every call. `LLMEnvironmentDetector` now joins the other two in the shared `common/` folder and is used by both snapshot testing packages, so all three behave the same way.

**This is a consistency fix more than a performance one.** Both call sites are on the failing path — a test is about to throw and possibly launch a diff tool — so the environment variable reads were never significant. The uneven caching looked unintentional rather than deliberate, which is why I am proposing the change; happy to drop it if the live read was intended.

The public `LLMContextDetector` API is untouched, so anything that genuinely needs a fresh read still gets one.

### Testing

Both suites pass: `Meziantou.Framework.SnapshotTesting.Tests` (288, net10.0 + net11.0) and `Meziantou.Framework.InlineSnapshotTesting.Tests` (115, three consecutive runs).

Worth flagging separately: while testing this I hit `InlineSnapshotSettingsTests.SnapshotUpdateStrategy_Default_CanBeConfiguredUsingEnvironmentVariable` failing intermittently. I checked and it reproduces on **unmodified `main`** — 2 failures in 5 consecutive local runs. `XunitCollectionBehavior.cs` in that project only disables parallelization under `#if GITHUB_ACTIONS`, so locally the tests that mutate `INLINESNAPSHOTTESTING_STRATEGY` race with each other. The `SnapshotTesting` test project avoids this with `<EnableXunitFullParallelization>false</EnableXunitFullParallelization>`. Unrelated to this PR, but worth fixing.