### PR TITLE
Detect ref/out and increment writes in LocalDataFlowAnalysis

### DIFF
--- a/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
+++ b/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
@@ -88,7 +88,7 @@ internal static partial class LocalDataFlowAnalysis
         if (GetLocalInitializer(operation.SemanticModel, local, cancellationToken) is not { } initializer)
             return null;
 
-        return HasWriteBetween(operation.SemanticModel, local, initializer.Syntax, operation.Syntax, cancellationToken) ? null : initializer;
+        return HasWriteBetween(operation.SemanticModel, local, initializer.Syntax, operation.Syntax) ? null : initializer;
     }
 
     private static IOperation? GetLastLocalAssignment(IOperation operation, ILocalSymbol local, CancellationToken cancellationToken)
@@ -121,7 +121,7 @@ internal static partial class LocalDataFlowAnalysis
         if (result is null)
             return null;
 
-        return HasWriteBetween(semanticModel, local, result.Syntax, operation.Syntax, cancellationToken) ? null : result;
+        return HasWriteBetween(semanticModel, local, result.Syntax, operation.Syntax) ? null : result;
     }
 
     private static IOperation? GetLocalInitializer(SemanticModel semanticModel, ILocalSymbol local, CancellationToken cancellationToken)
@@ -201,15 +201,18 @@ internal static partial class LocalDataFlowAnalysis
             if (syntaxReference.GetSyntax(cancellationToken) is not TypeDeclarationSyntax typeDeclaration)
                 continue;
 
-            foreach (var assignment in typeDeclaration.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+            foreach (var node in typeDeclaration.DescendantNodes())
             {
-                if (assignment.SyntaxTree == initializer.SyntaxTree && initializer.Span.Contains(assignment.Span))
+                if (GetWriteTarget(node) is not { } target)
                     continue;
 
-                if (!TryGetSemanticModel(semanticModel, assignment, out var assignmentSemanticModel))
+                if (target.SyntaxTree == initializer.SyntaxTree && initializer.Span.Contains(target.Span))
+                    continue;
+
+                if (!TryGetSemanticModel(semanticModel, target, out var targetSemanticModel))
                     return true;
 
-                var targetSymbol = assignmentSemanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol;
+                var targetSymbol = targetSemanticModel.GetSymbolInfo(target, cancellationToken).Symbol;
                 if (SymbolEquals(targetSymbol, symbol))
                     return true;
             }
@@ -228,7 +231,7 @@ internal static partial class LocalDataFlowAnalysis
         return dataFlow?.Succeeded == true && ContainsSymbol(dataFlow.Captured, local);
     }
 
-    private static bool HasWriteBetween(SemanticModel semanticModel, ISymbol symbol, SyntaxNode source, SyntaxNode destination, CancellationToken cancellationToken)
+    private static bool HasWriteBetween(SemanticModel semanticModel, ISymbol symbol, SyntaxNode source, SyntaxNode destination)
     {
         if (source.SyntaxTree != destination.SyntaxTree)
             return true;
@@ -239,9 +242,6 @@ internal static partial class LocalDataFlowAnalysis
         if (firstStatement is null || lastStatement is null)
             return false;
 
-        if (firstStatement is not StatementSyntax || lastStatement is not StatementSyntax)
-            return HasWriteBetweenBySyntax(semanticModel, symbol, source, destination, cancellationToken);
-
         var dataFlow = semanticModel.AnalyzeDataFlow(firstStatement, lastStatement);
         if (dataFlow?.Succeeded != true)
             return true;
@@ -251,37 +251,19 @@ internal static partial class LocalDataFlowAnalysis
             ContainsSymbol(dataFlow.Captured, symbol);
     }
 
