### PR TITLE
Parse POSIX expressions that fell back to ShellRawExpressionSyntax

### DIFF
--- a/ref/Meziantou.Framework.Language.Shell.cs
+++ b/ref/Meziantou.Framework.Language.Shell.cs
@@ -976,7 +976,8 @@ namespace Meziantou.Framework.Language.Shell
         NullCoalescing = 4096,
         CleanBlock = 8192,
         DelayedExpansion = 16384,
-        ArithmeticExpansion = 32768
+        ArithmeticExpansion = 32768,
+        ArithmeticExponentiation = 65536
     }
 
     public sealed class ShellEmbeddedExpressionSyntax : Meziantou.Framework.Language.Shell.ShellWordPartSyntax

--- a/src/Meziantou.Framework.Language.Shell/Internals/PosixParser.Expressions.cs
+++ b/src/Meziantou.Framework.Language.Shell/Internals/PosixParser.Expressions.cs
@@ -21,6 +21,7 @@ internal sealed partial class PosixParser
         ("==", 8, false), ("!=", 8, false),
         ("<<", 10, false), (">>", 10, false),
         ("<=", 9, false), (">=", 9, false),
+        ("**", 13, true),
         ("=", 1, true),
         ("|", 5, false), ("^", 6, false), ("&", 7, false),
         ("<", 9, false), (">", 9, false),
@@ -83,7 +84,7 @@ internal sealed partial class PosixParser
         var enclosingFailed = _expressionFailed;
         _expressionFailed = false;
         var expression = parse();
-        AccumulateInlineTrivia();
+        AccumulateStatementTrivia();
 
         var succeeded = !_expressionFailed && _lexer.Position == end && _diagnostics.Count == startDiagnostics;
         _expressionFailed = enclosingFailed;
