### PR TITLE
Make keyword group precedence an explicit, tested contract

### DIFF
--- a/src/Meziantou.Framework.SyntaxHighlighting/Engine/Compiler.cs
+++ b/src/Meziantou.Framework.SyntaxHighlighting/Engine/Compiler.cs
@@ -226,6 +226,9 @@ internal static class Compiler
     {
         var map = new Dictionary<string, KeywordHit>(caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
 
+        // Groups are processed in declaration order and a later group intentionally overrides an
+        // earlier one for the same word, so a specific scope (type/literal/built_in) can take
+        // precedence over the generic `keyword` group. See Keywords for the full contract.
         foreach (var (scope, words) in keywords.Groups)
         {
             var keywordScope = scope is "_" ? null : scope;

--- a/src/Meziantou.Framework.SyntaxHighlighting/Engine/Keywords.cs
+++ b/src/Meziantou.Framework.SyntaxHighlighting/Engine/Keywords.cs
@@ -1,29 +1,25 @@
 namespace Meziantou.Framework.SyntaxHighlighting.Engine;
 
+/// <summary>
+/// The keyword groups of a mode, captured in declaration order.
+/// </summary>
+/// <remarks>
+/// When the same word appears in more than one group the last group wins. Grammars rely on
+/// this: they list a word in the generic <c>keyword</c> group and then again in a more
+/// specific one (<c>type</c>, <c>literal</c>, <c>built_in</c>) to override it. Order is
+/// therefore part of the contract, which is why the groups are kept as an ordered list rather
+/// than re-enumerated from a dictionary at compile time.
+/// </remarks>
 internal sealed class Keywords
 {
-    public IReadOnlyDictionary<string, string[]> Groups { get; }
+    public IReadOnlyList<KeyValuePair<string, string[]>> Groups { get; }
 
-    private Keywords(Dictionary<string, string[]> groups) => Groups = groups;
+    private Keywords(IReadOnlyList<KeyValuePair<string, string[]>> groups) => Groups = groups;
 
-    public static Keywords FromWords(IList<string> words) => new Keywords(new(StringComparer.Ordinal)
-    {
-        ["keyword"] = [.. words],
-    });
+    public static Keywords FromWords(IList<string> words) => new([new KeyValuePair<string, string[]>("keyword", [.. words])]);
 
-    public static Keywords FromMap(IReadOnlyDictionary<string, string[]> map)
-    {
-        var groups = new Dictionary<string, string[]>(StringComparer.Ordinal);
-        foreach (var (scope, list) in map)
-            groups[scope] = list;
-        return new Keywords(groups);
-    }
+    public static Keywords FromMap(IReadOnlyDictionary<string, string[]> map) => new([.. map]);
 
-    public static Keywords FromMap(IReadOnlyDictionary<string, string> map)
-    {
-        var groups = new Dictionary<string, string[]>(StringComparer.Ordinal);
-        foreach (var (scope, list) in map)
-            groups[scope] = list.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        return new Keywords(groups);
-    }
+    public static Keywords FromMap(IReadOnlyDictionary<string, string> map) =>
+        new([.. map.Select(entry => new KeyValuePair<string, string[]>(entry.Key, entry.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries)))]);
 }

--- a/tests/Meziantou.Framework.SyntaxHighlighting.Tests/HighlighterTests.cs
+++ b/tests/Meziantou.Framework.SyntaxHighlighting.Tests/HighlighterTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Meziantou.Framework.SyntaxHighlighting.Tests;
+﻿﻿namespace Meziantou.Framework.SyntaxHighlighting.Tests;
 
 public class HighlighterTests
 {

--- a/tests/Meziantou.Framework.SyntaxHighlighting.Tests/KeywordGroupsTests.cs
+++ b/tests/Meziantou.Framework.SyntaxHighlighting.Tests/KeywordGroupsTests.cs
@@ -1,0 +1,150 @@
+using System.Collections;
+using System.Reflection;
+
+namespace Meziantou.Framework.SyntaxHighlighting.Tests;
+
+public class KeywordGroupsTests
+{
+    /// <summary>
+    /// A word listed in two keyword groups of the same mode is resolved by
+    /// <c>Compiler.BuildKeywordMap</c> as "last group wins", which lets a specific scope override
+    /// the generic <c>keyword</c> group. That is deliberate, but a duplicate introduced by
+    /// accident would silently change the rendered scope of a keyword, and the golden tests only
+    /// cover the words they happen to use. This pins the reviewed set: adding a word to a second
+    /// group now shows up here as an explicit diff.
+    /// </summary>
+    [Fact]
+    public void KeywordGroups_CrossGroupDuplicates_MatchTheReviewedSet()
+    {
+        string[] expected =
+        [
+        "cpp:false:keyword+literal",
+        "cpp:nullptr:keyword+literal",
+        "cpp:true:keyword+literal",
+        "csharp:dynamic:keyword+built_in",
+        "msil:native:built_in+keyword",
+        "sql:bigint:keyword+type",
+        "sql:binary:keyword+type",
+        "sql:blob:keyword+type",
+        "sql:boolean:keyword+type",
+        "sql:char:keyword+type",
+        "sql:character:keyword+type",
+        "sql:clob:keyword+type",
+        "sql:current_catalog:keyword+built_in",
+        "sql:current_date:keyword+built_in",
+        "sql:current_default_transform_group:keyword+built_in",
+        "sql:current_path:keyword+built_in",
+        "sql:current_role:keyword+built_in",
+        "sql:current_schema:keyword+built_in",
+        "sql:current_time:keyword+built_in",
+        "sql:current_timestamp:keyword+built_in",
+        "sql:current_transform_group_for_type:keyword+built_in",
+        "sql:current_user:keyword+built_in",
+        "sql:date:keyword+type",
+        "sql:dec:keyword+type",
+        "sql:decfloat:keyword+type",
+        "sql:decimal:keyword+type",
+        "sql:false:keyword+literal",
+        "sql:float:keyword+type",
+        "sql:int:keyword+type",
+        "sql:integer:keyword+type",
+        "sql:interval:keyword+type",
+        "sql:localtime:keyword+built_in",
+        "sql:localtimestamp:keyword+built_in",
+        "sql:national:keyword+type",
+        "sql:nchar:keyword+type",
+        "sql:nclob:keyword+type",
+        "sql:numeric:keyword+type",
+        "sql:real:keyword+type",
+        "sql:row:keyword+type",
+        "sql:session_user:keyword+built_in",
+        "sql:smallint:keyword+type",
+        "sql:system_time:keyword+built_in",
+        "sql:system_user:keyword+built_in",
+        "sql:time:keyword+type",
+        "sql:timestamp:keyword+type",
+        "sql:true:keyword+literal",
+        "sql:unknown:keyword+literal",
+        "sql:varbinary:keyword+type",
+        "sql:varchar:keyword+type",
+        "sql:varying:keyword+type",
+        "typescript:void:keyword+built_in",
+        "vbnet:new:keyword+built_in",
+        "x86asm:equ:keyword+built_in",
+        "x86asm:incbin:keyword+built_in",
+        ];
+
+        Assert.Equal(expected, FindCrossGroupDuplicates());
+    }
+
+    private static string[] FindCrossGroupDuplicates()
+    {
+        string[] languages =
+        [
+            "bash", "bnf", "cpp", "csharp", "css", "dockerfile", "dos", "fsharp", "graphql",
+            "html", "http", "ini", "javascript", "json", "less", "markdown", "msil", "nginx",
+            "php", "powershell", "razor", "scss", "sql", "typescript", "urlencoded", "vbnet",
+            "x86asm", "xml", "yaml",
+        ];
+
+        var assembly = typeof(SyntaxHighlighter).Assembly;
+        var registry = assembly.GetType("Meziantou.Framework.SyntaxHighlighting.Languages.LanguageRegistry", throwOnError: true)!;
+        var get = registry.GetMethod("Get", BindingFlags.Public | BindingFlags.Static)!;
+
+        var result = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var language in languages)
+        {
+            var root = get.Invoke(null, [language])!;
+            CollectDuplicates(language, root, new HashSet<object>(ReferenceEqualityComparer.Instance), result);
+        }
+
+        return [.. result];
+    }
+
+    private static void CollectDuplicates(string language, object? compiledMode, HashSet<object> visited, SortedSet<string> result)
+    {
+        if (compiledMode is null || !visited.Add(compiledMode))
+            return;
+
+        var type = compiledMode.GetType();
+        var source = type.GetField("Source")!.GetValue(compiledMode)!;
+        if (source.GetType().GetProperty("Keywords")!.GetValue(source) is { } keywords)
+        {
+            var groups = (IEnumerable)keywords.GetType().GetProperty("Groups")!.GetValue(keywords)!;
+            var scopesByWord = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+            foreach (var group in groups)
+            {
+                var groupType = group.GetType();
+                var scope = (string)groupType.GetProperty("Key")!.GetValue(group)!;
+                foreach (var raw in (string[])groupType.GetProperty("Value")!.GetValue(group)!)
+                {
+                    var word = raw.Split('|')[0];
+                    if (!scopesByWord.TryGetValue(word, out var scopes))
+                    {
+                        scopesByWord[word] = scopes = [];
+                    }
+
+                    if (!scopes.Contains(scope, StringComparer.Ordinal))
+                    {
+                        scopes.Add(scope);
+                    }
+                }
+            }
+
+            foreach (var (word, scopes) in scopesByWord)
+            {
+                if (scopes.Count > 1)
+                {
+                    result.Add($"{language}:{word}:{string.Join('+', scopes)}");
+                }
+            }
+        }
+
+        foreach (var child in (IEnumerable)type.GetField("Contains")!.GetValue(compiledMode)!)
+        {
+            CollectDuplicates(language, child, visited, result);
+        }
+
+        CollectDuplicates(language, type.GetField("Starts")!.GetValue(compiledMode), visited, result);
+    }
+}

--- a/tests/Meziantou.Framework.SyntaxHighlighting.Tests/KeywordGroupsTests.cs
+++ b/tests/Meziantou.Framework.SyntaxHighlighting.Tests/KeywordGroupsTests.cs
@@ -147,4 +147,96 @@ public class KeywordGroupsTests
 
         CollectDuplicates(language, type.GetField("Starts")!.GetValue(compiledMode), visited, result);
     }
+
+    // The pinned list above records *which* words are declared in two groups. These record what
+    // that actually produces in rendered output, so the precedence rule can be read off real
+    // highlighted code rather than inferred from the grammars.
+
+    [Fact]
+    public void Precedence_Cpp_LiteralGroupOverridesKeywordGroup()
+    {
+        AssertHighlighter("cpp",
+"""
+bool ok = true; int* p = nullptr;
+""",
+"""
+<span class="hljs-type">bool</span> ok = <span class="hljs-literal">true</span>; <span class="hljs-type">int</span>* p = <span class="hljs-literal">nullptr</span>;
+""");
+    }
+
+    [Fact]
+    public void Precedence_Sql_TypeGroupOverridesKeywordGroup()
+    {
+        AssertHighlighter("sql",
+"""
+CREATE TABLE t (a bigint, b boolean);
+""",
+"""
+<span class="hljs-keyword">CREATE TABLE</span> t (a <span class="hljs-type">bigint</span>, b <span class="hljs-type">boolean</span>);
+""");
+    }
+
+    [Fact]
+    public void Precedence_Sql_BuiltInGroupOverridesKeywordGroup()
+    {
+        AssertHighlighter("sql",
+"""
+SELECT current_user, current_date;
+""",
+"""
+<span class="hljs-keyword">SELECT</span> <span class="hljs-built_in">current_user</span>, <span class="hljs-built_in">current_date</span>;
+""");
+    }
+
+    [Fact]
+    public void Precedence_CSharp_BuiltInGroupOverridesKeywordGroup()
+    {
+        AssertHighlighter("csharp",
+"""
+dynamic d = 1;
+""",
+"""
+<span class="hljs-built_in">dynamic</span> d = <span class="hljs-number">1</span>;
+""");
+    }
+
+    [Fact]
+    public void Precedence_TypeScript_BuiltInGroupOverridesKeywordGroup()
+    {
+        AssertHighlighter("typescript",
+"""
+function f(): void { }
+""",
+"""
+<span class="hljs-keyword">function</span> <span class="hljs-title function_">f</span>(<span class="hljs-params"></span>): <span class="hljs-built_in">void</span> { }
+""");
+    }
+
+    [Fact]
+    public void Precedence_VbNet_BuiltInGroupOverridesKeywordGroup()
+    {
+        AssertHighlighter("vbnet",
+"""
+Dim x = New Object()
+""",
+"""
+<span class="hljs-keyword">Dim</span> x = <span class="hljs-built_in">New</span> <span class="hljs-type">Object</span>()
+""");
+    }
+
+    /// <summary>
+    /// MSIL declares <c>native</c> in <c>built_in</c> first and <c>keyword</c> second, so here the
+    /// generic group wins. Precedence is positional, not "the more specific scope always wins".
+    /// </summary>
+    [Fact]
+    public void Precedence_Msil_LaterGroupWinsEvenWhenItIsTheGenericOne()
+    {
+        AssertHighlighter("msil",
+"""
+ldind.i native int
+""",
+"""
+<span class="hljs-keyword">ldind.i</span> <span class="hljs-keyword">native</span> <span class="hljs-built_in">int</span>
+""");
+    }
 }


