### PR TITLE
Require the daemon to answer before reporting a container runtime as supported

### DIFF
--- a/ref/Meziantou.Framework.TemporaryContainers.cs
+++ b/ref/Meziantou.Framework.TemporaryContainers.cs
@@ -185,7 +185,7 @@ namespace Meziantou.Framework.TemporaryContainers
         public static Meziantou.Framework.TemporaryContainers.ContainerRuntime Podman { get => throw null; }
         public static Meziantou.Framework.TemporaryContainers.ContainerRuntime AppleContainer { get => throw null; }
         public static Meziantou.Framework.TemporaryContainers.ContainerRuntime Wslc { get => throw null; }
-        public virtual bool IsSupported() => throw null;
+        public virtual System.Threading.Tasks.Task<bool> IsSupportedAsync(System.Threading.CancellationToken cancellationToken = null) => throw null;
         public override string ToString() => throw null;
     }
 

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntime.cs
@@ -25,12 +25,14 @@ public abstract class ContainerRuntime
     public static ContainerRuntime Wslc { get; } = new DockerContainerRuntime(nameof(Wslc), DockerContainerRuntime.Flavor.Wslc);
 
     /// <summary>Determines whether this runtime can be resolved.</summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <remarks>The runtime is not considered available until its daemon answers, so the first call runs a command or opens a connection. A success is cached; a failure is not, so a daemon that starts later is still detected.</remarks>
     /// <returns><see langword="true"/> if the runtime executable is available and operational; otherwise, <see langword="false"/>.</returns>
-    public virtual bool IsSupported() => false;
+    public virtual Task<bool> IsSupportedAsync(CancellationToken cancellationToken = default) => Task.FromResult(false);
 
