### PR TITLE
Match the runtime type exactly in generated polymorphic write dispatch

### DIFF
--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.EmitPhase.cs
@@ -628,6 +628,11 @@ public sealed partial class YamlSerializerContextGenerator
                     builder.AppendLine("        var discriminatorStyle = options.PolymorphismOptions.DiscriminatorStyle;");
                 }
 
+                // The dispatch matches the runtime type exactly, like the reflection-based writer. A subclass of a
+                // registered derived type is not itself registered, so it must fail instead of silently being written
+                // under its base type's discriminator, which would drop the members it declares.
+                builder.AppendLine("        var runtimeType = value.GetType();");
+
                 for (var i = 0; i < polymorphism.DerivedTypes.Length; i++)
                 {
                     var derived = polymorphism.DerivedTypes[i];
@@ -637,8 +642,8 @@ public sealed partial class YamlSerializerContextGenerator
                         continue;
                     }
 
-                    var derivedLocal = $"derived{derivedIndex}";
-                    builder.Append("        if (value is ").Append(derivedTypeName).Append(' ').Append(derivedLocal).AppendLine(")");
+                    var derivedValue = $"(({derivedTypeName})value)";
+                    builder.Append("        if (runtimeType == typeof(").Append(derivedTypeName).AppendLine("))");
                     builder.AppendLine("        {");
 
                     if (derived.Tag is not null)
@@ -677,7 +682,7 @@ public sealed partial class YamlSerializerContextGenerator
                             builder.AppendLine("            }");
                         }
                     }
-                    builder.Append("            WriteMembers").Append(derivedIndex).Append("(writer, ").Append(derivedLocal).Append(", ")
+                    builder.Append("            WriteMembers").Append(derivedIndex).Append("(writer, ").Append(derivedValue).Append(", ")
                         .Append(mayWriteDiscriminatorProperty ? "discriminatorPropertyName" : "null").AppendLine(", runtimeConverters);");
                     builder.AppendLine("            writer.WriteEndMapping();");
                     if (emitLifecycleCallbacks)
@@ -688,9 +693,9 @@ public sealed partial class YamlSerializerContextGenerator
                     builder.AppendLine("        }");
                 }
 
-                builder.Append("        if (value.GetType() != typeof(").Append(typeName).AppendLine("))");
+                builder.Append("        if (runtimeType != typeof(").Append(typeName).AppendLine("))");
                 builder.AppendLine("        {");
-                builder.Append("            throw new global::System.NotSupportedException($\"Type '{value.GetType()}' is not a registered derived type of '{typeof(")
+                builder.Append("            throw new global::System.NotSupportedException($\"Type '{runtimeType}' is not a registered derived type of '{typeof(")
                     .Append(typeName).AppendLine(")}'.\");");
                 builder.AppendLine("        }");
                 builder.AppendLine();
@@ -790,6 +795,11 @@ public sealed partial class YamlSerializerContextGenerator
             builder.AppendLine("        var discriminatorStyle = options.PolymorphismOptions.DiscriminatorStyle;");
         }
 
+        // The dispatch matches the runtime type exactly, like the reflection-based writer. A subclass of a registered
+        // derived type is not itself registered, so it must fail instead of silently being written under its base
+        // type's discriminator, which would drop the members it declares.
+        builder.AppendLine("        var runtimeType = value.GetType();");
+
         for (var i = 0; i < polymorphism.DerivedTypes.Length; i++)
         {
             var derived = polymorphism.DerivedTypes[i];
@@ -799,8 +809,8 @@ public sealed partial class YamlSerializerContextGenerator
                 continue;
             }
 
-            var derivedLocal = $"derived{derivedIndex}";
-            builder.Append("        if (value is ").Append(derivedTypeName).Append(' ').Append(derivedLocal).AppendLine(")");
+            var derivedValue = $"(({derivedTypeName})value)";
+            builder.Append("        if (runtimeType == typeof(").Append(derivedTypeName).AppendLine("))");
             builder.AppendLine("        {");
 
             if (derived.Tag is not null)
@@ -840,7 +850,7 @@ public sealed partial class YamlSerializerContextGenerator
                 }
             }
 
-            builder.Append("            WriteMembers").Append(derivedIndex).Append("(writer, ").Append(derivedLocal).Append(", ")
+            builder.Append("            WriteMembers").Append(derivedIndex).Append("(writer, ").Append(derivedValue).Append(", ")
                 .Append(mayWriteDiscriminatorProperty ? "discriminatorPropertyName" : "null").AppendLine(", runtimeConverters);");
             builder.AppendLine("            writer.WriteEndMapping();");
             if (emitLifecycleCallbacks)
