### PR TITLE
Make SensitiveDataTypeConverter aware of the element type

### DIFF
--- a/src/Meziantou.Framework.SensitiveData/SensitiveDataTypeConverter.cs
+++ b/src/Meziantou.Framework.SensitiveData/SensitiveDataTypeConverter.cs
@@ -5,9 +5,27 @@ namespace Meziantou.Framework;
 [SuppressMessage("Usage", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated dynamically")]
 internal sealed class SensitiveDataTypeConverter : TypeConverter
 {
+    private readonly Type _type;
+
+    public SensitiveDataTypeConverter()
+        : this(typeof(SensitiveData<char>))
+    {
+    }
+
+    // TypeDescriptor uses this constructor when a converter declared by TypeConverterAttribute
+    // exposes it, and passes the type being described. SensitiveDataTypeConverter is declared on
+    // the open generic SensitiveData<T>, so without it the converter cannot tell SensitiveData<char>
+    // apart from any other construction of SensitiveData<T>.
+    public SensitiveDataTypeConverter(Type type)
+    {
+        _type = type;
+    }
+
+    private bool IsSupportedType => _type == typeof(SensitiveData<char>);
+
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
     {
-        return sourceType == typeof(string);
+        return IsSupportedType && sourceType == typeof(string);
     }
 
     public override bool CanConvertTo(ITypeDescriptorContext? context, [NotNullWhen(true)] Type? destinationType)
@@ -24,6 +42,9 @@ internal sealed class SensitiveDataTypeConverter : TypeConverter
     {
         if (value is string str)
         {
+            if (!IsSupportedType)
+                throw new NotSupportedException($"Cannot convert a string to '{_type}'. Only '{typeof(SensitiveData<char>)}' can be created from a string.");
+
             return SensitiveData.Create(str);
         }
 

--- a/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
+++ b/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
@@ -143,4 +143,12 @@ public sealed class SensitiveDataTests
         using var data = SensitiveData.Create("foo");
         Assert.Throws<InvalidOperationException>(() => TypeDescriptor.GetConverter(typeof(SensitiveData<char>)).ConvertToString(data));
     }
+
+    [Fact]
+    public void CannotConvertFromStringToNonCharElementType()
+    {
+        var converter = TypeDescriptor.GetConverter(typeof(SensitiveData<byte>));
+        Assert.False(converter.CanConvertFrom(typeof(string)));
+        Assert.Throws<NotSupportedException>(() => converter.ConvertFromString("bar"));
+    }
 }


### PR DESCRIPTION
Fixes the `[High]` finding from the `Meziantou.Framework.SensitiveData` project review.

## Problem

`SensitiveDataTypeConverter` is attached by `[TypeConverter]` to the **open generic** `SensitiveData<T>`, so `TypeDescriptor` hands it out for every construction of that type. But `ConvertFrom` hardcoded `SensitiveData.Create(str)`, which always returns a `SensitiveData<char>`:

```
TypeDescriptor.GetConverter(typeof(SensitiveData<byte>)).ConvertFromString("bar")
  result type = Meziantou.Framework.SensitiveData`1[System.Char]
  THREW InvalidCastException: Unable to cast object of type
        'SensitiveData`1[System.Char]' to type 'SensitiveData`1[System.Byte]'.
```

The converter exists to make `SensitiveData` bindable from configuration, and `SensitiveData<byte>` is a natural fit for that (API keys, signing keys). Today it fails at bind time with an `InvalidCastException` whose message points at the converter rather than at the offending configuration value.

The existing test only covered `SensitiveData<char>`, which is why this went unnoticed.

## Change

`TypeDescriptor` passes the type being described to a converter that declares a `ctor(Type)` — the same mechanism `NullableConverter` and `EnumConverter` use. This PR adds that constructor and uses it to answer honestly:

- `SensitiveData<char>` — unchanged, still converts from `string`.
- Every other element type — `CanConvertFrom` now returns `false`, and `ConvertFrom` throws `NotSupportedException` naming both the requested and the supported type.

Creating a `SensitiveData<byte>` from a string would require choosing a string encoding (base64? UTF-8?), which is a separate API decision and deliberately **not** made here. This PR only makes the unsupported cases fail comprehensibly instead of silently producing an instance of the wrong type.

No public API change — `SensitiveDataTypeConverter` is internal, so `ref/` is unchanged.

## Testing

- `CannotConvertFromStringToNonCharElementType` covers the reported case. It also pins the mechanism: if `TypeDescriptor` were not calling the new `ctor(Type)`, `_type` would fall back to `SensitiveData<char>` and the `Assert.False(CanConvertFrom)` would fail.
- `dotnet test -f net10.0 /p:TreatsWarningsAsErrors=true` → 23 passed, 0 failed.
- `dotnet test -f net11.0 /p:TreatsWarningsAsErrors=true` → 23 passed, 0 failed.
- `dotnet run ./eng/update-all.cs` → no changes produced.

Tested on macOS/arm64 only.