### PR TITLE
Exclude source-file snapshots from compilation

### DIFF
--- a/Meziantou.Framework.slnx
+++ b/Meziantou.Framework.slnx
@@ -239,6 +239,7 @@
     <Project Path="tests/Meziantou.Framework.SimpleQueryLanguage.Tests/Meziantou.Framework.SimpleQueryLanguage.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.SingleInstance.Tests/Meziantou.Framework.SingleInstance.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.Slug.Tests/Meziantou.Framework.Slug.Tests.csproj" />
+    <Project Path="tests/Meziantou.Framework.SnapshotTesting.PackageTests/Meziantou.Framework.SnapshotTesting.PackageTests.csproj" />
     <Project Path="tests/Meziantou.Framework.SnapshotTesting.Roslyn.Tests/Meziantou.Framework.SnapshotTesting.Roslyn.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.SnapshotTesting.Tool.Tests/Meziantou.Framework.SnapshotTesting.Tool.Tests.csproj" />

--- a/common/NuGetPackageFixture.cs
+++ b/common/NuGetPackageFixture.cs
@@ -5,7 +5,7 @@ using Xunit.Sdk;
 
 namespace TestUtilities;
 
-public abstract class NuGetPackageFixture(string packageProjectName) : IAsyncLifetime
+public abstract class NuGetPackageFixture(string packageProjectName, params string[] dependencyProjectNames) : IAsyncLifetime
 {
     private const string PackageVersionValue = "999.0.0-local";
     private const string ConfigurationValue = "Debug";
@@ -25,12 +25,9 @@ public abstract class NuGetPackageFixture(string packageProjectName) : IAsyncLif
 
         var repositoryRoot = GetRepositoryRoot();
         DotnetSdkVersion = ReadDotnetSdkVersion(repositoryRoot / "global.json");
-        var packageProjectPath = repositoryRoot / "src" / packageProjectName / (packageProjectName + ".csproj");
 
-        await RunDotNetCommand(repositoryRoot,
+        string[] commonArguments =
         [
-            "build",
-            packageProjectPath,
             "--configuration",
             ConfigurationValue,
             "--disable-build-servers",
@@ -41,25 +38,17 @@ public abstract class NuGetPackageFixture(string packageProjectName) : IAsyncLif
             "/p:RunAnalyzers=false",
             "/p:PublicApiGeneratorGenerateOnBuild=false",
             "/p:PublicApiGeneratorVerifyNoChangeOnBuild=false",
-        ], expectedExitCode: 0);
-        await RunDotNetCommand(repositoryRoot,
-        [
-            "pack",
-            packageProjectPath,
-            "--configuration",
-            ConfigurationValue,
-            "--no-build",
-            "--disable-build-servers",
-            "-nologo",
-            "--output",
-            PackagesDirectory,
-            "/p:ArtifactsPath=" + artifactsPath,
-            "/p:Version=" + PackageVersionValue,
-            "/p:GenerateSBOM=false",
-            "/p:RunAnalyzers=false",
-            "/p:PublicApiGeneratorGenerateOnBuild=false",
-            "/p:PublicApiGeneratorVerifyNoChangeOnBuild=false",
-        ], expectedExitCode: 0);
+        ];
+
+        // Building the main project also builds the projects it references, so they can all be packed without rebuilding.
+        // The Version property applies to them too, so the packages they produce must be available to restore the main one.
+        var packageProjectPath = GetProjectPath(repositoryRoot, packageProjectName);
+        await RunDotNetCommand(repositoryRoot, ["build", packageProjectPath, .. commonArguments], expectedExitCode: 0);
+
+        foreach (var projectName in new[] { packageProjectName }.Concat(dependencyProjectNames))
+        {
+            await RunDotNetCommand(repositoryRoot, ["pack", GetProjectPath(repositoryRoot, projectName), "--no-build", .. commonArguments, "--output", PackagesDirectory], expectedExitCode: 0);
+        }
 
         PackagePath = PackagesDirectory / $"{packageProjectName}.{PackageVersionValue}.nupkg";
         if (!File.Exists(PackagePath))
@@ -69,6 +58,11 @@ public abstract class NuGetPackageFixture(string packageProjectName) : IAsyncLif
     public async ValueTask DisposeAsync()
     {
         await _temporaryDirectory.DisposeAsync();
+    }
+
+    private static FullPath GetProjectPath(FullPath repositoryRoot, string projectName)
+    {
+        return repositoryRoot / "src" / projectName / (projectName + ".csproj");
     }
 
     private static string ReadDotnetSdkVersion(FullPath globalJsonPath)

--- a/common/NuGetPackageFixture.cs
+++ b/common/NuGetPackageFixture.cs
@@ -1,11 +1,13 @@
+using System.IO.Compression;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using System.Xml.Linq;
 using Meziantou.Framework;
 using Xunit.Sdk;
 
 namespace TestUtilities;
 
