### PR TITLE
Make the read timeout mean what the documentation says

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
@@ -134,7 +134,7 @@ internal sealed class ChangeJournalEntries : IEnumerable<ChangeJournalEntry>
                 StartUsn = _currentUSN.Value,
                 ReasonMask = (uint)Options.ReasonFilter,
                 ReturnOnlyOnClose = Options.ReturnOnlyOnClose ? 1u : 0u,
-                Timeout = (ulong)Options.Timeout.TotalSeconds,
+                Timeout = Options.TimeoutInSeconds,
                 UsnJournalID = ChangeJournal.Data.ID,
                 MinMajorVersion = Options.MinimumMajorVersion,
                 MaxMajorVersion = Options.MaximumMajorVersion,

--- a/src/Meziantou.Framework.Win32.ChangeJournal/Meziantou.Framework.Win32.ChangeJournal.csproj
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/Meziantou.Framework.Win32.ChangeJournal.csproj
@@ -13,6 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Meziantou.Framework.Win32.ChangeJournal.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.298">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Meziantou.Framework.Win32.ChangeJournal/ReadChangeJournalOptions.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ReadChangeJournalOptions.cs
@@ -2,11 +2,30 @@ namespace Meziantou.Framework.Win32;
 
 internal sealed class ReadChangeJournalOptions(Usn? initialUSN, ChangeReason reasonFilter, bool returnOnlyOnClose, TimeSpan timeout, bool unprivileged)
 {
+    /// <summary>
+    /// The value passed to <c>FSCTL_READ_USN_JOURNAL</c> when the caller asks to wait indefinitely.
+    /// The control code has no dedicated "infinite" value, so the largest practical timeout is used instead.
+    /// </summary>
+    private const ulong InfiniteTimeoutInSeconds = uint.MaxValue;
+
     public Usn? InitialUSN { get; } = initialUSN;
     public ChangeReason ReasonFilter { get; } = reasonFilter;
     public bool ReturnOnlyOnClose { get; } = returnOnlyOnClose;
     public bool Unprivileged { get; } = unprivileged;
-    public TimeSpan Timeout { get; } = timeout < TimeSpan.Zero ? TimeSpan.Zero : timeout;
+    public TimeSpan Timeout { get; } = timeout;
     public ushort MinimumMajorVersion { get; set; } = 2;
     public ushort MaximumMajorVersion { get; set; } = 4;
+
+    /// <summary>
+    /// Gets <see cref="Timeout"/> in the form expected by <c>FSCTL_READ_USN_JOURNAL</c>, whose timeout is a whole number of seconds.
+    /// <see cref="TimeSpan.Zero"/> maps to <c>0</c>, meaning the read returns as soon as the journal is exhausted instead of waiting.
+    /// A negative value, such as <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>, waits indefinitely.
+    /// Any other value is rounded up to a whole second, so a sub-second timeout waits for one second rather than not waiting at all.
+    /// </summary>
+    public ulong TimeoutInSeconds => Timeout switch
+    {
+        { Ticks: 0 } => 0,
+        { Ticks: < 0 } => InfiniteTimeoutInSeconds,
+        var value => (ulong)Math.Max(1, Math.Ceiling(value.TotalSeconds)),
+    };
 }

--- a/src/Meziantou.Framework.Win32.ChangeJournal/readme.md
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/readme.md
@@ -10,9 +10,11 @@ var entry = ChangeJournal.GetEntry(@"D:\test.txt");
 
 ## Get all records
 
+Use `TimeSpan.Zero` to read the records that are already in the journal and stop at the end of it.
+
 ```c#
 using var changeJournal = ChangeJournal.Open(new DriveInfo("D:"), unprivileged: false);
-foreach (var change in changeJournal.GetEntries(ChangeReason.All, returnOnlyOnClose: false, Timeout.InfiniteTimeSpan))
+foreach (var change in changeJournal.GetEntries(ChangeReason.All, returnOnlyOnClose: false, TimeSpan.Zero))
 {
     if (change is ChangeJournalEntryVersion2or3 changev2)
     {
@@ -26,7 +28,19 @@ foreach (var change in changeJournal.GetEntries(ChangeReason.All, returnOnlyOnCl
 ## Get all records from a USN
 
 ```c#
