### PR TITLE
Match InheritsFrom to Implements for constrained type parameters

### DIFF
--- a/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/TypeSymbolExtensions.cs
@@ -51,6 +51,14 @@ internal static partial class TypeSymbolExtensions
         }
     }
 
+    /// <summary>
+    /// Determines whether <paramref name="classSymbol"/> derives from <paramref name="baseClassType"/>. A type is not considered to derive from itself.
+    /// </summary>
+    /// <remarks>
+    /// When <paramref name="classSymbol"/> is a type parameter, its constraint types are inspected and a constraint that is <paramref name="baseClassType"/> is a match,
+    /// so <c>T</c> in <c>where T : Base</c> derives from <c>Base</c>. <see cref="Implements(ITypeSymbol, ITypeSymbol)"/> and
+    /// <see cref="ImplementsGenericInterface(ITypeSymbol, ITypeSymbol)"/> behave the same way.
+    /// </remarks>
     public static bool InheritsFrom(this ITypeSymbol classSymbol, [NotNullWhen(true)] ITypeSymbol? baseClassType)
     {
         return InheritsFrom(classSymbol, baseClassType, visitedTypeParameters: null);
@@ -65,7 +73,7 @@ internal static partial class TypeSymbolExtensions
         {
             return AnyConstraintTypeMatches(typeParameter, visitedTypeParameters, (constraintType, visitedTypeParameters) =>
             {
-                return !SymbolEquals(constraintType, baseClassType) && constraintType.InheritsFrom(baseClassType, visitedTypeParameters);
+                return SymbolEquals(constraintType, baseClassType) || constraintType.InheritsFrom(baseClassType, visitedTypeParameters);
             });
         }
 
@@ -81,6 +89,13 @@ internal static partial class TypeSymbolExtensions
         return false;
     }
 
+    /// <summary>
+    /// Determines whether <paramref name="classSymbol"/> implements <paramref name="interfaceType"/>. An interface is not considered to implement itself.
+    /// </summary>
+    /// <remarks>
+    /// When <paramref name="classSymbol"/> is a type parameter, its constraint types are inspected and a constraint that is <paramref name="interfaceType"/> is a match,
+    /// so <c>T</c> in <c>where T : ISample</c> implements <c>ISample</c>.
+    /// </remarks>
     public static bool Implements(this ITypeSymbol classSymbol, [NotNullWhen(true)] ITypeSymbol? interfaceType)
     {
         return Implements(classSymbol, interfaceType, visitedTypeParameters: null);
@@ -108,6 +123,14 @@ internal static partial class TypeSymbolExtensions
         return false;
     }
 
+    /// <summary>
+    /// Determines whether <paramref name="classSymbol"/> implements a construction of the generic interface <paramref name="interfaceType"/>, whatever its type arguments are.
+    /// An interface is not considered to implement itself.
+    /// </summary>
+    /// <remarks>
+    /// When <paramref name="classSymbol"/> is a type parameter, its constraint types are inspected and a constraint that is a construction of
+    /// <paramref name="interfaceType"/> is a match, so <c>T</c> in <c>where T : ISample&lt;int&gt;</c> implements <c>ISample&lt;&gt;</c>.
+    /// </remarks>
     public static bool ImplementsGenericInterface(this ITypeSymbol classSymbol, [NotNullWhen(true)] ITypeSymbol? interfaceType)
     {
         return ImplementsGenericInterface(classSymbol, interfaceType, visitedTypeParameters: null);
@@ -135,6 +158,9 @@ internal static partial class TypeSymbolExtensions
         return false;
     }
 
+    /// <summary>
+    /// Determines whether <paramref name="symbol"/> is <paramref name="interfaceType"/> or implements it.
+    /// </summary>
     public static bool IsOrImplements(this ITypeSymbol symbol, [NotNullWhen(true)] ITypeSymbol? interfaceType)
     {
         if (interfaceType is null)
@@ -143,6 +169,9 @@ internal static partial class TypeSymbolExtensions
         return SymbolEquals(symbol, interfaceType) || symbol.Implements(interfaceType);
     }
 
