### PR TITLE
Infer the whole closed hierarchy for polymorphic serialization

### DIFF
--- a/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
+++ b/src/Meziantou.Framework.Yaml.SourceGenerator/YamlSerializerContextGenerator.cs
@@ -665,8 +665,10 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         => (declarationOverride ?? sourceGenerationOptions.InferClosedTypePolymorphism ?? false) && ClosedTypeSymbolHelper.IsClosedType(baseType);
 
     /// <summary>
-    /// Registers each direct derived type of a closed hierarchy, using its name, without the generic arity suffix, as
-    /// its discriminator. Derived types are ordered by discriminator so the generated metadata is deterministic.
+    /// Registers every descendant of a closed hierarchy, using its name, without the generic arity suffix, as its
+    /// discriminator. A derived type that is itself closed brings its own hierarchy along, since it is known at
+    /// compile time as well. Derived types are ordered by discriminator, base types first, so the generated metadata
+    /// is deterministic.
     /// </summary>
     private static ImmutableArray<DerivedTypeInfoModel> InferClosedTypeDerivedTypes(
         INamedTypeSymbol baseType,
@@ -676,34 +678,49 @@ public sealed partial class YamlSerializerContextGenerator : IIncrementalGenerat
         var seenDiscriminators = new HashSet<string>(StringComparer.Ordinal);
         var location = baseType.Locations.FirstOrDefault();
 
-        foreach (var closedDerivedType in ClosedTypeSymbolHelper.GetClosedDerivedTypes(baseType).OrderBy(static type => type.Name, StringComparer.Ordinal))
+        // Each level is resolved against the type declaring it so an open generic derived type unifies with its own
+        // base type. Only a newly registered type is expanded, and a type can only be registered once, so the
+        // traversal always terminates.
+        var pendingHierarchies = new Queue<INamedTypeSymbol>();
+        pendingHierarchies.Enqueue(baseType);
+
+        while (pendingHierarchies.Count > 0)
         {
-            string? reason = null;
-            if (!TryResolveDerivedType(baseType, closedDerivedType, out var derivedType) || !IsAssignableTo(derivedType, baseType))
+            var declaringType = pendingHierarchies.Dequeue();
+            foreach (var closedDerivedType in ClosedTypeSymbolHelper.GetClosedDerivedTypes(declaringType).OrderBy(static type => type.Name, StringComparer.Ordinal))
             {
-                reason = $"it cannot be resolved for the base type '{baseType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)}'";
-            }
-            else if (!ClosedTypeSymbolHelper.IsAtLeastAsVisibleAs(derivedType, baseType))
-            {
-                reason = "it is less visible than the base type";
-            }
-            else if (!seenDiscriminators.Add(ClosedTypeSymbolHelper.GetInferredDiscriminator(derivedType)))
-            {
-                reason = $"another derived type already uses the discriminator '{ClosedTypeSymbolHelper.GetInferredDiscriminator(derivedType)}'";
-            }
+                string? reason = null;
+                if (!TryResolveDerivedType(declaringType, closedDerivedType, out var derivedType) || !IsAssignableTo(derivedType, baseType))
+                {
+                    reason = $"it cannot be resolved for the base type '{baseType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)}'";
+                }
+                else if (!ClosedTypeSymbolHelper.IsAtLeastAsVisibleAs(derivedType, baseType))
+                {
+                    reason = "it is less visible than the base type";
+                }
+                else if (!seenDiscriminators.Add(ClosedTypeSymbolHelper.GetInferredDiscriminator(derivedType)))
+                {
+                    reason = $"another derived type already uses the discriminator '{ClosedTypeSymbolHelper.GetInferredDiscriminator(derivedType)}'";
+                }
 
-            if (reason is not null)
-            {
-                diagnostics?.Add(Diagnostic.Create(
-                    IgnoredInferredDerivedType,
-                    location,
-                    closedDerivedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                    baseType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                    reason));
-                continue;
-            }
+                if (reason is not null)
+                {
+                    diagnostics?.Add(Diagnostic.Create(
+                        IgnoredInferredDerivedType,
+                        location,
+                        closedDerivedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        baseType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        reason));
+                    continue;
+                }
 
-            derivedTypes.Add(new DerivedTypeInfoModel(derivedType!, ClosedTypeSymbolHelper.GetInferredDiscriminator(derivedType!), tag: null));
+                derivedTypes.Add(new DerivedTypeInfoModel(derivedType!, ClosedTypeSymbolHelper.GetInferredDiscriminator(derivedType!), tag: null));
+
+                if (derivedType is INamedTypeSymbol namedDerivedType && ClosedTypeSymbolHelper.IsClosedType(namedDerivedType))
+                {
+                    pendingHierarchies.Enqueue(namedDerivedType);
+                }
+            }
         }
 
         return derivedTypes.ToImmutable();