@@ -854,16 +864,16 @@ public sealed partial class YamlSerializerContextGenerator
 
         if (canWriteBaseObject)
         {
-            builder.Append("        if (value.GetType() != typeof(").Append(typeName).AppendLine("))");
+            builder.Append("        if (runtimeType != typeof(").Append(typeName).AppendLine("))");
             builder.AppendLine("        {");
-            builder.Append("            throw new global::System.NotSupportedException($\"Type '{value.GetType()}' is not a registered derived type of '{typeof(")
+            builder.Append("            throw new global::System.NotSupportedException($\"Type '{runtimeType}' is not a registered derived type of '{typeof(")
                 .Append(typeName).AppendLine(")}'.\");");
             builder.AppendLine("        }");
             builder.AppendLine();
         }
         else
         {
-            builder.Append("        throw new global::System.NotSupportedException($\"Type '{value.GetType()}' is not a registered derived type of '{typeof(")
+            builder.Append("        throw new global::System.NotSupportedException($\"Type '{runtimeType}' is not a registered derived type of '{typeof(")
                 .Append(typeName).AppendLine(")}'.\");");
         }
     }

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -449,6 +449,11 @@ Name: Rex
 
 The same settings are available on `YamlSerializerOptions.PolymorphismOptions` for the whole serializer.
 
+`UnknownDerivedTypeHandling` applies while reading. While writing, the runtime type must match a registration exactly:
+serializing a subclass of a registered derived type that is not registered itself throws `NotSupportedException` rather
+than writing it under the discriminator of its closest registered base, which would silently drop the members it
+declares. This holds for both the reflection-based serializer and a source-generated `YamlSerializerContext`.
+
 ### Registering derived types at runtime
 
 `PolymorphismOptions.DerivedTypeMappings` registers derived types without touching the base type, which enables

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlPolymorphismTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlPolymorphismTests.cs
@@ -1,6 +1,60 @@
-﻿using Meziantou.Framework.Yaml.Serialization;
+﻿#pragma warning disable MA0048 // File name must match type name
+
+using Meziantou.Framework.Yaml.Serialization;
 
 namespace Meziantou.Framework.Yaml.Tests.Serialization;
