### PR TITLE
Set NoDelay on the connect socket

### DIFF
--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
@@ -80,7 +80,7 @@ internal static class ServerSideRequestForgeryConnectPipeline
 
         // The returned NetworkStream owns the socket lifetime once the connection succeeds.
 #pragma warning disable CA2000 // Dispose objects before losing scope
-        var socket = new Socket(selectedAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+        var socket = CreateConnectSocket(selectedAddress.AddressFamily);
 #pragma warning restore CA2000
         try
         {
@@ -92,6 +92,14 @@ internal static class ServerSideRequestForgeryConnectPipeline
             socket.Dispose();
             throw;
         }
+    }
+
+    internal static Socket CreateConnectSocket(AddressFamily addressFamily)
+    {
+        // Mirrors the defaults the runtime applies on its own connect path (HttpConnectionPool.ConnectToTcpHostAsync).
+        // Replacing ConnectCallback opts out of those defaults, and leaving Nagle's algorithm enabled adds latency
+        // to every request whose body is written in small chunks.
+        return new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
     }
 
     private static List<IPAddress> FilterSafeAddresses(Uri requestUri, IReadOnlyList<IPAddress> resolvedAddresses, ServerSideRequestForgeryOptions options, ILogger logger)

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
@@ -18,6 +18,19 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
         Assert.NotNull(handler.ConnectCallback);
     }
 
+    [Theory]
+    [InlineData(AddressFamily.InterNetwork)]
+    [InlineData(AddressFamily.InterNetworkV6)]
+    public void CreateConnectSocket_DisablesNagleAlgorithm(AddressFamily addressFamily)
+    {
+        using var socket = ServerSideRequestForgeryConnectPipeline.CreateConnectSocket(addressFamily);
+
+        Assert.True(socket.NoDelay);
+        Assert.Equal(addressFamily, socket.AddressFamily);
+        Assert.Equal(SocketType.Stream, socket.SocketType);
+        Assert.Equal(ProtocolType.Tcp, socket.ProtocolType);
+    }
+
     [Fact]
     public async Task ConnectCallback_SendsRequestToTheValidatedAddress()
     {


### PR DESCRIPTION
Addresses the "connect socket is created without `NoDelay`" finding from the SSRF project review.

> **Stacked PR** — targets `meziantou/ssrf-connect-path-tests` (#1988), which adds the connect-path coverage this builds on. Review/merge that one first; the diff here is just this change.

## Problem

The pipeline created its socket as:

```csharp
var socket = new Socket(selectedAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
```

The runtime path this replaces creates it as `new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true }` (`HttpConnectionPool.ConnectToTcpHostAsync`), and the [`ConnectCallback` documentation sample](https://learn.microsoft.com/dotnet/api/system.net.http.socketshttphandler.connectcallback) sets `NoDelay = true` for the same reason. Setting `ConnectCallback` opts out of those defaults, so Nagle's algorithm was left enabled on every connection the library makes.

Interacting with delayed ACK, that adds tens of milliseconds to requests whose body is written in small chunks — a latency regression that appears merely by installing this package, on every request, and is hard to attribute back to an SSRF library.

## Change

Set `NoDelay = true` at socket creation, extracted into an internal `CreateConnectSocket` factory. The extraction is what makes the setting testable: the socket is otherwise owned by the returned `NetworkStream` and never observable from a test, since `SocketsHttpConnectionContext` has no public constructor to invoke the callback directly.

`NoDelay` is the one runtime connect-path default that materially differed; the others (keep-alive tuning etc.) are opt-in on the runtime path too.

## Tests

`CreateConnectSocket_DisablesNagleAlgorithm` over both address families, asserting `NoDelay` plus the socket type/protocol. 76 tests pass across net10.0 and net11.0.

No public API change, so `ref/` is unchanged.