### PR TITLE
Strip the ALL_HEADERS block from SQL batch command text

### DIFF
--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsQueryRequestParser.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsQueryRequestParser.cs
@@ -18,7 +18,7 @@ internal static class TdsQueryRequestParser
             {
                 RemoteEndPoint = remoteEndPoint,
                 RequestType = TdsQueryRequestType.SqlBatch,
-                CommandText = DecodeUnicode(packet.Payload),
+                CommandText = DecodeUnicode(packet.Payload.AsSpan(GetAllHeadersLength(packet.Payload))),
                 UserContext = userContext,
             },
             TdsPacketType.Rpc => CreateRpcContext(packet.Payload, remoteEndPoint, userContext),
@@ -50,13 +50,7 @@ internal static class TdsQueryRequestParser
             return null;
         }
 
-        var position = 0;
-        var allHeadersLength = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(position, 4));
-        if (allHeadersLength >= 4 && allHeadersLength <= payload.Length)
-        {
-            position = (int)allHeadersLength;
-        }
-
+        var position = GetAllHeadersLength(payload);
         if (position + 4 > payload.Length)
         {
             return null;
@@ -456,9 +450,49 @@ internal static class TdsQueryRequestParser
         };
     }
 
-    private static string DecodeUnicode(byte[] payload)
+    /// <summary>
+    /// Returns the size of the ALL_HEADERS block that prefixes SQLBatch and RPC streams in TDS 7.2 and later,
+    /// or 0 when the payload does not start with a well-formed one.
+    /// </summary>
+    private static int GetAllHeadersLength(ReadOnlySpan<byte> payload)
     {
-        if (payload.Length == 0)
+        if (payload.Length < 4)
+        {
+            return 0;
+        }
+
+        // ALL_HEADERS is a total length (which includes itself) followed by headers, each of which is its own
+        // length (including itself) plus a 2-byte type. Anything that does not add up exactly is treated as
+        // absent, because TDS 7.1 clients send the SQL text with no header block at all.
+        var totalLength = BinaryPrimitives.ReadUInt32LittleEndian(payload[..4]);
+        if (totalLength < 4 || totalLength > (uint)payload.Length)
+        {
+            return 0;
+        }
+
+        var position = 4u;
+        while (position < totalLength)
+        {
+            if (totalLength - position < 6)
+            {
+                return 0;
+            }
+
+            var headerLength = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice((int)position, 4));
+            if (headerLength < 6 || headerLength > totalLength - position)
+            {
+                return 0;
+            }
+
+            position += headerLength;
+        }
+
+        return (int)totalLength;
+    }
+
+    private static string DecodeUnicode(ReadOnlySpan<byte> payload)
+    {
+        if (payload.IsEmpty)
         {
             return string.Empty;
         }

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -130,7 +130,7 @@ public sealed class TdsServerProtocolTests
 
         Assert.Equal(123, Convert.ToInt32(result, CultureInfo.InvariantCulture));
         Assert.Equal(TdsQueryRequestType.SqlBatch, capturedContext.RequestType);
-        Assert.Contains(Marker, capturedContext.CommandText);
+        Assert.Equal($"SELECT 1 /* {Marker} */", capturedContext.CommandText);
     }
 
     [Fact]
@@ -217,6 +217,39 @@ public sealed class TdsServerProtocolTests
 
         Assert.Equal(1, Convert.ToInt32(result, CultureInfo.InvariantCulture));
         Assert.Equal(UserId, capturedUserId);
+    }
+
+    [Fact]
+    public async Task SqlClient_TextQuery_SqlBatch_CommandTextExcludesAllHeaders()
+    {
+        const string Query = "SELECT 1 /* SqlBatchAllHeadersMarker */";
+        var queryContextTask = new TaskCompletionSource<TdsQueryContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) =>
+            {
+                queryContextTask.TrySetResult(context);
+                return ValueTask.FromResult(CreateScalarResultSet(TdsColumnType.Int32, 1));
+            });
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = Query;
+
+        _ = await command.ExecuteScalarAsync();
+        var capturedContext = await queryContextTask.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(Query, capturedContext.CommandText);
     }
 
     [Fact]


### PR DESCRIPTION
A TDS 7.2+ SQLBatch payload is `ALL_HEADERS` followed by the SQL text. The RPC path skipped the header block; the SQLBatch path decoded the *entire* payload — header included — as UTF-16 and exposed it as `TdsQueryContext.CommandText`.

Verified against a real `SqlConnection`: sending `SELECT 1` produced a **19-character** `CommandText` whose first 11 code points are `0016 0000 0012 0000 0002 0000 0000 0000 0000 0001 0000`, followed by `SELECT 1`. `CommandText.StartsWith("SELECT")` was `false`.

`CommandText` is a documented public API — the readme shows it as `"SELECT * FROM Users WHERE Id = @id"`. Any callback doing `StartsWith`, `Equals`, an anchored regex, or logging the statement got a wrong answer or corrupted output. The built-in query engine survived only because the SQL parser happens to tolerate leading control characters.

This extracts the header-skipping into `GetAllHeadersLength` and uses it on both paths. The shared helper also validates the block structure (each header's length must fit and the headers must add up exactly to the declared total) instead of trusting the first `DWORD`, so a TDS 7.1 client that sends no header block at all is still handled correctly. That is a small improvement to the RPC path too.

The existing `SqlClient_TextQuery_WithoutParameters_UsesSqlBatch` test asserted `Contains(marker)`, which is exactly why this went unnoticed — it is now an equality assertion, and a new test covers the round-trip explicitly.

Found by a review of `src/Meziantou.Framework.TdsServer`.