### PR TITLE
Validate TdsServerOptions.PacketSize

### DIFF
--- a/ref/Meziantou.Framework.TdsServer.cs
+++ b/ref/Meziantou.Framework.TdsServer.cs
@@ -14,6 +14,8 @@ namespace Meziantou.Framework.Tds
 
     public sealed class TdsServerOptions
     {
+        public const int MinimumPacketSize = 512;
+        public const int MaximumPacketSize = 65535;
         public int PacketSize { get => throw null; set { } }
         public bool RequireEncryption { get => throw null; set { } }
         public string? TlsPfxPath { get => throw null; set { } }

--- a/src/Meziantou.Framework.TdsServer/TdsServerOptions.cs
+++ b/src/Meziantou.Framework.TdsServer/TdsServerOptions.cs
@@ -6,14 +6,36 @@ namespace Meziantou.Framework.Tds;
 /// <summary>Configuration options for the TDS server.</summary>
 public sealed class TdsServerOptions
 {
+    /// <summary>The smallest packet size a TDS client is required to support.</summary>
+    public const int MinimumPacketSize = 512;
+
+    /// <summary>The largest packet size a TDS packet header can describe, since it stores the length in 16 bits.</summary>
+    public const int MaximumPacketSize = ushort.MaxValue;
+
     private readonly Lock _tlsCertificateLock = new();
+    private int _packetSize = 4096;
     private X509Certificate2? _tlsCertificate;
     private bool _tlsCertificateLoaded;
 
     internal List<TdsTcpListenerOptions> TcpListeners { get; } = [];
 
     /// <summary>Gets or sets the packet size used when writing TDS packets.</summary>
-    public int PacketSize { get; set; } = 4096;
+    /// <remarks>
+    /// Must be between <see cref="MinimumPacketSize"/> and <see cref="MaximumPacketSize"/>. The TDS packet
+    /// header stores the packet length in 16 bits, so a larger value cannot be represented on the wire.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">The value is outside the supported range.</exception>
+    public int PacketSize
+    {
+        get => _packetSize;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, MinimumPacketSize);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, MaximumPacketSize);
+
+            _packetSize = value;
+        }
+    }
 
     /// <summary>Gets or sets a value indicating whether encryption is required by the server.</summary>
     public bool RequireEncryption { get; set; }

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -917,6 +917,32 @@ public sealed class TdsServerProtocolTests
         throw new TimeoutException($"The test server on {IPAddress.Loopback}:{port} was not ready within {timeout}.", lastException);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(511)]
+    [InlineData(65536)]
+    [InlineData(100000)]
+    public void TdsServerOptions_PacketSize_OutsideTheSupportedRange_Throws(int packetSize)
+    {
+        var options = new TdsServerOptions();
+
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => options.PacketSize = packetSize);
+    }
+
+    [Theory]
+    [InlineData(512)]
+    [InlineData(4096)]
+    [InlineData(65535)]
+    public void TdsServerOptions_PacketSize_InsideTheSupportedRange_IsAccepted(int packetSize)
+    {
+        var options = new TdsServerOptions
+        {
+            PacketSize = packetSize,
+        };
+
+        Assert.Equal(packetSize, options.PacketSize);
+    }
+
     private static string CreateConnectionString(int port, string userName = "sa", string password = "Password123!", string encrypt = "Optional", bool trustServerCertificate = true, int connectTimeout = 5)
     {
         return $"Server={IPAddress.Loopback},{port};User ID={userName};Password={password};Database=master;Encrypt={encrypt};TrustServerCertificate={(trustServerCertificate ? "True" : "False")};Pooling=False;Connect Timeout={connectTimeout}";


### PR DESCRIPTION
`TdsServerOptions.PacketSize` was a plain settable `int` with no validation, and `TdsPacketWriter.WritePacketAsync` writes the length as `(ushort)(payload.Length + 8)` — an unchecked narrowing conversion.

Any `PacketSize` above 65 535 makes the header length wrap, so the client resynchronizes on garbage and the connection breaks in a way that points nowhere near the configuration that caused it. Raising the packet size for throughput is a plausible thing to try, and it produced a confusing protocol failure instead of an argument error.

The setter now rejects anything outside `[512, 65535]` — 512 being the smallest packet size a TDS client must support, 65 535 the largest the 16-bit header length can describe. Both bounds are exposed as constants and named in the XML docs.

The property signature is unchanged, so `ref/Meziantou.Framework.TdsServer.cs` gains only the two new constants.

Found by a review of `src/Meziantou.Framework.TdsServer`.