-foreach (var change in changeJournal.GetEntries(entry.UniqueSequenceNumber, ChangeReason.All, returnOnlyOnClose: false, Timeout.InfiniteTimeSpan))
+foreach (var change in changeJournal.GetEntries(entry.UniqueSequenceNumber, ChangeReason.All, returnOnlyOnClose: false, TimeSpan.Zero))
+{
+}
+```
+
+## Monitor changes as they happen
+
+Pass a non-zero timeout to wait for new records instead of stopping at the end of the journal.
+`Timeout.InfiniteTimeSpan` waits indefinitely, so the loop below never completes on its own.
+The underlying control code counts in whole seconds, so a sub-second timeout is rounded up to one second.
+
+```c#
+foreach (var change in changeJournal.GetEntries(ChangeReason.All, returnOnlyOnClose: false, Timeout.InfiniteTimeSpan))
 {
 }
 ```

--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
@@ -84,6 +84,21 @@ public class ChangeJournalTests
         Assert.NotEqual(default, identifier);
     }
 
+    [Theory]
+    [InlineData(0, 0ul)]                    // do not wait, return at the end of the journal
+    [InlineData(-1, uint.MaxValue)]         // Timeout.InfiniteTimeSpan
+    [InlineData(-5000, uint.MaxValue)]      // any negative value waits indefinitely
+    [InlineData(1, 1ul)]                    // sub-second values round up instead of becoming "do not wait"
+    [InlineData(500, 1ul)]
+    [InlineData(1000, 1ul)]
+    [InlineData(1500, 2ul)]
+    [InlineData(30_000, 30ul)]
+    public void ReadOptions_ConvertsTimeoutToWholeSeconds(int milliseconds, ulong expected)
+    {
+        var options = new ReadChangeJournalOptions(initialUSN: null, ChangeReason.All, returnOnlyOnClose: false, TimeSpan.FromMilliseconds(milliseconds), unprivileged: false);
+        Assert.Equal(expected, options.TimeoutInSeconds);
+    }
+
     [Fact]
     public void FileIdentifier128ToString()
     {


### PR DESCRIPTION
## The defect

Following the readme produced the opposite of what it promised.

Both `GetEntries` examples in `readme.md` passed `Timeout.InfiniteTimeSpan`. That is `TimeSpan.FromMilliseconds(-1)` — a negative value. `ReadChangeJournalOptions` clamped every negative `TimeSpan` to `TimeSpan.Zero`:

```csharp
public TimeSpan Timeout { get; } = timeout < TimeSpan.Zero ? TimeSpan.Zero : timeout;
```

and `ChangeJournalEntries.Read` then converted with `(ulong)Options.Timeout.TotalSeconds`. For `FSCTL_READ_USN_JOURNAL`, a timeout of zero means **do not wait** — return as soon as the journal is exhausted. So a user writing a file-change monitor from the documented example got a loop that terminated immediately at the tail, with nothing in the API surface or the exception behavior to explain why.

The same conversion truncated any sub-second value: `TimeSpan.FromMilliseconds(500)` also became "do not wait", silently.

## What changed

The conversion moved into a single named place, `ReadChangeJournalOptions.TimeoutInSeconds`, with the three cases made explicit:

| Caller passes | Sent to the IOCTL | Meaning |
|---|---|---|
| `TimeSpan.Zero` | `0` | return at the end of the journal — unchanged |
| negative, incl. `Timeout.InfiniteTimeSpan` | `uint.MaxValue` | wait indefinitely |
| anything else | `Math.Ceiling(seconds)`, minimum `1` | wait, rounded up to the control code's one-second granularity |

`TimeSpan.Zero` deliberately still maps to `0`. It is what the existing tests pass and what "read the journal and stop" needs; changing it would make them hang.

**The readme needed fixing too, and not just for accuracy.** Now that infinite genuinely waits, the old "Get all records" example would never terminate. So:

- "Get all records" and "Get all records from a USN" now pass `TimeSpan.Zero`, which is what those examples always actually did.
- A new "Monitor changes as they happen" section covers `Timeout.InfiniteTimeSpan`, states plainly that the loop never completes on its own, and documents the one-second granularity.

## Verification

`dotnet test --framework net11.0 -p:TreatWarningsAsErrors=true` → **15 total, 10 passed, 5 skipped** (up from 2 passed; the 5 skips are the pre-existing Windows/Administrator journal tests).

The 8 new `ReadOptions_ConvertsTimeoutToWholeSeconds` cases are pure logic with no Win32 dependency, so unlike most of this review's fixes they **execute on macOS and genuinely verify the change** — including the `Timeout.InfiniteTimeSpan` and sub-second cases that were previously wrong.

Testing them required exposing internals to the test assembly, so this PR adds `<InternalsVisibleTo Include="Meziantou.Framework.Win32.ChangeJournal.Tests" />` — the same pattern already used by `Meziantou.Extensions.Logging.InMemory` and `Meziantou.Framework.SnapshotTesting`. No public API change; `ref/` is unaffected.

## Behavior change to be aware of

Anyone currently passing `Timeout.InfiniteTimeSpan` and relying on the accidental "returns immediately" behavior will now block. That is the documented intent of the value they passed, but it is a real behavior change and worth a line in the release notes.