-public abstract class NuGetPackageFixture(string packageProjectName, params string[] dependencyProjectNames) : IAsyncLifetime
+public abstract class NuGetPackageFixture(string packageProjectName) : IAsyncLifetime
 {
     private const string PackageVersionValue = "999.0.0-local";
     private const string ConfigurationValue = "Debug";
@@ -41,13 +43,26 @@ public abstract class NuGetPackageFixture(string packageProjectName, params stri
         ];
 
         // Building the main project also builds the projects it references, so they can all be packed without rebuilding.
-        // The Version property applies to them too, so the packages they produce must be available to restore the main one.
-        var packageProjectPath = GetProjectPath(repositoryRoot, packageProjectName);
-        await RunDotNetCommand(repositoryRoot, ["build", packageProjectPath, .. commonArguments], expectedExitCode: 0);
+        // The Version property applies to them too, so a dependency using that version must be packed to restore the package.
+        await RunDotNetCommand(repositoryRoot, ["build", GetProjectPath(repositoryRoot, packageProjectName), .. commonArguments], expectedExitCode: 0);
 
-        foreach (var projectName in new[] { packageProjectName }.Concat(dependencyProjectNames))
+        var pendingProjectNames = new Queue<string>([packageProjectName]);
+        var packedProjectNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        while (pendingProjectNames.TryDequeue(out var projectName))
         {
-            await RunDotNetCommand(repositoryRoot, ["pack", GetProjectPath(repositoryRoot, projectName), "--no-build", .. commonArguments, "--output", PackagesDirectory], expectedExitCode: 0);
+            if (!packedProjectNames.Add(projectName))
+                continue;
+
+            var projectPath = GetProjectPath(repositoryRoot, projectName);
+            if (!File.Exists(projectPath))
+                throw new XunitException($"The package '{projectName}' is a dependency built by this repository, but '{projectPath}' does not exist.");
+
+            await RunDotNetCommand(repositoryRoot, ["pack", projectPath, "--no-build", .. commonArguments, "--output", PackagesDirectory], expectedExitCode: 0);
+
+            foreach (var dependency in GetDependenciesBuiltByThisRepository(PackagesDirectory / $"{projectName}.{PackageVersionValue}.nupkg"))
+            {
+                pendingProjectNames.Enqueue(dependency);
+            }
         }
 
         PackagePath = PackagesDirectory / $"{packageProjectName}.{PackageVersionValue}.nupkg";
@@ -58,6 +73,27 @@ public abstract class NuGetPackageFixture(string packageProjectName, params stri
     public async ValueTask DisposeAsync()
     {
         await _temporaryDirectory.DisposeAsync();
+    }
+
+    private static string[] GetDependenciesBuiltByThisRepository(FullPath packagePath)
+    {
+        using var package = ZipFile.OpenRead(packagePath);
+        var nuspecEntry = package.Entries.FirstOrDefault(entry => !entry.FullName.Contains('/', StringComparison.Ordinal) && entry.FullName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase));
+        if (nuspecEntry is null)
+            throw new XunitException($"The package '{packagePath}' does not contain a nuspec file.");
+
+        using var stream = nuspecEntry.Open();
+        var nuspec = XDocument.Load(stream);
+
+        // Projects referenced by the packed project use the same version, so they are not available on NuGet.org
+        return nuspec.Descendants()
+            .Where(element => element.Name.LocalName is "dependency")
+            .Where(element => string.Equals((string?)element.Attribute("version"), PackageVersionValue, StringComparison.OrdinalIgnoreCase))
+            .Select(element => element.Attribute("id")?.Value)
+            .OfType<string>()
+            .Where(id => id.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     private static FullPath GetProjectPath(FullPath repositoryRoot, string projectName)

--- a/slnx/Meziantou.Framework.ProcessWrapper.slnx
+++ b/slnx/Meziantou.Framework.ProcessWrapper.slnx
@@ -32,6 +32,7 @@
     <Project Path="../tests/Meziantou.Framework.PublicApiGenerator.MSBuild.Tests/Meziantou.Framework.PublicApiGenerator.MSBuild.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.PublicApiGenerator.Tests/Meziantou.Framework.PublicApiGenerator.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.Roslyn.PackageTests/Meziantou.Framework.Roslyn.PackageTests.csproj" />
+    <Project Path="../tests/Meziantou.Framework.SnapshotTesting.PackageTests/Meziantou.Framework.SnapshotTesting.PackageTests.csproj" />
     <Project Path="../tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.Tests/Meziantou.Framework.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.Yaml.FeatureSwitchSmoke/Meziantou.Framework.Yaml.FeatureSwitchSmoke.csproj" />

--- a/slnx/Meziantou.Framework.TemporaryDirectory.slnx
+++ b/slnx/Meziantou.Framework.TemporaryDirectory.slnx
@@ -58,6 +58,7 @@
     <Project Path="../tests/Meziantou.Framework.PublicApiGenerator.MSBuild.Tests/Meziantou.Framework.PublicApiGenerator.MSBuild.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.PublicApiGenerator.Tests/Meziantou.Framework.PublicApiGenerator.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.Roslyn.PackageTests/Meziantou.Framework.Roslyn.PackageTests.csproj" />
+    <Project Path="../tests/Meziantou.Framework.SnapshotTesting.PackageTests/Meziantou.Framework.SnapshotTesting.PackageTests.csproj" />
     <Project Path="../tests/Meziantou.Framework.SnapshotTesting.Roslyn.Tests/Meziantou.Framework.SnapshotTesting.Roslyn.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.SnapshotTesting.Tests/Meziantou.Framework.SnapshotTesting.Tests.csproj" />
     <Project Path="../tests/Meziantou.Framework.SnapshotTesting.Tool.Tests/Meziantou.Framework.SnapshotTesting.Tool.Tests.csproj" />

--- a/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
@@ -17,6 +17,8 @@
     <None Include="common/Meziantou.Framework.SourceRootRegistration.targets" Pack="true" PackagePath="build/Meziantou.Framework.SourceRootRegistration.targets" />
     <None Include="common/Meziantou.Framework.SourceRootRegistration.targets" Pack="true" PackagePath="buildTransitive/Meziantou.Framework.SourceRootRegistration.targets" />
     <None Include="common/Meziantou.Framework.SourceRootRegistration.targets" Pack="true" PackagePath="buildMultiTargeting/Meziantou.Framework.SourceRootRegistration.targets" />
+    <None Include="common/Meziantou.Framework.SnapshotFiles.targets" Pack="true" PackagePath="build/Meziantou.Framework.SnapshotFiles.targets" />
+    <None Include="common/Meziantou.Framework.SnapshotFiles.targets" Pack="true" PackagePath="buildTransitive/Meziantou.Framework.SnapshotFiles.targets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting/Meziantou.Framework.SnapshotTesting.csproj
@@ -14,10 +14,8 @@
     <None Include="build/**" Pack="true" PackagePath="build" />
     <None Include="buildTransitive/**" Pack="true" PackagePath="buildTransitive" />
     <None Include="buildMultiTargeting/**" Pack="true" PackagePath="buildMultiTargeting" />
-    <None Include="common/Meziantou.Framework.SourceRootRegistration.targets" Pack="true" PackagePath="build/Meziantou.Framework.SourceRootRegistration.targets" />
     <None Include="common/Meziantou.Framework.SourceRootRegistration.targets" Pack="true" PackagePath="buildTransitive/Meziantou.Framework.SourceRootRegistration.targets" />
     <None Include="common/Meziantou.Framework.SourceRootRegistration.targets" Pack="true" PackagePath="buildMultiTargeting/Meziantou.Framework.SourceRootRegistration.targets" />
-    <None Include="common/Meziantou.Framework.SnapshotFiles.targets" Pack="true" PackagePath="build/Meziantou.Framework.SnapshotFiles.targets" />
     <None Include="common/Meziantou.Framework.SnapshotFiles.targets" Pack="true" PackagePath="buildTransitive/Meziantou.Framework.SnapshotFiles.targets" />
   </ItemGroup>
 

--- a/src/Meziantou.Framework.SnapshotTesting/build/Meziantou.Framework.SnapshotTesting.targets
+++ b/src/Meziantou.Framework.SnapshotTesting/build/Meziantou.Framework.SnapshotTesting.targets
@@ -16,4 +16,13 @@
           DependsOnTargets="InitializeSourceRootMappedPaths;_MeziantouGenerateSourceRootsCore"
           BeforeTargets="CoreCompile"
           Condition="'$(SnapshotTestingGenerateSourceRoot)' != 'false' and '$(DeterministicSourcePaths)' == 'true'" />
+
+  <PropertyGroup>
+    <_MeziantouSharedSnapshotFilesTargetsPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'common', 'Meziantou.Framework.SnapshotFiles.targets'))</_MeziantouSharedSnapshotFilesTargetsPath>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)Meziantou.Framework.SnapshotFiles.targets"
+          Condition="Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SnapshotFiles.targets')" />
+  <Import Project="$(_MeziantouSharedSnapshotFilesTargetsPath)"
+          Condition="!Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SnapshotFiles.targets') and Exists('$(_MeziantouSharedSnapshotFilesTargetsPath)')" />
 </Project>

