### PR TITLE
Support the updated C# memory safety rules in PublicApiGenerator

### DIFF
--- a/ref/Meziantou.Extensions.Logging.FileLogger.cs
+++ b/ref/Meziantou.Extensions.Logging.FileLogger.cs
@@ -20,7 +20,7 @@ namespace Meziantou.Extensions.Logging
 
     public static class FileLoggerBuilderExtensions
     {
-        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(Meziantou.Extensions.Logging.FileLoggerOptions))]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof(Meziantou.Extensions.Logging.FileLoggerOptions))]
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access", Justification = "The members of FileLoggerOptions used by the configuration binder are preserved by the DynamicDependency attribute")]
         public static Microsoft.Extensions.Logging.ILoggingBuilder AddFile(this Microsoft.Extensions.Logging.ILoggingBuilder builder) => throw null;
         public static Microsoft.Extensions.Logging.ILoggingBuilder AddFile(this Microsoft.Extensions.Logging.ILoggingBuilder builder, string logsDirectory) => throw null;

--- a/ref/Meziantou.Framework.HumanReadableSerializer.cs
+++ b/ref/Meziantou.Framework.HumanReadableSerializer.cs
@@ -21,7 +21,7 @@ namespace Meziantou.Framework.HumanReadable
         public abstract void WriteValue(Meziantou.Framework.HumanReadable.HumanReadableTextWriter writer, object? value, System.Type valueType, Meziantou.Framework.HumanReadable.HumanReadableSerializerOptions options);
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Interface | System.AttributeTargets.Field | System.AttributeTargets.Property | System.AttributeTargets.Class, AllowMultiple = false)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface, AllowMultiple = false)]
     public sealed class HumanReadableConverterAttribute : Meziantou.Framework.HumanReadable.HumanReadableAttribute
     {
         public System.Type ConverterType { get => throw null; }
@@ -43,14 +43,14 @@ namespace Meziantou.Framework.HumanReadable
         protected abstract void WriteValue(Meziantou.Framework.HumanReadable.HumanReadableTextWriter writer, T value, Meziantou.Framework.HumanReadable.HumanReadableSerializerOptions options);
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple = false)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple = false)]
     public sealed class HumanReadableDefaultValueAttribute : Meziantou.Framework.HumanReadable.HumanReadableAttribute
     {
         public object? DefaultValue { get => throw null; }
         public HumanReadableDefaultValueAttribute(object? defaultValue) { }
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple = true)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple = true)]
     public sealed class HumanReadableIgnoreAttribute : Meziantou.Framework.HumanReadable.HumanReadableAttribute
     {
         public Meziantou.Framework.HumanReadable.HumanReadableIgnoreCondition Condition { get => throw null; set { } }
@@ -74,19 +74,19 @@ namespace Meziantou.Framework.HumanReadable
         public System.Exception? Exception { get => throw null; }
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple = false)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple = false)]
     public sealed class HumanReadableIncludeAttribute : Meziantou.Framework.HumanReadable.HumanReadableAttribute
     {
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple = false)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple = false)]
     public sealed class HumanReadablePropertyNameAttribute : Meziantou.Framework.HumanReadable.HumanReadableAttribute
     {
         public string Name { get => throw null; }
         public HumanReadablePropertyNameAttribute(string name) { }
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple = false)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple = false)]
     public sealed class HumanReadablePropertyOrderAttribute : Meziantou.Framework.HumanReadable.HumanReadableAttribute
     {
         public int Order { get => throw null; }

--- a/ref/Meziantou.Framework.Yaml.cs
+++ b/ref/Meziantou.Framework.Yaml.cs
@@ -787,7 +787,7 @@ namespace Meziantou.Framework.Yaml.Serialization
     {
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple = false)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple = false)]
     public sealed class YamlBlockSequenceItemStyleAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
         public Meziantou.Framework.Yaml.YamlSequenceItemStyle MappingStyle { get => throw null; set { } }
@@ -809,7 +809,7 @@ namespace Meziantou.Framework.Yaml.Serialization
         public abstract void Write(Meziantou.Framework.Yaml.Serialization.YamlWriter writer, object? value);
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Interface | System.AttributeTargets.Field | System.AttributeTargets.Property | System.AttributeTargets.Enum | System.AttributeTargets.Struct | System.AttributeTargets.Class, AllowMultiple = false)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface, AllowMultiple = false)]
     public sealed class YamlConverterAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
         [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
@@ -833,7 +833,7 @@ namespace Meziantou.Framework.Yaml.Serialization
         public abstract void Write(Meziantou.Framework.Yaml.Serialization.YamlWriter writer, T value);
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Interface | System.AttributeTargets.Class, AllowMultiple = true)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple = true)]
     public sealed class YamlDerivedTypeAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
         public System.Type DerivedType { get => throw null; }
@@ -863,44 +863,44 @@ namespace Meziantou.Framework.Yaml.Serialization
         public YamlEnumMemberNameAttribute(string name) { }
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
     public sealed class YamlExtensionDataAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Interface | System.AttributeTargets.Field | System.AttributeTargets.Property | System.AttributeTargets.Struct | System.AttributeTargets.Class, AllowMultiple = false)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface, AllowMultiple = false)]
     public sealed class YamlIgnoreAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
         public Meziantou.Framework.Yaml.YamlIgnoreCondition Condition { get => throw null; set { } }
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
     public sealed class YamlIncludeAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Interface | System.AttributeTargets.Field | System.AttributeTargets.Property | System.AttributeTargets.Struct | System.AttributeTargets.Class, AllowMultiple = false)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface, AllowMultiple = false)]
     public sealed class YamlNamingPolicyAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
         public Meziantou.Framework.Yaml.YamlKnownNamingPolicy NamingPolicy { get => throw null; }
         public YamlNamingPolicyAttribute(Meziantou.Framework.Yaml.YamlKnownNamingPolicy namingPolicy) { }
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property | System.AttributeTargets.Struct | System.AttributeTargets.Class, AllowMultiple = false)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple = false)]
     public sealed class YamlNumberHandlingAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
         public Meziantou.Framework.Yaml.YamlNumberHandling Handling { get => throw null; }
         public YamlNumberHandlingAttribute(Meziantou.Framework.Yaml.YamlNumberHandling handling) { }
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property | System.AttributeTargets.Struct | System.AttributeTargets.Class, AllowMultiple = false)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple = false)]
     public sealed class YamlObjectCreationHandlingAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
         public Meziantou.Framework.Yaml.YamlObjectCreationHandling Handling { get => throw null; }
         public YamlObjectCreationHandlingAttribute(Meziantou.Framework.Yaml.YamlObjectCreationHandling handling) { }
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Interface | System.AttributeTargets.Class)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface)]
     public sealed class YamlPolymorphicAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
         public string? TypeDiscriminatorPropertyName { get => throw null; set { } }
@@ -909,14 +909,14 @@ namespace Meziantou.Framework.Yaml.Serialization
         public bool InferClosedTypePolymorphism { get => throw null; set { } }
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
     public sealed class YamlPropertyNameAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
         public string Name { get => throw null; }
         public YamlPropertyNameAttribute(string name) { }
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
     public sealed class YamlPropertyOrderAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
         public int Order { get => throw null; }
