### PR TITLE
Fix OTLP response encoding, tail sampling, and add OTLP protocol support

### DIFF
--- a/ref/Meziantou.Framework.OpenTelemetryCollector.cs
+++ b/ref/Meziantou.Framework.OpenTelemetryCollector.cs
@@ -20,6 +20,7 @@ namespace Meziantou.Framework.OpenTelemetryCollector
     {
         public string Method { get => throw null; }
         public Meziantou.Framework.OpenTelemetryCollector.OpenTelemetryTransport Transport { get => throw null; }
+        public Meziantou.Framework.OpenTelemetryCollector.OpenTelemetryPartialSuccess PartialSuccess { get => throw null; }
     }
 
     public enum OpenTelemetryItemType
@@ -29,12 +30,20 @@ namespace Meziantou.Framework.OpenTelemetryCollector
         Metrics = 2
     }
 
+    public sealed class OpenTelemetryPartialSuccess
+    {
+        public long RejectedCount { get => throw null; }
+        public string? ErrorMessage { get => throw null; }
+        public void Reject(long count, string? errorMessage = null) { }
+    }
+
     public sealed class OpenTelemetryReceiverOptions
     {
         public string? HttpLogsEndpoint { get => throw null; set { } }
         public string? HttpTracesEndpoint { get => throw null; set { } }
         public string? HttpMetricsEndpoint { get => throw null; set { } }
         public bool EnableGrpcEndpoints { get => throw null; set { } }
+        public long? MaxHttpRequestBodySize { get => throw null; set { } }
         public System.Collections.Generic.IList<Meziantou.Framework.OpenTelemetryCollector.OpenTelemetrySampler> Samplers { get => throw null; }
     }
 
@@ -65,6 +74,7 @@ namespace Meziantou.Framework.OpenTelemetryCollector
         public int MaxBufferedSpans { get => throw null; set { } }
         public Meziantou.Framework.OpenTelemetryCollector.OpenTelemetryTailBufferOverflowPolicy OverflowPolicy { get => throw null; set { } }
         public Meziantou.Framework.OpenTelemetryCollector.OpenTelemetryTraceTailSampling? ShouldSample { get => throw null; set { } }
+        public System.TimeSpan? SweepInterval { get => throw null; set { } }
     }
 
     public sealed class OpenTelemetryTailTraceContext

--- a/ref/Meziantou.Framework.OpenTelemetryCollector.cs
+++ b/ref/Meziantou.Framework.OpenTelemetryCollector.cs
@@ -43,7 +43,6 @@ namespace Meziantou.Framework.OpenTelemetryCollector
         public string? HttpTracesEndpoint { get => throw null; set { } }
         public string? HttpMetricsEndpoint { get => throw null; set { } }
         public bool EnableGrpcEndpoints { get => throw null; set { } }
-        public long? MaxHttpRequestBodySize { get => throw null; set { } }
         public System.Collections.Generic.IList<Meziantou.Framework.OpenTelemetryCollector.OpenTelemetrySampler> Samplers { get => throw null; }
     }
 

--- a/src/Meziantou.Framework.OpenTelemetryCollector/Grpc/OpenTelemetryLogsGrpcService.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/Grpc/OpenTelemetryLogsGrpcService.cs
@@ -9,9 +9,10 @@ internal sealed class OpenTelemetryLogsGrpcService(OpenTelemetryRequestPipeline 
 
     public override async Task<ExportLogsServiceResponse> Export(ExportLogsServiceRequest request, ServerCallContext context)
     {
-        var receiverContext = OpenTelemetryHandlerContext.CreateGrpc(context.Method);
+        var partialSuccess = new OpenTelemetryPartialSuccess();
+        var receiverContext = OpenTelemetryHandlerContext.CreateGrpc(context.Method, partialSuccess);
         await _pipeline.HandleLogsAsync(receiverContext, request, context.CancellationToken);
 
-        return new ExportLogsServiceResponse();
+        return OpenTelemetryResponseFactory.CreateLogsResponse(partialSuccess);
     }
 }

--- a/src/Meziantou.Framework.OpenTelemetryCollector/Grpc/OpenTelemetryMetricsGrpcService.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/Grpc/OpenTelemetryMetricsGrpcService.cs
@@ -9,9 +9,10 @@ internal sealed class OpenTelemetryMetricsGrpcService(OpenTelemetryRequestPipeli
 
     public override async Task<ExportMetricsServiceResponse> Export(ExportMetricsServiceRequest request, ServerCallContext context)
     {
-        var receiverContext = OpenTelemetryHandlerContext.CreateGrpc(context.Method);
+        var partialSuccess = new OpenTelemetryPartialSuccess();
+        var receiverContext = OpenTelemetryHandlerContext.CreateGrpc(context.Method, partialSuccess);
         await _pipeline.HandleMetricsAsync(receiverContext, request, context.CancellationToken);
 
-        return new ExportMetricsServiceResponse();
+        return OpenTelemetryResponseFactory.CreateMetricsResponse(partialSuccess);
     }
 }

--- a/src/Meziantou.Framework.OpenTelemetryCollector/Grpc/OpenTelemetryTracesGrpcService.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/Grpc/OpenTelemetryTracesGrpcService.cs
@@ -9,9 +9,10 @@ internal sealed class OpenTelemetryTracesGrpcService(OpenTelemetryRequestPipelin
 
     public override async Task<ExportTraceServiceResponse> Export(ExportTraceServiceRequest request, ServerCallContext context)
     {
-        var receiverContext = OpenTelemetryHandlerContext.CreateGrpc(context.Method);
+        var partialSuccess = new OpenTelemetryPartialSuccess();
+        var receiverContext = OpenTelemetryHandlerContext.CreateGrpc(context.Method, partialSuccess);
         await _pipeline.HandleTracesAsync(receiverContext, request, context.CancellationToken);
 
-        return new ExportTraceServiceResponse();
+        return OpenTelemetryResponseFactory.CreateTracesResponse(partialSuccess);
     }
 }

--- a/src/Meziantou.Framework.OpenTelemetryCollector/Meziantou.Framework.OpenTelemetryCollector.csproj
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/Meziantou.Framework.OpenTelemetryCollector.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Version>2.0.1</Version>
+    <Version>2.1.0</Version>
     <Description>OpenTelemetry OTLP collector endpoint abstractions for HTTP and gRPC with configurable receiver mappings</Description>
     <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryEndpointRouteBuilderExtensions.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryEndpointRouteBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Google.Protobuf;
 using Meziantou.Framework.OpenTelemetryCollector.Abstractions.Grpc;
 using Microsoft.AspNetCore.Builder;
@@ -5,7 +6,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Microsoft.Net.Http.Headers;
 using OpenTelemetry.Proto.Collector.Logs.V1;
 using OpenTelemetry.Proto.Collector.Metrics.V1;
 using OpenTelemetry.Proto.Collector.Trace.V1;
@@ -14,31 +14,47 @@ namespace Meziantou.Framework.OpenTelemetryCollector;
 
 public static class OpenTelemetryEndpointRouteBuilderExtensions
 {
-    private const string ProtobufContentType = "application/x-protobuf";
-    private const string OctetStreamContentType = "application/octet-stream";
-
     public static IEndpointRouteBuilder MapOpenTelemetryReceiverEndpoints(this IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 
         var options = endpoints.ServiceProvider.GetRequiredService<IOptions<OpenTelemetryReceiverOptions>>().Value;
+        var maxRequestBodySize = options.MaxHttpRequestBodySize;
 
         if (options.HttpLogsEndpoint is not null)
         {
             endpoints.MapPost(options.HttpLogsEndpoint, (HttpRequest request, OpenTelemetryRequestPipeline pipeline, CancellationToken cancellationToken) =>
-                HandleLogsHttpRequestAsync(request, pipeline, cancellationToken));
+                HandleHttpRequestAsync(
+                    request,
+                    ExportLogsServiceRequest.Parser,
+                    (context, payload, ct) => pipeline.HandleLogsAsync(context, payload, ct),
+                    OpenTelemetryResponseFactory.CreateLogsResponse,
+                    maxRequestBodySize,
+                    cancellationToken));
         }
 
         if (options.HttpTracesEndpoint is not null)
         {
             endpoints.MapPost(options.HttpTracesEndpoint, (HttpRequest request, OpenTelemetryRequestPipeline pipeline, CancellationToken cancellationToken) =>
-                HandleTracesHttpRequestAsync(request, pipeline, cancellationToken));
+                HandleHttpRequestAsync(
+                    request,
+                    ExportTraceServiceRequest.Parser,
+                    (context, payload, ct) => pipeline.HandleTracesAsync(context, payload, ct),
+                    OpenTelemetryResponseFactory.CreateTracesResponse,
+                    maxRequestBodySize,
+                    cancellationToken));
         }
 
         if (options.HttpMetricsEndpoint is not null)
         {
             endpoints.MapPost(options.HttpMetricsEndpoint, (HttpRequest request, OpenTelemetryRequestPipeline pipeline, CancellationToken cancellationToken) =>
-                HandleMetricsHttpRequestAsync(request, pipeline, cancellationToken));
+                HandleHttpRequestAsync(
+                    request,
+                    ExportMetricsServiceRequest.Parser,
+                    (context, payload, ct) => pipeline.HandleMetricsAsync(context, payload, ct),
+                    OpenTelemetryResponseFactory.CreateMetricsResponse,
+                    maxRequestBodySize,
+                    cancellationToken));
         }
 
         if (options.EnableGrpcEndpoints)
@@ -51,88 +67,43 @@ public static class OpenTelemetryEndpointRouteBuilderExtensions
         return endpoints;
     }
 
