### PR TITLE
Return an ImmutableArray from GetAllInterfacesIncludingSelf

### DIFF
--- a/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
@@ -4,6 +4,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 
@@ -15,18 +16,19 @@ namespace Meziantou.Framework.Roslyn;
 #endif
 internal static partial class TypeSymbolExtensions
 {
-    public static IList<INamedTypeSymbol> GetAllInterfacesIncludingSelf(this ITypeSymbol type)
+    public static ImmutableArray<INamedTypeSymbol> GetAllInterfacesIncludingSelf(this ITypeSymbol type)
     {
         var allInterfaces = type.AllInterfaces;
-        if (type is INamedTypeSymbol namedType && namedType.TypeKind == TypeKind.Interface && !allInterfaces.Contains(namedType))
+        if (type is not INamedTypeSymbol { TypeKind: TypeKind.Interface } namedType)
+            return allInterfaces;
+
+        foreach (var @interface in allInterfaces)
         {
-            var result = new List<INamedTypeSymbol>(allInterfaces.Length + 1);
-            result.AddRange(allInterfaces);
-            result.Add(namedType);
-            return result;
+            if (SymbolEqualityComparer.Default.Equals(@interface, namedType))
+                return allInterfaces;
         }
 
-        return allInterfaces;
+        return allInterfaces.Add(namedType);
     }
 
     public static IEnumerable<ISymbol> GetAllMembers(this ITypeSymbol? symbol)

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -764,7 +764,37 @@ public sealed class RoslynHelperTests
             """);
         var type = GetRequiredType(compilation, "ISample");
 
-        Assert.Contains(type, type.GetAllInterfacesIncludingSelf());
+        Assert.Contains(type, type.GetAllInterfacesIncludingSelf(), SymbolEqualityComparer.Default);
+    }
+
+    [Fact]
+    public void GetAllInterfacesIncludingThis_DoesNotIncludeTheTypeWhenSymbolIsNotAnInterface()
+    {
+        var compilation = CreateCompilation("""
+            public interface ISample;
+            public class Sample : ISample;
+            """);
+        var type = GetRequiredType(compilation, "Sample");
+        var interfaceType = GetRequiredType(compilation, "ISample");
+
+        var interfaces = type.GetAllInterfacesIncludingSelf();
+
+        Assert.Contains(interfaceType, interfaces, SymbolEqualityComparer.Default);
+        Assert.DoesNotContain(type, interfaces, SymbolEqualityComparer.Default);
+    }
+
+    [Fact]
+    public void GetAllInterfacesIncludingThis_DoesNotDuplicateSelfWhenAlreadyPresent()
+    {
+        var compilation = CreateCompilation("""
+            public interface IBase;
+            public interface ISample : IBase;
+            """);
+        var type = GetRequiredType(compilation, "ISample");
+
+        var interfaces = type.GetAllInterfacesIncludingSelf();
+
+        Assert.Equal(1, interfaces.Count(i => SymbolEqualityComparer.Default.Equals(i, type)));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #2023

## What changed

`TypeSymbolExtensions.GetAllInterfacesIncludingSelf` now returns `ImmutableArray<INamedTypeSymbol>` instead of `IList<INamedTypeSymbol>`.

## Why

The old signature advertised mutability, but the concrete type depended on the input:

- interface symbol → a fresh, mutable `List<INamedTypeSymbol>`
- anything else → `type.AllInterfaces`, an `ImmutableArray<T>` boxed into `IList<T>`, whose mutating members throw `NotSupportedException`

A caller that added to the result would pass tests written against an interface symbol and crash at runtime on a class symbol. The boxing also allocated on the hot path of a helper likely to be called per-symbol.

Returning `ImmutableArray<INamedTypeSymbol>` is honest about mutability, removes the boxing, and lets the interface case use a single cheap `allInterfaces.Add(namedType)` append instead of allocating and copying into a `List<T>`.

## Symbol comparison

The membership test used `ImmutableArray.Contains`, which falls back to `EqualityComparer<INamedTypeSymbol>.Default` rather than the `SymbolEqualityComparer.Default` used by every other comparison in the project. It is now an explicit `SymbolEqualityComparer.Default` loop — allocation-free, and consistent with the rest of the codebase. This is what RS1024 exists to flag; the file's blanket `#pragma warning disable` was hiding it.

## Notes for reviewers

- **This is source-breaking** for consumers of the source package. `<Version>` is left at `1.0.4` because `eng/update-versions.cs` bumps versions from commit history in a separate PR (as in 7f1dae0d4). Worth a **minor** bump rather than a patch, which the script may not infer on its own.
- The only in-repo caller is the test suite, updated here.
- `IReadOnlyList<INamedTypeSymbol>` was the lower-friction alternative mentioned in the issue, but it keeps the boxing allocation, so this takes the `ImmutableArray` route the issue recommends.

## Tests

Updated the existing test to compare with `SymbolEqualityComparer.Default`, and added two cases: a class symbol returns its interfaces without including itself, and an interface with a base interface is not duplicated in the result.

## Verification

- Built `src/Meziantou.Framework.Roslyn` (net11.0 + netstandard2.0) and all four Roslyn test variants with `/p:TreatsWarningsAsErrors=true` — 0 warnings, 0 errors.
- Full test suite passes on Roslyn 4.8, 5.0, 5.3 and 5.6 — 214/214 each, across net10.0 and net11.0.
- `dotnet run ./eng/update-all.cs` ran clean and produced no additional file changes.