### PR TITLE
Clear the enumerator state in Reset

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
@@ -123,6 +123,11 @@ internal sealed class ChangeJournalEntries : IEnumerable<ChangeJournalEntry>
         {
             _currentUSN = Options.InitialUSN ?? Usn.Zero;
             _currentIndex = -1;
+
+            // Both must be cleared, otherwise MoveNext either stops immediately because the previous
+            // enumeration reached the end of the journal, or replays the last batch that was read.
+            _eof = false;
+            _entries.Clear();
         }
 
         private unsafe bool Read()


### PR DESCRIPTION
## The defect

`ChangeJournalEntriesEnumerator.Reset()` restored the USN and the index but left two pieces of state behind:

```csharp
public void Reset()
{
    _currentUSN = Options.InitialUSN ?? Usn.Zero;
    _currentIndex = -1;
}
```

Neither `_eof` nor `_entries` was cleared, which produces two different wrong outcomes depending on when `Reset()` is called:

- **After the enumeration finished.** `_eof` is still `true`, so the next `MoveNext()` returns `false` at the top of the method. The reset enumerator yields nothing at all.
- **Mid-enumeration.** `_entries` still holds the last batch read from the journal. `MoveNext()` advances `_currentIndex` to `0`, finds it in range, and returns the *previously read* records without re-issuing the IOCTL — so the caller silently gets a stale window replayed instead of an enumeration restarted from `InitialUSN`.

The second case is the worse one: it returns wrong data rather than throwing.

This is not reachable through `foreach`, which calls `GetEnumerator()` for a fresh instance each time — which is why it has gone unnoticed. It bites anything that holds the enumerator and resets it.

## What changed

`Reset()` now clears `_eof` and `_entries` as well, so the next `MoveNext()` re-reads from the journal starting at `InitialUSN`.

`Reset()` is also called from the constructor, where both are already at their initial values, so that path is unaffected.

I considered the alternative of throwing `NotSupportedException` instead — a legitimate choice, and more honest than a partial implementation. I went with fixing it because the method was clearly *meant* to work and the fix is two lines. Happy to switch if you would rather the type simply declared itself non-resettable.

## Verification

Compiles clean for `net10.0` and `net11.0` with `-p:TreatWarningsAsErrors=true`.

**No test.** Reaching `Reset()` needs a live `ChangeJournal` instance, which needs Windows and a real NTFS volume; this was written on macOS where those tests skip. The fix is a state-clearing change with no Win32 interaction, but it has not been executed.
