### PR TITLE
Send the journal deletion request to FSCTL_DELETE_USN_JOURNAL

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
@@ -173,19 +173,30 @@ public sealed class ChangeJournal : IDisposable
     public void Dispose() => ChangeJournalHandle.Dispose();
 
     /// <summary>Deletes the change journal and waits for the deletion to complete.</summary>
+    /// <remarks>Deleting a change journal requires a scan of every file on the volume, so it can take a long time and continues across system restarts.</remarks>
+    /// <exception cref="Win32Exception">Thrown when the operation fails.</exception>
     public void Delete() => Delete(waitForCompletion: true);
 
     /// <summary>Deletes the change journal.</summary>
-    /// <param name="waitForCompletion">If <see langword="true"/>, waits for the deletion to complete; otherwise, deletes asynchronously.</param>
+    /// <param name="waitForCompletion">If <see langword="true"/>, waits for the deletion to complete; otherwise, starts the deletion and returns immediately.</param>
+    /// <remarks>
+    /// Deleting a change journal requires a scan of every file on the volume, so it can take a long time and continues across system restarts.
+    /// While the deletion is in progress, any attempt to create, modify, delete, or query the change journal fails with <c>ERROR_JOURNAL_DELETE_IN_PROGRESS</c>.
+    /// </remarks>
+    /// <exception cref="Win32Exception">Thrown when the operation fails.</exception>
     public void Delete(bool waitForCompletion)
     {
+        // USN_DELETE_FLAG_DELETE requests the deletion. USN_DELETE_FLAG_NOTIFY on its own does not delete anything:
+        // it only waits for a deletion that may already be in progress, so both flags are needed to delete and wait.
         var deletionData = new DELETE_USN_JOURNAL_DATA
         {
             UsnJournalID = Data.ID,
-            DeleteFlags = waitForCompletion ? USN_DELETE_FLAGS.USN_DELETE_FLAG_NOTIFY : USN_DELETE_FLAGS.USN_DELETE_FLAG_DELETE,
+            DeleteFlags = waitForCompletion
+                ? USN_DELETE_FLAGS.USN_DELETE_FLAG_DELETE | USN_DELETE_FLAGS.USN_DELETE_FLAG_NOTIFY
+                : USN_DELETE_FLAGS.USN_DELETE_FLAG_DELETE,
         };
 
-        Win32DeviceControl.ControlWithInput(ChangeJournalHandle, Win32ControlCode.CreateUsnJournal, ref deletionData, initialBufferLength: 0);
+        Win32DeviceControl.ControlWithInput(ChangeJournalHandle, Win32ControlCode.DeleteUsnJournal, ref deletionData, initialBufferLength: 0);
         RefreshJournalData();
     }
 


### PR DESCRIPTION
## The defect

`ChangeJournal.Delete()` has never deleted a change journal. Two separate bugs stack up in the same method.

**1. Wrong control code** — `ChangeJournal.cs:188` built a `DELETE_USN_JOURNAL_DATA` and passed it to `Win32ControlCode.CreateUsnJournal` (`0x000900E7`) instead of `Win32ControlCode.DeleteUsnJournal` (`0x000900F8`). The correct constant already existed, unused, in `Natives/Win32ControlCode.cs`.

The two structures are layout-compatible by accident, so the driver does not reject the call:

| | `DELETE_USN_JOURNAL_DATA` | `CREATE_USN_JOURNAL_DATA` |
|---|---|---|
| bytes 0-7 | `UsnJournalID` | `MaximumSize` |
| bytes 8-15 | `DeleteFlags` + padding | `AllocationDelta` |

Both marshal to 16 bytes. `FSCTL_CREATE_USN_JOURNAL` on an existing journal *modifies* it, so the call reads the journal's own ID as a requested `MaximumSize` and the delete flags (1 or 2) as an `AllocationDelta`. At best it fails with `ERROR_INVALID_PARAMETER`; at worst it resizes the volume's journal to a garbage maximum derived from its own ID. It never deletes.

**2. Inverted flags** — `ChangeJournal.cs:185` mapped `waitForCompletion: true` to `USN_DELETE_FLAG_NOTIFY` alone. Per the [`DELETE_USN_JOURNAL_DATA` docs](https://learn.microsoft.com/windows/win32/api/winioctl/ns-winioctl-delete_usn_journal_data), `NOTIFY` without `DELETE` does not request deletion at all — it subscribes to notification of a deletion another process may already have started, and `UsnJournalID` is ignored entirely. So the parameterless `Delete()`, which defaults to `waitForCompletion: true`, would still delete nothing even after the control code was corrected.

`Delete(waitForCompletion: false)` mapped to `USN_DELETE_FLAG_DELETE` alone, which is correct — that variant starts the deletion and returns immediately.

Both bugs date to `4201432c3` (2018) and survived because nothing tests this method.

## What changed

- The IOCTL is now `Win32ControlCode.DeleteUsnJournal`.
- `waitForCompletion: true` now sends `USN_DELETE_FLAG_DELETE | USN_DELETE_FLAG_NOTIFY` — the documented way to start a deletion and block until it finishes on a synchronous handle. `false` keeps sending `USN_DELETE_FLAG_DELETE` alone.
- Documented that deletion scans every file on the volume, persists across restarts, and makes concurrent journal operations fail with `ERROR_JOURNAL_DELETE_IN_PROGRESS`.

Both changes are in one PR deliberately: fixing only the control code would leave `Delete()` still silently doing nothing, because the `NOTIFY`-only flag does not request deletion either.

## Verification

Compiles clean for `net10.0` and `net11.0` with `-p:TreatWarningsAsErrors=true`.

**This has not been executed against a real NTFS volume.** It was written on macOS, where every journal test skips. The change is doc-backed and the control-code substitution is unambiguous, but nobody has yet watched it delete a journal — please run it on Windows before merging.

There is still no test covering `Delete`. Doing it safely needs a VHD-mounted NTFS fixture, since a test that deletes the journal on a CI agent's system volume triggers a full volume scan that persists across reboots. That is tracked separately and is the reason this bug lived for eight years.
