### PR TITLE
Fix HTML tokenizer defects and add implied end tags

### DIFF
--- a/ref/Meziantou.Framework.Html.cs
+++ b/ref/Meziantou.Framework.Html.cs
@@ -482,12 +482,15 @@ namespace Meziantou.Framework.Html
 
     public sealed class HtmlOptions
     {
+        public System.Collections.Generic.ISet<string> ImpliedEndTagScopes { get => throw null; }
         public System.Collections.Generic.ISet<string> ParsedScriptTypes { get => throw null; }
         public System.Collections.Generic.ISet<string> EmptyNamespaces { get => throw null; }
         public System.Collections.Generic.ISet<string> EmptyNamespacesForXPath { get => throw null; }
         public bool ReaderThrowsOnEncodingMismatch { get => throw null; set { } }
         public bool ReaderRestartsOnEncodingDetected { get => throw null; set { } }
         public bool ReaderThrowsOnUnknownDetectedEncoding { get => throw null; set { } }
+        public System.Collections.Generic.IReadOnlyCollection<string> GetImpliedEndTags(string name) => throw null;
+        public void SetImpliedEndTags(string name, params string[] closedElementNames) { }
         public Meziantou.Framework.Html.HtmlElementWriteOptions GetElementWriteOptions(string name) => throw null;
         public void SetElementWriteOptions(string name, Meziantou.Framework.Html.HtmlElementWriteOptions options) { }
         public Meziantou.Framework.Html.HtmlElementReadOptions GetElementReadOptions(string name) => throw null;

--- a/src/Meziantou.Framework.Html/HtmlDocument.cs
+++ b/src/Meziantou.Framework.Html/HtmlDocument.cs
@@ -694,10 +694,49 @@ sealed class HtmlDocument : HtmlNode
         return new HtmlReader(reader, Options);
     }
 
