### PR TITLE
Ship the highlight.js third-party notice in the SyntaxHighlighting package

### DIFF
--- a/src/Meziantou.Framework.SyntaxHighlighting/Meziantou.Framework.SyntaxHighlighting.csproj
+++ b/src/Meziantou.Framework.SyntaxHighlighting/Meziantou.Framework.SyntaxHighlighting.csproj
@@ -6,4 +6,9 @@
     <Version>1.0.1</Version>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- BSD-3-Clause requires binary redistributions to reproduce the highlight.js notice -->
+    <None Include="THIRD_PARTY_NOTICES.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
 </Project>

--- a/src/Meziantou.Framework.SyntaxHighlighting/THIRD_PARTY_NOTICES.md
+++ b/src/Meziantou.Framework.SyntaxHighlighting/THIRD_PARTY_NOTICES.md
@@ -5,7 +5,7 @@ components. Each component is used under its own license.
 
 ## highlight.js
 
-The engine in `Highlighter/Engine/` and the grammars in `Highlighter/Languages/`
+The engine in `Engine/` and the grammars in `Languages/`
 are derived from highlight.js (https://highlightjs.org/), v11.10.0.
 
 highlight.js is distributed under the BSD-3-Clause license, the full text of

--- a/src/Meziantou.Framework.SyntaxHighlighting/readme.md
+++ b/src/Meziantou.Framework.SyntaxHighlighting/readme.md
@@ -76,3 +76,10 @@ The package currently supports these language identifiers and common aliases:
 - `x86asm`
 - `xml`, `xsd`, `xsl`, `plist`, `rss`, `atom`, `svg`
 - `yaml`, `yml`
+
+## Third-party code
+
+The engine and the language grammars are derived from
+[highlight.js](https://highlightjs.org/) v11.10.0, which is distributed under the
+BSD-3-Clause license. The full notice is in `THIRD_PARTY_NOTICES.md`, included in
+the NuGet package.


### PR DESCRIPTION
## Problem

`Meziantou.Framework.SyntaxHighlighting` is derived from [highlight.js](https://highlightjs.org/) v11.10.0 (BSD-3-Clause), and the repository correctly maintains `THIRD_PARTY_NOTICES.md` — but **that file never reaches consumers**. Packing v1.0.1 produces:

```
LICENSE.txt
README.md
icon.png
lib/net10.0/Meziantou.Framework.SyntaxHighlighting.dll
lib/net11.0/Meziantou.Framework.SyntaxHighlighting.dll
```

BSD-3-Clause requires binary redistributions to reproduce the copyright notice and license text "in the documentation and/or other materials provided with the distribution". A NuGet package is a binary redistribution, so the notice needs to be in it.

Two smaller problems in the same file: it points at `Highlighter/Engine/` and `Highlighter/Languages/`, but the actual directories are `Engine/` and `Languages/`.

## Changes

- Pack `THIRD_PARTY_NOTICES.md` into the package root.
- Correct the two stale directory paths inside the notice.
- Add a short "Third-party code" section to `readme.md` so the attribution is visible on nuget.org.

No code changes.

## Verification

Packed the project and listed the result — the notice is now included:

```
LICENSE.txt
README.md
THIRD_PARTY_NOTICES.md          <-- added
lib/net10.0/Meziantou.Framework.SyntaxHighlighting.dll
lib/net11.0/Meziantou.Framework.SyntaxHighlighting.dll
```

`dotnet run ./eng/update-all.cs` produces no further changes. Build is clean with `-p:TreatWarningsAsErrors=true`; all 4237 tests pass.

## Note

Other ported projects in this repository may have the same gap — worth a sweep.

---
Found during a review of `src/Meziantou.Framework.SyntaxHighlighting`.
