### PR TITLE
Fix XSS vectors in HtmlSanitizer

### DIFF
--- a/src/Meziantou.Framework.HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/Meziantou.Framework.HtmlSanitizer/HtmlSanitizer.cs
@@ -83,6 +83,7 @@ public sealed class HtmlSanitizer
     /// <summary>Sanitizes an HTML fragment by removing dangerous elements, attributes, and URLs while preserving safe HTML structure.</summary>
     /// <param name="html">The HTML fragment to sanitize.</param>
     /// <returns>A sanitized HTML fragment safe for rendering.</returns>
+    /// <remarks>Comments and CDATA sections are always removed, and markup characters in text are escaped.</remarks>
     [return: NotNullIfNotNull(nameof(html))]
     public string? SanitizeHtmlFragment(string? html)
     {
@@ -100,45 +101,82 @@ public sealed class HtmlSanitizer
 
     private void Sanitize(HtmlNode node)
     {
-        if (node is HtmlElement htmlElement)
+        if (node is not HtmlElement htmlElement)
         {
-            if (!IsValidNode(htmlElement.Name))
+            // Only plain text nodes are kept. Comments and CDATA sections are written back to the
+            // output verbatim, and browsers close them earlier than the parser does (a comment also
+            // ends at "--!>", "<!-->" is already a complete comment, and "<![CDATA[" is a bogus
+            // comment ending at the first ">"), so any markup they contain would become live
+            // content in the sanitized output.
+            if (node is not HtmlText { IsCData: false } text)
             {
-                htmlElement.Remove();
+                node.Remove();
                 return;
             }
 
-            for (var i = htmlElement.Attributes.Count - 1; i >= 0; i--)
-            {
-                var attribute = htmlElement.Attributes[i];
-                if (attribute is null)
-                    continue;
+            // Text values are also written verbatim. The parser leaves markup characters in text
+            // nodes when it recovers from malformed input (an unterminated comment, for instance, is
+            // re-emitted as text), so they must be escaped to stay text once re-parsed.
+            text.Value = EscapeMarkupCharacters(text.Value);
+            return;
+        }
 
-                if (!IsValidAttribute(attribute.Name))
+        if (!IsValidNode(htmlElement.Name))
+        {
+            htmlElement.Remove();
+            return;
+        }
+
+        SanitizeAttributes(htmlElement);
+
+        for (var i = htmlElement.ChildNodes.Count - 1; i >= 0; i--)
+        {
+            Sanitize(htmlElement.ChildNodes[i]);
+        }
+    }
+
+    private void SanitizeAttributes(HtmlElement htmlElement)
+    {
+        if (!htmlElement.HasAttributes)
+            return;
+
+        for (var i = htmlElement.Attributes.Count - 1; i >= 0; i--)
+        {
+            var attribute = htmlElement.Attributes[i];
+            if (!IsValidAttribute(attribute.Name))
+            {
+                // Remove by index. RemoveAttribute(name, namespaceURI) looks the attribute up by
+                // local name, so it silently fails to remove prefixed attributes such as "v-on:click".
+                htmlElement.Attributes.RemoveAt(i);
+            }
+            else if (UriAttributes.Contains(attribute.Name))
+            {
+                if (!UrlSanitizer.IsSafeUrl(attribute.Value))
                 {
-                    htmlElement.RemoveAttribute(attribute.Name, attribute.NamespaceURI);
+                    attribute.Value = "";
                 }
-                else if (UriAttributes.Contains(attribute.Name))
+            }
+            else if (SrcsetAttributes.Contains(attribute.Name))
+            {
+                if (!UrlSanitizer.IsSafeSrcset(attribute.Value))
                 {
-                    if (!UrlSanitizer.IsSafeUrl(attribute.Value))
-                    {
-                        attribute.Value = "";
-                    }
-                }
-                else if (SrcsetAttributes.Contains(attribute.Name))
-                {
-                    if (!UrlSanitizer.IsSafeSrcset(attribute.Value))
-                    {
-                        attribute.Value = "";
-                    }
+                    attribute.Value = "";
                 }
             }
         }
+    }
 
-        for (var i = node.ChildNodes.Count - 1; i >= 0; i--)
-        {
-            Sanitize(node.ChildNodes[i]);
-        }
+    /// <remarks>
+    /// Entities are left untouched: the parser does not decode them, so escaping '&amp;' would double-encode
+    /// text such as "&amp;amp;". Only '&lt;' and '&gt;' need to be neutralized.
+    /// </remarks>
+    [return: NotNullIfNotNull(nameof(value))]
+    private static string? EscapeMarkupCharacters(string? value)
+    {
+        if (value is null || value.AsSpan().IndexOfAny('<', '>') < 0)
+            return value;
+
+        return value.Replace("<", "&lt;", StringComparison.Ordinal).Replace(">", "&gt;", StringComparison.Ordinal);
     }
 
     private static HtmlDocument ParseHtmlFragment(string content)

--- a/src/Meziantou.Framework.HtmlSanitizer/readme.md
+++ b/src/Meziantou.Framework.HtmlSanitizer/readme.md
@@ -32,6 +32,20 @@ var result = sanitizer.SanitizeHtmlFragment("<p id='test'>test</p>");
 // Result: "<p>test</p>"
 ```
 
+### Remove Comments and CDATA Sections
+
+Comments and CDATA sections are always removed, and markup characters left in text are escaped. Browsers end a comment at `--!>` and treat `<!-->` as a complete comment, and they parse `<![CDATA[` as a comment ending at the first `>`. Keeping either of them would let an attacker smuggle live markup through the sanitizer:
+
+```csharp
+var sanitizer = new HtmlSanitizer();
+
+var result = sanitizer.SanitizeHtmlFragment("<p>a<!-- comment -->b</p>");
+// Result: "<p>ab</p>"
+
+var result = sanitizer.SanitizeHtmlFragment("<![CDATA[> <img src=x onerror=alert(1)>]]>");
+// Result: ""
+```
+
 ### Sanitize URLs
 
 The sanitizer validates URLs in attributes like `href` and `src` to prevent javascript: and other dangerous protocols:
@@ -152,10 +166,9 @@ This library is inspired by:
 - [Angular's HTML sanitizer](https://github.com/angular/angular/blob/main/packages/core/src/sanitization/html_sanitizer.ts)
 - [Sanitizer API specification](https://wicg.github.io/sanitizer-api/#default-configuration-dictionary)
 
-The library uses [AngleSharp](https://anglesharp.github.io/) for HTML parsing.
+The library uses the HTML parser from `Meziantou.Framework.Html`.
 
 ## Additional Resources
 
 - [Angular HTML Sanitizer](https://github.com/angular/angular/blob/main/packages/core/src/sanitization/html_sanitizer.ts)
 - [W3C Sanitizer API](https://wicg.github.io/sanitizer-api/)
-- [AngleSharp](https://anglesharp.github.io/)

--- a/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
+++ b/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
@@ -15,10 +15,34 @@ public class HtmlSanitizerTests
     [InlineData("<a href='https://example.com'>test</a>", "<a href='https://example.com'>test</a>")]
     [InlineData("<img srcset='javascript:alert() 300w, https://example.com 600w'>", "<img srcset='' />")]
     [InlineData("<img srcset='https://example.com 300w, https://example.com 600w'>", "<img srcset='https://example.com 300w, https://example.com 600w' />")]
+    // Comments are removed: they are serialized verbatim, and browsers end them at "--!>" or treat
+    // "<!-->" as a complete comment, which would turn the content into live markup
+    [InlineData("<!-- comment -->test", "test")]
+    [InlineData("<p>a<!--<script>-->b</p>", "<p>ab</p>")]
+    [InlineData("<!--x--!><img src=x onerror=alert(1)>-->", "")]
+    [InlineData("<!--[if IE]><img src=x onerror=alert(1)><![endif]-->", "")]
+    // CDATA sections are removed: browsers parse "<![CDATA[" as a comment ending at the first ">"
+    [InlineData("<![CDATA[> <img src=x onerror=alert(1)>]]>", "")]
+    [InlineData("<p><![CDATA[<script>alert(1)</script>]]></p>", "<p></p>")]
+    // Markup left in text nodes by the parser's error recovery is escaped
+    [InlineData("<!--> <img src=x onerror=alert(1)>", "&lt;&lt;!--&gt; &lt;img src=x onerror=alert(1)&gt;")]
+    [InlineData("<div>a</div", "<div>a&lt;/div</div>")]
+    [InlineData("<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>", "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>")]
+    [InlineData("<p>a &amp; b</p>", "<p>a &amp; b</p>")]
+    // Prefixed attributes are subject to the allow list like any other attribute
+    [InlineData("<p foo:onclick='alert(1)'>test</p>", "<p>test</p>")]
+    [InlineData("<p v-on:click='alert(1)'>test</p>", "<p>test</p>")]
+    [InlineData("<p xmlns:x='y' x:onclick='alert(1)'>test</p>", "<p>test</p>")]
+    [InlineData("<a xlink:href='javascript:alert(1)'>test</a>", "<a xlink:href=''>test</a>")]
+    [InlineData("<a xlink:href='https://example.com'>test</a>", "<a xlink:href='https://example.com'>test</a>")]
     public void Sanitize(string html, string expectedResult)
     {
         var sanitizer = new HtmlSanitizer();
         var actual = sanitizer.SanitizeHtmlFragment(html);
         Assert.Equal(expectedResult, actual);
+
+        // Sanitizing an already-sanitized fragment must be a no-op. If it is not, the output does not
+        // re-parse to the tree it was serialized from, which is how markup smuggles itself back in.
+        Assert.Equal(actual, sanitizer.SanitizeHtmlFragment(actual));
     }
 }


### PR DESCRIPTION
## What

Fixes three ways markup could get through `HtmlSanitizer`, plus a fourth found while verifying the first two.

**Comments and CDATA sections passed through verbatim.** Browsers close them earlier than the parser does: a comment also ends at `--!>`, `<!-->` is already a complete comment, and `<![CDATA[` is a bogus comment ending at the first `>`. Everything after those points became live markup. Both of these survived sanitization unchanged and executed in Chromium:

```
<![CDATA[> <img src=x onerror=alert(1)>]]>
<!--x--!><img src=x onerror=alert(1)>-->
```

`Sanitize` is now fail-closed on node type — only elements and plain text nodes are kept.

**Text nodes were written unescaped.** Dropping comment nodes was not enough: an unterminated comment never becomes a comment node at all. `HtmlReader` re-emits it as a raw text node, and `HtmlText.WriteTo` writes text verbatim, so `<!--> <img src=x onerror=alert(1)>` was still live after the first fix. Markup characters in kept text nodes are now escaped. Entities are deliberately left alone: the parser does not decode them, so escaping `&` would turn `&amp;` into `&amp;amp;`.

**Prefixed attributes bypassed the allow list entirely.** `RemoveAttribute(name, namespaceURI)` looks the attribute up by *local* name, but the *qualified* name was passed as the local name. The lookup never matched, and the failed removal was ignored — so every attribute whose name contains a colon survived, e.g. `<p foo:onclick="alert(1)" v-on:click="alert(1)">`. Attributes are now removed by index.

## Why it matters

The first two are live XSS. Inert in plain HTML, the third breaks the documented allow-list contract and is exploitable when the output feeds a client-side template engine (`v-on:click`, `:href`) or when a caller adds `svg`/`use` to `ValidElements`.

## Verification

- 15 new test cases using the exact attack strings.
- The existing theory now also asserts **idempotency** (`sanitize(sanitize(x)) == sanitize(x)`). This is the canary for the whole bug class — every one of these vectors showed up as a fragment that changed on a second pass, and it should catch the next one.
- Sanitized output re-checked in Chromium: `title=clean imgs=1 comments=0`. No handler fires, no comment nodes survive, and the `<!-->` payloads render as visible text. The one `<img>` is the legitimately allowed element with `onerror` stripped. The same harness reported the handler executing before the fix.
- 54 tests pass in Release with `TreatWarningsAsErrors`; the 86 `Meziantou.Framework.Html` tests still pass; `dotnet run ./eng/update-all.cs` produced no changes (public API untouched, so `ref/` is unchanged).

## Notes for the reviewer

- **Behavior change:** comments are no longer preserved in the output. They cannot be made safe without an escaping serializer, and this matches DOMPurify's default. Documented in the readme and in `<remarks>` on `SanitizeHtmlFragment`. Happy to add an opt-in `AllowComments` if you want the option.
- The readme also drops the claim that the library uses AngleSharp — it uses the parser from `Meziantou.Framework.Html`. Separate from the fix; say the word and I'll pull it out.
- Also removed a dead `attribute is null` check (the indexer returns non-null) and added a `HasAttributes` guard.

## Known issues left open

Found during the same review, deliberately not addressed here:

- Input nested deeper than 300 throws `HtmlException` from `HtmlNode.ClearCaches` during parsing — untrusted input crashes the caller with an undocumented exception.
- `file:` is in the default safe-protocol list; Angular's list, which this derives from, is not.
- `BlockedElements` is dead code: blocked and not-allowed elements both take the same `Remove()` path, which contradicts the readme.
- `<p>5 < 6</p>` still loses the `<` and the following token — parser-side data loss the sanitizer cannot recover.
- Performance: 282 KB in ≈45 ms and ≈48 MB allocated (~175x the input). The cost is the parser, not the traversal — `HtmlReader` materializes `Value.ToString()` per character inside the state machine. Also, `RegexOptions.Compiled` on `[GeneratedRegex]` is a no-op (verified in the generated source).
