### PR TITLE
Stop discarding C# highlighting for alias-qualified names

### DIFF
--- a/src/Meziantou.Framework.SyntaxHighlighting/Languages/CSharp.cs
+++ b/src/Meziantou.Framework.SyntaxHighlighting/Languages/CSharp.cs
@@ -354,7 +354,6 @@ internal static partial class CSharp
         {
             Keywords = keywords,
             KeywordValidator = ValidateKeyword,
-            Illegal = "::",
             Contains =
             [
                 xmlDocComment,

--- a/tests/Meziantou.Framework.SyntaxHighlighting.Tests/CSharpHighlighterTests.cs
+++ b/tests/Meziantou.Framework.SyntaxHighlighting.Tests/CSharpHighlighterTests.cs
@@ -1,4 +1,4 @@
-namespace Meziantou.Framework.SyntaxHighlighting.Tests;
+﻿namespace Meziantou.Framework.SyntaxHighlighting.Tests;
 
 public class CSharpHighlighterTests
 {
@@ -4124,6 +4124,54 @@ class Foo { }
 """
 <span class="hljs-keyword">class</span> <span class="hljs-title">Foo</span> { }
 
+""");
+    }
+
+    [Fact]
+    public void AliasQualifiedName_GlobalAlias()
+    {
+        AssertHighlighter("csharp",
+"""
+var value = global::System.String.Empty;
+""",
+"""
+<span class="hljs-keyword">var</span> <span class="hljs-keyword">value</span> = <span class="hljs-keyword">global</span>::System.String.Empty;
+""");
+    }
+
+    [Fact]
+    public void AliasQualifiedName_UsingAlias()
+    {
+        AssertHighlighter("csharp",
+"""
+using S = global::System;
+""",
+"""
+<span class="hljs-keyword">using</span> S = <span class="hljs-keyword">global</span>::System;
+""");
+    }
+
+    [Fact]
+    public void AliasQualifiedName_ExternAlias()
+    {
+        AssertHighlighter("csharp",
+"""
+extern alias Legacy;
+""",
+"""
+<span class="hljs-keyword">extern</span> <span class="hljs-keyword">alias</span> Legacy;
+""");
+    }
+
+    [Fact]
+    public void AliasQualifiedName_InsideTypeMember()
+    {
+        AssertHighlighter("csharp",
+"""
+class C { global::System.Int32 Value { get; set; } }
+""",
+"""
+<span class="hljs-keyword">class</span> <span class="hljs-title">C</span> { <span class="hljs-keyword">global</span>::System.Int32 Value { <span class="hljs-keyword">get</span>; <span class="hljs-keyword">set</span>; } }
 """);
     }
 }


### PR DESCRIPTION
## Problem

The C# grammar carried `Illegal = "::"` on its **root** mode (`Languages/CSharp.cs:357`). When any `illegal` pattern matches, `Tokenizer.Run` returns `null` and `Highlight` falls back to emitting the whole input as escaped plain text (`Engine/Tokenizer.cs:77-78`, `:13-22`) — with no signal to the caller, just a normal-looking string containing no `<span>`.

Because the rule sat on the root mode, any alias-qualified name in code position silently blanked highlighting for the entire block:

```
highlighted=False | var value = global::System.String.Empty;
highlighted=False | using S = global::System;
highlighted=False | class C { void M() { var s = global::System.String.Empty; } }
highlighted=False | extern alias A; class C { A::N.T x; }
highlighted=True  | class C { }
```

`::` inside a string or comment was already safe (child modes shadow the root rule), so the trigger was specifically C#'s alias-qualified-name syntax — common in generated code, in `extern alias` scenarios, and in the disambiguation examples people write blog posts about. There was no test covering `::` in the 299-test C# suite.

## Changes

Removes `Illegal = "::"` from the C# root mode.

In highlight.js a root-level `illegal` is primarily a *language auto-detection* signal — it tells `highlightAuto` "this probably isn't C#" so it can try another grammar. This library has no auto-detection: `LanguageRegistry.Get` resolves exactly one grammar from the caller's identifier. So the rule bought nothing here while costing whole-document highlighting.

## Verification

All 4237 pre-existing tests pass unchanged — the rule was not load-bearing for any current fixture.

4 new regression tests in `CSharpHighlighterTests.cs` covering `global::`, a `using` alias, `extern alias`, and an alias-qualified type in a member declaration. Previously all four produced zero highlighting; now, for example:

```html
<span class="hljs-keyword">var</span> <span class="hljs-keyword">value</span> = <span class="hljs-keyword">global</span>::System.String.Empty;
```

Build clean with `-p:TreatWarningsAsErrors=true`; 4241 tests pass (4237 + 4).

## Not addressed here

C++ and Dockerfile also carry root-level `Illegal = "</"` (`Languages/Cpp.cs:311`, `Languages/Dockerfile.cs:11`). I could not trigger a whole-block wipe with realistic input for either, so I left them alone — but the same reasoning would apply if you want them gone.

The broader question — whether an `illegal` hit should abandon only the offending mode instead of the whole document — is an engine change affecting all 29 languages and is deliberately out of scope.

---
Found during a review of `src/Meziantou.Framework.SyntaxHighlighting`.
