### PR TITLE
Report Unix memory protection failures instead of ignoring them

### DIFF
--- a/src/Meziantou.Framework.SensitiveData/Meziantou.Framework.SensitiveData.csproj
+++ b/src/Meziantou.Framework.SensitiveData/Meziantou.Framework.SensitiveData.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Meziantou.Framework.SensitiveData.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.298">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
+++ b/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
@@ -163,6 +163,28 @@ public static partial class SensitiveData
 /// contents, such as through a debugger or memory dump utility.
 /// </summary>
 /// <typeparam name="T">The unmanaged type of elements stored in this sensitive data buffer.</typeparam>
+/// <remarks>
+/// <para>The protection applied while the contents are at rest depends on the platform:</para>
+/// <list type="bullet">
+/// <item><description>
+/// Windows: the buffer is allocated on a private heap and encrypted with <c>CryptProtectMemory</c>.
+/// </description></item>
+/// <item><description>
+/// Linux and macOS: the buffer is mapped with <c>mmap</c> and made inaccessible with <c>mprotect(PROT_NONE)</c>.
+/// It is also locked into physical memory with <c>mlock</c> on a best-effort basis. Locking commonly fails when
+/// <c>RLIMIT_MEMLOCK</c> is low, which is the default in many container images; that failure is not reported, and
+/// the contents may then be written to swap. The contents are never encrypted on these platforms, so a core dump
+/// taken while the buffer is unprotected contains them in clear.
+/// </description></item>
+/// <item><description>
+/// Other platforms: the buffer is combined with a random key of the same length. The key lives in the same
+/// process, so this only guards against casual inspection.
+/// </description></item>
+/// </list>
+/// <para>
+/// Failing to apply or remove the protection throws; the instance is never silently left unprotected.
+/// </para>
+/// </remarks>
 /// <example>
 /// <code>
 /// // Create and use sensitive data
@@ -213,6 +235,20 @@ public sealed unsafe class SensitiveData<T> : IDisposable
     {
         ThrowIfDisposed();
         return _data.Length;
+    }
+
+    /// <summary>
+    /// Indicates whether the platform protection is currently applied to the buffer.
+    /// Exposed so tests can assert the protection is actually in effect rather than only that
+    /// the contents round-trip.
+    /// </summary>
+    internal bool IsProtected
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _data.IsProtected;
+        }
     }
 
     /// <summary>
@@ -337,6 +373,7 @@ public sealed unsafe class SensitiveData<T> : IDisposable
         private ProtectionMode _protectionMode;
         private bool _unixMemoryLocked;
         private bool _unixMemoryProtected;
+        private bool _isProtected;
 
         public NativeMemorySafeHandle()
             : base(invalidHandleValue: Invalid, ownsHandle: true)
@@ -346,6 +383,9 @@ public sealed unsafe class SensitiveData<T> : IDisposable
         public int Length { get; private set; }
 
         public Lock SyncLock { get; } = new();
+
+        // A zero-length buffer holds no contents, so there is nothing to protect and nothing to disclose.
+        public bool IsProtected => _allocatedBytes == 0 || _isProtected;
 
         public override bool IsInvalid => handle == Invalid;
 
@@ -399,14 +439,25 @@ public sealed unsafe class SensitiveData<T> : IDisposable
             if (OperatingSystem.IsWindows() && _protectionMode is ProtectionMode.Windows)
             {
                 WindowsHeap.ProtectMemory(handle, _allocatedBytes);
+                _isProtected = true;
             }
             else if ((OperatingSystem.IsLinux() || OperatingSystem.IsMacOS()) && _protectionMode is ProtectionMode.Unix)
             {
-                _unixMemoryProtected = SensitiveData.UnixMemoryProtection.TryProtect(handle, _allocatedBytes, SensitiveData.UnixMemoryProtection.PROT_NONE);
+                // Ignoring a failure here would leave the contents readable for the rest of the instance's
+                // life with nothing to indicate the protection is not applied, so report it like Unprotect
+                // and the Windows path already do.
+                if (!SensitiveData.UnixMemoryProtection.TryProtect(handle, _allocatedBytes, SensitiveData.UnixMemoryProtection.PROT_NONE))
+                {
+                    ThrowLastPInvokeError();
+                }
+
+                _unixMemoryProtected = true;
+                _isProtected = true;
             }
             else if (_protectionMode is ProtectionMode.Xor)
             {
                 XorWithKey();
+                _isProtected = true;
             }
         }
 
