### PR TITLE
Strip the ALL_HEADERS block from SQL batch CommandText

### DIFF
--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsQueryRequestParser.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsQueryRequestParser.cs
@@ -18,7 +18,7 @@ internal static class TdsQueryRequestParser
             {
                 RemoteEndPoint = remoteEndPoint,
                 RequestType = TdsQueryRequestType.SqlBatch,
-                CommandText = DecodeUnicode(packet.Payload),
+                CommandText = DecodeSqlBatchText(packet.Payload),
                 UserContext = userContext,
             },
             TdsPacketType.Rpc => CreateRpcContext(packet.Payload, remoteEndPoint, userContext),
@@ -50,13 +50,7 @@ internal static class TdsQueryRequestParser
             return null;
         }
 
-        var position = 0;
-        var allHeadersLength = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(position, 4));
-        if (allHeadersLength >= 4 && allHeadersLength <= payload.Length)
-        {
-            position = (int)allHeadersLength;
-        }
-
+        var position = GetPayloadOffsetAfterAllHeaders(payload);
         if (position + 4 > payload.Length)
         {
             return null;
@@ -456,9 +450,57 @@ internal static class TdsQueryRequestParser
         };
     }
 
-    private static string DecodeUnicode(byte[] payload)
+    private static string DecodeSqlBatchText(byte[] payload)
     {
-        if (payload.Length == 0)
+        return DecodeUnicode(payload.AsSpan(GetPayloadOffsetAfterAllHeaders(payload)));
+    }
+
+    /// <summary>
+    /// Returns the offset of the payload data that follows the ALL_HEADERS block, or 0 when the
+    /// payload does not start with a well-formed one.
+    /// </summary>
+    /// <remarks>
+    /// TDS 7.2 and later prefix SQLBatch and RPC payloads with ALL_HEADERS: a total length
+    /// (including itself) followed by headers of the form { length, type, data }. Earlier clients
+    /// send the data directly, so the block is validated rather than assumed.
+    /// </remarks>
+    private static int GetPayloadOffsetAfterAllHeaders(ReadOnlySpan<byte> payload)
+    {
+        if (payload.Length < 4)
+        {
+            return 0;
+        }
+
+        var totalLength = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(0, 4));
+        if (totalLength < 4 || totalLength > (uint)payload.Length)
+        {
+            return 0;
+        }
+
+        // Walk the headers: they must tile the block exactly, otherwise this is not ALL_HEADERS.
+        var position = 4u;
+        while (position < totalLength)
+        {
+            if (totalLength - position < 6)
+            {
+                return 0;
+            }
+
+            var headerLength = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice((int)position, 4));
+            if (headerLength < 6 || headerLength > totalLength - position)
+            {
+                return 0;
+            }
+
+            position += headerLength;
+        }
+
+        return (int)totalLength;
+    }
+
+    private static string DecodeUnicode(ReadOnlySpan<byte> payload)
+    {
+        if (payload.IsEmpty)
         {
             return string.Empty;
         }

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -130,7 +130,42 @@ public sealed class TdsServerProtocolTests
 
         Assert.Equal(123, Convert.ToInt32(result, CultureInfo.InvariantCulture));
         Assert.Equal(TdsQueryRequestType.SqlBatch, capturedContext.RequestType);
-        Assert.Contains(Marker, capturedContext.CommandText);
+        Assert.Equal($"SELECT 1 /* {Marker} */", capturedContext.CommandText);
+    }
+
+    [Fact]
+    public async Task SqlClient_TextQuery_CommandText_ExcludesAllHeaders()
+    {
+        var queryContextTask = new TaskCompletionSource<TdsQueryContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) =>
+            {
+                queryContextTask.TrySetResult(context);
+                return ValueTask.FromResult(CreateScalarResultSet(TdsColumnType.Int32, 1));
+            });
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+
+        _ = await command.ExecuteScalarAsync();
+        var capturedContext = await queryContextTask.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // The SQLBatch payload starts with an ALL_HEADERS block whose bytes decode to control
+        // characters. It must not be exposed through CommandText.
+        Assert.Equal("SELECT 1", capturedContext.CommandText);
+        Assert.DoesNotContain(capturedContext.CommandText, character => char.IsControl(character));
     }
 
     [Fact]
@@ -175,8 +210,7 @@ public sealed class TdsServerProtocolTests
 
         Assert.Equal(456, Convert.ToInt32(result, CultureInfo.InvariantCulture));
         Assert.Equal(TdsQueryRequestType.SqlBatch, capturedContext.RequestType);
-        Assert.Contains(Marker, capturedContext.CommandText);
-        Assert.True((capturedContext.CommandText?.Length ?? 0) > 6000);
+        Assert.Equal(query, capturedContext.CommandText);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

TDS 7.2 and later prefix `SQLBatch` payloads with an ALL_HEADERS block (a total-length DWORD followed by `{length, type, data}` headers). `TdsQueryRequestParser` decoded the entire payload as UTF-16, so the block leaked into `TdsQueryContext.CommandText`.

Every SQL batch from a real client arrived with 11 leading control characters. `SELECT 1` came through as:

```
0016 0000 0012 0000 0002 0000 0000 0000 0000 0001 0000  S E L E C T   1
```

`CommandText` is documented public API — the readme shows `var commandText = context.CommandText; // e.g. "SELECT * FROM Users WHERE Id = @id"` — so any handler that compares it, pattern-matches it, uses it as a cache key, or logs it gets garbage. The built-in query engine only kept working because `Microsoft.SqlServer.Management.SqlParser` happens to tolerate those characters as whitespace.

It also meant `string.IsNullOrWhiteSpace(context.CommandText)` in `TdsQueryEngineExecutor.GetCommandText` could never be true, so an empty batch never produced the intended "The SQL batch is empty" error.

## Fix

Skip the ALL_HEADERS block before decoding the batch text.

The new `GetPayloadOffsetAfterAllHeaders` helper validates that the headers tile the block exactly and returns 0 otherwise, so a pre-7.2 client that sends the text directly still works rather than having its first characters eaten. `TryParseRpc` now uses the same helper instead of trusting the length DWORD on its own — it is the same block, parsed two different ways before this change.

## Tests

The existing batch tests asserted with `Assert.Contains`, which is why the prefix went unnoticed; they now assert exact equality. A new test asserts `CommandText` contains no control characters at all.

Verified the new test fails on `main` and passes with the fix. Full suite green: 302/302.