### PR TITLE
Treat a failed data flow analysis as captured in LocalDataFlowAnalysis.IsCaptured

### DIFF
--- a/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
+++ b/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
@@ -225,7 +225,10 @@ internal static partial class LocalDataFlowAnalysis
             return false;
 
         var dataFlow = semanticModel.AnalyzeDataFlow(statement);
-        return dataFlow?.Succeeded == true && ContainsSymbol(dataFlow.Captured, local);
+        if (dataFlow?.Succeeded != true)
+            return true;
+
+        return ContainsSymbol(dataFlow.Captured, local);
     }
 
     private static bool HasWriteBetween(SemanticModel semanticModel, ISymbol symbol, SyntaxNode source, SyntaxNode destination, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes #2022

## What changed

`LocalDataFlowAnalysis.IsCaptured` folded a failed data flow analysis into "not captured":

```csharp
var dataFlow = semanticModel.AnalyzeDataFlow(statement);
return dataFlow?.Succeeded == true && ContainsSymbol(dataFlow.Captured, local);
```

It now fails closed:

```csharp
var dataFlow = semanticModel.AnalyzeDataFlow(statement);
if (dataFlow?.Succeeded != true)
    return true;

return ContainsSymbol(dataFlow.Captured, local);
```

## Why

`AnalyzeDataFlow` returns `null`, or a result with `Succeeded == false`, for syntax Roslyn cannot model — notably erroneous or partially-typed code, which is the normal state of a document while an analyzer runs as the user types.

The only caller, `GetLocalValue`, uses `IsCaptured` as a safety gate before trusting a local's value. Reporting "not captured" on a failed analysis turns an analysis failure into a possibly-wrong constant rather than a safe "don't know". Returning `true` makes `GetLocalValue` return `null` instead.

This also makes the method consistent with its sibling `HasWriteBetween`, which already returns `true` when the analysis does not succeed.

## Notes for the reviewer

- **No test.** As the issue notes, `Succeeded == false` isn't reachable from a self-contained compilation, and `IsCaptured` is a private member of an internal class, so there's no seam to force the branch without adding test-only plumbing.
- **Left alone, outside the issue's scope:** the earlier `if (statement is null) return false;` in the same method is the same fail-open direction, but flipping it would change behavior for every local reference outside a statement body, not just for error recovery.

## Verification

- `dotnet build src/Meziantou.Framework.Roslyn` with `/p:TreatsWarningsAsErrors=true` — 0 warnings, 0 errors
- `Meziantou.Framework.Roslyn.PackageTests` — 14/14 passed
- `Meziantou.Framework.Roslyn.Tests.Roslyn5_6` — 210/210 passed
- `dotnet run ./eng/update-all.cs` — no generated changes