### PR TITLE
Let TdsServer report connection failures through an ILogger

### DIFF
--- a/ref/Meziantou.Framework.TdsServer.cs
+++ b/ref/Meziantou.Framework.TdsServer.cs
@@ -8,6 +8,7 @@ namespace Meziantou.Framework.Tds
     {
         public System.Collections.Generic.IReadOnlyList<int> Ports { get => throw null; }
         public TdsServer(Meziantou.Framework.Tds.TdsServerOptions? options, Meziantou.Framework.Tds.Handler.TdsAuthenticationDelegate authenticationHandler, Meziantou.Framework.Tds.Handler.TdsQueryDelegate queryHandler) { }
+        public TdsServer(Meziantou.Framework.Tds.TdsServerOptions? options, Meziantou.Framework.Tds.Handler.TdsAuthenticationDelegate authenticationHandler, Meziantou.Framework.Tds.Handler.TdsQueryDelegate queryHandler, Microsoft.Extensions.Logging.ILogger? logger) { }
         public System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public void Dispose() { }
     }

--- a/src/Meziantou.Framework.TdsServer/TdsServer.cs
+++ b/src/Meziantou.Framework.TdsServer/TdsServer.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Sockets;
 using Meziantou.Framework.Tds.Handler;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Meziantou.Framework.Tds;
@@ -11,12 +12,26 @@ public sealed class TdsServer : IDisposable
     private readonly TdsServerOptions _options;
     private readonly TdsAuthenticationDelegate _authenticationHandler;
     private readonly TdsQueryDelegate _queryHandler;
+    private readonly ILogger _logger;
     private readonly List<TcpListener> _listeners = [];
     private CancellationTokenSource? _cts;
     private bool _disposed;
 
     /// <summary>Initializes a new instance of the <see cref="TdsServer"/> class.</summary>
     public TdsServer(TdsServerOptions? options, TdsAuthenticationDelegate authenticationHandler, TdsQueryDelegate queryHandler)
+        : this(options, authenticationHandler, queryHandler, logger: null)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="TdsServer"/> class.</summary>
+    /// <param name="options">The server options, or <see langword="null"/> to use the defaults.</param>
+    /// <param name="authenticationHandler">The callback invoked to authenticate a login.</param>
+    /// <param name="queryHandler">The callback invoked to answer a query.</param>
+    /// <param name="logger">
+    /// The logger used to report connection failures. When <see langword="null"/> nothing is logged, and a
+    /// connection that fails to negotiate, authenticate or answer a query does so silently.
+    /// </param>
+    public TdsServer(TdsServerOptions? options, TdsAuthenticationDelegate authenticationHandler, TdsQueryDelegate queryHandler, ILogger? logger)
     {
         ArgumentNullException.ThrowIfNull(authenticationHandler);
         ArgumentNullException.ThrowIfNull(queryHandler);
@@ -24,6 +39,7 @@ public sealed class TdsServer : IDisposable
         _options = options ?? new TdsServerOptions();
         _authenticationHandler = authenticationHandler;
         _queryHandler = queryHandler;
+        _logger = logger ?? NullLogger.Instance;
     }
 
     /// <summary>Gets the ports currently bound by the server.</summary>
@@ -111,6 +127,11 @@ public sealed class TdsServer : IDisposable
             {
                 return;
             }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Stopped accepting TDS connections after a listener failure");
+                return;
+            }
 
             _ = ProcessClientAsync(client, cancellationToken);
         }
@@ -120,7 +141,7 @@ public sealed class TdsServer : IDisposable
     {
         using var _ = client;
         var endpoint = client.Client.RemoteEndPoint ?? new IPEndPoint(IPAddress.Loopback, 0);
-        var processor = new TdsConnectionProcessor(_options, _authenticationHandler, _queryHandler, NullLogger.Instance);
+        var processor = new TdsConnectionProcessor(_options, _authenticationHandler, _queryHandler, _logger);
         try
         {
             using var stream = client.GetStream();
@@ -128,6 +149,11 @@ public sealed class TdsServer : IDisposable
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+        }
+        catch (Exception ex)
+        {
+            // This runs on a fire-and-forget task, so an escaping exception would otherwise be unobserved.
+            _logger.LogDebug(ex, "TDS connection closed with exception");
         }
     }
 }

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Data;
 using System.Net;
 using System.Net.Sockets;
@@ -6,6 +7,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Meziantou.Framework.Tds.Handler;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
 using Microsoft.SqlServer.Management.SqlParser.SqlCodeDom;
 using Meziantou.Xunit;
 using SqlParser = Microsoft.SqlServer.Management.SqlParser.Parser.Parser;
@@ -1161,6 +1163,53 @@ public sealed class TdsServerProtocolTests
         occupied.Stop();
         await server.StartAsync();
         Assert.Equal(2, server.Ports.Count);
+    }
+
+    [Fact]
+    public async Task TdsServer_Logger_ReceivesQueryHandlerFailures()
+    {
+        var logger = new CollectingLogger();
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) => throw new InvalidOperationException("boom"),
+            logger);
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+        _ = await Assert.ThrowsAsync<SqlException>(() => command.ExecuteScalarAsync());
+
+        Assert.Contains(logger.Entries, entry => entry.Contains("Unhandled exception in query handler", StringComparison.Ordinal));
+    }
+
+    private sealed class CollectingLogger : ILogger
+    {
+        private readonly ConcurrentQueue<string> _entries = new();
+
+        public IReadOnlyCollection<string> Entries => _entries;
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            _entries.Enqueue(formatter(state, exception));
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Stacked on #2005 → #2004. All three touch `TdsServer`; the changes themselves are independent.

`TdsServer.ProcessClientAsync` hardcoded `NullLogger.Instance`, and `TdsServer` exposed no way to supply a logger. Every `_logger.LogDebug`/`LogError` in `TdsConnectionProcessor` — failed PRELOGIN parses, failed LOGIN7 parses, TLS handshake failures, unhandled query-handler exceptions — went nowhere.

The standalone server is the path used outside ASP.NET Core hosting, and it was completely unobservable. When a client could not connect there was no signal at all about why, and because a connection can fail for several distinct reasons that all produced identical silence, there was nothing to tell them apart.

- A constructor overload takes an `ILogger`. The existing three-argument constructor delegates to it with `null`, so nothing changes for current callers, and the XML docs say plainly what `null` means.
- `ProcessClientAsync` and `AcceptLoopAsync` now catch and log the exceptions that escape them. Both run on fire-and-forget tasks, so anything escaping was previously an unobserved task fault — `AcceptLoopAsync` in particular would silently stop accepting connections on a listener failure.

The test drives a real `SqlConnection` against a server whose query handler throws, and asserts the failure reaches the supplied logger.

`ref/Meziantou.Framework.TdsServer.cs` is regenerated for the new overload.

Found by a review of `src/Meziantou.Framework.TdsServer`.