### PR TITLE
Handle ReportOnMethodName in the IMethodSymbol ReportDiagnostic overload

### DIFF
--- a/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/DiagnosticReporter/ContextExtensions.cs
@@ -116,6 +116,28 @@ internal static partial class ContextExtensions
         List<Location>? locations = null;
         foreach (var location in symbol.Locations)
         {
+            if (reportOptions.HasFlag(DiagnosticMethodReportOptions.ReportOnMethodName))
+            {
+                var node = location.SourceTree?.GetRoot(context.CancellationToken).FindNode(location.SourceSpan);
+                if (node is MethodDeclarationSyntax methodDeclarationSyntax)
+                {
+                    ReportDiagnostic(context, descriptor, properties, methodDeclarationSyntax.Identifier.GetLocation(), messageArgs);
+                    return;
+                }
+
+                if (node is DelegateDeclarationSyntax delegateDeclarationSyntax)
+                {
+                    ReportDiagnostic(context, descriptor, properties, delegateDeclarationSyntax.Identifier.GetLocation(), messageArgs);
+                    return;
+                }
+
+                if (node is LocalFunctionStatementSyntax localFunctionStatementSyntax)
+                {
+                    ReportDiagnostic(context, descriptor, properties, localFunctionStatementSyntax.Identifier.GetLocation(), messageArgs);
+                    return;
+                }
+            }
+
             if (reportOptions.HasFlag(DiagnosticMethodReportOptions.ReportOnReturnType))
             {
                 var node = location.SourceTree?.GetRoot(context.CancellationToken).FindNode(location.SourceSpan);
@@ -128,6 +150,12 @@ internal static partial class ContextExtensions
                 if (node is DelegateDeclarationSyntax delegateDeclarationSyntax)
                 {
                     ReportDiagnostic(context, descriptor, properties, delegateDeclarationSyntax.ReturnType.GetLocation(), messageArgs);
+                    return;
+                }
+
+                if (node is LocalFunctionStatementSyntax localFunctionStatementSyntax)
+                {
+                    ReportDiagnostic(context, descriptor, properties, localFunctionStatementSyntax.ReturnType.GetLocation(), messageArgs);
                     return;
                 }
             }

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -1309,6 +1309,120 @@ public sealed class RoslynHelperTests
         Assert.True(syntaxTree.IsGeneratedCode(analyzerOptions, default));
     }
 
+    [Fact]
+    public void ReportDiagnostic_MethodSymbol_ReportOnMethodName_ReportsOnTheIdentifier()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                public string Method() => "";
+            }
+            """);
+        var method = GetRequiredMethod(GetRequiredType(compilation, "Sample"), "Method");
+
+        var diagnostic = ReportMethodDiagnostic(compilation, method, DiagnosticMethodReportOptions.ReportOnMethodName);
+
+        Assert.Equal("Method", GetLocationText(diagnostic.Location));
+    }
+
+    [Fact]
+    public void ReportDiagnostic_MethodSymbol_ReportOnReturnType_ReportsOnTheReturnType()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                public string Method() => "";
+            }
+            """);
+        var method = GetRequiredMethod(GetRequiredType(compilation, "Sample"), "Method");
+
+        var diagnostic = ReportMethodDiagnostic(compilation, method, DiagnosticMethodReportOptions.ReportOnReturnType);
+
+        Assert.Equal("string", GetLocationText(diagnostic.Location));
+    }
+
+    [Fact]
+    public void ReportDiagnostic_MethodSymbol_ReportOnMethodName_TakesPrecedenceOverReportOnReturnType()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                public string Method() => "";
+            }
+            """);
+        var method = GetRequiredMethod(GetRequiredType(compilation, "Sample"), "Method");
+
+        var diagnostic = ReportMethodDiagnostic(compilation, method, DiagnosticMethodReportOptions.ReportOnMethodName | DiagnosticMethodReportOptions.ReportOnReturnType);
+
+        Assert.Equal("Method", GetLocationText(diagnostic.Location));
+    }
+
+    [Fact]
+    public void ReportDiagnostic_MethodSymbol_ReportOnMethodName_ReportsOnTheDelegateIdentifier()
+    {
+        var compilation = CreateCompilation("""
+            public delegate string Sample(int value);
+            """);
+        var invokeMethod = GetRequiredType(compilation, "Sample").DelegateInvokeMethod;
+        Assert.NotNull(invokeMethod);
+
+        var diagnostic = ReportMethodDiagnostic(compilation, invokeMethod, DiagnosticMethodReportOptions.ReportOnMethodName);
+
+        Assert.Equal("Sample", GetLocationText(diagnostic.Location));
+    }
+
+    [Fact]
+    public void ReportDiagnostic_MethodSymbol_ReportOnMethodName_ReportsOnTheLocalFunctionIdentifier()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                public void M()
+                {
+                    string Local() => "";
+                    Local();
+                }
+            }
+            """);
+        var semanticModel = GetSemanticModel(compilation);
+        var localFunction = semanticModel.SyntaxTree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single();
+        var symbol = (IMethodSymbol?)semanticModel.GetDeclaredSymbol(localFunction);
+        Assert.NotNull(symbol);
+
+        var diagnostic = ReportMethodDiagnostic(compilation, symbol, DiagnosticMethodReportOptions.ReportOnMethodName);
+
+        Assert.Equal("Local", GetLocationText(diagnostic.Location));
+    }
+
+    [Fact]
+    public void ReportDiagnostic_MethodSymbol_None_ReportsOnTheSymbolLocations()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                public string Method() => "";
+            }
+            """);
+        var method = GetRequiredMethod(GetRequiredType(compilation, "Sample"), "Method");
+
+        var diagnostic = ReportMethodDiagnostic(compilation, method, DiagnosticMethodReportOptions.None);
+
+        Assert.Equal(method.Locations, [diagnostic.Location]);
+    }
+
+    [Fact]
+    public void ReportDiagnostic_MethodSymbol_ReportOnMethodName_ReportsWithoutLocationForMetadataMethods()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample;
+            """);
+        var method = GetRequiredMethod(GetRequiredType(compilation, "System.Object"), "ToString");
+
+        var diagnostic = ReportMethodDiagnostic(compilation, method, DiagnosticMethodReportOptions.ReportOnMethodName);
+
+        Assert.False(diagnostic.Location.IsInSource);
+    }
+
     private static CSharpCompilation CreateCompilation(
         string source,
         string assemblyName = "Tests",
@@ -1466,6 +1580,29 @@ public sealed class RoslynHelperTests
         Assert.NotNull(operation);
 
         return operation;
+    }
+
+    private static Diagnostic ReportMethodDiagnostic(Compilation compilation, IMethodSymbol symbol, DiagnosticMethodReportOptions reportOptions)
+    {
+        Diagnostic? reported = null;
+
+        // A DiagnosticAnalyzer cannot be defined in this assembly (RS1041), so the context is created directly
+#pragma warning disable CS0618
+        var context = new SymbolAnalysisContext(symbol, compilation, new AnalyzerOptions([]), diagnostic => reported = diagnostic, _ => true, cancellationToken: default);
+#pragma warning restore CS0618
+
+        context.ReportDiagnostic(CreateDescriptor(), symbol, reportOptions);
+
+        Assert.NotNull(reported);
+
+        return reported;
+    }
+
+    private static string GetLocationText(Location location)
+    {
+        Assert.NotNull(location.SourceTree);
+
+        return location.SourceTree.GetText().ToString(location.SourceSpan);
     }
 
     private static DiagnosticDescriptor CreateDescriptor()