+    // Closes the elements that '<name>' implicitly closes, such as the open '<li>' of '<li>a<li>b'.
+    private static HtmlNode? CloseImpliedElements(HtmlOptions options, HtmlNode? current, string name)
+    {
+        while (current is HtmlElement)
+        {
+            var target = FindElementToImplicitlyClose(options, current, name);
+            if (target?.ParentNode is null)
+                break;
+
+            for (var node = current; node is HtmlElement element; node = node.ParentNode)
+            {
+                element.IsClosed = true;
+                element.IsEmpty = false;
+                if (node == target)
+                    break;
+            }
+
+            current = target.ParentNode;
+        }
+
+        return current;
+    }
+
+    private static HtmlElement? FindElementToImplicitlyClose(HtmlOptions options, HtmlNode? current, string name)
+    {
+        for (var node = current; node is HtmlElement element; node = node.ParentNode)
+        {
+            if (options.IsImpliedEndTag(name, element.Name))
+                return element;
+
+            // an element is never implicitly closed through a scope boundary
+            if (options.ImpliedEndTagScopes.Contains(element.Name))
+                return null;
+        }
+
+        return null;
+    }
+
     private bool InternalLoad(TextReader reader, bool firstPass)
     {
         HtmlNode? current = this;
         HtmlAttribute? currentAtt = null;
+        var inEndTag = false;
         var htmlReader = CreateReader(reader);
         while (htmlReader.Read())
         {
@@ -721,6 +760,7 @@ sealed class HtmlDocument : HtmlNode
                     break;
 
                 case HtmlFragmentType.TagOpen:
+                    inEndTag = false;
                     var stateValue = htmlReader.State.Value ?? string.Empty;
                     string elementName;
                     bool processingInstruction;
@@ -759,11 +799,13 @@ sealed class HtmlDocument : HtmlNode
                         element.IsProcessingInstruction = processingInstruction;
                     }
 
+                    current = CloseImpliedElements(htmlReader.Options, current, elementName);
                     current?.ChildNodes.Add(element);
                     current = element;
                     break;
 
                 case HtmlFragmentType.TagEnd:
+                    inEndTag = false;
                     element = current as HtmlElement;
                     if (!DetectEncoding(htmlReader, element, firstPass))
                         return false;
@@ -796,6 +838,7 @@ sealed class HtmlDocument : HtmlNode
 
                 case HtmlFragmentType.TagEndClose:
                 case HtmlFragmentType.TagClose:
+                    inEndTag = true;
                     element = current as HtmlElement;
                     if (!DetectEncoding(htmlReader, element, firstPass))
                         return false;
@@ -852,8 +895,13 @@ sealed class HtmlDocument : HtmlNode
                     break;
 
                 case HtmlFragmentType.AttName:
-                    if (string.Equals(htmlReader.State.Value, "?", StringComparison.Ordinal))
+                    // '<?xml version="1.0"?>': the trailing '?' is part of the processing instruction, not an attribute
+                    // '</p class="x">': attributes of an end tag are ignored, they must not land on the parent element
+                    if (inEndTag || string.Equals(htmlReader.State.Value, "?", StringComparison.Ordinal))
+                    {
+                        currentAtt = null;
                         break;
+                    }
 
                     var att = CreateAttribute(htmlReader.State.Value ?? string.Empty);
                     att.StreamOrder = htmlReader.Offset;

--- a/src/Meziantou.Framework.Html/HtmlOptions.cs
+++ b/src/Meziantou.Framework.Html/HtmlOptions.cs
@@ -13,6 +13,8 @@ sealed class HtmlOptions
     private readonly HashSet<string> _emptyNamespacesForXPath = new(StringComparer.Ordinal);
     private readonly HashSet<string> _emptyNamespaces = new(StringComparer.Ordinal);
     private readonly HashSet<string> _parsedScriptTypes = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, HashSet<string>> _impliedEndTags = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _impliedEndTagScopes = new(StringComparer.OrdinalIgnoreCase);
 
     public HtmlOptions()
     {
@@ -42,7 +44,10 @@ sealed class HtmlOptions
         _readOptions["spacer"] = HtmlElementReadOptions.AutoClosed;
         _readOptions["source"] = HtmlElementReadOptions.AutoClosed | HtmlElementReadOptions.NoChild;
         _readOptions["style"] = HtmlElementReadOptions.InnerRaw;
-        _readOptions["wbr"] = HtmlElementReadOptions.AutoClosed;
+        _readOptions["textarea"] = HtmlElementReadOptions.InnerRaw;
+        _readOptions["title"] = HtmlElementReadOptions.InnerRaw;
+        _readOptions["track"] = HtmlElementReadOptions.AutoClosed | HtmlElementReadOptions.NoChild;
+        _readOptions["wbr"] = HtmlElementReadOptions.AutoClosed | HtmlElementReadOptions.NoChild;
 
         // NOTE: This "NOXHTML" element is not defined in specs and is specific to us
         // It may just be used by the caller if he wants to make sure what is inside will never be changed.
@@ -89,18 +94,17 @@ sealed class HtmlOptions
         _writeOptions["h5"] = HtmlElementWriteOptions.AlwaysClose;
         _writeOptions["h6"] = HtmlElementWriteOptions.AlwaysClose;
         _writeOptions["header"] = HtmlElementWriteOptions.AlwaysClose;
-        _writeOptions["header"] = HtmlElementWriteOptions.AlwaysClose;
+        _writeOptions["hgroup"] = HtmlElementWriteOptions.AlwaysClose;
         _writeOptions["hr"] = HtmlElementWriteOptions.NoChild;
         _writeOptions["i"] = HtmlElementWriteOptions.AlwaysClose;
         _writeOptions["iframe"] = HtmlElementWriteOptions.AlwaysClose;
-        _writeOptions["i"] = HtmlElementWriteOptions.AlwaysClose;
         _writeOptions["img"] = HtmlElementWriteOptions.NoChild;
         _writeOptions["input"] = HtmlElementWriteOptions.NoChild;
         _writeOptions["ins"] = HtmlElementWriteOptions.AlwaysClose;
         _writeOptions["kbd"] = HtmlElementWriteOptions.AlwaysClose;
         _writeOptions["label"] = HtmlElementWriteOptions.AlwaysClose;
         _writeOptions["legend"] = HtmlElementWriteOptions.AlwaysClose;
-        _writeOptions["ins"] = HtmlElementWriteOptions.AlwaysClose;
+        _writeOptions["li"] = HtmlElementWriteOptions.AlwaysClose;
         _writeOptions["link"] = HtmlElementWriteOptions.NoChild;
         _writeOptions["map"] = HtmlElementWriteOptions.AlwaysClose;
         _writeOptions["mark"] = HtmlElementWriteOptions.AlwaysClose;
@@ -137,8 +141,84 @@ sealed class HtmlOptions
         _writeOptions["ul"] = HtmlElementWriteOptions.AlwaysClose;
         _writeOptions["video"] = HtmlElementWriteOptions.AlwaysClose;
 
+        // Elements that are implicitly closed when another element is opened.
+        // check https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody
+        string[] closesParagraph =
+        [
+            "address", "article", "aside", "blockquote", "center", "details", "dialog", "dir", "div", "dl",
+            "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6", "header",
+            "hgroup", "hr", "listing", "main", "menu", "nav", "ol", "p", "plaintext", "pre", "section", "summary",
+            "table", "ul", "xmp",
+        ];
+
+        foreach (var name in closesParagraph)
+        {
+            SetImpliedEndTags(name, "p");
+        }
+
+        SetImpliedEndTags("li", "li", "p");
+        SetImpliedEndTags("dd", "dd", "dt", "p");
+        SetImpliedEndTags("dt", "dd", "dt", "p");
+        SetImpliedEndTags("option", "option");
+        SetImpliedEndTags("optgroup", "optgroup", "option");
+        SetImpliedEndTags("rp", "rp", "rt");
+        SetImpliedEndTags("rt", "rp", "rt");
+        SetImpliedEndTags("td", "td", "th", "p");
+        SetImpliedEndTags("th", "td", "th", "p");
+        SetImpliedEndTags("tr", "tr", "td", "th", "p");
+
+        string[] tableSections = ["caption", "colgroup", "tbody", "tfoot", "thead"];
+        foreach (var name in tableSections)
+        {
+            SetImpliedEndTags(name, "caption", "colgroup", "tbody", "tfoot", "thead", "tr", "td", "th", "p");
+        }
+
+        // Elements that stop the search for an element to implicitly close.
+        foreach (var name in new[]
+        {
+            "html", "head", "body", "template", "table", "caption", "colgroup", "tbody", "tfoot", "thead", "tr",
+            "td", "th", "button", "object", "applet", "marquee", "select", "optgroup", "ol", "ul", "dl", "div",
+            "form", "fieldset", "blockquote", "section", "article", "aside", "nav", "main", "header", "footer",
+            "figure", "details", "dialog",
+        })
+        {
+            _impliedEndTagScopes.Add(name);
+        }
+
         // avoids using xhtml for all HTML xpath queries
         _emptyNamespacesForXPath.Add(HtmlNode.XhtmlNamespaceURI);
+    }
+
+    /// <summary>Gets the names of the open elements that are implicitly closed when <paramref name="name"/> is opened.</summary>
+    /// <param name="name">The name of the element being opened.</param>
+    /// <returns>The names of the elements to close, or an empty collection when <paramref name="name"/> closes nothing.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
+    public IReadOnlyCollection<string> GetImpliedEndTags(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        return _impliedEndTags.TryGetValue(name, out var names) ? names : [];
+    }
+
+    /// <summary>Sets the names of the open elements that are implicitly closed when <paramref name="name"/> is opened.</summary>
+    /// <param name="name">The name of the element being opened.</param>
+    /// <param name="closedElementNames">The names of the elements to close. Pass an empty array to close nothing.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> or <paramref name="closedElementNames"/> is <see langword="null"/>.</exception>
+    public void SetImpliedEndTags(string name, params string[] closedElementNames)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(closedElementNames);
+
+        _impliedEndTags[name] = new HashSet<string>(closedElementNames, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Gets the names of the elements that stop the search for an element to implicitly close.</summary>
+    /// <remarks>An open element is never implicitly closed through one of these elements.</remarks>
+    public ISet<string> ImpliedEndTagScopes => _impliedEndTagScopes;
+
+    internal bool IsImpliedEndTag(string name, string openElementName)
+    {
+        return _impliedEndTags.TryGetValue(name, out var names) && names.Contains(openElementName);
     }
 
     public HtmlElementWriteOptions GetElementWriteOptions(string name)

--- a/src/Meziantou.Framework.Html/HtmlReader.cs
+++ b/src/Meziantou.Framework.Html/HtmlReader.cs
@@ -15,6 +15,7 @@ sealed class HtmlReader
     private bool _attIsScriptType; // only for <script type=""...> parsing
     private int _eatNext;
     private bool _eof;
+    private bool _pendingTagStart; // the '<' that ended a text token belongs to the next token
 
     internal char QuoteChar { get; set; }
     internal int Line { get; set; } = 1;
@@ -83,7 +84,59 @@ sealed class HtmlReader
         {
             _currentElement = tag;
             _typeAttribute = null;
+            _attIsScriptType = false;
         }
+    }
+
+    // Called when a new tag is opened. Unlike SetCurrentElement, this always resets the
+    // '<script type="">' tracking, even when the new tag has the same name as the previous one.
+    private void StartElement(string tag)
+    {
+        _currentElement = tag;
+        _typeAttribute = null;
+        _attIsScriptType = false;
+    }
+
+    // Sets the state to enter after the '>' of a start tag has been read.
+    private void SetStateAfterTagEnd()
+    {
+        var readOptions = Options.GetElementReadOptions(_currentElement ?? string.Empty);
+        ParserState = (readOptions & HtmlElementReadOptions.InnerRaw) == HtmlElementReadOptions.InnerRaw && !Options.ParseScriptType(_typeAttribute)
+            ? HtmlParserState.RawText
+            : HtmlParserState.Text;
+    }
+
+    private void AdvancePosition(char c, char peek)
+    {
+        // a line break is "\n", "\r\n" or a lone "\r"
+        if (c == '\n' || (c == '\r' && peek != '\n'))
+        {
+            Line++;
+            Column = 1;
+        }
+        else if (c != '\r')
+        {
+            Column++;
+        }
+    }
+
+    // Returns true when the quote just appended to <paramref name="value"/> closes it.
+    // A doubled quote ("" or '') is an escaped quote and does not close the value.
+    private static bool ClosesQuotedValue(StringBuilder value, char quoteChar)
+    {
+        var run = 0;
+        for (var i = value.Length - 1; i >= 0 && value[i] == quoteChar; i--)
+        {
+            run++;
+        }
+
+        // the opening quote is not part of the content
+        if (run == value.Length)
+        {
+            run--;
+        }
+
+        return (run % 2) != 0;
     }
 
     private bool OnParsing(ref char c, ref char prev, ref char peek, out bool cont)
@@ -197,11 +250,21 @@ sealed class HtmlReader
 
             case HtmlParserState.TagOpen:
             case HtmlParserState.CommentOpen:
-                PushCurrentState(HtmlParserState.Text, "<" + _rawValue);
+            case HtmlParserState.Atts:
+                // _rawValue already contains the leading '<'
+                PushCurrentState(HtmlParserState.Text, _rawValue.ToString());
                 break;
 
-            case HtmlParserState.Atts:
-                PushCurrentState(HtmlParserState.Text, _rawValue.ToString());
+            case HtmlParserState.RawText:
+                if (Value.Length > 0)
+                {
+                    PushCurrentState(HtmlParserState.Text, Value.ToString());
+                }
+
+                break;
+
+            case HtmlParserState.CData:
+                PushCurrentState(HtmlParserState.CDataText, Value.ToString());
                 break;
 
             case HtmlParserState.AttName:
@@ -217,7 +280,7 @@ sealed class HtmlReader
                 break;
 
             case HtmlParserState.TagStart:
-                PushCurrentState(HtmlParserState.Text, "<");
+                PushCurrentState(HtmlParserState.Text, _rawValue.ToString());
                 break;
         }
     }
