### PR TITLE
Document the inherits parameter of the Roslyn attribute helpers

### DIFF
--- a/src/Meziantou.Framework.Roslyn/MethodSymbolExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/MethodSymbolExtensions.cs
@@ -129,6 +129,21 @@ internal static partial class MethodSymbolExtensions
         return false;
     }
 
+    /// <summary>
+    /// Gets the first return type attribute of <paramref name="method"/> that matches <paramref name="attributeType"/>.
+    /// Only the attributes applied to the return type of <paramref name="method"/> are considered. Unlike <c>Attribute.GetCustomAttributes(inherit: true)</c>,
+    /// the methods overridden by <paramref name="method"/> are never inspected.
+    /// </summary>
+    /// <param name="method">The method whose return type attributes are inspected.</param>
+    /// <param name="attributeType">The type of the attribute to look for. When <see langword="null"/>, no attribute is returned.</param>
+    /// <param name="inherits">
+    /// When <see langword="true"/>, an attribute also matches when its class derives from <paramref name="attributeType"/>.
+    /// When <see langword="false"/>, the attribute class must be exactly <paramref name="attributeType"/>.
+    /// This parameter is ignored when <paramref name="attributeType"/> is sealed, as no other class can derive from it.
+    /// Note this is unrelated to the <c>inherit</c> parameter of <c>Attribute.GetCustomAttributes</c>: it never makes the
+    /// methods overridden by <paramref name="method"/> be inspected.
+    /// </param>
+    /// <returns>The first matching attribute, or <see langword="null"/> when the return type of <paramref name="method"/> has no matching attribute.</returns>
     public static AttributeData? GetReturnTypeAttribute(this IMethodSymbol method, ITypeSymbol? attributeType, bool inherits = true)
     {
         if (attributeType is null)
@@ -157,6 +172,21 @@ internal static partial class MethodSymbolExtensions
         return null;
     }
 
