### PR TITLE
Remove a dead null check and a stray blank line

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
@@ -229,7 +229,6 @@ public sealed class ChangeJournal : IDisposable
             Flags = PInvoke.FLAG_USN_TRACK_MODIFIED_RANGES_ENABLE,
             ChunkSize = chunkSize,
             FileSizeThreshold = fileSizeThreshold,
-
         };
         Win32DeviceControl.ControlWithInput(ChangeJournalHandle, Win32ControlCode.TrackModifiedRanges, ref trackData, initialBufferLength: 0);
     }

--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
@@ -111,7 +111,7 @@ internal sealed class ChangeJournalEntries : IEnumerable<ChangeJournalEntry>
                 return false;
 
             _currentIndex++;
-            if (_entries is null || _currentIndex >= _entries.Count)
+            if (_currentIndex >= _entries.Count)
             {
                 return Read();
             }


### PR DESCRIPTION
Two unrelated one-line cleanups, bundled because two separate single-line PRs seemed like worse overhead than one. Say the word and I will split them.

## 1. Dead null check — `ChangeJournalEntries.cs:114`

```csharp
if (_entries is null || _currentIndex >= _entries.Count)
```

`_entries` is a `readonly` field initialized to `[]` at its declaration and never reassigned, so the null branch is unreachable. It also contradicts the nullable annotations the project otherwise trusts — `AGENTS.md` asks for exactly that: *"Trust the C# null annotations and don't add null checks when the type system says a value cannot be null."*

Removed the null test; the bounds check is unchanged.

## 2. Stray blank line — `ChangeJournal.cs:232`

An empty line between the last property and the closing brace of the `USN_TRACK_MODIFIED_RANGES` initializer in `EnableTrackModifiedRanges`. Removed.

## Verification

Compiles clean for `net10.0` and `net11.0` with `-p:TreatWarningsAsErrors=true`. Neither change can alter behavior: one deletes a condition that was always `false`, the other deletes whitespace.