@@ -956,7 +956,7 @@ namespace Meziantou.Framework.Yaml.Serialization
         public bool TryGetCustomConverter(System.Type typeToConvert, out Meziantou.Framework.Yaml.Serialization.YamlConverter? converter) => throw null;
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
     public sealed class YamlRequiredAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
     }
@@ -1119,7 +1119,7 @@ namespace Meziantou.Framework.Yaml.Serialization
         public override Meziantou.Framework.Yaml.Serialization.YamlTypeClassifier CreateYamlClassifier(Meziantou.Framework.Yaml.Serialization.YamlTypeClassifierContext context, Meziantou.Framework.Yaml.YamlSerializerOptions options) => throw null;
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Struct | System.AttributeTargets.Class, AllowMultiple = false)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct, AllowMultiple = false)]
     public sealed class YamlUnmappedMemberHandlingAttribute : Meziantou.Framework.Yaml.Serialization.YamlAttribute
     {
         public Meziantou.Framework.Yaml.YamlUnmappedMemberHandling Handling { get => throw null; }

--- a/ref/Meziantou.Framework.Yamlish.cs
+++ b/ref/Meziantou.Framework.Yamlish.cs
@@ -32,7 +32,7 @@ namespace Meziantou.Framework.Yamlish
         public sealed override Meziantou.Framework.Yamlish.Nodes.YamlishNode Write(object value, System.Type typeToConvert, Meziantou.Framework.Yamlish.YamlishSerializerOptions options) => throw null;
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Interface | System.AttributeTargets.Struct | System.AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
     public sealed class YamlishDerivedTypeAttribute : Meziantou.Framework.Yamlish.YamlishAttribute
     {
         public System.Type DerivedType { get => throw null; }
@@ -42,7 +42,7 @@ namespace Meziantou.Framework.Yamlish
         public YamlishDerivedTypeAttribute(System.Type derivedType, int typeDiscriminator) { }
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
     public sealed class YamlishIgnoreAttribute : Meziantou.Framework.Yamlish.YamlishAttribute
     {
         public Meziantou.Framework.Yamlish.YamlishIgnoreCondition Condition { get => throw null; set { } }
@@ -73,13 +73,13 @@ namespace Meziantou.Framework.Yamlish
         Populate = 1
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Interface | System.AttributeTargets.Struct | System.AttributeTargets.Class, Inherited = false)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Interface, Inherited = false)]
     public sealed class YamlishPolymorphicAttribute : Meziantou.Framework.Yamlish.YamlishAttribute
     {
         public string TypeDiscriminatorPropertyName { get => throw null; set { } }
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
     public sealed class YamlishPropertyNameAttribute : Meziantou.Framework.Yamlish.YamlishAttribute
     {
         public string Name { get => throw null; }
@@ -103,7 +103,7 @@ namespace Meziantou.Framework.Yamlish
         Folded = 5
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
     public sealed class YamlishScalarStyleAttribute : Meziantou.Framework.Yamlish.YamlishAttribute
     {
         public Meziantou.Framework.Yamlish.YamlishScalarStyle Style { get => throw null; }
@@ -118,7 +118,7 @@ namespace Meziantou.Framework.Yamlish
         Flow = 2
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Field | System.AttributeTargets.Property)]
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field)]
     public sealed class YamlishSequenceStyleAttribute : Meziantou.Framework.Yamlish.YamlishAttribute
     {
         public Meziantou.Framework.Yamlish.YamlishSequenceStyle Style { get => throw null; }

--- a/ref/Meziantou.Xunit.cs
+++ b/ref/Meziantou.Xunit.cs
@@ -25,7 +25,7 @@ namespace Meziantou.Xunit
         GitHubActions = 1
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public sealed class RunIfAttribute : Meziantou.Xunit.ConditionalTestAttributeBase
     {
         protected bool InvertCondition { get => throw null; }
@@ -35,7 +35,7 @@ namespace Meziantou.Xunit
         public RunIfAttribute(Meziantou.Xunit.TestOperatingSystems operatingSystem, Meziantou.Xunit.TestGlobalizationMode globalizationMode) { }
     }
 
-    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public sealed class SkipIfAttribute : Meziantou.Xunit.ConditionalTestAttributeBase
     {
         protected bool InvertCondition { get => throw null; }

--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
@@ -1,17 +1,21 @@
 using System.Collections.Immutable;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Meziantou.Framework.PublicApiGenerator;
 
 internal static class PublicApiModelBuilder
 {
     private static readonly NullabilityInfoContext NullabilityInfoContext = new();
+    private static readonly ConditionalWeakTable<Module, StrongBox<bool>> UpdatedMemorySafetyRulesCache = new();
     private const string CompilerGeneratedRefStructObsoleteMessage = "Types with embedded references are not supported in this version of your compiler.";
     private const string RequiresPreviewFeaturesAttributeFullName = "System.Runtime.Versioning.RequiresPreviewFeaturesAttribute";
     private const string ClosedAttributeFullName = "System.Runtime.CompilerServices.ClosedAttribute";
     private const string IsClosedTypeAttributeFullName = "System.Runtime.CompilerServices.IsClosedTypeAttribute";
     private const string UnionAttributeFullName = "System.Runtime.CompilerServices.UnionAttribute";
     private const string IUnionInterfaceFullName = "System.Runtime.CompilerServices.IUnion";
+    private const string MemorySafetyRulesAttributeFullName = "System.Runtime.CompilerServices.MemorySafetyRulesAttribute";
+    private const string RequiresUnsafeAttributeFullName = "System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute";
     private const GenericParameterAttributes AllowByRefLikeGenericParameterConstraint = (GenericParameterAttributes)0x20;
 
     private static readonly HashSet<string> IrrelevantAttributes = new(StringComparer.Ordinal)
@@ -46,6 +50,8 @@ internal static class PublicApiModelBuilder
         "System.Runtime.CompilerServices.ScopedRefAttribute",
         "System.Runtime.CompilerServices.ClosedAttribute",
         "System.Runtime.CompilerServices.IsClosedTypeAttribute",
+        MemorySafetyRulesAttributeFullName,
+        RequiresUnsafeAttributeFullName,
         "System.Reflection.AssemblyCompanyAttribute",
         "System.Reflection.AssemblyConfigurationAttribute",
         "System.Reflection.AssemblyCopyrightAttribute",
@@ -255,7 +261,8 @@ internal static class PublicApiModelBuilder
         AppendAttributes(sb, type.CustomAttributes, indentationLevel);
 
         var modifiers = GetTypeAccessibility(type);
-        var unsafeModifier = RequiresUnsafeContext(invokeMethod) ? " unsafe" : string.Empty;
+        // The unsafe modifier is not allowed on type declarations under the updated memory safety rules
+        var unsafeModifier = !HasUpdatedMemorySafetyRules(type.Module) && RequiresUnsafeContext(invokeMethod) ? " unsafe" : string.Empty;
         var genericArguments = BuildGenericArguments(type);
         var parameters = string.Join(", ", invokeMethod.GetParameters().Select(static parameter => BuildParameter(parameter, isExtensionReceiver: false)));
         var returnType = FormatReturnType(invokeMethod.ReturnParameter);
@@ -312,6 +319,11 @@ internal static class PublicApiModelBuilder
             modifiers.Add("const");
         }
 
+        if (IsRequiresUnsafeMember(field))
+        {
+            modifiers.Add("unsafe");
+        }
+
         var fieldNullability = NullabilityInfoContext.Create(field);
         var fieldType = isByRefField
             ? BuildByRefFieldType(field, fieldNullability)
@@ -352,6 +364,21 @@ internal static class PublicApiModelBuilder
             modifiers.Add("required");
         }
 
+        var getMethod = property.GetMethod is { } getter && IsExternallyVisible(getter) ? getter : null;
+        var setMethod = property.SetMethod is { } setter && IsExternallyVisible(setter) ? setter : null;
+        var isGetUnsafe = getMethod is not null && IsRequiresUnsafeMember(getMethod);
+        var isSetUnsafe = setMethod is not null && IsRequiresUnsafeMember(setMethod);
+
+        // The unsafe modifier can be set on the property or on its accessors, but not on both
+        var isPropertyUnsafe = IsRequiresUnsafeMember(property) ||
+                               (isGetUnsafe || isSetUnsafe) && isGetUnsafe == (getMethod is not null) && isSetUnsafe == (setMethod is not null);
+        if (isPropertyUnsafe)
+        {
+            modifiers.Add("unsafe");
+            isGetUnsafe = false;
+            isSetUnsafe = false;
+        }
+
         var indexParameters = property.GetMethod?.GetParameters() ?? property.SetMethod?.GetParameters().SkipLast(1).ToArray() ?? [];
         var propertyName = indexParameters.Length > 0
             ? $"this[{string.Join(", ", indexParameters.Select(static parameter => BuildParameter(parameter, isExtensionReceiver: false)))}]"
@@ -363,19 +390,17 @@ internal static class PublicApiModelBuilder
                 : null;
         var accessorDeclarations = new List<string>();
 
-        var getMethod = property.GetMethod;
-        if (getMethod is not null && IsExternallyVisible(getMethod))
+        if (getMethod is not null)
         {
-            var accessorModifier = BuildAccessorModifier(getMethod, representativeAccessor);
+            var accessorModifier = BuildAccessorModifier(getMethod, representativeAccessor) + (isGetUnsafe ? "unsafe " : string.Empty);
             var getAccessor = getMethod.IsAbstract ? "get;" : "get => throw null;";
             accessorDeclarations.Add($"{accessorModifier}{getAccessor}");
         }
 
-        var setMethod = property.SetMethod;
-        if (setMethod is not null && IsExternallyVisible(setMethod))
+        if (setMethod is not null)
         {
             var accessorKeyword = IsInitOnly(setMethod) ? "init" : "set";
-            var accessorModifier = BuildAccessorModifier(setMethod, representativeAccessor);
+            var accessorModifier = BuildAccessorModifier(setMethod, representativeAccessor) + (isSetUnsafe ? "unsafe " : string.Empty);
             var setAccessor = setMethod.IsAbstract ? $"{accessorKeyword};" : $"{accessorKeyword} {{ }}";
             accessorDeclarations.Add($"{accessorModifier}{setAccessor}");
         }
@@ -404,6 +429,12 @@ internal static class PublicApiModelBuilder
             modifiers.Add("static");
         }
 
