### PR TITLE
Decode varbinary(max) RPC parameters using PLP framing

### DIFF
--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsQueryRequestParser.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsQueryRequestParser.cs
@@ -337,8 +337,25 @@ internal static class TdsQueryRequestParser
             return null;
         }
 
-        _ = BinaryPrimitives.ReadUInt16LittleEndian(payload.Slice(position, 2));
+        var maxLength = BinaryPrimitives.ReadUInt16LittleEndian(payload.Slice(position, 2));
         position += 2;
+
+        if (maxLength == 0xFFFF)
+        {
+            var plpPayload = TryReadPlpPayload(payload, ref position, out var isNull);
+            if (isNull)
+            {
+                return CreateParameter(name, rawValue: null, TdsColumnType.Binary);
+            }
+
+            if (plpPayload is null)
+            {
+                return null;
+            }
+
+            return CreateParameter(name, plpPayload, TdsColumnType.Binary);
+        }
+
         var valueLength = BinaryPrimitives.ReadUInt16LittleEndian(payload.Slice(position, 2));
         position += 2;
 

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -265,6 +265,85 @@ public sealed class TdsServerProtocolTests
     }
 
     [Fact]
+    public async Task SqlClient_RpcParameter_VarBinaryMax_PreservesValue()
+    {
+        var payload = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 };
+        var queryContextTask = new TaskCompletionSource<TdsQueryContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) =>
+            {
+                if (context.RequestType == TdsQueryRequestType.Rpc)
+                {
+                    queryContextTask.TrySetResult(context);
+                }
+
+                return ValueTask.FromResult(CreateScalarResultSet(TdsColumnType.Int32, 1));
+            });
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT @value";
+        _ = command.Parameters.Add(new SqlParameter("@value", SqlDbType.VarBinary, -1) { Value = payload });
+
+        _ = await command.ExecuteScalarAsync();
+        var capturedContext = await queryContextTask.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var parameter = Assert.Single(capturedContext.Parameters, candidate => candidate.Name == "@value");
+        Assert.Equal(TdsColumnType.Binary, parameter.Type);
+        Assert.Equal(payload, parameter.AsBinary());
+    }
+
+    [Fact]
+    public async Task SqlClient_RpcParameter_VarBinaryMax_Null_IsDecodedAsNull()
+    {
+        var queryContextTask = new TaskCompletionSource<TdsQueryContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) =>
+            {
+                if (context.RequestType == TdsQueryRequestType.Rpc)
+                {
+                    queryContextTask.TrySetResult(context);
+                }
+
+                return ValueTask.FromResult(CreateScalarResultSet(TdsColumnType.Int32, 1));
+            });
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT @value";
+        _ = command.Parameters.Add(new SqlParameter("@value", SqlDbType.VarBinary, -1) { Value = DBNull.Value });
+
+        _ = await command.ExecuteScalarAsync();
+        var capturedContext = await queryContextTask.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var parameter = Assert.Single(capturedContext.Parameters, candidate => candidate.Name == "@value");
+        Assert.Equal(TdsColumnType.Binary, parameter.Type);
+        Assert.True(parameter.IsNull);
+    }
+
+    [Fact]
     public async Task SqlClient_TextQuery_ParsedWithSqlParser_ReturnsFilteredCustomers()
     {
         const string Query = "SELECT Id, Name FROM customers WHERE Id = 1";


### PR DESCRIPTION
`ParseVarBinaryParameter` always read a 2-byte value length, but `varbinary(max)` is sent partially-length-prefixed (PLP): an 8-byte total length followed by length-prefixed chunks. The parser read the low 16 bits of the PLP length as if it were the value length, then copied that many bytes starting *inside* the length field.

The result was silent data corruption on a supported parameter type. Verified against a real `SqlConnection`: a `SqlDbType.VarBinary, size -1` parameter with the value `01 02 03 04 05` reached the query callback as `00 00 00 00 00`. `AsBinary()` returned plausible-looking bytes that were simply not what the client sent.

`ParseNVarCharParameter` and `ParseVarCharParameter` already branch on a `0xFFFF` max length and call `TryReadPlpPayload`; the binary path was never given the same branch. This adds it.

Two tests, both driving a real `SqlConnection`: one round-trips a `varbinary(max)` value, one covers the NULL case.

Found by a review of `src/Meziantou.Framework.TdsServer`.