### PR TITLE
Update existing PRs in generator workflows instead of failing

### DIFF
--- a/.github/workflows/update-emoji-shortcodes.yml
+++ b/.github/workflows/update-emoji-shortcodes.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     paths:
-      - 'tools/Meziantou.Framework.Unicode.Generator/**'
+      - 'tools/Meziantou.Framework.HtmlToMarkdown.Emoji.Generator/**'
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -27,21 +27,21 @@ jobs:
       - name: Setup .NET
         uses: ./.github/actions/setup-dotnet
       - run: |
-          dotnet run --project tools/Meziantou.Framework.Unicode.Generator
+          dotnet run --project tools/Meziantou.Framework.HtmlToMarkdown.Emoji.Generator
           if ($LASTEXITCODE -ne 0) {
             git config --global user.email "git@meziantou.net"
             git config --global user.name "meziantou"
-            git checkout -b update-unicode-confusables
+            git checkout -b update-emoji-shortcodes
             git add .
-            git commit -m "Update Unicode confusables data"
-            git push origin update-unicode-confusables --force
+            git commit -m "Update emoji shortcode mappings"
+            git push origin update-emoji-shortcodes --force
             $runUrl = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            $body = "Update Unicode confusables data`n`nCreated by: $runUrl"
-            $openPr = gh pr list --head update-unicode-confusables --state open --json number --jq '.[0].number // empty'
+            $body = "Update emoji shortcode mappings`n`nCreated by: $runUrl"
+            $openPr = gh pr list --head update-emoji-shortcodes --state open --json number --jq '.[0].number // empty'
             if ($openPr) {
-              gh pr edit $openPr --title "Update Unicode confusables data" --body $body
+              gh pr edit $openPr --title "Update emoji shortcode mappings" --body $body
             } else {
-              gh pr create --title "Update Unicode confusables data" --body $body --base main --head update-unicode-confusables
+              gh pr create --title "Update emoji shortcode mappings" --body $body --base main --head update-emoji-shortcodes
             }
           }
         env:

--- a/.github/workflows/update-hsts-preload.yml
+++ b/.github/workflows/update-hsts-preload.yml
@@ -37,7 +37,12 @@ jobs:
             git push origin update-hsts-preload --force
             $runUrl = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             $body = "Update HSTS preload list`n`nCreated by: $runUrl"
-            gh pr create --title "Update HSTS preload list" --body $body --base main
+            $openPr = gh pr list --head update-hsts-preload --state open --json number --jq '.[0].number // empty'
+            if ($openPr) {
+              gh pr edit $openPr --title "Update HSTS preload list" --body $body
+            } else {
+              gh pr create --title "Update HSTS preload list" --body $body --base main --head update-hsts-preload
+            }
           }
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed

**`update-hsts-preload.yml` and `update-unicode-confusables.yml`** — replaced the unconditional `gh pr create` with a create-or-update sequence:

```pwsh
$openPr = gh pr list --head update-hsts-preload --state open --json number --jq '.[0].number // empty'
if ($openPr) {
  gh pr edit $openPr --title "Update HSTS preload list" --body $body
} else {
  gh pr create --title "Update HSTS preload list" --body $body --base main --head update-hsts-preload
}
```

`gh pr create` now passes `--head` explicitly instead of relying on the checked-out branch.

**`update-emoji-shortcodes.yml`** (new) — runs `tools/Meziantou.Framework.HtmlToMarkdown.Emoji.Generator` on the same weekly cron, plus `workflow_dispatch` and a `push` trigger on the generator's path.

## Why

Both existing workflows run weekly on a cron, force-push to a fixed branch, then call `gh pr create` unconditionally. When a PR from the previous run is still open, `gh pr create` fails with `a pull request for branch ... already exists` and the step errors. The fix mirrors the create-or-update sequence already in `eng/update-versions.cs` (~line 277): the body is refreshed so the existing PR points at the current run URL.

The emoji generator follows the same exit-code-1-means-changed contract as the other generators and writes `src/Meziantou.Framework.HtmlToMarkdown/EmojiShortcodeMappings.g.cs`, but had no workflow — the mappings only refreshed when someone ran it by hand.

## Notes for reviewers

- The generators themselves are unchanged.
- Validation: all three files parse as YAML; each `run:` block was extracted and parsed with the PowerShell parser (`Parser::ParseFile`) with no syntax errors; `dotnet run ./eng/update-all.cs` produced no changes; the emoji generator project builds clean with `TreatWarningsAsErrors=true`.
- The task description referenced `.github/workflows/update-public-suffix-list.yml` as the pattern source, but that file does not exist in the tree or anywhere in git history. The new emoji workflow is modelled on the two existing `update-*` workflows instead. If a public-suffix-list workflow was meant to exist, that is a separate gap.