### PR TITLE
Send oversized column values with PLP framing instead of truncating them

### DIFF
--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsPacketWriter.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsPacketWriter.cs
@@ -16,6 +16,9 @@ internal sealed class TdsPacketWriter
         _packetSize = Math.Max(packetSize, 512);
     }
 
+    /// <summary>Gets the number of payload bytes each TDS packet can carry.</summary>
+    public int PayloadSizePerPacket => _packetSize - 8;
+
     public async ValueTask WriteAsync(TdsPacketType packetType, ReadOnlyMemory<byte> payload, CancellationToken cancellationToken)
     {
         var maxPayloadPerPacket = _packetSize - 8;

--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsResponseSerializer.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsResponseSerializer.cs
@@ -9,6 +9,7 @@ namespace Meziantou.Framework.Tds.Protocol;
 internal static class TdsResponseSerializer
 {
     private const ushort MaxVariableColumnLength = 8000;
+    private const ushort PartiallyLengthPrefixedMarker = 0xFFFF;
     private static readonly byte[] DefaultCollation = [0x09, 0x04, 0xD0, 0x00, 0x34];
 
     public static byte[] CreateLoginSuccess(TdsAuthenticationResult authenticationResult)
@@ -60,7 +61,7 @@ internal static class TdsResponseSerializer
         return stream.ToArray();
     }
 
-    public static byte[] CreateQueryResponse(TdsQueryResult result)
+    public static byte[] CreateQueryResponse(TdsQueryResult result, int payloadSizePerPacket)
     {
         ArgumentNullException.ThrowIfNull(result);
 
@@ -84,7 +85,7 @@ internal static class TdsResponseSerializer
         {
             var resultSet = result.ResultSets[i];
             var hasMoreResults = i + 1 < result.ResultSets.Count;
-            WriteResultSet(writer, resultSet, hasMoreResults);
+            WriteResultSet(writer, resultSet, hasMoreResults, payloadSizePerPacket);
         }
 
         if (result.ResultSets.Count == 0)
@@ -106,17 +107,74 @@ internal static class TdsResponseSerializer
         return stream.ToArray();
     }
 
-    private static void WriteResultSet(BinaryWriter writer, TdsResultSet resultSet, bool hasMoreResults)
+    private static void WriteResultSet(BinaryWriter writer, TdsResultSet resultSet, bool hasMoreResults, int payloadSizePerPacket)
     {
-        WriteColumnMetadataToken(writer, resultSet.Columns);
+        var usePartialLength = GetPartiallyLengthPrefixedColumns(resultSet);
+        WriteColumnMetadataToken(writer, resultSet.Columns, usePartialLength);
 
         foreach (var row in resultSet.Rows)
         {
-            WriteRowToken(writer, resultSet.Columns, row);
+            WriteRowToken(writer, resultSet.Columns, usePartialLength, payloadSizePerPacket, row);
         }
 
         var status = hasMoreResults ? (ushort)0x0001 : (ushort)0x0000;
         WriteDoneToken(writer, status, (ulong)resultSet.Rows.Count);
+    }
+
+    /// <summary>
+    /// Determines, per column, whether values must be sent partially-length-prefixed because at least one of
+    /// them exceeds what a fixed-length column can carry. Short columns keep the cheaper 2-byte framing.
+    /// </summary>
+    private static bool[] GetPartiallyLengthPrefixedColumns(TdsResultSet resultSet)
+    {
+        var result = new bool[resultSet.Columns.Count];
+        for (var i = 0; i < resultSet.Columns.Count; i++)
+        {
+            var column = resultSet.Columns[i];
+            if (column.ColumnType is TdsColumnType.Json || IsFixedLengthColumn(column.ColumnType))
+            {
+                continue;
+            }
+
+            foreach (var row in resultSet.Rows)
+            {
+                if (i < row.Count && ExceedsFixedColumnLength(column, row[i]))
+                {
+                    result[i] = true;
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static bool IsFixedLengthColumn(TdsColumnType columnType)
+    {
+        return columnType is TdsColumnType.TinyInt
+            or TdsColumnType.SmallInt
+            or TdsColumnType.Int32
+            or TdsColumnType.Int64
+            or TdsColumnType.Boolean
+            or TdsColumnType.Real
+            or TdsColumnType.Double;
+    }
+
+    private static bool ExceedsFixedColumnLength(TdsColumn column, object? value)
+    {
+        if (value is null)
+        {
+            return false;
+        }
+
+        if (column.ColumnType is TdsColumnType.Binary)
+        {
+            return value is byte[] bytes
+                ? bytes.Length > MaxVariableColumnLength
+                : Encoding.UTF8.GetByteCount(value.ToString() ?? string.Empty) > MaxVariableColumnLength;
+        }
+
+        return Encoding.Unicode.GetByteCount(ConvertToSqlText(value, column.ColumnType)) > MaxVariableColumnLength;
     }
 
     private static void WriteLoginAckToken(BinaryWriter writer, string programName)
@@ -195,12 +253,14 @@ internal static class TdsResponseSerializer
         writer.Write(rowCount);
     }
 
-    private static void WriteColumnMetadataToken(BinaryWriter writer, Collection<TdsColumn> columns)
+    private static void WriteColumnMetadataToken(BinaryWriter writer, Collection<TdsColumn> columns, bool[] usePartialLength)
     {
         writer.Write((byte)0x81);
         writer.Write((ushort)columns.Count);
-        foreach (var column in columns)
+        for (var columnIndex = 0; columnIndex < columns.Count; columnIndex++)
         {
+            var column = columns[columnIndex];
+            var declaredLength = usePartialLength[columnIndex] ? PartiallyLengthPrefixedMarker : MaxVariableColumnLength;
             writer.Write((uint)0);
             var flags = column.IsNullable ? (ushort)0x0001 : (ushort)0x0000;
             writer.Write(flags);
@@ -286,14 +346,14 @@ internal static class TdsResponseSerializer
                     break;
                 case TdsColumnType.Binary:
                     writer.Write((byte)0xA5); // VARBINARY
-                    writer.Write(MaxVariableColumnLength);
+                    writer.Write(declaredLength);
                     break;
                 case TdsColumnType.Json:
                     writer.Write((byte)0xF4); // JSON
                     break;
                 default:
                     writer.Write((byte)0xE7); // NVARCHAR
-                    writer.Write(MaxVariableColumnLength);
+                    writer.Write(declaredLength);
                     writer.Write(DefaultCollation);
                     break;
             }
@@ -302,21 +362,21 @@ internal static class TdsResponseSerializer
         }
     }
 
-    private static void WriteRowToken(BinaryWriter writer, Collection<TdsColumn> columns, IReadOnlyList<object?> values)
+    private static void WriteRowToken(BinaryWriter writer, Collection<TdsColumn> columns, bool[] usePartialLength, int payloadSizePerPacket, IReadOnlyList<object?> values)
     {
         writer.Write((byte)0xD1);
         for (var i = 0; i < columns.Count; i++)
         {
             var value = i < values.Count ? values[i] : null;
-            WriteColumnValue(writer, columns[i], value);
+            WriteColumnValue(writer, columns[i], usePartialLength[i], payloadSizePerPacket, value);
         }
     }
 
-    private static void WriteColumnValue(BinaryWriter writer, TdsColumn column, object? value)
+    private static void WriteColumnValue(BinaryWriter writer, TdsColumn column, bool usePartialLength, int payloadSizePerPacket, object? value)
     {
         if (value is null)
         {
-            WriteNullValue(writer, column);
+            WriteNullValue(writer, column, usePartialLength);
             return;
         }
 
@@ -380,20 +440,34 @@ internal static class TdsResponseSerializer
                 break;
             case TdsColumnType.Binary:
                 var bytes = value as byte[] ?? Encoding.UTF8.GetBytes(value.ToString() ?? string.Empty);
-                var binaryLength = Math.Min(bytes.Length, MaxVariableColumnLength);
-                writer.Write((ushort)binaryLength);
-                writer.Write(bytes, 0, binaryLength);
+                if (usePartialLength)
+                {
+                    WritePartiallyLengthPrefixed(writer, bytes, payloadSizePerPacket);
+                }
+                else
+                {
+                    writer.Write((ushort)bytes.Length);
+                    writer.Write(bytes);
+                }
+
                 break;
             case TdsColumnType.Json:
                 var json = ConvertToSqlText(value, column.ColumnType);
-                WritePartiallyLengthPrefixedUtf8(writer, json);
+                WritePartiallyLengthPrefixed(writer, Encoding.UTF8.GetBytes(json), payloadSizePerPacket);
                 break;
             default:
                 var text = ConvertToSqlText(value, column.ColumnType);
                 var payload = Encoding.Unicode.GetBytes(text);
-                var length = Math.Min(payload.Length, MaxVariableColumnLength);
-                writer.Write((ushort)length);
-                writer.Write(payload, 0, length);
+                if (usePartialLength)
+                {
+                    WritePartiallyLengthPrefixed(writer, payload, payloadSizePerPacket);
+                }
+                else
+                {
+                    writer.Write((ushort)payload.Length);
+                    writer.Write(payload);
+                }
+
                 break;
         }
     }
@@ -413,8 +487,14 @@ internal static class TdsResponseSerializer
         writer.Write(bodyStream.ToArray());
     }
 
-    private static void WriteNullValue(BinaryWriter writer, TdsColumn column)
+    private static void WriteNullValue(BinaryWriter writer, TdsColumn column, bool usePartialLength)
     {
+        if (usePartialLength)
+        {
+            WritePartiallyLengthPrefixedNull(writer);
+            return;
+        }
+
         switch (column.ColumnType)
         {
             case TdsColumnType.TinyInt:
@@ -548,14 +628,22 @@ internal static class TdsResponseSerializer
         writer.Write(bytes);
     }
 
-    private static void WritePartiallyLengthPrefixedUtf8(BinaryWriter writer, string value)
+    private static void WritePartiallyLengthPrefixed(BinaryWriter writer, byte[] payload, int payloadSizePerPacket)
     {
-        var payload = Encoding.UTF8.GetBytes(value);
         writer.Write((ulong)payload.Length);
-        if (payload.Length > 0)
+
+        var offset = 0;
+        while (offset < payload.Length)
         {
-            writer.Write(payload.Length);
-            writer.Write(payload);
+            // End each chunk on a TDS packet boundary so no chunk is ever continued in the next packet.
+            var positionInPacket = (int)(writer.BaseStream.Position % payloadSizePerPacket);
+            var remainingInPacket = payloadSizePerPacket - positionInPacket - sizeof(int);
+            var count = remainingInPacket > 0 ? remainingInPacket : remainingInPacket + payloadSizePerPacket;
+            count = Math.Min(count, payload.Length - offset);
+
+            writer.Write(count);
+            writer.Write(payload, offset, count);
+            offset += count;
         }
 
         writer.Write(0);

--- a/src/Meziantou.Framework.TdsServer/TdsConnectionProcessor.cs
+++ b/src/Meziantou.Framework.TdsServer/TdsConnectionProcessor.cs
@@ -176,7 +176,7 @@ internal sealed class TdsConnectionProcessor
                     });
                 }
 
