### PR TITLE
Make TdsServer.Dispose idempotent

### DIFF
--- a/src/Meziantou.Framework.TdsServer/TdsServer.cs
+++ b/src/Meziantou.Framework.TdsServer/TdsServer.cs
@@ -13,6 +13,7 @@ public sealed class TdsServer : IDisposable
     private readonly TdsQueryDelegate _queryHandler;
     private readonly List<TcpListener> _listeners = [];
     private CancellationTokenSource? _cts;
+    private bool _disposed;
 
     /// <summary>Initializes a new instance of the <see cref="TdsServer"/> class.</summary>
     public TdsServer(TdsServerOptions? options, TdsAuthenticationDelegate authenticationHandler, TdsQueryDelegate queryHandler)
@@ -31,7 +32,7 @@ public sealed class TdsServer : IDisposable
     /// <summary>Starts the server.</summary>
     public Task StartAsync(CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(_cts is not null && _cts.IsCancellationRequested, this);
+        ObjectDisposedException.ThrowIf(_disposed, this);
         if (_cts is not null)
         {
             return Task.CompletedTask;
@@ -57,6 +58,12 @@ public sealed class TdsServer : IDisposable
     /// <summary>Stops the server and releases resources.</summary>
     public void Dispose()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
         _cts?.Cancel();
 
         foreach (var listener in _listeners)

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -917,6 +917,54 @@ public sealed class TdsServerProtocolTests
         throw new TimeoutException($"The test server on {IPAddress.Loopback}:{port} was not ready within {timeout}.", lastException);
     }
 
+    [Fact]
+    public async Task TdsServer_Dispose_IsIdempotent()
+    {
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success()),
+            (context, cancellationToken) => ValueTask.FromResult(new TdsQueryResult()));
+
+        await server.StartAsync();
+        server.Dispose();
+
+        Assert.Null(Record.Exception(server.Dispose));
+    }
+
+    [Fact]
+    public async Task TdsServer_StartAsync_AfterDispose_Throws()
+    {
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success()),
+            (context, cancellationToken) => ValueTask.FromResult(new TdsQueryResult()));
+
+        await server.StartAsync();
+        server.Dispose();
+
+        _ = await Assert.ThrowsAsync<ObjectDisposedException>(() => server.StartAsync());
+    }
+
+    [Fact]
+    public void TdsServer_Dispose_WithoutStart_DoesNotThrow()
+    {
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success()),
+            (context, cancellationToken) => ValueTask.FromResult(new TdsQueryResult()));
+
+        Assert.Null(Record.Exception(server.Dispose));
+    }
+
     private static string CreateConnectionString(int port, string userName = "sa", string password = "Password123!", string encrypt = "Optional", bool trustServerCertificate = true, int connectTimeout = 5)
     {
         return $"Server={IPAddress.Loopback},{port};User ID={userName};Password={password};Database=master;Encrypt={encrypt};TrustServerCertificate={(trustServerCertificate ? "True" : "False")};Pooling=False;Connect Timeout={connectTimeout}";


### PR DESCRIPTION
`Dispose` called `_cts?.Cancel()` and then `_cts?.Dispose()`, but never cleared `_cts`. `CancellationTokenSource.Cancel()` throws `ObjectDisposedException` on a disposed source, so the second `Dispose` threw.

Verified: `server.Dispose(); server.Dispose();` throws `System.ObjectDisposedException`.

`IDisposable.Dispose` is contractually required to be idempotent, and double disposal is routine — a `using` block around an object that some cleanup path also disposes, or a DI container disposing something the caller already released. The throw happens during teardown, where it is most likely to mask the real error.

Guarded with a `_disposed` flag, which `StartAsync` now uses for its disposal check as well; it previously inferred disposal from whether the token source had been cancelled.

Three tests: double `Dispose`, `Dispose` before `StartAsync`, and `StartAsync` after `Dispose` still throwing `ObjectDisposedException`.

Found by a review of `src/Meziantou.Framework.TdsServer`.