### PR TITLE
Apply SQL three-valued logic to query engine comparisons

### DIFF
--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
@@ -1010,26 +1010,39 @@ internal sealed class TdsQueryEngineExecutor
         return source.Query.Provider.CreateQuery(call);
     }
 
-    private Expression BuildBoolean(SqlBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext)
+    /// <summary>Builds a predicate that is true exactly when SQL would evaluate <paramref name="expression"/> to TRUE.</summary>
+    /// <param name="negated">When true, builds the predicate for <c>NOT expression</c>.</param>
+    /// <remarks>
+    /// SQL uses three-valued logic and a WHERE clause keeps a row only when the predicate is TRUE,
+    /// so UNKNOWN and FALSE can both be collapsed to <see langword="false"/> here. That collapse is
+    /// only valid if NOT never wraps an already-collapsed predicate, because <c>NOT UNKNOWN</c> is
+    /// UNKNOWN while <c>!false</c> is <see langword="true"/>. NOT is therefore pushed down into the
+    /// leaves instead: De Morgan for AND/OR (which holds in three-valued logic) and operator
+    /// negation for comparisons.
+    /// </remarks>
+    private Expression BuildBoolean(SqlBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext, bool negated = false)
     {
         return expression switch
         {
-            SqlComparisonBooleanExpression comparison => BuildComparison(comparison, aliases, parameter, parameters),
-            SqlInBooleanExpression inExpression => BuildInBoolean(inExpression, aliases, parameter, parameters, cteRoots, queryExecutionContext),
-            SqlIsNullBooleanExpression isNullExpression => BuildIsNullBoolean(isNullExpression, aliases, parameter, parameters),
-            SqlExistsBooleanExpression existsExpression => BuildExistsBoolean(existsExpression, aliases, parameter, parameters, cteRoots, queryExecutionContext),
-            SqlNotBooleanExpression notExpression => Expression.Not(BuildBoolean(notExpression.Expression, aliases, parameter, parameters, cteRoots, queryExecutionContext)),
-            SqlBinaryBooleanExpression { Operator: SqlBooleanOperatorType.And } binary => Expression.AndAlso(
-                BuildBoolean(binary.Left, aliases, parameter, parameters, cteRoots, queryExecutionContext),
-                BuildBoolean(binary.Right, aliases, parameter, parameters, cteRoots, queryExecutionContext)),
-            SqlBinaryBooleanExpression { Operator: SqlBooleanOperatorType.Or } orBinary => Expression.OrElse(
-                BuildBoolean(orBinary.Left, aliases, parameter, parameters, cteRoots, queryExecutionContext),
-                BuildBoolean(orBinary.Right, aliases, parameter, parameters, cteRoots, queryExecutionContext)),
+            SqlComparisonBooleanExpression comparison => BuildComparison(comparison, aliases, parameter, parameters, negated),
+            SqlInBooleanExpression inExpression => BuildInBoolean(inExpression, aliases, parameter, parameters, cteRoots, queryExecutionContext, negated),
+            SqlIsNullBooleanExpression isNullExpression => BuildIsNullBoolean(isNullExpression, aliases, parameter, parameters, negated),
+            SqlExistsBooleanExpression existsExpression => BuildExistsBoolean(existsExpression, aliases, parameter, parameters, cteRoots, queryExecutionContext, negated),
+            SqlNotBooleanExpression notExpression => BuildBoolean(notExpression.Expression, aliases, parameter, parameters, cteRoots, queryExecutionContext, !negated),
+            SqlBinaryBooleanExpression { Operator: SqlBooleanOperatorType.And } binary => BuildBinaryBoolean(binary, aliases, parameter, parameters, cteRoots, queryExecutionContext, negated, isAnd: true),
+            SqlBinaryBooleanExpression { Operator: SqlBooleanOperatorType.Or } orBinary => BuildBinaryBoolean(orBinary, aliases, parameter, parameters, cteRoots, queryExecutionContext, negated, isAnd: false),
             _ => throw new TdsQueryEngineException("Only comparison, IN, EXISTS, and IS NULL predicates combined with AND/OR/NOT are supported."),
         };
     }
 