-    private static Task<IResult> HandleLogsHttpRequestAsync(HttpRequest request, OpenTelemetryRequestPipeline pipeline, CancellationToken cancellationToken)
-    {
-        return HandleHttpRequestAsync(
-            request,
-            ExportLogsServiceRequest.Parser,
-            (context, payload, ct) => pipeline.HandleLogsAsync(context, payload, ct),
-            static () => new ExportLogsServiceResponse(),
-            cancellationToken);
-    }
-
-    private static Task<IResult> HandleTracesHttpRequestAsync(HttpRequest request, OpenTelemetryRequestPipeline pipeline, CancellationToken cancellationToken)
-    {
-        return HandleHttpRequestAsync(
-            request,
-            ExportTraceServiceRequest.Parser,
-            (context, payload, ct) => pipeline.HandleTracesAsync(context, payload, ct),
-            static () => new ExportTraceServiceResponse(),
-            cancellationToken);
-    }
-
-    private static Task<IResult> HandleMetricsHttpRequestAsync(HttpRequest request, OpenTelemetryRequestPipeline pipeline, CancellationToken cancellationToken)
-    {
-        return HandleHttpRequestAsync(
-            request,
-            ExportMetricsServiceRequest.Parser,
-            (context, payload, ct) => pipeline.HandleMetricsAsync(context, payload, ct),
-            static () => new ExportMetricsServiceResponse(),
-            cancellationToken);
-    }
-
     private static async Task<IResult> HandleHttpRequestAsync<TRequest, TResponse>(
         HttpRequest request,
         MessageParser<TRequest> parser,
         Func<OpenTelemetryHandlerContext, TRequest, CancellationToken, ValueTask> handler,
-        Func<TResponse> responseFactory,
+        Func<OpenTelemetryPartialSuccess, TResponse> responseFactory,
+        long? maxRequestBodySize,
         CancellationToken cancellationToken)
-        where TRequest : class, IMessage<TRequest>
+        where TRequest : class, IMessage<TRequest>, new()
+        where TResponse : class, IMessage<TResponse>
     {
-        if (!IsSupportedContentType(request.ContentType))
+        if (!OpenTelemetryHttpPayload.TryGetPayloadFormat(request.ContentType, out var format) ||
+            !OpenTelemetryHttpPayload.TryGetContentEncoding(request, out var decompressGzip))
         {
             return TypedResults.StatusCode(StatusCodes.Status415UnsupportedMediaType);
         }
 
-        TRequest payload;
+        var (payload, errorStatusCode) = await OpenTelemetryHttpPayload.ReadPayloadAsync(request, decompressGzip, maxRequestBodySize, cancellationToken);
+        if (payload is null)
+        {
+            return TypedResults.StatusCode(errorStatusCode);
+        }
+
+        TRequest message;
         try
         {
-            payload = await ParsePayloadAsync(parser, request, cancellationToken);
+            message = OpenTelemetryHttpPayload.Parse(parser, format, payload);
         }
-        catch (InvalidProtocolBufferException)
+        catch (Exception exception) when (exception is InvalidProtocolBufferException or InvalidJsonException or JsonException)
         {
             return TypedResults.BadRequest();
         }
 
+        var partialSuccess = new OpenTelemetryPartialSuccess();
         var method = $"{request.Method} {request.Path}";
-        var context = OpenTelemetryHandlerContext.CreateHttp(method);
-        await handler(context, payload, cancellationToken);
+        var context = OpenTelemetryHandlerContext.CreateHttp(method, partialSuccess);
+        await handler(context, message, cancellationToken);
 
-        return TypedResults.Ok(responseFactory());
-    }
-
-    private static bool IsSupportedContentType(string? contentType)
-    {
-        if (string.IsNullOrEmpty(contentType))
-        {
-            return true;
-        }
-
-        if (!MediaTypeHeaderValue.TryParse(contentType, out var mediaTypeHeaderValue))
-        {
-            return false;
-        }
-
-        var mediaType = mediaTypeHeaderValue.MediaType.Value;
-        return string.Equals(mediaType, ProtobufContentType, StringComparison.OrdinalIgnoreCase) ||
-               string.Equals(mediaType, OctetStreamContentType, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static async Task<TRequest> ParsePayloadAsync<TRequest>(MessageParser<TRequest> parser, HttpRequest request, CancellationToken cancellationToken)
-        where TRequest : class, IMessage<TRequest>
-    {
-        await using var stream = new MemoryStream();
-        await request.Body.CopyToAsync(stream, cancellationToken);
-        return parser.ParseFrom(stream.ToArray());
+        return new OpenTelemetryProtoResult<TResponse>(responseFactory(partialSuccess), format);
     }
 }

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryEndpointRouteBuilderExtensions.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryEndpointRouteBuilderExtensions.cs
@@ -19,7 +19,6 @@ public static class OpenTelemetryEndpointRouteBuilderExtensions
         ArgumentNullException.ThrowIfNull(endpoints);
 
         var options = endpoints.ServiceProvider.GetRequiredService<IOptions<OpenTelemetryReceiverOptions>>().Value;
-        var maxRequestBodySize = options.MaxHttpRequestBodySize;
 
         if (options.HttpLogsEndpoint is not null)
         {
@@ -29,7 +28,6 @@ public static class OpenTelemetryEndpointRouteBuilderExtensions
                     ExportLogsServiceRequest.Parser,
                     (context, payload, ct) => pipeline.HandleLogsAsync(context, payload, ct),
                     OpenTelemetryResponseFactory.CreateLogsResponse,
-                    maxRequestBodySize,
                     cancellationToken));
         }
 
@@ -41,7 +39,6 @@ public static class OpenTelemetryEndpointRouteBuilderExtensions
                     ExportTraceServiceRequest.Parser,
                     (context, payload, ct) => pipeline.HandleTracesAsync(context, payload, ct),
                     OpenTelemetryResponseFactory.CreateTracesResponse,
-                    maxRequestBodySize,
                     cancellationToken));
         }
 
@@ -53,7 +50,6 @@ public static class OpenTelemetryEndpointRouteBuilderExtensions
                     ExportMetricsServiceRequest.Parser,
                     (context, payload, ct) => pipeline.HandleMetricsAsync(context, payload, ct),
                     OpenTelemetryResponseFactory.CreateMetricsResponse,
-                    maxRequestBodySize,
                     cancellationToken));
         }
 
@@ -72,30 +68,24 @@ public static class OpenTelemetryEndpointRouteBuilderExtensions
         MessageParser<TRequest> parser,
         Func<OpenTelemetryHandlerContext, TRequest, CancellationToken, ValueTask> handler,
         Func<OpenTelemetryPartialSuccess, TResponse> responseFactory,