-    private static bool HasWriteBetweenBySyntax(SemanticModel semanticModel, ISymbol symbol, SyntaxNode source, SyntaxNode destination, CancellationToken cancellationToken)
+    private static ExpressionSyntax? GetWriteTarget(SyntaxNode node)
     {
-        if (source.SyntaxTree != destination.SyntaxTree)
-            return true;
-
-        var sourceEnd = source.Span.End;
-        var destinationStart = destination.SpanStart;
-        foreach (var assignment in destination.SyntaxTree.GetRoot(cancellationToken).DescendantNodes())
+        return node switch
         {
-            if (assignment.SpanStart < sourceEnd || assignment.Span.End > destinationStart)
-                continue;
-
-            SyntaxNode? target = assignment switch
-            {
-                AssignmentExpressionSyntax assignmentExpression => assignmentExpression.Left,
-                PrefixUnaryExpressionSyntax prefixUnaryExpression
-                    when prefixUnaryExpression.IsKind(SyntaxKind.PreIncrementExpression) || prefixUnaryExpression.IsKind(SyntaxKind.PreDecrementExpression) => prefixUnaryExpression.Operand,
-                PostfixUnaryExpressionSyntax postfixUnaryExpression
-                    when postfixUnaryExpression.IsKind(SyntaxKind.PostIncrementExpression) || postfixUnaryExpression.IsKind(SyntaxKind.PostDecrementExpression) => postfixUnaryExpression.Operand,
-                _ => null,
-            };
-
-            if (target is null)
-                continue;
-
-            var targetSymbol = semanticModel.GetSymbolInfo(target, cancellationToken).Symbol;
-            if (SymbolEquals(targetSymbol, symbol))
-                return true;
-        }
-
-        return false;
+            AssignmentExpressionSyntax assignmentExpression => assignmentExpression.Left,
+            PrefixUnaryExpressionSyntax prefixUnaryExpression
+                when prefixUnaryExpression.IsKind(SyntaxKind.PreIncrementExpression) || prefixUnaryExpression.IsKind(SyntaxKind.PreDecrementExpression) => prefixUnaryExpression.Operand,
+            PostfixUnaryExpressionSyntax postfixUnaryExpression
+                when postfixUnaryExpression.IsKind(SyntaxKind.PostIncrementExpression) || postfixUnaryExpression.IsKind(SyntaxKind.PostDecrementExpression) => postfixUnaryExpression.Operand,
+            ArgumentSyntax argument when !argument.RefKindKeyword.IsKind(SyntaxKind.None) => argument.Expression,
+            RefExpressionSyntax refExpression => refExpression.Expression,
+            _ => null,
+        };
     }
 
     private static bool TryGetSemanticModel(SemanticModel semanticModel, SyntaxNode syntax, [NotNullWhen(true)] out SemanticModel? result)
@@ -302,7 +284,7 @@ internal static partial class LocalDataFlowAnalysis
         return true;
     }
 
-    private static bool TryGetStatementRange(SyntaxNode source, SyntaxNode destination, out SyntaxNode? firstStatement, out SyntaxNode? lastStatement)
+    private static bool TryGetStatementRange(SyntaxNode source, SyntaxNode destination, out StatementSyntax? firstStatement, out StatementSyntax? lastStatement)
     {
         firstStatement = null;
         lastStatement = null;
@@ -333,7 +315,7 @@ internal static partial class LocalDataFlowAnalysis
         return true;
     }
 
-    private static bool TryGetGlobalStatementRange(StatementSyntax sourceStatement, StatementSyntax destinationStatement, out SyntaxNode? firstStatement, out SyntaxNode? lastStatement)
+    private static bool TryGetGlobalStatementRange(StatementSyntax sourceStatement, StatementSyntax destinationStatement, out StatementSyntax? firstStatement, out StatementSyntax? lastStatement)
     {
         firstStatement = null;
         lastStatement = null;
@@ -355,8 +337,19 @@ internal static partial class LocalDataFlowAnalysis
         if (sourceIndex + 1 >= destinationIndex)
             return true;
 
-        firstStatement = sourceCompilationUnit.Members[sourceIndex + 1];
-        lastStatement = sourceCompilationUnit.Members[destinationIndex - 1];
+        for (var index = sourceIndex + 1; index < destinationIndex; index++)
+        {
+            if (sourceCompilationUnit.Members[index] is not GlobalStatementSyntax globalStatement)
+            {
+                firstStatement = null;
+                lastStatement = null;
+                return false;
+            }
+
+            firstStatement ??= globalStatement.Statement;
+            lastStatement = globalStatement.Statement;
+        }
+
         return true;
     }
 

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -267,6 +267,119 @@ public sealed class RoslynHelperTests
     }
 
     [Fact]