+    /// <summary>
+    /// Indicates whether the return type of <paramref name="method"/> has an attribute matching <paramref name="attributeType"/>.
+    /// Only the attributes applied to the return type of <paramref name="method"/> are considered. Unlike <c>Attribute.GetCustomAttributes(inherit: true)</c>,
+    /// the methods overridden by <paramref name="method"/> are never inspected.
+    /// </summary>
+    /// <param name="method">The method whose return type attributes are inspected.</param>
+    /// <param name="attributeType">The type of the attribute to look for. When <see langword="null"/>, the method returns <see langword="false"/>.</param>
+    /// <param name="inherits">
+    /// When <see langword="true"/>, an attribute also matches when its class derives from <paramref name="attributeType"/>.
+    /// When <see langword="false"/>, the attribute class must be exactly <paramref name="attributeType"/>.
+    /// This parameter is ignored when <paramref name="attributeType"/> is sealed, as no other class can derive from it.
+    /// Note this is unrelated to the <c>inherit</c> parameter of <c>Attribute.GetCustomAttributes</c>: it never makes the
+    /// methods overridden by <paramref name="method"/> be inspected.
+    /// </param>
+    /// <returns><see langword="true"/> when the return type of <paramref name="method"/> has a matching attribute; otherwise <see langword="false"/>.</returns>
     public static bool HasReturnTypeAttribute(this IMethodSymbol method, [NotNullWhen(true)] ITypeSymbol? attributeType, bool inherits = true)
     {
         return GetReturnTypeAttribute(method, attributeType, inherits) is not null;

--- a/src/Meziantou.Framework.Roslyn/SymbolAttributeExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/SymbolAttributeExtensions.cs
@@ -13,6 +13,21 @@ namespace Meziantou.Framework.Roslyn;
 #endif
 internal static partial class SymbolAttributeExtensions
 {
+    /// <summary>
+    /// Gets the attributes applied to <paramref name="symbol"/> that match <paramref name="attributeType"/>.
+    /// Only the attributes applied to the symbol itself are considered. Unlike <c>Attribute.GetCustomAttributes(inherit: true)</c>,
+    /// the base types of the symbol and the members it overrides are never inspected.
+    /// </summary>
+    /// <param name="symbol">The symbol whose attributes are inspected.</param>
+    /// <param name="attributeType">The type of the attribute to look for. When <see langword="null"/>, no attribute is returned.</param>
+    /// <param name="inherits">
+    /// When <see langword="true"/>, an attribute also matches when its class derives from <paramref name="attributeType"/>.
+    /// When <see langword="false"/>, the attribute class must be exactly <paramref name="attributeType"/>.
+    /// This parameter is ignored when <paramref name="attributeType"/> is sealed, as no other class can derive from it.
+    /// Note this is unrelated to the <c>inherit</c> parameter of <c>Attribute.GetCustomAttributes</c>: it never makes the
+    /// base types of the symbol or the members it overrides be inspected.
+    /// </param>
+    /// <returns>The attributes applied to <paramref name="symbol"/> that match <paramref name="attributeType"/>.</returns>
     public static IEnumerable<AttributeData> GetAttributes(this ISymbol symbol, ITypeSymbol? attributeType, bool inherits = true)
     {
         if (attributeType is null)
@@ -41,6 +56,21 @@ internal static partial class SymbolAttributeExtensions
         }
     }
 
+    /// <summary>
+    /// Gets the first attribute applied to <paramref name="symbol"/> that matches <paramref name="attributeType"/>.
+    /// Only the attributes applied to the symbol itself are considered. Unlike <c>Attribute.GetCustomAttributes(inherit: true)</c>,
+    /// the base types of the symbol and the members it overrides are never inspected.
+    /// </summary>
+    /// <param name="symbol">The symbol whose attributes are inspected.</param>
+    /// <param name="attributeType">The type of the attribute to look for. When <see langword="null"/>, no attribute is returned.</param>
+    /// <param name="inherits">
+    /// When <see langword="true"/>, an attribute also matches when its class derives from <paramref name="attributeType"/>.
+    /// When <see langword="false"/>, the attribute class must be exactly <paramref name="attributeType"/>.
+    /// This parameter is ignored when <paramref name="attributeType"/> is sealed, as no other class can derive from it.
+    /// Note this is unrelated to the <c>inherit</c> parameter of <c>Attribute.GetCustomAttributes</c>: it never makes the
+    /// base types of the symbol or the members it overrides be inspected.
+    /// </param>
+    /// <returns>The first matching attribute, or <see langword="null"/> when <paramref name="symbol"/> has no matching attribute.</returns>
     public static AttributeData? GetFirstAttribute(this ISymbol symbol, ITypeSymbol? attributeType, bool inherits = true)
     {
         if (attributeType is null)
@@ -69,6 +99,21 @@ internal static partial class SymbolAttributeExtensions
         return null;
     }
 
+    /// <summary>
+    /// Indicates whether <paramref name="symbol"/> has an attribute matching <paramref name="attributeType"/>.
+    /// Only the attributes applied to the symbol itself are considered. Unlike <c>Attribute.GetCustomAttributes(inherit: true)</c>,
+    /// the base types of the symbol and the members it overrides are never inspected.
+    /// </summary>
+    /// <param name="symbol">The symbol whose attributes are inspected.</param>
+    /// <param name="attributeType">The type of the attribute to look for. When <see langword="null"/>, the method returns <see langword="false"/>.</param>
+    /// <param name="inherits">
+    /// When <see langword="true"/>, an attribute also matches when its class derives from <paramref name="attributeType"/>.
+    /// When <see langword="false"/>, the attribute class must be exactly <paramref name="attributeType"/>.
+    /// This parameter is ignored when <paramref name="attributeType"/> is sealed, as no other class can derive from it.
+    /// Note this is unrelated to the <c>inherit</c> parameter of <c>Attribute.GetCustomAttributes</c>: it never makes the
+    /// base types of the symbol or the members it overrides be inspected.
+    /// </param>
+    /// <returns><see langword="true"/> when <paramref name="symbol"/> has a matching attribute; otherwise <see langword="false"/>.</returns>
     public static bool HasAttribute(this ISymbol symbol, [NotNullWhen(true)] ITypeSymbol? attributeType, bool inherits = true)
     {
         return GetFirstAttribute(symbol, attributeType, inherits) is not null;

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -481,6 +481,33 @@ public sealed class RoslynHelperTests
     }
 
     [Fact]
+    public void HasReturnTypeAttribute_DoesNotConsiderAttributesAppliedToOverriddenMethods()
+    {
+        var compilation = CreateCompilation("""
+            using System;
+
+            public class BaseAttribute : Attribute;
+
+            public class Parent
+            {
+                [return: Base]
+                public virtual string M() => "";
+            }
+
+            public class Child : Parent
+            {
+                public override string M() => "";
+            }
+            """);
+        var child = GetRequiredType(compilation, "Child");
+        var baseAttribute = GetRequiredType(compilation, "BaseAttribute");
+        var method = GetRequiredMethod(child, "M");
+
+        Assert.False(method.HasReturnTypeAttribute(baseAttribute));
+        Assert.Null(method.GetReturnTypeAttribute(baseAttribute));
+    }
+
+    [Fact]
     public void Ancestors_ReturnsOperationParents()
     {
         var compilation = CreateCompilation("""
@@ -655,6 +682,26 @@ public sealed class RoslynHelperTests
         Assert.True(type.HasAttribute(baseAttribute));
         Assert.False(type.HasAttribute(baseAttribute, inherits: false));
         Assert.True(type.HasAttribute(specialAttribute, inherits: false));
+    }
+
+    [Fact]
+    public void HasAttribute_DoesNotConsiderAttributesAppliedToBaseTypes()
+    {
+        var compilation = CreateCompilation("""
+            using System;
+
+            public class BaseAttribute : Attribute;
+
+            [Base]
+            public class Parent;
+            public class Child : Parent;
+            """);
+        var child = GetRequiredType(compilation, "Child");
+        var baseAttribute = GetRequiredType(compilation, "BaseAttribute");
+
+        Assert.False(child.HasAttribute(baseAttribute));
+        Assert.Empty(child.GetAttributes(baseAttribute));
+        Assert.Null(child.GetFirstAttribute(baseAttribute));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #2029

## What changed

Added XML doc comments to the five attribute helpers in `Meziantou.Framework.Roslyn` that take an `inherits` parameter:

- `SymbolAttributeExtensions.GetAttributes`, `GetFirstAttribute`, `HasAttribute`
- `MethodSymbolExtensions.GetReturnTypeAttribute`, `HasReturnTypeAttribute`

Each `<summary>` states that only attributes applied to the symbol itself (or to the method's own return type) are considered, and that — unlike `Attribute.GetCustomAttributes(inherit: true)` — the base types of the symbol and the members it overrides are never inspected. The `<param name="inherits">` block explains that `true` means "an attribute also matches when its class derives from `attributeType`", that the parameter is ignored when `attributeType` is sealed, and that it is unrelated to the BCL `inherit` parameter.

Also added two tests to `RoslynHelperTests`, matching the repro in the issue:

- `HasAttribute_DoesNotConsiderAttributesAppliedToBaseTypes` — with `[Base] class Parent` and `class Child : Parent`, `HasAttribute` / `GetAttributes` / `GetFirstAttribute` report nothing on `Child`.
- `HasReturnTypeAttribute_DoesNotConsiderAttributesAppliedToOverriddenMethods` — a `[return: Base]` on the virtual method is not seen through the override.

## Why

`inherits: true` reads like the BCL `inherit: true`, but means something different. A consumer reaching for the familiar meaning gets a silently wrong answer, and no documentation corrected the impression.

## Notes for reviewers

- Behavior is unchanged; this is documentation plus regression tests.
- The parameter was not renamed to `includeDerivedAttributeTypes`. The issue defers that to a future major version, and the name is used at existing call sites.
- Verified: `dotnet build` with `/p:TreatsWarningsAsErrors=true` on `Roslyn5_6`, `Roslyn4_8` and `src/Meziantou.Framework.Roslyn` (0 warnings, 0 errors); `dotnet test` on `Roslyn5_6` — 214 passed, 0 failed. `dotnet run ./eng/update-all.cs` produced no other changes.