### PR TITLE
Bound the projection type cache and drop the global lock from cache hits

### DIFF
--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsProjectionTypeFactory.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsProjectionTypeFactory.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -5,51 +6,64 @@ namespace Meziantou.Framework.Tds.QueryEngine;
 
 internal static class TdsProjectionTypeFactory
 {
+    /// <summary>
+    /// Emitted types live in a non-collectible dynamic assembly, so they can never be reclaimed, and column
+    /// aliases come from client SQL -- which makes the number of distinct shapes client-controlled. Cap it so a
+    /// client cannot grow the process without bound by varying aliases across queries.
+    /// </summary>
+    private const int MaxCachedTypes = 1024;
+
     private static readonly AssemblyBuilder AssemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Meziantou.Framework.Tds.QueryEngine.Projections"), AssemblyBuilderAccess.Run);
     private static readonly ModuleBuilder ModuleBuilder = AssemblyBuilder.DefineDynamicModule("Projections");
-    private static readonly Lock Lock = new();
-    private static readonly Dictionary<string, Type> Types = [with(StringComparer.Ordinal)];
+    private static readonly Lock CreateLock = new();
+    private static readonly ConcurrentDictionary<string, Type> Types = new(StringComparer.Ordinal);
+    private static int s_createdTypeCount;
 
     public static Type GetProjectionType(IReadOnlyList<TdsProjectionMember> members)
     {
         ArgumentNullException.ThrowIfNull(members);
 
-        var key = CreateKey("Projection", members);
-        lock (Lock)
-        {
-            if (Types.TryGetValue(key, out var type))
-            {
-                return type;
-            }
-
-            type = CreateType("TdsProjection", members);
-            Types.Add(key, type);
-            return type;
-        }
+        return GetOrCreateType(CreateKey("Projection", members), "TdsProjection", members);
     }
 
     public static Type GetCarrierType(IReadOnlyList<TdsProjectionMember> members)
     {
         ArgumentNullException.ThrowIfNull(members);
 
-        var key = CreateKey("Carrier", members);
-        lock (Lock)
+        return GetOrCreateType(CreateKey("Carrier", members), "TdsCarrier", members);
+    }
+
+    private static Type GetOrCreateType(string key, string prefix, IReadOnlyList<TdsProjectionMember> members)
+    {
+        // Cache hits take no lock, so concurrent queries over known shapes do not serialize on type creation.
+        if (Types.TryGetValue(key, out var type))
         {
-            if (Types.TryGetValue(key, out var type))
+            return type;
+        }
+
+        lock (CreateLock)
+        {
+            if (Types.TryGetValue(key, out type))
             {
                 return type;
             }
 
-            type = CreateType("TdsCarrier", members);
-            Types.Add(key, type);
+            if (s_createdTypeCount >= MaxCachedTypes)
+            {
+                throw new TdsQueryEngineException($"The server reached its limit of {MaxCachedTypes} distinct query projection shapes.");
+            }
+
+            type = CreateType(prefix, s_createdTypeCount, members);
+            s_createdTypeCount++;
+            Types[key] = type;
             return type;
         }
     }
 
-    private static Type CreateType(string prefix, IReadOnlyList<TdsProjectionMember> members)
+    private static Type CreateType(string prefix, int index, IReadOnlyList<TdsProjectionMember> members)
     {
         var typeBuilder = ModuleBuilder.DefineType(
-            prefix + Types.Count.ToString(CultureInfo.InvariantCulture),
+            prefix + index.ToString(CultureInfo.InvariantCulture),
             TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed);
 
         _ = typeBuilder.DefineDefaultConstructor(MethodAttributes.Public);

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -3384,6 +3384,40 @@ public sealed class TdsQueryEngineTests
         Assert.Contains("late_root", exception.Message);
     }
 
+    [Fact]
+    [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "The SQL query is generated within the test and not user-controlled.")]
+    public async Task SqlClient_QueryEngine_ManyDistinctProjectionShapes_AreServedConcurrently()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            TdsQueryEngine.CreateQueryHandler(queryEngineOptions));
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        // Each alias produces a distinct projection shape, so this exercises both the emit path and the
+        // lock-free cache-hit path from several connections at once.
+        var results = await Task.WhenAll(Enumerable.Range(0, 24).Select(async index =>
+        {
+            await using var connection = new SqlConnection(CreateConnectionString(port));
+            await connection.OpenAsync();
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = $"SELECT Id AS Alias{index % 8} FROM customers";
+
+            await using var reader = await command.ExecuteReaderAsync();
+            return reader.GetName(0);
+        }));
+
+        Assert.Equal(Enumerable.Range(0, 24).Select(index => $"Alias{index % 8}"), results);
+    }
+
     private static TdsQueryEngineOptions CreateQueryEngineOptions()
     {
         var options = new TdsQueryEngineOptions();


### PR DESCRIPTION
Each distinct projection or join-carrier shape (the ordered set of column names and CLR types) emits a new type into a process-wide `AssemblyBuilderAccess.Run` dynamic assembly, cached forever in a `static Dictionary`.

Column **aliases** are part of the key, and aliases come from the client's SQL. `SELECT Id AS a1 FROM customers`, `SELECT Id AS a2 FROM customers`, … each emit and permanently retain a new type, and `Run` assemblies are not collectible, so nothing is ever reclaimed. An authenticated client could grow process memory without bound and it could not be recovered without a restart.

Secondly, both `GetProjectionType` and `GetCarrierType` took the same global `Lock` on *every* call including cache hits, so every concurrent query serialized on it twice.

- Cache hits now go through a `ConcurrentDictionary` and take no lock; only actual type emission is serialized.
- The number of emitted shapes is capped (1024) and exceeding it raises a query-engine error rather than growing the process.

**Tradeoff worth a second opinion:** the cap converts an unbounded-memory problem into a bounded-memory one, but a client that deliberately fills the cache makes subsequent *new* shapes fail until restart. I think bounded memory plus a diagnosable error beats an OOM, and 1024 distinct projection shapes is far more than a real application produces — but if you would rather have this configurable through `TdsQueryEngineOptions`, say so and I will add it.

I did not unit-test the cap itself: the cache is process-wide static state, so exercising it would leave the rest of the test run at the limit. The new test covers what is safely testable — many distinct-alias queries served concurrently across connections, exercising both the emit path and the lock-free hit path.

Found by a review of `src/Meziantou.Framework.TdsServer`.