### PR TITLE
Block IPv6 transition ranges that embed unsafe IPv4 addresses

### DIFF
--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryOptions.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryOptions.cs
@@ -20,6 +20,10 @@ public sealed class ServerSideRequestForgeryOptions
         IPNetwork.Parse("169.254.0.0/16"),
         // RFC1918 private IPv4 range.
         IPNetwork.Parse("172.16.0.0/12"),
+        // IETF protocol assignments (RFC6890), including the NAT64 discovery addresses. Not globally routable.
+        IPNetwork.Parse("192.0.0.0/24"),
+        // 6to4 relay anycast range (RFC3068), deprecated and not a valid remote target.
+        IPNetwork.Parse("192.88.99.0/24"),
         // RFC1918 private IPv4 range.
         IPNetwork.Parse("192.168.0.0/16"),
         // Benchmark/testing inter-network range (RFC2544), not for public routing.
@@ -28,10 +32,16 @@ public sealed class ServerSideRequestForgeryOptions
         IPNetwork.Parse("224.0.0.0/4"),
         // Reserved/experimental IPv4 range.
         IPNetwork.Parse("240.0.0.0/4"),
-        // IPv6 unspecified address.
-        IPNetwork.Parse("::/128"),
-        // IPv6 loopback address.
+        // IPv6 unspecified address and the deprecated IPv4-compatible range (::a.b.c.d), which embeds an IPv4 address.
+        IPNetwork.Parse("::/96"),
+        // IPv6 loopback address. Already covered by ::/96 above, but listed explicitly because it is the range most often looked for.
         IPNetwork.Parse("::1/128"),
+        // NAT64 well-known prefix (RFC6052). Embeds an IPv4 address, so it reaches IPv4 targets from an IPv6-only network.
+        IPNetwork.Parse("64:ff9b::/96"),
+        // Teredo tunneling range (RFC4380). Embeds an IPv4 address.
+        IPNetwork.Parse("2001::/32"),
+        // 6to4 range (RFC3056). Embeds an IPv4 address in the second and third groups.
+        IPNetwork.Parse("2002::/16"),
         // IPv6 unique local addresses (ULA), private scope.
         IPNetwork.Parse("fc00::/7"),
         // IPv6 link-local addresses.

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
@@ -63,6 +63,54 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
             cancellationToken: CancellationToken.None).AsTask());
     }
 
