### PR TITLE
Warn when no TLS certificate is configured

### DIFF
--- a/src/Meziantou.Framework.TdsServer/Hosting/TdsTcpConnectionHandler.cs
+++ b/src/Meziantou.Framework.TdsServer/Hosting/TdsTcpConnectionHandler.cs
@@ -21,6 +21,8 @@ internal sealed class TdsTcpConnectionHandler : ConnectionHandler
         _authenticationDelegateHolder = authenticationDelegateHolder;
         _queryDelegateHolder = queryDelegateHolder;
         _logger = logger;
+
+        TdsServer.WarnWhenEncryptionIsUnavailable(options, logger);
     }
 
     public override async Task OnConnectedAsync(ConnectionContext connection)

--- a/src/Meziantou.Framework.TdsServer/TdsServer.cs
+++ b/src/Meziantou.Framework.TdsServer/TdsServer.cs
@@ -55,7 +55,7 @@ public sealed class TdsServer : IDisposable
         }
 
         _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _ = _options.GetTlsCertificate();
+        WarnWhenEncryptionIsUnavailable(_options, _logger);
         var listenerOptions = _options.TcpListeners.Count > 0
             ? _options.TcpListeners
             : [new TdsTcpListenerOptions { BindAddress = IPAddress.Loopback, Port = 1433 }];
@@ -108,6 +108,19 @@ public sealed class TdsServer : IDisposable
         }
 
         _listeners.Clear();
+    }
+
+    internal static void WarnWhenEncryptionIsUnavailable(TdsServerOptions options, ILogger logger)
+    {
+        if (options.GetTlsCertificate() is not null)
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "No TLS certificate is configured, so the server answers PRELOGIN with NOT_SUPPORTED. Clients that " +
+            "allow unencrypted connections will send credentials protected only by the TDS password obfuscation, " +
+            "which is trivially reversible. Configure TlsPfxPath, or TlsPemCertificatePath and TlsPemPrivateKeyPath.");
     }
 
     private async Task AcceptLoopAsync(TcpListener listener, CancellationToken cancellationToken)

--- a/src/Meziantou.Framework.TdsServer/TdsServerOptions.cs
+++ b/src/Meziantou.Framework.TdsServer/TdsServerOptions.cs
@@ -38,6 +38,13 @@ public sealed class TdsServerOptions
     }
 
     /// <summary>Gets or sets a value indicating whether encryption is required by the server.</summary>
+    /// <remarks>
+    /// When this is <see langword="false"/> and no TLS certificate is configured, the server answers PRELOGIN
+    /// with NOT_SUPPORTED, and clients that allow it (for example <c>Encrypt=Optional</c>) log in over an
+    /// unencrypted connection. The LOGIN7 password is then protected only by the TDS nibble-swap and XOR
+    /// obfuscation, which is trivially reversible by anyone on the network path. Configure
+    /// <see cref="TlsPfxPath"/> or the PEM options for any deployment that is not loopback-only.
+    /// </remarks>
     public bool RequireEncryption { get; set; }
 
     /// <summary>Gets or sets the path to a PFX certificate file used for TLS.</summary>

--- a/src/Meziantou.Framework.TdsServer/readme.md
+++ b/src/Meziantou.Framework.TdsServer/readme.md
@@ -12,6 +12,18 @@
 - Native JSON column type serialization (`TDSType.JSON`, UTF-8 payload)
 - ASP.NET Core hosting integration through `IHostApplicationBuilder`
 
+## Security: configure TLS
+
+By default no TLS certificate is configured. The server then answers PRELOGIN with `NOT_SUPPORTED`, and a client
+that allows it (`Encrypt=Optional`, the common default) logs in over an unencrypted connection. The password in
+the LOGIN7 packet is protected only by the TDS nibble-swap and XOR obfuscation, which is trivially reversible by
+anyone on the network path. This mirrors SQL Server's own behaviour, and it is fine for a loopback-only test
+server, but **configure a certificate for anything else** - see [TLS configuration](#tls-configuration) below,
+and set `RequireEncryption` to reject clients that will not encrypt.
+
+The quickstart below binds to loopback and does not configure TLS, so its credential check is only meaningful
+on the local machine.
+
 ## Usage
 
 ```csharp

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -1213,6 +1213,49 @@ public sealed class TdsServerProtocolTests
     }
 
     [Fact]
+    public async Task TdsServer_WithoutTlsCertificate_LogsAWarning()
+    {
+        var logger = new CollectingLogger();
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success()),
+            (context, cancellationToken) => ValueTask.FromResult(new TdsQueryResult()),
+            logger);
+
+        await server.StartAsync();
+
+        Assert.Contains(logger.Entries, entry => entry.Contains("No TLS certificate is configured", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TdsServer_WithTlsCertificate_DoesNotLogAWarning()
+    {
+        using var tlsCertificateFiles = CreateTlsCertificateFiles();
+        var logger = new CollectingLogger();
+
+        var options = new TdsServerOptions
+        {
+            TlsPfxPath = tlsCertificateFiles.PfxPath,
+            TlsPfxPassword = tlsCertificateFiles.PfxPassword,
+        };
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success()),
+            (context, cancellationToken) => ValueTask.FromResult(new TdsQueryResult()),
+            logger);
+
+        await server.StartAsync();
+
+        Assert.DoesNotContain(logger.Entries, entry => entry.Contains("No TLS certificate is configured", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task TdsServer_Dispose_IsIdempotent()
     {
         var options = new TdsServerOptions();


### PR DESCRIPTION
Stacked on #2006 → #2005 → #2004, because the startup warning needs the logger from #2006.

With no certificate configured — the default, and what the readme's first example shows — the server answers PRELOGIN with `NOT_SUPPORTED`. `Microsoft.Data.SqlClient` with the common `Encrypt=Optional` then proceeds unencrypted, and the LOGIN7 password arrives protected only by TDS's nibble-swap-and-XOR-`0xA5` obfuscation, which `TdsLoginParser.ReadPassword` reverses in six lines. The readme's quickstart then compares that password against a literal.

That is a library default that transmits credentials recoverable by anyone on the network path, and someone following the readme end to end ships exactly that.

This is spec-conformant SQL Server behaviour and interop demands it, so the behaviour is unchanged. What changes is that the risk is no longer silent:

- A warning is logged at startup when no certificate is configured — on the standalone `TdsServer` path and on the Kestrel `TdsTcpConnectionHandler` path.
- `RequireEncryption` gets a `<remarks>` saying what leaving it `false` actually means.
- The readme gets a short security section before the quickstart, and says outright that the quickstart's credential check is only meaningful on loopback.

Tests cover the warning firing without a certificate and staying quiet with one.

Found by a review of `src/Meziantou.Framework.TdsServer`.