-        long? maxRequestBodySize,
         CancellationToken cancellationToken)
         where TRequest : class, IMessage<TRequest>, new()
         where TResponse : class, IMessage<TResponse>
     {
-        if (!OpenTelemetryHttpPayload.TryGetPayloadFormat(request.ContentType, out var format) ||
-            !OpenTelemetryHttpPayload.TryGetContentEncoding(request, out var decompressGzip))
+        if (!OpenTelemetryHttpPayload.TryGetPayloadFormat(request.ContentType, out var format))
         {
             return TypedResults.StatusCode(StatusCodes.Status415UnsupportedMediaType);
-        }
-
-        var (payload, errorStatusCode) = await OpenTelemetryHttpPayload.ReadPayloadAsync(request, decompressGzip, maxRequestBodySize, cancellationToken);
-        if (payload is null)
-        {
-            return TypedResults.StatusCode(errorStatusCode);
         }
 
         TRequest message;
         try
         {
+            var payload = await OpenTelemetryHttpPayload.ReadPayloadAsync(request, cancellationToken);
             message = OpenTelemetryHttpPayload.Parse(parser, format, payload);
         }
-        catch (Exception exception) when (exception is InvalidProtocolBufferException or InvalidJsonException or JsonException)
+        catch (Exception exception) when (exception is InvalidProtocolBufferException or InvalidJsonException or JsonException or InvalidDataException)
         {
+            // The payload is malformed, or the request decompression middleware could not decompress it
             return TypedResults.BadRequest();
         }
 

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryHandlerContext.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryHandlerContext.cs
@@ -2,23 +2,29 @@ namespace Meziantou.Framework.OpenTelemetryCollector;
 
 public readonly struct OpenTelemetryHandlerContext
 {
-    internal OpenTelemetryHandlerContext(OpenTelemetryTransport transport, string method)
+    private readonly OpenTelemetryPartialSuccess? _partialSuccess;
+
+    internal OpenTelemetryHandlerContext(OpenTelemetryTransport transport, string method, OpenTelemetryPartialSuccess partialSuccess)
     {
         Transport = transport;
         Method = method;
+        _partialSuccess = partialSuccess;
     }
 
     public string Method { get; }
 
     public OpenTelemetryTransport Transport { get; }
 
-    internal static OpenTelemetryHandlerContext CreateHttp(string method)
+    /// <summary>Gets the object used to report the records that could not be accepted, so they are sent back to the client in the OTLP <c>partial_success</c> response field.</summary>
+    public OpenTelemetryPartialSuccess PartialSuccess => _partialSuccess ?? OpenTelemetryPartialSuccess.Discarded;
+
+    internal static OpenTelemetryHandlerContext CreateHttp(string method, OpenTelemetryPartialSuccess partialSuccess)
     {
-        return new OpenTelemetryHandlerContext(OpenTelemetryTransport.Http, method);
+        return new OpenTelemetryHandlerContext(OpenTelemetryTransport.Http, method, partialSuccess);
     }
 
-    internal static OpenTelemetryHandlerContext CreateGrpc(string method)
+    internal static OpenTelemetryHandlerContext CreateGrpc(string method, OpenTelemetryPartialSuccess partialSuccess)
     {
-        return new OpenTelemetryHandlerContext(OpenTelemetryTransport.Grpc, method);
+        return new OpenTelemetryHandlerContext(OpenTelemetryTransport.Grpc, method, partialSuccess);
     }
 }

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryHttpPayload.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryHttpPayload.cs
@@ -1,5 +1,4 @@
 using System.Buffers;
-using System.IO.Compression;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Google.Protobuf;
@@ -13,10 +12,6 @@ internal static class OpenTelemetryHttpPayload
     public const string ProtobufContentType = "application/x-protobuf";
     public const string OctetStreamContentType = "application/octet-stream";
     public const string JsonContentType = "application/json";
-
-    private const string GzipContentEncoding = "gzip";
-    private const string IdentityContentEncoding = "identity";
-    private const int CopyBufferSize = 81920;
 
     private static readonly JsonParser OtlpJsonParser = new(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
 
@@ -50,92 +45,18 @@ internal static class OpenTelemetryHttpPayload
         return false;
     }
 
-    /// <summary>Determines whether the <c>Content-Encoding</c> of the request is supported.</summary>
-    public static bool TryGetContentEncoding(HttpRequest request, out bool decompressGzip)
+    /// <summary>Reads the request body.</summary>
+    /// <remarks>
+    /// Decompression and request size limits are handled by ASP.NET Core, through the request decompression
+    /// middleware and the server limits. Reading a body that could not be decompressed throws <see cref="InvalidDataException"/>.
+    /// </remarks>
+    public static async Task<byte[]> ReadPayloadAsync(HttpRequest request, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        decompressGzip = false;
-        foreach (var headerValue in request.Headers.ContentEncoding)
-        {
-            if (string.IsNullOrEmpty(headerValue))
-            {
-                continue;
-            }
-
-            foreach (var range in headerValue.AsSpan().Split(','))
-            {
-                var encoding = headerValue.AsSpan(range).Trim();
-                if (encoding.IsEmpty || encoding.Equals(IdentityContentEncoding, StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                // Only a single gzip layer is supported. Anything else must be reported as an unsupported media type.
-                if (!encoding.Equals(GzipContentEncoding, StringComparison.OrdinalIgnoreCase) || decompressGzip)
-                {
-                    return false;
-                }
-
-                decompressGzip = true;
-            }
-        }
-
-        return true;
-    }
-
-    /// <summary>Reads the request body, optionally decompressing it, and enforces <paramref name="maxRequestBodySize"/> on the decompressed payload.</summary>
-    /// <returns>The payload, or an HTTP status code describing why the payload could not be read.</returns>
-    public static async Task<(byte[]? Payload, int ErrorStatusCode)> ReadPayloadAsync(HttpRequest request, bool decompressGzip, long? maxRequestBodySize, CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-
-        try
-        {
-            // The limit is enforced on the decompressed payload so a compressed request cannot expand beyond it.
-            if (decompressGzip)
-            {
-                await using var gzipStream = new GZipStream(request.Body, CompressionMode.Decompress, leaveOpen: true);
-                return await ReadPayloadCoreAsync(gzipStream, maxRequestBodySize, cancellationToken);
-            }
-
-            return await ReadPayloadCoreAsync(request.Body, maxRequestBodySize, cancellationToken);
-        }
-        catch (InvalidDataException)
-        {
-            // The body is not a valid gzip stream
-            return (null, StatusCodes.Status400BadRequest);
-        }
-    }
-
-    private static async Task<(byte[]? Payload, int ErrorStatusCode)> ReadPayloadCoreAsync(Stream stream, long? maxRequestBodySize, CancellationToken cancellationToken)
-    {
         using var buffer = new MemoryStream();
-        var rentedBuffer = ArrayPool<byte>.Shared.Rent(CopyBufferSize);
-        try
-        {
-            while (true)
-            {
-                var readCount = await stream.ReadAsync(rentedBuffer, cancellationToken);
-                if (readCount is 0)
-                {
-                    break;
-                }
-
-                if (maxRequestBodySize is { } maxSize && buffer.Length + readCount > maxSize)
-                {
-                    return (null, StatusCodes.Status413PayloadTooLarge);
-                }
-
-                buffer.Write(rentedBuffer, 0, readCount);
-            }
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(rentedBuffer);
-        }
-
-        return (buffer.ToArray(), 0);
+        await request.Body.CopyToAsync(buffer, cancellationToken);
+        return buffer.ToArray();
     }
 
     public static TRequest Parse<TRequest>(MessageParser<TRequest> parser, OpenTelemetryPayloadFormat format, byte[] payload)

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryHttpPayload.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryHttpPayload.cs
@@ -1,0 +1,243 @@
+using System.Buffers;
+using System.IO.Compression;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Google.Protobuf;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace Meziantou.Framework.OpenTelemetryCollector;
+
+internal static class OpenTelemetryHttpPayload
+{
+    public const string ProtobufContentType = "application/x-protobuf";
+    public const string OctetStreamContentType = "application/octet-stream";
+    public const string JsonContentType = "application/json";
+
+    private const string GzipContentEncoding = "gzip";
+    private const string IdentityContentEncoding = "identity";
+    private const int CopyBufferSize = 81920;
+
+    private static readonly JsonParser OtlpJsonParser = new(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+
+    public static bool TryGetPayloadFormat(string? contentType, out OpenTelemetryPayloadFormat format)
+    {
+        format = OpenTelemetryPayloadFormat.Protobuf;
+        if (string.IsNullOrEmpty(contentType))
+        {
+            return true;
+        }
+
+        if (!MediaTypeHeaderValue.TryParse(contentType, out var mediaTypeHeaderValue))
+        {
+            return false;
+        }
+
+        var mediaType = mediaTypeHeaderValue.MediaType.Value;
+        if (string.Equals(mediaType, ProtobufContentType, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(mediaType, OctetStreamContentType, StringComparison.OrdinalIgnoreCase))
+        {
+            format = OpenTelemetryPayloadFormat.Protobuf;
+            return true;
+        }
+
+        if (string.Equals(mediaType, JsonContentType, StringComparison.OrdinalIgnoreCase))
+        {
+            format = OpenTelemetryPayloadFormat.Json;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Determines whether the <c>Content-Encoding</c> of the request is supported.</summary>
+    public static bool TryGetContentEncoding(HttpRequest request, out bool decompressGzip)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        decompressGzip = false;
+        foreach (var headerValue in request.Headers.ContentEncoding)
+        {
+            if (string.IsNullOrEmpty(headerValue))
+            {
+                continue;
+            }
+
+            foreach (var range in headerValue.AsSpan().Split(','))
+            {
+                var encoding = headerValue.AsSpan(range).Trim();
+                if (encoding.IsEmpty || encoding.Equals(IdentityContentEncoding, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // Only a single gzip layer is supported. Anything else must be reported as an unsupported media type.
+                if (!encoding.Equals(GzipContentEncoding, StringComparison.OrdinalIgnoreCase) || decompressGzip)
+                {
+                    return false;
+                }
+
+                decompressGzip = true;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>Reads the request body, optionally decompressing it, and enforces <paramref name="maxRequestBodySize"/> on the decompressed payload.</summary>
+    /// <returns>The payload, or an HTTP status code describing why the payload could not be read.</returns>
+    public static async Task<(byte[]? Payload, int ErrorStatusCode)> ReadPayloadAsync(HttpRequest request, bool decompressGzip, long? maxRequestBodySize, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            // The limit is enforced on the decompressed payload so a compressed request cannot expand beyond it.
+            if (decompressGzip)
+            {
+                await using var gzipStream = new GZipStream(request.Body, CompressionMode.Decompress, leaveOpen: true);
+                return await ReadPayloadCoreAsync(gzipStream, maxRequestBodySize, cancellationToken);
+            }
+
+            return await ReadPayloadCoreAsync(request.Body, maxRequestBodySize, cancellationToken);
+        }
+        catch (InvalidDataException)
+        {
+            // The body is not a valid gzip stream
+            return (null, StatusCodes.Status400BadRequest);
+        }
+    }
+
+    private static async Task<(byte[]? Payload, int ErrorStatusCode)> ReadPayloadCoreAsync(Stream stream, long? maxRequestBodySize, CancellationToken cancellationToken)
+    {
+        using var buffer = new MemoryStream();
+        var rentedBuffer = ArrayPool<byte>.Shared.Rent(CopyBufferSize);
+        try
+        {
+            while (true)
+            {
+                var readCount = await stream.ReadAsync(rentedBuffer, cancellationToken);
+                if (readCount is 0)
+                {
+                    break;
+                }
+
+                if (maxRequestBodySize is { } maxSize && buffer.Length + readCount > maxSize)
+                {
+                    return (null, StatusCodes.Status413PayloadTooLarge);
+                }
+
+                buffer.Write(rentedBuffer, 0, readCount);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rentedBuffer);
+        }
+
+        return (buffer.ToArray(), 0);
+    }
+
+    public static TRequest Parse<TRequest>(MessageParser<TRequest> parser, OpenTelemetryPayloadFormat format, byte[] payload)
+        where TRequest : class, IMessage<TRequest>, new()
+    {
+        ArgumentNullException.ThrowIfNull(parser);
+        ArgumentNullException.ThrowIfNull(payload);
+
+        if (format is OpenTelemetryPayloadFormat.Json)
+        {
+            var node = JsonNode.Parse(payload) ?? throw new JsonException("The OTLP/JSON payload is null.");
+            NormalizeIdentifiers(node);
+            return OtlpJsonParser.Parse<TRequest>(node.ToJsonString());
+        }
+
+        return parser.ParseFrom(payload);
+    }
+
+    /// <summary>Converts the hex-encoded identifiers of an OTLP/JSON payload to the base64 encoding used by the Protobuf JSON mapping.</summary>
+    /// <remarks>
+    /// OTLP/JSON deviates from the Protobuf JSON mapping: <c>trace_id</c> and <c>span_id</c> are hex-encoded instead of
+    /// base64-encoded. Both encodings have distinct lengths for a given identifier size, so they cannot be confused.
+    /// </remarks>
+    private static void NormalizeIdentifiers(JsonNode? node)
+    {
+        switch (node)
+        {
+            case JsonObject jsonObject:
+            {
+                List<KeyValuePair<string, string>>? updates = null;
+                foreach (var property in jsonObject)
+                {
+                    if (TryGetIdentifierByteCount(property.Key, out var byteCount)
+                        && property.Value is JsonValue jsonValue
+                        && jsonValue.TryGetValue<string>(out var text)
+                        && TryConvertHexToBase64(text, byteCount, out var base64))
+                    {
+                        updates ??= [];
+                        updates.Add(new KeyValuePair<string, string>(property.Key, base64));
+                    }
+                    else
+                    {
+                        NormalizeIdentifiers(property.Value);
+                    }
+                }
+
+                if (updates is not null)
+                {
+                    foreach (var (propertyName, value) in updates)
+                    {
+                        jsonObject[propertyName] = value;
+                    }
+                }
+
+                break;
+            }
+
+            case JsonArray jsonArray:
+            {
+                foreach (var item in jsonArray)
+                {
+                    NormalizeIdentifiers(item);
+                }
+
+                break;
+            }
+        }
+    }
+
+    private static bool TryGetIdentifierByteCount(string propertyName, out int byteCount)
+    {
+        switch (propertyName)
+        {
+            case "traceId" or "trace_id":
+                byteCount = 16;
+                return true;
+
+            case "spanId" or "span_id" or "parentSpanId" or "parent_span_id":
+                byteCount = 8;
+                return true;
+
+            default:
+                byteCount = 0;
+                return false;
+        }
+    }
+
+    private static bool TryConvertHexToBase64(string? value, int byteCount, [NotNullWhen(true)] out string? base64)
+    {
+        base64 = null;
+        if (value is null || value.Length != byteCount * 2)
+        {
+            return false;
+        }
+
+        Span<byte> bytes = stackalloc byte[16];
+        if (Convert.FromHexString(value, bytes, out _, out var written) is not OperationStatus.Done || written != byteCount)
+        {
+            return false;
+        }
+
+        base64 = Convert.ToBase64String(bytes[..byteCount]);
+        return true;
+    }
+}

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryPartialSuccess.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryPartialSuccess.cs
@@ -1,0 +1,86 @@
+namespace Meziantou.Framework.OpenTelemetryCollector;
+
+/// <summary>Collects the records rejected while handling an OTLP export request, so they can be reported back to the client through the OTLP <c>partial_success</c> response field.</summary>
+/// <remarks>
+/// Samplers and handlers can call <see cref="Reject(long, string?)"/> to report that some records could not be accepted.
+/// Rejected records are aggregated across all samplers and handlers of a single request.
+/// <para>
+/// Calls made after the response has been sent are ignored. This happens when a trace is dispatched by
+/// <see cref="OpenTelemetryTailSampler"/> because the spans are buffered and dispatched after the originating request completed.
+/// </para>
+/// </remarks>
+public sealed class OpenTelemetryPartialSuccess
+{
+    /// <summary>An instance that discards everything reported to it.</summary>
+    internal static OpenTelemetryPartialSuccess Discarded { get; } = new(discard: true);
+
+    private readonly Lock _gate = new();
+    private readonly bool _discard;
+
+    private long _rejectedCount;
+    private string? _errorMessage;
+
+    internal OpenTelemetryPartialSuccess()
+    {
+    }
+
+    private OpenTelemetryPartialSuccess(bool discard)
+    {
+        _discard = discard;
+    }
+
+    /// <summary>Gets the number of records rejected so far.</summary>
+    public long RejectedCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _rejectedCount;
+            }
+        }
+    }
+
+    /// <summary>Gets the aggregated error message describing why records were rejected, or <see langword="null"/> when no message was reported.</summary>
+    public string? ErrorMessage
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _errorMessage;
+            }
+        }
+    }
+
+    /// <summary>Reports that <paramref name="count"/> records were rejected.</summary>
+    /// <param name="count">The number of rejected records. Can be <c>0</c> to report a warning without rejecting any record.</param>
+    /// <param name="errorMessage">An optional human-readable message describing why the records were rejected.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is negative.</exception>
+    public void Reject(long count, string? errorMessage = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+        if (_discard || (count is 0 && string.IsNullOrEmpty(errorMessage)))
+            return;
+
+        lock (_gate)
+        {
+            _rejectedCount += count;
+            if (!string.IsNullOrEmpty(errorMessage))
+            {
+                _errorMessage = string.IsNullOrEmpty(_errorMessage) ? errorMessage : _errorMessage + "; " + errorMessage;
+            }
+        }
+    }
+
+    internal bool TryGetResult(out long rejectedCount, out string errorMessage)
+    {
+        lock (_gate)
+        {
+            rejectedCount = _rejectedCount;
+            errorMessage = _errorMessage ?? "";
+            return rejectedCount > 0 || errorMessage.Length > 0;
+        }
+    }
+}

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryPayloadFormat.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryPayloadFormat.cs
@@ -1,0 +1,7 @@
+namespace Meziantou.Framework.OpenTelemetryCollector;
+
+internal enum OpenTelemetryPayloadFormat
+{
+    Protobuf,
+    Json,
+}

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryProtoResult.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryProtoResult.cs
@@ -1,0 +1,32 @@
+using System.Text;
+using Google.Protobuf;
+using Microsoft.AspNetCore.Http;
+
+namespace Meziantou.Framework.OpenTelemetryCollector;
+
+/// <summary>Writes an OTLP response using the same encoding as the request, as required by the OTLP/HTTP specification.</summary>
+internal sealed class OpenTelemetryProtoResult<TResponse>(TResponse message, OpenTelemetryPayloadFormat format) : IResult
+    where TResponse : class, IMessage<TResponse>
+{
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        string contentType;
+        byte[] body;
+        if (format is OpenTelemetryPayloadFormat.Json)
+        {
+            contentType = OpenTelemetryHttpPayload.JsonContentType;
+            body = Encoding.UTF8.GetBytes(JsonFormatter.Default.Format(message));
+        }
+        else
+        {
+            contentType = OpenTelemetryHttpPayload.ProtobufContentType;
+            body = message.ToByteArray();
+        }
+
+        httpContext.Response.ContentType = contentType;
+        httpContext.Response.ContentLength = body.Length;
+        return httpContext.Response.Body.WriteAsync(body, httpContext.RequestAborted).AsTask();
+    }
+}

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryReceiverOptions.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryReceiverOptions.cs
@@ -7,5 +7,13 @@ public sealed class OpenTelemetryReceiverOptions
     public string? HttpMetricsEndpoint { get; set; } = "/v1/metrics";
     public bool EnableGrpcEndpoints { get; set; } = true;
 
+    /// <summary>Gets or sets the maximum size, in bytes, of an OTLP/HTTP request payload. Larger payloads are rejected with <c>413 Content Too Large</c>.</summary>
+    /// <remarks>
+    /// The limit applies to the payload after decompression, so a compressed request cannot expand beyond this size.
+    /// Set to <see langword="null"/> to only rely on the limit configured on the web server.
+    /// </remarks>
+    /// <value>The default value is 20 MiB.</value>
+    public long? MaxHttpRequestBodySize { get; set; } = 20 * 1024 * 1024;
+
     public IList<OpenTelemetrySampler> Samplers { get; } = [];
 }

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryReceiverOptions.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryReceiverOptions.cs
@@ -7,13 +7,5 @@ public sealed class OpenTelemetryReceiverOptions
     public string? HttpMetricsEndpoint { get; set; } = "/v1/metrics";
     public bool EnableGrpcEndpoints { get; set; } = true;
 
-    /// <summary>Gets or sets the maximum size, in bytes, of an OTLP/HTTP request payload. Larger payloads are rejected with <c>413 Content Too Large</c>.</summary>
-    /// <remarks>
-    /// The limit applies to the payload after decompression, so a compressed request cannot expand beyond this size.
-    /// Set to <see langword="null"/> to only rely on the limit configured on the web server.
-    /// </remarks>
-    /// <value>The default value is 20 MiB.</value>
-    public long? MaxHttpRequestBodySize { get; set; } = 20 * 1024 * 1024;
-
     public IList<OpenTelemetrySampler> Samplers { get; } = [];
 }

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryRequestPipeline.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryRequestPipeline.cs
@@ -84,6 +84,19 @@ internal sealed class OpenTelemetryRequestPipeline
         await _tailSamplerHandler.HandleAsync(context, request, _tailSampler, DispatchTracesAsync, cancellationToken);
     }
 