-    private BinaryExpression BuildComparison(SqlComparisonBooleanExpression comparison, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters)
+    private Expression BuildBinaryBoolean(SqlBinaryBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext, bool negated, bool isAnd)
+    {
+        var left = BuildBoolean(expression.Left, aliases, parameter, parameters, cteRoots, queryExecutionContext, negated);
+        var right = BuildBoolean(expression.Right, aliases, parameter, parameters, cteRoots, queryExecutionContext, negated);
+        return isAnd ^ negated ? Expression.AndAlso(left, right) : Expression.OrElse(left, right);
+    }
+
+    private Expression BuildComparison(SqlComparisonBooleanExpression comparison, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, bool negated)
     {
         var left = BuildScalar(comparison.Left, aliases, parameter, parameters);
         var right = BuildScalar(comparison.Right, aliases, parameter, parameters, left.Type);
@@ -1038,7 +1051,19 @@ internal sealed class TdsQueryEngineExecutor
             right = ConvertExpression(right, left.Type);
         }
 
-        return comparison.ComparisonOperator switch
+        var comparisonOperator = negated ? NegateComparisonOperator(comparison.ComparisonOperator) : comparison.ComparisonOperator;
+        return BuildComparisonCore(left, right, comparisonOperator, "Comparison operator");
+    }
+
+    private static Expression BuildComparisonCore(Expression left, Expression right, SqlComparisonBooleanExpressionType comparisonOperator, string operatorDescription)
+    {
+        // Any comparison with NULL is UNKNOWN in SQL, and never TRUE, whichever operator is used.
+        if (IsNullConstant(left) || IsNullConstant(right))
+        {
+            return Expression.Constant(value: false, typeof(bool));
+        }
+
+        Expression comparison = comparisonOperator switch
         {
             SqlComparisonBooleanExpressionType.Equals => Expression.Equal(left, right),
             SqlComparisonBooleanExpressionType.NotEqual => Expression.NotEqual(left, right),
@@ -1047,70 +1072,191 @@ internal sealed class TdsQueryEngineExecutor
             SqlComparisonBooleanExpressionType.GreaterThanOrEqual => Expression.GreaterThanOrEqual(left, right),
             SqlComparisonBooleanExpressionType.LessThan => Expression.LessThan(left, right),
             SqlComparisonBooleanExpressionType.LessThanOrEqual => Expression.LessThanOrEqual(left, right),
-            _ => throw new TdsQueryEngineException($"Comparison operator '{comparison.ComparisonOperator}' is not supported."),
+            _ => throw new TdsQueryEngineException($"{operatorDescription} '{comparisonOperator}' is not supported."),
+        };
+
+        // Ordering comparisons on Nullable<T> already yield false for a null operand, which matches
+        // SQL. Equality does not: null == null is true in .NET and null != x is true for any x.
+        var guardLeft = false;
+        var guardRight = false;
+        switch (comparisonOperator)
+        {
+            case SqlComparisonBooleanExpressionType.Equals:
+                // Only wrong when both sides are NULL, so guarding one side is enough.
+                guardLeft = CanBeNull(left) && CanBeNull(right);
+                break;
+
+            case SqlComparisonBooleanExpressionType.NotEqual:
+            case SqlComparisonBooleanExpressionType.LessOrGreaterThan:
+                guardLeft = CanBeNull(left);
+                guardRight = CanBeNull(right);
+                break;
+        }
+
+        if (guardRight)
+        {
+            comparison = Expression.AndAlso(BuildIsNotNull(right), comparison);
+        }
+
+        if (guardLeft)
+        {
+            comparison = Expression.AndAlso(BuildIsNotNull(left), comparison);
+        }
+
+        return comparison;
+    }
+
+    private static SqlComparisonBooleanExpressionType NegateComparisonOperator(SqlComparisonBooleanExpressionType comparisonOperator)
+    {
+        return comparisonOperator switch
+        {
+            SqlComparisonBooleanExpressionType.Equals => SqlComparisonBooleanExpressionType.NotEqual,
+            SqlComparisonBooleanExpressionType.NotEqual => SqlComparisonBooleanExpressionType.Equals,
+            SqlComparisonBooleanExpressionType.LessOrGreaterThan => SqlComparisonBooleanExpressionType.Equals,
+            SqlComparisonBooleanExpressionType.GreaterThan => SqlComparisonBooleanExpressionType.LessThanOrEqual,
+            SqlComparisonBooleanExpressionType.GreaterThanOrEqual => SqlComparisonBooleanExpressionType.LessThan,
+            SqlComparisonBooleanExpressionType.LessThan => SqlComparisonBooleanExpressionType.GreaterThanOrEqual,
+            SqlComparisonBooleanExpressionType.LessThanOrEqual => SqlComparisonBooleanExpressionType.GreaterThan,
+            // Unsupported operators are reported by the caller, which names the original operator.
+            _ => comparisonOperator,
         };
     }
 