@@ -225,31 +288,47 @@ sealed class HtmlReader
     private void DoRead()
     {
         _rawValue.Length = 0;
+        if (_pendingTagStart)
+        {
+            // the '<' was consumed while flushing the preceding text token: it belongs to this token
+            _rawValue.Append('<');
+            _pendingTagStart = false;
+        }
+
         Value.Length = 0;
 
         var c = char.MaxValue;
         while (true)
         {
             var prev = c;
-            c = (char)TextReader.Read();
+            var read = TextReader.Read();
+            var eof = read < 0;
+            c = eof ? char.MaxValue : (char)read;
+
+            var peekRead = TextReader.Peek();
+            var peek = peekRead < 0 ? char.MaxValue : (char)peekRead;
 
             if (_eatNext > 0)
             {
                 _eatNext--;
+                if (!eof)
+                {
+                    Offset++;
+                    AdvancePosition(c, peek);
+                }
+
                 continue;
             }
 
-            var peek = (char)TextReader.Peek();
-
+            _eof = eof;
             if (!OnParsing(ref c, ref prev, ref peek, out var cont))
                 return;
 
             if (cont)
                 continue;
 
-            if (c == char.MaxValue)
+            if (_eof)
             {
-                _eof = true;
                 PushEndOfFile();
                 return;
             }
@@ -263,18 +342,7 @@ sealed class HtmlReader
                 continue;
             }
 
-            if (c == '\n')
-            {
-                Line++;
-                Column = 1;
-            }
-            else
-            {
-                if (c != '\r')
-                {
-                    Column++;
-                }
-            }
+            AdvancePosition(c, peek);
 
             switch (ParserState)
             {
@@ -283,18 +351,13 @@ sealed class HtmlReader
                     {
                         if (Value.Length == 0)
                         {
-                            if (peek == '>')
-                            {
-                                PushCurrentState(HtmlParserState.Text, _rawValue.ToString());
-                                return;
-                            }
-
                             ParserState = HtmlParserState.TagStart;
                         }
                         else
                         {
                             PushCurrentState();
                             ParserState = HtmlParserState.TagStart;
+                            _pendingTagStart = true;
                             return;
                         }
                     }
@@ -314,13 +377,15 @@ sealed class HtmlReader
                     {
                         var rawText = Value.ToString(0, Value.Length - _currentElement.Length - 2);
                         PushCurrentState(HtmlParserState.Text, rawText);
+                        PushCurrentState(HtmlParserState.TagClose, _currentElement);
                         if (c == '>')
                         {
-                            PushCurrentState(HtmlParserState.TagClose, _currentElement);
                             ParserState = HtmlParserState.Text;
                             return;
                         }
 
+                        // '</script foo>': the end tag is already closed, parse and discard what remains
+                        StartElement("/" + _currentElement);
                         ParserState = HtmlParserState.Atts;
                         return;
                     }
@@ -349,7 +414,11 @@ sealed class HtmlReader
                         continue;
                     }
 
-                    if (IsWhiteSpace(c))
+                    // '<' is only the start of a tag when followed by a tag name, an end tag,
+                    // a markup declaration ('<!') or a processing instruction ('<?').
+                    // Anything else ('a < b', '1<2', '</ b') is text.
+                    if ((!char.IsAsciiLetter(c) && c is not '/' and not '!' and not '?') ||
+                        (c == '/' && !char.IsAsciiLetter(peek)))
                     {
                         Value = new StringBuilder(_rawValue.ToString());
                         ParserState = HtmlParserState.Text;
@@ -364,42 +433,40 @@ sealed class HtmlReader
                     if (c == '<')
                     {
                         AddError(HtmlErrorType.TagNotClosed);
-                        Value = new StringBuilder(c + _rawValue.ToString());
+                        Value = new StringBuilder(_rawValue.ToString());
                         ParserState = HtmlParserState.Text;
                         continue;
                     }
 
                     if (c == '>')
                     {
-                        SetCurrentElement(Value.ToString());
+                        StartElement(Value.ToString());
                         PushCurrentState();
                         PushCurrentState(HtmlParserState.TagEnd, _currentElement);
-                        if ((Options.GetElementReadOptions(_currentElement ?? string.Empty) & HtmlElementReadOptions.InnerRaw) == HtmlElementReadOptions.InnerRaw)
-                        {
-                            // no need to check for <script type='' ..> here
-                            ParserState = HtmlParserState.RawText;
-                        }
-                        else
-                        {
-                            ParserState = HtmlParserState.Text;
-                        }
-
+                        SetStateAfterTagEnd();
                         return;
                     }
 
-                    if (c == '/' && peek == '>')
+                    if (c == '/')
                     {
-                        SetCurrentElement(Value.ToString());
+                        StartElement(Value.ToString());
                         PushCurrentState();
-                        PushCurrentState(HtmlParserState.TagEndClose, _currentElement);
-                        ParserState = HtmlParserState.Text;
-                        _eatNext = 1;
+                        if (peek == '>')
+                        {
+                            PushCurrentState(HtmlParserState.TagEndClose, _currentElement);
+                            ParserState = HtmlParserState.Text;
+                            _eatNext = 1;
+                            return;
+                        }
+
+                        // '<br/ >': the solidus is not part of the tag name
+                        ParserState = HtmlParserState.Atts;
                         return;
                     }
 
                     if (IsWhiteSpace(c))
                     {
-                        SetCurrentElement(Value.ToString());
+                        StartElement(Value.ToString());
                         PushCurrentState();
                         ParserState = HtmlParserState.Atts;
                         return;
@@ -421,11 +488,33 @@ sealed class HtmlReader
                     break;
 
                 case HtmlParserState.CommentOpen:
-                    if (c == '>' && Value.Length > 2 && Value[^1] == '-' && Value[^2] == '-')
+                    if (c == '>')
                     {
-                        PushCurrentState(HtmlParserState.CommentClose, Value.Remove(Value.Length - 2, 2).ToString());
-                        ParserState = HtmlParserState.Text;
-                        return;
+                        // '<!-->' and '<!--->' are empty comments (abrupt closing)
+                        if (Value.Length == 0 || (Value.Length == 1 && Value[0] == '-'))
+                        {
+                            PushCurrentState(HtmlParserState.CommentClose, string.Empty);
+                            ParserState = HtmlParserState.Text;
+                            return;
+                        }
+
+                        // a comment ends with '-->' or with '--!>'
+                        var closingLength = 0;
+                        if (Value.Length >= 2 && Value[^1] == '-' && Value[^2] == '-')
+                        {
+                            closingLength = 2;
+                        }
+                        else if (Value.Length >= 3 && Value[^1] == '!' && Value[^2] == '-' && Value[^3] == '-')
+                        {
+                            closingLength = 3;
+                        }
+
+                        if (closingLength > 0)
+                        {
+                            PushCurrentState(HtmlParserState.CommentClose, Value.ToString(0, Value.Length - closingLength));
+                            ParserState = HtmlParserState.Text;
+                            return;
+                        }
                     }
 
                     Value.Append(c);
@@ -435,31 +524,22 @@ sealed class HtmlReader
                     if (c == '>')
                     {
                         PushCurrentState(HtmlParserState.TagEnd, _currentElement);
-                        if ((Options.GetElementReadOptions(_currentElement ?? string.Empty) & HtmlElementReadOptions.InnerRaw) == HtmlElementReadOptions.InnerRaw)
-                        {
-                            if (Options.ParseScriptType(_typeAttribute))
-                            {
-                                ParserState = HtmlParserState.Text;
-                            }
-                            else
-                            {
-                                ParserState = HtmlParserState.RawText;
-                            }
-                        }
-                        else
-                        {
-                            ParserState = HtmlParserState.Text;
-                        }
-
+                        SetStateAfterTagEnd();
                         return;
                     }
 
-                    if (c == '/' && peek == '>')
+                    if (c == '/')
                     {
-                        PushCurrentState(HtmlParserState.TagEndClose, _currentElement);
-                        ParserState = HtmlParserState.Text;
-                        _eatNext = 1;
-                        return;
+                        if (peek == '>')
+                        {
+                            PushCurrentState(HtmlParserState.TagEndClose, _currentElement);
+                            ParserState = HtmlParserState.Text;
+                            _eatNext = 1;
+                            return;
+                        }
+
+                        // a solidus that does not close the tag is not an attribute name
+                        break;
                     }
 
                     if (!IsWhiteSpace(c))
@@ -493,7 +573,7 @@ sealed class HtmlReader
                     {
                         Value.Append(c);
                         // check escaped quote
-                        if (c == QuoteChar && peek != QuoteChar && prev != QuoteChar)
+                        if (c == QuoteChar && peek != QuoteChar && ClosesQuotedValue(Value, QuoteChar))
                         {
                             PushCurrentState();
                             ParserState = HtmlParserState.Atts;
@@ -514,32 +594,24 @@ sealed class HtmlReader
                             PushCurrentState();
                             PushCurrentState(HtmlParserState.AttValue, value: null);
                             PushCurrentState(HtmlParserState.TagEnd, _currentElement);
-                            if ((Options.GetElementReadOptions(_currentElement ?? string.Empty) & HtmlElementReadOptions.InnerRaw) == HtmlElementReadOptions.InnerRaw)
-                            {
-                                if (Options.ParseScriptType(_typeAttribute))
-                                {
-                                    ParserState = HtmlParserState.Text;
-                                }
-                                else
-                                {
-                                    ParserState = HtmlParserState.RawText;
-                                }
-                            }
-                            else
-                            {
-                                ParserState = HtmlParserState.Text;
-                            }
-
+                            SetStateAfterTagEnd();
                             return;
                         }
 
-                        if (c == '/' && peek == '>')
+                        if (c == '/')
                         {
                             PushCurrentState();
                             PushCurrentState(HtmlParserState.AttValue, value: null);
-                            PushCurrentState(HtmlParserState.TagEndClose, _currentElement);
-                            ParserState = HtmlParserState.Text;
-                            _eatNext = 1;
+                            if (peek == '>')
+                            {
+                                PushCurrentState(HtmlParserState.TagEndClose, _currentElement);
+                                ParserState = HtmlParserState.Text;
+                                _eatNext = 1;
+                                return;
+                            }
+
+                            // a solidus that does not close the tag is not part of the attribute name
+                            ParserState = HtmlParserState.Atts;
                             return;
                         }
 
@@ -567,32 +639,23 @@ sealed class HtmlReader
                         PushCurrentState();
                         PushCurrentState(HtmlParserState.AttValue, value: null);
                         PushCurrentState(HtmlParserState.TagEnd, _currentElement);
-                        if ((Options.GetElementReadOptions(_currentElement ?? string.Empty) & HtmlElementReadOptions.InnerRaw) == HtmlElementReadOptions.InnerRaw)
-                        {
-                            if (Options.ParseScriptType(_typeAttribute))
-                            {
-                                ParserState = HtmlParserState.Text;
-                            }
-                            else
-                            {
-                                ParserState = HtmlParserState.RawText;
-                            }
-                        }
-                        else
-                        {
-                            ParserState = HtmlParserState.Text;
-                        }
-
+                        SetStateAfterTagEnd();
                         return;
                     }
 
-                    if (c == '/' && peek == '>')
+                    if (c == '/')
                     {
                         PushCurrentState();
                         PushCurrentState(HtmlParserState.AttValue, value: null);
-                        PushCurrentState(HtmlParserState.TagEndClose, _currentElement);
-                        ParserState = HtmlParserState.Text;
-                        _eatNext = 1;
+                        if (peek == '>')
+                        {
+                            PushCurrentState(HtmlParserState.TagEndClose, _currentElement);
+                            ParserState = HtmlParserState.Text;
+                            _eatNext = 1;
+                            return;
+                        }
+
+                        ParserState = HtmlParserState.Atts;
                         return;
                     }
 
@@ -611,19 +674,19 @@ sealed class HtmlReader
                 case HtmlParserState.AttValue:
                     if (Value.Length == 0) // first char?
                     {
+                        if (c == '>')
+                        {
+                            // '<a b=>' declares an empty value and ends the tag
+                            PushCurrentState();
+                            PushCurrentState(HtmlParserState.TagEnd, _currentElement);
+                            SetStateAfterTagEnd();
+                            return;
+                        }
+
                         if (!IsWhiteSpace(c))
                         {
-                            if (IsAnyQuote(c))
-                            {
-                                // quoted
-                                QuoteChar = c;
-                            }
-                            else
-                            {
-                                // not quoted
-                                QuoteChar = '\0';
-                            }
-
+                            // a quote as the first character starts a quoted value
+                            QuoteChar = IsAnyQuote(c) ? c : '\0';
                             Value.Append(c);
                         }
                         // else skip whitespaces
@@ -635,7 +698,7 @@ sealed class HtmlReader
                         {
                             Value.Append(c);
                             // check escaped quote
-                            if (c == QuoteChar && peek != QuoteChar && (prev != QuoteChar || Value.Length == 2)) // test "" or ''
+                            if (c == QuoteChar && peek != QuoteChar && ClosesQuotedValue(Value, QuoteChar))
                             {
                                 PushCurrentState();
                                 ParserState = HtmlParserState.Atts;
@@ -648,31 +711,7 @@ sealed class HtmlReader
                             {
                                 PushCurrentState();
                                 PushCurrentState(HtmlParserState.TagEnd, _currentElement);
-                                if ((Options.GetElementReadOptions(_currentElement ?? string.Empty) & HtmlElementReadOptions.InnerRaw) == HtmlElementReadOptions.InnerRaw)
-                                {
-                                    if (Options.ParseScriptType(_typeAttribute))
-                                    {
-                                        ParserState = HtmlParserState.Text;
-                                    }
-                                    else
-                                    {
-                                        ParserState = HtmlParserState.RawText;
-                                    }
-                                }
-                                else
-                                {
-                                    ParserState = HtmlParserState.Text;
-                                }
-
-                                return;
-                            }
-
-                            if (c == '/' && peek == '>')
-                            {
-                                PushCurrentState();
-                                PushCurrentState(HtmlParserState.TagEndClose, _currentElement);
-                                ParserState = HtmlParserState.Text;
-                                _eatNext = 1;
+                                SetStateAfterTagEnd();
                                 return;
                             }
 
@@ -683,6 +722,7 @@ sealed class HtmlReader
                                 return;
                             }
 
+                            // a solidus is part of an unquoted value ('<a href=foo/>' is href="foo/")
                             Value.Append(c);
                         }
                     }

--- a/src/Meziantou.Framework.Html/HtmlReaderState.cs
+++ b/src/Meziantou.Framework.Html/HtmlReaderState.cs
@@ -49,12 +49,14 @@ sealed class HtmlReaderState
             if (RawParserState == HtmlParserState.TagOpen && RawValue is not null && RawValue.StartsWith('/', StringComparison.Ordinal))
                 return RawValue[1..];
 
-            if (RawValue is not null && (RawParserState == HtmlParserState.AttValue || RawParserState == HtmlParserState.AttName) &&
-                ((RawValue.StartsWith('\'', StringComparison.Ordinal) && RawValue.EndsWith('\'', StringComparison.Ordinal)) ||
-                (RawValue.StartsWith('"', StringComparison.Ordinal) && RawValue.EndsWith('"', StringComparison.Ordinal))))
+            if (RawValue is not null && RawParserState is HtmlParserState.AttValue or HtmlParserState.AttName &&
+                RawValue.Length > 0 && HtmlReader.IsAnyQuote(RawValue[0]))
             {
                 var quote = RawValue[0];
-                return RawValue[1..^1].Replace(new string(quote, 2), new string(quote, 1), StringComparison.Ordinal);
+
+                // the closing quote is missing when the document ends in the middle of the value
+                var end = RawValue.Length > 1 && RawValue[^1] == quote ? RawValue.Length - 1 : RawValue.Length;
+                return RawValue[1..end].Replace(new string(quote, 2), new string(quote, 1), StringComparison.Ordinal);
             }
 
             return RawValue;

--- a/tests/Meziantou.Framework.Html.Tests/HtmlNodeDepthComparerTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/HtmlNodeDepthComparerTests.cs
@@ -18,7 +18,7 @@ public class HtmlNodeDepthComparerTests
     public void Compare_DirectionAscending_LessThan()
     {
         var document = new HtmlDocument();
-        document.LoadHtml("<p><span id='id1'>1</span><p><span id='id2'>2</span></p></p>");
+        document.LoadHtml("<div><span id='id1'>1</span><div><span id='id2'>2</span></div></div>");
         var element1 = document.SelectSingleNode("//span[@id='id1']");
         var element2 = document.SelectSingleNode("//span[@id='id2']");
 
@@ -34,7 +34,7 @@ public class HtmlNodeDepthComparerTests
     public void Compare_DirectionDescending_LessThan()
     {
         var document = new HtmlDocument();
-        document.LoadHtml("<p><span id='id1'>1</span><p><span id='id2'>2</span></p></p>");
+        document.LoadHtml("<div><span id='id1'>1</span><div><span id='id2'>2</span></div></div>");
         var element1 = document.SelectSingleNode("//span[@id='id1']");
         var element2 = document.SelectSingleNode("//span[@id='id2']");
 

--- a/tests/Meziantou.Framework.Html.Tests/HtmlParserTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/HtmlParserTests.cs
@@ -115,4 +115,426 @@ public class HtmlParserTests
         document.Load(memoryStream);
         Assert.Equal(Encoding.UTF8, document.DetectedEncoding);
     }
+
+    [Theory]
+    [InlineData("<!--comment-->", "comment")]
+    [InlineData("<!-- a -- b -->", " a -- b ")]
+    [InlineData("<!--<div>-->", "<div>")]
+    [InlineData("<!--<!-- -->", "<!-- ")]
+    // '--!>' also closes a comment
+    [InlineData("<!-- x --!>", " x ")]
+    [InlineData("<!----!>", "")]
+    // empty and abruptly closed comments
+    [InlineData("<!---->", "")]
+    [InlineData("<!-->", "")]
+    [InlineData("<!--->", "")]
+    [InlineData("<!----->", "-")]
+    // a bare '>' does not close a comment
+    [InlineData("<!--a>b-->", "a>b")]
+    public void HtmlParser_ParseCommentValue(string html, string expectedValue)
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml(html);
+
+        var comment = Assert.Single(document.ChildNodes);
+        Assert.Equal(HtmlNodeType.Comment, comment.NodeType);
+        Assert.Equal(expectedValue, comment.Value);
+    }
+
+    [Fact]
+    public void HtmlParser_CommentEndBangIsFollowedByText()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<!-- x --!>after");
+
+        Assert.Collection(
+            document.ChildNodes,
+            node =>
+            {
+                Assert.Equal(HtmlNodeType.Comment, node.NodeType);
+                Assert.Equal(" x ", node.Value);
+            },
+            node =>
+            {
+                Assert.Equal(HtmlNodeType.Text, node.NodeType);
+                Assert.Equal("after", node.Value);
+            });
+    }
+
+    [Theory]
+    // an unterminated construct at the end of the document degrades to text and keeps every character
+    [InlineData("<!--x")]
+    [InlineData("<!-- a")]
+    [InlineData("<div<p>x")]
+    [InlineData("<")]
+    [InlineData("a<")]
+    // '<' is only the start of a tag when followed by a tag name
+    [InlineData("a < b")]
+    [InlineData("a <3 b")]
+    [InlineData("1<2 and 3>4")]
+    [InlineData("a<<b")]
+    [InlineData("<<b>")]
+    [InlineData("<>x")]
+    [InlineData("a<>b")]
+    [InlineData("a</ b")]
+    [InlineData("</ p>x")]
+    [InlineData("2 < 3 && 4 > 1")]
+    public void HtmlParser_TextIsNotAlteredByTheParser(string html)
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml(html);
+
+        Assert.Equal(html, document.OuterHtml);
+        Assert.All(document.ChildNodes, node => Assert.Equal(HtmlNodeType.Text, node.NodeType));
+    }
+
+    [Fact]
+    public void HtmlParser_UnterminatedQuotedAttributeValue()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<a b='x");
+
+        var element = document.SelectSingleNode("//a");
+        Assert.NotNull(element);
+        Assert.Equal("x", element!.GetAttributeValue("b"));
+    }
+
+    [Theory]
+    [InlineData("<a b=\"")]
+    [InlineData("<a b='")]
+    [InlineData("<a \"")]
+    [InlineData("<a '")]
+    public void HtmlParser_DocumentEndingOnAnOpeningQuoteDoesNotThrow(string html)
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml(html);
+
+        Assert.NotNull(document.SelectSingleNode("//a"));
+    }
+
+    [Fact]
+    public void HtmlParser_UnterminatedAttributeValueKeepsEveryCharacter()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<a b=\"unclosed>z</a>");
+
+        var element = document.SelectSingleNode("//a");
+        Assert.NotNull(element);
+        Assert.Equal("unclosed>z</a>", element!.GetAttributeValue("b"));
+    }
+
+    [Fact]
+    public void HtmlParser_UnterminatedScriptKeepsItsContent()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<script>var a = 1;");
+
+        var script = document.SelectSingleNode("//script");
+        Assert.NotNull(script);
+        Assert.Equal("var a = 1;", script!.InnerText);
+    }
+
+    [Fact]
+    public void HtmlParser_UnterminatedStyleKeepsItsContent()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<style>a{color:red}");
+
+        var style = document.SelectSingleNode("//style");
+        Assert.NotNull(style);
+        Assert.Equal("a{color:red}", style!.InnerText);
+    }
+
+    [Fact]
+    public void HtmlParser_UnterminatedCDataKeepsItsContent()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<![CDATA[a]");
+
+        var text = Assert.Single(document.ChildNodes);
+        Assert.Equal(HtmlNodeType.Text, text.NodeType);
+        Assert.Equal("a]", text.Value);
+    }
+
+    [Fact]
+    public void HtmlParser_UnterminatedAttributeNameKeepsTheElement()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<div class");
+
+        var element = document.SelectSingleNode("//div");
+        Assert.NotNull(element);
+        Assert.True(element!.HasAttribute("class"));
+    }
+
+    [Theory]
+    // the end tag may hold whitespace or attributes, and what follows it must not be lost
+    [InlineData("<script>a</script >b", "a")]
+    [InlineData("<script>a</script\tfoo>b", "a")]
+    [InlineData("<script>a</script\n>b", "a")]
+    [InlineData("<script>a</SCRIPT>b", "a")]
+    [InlineData("<script>var a = \"1\";</script>b", "var a = \"1\";")]
+    public void HtmlParser_ScriptEndTag(string html, string expectedContent)
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml(html);
+
+        var script = document.SelectSingleNode("//script");
+        Assert.NotNull(script);
+        Assert.Equal(expectedContent, script!.InnerText);
+        Assert.Equal("b", document.LastChild!.Value);
+    }
+
+    [Fact]
+    public void HtmlParser_ScriptIsOnlyClosedByItsOwnEndTag()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<script>a</scriptx>b</script>");
+
+        var script = document.SelectSingleNode("//script");
+        Assert.NotNull(script);
+        Assert.Equal("a</scriptx>b", script!.InnerText);
+    }
+
+    [Fact]
+    public void HtmlParser_StyleEndTagWithWhitespace()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<style>a</style >b");
+
+        var style = document.SelectSingleNode("//style");
+        Assert.NotNull(style);
+        Assert.Equal("a", style!.InnerText);
+        Assert.Equal("b", document.LastChild!.Value);
+    }
+
+    [Fact]
+    public void HtmlParser_ScriptTypeIsNotInheritedByNestedScripts()
+    {
+        var document = new HtmlDocument();
+        document.Options.ParsedScriptTypes.Add("text/template");
+        document.LoadHtml("<script type=\"text/template\"><script src=\"x\"><b>a</b></script></script>");
+
+        var inner = document.SelectSingleNode("//script/script");
+        Assert.NotNull(inner);
+
+        // the inner script has no 'type' attribute: its content is raw text
+        var text = Assert.Single(inner!.ChildNodes);
+        Assert.Equal(HtmlNodeType.Text, text.NodeType);
+        Assert.Equal("<b>a</b>", text.Value);
+    }
+
+    [Fact]
+    public void HtmlParser_TitleContainsRawText()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<title>a<b</title>x");
+
+        var title = document.SelectSingleNode("//title");
+        Assert.NotNull(title);
+        Assert.Equal("a<b", title!.InnerText);
+        Assert.Equal("x", document.LastChild!.Value);
+    }
+
+    [Fact]
+    public void HtmlParser_TextAreaContainsRawText()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<textarea><p>hello</textarea>x");
+
+        var textarea = document.SelectSingleNode("//textarea");
+        Assert.NotNull(textarea);
+        Assert.Equal("<p>hello", textarea!.InnerText);
+        Assert.Empty(document.SelectNodes("//p"));
+    }
+
+    [Theory]
+    // a solidus is part of an unquoted attribute value
+    [InlineData("<a href=foo/>", "href", "foo/")]
+    [InlineData("<a href=/>", "href", "/")]
+    [InlineData("<a href=http://example.com/x>", "href", "http://example.com/x")]
+    // an attribute without a value is empty, it does not swallow the rest of the tag
+    [InlineData("<a b=>", "b", "")]
+    [InlineData("<a b= >", "b", "")]
+    // a doubled quote is an escaped quote
+    [InlineData("<a b=\"a\"\"b\">", "b", "a\"b")]
+    [InlineData("<a b=\"\">", "b", "")]
+    [InlineData("<a b=\"\"\"\">", "b", "\"")]
+    [InlineData("<a b='a''b'>", "b", "a'b")]
+    // a processing instruction ends with '?>'
+    [InlineData("<?xml version=\"1.0\"?>", "version", "1.0")]
+    [InlineData("<?xml version=\"1.0\" encoding=\"utf-8\"?>", "encoding", "utf-8")]
+    public void HtmlParser_ParseAttributeValue(string html, string attributeName, string expectedValue)
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml(html);
+
+        var element = (HtmlElement)document.FirstChild!;
+        Assert.Equal(expectedValue, element.GetAttributeValue(attributeName));
+    }
+
+    [Fact]
+    public void HtmlParser_AttributeValueEndsTheTag()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<a b=>z</a>");
+
+        var element = document.SelectSingleNode("//a");
+        Assert.NotNull(element);
+        Assert.Equal("", element!.GetAttributeValue("b"));
+        Assert.Equal("z", element.InnerText);
+    }
+
+    [Fact]
+    public void HtmlParser_SolidusIsNotPartOfTheTagName()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<br/ >x");
+
+        Assert.NotNull(document.SelectSingleNode("//br"));
+        Assert.Equal("x", document.LastChild!.Value);
+    }
+
+    [Fact]
+    public void HtmlParser_SolidusIsNotPartOfTheAttributeName()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<a b/c>");
+
+        var element = document.SelectSingleNode("//a");
+        Assert.NotNull(element);
+        Assert.True(element!.HasAttribute("b"));
+        Assert.True(element.HasAttribute("c"));
+    }
+
+    [Fact]
+    public void HtmlParser_EndTagAttributesAreNotAddedToTheParent()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<div><p>a</p class=\"x\"></div>");
+
+        var div = document.SelectSingleNode("//div");
+        Assert.NotNull(div);
+        Assert.False(div!.HasAttributes);
+        Assert.Equal("<div><p>a</p></div>", document.OuterHtml);
+    }
+
+    [Theory]
+    [InlineData("<p>a<p>b", "<p>a</p><p>b</p>")]
+    [InlineData("<p>a<div>b</div>", "<p>a</p><div>b</div>")]
+    [InlineData("<p>a<b>c<p>d", "<p>a<b>c</b></p><p>d</p>")]
+    [InlineData("<ul><li>1<li>2</ul>", "<ul><li>1</li><li>2</li></ul>")]
+    [InlineData("<ul><li><b>x<li>y</ul>", "<ul><li><b>x</b></li><li>y</li></ul>")]
+    [InlineData("<dl><dt>a<dd>b<dt>c</dl>", "<dl><dt>a</dt><dd>b</dd><dt>c</dt></dl>")]
+    [InlineData("<select><option>1<option>2</select>", "<select><option>1</option><option>2</option></select>")]
+    [InlineData("<table><tr><td>a<td>b<tr><td>c</table>", "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td></tr></table>")]
+    // already well-formed documents are not altered
+    [InlineData("<div><p>a</p><p>b</p></div>", "<div><p>a</p><p>b</p></div>")]
+    [InlineData("<ul><li>a</li><li>b</li></ul>", "<ul><li>a</li><li>b</li></ul>")]
+    // elements that do not imply an end tag still nest
+    [InlineData("<span>a<span>b</span></span>", "<span>a<span>b</span></span>")]
+    public void HtmlParser_ImpliedEndTags(string html, string expected)
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml(html);
+
+        Assert.Equal(expected, document.OuterHtml);
+    }
+
+    [Fact]
+    public void HtmlParser_ImpliedEndTagsCanBeConfigured()
+    {
+        var document = new HtmlDocument();
+        document.Options.SetImpliedEndTags("p");
+        document.LoadHtml("<p>a<p>b");
+
+        Assert.Equal("<p>a<p>b</p></p>", document.OuterHtml);
+    }
+
+    [Theory]
+    // the <li> of a nested list does not close the <li> of the outer list
+    [InlineData("<ul><li>a<ul><li>b</ul></ul>", "<ul><li>a<ul><li>b</li></ul></li></ul>")]
+    // the <td> of a nested table does not close the <td> of the outer table
+    [InlineData("<table><tr><td>a<table><tr><td>b</table></table>", "<table><tr><td>a<table><tr><td>b</td></tr></table></td></tr></table>")]
+    public void HtmlParser_ImpliedEndTagsDoNotCrossAScopeBoundary(string html, string expected)
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml(html);
+
+        Assert.Equal(expected, document.OuterHtml);
+    }
+
+    [Fact]
+    public void HtmlParser_ParseUnicodeNonCharacter()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("x￿y");
+
+        var text = Assert.Single(document.ChildNodes);
+        Assert.Equal("x￿y", text.Value);
+    }
+
+    [Theory]
+    // the '>' eaten after a '/' must still be counted: '<br/>' and '<br >' put '<p>' at the same offset
+    [InlineData("<br/><p>ab</p>")]
+    [InlineData("<br ><p>ab</p>")]
+    public void HtmlReader_TracksPositionsAcrossSelfClosingTags(string html)
+    {
+        var states = ReadAll(html);
+
+        var text = states.Single(s => s.ParserState == HtmlParserState.Text);
+        Assert.Equal("ab", text.Value);
+
+        // the state is pushed when the '<' of '</p>' is read, at offset 10
+        Assert.Equal(10, text.Offset);
+        Assert.Equal(1, text.Line);
+    }
+
+    [Fact]
+    public void HtmlReader_TracksOffsets()
+    {
+        var states = ReadAll("<p a='1'>b</p>");
+
+        Assert.Collection(
+            states,
+            state => AssertState(state, HtmlParserState.TagOpen, "p", offset: 2),
+            state => AssertState(state, HtmlParserState.AttName, "a", offset: 4),
+            state => AssertState(state, HtmlParserState.AttValue, "1", offset: 7),
+            state => AssertState(state, HtmlParserState.TagEnd, "p", offset: 8),
+            state => AssertState(state, HtmlParserState.Text, "b", offset: 10),
+            state => AssertState(state, HtmlParserState.TagClose, "p", offset: 13),
+            state => AssertState(state, HtmlParserState.TagEnd, "/p", offset: 13));
+
+        static void AssertState(HtmlReaderState state, HtmlParserState parserState, string value, int offset)
+        {
+            Assert.Equal(parserState, state.ParserState);
+            Assert.Equal(value, state.Value);
+            Assert.Equal(offset, state.Offset);
+        }
+    }
+
+    [Theory]
+    [InlineData("a\nb", 2)]
+    [InlineData("a\r\nb", 2)]
+    [InlineData("a\rb", 2)]
+    [InlineData("a\r\nb\rc\nd", 4)]
+    [InlineData("a\n\nb", 3)]
+    public void HtmlReader_CountsLines(string html, int expectedLine)
+    {
+        var states = ReadAll(html);
+
+        Assert.Equal(expectedLine, states[^1].Line);
+    }
+
+    private static List<HtmlReaderState> ReadAll(string html)
+    {
+        var reader = new HtmlReader(new StringReader(html));
+        var states = new List<HtmlReaderState>();
+        while (reader.Read())
+        {
+            states.Add(reader.State);
+        }
+
+        return states;
+    }
 }


