### PR TITLE
Expose whether a change journal is active on the volume

### DIFF
--- a/ref/Meziantou.Framework.Win32.ChangeJournal.cs
+++ b/ref/Meziantou.Framework.Win32.ChangeJournal.cs
@@ -116,6 +116,7 @@ namespace Meziantou.Framework.Win32
 
     public sealed class JournalData
     {
+        public bool IsActive { get => throw null; }
         public ulong ID { get => throw null; }
         public Meziantou.Framework.Win32.Usn FirstUSN { get => throw null; }
         public Meziantou.Framework.Win32.Usn NextUSN { get => throw null; }

--- a/src/Meziantou.Framework.Win32.ChangeJournal/JournalData.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/JournalData.cs
@@ -14,6 +14,7 @@ public sealed class JournalData
     /// <param name="nativeData"></param>
     internal JournalData(Windows.Win32.System.Ioctl.USN_JOURNAL_DATA_V2 nativeData)
     {
+        IsActive = true;
         ID = nativeData.UsnJournalID;
         FirstUSN = nativeData.FirstUsn;
         NextUSN = nativeData.NextUsn;
@@ -27,6 +28,14 @@ public sealed class JournalData
         RangeTrackChunkSize = nativeData.RangeTrackChunkSize;
         RangeTrackFileSizeThreshold = nativeData.RangeTrackFileSizeThreshold;
     }
+
+    /// <summary>Gets a value indicating whether a change journal is active on the volume.</summary>
+    /// <remarks>
+    ///     When this is <see langword="false"/>, the volume has no change journal and every other property is zero.
+    ///     Reading entries in that state fails with a <see cref="System.ComponentModel.Win32Exception"/>, so check this
+    ///     before enumerating. Use <see cref="ChangeJournal.Create(long, long)"/> to create the journal.
+    /// </remarks>
+    public bool IsActive { get; }
 
     /// <summary>64-bit unique journal identifier.</summary>
     public ulong ID { get; }


### PR DESCRIPTION
## The defect

"The volume has no change journal" is a routine, expected condition — MSDN notes journals are not necessarily created at startup — and it is the one case a caller most needs to branch on. It was not observable.

`ReadJournalDataImpl` catches `ERROR_JOURNAL_NOT_ACTIVE` and returns a default-constructed `JournalData`:

```csharp
catch (Win32Exception ex) when (ex.NativeErrorCode == (int)WIN32_ERROR.ERROR_JOURNAL_NOT_ACTIVE)
{
    return new JournalData();
}
```

Every property on that object is zero, including `ID`, and nothing distinguishes it from a journal that was read successfully. A caller who checks `Data` sees plausible-looking zeros.

Enumeration then proceeds anyway: `Read()` puts `UsnJournalID = 0` into `READ_USN_JOURNAL_DATA_V1`, the IOCTL fails, and a `Win32Exception` surfaces from inside `MoveNext()` — that is, from inside the caller's `foreach`, not from `Open()` where they could reasonably have handled it.

## What changed

Added `JournalData.IsActive`. The parameterless constructor leaves it `false`; the constructor that copies from `USN_JOURNAL_DATA_V2` sets it `true`. Callers can now check before enumerating:

```csharp
using var changeJournal = ChangeJournal.Open(new DriveInfo("D:"));
if (!changeJournal.Data.IsActive)
{
    changeJournal.Create(maximumSize: 10_000_000, allocationDelta: 1_000_000);
}
```

The XML docs state that every other property is zero when this is `false`, that enumerating throws in that state, and point at `Create` as the remedy.

This is deliberately the smaller half of the fix. The review that produced it also suggested having `GetEntries`/`Entries` throw a clear `InvalidOperationException` up front instead of surfacing a raw `Win32Exception` mid-enumeration. I left that out: it changes the exception type callers currently catch, which deserves its own decision rather than riding along with an additive property.

## Public API

Additive only — one new property, no signature changes. `ref/Meziantou.Framework.Win32.ChangeJournal.cs` is regenerated (one line).

I did not touch `<Version>` in the csproj, since version bumps appear to be batched into their own commits in this repo. This is an additive change, so a minor bump when you next do that.

## Verification

Compiles clean for `net10.0` and `net11.0` with `-p:TreatWarningsAsErrors=true`, and the `ref/` file regenerates to exactly the one expected line.

**The inactive-journal path itself was not executed** — that needs a Windows volume with no change journal, and this was written on macOS. The property is set in a constructor that the existing `ERROR_JOURNAL_NOT_ACTIVE` handler already called, so the change is confined to which constructor sets what.
