### PR TITLE
Fix flaky InlineSnapshotSettingsTests environment variable tests

### DIFF
--- a/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
+++ b/tests/Meziantou.Framework.InlineSnapshotTesting.Tests/InlineSnapshotSettingsTests.cs
@@ -1,6 +1,10 @@
 using Meziantou.Framework.InlineSnapshotTesting.Serialization;
 
 namespace Meziantou.Framework.InlineSnapshotTesting.Tests;
+
+// Some tests set the INLINESNAPSHOTTESTING_STRATEGY environment variable, which is process-wide and is inherited by the
+// processes started by the other tests, so this class does not run in parallel.
+[TestClass(DisableParallelization = true)]
 public sealed class InlineSnapshotSettingsTests
 {
     private const string SnapshotUpdateStrategyEnvironmentVariableName = "INLINESNAPSHOTTESTING_STRATEGY";
@@ -115,6 +119,10 @@ public sealed class InlineSnapshotSettingsTests
 
         public EnvironmentVariableScope(string name, string? value)
         {
+            // InlineSnapshotSettings.Default is created by the type initializer, which reads the environment variable.
+            // Force it to run now, so the other tests of the assembly never observe the value set by this scope.
+            _ = InlineSnapshotSettings.Default;
+
             _name = name;
             _previousValue = Environment.GetEnvironmentVariable(name);
             Environment.SetEnvironmentVariable(name, value);


### PR DESCRIPTION
## Problem

`InlineSnapshotSettingsTests.SnapshotUpdateStrategy_Default_CanBeConfiguredUsingEnvironmentVariable` is flaky locally — it failed 2 out of 5 consecutive runs of the suite on `main`. The typical failure is the `value: "OverwriteWithoutFailure"` row asserting `Assert.Same(AlwaysWithoutFailure, ...)` but getting `Always`, i.e. reading the value another theory row had set.

## Root cause

`Meziantou.NET.Sdk.Test` generates `[assembly: Xunit.v3.Parallelization(Mode = ParallelMode.All)]` into `obj/`, which parallelizes *individual test cases*, not just collections. Three tests in this class mutate the process-wide `INLINESNAPSHOTTESTING_STRATEGY` variable through the `EnvironmentVariableScope` helper, and `SnapshotUpdateStrategy.Default` reads it, so the theory rows race each other.

CI is unaffected because `Directory.Build.props` sets `EnableXunitFullParallelization=false` when `GITHUB_ACTIONS` is set, and `XunitCollectionBehavior.cs` forces `ParallelMode.None` there.

Running just this class in isolation on unmodified `main` failed 4 of its 8 tests on the first attempt, which made the fix easy to verify.

## Changes

Two changes in `InlineSnapshotSettingsTests.cs`, 8 lines total:

1. **`[TestClass(DisableParallelization = true)]` on the class.** This is the xUnit v3 mechanism that applies precisely under `ParallelMode.All`, and it is already the idiom in this repo (see `RedisContainerTests`).

2. **Force `InlineSnapshotSettings.Default` to be created before the variable is changed.** This addresses a separate latent hazard found while investigating: `Default` is a `static ... = new()` created by the type initializer, which the first `new InlineSnapshotSettings()` triggers. If that first construction happened *inside* an `EnvironmentVariableScope`, the process-wide `Default` would keep e.g. `Overwrite` for the rest of the run — which for `SnapshotSerializerTests` would mean a mismatched snapshot silently rewriting the test source instead of failing. This is pure ordering, not parallelism.

### Why not `EnableXunitFullParallelization=false` in the csproj

That is what `Meziantou.Framework.SnapshotTesting.Tests` and a few other projects do, but here it is both insufficient and expensive:

- **Insufficient**: it only drops to collection-level parallelism, and the leak is wider than one class. `InlineSnapshotTests.ExecuteDotNet` starts `dotnet` child processes that inherit the parent environment block, so a concurrently-set `INLINESNAPSHOTTESTING_STRATEGY=Overwrite` would leak into the sample builds other tests run. `DisableParallelization` covers that too.
- **Expensive**: fully sequential (`ParallelMode.None`) takes 63s; the class-level fix keeps the suite at ~10s, unchanged.

## Verification

| Configuration | Result |
| --- | --- |
| Class in isolation, 30 consecutive runs | 30/30 green (control: failed on run 1) |
| Full suite `net10.0`, 9 runs | 115/115 each, ~10s |
| Full suite `net11.0`, 3 runs | 115/115 each |
| `XunitParallelizationMode=None` (CI semantics) | 115/115, 63s |
| Build with `GITHUB_ACTIONS=true` | succeeds, no duplicate-attribute conflict |

All builds and test runs used `/p:TreatWarningsAsErrors=true` (0 warnings, 0 errors). `dotnet run ./eng/update-all.cs` completed successfully and produced no file changes.