+        // Event accessors cannot be marked as unsafe individually
+        if (IsRequiresUnsafeMember(@event))
+        {
+            modifiers.Add("unsafe");
+        }
+
         var eventNullability = NullabilityInfoContext.Create(addMethod.GetParameters().Single());
         AppendIndentedLine(sb, indentationLevel, $"{string.Join(' ', modifiers)} event {FormatType(@event.EventHandlerType!, eventNullability)} {EscapeIdentifier(@event.Name)};");
         return sb.ToString();
@@ -416,13 +447,15 @@ internal static class PublicApiModelBuilder
 
         var accessibility = GetMethodAccessibility(constructor);
         var modifiersPrefix = string.IsNullOrEmpty(accessibility) ? string.Empty : accessibility + " ";
-        var unsafeModifier = RequiresUnsafeContext(constructor) ? "unsafe " : string.Empty;
+        var requiresUnsafe = RequiresUnsafe(constructor);
+        var unsafeModifier = requiresUnsafe ? "unsafe " : string.Empty;
         var typeName = EscapeIdentifier(RemoveGenericArity(constructor.DeclaringType!.Name));
         var parametersList = constructor.GetParameters();
         var parameters = parametersList.Select(static parameter => BuildParameterDeclaration(parameter, isExtensionReceiver: false)).ToArray();
         var requiresNullableDisableDirective = parametersList.Any(static parameter => RequiresNullableDisableDirective(parameter));
         var initializer = BuildConstructorInitializer(constructor);
-        if (parametersList.Length == 0 && string.IsNullOrEmpty(initializer) && !constructor.CustomAttributes.Any(IsRequiresPreviewFeaturesAttribute))
+        // A parameterless constructor requiring an unsafe context is not equivalent to the implicit one as it doesn't satisfy the new() constraint
+        if (parametersList.Length == 0 && string.IsNullOrEmpty(initializer) && !requiresUnsafe && !constructor.CustomAttributes.Any(IsRequiresPreviewFeaturesAttribute))
             return null;
 
         AppendMemberWithParameters(
@@ -467,7 +500,7 @@ internal static class PublicApiModelBuilder
         var genericArguments = BuildGenericArguments(method);
         var constraints = BuildMethodConstraints(method, indentationLevel);
         var modifiersPrefix = modifiers.Count > 0 ? string.Join(' ', modifiers) + " " : string.Empty;
-        var unsafeModifier = RequiresUnsafeContext(method) ? "unsafe " : string.Empty;
+        var unsafeModifier = RequiresUnsafe(method) ? "unsafe " : string.Empty;
         var requiresNullableDisableDirective = RequiresNullableDisableDirective(method.ReturnParameter) ||
                                                method.GetParameters().Any(static parameter => RequiresNullableDisableDirective(parameter));
         var methodBody = BuildMethodBody(method);
@@ -736,6 +769,33 @@ internal static class PublicApiModelBuilder
         var parameterType = parameter.ParameterType.IsByRef ? parameter.ParameterType.GetElementType()! : parameter.ParameterType;
         var parameterNullability = NullabilityInfoContext.Create(parameter);
         return RequiresNullableDirectives(parameterType, parameterNullability);
+    }
+
+    private static bool HasUpdatedMemorySafetyRules(Module module)
+    {
+        return UpdatedMemorySafetyRulesCache.GetValue(
+            module,
+            static value => new StrongBox<bool>(HasAttribute(value.GetCustomAttributesData(), MemorySafetyRulesAttributeFullName))).Value;
+    }
+
+    private static bool HasAttribute(IEnumerable<CustomAttributeData> attributes, string attributeTypeFullName)
+    {
+        return attributes.Any(attribute => attribute.AttributeType.FullName == attributeTypeFullName);
+    }
+
+    private static bool IsRequiresUnsafeMember(MemberInfo member)
+    {
+        return HasUpdatedMemorySafetyRules(member.Module) &&
+               HasAttribute(member.GetCustomAttributesData(), RequiresUnsafeAttributeFullName);
+    }
+
+    private static bool RequiresUnsafe(MethodBase method)
+    {
+        // Under the updated memory safety rules, the compiler marks the members requiring an unsafe context with an attribute.
+        // Otherwise, a member requires an unsafe context when a pointer type appears in its signature (compiler compat mode).
+        return HasUpdatedMemorySafetyRules(method.Module)
+            ? HasAttribute(method.GetCustomAttributesData(), RequiresUnsafeAttributeFullName)
+            : RequiresUnsafeContext(method);
     }
 
     private static bool RequiresUnsafeContext(MethodBase method)

