### PR TITLE
Fix resource name and generated file name collisions in ResxSourceGenerator

### DIFF
--- a/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
+++ b/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
@@ -31,6 +31,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
     {
         // Group additional file by resource kind ((a.resx, a.en.resx, a.en-us.resx), (b.resx, b.en-us.resx))
         var resxGroups = ResxGeneratorCommon.GetResxGroups(files);
+        var hintNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var resxGroup in resxGroups)
         {
@@ -106,7 +107,22 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
 ";
             content += GenerateCode(ns, className, resourceName, visibility, generateResourcesType, generateKeyNamesType, entries!, supportNullableReferenceTypes);
 
-            context.AddSource($"{Path.GetFileName(resxGroup.Key)}.resx.g.cs", SourceText.From(content, Encoding.UTF8));
+            context.AddSource(GetHintName(hintNames, projectDir, resxGroup.Key), SourceText.From(content, Encoding.UTF8));
+        }
+    }
+
+    private static string GetHintName(HashSet<string> hintNames, string projectDir, string resourcePath)
+    {
+        var name = ResxGeneratorCommon.ComputeHintName(projectDir, resourcePath);
+        if (hintNames.Add(name))
+            return name + ".resx.g.cs";
+
+        // Two different paths can lead to the same name once the invalid characters are replaced
+        for (var i = 1; ; i++)
+        {
+            var candidate = name + i.ToString(CultureInfo.InvariantCulture);
+            if (hintNames.Add(candidate))
+                return candidate + ".resx.g.cs";
         }
     }
 