--- a/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
+++ b/src/Meziantou.Framework.Yaml/Serialization/Converters/YamlObjectConverter.cs
@@ -2596,27 +2596,44 @@ internal sealed class YamlObjectConverter<T> : YamlConverter<T?>, IYamlUnionCase
 
             if (inferredDerivedTypes is not null)
             {
-                foreach (var inferredDerivedType in inferredDerivedTypes)
+                // A derived type that is itself closed brings its own hierarchy along: the whole hierarchy is known at
+                // compile time, so every descendant is registered instead of only the direct derived types. Each level
+                // is resolved against the type declaring it so an open generic derived type unifies with its own base.
+                var pendingHierarchies = new Queue<(Type BaseType, Type[] DerivedTypes)>();
+                pendingHierarchies.Enqueue((type, inferredDerivedTypes));
+
+                while (pendingHierarchies.Count > 0)
                 {
-                    var derivedType = YamlDerivedTypeHelper.ResolveDerivedType(type, inferredDerivedType);
-                    if (!type.IsAssignableFrom(derivedType))
+                    var (declaringType, declaredDerivedTypes) = pendingHierarchies.Dequeue();
+                    foreach (var inferredDerivedType in declaredDerivedTypes)
                     {
-                        throw new InvalidOperationException($"Derived type '{derivedType}' is not assignable to '{type}'.");
-                    }
+                        var derivedType = YamlDerivedTypeHelper.ResolveDerivedType(declaringType, inferredDerivedType);
+                        if (!type.IsAssignableFrom(derivedType))
+                        {
+                            throw new InvalidOperationException($"Derived type '{derivedType}' is not assignable to '{type}'.");
+                        }
 
-                    if (!YamlClosedTypeHelper.IsAtLeastAsVisibleAs(derivedType, type))
-                    {
-                        throw new InvalidOperationException($"Derived type '{derivedType}' inferred for the closed type '{type}' is less visible than '{type}' and cannot be registered.");
-                    }
+                        if (!YamlClosedTypeHelper.IsAtLeastAsVisibleAs(derivedType, type))
+                        {
+                            throw new InvalidOperationException($"Derived type '{derivedType}' inferred for the closed type '{type}' is less visible than '{type}' and cannot be registered.");
+                        }
 
-                    var discriminator = YamlClosedTypeHelper.GetInferredDiscriminator(derivedType);
-                    if (discriminatorToType.ContainsKey(discriminator))
-                    {
-                        throw new InvalidOperationException($"Derived type '{derivedType}' inferred for the closed type '{type}' uses the discriminator '{discriminator}', which is already registered by another derived type.");
-                    }
+                        var discriminator = YamlClosedTypeHelper.GetInferredDiscriminator(derivedType);
+                        if (discriminatorToType.ContainsKey(discriminator))
+                        {
+                            throw new InvalidOperationException($"Derived type '{derivedType}' inferred for the closed type '{type}' uses the discriminator '{discriminator}', which is already registered by another derived type.");
+                        }
 
-                    discriminatorToType.Add(discriminator, derivedType);
-                    typeToDerived[derivedType] = new DerivedTypeInfo(discriminator, tag: null);
+                        discriminatorToType.Add(discriminator, derivedType);
+                        typeToDerived[derivedType] = new DerivedTypeInfo(discriminator, tag: null);
+
+                        // Only a newly registered type is expanded, and a type can only be registered once, so the
+                        // traversal always terminates.
+                        if (YamlClosedTypeHelper.IsClosedType(derivedType, out var nestedDerivedTypes) && nestedDerivedTypes is not null)
+                        {
+                            pendingHierarchies.Enqueue((derivedType, nestedDerivedTypes));
+                        }
+                    }
                 }
             }
 

