### PR TITLE
Snapshot query engine option collections when the handler is created

### DIFF
--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Security;
@@ -35,12 +36,36 @@ internal sealed class TdsQueryEngineExecutor
     }
 
     private readonly TdsQueryEngineOptions _options;
+    private readonly FrozenDictionary<string, TdsQueryRoot> _queryRoots;
+    private readonly FrozenDictionary<string, Delegate> _storedProcedures;
+    private readonly FrozenDictionary<string, TdsQueryScalarFunction> _scalarFunctions;
+    private readonly FrozenDictionary<string, XmlSchemaSet> _xmlSchemaCollections;
 
     public TdsQueryEngineExecutor(TdsQueryEngineOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
 
         _options = options;
+
+        // The option collections are plain mutable dictionaries handed out through the public API, and they are
+        // read from every connection thread. Snapshot them once so a late registration cannot race an in-flight
+        // query, and so the query-root lookup is not rebuilt per request.
+        _queryRoots = BuildQueryRoots(options.QueryRoots);
+        _storedProcedures = options.StoredProcedures.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        _scalarFunctions = options.ScalarFunctions.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        _xmlSchemaCollections = options.XmlSchemaCollections.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static FrozenDictionary<string, TdsQueryRoot> BuildQueryRoots(IEnumerable<TdsQueryRoot> queryRoots)
+    {
+        var result = new Dictionary<string, TdsQueryRoot>(StringComparer.OrdinalIgnoreCase);
+        foreach (var queryRoot in queryRoots)
+        {
+            // First registration wins, matching the previous behaviour.
+            _ = result.TryAdd(queryRoot.Name, queryRoot);
+        }
+
+        return result.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
     }
 
     public async ValueTask<TdsQueryResult> ExecuteAsync(TdsQueryContext context, CancellationToken cancellationToken)
@@ -79,18 +104,7 @@ internal sealed class TdsQueryEngineExecutor
 
     private QueryExecutionContext CreateQueryExecutionContext(TdsQueryContext queryContext)
     {
-        var result = new Dictionary<string, TdsQueryRoot>(StringComparer.OrdinalIgnoreCase);
-        foreach (var queryRoot in _options.QueryRoots)
-        {
-            if (result.ContainsKey(queryRoot.Name))
-            {
-                continue;
-            }
-
-            result.Add(queryRoot.Name, queryRoot);
-        }
-
-        return new QueryExecutionContext(queryContext, result);
+        return new QueryExecutionContext(queryContext, _queryRoots);
     }
 
     private async ValueTask<TdsQueryResult> ExecuteStoredProcedureAsync(TdsQueryContext context, CancellationToken cancellationToken)
@@ -100,7 +114,7 @@ internal sealed class TdsQueryEngineExecutor
             throw new TdsQueryEngineException("The RPC request does not specify a stored procedure name.");
         }
 
-        if (!_options.StoredProcedures.TryGetValue(context.ProcedureName, out var storedProcedure))
+        if (!_storedProcedures.TryGetValue(context.ProcedureName, out var storedProcedure))
         {
             throw new TdsQueryEngineException($"Unknown stored procedure '{context.ProcedureName}'.");
         }
@@ -1635,7 +1649,7 @@ internal sealed class TdsQueryEngineExecutor
         }
 
         var arguments = function.Arguments?.Select(argument => BuildScalar(argument, aliases, parameter, parameters)).ToArray() ?? [];
-        if (!_options.ScalarFunctions.TryGetValue(function.FunctionName, out var mapping))
+        if (!_scalarFunctions.TryGetValue(function.FunctionName, out var mapping))
         {
             throw new TdsQueryEngineException($"Scalar function '{function.FunctionName}' is not supported.");
         }
@@ -2082,7 +2096,7 @@ internal sealed class TdsQueryEngineExecutor
             ? null
             : NormalizeObjectIdentifier(dataTypeSpec.XmlSchemaCollection.Sql);
         XmlSchemaSet? schemaSet = null;
-        if (schemaCollectionName is not null && !_options.XmlSchemaCollections.TryGetValue(schemaCollectionName, out schemaSet))
+        if (schemaCollectionName is not null && !_xmlSchemaCollections.TryGetValue(schemaCollectionName, out schemaSet))
         {
             throw new TdsQueryEngineException($"Unknown XML schema collection '{schemaCollectionName}'.");
         }

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineOptions.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineOptions.cs
@@ -6,6 +6,11 @@ using Meziantou.Framework.Tds.Handler;
 namespace Meziantou.Framework.Tds.QueryEngine;
 
 /// <summary>Configures the built-in TDS query engine.</summary>
+/// <remarks>
+/// Configure the instance fully before passing it to <see cref="TdsQueryEngine.CreateQueryHandler"/>. The
+/// collections are snapshotted at that point, so later additions are ignored, and mutating them afterwards races
+/// with queries running on other connections.
+/// </remarks>
 public sealed class TdsQueryEngineOptions
 {
     private static readonly TdsQueryEngineAuthorizationHandler DefaultIsAuthorized = static (context, resourceKind, resourceName) =>

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -3108,6 +3108,38 @@ public sealed class TdsQueryEngineTests
         Assert.True(await invalidQueryTask.Task.WaitAsync(TimeSpan.FromSeconds(5)));
     }
 
+    [Fact]
+    public async Task SqlClient_QueryEngine_OptionsAreSnapshottedWhenTheHandlerIsCreated()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+        var handler = TdsQueryEngine.CreateQueryHandler(queryEngineOptions);
+
+        // Registering after the handler exists is ignored rather than racing in-flight queries.
+        queryEngineOptions.AddQueryRoot("late_root", _ => GetCustomers().AsQueryable());
+
+        var options = new TdsServerOptions();
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success("master")),
+            handler);
+
+        await server.StartAsync();
+        var port = Assert.Single(server.Ports);
+
+        await using var connection = new SqlConnection(CreateConnectionString(port));
+        await connection.OpenAsync();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT Id FROM late_root";
+
+        var exception = await Assert.ThrowsAsync<SqlException>(() => command.ExecuteReaderAsync());
+
+        Assert.Equal(50004, exception.Number);
+        Assert.Contains("late_root", exception.Message);
+    }
+
     private static TdsQueryEngineOptions CreateQueryEngineOptions()
     {
         var options = new TdsQueryEngineOptions();


### PR DESCRIPTION
`StoredProcedures` (a `Dictionary`), `QueryRoots` (a `Collection`), `ScalarFunctions` and `XmlSchemaCollections` are all handed out as mutable public collections and were read on every query from arbitrary connection threads.

The documented flow is configure-then-map, so this is safe as used, but nothing enforced it — an application that registers a stored procedure at runtime introduced a data race with in-flight queries that can corrupt the dictionary.

They are now snapshotted into `FrozenDictionary` instances in `TdsQueryEngineExecutor`'s constructor, and `TdsQueryEngineOptions` documents that the instance must be configured before it is passed to `CreateQueryHandler`. As a side effect, `CreateQueryExecutionContext` no longer rebuilds the query-root lookup on every request — it was doing that work per query purely to deal with the mutable source.

The settable delegates (`MaterializeAsync`, `IsAuthorized`, `NotAuthorizedErrorFactory`) are deliberately still read live: a delegate field read is atomic and cannot corrupt anything, so freezing them would remove flexibility without buying safety.

The behaviour change is that a registration made *after* `CreateQueryHandler` is now ignored instead of sometimes taking effect. The new test pins that contract.

Found by a review of `src/Meziantou.Framework.TdsServer`.