### PR TITLE
Skip build output and package folders when searching for snapshots

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting.Tool/Program.cs
+++ b/src/Meziantou.Framework.SnapshotTesting.Tool/Program.cs
@@ -8,6 +8,10 @@ namespace Meziantou.Framework.SnapshotTesting.Tool;
 internal static class Program
 {
     private const string ActualMarker = ".actual.";
+    private const string SnapshotDirectoryName = "__snapshots__";
+
+    /// <summary>Directories that never hold snapshots and can be expensive to walk.</summary>
+    private static readonly string[] SkippedDirectoryNames = ["bin", "obj", ".git", "node_modules"];
 
     public static Task<int> Main(string[] args)
     {
@@ -120,13 +124,13 @@ internal static class Program
 
     private static IEnumerable<FullPath> EnumerateSnapshotDirectories(FullPath rootPath, bool recurse)
     {
-        if (string.Equals(rootPath.Name, "__snapshots__", StringComparison.Ordinal))
+        if (string.Equals(rootPath.Name, SnapshotDirectoryName, StringComparison.Ordinal))
         {
             yield return rootPath;
         }
         else
         {
-            var localSnapshotDirectory = rootPath / "__snapshots__";
+            var localSnapshotDirectory = rootPath / SnapshotDirectoryName;
             if (Directory.Exists(localSnapshotDirectory))
             {
                 yield return localSnapshotDirectory;
@@ -136,10 +140,9 @@ internal static class Program
         if (!recurse)
             yield break;
 
-        var rootSnapshotDirectory = rootPath / "__snapshots__";
-        foreach (var directory in Directory.EnumerateDirectories(rootPath, "__snapshots__", SearchOption.AllDirectories))
+        var rootSnapshotDirectory = rootPath / SnapshotDirectoryName;
+        foreach (var snapshotDirectory in EnumerateSnapshotDirectoriesRecursively(rootPath))
         {
-            var snapshotDirectory = FullPath.FromPath(directory);
             if (string.Equals(snapshotDirectory.Value, rootSnapshotDirectory.Value, StringComparison.Ordinal))
             {
                 continue;
@@ -147,6 +150,63 @@ internal static class Program
 
             yield return snapshotDirectory;
         }
+    }
+
+    /// <summary>
+    /// Walks the tree looking for snapshot directories, skipping the ones that never hold source. On a large
+    /// repository, descending into every build output, package folder and the git database is what the run
+    /// spends its time on.
+    /// </summary>
+    private static IEnumerable<FullPath> EnumerateSnapshotDirectoriesRecursively(FullPath rootPath)
+    {
+        var pending = new Stack<FullPath>();
+        pending.Push(rootPath);
+
+        while (pending.Count > 0)
+        {
+            var current = pending.Pop();
+
+            string[] children;
+            try
+            {
+                children = Directory.GetDirectories(current);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                continue;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                continue;
+            }
+
+            foreach (var child in children)
+            {
+                var childPath = FullPath.FromPath(child);
+                var name = childPath.Name;
+                if (string.Equals(name, SnapshotDirectoryName, StringComparison.Ordinal))
+                {
+                    yield return childPath;
+                }
+                else if (IsSkippedDirectoryName(name))
+                {
+                    continue;
+                }
+
+                pending.Push(childPath);
+            }
+        }
+    }
+
+    private static bool IsSkippedDirectoryName(string name)
+    {
+        foreach (var skipped in SkippedDirectoryNames)
+        {
+            if (string.Equals(name, skipped, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
     }
 
     private static FullPath GetVerifiedPath(FullPath actualFile)

--- a/tests/Meziantou.Framework.SnapshotTesting.Tool.Tests/SnapshotTestingToolTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tool.Tests/SnapshotTestingToolTests.cs
@@ -45,6 +45,26 @@ public sealed class SnapshotTestingToolTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task Approve_SkipsDirectoriesThatNeverHoldSnapshots()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var sourceActualPath = await temp.CreateTextFileAsync("src/__snapshots__/sample.actual.txt", "source-value", XunitCancellationToken);
+        var binActualPath = await temp.CreateTextFileAsync("bin/__snapshots__/sample.actual.txt", "bin-value", XunitCancellationToken);
+        var objActualPath = await temp.CreateTextFileAsync("obj/__snapshots__/sample.actual.txt", "obj-value", XunitCancellationToken);
+        var gitActualPath = await temp.CreateTextFileAsync(".git/__snapshots__/sample.actual.txt", "git-value", XunitCancellationToken);
+        var nodeModulesActualPath = await temp.CreateTextFileAsync("node_modules/__snapshots__/sample.actual.txt", "node-value", XunitCancellationToken);
+
+        var result = await RunTool(["approve", "--folder", temp.FullPath]);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.False(File.Exists(sourceActualPath));
+        Assert.True(File.Exists(binActualPath));
+        Assert.True(File.Exists(objActualPath));
+        Assert.True(File.Exists(gitActualPath));
+        Assert.True(File.Exists(nodeModulesActualPath));
+    }
+
+    [Fact]
     public async Task Approve_InteractiveMode_AllowsRejectingSnapshots()
     {
         await using var temp = TemporaryDirectory.Create();


### PR DESCRIPTION
The `approve` command walked the whole tree with `SearchOption.AllDirectories`, descending into build output, package folders and the git database. On this repository that is **1239 directories against 503** once `bin`, `obj`, `.git` and `node_modules` are skipped, and the gap grows with the size of the build output — a checkout with a real `node_modules` is where this actually bites.

Being straight about the numbers: wall-clock on this repository is ~0.04 s either way, because 1239 directories is nothing. The scaling is the point, not the current measurement.

### The better argument is correctness

This also stops the tool approving snapshots it should leave alone. Renaming an `.actual` file that sits in `obj/` achieves nothing — it will be overwritten by the next build — and worse, it makes the run report a snapshot as approved while the real one next to the source was never touched.

### Also

The walk now tolerates a directory it cannot read (`UnauthorizedAccessException`, `DirectoryNotFoundException`) and carries on, instead of failing the whole run. `AllDirectories` would throw.

### Tests

Added `Approve_SkipsDirectoriesThatNeverHoldSnapshots`, which puts an `.actual` file in `src/`, `bin/`, `obj/`, `.git/` and `node_modules/` and asserts only the one under `src/` is approved. I confirmed it **fails** against the current implementation before making the change, so it genuinely covers this.

All 10 tool tests pass (5 x net10.0 + net11.0).

### One judgement call

`bin` and `obj` are skipped at any depth, so a source folder genuinely named `bin` containing a `__snapshots__` folder would now be missed. That seems very unlikely to be real, but say the word if you would rather match only at specific depths.