### PR TITLE
Stop silently dropping RPC parameters after an undecodable type

### DIFF
--- a/ref/Meziantou.Framework.TdsServer.cs
+++ b/ref/Meziantou.Framework.TdsServer.cs
@@ -98,6 +98,7 @@ namespace Meziantou.Framework.Tds.Handler
         public string? CommandText { get => throw null; init { } }
         public string? ProcedureName { get => throw null; init { } }
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Tds.Handler.TdsQueryParameter> Parameters { get => throw null; init { } }
+        public bool HasCompleteParameters { get => throw null; init { } }
         public System.Security.Claims.ClaimsPrincipal? UserContext { get => throw null; init { } }
     }
 

--- a/src/Meziantou.Framework.TdsServer/Handler/TdsQueryContext.cs
+++ b/src/Meziantou.Framework.TdsServer/Handler/TdsQueryContext.cs
@@ -21,6 +21,14 @@ public sealed class TdsQueryContext
     /// <summary>Gets the decoded RPC parameters.</summary>
     public IReadOnlyList<TdsQueryParameter> Parameters { get; init; } = [];
 
+    /// <summary>
+    /// Gets a value indicating whether every parameter sent by the client was decoded.
+    /// This is <see langword="false"/> when <see cref="Parameters"/> is truncated because the client sent a
+    /// parameter whose type the server cannot decode, or because the payload was malformed. Requests with
+    /// incomplete parameters should be rejected rather than acted on, because the missing values are silent.
+    /// </summary>
+    public bool HasCompleteParameters { get; init; } = true;
+
     /// <summary>Gets the authenticated user context associated with this query request.</summary>
     public ClaimsPrincipal? UserContext { get; init; }
 }

--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsQueryRequestParser.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsQueryRequestParser.cs
@@ -7,6 +7,8 @@ namespace Meziantou.Framework.Tds.Protocol;
 
 internal static class TdsQueryRequestParser
 {
+    private static readonly DateTime SqlEpoch = new(1900, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+
     public static TdsQueryContext Parse(TdsPacket packet, EndPoint remoteEndPoint, ClaimsPrincipal? userContext)
     {
         ArgumentNullException.ThrowIfNull(packet);
@@ -39,6 +41,7 @@ internal static class TdsQueryRequestParser
             RequestType = TdsQueryRequestType.Rpc,
             ProcedureName = request.ProcedureName,
             Parameters = request.Parameters,
+            HasCompleteParameters = request.HasCompleteParameters,
             UserContext = userContext,
         };
     }
@@ -101,11 +104,15 @@ internal static class TdsQueryRequestParser
         position += 2; // Option flags
 
         var parameters = new List<TdsQueryParameter>();
+        var hasCompleteParameters = true;
         while (position < payload.Length)
         {
             var parameter = TryParseParameter(payload, ref position);
             if (parameter is null)
             {
+                // The wire length of an undecodable parameter is unknown, so parsing cannot continue past it.
+                // Report the truncation instead of silently handing back a short parameter list.
+                hasCompleteParameters = false;
                 break;
             }
 
@@ -116,6 +123,7 @@ internal static class TdsQueryRequestParser
         {
             ProcedureName = procedureName,
             Parameters = parameters,
+            HasCompleteParameters = hasCompleteParameters,
         };
     }
 
@@ -141,12 +149,20 @@ internal static class TdsQueryRequestParser
 
         return typeToken switch
         {
+            0x24 => ParseGuidParameter(payload, ref position, name),
             0x26 => ParseIntNParameter(payload, ref position, name),
+            0x28 => ParseDateParameter(payload, ref position, name),
+            0x29 => ParseTimeParameter(payload, ref position, name),
+            0x2A => ParseDateTime2Parameter(payload, ref position, name),
+            0x2B => ParseDateTimeOffsetParameter(payload, ref position, name),
             0x68 => ParseBitNParameter(payload, ref position, name),
+            0x6A or 0x6C => ParseDecimalParameter(payload, ref position, name),
             0x6D => ParseFloatNParameter(payload, ref position, name),
-            0xA7 => ParseVarCharParameter(payload, ref position, name),
-            0xE7 => ParseNVarCharParameter(payload, ref position, name),
-            0xA5 => ParseVarBinaryParameter(payload, ref position, name),
+            0x6E => ParseMoneyParameter(payload, ref position, name),
+            0x6F => ParseDateTimeParameter(payload, ref position, name),
+            0xA5 or 0xAD => ParseVarBinaryParameter(payload, ref position, name),
+            0xA7 or 0xAF => ParseVarCharParameter(payload, ref position, name),
+            0xE7 or 0xEF => ParseNVarCharParameter(payload, ref position, name),
             0xF4 => ParseJsonParameter(payload, ref position, name),
             _ => null,
         };
@@ -388,6 +404,332 @@ internal static class TdsQueryRequestParser
         }
 
         return CreateParameter(name, Encoding.UTF8.GetString(plpPayload), TdsColumnType.Json);