+
+[YamlPolymorphic]
+[YamlDerivedType(typeof(SubclassDog), "dog")]
+internal abstract class SubclassPet
+{
+    public string Name { get; set; } = string.Empty;
+}
+
+internal class SubclassDog : SubclassPet
+{
+    public int BarkVolume { get; set; }
+}
+
+/// <summary>A subclass of a registered derived type that is not registered itself.</summary>
+internal sealed class SubclassLabrador : SubclassDog
+{
+    public string Coat { get; set; } = string.Empty;
+}
+
+/// <summary>Registers the base of a hierarchy before its more derived type, so write dispatch order matters.</summary>
+[YamlPolymorphic]
+[YamlDerivedType(typeof(NestedDog), "dog")]
+[YamlDerivedType(typeof(NestedLabrador), "labrador")]
+internal abstract class NestedPet
+{
+    public string Name { get; set; } = string.Empty;
+}
+
+internal class NestedDog : NestedPet
+{
+    public int BarkVolume { get; set; }
+}
+
+internal sealed class NestedLabrador : NestedDog
+{
+    public string Coat { get; set; } = string.Empty;
+}
+
+[YamlSerializable(typeof(SubclassPet))]
+[YamlSerializable(typeof(NestedPet))]
+internal sealed partial class SubclassPetYamlContext : YamlSerializerContext
+{
+    public SubclassPetYamlContext()
+    {
+    }
+
+    public SubclassPetYamlContext(YamlSerializerOptions options)
+        : base(options)
+    {
+    }
+}
+
 public class YamlPolymorphismTests
 {
     [YamlPolymorphic]
@@ -940,4 +994,57 @@ public class YamlPolymorphismTests
     {
         Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<ClosedShape>("$type: Nonexistent\n", InferClosedTypePolymorphismOptions));
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void WritingAnUnregisteredSubclassOfARegisteredDerivedTypeThrows(bool useSourceGeneration)
+    {
+        SubclassPet value = new SubclassLabrador { Name = "Rex", BarkVolume = 3, Coat = "yellow" };
+
+        var exception = Assert.Throws<NotSupportedException>(() => Serialize(value, useSourceGeneration));
+
+        Assert.Contains(typeof(SubclassLabrador).ToString(), exception.Message);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void WritingARegisteredDerivedTypeUsesItsOwnDiscriminator(bool useSourceGeneration)
+    {
+        SubclassPet value = new SubclassDog { Name = "Rex", BarkVolume = 3 };
+
+        var yaml = Serialize(value, useSourceGeneration);
+
+        Assert.Contains("$type: dog", yaml);
+        Assert.Contains("BarkVolume: 3", yaml);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void WritingARegisteredDerivedTypeIsNotShadowedByItsRegisteredBase(bool useSourceGeneration)
+    {
+        NestedPet value = new NestedLabrador { Name = "Rex", BarkVolume = 3, Coat = "yellow" };
+
+        var yaml = useSourceGeneration
+            ? YamlSerializer.Serialize(value, typeof(NestedPet), new SubclassPetYamlContext())
+            : YamlSerializer.Serialize(value, typeof(NestedPet));
+
+        Assert.Contains("$type: labrador", yaml);
+        Assert.Contains("Coat: yellow", yaml);
+
+        var roundtripped = useSourceGeneration
+            ? YamlSerializer.Deserialize(yaml, typeof(NestedPet), new SubclassPetYamlContext())
+            : YamlSerializer.Deserialize<NestedPet>(yaml);
+        var labrador = Assert.IsType<NestedLabrador>(roundtripped);
+        Assert.Equal("Rex", labrador.Name);
+        Assert.Equal(3, labrador.BarkVolume);
+        Assert.Equal("yellow", labrador.Coat);
+    }
+
+    private static string Serialize(SubclassPet value, bool useSourceGeneration)
+        => useSourceGeneration
+            ? YamlSerializer.Serialize(value, typeof(SubclassPet), new SubclassPetYamlContext())
+            : YamlSerializer.Serialize(value, typeof(SubclassPet));
 }

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSerializerContextGeneratorDiagnosticTests.cs
@@ -115,7 +115,7 @@ public class YamlSerializerContextGeneratorDiagnosticTests
 
         var result = RunGenerator(Source);
         Assert.Empty(result.GeneratorDiagnostics);
-        Assert.Contains("value is global::Dog", result.GeneratedSource);
+        Assert.Contains("runtimeType == typeof(global::Dog)", result.GeneratedSource);
     }
 
     [Fact]


### PR DESCRIPTION
## What

The reflection and source-generated polymorphic **write** paths disagreed when the runtime type is a subclass of a registered derived type but is not itself registered.

- Reflection (`YamlObjectConverter<T>.WritePolymorphic`) looks the runtime type up exactly and throws `NotSupportedException`.
- The generator emitted `if (value is DerivedType derivedN)`, so an unregistered subclass matched its base type's registration and was written under that discriminator. Members declared by the more derived type were silently dropped and the value round-tripped back as the base type.

Repro: register only `Dog` for a polymorphic base `Pet`, then serialize a `Labrador : Dog`. Reflection throws; the generated context wrote `$type: dog` and lost `Labrador`'s members.

## Decision: throw

Kept the reflection behavior, which matches `System.Text.Json`'s default `FailSerialization`. Silently writing a `Labrador` as `$type: dog` loses data with no signal, and this library's `UnknownDerivedTypeHandling` (`Fail` / `FallBackToBase`) is a *read*-side setting for unknown discriminators — there is no opt-in that would justify a nearest-ancestor write fallback.

## How

`YamlSerializerContextGenerator.EmitPhase.cs`, both write-dispatch sites (the inline class path and `EmitWritePolymorphicDispatch`, used for interfaces) now emit `var runtimeType = value.GetType();` and test `if (runtimeType == typeof(Derived))` instead of `if (value is Derived derivedN)`, passing `((Derived)value)` to `WriteMembersN`. An unregistered subclass falls through to the existing "not a registered derived type" throw, which reuses the same local and produces the same message as reflection.

## Note for reviewers

`OrderDerivedTypesForWriteDispatch` does not exist anywhere in the repo, so the write dispatch was **not** ordered most-derived-first — the shadowing case (a registered base shadowing a registered more-derived type) was live too. Exact-type matching fixes both at once and makes registration order irrelevant to write dispatch.

## Tests

Three `[Theory]` cases in `YamlPolymorphismTests.cs` run against both paths via a new `SubclassPetYamlContext`:

- `WritingAnUnregisteredSubclassOfARegisteredDerivedTypeThrows` — the `Labrador : Dog` repro; asserts `NotSupportedException` naming the runtime type.
- `WritingARegisteredDerivedTypeUsesItsOwnDiscriminator` — the registered `Dog` still writes normally.
- `WritingARegisteredDerivedTypeIsNotShadowedByItsRegisteredBase` — `NestedLabrador`, registered *after* its base `NestedDog`, still writes `$type: labrador` with `Coat`, and round-trips.

Stashing the generator fix makes exactly the two source-generation legs fail; the reflection legs pass either way, confirming the two paths now agree.

Also updated `YamlSerializerContextGeneratorDiagnosticTests.cs`, which asserted on the old `value is global::Dog` emission, and documented the write-side rule in `src/Meziantou.Framework.Yaml/readme.md`.

## Verification

- `dotnet build /p:TreatsWarningsAsErrors=true` clean for the test project, `Meziantou.Framework.Yaml.AotSmoke`, and `Meziantou.Framework.Yaml.FeatureSwitchSmoke`.
- 1810/1810 tests pass on net10.0 and net11.0.
- `dotnet run ./eng/update-all.cs` ran and produced no file drift.