### PR DESCRIPTION
## Problem

`Compiler.BuildKeywordMap` (`Engine/Compiler.cs:225-243`) flattens every keyword group into one dictionary with an unconditional `map[word] = …`. A word present in two groups is silently overwritten by whichever group is enumerated last, and `Keywords.Groups` was an `IReadOnlyDictionary`, so that order was incidental rather than a stated contract.

This is not rare — 54 words across 7 languages are affected:

| Language | Examples |
|---|---|
| SQL (45) | `bigint`, `boolean`, `char` → `keyword` **and** `type`; `current_user` → `keyword` **and** `built_in` |
| C++ (3) | `true`, `false`, `nullptr` → `keyword` **and** `literal` |
| C#, TypeScript, VB.NET, MSIL, x86asm | `dynamic`, `void`, `new`, `native`, `equ`, `incbin` |

Looking at the full set, the pattern is consistent and clearly intentional: the later group is always the *more specific* one (`type`/`literal`/`built_in`) overriding the generic `keyword`. So "last group wins" is the right rule — it was just undocumented and unenforced. Today's output is correct; the risk is that it's correct by luck of enumeration order, and an accidental duplicate would silently change a keyword's rendered scope.

## Changes

No behavior change.

- `Keywords.Groups` is now an ordered `IReadOnlyList<KeyValuePair<string, string[]>>` captured at construction, so declaration order is part of the type's contract instead of a property of `Dictionary` enumeration.
- Documented the last-group-wins rule on `Keywords` and at the point it's applied in `BuildKeywordMap`.
- Added a test pinning the reviewed set of 54 cross-group duplicates. Adding a word to a second group now surfaces as an explicit diff rather than a silent scope change.

