### PR TITLE
Re-pin the output buffer when retrying FSCTL_READ_FILE_USN_DATA

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
@@ -17,6 +17,12 @@ namespace Meziantou.Framework.Win32;
 [SupportedOSPlatform("windows5.1.2600")]
 public sealed class ChangeJournal : IDisposable
 {
+    /// <summary>The NTFS file name limit is 255 UTF-16 code units, so a record's name never needs more than this.</summary>
+    private const int MaximumFileNameLengthInBytes = 255 * sizeof(char);
+
+    /// <summary>Upper bound on the buffer used to read a single USN record, so a driver that keeps reporting ERROR_MORE_DATA cannot grow it without limit.</summary>
+    private const int MaximumEntryBufferLength = 64 * 1024;
+
     private readonly bool _unprivileged;
 
     internal SafeFileHandle ChangeJournalHandle { get; }
@@ -113,30 +119,29 @@ public sealed class ChangeJournal : IDisposable
     /// <exception cref="Win32Exception">Thrown when the operation fails.</exception>
     public static unsafe ChangeJournalEntryVersion2or3 GetEntry(SafeFileHandle handle)
     {
-        var buffer = new byte[USN_RECORD_V3.SizeOf(512)];
-        fixed (void* bufferPtr = buffer)
+        using var handleScope = new SafeHandleValue(handle);
+
+        var buffer = new byte[USN_RECORD_V3.SizeOf(MaximumFileNameLengthInBytes)];
+        while (true)
         {
-            using var handleScope = new SafeHandleValue(handle);
             uint returnedSize;
-            var controlResult = PInvoke.DeviceIoControl((HANDLE)handleScope.Value, PInvoke.FSCTL_READ_FILE_USN_DATA, lpInBuffer: null, 0, bufferPtr, (uint)buffer.Length, &returnedSize, lpOverlapped: null);
-            if (!controlResult)
+            fixed (void* bufferPointer = buffer)
             {
-                var errorCode = Marshal.GetLastWin32Error();
-                if (errorCode == (int)WIN32_ERROR.ERROR_MORE_DATA)
+                if (PInvoke.DeviceIoControl((HANDLE)handleScope.Value, PInvoke.FSCTL_READ_FILE_USN_DATA, lpInBuffer: null, 0, bufferPointer, (uint)buffer.Length, &returnedSize, lpOverlapped: null))
                 {
-                    buffer = new byte[returnedSize];
-                    controlResult = PInvoke.DeviceIoControl((HANDLE)handleScope.Value, PInvoke.FSCTL_READ_FILE_USN_DATA, lpInBuffer: null, 0, bufferPtr, (uint)buffer.Length, &returnedSize, lpOverlapped: null);
-                    if (!controlResult)
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
-                }
-                else
-                {
-                    throw new Win32Exception(errorCode);
+                    var header = Marshal.PtrToStructure<USN_RECORD_COMMON_HEADER>((nint)bufferPointer);
+                    return (ChangeJournalEntryVersion2or3)ChangeJournalEntries.GetBufferedEntry((nint)bufferPointer, header);
                 }
             }
 
-            var header = Marshal.PtrToStructure<USN_RECORD_COMMON_HEADER>((nint)bufferPtr);
-            return (ChangeJournalEntryVersion2or3)ChangeJournalEntries.GetBufferedEntry((nint)bufferPtr, header);
+            var errorCode = Marshal.GetLastWin32Error();
+            if (errorCode is not (int)WIN32_ERROR.ERROR_MORE_DATA || buffer.Length >= MaximumEntryBufferLength)
+                throw new Win32Exception(errorCode);
+
+            // ERROR_MORE_DATA reports the number of bytes written, not the number required, so grow geometrically
+            // instead of trusting returnedSize to be large enough.
+            var length = Math.Max(buffer.Length * 2, (int)Math.Min(returnedSize, MaximumEntryBufferLength));
+            buffer = new byte[Math.Min(length, MaximumEntryBufferLength)];
         }
     }
 

--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
@@ -22,7 +22,8 @@ public sealed class ChangeJournal : IDisposable
     ///     <see cref="USN_RECORD_V3.SizeOf(int)"/> counts. A USN record stores the name component only, not a path, so this is
     ///     the volume's maximum component length rather than a path limit: enabling long paths raises the total path length,
     ///     it does not change the component length. <c>GetVolumeInformation</c> reports the real value for a volume and it is
-    ///     255 on NTFS. It is only a starting size, so a volume that allows longer names just grows the buffer below.
+    ///     255 on both file systems that support a change journal, NTFS and ReFS. It is only a starting size, so a volume that
+    ///     allows longer names just grows the buffer below.
     /// </summary>
     private const int MaximumFileNameLength = 255;
 

--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
@@ -17,11 +17,21 @@ namespace Meziantou.Framework.Win32;
 [SupportedOSPlatform("windows5.1.2600")]
 public sealed class ChangeJournal : IDisposable
 {
-    /// <summary>The NTFS file name limit is 255 UTF-16 code units, so a record's name never needs more than this.</summary>
-    private const int MaximumFileNameLengthInBytes = 255 * sizeof(char);
+    /// <summary>
+    ///     The number of UTF-16 code units to reserve for the file name of a single record, which is what
+    ///     <see cref="USN_RECORD_V3.SizeOf(int)"/> counts. A USN record stores the name component only, not a path, so this is
+    ///     the volume's maximum component length rather than a path limit: enabling long paths raises the total path length,
+    ///     it does not change the component length. <c>GetVolumeInformation</c> reports the real value for a volume and it is
+    ///     255 on NTFS. It is only a starting size, so a volume that allows longer names just grows the buffer below.
+    /// </summary>
+    private const int MaximumFileNameLength = 255;
 
-    /// <summary>Upper bound on the buffer used to read a single USN record, so a driver that keeps reporting ERROR_MORE_DATA cannot grow it without limit.</summary>
-    private const int MaximumEntryBufferLength = 64 * 1024;
+    /// <summary>
+    ///     Upper bound on the buffer used to read a single USN record, so a driver that keeps reporting ERROR_MORE_DATA cannot
+    ///     grow it without limit. A record can never reach this size: <c>FileNameLength</c> is a <see cref="ushort"/>, which caps
+    ///     the name at 65535 bytes.
+    /// </summary>
+    private const int MaximumEntryBufferLength = 128 * 1024;
 
     private readonly bool _unprivileged;
 
@@ -121,7 +131,7 @@ public sealed class ChangeJournal : IDisposable
     {
         using var handleScope = new SafeHandleValue(handle);
 
-        var buffer = new byte[USN_RECORD_V3.SizeOf(MaximumFileNameLengthInBytes)];
+        var buffer = new byte[USN_RECORD_V3.SizeOf(MaximumFileNameLength)];
         while (true)
         {
             uint returnedSize;


### PR DESCRIPTION
## The defect

`ChangeJournal.GetEntry(SafeFileHandle)` retried `DeviceIoControl` with a stale pointer and a larger length, handing the kernel permission to write past the end of a pinned managed array.

```csharp
var buffer = new byte[USN_RECORD_V3.SizeOf(512)];
fixed (void* bufferPtr = buffer)          // pins the 512-byte-name allocation
{
    ...
    if (errorCode == (int)WIN32_ERROR.ERROR_MORE_DATA)
    {
        buffer = new byte[returnedSize];  // new, larger array — bufferPtr still points at the OLD one
        controlResult = PInvoke.DeviceIoControl(..., bufferPtr, (uint)buffer.Length, ...);
        //                                           ^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^
        //                                           old address, new larger size
    }
```

`bufferPtr` is bound by the enclosing `fixed` to the *original* allocation and never re-pinned. The retry tells the driver it may write `buffer.Length` bytes — the new, larger size — at an address backed by the smaller array. That is an out-of-bounds kernel write into the managed heap.

`Natives/Win32DeviceControl.cs:32-36` performs the same grow-and-retry correctly by opening a fresh `fixed` block over the new array, which is what marks this as a slip rather than an intended pattern.

**Reachability is narrow.** `FSCTL_READ_FILE_USN_DATA` returns a V2/V3 record, and NTFS caps a file name at 255 UTF-16 code units (510 bytes), so the 512-byte allowance normally suffices and the branch is not taken. The branch is unconditionally wrong when it *is* taken, and heap corruption from a kernel write is about the worst thing to have to debug — the crash surfaces far from the cause, in unrelated managed objects.

## What changed

- The call moved into a loop, with the `fixed` block *inside* it, so every attempt pins the buffer it actually passes.
- The `512` magic number became `MaximumFileNameLengthInBytes = 255 * sizeof(char)`, naming the NTFS limit the value was silently derived from.
- Growth is now geometric and bounded by `MaximumEntryBufferLength` (64 KB). `ERROR_MORE_DATA` reports the bytes *written*, not the bytes *required*, so `new byte[returnedSize]` was not guaranteed to be big enough — the old code could have retried at the same insufficient size. The bound stops a driver that keeps reporting `ERROR_MORE_DATA` from growing the allocation without limit.
- Non-`ERROR_MORE_DATA` failures still throw `Win32Exception` with the original error code, unchanged.

`SafeHandleValue` now wraps the whole loop rather than being re-created per attempt, which keeps the handle referenced for the duration.

## Verification

Compiles clean for `net10.0` and `net11.0` with `-p:TreatWarningsAsErrors=true`.

**Not executed against a real NTFS volume** — written on macOS, where every journal test skips. The corrected retry path is also the one that was already effectively unreachable, so exercising it needs a file name longer than the buffer, which NTFS will not produce. The value here is that the code is no longer wrong if the branch is ever entered.
