### PR TITLE
Make messageArgs a params parameter on every ReportDiagnostic overload

### DIFF
--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.cs
@@ -23,7 +23,7 @@ internal static partial class ContextExtensions
         return Diagnostic.Create(descriptor, location, properties, messageArgs);
     }
 
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, object?[]? messageArgs = null) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, locations, messageArgs);
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, locations, messageArgs);
     public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IEnumerable<Location> locations, params object?[]? messageArgs)
     {
         List<Location>? inSourceLocations = null;
@@ -60,35 +60,35 @@ internal static partial class ContextExtensions
         }
     }
 
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, SyntaxReference syntaxReference, object?[]? messageArgs = null)
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, SyntaxReference syntaxReference, params object?[]? messageArgs)
         => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, syntaxReference, messageArgs);
 
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxReference syntaxReference, object?[]? messageArgs = null)
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxReference syntaxReference, params object?[]? messageArgs)
     {
         var syntaxNode = syntaxReference.GetSyntax(context.CancellationToken);
         context.ReportDiagnostic(CreateDiagnostic(descriptor, syntaxNode.GetLocation(), properties, messageArgs));
     }
 
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, Location location, object?[]? messageArgs = null) => context.ReportDiagnostic(CreateDiagnostic(descriptor, location, ImmutableDictionary<string, string?>.Empty, messageArgs));
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, Location location, object?[]? messageArgs = null) => context.ReportDiagnostic(CreateDiagnostic(descriptor, location, properties, messageArgs));
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, Location location, params object?[]? messageArgs) => context.ReportDiagnostic(CreateDiagnostic(descriptor, location, ImmutableDictionary<string, string?>.Empty, messageArgs));
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, Location location, params object?[]? messageArgs) => context.ReportDiagnostic(CreateDiagnostic(descriptor, location, properties, messageArgs));
 
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, SyntaxNode syntax, object?[]? messageArgs = null) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, syntax.GetLocation(), messageArgs);
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxNode syntax, object?[]? messageArgs = null) => ReportDiagnostic(context, descriptor, properties, syntax.GetLocation(), messageArgs);
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, SyntaxNode syntax, params object?[]? messageArgs) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, syntax.GetLocation(), messageArgs);
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxNode syntax, params object?[]? messageArgs) => ReportDiagnostic(context, descriptor, properties, syntax.GetLocation(), messageArgs);
 
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, SyntaxToken token, object?[]? messageArgs = null) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, token.GetLocation(), messageArgs);
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, SyntaxToken token, params object?[]? messageArgs) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, token.GetLocation(), messageArgs);
     public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxToken syntaxToken, params object?[]? messageArgs)
     {
         context.ReportDiagnostic(CreateDiagnostic(descriptor, syntaxToken.GetLocation(), properties, messageArgs));
     }
 
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ISymbol symbol, object?[]? messageArgs = null) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, symbol, messageArgs);
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ISymbol symbol, object?[]? messageArgs = null)
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ISymbol symbol, params object?[]? messageArgs) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, symbol, messageArgs);
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ISymbol symbol, params object?[]? messageArgs)
     {
         ReportDiagnostic(context, descriptor, properties, symbol.Locations, messageArgs);
     }
 
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, IFieldSymbol symbol, DiagnosticFieldReportOptions reportOptions, object?[]? messageArgs = null) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, symbol, reportOptions, messageArgs);
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IFieldSymbol symbol, DiagnosticFieldReportOptions reportOptions, object?[]? messageArgs = null)
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, IFieldSymbol symbol, DiagnosticFieldReportOptions reportOptions, params object?[]? messageArgs) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, symbol, reportOptions, messageArgs);
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IFieldSymbol symbol, DiagnosticFieldReportOptions reportOptions, params object?[]? messageArgs)
     {
         List<Location>? locations = null;
         foreach (var location in symbol.Locations)
@@ -110,8 +110,8 @@ internal static partial class ContextExtensions
         ReportDiagnostic(context, descriptor, properties, locations ?? [], messageArgs);
     }
 
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, IMethodSymbol symbol, DiagnosticMethodReportOptions reportOptions, object?[]? messageArgs = null) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, symbol, reportOptions, messageArgs);
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IMethodSymbol symbol, DiagnosticMethodReportOptions reportOptions, object?[]? messageArgs = null)
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, IMethodSymbol symbol, DiagnosticMethodReportOptions reportOptions, params object?[]? messageArgs) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, symbol, reportOptions, messageArgs);
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IMethodSymbol symbol, DiagnosticMethodReportOptions reportOptions, params object?[]? messageArgs)
     {
         List<Location>? locations = null;
         foreach (var location in symbol.Locations)
@@ -139,8 +139,8 @@ internal static partial class ContextExtensions
         ReportDiagnostic(context, descriptor, properties, locations ?? [], messageArgs);
     }
 
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, IParameterSymbol symbol, DiagnosticParameterReportOptions reportOptions, object?[]? messageArgs = null) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, symbol, reportOptions, messageArgs);
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IParameterSymbol symbol, DiagnosticParameterReportOptions reportOptions, object?[]? messageArgs = null)
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, IParameterSymbol symbol, DiagnosticParameterReportOptions reportOptions, params object?[]? messageArgs) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, symbol, reportOptions, messageArgs);
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IParameterSymbol symbol, DiagnosticParameterReportOptions reportOptions, params object?[]? messageArgs)
     {
         List<Location>? locations = null;
         foreach (var location in symbol.Locations)
@@ -162,8 +162,8 @@ internal static partial class ContextExtensions
         ReportDiagnostic(context, descriptor, properties, locations ?? [], messageArgs);
     }
 
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, IPropertySymbol symbol, DiagnosticPropertyReportOptions reportOptions, object?[]? messageArgs = null) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, symbol, reportOptions, messageArgs);
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IPropertySymbol symbol, DiagnosticPropertyReportOptions reportOptions, object?[]? messageArgs = null)
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, IPropertySymbol symbol, DiagnosticPropertyReportOptions reportOptions, params object?[]? messageArgs) => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, symbol, reportOptions, messageArgs);
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IPropertySymbol symbol, DiagnosticPropertyReportOptions reportOptions, params object?[]? messageArgs)
     {
         List<Location>? locations = null;
         foreach (var location in symbol.Locations)
@@ -191,12 +191,12 @@ internal static partial class ContextExtensions
         ReportDiagnostic(context, descriptor, properties, locations ?? [], messageArgs);
     }
 
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, IOperation operation, object?[]? messageArgs = null)
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, IOperation operation, params object?[]? messageArgs)
         => ReportDiagnostic(context, descriptor, ImmutableDictionary<string, string?>.Empty, operation, messageArgs);
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, object?[]? messageArgs = null)
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[]? messageArgs)
         => context.ReportDiagnostic(CreateDiagnostic(descriptor, operation.Syntax.GetLocation(), properties, messageArgs));
 
