### PR TITLE
Fix HtmlSanitizer bypasses and content loss

### DIFF
--- a/ref/Meziantou.Framework.HtmlSanitizer.cs
+++ b/ref/Meziantou.Framework.HtmlSanitizer.cs
@@ -11,6 +11,7 @@ namespace Meziantou.Framework.Sanitizers
         public System.Collections.Generic.ISet<string> BlockedElements { get => throw null; }
         public System.Collections.Generic.ISet<string> UriAttributes { get => throw null; }
         public System.Collections.Generic.ISet<string> SrcsetAttributes { get => throw null; }
+        public bool AllowComments { get => throw null; set { } }
         public string? SanitizeHtmlFragment(string? html) => throw null;
     }
 

--- a/src/Meziantou.Framework.Html/HtmlDocument.cs
+++ b/src/Meziantou.Framework.Html/HtmlDocument.cs
@@ -1151,10 +1151,7 @@ sealed class HtmlDocument : HtmlNode
     {
         ArgumentNullException.ThrowIfNull(writer);
 
-        foreach (var node in ChildNodes)
-        {
-            node.WriteTo(writer);
-        }
+        WriteChildNodesTo(this, writer);
     }
 
     public override void WriteTo(XmlWriter writer)

--- a/src/Meziantou.Framework.Html/HtmlElement.cs
+++ b/src/Meziantou.Framework.Html/HtmlElement.cs
@@ -212,6 +212,19 @@ sealed class HtmlElement : HtmlNode
 
     public override void WriteTo(TextWriter writer)
     {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!WriteStartTagTo(writer))
+            return;
+
+        WriteChildNodesTo(this, writer);
+        WriteEndTagTo(writer);
+    }
+
+    /// <summary>Writes the tag of the element, up to and including its closing '&gt;'.</summary>
+    /// <returns><see langword="false"/> when nothing else has to be written for this element, either because the tag is self-closed or because the element is intentionally left open.</returns>
+    internal bool WriteStartTagTo(TextWriter writer)
+    {
         writer.Write('<');
         if (IsProcessingInstruction)
         {
@@ -266,39 +279,32 @@ sealed class HtmlElement : HtmlNode
                 writer.Write(CloseChar);
                 writer.Write('>');
             }
+
+            return false;
         }
-        else
+
+        writer.Write('>');
+        return !((!HasChildNodes || NoChild) && dontCloseIfEmpty);
+    }
+
+    /// <summary>Writes the end tag of the element, when it needs one.</summary>
+    internal void WriteEndTagTo(TextWriter writer)
+    {
+        if (_closed || AlwaysClose || (OwnerDocument?.IsXhtml == true))
         {
+            writer.Write("</");
+            writer.Write(Name);
             writer.Write('>');
-
-            if ((!HasChildNodes || NoChild) && dontCloseIfEmpty)
-                return;
-
-            WriteContentTo(writer);
-
-            if (_closed || alwaysClose || (OwnerDocument?.IsXhtml == true))
-            {
-                writer.Write("</");
-                writer.Write(Name);
-                writer.Write('>');
-            }
         }
     }
+
+    internal override bool HasContentToWrite => !NoChild && HasChildNodes;
 
     public override void WriteContentTo(TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(writer);
 
-        if (!NoChild)
-        {
-            if (HasChildNodes)
-            {
-                foreach (var node in ChildNodes)
-                {
-                    node.WriteTo(writer);
-                }
-            }
-        }
+        WriteChildNodesTo(this, writer);
     }
 
     public override void WriteTo(XmlWriter writer)

--- a/src/Meziantou.Framework.Html/HtmlNode.cs
+++ b/src/Meziantou.Framework.Html/HtmlNode.cs
@@ -13,8 +13,6 @@ internal
 #endif
 abstract partial class HtmlNode : INotifyPropertyChanged, IXmlNamespaceResolver
 {
-    private const int MaxRecursion = 300;
-
     public const string XmlnsPrefix = "xmlns";
     public const string XmlnsNamespaceURI = "http://www.w3.org/2000/xmlns/";
 
@@ -76,22 +74,16 @@ abstract partial class HtmlNode : INotifyPropertyChanged, IXmlNamespaceResolver
 
     protected internal virtual void ClearCaches()
     {
-        ClearCaches(0);
-    }
-
-    private void ClearCaches(int index)
-    {
-        // deep recursion testing. incurred because of xslt in general
-        if (index > MaxRecursion)
-            throw new HtmlException($"HTML0005: Maximum recursion depth ({MaxRecursion.ToString(CultureInfo.InvariantCulture)}) exceeded. This may be caused by a recursive XSLT.");
-
-        _innerHtml = null;
-        _innerText = null;
-        _innerXml = null;
-        _outerHtml = null;
-        _outerXml = null;
-
-        _parentNode?.ClearCaches(index + 1);
+        // Walking the ancestors iteratively instead of recursively: a document can legitimately be nested
+        // thousands of levels deep and a recursive walk would overflow the stack.
+        for (var node = this; node is not null; node = node._parentNode)
+        {
+            node._innerHtml = null;
+            node._innerText = null;
+            node._innerXml = null;
+            node._outerHtml = null;
+            node._outerXml = null;
+        }
     }
 
     protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/src/Meziantou.Framework.Html/HtmlNode.cs
+++ b/src/Meziantou.Framework.Html/HtmlNode.cs
@@ -72,6 +72,57 @@ abstract partial class HtmlNode : INotifyPropertyChanged, IXmlNamespaceResolver
         return Utilities.GetValidXmlName(name);
     }
 
