### PR TITLE
Fix the SensitiveData documentation samples so they compile

### DIFF
--- a/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
+++ b/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
@@ -179,9 +179,10 @@ public static partial class SensitiveData
 /// char[] revealed = secret.RevealToArray();
 ///
 /// // Use the data with a callback to avoid keeping it in memory
-/// secret.RevealAndUse(state: null, (span, _) => {
+/// secret.RevealAndUse(arg: Console.Out, static (span, output) =>
+/// {
 ///     // Process the sensitive data here
-///     Console.WriteLine($"Processing {span.Length} characters");
+///     output.WriteLine($"Processing {span.Length} characters");
 /// });
 /// </code>
 /// </example>

--- a/src/Meziantou.Framework.SensitiveData/readme.md
+++ b/src/Meziantou.Framework.SensitiveData/readme.md
@@ -3,14 +3,22 @@
 `Meziantou.Framework.SensitiveData` provides the `SensitiveData` class. This class represent sensitive data which should be difficult to accidentally disclose. But there's no effort to thwart *intentional* disclosure of these contents, such as through a debugger or memory dump utility.
 
 ````c#
-using var secret = SensitiveData.Create<string>("secret");
+// Create sensitive data from a string
+using var secret = SensitiveData.Create("secret");
 
-// Reveal data
-byte[] data = secret.RevealToArray();
+// Reveal the data
 string str = secret.RevealToString();
+char[] chars = secret.RevealToArray();
 
-var buffer = new byte[10];
+var buffer = new char[secret.GetLength()];
 secret.RevealInto(buffer);
+
+// Or use it without keeping a copy of your own
+secret.RevealAndUse(arg: Console.Out, static (span, output) => output.WriteLine(span.Length));
+
+// Create sensitive data from a buffer of any unmanaged type
+using var key = SensitiveData.Create(new byte[] { 1, 2, 3, 4, 5 });
+byte[] revealedKey = key.RevealToArray();
 ````
 
 # Additional resources


### PR DESCRIPTION
Fixes the `[Medium]` documentation finding from the `Meziantou.Framework.SensitiveData` project review.

## Problem

`src/Meziantou.Framework.SensitiveData/readme.md` is the NuGet package description page — for most users it is the entire documentation. Its only code sample does not compile. Every line is wrong:

```
error CS1503: Argument 1: cannot convert from 'string' to 'string[]'
error CS0029: Cannot implicitly convert type 'string[]' to 'byte[]'
error CS1929: 'SensitiveData<string>' does not contain a definition for 'RevealToString'
error CS1503: Argument 1: cannot convert from 'byte[]' to 'System.Span<string>'
```

`SensitiveData.Create<string>("secret")` is wrong twice over — `Create(string)` is not generic, and `string` cannot satisfy `where T : unmanaged`. The sample then treats the result as both `SensitiveData<byte>` and `SensitiveData<char>` in successive lines.

While fixing it I checked the XML doc samples as well, and the `<example>` on `SensitiveData<T>` turns out to be broken too — the review said it was fine, which was wrong. It passes `state: null` to `RevealAndUse`, whose parameter is named `arg` and whose `TArg` cannot be inferred from `null`:

```
error CS1739: The best overload for 'RevealAndUse' does not have a parameter named 'state'
```

The class-level `<example>` on `SensitiveData` was correct and is unchanged.

## Change

Rewrote both broken samples. The `RevealAndUse` call now passes `Console.Out` through the `arg` parameter rather than a placeholder, so the example also demonstrates what that parameter is for — passing state without allocating a closure.

Documentation only. No source behavior, no API change, `ref/` unchanged.

## Testing

Each sample in this PR was extracted into a program, compiled against the library, and executed before being pasted back — that is how the `state:` bug surfaced. All three now compile and run clean.

- `dotnet test -f net10.0 /p:TreatsWarningsAsErrors=true` → 22 passed, 0 failed.
- `dotnet run ./eng/update-all.cs` → no changes produced.

Tested on macOS/arm64 only.