### PR TITLE
Avoid copying every received TDS message twice

### DIFF
--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsPacketReader.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsPacketReader.cs
@@ -59,7 +59,7 @@ internal static class TdsPacketReader
             return new TdsPacket
             {
                 Type = messageType ?? TdsPacketType.TabularResult,
-                Payload = payloadLength == 0 ? [] : payload![..payloadLength].ToArray(),
+                Payload = payloadLength == 0 ? [] : payload.AsSpan(0, payloadLength).ToArray(),
             };
         }
         finally


### PR DESCRIPTION
`payload![..payloadLength].ToArray()` allocates twice: the range indexer on an array already allocates and copies, and `.ToArray()` copies that result again. So every request allocated two arrays the size of the whole message.

`payload.AsSpan(0, payloadLength).ToArray()` copies once.

Heads-up on merge order: this touches the same method as the pending fix for the unbounded pre-auth buffering in `TdsPacketReader` (the Critical finding from the same review, which I understand is being handled separately). It is a one-line change either way, but whichever lands second may need a trivial rebase.

Found by a review of `src/Meziantou.Framework.TdsServer`.