### PR TITLE
Derive the volume device path from the drive name only

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/VolumeHelper.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/VolumeHelper.cs
@@ -2,26 +2,18 @@ namespace Meziantou.Framework.Win32;
 
 internal static class VolumeHelper
 {
+    /// <summary>
+    /// Converts a drive into the device path that <c>CreateFile</c> expects for a volume, such as <c>\\.\C:</c>.
+    /// Only drive-letter volumes are supported, which is all a <see cref="DriveInfo"/> can designate.
+    /// </summary>
     internal static string GetValidVolumePath(DriveInfo driveInfo)
     {
-        string name;
-        if (!string.IsNullOrEmpty(driveInfo.Name))
-        {
-            name = driveInfo.Name;
-        }
-        else if (!string.IsNullOrEmpty(driveInfo.VolumeLabel))
-        {
-            name = driveInfo.VolumeLabel;
-        }
-        else
-        {
+        var name = driveInfo.Name;
+        if (string.IsNullOrEmpty(name))
             throw new ArgumentException("Cannot determine the name of the drive", nameof(driveInfo));
-        }
 
-        name = name
-            .Replace(":", "", StringComparison.Ordinal)
-            .Replace(Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture), "", StringComparison.Ordinal);
-
-        return $"\\\\.\\{name}:";
+        // DriveInfo.Name is a root path such as "C:\", so strip the separators and the colon before rebuilding it.
+        name = name.Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).TrimEnd(':');
+        return $@"\\.\{name}:";
     }
 }


### PR DESCRIPTION
## The defect

`VolumeHelper.GetValidVolumePath` had a fallback branch that was both unreachable and wrong:

```csharp
if (!string.IsNullOrEmpty(driveInfo.Name))
    name = driveInfo.Name;
else if (!string.IsNullOrEmpty(driveInfo.VolumeLabel))
    name = driveInfo.VolumeLabel;
```

`DriveInfo.Name` is never empty for a constructible `DriveInfo`, so the second branch cannot be reached. If it somehow were, it would be wrong twice over: `VolumeLabel` throws `IOException` on a drive that is not ready, and a volume *label* is a display string, so the method would go on to build `\\.\My Backup Disk:` and hand it to `CreateFile`.

Separately, the name was cleaned with:

```csharp
name = name
    .Replace(":", "", StringComparison.Ordinal)
    .Replace(Path.DirectorySeparatorChar.ToString(CultureInfo.InvariantCulture), "", StringComparison.Ordinal);
```

which strips `DirectorySeparatorChar` but not `AltDirectorySeparatorChar`, so a `/` in the name survives into the device path.

Low impact — the mainline `C:\` case works, which is what the tests and the readme use.

## What changed

- Dropped the `VolumeLabel` fallback. An empty `Name` now throws `ArgumentException` directly, which is what the old code did in its `else` anyway.
- `Trim` over both `DirectorySeparatorChar` and `AltDirectorySeparatorChar`, then `TrimEnd(':')`. `Trim` rather than `Replace` also means a separator in the middle of a name is no longer silently deleted.
- Documented that only drive-letter volumes are supported — which is all a `DriveInfo` can designate anyway. Supporting mount points or `\\?\Volume{…}\` paths would mean accepting a volume path string instead of a `DriveInfo`, a public API change I did not want to fold into a cleanup.

`"C:\"` maps to `\\.\C:` before and after.

## Verification

Compiles clean for `net10.0` and `net11.0` with `-p:TreatWarningsAsErrors=true`.

**No test**, deliberately. `VolumeHelper` is `internal`, and the `InternalsVisibleTo` entry that would make it reachable from the test project is added by the read-timeout PR (#2051). Adding it here too would conflict in the csproj. Once #2051 is in, this becomes straightforwardly unit-testable on any platform, and it is worth doing then.
