### PR TITLE
Fix conditional test attribute bugs and document Meziantou.Xunit

### DIFF
--- a/ref/Meziantou.Xunit.cs
+++ b/ref/Meziantou.Xunit.cs
@@ -56,9 +56,7 @@ namespace Meziantou.Xunit
     {
         Any = 0,
         Invariant = 1,
-        NotInvariant = 2,
-        Enabled = 1,
-        Disabled = 2
+        NotInvariant = 2
     }
 
     [System.Flags]

--- a/ref/Meziantou.Xunit.cs
+++ b/ref/Meziantou.Xunit.cs
@@ -25,6 +25,7 @@ namespace Meziantou.Xunit
         GitHubActions = 1
     }
 
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public sealed class RunIfAttribute : Meziantou.Xunit.ConditionalTestAttributeBase
     {
         protected bool InvertCondition { get => throw null; }
@@ -34,6 +35,7 @@ namespace Meziantou.Xunit
         public RunIfAttribute(Meziantou.Xunit.TestOperatingSystems operatingSystem, Meziantou.Xunit.TestGlobalizationMode globalizationMode) { }
     }
 
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public sealed class SkipIfAttribute : Meziantou.Xunit.ConditionalTestAttributeBase
     {
         protected bool InvertCondition { get => throw null; }
@@ -53,6 +55,8 @@ namespace Meziantou.Xunit
     public enum TestGlobalizationMode
     {
         Any = 0,
+        Invariant = 1,
+        NotInvariant = 2,
         Enabled = 1,
         Disabled = 2
     }

--- a/src/Meziantou.Xunit/ConditionalTestAttributeBase.cs
+++ b/src/Meziantou.Xunit/ConditionalTestAttributeBase.cs
@@ -4,46 +4,115 @@ using Xunit.v3;
 
 namespace Meziantou.Xunit;
 
+/// <summary>
+/// Base class for attributes that run or skip a test depending on the environment the test suite is running in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Conditions are combined with a logical AND: the attribute matches only when every condition it defines matches.
+/// </para>
+/// <para>
+/// Conditions are evaluated by <see cref="Before(MethodInfo, IXunitTest)"/>, which xUnit calls after the test class instance
+/// has been created. Class fixtures, the test class constructor and <c>IAsyncLifetime.InitializeAsync</c> therefore run even
+/// when the test ends up being skipped.
+/// </para>
+/// </remarks>
 public abstract class ConditionalTestAttributeBase : BeforeAfterTestAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConditionalTestAttributeBase"/> class.
+    /// </summary>
     protected ConditionalTestAttributeBase()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConditionalTestAttributeBase"/> class.
+    /// </summary>
+    /// <param name="operatingSystem">The operating systems the condition matches.</param>
     protected ConditionalTestAttributeBase(TestOperatingSystems operatingSystem)
     {
         OperatingSystem = operatingSystem;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConditionalTestAttributeBase"/> class.
+    /// </summary>
+    /// <param name="globalizationMode">The globalization mode the condition matches.</param>
     protected ConditionalTestAttributeBase(TestGlobalizationMode globalizationMode)
     {
         GlobalizationMode = globalizationMode;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConditionalTestAttributeBase"/> class.
+    /// </summary>
+    /// <param name="windowsGroup">The Windows group membership the condition matches.</param>
     protected ConditionalTestAttributeBase(WindowsGroups windowsGroup)
     {
         WindowsGroup = windowsGroup;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConditionalTestAttributeBase"/> class.
+    /// </summary>
+    /// <param name="operatingSystem">The operating systems the condition matches.</param>
+    /// <param name="globalizationMode">The globalization mode the condition matches.</param>
     protected ConditionalTestAttributeBase(TestOperatingSystems operatingSystem, TestGlobalizationMode globalizationMode)
     {
         OperatingSystem = operatingSystem;
         GlobalizationMode = globalizationMode;
     }
 
+    /// <summary>
+    /// Gets or sets the operating systems the condition matches. Defaults to <see cref="TestOperatingSystems.None"/>, which does not take part in the condition.
+    /// </summary>
     public TestOperatingSystems OperatingSystem { get; set; }
+
+    /// <summary>
+    /// Gets or sets the globalization mode the condition matches. Defaults to <see cref="TestGlobalizationMode.Any"/>, which does not take part in the condition.
+    /// </summary>
     public TestGlobalizationMode GlobalizationMode { get; set; } = TestGlobalizationMode.Any;
+
+    /// <summary>
+    /// Gets or sets the continuous integration environments the condition matches. Defaults to <see cref="ContinuousIntegrationEnvironments.None"/>, which does not take part in the condition.
+    /// </summary>
     public ContinuousIntegrationEnvironments ContinuousIntegration { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Windows group membership the condition matches. Defaults to <see cref="WindowsGroups.Any"/>, which does not take part in the condition.
+    /// </summary>
     public WindowsGroups WindowsGroup { get; set; } = WindowsGroups.Any;
 
+    /// <summary>
+    /// Gets a value indicating whether the test is skipped when the condition matches (<see langword="true"/>) or when it does not match (<see langword="false"/>).
+    /// </summary>
     protected abstract bool InvertCondition { get; }
 
+    private bool HasCondition => OperatingSystem is not TestOperatingSystems.None ||
+                                 GlobalizationMode is not TestGlobalizationMode.Any ||
+                                 ContinuousIntegration is not ContinuousIntegrationEnvironments.None ||
+                                 WindowsGroup is not WindowsGroups.Any;
+
+    /// <summary>
+    /// Evaluates the condition and skips the test when it is not satisfied.
+    /// </summary>
+    /// <param name="methodUnderTest">The method under test.</param>
+    /// <param name="test">The test that is about to run.</param>
+    /// <exception cref="InvalidOperationException">The attribute does not define any condition.</exception>
     public override void Before(MethodInfo methodUnderTest, IXunitTest test)
     {
-        var evaluation = EvaluateConditions(OperatingSystem, GlobalizationMode, ContinuousIntegration, WindowsGroup);
-        if (!evaluation.HasCondition)
-            return;
+        if (!HasCondition)
+        {
+            var typeName = GetType().Name;
+            var attributeName = typeName.EndsWith("Attribute", StringComparison.Ordinal)
+                ? typeName[..^"Attribute".Length]
+                : typeName;
 
+            throw new InvalidOperationException($"[{attributeName}] does not define any condition, so it has no effect. Set at least one of {nameof(OperatingSystem)}, {nameof(GlobalizationMode)}, {nameof(ContinuousIntegration)} or {nameof(WindowsGroup)}.");
+        }
+
+        var evaluation = EvaluateConditions();
         var shouldSkip = InvertCondition ? evaluation.IsMatch : !evaluation.IsMatch;
         if (!shouldSkip)
             return;
@@ -52,66 +121,63 @@ public abstract class ConditionalTestAttributeBase : BeforeAfterTestAttribute
             ? "Skip due to matching condition: " + evaluation.MatchDescription
             : evaluation.FailureReason ?? "Condition is not met";
 
-        throw new InvalidOperationException("$XunitDynamicSkip$" + reason);
+        throw new InvalidOperationException(DynamicSkipToken.Value + reason);
     }
 
-    private static ConditionEvaluation EvaluateConditions(TestOperatingSystems operatingSystem, TestGlobalizationMode globalizationMode, ContinuousIntegrationEnvironments continuousIntegration, WindowsGroups windowsGroup)
+    private ConditionEvaluation EvaluateConditions()
     {
-        var hasCondition = operatingSystem != TestOperatingSystems.None ||
-                           globalizationMode != TestGlobalizationMode.Any ||
-                           continuousIntegration != ContinuousIntegrationEnvironments.None ||
-                           windowsGroup != WindowsGroups.Any;
-
-        if (!hasCondition)
-            return new ConditionEvaluation(HasCondition: false, IsMatch: true, MatchDescription: string.Empty, FailureReason: null);
-
-        if (globalizationMode != TestGlobalizationMode.Any)
+        if (GlobalizationMode is not TestGlobalizationMode.Any)
         {
-            var isEnabled = TestEnvironment.IsGlobalizationInvariant();
-            if (globalizationMode is TestGlobalizationMode.Enabled && !isEnabled)
-            {
-                return new ConditionEvaluation(HasCondition: true, IsMatch: false, MatchDescription: string.Empty, FailureReason: "Run only in invariant globalization mode");
-            }
+            var isInvariant = TestEnvironment.IsGlobalizationInvariant();
+            if (GlobalizationMode is TestGlobalizationMode.Invariant && !isInvariant)
+                return new ConditionEvaluation(IsMatch: false, MatchDescription: string.Empty, FailureReason: "Run only in invariant globalization mode");
 
-            if (globalizationMode is TestGlobalizationMode.Disabled && isEnabled)
-            {
-                return new ConditionEvaluation(HasCondition: true, IsMatch: false, MatchDescription: string.Empty, FailureReason: "Run only in non-invariant globalization mode");
-            }
+            if (GlobalizationMode is TestGlobalizationMode.NotInvariant && isInvariant)
+                return new ConditionEvaluation(IsMatch: false, MatchDescription: string.Empty, FailureReason: "Run only in non-invariant globalization mode");
         }
 
-        if (operatingSystem != TestOperatingSystems.None && !IsMatchingOperatingSystem(operatingSystem))
-            return new ConditionEvaluation(HasCondition: true, IsMatch: false, MatchDescription: string.Empty, FailureReason: "Run only on " + operatingSystem);
+        if (OperatingSystem is not TestOperatingSystems.None && !IsMatchingOperatingSystem(OperatingSystem))
+            return new ConditionEvaluation(IsMatch: false, MatchDescription: string.Empty, FailureReason: "Run only on " + OperatingSystem);
 
-        if (continuousIntegration != ContinuousIntegrationEnvironments.None && !TestEnvironment.IsOnContinuousIntegration(continuousIntegration))
-            return new ConditionEvaluation(HasCondition: true, IsMatch: false, MatchDescription: string.Empty, FailureReason: "Run only on " + continuousIntegration);
+        if (ContinuousIntegration is not ContinuousIntegrationEnvironments.None && !TestEnvironment.IsOnContinuousIntegration(ContinuousIntegration))
+            return new ConditionEvaluation(IsMatch: false, MatchDescription: string.Empty, FailureReason: "Run only on " + ContinuousIntegration);
 
-        if (windowsGroup != WindowsGroups.Any)
+        if (WindowsGroup is not WindowsGroups.Any)
         {
             if (!global::System.OperatingSystem.IsWindows())
-                return new ConditionEvaluation(HasCondition: true, IsMatch: false, MatchDescription: string.Empty, FailureReason: "Run only on Windows");
+                return new ConditionEvaluation(IsMatch: false, MatchDescription: string.Empty, FailureReason: "Run only on Windows");
 
-            if (!IsMatchingWindowsGroup(windowsGroup))
-                return new ConditionEvaluation(HasCondition: true, IsMatch: false, MatchDescription: string.Empty, FailureReason: "Run only when current user is in Windows group " + windowsGroup);
+            if (!IsMatchingWindowsGroup(WindowsGroup))
+            {
+                var failureReason = WindowsGroup switch
+                {
+                    WindowsGroups.User => "Run only when the current user is a standard user that is not elevated as an administrator",
+                    WindowsGroups.Administrator => "Run only when the current user is elevated as an administrator",
+                    _ => "Run only when current user is in Windows group " + WindowsGroup,
+                };
+
+                return new ConditionEvaluation(IsMatch: false, MatchDescription: string.Empty, FailureReason: failureReason);
+            }
         }
 
-        var matchDescription = GetMatchDescription(operatingSystem, globalizationMode, continuousIntegration, windowsGroup);
-        return new ConditionEvaluation(HasCondition: true, IsMatch: true, MatchDescription: matchDescription, FailureReason: null);
+        var matchDescription = InvertCondition ? GetMatchDescription() : string.Empty;
+        return new ConditionEvaluation(IsMatch: true, MatchDescription: matchDescription, FailureReason: null);
     }
 
-    private static string GetMatchDescription(TestOperatingSystems operatingSystem, TestGlobalizationMode globalizationMode, ContinuousIntegrationEnvironments continuousIntegration, WindowsGroups windowsGroup)
+    private string GetMatchDescription()
     {
         var conditions = new List<string>(capacity: 4);
-        if (operatingSystem != TestOperatingSystems.None)
-            conditions.Add(nameof(OperatingSystem) + " = " + operatingSystem);
+        if (OperatingSystem is not TestOperatingSystems.None)
+            conditions.Add(nameof(OperatingSystem) + " = " + OperatingSystem);
 
-        if (globalizationMode != TestGlobalizationMode.Any)
-            conditions.Add(nameof(GlobalizationMode) + " = " + globalizationMode);
+        if (GlobalizationMode is not TestGlobalizationMode.Any)
+            conditions.Add(nameof(GlobalizationMode) + " = " + GlobalizationMode);
 
-        if (continuousIntegration != ContinuousIntegrationEnvironments.None)
-            conditions.Add(nameof(ContinuousIntegration) + " = " + continuousIntegration);
+        if (ContinuousIntegration is not ContinuousIntegrationEnvironments.None)
+            conditions.Add(nameof(ContinuousIntegration) + " = " + ContinuousIntegration);
 
-        if (windowsGroup != WindowsGroups.Any)
-            conditions.Add(nameof(WindowsGroup) + " = " + windowsGroup);
+        if (WindowsGroup is not WindowsGroups.Any)
+            conditions.Add(nameof(WindowsGroup) + " = " + WindowsGroup);
 
         return string.Join(", ", conditions);
     }
@@ -132,6 +198,7 @@ public abstract class ConditionalTestAttributeBase : BeforeAfterTestAttribute
 
     private static bool IsMatchingWindowsGroup(WindowsGroups windowsGroup)
     {
+        // Also required by the platform compatibility analyzer for WindowsIdentity
         if (!global::System.OperatingSystem.IsWindows())
             return false;
 
@@ -139,11 +206,12 @@ public abstract class ConditionalTestAttributeBase : BeforeAfterTestAttribute
         var principal = new WindowsPrincipal(identity);
         return windowsGroup switch
         {
-            WindowsGroups.User => principal.IsInRole(WindowsBuiltInRole.User),
+            // Administrators are members of the built-in Users group, so they must be excluded explicitly
+            WindowsGroups.User => principal.IsInRole(WindowsBuiltInRole.User) && !principal.IsInRole(WindowsBuiltInRole.Administrator),
             WindowsGroups.Administrator => principal.IsInRole(WindowsBuiltInRole.Administrator),
             _ => false,
         };
     }
 
-    private readonly record struct ConditionEvaluation(bool HasCondition, bool IsMatch, string MatchDescription, string? FailureReason);
+    private readonly record struct ConditionEvaluation(bool IsMatch, string MatchDescription, string? FailureReason);
 }

--- a/src/Meziantou.Xunit/ConditionalTestAttributeBase.cs
+++ b/src/Meziantou.Xunit/ConditionalTestAttributeBase.cs
@@ -95,22 +95,14 @@ public abstract class ConditionalTestAttributeBase : BeforeAfterTestAttribute
                                  WindowsGroup is not WindowsGroups.Any;
 
     /// <summary>
-    /// Evaluates the condition and skips the test when it is not satisfied.
+    /// Evaluates the condition and skips the test when it is not satisfied. Does nothing when the attribute defines no condition.
     /// </summary>
     /// <param name="methodUnderTest">The method under test.</param>
     /// <param name="test">The test that is about to run.</param>
-    /// <exception cref="InvalidOperationException">The attribute does not define any condition.</exception>
     public override void Before(MethodInfo methodUnderTest, IXunitTest test)
     {
         if (!HasCondition)
-        {
-            var typeName = GetType().Name;
-            var attributeName = typeName.EndsWith("Attribute", StringComparison.Ordinal)
-                ? typeName[..^"Attribute".Length]
-                : typeName;
-
-            throw new InvalidOperationException($"[{attributeName}] does not define any condition, so it has no effect. Set at least one of {nameof(OperatingSystem)}, {nameof(GlobalizationMode)}, {nameof(ContinuousIntegration)} or {nameof(WindowsGroup)}.");
-        }
+            return;
 
         var evaluation = EvaluateConditions();
         var shouldSkip = InvertCondition ? evaluation.IsMatch : !evaluation.IsMatch;

--- a/src/Meziantou.Xunit/ContinuousIntegrationEnvironments.cs
+++ b/src/Meziantou.Xunit/ContinuousIntegrationEnvironments.cs
@@ -1,8 +1,18 @@
 namespace Meziantou.Xunit;
 
+/// <summary>
+/// Describes the continuous integration environments a test requires.
+/// </summary>
 [Flags]
 public enum ContinuousIntegrationEnvironments
 {
+    /// <summary>
+    /// The continuous integration environment is not part of the condition.
+    /// </summary>
     None = 0,
+
+    /// <summary>
+    /// GitHub Actions.
+    /// </summary>
     GitHubActions = 1,
 }

--- a/src/Meziantou.Xunit/RunIfAttribute.cs
+++ b/src/Meziantou.Xunit/RunIfAttribute.cs
@@ -1,30 +1,58 @@
 namespace Meziantou.Xunit;
 
+/// <summary>
+/// Runs the test only when every condition defined by the attribute matches; otherwise the test is skipped.
+/// </summary>
+/// <remarks>
+/// The attribute can be applied to a test method and to its test class. When both define a condition, the test runs only when both match.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
 public sealed class RunIfAttribute : ConditionalTestAttributeBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RunIfAttribute"/> class. At least one condition must be set using the properties of the attribute.
+    /// </summary>
     public RunIfAttribute()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RunIfAttribute"/> class.
+    /// </summary>
+    /// <param name="operatingSystem">The operating systems the test runs on.</param>
     public RunIfAttribute(TestOperatingSystems operatingSystem)
         : base(operatingSystem)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RunIfAttribute"/> class.
+    /// </summary>
+    /// <param name="globalizationMode">The globalization mode the test runs in.</param>
     public RunIfAttribute(TestGlobalizationMode globalizationMode)
         : base(globalizationMode)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RunIfAttribute"/> class.
+    /// </summary>
+    /// <param name="windowsGroup">The Windows group membership the test requires.</param>
     public RunIfAttribute(WindowsGroups windowsGroup)
         : base(windowsGroup)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RunIfAttribute"/> class.
+    /// </summary>
+    /// <param name="operatingSystem">The operating systems the test runs on.</param>
+    /// <param name="globalizationMode">The globalization mode the test runs in.</param>
     public RunIfAttribute(TestOperatingSystems operatingSystem, TestGlobalizationMode globalizationMode)
         : base(operatingSystem, globalizationMode)
     {
     }
 
+    /// <inheritdoc />
     protected override bool InvertCondition => false;
 }

--- a/src/Meziantou.Xunit/SkipIfAttribute.cs
+++ b/src/Meziantou.Xunit/SkipIfAttribute.cs
@@ -1,30 +1,58 @@
 namespace Meziantou.Xunit;
 
+/// <summary>
+/// Skips the test when every condition defined by the attribute matches; otherwise the test runs.
+/// </summary>
+/// <remarks>
+/// The attribute can be applied to a test method and to its test class. When both define a condition, the test is skipped when either of them matches.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
 public sealed class SkipIfAttribute : ConditionalTestAttributeBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkipIfAttribute"/> class. At least one condition must be set using the properties of the attribute.
+    /// </summary>
     public SkipIfAttribute()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkipIfAttribute"/> class.
+    /// </summary>
+    /// <param name="operatingSystem">The operating systems the test is skipped on.</param>
     public SkipIfAttribute(TestOperatingSystems operatingSystem)
         : base(operatingSystem)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkipIfAttribute"/> class.
+    /// </summary>
+    /// <param name="globalizationMode">The globalization mode the test is skipped in.</param>
     public SkipIfAttribute(TestGlobalizationMode globalizationMode)
         : base(globalizationMode)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkipIfAttribute"/> class.
+    /// </summary>
+    /// <param name="windowsGroup">The Windows group membership that causes the test to be skipped.</param>
     public SkipIfAttribute(WindowsGroups windowsGroup)
         : base(windowsGroup)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SkipIfAttribute"/> class.
+    /// </summary>
+    /// <param name="operatingSystem">The operating systems the test is skipped on.</param>
+    /// <param name="globalizationMode">The globalization mode the test is skipped in.</param>
     public SkipIfAttribute(TestOperatingSystems operatingSystem, TestGlobalizationMode globalizationMode)
         : base(operatingSystem, globalizationMode)
     {
     }
 
+    /// <inheritdoc />
     protected override bool InvertCondition => true;
 }

--- a/src/Meziantou.Xunit/TestEnvironment.cs
+++ b/src/Meziantou.Xunit/TestEnvironment.cs
@@ -1,15 +1,34 @@
 namespace Meziantou.Xunit;
 
+/// <summary>
+/// Provides information about the environment the test suite is running in.
+/// </summary>
 public static class TestEnvironment
 {
+    /// <summary>
+    /// Determines whether the application runs in invariant globalization mode.
+    /// </summary>
+    /// <returns><see langword="true"/> when invariant globalization mode is enabled; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This mirrors how the runtime resolves the setting: the <c>System.Globalization.Invariant</c> switch, which is set by the
+    /// <c>InvariantGlobalization</c> MSBuild property, takes precedence over the <c>DOTNET_SYSTEM_GLOBALIZATION_INVARIANT</c>
+    /// environment variable.
+    /// </remarks>
     public static bool IsGlobalizationInvariant()
     {
         if (AppContext.TryGetSwitch("System.Globalization.Invariant", out var isEnabled))
             return isEnabled;
 
-        return false;
+        // The environment variable is read by the runtime but is not surfaced as an AppContext switch
+        var value = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");
+        return value is "1" || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Determines whether the test suite runs on one of the specified continuous integration environments.
+    /// </summary>
+    /// <param name="environment">The continuous integration environments to test for.</param>
+    /// <returns><see langword="true"/> when the test suite runs on any of the specified environments; otherwise <see langword="false"/>.</returns>
     public static bool IsOnContinuousIntegration(ContinuousIntegrationEnvironments environment)
     {
         if (environment == ContinuousIntegrationEnvironments.None)
@@ -21,6 +40,10 @@ public static class TestEnvironment
         return false;
     }
 
+    /// <summary>
+    /// Determines whether the test suite runs on GitHub Actions.
+    /// </summary>
+    /// <returns><see langword="true"/> when the test suite runs on GitHub Actions; otherwise <see langword="false"/>.</returns>
     public static bool IsOnGitHubActions()
     {
         return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));

--- a/src/Meziantou.Xunit/TestGlobalizationMode.cs
+++ b/src/Meziantou.Xunit/TestGlobalizationMode.cs
@@ -24,16 +24,4 @@ public enum TestGlobalizationMode
     /// The application does not run in invariant globalization mode, so the culture data of the operating system is available.
     /// </summary>
     NotInvariant = 2,
-
-    /// <summary>
-    /// The application runs in invariant globalization mode.
-    /// </summary>
-    [Obsolete($"Use {nameof(Invariant)} instead. The name was ambiguous: it means invariant globalization is enabled, i.e. culture data is not available.")]
-    Enabled = Invariant,
-
-    /// <summary>
-    /// The application does not run in invariant globalization mode, so the culture data of the operating system is available.
-    /// </summary>
-    [Obsolete($"Use {nameof(NotInvariant)} instead. The name was ambiguous: it means invariant globalization is disabled, i.e. culture data is available.")]
-    Disabled = NotInvariant,
 }

--- a/src/Meziantou.Xunit/TestGlobalizationMode.cs
+++ b/src/Meziantou.Xunit/TestGlobalizationMode.cs
@@ -1,8 +1,39 @@
 namespace Meziantou.Xunit;
 
+/// <summary>
+/// Describes the globalization mode a test requires.
+/// </summary>
+/// <remarks>
+/// Invariant globalization mode is enabled by the <c>InvariantGlobalization</c> MSBuild property or the
+/// <c>DOTNET_SYSTEM_GLOBALIZATION_INVARIANT</c> environment variable. In this mode the culture data of the
+/// operating system is not used, so culture-sensitive operations behave as if only the invariant culture existed.
+/// </remarks>
 public enum TestGlobalizationMode
 {
-    Any,
-    Enabled,
-    Disabled,
+    /// <summary>
+    /// The globalization mode is not part of the condition.
+    /// </summary>
+    Any = 0,
+
+    /// <summary>
+    /// The application runs in invariant globalization mode.
+    /// </summary>
+    Invariant = 1,
+
+    /// <summary>
+    /// The application does not run in invariant globalization mode, so the culture data of the operating system is available.
+    /// </summary>
+    NotInvariant = 2,
+
+    /// <summary>
+    /// The application runs in invariant globalization mode.
+    /// </summary>
+    [Obsolete($"Use {nameof(Invariant)} instead. The name was ambiguous: it means invariant globalization is enabled, i.e. culture data is not available.")]
+    Enabled = Invariant,
+
+    /// <summary>
+    /// The application does not run in invariant globalization mode, so the culture data of the operating system is available.
+    /// </summary>
+    [Obsolete($"Use {nameof(NotInvariant)} instead. The name was ambiguous: it means invariant globalization is disabled, i.e. culture data is available.")]
+    Disabled = NotInvariant,
 }

--- a/src/Meziantou.Xunit/TestOperatingSystems.cs
+++ b/src/Meziantou.Xunit/TestOperatingSystems.cs
@@ -1,11 +1,33 @@
 namespace Meziantou.Xunit;
 
+/// <summary>
+/// Describes the operating systems a test requires.
+/// </summary>
 [Flags]
 public enum TestOperatingSystems
 {
+    /// <summary>
+    /// The operating system is not part of the condition.
+    /// </summary>
     None = 0,
+
+    /// <summary>
+    /// Windows.
+    /// </summary>
     Windows = 1,
+
+    /// <summary>
+    /// Linux.
+    /// </summary>
     Linux = 2,
+
+    /// <summary>
+    /// macOS.
+    /// </summary>
     MacOS = 4,
+
+    /// <summary>
+    /// Windows, Linux or macOS.
+    /// </summary>
     All = Windows | Linux | MacOS,
 }

--- a/src/Meziantou.Xunit/WindowsGroups.cs
+++ b/src/Meziantou.Xunit/WindowsGroups.cs
@@ -1,8 +1,22 @@
 namespace Meziantou.Xunit;
 
+/// <summary>
+/// Describes the Windows group membership a test requires. Any value other than <see cref="Any"/> also requires Windows.
+/// </summary>
 public enum WindowsGroups
 {
-    Any,
-    User,
-    Administrator,
+    /// <summary>
+    /// The Windows group membership is not part of the condition.
+    /// </summary>
+    Any = 0,
+
+    /// <summary>
+    /// The current user is a member of the built-in <c>Users</c> group and is not running elevated as an administrator.
+    /// </summary>
+    User = 1,
+
+    /// <summary>
+    /// The current user is running elevated as a member of the built-in <c>Administrators</c> group.
+    /// </summary>
+    Administrator = 2,
 }

--- a/src/Meziantou.Xunit/readme.md
+++ b/src/Meziantou.Xunit/readme.md
@@ -23,7 +23,7 @@ public sealed class SampleTests
     }
 
     [Fact]
-    [RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void Runs_only_when_invariant_globalization_is_disabled()
     {
     }
@@ -44,11 +44,21 @@ public sealed class SampleTests
 
 `RunIf` executes the test only when all specified conditions match. `SkipIf` skips the test when all specified conditions match.
 
+Both attributes can be applied to a test method and to its test class, but only once per target. An attribute that specifies no condition would have no effect, so it fails the test instead of being silently ignored.
+
+Conditions are evaluated once the test class instance has been created. Class fixtures, the test class constructor and `IAsyncLifetime.InitializeAsync` therefore run even when the test ends up being skipped.
+
 ## Supported conditions
 
 | Condition | Type | Values |
 | :--- | :--- | :--- |
 | `OperatingSystem` | `TestOperatingSystems` | `Windows`, `Linux`, `MacOS` (`Flags`) |
-| `GlobalizationMode` | `TestGlobalizationMode` | `Any`, `Enabled` (invariant mode), `Disabled` (non-invariant mode) |
+| `GlobalizationMode` | `TestGlobalizationMode` | `Any`, `Invariant`, `NotInvariant` |
 | `ContinuousIntegration` | `ContinuousIntegrationEnvironments` | `GitHubActions` |
 | `WindowsGroup` | `WindowsGroups` | `Any`, `User`, `Administrator` |
+
+`GlobalizationMode` reflects [invariant globalization mode](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/globalization), which is enabled by the `InvariantGlobalization` MSBuild property or the `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT` environment variable. `Invariant` means culture data is **not** available; `NotInvariant` means it is.
+
+`WindowsGroups.User` means the current user is a member of the built-in `Users` group and is **not** elevated as an administrator. Any value other than `Any` also requires Windows.
+
+> `TestGlobalizationMode.Enabled` and `TestGlobalizationMode.Disabled` are obsolete aliases for `Invariant` and `NotInvariant`.

--- a/src/Meziantou.Xunit/readme.md
+++ b/src/Meziantou.Xunit/readme.md
@@ -44,7 +44,7 @@ public sealed class SampleTests
 
 `RunIf` executes the test only when all specified conditions match. `SkipIf` skips the test when all specified conditions match.
 
-Both attributes can be applied to a test method and to its test class, but only once per target. An attribute that specifies no condition would have no effect, so it fails the test instead of being silently ignored.
+Both attributes can be applied to a test method and to its test class, but only once per target. An attribute that specifies no condition has no effect.
 
 Conditions are evaluated once the test class instance has been created. Class fixtures, the test class constructor and `IAsyncLifetime.InitializeAsync` therefore run even when the test ends up being skipped.
 
@@ -60,5 +60,3 @@ Conditions are evaluated once the test class instance has been created. Class fi
 `GlobalizationMode` reflects [invariant globalization mode](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/globalization), which is enabled by the `InvariantGlobalization` MSBuild property or the `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT` environment variable. `Invariant` means culture data is **not** available; `NotInvariant` means it is.
 
 `WindowsGroups.User` means the current user is a member of the built-in `Users` group and is **not** elevated as an administrator. Any value other than `Any` also requires Windows.
-
-> `TestGlobalizationMode.Enabled` and `TestGlobalizationMode.Disabled` are obsolete aliases for `Invariant` and `NotInvariant`.

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -74,7 +74,7 @@ public sealed partial class SerializerTests : SerializerTestsBase
     public void CultureInfo_Invariant()
         => AssertSerialization(CultureInfo.InvariantCulture, "Invariant Language (Invariant Country)");
 
-    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void CultureInfo_EnUs()
         => AssertSerialization(CultureInfo.GetCultureInfo("en-US"), "en-US");
 

--- a/tests/Meziantou.Framework.PostgreSqlServer.Tests/PostgreSqlServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.PostgreSqlServer.Tests/PostgreSqlServerProtocolTests.cs
@@ -7,7 +7,7 @@ using Meziantou.Xunit;
 
 namespace Meziantou.Framework.PostgreSql.Tests;
 
-[RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+[RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
 public sealed class PostgreSqlServerProtocolTests
 {
     [Fact]

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/ResxGeneratorTests.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/ResxGeneratorTests.cs
@@ -6,7 +6,7 @@ namespace Meziantou.Framework.ResxSourceGenerator.GeneratorTests;
 
 public class ResxGeneratorTests
 {
-    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void FormatString()
     {
         CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
@@ -16,14 +16,14 @@ public class ResxGeneratorTests
         Assert.Equal("Bonjour le monde!", Resource1.FormatHello("le monde"));
     }
 
-    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void ResxWithCustomParameterElementsCanBeReadByResourceManager()
     {
         Assert.Equal("Hello {0}!", Resource1.ResourceManager.GetString("Hello", CultureInfo.GetCultureInfo("en-US")));
         Assert.Equal("Bonjour {0}!", Resource1.ResourceManager.GetString("Hello", CultureInfo.GetCultureInfo("fr")));
     }
 
-    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void StringValue()
     {
         CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");

--- a/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
@@ -522,7 +522,7 @@ public partial class RecurrenceRuleTests
     }
 
     [Fact]
-    [RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void Secondly_GetHumanText_en_us()
     {
         TestGetHumanText("FREQ=SECONDLY", "en-US", "every second");
@@ -531,7 +531,7 @@ public partial class RecurrenceRuleTests
     }
 
     [Fact]
-    [RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void Secondly_GetHumanText_fr_fr()
     {
         TestGetHumanText("FREQ=SECONDLY", "fr-FR", "toutes les secondes");
@@ -540,7 +540,7 @@ public partial class RecurrenceRuleTests
     }
 
     [Fact]
-    [RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void Minutely_GetHumanText_en_us()
     {
         TestGetHumanText("FREQ=MINUTELY", "en-US", "every minute");
@@ -549,7 +549,7 @@ public partial class RecurrenceRuleTests
     }
 
     [Fact]
-    [RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void Minutely_GetHumanText_fr_fr()
     {
         TestGetHumanText("FREQ=MINUTELY", "fr-FR", "toutes les minutes");
@@ -558,7 +558,7 @@ public partial class RecurrenceRuleTests
     }
 
     [Fact]
-    [RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void Hourly_GetHumanText_en_us()
     {
         TestGetHumanText("FREQ=HOURLY", "en-US", "every hour");
@@ -568,7 +568,7 @@ public partial class RecurrenceRuleTests
     }
 
     [Fact]
-    [RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void Hourly_GetHumanText_fr_fr()
     {
         TestGetHumanText("FREQ=HOURLY", "fr-FR", "toutes les heures");

--- a/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
+++ b/tests/Meziantou.Framework.Slug.Tests/SlugTests.cs
@@ -159,7 +159,7 @@ public class SlugTests
     }
 
     [Fact]
-    [RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void Slug_Culture_IsUsedForCasing()
     {
         var options = new SlugOptions
@@ -203,7 +203,7 @@ public class SlugTests
     }
 
     [Theory]
-    [RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     [InlineData(1, "")]
     [InlineData(2, "\u00E9")]
     [InlineData(3, "\u00E9\u00E9")]
@@ -232,7 +232,7 @@ public class SlugTests
     }
 
     [Fact]
-    [RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void Slug_MaximumLength_NeverStripsCombiningMarksFromTheLastCharacter()
     {
         var options = new SlugOptions { MaximumLength = 4 };

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -9,7 +9,7 @@ using Meziantou.Xunit;
 
 namespace Meziantou.Framework.Tds.Tests;
 
-[RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+[RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
 public sealed class TdsQueryEngineTests
 {
     [Fact]

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -14,7 +14,7 @@ using SqlParserParseResult = Microsoft.SqlServer.Management.SqlParser.Parser.Par
 
 namespace Meziantou.Framework.Tds.Tests;
 
-[RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+[RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
 public sealed class TdsServerProtocolTests
 {
     [Fact]

--- a/tests/Meziantou.Framework.Tests/CountryTests.cs
+++ b/tests/Meziantou.Framework.Tests/CountryTests.cs
@@ -15,7 +15,7 @@ public sealed class CountryTests
         Assert.Equal("\U0001F1EB\U0001F1F7", Country.GetUnicodeFlag(name));
     }
 
-    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void FrenchFlagFromRegion()
     {
         Assert.Equal("\U0001F1EB\U0001F1F7", Country.GetUnicodeFlag(new RegionInfo("FR")));

--- a/tests/Meziantou.Framework.Tests/CultureInfoUtilitiesTests.cs
+++ b/tests/Meziantou.Framework.Tests/CultureInfoUtilitiesTests.cs
@@ -4,19 +4,19 @@ namespace Meziantou.Framework.Tests;
 
 public class CultureInfoUtilitiesTests
 {
-    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void NeutralEquals_fr()
     {
         Assert.True(CultureInfo.GetCultureInfo("fr-FR").NeutralEquals(CultureInfo.GetCultureInfo("fr-CA")));
     }
 
-    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void NeutralEquals_fr2()
     {
         Assert.True(CultureInfo.GetCultureInfo("fr").NeutralEquals(CultureInfo.GetCultureInfo("fr-CA")));
     }
 
-    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void NeutralEquals_en()
     {
         var fr = CultureInfo.GetCultureInfo("fr-FR");

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_Int32To.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_Int32To.cs
@@ -4,7 +4,7 @@ namespace Meziantou.Framework.Tests;
 
 public class DefaultConverterTests_Int32To
 {
-    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void TryConvert_Int32ToCultureInfo_LcidAsInt()
     {
         var converter = new DefaultConverter();

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_StringTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_StringTo.cs
@@ -114,7 +114,7 @@ public class DefaultConverterTests_StringTo
         Assert.Equal("es", value.Name);
     }
 
-    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void TryConvert_StringToCultureInfo_LcidAsString()
     {
         var converter = new DefaultConverter();
@@ -133,7 +133,7 @@ public class DefaultConverterTests_StringTo
         }
     }
 
-    [Fact, RunIf(globalizationMode: TestGlobalizationMode.Disabled)]
+    [Fact, RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
     public void TryConvert_StringToCultureInfo_InvalidCulture()
     {
         var converter = new DefaultConverter();


### PR DESCRIPTION
Fixes several bugs in the `RunIf` / `SkipIf` attributes and adds XML documentation to the package's public API.

> [!WARNING]
> **Breaking change.** `TestGlobalizationMode.Enabled` and `TestGlobalizationMode.Disabled` are removed, and `RunIf` / `SkipIf` can no longer be applied more than once per target or at assembly level.

## Invariant globalization was not detected from the environment variable

`TestEnvironment.IsGlobalizationInvariant()` only read the `System.Globalization.Invariant` `AppContext` switch. The runtime resolves the setting from that switch **and then** from `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT`, and the environment variable is not surfaced as a switch:

```
env='1' TryGetSwitch=False/False realInvariant=True currentEnglishName='Invariant Language (Invariant Country)'
```

So only the `InvariantGlobalization` MSBuild property worked, because it writes the switch into `runtimeconfig.json`. Tests guarded by `RunIf(globalizationMode: ...)` ran instead of being skipped under env-var-driven invariant mode. Measured on this repository's own tests with `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`:

| `Meziantou.Framework.TypeConverter.Tests` culture tests | before | after |
| :--- | :--- | :--- |
| skipped | 0 | **3** |
| failed | **1** | 0 |

## `WindowsGroups.User` could never mean "standard user"

`IsInRole(WindowsBuiltInRole.User)` checks `BUILTIN\Users` (S-1-5-32-545), which Authenticated Users belongs to by default — so it was also true when running elevated. It now requires `IsInRole(User) && !IsInRole(Administrator)`. `Administrator` is unchanged. Skip messages are now explicit ("Run only when the current user is elevated as an administrator") rather than naming a group.

## Hardcoded dynamic skip token

`"$XunitDynamicSkip$"` is replaced by `Xunit.v3.DynamicSkipToken.Value`, so a token change in a future xUnit is a build error rather than skips silently becoming failures.

## `TestGlobalizationMode.Enabled` meant globalization was *unavailable*

`GlobalizationMode = Enabled` meant invariant mode was on. Renamed to `Invariant` / `NotInvariant`, matching `System.Globalization.GlobalizationMode.Invariant`. **`Enabled` and `Disabled` are removed outright**, not kept as obsolete aliases. The 23 call sites in this repository are updated.

## `RunIf` / `SkipIf` inherited `AllowMultiple = true`

From `BeforeAfterTestAttribute`, so `[RunIf(Windows)] [RunIf(Linux)]` compiled into two independent AND-ed checks and the test could never run. Both attributes now declare `[AttributeUsage(Class | Method, AllowMultiple = false)]`. Verified by compilation: duplicates are `CS0579`, assembly-level use is `CS0592`, and `RunIf` + `SkipIf` on one method plus a class-level `RunIf` still compile.

## Documentation

XML docs on every public type and member, plus a readme covering the new names, the one-per-target rule, and the fact that conditions are evaluated *after* the test class is constructed — class fixtures, the constructor and `IAsyncLifetime.InitializeAsync` all run even when the test is skipped.

An attribute that defines no condition remains a no-op. Worth noting for review: the guard for that case cannot simply be deleted, because `EvaluateConditions` reports a match when nothing is set, which would make `SkipIf` skip every test with an empty reason.

## Notes for reviewers

- `<Version>` is left at `2.0.0` despite the breaking changes, since version bumps happen in their own PRs here — say if you'd rather bump it.
- `ref/Meziantou.Xunit.cs` regenerated with a Release + `IsOfficialBuild` build.
- **`WindowsGroups.User` is untested here** — no test in the repo uses it, and the `Win32.*` projects are Windows-only. It was verified by reading, not by running.
- **`Meziantou.Xunit` still has no test project**, unlike almost every other `src/` package. The globalization bug is exactly what one would have caught; worth a follow-up.

## Testing

Rebased on `main` at d70e086f7. `dotnet run ./eng/update-all.cs` produced no changes, and the library builds clean for `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`. Behavior was checked in a scratch xUnit v3 harness — real conditions report as SKIP, condition-less attributes are no-ops for both `RunIf` and `SkipIf` — and across the affected test projects, including the `/p:InvariantGlobalization=true` matrix configuration:

| project | default | `/p:InvariantGlobalization=true` |
| :--- | :--- | :--- |
| `Meziantou.Framework.Slug.Tests` | 106 passed | 92 passed, 14 skipped |
| `Meziantou.Framework.TypeConverter.Tests` | 116 passed | 110 passed, 6 skipped |
| `Meziantou.Framework.Tests` | 1850 passed, 12 skipped | — |