--- a/src/Meziantou.Framework.ResxSourceGenerator/ResxGeneratorCommon.cs
+++ b/src/Meziantou.Framework.ResxSourceGenerator/ResxGeneratorCommon.cs
@@ -44,7 +44,8 @@ internal static class ResxGeneratorCommon
         string? result = null;
         foreach (var file in additionalFiles)
         {
-            if (analyzerConfigOptionsProvider.GetOptions(file).TryGetValue("build_metadata.AdditionalFiles." + name, out var value))
+            // An unset metadata is reported as an empty value, so it must not be considered as a different value
+            if (analyzerConfigOptionsProvider.GetOptions(file).TryGetValue("build_metadata.AdditionalFiles." + name, out var value) && !string.IsNullOrEmpty(value))
             {
                 if (result is not null && value != result)
                 {

--- a/src/Meziantou.Framework.ResxSourceGenerator/ResxGeneratorCommon.cs
+++ b/src/Meziantou.Framework.ResxSourceGenerator/ResxGeneratorCommon.cs
@@ -100,6 +100,35 @@ internal static class ResxGeneratorCommon
         return null;
     }
 
+    /// <summary>
+    /// Computes the base name of the generated file. Two resx files can share the same file name, so the path
+    /// relative to the project is used to keep the name unique within the generator.
+    /// </summary>
+    internal static string ComputeHintName(string projectDir, string resourcePath)
+    {
+        var fullProjectDir = EnsureEndSeparator(Path.GetFullPath(projectDir));
+        var fullResourcePath = Path.GetFullPath(resourcePath);
+
+        var name = fullResourcePath.StartsWith(fullProjectDir, StringComparison.Ordinal)
+            ? fullResourcePath[fullProjectDir.Length..]
+            : Path.GetFileName(resourcePath);
+
+        var sb = new StringBuilder(name.Length);
+        foreach (var c in name)
+        {
+            sb.Append(c switch
+            {
+                '/' or '\\' => '.',
+                // Characters allowed in a hint name (Microsoft.CodeAnalysis.AdditionalSourcesCollection)
+                '.' or ',' or '-' or '_' or ' ' or '(' or ')' or '[' or ']' => c,
+                _ when char.IsLetterOrDigit(c) => c,
+                _ => '_',
+            });
+        }
+
+        return sb.ToString();
+    }
+
     private static string EnsureEndSeparator(string path)
     {
         if (path[^1] == Path.DirectorySeparatorChar)

--- a/src/Meziantou.Framework.ResxSourceGenerator/build/Meziantou.Framework.ResxSourceGenerator.props
+++ b/src/Meziantou.Framework.ResxSourceGenerator/build/Meziantou.Framework.ResxSourceGenerator.props
@@ -15,11 +15,27 @@
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="GenerateResources" />
   </ItemGroup>
 
-  <Target Name="AddManifestResourceNameToAdditionalFiles" AfterTargets="CreateManifestResourceNames" BeforeTargets="CoreCompile">
-    <!-- Update AdditionalFiles metadata based on matching EmbeddedResource items -->
+  <Target Name="AddManifestResourceNameToAdditionalFiles" AfterTargets="CreateManifestResourceNames" BeforeTargets="CoreCompile" DependsOnTargets="_CollectResxManifestResourceNames;_AddManifestResourceNameToAdditionalFile" />
+
+  <!-- Only the culture-neutral resx files carry the resource name. The generator reads the metadata from
+       every file of a group (Resource1.resx, Resource1.fr.resx, etc.) and considers the group invalid when the
+       values differ, so the satellite files must be left alone. -->
+  <Target Name="_CollectResxManifestResourceNames">
     <ItemGroup>
-      <AdditionalFiles Update="@(AdditionalFiles)">
-        <DefaultResourceName>%(EmbeddedResource.ManifestResourceName)</DefaultResourceName>
+      <_ResxManifestResourceName Include="@(EmbeddedResource)" Condition="'%(EmbeddedResource.Extension)' == '.resx' AND '%(EmbeddedResource.WithCulture)' != 'true'" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Update AdditionalFiles metadata based on matching EmbeddedResource items. The target is batched so that
+       each AdditionalFiles item gets the name of the resx it points to instead of the name of the last resource. -->
+  <Target Name="_AddManifestResourceNameToAdditionalFile" Outputs="%(_ResxManifestResourceName.Identity)">
+    <PropertyGroup>
+      <_ResxFullPath>%(_ResxManifestResourceName.FullPath)</_ResxFullPath>
+      <_ResxManifestName>%(_ResxManifestResourceName.ManifestResourceName)</_ResxManifestName>
+    </PropertyGroup>
+    <ItemGroup>
+      <AdditionalFiles Condition="'%(AdditionalFiles.FullPath)' == '$(_ResxFullPath)'">
+        <DefaultResourceName>$(_ResxManifestName)</DefaultResourceName>
       </AdditionalFiles>
     </ItemGroup>
   </Target>

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Folder1/Resource2.resx
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Folder1/Resource2.resx
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Sample" xml:space="preserve">
+    <value>value from Folder1</value>
+  </data>
+</root>

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Folder2/Resource2.resx
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Folder2/Resource2.resx
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Sample" xml:space="preserve">
+    <value>value from Folder2</value>
+  </data>
+</root>

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests.csproj
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests.csproj
@@ -11,4 +11,7 @@
     <AdditionalFiles Include="**/*.resx" />
   </ItemGroup>
 
+  <!-- Use the props shipped in the package, so the MSBuild logic computing the resource names is also tested -->
+  <Import Project="../../src/Meziantou.Framework.ResxSourceGenerator/build/Meziantou.Framework.ResxSourceGenerator.props" />
+
 </Project>

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/ResxGeneratorTests.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/ResxGeneratorTests.cs
@@ -47,6 +47,13 @@ public class ResxGeneratorTests
     }
 
     [Fact]
+    public void EachResourceUsesItsOwnManifestResourceName()
+    {
+        Assert.Equal("value", Resource1.Sample);
+        Assert.Equal("value from Folder1", Folder1.Resource2.Sample);
+    }
+
+    [Fact]
     public void BinaryFile()
     {
         Assert.Equal([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A], Resource1.Image1!.AsSpan()[..8]);

--- a/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/ResxGeneratorTests.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.GeneratorTests/ResxGeneratorTests.cs
@@ -54,6 +54,13 @@ public class ResxGeneratorTests
     }
 
     [Fact]
+    public void ResxFilesWithSameFileNameAreBothGenerated()
+    {
+        Assert.Equal("value from Folder1", Folder1.Resource2.Sample);
+        Assert.Equal("value from Folder2", Folder2.Resource2.Sample);
+    }
+
+    [Fact]
     public void BinaryFile()
     {
         Assert.Equal([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A], Resource1.Image1!.AsSpan()[..8]);

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
@@ -281,6 +281,35 @@ public sealed class ResxGeneratorTest
     }
 
     [Fact]
+    public async Task ResxFilesWithSameFileName()
+    {
+        var element1 = new XElement("root", new XElement("data", new XAttribute("name", "Sample"), new XElement("value", "from Folder1")));
+        var element2 = new XElement("root", new XElement("data", new XAttribute("name", "Sample"), new XElement("value", "from Folder2")));
+
+        var result = await GenerateFiles(
+            [
+                (FullPath.GetTempPath() / "proj" / "Folder1" / "Messages.resx", element1.ToString()),
+                (FullPath.GetTempPath() / "proj" / "Folder2" / "Messages.resx", element2.ToString()),
+            ], new OptionProvider
+            {
+                ProjectDir = FullPath.GetTempPath() / "proj",
+                RootNamespace = "Test",
+            });
+
+        Assert.Collection(result.GeneratedTrees.OrderBy(t => t.FilePath, StringComparer.Ordinal),
+            tree =>
+            {
+                Assert.Equal("Folder1.Messages.resx.g.cs", Path.GetFileName(tree.FilePath));
+                Assert.Equal("Test.Folder1", tree.GetRoot(XunitCancellationToken).GetNamespace());
+            },
+            tree =>
+            {
+                Assert.Equal("Folder2.Messages.resx.g.cs", Path.GetFileName(tree.FilePath));
+                Assert.Equal("Test.Folder2", tree.GetRoot(XunitCancellationToken).GetNamespace());
+            });
+    }
+
+    [Fact]
     public async Task ComputeNamespace_RootDir()
     {
         var result = await GenerateFiles([(FullPath.GetTempPath() / "dir" / "proj" / "test.resx", new XElement("root").ToString())], new OptionProvider

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
@@ -331,10 +331,10 @@ public sealed class ResxGeneratorTest
         };
         var options = new OptionProvider
         {
-            PerFileNamespace = new Dictionary<string, string>(StringComparer.Ordinal)
+            PerFileMetadata = new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal)
             {
-                ["test.resx"] = "A",
-                ["test.fr.resx"] = "B",
+                ["test.resx"] = new(StringComparer.Ordinal) { ["Namespace"] = "A" },
+                ["test.fr.resx"] = new(StringComparer.Ordinal) { ["Namespace"] = "B" },
             },
         };
 
@@ -344,6 +344,33 @@ public sealed class ResxGeneratorTest
 
         var diagnostics = await AnalyzeFiles(files, options);
         Assert.Collection(diagnostics, diag => Assert.Equal("MFRG0004", diag.Id));
+    }
+
+    [Fact]
+    public async Task EmptyMetadataIsNotInconsistent()
+    {
+        // MSBuild reports an unset metadata as an empty value, so only the neutral resx file carries the resource name
+        var element = new XElement("root", new XElement("data", new XAttribute("name", "Sample"), new XElement("value", "Value")));
+        var files = new[]
+        {
+            (ResxPath: "test.fr.resx", ResxContent: element.ToString()),
+            (ResxPath: "test.resx", ResxContent: element.ToString()),
+        };
+        var options = new OptionProvider
+        {
+            Namespace = "test",
+            PerFileMetadata = new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal)
+            {
+                ["test.resx"] = new(StringComparer.Ordinal) { ["DefaultResourceName"] = "Sample.Test" },
+                ["test.fr.resx"] = new(StringComparer.Ordinal) { ["DefaultResourceName"] = "" },
+            },
+        };
+
+        var result = await GenerateFiles(files, options);
+        Assert.Contains("Sample.Test", result.GeneratedFileRoot.ToFullString());
+
+        var diagnostics = await AnalyzeFiles(files, options);
+        Assert.Empty(diagnostics);
     }
 
     private sealed class OptionProvider : AnalyzerConfigOptionsProvider
