### PR TITLE
Scope LocalDataFlowAnalysis walks to the local's declaring scope

### DIFF
--- a/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
+++ b/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Meziantou.Framework.Roslyn;
 
@@ -98,8 +99,10 @@ internal static partial class LocalDataFlowAnalysis
             return null;
 
         IOperation? result = null;
-        foreach (var assignmentSyntax in operation.Syntax.SyntaxTree.GetRoot(cancellationToken).DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        foreach (var assignmentSyntax in GetLocalScope(local, operation.Syntax, cancellationToken).DescendantNodes().OfType<AssignmentExpressionSyntax>())
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (assignmentSyntax.Span.End > operation.Syntax.SpanStart)
                 continue;
 
@@ -258,8 +261,15 @@ internal static partial class LocalDataFlowAnalysis
 
         var sourceEnd = source.Span.End;
         var destinationStart = destination.SpanStart;
-        foreach (var assignment in destination.SyntaxTree.GetRoot(cancellationToken).DescendantNodes())
+        if (sourceEnd > destinationStart)
+            return false;
+
+        // Any node located between the source and the destination is a descendant of the smallest node containing that range
+        var scope = destination.SyntaxTree.GetRoot(cancellationToken).FindNode(TextSpan.FromBounds(sourceEnd, destinationStart));
+        foreach (var assignment in scope.DescendantNodesAndSelf())
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (assignment.SpanStart < sourceEnd || assignment.Span.End > destinationStart)
                 continue;
 
@@ -358,6 +368,37 @@ internal static partial class LocalDataFlowAnalysis
         firstStatement = sourceCompilationUnit.Members[sourceIndex + 1];
         lastStatement = sourceCompilationUnit.Members[destinationIndex - 1];
         return true;
+    }
+
+    private static SyntaxNode GetLocalScope(ILocalSymbol local, SyntaxNode reference, CancellationToken cancellationToken)
+    {
+        foreach (var syntaxReference in local.DeclaringSyntaxReferences)
+        {
+            var declaration = syntaxReference.GetSyntax(cancellationToken);
+            if (declaration.SyntaxTree == reference.SyntaxTree)
+                return GetEnclosingScope(declaration);
+        }
+
+        return GetEnclosingScope(reference);
+    }
+
+    private static SyntaxNode GetEnclosingScope(SyntaxNode syntax)
+    {
+        var current = syntax;
+        while (true)
+        {
+            // Top-level statements are spread over multiple members of the compilation unit
+            if (current is GlobalStatementSyntax { Parent: { } compilationUnit })
+                return compilationUnit;
+
+            if (current is MemberDeclarationSyntax)
+                return current;
+
+            if (current.Parent is null)
+                return current;
+
+            current = current.Parent;
+        }
     }
 
     private static bool IsInNestedFunction(SyntaxNode syntax)

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -267,6 +267,62 @@ public sealed class RoslynHelperTests
     }
 
     [Fact]
+    public void GetActualType_IgnoresAssignmentsFromOtherMembers()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                public void Other()
+                {
+                    object value = "text";
+                    value = 41;
+                }
+
+                public void M()
+                {
+                    object value = 42;
+                    object boxed = value;
+                }
+            }
+            """);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.Equal(SpecialType.System_Int32, boxed.GetActualType(default)?.SpecialType);
+    }
+
+    [Fact]
+    public void TryGetConstantValue_FollowsAssignmentsInTopLevelStatements()
+    {
+        var compilation = CreateCompilation("""
+            var value = 41;
+            value = 42;
+            object boxed = value;
+            """, outputKind: OutputKind.ConsoleApplication);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.True(boxed.TryGetConstantValue(out var value, default));
+        Assert.Equal(42, value);
+    }
+
+    [Fact]
+    public void TryGetConstantValue_ReturnsFalseWhenATopLevelStatementWritesTheLocal()
+    {
+        var compilation = CreateCompilation("""
+            var value = 41;
+            value = 42;
+            value++;
+            object boxed = value;
+            """, outputKind: OutputKind.ConsoleApplication);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.False(boxed.TryGetConstantValue(out var value, default));
+        Assert.Null(value);
+    }
+
+    [Fact]
     public void GetActualType_WithoutDataFlowAnalysis_OnlyUnwrapsConversions()
     {
         var compilation = CreateCompilation("""