### PR DESCRIPTION
Closes #2026

## What changed

`ContextExtensions.ReportDiagnostic(…, IMethodSymbol, DiagnosticMethodReportOptions, …)` only tested `ReportOnReturnType`. `DiagnosticMethodReportOptions.ReportOnMethodName` was never read there, so it fell through to the default `symbol.Locations` path.

The flag is now handled explicitly: the declaring syntax is resolved and the diagnostic is reported on `.Identifier` for `MethodDeclarationSyntax`, `DelegateDeclarationSyntax`, and `LocalFunctionStatementSyntax`. The method-name branch runs before the return-type branch, matching the precedence the `ILocalFunctionOperation` overload already uses.

## Why

`IMethodSymbol.Locations` is already the identifier token, so for a plain method the flag was inert rather than wrong. But a reader could not tell from the call site whether it did anything, and a future change to the default path would silently change what the flag means.

## One behavior change worth reviewing

The issue predicted the flag was purely inert. That is true except for one case: passing `ReportOnMethodName | ReportOnReturnType` previously reported on the **return type**, because only the return-type branch existed. The method name now wins. `ReportDiagnostic_MethodSymbol_ReportOnMethodName_TakesPrecedenceOverReportOnReturnType` is the test that fails against the old code — verified by reverting the source and re-running.

## Beyond the issue's scope

`ReportOnReturnType` also handles `LocalFunctionStatementSyntax` now. Without it the two flags would be asymmetric for local-function symbols — the name flag would resolve them, the return-type flag would silently fall through to `symbol.Locations`, which is exactly the confusion this issue is about.

## Tests

Seven tests added to `RoslynHelperTests`: method identifier, return type, flag precedence, delegate identifier, local-function identifier, `None` falling through to `symbol.Locations`, and a metadata method reporting with no source location.

The helper constructs `SymbolAnalysisContext` directly. I first wrote it as a real `DiagnosticAnalyzer` run through `CompilationWithAnalyzers`, but defining an analyzer type in this test assembly trips RS1036/RS1041 on the Roslyn 5.x variants (the assembly targets net10.0/net11.0). Direct construction needs one scoped `CS0618` suppression instead and works across all four Roslyn versions.

## Verification

- `dotnet build /p:TreatsWarningsAsErrors=true` — succeeded
- All four Roslyn test variants (4.8, 5.0, 5.3, 5.6): 224 passed, 0 failed each
- `Meziantou.Framework.Roslyn.PackageTests`: 14 passed, 0 failed
- `dotnet run ./eng/update-all.cs` — ran, produced no changes