-    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, object?[]? messageArgs = null)
+    public static void ReportDiagnostic(this DiagnosticReporter context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[]? messageArgs)
     {
         if (options.HasFlag(DiagnosticMethodReportOptions.ReportOnMethodName) && operation.Syntax is LocalFunctionStatementSyntax memberAccessExpression)
         {

--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.g.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.g.cs
@@ -12,7 +12,7 @@ namespace Meziantou.Framework.Roslyn;
 
 internal static partial class ContextExtensions
 {
-    public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, object?[]? messageArgs = null) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
+    public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
 
     public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, locations, messageArgs);
 
@@ -70,19 +70,19 @@ internal static partial class ContextExtensions
     public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxReference syntaxReference, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxReference, messageArgs);
 
-    public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[] messageArgs)
-        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties: null, operation, options, messageArgs);
+    public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[] messageArgs)
+    public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[] messageArgs)
+    public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[] messageArgs)
+    public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, operation, messageArgs);
 
-    public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[] messageArgs)
+    public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, messageArgs);
 
     public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, AttributeData attribute, params object?[]? messageArgs)
@@ -90,7 +90,7 @@ internal static partial class ContextExtensions
 
     public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, AttributeData attribute, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, attribute, messageArgs);
-    public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, object?[]? messageArgs = null) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
+    public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
 
     public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, locations, messageArgs);
 