### PR DESCRIPTION
## Why

While auditing `Meziantou.Framework.Html` for syntaxes it handles incorrectly, I found a crash, several cases of silent data loss, and a number of divergences from HTML tokenization. Every case below was reproduced against the parser before being fixed, and each one has a test.

## Crashes and data loss

- **`<a b="` threw `ArgumentOutOfRangeException`.** The unquoting logic tested `StartsWith(quote) && EndsWith(quote)`, which is true for a *single* quote character, so `RawValue[1..^1]` went negative. Any truncated HTML ending on an opening quote killed the parse.
- **Unterminated `<script>` / `<style>` content was discarded**, and **unterminated `<![CDATA[` discarded the entire document** — `PushEndOfFile` had no case for `RawText` or `CData`.
- **`<script>a</script >b` lost `b`.** An end tag with whitespace before `>` left `RawText` through the `Atts` path, which emits `TagEnd` rather than `TagClose`, so the element never closed and the trailing text hit the case above.
- **`a<<b` and `a < b` lost a character.** The `<` that terminates a text token was consumed and never re-emitted.

## Comments

The close test was `c == '>' && Value.Length > 2 && Value[^1] == '-' && Value[^2] == '-'`, which has three separate defects:

| Input | Before | After |
|---|---|---|
| `<!-- x --!>after` | text `<<!-- x --!>after` | comment ` x `, text `after` |
| `<!---->x` | text `<<!---->x` | empty comment, text `x` |
| `<!-->x` / `<!--->x` | text | empty comment, text `x` |
| `<!--x` | text `<<!--x` | text `<!--x` |