@@ -191,13 +192,13 @@ internal sealed partial class PosixParser
 
         while (true)
         {
-            AccumulateInlineTrivia();
+            AccumulateStatementTrivia();
 
             if (_lexer.Current == '?' && TernaryPrecedence >= minimumPrecedence)
             {
                 var questionToken = ReadOperatorToken(ShellSyntaxKind.QuestionToken, length: 1);
                 var whenTrue = ParseArithmetic(0);
-                AccumulateInlineTrivia();
+                AccumulateStatementTrivia();
                 if (_lexer.Current != ':')
                 {
                     _expressionFailed = true;
@@ -229,6 +230,10 @@ internal sealed partial class PosixParser
             if (!MatchesAt(_lexer.Position, candidate.Text))
                 continue;
 
+            // Exponentiation is a bash and zsh extension; in sh the text is not arithmetic this grammar fits.
+            if (candidate.Text == "**" && !_options.Dialect.HasFeature(ShellDialectFeatures.ArithmeticExponentiation))
+                return null;
+
             // `=` is assignment, but `==` is equality; the table is ordered so the longer one is seen first.
             return candidate;
         }
@@ -238,7 +243,7 @@ internal sealed partial class PosixParser
 
     private ShellExpressionSyntax ParseArithmeticUnaryCore()
     {
-        AccumulateInlineTrivia();
+        AccumulateStatementTrivia();
 
         foreach (var prefix in new[] { "++", "--" })
         {
@@ -264,7 +269,7 @@ internal sealed partial class PosixParser
     {
         var operand = ParseArithmeticPrimary();
 
-        AccumulateInlineTrivia();
+        AccumulateStatementTrivia();
         foreach (var postfix in new[] { "++", "--" })
         {
             if (MatchesAt(_lexer.Position, postfix))
@@ -280,13 +285,13 @@ internal sealed partial class PosixParser
 
     private ShellExpressionSyntax ParseArithmeticPrimary()
     {
-        AccumulateInlineTrivia();
+        AccumulateStatementTrivia();
 
         if (_lexer.Current == '(')
         {
             var openParenToken = ReadOperatorToken(ShellSyntaxKind.OpenParenToken, length: 1);
             var inner = ParseArithmetic(0);
-            AccumulateInlineTrivia();
+            AccumulateStatementTrivia();
             if (_lexer.Current != ')')
             {
                 _expressionFailed = true;
@@ -371,7 +376,7 @@ internal sealed partial class PosixParser
 
         while (true)
         {
-            AccumulateInlineTrivia();
+            AccumulateStatementTrivia();
             if (!MatchesAt(_lexer.Position, "||"))
                 break;
 
@@ -388,7 +393,7 @@ internal sealed partial class PosixParser
 
         while (true)
         {
-            AccumulateInlineTrivia();
+            AccumulateStatementTrivia();
             if (!MatchesAt(_lexer.Position, "&&"))
                 break;
 
@@ -401,7 +406,7 @@ internal sealed partial class PosixParser
 
     private ShellExpressionSyntax ParseConditionalUnaryCore()
     {
-        AccumulateInlineTrivia();
+        AccumulateStatementTrivia();
 
         if (_lexer.Current == '!')
         {
@@ -414,7 +419,7 @@ internal sealed partial class PosixParser
         {
             var openParenToken = ReadOperatorToken(ShellSyntaxKind.OpenParenToken, length: 1);
             var inner = ParseConditionalOr();
-            AccumulateInlineTrivia();
+            AccumulateStatementTrivia();
             if (_lexer.Current != ')')
             {
                 _expressionFailed = true;
@@ -447,8 +452,9 @@ internal sealed partial class PosixParser
                 continue;
 
             var operatorToken = ReadOperatorToken(ShellSyntaxKind.OperatorToken, candidate.Length);
+            var right = candidate is "=~" ? ParseConditionalRegexOperand() : ParseConditionalOperand();
 
-            return new ShellBinaryExpressionSyntax(left, operatorToken, ParseConditionalOperand());
+            return new ShellBinaryExpressionSyntax(left, operatorToken, right);
         }
 
         return left;
@@ -468,6 +474,36 @@ internal sealed partial class PosixParser
         }
 
         return new ShellOperandExpressionSyntax(word);
+    }
+
+    /// <summary>
+    /// Reads the pattern on the right of <c>=~</c>. It is an extended regular expression, so <c>(</c>, <c>|</c>, and
+    /// the <c>)</c> that closes an open group are part of it rather than word boundaries. A <c>)</c> that closes
+    /// nothing ends it, and a group left open means the text is not a conditional expression after all.
+    /// </summary>
+    private ShellOperandExpressionSyntax ParseConditionalRegexOperand()
+    {
+        AccumulateInlineTrivia();
+
+        var enclosingDepth = _regexParenDepth;
+        _regexParenDepth = 0;
+        try
+        {
+            var word = _lexer.IsAtEnd || IsWordTerminator(_lexer.Current)
+                ? new ShellWordSyntax([])
+                : ParseWord();
+
+            if (word.Parts.Count == 0 || _regexParenDepth != 0)
+            {
+                _expressionFailed = true;
+            }
+
+            return new ShellOperandExpressionSyntax(word);
+        }
+        finally
+        {
+            _regexParenDepth = enclosingDepth;
+        }
     }
 
     private string? PeekConditionalWord()

--- a/src/Meziantou.Framework.Language.Shell/Internals/PosixParser.cs
+++ b/src/Meziantou.Framework.Language.Shell/Internals/PosixParser.cs
@@ -17,6 +17,9 @@ internal sealed partial class PosixParser
     private int _backtickDepth;
     private int _zshBraceDepth;
 
+    /// <summary>Open-parenthesis count inside the pattern of a <c>=~</c>, or -1 when no pattern is being read.</summary>
+    private int _regexParenDepth = -1;
+
     public PosixParser(string text, ShellParseOptions options)
     {
         _options = options;
@@ -453,6 +456,11 @@ internal sealed partial class PosixParser
         var start = _lexer.Position;
         while (!_lexer.IsAtEnd && !IsWordTerminator(_lexer.Current) && !IsWordPartStart(_lexer.Current))
         {
+            if (_regexParenDepth >= 0 && _lexer.Current is '(' or ')')
+            {
+                _regexParenDepth += _lexer.Current == '(' ? 1 : -1;
+            }
+
             _lexer.Position++;
         }
 
@@ -1048,6 +1056,11 @@ internal sealed partial class PosixParser
     /// </summary>
     private bool IsWordTerminator(char value)
     {
+        // Inside a `=~` pattern the regular expression grammar wins: `(`, `|`, and the `)` that closes an open group
+        // belong to the pattern. A `)` that closes nothing still ends it, so `[[ (a =~ b) ]]` keeps its group.
+        if (_regexParenDepth >= 0 && (value is '(' or '|' || (value == ')' && _regexParenDepth > 0)))
+            return false;
+
         if (PosixLexer.IsWordBoundary(value))
             return true;
 

--- a/src/Meziantou.Framework.Language.Shell/ShellDialect.cs
+++ b/src/Meziantou.Framework.Language.Shell/ShellDialect.cs
@@ -20,7 +20,8 @@ public sealed class ShellDialect
         ShellDialectFeatures.FunctionKeyword |
         ShellDialectFeatures.ProcessSubstitution |
         ShellDialectFeatures.Coproc |
-        ShellDialectFeatures.SelectLoop;
+        ShellDialectFeatures.SelectLoop |
+        ShellDialectFeatures.ArithmeticExponentiation;
 
     private ShellDialect(string name, ShellDialectFamily family, ShellDialectFeatures features)
     {

--- a/src/Meziantou.Framework.Language.Shell/ShellDialectFeatures.cs
+++ b/src/Meziantou.Framework.Language.Shell/ShellDialectFeatures.cs
@@ -53,4 +53,7 @@ public enum ShellDialectFeatures
 
     /// <summary>The <c>$(( ... ))</c> arithmetic expansion. POSIX defines it, so every dialect in the family has it.</summary>
     ArithmeticExpansion = 1 << 15,
+
+    /// <summary>The <c>**</c> exponentiation operator in arithmetic. POSIX defines no such operator, so <c>sh</c> lacks it.</summary>
+    ArithmeticExponentiation = 1 << 16,
 }

--- a/src/Meziantou.Framework.Language.Shell/readme.md
+++ b/src/Meziantou.Framework.Language.Shell/readme.md
@@ -13,7 +13,7 @@
 | `ShellDialect` | Family | Notes |
 | --- | --- | --- |
 | `Sh` | POSIX | strict POSIX baseline |
-| `Bash` | POSIX | `[[ ]]`, `(( ))`, `<<<`, arrays, `function`, `<(…)`, `coproc`, `select` |
+| `Bash` | POSIX | `[[ ]]`, `(( ))`, `<<<`, arrays, `function`, `<(…)`, `coproc`, `select`, arithmetic `**` |
 | `Zsh` | POSIX | the bash set plus `foreach`/`end`, `repeat`, `always`, anonymous functions, `=(…)`, glob qualifiers, and brace groups that close without a separator |
 | `PowerShell` | PowerShell | Windows PowerShell 5.1 |
 | `PowerShellCore` | PowerShell | pwsh 7+: `&&`/`\|\|`, ternary `? :`, `??`/`??=`, `clean` blocks |

--- a/tests/Meziantou.Framework.Language.Shell.Tests/PosixExpressionTests.cs
+++ b/tests/Meziantou.Framework.Language.Shell.Tests/PosixExpressionTests.cs
@@ -50,6 +50,14 @@ public sealed class PosixExpressionTests
     [InlineData("a ? b : c", "(a ? b : c)")]
     [InlineData("a ? b : c ? d : e", "(a ? b : (c ? d : e))")]
     [InlineData("a += 2", "(a += 2)")]
+    // `**` binds tighter than `*` and is right-associative, and unary minus binds tighter still: bash reads
+    // `-2**2` as `(-2)**2`, which is 4.
+    [InlineData("2 ** 3", "(2 ** 3)")]
+    [InlineData("2**3**2", "(2 ** (3 ** 2))")]
+    [InlineData("2**2*3", "((2 ** 2) * 3)")]
+    [InlineData("1+2**2", "(1 + (2 ** 2))")]
+    [InlineData("-2**2", "((- 2) ** 2)")]
+    [InlineData("a *= b", "(a *= b)")]
     public void Arithmetic_PrecedenceAndAssociativityAreInTheTree(string text, string expected)
     {
         Assert.Equal(expected, Shape(Arithmetic(text)));
@@ -100,6 +108,14 @@ public sealed class PosixExpressionTests
     [InlineData("-f a || -d b", "((-f a) || (-d b))")]
     [InlineData("-f a && -d b || -x c", "(((-f a) && (-d b)) || (-x c))")]
     [InlineData("( -f a || -d b ) && -x c", "([((-f a) || (-d b))] && (-x c))")]
+    // The right side of `=~` is a regular expression, so `(`, `|`, and the `)` that closes a group belong to it.
+    [InlineData("$x =~ (a|b)", "($x =~ (a|b))")]
+    [InlineData("$x =~ ^(a|b)c$", "($x =~ ^(a|b)c$)")]
+    [InlineData("$x =~ a|b", "($x =~ a|b)")]
+    [InlineData("$x =~ (a|b) && -f c", "(($x =~ (a|b)) && (-f c))")]
+    [InlineData("( $x =~ (a|b) )", "[($x =~ (a|b))]")]
+    // A `)` that closes nothing ends the pattern, so the enclosing group still gets its closing parenthesis.
+    [InlineData("($x =~ a)", "[($x =~ a)]")]
     public void Conditional_BuildsTheExpectedShape(string text, string expected)
     {
         Assert.Equal(expected, Shape(Conditional(text)));
@@ -124,12 +140,60 @@ public sealed class PosixExpressionTests
     }
 
     [Theory]
+    // `**` is a bash and zsh extension; sh has no exponentiation, so there the text is not arithmetic.
+    [InlineData("2 ** 3", false)]
+    [InlineData("a ** b", false)]
+    [InlineData("a * b", true)]
+    [InlineData("a *= b", true)]
+    public void Arithmetic_ExponentiationIsBashAndZshOnly(string text, bool expectedInSh)
+    {
+        var tree = ShellSyntaxAssert.TextIsFaithful($"echo $(({text}))", ShellDialect.Sh);
+        var expansion = Assert.Single(tree.Root.DescendantNodes().OfType<PosixArithmeticExpansionSyntax>());
+
+        Assert.Equal(expectedInSh, expansion.Expression is not ShellRawExpressionSyntax);
+        Assert.IsNotType<ShellRawExpressionSyntax>(Arithmetic(text));
+    }
+
+    [Theory]
+    // A line break is ordinary space in arithmetic; it may sit anywhere an operator or an operand may.
+    [InlineData("1 +\n2", "(1 + 2)")]
+    [InlineData("1\n+\n2", "(1 + 2)")]
+    [InlineData("\n1 + 2\n", "(1 + 2)")]
+    [InlineData("(1\n+ 2)\n* 3", "([(1 + 2)] * 3)")]
+    [InlineData("a\n? b\n: c", "(a ? b : c)")]
+    public void Arithmetic_LineBreaksAreJustSpace(string text, string expected)
+    {
+        Assert.Equal(expected, Shape(Arithmetic(text)));
+    }
+
+    [Theory]
+    // In a conditional a line break separates the operands of `&&` and `||`, and may follow `[[`, `!`, and `(`.
+    [InlineData("-f a\n&& -d b", "((-f a) && (-d b))")]
+    [InlineData("-f a &&\n-d b", "((-f a) && (-d b))")]
+    [InlineData("\n-f a\n", "(-f a)")]
+    [InlineData("!\n-f a", "(! (-f a))")]
+    [InlineData("(\n-f a\n)", "[(-f a)]")]
+    public void Conditional_LineBreaksSeparateOperands(string text, string expected)
+    {
+        Assert.Equal(expected, Shape(Conditional(text)));
+    }
+
+    [Theory]
     // Text the grammar does not fit is kept verbatim rather than being forced into a shape it does not have.
     [InlineData("echo $((|))")]
     [InlineData("echo $((+))")]
     [InlineData("(( ))")]
     [InlineData("[[ ]]")]
     [InlineData("[[ && ]]")]
+    // Bash rejects each of these too: `**=` is not an operator, `-a` and `-o` are not `[[ ]]` operators, a
+    // regular expression may not leave a group open, and a line break may not split an operator from its operand.
+    [InlineData("echo $((a **= b))")]
+    [InlineData("[[ -f a -o -f b ]]")]
+    [InlineData("[[ -f a -a -f b ]]")]
+    [InlineData("[[ $x =~ (a ]]")]
+    [InlineData("[[ $x =~ ) ]]")]
+    [InlineData("[[ -d\n/tmp ]]")]
+    [InlineData("[[ $x ==\ny ]]")]
     public void TextThatIsNotAnExpression_FallsBackToRawAndStillRoundTrips(string text)
     {
         var tree = ShellSyntaxAssert.TextIsFaithful(text, ShellDialect.Bash);


### PR DESCRIPTION
`ShellRawExpressionSyntax` exists for constructs the tree deliberately does not model, and as the never-throw fallback when text cannot be parsed as an expression. This PR audits every place the parsers produce one and makes sure it is never standing in for a gap in the grammar.

## How the sites were audited

There are 9 construction sites, split by cause:

- **PowerShell (5 sites, `PowerShellParser.Expressions.cs`)** — one is the empty-input case of `ParseSingleExpression`, the other four are `TryEnterRecursion` depth guards, i.e. the stack-safety net. Not grammar gaps, so they are unchanged.
- **POSIX (3 sites)** — `$(( ))`, `(( ))`, and `[[ ]]`, which fall back when `TryParseDelimited` does not consume the whole text. These were probed with ~130 valid bash expressions, and every disagreement was cross-checked against real `bash` before deciding whether it was a parser bug or a genuinely invalid script.

Three real gaps came out of that, all fixed here.

## What changed

**1. The `**` exponentiation operator was missing.** `$((2**3))` and `$((a ** b))` fell back to raw. It is now in the arithmetic operator table at precedence 13, right-associative. The resulting trees match how bash evaluates them:

| input | tree |
| --- | --- |
| `2**3**2` | `(2 ** (3 ** 2))` |
| `2**2*3` | `((2 ** 2) * 3)` |
| `1+2**2` | `(1 + (2 ** 2))` |
| `-2**2` | `((- 2) ** 2)` — bash gives 4, so unary binds tighter |

POSIX defines no such operator (`dash` errors on it), so it is gated behind a new `ShellDialectFeatures.ArithmeticExponentiation`, set for bash and zsh. In `sh` the text still round-trips verbatim, consistent with the dialect-fidelity contract the readme states for `(( ))`.

**2. A line break ended the expression.** `$((1 +\n2))`, `(( 1 +\n2 ))` and `[[ -f a\n&& -f b ]]` are all valid bash but went raw, because the expression grammars accumulated inline trivia only. Arithmetic now takes line breaks anywhere (bash treats them as plain space). The conditional takes them only where bash does — after `[[`, `!`, `(`, around `&&`/`||`, before `)` and `]]` — and **not** between an operator and its operand, so `[[ -d\n/tmp ]]` and `[[ $x ==\ny ]]` keep falling back, exactly as bash rejects them.

**3. `=~` patterns containing `(`, `)`, or `|`.** `[[ $x =~ (a|b) ]]` went raw because the right operand was read as an ordinary word, where those characters are boundaries. It now reads the pattern as a regular expression using bash's own paren balancing: `(`, `|`, and the `)` that closes an open group belong to the pattern, while a `)` that closes nothing ends it — so `[[ ($x =~ a) ]]` still keeps its group. An unbalanced pattern (`[[ $x =~ (a ]]`) falls back, matching bash's rejection.

## Confirmed correct as raw

These were checked against bash and it rejects each one, so raw is the right answer and they are now pinned by tests: `[[ -f a -o -f b ]]` and the `-a` form, `$(( a **= b ))`, `$(( func(1) ))`, `[[ $x =~ ) ]]`.

## Notes for the reviewer

- **`ShellDialectFeatures.ArithmeticExponentiation` is a new public enum member**, so this is a small API addition rather than a purely internal fix. I went that way because the readme states the dialect-fidelity contract explicitly ("the `((1+2))` arithmetic command is bash and zsh only and stays plain text in sh"); silently accepting `**` in `sh` would have broken it. `ref/Meziantou.Framework.Language.Shell.cs` is regenerated accordingly.
- `_regexParenDepth` on `PosixParser` is `-1` when no `=~` pattern is being read, which keeps the regex rules out of the way of ordinary word parsing. It follows the existing `_backtickDepth` / `_zshBraceDepth` pattern in `IsWordTerminator`.
- Round-trip fidelity holds on every case, including the ones that still fall back to raw.

## Verification

- `dotnet build /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- Full `Meziantou.Framework.Language.Shell.Tests` suite: **2898 passed, 0 failed** across net10.0 and net11.0, up from 2832 (66 new cases in `PosixExpressionTests.cs`)
- `dotnet run ./eng/update-all.cs` ran; its only output was the `ref/` regeneration included here
