### PR TITLE
Bound the file name and extents to the USN record length

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
@@ -34,23 +34,21 @@ internal sealed class ChangeJournalEntries : IEnumerable<ChangeJournalEntry>
         if (header is { MajorVersion: 2, MinorVersion: 0 })
         {
             var entry = Marshal.PtrToStructure<USN_RECORD_V2>(bufferPointer);
-            var filenamePointer = bufferPointer + entry.FileNameOffset;
-            var name = Marshal.PtrToStringAuto(filenamePointer, entry.FileNameLength / 2);
-            Debug.Assert(name is not null);
-            return new ChangeJournalEntryVersion2or3(entry, name);
+            return new ChangeJournalEntryVersion2or3(entry, GetFileName(bufferPointer, header, entry.FileNameOffset, entry.FileNameLength));
         }
         else if (header is { MajorVersion: 3, MinorVersion: 0 })
         {
             var entry = Marshal.PtrToStructure<USN_RECORD_V3>(bufferPointer);
-            var filenamePointer = bufferPointer + entry.FileNameOffset;
-            var name = Marshal.PtrToStringAuto(filenamePointer, entry.FileNameLength / 2);
-            Debug.Assert(name is not null);
-            return new ChangeJournalEntryVersion2or3(entry, name);
+            return new ChangeJournalEntryVersion2or3(entry, GetFileName(bufferPointer, header, entry.FileNameOffset, entry.FileNameLength));
         }
         else if (header is { MajorVersion: 4, MinorVersion: 0 })
         {
             var entry = Marshal.PtrToStructure<USN_RECORD_V4>(bufferPointer);
             var extendOffset = Marshal.OffsetOf<USN_RECORD_V4>(nameof(USN_RECORD_V4.Extents));
+
+            // The extents are stored inside the record, so they must not extend past the record's own length.
+            if (entry.ExtentSize < Marshal.SizeOf<USN_RECORD_EXTENT>() || (long)extendOffset + ((long)entry.NumberOfExtents * entry.ExtentSize) > header.RecordLength)
+                throw new InvalidDataException($"The change journal returned a record of length {header.RecordLength} holding {entry.NumberOfExtents} extents of {entry.ExtentSize} bytes at offset {extendOffset}");
 
             var extents = new ChangeJournalEntryExtent[entry.NumberOfExtents];
             for (var i = 0; i < entry.NumberOfExtents; i++)
@@ -66,6 +64,18 @@ internal sealed class ChangeJournalEntries : IEnumerable<ChangeJournalEntry>
         {
             throw new NotSupportedException($"Record version {header.MajorVersion}.{header.MinorVersion} is not supported");
         }
+    }
+
+    private static string GetFileName(IntPtr bufferPointer, USN_RECORD_COMMON_HEADER header, ushort fileNameOffset, ushort fileNameLength)
+    {
+        // The name is stored inside the record, so it must not extend past the record's own length.
+        if ((uint)fileNameOffset + fileNameLength > header.RecordLength)
+            throw new InvalidDataException($"The change journal returned a record of length {header.RecordLength} holding a file name of {fileNameLength} bytes at offset {fileNameOffset}");
+
+        // Names in a USN record are always UTF-16, which is what the length in bytes is converted with.
+        var name = Marshal.PtrToStringUni(bufferPointer + fileNameOffset, fileNameLength / sizeof(char));
+        Debug.Assert(name is not null);
+        return name;
     }
 
     private sealed class ChangeJournalEntriesEnumerator : IEnumerator<ChangeJournalEntry>


### PR DESCRIPTION
## The defects

`GetBufferedEntry` projects a variable-length `USN_RECORD_*` into a managed object using offsets and lengths taken from the record itself, none of which were checked against the record's own `RecordLength`.

**File name (V2 and V3).** `FileNameOffset` and `FileNameLength` were used directly:

```csharp
var filenamePointer = bufferPointer + entry.FileNameOffset;
var name = Marshal.PtrToStringAuto(filenamePointer, entry.FileNameLength / 2);
```

Nothing constrained the name to lie inside the record, so an out-of-range offset or length reads past it.

**Extents (V4).** Same shape, one multiplication further out:

```csharp
var extentPointer = bufferPointer + extendOffset + i * entry.ExtentSize;
```

`NumberOfExtents × ExtentSize` was never compared against `RecordLength`, and an `ExtentSize` of `0` would have made every iteration re-read the same extent.

**Encoding.** `Marshal.PtrToStringAuto` means "whatever the platform default is", while the very next expression — `FileNameLength / 2` — asserts the name is definitely UTF-16. It resolves to `PtrToStringUni` on Windows so the behavior was correct, but the call and the arithmetic disagreed about what they knew.

As with the sibling PR on the record loop, this data comes from the NTFS driver rather than an attacker. The point is that malformed input produces an exception instead of an out-of-bounds read.

## What changed

- The V2 and V3 branches now share a `GetFileName` helper that checks `FileNameOffset + FileNameLength` against `RecordLength` before reading, and throws `InvalidDataException` naming all three values if it does not fit. This also removes the duplicated four-line name-decoding block that the two branches had in common.
- The V4 branch validates `ExtentSize` against `sizeof(USN_RECORD_EXTENT)` and checks that `Extents` offset + `NumberOfExtents × ExtentSize` fits within `RecordLength`. The multiplication is done in `long` so it cannot overflow before the comparison.
- `PtrToStringAuto` → `PtrToStringUni`, and `/ 2` → `/ sizeof(char)`, so the call states the invariant the arithmetic already depended on.

Behavior for well-formed records is unchanged.

## Verification

Compiles clean for `net10.0` and `net11.0` with `-p:TreatWarningsAsErrors=true`.

**Not executed.** This needs a live journal on Windows, and the new branches need a driver returning a malformed record, which the public API cannot produce. The `PtrToStringAuto` → `PtrToStringUni` change is behavior-preserving on Windows, which is the only platform this assembly runs on.

Note the V4 path has no test coverage at all, before or after this change — `USN_RECORD_V4` records only appear once range tracking is enabled via `EnableTrackModifiedRanges`, which nothing in the test suite calls.