--- a/src/Meziantou.Framework.SnapshotTesting/build/Meziantou.Framework.SnapshotTesting.targets
+++ b/src/Meziantou.Framework.SnapshotTesting/build/Meziantou.Framework.SnapshotTesting.targets
@@ -1,8 +1,3 @@
 <Project>
-  <!--
-    NuGet resolves the build assets of a PackageReference to the 'buildTransitive' folder when it contains a file with
-    this name, for both direct and transitive references, so this file is only used by packages.config projects.
-    Everything lives in the 'buildTransitive' file so both entry points behave the same way.
-  -->
-  <Import Project="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'buildTransitive', 'Meziantou.Framework.SnapshotTesting.targets'))" />
+  <Import Project="$(MSBuildThisFileDirectory)../buildTransitive/Meziantou.Framework.SnapshotTesting.targets" />
 </Project>

--- a/src/Meziantou.Framework.SnapshotTesting/build/Meziantou.Framework.SnapshotTesting.targets
+++ b/src/Meziantou.Framework.SnapshotTesting/build/Meziantou.Framework.SnapshotTesting.targets
@@ -1,28 +1,8 @@
 <Project>
-  <PropertyGroup>
-    <_MeziantouSharedSourceRootTargetsPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'common', 'Meziantou.Framework.SourceRootRegistration.targets'))</_MeziantouSharedSourceRootTargetsPath>
-    <_MeziantouSourceRootGeneratedFileName>SnapshotTestingSourceRoot.g.cs</_MeziantouSourceRootGeneratedFileName>
-    <_MeziantouSourceRootRegistrationMethod>global::Meziantou.Framework.SnapshotTesting.Snapshot.RegisterSourceRootMapping</_MeziantouSourceRootRegistrationMethod>
-    <_MeziantouSourceRootAssemblyMetadataName>SnapshotTestingSourceRootMappings</_MeziantouSourceRootAssemblyMetadataName>
-    <_MeziantouSourceRootInitializerClassName>SnapshotTestingSourceRootInitializer</_MeziantouSourceRootInitializerClassName>
-  </PropertyGroup>
-
-  <Import Project="$(MSBuildThisFileDirectory)Meziantou.Framework.SourceRootRegistration.targets"
-          Condition="Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SourceRootRegistration.targets')" />
-  <Import Project="$(_MeziantouSharedSourceRootTargetsPath)"
-          Condition="!Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SourceRootRegistration.targets') and Exists('$(_MeziantouSharedSourceRootTargetsPath)')" />
-
-  <Target Name="GenerateSnapshotTestingSourceRoots"
-          DependsOnTargets="InitializeSourceRootMappedPaths;_MeziantouGenerateSourceRootsCore"
-          BeforeTargets="CoreCompile"
-          Condition="'$(SnapshotTestingGenerateSourceRoot)' != 'false' and '$(DeterministicSourcePaths)' == 'true'" />
-
-  <PropertyGroup>
-    <_MeziantouSharedSnapshotFilesTargetsPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'common', 'Meziantou.Framework.SnapshotFiles.targets'))</_MeziantouSharedSnapshotFilesTargetsPath>
-  </PropertyGroup>
-
-  <Import Project="$(MSBuildThisFileDirectory)Meziantou.Framework.SnapshotFiles.targets"
-          Condition="Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SnapshotFiles.targets')" />
-  <Import Project="$(_MeziantouSharedSnapshotFilesTargetsPath)"
-          Condition="!Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SnapshotFiles.targets') and Exists('$(_MeziantouSharedSnapshotFilesTargetsPath)')" />
+  <!--
+    NuGet resolves the build assets of a PackageReference to the 'buildTransitive' folder when it contains a file with
+    this name, for both direct and transitive references, so this file is only used by packages.config projects.
+    Everything lives in the 'buildTransitive' file so both entry points behave the same way.
+  -->
+  <Import Project="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'buildTransitive', 'Meziantou.Framework.SnapshotTesting.targets'))" />
 </Project>

--- a/src/Meziantou.Framework.SnapshotTesting/buildTransitive/Meziantou.Framework.SnapshotTesting.targets
+++ b/src/Meziantou.Framework.SnapshotTesting/buildTransitive/Meziantou.Framework.SnapshotTesting.targets
@@ -1,13 +1,25 @@
 <Project>
+  <PropertyGroup>
+    <_MeziantouSnapshotTestingSharedDirectory>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', 'common'))</_MeziantouSnapshotTestingSharedDirectory>
+    <_MeziantouSourceRootGeneratedFileName>SnapshotTestingSourceRoot.g.cs</_MeziantouSourceRootGeneratedFileName>
+    <_MeziantouSourceRootRegistrationMethod>global::Meziantou.Framework.SnapshotTesting.Snapshot.RegisterSourceRootMapping</_MeziantouSourceRootRegistrationMethod>
+    <_MeziantouSourceRootAssemblyMetadataName>SnapshotTestingSourceRootMappings</_MeziantouSourceRootAssemblyMetadataName>
+    <_MeziantouSourceRootInitializerClassName>SnapshotTestingSourceRootInitializer</_MeziantouSourceRootInitializerClassName>
+  </PropertyGroup>
+
+  <!-- The shared files are next to this one in the NuGet package, and in the 'common' folder in the repository -->
   <Import Project="$(MSBuildThisFileDirectory)Meziantou.Framework.SourceRootRegistration.targets"
           Condition="Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SourceRootRegistration.targets')" />
