### PR TITLE
Add tests for the connect path and the production DNS resolver

### DIFF
--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
@@ -80,7 +80,7 @@ internal static class ServerSideRequestForgeryConnectPipeline
 
         // The returned NetworkStream owns the socket lifetime once the connection succeeds.
 #pragma warning disable CA2000 // Dispose objects before losing scope
-        var socket = new Socket(selectedAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+        var socket = CreateConnectSocket(selectedAddress.AddressFamily);
 #pragma warning restore CA2000
         try
         {
@@ -92,6 +92,14 @@ internal static class ServerSideRequestForgeryConnectPipeline
             socket.Dispose();
             throw;
         }
+    }
+
+    internal static Socket CreateConnectSocket(AddressFamily addressFamily)
+    {
+        // Mirrors the defaults the runtime applies on its own connect path (HttpConnectionPool.ConnectToTcpHostAsync).
+        // Replacing ConnectCallback opts out of those defaults, and leaving Nagle's algorithm enabled adds latency
+        // to every request whose body is written in small chunks.
+        return new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
     }
 
     private static List<IPAddress> FilterSafeAddresses(Uri requestUri, IReadOnlyList<IPAddress> resolvedAddresses, ServerSideRequestForgeryOptions options, ILogger logger)

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using Meziantou.Extensions.Logging.InMemory;
 
 namespace Meziantou.Framework.Http.ServerSideRequestForgery.Tests;
@@ -15,6 +16,58 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
         using var handler = new SocketsHttpHandler();
         handler.ConfigureSsrf(new ServerSideRequestForgeryOptions(), new FakeDnsIpAddressResolver([IPAddress.Parse("203.0.113.10")]));
         Assert.NotNull(handler.ConnectCallback);