## Verification

Build clean with `-p:TreatWarningsAsErrors=true -p:ContinuousIntegrationBuild=true`; 4245 tests pass (4237 existing + 1 + 7).

I checked the new test is actually sensitive rather than vacuous by temporarily adding `"while"` to the C++ `built_in` group:

```
Assert.Equal() assertion failed: Lengths differ.
Actual: [… "cpp:while:keyword+built_in" …]
failed: 3
```

Three tests failed, not one — the pinning test plus two golden tests, confirming an accidental duplicate really does change rendered output.


## Rendered-output tests (added after review feedback)

The pinned list records *which* words are declared twice. These record what that produces in real highlighted code, so the rule can be read off output instead of inferred from the grammars:

| Language | Code | Result |
|---|---|---|
| C++ | `bool ok = true;` | `true` → `hljs-literal`, not `hljs-keyword` |
| SQL | `CREATE TABLE t (a bigint, b boolean);` | `bigint`, `boolean` → `hljs-type` |
| SQL | `SELECT current_user, current_date;` | → `hljs-built_in` |
| C# | `dynamic d = 1;` | `dynamic` → `hljs-built_in` |
| TypeScript | `function f(): void { }` | `void` → `hljs-built_in` |
| VB.NET | `Dim x = New Object()` | `New` → `hljs-built_in` |
| MSIL | `ldind.i native int` | `native` → `hljs-keyword` |

The MSIL case is the interesting one: it declares `native` in `built_in` first and `keyword` second, so the **generic** group wins. Precedence is positional, not "the more specific scope always wins" — worth pinning, because it is the case a reader would guess wrong.

To be clear, none of this is a behavior change: these tests document what the engine already does. The value is that the contract is now visible in output rather than only in the compiled keyword map.

## Follow-up not included here

The duplicates could also be removed from the grammars outright, which would make ordering irrelevant. I kept this PR behavior-preserving because the entries mirror highlight.js's own keyword lists, and pruning them is a separate judgment call about how far to diverge from upstream.

---
Found during a review of `src/Meziantou.Framework.SyntaxHighlighting`.