@@ -148,19 +148,19 @@ internal static partial class ContextExtensions
     public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxReference syntaxReference, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxReference, messageArgs);
 
-    public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[] messageArgs)
-        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties: null, operation, options, messageArgs);
+    public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[] messageArgs)
+    public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[] messageArgs)
+    public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[] messageArgs)
+    public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, operation, messageArgs);
 
-    public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[] messageArgs)
+    public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, messageArgs);
 
     public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, AttributeData attribute, params object?[]? messageArgs)
@@ -168,7 +168,7 @@ internal static partial class ContextExtensions
 
     public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, AttributeData attribute, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, attribute, messageArgs);
-    public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, object?[]? messageArgs = null) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
+    public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
 
     public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, locations, messageArgs);
 
@@ -226,19 +226,19 @@ internal static partial class ContextExtensions
     public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxReference syntaxReference, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxReference, messageArgs);
 
-    public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[] messageArgs)
-        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties: null, operation, options, messageArgs);
+    public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[] messageArgs)
+    public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[] messageArgs)
+    public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[] messageArgs)
+    public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, operation, messageArgs);
 
-    public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[] messageArgs)
+    public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, messageArgs);
 
     public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, AttributeData attribute, params object?[]? messageArgs)
@@ -246,7 +246,7 @@ internal static partial class ContextExtensions
 
     public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, AttributeData attribute, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, attribute, messageArgs);
-    public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, object?[]? messageArgs = null) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
+    public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
 
     public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, locations, messageArgs);
 
@@ -304,19 +304,19 @@ internal static partial class ContextExtensions
     public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxReference syntaxReference, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxReference, messageArgs);
 
-    public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[] messageArgs)
-        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties: null, operation, options, messageArgs);
+    public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[] messageArgs)
+    public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[] messageArgs)
+    public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[] messageArgs)
+    public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, operation, messageArgs);
 
-    public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[] messageArgs)
+    public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, messageArgs);
 
     public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, AttributeData attribute, params object?[]? messageArgs)
@@ -324,7 +324,7 @@ internal static partial class ContextExtensions
 
     public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, AttributeData attribute, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, attribute, messageArgs);
-    public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, object?[]? messageArgs = null) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
+    public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
 
     public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, locations, messageArgs);
 
@@ -382,19 +382,19 @@ internal static partial class ContextExtensions
     public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxReference syntaxReference, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxReference, messageArgs);
 
-    public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[] messageArgs)
-        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties: null, operation, options, messageArgs);
+    public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[] messageArgs)
+    public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[] messageArgs)
+    public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[] messageArgs)
+    public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, IOperation operation, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, operation, messageArgs);
 
-    public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[] messageArgs)
+    public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, messageArgs);
 
     public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticDescriptor descriptor, AttributeData attribute, params object?[]? messageArgs)

--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.tt
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.tt
@@ -17,7 +17,7 @@ namespace Meziantou.Framework.Roslyn;
 internal static partial class ContextExtensions
 {
 <# foreach (string type in new string[] { "SyntaxNodeAnalysisContext", "SymbolAnalysisContext", "OperationAnalysisContext", "OperationBlockAnalysisContext", "CompilationAnalysisContext" }) { #>
-    public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, object?[]? messageArgs = null) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
+    public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, locations, messageArgs);
 
     public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IEnumerable<Location> locations, params object?[]? messageArgs) => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, locations, messageArgs);
 
