### PR TITLE
Mark ReadJournalData as obsolete

### DIFF
--- a/ref/Meziantou.Framework.Win32.ChangeJournal.cs
+++ b/ref/Meziantou.Framework.Win32.ChangeJournal.cs
@@ -16,6 +16,7 @@ namespace Meziantou.Framework.Win32
         public static Meziantou.Framework.Win32.ChangeJournalEntryVersion2or3 GetEntry(string path) => throw null;
         public static Meziantou.Framework.Win32.ChangeJournalEntryVersion2or3 GetEntry(Microsoft.Win32.SafeHandles.SafeFileHandle handle) => throw null;
         public void RefreshJournalData() { }
+        [System.Obsolete("Use RefreshJournalData instead.")]
         public void ReadJournalData() { }
         public void Dispose() { }
         public void Delete() { }

--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
@@ -147,6 +147,7 @@ public sealed class ChangeJournal : IDisposable
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use RefreshJournalData instead.")]
     public void ReadJournalData()
     {
         RefreshJournalData();


### PR DESCRIPTION
## The defect

`ChangeJournal.ReadJournalData()` is a pass-through to `RefreshJournalData()` kept for compatibility:

```csharp
[EditorBrowsable(EditorBrowsableState.Never)]
public void ReadJournalData()
{
    RefreshJournalData();
}
```

`[EditorBrowsable(Never)]` hides it from IntelliSense but produces no build diagnostic. Existing callers get no signal to migrate, and new code can still bind to it — the attribute only affects what the editor offers, not what the compiler accepts.

## What changed

Added `[Obsolete("Use RefreshJournalData instead.")]`, so callers now get `CS0618` pointing at the replacement. `[EditorBrowsable(Never)]` stays, so it also remains hidden from completion.

Nothing in the repository calls it — I grepped `src` and `tests` — so this does not introduce any warning in-tree, and the build is clean with `-p:TreatWarningsAsErrors=true`.

## Public API

`ref/Meziantou.Framework.Win32.ChangeJournal.cs` is regenerated to record the attribute (one line). The method itself is unchanged and still works.

**This is a source-breaking change for downstream consumers** who call `ReadJournalData()` and build with warnings-as-errors. That is the intent — it is the signal the `[EditorBrowsable]` attribute could not send — but it is worth a release-note line, and worth deciding whether it should ride with the next major rather than a patch. Happy to hold this one if you would rather it waited.

## Verification

Compiles clean for `net10.0` and `net11.0` with `-p:TreatWarningsAsErrors=true`, and the `ref/` file regenerates to exactly the expected line. An attribute-only change with no behavior to execute.
