### PR TITLE
Stop token length fields from wrapping on long messages

### DIFF
--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsResponseSerializer.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsResponseSerializer.cs
@@ -9,6 +9,9 @@ namespace Meziantou.Framework.Tds.Protocol;
 internal static class TdsResponseSerializer
 {
     private const ushort MaxVariableColumnLength = 8000;
+
+    // A token's length field is 16 bits, so a message has to leave room for the rest of the token body.
+    private const int MaxTokenMessageLength = 32000;
     private static readonly byte[] DefaultCollation = [0x09, 0x04, 0xD0, 0x00, 0x34];
 
     public static byte[] CreateLoginSuccess(TdsAuthenticationResult authenticationResult)
@@ -132,9 +135,7 @@ internal static class TdsResponseSerializer
         bodyWriter.Write((byte)0);
         bodyWriter.Flush();
 
-        writer.Write((byte)0xAD);
-        writer.Write((ushort)bodyStream.Length);
-        writer.Write(bodyStream.ToArray());
+        WriteToken(writer, token: 0xAD, bodyStream);
     }
 
     private static void WriteEnvironmentChangeToken(BinaryWriter writer, byte environmentType, string newValue, string oldValue)
@@ -146,9 +147,7 @@ internal static class TdsResponseSerializer
         WriteBVarChar(bodyWriter, oldValue);
         bodyWriter.Flush();
 
-        writer.Write((byte)0xE3);
-        writer.Write((ushort)bodyStream.Length);
-        writer.Write(bodyStream.ToArray());
+        WriteToken(writer, token: 0xE3, bodyStream);
     }
 
     private static void WriteInfoToken(BinaryWriter writer, string message)
@@ -158,15 +157,13 @@ internal static class TdsResponseSerializer
         bodyWriter.Write((uint)0);
         bodyWriter.Write((byte)1);
         bodyWriter.Write((byte)10);
-        WriteUsVarChar(bodyWriter, message);
+        WriteUsVarChar(bodyWriter, Truncate(message, MaxTokenMessageLength));
         WriteBVarChar(bodyWriter, "TdsServer");
         WriteBVarChar(bodyWriter, string.Empty);
         bodyWriter.Write((uint)1);
         bodyWriter.Flush();
 
-        writer.Write((byte)0xAB);
-        writer.Write((ushort)bodyStream.Length);
-        writer.Write(bodyStream.ToArray());
+        WriteToken(writer, token: 0xAB, bodyStream);
     }
 
     private static void WriteErrorToken(BinaryWriter writer, uint number, byte state, byte @class, string message)
@@ -176,15 +173,13 @@ internal static class TdsResponseSerializer
         bodyWriter.Write(number);
         bodyWriter.Write(state);
         bodyWriter.Write(@class);
-        WriteUsVarChar(bodyWriter, message);
+        WriteUsVarChar(bodyWriter, Truncate(message, MaxTokenMessageLength));
         WriteBVarChar(bodyWriter, "TdsServer");
         WriteBVarChar(bodyWriter, string.Empty);
         bodyWriter.Write((uint)1);
         bodyWriter.Flush();
 
-        writer.Write((byte)0xAA);
-        writer.Write((ushort)bodyStream.Length);
-        writer.Write(bodyStream.ToArray());
+        WriteToken(writer, token: 0xAA, bodyStream);
     }
 
     private static void WriteDoneToken(BinaryWriter writer, ushort status, ulong rowCount)
@@ -408,9 +403,7 @@ internal static class TdsResponseSerializer
         bodyWriter.Write((byte)0);
         bodyWriter.Flush();
 
-        writer.Write((byte)0xE3);
-        writer.Write((ushort)bodyStream.Length);
-        writer.Write(bodyStream.ToArray());
+        WriteToken(writer, token: 0xE3, bodyStream);
     }
 
     private static void WriteNullValue(BinaryWriter writer, TdsColumn column)
@@ -525,6 +518,25 @@ internal static class TdsResponseSerializer
             TdsColumnType.Variant => value.ToString() ?? string.Empty,
             _ => Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
         };
+    }
+
+    private static void WriteToken(BinaryWriter writer, byte token, MemoryStream bodyStream)
+    {
+        writer.Write(token);
+        writer.Write(checked((ushort)bodyStream.Length));
+        writer.Write(bodyStream.ToArray());
+    }
+
+    private static string Truncate(string value, int maxLength)
+    {
+        if (value.Length <= maxLength)
+        {
+            return value;
+        }
+
+        // Do not split a surrogate pair, which would leave an unpaired surrogate in the message.
+        var length = char.IsHighSurrogate(value[maxLength - 1]) ? maxLength - 1 : maxLength;
+        return value[..length];
     }
 
     private static void WriteUsVarChar(BinaryWriter writer, string value)

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -917,6 +917,44 @@ public sealed class TdsServerProtocolTests
         throw new TimeoutException($"The test server on {IPAddress.Loopback}:{port} was not ready within {timeout}.", lastException);
     }
 
+    [Fact]
+    public async Task SqlClient_QueryError_WithAVeryLongMessage_IsTruncatedInsteadOfOverflowingTheToken()
+    {
+        var result = TdsQueryResult.FromError(new TdsQueryError
+        {
+            Number = 50004,
+            State = 1,
+            Class = 16,
+            Message = new string('e', 100_000),
+        });
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            (context, cancellationToken) => ValueTask.FromResult(result));
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+
+        var exception = await Assert.ThrowsAsync<SqlException>(() => command.ExecuteScalarAsync());
+
+        Assert.Equal(50004, exception.Number);
+
+        // The message fits in the token's 16-bit length field rather than wrapping it. SqlClient appends its
+        // own note about the severity, so compare the first line only.
+        var reportedMessage = exception.Message.Split('\n')[0];
+        Assert.Equal(new string('e', 32_000), reportedMessage);
+    }
+
     private static string CreateConnectionString(int port, string userName = "sa", string password = "Password123!", string encrypt = "Optional", bool trustServerCertificate = true, int connectTimeout = 5)
     {
         return $"Server={IPAddress.Loopback},{port};User ID={userName};Password={password};Database=master;Encrypt={encrypt};TrustServerCertificate={(trustServerCertificate ? "True" : "False")};Pooling=False;Connect Timeout={connectTimeout}";


### PR DESCRIPTION
Each token wrote its body length as `writer.Write((ushort)bodyStream.Length)` — an unchecked cast — while `WriteUsVarChar` allowed message strings up to 65 535 characters. A message longer than about 32 750 characters therefore produced a body over 65 535 bytes and the declared token length wrapped.

Attacker-influenced messages reach this: `Unknown stored procedure '{name}'` embeds an RPC procedure name of up to 65 535 characters.

Scope, honestly: I could not make this break the reference client. A 40 000-character error message did **not** confuse `Microsoft.Data.SqlClient`, which appears to parse the ERROR token field-by-field rather than trusting the declared length. So this is a spec violation with no demonstrated impact on SqlClient — but other TDS clients (JDBC, ODBC, the Go and Python drivers) may well trust the length field, and an unchecked cast that silently produces a malformed frame is worth closing regardless.

- All five token writers now go through a single `WriteToken` helper that casts `checked`, so a future change fails loudly instead of wrapping.
- `WriteErrorToken` and `WriteInfoToken` cap the message so the body always fits, without splitting a surrogate pair at the cut.

The test sends a 100 000-character error message and asserts the client receives it capped at 32 000 characters with the correct error number.

Found by a review of `src/Meziantou.Framework.TdsServer`.