@@ -358,7 +385,7 @@ public sealed class ResxGeneratorTest
         public string? Visibility { get; set; }
         public string? GenerateResourcesType { get; set; }
         public string? GenerateKeyNamesType { get; set; }
-        public Dictionary<string, string> PerFileNamespace { get; set; } = new(StringComparer.Ordinal);
+        public Dictionary<string, Dictionary<string, string>> PerFileMetadata { get; set; } = new(StringComparer.Ordinal);
 
         public override AnalyzerConfigOptions GlobalOptions => new Options(this);
 
@@ -395,7 +422,7 @@ public sealed class ResxGeneratorTest
                     return false;
                 }
 
-                if (_path is not null && string.Equals(key, nameof(OptionProvider.Namespace), StringComparison.Ordinal) && _optionProvider.PerFileNamespace.TryGetValue(_path, out value))
+                if (_path is not null && _optionProvider.PerFileMetadata.TryGetValue(_path, out var metadata) && metadata.TryGetValue(key, out value))
                 {
                     return true;
                 }


### PR DESCRIPTION
Fixes #2042
Fixes #2043

Two independent defects that both silently broke every resource class in a project with more than one resx.

## Every resx got the resource name of the last EmbeddedResource (#2042)

`AddManifestResourceNameToAdditionalFiles` read `%(EmbeddedResource.ManifestResourceName)` while updating every `AdditionalFiles` item, so the `ItemGroup` batched over `EmbeddedResource` and each batch overwrote the metadata on all of them. The last batch won. In a WPF project the last `EmbeddedResource` is the markup compiler's `.g.resources`, so every member threw `MissingManifestResourceException` at runtime while the project compiled cleanly.