-    internal void EnsureSupported()
+    internal async Task EnsureSupportedAsync(CancellationToken cancellationToken)
     {
-        if (!IsSupported())
+        if (!await IsSupportedAsync(cancellationToken).ConfigureAwait(false))
             throw CreateUnavailableRuntimeException(this);
     }
 

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
@@ -9,12 +9,16 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
 {
     private const string ReuseNamePrefix = "meziantou-tc-";
 
-    public AppleContainerRuntime(string name)
-        : base(name)
+    public AppleContainerRuntime(string name, string? executablePath = null)
+        : base(name, executablePath)
     {
     }
 
     internal override string ExecutableName => "container";
+
+    // 'container --version' is answered by the CLI itself, so the probe has to go through the API server: listing the
+    // containers is the cheapest command that does.
+    internal override IReadOnlyList<string> BuildProbeArguments() => ["ls", "-q"];
 
     internal override Task<string> EnsureCreatedAsync(ContainerDefinition definition, CancellationToken cancellationToken)
     {

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AutoContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AutoContainerRuntime.cs
@@ -1,10 +1,10 @@
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Meziantou.Framework.TemporaryContainers.Internals;
 
 internal sealed class AutoContainerRuntime : ContainerRuntime
 {
-    private readonly Lock _syncObject = new();
     private readonly DockerApiRuntime _dockerApiRuntime = new();
     private ContainerRuntime? _resolvedRuntime;
 
@@ -13,35 +13,37 @@ internal sealed class AutoContainerRuntime : ContainerRuntime
     {
     }
 
-    public override bool IsSupported()
+    public override async Task<bool> IsSupportedAsync(CancellationToken cancellationToken = default)
     {
-        return GetResolvedRuntimeOrNull() is not null;
+        return await GetResolvedRuntimeOrNullAsync(cancellationToken).ConfigureAwait(false) is not null;
     }
 
-    internal ContainerRuntime? GetResolvedRuntimeOrNull()
+    internal async Task<ContainerRuntime?> GetResolvedRuntimeOrNullAsync(CancellationToken cancellationToken)
     {
+        // Only a success is cached, so a runtime that becomes available later is still detected.
         if (_resolvedRuntime is { } runtime)
             return runtime;
 
-        lock (_syncObject)
+        foreach (var candidate in GetAllCandidates())
         {
-            if (_resolvedRuntime is { } resolved)
-                return resolved;
-
-            foreach (var candidate in GetAllCandidates())
+            if (await candidate.IsSupportedAsync(cancellationToken).ConfigureAwait(false))
             {
-                if (candidate.IsSupported())
-                    return _resolvedRuntime = candidate;
+                // Concurrent callers probe the candidates in the same order, so they resolve the same runtime; the
+                // exchange only makes sure they all report the one that was published.
+                return Interlocked.CompareExchange(ref _resolvedRuntime, candidate, comparand: null) ?? candidate;
             }
-
-            return null;
         }
+
+        return null;
     }
 
-    private ContainerRuntime GetResolvedRuntimeOrThrow()
+    private async Task<ContainerRuntime> GetResolvedRuntimeOrThrowAsync(CancellationToken cancellationToken)
     {
-        return GetResolvedRuntimeOrNull() ?? throw CreateUnavailableRuntimeException(this);
+        return await GetResolvedRuntimeOrNullAsync(cancellationToken).ConfigureAwait(false) ?? throw CreateUnavailableRuntimeException(this);
     }
+
+    /// <summary>The runtime resolved by a previous operation. The container resolves the runtime before it runs anything, so the members that cannot await do not have to resolve it themselves.</summary>
+    private ContainerRuntime ResolvedRuntime => _resolvedRuntime ?? throw CreateUnavailableRuntimeException(this);
 
     private IEnumerable<ContainerRuntime> GetAllCandidates()
     {
@@ -56,58 +58,107 @@ internal sealed class AutoContainerRuntime : ContainerRuntime
         yield return Podman;
     }
 
-    internal override bool SupportsPause => GetResolvedRuntimeOrThrow().SupportsPause;
+    internal override bool SupportsPause => ResolvedRuntime.SupportsPause;
 
-    internal override bool SupportsRestart => GetResolvedRuntimeOrThrow().SupportsRestart;
+    internal override bool SupportsRestart => ResolvedRuntime.SupportsRestart;
 
-    internal override Task<string> EnsureCreatedAsync(ContainerDefinition definition, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().EnsureCreatedAsync(definition, cancellationToken);
+    internal override async Task<string> EnsureCreatedAsync(ContainerDefinition definition, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        return await runtime.EnsureCreatedAsync(definition, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override Task StartAsync(string id, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().StartAsync(id, cancellationToken);
+    internal override async Task StartAsync(string id, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        await runtime.StartAsync(id, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override Task StopAsync(string id, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().StopAsync(id, cancellationToken);
+    internal override async Task StopAsync(string id, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        await runtime.StopAsync(id, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override Task RestartAsync(string id, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().RestartAsync(id, cancellationToken);
+    internal override async Task RestartAsync(string id, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        await runtime.RestartAsync(id, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override Task PauseAsync(string id, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().PauseAsync(id, cancellationToken);
+    internal override async Task PauseAsync(string id, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        await runtime.PauseAsync(id, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override Task UnpauseAsync(string id, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().UnpauseAsync(id, cancellationToken);
+    internal override async Task UnpauseAsync(string id, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        await runtime.UnpauseAsync(id, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override Task KillAsync(string id, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().KillAsync(id, cancellationToken);
+    internal override async Task KillAsync(string id, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        await runtime.KillAsync(id, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override Task DeleteAsync(string id, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().DeleteAsync(id, cancellationToken);
+    internal override async Task DeleteAsync(string id, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        await runtime.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override Task<bool> ExistsAsync(string id, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().ExistsAsync(id, cancellationToken);
+    internal override async Task<bool> ExistsAsync(string id, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        return await runtime.ExistsAsync(id, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override Task<ContainerInfo> InspectAsync(string id, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().InspectAsync(id, cancellationToken);
+    internal override async Task<ContainerInfo> InspectAsync(string id, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        return await runtime.InspectAsync(id, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override IAsyncEnumerable<LogEntry> GetLogsAsync(string id, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().GetLogsAsync(id, cancellationToken);
+    internal override async IAsyncEnumerable<LogEntry> GetLogsAsync(string id, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        await foreach (var entry in runtime.GetLogsAsync(id, cancellationToken).ConfigureAwait(false))
+            yield return entry;
+    }
 
-    internal override Task<ExecResult> ExecAsync(string id, ExecOptions options, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().ExecAsync(id, options, cancellationToken);
+    internal override async Task<ExecResult> ExecAsync(string id, ExecOptions options, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        return await runtime.ExecAsync(id, options, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override Task<Stream> OpenReadAsync(string id, string path, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().OpenReadAsync(id, path, cancellationToken);
+    internal override async Task<Stream> OpenReadAsync(string id, string path, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        return await runtime.OpenReadAsync(id, path, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override Task WriteFileAsync(string id, string path, Stream content, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().WriteFileAsync(id, path, content, cancellationToken);
+    internal override async Task WriteFileAsync(string id, string path, Stream content, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        await runtime.WriteFileAsync(id, path, content, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override Task CopyToContainerAsync(string id, string source, string destination, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().CopyToContainerAsync(id, source, destination, cancellationToken);
+    internal override async Task CopyToContainerAsync(string id, string source, string destination, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        await runtime.CopyToContainerAsync(id, source, destination, cancellationToken).ConfigureAwait(false);
+    }
 
-    internal override Task CopyFromContainerAsync(string id, string source, string destination, CancellationToken cancellationToken)
-        => GetResolvedRuntimeOrThrow().CopyFromContainerAsync(id, source, destination, cancellationToken);
+    internal override async Task CopyFromContainerAsync(string id, string source, string destination, CancellationToken cancellationToken)
+    {
+        var runtime = await GetResolvedRuntimeOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        await runtime.CopyFromContainerAsync(id, source, destination, cancellationToken).ConfigureAwait(false);
+    }
 
     internal override IReadOnlyDictionary<int, int> ResolvePortMap(ContainerInfo info, ContainerDefinition definition)
-        => GetResolvedRuntimeOrThrow().ResolvePortMap(info, definition);
+        => ResolvedRuntime.ResolvePortMap(info, definition);
 }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
@@ -12,10 +12,8 @@ namespace Meziantou.Framework.TemporaryContainers.Internals;
 
 internal sealed class DockerApiRuntime : ContainerRuntime
 {
-    private readonly Lock _syncObject = new();
-    private HttpClient? _httpClient;
-    private string? _apiVersion;
     private readonly DockerRegistryAuthProvider _authProvider;
+    private DockerApiConnection? _connection;
 
     internal DockerApiRuntime()
         : base("DockerApi")
@@ -23,7 +21,8 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         _authProvider = new DockerRegistryAuthProvider();
     }
 
-    public override bool IsSupported() => EnsureInitializedCore() is not null;
+    public override async Task<bool> IsSupportedAsync(CancellationToken cancellationToken = default)
+        => await EnsureConnectionAsync(cancellationToken).ConfigureAwait(false) is not null;
 
     internal override bool SupportsPause => true;
 
@@ -233,14 +232,14 @@ internal sealed class DockerApiRuntime : ContainerRuntime
 
     private async Task PullImageAsync(string imageName, CancellationToken cancellationToken)
     {
+        var connection = await EnsureConnectionOrThrowAsync(cancellationToken).ConfigureAwait(false);
         var endpoint = "/images/create?fromImage=" + Uri.EscapeDataString(imageName);
-        using var request = new HttpRequestMessage(HttpMethod.Post, BuildEndpoint(endpoint));
+        using var request = new HttpRequestMessage(HttpMethod.Post, BuildEndpoint(connection, endpoint));
         var registryAuth = await _authProvider.GetRegistryAuthHeaderValueAsync(imageName, cancellationToken).ConfigureAwait(false);
         if (!string.IsNullOrEmpty(registryAuth))
             request.Headers.TryAddWithoutValidation("X-Registry-Auth", registryAuth);
 
-        var httpClient = EnsureInitializedOrThrow();
-        using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        using var response = await connection.HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
             throw await CreateRequestExceptionAsync(response, request.Method.Method, request.RequestUri?.AbsolutePath ?? endpoint, cancellationToken).ConfigureAwait(false);
@@ -258,13 +257,13 @@ internal sealed class DockerApiRuntime : ContainerRuntime
 
     private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string endpoint, HttpContent? content, CancellationToken cancellationToken, bool allowNotFound = false, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
     {
-        using var request = new HttpRequestMessage(method, BuildEndpoint(endpoint))
+        var connection = await EnsureConnectionOrThrowAsync(cancellationToken).ConfigureAwait(false);
+        using var request = new HttpRequestMessage(method, BuildEndpoint(connection, endpoint))
         {
             Content = content,
         };
 
-        var httpClient = EnsureInitializedOrThrow();
-        var response = await httpClient.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
+        var response = await connection.HttpClient.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
 
         if (response.IsSuccessStatusCode || allowNotFound && response.StatusCode == HttpStatusCode.NotFound)
             return response;
@@ -272,13 +271,12 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         throw await CreateRequestExceptionAsync(response, method.Method, request.RequestUri?.AbsolutePath ?? endpoint, cancellationToken).ConfigureAwait(false);
     }
 
-    private string BuildEndpoint(string endpoint)
+    private static string BuildEndpoint(DockerApiConnection connection, string endpoint)
     {
         if (!endpoint.StartsWith('/', StringComparison.Ordinal))
             endpoint = "/" + endpoint;
 
-        var apiVersion = EnsureInitializedOrThrowApiVersion();
-        return "/v" + apiVersion + endpoint;
+        return "/v" + connection.ApiVersion + endpoint;
     }
 
     private static async Task<Exception> CreateRequestExceptionAsync(HttpResponseMessage response, string method, string endpoint, CancellationToken cancellationToken)
@@ -431,68 +429,65 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         return new StringContent(json, Encoding.UTF8, "application/json");
     }
 
-    private HttpClient EnsureInitializedOrThrow()
+    private async Task<DockerApiConnection> EnsureConnectionOrThrowAsync(CancellationToken cancellationToken)
     {
-        return EnsureInitializedCore() ?? throw CreateUnavailableRuntimeException(this);
+        return await EnsureConnectionAsync(cancellationToken).ConfigureAwait(false) ?? throw CreateUnavailableRuntimeException(this);
     }
 
-    private string EnsureInitializedOrThrowApiVersion()
+    private async Task<DockerApiConnection?> EnsureConnectionAsync(CancellationToken cancellationToken)
     {
-        _ = EnsureInitializedOrThrow();
-        return _apiVersion ?? throw CreateUnavailableRuntimeException(this);
-    }
+        // Only a success is cached, so a daemon started after a failed attempt is still detected.
+        if (_connection is { } connection)
+            return connection;
 
-    private HttpClient? EnsureInitializedCore()
-    {
-        if (_httpClient is { } client)
-            return client;
-
-        lock (_syncObject)
+        foreach (var endpoint in DockerApiTransport.GetEndpoints())
         {
-            if (_httpClient is { } existingClient)
-                return existingClient;
-
-            foreach (var endpoint in DockerApiTransport.GetEndpoints())
+            HttpClient? candidateClient = null;
+            try
             {
-                HttpClient? candidateClient = null;
-                try
-                {
-                    candidateClient = DockerApiTransport.CreateClient(endpoint);
-                    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-                    var versionResponse = candidateClient.GetAsync("/version", cts.Token).ConfigureAwait(false).GetAwaiter().GetResult();
-                    if (!versionResponse.IsSuccessStatusCode)
-                        continue;
+                candidateClient = DockerApiTransport.CreateClient(endpoint);
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(TimeSpan.FromSeconds(2));
+                using var versionResponse = await candidateClient.GetAsync("/version", cts.Token).ConfigureAwait(false);
+                if (!versionResponse.IsSuccessStatusCode)
+                    continue;
 
-                    using var stream = versionResponse.Content.ReadAsStream();
-                    var version = JsonSerializer.Deserialize(stream, DockerApiJsonContext.Default.Version);
-                    if (string.IsNullOrWhiteSpace(version?.ApiVersion))
-                        continue;
+                await using var stream = await versionResponse.Content.ReadAsStreamAsync(cts.Token).ConfigureAwait(false);
+                var version = await JsonSerializer.DeserializeAsync(stream, DockerApiJsonContext.Default.Version, cts.Token).ConfigureAwait(false);
+                if (string.IsNullOrWhiteSpace(version?.ApiVersion))
+                    continue;
 
-                    _httpClient = candidateClient;
-                    _apiVersion = version.ApiVersion;
+                // The client and the API version are published together, so a caller that sees the connection sees both.
+                // Concurrent callers may reach this point at the same time: the first one published wins and the others
+                // dispose the client they built.
+                var candidate = new DockerApiConnection(candidateClient, version.ApiVersion);
+                var published = Interlocked.CompareExchange(ref _connection, candidate, comparand: null) ?? candidate;
+                if (ReferenceEquals(published, candidate))
                     candidateClient = null;
-                    return _httpClient;
-                }
-                catch (OperationCanceledException)
-                {
-                }
-                catch (HttpRequestException)
-                {
-                }
-                catch (SocketException)
-                {
-                }
-                catch (IOException)
-                {
-                }
-                finally
-                {
-                    candidateClient?.Dispose();
-                }
-            }
 
-            return null;
+                return published;
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch (HttpRequestException)
+            {
+            }
+            catch (SocketException)
+            {
+            }
+            catch (IOException)
+            {
+            }
+            finally
+            {
+                candidateClient?.Dispose();
+            }
         }
+
+        return null;
     }
 
+    /// <summary>The endpoint the runtime talks to, published as a single value so that a caller never sees a client without its API version.</summary>
+    private sealed record DockerApiConnection(HttpClient HttpClient, string ApiVersion);
 }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerRuntime.cs
@@ -12,8 +12,8 @@ internal sealed class DockerContainerRuntime : ExecutableContainerRuntime
 
     private readonly Flavor _flavor;
 
-    public DockerContainerRuntime(string name, Flavor flavor)
-        : base(name)
+    public DockerContainerRuntime(string name, Flavor flavor, string? executablePath = null)
+        : base(name, executablePath)
     {
         _flavor = flavor;
     }
@@ -24,6 +24,13 @@ internal sealed class DockerContainerRuntime : ExecutableContainerRuntime
         Flavor.Podman => "podman",
         Flavor.Wslc => "wslc",
         _ => throw new InvalidOperationException($"Unknown flavor: {_flavor}"),
+    };
+
+    internal override IReadOnlyList<string> BuildProbeArguments() => _flavor switch
+    {
+        // wslc reports its version through '--version', which the CLI answers on its own, so the probe lists the containers instead.
+        Flavor.Wslc => ["list", "-q"],
+        _ => ["version"],
     };
 
     internal override bool LogsIncludeTimestamps => true;

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ExecutableContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ExecutableContainerRuntime.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
@@ -7,12 +8,19 @@ namespace Meziantou.Framework.TemporaryContainers.Internals;
 /// <summary>Base runtime backed by an executable CLI.</summary>
 internal abstract class ExecutableContainerRuntime : ContainerRuntime
 {
-    private ContainerCli? _cli;
-    private readonly Lock _syncObject = new();
+    // A daemon that is reachable but busy can take a while to answer. The timeout only matters when it never answers.
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(30);
 
-    protected ExecutableContainerRuntime(string name)
+    private readonly string? _executablePath;
+    private readonly Lock _syncObject = new();
+    private ContainerCli? _cli;
+    private bool _isOperational;
+
+    /// <param name="executablePath">When set, the CLI to run instead of looking <see cref="ExecutableName"/> up in the PATH.</param>
+    protected ExecutableContainerRuntime(string name, string? executablePath = null)
         : base(name)
     {
+        _executablePath = executablePath;
     }
 
     private protected ContainerCli Cli
@@ -25,10 +33,22 @@ internal abstract class ExecutableContainerRuntime : ContainerRuntime
 
     internal abstract string ExecutableName { get; }
 
-    public override bool IsSupported() => EnsureCliInitialized() is not null;
+    public override async Task<bool> IsSupportedAsync(CancellationToken cancellationToken = default)
+    {
+        if (EnsureCliInitialized() is not { } cli)
+            return false;
+
+        return await IsOperationalAsync(cli, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Arguments of a cheap command that succeeds only when the daemon behind the CLI answers.</summary>
+    internal abstract IReadOnlyList<string> BuildProbeArguments();
 
     internal string? FindExecutable()
     {
+        if (_executablePath is not null)
+            return _executablePath;
+
         // On Windows, Docker Desktop ships both an extensionless shim and the real '.exe';
         // the shim cannot be launched by Process.Start, so prefer an executable extension.
         if (OperatingSystem.IsWindows())
@@ -59,6 +79,38 @@ internal abstract class ExecutableContainerRuntime : ContainerRuntime
 
             _cli = new ContainerCli(this, executable);
             return _cli;
+        }
+    }
+
+    /// <summary>Checks that the daemon behind the CLI answers. Finding the executable is not enough: Docker Desktop leaves 'docker' on the PATH when the engine is stopped, and every command then fails with a connection error.</summary>
+    private async Task<bool> IsOperationalAsync(ContainerCli cli, CancellationToken cancellationToken)
+    {
+        if (_isOperational)
+            return true;
+
+        if (!await RunProbeAsync(cli, cancellationToken).ConfigureAwait(false))
+            return false;
+
+        // Only a success is cached, so a daemon started after a failed probe is still detected. Concurrent callers may
+        // probe at the same time, which costs an extra process at worst.
+        _isOperational = true;
+        return true;
+    }
+
+    private async Task<bool> RunProbeAsync(ContainerCli cli, CancellationToken cancellationToken)
+    {
+        using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cancellationTokenSource.CancelAfter(ProbeTimeout);
+        try
+        {
+            var result = await cli.RunBufferedAsync(BuildProbeArguments(), cancellationTokenSource.Token, allowNonZero: true).ConfigureAwait(false);
+            return result.ExitCode == 0;
+        }
+        catch (Exception ex) when (ex is Win32Exception or InvalidOperationException or IOException ||
+            ex is OperationCanceledException && !cancellationToken.IsCancellationRequested)
+        {
+            // The probe is a diagnostic: whatever prevents it from completing, including the timeout, means the runtime cannot be used.
+            return false;
         }
     }
 

--- a/src/Meziantou.Framework.TemporaryContainers/TemporaryContainer.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/TemporaryContainer.cs
@@ -30,24 +30,14 @@ public partial class TemporaryContainer : IAsyncDisposable
     public ContainerDefinition Definition => _definition;
 
     /// <summary>Gets the container runtime in use.</summary>
-    public ContainerRuntime Runtime
+    public ContainerRuntime Runtime => _runtime ??= _definition.Runtime;
+
+    /// <summary>Resolves the runtime and checks that it can actually be used, which may run a command or open a connection.</summary>
+    private async Task EnsureRuntimeSupportedAsync(CancellationToken cancellationToken)
     {
-        get
-        {
-            EnsureRuntimeCreated();
-            return _runtime;
-        }
+        _runtime ??= _definition.Runtime;
+        await _runtime.EnsureSupportedAsync(cancellationToken).ConfigureAwait(false);
     }
-
-[MemberNotNull(nameof(_runtime))]
-private void EnsureRuntimeCreated()
-{
-    if (_runtime is not null)
-        return;
-
-    _runtime = _definition.Runtime;
-    _runtime.EnsureSupported();
-}
 
     /// <summary>Creates the container if it does not exist yet, without starting it. When <see cref="ContainerDefinition.ReuseId"/> is set, an existing matching container is adopted instead.</summary>
     /// <param name="cancellationToken">A cancellation token.</param>
@@ -58,7 +48,7 @@ private void EnsureRuntimeCreated()
         if (_created)
             return;
 
-        EnsureRuntimeCreated();
+        await EnsureRuntimeSupportedAsync(cancellationToken).ConfigureAwait(false);
 
         _id = await Runtime.EnsureCreatedAsync(_definition, cancellationToken).ConfigureAwait(false);
 

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerRuntimeAdapterTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerRuntimeAdapterTests.cs
@@ -19,6 +19,7 @@ public sealed class AppleContainerRuntimeAdapterTests
         Assert.Equal("copy src abc:/dst", string.Join(' ', runtime.BuildCopyToContainerArguments("abc", "src", "/dst")));
         Assert.Equal("copy abc:/src dst", string.Join(' ', runtime.BuildCopyFromContainerArguments("abc", "/src", "dst")));
         Assert.Equal("logs --follow abc", string.Join(' ', runtime.BuildLogsArguments("abc")));
+        Assert.Equal("ls -q", string.Join(' ', runtime.BuildProbeArguments()));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerDefinitionTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerDefinitionTests.cs
@@ -190,7 +190,7 @@ public sealed class ContainerDefinitionTests
 
         public ContainerState State { get; set; } = ContainerState.Created;
 
-        public override bool IsSupported() => true;
+        public override Task<bool> IsSupportedAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
 
         internal override Task<string> EnsureCreatedAsync(ContainerDefinition definition, CancellationToken cancellationToken)
         {

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -5,8 +5,8 @@ using Meziantou.Xunit;
 
 namespace Meziantou.Framework.TemporaryContainers.Tests;
 
-/// <summary>Integration tests shared by every runtime. One concrete subclass per runtime supplies the runtime to exercise; the whole class is skipped when that runtime is not installed.</summary>
-public abstract class ContainerRuntimeTestsBase
+/// <summary>Integration tests shared by every runtime. One concrete subclass per runtime supplies the runtime to exercise; the whole class is skipped when that runtime is not available.</summary>
+public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
 {
     private const string LinuxImage = "busybox:1.37";
     private const string WindowsImage = "mcr.microsoft.com/windows/servercore:ltsc2022";
@@ -17,7 +17,7 @@ public abstract class ContainerRuntimeTestsBase
     private const string LinuxHttpServerCommand = "mkdir -p /www; printf 'hello from container' > /www/index.html; echo SERVER READY; exec httpd -f -p 8080 -h /www";
     private const string WindowsHttpServerCommand = "$content='hello from container'; New-Item -ItemType Directory -Path C:/www -Force | Out-Null; Set-Content -Path C:/www/index.html -Value $content -NoNewline; $listener=[System.Net.HttpListener]::new(); $listener.Prefixes.Add('http://+:8080/'); $listener.Start(); Write-Output 'SERVER READY'; while ($true) { $context=$listener.GetContext(); $bytes=[System.Text.Encoding]::UTF8.GetBytes($content); $context.Response.ContentLength64=$bytes.Length; $context.Response.OutputStream.Write($bytes, 0, $bytes.Length); $context.Response.OutputStream.Close(); }";
 
-    private readonly bool _useWindowsContainerImages;
+    private bool _useWindowsContainerImages;
 
     private bool UseWindowsContainerImages => _useWindowsContainerImages;
 
@@ -32,12 +32,19 @@ public abstract class ContainerRuntimeTestsBase
     protected ContainerRuntimeTestsBase(ContainerRuntime runtime)
     {
         Runtime = runtime;
-        _useWindowsContainerImages = DetectUseWindowsContainerImages(runtime);
-
-        global::Xunit.Assert.SkipUnless(runtime.IsSupported(), $"The '{runtime}' container runtime is not available on this system.");
     }
 
     protected ContainerRuntime Runtime { get; }
+
+    /// <summary>Checking that the runtime answers is asynchronous, so the skip gate cannot live in the constructor.</summary>
+    public async ValueTask InitializeAsync()
+    {
+        global::Xunit.Assert.SkipUnless(await Runtime.IsSupportedAsync(XunitCancellationToken), $"The '{Runtime}' container runtime is not available on this system.");
+
+        _useWindowsContainerImages = DetectUseWindowsContainerImages(Runtime);
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static bool DetectUseWindowsContainerImages(ContainerRuntime runtime)
     {

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRuntimeAdapterTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRuntimeAdapterTests.cs
@@ -58,14 +58,15 @@ public sealed class DockerRuntimeAdapterTests
         Assert.Equal("cp src abc:/dst", string.Join(' ', runtime.BuildCopyToContainerArguments("abc", "src", "/dst")));
         Assert.Equal("cp abc:/src dst", string.Join(' ', runtime.BuildCopyFromContainerArguments("abc", "/src", "dst")));
         Assert.Contains("--timestamps", runtime.BuildLogsArguments("abc"));
+        Assert.Equal("version", string.Join(' ', runtime.BuildProbeArguments()));
     }
 
     [Fact]
     public void PodmanUsesDockerDialect()
     {
-        var runtime = ContainerRuntime.Podman;
+        var runtime = Assert.IsAssignableTo<DockerContainerRuntime>(ContainerRuntime.Podman);
 
-        Assert.IsAssignableTo<DockerContainerRuntime>(runtime);
+        Assert.Equal("version", string.Join(' ', runtime.BuildProbeArguments()));
     }
 
     [Fact]
@@ -73,7 +74,67 @@ public sealed class DockerRuntimeAdapterTests
     {
         var runtime = Assert.IsAssignableTo<DockerContainerRuntime>(ContainerRuntime.Wslc);
 
-        Assert.IsAssignableTo<DockerContainerRuntime>(runtime);
+        Assert.Equal("list -q", string.Join(' ', runtime.BuildProbeArguments()));
+    }
+
+    [Fact]
+    public async Task IsSupportedAsync_ReturnsTrueWhenTheProbeCommandSucceeds()
+    {
+        var executable = CreateStubCli(exitCode: 0);
+        try
+        {
+            var runtime = new DockerContainerRuntime(nameof(ContainerRuntime.Docker), DockerContainerRuntime.Flavor.Docker, executable);
+
+            Assert.True(await runtime.IsSupportedAsync(XunitCancellationToken));
+        }
+        finally
+        {
+            File.Delete(executable);
+        }
+    }
+
+    [Fact]
+    public async Task IsSupportedAsync_ReturnsFalseWhenTheProbeCommandFails()
+    {
+        // The daemon is not reachable: the CLI is there, but every command it runs fails.
+        var executable = CreateStubCli(exitCode: 1);
+        try
+        {
+            var runtime = new DockerContainerRuntime(nameof(ContainerRuntime.Docker), DockerContainerRuntime.Flavor.Docker, executable);
+
+            Assert.False(await runtime.IsSupportedAsync(XunitCancellationToken));
+        }
+        finally
+        {
+            File.Delete(executable);
+        }
+    }
+
+    [Fact]
+    public async Task IsSupportedAsync_ReturnsFalseWhenTheExecutableCannotBeStarted()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "MezTC-missing-" + Guid.NewGuid().ToString("N"));
+        var runtime = new DockerContainerRuntime(nameof(ContainerRuntime.Docker), DockerContainerRuntime.Flavor.Docker, missing);
+
+        Assert.False(await runtime.IsSupportedAsync(XunitCancellationToken));
+    }
+
+    [Fact]
+    public async Task IsSupportedAsync_CachesTheSuccessfulProbe()
+    {
+        var executable = CreateStubCli(exitCode: 0);
+        var runtime = new DockerContainerRuntime(nameof(ContainerRuntime.Docker), DockerContainerRuntime.Flavor.Docker, executable);
+        try
+        {
+            Assert.True(await runtime.IsSupportedAsync(XunitCancellationToken));
+        }
+        finally
+        {
+            File.Delete(executable);
+        }
+
+        // The CLI is gone, so a second probe would fail: the runtime must answer from what it already knows.
+        Assert.True(await runtime.IsSupportedAsync(XunitCancellationToken));
     }
 
     [Fact]
@@ -149,5 +210,24 @@ public sealed class DockerRuntimeAdapterTests
         var container = runtime.ParseInspect(inspectOutput);
 
         Assert.Equal(unchecked((int)3221225786u), container.ExitCode);
+    }
+
+    /// <summary>Writes a CLI that exits with <paramref name="exitCode"/> whatever it is asked to do, so the outcome of the probe can be forced.</summary>
+    private static string CreateStubCli(int exitCode)
+    {
+        var path = Path.Combine(Path.GetTempPath(), "MezTC-stub-" + Guid.NewGuid().ToString("N"));
+        if (OperatingSystem.IsWindows())
+        {
+            path += ".cmd";
+            File.WriteAllText(path, $"@exit /b {exitCode}\r\n");
+        }
+        else
+        {
+            path += ".sh";
+            File.WriteAllText(path, $"#!/bin/sh\nexit {exitCode}\n");
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        return path;
     }
 }


### PR DESCRIPTION
Fixes #2041.

## What changed

`ExecutableContainerRuntime.IsSupported()` reported a runtime as supported as soon as the CLI was found on the `PATH`. On the GitHub Actions `windows-2025` image, `docker.EXE` is installed but no engine runs, so the skip gate in `ContainerRuntimeTestsBase` never fired and the tests ran against a dead daemon.

The runtime is now probed with a cheap command that only succeeds when the daemon answers:

| Runtime | Probe | Why |
| --- | --- | --- |
| `docker`, `podman` | `version` | Exits 1 with the exact connection error from the issue when the engine is down |
| `wslc` | `list -q` | `wslc` serves its version through `--version`, so it cannot tell a stopped daemon apart |
| Apple `container` | `ls -q` | `container --version` is answered by the CLI itself, so the probe has to reach the API server |

Only a success is cached, so a daemon started after a failed probe is still detected. This is option 1 of the issue: it matches the documented "available **and operational**" and what `DockerApiRuntime` already did with its `/version` ping.

## Breaking change: the check is now asynchronous

Checking that a daemon answers is I/O, so blocking on it was wrong:

```diff
-public virtual bool IsSupported()
+public virtual Task<bool> IsSupportedAsync(CancellationToken cancellationToken = default)
```

`ref/Meziantou.Framework.TemporaryContainers.cs` is regenerated. Nothing else in the repository consumed the old member.

This also removed the pre-existing sync-over-async in `DockerApiRuntime`, which blocked on `HttpClient` (`GetAwaiter().GetResult()`) and used `ReadAsStream` to find its endpoint.

## Notes for the reviewer

- **No `SemaphoreSlim` around the probes.** CA1001 fires on these process-lifetime singletons, and making `ContainerRuntime` disposable is the wrong public shape. Success is cached and `Interlocked.CompareExchange` publishes the winner (the Docker API loser disposes the client it built). The cost is at most a duplicate probe under a race, where the previous code used a single-flight lock.
- **`DockerApiRuntime` now publishes its client and API version as one `DockerApiConnection`.** Previously `_httpClient` was assigned before `_apiVersion`, so a reader on the fast path could see a client without a version. Endpoints are built from the connection the caller already awaited.
- **`TemporaryContainer.Runtime` no longer validates**, because a property cannot await. The check moved into `EnsureCreatedAsync`, so an unavailable runtime throws from the first async operation rather than from the property getter. Every path that touches the runtime goes through `Id`/`EnsureCreatedAsync` first, so nothing reaches an unchecked runtime.
- **`AutoContainerRuntime`'s three members that cannot await** (`SupportsPause`, `SupportsRestart`, `ResolvePortMap`) read the runtime resolved by the operation that necessarily preceded them.
- Cancellation: the probe timeout is a CTS linked to the caller's token, so a timeout yields `false` while a caller cancellation propagates as `OperationCanceledException`.

## Tests

The skip gate moved from the constructor to `IAsyncLifetime.InitializeAsync`; xunit still honours dynamic skip from there (`PodmanContainerTests` and `WslcContainerTests` report as skipped, not failed). Four new facts drive a stub CLI with a forced exit code: exit 0 → supported, exit 1 → not supported, missing executable → not supported, and the success cache.

Verified on macOS arm64 with `/p:TreatWarningsAsErrors=true`, plus `dotnet run ./eng/update-all.cs` (no changes): full suite `total: 200 / failed: 9 / skipped: 38`, with `DockerContainerTests` 10/10 and `AppleContainerContainerTests` 10/10 on both target frameworks. The 9 failures are the pre-existing local environment ones (the mongo image's readiness line under the Apple runtime, the mssql image having no arm64 variant, postgres flaking on one TFM) and are unchanged by this PR.

Not verifiable on this machine: the Windows `.cmd` stub path in the new test, and `wslc list -q` against a real `wslc`.