+    /// <summary>Gets a value indicating whether the child nodes of this node have to be written by <see cref="WriteChildNodesTo"/>.</summary>
+    internal virtual bool HasContentToWrite => HasChildNodes;
+
+    // The tree is walked iteratively: a document can be nested thousands of levels deep and recursing once per
+    // level would overflow the stack, which cannot be caught and takes the whole process down.
+    private protected static void WriteChildNodesTo(HtmlNode parent, TextWriter writer)
+    {
+        if (!parent.HasContentToWrite)
+            return;
+
+        var pendingNodes = new Stack<PendingWrite>();
+        PushChildNodes(pendingNodes, parent);
+
+        while (pendingNodes.Count > 0)
+        {
+            var pending = pendingNodes.Pop();
+            if (pending.IsEndTag)
+            {
+                ((HtmlElement)pending.Node).WriteEndTagTo(writer);
+            }
+            else if (pending.Node is HtmlElement element)
+            {
+                if (!element.WriteStartTagTo(writer))
+                    continue;
+
+                pendingNodes.Push(new PendingWrite(element, IsEndTag: true));
+                PushChildNodes(pendingNodes, element);
+            }
+            else
+            {
+                // Any other node is a leaf: it writes itself entirely
+                pending.Node.WriteTo(writer);
+            }
+        }
+    }
+
+    private static void PushChildNodes(Stack<PendingWrite> pendingNodes, HtmlNode parent)
+    {
+        if (!parent.HasContentToWrite)
+            return;
+
+        // The children are pushed in reverse so that they are popped in document order
+        var childNodes = parent.ChildNodes;
+        for (var i = childNodes.Count - 1; i >= 0; i--)
+        {
+            pendingNodes.Push(new PendingWrite(childNodes[i], IsEndTag: false));
+        }
+    }
+
+    private readonly record struct PendingWrite(HtmlNode Node, bool IsEndTag);
+
     protected internal virtual void ClearCaches()
     {
         // Walking the ancestors iteratively instead of recursively: a document can legitimately be nested

--- a/src/Meziantou.Framework.Html/HtmlOptions.cs
+++ b/src/Meziantou.Framework.Html/HtmlOptions.cs
@@ -32,14 +32,19 @@ sealed class HtmlOptions
         _readOptions["embed"] = HtmlElementReadOptions.AutoClosed | HtmlElementReadOptions.NoChild;
         _readOptions["frame"] = HtmlElementReadOptions.AutoClosed;
         _readOptions["hr"] = HtmlElementReadOptions.AutoClosed | HtmlElementReadOptions.NoChild;
+        _readOptions["iframe"] = HtmlElementReadOptions.InnerRaw;
         _readOptions["img"] = HtmlElementReadOptions.AutoClosed | HtmlElementReadOptions.NoChild;
         _readOptions["input"] = HtmlElementReadOptions.AutoClosed | HtmlElementReadOptions.NoChild;
         _readOptions["isindex"] = HtmlElementReadOptions.AutoClosed;
         _readOptions["keygen"] = HtmlElementReadOptions.AutoClosed;
         _readOptions["link"] = HtmlElementReadOptions.AutoClosed | HtmlElementReadOptions.NoChild;
         _readOptions["meta"] = HtmlElementReadOptions.AutoClosed | HtmlElementReadOptions.NoChild;
+        _readOptions["noembed"] = HtmlElementReadOptions.InnerRaw;
+        _readOptions["noframes"] = HtmlElementReadOptions.InnerRaw;
+        _readOptions["noscript"] = HtmlElementReadOptions.InnerRaw;
         _readOptions["p"] = HtmlElementReadOptions.AutoClosed;
         _readOptions["param"] = HtmlElementReadOptions.AutoClosed | HtmlElementReadOptions.NoChild;
+        _readOptions["plaintext"] = HtmlElementReadOptions.InnerRaw;
         _readOptions["script"] = HtmlElementReadOptions.InnerRaw;
         _readOptions["spacer"] = HtmlElementReadOptions.AutoClosed;
         _readOptions["source"] = HtmlElementReadOptions.AutoClosed | HtmlElementReadOptions.NoChild;
@@ -48,6 +53,7 @@ sealed class HtmlOptions
         _readOptions["title"] = HtmlElementReadOptions.InnerRaw;
         _readOptions["track"] = HtmlElementReadOptions.AutoClosed | HtmlElementReadOptions.NoChild;
         _readOptions["wbr"] = HtmlElementReadOptions.AutoClosed | HtmlElementReadOptions.NoChild;
+        _readOptions["xmp"] = HtmlElementReadOptions.InnerRaw;
 
         // NOTE: This "NOXHTML" element is not defined in specs and is specific to us
         // It may just be used by the caller if he wants to make sure what is inside will never be changed.

--- a/src/Meziantou.Framework.HtmlSanitizer/HtmlSanitizer.cs
+++ b/src/Meziantou.Framework.HtmlSanitizer/HtmlSanitizer.cs
@@ -44,7 +44,7 @@ public sealed class HtmlSanitizer
 
     private static readonly string[] DefaulValidAttrs = [.. DefaulUriAttrs, .. DefaulSrcsetAttrs, .. DefaultHtmlAttrs];
 
-    /// <summary>Gets the set of HTML elements that are allowed in sanitized output. Elements not in this set will be removed unless they are in the BlockedElements set.</summary>
+    /// <summary>Gets the set of HTML elements that are allowed in sanitized output. Elements not in this set are unwrapped: the tag is dropped but its content is kept, unless the element is in the BlockedElements set.</summary>
     public ISet<string> ValidElements { get; } = ToHashSet(DefaulValidElements);
 
     /// <summary>Gets the set of HTML attributes that are allowed in sanitized output. Attributes not in this set will be removed from elements.</summary>
@@ -58,6 +58,9 @@ public sealed class HtmlSanitizer
 
     /// <summary>Gets the set of attribute names that contain srcset values (responsive image sources) and should be validated for safety.</summary>
     public ISet<string> SrcsetAttributes { get; } = ToHashSet(DefaulSrcsetAttrs);
+
+    /// <summary>Gets or sets a value indicating whether HTML comments are kept in the sanitized output. Comments are removed by default because downlevel-hidden conditional comments (<c>&lt;!--[if IE]&gt;&lt;script&gt;…&lt;/script&gt;&lt;![endif]--&gt;</c>) are executed by legacy browsers.</summary>
+    public bool AllowComments { get; set; }
 
     private static HashSet<string> ToHashSet(string[] values) => new(values, StringComparer.OrdinalIgnoreCase);
 
@@ -89,56 +92,109 @@ public sealed class HtmlSanitizer
         if (html is null)
             return null;
 
-        var element = ParseHtmlFragment(html);
-        for (var i = element.ChildNodes.Count - 1; i >= 0; i--)
-        {
-            Sanitize(element.ChildNodes[i]);
-        }
-
-        return element.InnerHtml;
+        var document = ParseHtmlFragment(html);
+        Sanitize(document);
+        return document.InnerHtml;
     }
 
