### PR TITLE
Support the No-Vary-Search response header

### DIFF
--- a/ref/Meziantou.Framework.Http.Caching.cs
+++ b/ref/Meziantou.Framework.Http.Caching.cs
@@ -8,6 +8,8 @@ namespace Meziantou.Framework.Http.Caching
     {
         public bool SecondaryKeyMatchNone { get => throw null; set { } }
         public System.Collections.Generic.Dictionary<string, string>? SecondaryKeyHeaders { get => throw null; set { } }
+        public string? NoVarySearch { get => throw null; set { } }
+        public string? NormalizedQuery { get => throw null; set { } }
         public System.DateTimeOffset RequestTime { get => throw null; set { } }
         public System.DateTimeOffset ResponseTime { get => throw null; set { } }
         public System.DateTimeOffset ResponseDate { get => throw null; set { } }

--- a/src/Meziantou.Framework.Http.Caching.Sqlite/SqliteHttpCacheStore.cs
+++ b/src/Meziantou.Framework.Http.Caching.Sqlite/SqliteHttpCacheStore.cs
@@ -12,6 +12,8 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
     private const string SplitColumnsSql =
         "SecondaryKeyMatchNone, " +
         "SecondaryKeyHeadersJson, " +
+        "NoVarySearch, " +
+        "NormalizedQuery, " +
         "RequestTimeUtcTicks, " +
         "ResponseTimeUtcTicks, " +
         "ResponseDateUtcTicks, " +
@@ -97,7 +99,7 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
         command.CommandText =
             "INSERT INTO HttpCacheEntries(" +
             "PrimaryKey, SecondaryKey, " +
-            "SecondaryKeyMatchNone, SecondaryKeyHeadersJson, " +
+            "SecondaryKeyMatchNone, SecondaryKeyHeadersJson, NoVarySearch, NormalizedQuery, " +
             "RequestTimeUtcTicks, ResponseTimeUtcTicks, ResponseDateUtcTicks, " +
             "AgeValueTicks, MaxAgeTicks, SharedMaxAgeTicks, ExpiresUtcTicks, " +
             "MustRevalidate, ProxyRevalidate, ResponseNoCache, Public, Private, NoTransform, Immutable, " +
@@ -105,7 +107,7 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
             "StaleAtUtcTicks, DeleteWhenExpired, Payload) " +
             "VALUES (" +
             "$primaryKey, $secondaryKey, " +
-            "$secondaryKeyMatchNone, $secondaryKeyHeadersJson, " +
+            "$secondaryKeyMatchNone, $secondaryKeyHeadersJson, $noVarySearch, $normalizedQuery, " +
             "$requestTimeUtcTicks, $responseTimeUtcTicks, $responseDateUtcTicks, " +
             "$ageValueTicks, $maxAgeTicks, $sharedMaxAgeTicks, $expiresUtcTicks, " +
             "$mustRevalidate, $proxyRevalidate, $responseNoCache, $public, $private, $noTransform, $immutable, " +
@@ -114,6 +116,8 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
             "ON CONFLICT(PrimaryKey, SecondaryKey) DO UPDATE SET " +
             "SecondaryKeyMatchNone = excluded.SecondaryKeyMatchNone, " +
             "SecondaryKeyHeadersJson = excluded.SecondaryKeyHeadersJson, " +
+            "NoVarySearch = excluded.NoVarySearch, " +
+            "NormalizedQuery = excluded.NormalizedQuery, " +
             "RequestTimeUtcTicks = excluded.RequestTimeUtcTicks, " +
             "ResponseTimeUtcTicks = excluded.ResponseTimeUtcTicks, " +
             "ResponseDateUtcTicks = excluded.ResponseDateUtcTicks, " +
@@ -139,6 +143,8 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
         command.Parameters.AddWithValue("$secondaryKey", secondaryKey);
         command.Parameters.AddWithValue("$secondaryKeyMatchNone", entry.SecondaryKeyMatchNone ? 1 : 0);
         command.Parameters.AddWithValue("$secondaryKeyHeadersJson", (object?)secondaryKeyHeadersJson ?? DBNull.Value);
+        command.Parameters.AddWithValue("$noVarySearch", (object?)entry.NoVarySearch ?? DBNull.Value);
+        command.Parameters.AddWithValue("$normalizedQuery", (object?)entry.NormalizedQuery ?? DBNull.Value);
         command.Parameters.AddWithValue("$requestTimeUtcTicks", entry.RequestTime.UtcDateTime.Ticks);
         command.Parameters.AddWithValue("$responseTimeUtcTicks", entry.ResponseTime.UtcDateTime.Ticks);
         command.Parameters.AddWithValue("$responseDateUtcTicks", entry.ResponseDate.UtcDateTime.Ticks);
@@ -342,6 +348,8 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
             "SecondaryKey TEXT NOT NULL, " +
             "SecondaryKeyMatchNone INTEGER NOT NULL, " +
             "SecondaryKeyHeadersJson TEXT NULL, " +
+            "NoVarySearch TEXT NULL, " +
+            "NormalizedQuery TEXT NULL, " +
             "RequestTimeUtcTicks INTEGER NOT NULL, " +
             "ResponseTimeUtcTicks INTEGER NOT NULL, " +
             "ResponseDateUtcTicks INTEGER NOT NULL, " +
@@ -383,6 +391,8 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
     [
         ("SecondaryKeyMatchNone", "INTEGER"),
         ("SecondaryKeyHeadersJson", "TEXT"),
+        ("NoVarySearch", "TEXT"),
+        ("NormalizedQuery", "TEXT"),
         ("RequestTimeUtcTicks", "INTEGER"),
         ("ResponseTimeUtcTicks", "INTEGER"),
         ("ResponseDateUtcTicks", "INTEGER"),
@@ -492,6 +502,8 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
             {
                 SecondaryKeyMatchNone = ReadBoolean(reader, ordinals.SecondaryKeyMatchNone),
                 SecondaryKeyHeaders = DeserializeSecondaryKeyHeaders(headersJson),
+                NoVarySearch = ReadNullableString(reader, ordinals.NoVarySearch),
+                NormalizedQuery = ReadNullableString(reader, ordinals.NormalizedQuery),
                 RequestTime = FromUtcTicks(reader.GetInt64(ordinals.RequestTimeUtcTicks)),
                 ResponseTime = FromUtcTicks(reader.GetInt64(ordinals.ResponseTimeUtcTicks)),
                 ResponseDate = FromUtcTicks(reader.GetInt64(ordinals.ResponseDateUtcTicks)),
@@ -516,6 +528,14 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
         {
             return null;
         }
+    }
+
+    private static string? ReadNullableString(SqliteDataReader reader, int ordinal)
+    {
+        if (ordinal < 0 || reader.IsDBNull(ordinal))
+            return null;
+
+        return reader.GetString(ordinal);
     }
 
     private static bool ReadBoolean(SqliteDataReader reader, int ordinal)
@@ -562,6 +582,8 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
     {
         public int SecondaryKeyMatchNone { get; init; }
         public int SecondaryKeyHeadersJson { get; init; }
+        public int NoVarySearch { get; init; }
+        public int NormalizedQuery { get; init; }
         public int RequestTimeUtcTicks { get; init; }
         public int ResponseTimeUtcTicks { get; init; }
         public int ResponseDateUtcTicks { get; init; }
@@ -588,6 +610,8 @@ public sealed class SqliteHttpCacheStore : IHttpCacheStore, IDisposable
             {
                 SecondaryKeyMatchNone = GetOrdinal(reader, "SecondaryKeyMatchNone"),
                 SecondaryKeyHeadersJson = GetOrdinal(reader, "SecondaryKeyHeadersJson"),
+                NoVarySearch = GetOrdinal(reader, "NoVarySearch"),
+                NormalizedQuery = GetOrdinal(reader, "NormalizedQuery"),
                 RequestTimeUtcTicks = GetOrdinal(reader, "RequestTimeUtcTicks"),
                 ResponseTimeUtcTicks = GetOrdinal(reader, "ResponseTimeUtcTicks"),
                 ResponseDateUtcTicks = GetOrdinal(reader, "ResponseDateUtcTicks"),

--- a/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
+++ b/src/Meziantou.Framework.Http.Caching/CacheEntry.cs
@@ -70,7 +70,23 @@ internal sealed class CacheEntry
         // Handle Vary header for secondary key
         entry.SecondaryKey = BuildSecondaryKey(request, response);
 
+        // draft-ietf-httpbis-no-vary-search Section 5.2
+        entry.VariationConfig = ParseVariationConfig(response);
+        if (!entry.VariationConfig.IsDefault)
+        {
+            entry.NormalizedQuery = entry.VariationConfig.NormalizeQuery(request.RequestUri?.Query ?? string.Empty);
+        }
+
         return entry;
+    }
+
+    private static UrlVariationConfig ParseVariationConfig(HttpResponseMessage response)
+    {
+        if (!response.Headers.TryGetValues("No-Vary-Search", out var values))
+            return UrlVariationConfig.Default;
+
+        // RFC 8941 Section 4.2: the field lines of a dictionary field combine into a single value
+        return UrlVariationConfig.Parse(string.Join(", ", values));
     }
 
     private static bool HasImmutableDirective(CacheControlHeaderValue cacheControl)
@@ -181,6 +197,18 @@ internal sealed class CacheEntry
     }
 
     public CacheEntrySecondaryKey SecondaryKey { get; private set; }
+
+    /// <summary>Gets the <c>No-Vary-Search</c> config declared by the stored response.</summary>
+    /// <remarks>
+    /// The config decides the storage key, which cannot be rewritten afterwards, so it is captured when the
+    /// response is stored and is not updated from a later 304 response.
+    /// </remarks>
+    public UrlVariationConfig VariationConfig { get; private set; } = UrlVariationConfig.Default;
+
+    /// <summary>Gets the query of the request the response was stored for, canonicalized with <see cref="VariationConfig"/>.</summary>
+    /// <remarks>Only set for a non-default config: otherwise the query is already part of the primary key.</remarks>
+    public string? NormalizedQuery { get; private set; }
+
     public DateTimeOffset RequestTime { get; private set; }
     public DateTimeOffset ResponseTime { get; private set; }
     public DateTimeOffset ResponseDate { get; private set; }
@@ -211,6 +239,8 @@ internal sealed class CacheEntry
         {
             SecondaryKeyMatchNone = SecondaryKey.IsMatchNone,
             SecondaryKeyHeaders = SecondaryKey.Headers is null ? null : new Dictionary<string, string>(SecondaryKey.Headers, StringComparer.OrdinalIgnoreCase),
+            NoVarySearch = VariationConfig.IsDefault ? null : VariationConfig.ToHeaderValue(),
+            NormalizedQuery = NormalizedQuery,
             RequestTime = RequestTime,
             ResponseTime = ResponseTime,
             ResponseDate = ResponseDate,
@@ -242,6 +272,8 @@ internal sealed class CacheEntry
         var cacheEntry = new CacheEntry(serializedResponse)
         {
             SecondaryKey = CacheEntrySecondaryKey.Create(entry.SecondaryKeyMatchNone, entry.SecondaryKeyHeaders),
+            VariationConfig = UrlVariationConfig.Parse(entry.NoVarySearch),
+            NormalizedQuery = entry.NormalizedQuery,
             RequestTime = entry.RequestTime,
             ResponseTime = entry.ResponseTime,
             ResponseDate = entry.ResponseDate,
@@ -262,6 +294,20 @@ internal sealed class CacheEntry
         };
 
         return cacheEntry;
+    }
+
+    /// <summary>Indicates whether an entry stored under a query-independent key can answer a request for <paramref name="uri"/>.</summary>
+    /// <remarks>
+    /// draft-ietf-httpbis-no-vary-search Section 6: the scheme, host, port, and path are already part of the
+    /// storage key, so only the queries remain to be compared. An entry whose config is the default one does
+    /// not belong to that key, and never matches.
+    /// </remarks>
+    public bool MatchesQuery(Uri uri)
+    {
+        if (VariationConfig.IsDefault)
+            return false;
+
+        return string.Equals(VariationConfig.NormalizeQuery(uri.Query), NormalizedQuery, StringComparison.Ordinal);
     }
 
     /// <summary>Calculates the freshness lifetime per RFC 7234 Section 4.2.1.</summary>

--- a/src/Meziantou.Framework.Http.Caching/HttpCache.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCache.cs
@@ -20,18 +20,39 @@ internal sealed class HttpCache
     // RFC 9111 Section 2: the primary cache key is composed of the request method and the target URI.
     // GET and HEAD must not share a key, otherwise a stored HEAD response (which has no body) could be
     // served for a subsequent GET.
-    private static string ComputePrimaryKey(HttpMethod method, Uri? uri)
+    private static string ComputePrimaryKey(HttpMethod method, Uri uri)
     {
-        return method.Method + " " + (uri?.GetLeftPart(UriPartial.Query) ?? string.Empty);
+        return method.Method + " " + uri.GetLeftPart(UriPartial.Query);
+    }
+
+    // draft-ietf-httpbis-no-vary-search Section 7: a response that declares a URL variation config can be
+    // reused for any equivalent URL, so it cannot be stored under a key that contains the query. Those
+    // responses get their own key, built from the URL without its query. The marker holds a space, which a
+    // URI never does because Uri escapes it, so the key can never collide with that of a query-less URL.
+    private static string ComputeNoVarySearchKey(HttpMethod method, Uri uri)
+    {
+        return method.Method + " " + uri.GetLeftPart(UriPartial.Path) + " no-vary-search";
     }
 
     public async ValueTask<CacheEntry?> TryGetAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        if (request.RequestUri is null)
+        var uri = request.RequestUri;
+        if (uri is null)
             return null;
 
-        var primaryKey = ComputePrimaryKey(request.Method, request.RequestUri);
-        var persistedEntries = await _persistenceProvider.GetEntriesAsync(primaryKey, cancellationToken).ConfigureAwait(false);
+        // An entry stored under the exact target URI always matches, so it is looked up first. Section 7 of
+        // the No-Vary-Search draft allows preferring it over an entry that only matches modulo its config,
+        // and it keeps the cost of a cache hit to a single lookup for responses without the header.
+        var exactMatch = await TryGetAsync(ComputePrimaryKey(request.Method, uri), request, uri, matchQuery: false, cancellationToken).ConfigureAwait(false);
+        if (exactMatch is not null)
+            return exactMatch;
+
+        return await TryGetAsync(ComputeNoVarySearchKey(request.Method, uri), request, uri, matchQuery: true, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask<CacheEntry?> TryGetAsync(string key, HttpRequestMessage request, Uri uri, bool matchQuery, CancellationToken cancellationToken)
+    {
+        var persistedEntries = await _persistenceProvider.GetEntriesAsync(key, cancellationToken).ConfigureAwait(false);
         if (persistedEntries.Count is 0)
             return null;
 
@@ -58,7 +79,14 @@ internal sealed class HttpCache
             if (!entry.SecondaryKey.MatchRequest(request))
                 continue;
 
+            // draft-ietf-httpbis-no-vary-search Section 6: the entries stored under this key were kept for
+            // other queries of the same path, and only answer requests for an equivalent URL.
+            if (matchQuery && !entry.MatchesQuery(uri))
+                continue;
+
             // RFC 7234 Section 4: Use most recent response by Date header
+            // draft-ietf-httpbis-no-vary-search Section 7: preferring the most recent Date also makes caches
+            // converge on the latest config when several of them are stored.
             if (entry.ResponseDate > latestDate)
             {
                 latestDate = entry.ResponseDate;
@@ -88,14 +116,12 @@ internal sealed class HttpCache
         if (maximumResponseSize is not null && response.Content?.Headers.ContentLength > maximumResponseSize.GetValueOrDefault())
             return;
 
-        var primaryKey = ComputePrimaryKey(request.Method, request.RequestUri);
-
         // The size limit applies to the serialized entry, which includes headers and metadata.
         var entry = await CacheEntry.CreateAsync(request, response, requestTime, responseTime, maximumResponseSize, cancellationToken).ConfigureAwait(false);
         if (entry is null)
             return;
 
-        await _persistenceProvider.SetEntryAsync(primaryKey, entry.ToPersistenceEntry(), cancellationToken).ConfigureAwait(false);
+        await _persistenceProvider.SetEntryAsync(ComputeStorageKey(request.Method, request.RequestUri, entry), entry.ToPersistenceEntry(), cancellationToken).ConfigureAwait(false);
     }
 
     public ValueTask PersistEntryAsync(HttpMethod method, Uri? uri, CacheEntry entry, CancellationToken cancellationToken)
@@ -103,8 +129,12 @@ internal sealed class HttpCache
         if (uri is null)
             return ValueTask.CompletedTask;
 
-        var primaryKey = ComputePrimaryKey(method, uri);
-        return _persistenceProvider.SetEntryAsync(primaryKey, entry.ToPersistenceEntry(), cancellationToken);
+        return _persistenceProvider.SetEntryAsync(ComputeStorageKey(method, uri, entry), entry.ToPersistenceEntry(), cancellationToken);
+    }
+
+    private static string ComputeStorageKey(HttpMethod method, Uri uri, CacheEntry entry)
+    {
+        return entry.VariationConfig.IsDefault ? ComputePrimaryKey(method, uri) : ComputeNoVarySearchKey(method, uri);
     }
 
     public async ValueTask InvalidateAsync(Uri? uri, CancellationToken cancellationToken)
@@ -115,6 +145,13 @@ internal sealed class HttpCache
         // The primary key includes the request method, so every cacheable method must be invalidated.
         await _persistenceProvider.RemoveEntriesAsync(ComputePrimaryKey(HttpMethod.Get, uri), cancellationToken).ConfigureAwait(false);
         await _persistenceProvider.RemoveEntriesAsync(ComputePrimaryKey(HttpMethod.Head, uri), cancellationToken).ConfigureAwait(false);
+
+        // draft-ietf-httpbis-no-vary-search Section 7: invalidating the URLs that are only equivalent modulo
+        // a variation config is optional. Dropping the whole key is the conservative choice: the entries it
+        // holds are keyed on the URL without its query, so the query of the invalidated URL says nothing
+        // about which of them are still valid.
+        await _persistenceProvider.RemoveEntriesAsync(ComputeNoVarySearchKey(HttpMethod.Get, uri), cancellationToken).ConfigureAwait(false);
+        await _persistenceProvider.RemoveEntriesAsync(ComputeNoVarySearchKey(HttpMethod.Head, uri), cancellationToken).ConfigureAwait(false);
     }
 
     private static bool IsCacheable(HttpRequestMessage request, HttpResponseMessage response)

--- a/src/Meziantou.Framework.Http.Caching/HttpCachePersistenceEntry.cs
+++ b/src/Meziantou.Framework.Http.Caching/HttpCachePersistenceEntry.cs
@@ -18,6 +18,19 @@ public sealed class HttpCachePersistenceEntry
     /// <summary>Gets or sets the normalized vary-based secondary key headers.</summary>
     public Dictionary<string, string>? SecondaryKeyHeaders { get; set; }
 
+    /// <summary>
+    /// Gets or sets the canonical <c>No-Vary-Search</c> value of the response, or <see langword="null"/> when
+    /// the response does not declare one.
+    /// </summary>
+    public string? NoVarySearch { get; set; }
+
+    /// <summary>Gets or sets the query the response was stored for, canonicalized with <see cref="NoVarySearch"/>.</summary>
+    /// <remarks>
+    /// Only set together with <see cref="NoVarySearch"/>: those entries are stored under a primary key that
+    /// leaves the query out, so the query belongs to their secondary key.
+    /// </remarks>
+    public string? NormalizedQuery { get; set; }
+
     /// <summary>Gets or sets the request time.</summary>
     public DateTimeOffset RequestTime { get; set; }
 
@@ -99,6 +112,8 @@ public sealed class HttpCachePersistenceEntry
         {
             SecondaryKeyMatchNone = SecondaryKeyMatchNone,
             SecondaryKeyHeaders = SecondaryKeyHeaders is null ? null : new Dictionary<string, string>(SecondaryKeyHeaders, StringComparer.OrdinalIgnoreCase),
+            NoVarySearch = NoVarySearch,
+            NormalizedQuery = NormalizedQuery,
             RequestTime = RequestTime,
             ResponseTime = ResponseTime,
             ResponseDate = ResponseDate,
@@ -204,6 +219,16 @@ public sealed class HttpCachePersistenceEntry
             }
         }
 
+        // A response that declares a No-Vary-Search config is stored under a primary key that leaves the
+        // query out, so the query, and the config used to canonicalize it, take part in the secondary key.
+        if (NoVarySearch is not null)
+        {
+            stringBuilder.Append('\u001d');
+            stringBuilder.Append(NoVarySearch);
+            stringBuilder.Append('\u001e');
+            stringBuilder.Append(NormalizedQuery);
+        }
+
         var bytes = Encoding.UTF8.GetBytes(stringBuilder.ToString());
         Span<byte> hash = stackalloc byte[32];
         SHA256.HashData(bytes, hash);
@@ -217,6 +242,12 @@ public sealed class HttpCachePersistenceEntry
         ArgumentNullException.ThrowIfNull(right);
 
         if (left.SecondaryKeyMatchNone != right.SecondaryKeyMatchNone)
+            return false;
+
+        if (!string.Equals(left.NoVarySearch, right.NoVarySearch, StringComparison.Ordinal))
+            return false;
+
+        if (!string.Equals(left.NormalizedQuery, right.NormalizedQuery, StringComparison.Ordinal))
             return false;
 
         var leftHeaders = left.SecondaryKeyHeaders;

--- a/src/Meziantou.Framework.Http.Caching/StructuredFieldItem.cs
+++ b/src/Meziantou.Framework.Http.Caching/StructuredFieldItem.cs
@@ -1,0 +1,21 @@
+namespace Meziantou.Framework.Http.Caching;
+
+/// <summary>A Structured Fields bare item.</summary>
+internal readonly struct StructuredFieldItem
+{
+    private StructuredFieldItem(StructuredFieldItemType type, bool booleanValue, string? stringValue)
+    {
+        Type = type;
+        BooleanValue = booleanValue;
+        StringValue = stringValue;
+    }
+
+    public static StructuredFieldItem True { get; } = new(StructuredFieldItemType.Boolean, booleanValue: true, stringValue: null);
+    public static StructuredFieldItem False { get; } = new(StructuredFieldItemType.Boolean, booleanValue: false, stringValue: null);
+
+    public static StructuredFieldItem FromString(string value) => new(StructuredFieldItemType.String, booleanValue: false, value);
+
+    public StructuredFieldItemType Type { get; }
+    public bool BooleanValue { get; }
+    public string? StringValue { get; }
+}

--- a/src/Meziantou.Framework.Http.Caching/StructuredFieldItemType.cs
+++ b/src/Meziantou.Framework.Http.Caching/StructuredFieldItemType.cs
@@ -1,0 +1,9 @@
+namespace Meziantou.Framework.Http.Caching;
+
+internal enum StructuredFieldItemType
+{
+    /// <summary>An item whose type is not used by <c>No-Vary-Search</c>: integer, decimal, token, or byte sequence.</summary>
+    Other,
+    Boolean,
+    String,
+}

--- a/src/Meziantou.Framework.Http.Caching/StructuredFieldValue.cs
+++ b/src/Meziantou.Framework.Http.Caching/StructuredFieldValue.cs
@@ -1,0 +1,24 @@
+namespace Meziantou.Framework.Http.Caching;
+
+/// <summary>The value of a Structured Fields dictionary member: either a single item or an inner list.</summary>
+internal readonly struct StructuredFieldValue
+{
+    private readonly List<StructuredFieldItem>? _innerList;
+    private readonly StructuredFieldItem _item;
+
+    private StructuredFieldValue(StructuredFieldItem item, List<StructuredFieldItem>? innerList)
+    {
+        _item = item;
+        _innerList = innerList;
+    }
+
+    public static StructuredFieldValue FromItem(StructuredFieldItem item) => new(item, innerList: null);
+
+    public static StructuredFieldValue FromInnerList(List<StructuredFieldItem> items) => new(default, items);
+
+    public bool IsInnerList => _innerList is not null;
+
+    public StructuredFieldItem Item => _item;
+
+    public IReadOnlyList<StructuredFieldItem> InnerList => _innerList ?? [];
+}

--- a/src/Meziantou.Framework.Http.Caching/StructuredFieldsParser.cs
+++ b/src/Meziantou.Framework.Http.Caching/StructuredFieldsParser.cs
@@ -1,0 +1,326 @@
+namespace Meziantou.Framework.Http.Caching;
+
+/// <summary>Parses the Structured Fields dictionary syntax (RFC 8941 Section 4.2.2).</summary>
+/// <remarks>
+/// Only the shapes used by <c>No-Vary-Search</c> are materialized: booleans, strings, and inner lists of
+/// those. Any other item type still has to parse, because an unknown dictionary member must not fail the
+/// whole field, but its value is reported as <see cref="StructuredFieldItemType.Other"/>.
+/// </remarks>
+internal static class StructuredFieldsParser
+{
+    /// <summary>Parses <paramref name="value"/> as a dictionary, or returns <see langword="false"/> when it is malformed.</summary>
+    public static bool TryParseDictionary(string value, [NotNullWhen(true)] out Dictionary<string, StructuredFieldValue>? result)
+    {
+        result = null;
+
+        var input = value.AsSpan();
+        var position = 0;
+        var dictionary = new Dictionary<string, StructuredFieldValue>(StringComparer.Ordinal);
+
+        SkipSpaces(input, ref position);
+        while (position < input.Length)
+        {
+            if (!TryParseKey(input, ref position, out var key))
+                return false;
+
+            StructuredFieldValue memberValue;
+            if (position < input.Length && input[position] is '=')
+            {
+                position++;
+                if (!TryParseItemOrInnerList(input, ref position, out memberValue))
+                    return false;
+            }
+            else
+            {
+                // RFC 8941 Section 4.2.2: a member without a value is the boolean true
+                memberValue = StructuredFieldValue.FromItem(StructuredFieldItem.True);
+                if (!TrySkipParameters(input, ref position))
+                    return false;
+            }
+
+            // RFC 8941 Section 4.2.2: a duplicate key keeps the last value
+            dictionary[key] = memberValue;
+
+            SkipOptionalWhitespace(input, ref position);
+            if (position >= input.Length)
+                break;
+
+            if (input[position] is not ',')
+                return false;
+
+            position++;
+            SkipOptionalWhitespace(input, ref position);
+
+            // RFC 8941 Section 4.2.2: a trailing comma is not allowed
+            if (position >= input.Length)
+                return false;
+        }
+
+        result = dictionary;
+        return true;
+    }
+
+    private static bool TryParseKey(ReadOnlySpan<char> input, ref int position, [NotNullWhen(true)] out string? key)
+    {
+        // RFC 8941 Section 4.2.3.3
+        key = null;
+        if (position >= input.Length)
+            return false;
+
+        if (!IsLowerCaseAlpha(input[position]) && input[position] is not '*')
+            return false;
+
+        var start = position;
+        position++;
+        while (position < input.Length && (IsLowerCaseAlpha(input[position]) || char.IsAsciiDigit(input[position]) || input[position] is '_' or '-' or '.' or '*'))
+        {
+            position++;
+        }
+
+        key = input[start..position].ToString();
+        return true;
+    }
+
+    private static bool TryParseItemOrInnerList(ReadOnlySpan<char> input, ref int position, out StructuredFieldValue value)
+    {
+        // RFC 8941 Section 4.2.1
+        if (position < input.Length && input[position] is '(')
+            return TryParseInnerList(input, ref position, out value);
+
+        value = default;
+        if (!TryParseBareItem(input, ref position, out var item))
+            return false;
+
+        if (!TrySkipParameters(input, ref position))
+            return false;
+
+        value = StructuredFieldValue.FromItem(item);
+        return true;
+    }
+
+    private static bool TryParseInnerList(ReadOnlySpan<char> input, ref int position, out StructuredFieldValue value)
+    {
+        // RFC 8941 Section 4.2.1.2
+        value = default;
+        position++;
+
+        var items = new List<StructuredFieldItem>();
+        while (true)
+        {
+            SkipSpaces(input, ref position);
+            if (position >= input.Length)
+                return false;
+
+            if (input[position] is ')')
+            {
+                position++;
+                if (!TrySkipParameters(input, ref position))
+                    return false;
+
+                value = StructuredFieldValue.FromInnerList(items);
+                return true;
+            }
+
+            if (!TryParseBareItem(input, ref position, out var item))
+                return false;
+
+            if (!TrySkipParameters(input, ref position))
+                return false;
+
+            items.Add(item);
+
+            if (position >= input.Length)
+                return false;
+
+            if (input[position] is not ' ' and not ')')
+                return false;
+        }
+    }
+
+    private static bool TrySkipParameters(ReadOnlySpan<char> input, ref int position)
+    {
+        // RFC 8941 Section 4.2.3.2: parameters are parsed but carry no meaning for No-Vary-Search
+        while (position < input.Length && input[position] is ';')
+        {
+            position++;
+            SkipSpaces(input, ref position);
+
+            if (!TryParseKey(input, ref position, out _))
+                return false;
+
+            if (position < input.Length && input[position] is '=')
+            {
+                position++;
+                if (!TryParseBareItem(input, ref position, out _))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryParseBareItem(ReadOnlySpan<char> input, ref int position, out StructuredFieldItem item)
+    {
+        // RFC 8941 Section 4.2.3.1
+        item = default;
+        if (position >= input.Length)
+            return false;
+
+        var c = input[position];
+        if (c is '-' || char.IsAsciiDigit(c))
+            return TrySkipNumber(input, ref position);
+
+        if (c is '"')
+            return TryParseString(input, ref position, out item);
+
+        if (c is '?')
+            return TryParseBoolean(input, ref position, out item);
+
+        if (c is ':')
+            return TrySkipByteSequence(input, ref position);
+
+        if (c is '*' || char.IsAsciiLetter(c))
+            return TrySkipToken(input, ref position);
+
+        return false;
+    }
+
+    private static bool TryParseBoolean(ReadOnlySpan<char> input, ref int position, out StructuredFieldItem item)
+    {
+        // RFC 8941 Section 4.2.8
+        item = default;
+        if (position + 1 >= input.Length)
+            return false;
+
+        var value = input[position + 1];
+        if (value is not '0' and not '1')
+            return false;
+
+        position += 2;
+        item = value is '1' ? StructuredFieldItem.True : StructuredFieldItem.False;
+        return true;
+    }
+
+    private static bool TryParseString(ReadOnlySpan<char> input, ref int position, out StructuredFieldItem item)
+    {
+        // RFC 8941 Section 4.2.5
+        item = default;
+        position++;
+
+        var builder = new StringBuilder();
+        while (position < input.Length)
+        {
+            var c = input[position++];
+            if (c is '\\')
+            {
+                if (position >= input.Length)
+                    return false;
+
+                var escaped = input[position++];
+                if (escaped is not '\\' and not '"')
+                    return false;
+
+                builder.Append(escaped);
+                continue;
+            }
+
+            if (c is '"')
+            {
+                item = StructuredFieldItem.FromString(builder.ToString());
+                return true;
+            }
+
+            if (c is < ' ' or > '~')
+                return false;
+
+            builder.Append(c);
+        }
+
+        return false;
+    }
+
+    private static bool TrySkipNumber(ReadOnlySpan<char> input, ref int position)
+    {
+        // RFC 8941 Section 4.2.4
+        if (input[position] is '-')
+        {
+            position++;
+        }
+
+        var digits = 0;
+        var hasDecimalPoint = false;
+        while (position < input.Length)
+        {
+            if (char.IsAsciiDigit(input[position]))
+            {
+                digits++;
+                position++;
+                continue;
+            }
+
+            if (input[position] is '.' && !hasDecimalPoint && digits > 0)
+            {
+                hasDecimalPoint = true;
+                position++;
+                continue;
+            }
+
+            break;
+        }
+
+        return digits > 0;
+    }
+
+    private static bool TrySkipByteSequence(ReadOnlySpan<char> input, ref int position)
+    {
+        // RFC 8941 Section 4.2.7
+        position++;
+        while (position < input.Length)
+        {
+            var c = input[position++];
+            if (c is ':')
+                return true;
+
+            if (!char.IsAsciiLetterOrDigit(c) && c is not '+' and not '/' and not '=')
+                return false;
+        }
+
+        return false;
+    }
+
+    private static bool TrySkipToken(ReadOnlySpan<char> input, ref int position)
+    {
+        // RFC 8941 Section 4.2.6
+        position++;
+        while (position < input.Length && IsTokenChar(input[position]))
+        {
+            position++;
+        }
+
+        return true;
+    }
+
+    private static bool IsTokenChar(char c)
+    {
+        // RFC 9110 Section 5.6.2 tchar, plus ":" and "/"
+        return char.IsAsciiLetterOrDigit(c) || c is '!' or '#' or '$' or '%' or '&' or '\'' or '*' or '+' or '-' or '.' or '^' or '_' or '`' or '|' or '~' or ':' or '/';
+    }
+
+    private static bool IsLowerCaseAlpha(char c) => c is >= 'a' and <= 'z';
+
+    private static void SkipSpaces(ReadOnlySpan<char> input, ref int position)
+    {
+        while (position < input.Length && input[position] is ' ')
+        {
+            position++;
+        }
+    }
+
+    private static void SkipOptionalWhitespace(ReadOnlySpan<char> input, ref int position)
+    {
+        while (position < input.Length && input[position] is ' ' or '\t')
+        {
+            position++;
+        }
+    }
+}

--- a/src/Meziantou.Framework.Http.Caching/UrlVariationConfig.cs
+++ b/src/Meziantou.Framework.Http.Caching/UrlVariationConfig.cs
@@ -1,0 +1,290 @@
+namespace Meziantou.Framework.Http.Caching;
+
+/// <summary>
+/// The URL variation config conveyed by the <c>No-Vary-Search</c> response header field, as defined by
+/// <see href="https://httpwg.org/http-extensions/draft-ietf-httpbis-no-vary-search.html">draft-ietf-httpbis-no-vary-search</see>.
+/// </summary>
+/// <remarks>
+/// The config tells which query parameters make two URLs different. A response stored with a non-default
+/// config can answer a request for any URL that is equivalent modulo the config, which is decided by
+/// comparing the queries canonicalized by <see cref="NormalizeQuery"/>.
+/// </remarks>
+internal sealed class UrlVariationConfig
+{
+    /// <summary>The config used when the response does not carry a usable <c>No-Vary-Search</c> header: every parameter, and their order, matters.</summary>
+    public static UrlVariationConfig Default { get; } = new(noVaryParams: [], varyParams: null, varyOnKeyOrder: true);
+
+    // Section 4: exactly one of the two lists is the wildcard, which is represented by null.
+    private readonly string[]? _noVaryParams;
+    private readonly string[]? _varyParams;
+
+    private UrlVariationConfig(string[]? noVaryParams, string[]? varyParams, bool varyOnKeyOrder)
+    {
+        _noVaryParams = noVaryParams;
+        _varyParams = varyParams;
+        VaryOnKeyOrder = varyOnKeyOrder;
+    }
+
+    /// <summary>Gets a value indicating whether the order of the query parameters makes two URLs different.</summary>
+    public bool VaryOnKeyOrder { get; }
+
+    /// <summary>Gets a value indicating whether the config leaves the standard URL comparison untouched.</summary>
+    public bool IsDefault => VaryOnKeyOrder && _varyParams is null && _noVaryParams!.Length is 0;
+
+    /// <summary>Parses a <c>No-Vary-Search</c> header value (Section 5.1).</summary>
+    /// <remarks>
+    /// Parsing is deliberately strict: anything unrecognized falls back to <see cref="Default"/>, which only
+    /// costs cache hits. Two spellings of the allowlist form are accepted, because the header shipped in
+    /// browsers before the syntax was revised: <c>except=("a")</c>, as specified by the draft, and
+    /// <c>params, except=("a")</c>, as documented by MDN. Both describe the same config.
+    /// </remarks>
+    public static UrlVariationConfig Parse(string? headerValue)
+    {
+        if (headerValue is null)
+            return Default;
+
+        if (!StructuredFieldsParser.TryParseDictionary(headerValue, out var dictionary))
+            return Default;
+
+        var varyOnKeyOrder = true;
+        if (dictionary.TryGetValue("key-order", out var keyOrder))
+        {
+            if (keyOrder.IsInnerList || keyOrder.Item.Type is not StructuredFieldItemType.Boolean)
+                return Default;
+
+            varyOnKeyOrder = !keyOrder.Item.BooleanValue;
+        }
+
+        var hasParams = dictionary.TryGetValue("params", out var paramsValue);
+        var hasExcept = dictionary.TryGetValue("except", out var exceptValue);
+
+        // "params" with a boolean value is the browser spelling of the wildcard: every parameter is ignored,
+        // except the ones listed by "except".
+        if (hasParams && !paramsValue.IsInnerList && paramsValue.Item.Type is StructuredFieldItemType.Boolean)
+        {
+            if (!paramsValue.Item.BooleanValue)
+            {
+                // "params=?0" means the same as omitting the entry
+                hasParams = false;
+            }
+            else if (hasExcept)
+            {
+                return TryGetKeys(exceptValue, out var exceptKeys)
+                    ? new UrlVariationConfig(noVaryParams: null, exceptKeys, varyOnKeyOrder)
+                    : Default;
+            }
+            else
+            {
+                return new UrlVariationConfig(noVaryParams: null, varyParams: [], varyOnKeyOrder);
+            }
+        }
+
+        // Section 5.1: the two entries cannot be combined
+        if (hasParams && hasExcept)
+            return Default;
+
+        if (hasParams)
+        {
+            return TryGetKeys(paramsValue, out var paramsKeys)
+                ? new UrlVariationConfig(paramsKeys, varyParams: null, varyOnKeyOrder)
+                : Default;
+        }
+
+        if (hasExcept)
+        {
+            return TryGetKeys(exceptValue, out var exceptKeys)
+                ? new UrlVariationConfig(noVaryParams: null, exceptKeys, varyOnKeyOrder)
+                : Default;
+        }
+
+        return varyOnKeyOrder ? Default : new UrlVariationConfig(noVaryParams: [], varyParams: null, varyOnKeyOrder);
+    }
+
+    /// <summary>Writes the config back to a canonical <c>No-Vary-Search</c> header value.</summary>
+    /// <remarks>
+    /// The parameter names are sorted and deduplicated so that two configs with the same meaning produce the
+    /// same text. Cache entries are keyed on this value, so equivalent configs share a single entry.
+    /// </remarks>
+    public string ToHeaderValue()
+    {
+        var builder = new StringBuilder();
+        if (!VaryOnKeyOrder)
+        {
+            builder.Append("key-order");
+        }
+
+        if (_varyParams is not null)
+        {
+            AppendKeys(builder, "except", _varyParams);
+        }
+        else if (_noVaryParams!.Length > 0)
+        {
+            AppendKeys(builder, "params", _noVaryParams);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>Canonicalizes a query so that two URLs equivalent modulo this config produce the same text (Section 6).</summary>
+    /// <param name="query">The query of the URL, including its leading <c>?</c>, as returned by <see cref="Uri.Query"/>.</param>
+    public string NormalizeQuery(string query)
+    {
+        // Section 6: with the default config the queries are compared character by character, which makes
+        // "/a" and "/a?" different URLs.
+        if (IsDefault)
+            return query;
+
+        var parameters = ParseQuery(query);
+        if (_noVaryParams is not null)
+        {
+            parameters.RemoveAll(parameter => Array.IndexOf(_noVaryParams, parameter.Key) >= 0);
+        }
+        else
+        {
+            parameters.RemoveAll(parameter => Array.IndexOf(_varyParams!, parameter.Key) < 0);
+        }
+
+        // Section 6: sorting is by key in code unit order, and must be stable so that repeated keys keep
+        // their relative order.
+        IEnumerable<KeyValuePair<string, string>> ordered = VaryOnKeyOrder ? parameters : parameters.OrderBy(parameter => parameter.Key, StringComparer.Ordinal);
+
+        var builder = new StringBuilder();
+        foreach (var (key, value) in ordered)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append('&');
+            }
+
+            builder.Append(Uri.EscapeDataString(key)).Append('=').Append(Uri.EscapeDataString(value));
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendKeys(StringBuilder builder, string name, string[] keys)
+    {
+        if (builder.Length > 0)
+        {
+            builder.Append(", ");
+        }
+
+        builder.Append(name).Append("=(");
+
+        var first = true;
+        foreach (var key in keys.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal))
+        {
+            if (!first)
+            {
+                builder.Append(' ');
+            }
+
+            first = false;
+
+            // Percent-encoding keeps the value inside the printable ASCII range allowed for a structured
+            // field string, and is undone by ParseKey when the value is read back.
+            builder.Append('"').Append(Uri.EscapeDataString(key)).Append('"');
+        }
+
+        builder.Append(')');
+    }
+
+    private static bool TryGetKeys(StructuredFieldValue value, out string[] keys)
+    {
+        keys = [];
+        if (!value.IsInnerList)
+            return false;
+
+        var items = value.InnerList;
+        if (items.Count is 0)
+            return true;
+
+        var result = new string[items.Count];
+        for (var i = 0; i < items.Count; i++)
+        {
+            // Section 5.1: tokens and other item types are not valid parameter names
+            if (items[i].Type is not StructuredFieldItemType.String)
+                return false;
+
+            result[i] = Decode(items[i].StringValue);
+        }
+
+        keys = result;
+        return true;
+    }
+
+    private static List<KeyValuePair<string, string>> ParseQuery(string query)
+    {
+        // The application/x-www-form-urlencoded parser defined by the URL Standard
+        var input = query.AsSpan();
+        if (input.Length > 0 && input[0] is '?')
+        {
+            input = input[1..];
+        }
+
+        var parameters = new List<KeyValuePair<string, string>>();
+        foreach (var range in input.Split('&'))
+        {
+            var sequence = input[range];
+            if (sequence.IsEmpty)
+                continue;
+
+            var separator = sequence.IndexOf('=');
+            var name = separator < 0 ? sequence : sequence[..separator];
+            var value = separator < 0 ? ReadOnlySpan<char>.Empty : sequence[(separator + 1)..];
+
+            parameters.Add(new KeyValuePair<string, string>(Decode(name), Decode(value)));
+        }
+
+        return parameters;
+    }
+
+    private static string Decode(ReadOnlySpan<char> value)
+    {
+        // Section 5.3, and the percent-decoding done by the application/x-www-form-urlencoded parser: "+" is
+        // a space, percent-escapes are decoded, and the bytes are read as UTF-8. Uri.UnescapeDataString
+        // cannot be used, because it leaves invalid UTF-8 sequences untouched instead of replacing them with
+        // U+FFFD, which would make "?a=%f6" and "?a=%ef%bf%bd" different.
+        if (value.IsEmpty)
+            return string.Empty;
+
+        var bytes = new byte[Encoding.UTF8.GetMaxByteCount(value.Length)];
+        var count = 0;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (c is '+')
+            {
+                bytes[count++] = (byte)' ';
+            }
+            else if (c is '%' && i + 2 < value.Length && TryParseHexDigit(value[i + 1], out var high) && TryParseHexDigit(value[i + 2], out var low))
+            {
+                bytes[count++] = (byte)((high << 4) | low);
+                i += 2;
+            }
+            else if (c <= 0xFF)
+            {
+                bytes[count++] = (byte)c;
+            }
+            else
+            {
+                count += Encoding.UTF8.GetBytes(value.Slice(i, 1), bytes.AsSpan(count));
+            }
+        }
+
+        return Encoding.UTF8.GetString(bytes, 0, count);
+    }
+
+    private static bool TryParseHexDigit(char c, out int value)
+    {
+        value = c switch
+        {
+            >= '0' and <= '9' => c - '0',
+            >= 'a' and <= 'f' => c - 'a' + 10,
+            >= 'A' and <= 'F' => c - 'A' + 10,
+            _ => -1,
+        };
+
+        return value >= 0;
+    }
+}

--- a/src/Meziantou.Framework.Http.Caching/readme.md
+++ b/src/Meziantou.Framework.Http.Caching/readme.md
@@ -1,6 +1,6 @@
 # Meziantou.Framework.Http.Caching
 
-An HTTP caching implementation for `HttpClient` that follows [RFC 7234 (HTTP Caching)](https://www.rfc-editor.org/rfc/rfc7234.html), since obsoleted by [RFC 9111](https://www.rfc-editor.org/rfc/rfc9111.html), together with [RFC 8246 (Immutable directive)](https://www.rfc-editor.org/rfc/rfc8246.html) and [RFC 5861 (stale-if-error)](https://www.rfc-editor.org/rfc/rfc5861.html).
+An HTTP caching implementation for `HttpClient` that follows [RFC 7234 (HTTP Caching)](https://www.rfc-editor.org/rfc/rfc7234.html), since obsoleted by [RFC 9111](https://www.rfc-editor.org/rfc/rfc9111.html), together with [RFC 8246 (Immutable directive)](https://www.rfc-editor.org/rfc/rfc8246.html), [RFC 5861 (stale-if-error)](https://www.rfc-editor.org/rfc/rfc5861.html), and [No-Vary-Search](https://httpwg.org/http-extensions/draft-ietf-httpbis-no-vary-search.html).
 
 This is a **private** cache: it is attached to a single `HttpClient` and its entries are not shared between users.
 
@@ -15,6 +15,7 @@ This is a **private** cache: it is attached to a single `HttpClient` and its ent
 - ✅ **Cache-Control Directives**: Supports `max-age`, `no-cache`, `no-store`, `must-revalidate`, `max-stale`, `min-fresh`, `only-if-cached`
 - ✅ **Conditional Requests**: Automatic validation using `ETag` and `Last-Modified` headers
 - ✅ **Vary Support**: Caches multiple variants based on request headers (e.g., `Accept-Language`, `Accept-Encoding`)
+- ✅ **No-Vary-Search**: Reuses a cached response for URLs that only differ by query parameters the server declares irrelevant
 - ✅ **Cache Invalidation**: Automatically invalidates cache entries on unsafe methods (POST, PUT, DELETE, PATCH)
 - ✅ **Pragma Support**: Handles `Pragma: no-cache` for HTTP/1.0 backward compatibility
 - ✅ **Thread-Safe**: Designed for concurrent access across multiple threads
@@ -191,6 +192,36 @@ request2.Headers.Add("Accept-Language", "fr-FR");
 var response2 = await httpClient.SendAsync(request2); // Fetches new response and caches separately
 ```
 
+### No-Vary-Search Support
+
+By default, two URLs that differ by a single query parameter are two different cache entries. A server can use the [`No-Vary-Search`](https://httpwg.org/http-extensions/draft-ietf-httpbis-no-vary-search.html) response header to declare which query parameters do *not* change the response, so a single entry can answer all of them:
+
+```csharp
+// Server responds with:
+// Cache-Control: max-age=3600
+// No-Vary-Search: params=("utm_source")
+
+var response1 = await httpClient.GetAsync("https://api.example.com/data?utm_source=newsletter");
+var response2 = await httpClient.GetAsync("https://api.example.com/data?utm_source=twitter"); // Served from cache
+var response3 = await httpClient.GetAsync("https://api.example.com/data"); // Served from cache
+```
+
+The header is a structured field dictionary with three entries:
+
+| Value | Meaning |
+|-------|---------|
+| `key-order` | Only the order of the query parameters is irrelevant |
+| `params=("a" "b")` | The listed parameters are irrelevant; every other one still separates entries |
+| `except=("a" "b")` | Only the listed parameters are relevant; every other one is ignored |
+| `params, except=("a" "b")` | The spelling of `except` [documented by MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/No-Vary-Search), and implemented by browsers. It has the same meaning as `except` alone |
+| `except=()` | Every query parameter is irrelevant |
+
+The entries can be combined: `No-Vary-Search: key-order, params=("utm_source")`.
+
+Queries are compared after being parsed as `application/x-www-form-urlencoded`, so `?a=x`, `?%61=%78`, and `?a=x&&&` are the same query. A malformed or unrecognized header value is ignored, and the URLs are compared exactly, as if the header was absent.
+
+`No-Vary-Search` works alongside `Vary`: a request must match both the variation config and the `Vary` headers to reuse an entry. An unsafe method (`POST`, `PUT`, …) invalidates every entry stored for the target path, including the ones that only match modulo their variation config.
+
 ### Immutable Directive (RFC 8246)
 
 The `immutable` directive indicates that the response body will not change over time. When a response has `Cache-Control: immutable` and is still fresh, the cache will NOT perform conditional revalidation even if the client sends `Cache-Control: no-cache`:
@@ -241,6 +272,7 @@ This is particularly useful for versioned resources (e.g., `/assets/script.v123.
 | `Last-Modified` | `<date>` | Last modification date for conditional requests |
 | | `stale-if-error=<seconds>` | Serve the stale response when revalidation fails or the origin cannot be reached (RFC 5861) |
 | `Vary` | `<headers>` | Headers that affect response variant |
+| `No-Vary-Search` | `key-order`, `params`, `except` | Query parameters that do not affect the response |
 | `Age` | `<seconds>` | Age of cached response (added when serving from cache) |
 
 ## Thread Safety

--- a/tests/Meziantou.Framework.Http.Caching.Tests/NoVarySearchTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/NoVarySearchTests.cs
@@ -1,0 +1,531 @@
+using System.Net;
+
+namespace Meziantou.Framework.Http.Caching.Tests;
+
+/// <summary>Tests for the No-Vary-Search response header (draft-ietf-httpbis-no-vary-search).</summary>
+public sealed class NoVarySearchTests
+{
+    [Fact]
+    public async Task WhenParameterIsIgnoredThenUsesCache()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "content",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "params=(\"utm_source\")"));
+
+        await context.SnapshotResponse("http://example.com/resource?utm_source=a", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: params=("utm_source")
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+
+        await context.SnapshotResponse("http://example.com/resource?utm_source=b", """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=3600
+              No-Vary-Search: params=("utm_source")
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+    }
+
+    [Fact]
+    public async Task WhenParameterIsIgnoredAndMissingThenUsesCache()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "content",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "params=(\"id\")"));
+
+        await context.SnapshotResponse("http://example.com/users?id=345", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: params=("id")
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+
+        await context.SnapshotResponse("http://example.com/users", """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=3600
+              No-Vary-Search: params=("id")
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+    }
+
+    [Fact]
+    public async Task WhenAnotherParameterDiffersThenFetchesNewResponse()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "first",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "params=(\"id\")"));
+        context.AddResponse(HttpStatusCode.OK, "second",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "params=(\"id\")"));
+
+        await context.SnapshotResponse("http://example.com/users?id=1&sort=name", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: params=("id")
+            Content:
+              Headers:
+                Content-Length: 5
+                Content-Type: text/plain; charset=utf-8
+              Value: first
+            """);
+
+        await context.SnapshotResponse("http://example.com/users?id=2&sort=date", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: params=("id")
+            Content:
+              Headers:
+                Content-Length: 6
+                Content-Type: text/plain; charset=utf-8
+              Value: second
+            """);
+    }
+
+    [Fact]
+    public async Task WhenKeyOrderIsIgnoredThenUsesCache()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "content",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "key-order"));
+
+        await context.SnapshotResponse("http://example.com/search?a=1&b=2&c=3", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: key-order
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+
+        await context.SnapshotResponse("http://example.com/search?b=2&a=1&c=3", """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=3600
+              No-Vary-Search: key-order
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+    }
+
+    [Fact]
+    public async Task WhenKeyOrderIsIgnoredAndParameterIsAddedThenFetchesNewResponse()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "first",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "key-order"));
+        context.AddResponse(HttpStatusCode.OK, "second",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "key-order"));
+
+        await context.SnapshotResponse("http://example.com/search?a=1&b=2", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: key-order
+            Content:
+              Headers:
+                Content-Length: 5
+                Content-Type: text/plain; charset=utf-8
+              Value: first
+            """);
+
+        await context.SnapshotResponse("http://example.com/search?b=2&a=1&c=3", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: key-order
+            Content:
+              Headers:
+                Content-Length: 6
+                Content-Type: text/plain; charset=utf-8
+              Value: second
+            """);
+    }
+
+    [Fact]
+    public async Task WhenExceptListsTheParameterThenFetchesNewResponse()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "first",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "params, except=(\"id\")"));
+        context.AddResponse(HttpStatusCode.OK, "second",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "params, except=(\"id\")"));
+
+        await context.SnapshotResponse("http://example.com/users?id=1&order=asc", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: params, except=("id")
+            Content:
+              Headers:
+                Content-Length: 5
+                Content-Type: text/plain; charset=utf-8
+              Value: first
+            """);
+
+        // The order parameter is ignored, so this hits the entry stored for id=1
+        await context.SnapshotResponse("http://example.com/users?id=1&order=desc", """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=3600
+              No-Vary-Search: params, except=("id")
+            Content:
+              Headers:
+                Content-Length: 5
+                Content-Type: text/plain; charset=utf-8
+              Value: first
+            """);
+
+        await context.SnapshotResponse("http://example.com/users?id=2&order=asc", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: params, except=("id")
+            Content:
+              Headers:
+                Content-Length: 6
+                Content-Type: text/plain; charset=utf-8
+              Value: second
+            """);
+    }
+
+    [Fact]
+    public async Task WhenExceptIsUsedWithoutParamsThenAllOtherParametersAreIgnored()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "content",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "except=(\"id\")"));
+
+        await context.SnapshotResponse("http://example.com/users?id=1&order=asc&lang=fr", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: except=("id")
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+
+        await context.SnapshotResponse("http://example.com/users?lang=en&id=1", """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=3600
+              No-Vary-Search: except=("id")
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+    }
+
+    [Fact]
+    public async Task WhenQueryIsCanonicallyEquivalentThenUsesCache()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "content",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "key-order"));
+
+        await context.SnapshotResponse("http://example.com/resource?a=x", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: key-order
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+
+        // The application/x-www-form-urlencoded parser decodes the escapes and drops the empty sequences
+        await context.SnapshotResponse("http://example.com/resource?%61=%78&&&", """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=3600
+              No-Vary-Search: key-order
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+    }
+
+    [Fact]
+    public async Task WhenHeaderIsInvalidThenQueryIsComparedExactly()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "first",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "params=(not-a-string)"));
+        context.AddResponse(HttpStatusCode.OK, "second",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "params=(not-a-string)"));
+
+        await context.SnapshotResponse("http://example.com/resource?a=1", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: params=(not-a-string)
+            Content:
+              Headers:
+                Content-Length: 5
+                Content-Type: text/plain; charset=utf-8
+              Value: first
+            """);
+
+        await context.SnapshotResponse("http://example.com/resource?a=2", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: params=(not-a-string)
+            Content:
+              Headers:
+                Content-Length: 6
+                Content-Type: text/plain; charset=utf-8
+              Value: second
+            """);
+    }
+
+    [Fact]
+    public async Task WhenVaryHeaderDoesNotMatchThenFetchesNewResponse()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "en-content",
+            ("Cache-Control", "max-age=3600"),
+            ("Vary", "Accept-Language"),
+            ("No-Vary-Search", "params=(\"id\")"));
+        context.AddResponse(HttpStatusCode.OK, "fr-content",
+            ("Cache-Control", "max-age=3600"),
+            ("Vary", "Accept-Language"),
+            ("No-Vary-Search", "params=(\"id\")"));
+
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, "http://example.com/users?id=1");
+        request1.Headers.Add("Accept-Language", "en-US");
+        await context.SnapshotResponse(request1, """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: params=("id")
+              Vary: Accept-Language
+            Content:
+              Headers:
+                Content-Length: 10
+                Content-Type: text/plain; charset=utf-8
+              Value: en-content
+            """);
+
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, "http://example.com/users?id=2");
+        request2.Headers.Add("Accept-Language", "fr-FR");
+        await context.SnapshotResponse(request2, """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: params=("id")
+              Vary: Accept-Language
+            Content:
+              Headers:
+                Content-Length: 10
+                Content-Type: text/plain; charset=utf-8
+              Value: fr-content
+            """);
+
+        using var request3 = new HttpRequestMessage(HttpMethod.Get, "http://example.com/users?id=3");
+        request3.Headers.Add("Accept-Language", "en-US");
+        await context.SnapshotResponse(request3, """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=3600
+              No-Vary-Search: params=("id")
+              Vary: Accept-Language
+            Content:
+              Headers:
+                Content-Length: 10
+                Content-Type: text/plain; charset=utf-8
+              Value: en-content
+            """);
+    }
+
+    [Fact]
+    public async Task WhenUnsafeMethodSucceedsThenEntriesAreInvalidated()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "cached",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "params=(\"id\")"));
+        context.AddResponse(HttpStatusCode.OK, "posted");
+        context.AddResponse(HttpStatusCode.OK, "refreshed",
+            ("Cache-Control", "max-age=3600"),
+            ("No-Vary-Search", "params=(\"id\")"));
+
+        await context.SnapshotResponse("http://example.com/users?id=1", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: params=("id")
+            Content:
+              Headers:
+                Content-Length: 6
+                Content-Type: text/plain; charset=utf-8
+              Value: cached
+            """);
+
+        await context.SnapshotResponse(HttpMethod.Post, "http://example.com/users?id=1", """
+            StatusCode: 200 (OK)
+            Content:
+              Headers:
+                Content-Length: 6
+                Content-Type: text/plain; charset=utf-8
+              Value: posted
+            """);
+
+        await context.SnapshotResponse("http://example.com/users?id=2", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+              No-Vary-Search: params=("id")
+            Content:
+              Headers:
+                Content-Length: 9
+                Content-Type: text/plain; charset=utf-8
+              Value: refreshed
+            """);
+    }
+
+    [Fact]
+    public async Task WhenStaleThenRevalidatesTheEntryOfAnEquivalentUrl()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "content",
+            ("Cache-Control", "max-age=1"),
+            ("ETag", "\"v1\""),
+            ("No-Vary-Search", "params=(\"utm_source\")"));
+        context.AddNotModifiedResponse(
+            [("If-None-Match", "\"v1\"")],
+            ("Cache-Control", "max-age=3600"),
+            ("ETag", "\"v1\""),
+            ("No-Vary-Search", "params=(\"utm_source\")"));
+
+        await context.SnapshotResponse("http://example.com/resource?utm_source=a", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=1
+              ETag: "v1"
+              No-Vary-Search: params=("utm_source")
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+
+        context.TimeProvider.Advance(TimeSpan.FromSeconds(30));
+
+        await context.SnapshotResponse("http://example.com/resource?utm_source=b", """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=3600
+              ETag: "v1"
+              No-Vary-Search: params=("utm_source")
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+
+        // The revalidated entry is still reachable from any equivalent URL
+        await context.SnapshotResponse("http://example.com/resource?utm_source=c", """
+            StatusCode: 200 (OK)
+            Headers:
+              Age: 0
+              Cache-Control: max-age=3600
+              ETag: "v1"
+              No-Vary-Search: params=("utm_source")
+            Content:
+              Headers:
+                Content-Length: 7
+                Content-Type: text/plain; charset=utf-8
+              Value: content
+            """);
+    }
+
+    [Fact]
+    public async Task WhenHeaderIsAbsentThenQueryIsComparedExactly()
+    {
+        await using var context = new HttpTestContext();
+        context.AddResponse(HttpStatusCode.OK, "first", ("Cache-Control", "max-age=3600"));
+        context.AddResponse(HttpStatusCode.OK, "second", ("Cache-Control", "max-age=3600"));
+
+        await context.SnapshotResponse("http://example.com/resource?a=1", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+            Content:
+              Headers:
+                Content-Length: 5
+                Content-Type: text/plain; charset=utf-8
+              Value: first
+            """);
+
+        await context.SnapshotResponse("http://example.com/resource?a=2", """
+            StatusCode: 200 (OK)
+            Headers:
+              Cache-Control: max-age=3600
+            Content:
+              Headers:
+                Content-Length: 6
+                Content-Type: text/plain; charset=utf-8
+              Value: second
+            """);
+    }
+}

--- a/tests/Meziantou.Framework.Http.Caching.Tests/PersistenceProvidersTests.cs
+++ b/tests/Meziantou.Framework.Http.Caching.Tests/PersistenceProvidersTests.cs
@@ -208,6 +208,43 @@ public class PersistenceProvidersTests
     }
 
     [Fact]
+    public async Task SqliteProviderPersistsNoVarySearchSecondaryKey()
+    {
+        var connectionString = CreateInMemorySqliteConnectionString();
+        using var keepAliveConnection = CreateSqliteAnchorConnection(connectionString);
+        using var provider = new SqliteHttpCacheStore(connectionString);
+
+        var primaryKey = "GET http://example.com/users no-vary-search";
+        var now = new DateTimeOffset(2026, 03, 12, 12, 00, 00, TimeSpan.Zero);
+
+        var first = CreatePersistenceEntry(now, maxAge: TimeSpan.FromMinutes(5), mustRevalidate: false);
+        first.NoVarySearch = "params=(\"utm_source\")";
+        first.NormalizedQuery = "id=1";
+        await provider.SetEntryAsync(primaryKey, first, CancellationToken.None);
+
+        var second = CreatePersistenceEntry(now, maxAge: TimeSpan.FromMinutes(5), mustRevalidate: false);
+        second.NoVarySearch = "params=(\"utm_source\")";
+        second.NormalizedQuery = "id=2";
+        await provider.SetEntryAsync(primaryKey, second, CancellationToken.None);
+
+        var entries = await provider.GetEntriesAsync(primaryKey, CancellationToken.None);
+
+        // The queries take part in the secondary key, so both entries are kept
+        Assert.Equal(2, entries.Count);
+        Assert.All(entries, entry => Assert.Equal("params=(\"utm_source\")", entry.NoVarySearch));
+        Assert.Equal(["id=1", "id=2"], entries.Select(entry => entry.NormalizedQuery).Order(StringComparer.Ordinal));
+
+        // Storing an entry with the same secondary key replaces it
+        var replacement = CreatePersistenceEntry(now, maxAge: TimeSpan.FromMinutes(5), mustRevalidate: false);
+        replacement.NoVarySearch = "params=(\"utm_source\")";
+        replacement.NormalizedQuery = "id=1";
+        await provider.SetEntryAsync(primaryKey, replacement, CancellationToken.None);
+
+        entries = await provider.GetEntriesAsync(primaryKey, CancellationToken.None);
+        Assert.Equal(2, entries.Count);
+    }
+
+    [Fact]
     public async Task SqliteProviderSupportsConcurrentOperations()
     {
         var connectionString = CreateInMemorySqliteConnectionString();


### PR DESCRIPTION
Adds support for the [`No-Vary-Search`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/No-Vary-Search) response header to `Meziantou.Framework.Http.Caching`. A response can now declare which query parameters do not change it, so a single cache entry answers every equivalent URL:

```
Cache-Control: max-age=3600
No-Vary-Search: params=("utm_source")
```

`/data?utm_source=newsletter`, `/data?utm_source=twitter`, and `/data` all hit the same entry.

## Which syntax

The implementation follows the IETF draft ([draft-ietf-httpbis-no-vary-search](https://httpwg.org/http-extensions/draft-ietf-httpbis-no-vary-search.html)) rather than the MDN page, because MDN documents Chrome's pre-standard syntax — notably `params` as a boolean, which the draft dropped in favour of `except=()`.

Both spellings are accepted, since they describe the same config:

| Value | Meaning |
|-------|---------|
| `key-order` | Only the order of the parameters is irrelevant |
| `params=("a" "b")` | The listed parameters are irrelevant |
| `except=("a" "b")` | Only the listed parameters are relevant |
| `params, except=("a" "b")` | The MDN/browser spelling of `except`; same meaning as `except` alone |
| `except=()` | Every parameter is irrelevant |

A malformed or unrecognized value falls back to comparing the URLs exactly, as if the header was absent.

## How it is stored

- Responses carrying a usable variation config are stored under a key built from the URL **without** its query. Everything else keeps today's exact-URI key.
- The canonicalized query, and the canonical form of the config, join the secondary key, so entries for different parameter values coexist under that key while equivalent URLs collapse onto a single entry.
- Lookup tries the exact target URI first and only falls back to the query-independent key on a miss, so a cache hit for a response without the header still costs a single store lookup. Section 7 of the draft explicitly allows preferring an exact match.

## Notable decisions

- **Invalidation is coarse.** An unsafe method drops the whole query-independent key for that path rather than only the equivalent URLs. Section 7 makes equivalent-URL invalidation optional, and over-invalidating only costs cache hits.
- **A 304 does not rewrite an entry's config.** The config picks the storage key, which cannot be rewritten in place, so it is captured when the response is stored.
- **Custom percent-decoding.** `Uri.UnescapeDataString` leaves invalid UTF-8 intact instead of substituting U+FFFD, which the spec requires for `?a=%f6` ≡ `?a=%ef%bf%bd`.
- **A minimal RFC 8941 parser** was needed: unknown dictionary members must still parse so they can be ignored, so it handles every bare-item type even though only booleans and strings are materialized.

## Reviewer notes

- `HttpCachePersistenceEntry` gains two public properties (`NoVarySearch`, `NormalizedQuery`); `ref/` is regenerated accordingly.
- That means two new SQLite columns, added to the existing `MigratedColumns` list so databases created by an earlier version are upgraded in place. The Redis and in-memory stores serialize the whole entry, so they need no change.
- `<Version>` is intentionally untouched — version bumps are handled by the bot in separate PRs.

## Verification

- 13 new end-to-end tests in `NoVarySearchTests.cs`, plus a SQLite round-trip test covering the new columns and secondary-key separation.
- Full caching suite: **384 passed, 0 failed, 6 skipped** (the Linux-only Redis container tests) across net10.0 and net11.0 with `/p:TreatsWarningsAsErrors=true`.
- The spec's own conformance tables (§5.2.1 Tables 1–3 and §6.1 Table 4) were run through a scratch harness during development; all cases match.
- `dotnet run ./eng/update-all.cs` run; trim/AOT publish of `tests/Trimmable` is clean.