+    }
+
+    private static TdsQueryParameter? ParseGuidParameter(ReadOnlySpan<byte> payload, ref int position, string name)
+    {
+        if (position + 2 > payload.Length)
+        {
+            return null;
+        }
+
+        _ = payload[position++]; // max length
+        var valueLength = payload[position++];
+        if (valueLength == 0)
+        {
+            return CreateParameter(name, rawValue: null, TdsColumnType.Guid);
+        }
+
+        if (valueLength != 16 || position + valueLength > payload.Length)
+        {
+            return null;
+        }
+
+        var value = new Guid(payload.Slice(position, 16));
+        position += valueLength;
+        return CreateParameter(name, value, TdsColumnType.Guid);
+    }
+
+    private static TdsQueryParameter? ParseDecimalParameter(ReadOnlySpan<byte> payload, ref int position, string name)
+    {
+        if (position + 4 > payload.Length)
+        {
+            return null;
+        }
+
+        _ = payload[position++]; // max length
+        _ = payload[position++]; // precision
+        var scale = payload[position++];
+        var valueLength = payload[position++];
+        if (valueLength == 0)
+        {
+            return CreateParameter(name, rawValue: null, TdsColumnType.Decimal);
+        }
+
+        if (position + valueLength > payload.Length)
+        {
+            return null;
+        }
+
+        var encoded = payload.Slice(position, valueLength);
+        position += valueLength;
+
+        // DECIMALN/NUMERICN values are a sign byte followed by a little-endian magnitude.
+        var isNegative = encoded[0] == 0;
+        var magnitude = encoded[1..];
+        if (scale > 28 || !TryReadDecimalMagnitude(magnitude, out var low, out var middle, out var high))
+        {
+            // The value does not fit in System.Decimal; surface the raw payload rather than losing it.
+            return CreateParameter(name, encoded.ToArray(), TdsColumnType.Variant);
+        }
+
+        var value = new decimal((int)low, (int)middle, (int)high, isNegative, scale);
+        return CreateParameter(name, value, TdsColumnType.Decimal);
+    }
+
+    private static bool TryReadDecimalMagnitude(ReadOnlySpan<byte> magnitude, out uint low, out uint middle, out uint high)
+    {
+        low = 0;
+        middle = 0;
+        high = 0;
+
+        Span<byte> bits = stackalloc byte[12];
+        bits.Clear();
+        for (var i = 0; i < magnitude.Length; i++)
+        {
+            if (i >= bits.Length)
+            {
+                if (magnitude[i] != 0)
+                {
+                    return false;
+                }
+
+                continue;
+            }
+
+            bits[i] = magnitude[i];
+        }
+
+        low = BinaryPrimitives.ReadUInt32LittleEndian(bits[..4]);
+        middle = BinaryPrimitives.ReadUInt32LittleEndian(bits[4..8]);
+        high = BinaryPrimitives.ReadUInt32LittleEndian(bits[8..12]);
+        return true;
+    }
+
+    private static TdsQueryParameter? ParseMoneyParameter(ReadOnlySpan<byte> payload, ref int position, string name)
+    {
+        if (position + 2 > payload.Length)
+        {
+            return null;
+        }
+
+        var maxLength = payload[position++];
+        var columnType = maxLength == 4 ? TdsColumnType.SmallMoney : TdsColumnType.Money;
+        var valueLength = payload[position++];
+        if (valueLength == 0)
+        {
+            return CreateParameter(name, rawValue: null, columnType);
+        }
+
+        if (position + valueLength > payload.Length)
+        {
+            return null;
+        }
+
+        var encoded = payload.Slice(position, valueLength);
+        position += valueLength;
+
+        // MONEY is stored as an integer number of ten-thousandths, with the high word first.
+        var units = valueLength switch
+        {
+            4 => BinaryPrimitives.ReadInt32LittleEndian(encoded),
+            8 => ((long)BinaryPrimitives.ReadInt32LittleEndian(encoded[..4]) << 32) | BinaryPrimitives.ReadUInt32LittleEndian(encoded[4..8]),
+            _ => (long?)null,
+        };
+
+        return units is null
+            ? CreateParameter(name, encoded.ToArray(), TdsColumnType.Variant)
+            : CreateParameter(name, units.Value / 10000m, columnType);
+    }
+
+    private static TdsQueryParameter? ParseDateTimeParameter(ReadOnlySpan<byte> payload, ref int position, string name)
+    {
+        if (position + 2 > payload.Length)
+        {
+            return null;
+        }
+
+        _ = payload[position++]; // max length
+        var valueLength = payload[position++];
+        if (valueLength == 0)
+        {
+            return CreateParameter(name, rawValue: null, TdsColumnType.DateTime);
+        }
+
+        if (position + valueLength > payload.Length)
+        {
+            return null;
+        }
+
+        var encoded = payload.Slice(position, valueLength);
+        position += valueLength;
+
+        // Both forms count days from 1900-01-01; DATETIME uses 1/300s ticks, SMALLDATETIME whole minutes.
+        var value = valueLength switch
+        {
+            4 => SqlEpoch.AddDays(BinaryPrimitives.ReadUInt16LittleEndian(encoded[..2])).AddMinutes(BinaryPrimitives.ReadUInt16LittleEndian(encoded[2..4])),
+            8 => SqlEpoch.AddDays(BinaryPrimitives.ReadInt32LittleEndian(encoded[..4])).AddTicks(BinaryPrimitives.ReadUInt32LittleEndian(encoded[4..8]) * TimeSpan.TicksPerSecond / 300),
+            _ => (DateTime?)null,
+        };
+
+        return value is null
+            ? CreateParameter(name, encoded.ToArray(), TdsColumnType.Variant)
+            : CreateParameter(name, value.Value, TdsColumnType.DateTime);
+    }
+
+    private static TdsQueryParameter? ParseDateParameter(ReadOnlySpan<byte> payload, ref int position, string name)
+    {
+        // DATE carries no scale byte, only the value length.
+        if (position + 1 > payload.Length)
+        {
+            return null;
+        }
+
+        var valueLength = payload[position++];
+        if (valueLength == 0)
+        {
+            return CreateParameter(name, rawValue: null, TdsColumnType.Date);
+        }
+
+        if (valueLength != 3 || position + valueLength > payload.Length)
+        {
+            return null;
+        }
+
+        var value = DateOnly.MinValue.AddDays(ReadUInt24LittleEndian(payload.Slice(position, 3)));
+        position += valueLength;
+        return CreateParameter(name, value, TdsColumnType.Date);
+    }
+
+    private static TdsQueryParameter? ParseTimeParameter(ReadOnlySpan<byte> payload, ref int position, string name)
+    {
+        if (position + 2 > payload.Length)
+        {
+            return null;
+        }
+
+        var scale = payload[position++];
+        var valueLength = payload[position++];
+        if (valueLength == 0)
+        {
+            return CreateParameter(name, rawValue: null, TdsColumnType.Time);
+        }
+
+        if (position + valueLength > payload.Length)
+        {
+            return null;
+        }
+
+        if (!TryReadScaledTime(payload.Slice(position, valueLength), scale, out var timeOfDay))
+        {
+            return null;
+        }
+
+        position += valueLength;
+        return CreateParameter(name, TimeOnly.FromTimeSpan(timeOfDay), TdsColumnType.Time);
+    }
+
+    private static TdsQueryParameter? ParseDateTime2Parameter(ReadOnlySpan<byte> payload, ref int position, string name)
+    {
+        if (position + 2 > payload.Length)
+        {
+            return null;
+        }
+
+        var scale = payload[position++];
+        var valueLength = payload[position++];
+        if (valueLength == 0)
+        {
+            return CreateParameter(name, rawValue: null, TdsColumnType.DateTime2);
+        }
+
+        if (position + valueLength > payload.Length)
+        {
+            return null;
+        }
+
+        if (!TryReadDateTime2(payload.Slice(position, valueLength), scale, out var value))
+        {
+            return null;
+        }
+
+        position += valueLength;
+        return CreateParameter(name, value, TdsColumnType.DateTime2);
+    }
+
+    private static TdsQueryParameter? ParseDateTimeOffsetParameter(ReadOnlySpan<byte> payload, ref int position, string name)
+    {
+        if (position + 2 > payload.Length)
+        {
+            return null;
+        }
+
+        var scale = payload[position++];
+        var valueLength = payload[position++];
+        if (valueLength == 0)
+        {
+            return CreateParameter(name, rawValue: null, TdsColumnType.DateTimeOffset);
+        }
+
+        if (valueLength < 3 || position + valueLength > payload.Length)
+        {
+            return null;
+        }
+
+        var encoded = payload.Slice(position, valueLength);
+
+        // A DATETIMEOFFSET value is a UTC DATETIME2 followed by the offset in signed minutes.
+        if (!TryReadDateTime2(encoded[..^2], scale, out var utcValue))
+        {
+            return null;
+        }
+
+        var offset = TimeSpan.FromMinutes(BinaryPrimitives.ReadInt16LittleEndian(encoded[^2..]));
+        position += valueLength;
+        return CreateParameter(name, new DateTimeOffset(utcValue, TimeSpan.Zero).ToOffset(offset), TdsColumnType.DateTimeOffset);
+    }
+
+    private static bool TryReadDateTime2(ReadOnlySpan<byte> encoded, byte scale, out DateTime value)
+    {
+        value = default;
+        if (encoded.Length < 4)
+        {
+            return false;
+        }
+
+        if (!TryReadScaledTime(encoded[..^3], scale, out var timeOfDay))
+        {
+            return false;
+        }
+
+        value = DateTime.MinValue.AddDays(ReadUInt24LittleEndian(encoded[^3..])).Add(timeOfDay);
+        return true;
+    }
+
+    private static bool TryReadScaledTime(ReadOnlySpan<byte> encoded, byte scale, out TimeSpan value)
+    {
+        value = default;
+        if (scale > 7 || encoded.Length is < 3 or > 5)
+        {
+            return false;
+        }
+
+        ulong units = 0;
+        for (var i = encoded.Length - 1; i >= 0; i--)
+        {
+            units = (units << 8) | encoded[i];
+        }
+
+        // The value counts 10^-scale seconds; scale it up to 100ns ticks.
+        var ticksPerUnit = 1L;
+        for (var i = scale; i < 7; i++)
+        {
+            ticksPerUnit *= 10;
+        }
+
+        var ticks = (long)units * ticksPerUnit;
+        if (ticks is < 0 or >= TimeSpan.TicksPerDay)
+        {
+            return false;
+        }
+
+        value = TimeSpan.FromTicks(ticks);
+        return true;
+    }
+
+    private static int ReadUInt24LittleEndian(ReadOnlySpan<byte> value)
+    {
+        return value[0] | (value[1] << 8) | (value[2] << 16);
     }
 
     private static byte[]? TryReadPlpPayload(ReadOnlySpan<byte> payload, ref int position, out bool isNull)

