### PR TITLE
Validate the records returned by FSCTL_READ_USN_JOURNAL

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
@@ -144,35 +144,44 @@ internal sealed class ChangeJournalEntries : IEnumerable<ChangeJournalEntry>
 
             var controlCode = Options.Unprivileged ? Win32ControlCode.ReadUnprivilegedUsnJournal : Win32ControlCode.ReadUsnJournal;
             var entryData = Win32DeviceControl.ControlWithInput(handle, controlCode, ref readData, BufferSize);
+            _entries.Clear();
+
             if (entryData.Length > CurrentUSNLength) // There are more data than just data currentUSN.
             {
+                var headerLength = Marshal.SizeOf<USN_RECORD_COMMON_HEADER>();
                 fixed (byte* fixedBufferPointer = entryData)
                 {
                     var bufferPointer = (nint)fixedBufferPointer;
                     _currentUSN = Marshal.ReadInt64(bufferPointer);
 
                     // Enumerate entries
-                    _entries.Clear();
                     var offset = CurrentUSNLength; // Skip currentUSN field
                     while (offset < entryData.Length)
                     {
                         var entryPointer = bufferPointer + offset;
                         var header = Marshal.PtrToStructure<USN_RECORD_COMMON_HEADER>(entryPointer);
 
-                        var entry = GetBufferedEntry(entryPointer, header);
-                        offset += (int)header.RecordLength;
-                        _entries.Add(entry);
-                    }
+                        // A record must be large enough to hold its own header and must not extend past the data that
+                        // was returned. Without this check, a length of 0 loops forever and an oversized length makes
+                        // the next iteration read past the end of the buffer.
+                        if (header.RecordLength < headerLength || header.RecordLength > (uint)(entryData.Length - offset))
+                            throw new InvalidDataException($"The change journal returned a record of length {header.RecordLength} at offset {offset}, which does not fit in the {entryData.Length}-byte buffer");
 
-                    _currentIndex = 0;
-                    return true;
+                        _entries.Add(GetBufferedEntry(entryPointer, header));
+                        offset += (int)header.RecordLength;
+                    }
                 }
             }
-            else
+
+            // The buffer can hold the current USN without holding any record, in which case there is nothing to enumerate.
+            if (_entries.Count is 0)
             {
                 _eof = true;
                 return false;
             }
+
+            _currentIndex = 0;
+            return true;
         }
     }
 }


### PR DESCRIPTION
## The defects

Two problems in `ChangeJournalEntriesEnumerator.Read()`, fixed together because they sit in the same hunk — the record loop ends on one line and the `return true` is two lines later.

**1. The record loop trusted `RecordLength` without any bounds check.**

```csharp
while (offset < entryData.Length)
{
    var entryPointer = bufferPointer + offset;
    var header = Marshal.PtrToStructure<USN_RECORD_COMMON_HEADER>(entryPointer);

    var entry = GetBufferedEntry(entryPointer, header);
    offset += (int)header.RecordLength;   // never validated
    _entries.Add(entry);
}
```

A `RecordLength` of `0` leaves `offset` unchanged, so the loop spins forever, appending an unbounded number of entries to `_entries` until the process runs out of memory. A `RecordLength` that overruns the remaining buffer makes the *next* iteration read a header — and then a full `USN_RECORD_V2/V3/V4` and its file name — from past the end of the pinned array.

**2. `Read()` could return `true` having parsed nothing.**

The guard was `entryData.Length > CurrentUSNLength`, i.e. "more than the 8-byte USN prefix". If the driver returned between 9 bytes and one full record, the loop added no entries, `_currentIndex = 0` was set anyway, and `Read()` returned `true`. `MoveNext()` then reported success while `Current` threw `InvalidOperationException("You must call MoveNext before")` — a distinctly unhelpful message for a caller who had just done exactly that.

Neither is attacker-reachable: the data comes from the NTFS driver, so this is about not hanging or corrupting memory if it ever returns something unexpected. The guards cost two comparisons on a path that already does a `Marshal.PtrToStructure` per record.

## What changed

- Each record's `RecordLength` is validated before use: it must be at least the size of `USN_RECORD_COMMON_HEADER` and must not extend past the returned data. A violation throws `InvalidDataException` naming the length, the offset and the buffer size, instead of hanging or reading out of bounds.
- `_entries.Clear()` moved above the length check, and the return value is now derived from `_entries.Count`. An empty batch sets `_eof` and returns `false`, so `MoveNext()` never reports an element that `Current` cannot produce.

The behavior for well-formed input is unchanged — same records, same order, same `_currentUSN` handling.

## Verification

Compiles clean for `net10.0` and `net11.0` with `-p:TreatWarningsAsErrors=true`.

**Not executed.** Reaching this code needs a live journal on Windows, and reaching the *new* branches needs a driver returning malformed records, which cannot be produced from the public API. Testing it properly would mean extracting the parse loop behind a seam that takes a byte buffer — worth doing, but a larger refactor than this fix, and I did not want to bundle it in.