-                await writer.WriteAsync(TdsPacketType.TabularResult, TdsResponseSerializer.CreateQueryResponse(queryResult), cancellationToken).ConfigureAwait(false);
+                await writer.WriteAsync(TdsPacketType.TabularResult, TdsResponseSerializer.CreateQueryResponse(queryResult, writer.PayloadSizePerPacket), cancellationToken).ConfigureAwait(false);
             }
         }
         catch (AuthenticationException ex)

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -253,6 +253,106 @@ public sealed class TdsServerProtocolTests
         Assert.Equal(UserId, capturedUserId);
     }
 
+    [Theory]
+    [InlineData(10)]
+    [InlineData(4000)]
+    [InlineData(4001)]
+    [InlineData(100000)]
+    public async Task SqlClient_ResultSet_NVarCharValue_IsNotTruncated(int length)
+    {
+        var expected = string.Create(length, length, (span, _) =>
+        {
+            for (var i = 0; i < span.Length; i++)
+            {
+                span[i] = (char)('a' + (i % 26));
+            }
+        });
+
+        var resultSet = new TdsResultSet();
+        resultSet.Columns.Add(new TdsColumn("Value", TdsColumnType.NVarChar));
+        resultSet.Rows.Add([expected]);
+        resultSet.Rows.Add([null]);
+
+        var rows = await ReadStringColumnAsync(resultSet);
+
+        Assert.Equal([expected, null], rows);
+    }
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(8000)]
+    [InlineData(100000)]
+    public async Task SqlClient_ResultSet_BinaryValue_IsNotTruncated(int length)
+    {
+        var expected = new byte[length];
+        for (var i = 0; i < expected.Length; i++)
+        {
+            expected[i] = (byte)(i % 256);
+        }
+
+        var resultSet = new TdsResultSet();
+        resultSet.Columns.Add(new TdsColumn("Value", TdsColumnType.Binary));
+        resultSet.Rows.Add([expected]);
+        resultSet.Rows.Add([null]);
+
+        var rows = await ReadResultSetAsync(resultSet, (reader, ordinal) => reader.IsDBNull(ordinal) ? null : Convert.ToHexString((byte[])reader.GetValue(ordinal)));
+
+        Assert.Equal([Convert.ToHexString(expected), null], rows);
+    }
+
+    [Fact]
+    public async Task SqlClient_ResultSet_MixedLengths_UseIndependentColumnFraming()
+    {
+        var longValue = new string('x', 9000);
+
+        var resultSet = new TdsResultSet();
+        resultSet.Columns.Add(new TdsColumn("Short", TdsColumnType.NVarChar));
+        resultSet.Columns.Add(new TdsColumn("Long", TdsColumnType.NVarChar));
+        resultSet.Rows.Add(["abc", longValue]);
+        resultSet.Rows.Add([null, "def"]);
+
+        var rows = await ReadResultSetAsync(resultSet, (reader, _) => (reader.IsDBNull(0) ? null : reader.GetString(0)) + "|" + reader.GetString(1));
+
+        Assert.Equal(["abc|" + longValue, "|def"], rows);
+    }
+
+    private static Task<List<string?>> ReadStringColumnAsync(TdsResultSet resultSet)
+    {
+        return ReadResultSetAsync(resultSet, (reader, ordinal) => reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal));
+    }
+
+    private static async Task<List<T>> ReadResultSetAsync<T>(TdsResultSet resultSet, Func<SqlDataReader, int, T> readValue)
+    {
+        var result = new TdsQueryResult();
+        result.ResultSets.Add(resultSet);
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) => ValueTask.FromResult(result));
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+
+        await using var reader = await command.ExecuteReaderAsync();
+        var rows = new List<T>();
+        while (await reader.ReadAsync())
+        {
+            rows.Add(readValue(reader, 0));
+        }
+
+        return rows;
+    }
+
     [Fact]
     public async Task SqlClient_TextQuery_WithParameters_UsesRpc()
     {


### PR DESCRIPTION
Every variable-length column was declared as `NVARCHAR(8000)`/`VARBINARY(8000)` and `WriteColumnValue` clamped the payload with `Math.Min(payload.Length, MaxVariableColumnLength)`. Longer values were cut and written as if complete — no error, no warning token.

Verified against a real `SqlConnection`: a callback returning a 10 000-character string produced a 4 000-character value at the client (8 000 bytes ÷ 2 for UTF-16). An application returning a JSON document, an XML fragment, or any text over 4 000 characters had it silently truncated on the way to its clients.

Columns whose values all fit keep the cheap 2-byte framing; a column switches to partially-length-prefixed (`0xFFFF` max length) only when one of its values actually needs it, so the common case pays nothing extra.

### The packet-alignment part

Emitting PLP was not sufficient on its own. With the value in one chunk, `Microsoft.Data.SqlClient` threw `ArgumentOutOfRangeException` out of `TryReadPlpUnicodeCharsChunk` whenever the value spanned more than one TDS packet — nondeterministically, depending on socket read timing.

I captured the server→client bytes through a proxy and confirmed both the token stream and the packet headers were well-formed; the same bytes read fine whenever they happened to fit in a single packet.

The difference from a real SQL Server is that SQL Server flushes a PLP chunk at each packet boundary, so a chunk is never *continued* in the next packet. `WritePartiallyLengthPrefixed` now does the same, which required threading the packet payload size in from `TdsPacketWriter`. With that, every size passes across packet sizes from 512 to 65535.

Tests round-trip `nvarchar` at 10 / 4000 / 4001 / 100000 characters and `varbinary` at 10 / 8000 / 100000 bytes through a real `SqlConnection`, including NULLs, plus a mixed-width result set covering the per-column decision.

Found by a review of `src/Meziantou.Framework.TdsServer`.