The target is now batched over the resx `EmbeddedResource` items, with the batch values captured into properties so the inner `ItemGroup` batches only over `AdditionalFiles` and matches by `FullPath`.

Worth knowing for review: the item-function join proposed in the issue does **not** work on this SDK — I measured it producing an empty `DefaultResourceName` for every file. Inside an item transform `%()` resolves against the transformed item type, so `%(AdditionalFiles.FullPath)` reaches `WithMetadataValue` empty and matches nothing. Target batching was the approach that actually worked.

Only culture-neutral files are stamped. The generator reads the metadata across a whole resx group (`Resource1.resx`, `Resource1.fr.resx`) and treats differing values as inconsistent, and a satellite necessarily gets a different manifest name.

That exposed a latent generator bug: MSBuild writes an unset metadata to the generated `.editorconfig` as `build_metadata.AdditionalFiles.DefaultResourceName = ` (empty), which `TryGetValue` reports as present. An empty value therefore counted as a third, conflicting value. `GetMetadataValue` now ignores empty values, matching the `IsNullOrEmpty` check already at the end of the method. This also fixes setting a metadata such as `ClassName` on the neutral file only, which previously reported MFRG0004 and generated nothing.

## Two resx with the same file name disabled the generator (#2043)

The hint name came from the resx file name alone, so `Folder1/Messages.resx` and `Folder2/Messages.resx` collided, `AddSource` threw, and the generator contributed nothing at all — a `CS8785` warning plus `CS0103` at every unrelated call site.

The name is now built from the project-relative path, with directory separators replaced by `.` and any character Roslyn rejects in a hint name replaced by `_` (`/` and `\` are not valid hint-name characters, so the substitution is required, not cosmetic).

I used the relative path rather than the resource name the issue suggested, so a resx at the project root keeps the name it had today and most users see no churn in `EmitCompilerGeneratedFiles` output. Files outside the project directory fall back to their file name, and used names are tracked with a numeric suffix on collision — so the generator can no longer throw here, which is why no duplicate-hint-name diagnostic is added. `ClassName`, `Namespace` and `ResourceName` are untouched; the generated API does not change.

## Tests

`Meziantou.Framework.ResxSourceGenerator.GeneratorTests` now imports the props shipped in the package, so the MSBuild logic is covered end to end rather than only through hand-built option providers. Two new resx files (`Folder1/Resource2.resx`, `Folder2/Resource2.resx`) exercise both a second resource and a duplicate file name.

Each fix was checked to be genuinely covered: reverting only the props target makes all 7 tests in that project fail, and reverting only the hint name reproduces the issue's exact `CS8785` plus `CS0103` cascade.

Solution builds with `/p:TreatsWarningsAsErrors=true` and 0 warnings; 38/38 and 16/16 tests pass; `dotnet run ./eng/update-all.cs` is clean.

The package version is left alone, since versions are bumped in their own commits in this repo.
