### PR TITLE
Return an error token when a response cannot be built

### DIFF
--- a/src/Meziantou.Framework.TdsServer/TdsConnectionProcessor.cs
+++ b/src/Meziantou.Framework.TdsServer/TdsConnectionProcessor.cs
@@ -158,25 +158,46 @@ internal sealed class TdsConnectionProcessor
                     continue;
                 }
 
-                var queryContext = TdsQueryRequestParser.Parse(packet, remoteEndPoint, authenticationResult.UserContext);
-                TdsQueryResult queryResult;
+                byte[] responsePayload;
                 try
                 {
-                    queryResult = await _queryHandler(queryContext, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Unhandled exception in query handler");
-                    queryResult = TdsQueryResult.FromError(new TdsQueryError
+                    var queryContext = TdsQueryRequestParser.Parse(packet, remoteEndPoint, authenticationResult.UserContext);
+                    TdsQueryResult queryResult;
+                    try
                     {
-                        Number = 50002,
-                        State = 1,
-                        Class = 16,
-                        Message = "Unhandled query handler exception",
-                    });
+                        queryResult = await _queryHandler(queryContext, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Unhandled exception in query handler");
+                        queryResult = TdsQueryResult.FromError(new TdsQueryError
+                        {
+                            Number = 50002,
+                            State = 1,
+                            Class = 16,
+                            Message = "Unhandled query handler exception",
+                        });
+                    }
+
+                    responsePayload = TdsResponseSerializer.CreateQueryResponse(queryResult, writer.PayloadSizePerPacket);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    // Request parsing and response serialization run on caller-supplied data, so a bad request
+                    // or a value that does not match its declared column type must not drop the connection.
+                    _logger.LogError(ex, "Failed to build the TDS response");
+                    responsePayload = TdsResponseSerializer.CreateQueryResponse(
+                        TdsQueryResult.FromError(new TdsQueryError
+                        {
+                            Number = 50005,
+                            State = 1,
+                            Class = 16,
+                            Message = "Failed to build the query response",
+                        }),
+                        writer.PayloadSizePerPacket);
                 }
 
-                await writer.WriteAsync(TdsPacketType.TabularResult, TdsResponseSerializer.CreateQueryResponse(queryResult, writer.PayloadSizePerPacket), cancellationToken).ConfigureAwait(false);
+                await writer.WriteAsync(TdsPacketType.TabularResult, responsePayload, cancellationToken).ConfigureAwait(false);
             }
         }
         catch (AuthenticationException ex)

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -318,6 +318,40 @@ public sealed class TdsServerProtocolTests
         Assert.Equal(["abc|" + longValue, "|def"], rows);
     }
 
+    [Fact]
+    public async Task SqlClient_ResultSet_ValueThatCannotBeSerialized_ReturnsErrorInsteadOfDroppingTheConnection()
+    {
+        var resultSet = new TdsResultSet();
+        resultSet.Columns.Add(new TdsColumn("Value", TdsColumnType.Int32));
+        resultSet.Rows.Add(["not-a-number"]);
+
+        var result = new TdsQueryResult();
+        result.ResultSets.Add(resultSet);
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) => ValueTask.FromResult(result));
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+
+        var exception = await Assert.ThrowsAsync<SqlException>(() => command.ExecuteScalarAsync());
+
+        // A SQL error, not "A transport-level error has occurred", which retry logic treats as transient.
+        Assert.Equal(50005, exception.Number);
+        Assert.Contains("Failed to build the query response", exception.Message);
+    }
+
     private static Task<List<string?>> ReadStringColumnAsync(TdsResultSet resultSet)
     {
         return ReadResultSetAsync(resultSet, (reader, ordinal) => reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal));


### PR DESCRIPTION
Stacked on #2000 — review that one first. (It only needs the `CreateQueryResponse` signature from that PR; there is no other coupling.)

The query handler call was wrapped in `try`/`catch`, but the two calls around it were not. `TdsQueryRequestParser.Parse` and `TdsResponseSerializer.CreateQueryResponse` both run on caller-supplied data — the serializer calls `Convert.ToInt32`/`ToDecimal`/`ToByte` on whatever the handler put in a row — so a value that does not match its declared column type threw straight out of `ProcessAsync`.

Verified against a real `SqlConnection`: a handler returning `"not-a-number"` for a column declared `TdsColumnType.Int32` produced

```
SqlException: A transport-level error has occurred when receiving results
from the server. (provider: TCP Provider, error: 2 - Connection was terminated)
```

with nothing logged. In the Kestrel hosting path the exception at least reaches `TdsTcpConnectionHandler`'s catch-all and is logged at `Debug`; in the standalone `TdsServer` path, `ProcessClientAsync` catches only `OperationCanceledException`, so it became an unobserved fire-and-forget task fault and vanished.

An application bug that should surface as a numbered SQL error instead looked to the client like a network failure and to the operator like nothing at all — and it also makes retry logic misbehave, since transport errors are normally treated as transient and retried.

Both calls are now covered and failures are reported as error 50005, the same shape the existing handler-exception path (50002) already uses. `OperationCanceledException` is excluded so shutdown still propagates.

Found by a review of `src/Meziantou.Framework.TdsServer`.