### PR TITLE
Reject connections that target an HTTP proxy

### DIFF
--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/Log.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/Log.cs
@@ -21,4 +21,7 @@ internal static partial class Log
 
     [LoggerMessage(EventId = 6, Level = LogLevel.Warning, Message = "Rejected request to {requestUri}. Resolution strategy failed: {reason}")]
     public static partial void RejectedResolutionStrategyFailure(ILogger logger, Uri requestUri, string reason);
+
+    [LoggerMessage(EventId = 7, Level = LogLevel.Warning, Message = "Rejected request to {requestUri}. The connection targets proxy '{proxyHost}', whose tunnelled destination cannot be validated.")]
+    public static partial void RejectedProxyConnection(ILogger logger, Uri requestUri, string proxyHost);
 }

--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
@@ -6,6 +6,9 @@ namespace Meziantou.Framework.Http.ServerSideRequestForgery;
 
 internal static class ServerSideRequestForgeryConnectPipeline
 {
+    // Reserved TLD (RFC2606): never a real destination, so a proxy returned for it is the handler's proxy address.
+    private static readonly Uri[] ProxyProbeUris = [new("https://ssrf-proxy-probe.invalid/"), new("http://ssrf-proxy-probe.invalid/")];
+
     internal static void Configure(SocketsHttpHandler handler, ServerSideRequestForgeryOptions options, IDnsIpAddressResolver dnsIpAddressResolver)
     {
         ArgumentNullException.ThrowIfNull(handler);
@@ -13,7 +16,7 @@ internal static class ServerSideRequestForgeryConnectPipeline
         ArgumentNullException.ThrowIfNull(options.ResolutionStrategy);
         ArgumentNullException.ThrowIfNull(dnsIpAddressResolver);
 
-        handler.ConnectCallback = (context, cancellationToken) => ConnectAsync(context, options, dnsIpAddressResolver, cancellationToken);
+        handler.ConnectCallback = (context, cancellationToken) => ConnectGuardingAgainstProxyAsync(handler, context, options, dnsIpAddressResolver, cancellationToken);
     }
 
     internal static async ValueTask<IPAddress> ResolveAndSelectIpAddressAsync(Uri requestUri, DnsEndPoint dnsEndPoint, ServerSideRequestForgeryOptions options, IDnsIpAddressResolver dnsIpAddressResolver, CancellationToken cancellationToken)
@@ -69,6 +72,15 @@ internal static class ServerSideRequestForgeryConnectPipeline
         }
 
         return selectedAddress;
+    }
+
+    private static ValueTask<Stream> ConnectGuardingAgainstProxyAsync(SocketsHttpHandler handler, SocketsHttpConnectionContext context, ServerSideRequestForgeryOptions options, IDnsIpAddressResolver dnsIpAddressResolver, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var requestUri = context.InitialRequestMessage?.RequestUri ?? throw new InvalidOperationException("The request URI cannot be null.");
+        EnsureConnectionIsNotToAProxy(handler, requestUri, context.DnsEndPoint, options);
+        return ConnectAsync(context, options, dnsIpAddressResolver, cancellationToken);
     }
 
     private static async ValueTask<Stream> ConnectAsync(SocketsHttpConnectionContext context, ServerSideRequestForgeryOptions options, IDnsIpAddressResolver dnsIpAddressResolver, CancellationToken cancellationToken)
@@ -146,6 +158,63 @@ internal static class ServerSideRequestForgeryConnectPipeline
         }
 
         return !options.UnsafeIpNetworks.Any(network => network.Contains(normalizedAddress));