--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelBuilder.cs
@@ -1812,23 +1812,98 @@ internal static class PublicApiModelBuilder
 
     private static string FormatEnumValue(Type enumType, object enumValue)
     {
-        var typedEnumValue = Enum.ToObject(enumType, enumValue);
-        var text = typedEnumValue.ToString();
-        if (string.IsNullOrEmpty(text))
-            return "(" + FormatType(enumType) + ")" + Convert.ToString(enumValue, System.Globalization.CultureInfo.InvariantCulture);
+        var formattedTypeName = FormatType(enumType);
+        var underlyingValue = enumValue is Enum
+            ? Convert.ChangeType(enumValue, Enum.GetUnderlyingType(enumType), System.Globalization.CultureInfo.InvariantCulture)
+            : enumValue;
 
-        if (char.IsDigit(text[0]) || text[0] == '-')
-            return "(" + FormatType(enumType) + ")" + Convert.ToString(enumValue, System.Globalization.CultureInfo.InvariantCulture);
+        if (TryFormatEnumValueUsingMembers(enumType, formattedTypeName, underlyingValue, out var result))
+            return result;
 
-        if (text.Contains(", ", StringComparison.Ordinal))
+        return "(" + formattedTypeName + ")" + Convert.ToString(underlyingValue, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static bool TryFormatEnumValueUsingMembers(Type enumType, string formattedTypeName, object? enumValue, out string result)
+    {
+        result = string.Empty;
+        if (enumValue is null || !TryGetEnumValueBits(enumValue, out var enumValueBits))
+            return false;
+
+        var members = GetEnumMembersDescending(enumType);
+        if (members.Length == 0)
+            return false;
+
+        foreach (var member in members)
         {
-            return string.Join(
-                " | ",
-                text.Split(", ", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .Select(memberName => FormatType(enumType) + "." + memberName));
+            if (member.Value == enumValueBits)
+            {
+                result = formattedTypeName + "." + member.Name;
+                return true;
+            }
         }
 
-        return FormatType(enumType) + "." + text;
+        if (!HasAttribute(enumType.GetCustomAttributesData(), "System.FlagsAttribute"))
+            return false;
+
+        var remainingValue = enumValueBits;
+        var formattedMemberNames = new List<string>();
+        foreach (var member in members)
+        {
+            if (member.Value == 0)
+                continue;
+
+            if ((remainingValue & member.Value) != member.Value)
+                continue;
+
+            formattedMemberNames.Add(formattedTypeName + "." + member.Name);
+            remainingValue &= ~member.Value;
+        }
+
+        if (remainingValue != 0 || formattedMemberNames.Count == 0)
+            return false;
+
+        // The members are matched from the largest value to the smallest one, but they are formatted from the smallest to the largest one
+        formattedMemberNames.Reverse();
+        result = string.Join(" | ", formattedMemberNames);
+        return true;
+    }
+
+    private static ImmutableArray<EnumMember> GetEnumMembersDescending(Type enumType)
+    {
+        var members = new List<EnumMember>();
+        foreach (var field in enumType.GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (field.GetRawConstantValue() is { } constantValue && TryGetEnumValueBits(constantValue, out var memberValue))
+            {
+                members.Add(new EnumMember(memberValue, field.Name));
+            }
+        }
+
+        // Several members can share the same value, so they are ordered by name to always use the same one
+        return
+        [
+            .. members
+                .OrderByDescending(static member => member.Value)
+                .ThenBy(static member => member.Name, StringComparer.Ordinal),
+        ];
+    }
+
+    private static bool TryGetEnumValueBits(object value, out ulong bits)
+    {
+        bits = value switch
+        {
+            sbyte sbyteValue => unchecked((ulong)sbyteValue),
+            byte byteValue => byteValue,
+            short shortValue => unchecked((ulong)shortValue),
+            ushort ushortValue => ushortValue,
+            int intValue => unchecked((ulong)intValue),
+            uint uintValue => uintValue,
+            long longValue => unchecked((ulong)longValue),
+            ulong ulongValue => ulongValue,
+            _ => 0,
+        };
+
+        return value is sbyte or byte or short or ushort or int or uint or long or ulong;
     }
 
     private static string RemoveGenericArity(string name)
@@ -1851,6 +1926,8 @@ internal static class PublicApiModelBuilder
 
         sb.AppendLine(text);
     }
+
+    private readonly record struct EnumMember(ulong Value, string Name);
 
     private sealed record ParameterDeclaration(string Text, bool RequiresNullableDirectives);
     private sealed record ExtensionPropertyBuilderReflection(ParameterInfo ReceiverParameter, string PropertyName, MethodInfo? Getter, MethodInfo? Setter, int Order);

--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
 
 namespace Meziantou.Framework.PublicApiGenerator;
 
@@ -15,9 +16,12 @@ internal static class PublicApiModelReader
     private const string IsClosedTypeAttributeFullName = "System.Runtime.CompilerServices.IsClosedTypeAttribute";
     private const string UnionAttributeFullName = "System.Runtime.CompilerServices.UnionAttribute";
     private const string IUnionInterfaceFullName = "System.Runtime.CompilerServices.IUnion";
+    private const string MemorySafetyRulesAttributeFullName = "System.Runtime.CompilerServices.MemorySafetyRulesAttribute";
+    private const string RequiresUnsafeAttributeFullName = "System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute";
     private const GenericParameterAttributes AllowByRefLikeGenericParameterConstraint = (GenericParameterAttributes)0x20;
     private static readonly Lock EnumMetadataCacheLock = new();
     private static readonly Dictionary<string, EnumMetadata?> EnumMetadataCache = new(StringComparer.Ordinal);
+    private static readonly ConditionalWeakTable<MetadataReader, StrongBox<bool>> UpdatedMemorySafetyRulesCache = new();
 
     private static readonly HashSet<string> IrrelevantAttributes = new(StringComparer.Ordinal)
     {
@@ -51,6 +55,8 @@ internal static class PublicApiModelReader
         "System.Runtime.CompilerServices.ScopedRefAttribute",
         "System.Runtime.CompilerServices.ClosedAttribute",
         "System.Runtime.CompilerServices.IsClosedTypeAttribute",
+        MemorySafetyRulesAttributeFullName,
+        RequiresUnsafeAttributeFullName,
         "System.Reflection.AssemblyCompanyAttribute",
         "System.Reflection.AssemblyConfigurationAttribute",
         "System.Reflection.AssemblyCopyrightAttribute",
@@ -145,7 +151,10 @@ internal static class PublicApiModelReader
                 invokeSignature.Signature.ReturnType,
                 GetNullableMetadataInfo(metadataReader, typeDefinitionHandle, GetParameterCustomAttributes(metadataReader, invokeMethod, sequenceNumber: 0), invokeMethodHandle));
             var parameters = BuildParameterDeclarations(metadataReader, typeDefinitionHandle, invokeMethodHandle, invokeMethod, invokeSignature.Signature.ParameterTypes, invokeSignature.Signature.ReturnType, isExtensionMethod: false);
-            var unsafeModifier = RequiresUnsafeContext(invokeSignature.Signature.ReturnType, invokeSignature.Signature.ParameterTypes) ? " unsafe" : string.Empty;
+            // The unsafe modifier is not allowed on type declarations under the updated memory safety rules
+            var unsafeModifier = !HasUpdatedMemorySafetyRules(metadataReader) && RequiresUnsafeContext(invokeSignature.Signature.ReturnType, invokeSignature.Signature.ParameterTypes)
+                ? " unsafe"
+                : string.Empty;
 
             var delegateBuilder = new StringBuilder();
             foreach (var attribute in typeAttributes)
@@ -153,7 +162,7 @@ internal static class PublicApiModelReader
                 delegateBuilder.AppendLine(attribute);
             }
 
-            delegateBuilder.Append($"{accessibility}{unsafeModifier} delegate {returnType} {escapedTypeName}{genericArguments}({string.Join(", ", parameters.Select(static parameter => parameter.Text))}){FormatConstraintsInline(constraints)};");
+            delegateBuilder.AppendLine($"{accessibility}{unsafeModifier} delegate {returnType} {escapedTypeName}{genericArguments}({string.Join(", ", parameters.Select(static parameter => parameter.Text))}){FormatConstraintsInline(constraints)};");
             return delegateBuilder.ToString();
         }
 