@@ -75,19 +75,19 @@ internal static partial class ContextExtensions
     public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, SyntaxReference syntaxReference, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, syntaxReference, messageArgs);
 
-    public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[] messageArgs)
-        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties: null, operation, options, messageArgs);
+    public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
+        => ReportDiagnostic(new DiagnosticReporter(context), descriptor, ImmutableDictionary<string, string?>.Empty, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[] messageArgs)
+    public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IInvocationOperation operation, DiagnosticInvocationReportOptions options, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[] messageArgs)
+    public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, ILocalFunctionOperation operation, DiagnosticMethodReportOptions options, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, options, messageArgs);
 
-    public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, IOperation operation, params object?[] messageArgs)
+    public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, IOperation operation, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, operation, messageArgs);
 
-    public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[] messageArgs)
+    public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, ImmutableDictionary<string, string?>? properties, IOperation operation, params object?[]? messageArgs)
         => ReportDiagnostic(new DiagnosticReporter(context), descriptor, properties, operation, messageArgs);
 
     public static void ReportDiagnostic(this <#= type #> context, DiagnosticDescriptor descriptor, AttributeData attribute, params object?[]? messageArgs)

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using System.Collections.Immutable;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
@@ -212,6 +214,49 @@ public sealed class RoslynHelperTests
         var reportDiagnosticMethods = typeof(ContextExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static);
 
         Assert.Contains(reportDiagnosticMethods, method => method.Name == "ReportDiagnostic");
+    }
+
+    [Fact]
+    public void ReportDiagnostic_DeclaresMessageArgsAsParams()
+    {
+        var messageArgsParameters = typeof(ContextExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(method => method.Name == "ReportDiagnostic")
+            .Select(method => method.GetParameters()[^1])
+            .ToArray();
+
+        Assert.NotEmpty(messageArgsParameters);
+        Assert.All(messageArgsParameters, parameter =>
+        {
+            Assert.Equal("messageArgs", parameter.Name);
+            Assert.True(parameter.IsDefined(typeof(ParamArrayAttribute), inherit: false), $"messageArgs is not a params parameter on {parameter.Member}");
+        });
+    }
+
+    [Fact]
+    public async Task ReportDiagnostic_AcceptsMessageArgsWithoutAnExplicitArray()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+            }
+            """);
+
+        var diagnostics = await compilation
+            .WithAnalyzers([new MessageArgsAnalyzer()])
+            .GetAnalyzerDiagnosticsAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            [
+                "Message context-locations",
+                "Message context-node",
+                "Message reporter-location",
+                "Message reporter-locations",
+                "Message reporter-node",
+                "Message reporter-properties",
+                "Message reporter-token",
+                "Message {0}",
+            ],
+            diagnostics.Select(diagnostic => diagnostic.GetMessage(CultureInfo.InvariantCulture)).OrderBy(message => message, StringComparer.Ordinal));
     }
 
     [Fact]
@@ -1472,6 +1517,42 @@ public sealed class RoslynHelperTests
     {
         return new DiagnosticDescriptor("MFTEST001", "Title", "Message", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
     }
+
+    // RS1036/RS1041 only apply to analyzers shipped in an analyzer package. This one only exists to exercise the extension methods.
+#pragma warning disable RS1036 // A project containing analyzers or source generators should specify the property '<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>'
+#pragma warning disable RS1041 // This compiler extension should not be implemented in an assembly with target framework
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    private sealed class MessageArgsAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Descriptor = new("MFTEST002", "Title", "Message {0}", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterSyntaxNodeAction(AnalyzeClassDeclaration, SyntaxKind.ClassDeclaration);
+        }
+
+        private static void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var declaration = (ClassDeclarationSyntax)context.Node;
+            var location = declaration.GetLocation();
+            DiagnosticReporter reporter = context;
+
+            reporter.ReportDiagnostic(Descriptor, declaration, "reporter-node");
+            reporter.ReportDiagnostic(Descriptor, declaration.Identifier, "reporter-token");
+            reporter.ReportDiagnostic(Descriptor, location, "reporter-location");
+            reporter.ReportDiagnostic(Descriptor, (IEnumerable<Location>)[location], "reporter-locations");
+            reporter.ReportDiagnostic(Descriptor, ImmutableDictionary<string, string?>.Empty, declaration, "reporter-properties");
+            reporter.ReportDiagnostic(Descriptor, location);
+            context.ReportDiagnostic(Descriptor, declaration, "context-node");
+            context.ReportDiagnostic(Descriptor, (IEnumerable<Location>)[location], "context-locations");
+        }
+    }
+#pragma warning restore RS1041
+#pragma warning restore RS1036
 
     private sealed class GeneratedCodeOptionProvider(string? generatedCode) : AnalyzerConfigOptionsProvider
     {


### PR DESCRIPTION
Fixes #2027

## What changed

`Meziantou.Framework.Roslyn`'s `DiagnosticReporter` extension surface declared `messageArgs` inconsistently — some overloads used `params object?[]?`, others `object?[]? messageArgs = null`. On a `DiagnosticReporter` held directly, that meant:

```csharp
reporter.ReportDiagnostic(rule, syntaxNode, "arg");              // did not compile
reporter.ReportDiagnostic(rule, properties, syntaxToken, "arg"); // compiled
```

All overloads now use `params object?[]? messageArgs`, in both `ContextExtensions.cs` and the T4 template that generates the per-context wrappers.

Two smaller inconsistencies in the generated wrappers are aligned in the same pass:
- the `IOperation` / `IInvocationOperation` / `ILocalFunctionOperation` overloads used a non-nullable `params object?[]` while the core methods use `object?[]?`
- the `IInvocationOperation` convenience wrapper passed `properties: null` where the other convenience wrappers pass `ImmutableDictionary.Empty`

## Why it's safe

Adding `params` to a parameter that already accepted an array is source-compatible for existing callers. The only behavioral difference is that a call omitting `messageArgs` now passes an empty array instead of `null`, and `Diagnostic.Create` normalizes `null` to `Array.Empty<object?>()` anyway — so the formatted message is unchanged.

## Tests

Two tests added to `RoslynHelperTests`:

- `ReportDiagnostic_DeclaresMessageArgsAsParams` — reflection guard asserting every public `ReportDiagnostic` overload (hand-written *and* generated) declares `messageArgs` as a `params` parameter, so the inconsistency can't come back.
- `ReportDiagnostic_AcceptsMessageArgsWithoutAnExplicitArray` — runs a real analyzer that calls the expanded form on both `DiagnosticReporter` and `SyntaxNodeAnalysisContext`, verifying the messages format correctly (including the no-args case, which must still yield the raw message format).

The test-only analyzer trips `RS1036`/`RS1041`, which only apply to analyzers shipped in an analyzer package. They're suppressed with `#pragma warning disable`/`restore` scoped to that class, so both rules stay enforced everywhere else in the project.

## Verification

- `dotnet build /p:TreatWarningsAsErrors=true` clean on `Meziantou.Framework.Roslyn` and all 7 projects that compile these sources (FullPath.Analyzer/CodeFix, Assertions.Analyzer/CodeFix, Yaml.SourceGenerator, StronglyTypedId, FastEnumGenerator) — no overload-resolution fallout.
- `Meziantou.Framework.Roslyn.Tests` across all 4 Roslyn versions (4.8, 5.0, 5.3, 5.6): 214 passed each, 0 failed.
- Downstream suites green: Assertions.Analyzer.Tests (203), FullPath.Analyzer.Tests (105), Roslyn.PackageTests (14), Yaml.Tests (1818), StronglyTypedId.GeneratorTests (172), FastEnumGenerator.GeneratorTests (86).
- `dotnet run ./eng/update-all.cs` ran clean with no further file updates.