### PR TITLE
Skip normalization when an inline snapshot is already normalized

### DIFF
--- a/benchmarks/SnapshotTestingBenchmarks/InlineSnapshotBenchmark.cs
+++ b/benchmarks/SnapshotTestingBenchmarks/InlineSnapshotBenchmark.cs
@@ -1,0 +1,23 @@
+using BenchmarkDotNet.Attributes;
+using Meziantou.Framework.InlineSnapshotTesting;
+
+namespace SnapshotTestingBenchmarks;
+
+/// <summary>Measures an inline snapshot assertion whose value already matches, which is what a passing test does.</summary>
+[MemoryDiagnoser]
+public class InlineSnapshotBenchmark
+{
+    private readonly object _value = new { FirstName = "John", LastName = "Doe", Age = 42 };
+    private InlineSnapshotSettings _settings = null!;
+    private string _expected = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _settings = InlineSnapshotSettings.Default with { };
+        _expected = _settings.SnapshotSerializer.Serialize(_value) ?? "";
+    }
+
+    [Benchmark]
+    public void Validate() => InlineSnapshot.Validate(_value, _settings, _expected, filePath: "Benchmark.cs", lineNumber: 1);
+}

--- a/benchmarks/SnapshotTestingBenchmarks/SnapshotTestingBenchmarks.csproj
+++ b/benchmarks/SnapshotTestingBenchmarks/SnapshotTestingBenchmarks.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../src/Meziantou.Framework.InlineSnapshotTesting/Meziantou.Framework.InlineSnapshotTesting.csproj" />
     <ProjectReference Include="../../src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj" />
   </ItemGroup>
 

--- a/src/Meziantou.Framework.InlineSnapshotTesting/SnapshotComparer.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/SnapshotComparer.cs
@@ -26,6 +26,9 @@ public abstract class SnapshotComparer
             if (value is null)
                 return null;
 
+            if (IsAlreadyNormalized(value))
+                return value;
+
             var sb = new StringBuilder(value.Length);
             foreach (var (line, eol) in StringUtils.EnumerateLines(value))
             {
@@ -61,5 +64,29 @@ public abstract class SnapshotComparer
         }
 
         public override bool AreEqual(string? actual, string? expected) => actual == expected;
+
+        /// <summary>
+        /// Reports whether normalizing would hand back the value unchanged, which is the common case: the
+        /// serializers emit LF-separated text with no tabs and no whitespace-only lines, and the compiler
+        /// has already stripped the indentation of a raw string literal. Scanning costs nothing, while
+        /// normalizing builds a string as large as the snapshot for both the actual and the expected value
+        /// on every assertion.
+        /// </summary>
+        private static bool IsAlreadyNormalized(string value)
+        {
+            foreach (var (line, eol) in StringUtils.EnumerateLines(value))
+            {
+                if (line.Contains('\t'))
+                    return false;
+
+                if (!line.IsEmpty && line.IsWhiteSpace())
+                    return false;
+
+                if (!eol.IsEmpty && !eol.SequenceEqual("\n"))
+                    return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/SnapshotComparerTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/SnapshotComparerTests.cs
@@ -7,4 +7,44 @@ public sealed class SnapshotComparerTests
         var actual = SnapshotComparer.Default.NormalizeValue("ab\r\n  \n\tcd");
         Assert.Equal("ab\n\n    cd", actual);
     }
+
+    [Theory]
+    // Already normalized: LF only, no tabs, no whitespace-only lines
+    [InlineData("", "")]
+    [InlineData("ab", "ab")]
+    [InlineData("ab\ncd", "ab\ncd")]
+    [InlineData("ab\n\ncd", "ab\n\ncd")]
+    [InlineData("ab\n", "ab\n")]
+    [InlineData("a b  c", "a b  c")]
+    // Line endings
+    [InlineData("ab\r\ncd", "ab\ncd")]
+    [InlineData("ab\rcd", "ab\ncd")]
+    [InlineData("ab\u2028cd", "ab\ncd")]
+    // Tabs become four spaces
+    [InlineData("\tab", "    ab")]
+    [InlineData("a\tb", "a    b")]
+    // Whitespace-only lines keep their line break but lose their content
+    [InlineData("ab\n  \ncd", "ab\n\ncd")]
+    [InlineData("ab\n\t\ncd", "ab\n\ncd")]
+    [InlineData("   ", "")]
+    public void NormalizeValue_Cases(string value, string expected)
+    {
+        Assert.Equal(expected, SnapshotComparer.Default.NormalizeValue(value));
+    }
+
+    [Fact]
+    public void NormalizeValue_ReturnsNullForNull()
+    {
+        Assert.Null(SnapshotComparer.Default.NormalizeValue(value: null));
+    }
+
+    [Fact]
+    public void NormalizeValue_IsIdempotent()
+    {
+        foreach (var value in new[] { "ab\r\n  \n\tcd", "ab\ncd", "", "   ", "a\tb\r\n\r\n" })
+        {
+            var once = SnapshotComparer.Default.NormalizeValue(value);
+            Assert.Equal(once, SnapshotComparer.Default.NormalizeValue(once));
+        }
+    }
 }


### PR DESCRIPTION
Every inline snapshot assertion normalizes **both** the actual and the expected value, building a `StringBuilder` and a string the size of the snapshot for each — even though normalizing is usually a no-op. The serializers emit LF-separated text with no tabs and no whitespace-only lines, and the compiler has already stripped the indentation of a raw string literal, so the normalized value is very often identical to the input.

Scanning for the three things normalization would change (a tab, a whitespace-only line, a line ending that is not LF) costs nothing and lets the value be handed back untouched. If anything would change, the original code path runs exactly as before.

The public `SnapshotComparer` contract is untouched — this only affects the built-in `DefaultSnapshotComparer`.

### Results

New `InlineSnapshotBenchmark` (an assertion whose value already matches), net10.0:

| | Before | After |
| --- | --- | --- |
| matching snapshot | 371.1 ns, 1.39 KB | **318.6 ns, 928 B** |

14% faster and 35% less allocated on a small snapshot. The allocation saved scales with the snapshot, since it is two copies of it.

### Tests

`SnapshotComparerTests` had exactly one test, which is thin for a change to normalization. Added the line ending cases (CRLF, CR, U+2028), tab expansion, whitespace-only lines, the empty and null inputs, and an idempotence check — 17 cases in total.

As with the PNG PR, these were written against the **previous** implementation and confirmed passing on it unmodified before the fast path went in, so they check the two paths agree rather than restating what the new code does.

### Unrelated flaky test

While running this suite I hit `InlineSnapshotSettingsTests.SnapshotUpdateStrategy_Default_CanBeConfiguredUsingEnvironmentVariable` failing intermittently. It reproduces on unmodified `main` (2 failures in 5 consecutive runs) — those tests mutate a process-wide environment variable and `XunitCollectionBehavior.cs` only disables parallelization under `#if GITHUB_ACTIONS`. Not caused by this PR; noted in #1954 too.