@@ -508,6 +517,11 @@ internal static class PublicApiModelReader
             modifiers.Add("const");
         }
 
+        if (IsRequiresUnsafeMember(metadataReader, field.GetCustomAttributes()))
+        {
+            modifiers.Add("unsafe");
+        }
+
         var declaration = $"{string.Join(' ', modifiers)} {typeName} {EscapeIdentifier(metadataReader.GetString(field.Name))}";
         if (field.Attributes.HasFlag(FieldAttributes.Literal) && !field.GetDefaultValue().IsNil)
         {
@@ -555,6 +569,19 @@ internal static class PublicApiModelReader
             modifiers.Add("required");
         }
 
+        var isGetUnsafe = isGetVisible && IsRequiresUnsafeMember(metadataReader, getAccessor!.Value.GetCustomAttributes());
+        var isSetUnsafe = isSetVisible && IsRequiresUnsafeMember(metadataReader, setAccessor!.Value.GetCustomAttributes());
+
+        // The unsafe modifier can be set on the property or on its accessors, but not on both
+        var isPropertyUnsafe = IsRequiresUnsafeMember(metadataReader, property.GetCustomAttributes()) ||
+                               (isGetUnsafe || isSetUnsafe) && isGetUnsafe == isGetVisible && isSetUnsafe == isSetVisible;
+        if (isPropertyUnsafe)
+        {
+            modifiers.Add("unsafe");
+            isGetUnsafe = false;
+            isSetUnsafe = false;
+        }
+
         NullableMetadataInfo propertyNullableInfo;
         if (isGetVisible && !getAccessorHandle.IsNil && getAccessor is MethodDefinition getter)
         {
@@ -587,7 +614,7 @@ internal static class PublicApiModelReader
         var accessorText = new List<string>();
         if (isGetVisible)
         {
-            var accessorModifier = BuildAccessorModifier(getAccessor!.Value.Attributes, representativeAttributes);
+            var accessorModifier = BuildAccessorModifier(getAccessor!.Value.Attributes, representativeAttributes) + (isGetUnsafe ? "unsafe " : string.Empty);
             var accessorBody = getAccessor.Value.Attributes.HasFlag(MethodAttributes.Abstract) ? "get;" : "get => throw null;";
             accessorText.Add(accessorModifier + accessorBody);
         }
@@ -596,7 +623,7 @@ internal static class PublicApiModelReader
         {
             var setterSignature = DecodeMethodSignature(metadataReader, declaringTypeHandle, setAccessorHandle, setAccessor!.Value);
             var accessorKeyword = setterSignature.ContainsIsExternalInitModifier ? "init" : "set";
-            var accessorModifier = BuildAccessorModifier(setAccessor.Value.Attributes, representativeAttributes);
+            var accessorModifier = BuildAccessorModifier(setAccessor.Value.Attributes, representativeAttributes) + (isSetUnsafe ? "unsafe " : string.Empty);
             var accessorBody = setAccessor.Value.Attributes.HasFlag(MethodAttributes.Abstract)
                 ? accessorKeyword + ";"
                 : accessorKeyword + " { }";
@@ -629,6 +656,12 @@ internal static class PublicApiModelReader
         if (addMethod.Attributes.HasFlag(MethodAttributes.Static))
         {
             modifiers.Add("static");
+        }
+
+        // Event accessors cannot be marked as unsafe individually
+        if (IsRequiresUnsafeMember(metadataReader, eventDefinition.GetCustomAttributes()))
+        {
+            modifiers.Add("unsafe");
         }
 
         var eventNullableInfo = GetNullableMetadataInfo(
@@ -671,7 +704,7 @@ internal static class PublicApiModelReader
         var methodBody = BuildMethodBody(metadataReader, method, signature);
         var methodName = isExplicitInterfaceImplementation ? BuildExplicitInterfaceMethodName(name) : EscapeIdentifier(name);
         var modifiersPrefix = modifiers.Count > 0 ? string.Join(' ', modifiers) + " " : string.Empty;
-        var unsafeModifier = RequiresUnsafeContext(signature.Signature.ReturnType, signature.Signature.ParameterTypes) ? "unsafe " : string.Empty;
+        var unsafeModifier = RequiresUnsafe(metadataReader, method.GetCustomAttributes(), signature.Signature.ReturnType, signature.Signature.ParameterTypes) ? "unsafe " : string.Empty;
         var requiresNullableDisableDirective = RequiresNullableDirectives(signature.Signature.ReturnType, returnNullableInfo) ||
                                                RequiresNullableDisableDirectiveForParameters(metadataReader, declaringTypeHandle, methodHandle, method, signature.Signature.ParameterTypes, signature.Signature.ReturnType);
         var methodSuffix = FormatConstraintsInline(constraints) + methodBody;
@@ -700,11 +733,14 @@ internal static class PublicApiModelReader
         var typeName = EscapeIdentifier(RemoveGenericArity(metadataReader.GetString(declaringType.Name)));
         var accessibility = GetAccessibility(method.Attributes);
         var modifiersPrefix = string.IsNullOrEmpty(accessibility) ? string.Empty : accessibility + " ";
-        var unsafeModifier = RequiresUnsafeContext(signature.Signature.ReturnType, signature.Signature.ParameterTypes) ? "unsafe " : string.Empty;
+        var requiresUnsafe = RequiresUnsafe(metadataReader, method.GetCustomAttributes(), signature.Signature.ReturnType, signature.Signature.ParameterTypes);
+        var unsafeModifier = requiresUnsafe ? "unsafe " : string.Empty;
         var parameters = BuildParameterDeclarations(metadataReader, declaringTypeHandle, methodHandle, method, signature.Signature.ParameterTypes, signature.Signature.ReturnType, isExtensionMethod: false);
         var requiresNullableDisableDirective = RequiresNullableDisableDirectiveForParameters(metadataReader, declaringTypeHandle, methodHandle, method, signature.Signature.ParameterTypes, signature.Signature.ReturnType);
         var initializer = BuildConstructorInitializer(metadataReader, declaringType);
-        if (signature.Signature.ParameterTypes.Length == 0 && string.IsNullOrEmpty(initializer) && !HasAttribute(metadataReader, method.GetCustomAttributes(), RequiresPreviewFeaturesAttributeFullName))
+
+        // A parameterless constructor requiring an unsafe context is not equivalent to the implicit one as it doesn't satisfy the new() constraint
+        if (signature.Signature.ParameterTypes.Length == 0 && string.IsNullOrEmpty(initializer) && !requiresUnsafe && !HasAttribute(metadataReader, method.GetCustomAttributes(), RequiresPreviewFeaturesAttributeFullName))
             return null;
 
         var methodBody = method.Attributes.HasFlag(MethodAttributes.Abstract) ? ";" : " { }";
@@ -1089,6 +1125,28 @@ internal static class PublicApiModelReader
 
         var topLevelAnnotation = nullableInfo.Flags.IsDefaultOrEmpty ? nullableInfo.ContextFlag : nullableInfo.Flags[0];
         return topLevelAnnotation == 0;
+    }
+
+    private static bool HasUpdatedMemorySafetyRules(MetadataReader metadataReader)
+    {
+        return UpdatedMemorySafetyRulesCache.GetValue(
+            metadataReader,
+            static reader => new StrongBox<bool>(HasAttribute(reader, reader.GetModuleDefinition().GetCustomAttributes(), MemorySafetyRulesAttributeFullName))).Value;
+    }
+
+    private static bool IsRequiresUnsafeMember(MetadataReader metadataReader, CustomAttributeHandleCollection customAttributes)
+    {
+        return HasUpdatedMemorySafetyRules(metadataReader) &&
+               HasAttribute(metadataReader, customAttributes, RequiresUnsafeAttributeFullName);
+    }
+
+    private static bool RequiresUnsafe(MetadataReader metadataReader, CustomAttributeHandleCollection customAttributes, DecodedType returnType, ImmutableArray<DecodedType> parameterTypes)
+    {
+        // Under the updated memory safety rules, the compiler marks the members requiring an unsafe context with an attribute.
+        // Otherwise, a member requires an unsafe context when a pointer type appears in its signature (compiler compat mode).
+        return HasUpdatedMemorySafetyRules(metadataReader)
+            ? HasAttribute(metadataReader, customAttributes, RequiresUnsafeAttributeFullName)
+            : RequiresUnsafeContext(returnType, parameterTypes);
     }
 
     private static bool RequiresUnsafeContext(DecodedType returnType, ImmutableArray<DecodedType> parameterTypes)
@@ -2406,6 +2464,8 @@ internal static class PublicApiModelReader
             return false;
         }
 
+        // The members are matched from the largest value to the smallest one, but they are formatted from the smallest to the largest one (same as Enum.ToString)
+        formattedMemberNames.Reverse();
         result = string.Join(" | ", formattedMemberNames);
         return true;
     }