@@ -1315,7 +1371,8 @@ public sealed class RoslynHelperTests
         IReadOnlyCollection<MetadataReference>? additionalReferences = null,
         CSharpParseOptions? parseOptions = null,
         int? dotnetMajorVersion = null,
-        bool allowInvalidCode = false)
+        bool allowInvalidCode = false,
+        OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary)
     {
         var references = CreateMetadataReferences(dotnetMajorVersion);
         if (additionalReferences is not null)
@@ -1327,7 +1384,7 @@ public sealed class RoslynHelperTests
             assemblyName,
             [CSharpSyntaxTree.ParseText(source, parseOptions ?? DefaultParseOptions, path: assemblyName + ".cs")],
             references,
-            DefaultCompilationOptions);
+            DefaultCompilationOptions.WithOutputKind(outputKind));
 
         if (!allowInvalidCode)
         {


### PR DESCRIPTION
Fixes #2020

## What changed

`src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs`

- `GetLastLocalAssignment` enumerated every node of the syntax tree (`GetRoot().DescendantNodes()`) and called `GetOperation` on every assignment preceding the reference, even though a local can only be assigned inside its own declaring member. It now walks the local's declaring scope, computed by the new `GetLocalScope`/`GetEnclosingScope` helpers.
- `GetEnclosingScope` returns the enclosing `MemberDeclarationSyntax`, except for locals declared inside a `GlobalStatementSyntax`: top-level statements are spread over multiple members of the compilation unit, so scoping to the enclosing member declaration would stop at a single statement and silently lose the later assignments. Those locals are scoped to the compilation unit instead.
- `HasWriteBetweenBySyntax` did the same tree-wide walk. It now walks the smallest node containing the `[source.End, destination.Start]` range (`FindNode`), plus an early return when that range is empty or inverted. Any node fully inside the range is necessarily a descendant of that node, so the result is unchanged.
- Both loops now honor the cancellation token, so the IDE can abandon stale work.

No cache was added: the scoping removes the quadratic factor, and a static cache in a source-embedded helper would be a lifetime hazard for consumers.

## Measurements

Synthetic file of *N* methods, each with one local, one assignment and one reference, resolving every reference through `GetActualType`:

| Methods / references | Before | After |
|---|---|---|
| 800 | 3.48 s | 0.69 s |
| 1,600 | 10.60 s | 1.15 s |
| 3,200 | 41.05 s | 1.60 s |

Growth is linear instead of ~3.5x per doubling. Measured with a throwaway test that is not part of this PR.

## Tests

Three tests added to `RoslynHelperTests`:

- `GetActualType_IgnoresAssignmentsFromOtherMembers`
- `TryGetConstantValue_FollowsAssignmentsInTopLevelStatements`
- `TryGetConstantValue_ReturnsFalseWhenATopLevelStatementWritesTheLocal` (exercises the new `HasWriteBetweenBySyntax` path)

`CreateCompilation` gained an `outputKind` parameter so top-level statements compile without errors.

Removing the `GlobalStatementSyntax` branch makes `TryGetConstantValue_FollowsAssignmentsInTopLevelStatements` fail, so the special case is covered.

## Validation

- `Meziantou.Framework.Roslyn.Tests` on Roslyn 4.8 / 5.0 / 5.3 / 5.6: 216 passed, 0 failed on each (net10.0 + net11.0).
- `Meziantou.Framework.Roslyn.PackageTests`: 14 passed.
- `dotnet run ./eng/update-all.cs`: no generated file changed.