`--!>` is now a terminator, the length guard is `>= 2` so the empty comment `<!---->` closes, and the abrupt-closing forms are recognized. The `<<` in the "before" column is a separate bug: the EOF fallback prepended `"<"` to a raw value that already had one.

## Tokenizer state

- **U+FFFF was read as EOF** — `(char)TextReader.Read()` maps `-1` to `char.MaxValue`, colliding with a real character. `x￿y` parsed as `x`. EOF is now detected from `read < 0`.
- **Offsets and columns drifted by one per self-closing tag.** The `_eatNext` skip `continue`d before the position bookkeeping, so the `>` eaten after `/` was never counted; every `/>` added another unit of drift to error positions. A lone `\r` now also advances the line counter.
- **`<a b="""">` swallowed the rest of the document.** The `prev`-based doubled-quote heuristic is replaced by `ClosesQuotedValue`, which decides on the parity of the trailing quote run.
- **Solidus handling:** `<br/ >` is `<br>` (was an element named `br/`), `<a b/c>` yields attributes `b` and `c`, and `/` in an unquoted value is content — `href=foo/` is `"foo/"`, matching HTML.
- **`<a b=>`** is an empty value that ends the tag; it previously read `>` as the value's first character and consumed `>z</a`.
- **`<` only starts a tag before an ASCII letter, `/`, `!` or `?`.** `a <3 b` and `1<2 and 3>4` were producing elements named `3` and `2`.
- **A nested `<script>` no longer inherits the outer one's `type`.** `SetCurrentElement` only reset the tracking when the tag name *changed*, so `<script type="text/template"><script src=x>…` parsed the inner script as markup.

