### PR TITLE
Fix the bump-versions script: body length and commit window

### DIFF
--- a/eng/update-versions.cs
+++ b/eng/update-versions.cs
@@ -10,18 +10,20 @@ using Meziantou.Framework;
 var createPullRequest = false;
 var forceBumpAll = false;
 var numberOfCommits = 50;
+var since = "2 weeks ago";
 
 for (var i = 0; i < args.Length; i++)
 {
     switch (args[i])
     {
         case "--help" or "-h":
-            Console.WriteLine("Usage: dotnet run update-versions.cs [-- --create-pull-request --force-bump-all --number-of-commits <N>]");
+            Console.WriteLine("Usage: dotnet run update-versions.cs [-- --create-pull-request --force-bump-all --number-of-commits <N> --since <date>]");
             Console.WriteLine("Bumps package versions based on git commit history.");
             Console.WriteLine("Options:");
             Console.WriteLine("  --create-pull-request      Create or update a GitHub pull request");
             Console.WriteLine("  --force-bump-all           Bump all packable package versions");
-            Console.WriteLine("  --number-of-commits <N>    Number of commits to analyze (default: 50)");
+            Console.WriteLine("  --number-of-commits <N>    Minimum number of commits to analyze (default: 50)");
+            Console.WriteLine("  --since <date>             Also analyze every commit newer than <date> (default: 2 weeks ago)");
             return 0;
         case "--create-pull-request":
             createPullRequest = true;
@@ -31,6 +33,9 @@ for (var i = 0; i < args.Length; i++)
             break;
         case "--number-of-commits" when i + 1 < args.Length:
             numberOfCommits = int.Parse(args[++i], CultureInfo.InvariantCulture);
+            break;
+        case "--since" when i + 1 < args.Length:
+            since = args[++i];
             break;
     }
 }
@@ -44,10 +49,12 @@ var skippedCommits = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
 var rootPath = GetRepositoryRoot();
 var srcPath = rootPath / "src";
 
-// Get recent commits
-var commits = RunAndCapture("git", ["log", $"--pretty=format:%H", "-n", numberOfCommits.ToString(CultureInfo.InvariantCulture)])
-    .Split('\n', StringSplitOptions.RemoveEmptyEntries)
-    .Select(c => c.Trim().Trim('\''))
+// Get recent commits: the last N commits, plus every commit made in the time window.
+// Both lists are ordered from the newest commit to the oldest, and the second one is a prefix of the first
+// or an extension of it, so removing the duplicates keeps that order.
+var commits = GetCommitHashes(["-n", numberOfCommits.ToString(CultureInfo.InvariantCulture)])
+    .Concat(GetCommitHashes([$"--since={since}"]))
+    .Distinct(StringComparer.Ordinal)
     .ToArray();
 Console.WriteLine($"Commits loaded ({commits.Length} commits)");
 
@@ -498,6 +505,14 @@ static void RunProcess(string fileName, string[] arguments)
 }
 
 static FullPath GetRepositoryRoot() => FullPath.CurrentDirectory().FindRequiredGitRepositoryRoot();