+    [Theory]
+    // IPv4 ranges that are reserved but were not covered by the original default list.
+    [InlineData("192.0.0.170")]
+    [InlineData("192.88.99.1")]
+    // IPv6 forms that embed an unsafe IPv4 address. Each of these reaches 127.0.0.1 or 169.254.169.254
+    // on a network that routes the corresponding transition mechanism.
+    [InlineData("::ffff:127.0.0.1")]
+    [InlineData("::ffff:169.254.169.254")]
+    [InlineData("::127.0.0.1")]
+    [InlineData("::169.254.169.254")]
+    [InlineData("64:ff9b::7f00:1")]
+    [InlineData("64:ff9b::a9fe:a9fe")]
+    [InlineData("2002:7f00:0001::")]
+    [InlineData("2002:a9fe:a9fe::")]
+    [InlineData("2001::1")]
+    public async Task ResolveAndSelectIpAddressAsync_RejectsAddressEmbeddingUnsafeIpv4Target(string address)
+    {
+        await Assert.ThrowsAsync<ServerSideRequestForgeryException>(() => ServerSideRequestForgeryConnectPipeline.ResolveAndSelectIpAddressAsync(
+            requestUri: new Uri("https://example.com"),
+            dnsEndPoint: new DnsEndPoint("example.com", 443),
+            options: new ServerSideRequestForgeryOptions(),
+            dnsIpAddressResolver: new FakeDnsIpAddressResolver([IPAddress.Parse(address)]),
+            cancellationToken: CancellationToken.None).AsTask());
+    }
+
+    [Theory]
+    // Global unicast addresses that sit close to the newly blocked ranges and must stay reachable.
+    [InlineData("2001:4860:4860::8888")]
+    [InlineData("2003::1")]
+    [InlineData("192.1.0.1")]
+    [InlineData("192.89.0.1")]
+    public async Task ResolveAndSelectIpAddressAsync_AllowsGlobalUnicastAddressNearBlockedRange(string address)
+    {
+        var options = new ServerSideRequestForgeryOptions
+        {
+            ResolutionStrategy = IpAddressResolutionStrategy.Random,
+        };
+
+        var selectedAddress = await ServerSideRequestForgeryConnectPipeline.ResolveAndSelectIpAddressAsync(
+            requestUri: new Uri("https://example.com"),
+            dnsEndPoint: new DnsEndPoint("example.com", 443),
+            options: options,
+            dnsIpAddressResolver: new FakeDnsIpAddressResolver([IPAddress.Parse(address)]),
+            cancellationToken: CancellationToken.None);
+
+        Assert.Equal(IPAddress.Parse(address), selectedAddress);
+    }
+
     [Fact]
     public async Task ResolveAndSelectIpAddressAsync_UsesResolutionStrategyFromOptions()
     {


### PR DESCRIPTION
Addresses the "default unsafe list misses IPv6 transition ranges" finding from the SSRF project review.

## Problem

`NormalizeAddress` handles IPv4-**mapped** addresses (`::ffff:a.b.c.d`), but every other IPv6 form that carries an IPv4 address in its low bits was matched as ordinary global unicast and fell through to "safe". Running the current `IsSafeAddress` logic against the default options:

```
  ::ffff:127.0.0.1         IsIPv4Mapped=True  => unsafe (blocked)
  ::127.0.0.1              IsIPv4Mapped=False => SAFE (allowed)
  64:ff9b::a9fe:a9fe       IsIPv4Mapped=False => SAFE (allowed)     <- NAT64 -> 169.254.169.254
  2002:a9fe:a9fe::         IsIPv4Mapped=False => SAFE (allowed)     <- 6to4  -> 169.254.169.254
  2001:0:0:0:0:0:0:1       IsIPv4Mapped=False => SAFE (allowed)     <- Teredo
  192.0.0.170              => SAFE (allowed)
  192.88.99.1              => SAFE (allowed)
```

Most of these are dead in practice: 6to4 and Teredo need relays that essentially no longer exist, and `::a.b.c.d` is deprecated and generally unroutable. **NAT64 is the exception and is not theoretical** — in an IPv6-only network with NAT64/DNS64 (an offered configuration on the major clouds), `64:ff9b::a9fe:a9fe` routes to `169.254.169.254`. In that environment the default block list did not block the metadata service.

## Change

Added to `DefaultUnsafeIpNetworks`:

| Range | Why |
|---|---|
| `64:ff9b::/96` | NAT64 well-known prefix (RFC6052) — the practically exploitable one |
| `2002::/16` | 6to4 (RFC3056) |
| `2001::/32` | Teredo (RFC4380) |
| `::/96` | Deprecated IPv4-compatible `::a.b.c.d`; supersedes the previous `::/128` entry |
| `192.0.0.0/24` | IETF protocol assignments (RFC6890), incl. NAT64 discovery |
| `192.88.99.0/24` | 6to4 relay anycast (RFC3068), deprecated |

`2001::/32` matches only `2001:0000:…`, so global unicast such as `2001:4860:4860::8888` is unaffected — there is a test asserting exactly that, since over-blocking is the obvious risk with these prefixes.

## Tests

Two theories in `ServerSideRequestForgeryConnectPipelineTests`: one asserting each embedding form is rejected (including `::ffff:127.0.0.1`, which already worked and now has a regression guard), one asserting global unicast addresses adjacent to the new ranges still resolve. 40 tests pass on net10.0 and net11.0 (was 25).

## Compatibility

This only widens the default deny list. A caller relying on any of these ranges being reachable must now allow-list it explicitly via `SafeIpNetworks`, so it warrants a minor version bump.