### PR TITLE
Reject negative sizes in Create

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
@@ -207,8 +207,12 @@ public sealed class ChangeJournal : IDisposable
     /// <summary>Creates a new change journal or modifies an existing one.</summary>
     /// <param name="maximumSize">The maximum size, in bytes, that the journal can use on the volume.</param>
     /// <param name="allocationDelta">The size, in bytes, by which the journal grows when needed.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maximumSize"/> or <paramref name="allocationDelta"/> is negative.</exception>
     public void Create(long maximumSize, long allocationDelta)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(maximumSize);
+        ArgumentOutOfRangeException.ThrowIfNegative(allocationDelta);
+
         var creationData = new CREATE_USN_JOURNAL_DATA
         {
             AllocationDelta = (ulong)allocationDelta,


### PR DESCRIPTION
## The defect

`Create(long, long)` cast both parameters to `ulong` without checking them:

```csharp
public void Create(long maximumSize, long allocationDelta)
{
    var creationData = new CREATE_USN_JOURNAL_DATA
    {
        AllocationDelta = (ulong)allocationDelta,
        MaximumSize = (ulong)maximumSize,
    };
```

The cast is unchecked, so `Create(-1, -1)` asks the driver for a journal of `18446744073709551615` bytes with the same allocation delta. The driver rejects it, but the caller gets an opaque `Win32Exception` that says nothing about which argument was wrong.

The `long` overload exists precisely so callers can pass ordinary integer literals — which is also how a computed negative slips in.

## What changed

`ArgumentOutOfRangeException.ThrowIfNegative` on both parameters before the cast, plus the matching `<exception>` documentation.

The `ulong` overload needs no equivalent: it cannot express a negative value.

## Verification

Compiles clean for `net10.0` and `net11.0` with `-p:TreatWarningsAsErrors=true`.

**No test.** The guard runs before any native call, but reaching it still needs a `ChangeJournal` instance, which needs Windows and a real NTFS volume — this was written on macOS, where those tests skip. The change is two guard clauses ahead of the existing code, with no effect on any non-negative input.
