### PR TITLE
Roll back bound listeners when StartAsync fails part way

### DIFF
--- a/src/Meziantou.Framework.TdsServer/TdsServer.cs
+++ b/src/Meziantou.Framework.TdsServer/TdsServer.cs
@@ -44,11 +44,26 @@ public sealed class TdsServer : IDisposable
             ? _options.TcpListeners
             : [new TdsTcpListenerOptions { BindAddress = IPAddress.Loopback, Port = 1433 }];
 
-        foreach (var listenerOption in listenerOptions)
+        try
         {
-            var listener = new TcpListener(listenerOption.BindAddress, listenerOption.Port);
-            listener.Start();
-            _listeners.Add(listener);
+            foreach (var listenerOption in listenerOptions)
+            {
+                var listener = new TcpListener(listenerOption.BindAddress, listenerOption.Port);
+                listener.Start();
+                _listeners.Add(listener);
+            }
+        }
+        catch
+        {
+            // Binding is all-or-nothing: the caller has no reason to dispose a server whose start threw.
+            StopListeners();
+            _cts.Dispose();
+            _cts = null;
+            throw;
+        }
+
+        foreach (var listener in _listeners)
+        {
             _ = AcceptLoopAsync(listener, _cts.Token);
         }
 
@@ -65,14 +80,18 @@ public sealed class TdsServer : IDisposable
 
         _disposed = true;
         _cts?.Cancel();
+        StopListeners();
+        _cts?.Dispose();
+    }
 
+    private void StopListeners()
+    {
         foreach (var listener in _listeners)
         {
             listener.Stop();
         }
 
         _listeners.Clear();
-        _cts?.Dispose();
     }
 
     private async Task AcceptLoopAsync(TcpListener listener, CancellationToken cancellationToken)

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -1138,6 +1138,32 @@ public sealed class TdsServerProtocolTests
     }
 
     [Fact]
+    public async Task TdsServer_StartAsync_WhenAListenerCannotBind_RollsBackTheOthers()
+    {
+        using var occupied = new TcpListener(IPAddress.Loopback, 0);
+        occupied.Start();
+        var occupiedPort = ((IPEndPoint)occupied.LocalEndpoint).Port;
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+        options.AddTcpListener(occupiedPort, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success()),
+            (context, cancellationToken) => ValueTask.FromResult(new TdsQueryResult()));
+
+        _ = await Assert.ThrowsAsync<SocketException>(() => server.StartAsync());
+
+        // The listener that did bind is released, so the server is not half-started.
+        Assert.Empty(server.Ports);
+
+        occupied.Stop();
+        await server.StartAsync();
+        Assert.Equal(2, server.Ports.Count);
+    }
+
+    [Fact]
     public async Task TdsServer_Dispose_IsIdempotent()
     {
         var options = new TdsServerOptions();


### PR DESCRIPTION
Stacked on #2004 — review that one first. (Only stacked because both touch `TdsServer`; the changes are independent.)

`StartAsync` started listeners in a loop with no rollback. If a later `listener.Start()` threw — the usual cause being a port already in use — the exception propagated to the caller with the earlier listeners bound, `_cts` set, and their accept loops running. A caller whose `StartAsync` threw has no reason to believe it now owns something that needs disposing, so those ports stayed held for the lifetime of the process.

Binding is now all-or-nothing: every listener is bound first, accept loops start only once they all succeed, and anything already bound is released if one fails.

The test occupies a port, configures a server with one free and one occupied listener, and asserts that `StartAsync` throws, that `Ports` is empty afterwards, and that the server starts cleanly once the port is released.

Found by a review of `src/Meziantou.Framework.TdsServer`.