Four copies of the "what state follows `>`" logic are collapsed into `SetStateAfterTagEnd`.

## Tree builder

- **End-tag attributes landed on the parent.** `<div><p>a</p class="x"></div>` was putting `class` on the `<div>`.
- **`<?xml version="1.0"?>` was mangled.** The trailing `?` attribute name is skipped, but `currentAtt` stayed pointing at `version`, so the following null value overwrote it. `version` came out empty.
- **Implied end tags.** No element did them before, so `<li>a<li>b` and `<p>a<p>b` nested instead of producing siblings. `CloseImpliedElements` closes the elements a start tag implies, walking ancestors but never crossing a scope boundary — so a nested list's `<li>` does not close the outer one.

## Options

`title` and `textarea` now hold raw text (`<title>a<b</title>` was building a `<b` element); `track` is void and `wbr` is marked `NoChild`; the duplicated `header` / `i` / `ins` write-option lines are removed.

## Reviewer notes

- **New public API on `HtmlOptions`:** `GetImpliedEndTags`, `SetImpliedEndTags`, `ImpliedEndTagScopes`. `ref/Meziantou.Framework.Html.cs` is regenerated accordingly. The implied-end-tag table is fully configurable — `SetImpliedEndTags("p")` restores the old nesting.
- **Deliberately unchanged:** `<![CDATA[…]]>` is still honored in HTML content rather than treated as a bogus comment, since it is a real feature of this library (`HtmlText.IsCData`, `HtmlFragmentType.CDataText`) — only the unterminated-CDATA data loss is fixed. Character references are still not decoded in text nodes, keeping documents round-trippable. Truncated constructs at EOF still degrade to text rather than becoming comments or elements, matching the existing design intent, just without losing characters. The implied-end-tag walk is a scope-bounded approximation of the HTML5 algorithm, not the full adoption-agency machinery, so `<b>a<i>b</b>c</i>` still reports `TagNotOpened`.
- **One pre-existing test updated:** `HtmlNodeDepthComparerTests` used `<p><span/><p><span/></p></p>` to obtain two different depths. That markup correctly no longer nests, so the markup is now `<div>`-based; the test is about the comparer, not about `<p>`.

## Verification

`HtmlParserTests` goes from 8 to 39 test methods (43 → 256 cases across both TFMs), covering every case above.

| Suite | Tests | Failed |
|---|---|---|
| Html.Tests | 256 | 0 |
| HtmlSanitizer.Tests | 24 | 0 |
| HumanReadableSerializer.Tests (embeds the Html sources) | 532 | 0 |
| HtmlToMarkdown.Tests | 1694 | 0 |
| Html.Tool.Tests | 12 | 0 |
| Templating.Html.Tests | 18 | 0 |

Full-repo `dotnet build /p:TreatWarningsAsErrors=true` is clean, `dotnet run ./eng/update-all.cs` was run, and `ref/` was verified stable under Release + `IsOfficialBuild`.