+    /// <summary>Gets the interval at which buffered traces must be swept, or <see langword="null"/> when no tail sampler is configured.</summary>
+    public TimeSpan? TailSamplerSweepInterval => _tailSampler?.GetSweepInterval();
+
+    public ValueTask FlushTimedOutTracesAsync(CancellationToken cancellationToken)
+    {
+        if (_tailSampler is null)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return _tailSamplerHandler.FlushTimedOutTracesAsync(_tailSampler, DispatchTracesAsync, cancellationToken);
+    }
+
     private async ValueTask DispatchTracesAsync(OpenTelemetryHandlerContext context, ExportTraceServiceRequest request, CancellationToken cancellationToken)
     {
         foreach (var receiver in _receivers)

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryResponseFactory.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryResponseFactory.cs
@@ -1,0 +1,53 @@
+using OpenTelemetry.Proto.Collector.Logs.V1;
+using OpenTelemetry.Proto.Collector.Metrics.V1;
+using OpenTelemetry.Proto.Collector.Trace.V1;
+
+namespace Meziantou.Framework.OpenTelemetryCollector;
+
+internal static class OpenTelemetryResponseFactory
+{
+    public static ExportLogsServiceResponse CreateLogsResponse(OpenTelemetryPartialSuccess partialSuccess)
+    {
+        var response = new ExportLogsServiceResponse();
+        if (partialSuccess.TryGetResult(out var rejectedCount, out var errorMessage))
+        {
+            response.PartialSuccess = new ExportLogsPartialSuccess
+            {
+                RejectedLogRecords = rejectedCount,
+                ErrorMessage = errorMessage,
+            };
+        }
+
+        return response;
+    }
+
+    public static ExportTraceServiceResponse CreateTracesResponse(OpenTelemetryPartialSuccess partialSuccess)
+    {
+        var response = new ExportTraceServiceResponse();
+        if (partialSuccess.TryGetResult(out var rejectedCount, out var errorMessage))
+        {
+            response.PartialSuccess = new ExportTracePartialSuccess
+            {
+                RejectedSpans = rejectedCount,
+                ErrorMessage = errorMessage,
+            };
+        }
+
+        return response;
+    }
+
+    public static ExportMetricsServiceResponse CreateMetricsResponse(OpenTelemetryPartialSuccess partialSuccess)
+    {
+        var response = new ExportMetricsServiceResponse();
+        if (partialSuccess.TryGetResult(out var rejectedCount, out var errorMessage))
+        {
+            response.PartialSuccess = new ExportMetricsPartialSuccess
+            {
+                RejectedDataPoints = rejectedCount,
+                ErrorMessage = errorMessage,
+            };
+        }
+
+        return response;
+    }
+}

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryServiceCollectionExtensions.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace Meziantou.Framework.OpenTelemetryCollector;
 
@@ -11,6 +12,7 @@ public static class OpenTelemetryServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         AddOpenTelemetryInfrastructure(services, configure);
+        services.TryAddSingleton<TReceiver>();
         services.AddSingleton<OpenTelemetryHandlerRegistration>(static serviceProvider => new OpenTelemetryHandlerRegistration(serviceProvider.GetRequiredService<TReceiver>()));
         return services;
     }
@@ -36,7 +38,9 @@ public static class OpenTelemetryServiceCollectionExtensions
             services.Configure(configure);
         }
 
+        services.TryAddSingleton(TimeProvider.System);
         services.TryAddSingleton<OpenTelemetryTraceTailSamplerHandler>();
         services.TryAddSingleton<OpenTelemetryRequestPipeline>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, OpenTelemetryTailSamplerBackgroundService>());
     }
 }

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryTailSampler.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryTailSampler.cs
@@ -11,4 +11,20 @@ public sealed class OpenTelemetryTailSampler : OpenTelemetrySampler
     public OpenTelemetryTailBufferOverflowPolicy OverflowPolicy { get; set; } = OpenTelemetryTailBufferOverflowPolicy.DropWholeTrace;
 
     public OpenTelemetryTraceTailSampling? ShouldSample { get; set; }