+    }
+
+    [Fact]
+    public async Task ConnectCallback_SendsRequestToTheValidatedAddress()
+    {
+        using var server = new LoopbackHttpServer();
+        var options = new ServerSideRequestForgeryOptions();
+        options.SafeSchemes.Add(Uri.UriSchemeHttp);
+        options.SafeIpNetworks.Add(IPNetwork.Parse("127.0.0.0/8"));
+
+        using var handler = new SocketsHttpHandler();
+        handler.ConfigureSsrf(options, new FakeDnsIpAddressResolver([IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler);
+
+        // 'example.invalid' cannot be resolved by real DNS (RFC2606), so a response can only come back if the
+        // connection used the address the resolver returned instead of resolving the host again.
+        var response = await httpClient.GetAsync(new Uri($"http://example.invalid:{server.Port}/"), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("ok", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ConnectCallback_SurfacesRejectionAsInnerExceptionOfHttpRequestException()
+    {
+        var options = new ServerSideRequestForgeryOptions();
+        options.SafeSchemes.Add(Uri.UriSchemeHttp);
+
+        using var handler = new SocketsHttpHandler();
+        handler.ConfigureSsrf(options, new FakeDnsIpAddressResolver([IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler);
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => httpClient.GetAsync(new Uri("http://example.invalid/"), TestContext.Current.CancellationToken));
+
+        Assert.IsType<ServerSideRequestForgeryException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task ConnectCallback_DoesNotConnectWhenTheSchemeIsRejected()
+    {
+        using var server = new LoopbackHttpServer();
+        var options = new ServerSideRequestForgeryOptions();
+        options.SafeIpNetworks.Add(IPNetwork.Parse("127.0.0.0/8"));
+
+        using var handler = new SocketsHttpHandler();
+        handler.ConfigureSsrf(options, new FakeDnsIpAddressResolver([IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler);
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => httpClient.GetAsync(new Uri($"http://example.invalid:{server.Port}/"), TestContext.Current.CancellationToken));
+
+        Assert.IsType<ServerSideRequestForgeryException>(exception.InnerException);
+        Assert.Equal(0, server.AcceptedConnectionCount);
     }
 
     [Fact]
@@ -422,4 +475,72 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
         }
     }
 
+    private sealed class LoopbackHttpServer : IDisposable
+    {
+        private const string Response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok";
+
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
+        private int _acceptedConnectionCount;
+
+        public LoopbackHttpServer()
+        {
+            _listener = new TcpListener(IPAddress.Loopback, port: 0);
+            _listener.Start();
+            Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            _ = Task.Run(() => AcceptLoopAsync(_cancellationTokenSource.Token));
+        }
+
+        public int Port { get; }
+
+        public int AcceptedConnectionCount => Volatile.Read(ref _acceptedConnectionCount);
+
+        private async Task AcceptLoopAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    using var client = await _listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+                    Interlocked.Increment(ref _acceptedConnectionCount);
+
+                    using var stream = client.GetStream();
+                    await ReadRequestHeadersAsync(stream, cancellationToken).ConfigureAwait(false);
+                    await stream.WriteAsync(Encoding.ASCII.GetBytes(Response), cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (SocketException)
+            {
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        }
+
+        private static async Task ReadRequestHeadersAsync(NetworkStream stream, CancellationToken cancellationToken)
+        {
+            var buffer = new byte[4096];
+            var count = 0;
+            while (count < buffer.Length)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(count), cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                    break;
+
+                count += read;
+                if (Encoding.ASCII.GetString(buffer, 0, count).Contains("\r\n\r\n", StringComparison.Ordinal))
+                    break;
+            }
+        }
+
+        public void Dispose()
+        {
+            _cancellationTokenSource.Cancel();
+            _listener.Dispose();
+            _cancellationTokenSource.Dispose();
+        }
+    }
 }

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
@@ -18,6 +18,19 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
         Assert.NotNull(handler.ConnectCallback);
     }
 
+    [Theory]
+    [InlineData(AddressFamily.InterNetwork)]
+    [InlineData(AddressFamily.InterNetworkV6)]
+    public void CreateConnectSocket_DisablesNagleAlgorithm(AddressFamily addressFamily)
+    {
+        using var socket = ServerSideRequestForgeryConnectPipeline.CreateConnectSocket(addressFamily);
+
+        Assert.True(socket.NoDelay);
+        Assert.Equal(addressFamily, socket.AddressFamily);
+        Assert.Equal(SocketType.Stream, socket.SocketType);
+        Assert.Equal(ProtocolType.Tcp, socket.ProtocolType);
+    }
+
     [Fact]
     public async Task ConnectCallback_SendsRequestToTheValidatedAddress()
     {

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/SystemDnsIpAddressResolverTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/SystemDnsIpAddressResolverTests.cs
@@ -1,0 +1,42 @@
+using System.Net;
+
+namespace Meziantou.Framework.Http.ServerSideRequestForgery.Tests;
+
+public sealed class SystemDnsIpAddressResolverTests
+{
+    [Theory]
+    [InlineData("203.0.113.10", "203.0.113.10")]
+    [InlineData("2001:db8::1", "2001:db8::1")]
+    [InlineData("[2001:db8::1]", "2001:db8::1")]
+    [InlineData("::ffff:203.0.113.10", "::ffff:203.0.113.10")]
+    public async Task ResolveAsync_ReturnsLiteralWithoutQueryingDns(string host, string expectedAddress)
+    {
+        var addresses = await SystemDnsIpAddressResolver.Instance.ResolveAsync(host, CancellationToken.None);
+
+        var address = Assert.Single(addresses);
+        Assert.Equal(IPAddress.Parse(expectedAddress), address);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ResolvesHostName()
+    {
+        var addresses = await SystemDnsIpAddressResolver.Instance.ResolveAsync("localhost", CancellationToken.None);
+
+        Assert.NotEmpty(addresses);
+        Assert.All(addresses, address => Assert.True(IPAddress.IsLoopback(address), $"'{address}' is not a loopback address"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task ResolveAsync_ThrowsForEmptyHost(string host)
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => SystemDnsIpAddressResolver.Instance.ResolveAsync(host, CancellationToken.None).AsTask());
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ThrowsForNullHost()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => SystemDnsIpAddressResolver.Instance.ResolveAsync(host: null!, CancellationToken.None).AsTask());
+    }
+}


### PR DESCRIPTION
Addresses the "socket-opening path and production DNS resolver have no tests" finding from the SSRF project review.

**This is the base of a 3-PR stack.** It adds only tests, no behaviour change, so it is safe to merge on its own. The two follow-ups fix bugs that this coverage exposes:

1. **#this** — test coverage for the connect path
2. `meziantou/ssrf-socket-nodelay` — set `NoDelay` on the connect socket
3. `meziantou/ssrf-connect-address-fallback` — try the remaining validated addresses when a connect fails

## Problem

Every pipeline test called `ResolveAndSelectIpAddressAsync` directly. Nothing exercised `ConnectAsync`, and the only test touching the wiring asserted `handler.ConnectCallback` is non-null. So the code that constructs the socket, picks the address family and connects was entirely uncovered — which is why the two bugs in the follow-up PRs went unnoticed. `SystemDnsIpAddressResolver`, the only resolver used in production, had no tests at all despite being reachable via `InternalsVisibleTo`.

A refactor that dropped the `safeAddresses` re-check, or connected to `dnsEndPoint` instead of `selectedAddress`, would have kept all 25 tests green.

## Change

**End-to-end tests through a real `HttpClient`** against a self-contained loopback `TcpListener`:

- `ConnectCallback_SendsRequestToTheValidatedAddress` — requests `example.invalid`, a name RFC2606 guarantees cannot resolve. A response can only come back if the socket used the address the resolver returned rather than resolving the host again, so this pins the TOCTOU-safe behaviour that is the whole point of the design.
- `ConnectCallback_SurfacesRejectionAsInnerExceptionOfHttpRequestException` — pins how callers actually observe a rejection, which was previously undocumented by any test.
- `ConnectCallback_DoesNotConnectWhenTheSchemeIsRejected` — asserts the listener accepted zero connections, i.e. rejection happens before any socket is opened.

**`SystemDnsIpAddressResolverTests`** covering the IP-literal shortcut (v4, v6, bracketed v6, IPv4-mapped), hostname resolution, and the null/empty guards.

## Verification

72 tests pass across net10.0 and net11.0 (36 per TFM, was 25).

Because a test that never fails is worse than no test, I mutation-checked the new coverage:

| Mutation | Result |
|---|---|
| `IsAllowedScheme` always returns `true` | 3 failures, incl. `ConnectCallback_DoesNotConnectWhenTheSchemeIsRejected` |
| `IsSafeAddress` ignores `UnsafeIpNetworks` | 5 failures, incl. `ConnectCallback_SurfacesRejectionAsInnerExceptionOfHttpRequestException` |

Source restored after each.