--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
@@ -2533,7 +2533,6 @@ internal static class PublicApiModelReader
             return false;
         }
 
-        var memberNamesByValue = new Dictionary<ulong, string>();
         var members = new List<EnumMember>();
         foreach (var fieldHandle in typeDefinition.GetFields())
         {
@@ -2549,11 +2548,7 @@ internal static class PublicApiModelReader
             if (!TryGetEnumValueBits(constantValue!, out var memberValue))
                 continue;
 
-            var memberName = metadataReader.GetString(field.Name);
-            if (memberNamesByValue.TryAdd(memberValue, memberName))
-            {
-                members.Add(new EnumMember(memberValue, memberName));
-            }
+            members.Add(new EnumMember(memberValue, metadataReader.GetString(field.Name)));
         }
 
         if (members.Count == 0)
@@ -2562,11 +2557,23 @@ internal static class PublicApiModelReader
             return false;
         }
 
+        // Several members can share the same value, so they are ordered by name to always use the same one
+        var membersDescending = members
+            .OrderByDescending(static member => member.Value)
+            .ThenBy(static member => member.Name, StringComparer.Ordinal)
+            .ToImmutableArray();
+
+        var memberNamesByValue = new Dictionary<ulong, string>();
+        foreach (var member in membersDescending)
+        {
+            memberNamesByValue.TryAdd(member.Value, member.Name);
+        }
+
         var isFlags = HasAttribute(metadataReader, typeDefinition.GetCustomAttributes(), "System.FlagsAttribute");
         enumMetadata = new EnumMetadata(
             IsFlags: isFlags,
             MemberNamesByValue: memberNamesByValue,
-            MembersDescending: [.. members.OrderByDescending(static member => member.Value).ThenBy(static member => member.Name, StringComparer.Ordinal)]);
+            MembersDescending: membersDescending);
         return true;
     }
 

--- a/src/Meziantou.Framework.PublicApiGenerator/readme.md
+++ b/src/Meziantou.Framework.PublicApiGenerator/readme.md
@@ -54,6 +54,12 @@ var files = PublicApi.Generate(
 
 If `TargetFrameworkMoniker` is omitted (or empty), the generator infers it from assembly metadata.
 
+## Memory safety rules
+
+For assemblies compiled with the updated memory safety rules (`<Features>$(Features);updated-memory-safety-rules</Features>`), the `unsafe` modifier reflects the members the compiler marked as requiring an unsafe context, whatever their signature. Pointers in a signature no longer imply `unsafe`, and delegate declarations are never `unsafe`. Generated files may therefore need the same feature to be compiled.
+
+For other assemblies, a member is `unsafe` when a pointer type appears in its signature, which matches the compatibility mode of the compiler.
+
 ## Example output
 
 Input API:

--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
@@ -12,6 +12,7 @@ public sealed class PublicApiGeneratorTests
 {
     private const string CompilationCacheVersion = "v1";
     private const string CompilationCacheDirectoryEnvironmentVariable = "MEZIANTOU_PUBLIC_API_TEST_CACHE_DIRECTORY";
+    private static readonly Lazy<Task<string>> DotNetSdkVersion = new(GetDotNetSdkVersionAsync);
 
     [Fact]
     public async Task EmptyClass()
@@ -272,6 +273,29 @@ public sealed class PublicApiGeneratorTests
     }
 
     [Fact]
+    public async Task Delegate_FollowedByClass()
+    {
+        await Validate("""
+            public delegate int SimpleDelegate(int value);
+
+            public class Sample
+            {
+                public int Method(int value) => value;
+            }
+            """, """
+            #nullable enable
+
+            public class Sample
+            {
+                public int Method(int value) => throw null;
+            }
+
+
+            public delegate int SimpleDelegate(int value);
+            """);
+    }
+
+    [Fact]
     public async Task Method_Pointer()
     {
         await Validate("""
@@ -287,6 +311,87 @@ public sealed class PublicApiGeneratorTests
                 public unsafe int* M(int* value) => throw null;
             }
             """);
+    }
+
+    [Fact]
+    public async Task MemorySafetyRules_UnsafeMembers()
+    {
+        await Validate("""
+            public class Sample
+            {
+                public unsafe int Field;
+
+                public unsafe Sample() { }
+
+                public unsafe void Method() { }
+
+                public unsafe int Property { get => 0; set { } }
+
+                public int PropertyWithUnsafeGetter { unsafe get => 0; set { } }
+
+                public unsafe event System.Action? Event;
+
+                public static unsafe int operator +(Sample left, Sample right) => 0;
+            }
+            """, """
+            #nullable enable
+
+            public class Sample
+            {
+                public unsafe int Field;
+                public unsafe int Property { get => throw null; set { } }
+                public int PropertyWithUnsafeGetter { unsafe get => throw null; set { } }
+                public unsafe event System.Action? Event;
+                public unsafe Sample() { }
+                public unsafe void Method() { }
+                public static unsafe int operator +(Sample left, Sample right) => throw null;
+            }
+            """, compilerOptions: new CompilerOptions
+        {
+            UpdatedMemorySafetyRules = true,
+        });
+    }
+
+    [Fact]
+    public async Task MemorySafetyRules_SafeMembersWithPointers()
+    {
+        await Validate("""
+            public class Sample
+            {
+                public int* Field;
+
+                public int* Property { get => null; set { } }
+
+                public int* Method(int* value) => value;
+            }
+            """, """
+            #nullable enable
+
+            public class Sample
+            {
+                public int* Field;
+                public int* Property { get => throw null; set { } }
+                public int* Method(int* value) => throw null;
+            }
+            """, compilerOptions: new CompilerOptions
+        {
+            UpdatedMemorySafetyRules = true,
+        });
+    }
+
+    [Fact]
+    public async Task MemorySafetyRules_Delegate_Pointer()
+    {
+        await Validate("""
+            public delegate int* PointerDelegate(int* value);
+            """, """
+            #nullable enable
+
+            public delegate int* PointerDelegate(int* value);
+            """, compilerOptions: new CompilerOptions
+        {
+            UpdatedMemorySafetyRules = true,
+        });
     }
 
     [Fact]
@@ -1994,6 +2099,62 @@ public sealed class PublicApiGeneratorTests
     }
 
     [Fact]