+
+    /// <summary>Gets or sets how often buffered traces are checked for reaching <see cref="MaxTraceDuration"/>.</summary>
+    /// <remarks>
+    /// Traces that never receive their root span are evaluated by a background sweep, so they are released even when no
+    /// other trace is received. When <see langword="null"/>, the interval is a quarter of <see cref="MaxTraceDuration"/>.
+    /// </remarks>
+    public TimeSpan? SweepInterval { get; set; }
+
+    internal TimeSpan GetSweepInterval()
+    {
+        if (SweepInterval is { } interval && interval > TimeSpan.Zero)
+            return interval;
+
+        var ticks = Math.Max(MaxTraceDuration.Ticks / 4, TimeSpan.TicksPerMillisecond);
+        return TimeSpan.FromTicks(ticks);
+    }
 }

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryTailSamplerBackgroundService.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryTailSamplerBackgroundService.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Meziantou.Framework.OpenTelemetryCollector;
+
+/// <summary>Periodically releases the buffered traces that reached <see cref="OpenTelemetryTailSampler.MaxTraceDuration"/>.</summary>
+internal sealed class OpenTelemetryTailSamplerBackgroundService(
+    OpenTelemetryRequestPipeline pipeline,
+    TimeProvider timeProvider,
+    ILogger<OpenTelemetryTailSamplerBackgroundService> logger) : BackgroundService
+{
+    private readonly OpenTelemetryRequestPipeline _pipeline = pipeline;
+    private readonly TimeProvider _timeProvider = timeProvider;
+    private readonly ILogger<OpenTelemetryTailSamplerBackgroundService> _logger = logger;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (_pipeline.TailSamplerSweepInterval is not { } interval)
+        {
+            return;
+        }
+
+        using var timer = new PeriodicTimer(interval, _timeProvider);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken))
+            {
+                try
+                {
+                    await _pipeline.FlushTimedOutTracesAsync(stoppingToken);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Cannot dispatch the buffered traces that reached the maximum trace duration");
+                }
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+        }
+    }
+}

--- a/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryTraceTailSamplerHandler.cs
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/OpenTelemetryTraceTailSamplerHandler.cs
@@ -5,11 +5,18 @@ using OpenTelemetry.Proto.Trace.V1;
 
 namespace Meziantou.Framework.OpenTelemetryCollector;
 
-internal sealed class OpenTelemetryTraceTailSamplerHandler
+internal sealed class OpenTelemetryTraceTailSamplerHandler(TimeProvider timeProvider)
 {
+    private readonly TimeProvider _timeProvider = timeProvider;
     private readonly System.Threading.Lock _gate = new();
 
     private readonly Dictionary<string, BufferedTraceState> _traces = new(StringComparer.Ordinal);
+
+    // Traces that exceeded their own span limit while using OpenTelemetryTailBufferOverflowPolicy.DropWholeTrace.
+    // The decision must be remembered, otherwise the next batch of the same trace starts buffering again and the
+    // trace is emitted as a set of fragments instead of being dropped. The value is the last time a span was seen.
+    private readonly Dictionary<string, DateTimeOffset> _droppedTraces = new(StringComparer.Ordinal);
+
     private int _bufferedSpanCount;
 
     public async ValueTask HandleAsync(
@@ -31,14 +38,23 @@ internal sealed class OpenTelemetryTraceTailSamplerHandler
             return;
         }
 
-        var now = DateTimeOffset.UtcNow;
+        var now = _timeProvider.GetUtcNow();
         var evaluations = new List<BufferedTraceEvaluation>();
+        var rejectedSpanCount = 0;
         lock (_gate)
         {
+            PurgeDroppedTraces(tailSampling, now);
             CollectTimedOutTraces(tailSampling, now, evaluations);
 
             foreach (var (traceId, entries) in incomingByTrace)
             {
+                if (_droppedTraces.ContainsKey(traceId))
+                {
+                    _droppedTraces[traceId] = now;
+                    rejectedSpanCount += entries.Count;
+                    continue;
+                }
+
                 if (!_traces.TryGetValue(traceId, out var state))
                 {
                     state = new BufferedTraceState(traceId, now);
@@ -48,7 +64,16 @@ internal sealed class OpenTelemetryTraceTailSamplerHandler
                 state.LastContext = context;
 
                 AppendEntries(state, entries);
-                ApplyCapacityPolicy(tailSampling, state);
+
+                var (removedSpanCount, exceededPerTraceLimit) = ApplyCapacityPolicy(tailSampling, state);
+                if (removedSpanCount > 0)
+                {
+                    rejectedSpanCount += removedSpanCount;
+                    if (exceededPerTraceLimit && tailSampling.OverflowPolicy is OpenTelemetryTailBufferOverflowPolicy.DropWholeTrace)
+                    {
+                        _droppedTraces[traceId] = now;
+                    }
+                }
 
                 if (state.SpanCount is 0)
                 {
@@ -64,23 +89,113 @@ internal sealed class OpenTelemetryTraceTailSamplerHandler
             }
         }
 
+        if (rejectedSpanCount > 0)
+        {
+            context.PartialSuccess.Reject(rejectedSpanCount, "Spans were dropped because the tail sampling buffer is full");
+        }
+
+        await EvaluateAsync(evaluations, tailSampling, acceptedTraceHandler);
+    }
+
+    /// <summary>Evaluates the traces that reached <see cref="OpenTelemetryTailSampler.MaxTraceDuration"/> without having received their root span.</summary>
+    /// <remarks>
+    /// This is called by a background sweep. Without it, a buffered trace whose root span never arrives would only be
+    /// released when another trace happens to be received, and would be kept in memory forever if traffic stops.
+    /// </remarks>
+    public async ValueTask FlushTimedOutTracesAsync(
+        OpenTelemetryTailSampler tailSampling,
+        Func<OpenTelemetryHandlerContext, ExportTraceServiceRequest, CancellationToken, ValueTask> acceptedTraceHandler,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(tailSampling);
+        ArgumentNullException.ThrowIfNull(acceptedTraceHandler);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var now = _timeProvider.GetUtcNow();
+        var evaluations = new List<BufferedTraceEvaluation>();
+        lock (_gate)
+        {
+            PurgeDroppedTraces(tailSampling, now);
+            CollectTimedOutTraces(tailSampling, now, evaluations);
+        }
+
+        if (evaluations.Count is 0)
+        {
+            return;
+        }
+
+        await EvaluateAsync(evaluations, tailSampling, acceptedTraceHandler);
+    }
+
+    private static async ValueTask EvaluateAsync(
+        List<BufferedTraceEvaluation> evaluations,
+        OpenTelemetryTailSampler tailSampling,
+        Func<OpenTelemetryHandlerContext, ExportTraceServiceRequest, CancellationToken, ValueTask> acceptedTraceHandler)
+    {
+        // The spans of these traces were already removed from the buffer, so they are dispatched without a cancellation
+        // token: aborting here would silently discard buffered data that belongs to other requests. For the same reason
+        // a failing trace must not prevent the remaining ones from being dispatched.
+        List<Exception>? errors = null;
         foreach (var evaluation in evaluations)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var accepted = true;
-            if (tailSampling.ShouldSample is not null)
+            try
             {
-                accepted = await tailSampling.ShouldSample(evaluation.Context, cancellationToken);
-            }
+                var accepted = true;
+                if (tailSampling.ShouldSample is not null)
+                {
+                    accepted = await tailSampling.ShouldSample(evaluation.Context, CancellationToken.None);
+                }
 
-            if (!accepted)
+                if (!accepted)
+                {
+                    continue;
+                }
+
+                var acceptedRequest = CreateTraceRequest(evaluation.Entries);
+                await acceptedTraceHandler(evaluation.Context.HandlerContext, acceptedRequest, CancellationToken.None);
+            }
+            catch (Exception ex)
             {
-                continue;
+                errors ??= [];
+                errors.Add(ex);
             }
+        }
 
-            var acceptedRequest = CreateTraceRequest(evaluation.Entries);
-            await acceptedTraceHandler(evaluation.Context.HandlerContext, acceptedRequest, cancellationToken);
+        if (errors is not null)
+        {
+            throw new AggregateException("One or more buffered traces could not be dispatched.", errors);
+        }
+    }
+
+    private void PurgeDroppedTraces(OpenTelemetryTailSampler tailSampling, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(tailSampling);
+
+        if (_droppedTraces.Count is 0)
+        {
+            return;
+        }
+
+        var maxTraceDuration = tailSampling.MaxTraceDuration;
+        List<string>? expiredTraceIds = null;
+        foreach (var (traceId, lastSpanReceivedAt) in _droppedTraces)
+        {
+            if (now - lastSpanReceivedAt >= maxTraceDuration)
+            {
+                expiredTraceIds ??= [];
+                expiredTraceIds.Add(traceId);
+            }
+        }
+
+        if (expiredTraceIds is null)
+        {
+            return;
+        }
+
+        foreach (var traceId in expiredTraceIds)
+        {
+            _droppedTraces.Remove(traceId);
         }
     }
 
@@ -120,7 +235,7 @@ internal sealed class OpenTelemetryTraceTailSamplerHandler
         state.HasRootSpan = ContainsRootSpan(state.Entries);
     }
 
-    private void ApplyCapacityPolicy(OpenTelemetryTailSampler tailSampling, BufferedTraceState state)
+    private (int RemovedSpanCount, bool ExceededPerTraceLimit) ApplyCapacityPolicy(OpenTelemetryTailSampler tailSampling, BufferedTraceState state)
     {
         ArgumentNullException.ThrowIfNull(tailSampling);
         ArgumentNullException.ThrowIfNull(state);
@@ -133,9 +248,13 @@ internal sealed class OpenTelemetryTraceTailSamplerHandler
         var allowedSpansInTrace = Math.Min(maxBufferedSpansPerTrace, allowedByGlobalCapacity);
         if (state.SpanCount <= allowedSpansInTrace)
         {
-            return;
+            return (0, false);
         }
 
+        // Only a trace larger than its own limit is oversized. Running out of global capacity is transient back
+        // pressure caused by other traces, so it must not mark this trace as permanently dropped.
+        var exceededPerTraceLimit = state.SpanCount > maxBufferedSpansPerTrace;
+        var initialSpanCount = state.SpanCount;
         var spansToRemove = state.SpanCount - allowedSpansInTrace;
         switch (tailSampling.OverflowPolicy)
         {
@@ -153,6 +272,7 @@ internal sealed class OpenTelemetryTraceTailSamplerHandler
         }
 
         state.HasRootSpan = ContainsRootSpan(state.Entries);
+        return (initialSpanCount - state.SpanCount, exceededPerTraceLimit);
     }
 
     private void TrimFromStart(BufferedTraceState state, int spanCount)