-    private Expression BuildInBoolean(SqlInBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext)
+    /// <summary>Returns whether the expression can evaluate to NULL at run time.</summary>
+    /// <remarks>SQL parameters and literals are baked in as constants, so their nullness is known while translating.</remarks>
+    private static bool CanBeNull(Expression expression)
+    {
+        if (expression.Type.IsValueType && Nullable.GetUnderlyingType(expression.Type) is null)
+        {
+            return false;
+        }
+
+        return expression is not ConstantExpression { Value: not null };
+    }
+
+    private static bool IsNullConstant(Expression expression)
+    {
+        return expression is ConstantExpression { Value: null };
+    }
+
+    private static Expression BuildIsNotNull(Expression expression)
+    {
+        return Expression.NotEqual(expression, Expression.Constant(null, expression.Type));
+    }
+
+    private Expression BuildInBoolean(SqlInBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext, bool negated)
     {
         var inExpression = BuildScalar(expression.InExpression, aliases, parameter, parameters);
-        Expression containsExpression = expression.ComparisonValue switch
+        var hasNot = expression.HasNot ^ negated;
+        return expression.ComparisonValue switch
         {
-            SqlInBooleanExpressionCollectionValue collectionValue => BuildInCollectionExpression(collectionValue, inExpression, aliases, parameter, parameters),
-            SqlInBooleanExpressionQueryValue queryValue => BuildInSubqueryExpression(queryValue, inExpression, aliases, parameter, parameters, cteRoots, queryExecutionContext),
+            SqlInBooleanExpressionCollectionValue collectionValue => BuildInCollectionBoolean(collectionValue, inExpression, aliases, parameter, parameters, hasNot),
+            SqlInBooleanExpressionQueryValue queryValue => BuildInSubqueryBoolean(queryValue, inExpression, aliases, parameter, parameters, cteRoots, queryExecutionContext, hasNot),
             _ => throw new TdsQueryEngineException("Only IN collections and simple IN subqueries are supported."),
         };
-
-        return expression.HasNot ? Expression.Not(containsExpression) : containsExpression;
     }
 