@@ -418,6 +469,7 @@ public sealed unsafe class SensitiveData<T> : IDisposable
             if (OperatingSystem.IsWindows() && _protectionMode is ProtectionMode.Windows)
             {
                 WindowsHeap.UnprotectMemory(handle, _allocatedBytes);
+                _isProtected = false;
             }
             else if ((OperatingSystem.IsLinux() || OperatingSystem.IsMacOS()) && _protectionMode is ProtectionMode.Unix)
             {
@@ -430,10 +482,12 @@ public sealed unsafe class SensitiveData<T> : IDisposable
                 }
 
                 _unixMemoryProtected = false;
+                _isProtected = false;
             }
             else if (_protectionMode is ProtectionMode.Xor)
             {
                 XorWithKey();
+                _isProtected = false;
             }
         }
 

--- a/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
+++ b/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
@@ -69,6 +69,19 @@ public sealed class SensitiveDataTests
     }
 
     [Fact]
+    public void ProtectionIsAppliedAtRestAndLiftedWhileRevealing()
+    {
+        using var data = SensitiveData.Create("foo");
+
+        Assert.True(data.IsProtected);
+        data.RevealAndUse(arg: data, static (span, secret) => Assert.False(secret.IsProtected));
+        Assert.True(data.IsProtected);
+
+        data.RevealToArray();
+        Assert.True(data.IsProtected);
+    }
+
+    [Fact]
     public void Clone_CreatesIndependentCopy()
     {
         var original = SensitiveData.Create("foo");


### PR DESCRIPTION
Fixes the `[Medium]` "protection failures on Unix are discarded" finding from the `Meziantou.Framework.SensitiveData` project review.

## Problem

`Protect()` stored the result of `mprotect(PROT_NONE)` and did nothing with a failure:

```csharp
_unixMemoryProtected = UnixMemoryProtection.TryProtect(handle, _allocatedBytes, PROT_NONE);
```

If that call fails, the contents stay readable in the process for the rest of the instance's life — and the object carries on working normally, because every later `Unprotect()` takes the early return on `!_unixMemoryProtected`. Nothing, inside the process or out, indicates that the secret is sitting in plain memory. `Unprotect()` (same file) and both Windows paths already throw in exactly this situation, so the silent branch was also inconsistent.

This is the "works on the dev box, silently degraded in production" shape: the entire value of the library is that the contents are protected at rest, and the caller gets the API's guarantee without its behavior.

## Change

**`mprotect` failure now throws.** An instance is never silently left unprotected. There is no reasonable way to continue from that failure, and this matches what `Unprotect()` and Windows already do.

**`mlock` stays best-effort, and is now documented.** It fails with `EPERM`/`ENOMEM` whenever `RLIMIT_MEMLOCK` is low — the default in many container images — and refusing to construct a `SensitiveData` there would be a worse outcome than a swappable buffer. Instead the per-platform behavior is spelled out in `<remarks>` on `SensitiveData<T>`: what Windows does, what Linux/macOS do, that locking is best-effort and its failure unreported, that the contents are never encrypted on Unix, and what the fallback does on other platforms. Documentation is what actually tells the caller here.

**Protection state is now tracked and visible to tests** via an `internal bool IsProtected`, so the protect/unprotect layer can be asserted directly rather than only inferred from contents round-tripping. This is also what a future public or `EventSource` signal would build on, if you want one — that needs an API decision, so it is not made here.

### Note on blast radius

`Protect()` is called from `finally` blocks, so on Unix a failure can now mask an in-flight exception from a caller's `RevealAndUse` callback. That is the pre-existing `[Low]` finding about `Protect()` throwing from a `finally`, which until now only applied on Windows; this change widens it to Unix. Trading a silent unprotected secret for a masked exception in an already-failing path is the right side of that trade, but it is a real consequence and worth fixing separately.

## Testing

- New `ProtectionIsAppliedAtRestAndLiftedWhileRevealing` asserts protection is applied at rest and lifted only inside a reveal.
- **Verified the test actually bites**: with the Unix protect path sabotaged to a no-op, it fails — while all 22 pre-existing tests still pass. That is the separate `[Medium]` test-coverage finding in miniature.
- `dotnet test -f net10.0 /p:TreatsWarningsAsErrors=true` → 23 passed, 0 failed.
- `dotnet test -f net11.0 /p:TreatsWarningsAsErrors=true` → 23 passed, 0 failed.
- `dotnet run ./eng/update-all.cs` → no changes produced. No public API change, `ref/` unchanged.

The `mprotect`-failure path itself cannot be provoked through the public API, so it is covered by inspection, not by a test.

Tested on macOS/arm64 only — the Windows and XOR paths are unchanged by this PR but were not executed.