-    private void Sanitize(HtmlNode node)
+    // The traversal is iterative on purpose: a hostile fragment can nest elements thousands of levels deep
+    // and a recursive walk would overflow the stack.
+    private void Sanitize(HtmlNode root)
     {
-        if (node is HtmlElement htmlElement)
+        var pendingNodes = new Stack<HtmlNode>();
+        pendingNodes.Push(root);
+
+        while (pendingNodes.Count > 0)
         {
-            if (!IsValidNode(htmlElement.Name))
+            var parent = pendingNodes.Pop();
+            for (var i = parent.ChildNodes.Count - 1; i >= 0; i--)
             {
-                htmlElement.Remove();
-                return;
-            }
-
-            for (var i = htmlElement.Attributes.Count - 1; i >= 0; i--)
-            {
-                var attribute = htmlElement.Attributes[i];
-                if (attribute is null)
-                    continue;
-
-                if (!IsValidAttribute(attribute.Name))
+                switch (parent.ChildNodes[i])
                 {
-                    htmlElement.RemoveAttribute(attribute.Name, attribute.NamespaceURI);
-                }
-                else if (UriAttributes.Contains(attribute.Name))
-                {
-                    if (!UrlSanitizer.IsSafeUrl(attribute.Value))
+                    case HtmlElement element when !IsValidNode(element.Name):
                     {
-                        attribute.Value = "";
+                        // Blocked elements, and elements whose content is raw text rather than markup, are removed
+                        // with their content. The content of a raw text element (script, style, title, textarea, …)
+                        // is written back verbatim, so promoting it to the parent would re-inject markup.
+                        if (BlockedElements.Contains(element.Name) || HasRawTextContent(element))
+                        {
+                            element.Remove();
+                            break;
+                        }
+
+                        // The element is not allowed but its content is, so only the tag is dropped.
+                        var promotedCount = element.ChildNodes.Count;
+                        element.Remove(keepChildren: true);
+
+                        // The promoted children take the place of the element, so they must be sanitized too.
+                        i += promotedCount;
+                        break;
                     }
-                }
-                else if (SrcsetAttributes.Contains(attribute.Name))
-                {
-                    if (!UrlSanitizer.IsSafeSrcset(attribute.Value))
-                    {
-                        attribute.Value = "";
-                    }
+
+                    case HtmlElement element:
+                        SanitizeAttributes(element);
+                        pendingNodes.Push(element);
+                        break;
+
+                    case HtmlComment comment when !AllowComments:
+                        comment.Remove();
+                        break;
+
+                    case HtmlText { IsCData: true } text:
+                        // "<![CDATA[…]]>" is not a CDATA section in an HTML document: it is a bogus comment that ends
+                        // at the first ">". Writing the section back as-is would let everything after that ">" escape
+                        // the comment and be parsed as markup, so the content is turned into escaped text instead.
+                        text.IsCData = false;
+                        text.Value = EscapeText(text.Value);
+                        break;
                 }
             }
         }
+    }
 
-        for (var i = node.ChildNodes.Count - 1; i >= 0; i--)
+    private void SanitizeAttributes(HtmlElement element)
+    {
+        for (var i = element.Attributes.Count - 1; i >= 0; i--)
         {
-            Sanitize(node.ChildNodes[i]);
+            var attribute = element.Attributes[i];
+            if (!IsValidAttribute(attribute.Name))
+            {
+                // Removing by index instead of by name: HtmlNode.RemoveAttribute expects a local name, so a
+                // namespace-qualified attribute such as "xxx:onclick" would never be found and would survive.
+                element.Attributes.RemoveAt(i);
+            }
+            else if (UriAttributes.Contains(attribute.Name))
+            {
+                if (!UrlSanitizer.IsSafeUrl(attribute.Value))
+                {
+                    attribute.Value = "";
+                }
+            }
+            else if (SrcsetAttributes.Contains(attribute.Name))
+            {
+                if (!UrlSanitizer.IsSafeSrcset(attribute.Value))
+                {
+                    attribute.Value = "";
+                }
+            }
         }
+    }
+
+    private static bool HasRawTextContent(HtmlElement element)
+    {
+        var options = element.OwnerDocument?.Options.GetElementReadOptions(element.Name) ?? HtmlElementReadOptions.None;
+        return (options & HtmlElementReadOptions.InnerRaw) == HtmlElementReadOptions.InnerRaw;
+    }
+
+    private static string EscapeText(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return "";
+
+        return text
+            .Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal);
     }
 
     private static HtmlDocument ParseHtmlFragment(string content)

--- a/src/Meziantou.Framework.HtmlSanitizer/Meziantou.Framework.HtmlSanitizer.csproj
+++ b/src/Meziantou.Framework.HtmlSanitizer/Meziantou.Framework.HtmlSanitizer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Meziantou.Framework.Sanitizers</RootNamespace>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <IsTrimmable>false</IsTrimmable>
     <Description>Provide helpers to sanitize HTML fragment</Description>
   </PropertyGroup>

--- a/src/Meziantou.Framework.HtmlSanitizer/UrlSanitizer.cs
+++ b/src/Meziantou.Framework.HtmlSanitizer/UrlSanitizer.cs
@@ -47,6 +47,7 @@ public static partial class UrlSanitizer
     private static partial Regex DataUrlPattern();
 
     private static readonly char[] Whitespaces = ['\t', '\r', '\n', ' ', '\f'];
+    private static readonly char[] SrcsetCandidateSeparators = ['\t', '\r', '\n', ' ', '\f', ','];
 
     /// <summary>Determines whether a URL is safe by checking if it uses an allowed protocol (http, https, mailto, ftp, tel, file) or is a relative URL, or a safe data URL.</summary>
     /// <param name="url">The URL to validate.</param>
@@ -69,25 +70,35 @@ public static partial class UrlSanitizer
         if (url is null)
             return true;
 
+        // https://html.spec.whatwg.org/multipage/images.html#parsing-a-srcset-attribute
+        // A candidate is a run of non-whitespace characters (the URL) optionally followed by descriptors.
+        // The URL itself may contain commas, so the value cannot simply be split on ','.
         var remaining = url.AsSpan();
         while (true)
         {
-            var separatorIndex = remaining.IndexOf(',');
-            var segment = separatorIndex < 0 ? remaining : remaining[..separatorIndex];
-            segment = segment.Trim(Whitespaces);
-
-            if (!segment.IsEmpty)
-            {
-                var valueSeparator = segment.IndexOfAny(Whitespaces);
-                var value = valueSeparator < 0 ? segment : segment[..valueSeparator];
-                if (!IsSafeUrl(value))
-                    return false;
-            }
-
-            if (separatorIndex < 0)
+            // A candidate starts after any leading whitespace and separating commas
+            remaining = remaining.TrimStart(SrcsetCandidateSeparators);
+            if (remaining.IsEmpty)
                 return true;
 
-            remaining = remaining[(separatorIndex + 1)..];
+            var whitespaceIndex = remaining.IndexOfAny(Whitespaces);
+            var candidateUrl = whitespaceIndex < 0 ? remaining : remaining[..whitespaceIndex];
+            remaining = whitespaceIndex < 0 ? [] : remaining[whitespaceIndex..];
+
+            if (candidateUrl[^1] is ',')
+            {
+                // The candidate has no descriptor, the next one starts right after the trailing commas
+                candidateUrl = candidateUrl.TrimEnd(',');
+            }
+            else
+            {
+                // Skip the descriptors of the candidate, they end at the next comma
+                var descriptorSeparatorIndex = remaining.IndexOf(',');
+                remaining = descriptorSeparatorIndex < 0 ? [] : remaining[(descriptorSeparatorIndex + 1)..];
+            }
+
+            if (!candidateUrl.IsEmpty && !IsSafeUrl(candidateUrl))
+                return false;
         }
     }
 

