### PR TITLE
Update xunit.v3.extensibility.core to 4.0.0

### DIFF
--- a/src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/Meziantou.Extensions.Logging.Xunit.v3.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
-    <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
+    <PackageReference Include="xunit.v3.extensibility.core" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Meziantou.Xunit/Meziantou.Xunit.csproj
+++ b/src/Meziantou.Xunit/Meziantou.Xunit.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
+    <PackageReference Include="xunit.v3.extensibility.core" Version="4.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Replaces #1869 (leaving the Renovate branch untouched so Renovate keeps updating it).

Bumps `xunit.v3.extensibility.core` from `3.2.2` to `4.0.0` in `Meziantou.Xunit` and `Meziantou.Extensions.Logging.Xunit.v3`.

### No breaking changes to handle

`Meziantou.NET.Sdk.Test` already resolves the xunit.v3 stack at `4.0.0` for every test project, so the explicit `3.2.2` reference in these two projects was only affecting the dependency version declared by the produced NuGet packages. This aligns them.

Verified locally:

- Both projects build in `Release` with `0 warnings / 0 errors`.
- Full `eng/build.proj` `Release` build: `0 warnings / 0 errors`.
- `ref/` public API files are unchanged after a `Release` `/p:IsOfficialBuild=true` build — no public API surface change.
- `dotnet run ./eng/update-all.cs` produces no changes.
- `Meziantou.Extensions.Logging.Xunit.v3.Tests`: 4/4 passed.

### About the CI failure on #1869

The 16 failures on `build_and_test (windows-2025-vs2026, Release, 2)` are all `DockerContainerTests` failing with `The container could not be started after 4 attempts. (Process exited with code 1. Command: C:\Windows\system32\docker.EXE)`. They are unrelated to this upgrade:

- The same 8 tests × 2 TFMs failed identically on a `main` push (run 32444599492, job `windows-2025-vs2026, Debug, /p:InvariantGlobalization=true, 2`), which does not contain this change.
- Within #1869's own run, the same suite passed 50/0/37 on three other Windows jobs (`Debug, 2`, `Debug, InvariantGlobalization, 2`, `Release, InvariantGlobalization, 2`).
- The failures cluster in the 06:35–06:50 UTC window on 2026-08-21 across both `main` and the PR, while jobs before and after passed.

`TemporaryContainers.Tests` was also run locally against this branch and against `origin/main`: both produce exactly 174 total / 110 passed / 30 failed / 34 skipped with the same test names (local `AppleContainer` + DB-image environment limitations), i.e. no regression from this change.