--- a/src/Meziantou.Framework.OpenTelemetryCollector/readme.md
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/readme.md
@@ -2,8 +2,10 @@
 
 This package provides OpenTelemetry OTLP receiver endpoints for:
 
-- HTTP (`/v1/logs`, `/v1/traces`, `/v1/metrics`)
+- HTTP (`/v1/logs`, `/v1/traces`, `/v1/metrics`), using either `application/x-protobuf` or `application/json` (OTLP/JSON)
 - gRPC (`LogsService`, `TraceService`, `MetricsService`)
+
+OTLP/HTTP requests compressed with `Content-Encoding: gzip` are supported, and responses use the same encoding as the request.
 
 The receiver API is abstract, so you can implement custom handling logic and register one or multiple receivers.
 
@@ -64,8 +66,53 @@ builder.Services.AddOpenTelemetryReceiver<MyReceiver>(options =>
 });
 ```
 
+Traces that never receive their root span are evaluated by a background sweep, so they are released even when no other
+trace is received. The sweep runs every `SweepInterval`, which defaults to a quarter of `MaxTraceDuration`.
+
+Once spans left the buffer they are dispatched to the handlers without a cancellation token: the originating request has
+already been answered, so aborting the dispatch would silently discard buffered data belonging to other requests.
+
 Overflow behavior is configurable through `OpenTelemetryTailBufferOverflowPolicy`:
 
 - `DropWholeTrace`: drop the whole buffered trace
 - `DropOldestSpans`: keep newest spans
 - `DropNewestSpans`: keep oldest spans
+
+A trace that exceeds `MaxBufferedSpansPerTrace` while using `DropWholeTrace` is remembered, so the spans of the same
+trace received later are dropped too instead of being emitted as fragments. Exceeding the global `MaxBufferedSpans`
+limit is transient back pressure and does not mark the trace as dropped.
+
+### Reporting rejected records
+
+Samplers and handlers can report the records they could not accept. They are sent back to the client in the OTLP
+`partial_success` response field:
+
+```csharp
+public sealed class DropOversizedLogsHandler : OpenTelemetryHandler
+{
+    public override ValueTask HandleLogsAsync(OpenTelemetryHandlerContext context, ExportLogsServiceRequest request, CancellationToken cancellationToken)
+    {
+        var rejected = Store(request);
+        if (rejected > 0)
+        {
+            context.PartialSuccess.Reject(rejected, "The storage quota is exceeded");
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}
+```
+
+Spans dropped by `OpenTelemetryTailSampler` because a buffer limit is reached are reported the same way.
+
+### Limiting the request size
+
+OTLP/HTTP payloads larger than `MaxHttpRequestBodySize` (20 MiB by default) are rejected with `413 Content Too Large`.
+The limit applies to the payload after decompression, so a compressed request cannot expand beyond it.
+
+```csharp
+builder.Services.AddOpenTelemetryReceiver<MyReceiver>(options =>
+{
+    options.MaxHttpRequestBodySize = 4 * 1024 * 1024;
+});
+```

--- a/src/Meziantou.Framework.OpenTelemetryCollector/readme.md
+++ b/src/Meziantou.Framework.OpenTelemetryCollector/readme.md
@@ -5,7 +5,18 @@ This package provides OpenTelemetry OTLP receiver endpoints for:
 - HTTP (`/v1/logs`, `/v1/traces`, `/v1/metrics`), using either `application/x-protobuf` or `application/json` (OTLP/JSON)
 - gRPC (`LogsService`, `TraceService`, `MetricsService`)
 
-OTLP/HTTP requests compressed with `Content-Encoding: gzip` are supported, and responses use the same encoding as the request.
+Responses use the same encoding as the request.
+
+Compressed requests are handled by the ASP.NET Core request decompression middleware, so any encoding it supports
+(`gzip`, `br`, `deflate`, or a custom provider) works:
+
+```csharp
+builder.Services.AddRequestDecompression();
+
+var app = builder.Build();
+app.UseRequestDecompression();
+app.MapOpenTelemetryReceiverEndpoints();
+```
 
 The receiver API is abstract, so you can implement custom handling logic and register one or multiple receivers.
 
@@ -104,15 +115,3 @@ public sealed class DropOversizedLogsHandler : OpenTelemetryHandler
 ```
 
 Spans dropped by `OpenTelemetryTailSampler` because a buffer limit is reached are reported the same way.
-
-### Limiting the request size
-
-OTLP/HTTP payloads larger than `MaxHttpRequestBodySize` (20 MiB by default) are rejected with `413 Content Too Large`.
-The limit applies to the payload after decompression, so a compressed request cannot expand beyond it.
-
-```csharp
-builder.Services.AddOpenTelemetryReceiver<MyReceiver>(options =>
-{
-    options.MaxHttpRequestBodySize = 4 * 1024 * 1024;
-});
-```

--- a/tests/Meziantou.Framework.OpenTelemetry.Tests/Meziantou.Framework.OpenTelemetry.Tests.csproj
+++ b/tests/Meziantou.Framework.OpenTelemetry.Tests/Meziantou.Framework.OpenTelemetry.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
     <ProjectReference Include="../../src/Meziantou.Framework.OpenTelemetryCollector/Meziantou.Framework.OpenTelemetryCollector.csproj" />
     <ProjectReference Include="../../src/Meziantou.Framework.OpenTelemetryCollector.InMemory/Meziantou.Framework.OpenTelemetryCollector.InMemory.csproj" />
   </ItemGroup>
@@ -17,6 +18,5 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.10" />
   </ItemGroup>
-
 
 </Project>

--- a/tests/Meziantou.Framework.OpenTelemetry.Tests/OpenTelemetryReceiverTests.cs
+++ b/tests/Meziantou.Framework.OpenTelemetry.Tests/OpenTelemetryReceiverTests.cs
@@ -1,11 +1,14 @@
+using System.IO.Compression;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Text;
 using Google.Protobuf;
 using Grpc.Net.Client;
 using Meziantou.Framework.OpenTelemetryCollector.InMemory;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using OpenTelemetry.Proto.Collector.Logs.V1;
 using OpenTelemetry.Proto.Collector.Metrics.V1;
 using OpenTelemetry.Proto.Collector.Trace.V1;
@@ -42,8 +45,8 @@ public sealed class OpenTelemetryReceiverTests
     {
         await using var app = await TestApplication.CreateAsync();
 
-        using var content = new StringContent("{}");
-        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        using var content = new StringContent("hello");
+        content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
         using var response = await app.HttpClient.PostAsync("/v1/logs", content, XunitCancellationToken);
 
         Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
@@ -335,6 +338,287 @@ public sealed class OpenTelemetryReceiverTests
         Assert.HasCount(3, app.Receiver.Logs);
     }
 
+    [Fact]
+    public async Task Http_Response_IsProtobufEncoded()
+    {
+        await using var app = await TestApplication.CreateAsync();
+
+        using var response = await PostAsync(app.HttpClient, "/v1/logs", new ExportLogsServiceRequest());
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/x-protobuf", response.Content.Headers.ContentType?.MediaType);
+
+        var body = await response.Content.ReadAsByteArrayAsync(XunitCancellationToken);
+        var parsed = ExportLogsServiceResponse.Parser.ParseFrom(body);
+        Assert.Null(parsed.PartialSuccess);
+    }
+
+    [Fact]
+    public async Task AddOpenTelemetryReceiver_RegistersTheReceiverInDependencyInjection()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddOpenTelemetryReceiver<TestReceiver>();
+
+        await using var app = builder.Build();
+        app.MapOpenTelemetryReceiverEndpoints();
+        await app.StartAsync(XunitCancellationToken);
+
+        using var httpClient = app.GetTestClient();
+        await SendLogsAsync(httpClient, "from-http");
+
+        Assert.Equal(1, app.Services.GetRequiredService<TestReceiver>().ReceivedLogsCount);
+    }
+
+    [Fact]
+    public async Task Http_JsonPayload_IsSupported()
+    {
+        await using var app = await TestApplication.CreateAsync();
+
+        const string Payload = """{"resourceLogs":[{"scopeLogs":[{"logRecords":[{"body":{"stringValue":"from-json"}}]}]}]}""";
+        using var response = await PostJsonAsync(app.HttpClient, "/v1/logs", Payload);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        var item = Assert.IsType<OpenTelemetryLogsItem>(Assert.Single(app.Receiver.Logs));
+        Assert.Equal("from-json", item.Request.ResourceLogs[0].ScopeLogs[0].LogRecords[0].Body.StringValue);
+    }
+
+    [Fact]
+    public async Task Http_JsonPayload_DecodesHexEncodedIdentifiers()
+    {
+        await using var app = await TestApplication.CreateAsync();
+
+        // OTLP/JSON hex-encodes trace and span ids instead of using the base64 encoding of the Protobuf JSON mapping.
+        const string Payload = """
+            {"resourceSpans":[{"scopeSpans":[{"spans":[{"traceId":"000102030405060708090a0b0c0d0e0f","spanId":"1011121314151617","parentSpanId":"18191a1b1c1d1e1f","name":"json-span"}]}]}]}
+            """;
+        using var response = await PostJsonAsync(app.HttpClient, "/v1/traces", Payload);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var span = Assert.Single(GetTraceSpans(app.Receiver));
+        Assert.Equal("json-span", span.Name);
+        Assert.Equal("000102030405060708090A0B0C0D0E0F", Convert.ToHexString(span.TraceId.ToByteArray()));
+        Assert.Equal("1011121314151617", Convert.ToHexString(span.SpanId.ToByteArray()));
+        Assert.Equal("18191A1B1C1D1E1F", Convert.ToHexString(span.ParentSpanId.ToByteArray()));
+    }
+
+    [Fact]
+    public async Task Http_GzipEncodedPayload_IsSupported()
+    {
+        await using var app = await TestApplication.CreateAsync();
+
+        var payload = new ExportLogsServiceRequest();
+        payload.ResourceLogs.Add(new global::OpenTelemetry.Proto.Logs.V1.ResourceLogs());
+
+        using var buffer = new MemoryStream();
+        await using (var gzipStream = new GZipStream(buffer, CompressionMode.Compress, leaveOpen: true))
+        {
+            await gzipStream.WriteAsync(payload.ToByteArray(), XunitCancellationToken);
+        }
+
+        using var content = new ByteArrayContent(buffer.ToArray());
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/x-protobuf");
+        content.Headers.ContentEncoding.Add("gzip");
+
+        using var response = await app.HttpClient.PostAsync("/v1/logs", content, XunitCancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var item = Assert.IsType<OpenTelemetryLogsItem>(Assert.Single(app.Receiver.Logs));
+        _ = Assert.Single(item.Request.ResourceLogs);
+    }
+
+    [Fact]
+    public async Task Http_UnsupportedContentEncoding_Returns415()
+    {
+        await using var app = await TestApplication.CreateAsync();
+
+        using var content = new ByteArrayContent(new ExportLogsServiceRequest().ToByteArray());
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/x-protobuf");
+        content.Headers.ContentEncoding.Add("br");
+
+        using var response = await app.HttpClient.PostAsync("/v1/logs", content, XunitCancellationToken);
+
+        Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+        Assert.Empty(app.Receiver.Logs);
+    }
+
+    [Fact]
+    public async Task Http_InvalidGzipPayload_Returns400()
+    {
+        await using var app = await TestApplication.CreateAsync();
+
+        using var content = new ByteArrayContent([0x00, 0xFF, 0xA5]);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/x-protobuf");
+        content.Headers.ContentEncoding.Add("gzip");
+
+        using var response = await app.HttpClient.PostAsync("/v1/logs", content, XunitCancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Empty(app.Receiver.Logs);
+    }
+
+    [Fact]
+    public async Task Http_PayloadExceedingTheConfiguredLimit_Returns413()
+    {
+        await using var app = await TestApplication.CreateAsync(configureServices: static services => services.Configure<OpenTelemetryReceiverOptions>(static options => options.MaxHttpRequestBodySize = 16));
+
+        var payload = new ExportLogsServiceRequest();
+        payload.ResourceLogs.Add(new global::OpenTelemetry.Proto.Logs.V1.ResourceLogs
+        {
+            SchemaUrl = new string('a', 512),
+        });
+
+        using var response = await PostAsync(app.HttpClient, "/v1/logs", payload);
+
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
+        Assert.Empty(app.Receiver.Logs);
+    }
+
+    [Fact]
+    public async Task Grpc_PartialSuccess_IsReportedToTheClient()
+    {
+        await using var app = await TestApplication.CreateAsync(configureServices: static services => services.AddOpenTelemetryReceiver(static _ => new RejectingHandler()));
+
+        var client = new LogsService.LogsServiceClient(app.GrpcChannel);
+        var response = await client.ExportAsync(new ExportLogsServiceRequest(), cancellationToken: XunitCancellationToken).ResponseAsync;
+
+        Assert.Equal(2, response.PartialSuccess.RejectedLogRecords);
+        Assert.Equal("rejected", response.PartialSuccess.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Http_PartialSuccess_IsReportedToTheClient()
+    {
+        await using var app = await TestApplication.CreateAsync(configureServices: static services => services.AddOpenTelemetryReceiver(static _ => new RejectingHandler()));
+
+        using var response = await PostAsync(app.HttpClient, "/v1/logs", new ExportLogsServiceRequest());
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsByteArrayAsync(XunitCancellationToken);
+        var parsed = ExportLogsServiceResponse.Parser.ParseFrom(body);
+        Assert.Equal(2, parsed.PartialSuccess.RejectedLogRecords);
+        Assert.Equal("rejected", parsed.PartialSuccess.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Http_TailFilter_FlushesTimedOutTracesWithoutFurtherTraffic()
+    {
+        var timeProvider = new FakeTimeProvider();
+        await using var app = await TestApplication.CreateAsync(configureServices: services =>
+        {
+            services.AddSingleton<TimeProvider>(timeProvider);
+            services.Configure<OpenTelemetryReceiverOptions>(static options => options.Samplers.Add(new OpenTelemetryTailSampler
+            {
+                MaxTraceDuration = TimeSpan.FromMinutes(1),
+                ShouldSample = static (context, _) => ValueTask.FromResult(context.TimedOut),
+            }));
+        });
+
+        await SendTracesAsync(app.HttpClient, CreateTraceRequest("00000000000000000000000000000061", ("0000000000000062", "0000000000000061", "orphan-child")));
+        Assert.Empty(GetTraceSpans(app.Receiver));
+
+        timeProvider.Advance(TimeSpan.FromMinutes(2));
+
+        // No other trace is received: only the background sweep can release the buffered trace.
+        await WaitForAsync(() => GetTraceSpans(app.Receiver).Count > 0);
+
+        var span = Assert.Single(GetTraceSpans(app.Receiver));
+        Assert.Equal("orphan-child", span.Name);
+    }
+
+    [Fact]
+    public async Task Http_TailFilter_DispatchesBufferedTracesWithoutTheRequestCancellationToken()
+    {
+        var recordingHandler = new CancellationRecordingHandler();
+        await using var app = await TestApplication.CreateAsync(configureServices: services => services.AddOpenTelemetryReceiver(_ => recordingHandler, static options => options.Samplers.Add(new OpenTelemetryTailSampler
+        {
+            MaxTraceDuration = TimeSpan.FromMinutes(1),
+        })));
+
+        await SendTracesAsync(app.HttpClient, CreateTraceRequest(
+            "00000000000000000000000000000071",
+            ("0000000000000072", "0000000000000071", "child"),
+            ("0000000000000071", null, "root")));
+
+        // The spans left the buffer, so aborting the request must not discard them.
+        Assert.Equal(1, recordingHandler.TracesCallCount);
+        Assert.False(recordingHandler.LastTracesTokenCanBeCanceled);
+    }
+
+    [Fact]
+    public async Task Http_TailFilter_DropWholeTrace_KeepsDroppingLaterBatchesOfTheSameTrace()
+    {
+        await using var app = await TestApplication.CreateAsync(configureServices: static services => services.Configure<OpenTelemetryReceiverOptions>(static options => options.Samplers.Add(new OpenTelemetryTailSampler
+        {
+            MaxTraceDuration = TimeSpan.FromMinutes(1),
+            MaxBufferedSpansPerTrace = 2,
+            OverflowPolicy = OpenTelemetryTailBufferOverflowPolicy.DropWholeTrace,
+        })));
+
+        const string TraceId = "00000000000000000000000000000081";
+        await SendTracesAsync(app.HttpClient, CreateTraceRequest(
+            TraceId,
+            ("0000000000000082", "0000000000000081", "child-1"),
+            ("0000000000000083", "0000000000000081", "child-2"),
+            ("0000000000000084", "0000000000000081", "child-3")));
+
+        // The trace exceeded its own limit, so the later batch carrying the root span must be dropped too.
+        await SendTracesAsync(app.HttpClient, CreateTraceRequest(TraceId, ("0000000000000081", null, "root")));
+
+        Assert.Empty(GetTraceSpans(app.Receiver));
+    }
+
+    [Fact]
+    public async Task Http_TailFilter_ReportsDroppedSpansAsPartialSuccess()
+    {
+        await using var app = await TestApplication.CreateAsync(configureServices: static services => services.Configure<OpenTelemetryReceiverOptions>(static options => options.Samplers.Add(new OpenTelemetryTailSampler
+        {
+            MaxTraceDuration = TimeSpan.FromMinutes(1),
+            MaxBufferedSpansPerTrace = 2,
+            OverflowPolicy = OpenTelemetryTailBufferOverflowPolicy.DropWholeTrace,
+        })));
+
+        using var response = await PostAsync(app.HttpClient, "/v1/traces", CreateTraceRequest(
+            "00000000000000000000000000000091",
+            ("0000000000000092", "0000000000000091", "child-1"),
+            ("0000000000000093", "0000000000000091", "child-2"),
+            ("0000000000000094", "0000000000000091", "child-3")));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsByteArrayAsync(XunitCancellationToken);
+        var parsed = ExportTraceServiceResponse.Parser.ParseFrom(body);
+        Assert.Equal(3, parsed.PartialSuccess.RejectedSpans);
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition)
+    {
+        for (var i = 0; i < 200; i++)
+        {
+            if (condition())
+                return;
+
+            await Task.Delay(25, XunitCancellationToken);
+        }
+
+        Assert.Fail("The condition was not met before the timeout");
+    }
+
+    private static async Task<HttpResponseMessage> PostAsync(HttpClient httpClient, string endpoint, IMessage payload)
+    {
+        using var content = new ByteArrayContent(payload.ToByteArray());
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/x-protobuf");
+        return await httpClient.PostAsync(endpoint, content, XunitCancellationToken);
+    }
+
+    private static async Task<HttpResponseMessage> PostJsonAsync(HttpClient httpClient, string endpoint, string payload)
+    {
+        using var content = new ByteArrayContent(Encoding.UTF8.GetBytes(payload));
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        return await httpClient.PostAsync(endpoint, content, XunitCancellationToken);
+    }
+
     private static async Task SendLogsAsync(HttpClient httpClient, string body, string endpoint = "/v1/logs")
     {
         var payload = new ExportLogsServiceRequest();
@@ -446,6 +730,45 @@ public sealed class OpenTelemetryReceiverTests
             cancellationToken.ThrowIfCancellationRequested();
             return ValueTask.CompletedTask;
         }
+    }
+
+    private sealed class RejectingHandler : OpenTelemetryHandler
+    {
+        public override ValueTask HandleLogsAsync(OpenTelemetryHandlerContext context, ExportLogsServiceRequest request, CancellationToken cancellationToken)
+        {
+            context.PartialSuccess.Reject(2, "rejected");
+            return ValueTask.CompletedTask;
+        }
+
+        public override ValueTask HandleTracesAsync(OpenTelemetryHandlerContext context, ExportTraceServiceRequest request, CancellationToken cancellationToken)
+        {
+            context.PartialSuccess.Reject(2, "rejected");
+            return ValueTask.CompletedTask;
+        }
+
+        public override ValueTask HandleMetricsAsync(OpenTelemetryHandlerContext context, ExportMetricsServiceRequest request, CancellationToken cancellationToken)
+        {
+            context.PartialSuccess.Reject(2, "rejected");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class CancellationRecordingHandler : OpenTelemetryHandler
+    {
+        public int TracesCallCount { get; private set; }
+
+        public bool? LastTracesTokenCanBeCanceled { get; private set; }
+
+        public override ValueTask HandleLogsAsync(OpenTelemetryHandlerContext context, ExportLogsServiceRequest request, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public override ValueTask HandleTracesAsync(OpenTelemetryHandlerContext context, ExportTraceServiceRequest request, CancellationToken cancellationToken)
+        {
+            TracesCallCount++;
+            LastTracesTokenCanBeCanceled = cancellationToken.CanBeCanceled;
+            return ValueTask.CompletedTask;
+        }
+
+        public override ValueTask HandleMetricsAsync(OpenTelemetryHandlerContext context, ExportMetricsServiceRequest request, CancellationToken cancellationToken) => ValueTask.CompletedTask;
     }
 
     private sealed class TestApplication(WebApplication app, HttpClient httpClient, GrpcChannel grpcChannel, InMemoryOpenTelemetryHandler receiver) : IAsyncDisposable

--- a/tests/Meziantou.Framework.OpenTelemetry.Tests/OpenTelemetryReceiverTests.cs
+++ b/tests/Meziantou.Framework.OpenTelemetry.Tests/OpenTelemetryReceiverTests.cs
@@ -405,9 +405,11 @@ public sealed class OpenTelemetryReceiverTests
     }
 
     [Fact]
-    public async Task Http_GzipEncodedPayload_IsSupported()
+    public async Task Http_CompressedPayload_IsSupportedThroughTheRequestDecompressionMiddleware()
     {
-        await using var app = await TestApplication.CreateAsync();
+        await using var app = await TestApplication.CreateAsync(
+            configureServices: static services => services.AddRequestDecompression(),
+            configureApp: static app => app.UseRequestDecompression());
 
         var payload = new ExportLogsServiceRequest();
         payload.ResourceLogs.Add(new global::OpenTelemetry.Proto.Logs.V1.ResourceLogs());
@@ -430,24 +432,11 @@ public sealed class OpenTelemetryReceiverTests
     }
 
     [Fact]
-    public async Task Http_UnsupportedContentEncoding_Returns415()
+    public async Task Http_InvalidCompressedPayload_Returns400()
     {
-        await using var app = await TestApplication.CreateAsync();
-
-        using var content = new ByteArrayContent(new ExportLogsServiceRequest().ToByteArray());
-        content.Headers.ContentType = new MediaTypeHeaderValue("application/x-protobuf");
-        content.Headers.ContentEncoding.Add("br");
-
-        using var response = await app.HttpClient.PostAsync("/v1/logs", content, XunitCancellationToken);
-
-        Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
-        Assert.Empty(app.Receiver.Logs);
-    }
-
-    [Fact]
-    public async Task Http_InvalidGzipPayload_Returns400()
-    {
-        await using var app = await TestApplication.CreateAsync();
+        await using var app = await TestApplication.CreateAsync(
+            configureServices: static services => services.AddRequestDecompression(),
+            configureApp: static app => app.UseRequestDecompression());
 
         using var content = new ByteArrayContent([0x00, 0xFF, 0xA5]);
         content.Headers.ContentType = new MediaTypeHeaderValue("application/x-protobuf");
@@ -456,23 +445,6 @@ public sealed class OpenTelemetryReceiverTests
         using var response = await app.HttpClient.PostAsync("/v1/logs", content, XunitCancellationToken);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        Assert.Empty(app.Receiver.Logs);
-    }
-
-    [Fact]
-    public async Task Http_PayloadExceedingTheConfiguredLimit_Returns413()
-    {
-        await using var app = await TestApplication.CreateAsync(configureServices: static services => services.Configure<OpenTelemetryReceiverOptions>(static options => options.MaxHttpRequestBodySize = 16));
-
-        var payload = new ExportLogsServiceRequest();
-        payload.ResourceLogs.Add(new global::OpenTelemetry.Proto.Logs.V1.ResourceLogs
-        {
-            SchemaUrl = new string('a', 512),
-        });
-
-        using var response = await PostAsync(app.HttpClient, "/v1/logs", payload);
-
-        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
         Assert.Empty(app.Receiver.Logs);
     }
 
@@ -781,7 +753,7 @@ public sealed class OpenTelemetryReceiverTests
 
         public InMemoryOpenTelemetryHandler Receiver { get; } = receiver;
 
-        public static async Task<TestApplication> CreateAsync(InMemoryOpenTelemetryHandlerOptions? options = null, Action<IServiceCollection>? configureServices = null)
+        public static async Task<TestApplication> CreateAsync(InMemoryOpenTelemetryHandlerOptions? options = null, Action<IServiceCollection>? configureServices = null, Action<WebApplication>? configureApp = null)
         {
             var builder = WebApplication.CreateBuilder();
             builder.WebHost.UseTestServer();
@@ -791,6 +763,7 @@ public sealed class OpenTelemetryReceiverTests
             configureServices?.Invoke(builder.Services);
 
             var app = builder.Build();
+            configureApp?.Invoke(app);
             app.MapOpenTelemetryReceiverEndpoints();
 
             await app.StartAsync(XunitCancellationToken);


### PR DESCRIPTION
Fixes five bugs in `Meziantou.Framework.OpenTelemetryCollector` and closes two OTLP protocol gaps. Each bug below was reproduced before being fixed, and each fix is covered by a test that fails without it.

## Bugs

**HTTP responses were JSON instead of protobuf.** The endpoints returned `TypedResults.Ok(protobufMessage)`, which serialises through `System.Text.Json`. Clients received `Content-Type: application/json` with `{"partialSuccess":null}` rather than the protobuf response OTLP/HTTP requires. Worse, in an app where reflection-based JSON is disabled (trimming, AOT, `JsonSerializerIsReflectionEnabledByDefault=false`), *every* export failed with a 500:

```
System.NotSupportedException: JsonTypeInfo metadata for type
'OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse' was not provided...
```

Responses are now written by `OpenTelemetryProtoResult<T>` using the same encoding as the request.

**`AddOpenTelemetryReceiver<TReceiver>()` never registered `TReceiver`.** It called `GetRequiredService<TReceiver>()` on a type nothing had registered, so the usage shown in the readme failed at the first request with `No service for type 'MyReceiver' has been registered`. Now uses `TryAddSingleton<TReceiver>()`.

**Tail-sampling timeouts only fired when another request happened to arrive.** `MaxTraceDuration` was only checked from inside the request path, so a trace whose root span never arrived was neither released nor freed once traffic stopped — an unbounded buffer and traces that never get delivered. A `BackgroundService` now sweeps on a `PeriodicTimer` driven by `TimeProvider`; the interval defaults to a quarter of `MaxTraceDuration` and is configurable via the new `SweepInterval`.

**Client cancellation destroyed other traces' buffered data.** The evaluation loop threw on cancellation *after* traces had been removed from the buffer, so one exporter disconnecting mid-request discarded every timed-out trace collected in that batch, including traces from unrelated callers. Dequeued traces are now dispatched without a cancellation token, and a failing trace no longer prevents the rest from being dispatched — errors are aggregated instead.

**`DropWholeTrace` did not remember its decision.** The state was trimmed to zero and removed from the map, so the next batch for the same trace id started buffering again and the trace was emitted as fragments rather than dropped. Oversized traces are now remembered with a last-seen expiry.

One thing worth a reviewer's attention here: only exceeding the **per-trace** limit marks a trace as dropped. Exceeding the global `MaxBufferedSpans` is transient back pressure caused by *other* traces, and marking traces on that path would poison every trace id arriving while the buffer is full. `ApplyCapacityPolicy` now distinguishes the two.

## Protocol support

- **OTLP/JSON** — `application/json` requests are accepted and answered in JSON. This needed real work: OTLP/JSON deviates from the Protobuf JSON mapping by hex-encoding `trace_id`/`span_id`, and `JsonParser` would silently base64-decode a 32-char hex trace id into 24 unrelated bytes instead of failing. Those fields are converted before parsing. The two encodings have distinct lengths for a given id size (16 bytes → 32 hex chars vs 24 base64 chars), so there is no ambiguity.
- **Partial success** — new public `OpenTelemetryPartialSuccess`, reachable from `OpenTelemetryHandlerContext`, lets samplers and handlers report rejected records through the OTLP `partial_success` response field over both HTTP and gRPC. Spans dropped by the tail sampler report themselves this way.

## Compression and request size are the framework's job

An earlier revision of this branch hand-rolled `Content-Encoding: gzip` support and a `MaxHttpRequestBodySize` option. Both were reimplementations of behaviour ASP.NET Core already provides, and both have been removed (see the second commit):

- Applications opt into `AddRequestDecompression()` / `UseRequestDecompression()`, which supports gzip, brotli, deflate, and custom providers — strictly more than the gzip-only version, which also returned 415 for anything else.
- Kestrel enforces `MaxRequestBodySize`, and the decompression middleware bounds the decompressed stream via `IHttpMaxRequestBodySizeFeature`, so compressed payloads that expand past the limit are already rejected.

The collector keeps only the piece that is actually its own: mapping a body the middleware could not decompress (`InvalidDataException`) to 400 rather than letting it become a 500. That mapping is covered by a test that fails without it.

## Verification

- 58/58 tests pass (29 × net10.0/net11.0). Release build with `IsOfficialBuild=true` is clean, and `dotnet run ./eng/update-all.cs` produced no further changes.
- Verified end-to-end against a real Kestrel app, not just `TestServer`: protobuf responses carry `partial_success` and the right content type; gzip, brotli, and deflate all round-trip; an OTLP/JSON payload preserves hex ids exactly; a corrupt compressed body returns 400; and a gzip bomb of 2,956 bytes expanding to 3 MB is rejected with 413 under a 1 MB Kestrel limit.
- Confirmed the new tests actually fail without the fixes by temporarily mutating the source: reverting the sticky-drop and the cancellation change failed exactly the two intended tests; removing the hosted-service registration failed exactly the sweep test.

## Notes for the reviewer

- **One existing test changed meaning.** `Http_UnsupportedContentType_Returns415` asserted that `application/json` returns 415 — the exact limitation this PR removes. It now uses `text/plain`, and OTLP/JSON has its own coverage.
- **Version moves to 2.1.0.** The `ref/` diff is additive only. `Meziantou.Framework.OpenTelemetryCollector.InMemory` has no API change and stays at 2.0.1.
- The tail sampler's `TimeProvider` dependency is registered with `TryAddSingleton(TimeProvider.System)`, so an app that already registers its own keeps it.
- Deliberately out of scope, and still open: the span-cloning and `ContainsRootSpan` inefficiencies, `MapOpenTelemetryReceiverEndpoints` not returning a convention builder (so callers still cannot add `RequireAuthorization()`), the tail sampler being modelled as an item in `Samplers`, and the stale `...Abstractions.Grpc` namespace. The redundant `ArgumentNullException.ThrowIfNull` calls in the rewritten tail-sampler methods were left as-is to keep the diff focused.