-
-  <PropertyGroup>
-    <_MeziantouSharedSnapshotFilesTargetsPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'common', 'Meziantou.Framework.SnapshotFiles.targets'))</_MeziantouSharedSnapshotFilesTargetsPath>
-  </PropertyGroup>
+  <Import Project="$(_MeziantouSnapshotTestingSharedDirectory)Meziantou.Framework.SourceRootRegistration.targets"
+          Condition="!Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SourceRootRegistration.targets') and Exists('$(_MeziantouSnapshotTestingSharedDirectory)Meziantou.Framework.SourceRootRegistration.targets')" />
 
   <Import Project="$(MSBuildThisFileDirectory)Meziantou.Framework.SnapshotFiles.targets"
           Condition="Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SnapshotFiles.targets')" />
-  <Import Project="$(_MeziantouSharedSnapshotFilesTargetsPath)"
-          Condition="!Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SnapshotFiles.targets') and Exists('$(_MeziantouSharedSnapshotFilesTargetsPath)')" />
+  <Import Project="$(_MeziantouSnapshotTestingSharedDirectory)Meziantou.Framework.SnapshotFiles.targets"
+          Condition="!Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SnapshotFiles.targets') and Exists('$(_MeziantouSnapshotTestingSharedDirectory)Meziantou.Framework.SnapshotFiles.targets')" />
+
+  <Target Name="GenerateSnapshotTestingSourceRoots"
+          DependsOnTargets="InitializeSourceRootMappedPaths;_MeziantouGenerateSourceRootsCore"
+          BeforeTargets="CoreCompile"
+          Condition="'$(SnapshotTestingGenerateSourceRoot)' != 'false' and '$(DeterministicSourcePaths)' == 'true'" />
 </Project>

--- a/src/Meziantou.Framework.SnapshotTesting/buildTransitive/Meziantou.Framework.SnapshotTesting.targets
+++ b/src/Meziantou.Framework.SnapshotTesting/buildTransitive/Meziantou.Framework.SnapshotTesting.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <_MeziantouSnapshotTestingSharedDirectory>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', 'common'))</_MeziantouSnapshotTestingSharedDirectory>
+    <_MeziantouSnapshotTestingSharedDirectory>$(MSBuildThisFileDirectory)../common/</_MeziantouSnapshotTestingSharedDirectory>
     <_MeziantouSourceRootGeneratedFileName>SnapshotTestingSourceRoot.g.cs</_MeziantouSourceRootGeneratedFileName>
     <_MeziantouSourceRootRegistrationMethod>global::Meziantou.Framework.SnapshotTesting.Snapshot.RegisterSourceRootMapping</_MeziantouSourceRootRegistrationMethod>
     <_MeziantouSourceRootAssemblyMetadataName>SnapshotTestingSourceRootMappings</_MeziantouSourceRootAssemblyMetadataName>

--- a/src/Meziantou.Framework.SnapshotTesting/buildTransitive/Meziantou.Framework.SnapshotTesting.targets
+++ b/src/Meziantou.Framework.SnapshotTesting/buildTransitive/Meziantou.Framework.SnapshotTesting.targets
@@ -1,4 +1,13 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)Meziantou.Framework.SourceRootRegistration.targets"
           Condition="Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SourceRootRegistration.targets')" />
+
+  <PropertyGroup>
+    <_MeziantouSharedSnapshotFilesTargetsPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'common', 'Meziantou.Framework.SnapshotFiles.targets'))</_MeziantouSharedSnapshotFilesTargetsPath>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)Meziantou.Framework.SnapshotFiles.targets"
+          Condition="Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SnapshotFiles.targets')" />
+  <Import Project="$(_MeziantouSharedSnapshotFilesTargetsPath)"
+          Condition="!Exists('$(MSBuildThisFileDirectory)Meziantou.Framework.SnapshotFiles.targets') and Exists('$(_MeziantouSharedSnapshotFilesTargetsPath)')" />
 </Project>

--- a/src/Meziantou.Framework.SnapshotTesting/common/Meziantou.Framework.SnapshotFiles.targets
+++ b/src/Meziantou.Framework.SnapshotTesting/common/Meziantou.Framework.SnapshotFiles.targets
@@ -1,0 +1,18 @@
+<Project>
+  <PropertyGroup>
+    <SnapshotTestingExcludeSnapshotFilesFromCompilation Condition="'$(SnapshotTestingExcludeSnapshotFilesFromCompilation)' == ''">true</SnapshotTestingExcludeSnapshotFilesFromCompilation>
+  </PropertyGroup>
+
+  <!--
+    Snapshots stored as source files (.cs / .vb) live next to the test source files and must not be compiled with the project.
+    The removal/inclusion pair is idempotent, so importing this file more than once is harmless.
+  -->
+  <ItemGroup Condition="'$(SnapshotTestingExcludeSnapshotFilesFromCompilation)' == 'true' and '$(EnableDefaultItems)' != 'false' and '$(EnableDefaultCompileItems)' != 'false'">
+    <Compile Remove="**/__snapshots__/**/*.cs" />
+    <Compile Remove="**/__snapshots__/**/*.vb" />
+    <None Remove="**/__snapshots__/**/*.cs" />
+    <None Remove="**/__snapshots__/**/*.vb" />
+    <None Include="**/__snapshots__/**/*.cs" />
+    <None Include="**/__snapshots__/**/*.vb" />
+  </ItemGroup>
+</Project>

