### PR TITLE
Dispose the SslStream after a post-login encryption downgrade

### DIFF
--- a/src/Meziantou.Framework.TdsServer/TdsConnectionProcessor.cs
+++ b/src/Meziantou.Framework.TdsServer/TdsConnectionProcessor.cs
@@ -43,6 +43,7 @@ internal sealed class TdsConnectionProcessor
         var transportOutput = output;
         var writer = new TdsPacketWriter(output, _options.PacketSize);
         SslStream? sslStream = null;
+        var usingTls = false;
         TdsPreLoginNegotiationResult? negotiationResult = null;
         try
         {
@@ -87,6 +88,7 @@ internal sealed class TdsConnectionProcessor
             if (negotiationResult.Value.UpgradeToTls)
             {
                 sslStream = await UpgradeToTlsAsync(transportInput, transportOutput, serverCertificate!, _options.PacketSize, cancellationToken).ConfigureAwait(false);
+                usingTls = true;
                 input = sslStream;
                 output = sslStream;
                 writer = new TdsPacketWriter(output, _options.PacketSize);
@@ -128,9 +130,11 @@ internal sealed class TdsConnectionProcessor
                 return;
             }
 
-            if (negotiationResult.Value.DowngradeAfterLogin && sslStream is not null)
+            if (negotiationResult.Value.DowngradeAfterLogin && usingTls)
             {
-                sslStream = null;
+                // The client asked for encryption of the login packet only, so the rest of the session goes back
+                // to the raw transport. Keep the SslStream reference so the finally block still disposes it.
+                usingTls = false;
                 input = transportInput;
                 output = transportOutput;
                 writer = new TdsPacketWriter(output, _options.PacketSize);

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -910,6 +910,39 @@ public sealed class TdsServerProtocolTests
     }
 
     [Fact]
+    public async Task SqlClient_EncryptOptional_DowngradesAfterLogin_AndKeepsServingQueries()
+    {
+        using var tlsCertificateFiles = CreateTlsCertificateFiles();
+
+        var options = new TdsServerOptions
+        {
+            TlsPfxPath = tlsCertificateFiles.PfxPath,
+            TlsPfxPassword = tlsCertificateFiles.PfxPassword,
+        };
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) => ValueTask.FromResult(CreateScalarResultSet(TdsColumnType.Int32, 7)));
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        // Encrypt=Optional negotiates ENCRYPT_OFF: the login packet is encrypted and the session then
+        // reverts to the raw transport. Several round trips confirm the swap left a usable connection.
+        await using var connection = new SqlConnection(CreateConnectionString(port, encrypt: "Optional"));
+        await connection.OpenAsync();
+
+        for (var i = 0; i < 3; i++)
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT 1";
+            Assert.Equal(7, Convert.ToInt32(await command.ExecuteScalarAsync(), CultureInfo.InvariantCulture));
+        }
+    }
+
+    [Fact]
     public async Task SqlClient_EncryptOptional_AndEncryptTrue_WorkOnSameEndpoint()
     {
         using var tlsCertificateFiles = CreateTlsCertificateFiles();


### PR DESCRIPTION
Stacked on #2002 (which is stacked on #2000). This change is independent of both — it is only stacked because all three touch `TdsConnectionProcessor.ProcessAsync`.

When PRELOGIN negotiates `ENCRYPT_OFF` — TLS for the login packet, plaintext afterwards, which is standard SQL Server behavior and what `Encrypt=Optional` asks for — the post-login downgrade set the local `sslStream = null` to switch the reader and writer back to the raw transport. That local was the *only* reference the `finally` block had, so `if (sslStream is not null)` was false and `DisposeAsync` was never called.

Every `Encrypt=Optional` connection against a TLS-configured server therefore abandoned a live `SslStream` and its native TLS context, released only when the finalizer eventually ran. On a server handling many short connections that shows up as growing unmanaged memory and handle count under GC pressure rather than as a clean leak, which makes it unpleasant to diagnose.

The fix tracks "currently using TLS" separately from "the stream that must be disposed", so the swap no longer clears the reference.

One correction to how I originally wrote this finding up: I said no test exercised the downgrade path. That was wrong — `Encrypt=Optional` *is* `ENCRYPT_OFF`, so `SqlClient_EncryptOptional_AndEncryptTrue_WorkOnSameEndpoint` already covered it functionally. What no test could see is the leak itself, and I have not found a way to assert disposal from outside that is not flaky, so this PR does not add one. The new test instead pins the behaviour this change could plausibly break — that the stream swap still leaves a connection able to serve several round trips after login — and the existing TLS tests continue to pass.

Found by a review of `src/Meziantou.Framework.TdsServer`.