-    private MethodCallExpression BuildInCollectionExpression(SqlInBooleanExpressionCollectionValue collectionValue, Expression inExpression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters)
+    private Expression BuildInCollectionBoolean(SqlInBooleanExpressionCollectionValue collectionValue, Expression inExpression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, bool hasNot)
     {
         var values = collectionValue.Values
             .Select(value => BuildScalar(value, aliases, parameter, parameters, inExpression.Type))
-            .Select(value => value.Type == inExpression.Type ? value : ConvertExpression(value, inExpression.Type));
+            .Select(value => value.Type == inExpression.Type ? value : ConvertExpression(value, inExpression.Type))
+            .ToArray();
         var valuesArray = Expression.NewArrayInit(inExpression.Type, values);
-
-        return Expression.Call(
+        Expression contains = Expression.Call(
             typeof(Enumerable),
             nameof(Enumerable.Contains),
             [inExpression.Type],
             valuesArray,
             inExpression);
+
+        Expression? containsNull = null;
+        if (hasNot && Array.Exists(values, CanBeNull))
+        {
+            containsNull = Expression.Call(
+                typeof(Enumerable),
+                nameof(Enumerable.Contains),
+                [inExpression.Type],
+                valuesArray,
+                Expression.Constant(null, inExpression.Type));
+        }
+
+        return BuildInResult(contains, containsNull, inExpression, hasNot);
     }
 
-    private MethodCallExpression BuildInSubqueryExpression(SqlInBooleanExpressionQueryValue queryValue, Expression inExpression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext)
+    private Expression BuildInSubqueryBoolean(SqlInBooleanExpressionQueryValue queryValue, Expression inExpression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext, bool hasNot)
     {
         var subquery = TranslateInSubquery(queryValue.Value, inExpression.Type, aliases, parameter, parameters, cteRoots, queryExecutionContext);
-        return Expression.Call(
+        Expression contains = Expression.Call(
             typeof(Queryable),
             nameof(Queryable.Contains),
             [inExpression.Type],
             subquery.Expression,
             inExpression);
+
+        Expression? containsNull = null;
+        if (hasNot && !(inExpression.Type.IsValueType && Nullable.GetUnderlyingType(inExpression.Type) is null))
+        {
+            containsNull = Expression.Call(
+                typeof(Queryable),
+                nameof(Queryable.Contains),
+                [inExpression.Type],
+                subquery.Expression,
+                Expression.Constant(null, inExpression.Type));
+        }
+
+        return BuildInResult(contains, containsNull, inExpression, hasNot);
     }
 
-    private MethodCallExpression BuildExistsBoolean(SqlExistsBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext)
+    /// <remarks>
+    /// <c>x IN (...)</c> is TRUE only when x is not NULL and matches a non-NULL element: a NULL in
+    /// the list makes a non-match UNKNOWN rather than FALSE, which excludes the row either way.
+    /// <c>x NOT IN (...)</c> additionally becomes UNKNOWN whenever the list contains a NULL, so no
+    /// row qualifies at all.
+    /// </remarks>
+    private static Expression BuildInResult(Expression contains, Expression? containsNull, Expression inExpression, bool hasNot)
+    {
+        var result = hasNot ? Expression.Not(contains) : contains;
+        if (containsNull is not null)
+        {
+            result = Expression.AndAlso(Expression.Not(containsNull), result);
+        }
+
+        if (CanBeNull(inExpression))
+        {
+            result = Expression.AndAlso(BuildIsNotNull(inExpression), result);
+        }
+
+        return result;
+    }
+
+    private Expression BuildExistsBoolean(SqlExistsBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext, bool negated)
     {
         var subquery = TranslateExistsSubquery(expression.QueryExpression, aliases, parameter, parameters, cteRoots, queryExecutionContext);
-        return Expression.Call(
+        Expression any = Expression.Call(
             typeof(Queryable),
             nameof(Queryable.Any),
             [subquery.ElementType],
             subquery.Expression);
+
+        // EXISTS is never UNKNOWN, so it can be negated directly.
+        return negated ? Expression.Not(any) : any;
     }
 
-    private Expression BuildIsNullBoolean(SqlIsNullBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters)
+    private Expression BuildIsNullBoolean(SqlIsNullBooleanExpression expression, IReadOnlyDictionary<string, AliasBinding> aliases, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, bool negated)
     {
         var value = BuildScalar(expression.Expression, aliases, parameter, parameters);
+
+        // IS NULL is never UNKNOWN, so it can be negated directly.
+        var hasNot = expression.HasNot ^ negated;
         if (value.Type.IsValueType && Nullable.GetUnderlyingType(value.Type) is null)
         {
-            return Expression.Constant(expression.HasNot, typeof(bool));
+            return Expression.Constant(hasNot, typeof(bool));
         }
 
         var nullExpression = Expression.Constant(null, value.Type);
         var isNullExpression = Expression.Equal(value, nullExpression);
-        return expression.HasNot ? Expression.Not(isNullExpression) : isNullExpression;
+        return hasNot ? Expression.Not(isNullExpression) : isNullExpression;
     }
 
     private IQueryable TranslateInSubquery(SqlQueryExpression queryExpression, Type targetType, IReadOnlyDictionary<string, AliasBinding> outerAliases, ParameterExpression outerParameter, IReadOnlyDictionary<string, TdsQueryParameter> parameters, IReadOnlyDictionary<string, TdsQueryRoot> cteRoots, QueryExecutionContext? queryExecutionContext)
@@ -1294,7 +1440,7 @@ internal sealed class TdsQueryEngineExecutor
         return expression.HasNot ? Expression.Not(isNullExpression) : isNullExpression;
     }
 
-    private BinaryExpression BuildGroupComparison(SqlComparisonBooleanExpression comparison, GroupedQuerySource source, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter>? parameters)
+    private Expression BuildGroupComparison(SqlComparisonBooleanExpression comparison, GroupedQuerySource source, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter>? parameters)
     {
         var left = BuildGroupScalar(comparison.Left, source, parameter, parameters);
         var right = BuildGroupScalar(comparison.Right, source, parameter, parameters, left.Type);
@@ -1303,17 +1449,7 @@ internal sealed class TdsQueryEngineExecutor
             right = ConvertExpression(right, left.Type);
         }
 
-        return comparison.ComparisonOperator switch
-        {
-            SqlComparisonBooleanExpressionType.Equals => Expression.Equal(left, right),
-            SqlComparisonBooleanExpressionType.NotEqual => Expression.NotEqual(left, right),
-            SqlComparisonBooleanExpressionType.LessOrGreaterThan => Expression.NotEqual(left, right),
-            SqlComparisonBooleanExpressionType.GreaterThan => Expression.GreaterThan(left, right),
-            SqlComparisonBooleanExpressionType.GreaterThanOrEqual => Expression.GreaterThanOrEqual(left, right),
-            SqlComparisonBooleanExpressionType.LessThan => Expression.LessThan(left, right),
-            SqlComparisonBooleanExpressionType.LessThanOrEqual => Expression.LessThanOrEqual(left, right),
-            _ => throw new TdsQueryEngineException($"HAVING comparison operator '{comparison.ComparisonOperator}' is not supported."),
-        };
+        return BuildComparisonCore(left, right, comparison.ComparisonOperator, "HAVING comparison operator");
     }
 
     private Expression BuildGroupScalar(SqlScalarExpression expression, GroupedQuerySource source, ParameterExpression parameter, IReadOnlyDictionary<string, TdsQueryParameter>? parameters, Type? targetType = null)

--- a/src/Meziantou.Framework.TdsServer/readme.md
+++ b/src/Meziantou.Framework.TdsServer/readme.md
@@ -137,6 +137,8 @@ The initial SQL text support is intentionally small: one `SELECT` statement with
 
 Built-in scalar function mappings can be customized through `TdsQueryEngineOptions.ScalarFunctions` (or `AddScalarFunction`). By default `UPPER` maps to `string.ToUpperInvariant` and `LOWER` maps to `string.ToLowerInvariant`, but you can replace them (for example with provider-specific `ToUpper` / `ToLower` mappings).
 
+Comparisons follow SQL's three-valued logic: a comparison with `NULL` is never true, `<>` and `NOT` do not match `NULL` rows, and `NOT IN` over a list containing `NULL` matches nothing. `NOT` is pushed down into the predicate instead of negating an already-evaluated result, so `WHERE NOT (Name = 'a')` excludes rows where `Name` is `NULL`, as SQL Server does. `JOIN ... ON` is an exception: it currently matches `NULL` keys to each other.
+
 Main unsupported SQL features include `LIKE`, recursive CTEs, many advanced subquery forms (for example scalar subqueries in projections), DML (`INSERT`/`UPDATE`/`DELETE`), and multiple statements/result sets.
 
 ## Access command text, stored procedure name, and parameters

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -927,6 +927,250 @@ public sealed class TdsQueryEngineTests
     }
 
     [Fact]
