### PR TITLE
Give up the write-between check when a jump can reorder the flow

### DIFF
--- a/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
+++ b/src/Meziantou.Framework.Roslyn/LocalDataFlowAnalysis.cs
@@ -233,6 +233,11 @@ internal static partial class LocalDataFlowAnalysis
         if (source.SyntaxTree != destination.SyntaxTree)
             return true;
 
+        // The range between the two nodes is computed in source order, so a write that is textually after the read but
+        // reachable before it through a jump would be missed. Give up as soon as the enclosing scope contains a label.
+        if (ContainsJumpStatement(source) || ContainsJumpStatement(destination))
+            return true;
+
         if (!TryGetStatementRange(source, destination, out var firstStatement, out var lastStatement))
             return true;
 
@@ -358,6 +363,29 @@ internal static partial class LocalDataFlowAnalysis
         firstStatement = sourceCompilationUnit.Members[sourceIndex + 1];
         lastStatement = sourceCompilationUnit.Members[destinationIndex - 1];
         return true;
+    }
+
+    private static bool ContainsJumpStatement(SyntaxNode syntax)
+    {
+        var scope = GetEnclosingScope(syntax);
+        if (scope is null)
+            return false;
+
+        return scope.DescendantNodes().Any(node => node is LabeledStatementSyntax or GotoStatementSyntax);
+    }
+
+    private static SyntaxNode? GetEnclosingScope(SyntaxNode syntax)
+    {
+        for (var current = syntax; current is not null; current = current.Parent)
+        {
+            if (current is AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax or CompilationUnitSyntax)
+                return current;
+
+            if (current is MemberDeclarationSyntax and not GlobalStatementSyntax)
+                return current;
+        }
+
+        return null;
     }
 
     private static bool IsInNestedFunction(SyntaxNode syntax)

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -267,6 +267,102 @@ public sealed class RoslynHelperTests
     }
 
     [Fact]
+    public void TryGetConstantValue_ReturnsFalseWhenABackwardGotoCanReachTheReadAfterAWrite()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                public void M(bool condition)
+                {
+                    var value = "a";
+                Loop:
+                    if (condition) { }
+                    object boxed = value;
+                    value = "b";
+                    if (condition) goto Loop;
+                }
+            }
+            """);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.False(boxed.TryGetConstantValue(out var value, default));
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryGetConstantValue_ReturnsFalseWhenAGotoCanSkipAnAssignment()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                public void M(bool condition)
+                {
+                    var value = "a";
+                    if (condition) goto Skip;
+                    value = "b";
+                Skip:
+                    object boxed = value;
+                }
+            }
+            """);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.False(boxed.TryGetConstantValue(out var value, default));
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryGetConstantValue_IsNotAffectedByAJumpInAnotherMethod()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                public void M()
+                {
+                    var value = 42;
+                    object boxed = value;
+                }
+
+                public void Other(bool condition)
+                {
+                Loop:
+                    if (condition) goto Loop;
+                }
+            }
+            """);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.True(boxed.TryGetConstantValue(out var value, default));
+        Assert.Equal(42, value);
+    }
+
+    [Fact]
+    public void GetActualType_ReturnsTheDeclaredTypeWhenABackwardGotoCanReachTheReadAfterAWrite()
+    {
+        var compilation = CreateCompilation("""
+            public class Sample
+            {
+                public void M(bool condition)
+                {
+                    object value = 42;
+                Loop:
+                    if (condition) { }
+                    object boxed = value;
+                    value = "b";
+                    if (condition) goto Loop;
+                }
+            }
+            """);
+        var semanticModel = GetSemanticModel(compilation);
+        var boxed = GetInitializerOperation(semanticModel, "boxed");
+
+        Assert.Equal(SpecialType.System_Object, boxed.GetActualType(default)?.SpecialType);
+    }
+
+    [Fact]
     public void GetActualType_WithoutDataFlowAnalysis_OnlyUnwrapsConversions()
     {
         var compilation = CreateCompilation("""


### PR DESCRIPTION
Fixes #2021

## What

`HasWriteBetween` / `TryGetStatementRange` in `LocalDataFlowAnalysis` decide "was this symbol written between the value and the read" purely in source order: they take the statements between the two and ask `AnalyzeDataFlow` whether the symbol is written there. A write that is textually *after* the read but reachable before it through a backward `goto` is never examined, so `TryGetConstantValue` and `GetActualType` return a confidently wrong value:

```csharp
public void M(bool condition)
{
    var value = "a";
Loop:
    if (condition) { }
    object boxed = value;   // "a" on the first pass, "b" on every later one
    value = "b";
    if (condition) goto Loop;
}
```

`for` / `while` / `foreach` are unaffected because their bodies sit in a nested block and `TryGetStatementRange` already bails on the block mismatch. A `goto` in a flat block slips through.

`HasWriteBetween` now returns `true` ("assume written") as soon as the enclosing scope contains a `LabeledStatementSyntax` or a `GotoStatementSyntax`. Two helpers back it: `ContainsJumpStatement` and `GetEnclosingScope`, the latter walking up to the nearest lambda, local function, member declaration or compilation unit — so a `goto` in an unrelated method does not disable the analysis of this one.

## Why this approach

It matches how the rest of the file handles constructs it cannot model, and it is one cheap check. Building a `ControlFlowGraph` would be more principled but is far more work than `goto` justifies.

## Reviewer notes

The check is deliberately conservative: a purely forward `goto`, or a label with no `goto` at all, also disables constant folding for the whole member. That trades some precision for never returning a wrong constant. `goto` is rare enough that the lost precision should not matter in practice.

## Tests

Four tests added to `RoslynHelperTests`:

- the issue's backward-`goto` repro, for both `TryGetConstantValue` and `GetActualType`
- a `goto` that skips an assignment
- a guard that a jump in an unrelated method still allows folding

The two backward-`goto` tests were confirmed to fail without the fix (by neutralizing the new check and re-running). The skip-assignment case already returned `false` beforehand — the labeled statement happened to break the block match — so it is a guard rather than a regression test.

All four Roslyn-version test projects pass (218 tests each, across both TFMs), plus `Meziantou.Framework.Roslyn.PackageTests` (14). Built with `/p:TreatsWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` ran clean with no generated changes.