+    public void TryGetConstantValue_ReturnsFalseWhenReadOnlyFieldIsWrittenThroughAnOutArgument()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                private readonly int _x = 5;
+
+                public Sample()
+                {
+                    Init(out _x);
+                }
+
+                private static void Init(out int value) => value = 10;
+
+                public void M()
+                {
+                    object boxed = _x;
+                }
+            }
+            """);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.False(boxed.TryGetConstantValue(out var value, default));
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryGetConstantValue_ReturnsFalseWhenReadOnlyFieldIsIncrementedInConstructor()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                private readonly int _x = 5;
+
+                public Sample()
+                {
+                    _x++;
+                }
+
+                public void M()
+                {
+                    object boxed = _x;
+                }
+            }
+            """);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.False(boxed.TryGetConstantValue(out var value, default));
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryGetConstantValue_ReturnsFalseWhenReadOnlyFieldIsAliasedByARefLocal()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                private readonly int _x = 5;
+
+                public Sample()
+                {
+                    ref var alias = ref _x;
+                    alias = 10;
+                }
+
+                public void M()
+                {
+                    object boxed = _x;
+                }
+            }
+            """);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.False(boxed.TryGetConstantValue(out var value, default));
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryGetConstantValue_ReturnsFalseWhenLocalIsWrittenThroughARefArgumentInTopLevelStatements()
+    {
+        var compilation = CreateCompilation("""
+            var text = "a";
+            Modify(ref text);
+            object boxed = text;
+
+            static void Modify(ref string value) => value = "b";
+            """, compilationOptions: DefaultCompilationOptions.WithOutputKind(OutputKind.ConsoleApplication));
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.False(boxed.TryGetConstantValue(out var value, default));
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryGetConstantValue_FollowsLocalInitializersInTopLevelStatements()
+    {
+        var compilation = CreateCompilation("""
+            var text = "a";
+            System.Console.WriteLine("unrelated");
+            object boxed = text;
+            """, compilationOptions: DefaultCompilationOptions.WithOutputKind(OutputKind.ConsoleApplication));
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.True(boxed.TryGetConstantValue(out var value, default));
+        Assert.Equal("a", value);
+    }
+
+    [Fact]
     public void GetActualType_WithoutDataFlowAnalysis_OnlyUnwrapsConversions()
     {
         var compilation = CreateCompilation("""
@@ -1314,6 +1427,7 @@ public sealed class RoslynHelperTests
         string assemblyName = "Tests",
         IReadOnlyCollection<MetadataReference>? additionalReferences = null,
         CSharpParseOptions? parseOptions = null,
+        CSharpCompilationOptions? compilationOptions = null,
         int? dotnetMajorVersion = null,
         bool allowInvalidCode = false)
     {
@@ -1327,7 +1441,7 @@ public sealed class RoslynHelperTests
             assemblyName,
             [CSharpSyntaxTree.ParseText(source, parseOptions ?? DefaultParseOptions, path: assemblyName + ".cs")],
             references,
-            DefaultCompilationOptions);
+            compilationOptions ?? DefaultCompilationOptions);
 
         if (!allowInvalidCode)
         {


### PR DESCRIPTION
Fixes #2019

`LocalDataFlowAnalysis.TryGetConstantValue` returned `true` with a stale value in three cases where the code provably reassigns the value.

## What changed

**`HasAssignmentOutsideInitializer` only inspected `AssignmentExpressionSyntax`**, so a private readonly field written through an `out`/`ref` argument (`Init(out _x)`) or mutated with `++`/`--` in a constructor still reported its initializer as the constant. The node-kind switch that used to live inside `HasWriteBetweenBySyntax` is now a shared `GetWriteTarget` helper — extended with `ref`/`out`/`in` arguments and `ref` expressions — and `HasAssignmentOutsideInitializer` walks every descendant node through it.

**`TryGetGlobalStatementRange` returned `GlobalStatementSyntax` nodes**, which are not `StatementSyntax`, so top-level statements diverted to `HasWriteBetweenBySyntax` — a weaker scan that does not recognise `ref`/`out` writes. The identical code inside a method body went through `AnalyzeDataFlow` and was correctly rejected, so the answer depended on whether the user wrote top-level statements. It now returns the inner `StatementSyntax` of each global statement (bailing out if any member in the range is not a global statement), keeping the range analysable by `AnalyzeDataFlow`.

That makes the syntax-based fallback unreachable — both out-params of `TryGetStatementRange` are now typed `StatementSyntax?` — so `HasWriteBetweenBySyntax` is removed rather than left as a second path that can disagree with the first. `HasWriteBetween` loses its now-unused `CancellationToken` parameter.

## Notes for reviewers

- `ref`/`out` are genuine write channels; `in` cannot write through the reference, but it is included for the same conservatism the rest of the file applies (it can only cause a missed constant, never a wrong one).
- `AnalyzeDataFlow(first, last)` accepts statements whose parents are two distinct `GlobalStatementSyntax` nodes — verified against a real `CSharpCompilation` before relying on it.

## Tests

Five tests added to `RoslynHelperTests`: the three reported cases, the `ref`-local alias variant, and a positive top-level case asserting the initializer is still folded when nothing writes to it. `CreateCompilation` gained an optional `compilationOptions` parameter so the top-level tests can compile as `ConsoleApplication`.

The four negative tests fail on the pre-fix source and pass after; the positive one passes both ways. All four Roslyn test projects (4.8, 5.0, 5.3, 5.6) pass with `/p:TreatsWarningsAsErrors=true` — 220 tests each — plus the package tests, and the eight projects that compile these sources build with no warnings. `dotnet run ./eng/update-all.cs` produced no changes.