+    /// <summary>
+    /// Determines whether <paramref name="symbol"/> is <paramref name="expectedType"/> or derives from it.
+    /// </summary>
     public static bool IsOrInheritsFrom(this ITypeSymbol symbol, [NotNullWhen(true)] ITypeSymbol? expectedType)
     {
         return IsOrInheritsFrom(symbol, expectedType, visitedTypeParameters: null);

--- a/src/Meziantou.Framework.Roslyn/readme.md
+++ b/src/Meziantou.Framework.Roslyn/readme.md
@@ -39,8 +39,22 @@ using Meziantou.Framework.Roslyn;
 - `ISymbol.GetFirstSourceLocation`
 - `ISymbol.IsVisibleOutsideOfAssembly`
 - `ITypeSymbol.GetUnderlyingNullableTypeOrSelf`
+- `TypeSymbolExtensions`
 
 The package also defines Roslyn and C# feature constants before compilation based on the referenced `Microsoft.CodeAnalysis.*` package version, such as `ROSLYN_4_8_OR_GREATER` and `CSHARP12_OR_GREATER`.
+
+### Type relationships
+
+`InheritsFrom`, `Implements` and `ImplementsGenericInterface` are strict: a type never derives from or implements itself. When the queried symbol is a type parameter, its constraints are inspected and a constraint that is the queried type is a match, so `T` in `where T : Base` derives from `Base` and `T` in `where T : ISample` implements `ISample`.
+
+Use `IsOrInheritsFrom` and `IsOrImplements` to ask whether a type is assignable to another one; they include the type itself, so they don't depend on that distinction:
+
+````csharp
+// true when the type is Base or derives from it
+if (type.IsOrInheritsFrom(baseType))
+{
+}
+````
 
 ## Type embedding
 

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -814,15 +814,20 @@ public sealed class RoslynHelperTests
             public class Sample : Base
             {
                 public T M<T>(T value) where T : Sample => value;
+                public T MConstrainedToBase<T>(T value) where T : Base => value;
             }
             """);
         var baseType = GetRequiredType(compilation, "Base");
         var sampleType = GetRequiredType(compilation, "Sample");
         var typeParameter = GetRequiredMethod(sampleType, "M").TypeParameters.Single();
+        var typeParameterConstrainedToBase = GetRequiredMethod(sampleType, "MConstrainedToBase").TypeParameters.Single();
 
         Assert.True(sampleType.InheritsFrom(baseType));
         Assert.True(typeParameter.InheritsFrom(baseType));
+        Assert.True(typeParameterConstrainedToBase.InheritsFrom(baseType));
+        Assert.False(baseType.InheritsFrom(baseType));
         Assert.False(baseType.InheritsFrom(sampleType));
+        Assert.False(typeParameterConstrainedToBase.InheritsFrom(sampleType));
     }
 
     [Fact]
@@ -830,18 +835,25 @@ public sealed class RoslynHelperTests
     {
         var compilation = CreateCompilation("""
             public interface ISample;
+            public interface IDerived : ISample;
             public class Sample : ISample
             {
                 public T M<T>(T value) where T : ISample => value;
+                public T MConstrainedToDerived<T>(T value) where T : IDerived => value;
             }
             """);
         var interfaceType = GetRequiredType(compilation, "ISample");
+        var derivedInterfaceType = GetRequiredType(compilation, "IDerived");
         var sampleType = GetRequiredType(compilation, "Sample");
         var typeParameter = GetRequiredMethod(sampleType, "M").TypeParameters.Single();
+        var typeParameterConstrainedToDerived = GetRequiredMethod(sampleType, "MConstrainedToDerived").TypeParameters.Single();
 
         Assert.True(sampleType.Implements(interfaceType));
         Assert.True(typeParameter.Implements(interfaceType));
+        Assert.True(typeParameterConstrainedToDerived.Implements(interfaceType));
+        Assert.True(typeParameterConstrainedToDerived.Implements(derivedInterfaceType));
         Assert.False(interfaceType.Implements(interfaceType));
+        Assert.False(typeParameter.Implements(derivedInterfaceType));
     }
 
     [Fact]
@@ -849,12 +861,17 @@ public sealed class RoslynHelperTests
     {
         var compilation = CreateCompilation("""
             public interface ISample<T>;
-            public class Sample : ISample<string>;
+            public class Sample : ISample<string>
+            {
+                public T M<T>(T value) where T : ISample<int> => value;
+            }
             """);
         var interfaceType = GetRequiredType(compilation, "ISample`1");
         var sampleType = GetRequiredType(compilation, "Sample");
+        var typeParameter = GetRequiredMethod(sampleType, "M").TypeParameters.Single();
 
         Assert.True(sampleType.ImplementsGenericInterface(interfaceType));
+        Assert.True(typeParameter.ImplementsGenericInterface(interfaceType));
         Assert.False(interfaceType.ImplementsGenericInterface(interfaceType));
     }
 
@@ -863,15 +880,21 @@ public sealed class RoslynHelperTests
     {
         var compilation = CreateCompilation("""
             public interface ISample;
-            public class Sample : ISample;
+            public class Sample : ISample
+            {
+                public T M<T>(T value) where T : ISample => value;
+            }
+
             public class Other;
             """);
         var interfaceType = GetRequiredType(compilation, "ISample");
         var sampleType = GetRequiredType(compilation, "Sample");
         var otherType = GetRequiredType(compilation, "Other");
+        var typeParameter = GetRequiredMethod(sampleType, "M").TypeParameters.Single();
 
         Assert.True(interfaceType.IsOrImplements(interfaceType));
         Assert.True(sampleType.IsOrImplements(interfaceType));
+        Assert.True(typeParameter.IsOrImplements(interfaceType));
         Assert.False(otherType.IsOrImplements(interfaceType));
     }
 
@@ -880,14 +903,20 @@ public sealed class RoslynHelperTests
     {
         var compilation = CreateCompilation("""
             public class Base;
-            public class Sample : Base;
+            public class Sample : Base
+            {
+                public T M<T>(T value) where T : Base => value;
+            }
             """);
         var baseType = GetRequiredType(compilation, "Base");
         var sampleType = GetRequiredType(compilation, "Sample");
+        var typeParameter = GetRequiredMethod(sampleType, "M").TypeParameters.Single();
 
         Assert.True(baseType.IsOrInheritsFrom(baseType));
         Assert.True(sampleType.IsOrInheritsFrom(baseType));
+        Assert.True(typeParameter.IsOrInheritsFrom(baseType));
         Assert.False(baseType.IsOrInheritsFrom(sampleType));
+        Assert.False(typeParameter.IsOrInheritsFrom(sampleType));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #2024

## What changed

`InheritsFrom` skipped a constraint type that was the queried type itself:

```csharp
return !SymbolEquals(constraintType, baseClassType) && constraintType.InheritsFrom(...);
```

`Implements` and `ImplementsGenericInterface` had no such guard, so the three helpers disagreed on the same input — `T where T : Base` did not derive from `Base`, while `T where T : Derived` did, and `T where T : ISample` did implement `ISample`.

The guard is gone, so the type-parameter path is consistent across all three: a constraint that is the queried type is a match.

## Why lenient rather than strict

- Two of the three helpers already behaved this way, and `Implements`' behavior was pinned by an existing test.
- It is the answer a consumer wants: the strict reading is "every substitution of `T` is a *proper* subclass of `Base`", which is neither knowable from the constraint nor useful.
- The divergence was invisible at the call site and only reachable in generic code.

Concrete types are unchanged and still strict — `Base.InheritsFrom(Base)` and `ISample.Implements(ISample)` remain `false`.

## Also in this PR

- XML doc comments on `InheritsFrom`, `Implements`, `ImplementsGenericInterface`, `IsOrInheritsFrom` and `IsOrImplements` stating the rule both ways (a type never matches itself; a type parameter matches through its constraints).
- A "Type relationships" section in the package readme that documents the same rule and steers assignability checks to `IsOrInheritsFrom` / `IsOrImplements`.
- The five helper tests now cover the previously untested shapes (`T : Base`, `T : IDerived`, `T : ISample<int>`) and the self-match negatives.

## Validation

- The new `InheritsFrom` assertion was confirmed to fail against the old code before the fix was restored.
- All four Roslyn test variants (4.8 / 5.0 / 5.3 / 5.6) pass, 210 tests each; the affected tests were confirmed present in the TRX output.
- The seven projects that embed these helpers build warning-free with `/p:TreatsWarningsAsErrors=true`, and their suites pass: Assertions.Analyzer 203, FullPath.Analyzer 105, StronglyTypedId 172, FastEnumGenerator 86, Yaml 1818.
- `dotnet run ./eng/update-all.cs` produced no further changes.