--- a/src/Meziantou.Framework.Yaml/readme.md
+++ b/src/Meziantou.Framework.Yaml/readme.md
@@ -496,8 +496,8 @@ internal sealed class Dog<T> : Animal<T>  // Animal<string> uses Dog<string>, An
 ### Closed hierarchies
 
 A `closed` class hierarchy already lists its derived types in metadata, so they do not need to be repeated with
-`YamlDerivedTypeAttribute`. Set `InferClosedTypePolymorphism` to register every direct derived type of a closed base
-type automatically, using the derived type name, without the generic arity suffix, as its discriminator.
+`YamlDerivedTypeAttribute`. Set `InferClosedTypePolymorphism` to register every derived type of a closed base type
+automatically, using the derived type name, without the generic arity suffix, as its discriminator.
 
 ```csharp
 public closed class Shape
@@ -529,9 +529,10 @@ public closed class Shape
 
 Explicit registrations replace inference: a type declaring `YamlDerivedTypeAttribute` or a runtime mapping registers
 only those derived types. Enabling `YamlPolymorphicAttribute.InferClosedTypePolymorphism` on a type that is not declared
-`closed` throws an `InvalidOperationException` and reports the `MFY023` diagnostic. Only the direct derived types of the
-closed base type are registered, as with explicit registrations: when a derived type is itself `closed`, its own derived
-types are registered under it and not under the root of the hierarchy.
+`closed` throws an `InvalidOperationException` and reports the `MFY023` diagnostic. A derived type that is itself
+`closed` brings its own hierarchy along: its derived types are registered under the root of the hierarchy too, so the
+most derived type of a fully closed hierarchy is the one written and read back. A derived type that is not `closed` ends
+the inference, as its own derived types are not known.
 
 A derived type must be at least as visible as the base type it is registered under, and two derived types cannot share a
 name. Reflection-based serialization throws an `InvalidOperationException` in those cases, and the source generator skips

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlPolymorphismTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlPolymorphismTests.cs
@@ -977,11 +977,16 @@ public class YamlPolymorphismTests
     }
 
     [Fact]
-    public void ClosedTypeInferenceRegistersDirectDerivedTypesOnly()
+    public void ClosedTypeInferenceRegistersTransitiveDerivedTypes()
     {
         ClosedNestedRoot value = new ClosedNestedLeaf { Name = "leaf", Level = 2, Detail = "detail" };
+        var rootYaml = YamlSerializer.Serialize(value, typeof(ClosedNestedRoot), InferClosedTypePolymorphismOptions);
 
-        Assert.Throws<NotSupportedException>(() => YamlSerializer.Serialize(value, typeof(ClosedNestedRoot), InferClosedTypePolymorphismOptions));
+        Assert.Contains("$type: ClosedNestedLeaf", rootYaml);
+        var leaf = Assert.IsType<ClosedNestedLeaf>(YamlSerializer.Deserialize<ClosedNestedRoot>(rootYaml, InferClosedTypePolymorphismOptions));
+        Assert.Equal("leaf", leaf.Name);
+        Assert.Equal(2, leaf.Level);
+        Assert.Equal("detail", leaf.Detail);
 
         ClosedNestedMiddle middleValue = new ClosedNestedLeaf { Name = "leaf", Level = 2, Detail = "detail" };
         var yaml = YamlSerializer.Serialize(middleValue, typeof(ClosedNestedMiddle), InferClosedTypePolymorphismOptions);
@@ -993,6 +998,58 @@ public class YamlPolymorphismTests
     public void ClosedTypeInferenceFailsForUnknownDiscriminator()
     {
         Assert.Throws<YamlException>(() => YamlSerializer.Deserialize<ClosedShape>("$type: Nonexistent\n", InferClosedTypePolymorphismOptions));
+    }
+
+    private closed class ClosedPet
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class ClosedCat : ClosedPet
+    {
+        public bool Indoor { get; set; }
+    }
+
+    private closed class ClosedDog : ClosedPet
+    {
+        public bool GoodBoy { get; set; }
+    }
+
+    private sealed class ClosedLabrador : ClosedDog
+    {
+        public string Color { get; set; } = string.Empty;
+    }
+
+    private sealed class ClosedCollie : ClosedDog
+    {
+        public bool Herding { get; set; }
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceRegistersDescendantsOfNestedClosedTypes()
+    {
+        ClosedPet value = new ClosedLabrador { Name = "Rex", GoodBoy = true, Color = "chocolate" };
+        var yaml = YamlSerializer.Serialize(value, typeof(ClosedPet), InferClosedTypePolymorphismOptions);
+
+        Assert.Contains("$type: ClosedLabrador", yaml);
+
+        var labrador = Assert.IsType<ClosedLabrador>(YamlSerializer.Deserialize<ClosedPet>(yaml, InferClosedTypePolymorphismOptions));
+        Assert.Equal("Rex", labrador.Name);
+        Assert.True(labrador.GoodBoy);
+        Assert.Equal("chocolate", labrador.Color);
+    }
+
+    [Fact]
+    public void ClosedTypeInferenceRegistersEveryDescendantOfANestedClosedHierarchy()
+    {
+        ClosedPet collie = new ClosedCollie { Name = "Lassie", GoodBoy = true, Herding = true };
+        Assert.Contains("$type: ClosedCollie", YamlSerializer.Serialize(collie, typeof(ClosedPet), InferClosedTypePolymorphismOptions));
+
+        ClosedPet cat = new ClosedCat { Name = "Mittens", Indoor = true };
+        Assert.Contains("$type: ClosedCat", YamlSerializer.Serialize(cat, typeof(ClosedPet), InferClosedTypePolymorphismOptions));
+
+        ClosedDog dog = new ClosedLabrador { Name = "Rex", Color = "black" };
+        Assert.Contains("$type: ClosedLabrador", YamlSerializer.Serialize(dog, typeof(ClosedDog), InferClosedTypePolymorphismOptions));
     }
 
     [Theory]

--- a/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSourceGeneratedDerivedTypeMappingTests.cs
+++ b/tests/Meziantou.Framework.Yaml.Tests/Serialization/YamlSourceGeneratedDerivedTypeMappingTests.cs
@@ -76,6 +76,36 @@ namespace Meziantou.Framework.Yaml.Tests.Serialization.ClosedHierarchy
         public double Height { get; set; }
     }
 
+    internal closed class Pet
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    internal sealed class Cat : Pet
+    {
+        public bool Indoor { get; set; }
+    }
+
+    internal closed class Dog : Pet
+    {
+        public bool GoodBoy { get; set; }
+    }
+
+    internal sealed class Labrador : Dog
+    {
+        public string Color { get; set; } = string.Empty;
+    }
+
+    internal sealed class Collie : Dog
+    {
+        public bool Herding { get; set; }
+    }
+
+    internal sealed class PetHolder
+    {
+        public Pet? Pet { get; set; }
+    }
+
     internal sealed class ShapeHolder
     {
         public Shape? Shape { get; set; }
@@ -117,6 +147,7 @@ namespace Meziantou.Framework.Yaml.Tests.Serialization
     }
     [YamlSourceGenerationOptions(InferClosedTypePolymorphism = true)]
     [YamlSerializable(typeof(ClosedHierarchy.ShapeHolder))]
+    [YamlSerializable(typeof(ClosedHierarchy.PetHolder))]
     internal sealed partial class InferredClosedTypeYamlContext : YamlSerializerContext
     {
     }
@@ -165,6 +196,55 @@ namespace Meziantou.Framework.Yaml.Tests.Serialization
 
             Assert.Contains("$type: Square", yaml);
             Assert.IsType<ClosedHierarchy.Square>(YamlSerializer.Deserialize(yaml, typeInfo)?.Shape);
+        }
+
+        [Fact]
+        public void GeneratedContextInfersDescendantsOfNestedClosedTypes()
+        {
+            var context = new InferredClosedTypeYamlContext();
+            var typeInfo = context.PetHolder;
+
+            var yaml = YamlSerializer.Serialize(
+                new ClosedHierarchy.PetHolder
+                {
+                    Pet = new ClosedHierarchy.Labrador { Name = "Rex", GoodBoy = true, Color = "chocolate" },
+                },
+                typeInfo);
+
+            Assert.Contains("$type: Labrador", yaml);
+
+            var roundtripped = YamlSerializer.Deserialize(yaml, typeInfo);
+            var labrador = Assert.IsType<ClosedHierarchy.Labrador>(roundtripped?.Pet);
+            Assert.Equal("Rex", labrador.Name);
+            Assert.True(labrador.GoodBoy);
+            Assert.Equal("chocolate", labrador.Color);
+        }
+
+        [Fact]
+        public void GeneratedContextInfersEveryDescendantOfANestedClosedHierarchy()
+        {
+            var context = new InferredClosedTypeYamlContext();
+            var typeInfo = context.PetHolder;
+
+            var collieYaml = YamlSerializer.Serialize(
+                new ClosedHierarchy.PetHolder
+                {
+                    Pet = new ClosedHierarchy.Collie { Name = "Lassie", Herding = true },
+                },
+                typeInfo);
+
+            Assert.Contains("$type: Collie", collieYaml);
+            Assert.IsType<ClosedHierarchy.Collie>(YamlSerializer.Deserialize(collieYaml, typeInfo)?.Pet);
+
+            var catYaml = YamlSerializer.Serialize(
+                new ClosedHierarchy.PetHolder
+                {
+                    Pet = new ClosedHierarchy.Cat { Name = "Mittens", Indoor = true },
+                },
+                typeInfo);
+
+            Assert.Contains("$type: Cat", catYaml);
+            Assert.IsType<ClosedHierarchy.Cat>(YamlSerializer.Deserialize(catYaml, typeInfo)?.Pet);
         }
 
         [Fact]


### PR DESCRIPTION
`InferClosedTypePolymorphism` only registered the **direct** derived types of a `closed` base type. When a derived type was itself `closed`, its own derived types were registered under it and not under the root of the hierarchy, so serializing a leaf through the root failed.

This is the YAML equivalent of [dotnet/runtime#132660](https://github.com/dotnet/runtime/issues/132660), reported against `System.Text.Json`.

## Reproduction

```csharp
closed class Pet { public string Name { get; set; } = ""; }
sealed class Cat : Pet;
closed class Dog : Pet;
sealed class Labrador : Dog;
sealed class Collie : Dog;

