### PR TITLE
Validate HighlightOptions.ClassPrefix as a CSS identifier

### DIFF
--- a/src/Meziantou.Framework.SyntaxHighlighting/HighlightOptions.cs
+++ b/src/Meziantou.Framework.SyntaxHighlighting/HighlightOptions.cs
@@ -1,8 +1,37 @@
+using System.Buffers;
+
 namespace Meziantou.Framework.SyntaxHighlighting;
 
 public sealed class HighlightOptions
 {
-    public string ClassPrefix { get; init; } = "hljs-";
+    private static readonly SearchValues<char> ValidClassPrefixChars =
+        SearchValues.Create("-_0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
+    private readonly string _classPrefix = "hljs-";
+
+    /// <summary>
+    /// The prefix prepended to every generated CSS class name. The value is written directly
+    /// into the <c>class</c> attribute of the generated markup, so it is restricted to
+    /// characters that are valid in a CSS identifier: letters, digits, <c>-</c> and <c>_</c>.
+    /// It cannot start with a digit.
+    /// </summary>
+    /// <exception cref="ArgumentException">The value contains a character that is not valid in a CSS identifier, or it starts with a digit.</exception>
+    public string ClassPrefix
+    {
+        get => _classPrefix;
+        init
+        {
+            ArgumentNullException.ThrowIfNull(value);
+
+            if (value.AsSpan().ContainsAnyExcept(ValidClassPrefixChars))
+                throw new ArgumentException($"'{value}' is not a valid CSS class prefix: only letters, digits, '-' and '_' are allowed.", nameof(value));
+
+            if (value.Length > 0 && char.IsAsciiDigit(value[0]))
+                throw new ArgumentException($"'{value}' is not a valid CSS class prefix: it cannot start with a digit.", nameof(value));
+
+            _classPrefix = value;
+        }
+    }
 
     internal static HighlightOptions Default { get; } = new();
 }

--- a/tests/Meziantou.Framework.SyntaxHighlighting.Tests/HighlightOptionsTests.cs
+++ b/tests/Meziantou.Framework.SyntaxHighlighting.Tests/HighlightOptionsTests.cs
@@ -1,0 +1,35 @@
+namespace Meziantou.Framework.SyntaxHighlighting.Tests;
+
+public class HighlightOptionsTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("hljs-")]
+    [InlineData("syntax-")]
+    [InlineData("_private")]
+    [InlineData("a0-b_c")]
+    public void ClassPrefix_ValidValue_IsAccepted(string prefix)
+    {
+        var options = new HighlightOptions { ClassPrefix = prefix };
+
+        Assert.Equal(prefix, options.ClassPrefix);
+    }
+
+    [Theory]
+    [InlineData("\"><script>alert(1)</script><span class=\"")]
+    [InlineData("a b")]
+    [InlineData("a.b")]
+    [InlineData("a<b")]
+    [InlineData("a\"b")]
+    [InlineData("1abc")]
+    public void ClassPrefix_InvalidValue_Throws(string prefix)
+    {
+        Assert.Throws<ArgumentException>(() => new HighlightOptions { ClassPrefix = prefix });
+    }
+
+    [Fact]
+    public void ClassPrefix_Null_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new HighlightOptions { ClassPrefix = null! });
+    }
+}


### PR DESCRIPTION
## Problem

`HighlightOptions.ClassPrefix` is concatenated straight into the generated `class` attribute (`Engine/HtmlEmitter.cs:41`, via `ScopeToCssClass` at `:72-86`) with no validation:

```csharp
SyntaxHighlighter.Highlight("public class C {}", "csharp",
    new HighlightOptions { ClassPrefix = "\"><script>alert(1)</script><span class=\"" });
```

```html
<span class=""><script>alert(1)</script><span class="keyword">public</span> …
```

The prefix is caller-supplied rather than attacker-supplied, so this is not an XSS hole on its own — it becomes one only if an application lets end users pick a theme prefix. The cost today is that the library's otherwise airtight escaping has one unguarded seam, and a typo (a stray quote or space) silently produces malformed HTML instead of an error.

Worth noting: escaping of the *highlighted text* is correct. I fuzzed 11,861 results across all 29 languages with hostile and random input and found zero cases where content escaped the emitter's tags. This PR closes the one remaining gap, which is on the configuration side.

## Changes

Validate in the `init` accessor and fail fast at configuration time rather than producing corrupt output at render time:

- `null` → `ArgumentNullException`
- any character outside `[A-Za-z0-9_-]` → `ArgumentException`
- a leading digit → `ArgumentException`

Validating is stricter than escaping and gives the caller a clear error. Empty string stays valid (it means "no prefix").

## Verification

12 new tests in `HighlighterTests.cs` covering accepted prefixes (including `""`, `hljs-`, `syntax-`), rejected ones (the injection payload above, plus space/dot/angle/quote/leading-digit), and `null`.

Build clean with `-p:TreatWarningsAsErrors=true`; 4249 tests pass (4237 existing + 12).

No public API shape change, so `ref/Meziantou.Framework.SyntaxHighlighting.cs` is unchanged.

## Compatibility

Technically breaking for anyone currently passing a prefix with unusual characters — but any such value was already producing broken markup.

---
Found during a review of `src/Meziantou.Framework.SyntaxHighlighting`.