+
+static string[] GetCommitHashes(string[] arguments)
+{
+    return RunAndCapture("git", ["log", "--pretty=format:%H", .. arguments])
+        .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+        .Select(c => c.Trim().Trim('\''))
+        .ToArray();
+}
 
 static string TruncatePullRequestBody(string body)
 {

--- a/eng/update-versions.cs
+++ b/eng/update-versions.cs
@@ -9,7 +9,6 @@ using Meziantou.Framework;
 
 var createPullRequest = false;
 var forceBumpAll = false;
-var numberOfCommits = 50;
 var since = "2 weeks ago";
 
 for (var i = 0; i < args.Length; i++)
@@ -17,22 +16,18 @@ for (var i = 0; i < args.Length; i++)
     switch (args[i])
     {
         case "--help" or "-h":
-            Console.WriteLine("Usage: dotnet run update-versions.cs [-- --create-pull-request --force-bump-all --number-of-commits <N> --since <date>]");
+            Console.WriteLine("Usage: dotnet run update-versions.cs [-- --create-pull-request --force-bump-all --since <date>]");
             Console.WriteLine("Bumps package versions based on git commit history.");
             Console.WriteLine("Options:");
             Console.WriteLine("  --create-pull-request      Create or update a GitHub pull request");
             Console.WriteLine("  --force-bump-all           Bump all packable package versions");
-            Console.WriteLine("  --number-of-commits <N>    Minimum number of commits to analyze (default: 50)");
-            Console.WriteLine("  --since <date>             Also analyze every commit newer than <date> (default: 2 weeks ago)");
+            Console.WriteLine("  --since <date>             Analyze every commit newer than <date> (default: 2 weeks ago)");
             return 0;
         case "--create-pull-request":
             createPullRequest = true;
             break;
         case "--force-bump-all":
             forceBumpAll = true;
-            break;
-        case "--number-of-commits" when i + 1 < args.Length:
-            numberOfCommits = int.Parse(args[++i], CultureInfo.InvariantCulture);
             break;
         case "--since" when i + 1 < args.Length:
             since = args[++i];
@@ -49,12 +44,10 @@ var skippedCommits = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
 var rootPath = GetRepositoryRoot();
 var srcPath = rootPath / "src";
 
-// Get recent commits: the last N commits, plus every commit made in the time window.
-// Both lists are ordered from the newest commit to the oldest, and the second one is a prefix of the first
-// or an extension of it, so removing the duplicates keeps that order.
-var commits = GetCommitHashes(["-n", numberOfCommits.ToString(CultureInfo.InvariantCulture)])
-    .Concat(GetCommitHashes([$"--since={since}"]))
-    .Distinct(StringComparer.Ordinal)
+// Get the commits made in the time window, from the newest to the oldest
+var commits = RunAndCapture("git", ["log", "--pretty=format:%H", $"--since={since}"])
+    .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+    .Select(c => c.Trim().Trim('\''))
     .ToArray();
 Console.WriteLine($"Commits loaded ({commits.Length} commits)");
 
@@ -505,14 +498,6 @@ static void RunProcess(string fileName, string[] arguments)
 }
 
 static FullPath GetRepositoryRoot() => FullPath.CurrentDirectory().FindRequiredGitRepositoryRoot();
-
-static string[] GetCommitHashes(string[] arguments)
-{
-    return RunAndCapture("git", ["log", "--pretty=format:%H", .. arguments])
-        .Split('\n', StringSplitOptions.RemoveEmptyEntries)
-        .Select(c => c.Trim().Trim('\''))
-        .ToArray();
-}
 
 static string TruncatePullRequestBody(string body)
 {

--- a/eng/update-versions.cs
+++ b/eng/update-versions.cs
@@ -261,11 +261,9 @@ foreach (var (csproj, info) in projectsToUpdate.OrderBy(kv => kv.Key, StringComp
         {
             foreach (var commit in info.Commits.Distinct(StringComparer.Ordinal))
             {
-                var message = RunAndCapture("git", ["log", "--format=%B", "-n", "1", commit]);
-                message = Regex.Replace(message, @"\r?\n", "\n", RegexOptions.NonBacktracking);
-                message = Regex.Replace(message, @"\s+", " ", RegexOptions.NonBacktracking);
-                message = message.Replace("Co-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>", "", StringComparison.OrdinalIgnoreCase);
-                message = message.Trim();
+                // Only the subject: commit bodies are long enough that including them blows past the pull request body limit
+                var message = RunAndCapture("git", ["log", "--format=%s", "-n", "1", commit]);
+                message = Regex.Replace(message, @"\s+", " ", RegexOptions.NonBacktracking).Trim();
                 prMessage.Append($"- {commit}: {message}\n");
             }
         }
@@ -274,7 +272,7 @@ foreach (var (csproj, info) in projectsToUpdate.OrderBy(kv => kv.Key, StringComp
 
 if (updated)
 {
-    var prBody = prMessage.ToString();
+    var prBody = TruncatePullRequestBody(prMessage.ToString());
     Console.WriteLine(prBody);
 
     if (createPullRequest)
@@ -500,6 +498,22 @@ static void RunProcess(string fileName, string[] arguments)
 }
 
 static FullPath GetRepositoryRoot() => FullPath.CurrentDirectory().FindRequiredGitRepositoryRoot();
+
+static string TruncatePullRequestBody(string body)
+{
+    // GitHub rejects a pull request body longer than 65536 characters
+    const int MaximumLength = 65536;
+    const string TruncationNotice = "\n_The list of commits is truncated because the pull request body exceeds the maximum length allowed by GitHub._\n";
+
+    if (body.Length <= MaximumLength)
+        return body;
+
+    var length = MaximumLength - TruncationNotice.Length;
+    var lastLineBreak = body.AsSpan(0, length).LastIndexOf('\n');
+    length = lastLineBreak > 0 ? lastLineBreak + 1 : char.IsHighSurrogate(body[length - 1]) ? length - 1 : length;
+
+    return string.Concat(body[..length], TruncationNotice);
+}
 
 internal sealed class CsprojInfo
 {


### PR DESCRIPTION
The scheduled `bump-versions` workflow [failed](https://github.com/meziantou/Meziantou.Framework/actions/runs/32607170760/job/97114297056) at `gh pr create`:

```
pull request create failed: GraphQL: Body is too long (maximum is 65536 characters) (createPullRequest)
```

## Keep the pull request body under GitHub's limit

`eng/update-versions.cs` built the pull request body from the full commit message (`git log --format=%B`), and squash-merge bodies in this repository run to several thousand characters each. A commit that touches several packages is repeated once per package section, so the body reached roughly 200 KB — three times over the limit. The `gh pr edit` path uses the same body and would have failed the same way once a pull request existed.

- Only the commit subject (`--format=%s`) goes into the body now. The details stay one click away behind the commit sha. The renovate co-author removal and the CRLF normalization only ever matched text in the body, so they are removed as dead code.
- `TruncatePullRequestBody` is a safety net for a future flood of commits: above 65536 characters it cuts at the last line break that fits and appends a notice, so the job can never fail this way again.

## Select the commits to analyze by date

The script looked at a fixed number of commits (50), so a package whose only changes fell outside that window was never bumped. `--number-of-commits` is replaced by `--since`, defaulting to two weeks ago.

Widening the window does not re-list already-released commits: the per-project walk goes from the newest commit to the oldest and stops at the commit that last bumped that package's version.

## Verification

- `dotnet run ./eng/update-versions.cs` (without `--create-pull-request`) over the same history that broke CI: 154 commits analyzed instead of 50, and a body of **13796 characters** instead of ~200 KB. The version bumps it wrote locally were reverted.
- The truncation helper was exercised standalone: a short body is returned unchanged, a 190 KB body is cut to 65510 characters ending on a whole line followed by the notice, a body containing no newline at all is still capped, and a surrogate pair sitting on the cut point is not split.
- `dotnet run ./eng/update-all.cs` runs clean and produces no further changes.