Pet pet = new Labrador { Name = "Rex" };
YamlSerializer.Serialize(pet, typeof(Pet), inferClosedTypePolymorphismOptions);
```

- **Reflection**: `NotSupportedException: Type 'Labrador' is not a registered derived type of 'Pet'`
- **Source generator**: silently wrote `$type: Dog` and dropped the members `Labrador` declares, so the value round-tripped back as a `Dog`

The existing `ClosedTypeInferenceRegistersDirectDerivedTypesOnly` test codified the old behavior.

## Change

A derived type that is itself `closed` now brings its own hierarchy along: the traversal expands every descendant of a fully closed hierarchy and registers it under the root, in both the reflection resolver (`YamlObjectConverter.PolymorphismModel.TryCreate`) and the source generator (`InferClosedTypeDerivedTypes`).

- Each level is resolved against the type declaring it, so an open generic derived type still unifies with its own base type — the same unification problem as level one, no special casing.
- A derived type that is not `closed` ends the inference, since its own derived types are not knowable.
- Only a newly registered type is expanded, and a type can only be registered once (a duplicate discriminator throws / reports `MFY025`), so the traversal always terminates.

The visibility and duplicate-discriminator rules are unchanged and are still evaluated against the root of the hierarchy, which is where the descendants get registered.

## Notes for reviewers

- This builds on #1969, which made the generated write dispatch match the runtime type exactly. That commit is what makes a registered leaf win over its registered base regardless of order, so no ordering work is needed here.
- Public API is unchanged, so there are no `ref/` updates.
- The `MFY025` diagnostic now also covers descendants found at deeper levels; its location still points at the root base type.

## Tests

- `ClosedTypeInferenceRegistersDescendantsOfNestedClosedTypes` and `ClosedTypeInferenceRegistersEveryDescendantOfANestedClosedHierarchy` (reflection) use the issue's `Pet`/`Cat`/`Dog`/`Labrador`/`Collie` shape.
- `GeneratedContextInfersDescendantsOfNestedClosedTypes` and `GeneratedContextInfersEveryDescendantOfANestedClosedHierarchy` cover the same shape through a generated context.
- `ClosedTypeInferenceRegistersDirectDerivedTypesOnly` was rewritten as `ClosedTypeInferenceRegistersTransitiveDerivedTypes`.

Verified with `/p:TreatsWarningsAsErrors=true`: `Meziantou.Framework.Yaml.Tests` 1818/1818 pass on net10.0 and net11.0, `Meziantou.Framework.Yamlish.Tests` 385/385 pass, and the AotSmoke, FeatureSwitchSmoke, Trimmable, and DependencyScanning projects build clean. `dotnet run ./eng/update-all.cs` produced no changes.