+    public async Task Attribute_FlagsEnumArgument_UsesAscendingValueOrder()
+    {
+        await Validate("""
+            namespace System.Diagnostics
+            {
+                [System.Flags]
+                public enum SampleFlags
+                {
+                    None = 0,
+                    First = 1,
+                    Second = 2,
+                    Third = 4,
+                    All = 7,
+                }
+
+                [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+                public sealed class SampleAttribute : System.Attribute
+                {
+                    public SampleAttribute(SampleFlags flags) { }
+                }
+            }
+
+            [System.Diagnostics.Sample(System.Diagnostics.SampleFlags.First | System.Diagnostics.SampleFlags.Second)]
+            public class Sample
+            {
+            }
+            """, """
+            #nullable enable
+
+            [System.Diagnostics.Sample(System.Diagnostics.SampleFlags.First | System.Diagnostics.SampleFlags.Second)]
+            public class Sample
+            {
+            }
+
+            namespace System.Diagnostics
+            {
+                [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+                public sealed class SampleAttribute : System.Attribute
+                {
+                    public SampleAttribute(System.Diagnostics.SampleFlags flags) { }
+                }
+
+                [System.Flags]
+                public enum SampleFlags
+                {
+                    None = 0,
+                    First = 1,
+                    Second = 2,
+                    Third = 4,
+                    All = 7
+                }
+            }
+            """);
+    }
+
+    [Fact]
     public async Task AttributeTypeArgument_UsesCSharpGenericTypeSyntax()
     {
         var files = await BuildFiles(
@@ -2399,6 +2560,10 @@ public sealed class PublicApiGeneratorTests
                 public sealed class ClosedAttribute : System.Attribute
                 {
                 }
+
+                public sealed class IsClosedTypeAttribute : System.Attribute
+                {
+                }
             }
 
             public closed class Sample
@@ -2415,6 +2580,10 @@ public sealed class PublicApiGeneratorTests
             {
                 [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
                 public sealed class ClosedAttribute : System.Attribute
+                {
+                }
+
+                public sealed class IsClosedTypeAttribute : System.Attribute
                 {
                 }
             }
@@ -2494,6 +2663,8 @@ public sealed class PublicApiGeneratorTests
             IncludeAutoGeneratedComment = false,
         };
 
+        var features = compilerOptions.UpdatedMemorySafetyRules ? "\n    <Features>$(Features);updated-memory-safety-rules</Features>" : "";
+
         // Build the project
         var sourceProjectDirectory = temporaryDirectory / "source";
         temporaryDirectory.CreateTextFile(sourceProjectDirectory / "project.csproj", $$"""
@@ -2503,7 +2674,7 @@ public sealed class PublicApiGeneratorTests
                 <LangVersion>preview</LangVersion>
                 <Nullable>{{(compilerOptions.Nullable ? "enable" : "disable")}}</Nullable>
                 <ImplicitUsings>enable</ImplicitUsings>
-                <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+                <AllowUnsafeBlocks>true</AllowUnsafeBlocks>{{features}}
               </PropertyGroup>
             </Project>
             """);
@@ -2534,7 +2705,7 @@ public sealed class PublicApiGeneratorTests
                 <LangVersion>preview</LangVersion>
                 <Nullable>{{(compilerOptions.Nullable ? "enable" : "disable")}}</Nullable>
                 <ImplicitUsings>enable</ImplicitUsings>
-                <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+                <AllowUnsafeBlocks>true</AllowUnsafeBlocks>{{features}}
               </PropertyGroup>
             </Project>
             """);
@@ -2559,6 +2730,7 @@ public sealed class PublicApiGeneratorTests
     {
         await using var temporaryDirectory = TemporaryDirectory.Create();
         compilerOptions ??= new CompilerOptions();
+        var features = compilerOptions.UpdatedMemorySafetyRules ? "\n    <Features>$(Features);updated-memory-safety-rules</Features>" : "";
 
         var sourceProjectDirectory = temporaryDirectory / "source";
         temporaryDirectory.CreateTextFile(sourceProjectDirectory / "project.csproj", $$"""
@@ -2568,7 +2740,7 @@ public sealed class PublicApiGeneratorTests
                 <LangVersion>preview</LangVersion>
                 <Nullable>{{(compilerOptions.Nullable ? "enable" : "disable")}}</Nullable>
                 <ImplicitUsings>enable</ImplicitUsings>
-                <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+                <AllowUnsafeBlocks>true</AllowUnsafeBlocks>{{features}}
               </PropertyGroup>
             </Project>
             """);
@@ -2674,7 +2846,7 @@ public sealed class PublicApiGeneratorTests
     {
         var projectPath = FullPath.FromPath(Assert.Single(Directory.EnumerateFiles(temporaryDirectory, "*.csproj", SearchOption.TopDirectoryOnly)));
         var cacheDirectory = GetCompilationCacheDirectory();
-        var cacheKey = ComputeCompilationCacheKey(temporaryDirectory);
+        var cacheKey = ComputeCompilationCacheKey(temporaryDirectory, await DotNetSdkVersion.Value);
         var cachedAssemblyPath = cacheDirectory / cacheKey / "Source.dll";
         if (File.Exists(cachedAssemblyPath))
             return cachedAssemblyPath;
@@ -2745,10 +2917,28 @@ public sealed class PublicApiGeneratorTests
         return FullPath.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) / "Meziantou.Framework" / "PublicApiGeneratorTests" / "CompilationCache";
     }
 
-    private static string ComputeCompilationCacheKey(FullPath sourceProjectDirectory)
+    private static async Task<string> GetDotNetSdkVersionAsync()
+    {
+        // The compiler ships with the SDK, so the cached assemblies must not be reused after an SDK update.
+        // The sample projects are built in the temporary directory, so resolve the SDK from there to ignore the global.json of the repository.
+        var processResult = await ProcessWrapper.Create("dotnet")
+            .WithArguments(["--version"])
+            .WithWorkingDirectory(FullPath.FromPath(Path.GetTempPath()))
+            .WithEnvironmentVariables(env => env.Set("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "1"))
+            .WithValidation(ProcessValidationMode.None)
+            .ExecuteBufferedAsync(XunitCancellationToken);
+
+        if (!processResult.ExitCode.IsSuccess)
+            throw new XunitException($"Command failed: dotnet --version\nstderr:\n{string.Join('\n', processResult.Output.StandardError.Select(line => line.Text))}");
+
+        return string.Join('\n', processResult.Output.StandardOutput.Select(line => line.Text)).Trim();
+    }
+
+    private static string ComputeCompilationCacheKey(FullPath sourceProjectDirectory, string sdkVersion)
     {
         using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         AddHashData(hash, CompilationCacheVersion);
+        AddHashData(hash, sdkVersion);
 
         var files = Directory
             .EnumerateFiles(sourceProjectDirectory, "*", SearchOption.AllDirectories)
@@ -2800,5 +2990,6 @@ public sealed class PublicApiGeneratorTests
     {
         public bool Nullable { get; set; } = true;
         public string TargetFramework { get; set; } = "net8.0";
+        public bool UpdatedMemorySafetyRules { get; set; }
     }
 }

--- a/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
+++ b/tests/Meziantou.Framework.PublicApiGenerator.Tests/PublicApiGeneratorTests.cs
@@ -2155,6 +2155,71 @@ public sealed class PublicApiGeneratorTests
     }
 
     [Fact]
+    public async Task Attribute_FlagsEnumArgument_WithSameValueMembers_UsesFirstMemberInOrdinalOrder()
+    {
+        await Validate("""
+            namespace System.Diagnostics
+            {
+                [System.Flags]
+                public enum SampleFlags
+                {
+                    None = 0,
+                    Zebra = 1,
+                    Alpha = 1,
+                    Second = 2,
+                }
+
+                [System.AttributeUsage(System.AttributeTargets.All)]
+                public sealed class SampleAttribute : System.Attribute
+                {
+                    public SampleAttribute(SampleFlags flags) { }
+                }
+            }
+
+            [System.Diagnostics.Sample(System.Diagnostics.SampleFlags.Zebra | System.Diagnostics.SampleFlags.Second)]
+            public class SampleCombined
+            {
+            }
+
+            [System.Diagnostics.Sample(System.Diagnostics.SampleFlags.Zebra)]
+            public class SampleSingle
+            {
+            }
+            """, """
+            #nullable enable
+
+            [System.Diagnostics.Sample(System.Diagnostics.SampleFlags.Alpha | System.Diagnostics.SampleFlags.Second)]
+            public class SampleCombined
+            {
+            }
+
+
+            [System.Diagnostics.Sample(System.Diagnostics.SampleFlags.Alpha)]
+            public class SampleSingle
+            {
+            }
+
+            namespace System.Diagnostics
+            {
+                [System.AttributeUsage(System.AttributeTargets.All)]
+                public sealed class SampleAttribute : System.Attribute
+                {
+                    public SampleAttribute(System.Diagnostics.SampleFlags flags) { }
+                }
+
+                [System.Flags]
+                public enum SampleFlags
+                {
+                    None = 0,
+                    Zebra = 1,
+                    Alpha = 1,
+                    Second = 2
+                }
+            }
+            """);
+    }
+
+    [Fact]
     public async Task AttributeTypeArgument_UsesCSharpGenericTypeSyntax()
     {
         var files = await BuildFiles(


### PR DESCRIPTION
## What

Teaches `Meziantou.Framework.PublicApiGenerator` about the updated C# memory safety rules (`<Features>$(Features);updated-memory-safety-rules</Features>`, preview in C# 15 / .NET 11).

Under those rules `unsafe` on a member is a caller-facing contract rather than a pointer-permission marker. The compiler stamps the module with `System.Runtime.CompilerServices.MemorySafetyRulesAttribute` and marks each caller-unsafe member with `System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute` (note the namespace — the csharplang proposal still documents it under `CompilerServices`). Verified against SDK `11.0.100-preview.7.26381.103`, on both net8.0 and net10.0 targets.

For a module using the updated rules:

- `unsafe` comes from `RequiresUnsafeAttribute` on methods, constructors, operators, fields, properties, and events; when only one accessor is marked, the modifier goes on that accessor (`{ unsafe get; set; }`), never on the property *and* its accessors.
- Pointers in a signature no longer imply `unsafe`: `public int* Method(int* value)` is emitted without the modifier when the compiler did not mark it.
- Delegate declarations are never `unsafe`, since the modifier is an error on type declarations.
- A parameterless constructor marked caller-unsafe is emitted instead of being dropped as "the implicit one" — it no longer satisfies the `new()` constraint.
- Both attributes are filtered from the printed attribute list; previously `[System.Diagnostics.CodeAnalysis.RequiresUnsafe]` was emitted, which is error CS9379 in source.

Assemblies without the module attribute keep the current pointer heuristic, which matches the compatibility mode of the compiler, so their generated files are unchanged.

The repository itself is **not** switched to the new feature — that stays a separate change.

## Drive-by fixes

Found while testing the above; each is covered by a test that fails without the fix.

1. **Delegate spacing differed between the two reading paths.** The metadata reader ended a delegate source without a trailing newline while every other type kind (and the reflection builder) added one, so an assembly with a delegate in the global namespace produced different text from `PublicApi.Generate(path, …)` and `PublicApi.Generate(Assembly, …)`. Invisible for namespaced delegates because the emitter re-reads those line by line.
2. **Flags enum arguments were ordered differently.** The metadata reader matched members from the largest value down (needed so composite members win) and emitted them in that order, while the reflection builder relies on `Enum.ToString`, which emits ascending. Both now emit ascending — this is why the `ref/` files change (`AttributeTargets.Method | AttributeTargets.Class` → `AttributeTargets.Class | AttributeTargets.Method`).
3. **`Class_Closed` no longer compiled with the pinned SDK** (`CS0656 IsClosedTypeAttribute..ctor`); it passed only because the on-disk compilation cache reused an assembly built by an older SDK. The sample now declares `IsClosedTypeAttribute`, and the cache key includes `dotnet --version` so a compiler upgrade cannot mask failures again.

## Notes for reviewers

- The `ref/*.cs` changes are entirely flag reorderings from fix 2 (29 lines across 5 files). They were regenerated with `--configuration Release /p:IsOfficialBuild=true`, and a follow-up build with `/p:PublicApiGeneratorVerifyNoChangeOnBuild=true` passes.
- `CompilerOptions.UpdatedMemorySafetyRules` in the tests adds the feature to the sample project **and** to the project that compiles the generated files, so the output is checked against the same rules it describes. The `<Features>` line is interpolated inline so that projects not using it keep a byte-identical csproj and their cache entries.
- The `safe` contextual keyword on `extern` members is still unhandled: the metadata path does not emit `extern` at all today, so that pre-existing parity gap would have to be closed first.

## Testing

- `dotnet test tests/Meziantou.Framework.PublicApiGenerator.Tests` → 196/196 (98 × net10.0/net11.0), including a full cold-cache run after the cache key change.
- `dotnet test tests/Meziantou.Framework.PublicApiGenerator.MSBuild.Tests` → 16/16.
- `dotnet run ./eng/update-all.cs` → no changes.