--- a/src/Meziantou.Framework.SnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.SnapshotTesting/readme.md
@@ -59,6 +59,19 @@ You can choose how snapshot names are generated using `SnapshotSettings.Snapshot
 - `SnapshotNamingStrategies.ClassName_TestName` (default)
 - `SnapshotNamingStrategies.FullName`
 
+## Snapshots stored as source files
+
+Some snapshots are source files (for example the output of a source generator, see [`Meziantou.Framework.SnapshotTesting.Roslyn`](https://www.nuget.org/packages/Meziantou.Framework.SnapshotTesting.Roslyn)).
+The package ships MSBuild targets that remove `**/__snapshots__/**/*.cs` and `**/__snapshots__/**/*.vb` from the `Compile` items and add them as `None` items, so they still show up in the IDE but are not compiled with the test project.
+
+Set `SnapshotTestingExcludeSnapshotFilesFromCompilation` to `false` to opt out:
+
+```xml
+<PropertyGroup>
+  <SnapshotTestingExcludeSnapshotFilesFromCompilation>false</SnapshotTestingExcludeSnapshotFilesFromCompilation>
+</PropertyGroup>
+```
+
 ## Approving snapshots
 
 To approve generated `*.actual.*` files, you can use the dedicated tool package:

--- a/tests/Meziantou.Framework.SnapshotTesting.PackageTests/Meziantou.Framework.SnapshotTesting.PackageTests.csproj
+++ b/tests/Meziantou.Framework.SnapshotTesting.PackageTests/Meziantou.Framework.SnapshotTesting.PackageTests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Meziantou.NET.Sdk.Test">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../../common/NuGetPackageFixture.cs" Link="NuGetPackageFixture.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Meziantou.Framework.ProcessWrapper/Meziantou.Framework.ProcessWrapper.csproj" />
+    <ProjectReference Include="../../src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Meziantou.Framework.SnapshotTesting.PackageTests/SnapshotTestingPackageFixture.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.PackageTests/SnapshotTestingPackageFixture.cs
@@ -3,15 +3,7 @@ using TestUtilities;
 namespace Meziantou.Framework.SnapshotTesting.PackageTests;
 
 public sealed class SnapshotTestingPackageFixture()
-    : NuGetPackageFixture(PackageName, DependencyPackageNames)
+    : NuGetPackageFixture(PackageName)
 {
     public const string PackageName = "Meziantou.Framework.SnapshotTesting";
-
-    private static readonly string[] DependencyPackageNames =
-    [
-        "Meziantou.Framework.DiffEngine",
-        "Meziantou.Framework.FullPath",
-        "Meziantou.Framework.HumanReadableSerializer",
-        "Meziantou.Framework.LLMContext",
-    ];
 }

--- a/tests/Meziantou.Framework.SnapshotTesting.PackageTests/SnapshotTestingPackageFixture.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.PackageTests/SnapshotTestingPackageFixture.cs
@@ -1,0 +1,17 @@
+using TestUtilities;
+
+namespace Meziantou.Framework.SnapshotTesting.PackageTests;
+
+public sealed class SnapshotTestingPackageFixture()
+    : NuGetPackageFixture(PackageName, DependencyPackageNames)
+{
+    public const string PackageName = "Meziantou.Framework.SnapshotTesting";
+
+    private static readonly string[] DependencyPackageNames =
+    [
+        "Meziantou.Framework.DiffEngine",
+        "Meziantou.Framework.FullPath",
+        "Meziantou.Framework.HumanReadableSerializer",
+        "Meziantou.Framework.LLMContext",
+    ];
+}

--- a/tests/Meziantou.Framework.SnapshotTesting.PackageTests/SnapshotTestingPackageTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.PackageTests/SnapshotTestingPackageTests.cs
@@ -1,0 +1,201 @@
+using System.IO.Compression;
+using Xunit.Sdk;
+
+namespace Meziantou.Framework.SnapshotTesting.PackageTests;
+
+public sealed class SnapshotTestingPackageTests(SnapshotTestingPackageFixture fixture) : IClassFixture<SnapshotTestingPackageFixture>
+{
+    private const string DuplicateTypeSource = "namespace Consumer; internal sealed class Duplicate { }";
+
+    [Fact]
+    public void Package_ContainsTheBuildFiles()
+    {
+        using var package = ZipFile.OpenRead(fixture.PackagePath);
+
+        // NuGet uses 'buildTransitive' for PackageReference, so everything must be reachable from there
+        AssertEntry(package, "buildTransitive/Meziantou.Framework.SnapshotTesting.targets");
+        AssertEntry(package, "buildTransitive/Meziantou.Framework.SnapshotFiles.targets");
+        AssertEntry(package, "buildTransitive/Meziantou.Framework.SourceRootRegistration.targets");
+        AssertEntry(package, "build/Meziantou.Framework.SnapshotTesting.targets");
+        AssertEntry(package, "buildMultiTargeting/Meziantou.Framework.SnapshotTesting.targets");
+    }
+
+    [Fact]
+    public async Task Package_DoesNotCompileSnapshotSourceFiles()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var projectDirectory = CreateConsumer(temporaryDirectory, "consumer", additionalProperties: "");
+
+        await RunDotNetCommand(projectDirectory, ["restore", "--disable-build-servers"], expectedExitCode: 0);
+        await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 0);
+    }
+
+    [Fact]
+    public async Task Package_CompilesSnapshotSourceFiles_WhenOptedOut()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var projectDirectory = CreateConsumer(temporaryDirectory, "consumer-optout", additionalProperties: "<SnapshotTestingExcludeSnapshotFilesFromCompilation>false</SnapshotTestingExcludeSnapshotFilesFromCompilation>");
+
+        await RunDotNetCommand(projectDirectory, ["restore", "--disable-build-servers"], expectedExitCode: 0);
+        var result = await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 1);
+
+        var output = string.Join('\n', result.Output);
+        Assert.Contains("CS0101", output);
+    }
+
+    [Fact]
+    public async Task Package_GeneratesTheSourceRootFile()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var projectDirectory = CreateConsumer(temporaryDirectory, "consumer-sourceroot", additionalProperties: "<DeterministicSourcePaths>true</DeterministicSourcePaths>");
+
+        await RunDotNetCommand(projectDirectory, ["restore", "--disable-build-servers"], expectedExitCode: 0);
+        await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 0);
+
+        AssertSourceRootFileWasGenerated(projectDirectory);
+    }
+
+    [Fact]
+    public async Task Package_AppliesToProjectsReferencingThePackageTransitively()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var rootDirectory = temporaryDirectory.CreateDirectory("consumer-transitive");
+        CreateGlobalJson(rootDirectory, fixture.DotnetSdkVersion);
+        CreateNuGetConfig(rootDirectory, fixture.PackagesDirectory);
+
+        temporaryDirectory.CreateTextFile("consumer-transitive/Library/Library.csproj", $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="{{SnapshotTestingPackageFixture.PackageName}}" Version="{{fixture.PackageVersion}}" />
+              </ItemGroup>
+            </Project>
+            """);
+        temporaryDirectory.CreateTextFile("consumer-transitive/Library/Library.cs", "namespace Library; internal sealed class Sample { }");
+
+        temporaryDirectory.CreateTextFile("consumer-transitive/Consumer/Consumer.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <DeterministicSourcePaths>true</DeterministicSourcePaths>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <ProjectReference Include="../Library/Library.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        temporaryDirectory.CreateTextFile("consumer-transitive/Consumer/Consumer.cs", DuplicateTypeSource);
+        temporaryDirectory.CreateTextFile("consumer-transitive/Consumer/Nested/__snapshots__/Consumer_Snapshot.verified.cs", DuplicateTypeSource);
+
+        var projectDirectory = rootDirectory / "Consumer";
+        await RunDotNetCommand(projectDirectory, ["restore", "--disable-build-servers"], expectedExitCode: 0);
+        await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 0);
+
+        AssertSourceRootFileWasGenerated(projectDirectory);
+    }
+
+    private FullPath CreateConsumer(TemporaryDirectory temporaryDirectory, string directoryName, string additionalProperties)
+    {
+        var projectDirectory = temporaryDirectory.CreateDirectory(directoryName);
+        CreateGlobalJson(projectDirectory, fixture.DotnetSdkVersion);
+        CreateNuGetConfig(projectDirectory, fixture.PackagesDirectory);
+
+        temporaryDirectory.CreateTextFile($"{directoryName}/Sample.csproj", $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                {{additionalProperties}}
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="{{SnapshotTestingPackageFixture.PackageName}}" Version="{{fixture.PackageVersion}}" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        // Both files declare the same type, so the build only succeeds when the snapshot is not compiled
+        temporaryDirectory.CreateTextFile($"{directoryName}/Consumer.cs", DuplicateTypeSource);
+        temporaryDirectory.CreateTextFile($"{directoryName}/Nested/__snapshots__/Sample_Snapshot.verified.cs", DuplicateTypeSource);
+
+        return projectDirectory;
+    }
+
+    private static void AssertSourceRootFileWasGenerated(FullPath projectDirectory)
+    {
+        var intermediateDirectory = projectDirectory / "obj";
+        var files = Directory.Exists(intermediateDirectory)
+            ? Directory.GetFiles(intermediateDirectory, "SnapshotTestingSourceRoot.g.cs", SearchOption.AllDirectories)
+            : [];
+
+        Assert.NotEmpty(files, $"No source root file was generated in '{intermediateDirectory}'.");
+    }
+
+    private static ZipArchiveEntry AssertEntry(ZipArchive package, string entryName)
+    {
+        var entry = package.GetEntry(entryName);
+        if (entry is null)
+            throw new XunitException($"The package does not contain '{entryName}'. Entries:{Environment.NewLine}{string.Join(Environment.NewLine, package.Entries.Select(item => item.FullName))}");
+
+        return entry;
+    }
+
+    private static void CreateGlobalJson(FullPath projectDirectory, string dotnetSdkVersion)
+    {
+        File.WriteAllText(projectDirectory / "global.json", $$"""
+            {
+              "sdk": {
+                "version": "{{dotnetSdkVersion}}",
+                "rollForward": "latestFeature"
+              }
+            }
+            """);
+    }
+
+    private static void CreateNuGetConfig(FullPath projectDirectory, FullPath packagesDirectory)
+    {
+        var packagesCachePath = packagesDirectory / "global-packages";
+        File.WriteAllText(projectDirectory / "NuGet.config", $$"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <config>
+                <add key="globalPackagesFolder" value="{{packagesCachePath}}" />
+              </config>
+              <packageSources>
+                <clear />
+                <add key="local" value="{{packagesDirectory}}" />
+                <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="local">
+                  <package pattern="Meziantou.Framework.*" />
+                </packageSource>
+                <packageSource key="nuget.org">
+                  <package pattern="*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+    }
+
+    private static async Task<BufferedProcessResult> RunDotNetCommand(FullPath workingDirectory, IReadOnlyList<string> arguments, int expectedExitCode)
+    {
+        var result = await ProcessWrapper.Create("dotnet")
+            .WithArguments(arguments)
+            .WithWorkingDirectory(workingDirectory)
+            .WithEnvironmentVariables(env => env.Set("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1"))
+            .WithValidation(ProcessValidationMode.None)
+            .ExecuteBufferedAsync(XunitCancellationToken);
+
+        if (result.ExitCode != expectedExitCode)
+        {
+            var output = string.Join('\n', result.Output);
+            throw new XunitException($"Command failed: dotnet {string.Join(' ', arguments)}{Environment.NewLine}Expected exit code: {expectedExitCode}{Environment.NewLine}Actual exit code: {result.ExitCode}{Environment.NewLine}Output:{Environment.NewLine}{output}");
+        }
+
+        return result;
+    }
+}

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -80,7 +80,32 @@ public sealed partial class SnapshotEndToEndTests
                 }
             }
             """,
-            assertGeneratedSourceRootFileIsEmbeddedInBinlog: true);
+            assertGeneratedSourceRootFile: true);
+
+        AssertSnapshotContent(snapshotFiles,
+        [
+            ("__snapshots__/GeneratedSnapshotTests_SampleTest.verified.txt", "sample"),
+        ]);
+    }
+
+    [Fact]
+    public async Task Validate_EndToEnd_EmbedsGeneratedSourceRootFileInBinlog_WhenImportingBuildTransitiveTargets()
+    {
+        // NuGet imports the 'buildTransitive' targets for both direct and transitive package references,
+        // so everything the 'build' targets provide must also be available there
+        var snapshotFiles = await AssertSnapshot(
+            """
+            public sealed class GeneratedSnapshotTests
+            {
+                [Fact]
+                public void SampleTest()
+                {
+                    Snapshot.Validate("sample", SnapshotTestUtilities.CreateSuccessSettings());
+                }
+            }
+            """,
+            assertGeneratedSourceRootFile: true,
+            importBuildTransitiveTargets: true);
 
         AssertSnapshotContent(snapshotFiles,
         [
@@ -1208,7 +1233,8 @@ public sealed partial class SnapshotEndToEndTests
         string? testFilter = null,
         string? directoryBuildPropsContent = null,
         int buildRetryCount = 0,
-        bool assertGeneratedSourceRootFileIsEmbeddedInBinlog = false)
+        bool assertGeneratedSourceRootFile = false,
+        bool importBuildTransitiveTargets = false)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(buildRetryCount);
         await using var directory = TemporaryDirectory.Create();
@@ -1216,7 +1242,8 @@ public sealed partial class SnapshotEndToEndTests
         Assert.NotNull(dotnetPath);
 
         var snapshotProjectPath = GetRepositoryRoot() / "src" / "Meziantou.Framework.SnapshotTesting" / "Meziantou.Framework.SnapshotTesting.csproj";
-        var snapshotTargetsPath = GetRepositoryRoot() / "src" / "Meziantou.Framework.SnapshotTesting" / "build" / "Meziantou.Framework.SnapshotTesting.targets";
+        var targetsFolder = importBuildTransitiveTargets ? "buildTransitive" : "build";
+        var snapshotTargetsPath = GetRepositoryRoot() / "src" / "Meziantou.Framework.SnapshotTesting" / targetsFolder / "Meziantou.Framework.SnapshotTesting.targets";
         CreateTextFile("Project.csproj", $$"""
             <Project Sdk="Microsoft.NET.Sdk">
               <Import Project="{{snapshotTargetsPath}}" />
@@ -1224,7 +1251,7 @@ public sealed partial class SnapshotEndToEndTests
                 <TargetFramework>{{targetFramework ?? TargetFrameworkHelper.GetTargetFrameworkMoniker()}}</TargetFramework>
                 <Nullable>disable</Nullable>
                 <IsPackable>false</IsPackable>
-                {{(assertGeneratedSourceRootFileIsEmbeddedInBinlog ? "<DeterministicSourcePaths>true</DeterministicSourcePaths>" : "")}}
+                {{(assertGeneratedSourceRootFile ? "<DeterministicSourcePaths>true</DeterministicSourcePaths>" : "")}}
                 {{GetAdditionalProjectProperties(testFramework)}}
               </PropertyGroup>
               <ItemGroup>
@@ -1271,14 +1298,15 @@ public sealed partial class SnapshotEndToEndTests
         };
 
         var binlogPath = directory.GetFullPath("build.binlog");
-        if (assertGeneratedSourceRootFileIsEmbeddedInBinlog)
+        if (assertGeneratedSourceRootFile)
         {
             buildArguments.Add("/bl:" + binlogPath);
         }
 
         await ExecuteDotNetWithRetry(directory.FullPath, dotnetPath, buildArguments, expectedExitCode: 0);
-        if (assertGeneratedSourceRootFileIsEmbeddedInBinlog)
+        if (assertGeneratedSourceRootFile)
         {
+            AssertGeneratedSourceRootFileExists(directory.FullPath);
             AssertBinlogContains(binlogPath, "SnapshotTestingSourceRoot.g.cs");
         }
 
@@ -1355,6 +1383,16 @@ public sealed partial class SnapshotEndToEndTests
             .OrderBy(path => path.RelativePath, StringComparer.Ordinal)
             .Select(file => new SnapshotFile(file.RelativePath, File.ReadAllBytes(file.AbsolutePath)))
             .ToArray();
+    }
+
+    private static void AssertGeneratedSourceRootFileExists(FullPath rootPath)
+    {
+        var intermediateDirectory = Path.Combine(rootPath, "obj");
+        var files = Directory.Exists(intermediateDirectory)
+            ? Directory.GetFiles(intermediateDirectory, "SnapshotTestingSourceRoot.g.cs", SearchOption.AllDirectories)
+            : [];
+
+        Assert.NotEmpty(files, $"No source root file was generated in '{intermediateDirectory}'.");
     }
 
     private static void AssertBinlogContains(FullPath binlogPath, string value)

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotEndToEndTests.cs
@@ -834,6 +834,65 @@ public sealed partial class SnapshotEndToEndTests
         ]);
     }
 
+    [Fact]
+    public async Task Validate_EndToEnd_ExcludesCSharpSnapshotFilesFromCompilation()
+    {
+        var snapshotFiles = await AssertSnapshot(
+            """
+            public sealed class GeneratedSnapshotTests
+            {
+                [Fact]
+                public void SampleTest()
+                {
+                    Snapshot.Validate("class GeneratedSnapshotTests { }", SnapshotType.Create("cs"), SnapshotTestUtilities.CreateSuccessSettings());
+                }
+            }
+            """,
+            existingFiles:
+            [
+                // Compiling those files would report CS0101 as GeneratedSnapshotTests is already defined
+                new SnapshotFile("__snapshots__/GeneratedSnapshotTests_SampleTest.verified.cs", "class GeneratedSnapshotTests { }"u8.ToArray()),
+                new SnapshotFile("Nested/__snapshots__/NestedSnapshot.verified.cs", "class GeneratedSnapshotTests { }"u8.ToArray()),
+            ]);
+
+        AssertSnapshotContent(snapshotFiles,
+        [
+            ("__snapshots__/GeneratedSnapshotTests_SampleTest.verified.cs", "class GeneratedSnapshotTests { }"),
+        ]);
+    }
+
+    [Fact]
+    public async Task Build_EndToEnd_ExcludesVisualBasicSnapshotFilesFromCompilation()
+    {
+        await using var directory = TemporaryDirectory.Create();
+        var dotnetPath = ExecutableFinder.GetFullExecutablePath("dotnet");
+        Assert.NotNull(dotnetPath);
+
+        var snapshotTargetsPath = GetRepositoryRoot() / "src" / "Meziantou.Framework.SnapshotTesting" / "build" / "Meziantou.Framework.SnapshotTesting.targets";
+        File.WriteAllText(directory.GetFullPath("Project.vbproj"), $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <Import Project="{snapshotTargetsPath}" />
+              <PropertyGroup>
+                <TargetFramework>{TargetFrameworkHelper.GetTargetFrameworkMoniker()}</TargetFramework>
+                <IsPackable>false</IsPackable>
+                <SnapshotTestingGenerateSourceRoot>false</SnapshotTestingGenerateSourceRoot>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(directory.GetFullPath("Sample.vb"), """
+            Public Class Sample
+            End Class
+            """);
+
+        // Compiling this file would report BC30203 as it is not valid Visual Basic
+        var snapshotPath = directory.GetFullPath("Nested/__snapshots__/Sample_SampleTest.verified.vb");
+        snapshotPath.CreateParentDirectory();
+        File.WriteAllText(snapshotPath, "-- not valid Visual Basic --");
+
+        await ExecuteDotNetWithRetry(directory.FullPath, dotnetPath, ["build", "--disable-build-servers"], expectedExitCode: 0);
+    }
+
     private static string GetFrameworkSmokeSource(SnapshotTestFramework framework)
     {
         return framework switch


### PR DESCRIPTION
## What

`Meziantou.Framework.SnapshotTesting` now ships MSBuild targets that keep snapshots stored as source files out of the compilation:

```xml
<Compile Remove="**/__snapshots__/**/*.cs" />
<Compile Remove="**/__snapshots__/**/*.vb" />
<None Remove="**/__snapshots__/**/*.cs" />
<None Remove="**/__snapshots__/**/*.vb" />
<None Include="**/__snapshots__/**/*.cs" />
<None Include="**/__snapshots__/**/*.vb" />
```

Opt out with `<SnapshotTestingExcludeSnapshotFilesFromCompilation>false</SnapshotTestingExcludeSnapshotFilesFromCompilation>`; it is enabled by default.

## Why

Snapshots produced by `Meziantou.Framework.SnapshotTesting.Roslyn` (source generator output, syntax trees) are `.cs` files written to a `__snapshots__` directory next to the test source file. The SDK's default globs pick them up as `Compile` items, so the test project stops building as soon as a generated source snapshot is written — typically with `CS0101` when the snapshot contains a type that is also declared in the test itself.

## Also fixes: the `build` targets were never imported

While deduplicating the two targets files, it turned out that **NuGet resolves the build assets of a `PackageReference` to `buildTransitive/` whenever it holds a file with the same name — for direct references as well as transitive ones**. `build/Meziantou.Framework.SnapshotTesting.targets` was therefore never imported by any `PackageReference` consumer, and `GenerateSnapshotTestingSourceRoots` was declared only there. The source root mapping has consequently never been generated for package consumers.

```
$ dotnet build -t:GenerateSnapshotTestingSourceRoots        # before
error MSB4057: The target "GenerateSnapshotTestingSourceRoots" does not exist in the project.
```

`project.assets.json` confirms the resolution — the `build` group of a direct reference points into `buildTransitive`:

```json
"build": ["buildTransitive/Meziantou.Framework.SnapshotTesting.targets"]
```

Everything now lives in the `buildTransitive` file and `build` is a thin import of it, which removes the duplication and makes the source root generation actually reach consumers. The now-unreferenced copies of the shared files under the package's `build/` folder are no longer packed.

## Notes for reviewers

Three details in the item group are deliberate:

- **`**/__snapshots__/**` rather than `__snapshots__/**`** — the default path strategy puts snapshots in `SourceFilePath.Parent / "__snapshots__"`, so they end up in whichever subdirectory the test source file lives in. A root-anchored glob would miss almost every real case; the `**/`-prefixed form still matches the root directory as well.
- **`<None Remove>` before `<None Include>`** — a `.vb` file is already a default `None` item in a C# project (and a `.cs` file in a VB project), so a bare `Include` would produce duplicate items and `NETSDK1022`. Removing first also makes the block idempotent if it ever gets imported twice.
- **`EnableDefaultItems` / `EnableDefaultCompileItems` guard** — when a project lists its `Compile` items manually, removing files it explicitly added would be wrong.

## Testing

**New `Meziantou.Framework.SnapshotTesting.PackageTests`** — packs the real package and restores/builds actual consumer projects, which is what would have caught the `build`/`buildTransitive` issue in the first place. Nothing previously exercised this package through NuGet; the existing tests import the targets by path, which is exactly why the shadowing went unnoticed.

- `Package_ContainsTheBuildFiles` — package layout.
- `Package_DoesNotCompileSnapshotSourceFiles` — a consumer whose `Nested/__snapshots__/*.cs` declares the same type as its own source builds successfully.
- `Package_CompilesSnapshotSourceFiles_WhenOptedOut` — the same consumer fails with `CS0101` when the property is `false`, so the property is what gates the behaviour.
- `Package_GeneratesTheSourceRootFile` — `SnapshotTestingSourceRoot.g.cs` reaches the intermediate output directory.
- `Package_AppliesToProjectsReferencingThePackageTransitively` — a project referencing a library that holds the `PackageReference` gets both features.

`NuGetPackageFixture` packed a single project, which is not enough here: the `Version` it sets applies to the referenced projects too, so the package declares dependencies on versions of `DiffEngine`, `FullPath`, `HumanReadableSerializer` and `LLMContext` that exist nowhere and the consumer cannot restore. The fixture now reads the dependencies of the package it just packed and packs the ones carrying the local version, since those are the ones built by this repository, recursing through their own dependencies. Nothing is hardcoded and the signature is unchanged, so the four existing fixtures are untouched. Building the main project already builds the referenced projects, so they only need packing.

**`SnapshotEndToEndTests`** gains three tests:

- `Validate_EndToEnd_ExcludesCSharpSnapshotFilesFromCompilation` — root and nested `__snapshots__`, `CS0101` if compiled.
- `Build_EndToEnd_ExcludesVisualBasicSnapshotFilesFromCompilation` — a `.vbproj` with an invalid `.vb` snapshot, since a `.vb` file in the C# harness would never be compiled and the test would be vacuous.
- `Validate_EndToEnd_EmbedsGeneratedSourceRootFileInBinlog_WhenImportingBuildTransitiveTargets`.

`AssertBinlogContains` searches the raw binlog bytes, and `SnapshotTestingSourceRoot.g.cs` appears there as soon as the `_MeziantouSourceRootGeneratedFileName` property is evaluated — so the pre-existing binlog assertion passed even with the target deleted. It now also asserts the file was written to the intermediate output directory.

Every new test was checked to be non-vacuous by deleting the relevant targets and confirming it fails.

- `dotnet build /p:TreatsWarningsAsErrors=true`: clean
- `Meziantou.Framework.SnapshotTesting.Tests`: 156/156 (153 before + 3 new)
- `Meziantou.Framework.SnapshotTesting.PackageTests`: 5/5 (new)
- `Meziantou.Framework.SnapshotTesting.Roslyn.Tests`: 19/19
- Existing users of the shared fixture — `Roslyn.PackageTests` 7/7, `PublicApiGenerator.MSBuild.Tests` 8/8, `EmbeddedConstantsGenerator.Tests` 6/6, `Yaml.Tests` 938/938
- `dotnet run ./eng/update-all.cs`: registers the new project in the solution files