+    public async Task SqlClient_QueryEngine_WhereNotEquals_ExcludesNullRows()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id
+                    FROM nullable_customers
+                    WHERE Name <> 'Alice'
+                    """;
+            },
+            """
+            Id
+            2
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Where(nullableCustomer => ((nullableCustomer.Name != null) AndAlso (nullableCustomer.Name != \"Alice\"))).Select(nullableCustomer2 => new TdsProjection() {Id = nullableCustomer2.Id})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_WhereNotComparison_ExcludesNullRows()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id
+                    FROM nullable_customers
+                    WHERE NOT (Name = 'Alice')
+                    """;
+            },
+            """
+            Id
+            2
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Where(nullableCustomer => ((nullableCustomer.Name != null) AndAlso (nullableCustomer.Name != \"Alice\"))).Select(nullableCustomer2 => new TdsProjection() {Id = nullableCustomer2.Id})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_WhereNotAnd_AppliesDeMorgan()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        // UNKNOWN AND FALSE is FALSE in SQL, so NOT (...) is TRUE for the NULL row.
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id
+                    FROM nullable_customers
+                    WHERE NOT (Name = 'Alice' AND Id = 1)
+                    """;
+            },
+            """
+            Id
+            2
+            3
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Where(nullableCustomer => (((nullableCustomer.Name != null) AndAlso (nullableCustomer.Name != \"Alice\")) OrElse (nullableCustomer.Id != 1))).Select(nullableCustomer2 => new TdsProjection() {Id = nullableCustomer2.Id})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_WhereNotIsNull_ReturnsNonNullRows()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id
+                    FROM nullable_customers
+                    WHERE NOT (Name IS NULL)
+                    """;
+            },
+            """
+            Id
+            1
+            2
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Where(nullableCustomer => Not((nullableCustomer.Name == null))).Select(nullableCustomer2 => new TdsProjection() {Id = nullableCustomer2.Id})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_WhereEqualsNullLiteral_ReturnsNoRows()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id
+                    FROM nullable_customers
+                    WHERE Name = NULL
+                    """;
+            },
+            """
+            Id
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Where(nullableCustomer => False).Select(nullableCustomer2 => new TdsProjection() {Id = nullableCustomer2.Id})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_WhereNotEqualsNullLiteral_ReturnsNoRows()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id
+                    FROM nullable_customers
+                    WHERE Name <> NULL
+                    """;
+            },
+            """
+            Id
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Where(nullableCustomer => False).Select(nullableCustomer2 => new TdsProjection() {Id = nullableCustomer2.Id})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_WhereEqualsNullParameter_ReturnsNoRows()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id
+                    FROM nullable_customers
+                    WHERE Name = @name
+                    """;
+                _ = command.Parameters.Add(new SqlParameter("@name", SqlDbType.NVarChar, 50) { Value = DBNull.Value });
+            },
+            """
+            Id
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Where(nullableCustomer => False).Select(nullableCustomer2 => new TdsProjection() {Id = nullableCustomer2.Id})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_WhereNotInWithoutNull_ExcludesNullRows()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id
+                    FROM nullable_customers
+                    WHERE Name NOT IN ('Alice')
+                    """;
+            },
+            """
+            Id
+            2
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Where(nullableCustomer => ((nullableCustomer.Name != null) AndAlso Not(new [] {\"Alice\"}.Contains(nullableCustomer.Name)))).Select(nullableCustomer2 => new TdsProjection() {Id = nullableCustomer2.Id})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_WhereInCollectionContainingNull_ReturnsMatchingRows()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id
+                    FROM nullable_customers
+                    WHERE Name IN ('Alice', NULL)
+                    """;
+            },
+            """
+            Id
+            1
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Where(nullableCustomer => ((nullableCustomer.Name != null) AndAlso new [] {\"Alice\", null}.Contains(nullableCustomer.Name))).Select(nullableCustomer2 => new TdsProjection() {Id = nullableCustomer2.Id})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_WhereNotInCollectionContainingNull_ReturnsNoRows()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        // NOT IN over a list containing NULL is UNKNOWN for every row, so nothing qualifies.
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Id
+                    FROM nullable_customers
+                    WHERE Name NOT IN ('Alice', NULL)
+                    """;
+            },
+            """
+            Id
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].Where(nullableCustomer => ((nullableCustomer.Name != null) AndAlso (Not(new [] {\"Alice\", null}.Contains(null)) AndAlso Not(new [] {\"Alice\", null}.Contains(nullableCustomer.Name))))).Select(nullableCustomer2 => new TdsProjection() {Id = nullableCustomer2.Id})");
+    }
+
+    [Fact]
+    public async Task SqlClient_QueryEngine_HavingNotEquals_ExcludesNullGroups()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        await ExecuteQuery(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT Name, COUNT(*) AS Total
+                    FROM nullable_customers
+                    GROUP BY Name
+                    HAVING Name <> 'Alice'
+                    """;
+            },
+            """
+            Name Total
+            Bob 1
+            """,
+            expectedMaterializedQueries: "NullableCustomer[].GroupBy(nullableCustomer => nullableCustomer.Name).Where(group => ((group.Key != null) AndAlso (group.Key != \"Alice\"))).Select(group2 => new TdsProjection() {Name = group2.Key, Total = group2.Count()})");
+    }
+
+    [Fact]
     public async Task SqlClient_QueryEngine_WhereInCollection_ReturnsFilteredRows()
     {
         var queryEngineOptions = CreateQueryEngineOptions();


### PR DESCRIPTION
## Problem

WHERE and HAVING comparisons were translated straight to `Expression.Equal` / `Expression.NotEqual`, which use .NET's two-valued logic. SQL evaluates a comparison involving `NULL` as UNKNOWN and a WHERE clause keeps a row only when the predicate is TRUE, so the engine returned rows SQL Server excludes.

Against rows `(1,'Alice')`, `(2,'Bob')`, `(3,NULL)`:

| Query | Before | SQL Server |
|---|---|---|
| `WHERE Name = @p` with `@p = NULL` | 3 | *(none)* |
| `WHERE Name = NULL` | 3 | *(none)* |
| `WHERE Name <> 'Alice'` | 2, 3 | 2 |
| `WHERE NOT (Name = 'Alice')` | 2, 3 | 2 |
| `WHERE Name NOT IN ('Alice')` | 2, 3 | 2 |

This is the failure mode that leaks data. Applications write tenant filters, ownership checks and soft-delete predicates in SQL and expect SQL Server semantics; the engine silently widened them. The parameter case is the worst of the set, because a **client** controls whether a parameter is NULL — sending `@tenant = NULL` turned a tenant filter into "give me every row with no tenant".

## Approach

UNKNOWN and FALSE both mean "drop the row", so predicates can still collapse to `bool`. That collapse is only sound if `NOT` never wraps an already-collapsed predicate, because `NOT UNKNOWN` is UNKNOWN while `!false` is `true`.

`NOT` is therefore pushed down to the leaves instead of being wrapped around the result:

- **AND/OR** — De Morgan, which holds in three-valued logic.
- **Comparisons** — operator negation (`=` ↔ `<>`, `>` ↔ `<=`, …).
- **IS NULL / EXISTS** — never UNKNOWN, so they are negated directly.

Comparisons then get explicit null guards, but **only where the result would otherwise be wrong**:

- ordering comparisons on `Nullable<T>` are already lifted to `false` for a null operand, matching SQL — no guard;
- `=` is only wrong when *both* operands can be null — one guard;
- `<>` is wrong when *either* can be null — guard both.

Literals and SQL parameters are baked in as constants during translation, so their nullness is known statically: `Name = 'Alice'` is unchanged, and `Name = @p` with a null `@p` folds to a constant `false`. That is why **all 300 existing tests pass without a single expectation being touched** — the emitted expression trees only change where they were wrong.

`IN` / `NOT IN` follow the same rules, including the SQL gotcha that `NOT IN` over a list containing `NULL` matches nothing.

## Not covered

`JOIN ... ON` still matches `NULL` keys to each other, because `Queryable.Join` uses the default equality comparer and `LEFT JOIN` cannot simply pre-filter null keys off the left side. That is a separate deviation; it is now documented in the readme and left for a follow-up.

## Tests

11 new tests over the existing `nullable_customers` root covering `<>`, `NOT (…)`, De Morgan over `AND`, `NOT (… IS NULL)`, `= NULL` / `<> NULL` literals, a NULL SQL parameter, `NOT IN`, `IN` and `NOT IN` over lists containing `NULL`, and `HAVING <>` over a NULL group. Each asserts both the rows and the translated expression tree.

Full suite green: 322/322.