--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsRpcRequest.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsRpcRequest.cs
@@ -7,4 +7,6 @@ internal sealed class TdsRpcRequest
     public string? ProcedureName { get; init; }
 
     public required List<TdsQueryParameter> Parameters { get; init; }
+
+    public bool HasCompleteParameters { get; init; } = true;
 }

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
@@ -50,6 +50,11 @@ internal sealed class TdsQueryEngineExecutor
         var queryExecutionContext = CreateQueryExecutionContext(context);
         try
         {
+            if (!context.HasCompleteParameters)
+            {
+                throw new TdsQueryEngineException("The request contains a parameter whose type could not be decoded, so the parameter list is incomplete.");
+            }
+
             if (context.RequestType == TdsQueryRequestType.Rpc && !string.Equals(context.ProcedureName, "sp_executesql", StringComparison.OrdinalIgnoreCase))
             {
                 return await ExecuteStoredProcedureAsync(context, cancellationToken).ConfigureAwait(false);

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -305,6 +305,113 @@ public sealed class TdsServerProtocolTests
     }
 
     [Fact]
+    public async Task SqlClient_RpcParameters_CommonSqlTypes_AreAllDecoded()
+    {
+        var expectedGuid = Guid.Parse("1b4e28ba-2fa1-11d2-883f-0016d3cca427");
+        var queryContextTask = new TaskCompletionSource<TdsQueryContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) =>
+            {
+                if (context.RequestType == TdsQueryRequestType.Rpc)
+                {
+                    queryContextTask.TrySetResult(context);
+                }
+
+                return ValueTask.FromResult(CreateScalarResultSet(TdsColumnType.Int32, 1));
+            });
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT @guid, @decimal, @money, @smallmoney, @datetime, @smalldatetime, @date, @time, @datetime2, @offset, @int";
+        _ = command.Parameters.Add(new SqlParameter("@guid", SqlDbType.UniqueIdentifier) { Value = expectedGuid });
+        _ = command.Parameters.Add(new SqlParameter("@decimal", SqlDbType.Decimal) { Precision = 18, Scale = 4, Value = 1234.5678m });
+        _ = command.Parameters.Add(new SqlParameter("@money", SqlDbType.Money) { Value = 12.34m });
+        _ = command.Parameters.Add(new SqlParameter("@smallmoney", SqlDbType.SmallMoney) { Value = -1.5m });
+        _ = command.Parameters.Add(new SqlParameter("@datetime", SqlDbType.DateTime) { Value = new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Unspecified) });
+        _ = command.Parameters.Add(new SqlParameter("@smalldatetime", SqlDbType.SmallDateTime) { Value = new DateTime(2020, 1, 2, 3, 4, 0, DateTimeKind.Unspecified) });
+        _ = command.Parameters.Add(new SqlParameter("@date", SqlDbType.Date) { Value = new DateTime(2020, 1, 2, 0, 0, 0, DateTimeKind.Unspecified) });
+        _ = command.Parameters.Add(new SqlParameter("@time", SqlDbType.Time) { Value = new TimeSpan(0, 3, 4, 5, 123) });
+        _ = command.Parameters.Add(new SqlParameter("@datetime2", SqlDbType.DateTime2) { Value = new DateTime(2020, 1, 2, 3, 4, 5, 123, DateTimeKind.Unspecified) });
+        _ = command.Parameters.Add(new SqlParameter("@offset", SqlDbType.DateTimeOffset) { Value = new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.FromHours(2)) });
+        _ = command.Parameters.Add(new SqlParameter("@int", SqlDbType.Int) { Value = 42 });
+
+        _ = await command.ExecuteScalarAsync();
+        var capturedContext = await queryContextTask.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(capturedContext.HasCompleteParameters);
+        Assert.Equal(expectedGuid, GetParameterValue(capturedContext, "@guid", TdsColumnType.Guid));
+        Assert.Equal(1234.5678m, GetParameterValue(capturedContext, "@decimal", TdsColumnType.Decimal));
+        Assert.Equal(12.34m, GetParameterValue(capturedContext, "@money", TdsColumnType.Money));
+        Assert.Equal(-1.5m, GetParameterValue(capturedContext, "@smallmoney", TdsColumnType.SmallMoney));
+        Assert.Equal(new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Unspecified), GetParameterValue(capturedContext, "@datetime", TdsColumnType.DateTime));
+        Assert.Equal(new DateTime(2020, 1, 2, 3, 4, 0, DateTimeKind.Unspecified), GetParameterValue(capturedContext, "@smalldatetime", TdsColumnType.DateTime));
+        Assert.Equal(new DateOnly(2020, 1, 2), GetParameterValue(capturedContext, "@date", TdsColumnType.Date));
+        Assert.Equal(new TimeOnly(3, 4, 5, 123), GetParameterValue(capturedContext, "@time", TdsColumnType.Time));
+        Assert.Equal(new DateTime(2020, 1, 2, 3, 4, 5, 123, DateTimeKind.Unspecified), GetParameterValue(capturedContext, "@datetime2", TdsColumnType.DateTime2));
+        Assert.Equal(new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.FromHours(2)), GetParameterValue(capturedContext, "@offset", TdsColumnType.DateTimeOffset));
+
+        // The int parameter is sent last: before this fix the first undecodable type dropped everything after it.
+        Assert.Equal(42, GetParameterValue(capturedContext, "@int", TdsColumnType.Int32));
+    }
+
+    [Fact]
+    public async Task SqlClient_RpcParameters_UndecodableType_ReportsIncompleteParameters()
+    {
+        var queryContextTask = new TaskCompletionSource<TdsQueryContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) =>
+            {
+                if (context.RequestType == TdsQueryRequestType.Rpc)
+                {
+                    queryContextTask.TrySetResult(context);
+                }
+
+                return ValueTask.FromResult(CreateScalarResultSet(TdsColumnType.Int32, 1));
+            });
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT @xml, @int";
+        _ = command.Parameters.Add(new SqlParameter("@xml", SqlDbType.Xml) { Value = "<root />" });
+        _ = command.Parameters.Add(new SqlParameter("@int", SqlDbType.Int) { Value = 42 });
+
+        _ = await command.ExecuteScalarAsync();
+        var capturedContext = await queryContextTask.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(capturedContext.HasCompleteParameters);
+        Assert.DoesNotContain(capturedContext.Parameters, parameter => parameter.Name == "@int");
+    }
+
+    private static object? GetParameterValue(TdsQueryContext context, string name, TdsColumnType expectedType)
+    {
+        var parameter = Assert.Single(context.Parameters, candidate => candidate.Name == name);
+        Assert.Equal(expectedType, parameter.Type);
+        return parameter.Value;
+    }
+
+    [Fact]
     public async Task SqlClient_RpcParameter_VarBinaryMax_Null_IsDecodedAsNull()
     {
         var queryContextTask = new TaskCompletionSource<TdsQueryContext>(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
Stacked on #1993 — review that one first.

`TryParseParameter` handled seven type tokens and returned `null` for everything else. The caller treated `null` as "stop", `break`'d out of the loop, and returned the parameters collected so far. Because the parser cannot know the wire length of a type it does not recognise, it cannot skip it — so **one** unknown parameter silently discarded every parameter after it.

`DATETIME2`, `DATETIME`, `DATE`, `TIME`, `DECIMAL`/`NUMERIC`, `MONEY`, `UNIQUEIDENTIFIER`, `CHAR`/`NCHAR` and `BINARY` were all in the unhandled set — a `DateTime` parameter is unremarkable in real client code.

Verified against a real `SqlConnection`: `SELECT @a, @b, @c, @d` with `@a varbinary(max)`, `@b datetime2`, `@c nvarchar(10)`, `@d int` reached the query callback with only `@a` present. `@c` and `@d` — both supported types — were gone, with no indication anything was lost.

Two halves to the fix:

**Decode the remaining common `TYPE_INFO` tokens** so they stop being unknown: `GUIDN`, `DECIMALN`/`NUMERICN`, `MONEYN`, `DATETIMN` (both `datetime` and `smalldatetime`), `DATEN`, `TIMEN`, `DATETIME2N`, `DATETIMEOFFSETN`, plus the fixed-length `BIGCHAR`/`NCHAR`/`BIGBINARY` tokens which share a layout with their varying counterparts. Values that do not fit `System.Decimal` fall back to the raw payload as `Variant` rather than being lost, matching the existing `INTN` fallback.

**Stop pretending a truncated parse succeeded.** `TdsQueryContext` gains `HasCompleteParameters`, which is `false` when the parameter list was cut short. The built-in query engine now rejects such requests with a clear error instead of running a query with silently missing values; low-level callbacks can check the flag themselves. It defaults to `true`, so existing code is unaffected.

Tests round-trip all ten types through a real `SqlConnection` in a single RPC and assert each decoded value — which is also what validates the length arithmetic in each new decoder — plus a test that a still-undecodable type (`xml`) sets the flag and that the following parameter is absent.

Found by a review of `src/Meziantou.Framework.TdsServer`.