--- a/src/Meziantou.Framework.HtmlSanitizer/readme.md
+++ b/src/Meziantou.Framework.HtmlSanitizer/readme.md
@@ -64,6 +64,17 @@ var result = sanitizer.SanitizeHtmlFragment("<img srcset='https://example.com/im
 // Result: "<img srcset='https://example.com/img1.jpg 300w, https://example.com/img2.jpg 600w'>"
 ```
 
+### Keeping Comments
+
+Comments are removed by default: downlevel-hidden conditional comments (`<!--[if IE]><script>...</script><![endif]-->`)
+are executed by legacy browsers. Set `AllowComments` to keep them:
+
+```csharp
+var sanitizer = new HtmlSanitizer { AllowComments = true };
+var result = sanitizer.SanitizeHtmlFragment("<p>a<!-- comment -->b</p>");
+// Result: "<p>a<!-- comment -->b</p>"
+```
+
 ### Customizing Allowed Elements
 
 You can customize which elements are allowed:
@@ -106,6 +117,26 @@ By default, the sanitizer allows:
 - **Block elements**: `address`, `article`, `aside`, `blockquote`, `caption`, `center`, `col`, `colgroup`, `dd`, `div`, `dl`, `dt`, `figure`, `figcaption`, `footer`, `h1`-`h6`, `header`, `hgroup`, `hr`, `li`, `nav`, `ol`, `p`, `pre`, `section`, `table`, `tbody`, `td`, `tfoot`, `th`, `thead`, `tr`, `ul`, and more
 - **Inline elements**: `a`, `abbr`, `acronym`, `b`, `bdi`, `bdo`, `big`, `br`, `cite`, `code`, `del`, `dfn`, `em`, `font`, `i`, `img`, `ins`, `kbd`, `label`, `map`, `mark`, `q`, `ruby`, `rp`, `rt`, `s`, `samp`, `small`, `span`, `strike`, `strong`, `sub`, `sup`, `time`, `tt`, `u`, `var`
 - **Void elements**: `area`, `br`, `col`, `hr`, `img`, `wbr`
+
+### Element Handling
+
+An element is handled in one of three ways:
+
+- It is in `ValidElements` (and not in `BlockedElements`): the element and its content are kept, and its attributes are sanitized.
+- It is in `BlockedElements`, or its content is raw text rather than markup (`script`, `style`, `title`, `textarea`, `iframe`, `noscript`, `noembed`, `noframes`, `plaintext`, `xmp`): the element is removed **with its content**.
+- Otherwise the element is unwrapped: the tag is dropped but its content is kept and sanitized.
+
+```csharp
+var sanitizer = new HtmlSanitizer();
+
+// script is blocked, so its content is removed too
+sanitizer.SanitizeHtmlFragment("<p>Hello <script>alert('xss')</script>World</p>");
+// Result: "<p>Hello World</p>"
+
+// form is not allowed, but its content is kept
+sanitizer.SanitizeHtmlFragment("<form><p>Hello</p></form>");
+// Result: "<p>Hello</p>"
+```
 
 ### Blocked Elements
 
@@ -152,10 +183,9 @@ This library is inspired by:
 - [Angular's HTML sanitizer](https://github.com/angular/angular/blob/main/packages/core/src/sanitization/html_sanitizer.ts)
 - [Sanitizer API specification](https://wicg.github.io/sanitizer-api/#default-configuration-dictionary)
 
-The library uses [AngleSharp](https://anglesharp.github.io/) for HTML parsing.
+The library uses [Meziantou.Framework.Html](../Meziantou.Framework.Html) for HTML parsing.
 
 ## Additional Resources
 
 - [Angular HTML Sanitizer](https://github.com/angular/angular/blob/main/packages/core/src/sanitization/html_sanitizer.ts)
 - [W3C Sanitizer API](https://wicg.github.io/sanitizer-api/)
-- [AngleSharp](https://anglesharp.github.io/)

--- a/tests/Meziantou.Framework.Html.Tests/HtmlParserTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/HtmlParserTests.cs
@@ -381,13 +381,34 @@ public class HtmlParserTests
     [Fact]
     public void HtmlParser_DeeplyNestedDocument()
     {
-        const int Depth = 2_000;
+        const int Depth = 10_000;
         var html = string.Concat(Enumerable.Repeat("<div>", Depth)) + "test" + string.Concat(Enumerable.Repeat("</div>", Depth));
 
-        var document = new HtmlDocument();
-        document.LoadHtml(html);
+        string? actual = null;
+        Exception? exception = null;
 
-        Assert.Equal(html, document.InnerHtml);
+        // Parsing and writing a document must not recurse once per level. The work runs on a thread with the
+        // stack size Windows uses by default, which is much smaller than the main thread of the other platforms,
+        // so a recursive implementation fails here instead of only on Windows.
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                var document = new HtmlDocument();
+                document.LoadHtml(html);
+                actual = document.InnerHtml;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+        }, maxStackSize: 1024 * 1024);
+
+        thread.Start();
+        thread.Join();
+
+        Assert.Null(exception);
+        Assert.Equal(html, actual);
     }
 
     [Theory]

--- a/tests/Meziantou.Framework.Html.Tests/HtmlParserTests.cs
+++ b/tests/Meziantou.Framework.Html.Tests/HtmlParserTests.cs
@@ -349,6 +349,48 @@ public class HtmlParserTests
     }
 
     [Theory]
+    // https://html.spec.whatwg.org/multipage/parsing.html#rawtext-state
+    [InlineData("iframe")]
+    [InlineData("noembed")]
+    [InlineData("noframes")]
+    [InlineData("noscript")]
+    [InlineData("xmp")]
+    public void HtmlParser_RawTextElementContainsRawText(string tagName)
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml($"<{tagName}><p>hello</{tagName}>x");
+
+        var element = document.SelectSingleNode($"//{tagName}");
+        Assert.NotNull(element);
+        Assert.Equal("<p>hello", element!.InnerText);
+        Assert.Empty(document.SelectNodes("//p"));
+    }
+
+    [Fact]
+    public void HtmlParser_PlainTextElementContainsRawTextUntilTheEndOfTheDocument()
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml("<plaintext>a<p>b");
+
+        var element = document.SelectSingleNode("//plaintext");
+        Assert.NotNull(element);
+        Assert.Equal("a<p>b", element!.InnerText);
+        Assert.Empty(document.SelectNodes("//p"));
+    }
+
+    [Fact]
+    public void HtmlParser_DeeplyNestedDocument()
+    {
+        const int Depth = 2_000;
+        var html = string.Concat(Enumerable.Repeat("<div>", Depth)) + "test" + string.Concat(Enumerable.Repeat("</div>", Depth));
+
+        var document = new HtmlDocument();
+        document.LoadHtml(html);
+
+        Assert.Equal(html, document.InnerHtml);
+    }
+
+    [Theory]
     // a solidus is part of an unquoted attribute value
     [InlineData("<a href=foo/>", "href", "foo/")]
     [InlineData("<a href=/>", "href", "/")]

--- a/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
+++ b/tests/Meziantou.Framework.HtmlSanitizer.Tests/HtmlSanitizerTests.cs
@@ -21,4 +21,280 @@ public class HtmlSanitizerTests
         var actual = sanitizer.SanitizeHtmlFragment(html);
         Assert.Equal(expectedResult, actual);
     }
+
+    [Fact]
+    public void Sanitize_Null_ReturnsNull()
+    {
+        var sanitizer = new HtmlSanitizer();
+        Assert.Null(sanitizer.SanitizeHtmlFragment(html: null));
+    }
+
+    [Theory]
+    // A "<![CDATA[…]]>" section is not a CDATA section in an HTML document, it is a bogus comment that ends at
+    // the first ">". Writing the section back as-is would let everything after that ">" be parsed as markup,
+    // so its content is written as escaped text instead.
+    [InlineData("<![CDATA[a><script>alert(1)</script>]]>", "a&gt;&lt;script&gt;alert(1)&lt;/script&gt;")]
+    [InlineData("<![CDATA[a><img src=x onerror=alert(1)>]]>", "a&gt;&lt;img src=x onerror=alert(1)&gt;")]
+    [InlineData("<p>a<![CDATA[><img src=x onerror=alert(1)>]]>b</p>", "<p>a&gt;&lt;img src=x onerror=alert(1)&gt;b</p>")]
+    [InlineData("<![CDATA[a & b]]>", "a &amp; b")]
+    public void Sanitize_CDataSectionIsEscaped(string html, string expectedResult)
+    {
+        var sanitizer = new HtmlSanitizer();
+        Assert.Equal(expectedResult, sanitizer.SanitizeHtmlFragment(html));
+    }
+
+    [Theory]
+    // Elements that are not allowed but whose content is are unwrapped: the tag is dropped, the content is kept
+    [InlineData("<html><body><p>test</p></body></html>", "<p>test</p>")]
+    [InlineData("<form><p>test</p></form>", "<p>test</p>")]
+    [InlineData("<div><form>test</form></div>", "<div>test</div>")]
+    [InlineData("<unknown-element>test</unknown-element>", "test")]
+    [InlineData("<p><object data='x'><b>keep</b></object></p>", "<p><b>keep</b></p>")]
+    [InlineData("<form><form><form>test</form></form></form>", "test")]
+    [InlineData("<form><p>a</p>b<span>c</span></form>", "<p>a</p>b<span>c</span>")]
+    // Attributes of an unwrapped element are dropped with the tag
+    [InlineData("<button onclick='alert(1)'>test</button>", "test")]
+    // The promoted content is sanitized too
+    [InlineData("<form><script>alert(1)</script>test</form>", "test")]
+    [InlineData("<form><p onclick='alert(1)'>test</p></form>", "<p>test</p>")]
+    [InlineData("<form><a href='javascript:alert(1)'>test</a></form>", "<a href=''>test</a>")]
+    // Processing instructions and doctypes are not real elements, they carry no content
+    [InlineData("<!DOCTYPE html><p>test</p>", "<p>test</p>")]
+    [InlineData("<?xml version='1.0'?><p>test</p>", "<p>test</p>")]
+    [InlineData("<?php echo '<script>alert(1)</script>'; ?><p>test</p>", "<p>test</p>")]
+    public void Sanitize_UnwrapsInvalidElements(string html, string expectedResult)
+    {
+        var sanitizer = new HtmlSanitizer();
+        Assert.Equal(expectedResult, sanitizer.SanitizeHtmlFragment(html));
+    }
+
+    [Theory]
+    // Blocked elements are removed with their content
+    [InlineData("<script>alert(1)</script>", "")]
+    [InlineData("<SCRIPT>alert(1)</SCRIPT>", "")]
+    [InlineData("<style>body{color:red}</style>", "")]
+    [InlineData("<p>a<script>alert(1)</script>b</p>", "<p>ab</p>")]
+    // The content of a raw text element is written back verbatim, so it must never be promoted to the parent
+    [InlineData("<title><img src=x onerror=alert(1)></title>", "")]
+    [InlineData("<textarea><img src=x onerror=alert(1)></textarea>", "")]
+    [InlineData("<xmp><img src=x onerror=alert(1)></xmp>", "")]
+    [InlineData("<iframe><img src=x onerror=alert(1)></iframe>", "")]
+    [InlineData("<noembed><img src=x onerror=alert(1)></noembed>", "")]
+    [InlineData("<noframes><img src=x onerror=alert(1)></noframes>", "")]
+    [InlineData("<noxhtml><img src=x onerror=alert(1)></noxhtml>", "")]
+    [InlineData("<noscript><img src=x onerror=alert(1)></noscript>", "")]
+    [InlineData("<p>a<title><img src=x onerror=alert(1)></title>b</p>", "<p>ab</p>")]
+    public void Sanitize_RemovesElementsWithNonMarkupContent(string html, string expectedResult)
+    {
+        var sanitizer = new HtmlSanitizer();
+        Assert.Equal(expectedResult, sanitizer.SanitizeHtmlFragment(html));
+    }
+
+    [Theory]
+    // Attributes that are not in the allow list must be removed, including namespace-qualified ones
+    [InlineData("<p onclick='alert(1)'>x</p>", "<p>x</p>")]
+    [InlineData("<p xxx:onclick='alert(1)'>x</p>", "<p>x</p>")]
+    [InlineData("<p xml:onclick='alert(1)'>x</p>", "<p>x</p>")]
+    [InlineData("<p xmlns:x='u' x:onclick='alert(1)'>y</p>", "<p>y</p>")]
+    [InlineData("<p foo:class='x'>y</p>", "<p>y</p>")]
+    [InlineData("<p ONCLICK='alert(1)' class='c'>x</p>", "<p class='c'>x</p>")]
+    [InlineData("<p onclick='a' class='b' onclick='c'>x</p>", "<p class='b'>x</p>")]
+    [InlineData("<a href=x onclick=alert(1)>x</a>", "<a href=\"x\">x</a>")]
+    [InlineData("<p/onclick=alert(1)>x</p>", "<p>x</p>")]
+    // xlink:href is allowed but is a URI attribute, so its value is validated
+    [InlineData("<a xlink:href='javascript:alert(1)'>x</a>", "<a xlink:href=''>x</a>")]
+    [InlineData("<a xlink:href='https://example.com'>x</a>", "<a xlink:href='https://example.com'>x</a>")]
+    // Duplicated attributes are each sanitized on their own
+    [InlineData("<a href='https://ok' href='javascript:alert(1)'>x</a>", "<a href='https://ok' href=''>x</a>")]
+    [InlineData("<a href='javascript:alert(1)' href='https://ok'>x</a>", "<a href='' href='https://ok'>x</a>")]
+    // Valueless attributes are kept as-is
+    [InlineData("<a href>x</a>", "<a href>x</a>")]
+    public void Sanitize_Attributes(string html, string expectedResult)
+    {
+        var sanitizer = new HtmlSanitizer();
+        Assert.Equal(expectedResult, sanitizer.SanitizeHtmlFragment(html));
+    }
+
+    [Theory]
+    // The value of an attribute is re-written with a quote character that cannot be closed by the value itself
+    [InlineData("<p title='a\" onmouseover=\"alert(1)'>x</p>", "<p title='a\" onmouseover=\"alert(1)'>x</p>")]
+    [InlineData("<p title=\"a' onmouseover='alert(1)\">x</p>", "<p title=\"a' onmouseover='alert(1)\">x</p>")]
+    [InlineData("<p title=a\"onmouseover=alert(1)\"x>y</p>", "<p title='a\"onmouseover=alert(1)\"x'>y</p>")]
+    [InlineData("<p title=a\"b'c>x</p>", "<p title='a\"b&apos;c'>x</p>")]
+    [InlineData("<p title=\"</p><script>alert(1)</script>\">x</p>", "<p title=\"</p><script>alert(1)</script>\">x</p>")]
+    // Entities in an attribute value are kept encoded
+    [InlineData("<p title='&lt;script&gt;'>x</p>", "<p title='&lt;script&gt;'>x</p>")]
+    [InlineData("<p title=&quot;onmouseover=alert(1)&quot;>x</p>", "<p title=\"&quot;onmouseover=alert(1)&quot;\">x</p>")]
+    [InlineData("<a href='http://example.com/?a=1&amp;b=2'>x</a>", "<a href='http://example.com/?a=1&amp;b=2'>x</a>")]
+    public void Sanitize_AttributeValuesCannotEscapeTheirQuotes(string html, string expectedResult)
+    {
+        var sanitizer = new HtmlSanitizer();
+        Assert.Equal(expectedResult, sanitizer.SanitizeHtmlFragment(html));
+    }
+
+    [Theory]
+    // Text is kept as it was written in the source, so encoded markup stays encoded
+    [InlineData("&lt;script&gt;alert(1)&lt;/script&gt;", "&lt;script&gt;alert(1)&lt;/script&gt;")]
+    [InlineData("<p>&lt;img src=x onerror=alert(1)&gt;</p>", "<p>&lt;img src=x onerror=alert(1)&gt;</p>")]
+    [InlineData("<p>&#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e;</p>", "<p>&#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e;</p>")]
+    [InlineData("a &amp; b", "a &amp; b")]
+    [InlineData("a & b", "a & b")]
+    [InlineData("<p>a < b</p>", "<p>a < b</p>")]
+    public void Sanitize_KeepsTextAsIs(string html, string expectedResult)
+    {
+        var sanitizer = new HtmlSanitizer();
+        Assert.Equal(expectedResult, sanitizer.SanitizeHtmlFragment(html));
+    }
+
+    [Theory]
+    [InlineData("<!-- comment -->", "")]
+    [InlineData("<p>a<!-- comment -->b</p>", "<p>ab</p>")]
+    // Downlevel-hidden conditional comments are executed by legacy browsers
+    [InlineData("<!--[if gte IE 4]><script>alert(1)</script><![endif]-->", "")]
+    [InlineData("<p><!--[if gte IE 4]><script>alert(1)</script><![endif]--></p>", "<p></p>")]
+    public void Sanitize_RemovesComments(string html, string expectedResult)
+    {
+        var sanitizer = new HtmlSanitizer();
+        Assert.Equal(expectedResult, sanitizer.SanitizeHtmlFragment(html));
+    }
+
+    [Theory]
+    [InlineData("<!-- comment -->", "<!-- comment -->")]
+    [InlineData("<p>a<!-- comment -->b</p>", "<p>a<!-- comment -->b</p>")]
+    // A comment can never be closed by its own content, so it cannot escape
+    [InlineData("<p><!--a--!>b--></p>", "<p><!--a-->b--></p>")]
+    public void Sanitize_AllowComments(string html, string expectedResult)
+    {
+        var sanitizer = new HtmlSanitizer { AllowComments = true };
+        Assert.Equal(expectedResult, sanitizer.SanitizeHtmlFragment(html));
+    }
+
+    [Theory]
+    // Legacy and foreign-content vectors: none of these elements are allowed
+    [InlineData("<svg><script>alert(1)</script></svg>", "")]
+    [InlineData("<svg onload='alert(1)'></svg>", "")]
+    [InlineData("<math><mtext><table><mglyph><style><img src=x onerror=alert(1)>", "<table></table>")]
+    // The end tag closes the raw text of the noscript element, exactly like a browser does, and the img that
+    // follows it is a real element whose event handler is removed
+    [InlineData("<noscript><p title=\"</noscript><img src=x onerror=alert(1)>\">", "<img src=\"x\" />\">")]
+    [InlineData("<template><script>alert(1)</script></template>", "")]
+    [InlineData("<base href='javascript:alert(1)'>", "")]
+    [InlineData("<meta http-equiv='refresh' content='0;url=javascript:alert(1)'>", "")]
+    [InlineData("<link rel='stylesheet' href='javascript:alert(1)'>", "")]
+    [InlineData("<embed src='javascript:alert(1)'>", "")]
+    [InlineData("<input onfocus='alert(1)' autofocus>", "")]
+    // Everything that follows a plaintext element is raw text, so it is removed with it
+    [InlineData("<p><plaintext><img src=x onerror=alert(1)>", "<p></p>")]
+    [InlineData("<plaintext>a<b>c", "")]
+    public void Sanitize_KnownXssVectors(string html, string expectedResult)
+    {
+        var sanitizer = new HtmlSanitizer();
+        Assert.Equal(expectedResult, sanitizer.SanitizeHtmlFragment(html));
+    }
+
+    [Fact]
+    public void Sanitize_DeeplyNestedFragment()
+    {
+        const int Depth = 2_000;
+        var html = string.Concat(Enumerable.Repeat("<div>", Depth)) + "test" + string.Concat(Enumerable.Repeat("</div>", Depth));
+
+        var sanitizer = new HtmlSanitizer();
+        var actual = sanitizer.SanitizeHtmlFragment(html);
+
+        Assert.Equal(html, actual);
+    }
+
+    [Fact]
+    public void Sanitize_DeeplyNestedBlockedElement()
+    {
+        const int Depth = 2_000;
+        var html = string.Concat(Enumerable.Repeat("<div>", Depth)) + "<script>alert(1)</script>" + string.Concat(Enumerable.Repeat("</div>", Depth));
+        var expected = string.Concat(Enumerable.Repeat("<div>", Depth)) + string.Concat(Enumerable.Repeat("</div>", Depth));
+
+        var sanitizer = new HtmlSanitizer();
+        Assert.Equal(expected, sanitizer.SanitizeHtmlFragment(html));
+    }
+
+    [Fact]
+    public void Sanitize_DeeplyNestedInvalidElement()
+    {
+        const int Depth = 2_000;
+        var html = string.Concat(Enumerable.Repeat("<form>", Depth)) + "test" + string.Concat(Enumerable.Repeat("</form>", Depth));
+
+        var sanitizer = new HtmlSanitizer();
+        Assert.Equal("test", sanitizer.SanitizeHtmlFragment(html));
+    }
+
+    [Fact]
+    public void Sanitize_CanAllowAdditionalElements()
+    {
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.ValidElements.Add("custom-element");
+
+        Assert.Equal("<custom-element>test</custom-element>", sanitizer.SanitizeHtmlFragment("<custom-element>test</custom-element>"));
+    }
+
+    [Fact]
+    public void Sanitize_CanDisallowElements()
+    {
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.ValidElements.Remove("img");
+
+        Assert.Equal("<p>test</p>", sanitizer.SanitizeHtmlFragment("<p><img src='https://example.com'>test</p>"));
+    }
+
+    [Fact]
+    public void Sanitize_CanBlockElements()
+    {
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.BlockedElements.Add("p");
+
+        Assert.Equal("<div></div>", sanitizer.SanitizeHtmlFragment("<div><p>test</p></div>"));
+    }
+
+    [Fact]
+    public void Sanitize_BlockedElementsWinOverValidElements()
+    {
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.ValidElements.Add("script");
+
+        Assert.Equal("", sanitizer.SanitizeHtmlFragment("<script>alert(1)</script>"));
+    }
+
+    [Fact]
+    public void Sanitize_UnblockedRawTextElementIsStillNotUnwrapped()
+    {
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.BlockedElements.Remove("script");
+
+        Assert.Equal("", sanitizer.SanitizeHtmlFragment("<script>alert(1)</script>"));
+    }
+
+    [Fact]
+    public void Sanitize_CanAllowAdditionalAttributes()
+    {
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.ValidAttributes.Add("data-custom");
+
+        Assert.Equal("<p data-custom='1'>test</p>", sanitizer.SanitizeHtmlFragment("<p data-custom='1'>test</p>"));
+    }
+
+    [Fact]
+    public void Sanitize_CanDisallowAttributes()
+    {
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.ValidAttributes.Remove("target");
+
+        Assert.Equal("<a href='https://example.com'>test</a>", sanitizer.SanitizeHtmlFragment("<a href='https://example.com' target='_blank'>test</a>"));
+    }
+
+    [Fact]
+    public void Sanitize_CanAddUriAttributes()
+    {
+        var sanitizer = new HtmlSanitizer();
+        sanitizer.ValidAttributes.Add("data-url");
+        sanitizer.UriAttributes.Add("data-url");
+
+        Assert.Equal("<p data-url=''>test</p>", sanitizer.SanitizeHtmlFragment("<p data-url='javascript:alert(1)'>test</p>"));
+    }
 }

--- a/tests/Meziantou.Framework.HtmlSanitizer.Tests/UrlSanitizerTests.cs
+++ b/tests/Meziantou.Framework.HtmlSanitizer.Tests/UrlSanitizerTests.cs
@@ -1,0 +1,118 @@
+namespace Meziantou.Framework.Sanitizers.Tests;
+
+public class UrlSanitizerTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("https://example.com")]
+    [InlineData("HTTP://example.com")]
+    [InlineData("http://example.com/?a=1&b=2")]
+    [InlineData("ftp://example.com")]
+    [InlineData("mailto:user@example.com")]
+    [InlineData("tel:+33123456789")]
+    [InlineData("file:///tmp/test.txt")]
+    [InlineData("//example.com")]
+    [InlineData("/path/to/page")]
+    [InlineData("relative/path")]
+    [InlineData("#fragment")]
+    [InlineData("?query=1")]
+    // A colon that appears after a '/', '?' or '#' cannot be a scheme separator
+    [InlineData("#javascript:alert(1)")]
+    [InlineData("?javascript:alert(1)")]
+    [InlineData("/javascript:alert(1)")]
+    [InlineData("data:image/png;base64,iVBORw0KGgo=")]
+    [InlineData("data:image/gif;base64,R0lGOD==")]
+    [InlineData("data:video/mp4;base64,AAAA")]
+    [InlineData("data:audio/mp3;base64,AAAA")]
+    public void IsSafeUrl_Safe(string url)
+    {
+        Assert.True(UrlSanitizer.IsSafeUrl(url));
+    }
+
+    [Fact]
+    public void IsSafeUrl_Null()
+    {
+        Assert.True(UrlSanitizer.IsSafeUrl(url: null));
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("JaVaScRiPt:alert(1)")]
+    [InlineData(" javascript:alert(1)")]
+    [InlineData("\tjavascript:alert(1)")]
+    [InlineData("\njavascript:alert(1)")]
+    [InlineData("java\tscript:alert(1)")]
+    [InlineData("java\0script:alert(1)")]
+    [InlineData("vbscript:msgbox(1)")]
+    // An entity cannot be used to mask the scheme: '&' is not allowed before the first '/', '?' or '#'
+    [InlineData("&#106;avascript:alert(1)")]
+    [InlineData("&#x6a;avascript:alert(1)")]
+    [InlineData("java&#9;script:alert(1)")]
+    [InlineData("&Tab;javascript:alert(1)")]
+    // Only image, video and audio data URLs are allowed
+    [InlineData("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==")]
+    [InlineData("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=")]
+    [InlineData("data:image/png,<svg onload=alert(1)>")]
+    [InlineData("data:application/javascript;base64,YWxlcnQoMSk=")]
+    public void IsSafeUrl_Unsafe(string url)
+    {
+        Assert.False(UrlSanitizer.IsSafeUrl(url));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(",")]
+    [InlineData(",,,")]
+    [InlineData("https://example.com/a.png")]
+    [InlineData("https://example.com/a.png 1x")]
+    [InlineData("https://example.com/a.png 300w, https://example.com/b.png 600w")]
+    [InlineData("https://example.com/a.png 1x,")]
+    [InlineData("https://example.com/a.png,https://example.com/b.png")]
+    [InlineData(" , https://example.com/a.png 1x , https://example.com/b.png 2x , ")]
+    [InlineData("/a.png 1x, /b.png 2x")]
+    // A data URL contains a comma, so the value cannot be split on ','
+    [InlineData("data:image/png;base64,iVBORw0KGgo= 1x")]
+    [InlineData("data:image/png;base64,iVBORw0KGgo= 1x, data:image/gif;base64,R0lGOD== 2x")]
+    [InlineData("data:image/png;base64,iVBORw0KGgo=")]
+    // A comma inside a URL that is not followed by a descriptor is part of the URL
+    [InlineData("a,b.png")]
+    [InlineData("a,b.png 1x, c,d.png 2x")]
+    public void IsSafeSrcset_Safe(string srcset)
+    {
+        Assert.True(UrlSanitizer.IsSafeSrcset(srcset));
+    }
+
+    [Fact]
+    public void IsSafeSrcset_Null()
+    {
+        Assert.True(UrlSanitizer.IsSafeSrcset(url: null));
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("javascript:alert(1) 1x")]
+    [InlineData(",javascript:alert(1)")]
+    [InlineData(" , javascript:alert(1) 1x")]
+    [InlineData("https://example.com/a.png 1x, javascript:alert(1) 2x")]
+    [InlineData("javascript:alert(1) 1x, https://example.com/a.png 2x")]
+    [InlineData("https://example.com/a.png 1x,javascript:alert(1)")]
+    [InlineData("data:text/html;base64,PHNjcmlwdD4= 1x")]
+    // "a,javascript:alert(1)" is a single relative URL for a browser, but a colon that appears before the first
+    // '/', '?' or '#' makes the URL ambiguous, so it is rejected like any other URL with an unknown scheme
+    [InlineData("a,javascript:alert(1)")]
+    public void IsSafeSrcset_Unsafe(string srcset)
+    {
+        Assert.False(UrlSanitizer.IsSafeSrcset(srcset));
+    }
+
+    [Theory]
+    [InlineData("<img srcset='data:image/png;base64,iVBORw0KGgo= 1x'>", "<img srcset='data:image/png;base64,iVBORw0KGgo= 1x' />")]
+    [InlineData("<img srcset='https://example.com/a.png 1x, javascript:alert(1) 2x'>", "<img srcset='' />")]
+    [InlineData("<img srcset=''>", "<img srcset='' />")]
+    public void Sanitize_Srcset(string html, string expectedResult)
+    {
+        var sanitizer = new HtmlSanitizer();
+        Assert.Equal(expectedResult, sanitizer.SanitizeHtmlFragment(html));
+    }
+}


### PR DESCRIPTION
I probed `HtmlSanitizer` with ~120 hostile inputs and found five bugs, one of them a full XSS bypass. Each is fixed and covered by tests.

## Bugs fixed

### 1. CDATA sections were a complete sanitizer bypass

```csharp
new HtmlSanitizer().SanitizeHtmlFragment("<![CDATA[a><script>alert(1)</script>]]>")
// returned the input verbatim - script tag intact
```

`<![CDATA[` is *not* a CDATA section in an HTML document. Browsers treat it as a **bogus comment that ends at the first `>`**, so everything after that `>` is parsed as live markup. The parser produced a CDATA text node and the serializer wrote it back raw. CDATA nodes are now written as escaped text.

### 2. Namespace-qualified attributes were never removed

`<p xxx:onclick='alert(1)'>` kept its attribute. `SanitizeAttributes` called `RemoveAttribute(attribute.Name, ...)`, but that overload matches on the **local name** while `Name` returns the qualified name (`xxx:onclick`), so the lookup silently failed and returned `false`. Any prefixed attribute bypassed the allow list. Attributes are now removed by index.

### 3. Non-allowed elements deleted their content

`<html><body><p>test</p></body></html>` and `<form><p>test</p></form>` both returned `""`. This also made `BlockedElements` and `ValidElements` behave identically, contradicting the documented distinction between them.

Non-allowed elements are now **unwrapped**: the tag is dropped, the content is kept and sanitized - matching Angular's sanitizer, which this class is modeled on. Blocked elements *and* raw text elements still take their content with them, because that content is written back verbatim and promoting it would re-inject markup.

### 4. `srcset` split on commas, so data URLs were destroyed

`srcset="data:image/png;base64,AAAA= 1x"` was rejected outright - a data URL always contains a comma. Rewritten to follow the [spec's candidate parsing](https://html.spec.whatwg.org/multipage/images.html#parsing-a-srcset-attribute).

### 5. Denial of service: anything nested deeper than 300 threw

`HtmlNode.ClearCaches` walked ancestors recursively behind a hard `MaxRecursion = 300` guard, so a 400-`<div>` fragment threw `HtmlException`. The walk is now iterative, and the sanitizer's own traversal is iterative too. A 16 000-deep fragment now sanitizes in about 1.2 s.

## Other changes

- **Comments are dropped by default.** `<!--[if IE]><script>...</script><![endif]-->` executes on legacy IE, so keeping comments kept a way to run script. New `AllowComments` property opts back in.
- **Parser conformance:** `iframe`, `noembed`, `noframes`, `noscript`, `plaintext` and `xmp` are RAWTEXT per spec but were parsed as markup. Added to `HtmlElementReadOptions.InnerRaw`.
- **Readme:** it claimed the library uses AngleSharp; it does not. Also documents the three-way element handling and `AllowComments`.

## For the reviewer

**Version bump is a judgement call.** I set `3.1.0` following the additive-API convention, since `AllowComments` is the only new public member. But the *default output* changes for several inputs (unwrapping instead of deleting, comments removed), so `4.0.0` may be the better call - happy to change it.

**One divergence I deliberately did not fix.** `<scr<script>ipt>alert(1)</script>` round-trips verbatim: the tokenizer abandons a tag when `<` appears inside the name and re-emits it as raw text, whereas the spec appends `<` to the tag name. I traced the browser parse of the output - the resulting tag name always contains `<`, so it is always an unknown element and no handler ever fires. It is inert, but it does mean the output can contain a literal `<script>` substring. Fixing it means changing the core tokenizer's `TagOpen` state, which felt out of scope for a security pass.

## Verification

New tests: 168 sanitizer tests per TFM (was 12), plus 7 new parser tests.

All suites that touch the HTML parser pass:

| Suite | Tests |
| --- | --- |
| `Meziantou.Framework.HtmlSanitizer.Tests` | 336 |
| `Meziantou.Framework.Html.Tests` | 270 |
| `Meziantou.Framework.Html.Tool.Tests` | 12 |
| `Meziantou.Framework.HumanReadableSerializer.Tests` | 532 |
| `Meziantou.Framework.HtmlToMarkdown.Tests` | 1694 |

All touched projects build clean with `/p:TreatWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` ran clean, and `ref/Meziantou.Framework.HtmlSanitizer.cs` was regenerated for the new `AllowComments` API.
