### PR TITLE
Try the remaining validated addresses when a connect fails

### DIFF
--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
@@ -18,6 +18,12 @@ internal static class ServerSideRequestForgeryConnectPipeline
 
     internal static async ValueTask<IPAddress> ResolveAndSelectIpAddressAsync(Uri requestUri, DnsEndPoint dnsEndPoint, ServerSideRequestForgeryOptions options, IDnsIpAddressResolver dnsIpAddressResolver, CancellationToken cancellationToken)
     {
+        var safeAddresses = await ResolveSafeIpAddressesAsync(requestUri, dnsEndPoint, options, dnsIpAddressResolver, cancellationToken).ConfigureAwait(false);
+        return await SelectIpAddressAsync(requestUri, safeAddresses, options, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async ValueTask<List<IPAddress>> ResolveSafeIpAddressesAsync(Uri requestUri, DnsEndPoint dnsEndPoint, ServerSideRequestForgeryOptions options, IDnsIpAddressResolver dnsIpAddressResolver, CancellationToken cancellationToken)
+    {
         ArgumentNullException.ThrowIfNull(requestUri);
         ArgumentNullException.ThrowIfNull(dnsEndPoint);
         ArgumentNullException.ThrowIfNull(options);
@@ -48,7 +54,12 @@ internal static class ServerSideRequestForgeryConnectPipeline
             throw new SocketException((int)SocketError.HostNotFound);
         }
 
-        var safeAddresses = FilterSafeAddresses(requestUri, resolvedAddresses, options, logger);
+        return FilterSafeAddresses(requestUri, resolvedAddresses, options, logger);
+    }
+
+    internal static async ValueTask<IPAddress> SelectIpAddressAsync(Uri requestUri, List<IPAddress> safeAddresses, ServerSideRequestForgeryOptions options, CancellationToken cancellationToken)
+    {
+        var logger = options.Logger;
         IPAddress selectedAddress;
         try
         {
@@ -76,22 +87,49 @@ internal static class ServerSideRequestForgeryConnectPipeline
         ArgumentNullException.ThrowIfNull(context);
 
         var requestUri = context.InitialRequestMessage?.RequestUri ?? throw new InvalidOperationException("The request URI cannot be null.");
-        var selectedAddress = await ResolveAndSelectIpAddressAsync(requestUri, context.DnsEndPoint, options, dnsIpAddressResolver, cancellationToken).ConfigureAwait(false);
+        var safeAddresses = await ResolveSafeIpAddressesAsync(requestUri, context.DnsEndPoint, options, dnsIpAddressResolver, cancellationToken).ConfigureAwait(false);
 
-        // The returned NetworkStream owns the socket lifetime once the connection succeeds.
+        // Every address here has already been validated. Ask the strategy again after each failure, over the
+        // addresses that are left, so the fallback keeps whatever constraint the strategy expresses: Ipv4Only
+        // never falls back to IPv6, and PreferIpv4 falls back to IPv6 only once every IPv4 address has failed.
+        var remainingAddresses = safeAddresses;
+        Exception? lastConnectException = null;
+        while (remainingAddresses.Count > 0)
+        {
+            IPAddress selectedAddress;
+            try
+            {
+                selectedAddress = await SelectIpAddressAsync(requestUri, remainingAddresses, options, cancellationToken).ConfigureAwait(false);
+            }
+            catch (ServerSideRequestForgeryException) when (lastConnectException is not null)
+            {
+                // The strategy has no candidate left among the addresses that have not already failed.
+                break;
+            }
+
+            // The returned NetworkStream owns the socket lifetime once the connection succeeds.
 #pragma warning disable CA2000 // Dispose objects before losing scope
-        var socket = CreateConnectSocket(selectedAddress.AddressFamily);
+            var socket = CreateConnectSocket(selectedAddress.AddressFamily);
 #pragma warning restore CA2000
-        try
-        {
-            await socket.ConnectAsync(new IPEndPoint(selectedAddress, context.DnsEndPoint.Port), cancellationToken).ConfigureAwait(false);
-            return new NetworkStream(socket, ownsSocket: true);
+            try
+            {
+                await socket.ConnectAsync(new IPEndPoint(selectedAddress, context.DnsEndPoint.Port), cancellationToken).ConfigureAwait(false);
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch (Exception ex)
+            {
+                socket.Dispose();
+                if (ex is OperationCanceledException || cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+
+                lastConnectException = ex;
+                remainingAddresses.Remove(selectedAddress);
+            }
         }
-        catch
-        {
-            socket.Dispose();
-            throw;
-        }
+
+        throw lastConnectException ?? new SocketException((int)SocketError.HostNotFound);
     }
 
     internal static Socket CreateConnectSocket(AddressFamily addressFamily)

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
@@ -52,6 +52,78 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
     }
 
     [Fact]
+    public async Task ConnectCallback_FallsBackToAnotherValidatedAddressWhenTheConnectFails()
+    {
+        using var server = new LoopbackHttpServer();
+        var options = new ServerSideRequestForgeryOptions
+        {
+            // Picks the first remaining address, so the unreachable IPv6 loopback is tried before the live server.
+            ResolutionStrategy = new FirstAddressStrategy(),
+        };
+        options.SafeSchemes.Add(Uri.UriSchemeHttp);
+        options.SafeIpNetworks.Add(IPNetwork.Parse("::1/128"));
+        options.SafeIpNetworks.Add(IPNetwork.Parse("127.0.0.0/8"));
+
+        using var handler = new SocketsHttpHandler();
+        handler.ConfigureSsrf(options, new FakeDnsIpAddressResolver([IPAddress.IPv6Loopback, IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler);
+
+        // The server listens on the IPv4 loopback only, so the IPv6 attempt on the same port cannot succeed.
+        var response = await httpClient.GetAsync(new Uri($"http://example.invalid:{server.Port}/"), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, server.AcceptedConnectionCount);
+    }
+
+    [Fact]
+    public async Task ConnectCallback_AsksTheStrategyAgainWithoutTheAddressThatFailed()
+    {
+        using var server = new LoopbackHttpServer();
+        var strategy = new RecordingStrategy();
+        var options = new ServerSideRequestForgeryOptions
+        {
+            ResolutionStrategy = strategy,
+        };
+        options.SafeSchemes.Add(Uri.UriSchemeHttp);
+        options.SafeIpNetworks.Add(IPNetwork.Parse("::1/128"));
+        options.SafeIpNetworks.Add(IPNetwork.Parse("127.0.0.0/8"));
+
+        using var handler = new SocketsHttpHandler();
+        handler.ConfigureSsrf(options, new FakeDnsIpAddressResolver([IPAddress.IPv6Loopback, IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler);
+
+        _ = await httpClient.GetAsync(new Uri($"http://example.invalid:{server.Port}/"), TestContext.Current.CancellationToken);
+
+        Assert.Collection(
+            strategy.Calls,
+            firstCall => Assert.Equal([IPAddress.IPv6Loopback, IPAddress.Loopback], firstCall),
+            secondCall => Assert.Equal([IPAddress.Loopback], secondCall));
+    }
+
+    [Fact]
+    public async Task ConnectCallback_DoesNotFallBackToAnAddressTheStrategyExcludes()
+    {
+        using var server = new LoopbackHttpServer();
+        var options = new ServerSideRequestForgeryOptions
+        {
+            ResolutionStrategy = IpAddressResolutionStrategy.Ipv6Only,
+        };
+        options.SafeSchemes.Add(Uri.UriSchemeHttp);
+        options.SafeIpNetworks.Add(IPNetwork.Parse("::1/128"));
+        options.SafeIpNetworks.Add(IPNetwork.Parse("127.0.0.0/8"));
+
+        using var handler = new SocketsHttpHandler();
+        handler.ConfigureSsrf(options, new FakeDnsIpAddressResolver([IPAddress.IPv6Loopback, IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler);
+
+        // The live server is on the IPv4 loopback, which Ipv6Only must never fall back to even though the
+        // address passed validation and is reachable.
+        await Assert.ThrowsAsync<HttpRequestException>(() => httpClient.GetAsync(new Uri($"http://example.invalid:{server.Port}/"), TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, server.AcceptedConnectionCount);
+    }
+
+    [Fact]
     public async Task ConnectCallback_SurfacesRejectionAsInnerExceptionOfHttpRequestException()
     {
         var options = new ServerSideRequestForgeryOptions();
@@ -499,6 +571,35 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
             _ = host;
             _ = cancellationToken;
             return ValueTask.FromResult(addresses);
+        }
+    }
+
+    private sealed class FirstAddressStrategy : IpAddressResolutionStrategy
+    {
+        protected internal override ValueTask<IPAddress> ResolveAsync(IReadOnlyList<IPAddress> addresses, ServerSideRequestForgeryOptions options, CancellationToken cancellationToken)
+        {
+            _ = options;
+            _ = cancellationToken;
+            if (addresses.Count == 0)
+                throw new ServerSideRequestForgeryException("No safe IP addresses available after validation.");
+
+            return ValueTask.FromResult(addresses[0]);
+        }
+    }
+
+    private sealed class RecordingStrategy : IpAddressResolutionStrategy
+    {
+        public List<IPAddress[]> Calls { get; } = [];
+
+        protected internal override ValueTask<IPAddress> ResolveAsync(IReadOnlyList<IPAddress> addresses, ServerSideRequestForgeryOptions options, CancellationToken cancellationToken)
+        {
+            _ = options;
+            _ = cancellationToken;
+            Calls.Add([.. addresses]);
+            if (addresses.Count == 0)
+                throw new ServerSideRequestForgeryException("No safe IP addresses available after validation.");
+
+            return ValueTask.FromResult(addresses[0]);
         }
     }
 


### PR DESCRIPTION
Addresses the "only one resolved address is ever tried" finding from the SSRF project review.

> **Stacked PR** — targets `meziantou/ssrf-socket-nodelay` (#1989), which targets `meziantou/ssrf-connect-path-tests` (#1988). Merge order: #1988 → #1989 → this.

## Problem

`IpAddressResolutionStrategy.ResolveAsync` returns a single `IPAddress`, and `ConnectAsync` made exactly one `socket.ConnectAsync` attempt against it. If that address was unreachable the request failed, even when the host resolved to other addresses validated as safe in the same call.

The runtime path this replaces passes the whole `DnsEndPoint` to `Socket.ConnectAsync`, which tries every resolved address in turn. So installing this library converted a transparent failover into an outage — against exactly the multi-homed hosts that are multi-homed for availability. The `PreferIpv4` default made it worse in one specific way: on a dual-stack host whose IPv4 address is down, every request failed despite a working IPv6 address sitting in the validated set.

## Change

The obvious fix — have the strategy return a ranked list — is a breaking change for every custom `IpAddressResolutionStrategy`. Instead, the connect loop **asks the strategy again after each failure, over the addresses that have not failed yet**.

That turns out to be better than a static ordering, because it preserves whatever constraint the strategy expresses rather than second-guessing it:

- `Ipv4Only` still never falls back to IPv6 — when no IPv4 address is left it throws, the loop stops, and the original connect error is surfaced.
- `PreferIpv4` falls back to IPv6 only once every IPv4 address has failed.
- `Random` / `RoundRobin` keep picking from what remains.

`ResolveAndSelectIpAddressAsync` is split into `ResolveSafeIpAddressesAsync` (scheme check, host check, DNS, filtering) and `SelectIpAddressAsync` (strategy + safe-set verification) so the loop can re-run only the second half. The original method is kept as a composition of the two, so its signature and every existing test are untouched.

## Security

Unchanged. Every address attempted still comes from `safeAddresses`, and the "selected address was in the validated set" re-check runs on **each** iteration, not just the first. Cancellation — including the handler's `ConnectTimeout`, which binds the token passed into `ConnectCallback` — breaks the loop rather than being retried, so the timeout still bounds the whole operation as it does on the runtime path.

## Tests

| Test | Asserts |
|---|---|
| `ConnectCallback_FallsBackToAnotherValidatedAddressWhenTheConnectFails` | request succeeds after the first address refuses; server accepted exactly 1 connection |
| `ConnectCallback_AsksTheStrategyAgainWithoutTheAddressThatFailed` | strategy called twice, second call excludes the failed address |
| `ConnectCallback_DoesNotFallBackToAnAddressTheStrategyExcludes` | `Ipv6Only` fails rather than using a reachable, validated IPv4 address; server accepted 0 connections |

The unreachable address is the IPv6 loopback on a port where the test server listens on IPv4 only, so the failure is immediate and deterministic rather than a timeout.

Checked against the parent branch: the first two tests fail without this change, and the third passes both before and after — it is a guard against the fix over-reaching, not a regression test. 82 tests pass across net10.0 and net11.0.

No public API change, so `ref/` is unchanged.