+    }
+
+    internal static void EnsureConnectionIsNotToAProxy(SocketsHttpHandler handler, Uri requestUri, DnsEndPoint dnsEndPoint, ServerSideRequestForgeryOptions options)
+    {
+        if (!IsConnectionToAProxy(handler, requestUri, dnsEndPoint))
+            return;
+
+        Log.RejectedProxyConnection(options.Logger, requestUri, dnsEndPoint.Host);
+        ServerSideRequestForgeryMetrics.IncrementRejectedRequest("proxy_connection");
+        throw new ServerSideRequestForgeryException("The connection targets a proxy. The request's real destination is established by the proxy and is not visible here, so it cannot be validated. Set SocketsHttpHandler.UseProxy to false, or send requests that need SSRF protection through a handler that does not use a proxy.");
+    }
+
+    private static bool IsConnectionToAProxy(SocketsHttpHandler handler, Uri requestUri, DnsEndPoint dnsEndPoint)
+    {
+        // Reading the proxy here rather than when the callback is installed keeps the check correct when the
+        // proxy is assigned after ConfigureSsrf, or when HttpClient.DefaultProxy changes later.
+        var proxy = handler.UseProxy ? handler.Proxy ?? HttpClient.DefaultProxy : null;
+        if (proxy is null)
+            return false;
+
+        // Asking about the request URI alone is not enough. For an https target the pool substitutes the proxy's
+        // own URI as the initial request, and GetProxy then returns that same URI - which is indistinguishable
+        // from "this destination is bypassed". So also probe with destinations that are certainly not the proxy,
+        // which reveals the proxy's address even when the request URI has been substituted.
+        if (ProxyAddressMatchesEndPoint(proxy, requestUri, dnsEndPoint, unknownMeansProxied: true))
+            return true;
+
+        foreach (var probeUri in ProxyProbeUris)
+        {
+            if (ProxyAddressMatchesEndPoint(proxy, probeUri, dnsEndPoint, unknownMeansProxied: false))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool ProxyAddressMatchesEndPoint(IWebProxy proxy, Uri destination, DnsEndPoint dnsEndPoint, bool unknownMeansProxied)
+    {
+        Uri? proxyUri;
+        try
+        {
+            proxyUri = proxy.GetProxy(destination);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A proxy that cannot answer for the real request is treated as one that applies, so the connection
+            // fails closed. A probe destination it dislikes tells us nothing and must not fail an ordinary request.
+            return unknownMeansProxied;
+        }
+
+        // IWebProxy reports "no proxy for this destination" either by returning null (HttpClient.DefaultProxy)
+        // or by returning the destination itself (WebProxy when the address is bypassed).
+        if (proxyUri is null || proxyUri == destination)
+            return false;
+
+        return proxyUri.Port == dnsEndPoint.Port
+            && string.Equals(NormalizeHost(proxyUri.IdnHost), NormalizeHost(dnsEndPoint.Host), StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsAllowedScheme(Uri requestUri, ServerSideRequestForgeryOptions options)

--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/readme.md
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/readme.md
@@ -31,3 +31,23 @@ using var httpClient = new HttpClient(handler, disposeHandler: true);
 - Validates each resolved address against `UnsafeIpNetworks` and `SafeIpNetworks`.
 - Optionally rejects mixed safe/unsafe DNS responses.
 - Uses `IpAddressResolutionStrategy` to select the final address (`Ipv4Only`, `Ipv6Only`, `PreferIpv4`, `Random`, `RoundRobin`).
+- Rejects connections that target an HTTP proxy.
+
+## Proxies
+
+Validation happens when the connection is opened, which for a proxied request is the connection to the
+*proxy*, not to the target. The proxy then reaches the real target itself, over a tunnel this library
+cannot inspect, so a proxied request cannot be validated at all.
+
+Rather than appear to protect such a request, the handler rejects it with a
+`ServerSideRequestForgeryException`. Note that `SocketsHttpHandler.UseProxy` defaults to `true` and
+`HttpClient.DefaultProxy` reads `HTTP_PROXY`, `HTTPS_PROXY` and `ALL_PROXY`, so a proxy can be in effect
+without the application configuring one. Send requests that need SSRF protection through a handler with
+`UseProxy = false`:
+
+```csharp
+var handler = new SocketsHttpHandler { UseProxy = false };
+handler.ConfigureSsrf(options);
+```
+
+Requests the proxy is configured to bypass are connected to directly and are validated normally.

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
@@ -18,6 +18,107 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
     }
 
     [Fact]
+    public async Task ConnectCallback_RejectsConnectionThroughAProxy()
+    {
+        var options = CreateProxyTestOptions();
+        using var handler = new SocketsHttpHandler
+        {
+            UseProxy = true,
+            Proxy = new WebProxy("http://127.0.0.1:9", BypassOnLocal: false),
+        };
+        handler.ConfigureSsrf(options, new FakeDnsIpAddressResolver([IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => httpClient.GetAsync(new Uri("https://example.invalid/"), TestContext.Current.CancellationToken));
+
+        // Without the guard this reaches the proxy and fails with a socket error instead.
+        Assert.IsType<ServerSideRequestForgeryException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task ConnectCallback_AllowsDirectConnectionWhenTheProxyBypassesTheTarget()
+    {
+        var options = CreateProxyTestOptions();
+        using var handler = new SocketsHttpHandler
+        {
+            UseProxy = true,
+            Proxy = new WebProxy("http://127.0.0.1:9", BypassOnLocal: false, BypassList: ["example\\.invalid"]),
+        };
+        handler.ConfigureSsrf(options, new FakeDnsIpAddressResolver([IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => httpClient.GetAsync(new Uri("http://example.invalid:1/"), TestContext.Current.CancellationToken));
+
+        // The connection is direct, so validation passes and the request fails only because nothing is listening.
+        Assert.IsType<SocketException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task ConnectCallback_AllowsConnectionWhenUseProxyIsFalse()
+    {
+        var options = CreateProxyTestOptions();
+        using var handler = new SocketsHttpHandler
+        {
+            UseProxy = false,
+            Proxy = new WebProxy("http://127.0.0.1:9", BypassOnLocal: false),
+        };
+        handler.ConfigureSsrf(options, new FakeDnsIpAddressResolver([IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => httpClient.GetAsync(new Uri("http://example.invalid:1/"), TestContext.Current.CancellationToken));
+
+        Assert.IsType<SocketException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void EnsureConnectionIsNotToAProxy_LogsRejectionReason()
+    {
+        using var loggerProvider = new InMemoryLoggerProvider();
+        var options = new ServerSideRequestForgeryOptions
+        {
+            Logger = loggerProvider.CreateLogger("ssrf-test"),
+        };
+        using var handler = new SocketsHttpHandler
+        {
+            UseProxy = true,
+            Proxy = new WebProxy("http://proxy.invalid:8080", BypassOnLocal: false),
+        };
+
+        Assert.Throws<ServerSideRequestForgeryException>(() => ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
+            handler,
+            new Uri("https://example.com/"),
+            new DnsEndPoint("proxy.invalid", 8080),
+            options));
+
+        Assert.Contains(loggerProvider.Logs.Warnings, entry => entry.EventId.Id == 7);
+    }
+
+    [Fact]
+    public void EnsureConnectionIsNotToAProxy_DoesNotThrowWhenTheEndPointIsNotTheProxy()
+    {
+        var options = new ServerSideRequestForgeryOptions();
+        using var handler = new SocketsHttpHandler
+        {
+            UseProxy = true,
+            Proxy = new WebProxy("http://proxy.invalid:8080", BypassOnLocal: false),
+        };
+
+        ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
+            handler,
+            new Uri("https://example.com/"),
+            new DnsEndPoint("example.com", 443),
+            options);
+    }
+
+    private static ServerSideRequestForgeryOptions CreateProxyTestOptions()
+    {
+        var options = new ServerSideRequestForgeryOptions();
+        options.SafeSchemes.Add(Uri.UriSchemeHttp);
+        options.SafeIpNetworks.Add(IPNetwork.Parse("127.0.0.0/8"));
+        return options;
+    }
+
+    [Fact]
     public async Task ResolveAndSelectIpAddressAsync_RejectsUnsafeScheme()
     {
         var options = new ServerSideRequestForgeryOptions();


### PR DESCRIPTION
Fixes the highest-severity finding from the SSRF project review: **a proxy tunnel bypasses target validation entirely.**

## The bypass

When a proxy is in play, `SocketsHttpHandler` calls `ConnectCallback` for the connection to the *proxy*, not to the origin. `context.DnsEndPoint` is the proxy, and for an https target the pool substitutes the proxy's own URI as `InitialRequestMessage.RequestUri`:

```
Requested: https://example.com/path?q=1
  [direct     ] DnsEndPoint       = Unspecified/example.com:443
  [direct     ] InitialRequestUri = https://example.com/path?q=1
  [https+proxy] DnsEndPoint       = Unspecified/127.0.0.1:9
  [https+proxy] InitialRequestUri = http://127.0.0.1:9/          <-- the proxy, not the target
```

So the scheme check and `HostsMatch` compare the proxy against itself and pass, `FilterSafeAddresses` validates the *proxy's* address, and the origin is reached over a `CONNECT` tunnel the pipeline never sees.

Confirmed with a local CONNECT proxy. With `http` in `SafeSchemes` and the proxy's address permitted, requesting `https://169.254.169.254/latest/meta-data/` — an address in the **default** `UnsafeIpNetworks` list:

```
PROXY SAW: CONNECT 169.254.169.254:443 HTTP/1.1
```

Both preconditions are ordinary: `UseProxy` defaults to `true` and `HttpClient.DefaultProxy` reads `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`, so an environment variable is enough and the application need not mention proxies. The proxy needs no allow-listing if it sits on a public IP, as egress proxies typically do.

With the default `SafeSchemes` the tunnel is rejected on scheme, so the failure was closed — but also total and misdiagnosed: every request in a proxied environment died with `The URI scheme 'http' is not allowed`, pointing the operator at their scheme configuration rather than at the proxy.

## The fix

A proxied request cannot be validated at all, so it is rejected rather than appearing to be protected. Same PoC after the change:

```
RESULT: ServerSideRequestForgeryException: The connection targets a proxy. ...
PROXY SAW: <nothing: connection never reached the proxy>
```

Two details worth review:

**Asking about the request URI alone is not sufficient.** My first attempt did exactly that and *failed to close the bypass*, because once the URI has been substituted with the proxy's own, `GetProxy(proxyUri)` returns that same URI — indistinguishable from "this destination is bypassed". The check therefore also probes with a destination that is certainly not the proxy (`*.invalid`, RFC2606), which reveals the proxy's address in that case.

**The proxy is read on every connection**, not captured when the callback is installed, so assigning `handler.Proxy` after `ConfigureSsrf` — or changing `HttpClient.DefaultProxy` later — is still caught. A configure-time check would also have false-positived on callers whose proxy bypasses the hosts they actually call; matching the proxy address against the endpoint being connected to avoids that.

## Not a blanket rejection

Verified that legitimate direct connections are unaffected:

```
Direct connections that must NOT be rejected:
  no proxy (UseProxy default true, DefaultProxy)       => 200 OK
  UseProxy = false                                     => 200 OK
  proxy on a different port, target bypassed           => 200 OK
  proxy set but UseProxy = false                       => 200 OK

Proxied connection that MUST be rejected:
  proxy applying to everything                         => REJECTED
```

## Tests

Five tests covering rejection through a proxy, a bypassed target connecting directly, `UseProxy = false`, and the new log event (id 7) / metric reason (`proxy_connection`). 60 tests pass across net10.0 and net11.0.

The bypass-list test initially failed and was right to: `WebProxy` bypass regexes match the whole URI, so my `$`-anchored pattern never matched and the proxy genuinely applied.

Readme gains a **Proxies** section. No public API change, so `ref/` is unchanged.