### PR TITLE
Give every grammar regex a finite match timeout

### DIFF
--- a/src/Meziantou.Framework.SyntaxHighlighting/Engine/BeginGuards.cs
+++ b/src/Meziantou.Framework.SyntaxHighlighting/Engine/BeginGuards.cs
@@ -10,10 +10,10 @@ namespace Meziantou.Framework.SyntaxHighlighting.Engine;
 /// </summary>
 internal static partial class BeginGuards
 {
-    [GeneratedRegex(@"^\s*=", RegexOptions.CultureInvariant, matchTimeoutMilliseconds: -1)]
+    [GeneratedRegex(@"^\s*=", RegexOptions.CultureInvariant, matchTimeoutMilliseconds: 30_000)]
     private static partial Regex LeadingEquals();
 
-    [GeneratedRegex(@"^\s+extends\s+", RegexOptions.CultureInvariant, matchTimeoutMilliseconds: -1)]
+    [GeneratedRegex(@"^\s+extends\s+", RegexOptions.CultureInvariant, matchTimeoutMilliseconds: 30_000)]
     private static partial Regex LeadingExtends();
 
     public static bool Accept(string name, Match match, string input) => name switch

--- a/src/Meziantou.Framework.SyntaxHighlighting/Engine/Compiler.cs
+++ b/src/Meziantou.Framework.SyntaxHighlighting/Engine/Compiler.cs
@@ -4,7 +4,12 @@ namespace Meziantou.Framework.SyntaxHighlighting.Engine;
 
 internal static class Compiler
 {
-    private static readonly TimeSpan RegexTimeout = Timeout.InfiniteTimeSpan;
+    // Grammar patterns run against untrusted input, so a match must not be able to run forever.
+    // The bound is deliberately generous: the slowest legitimate single match measured across the
+    // grammars is ~4.7s (the YAML key pattern over a 48 KB document of prose), so 30s leaves ample
+    // headroom while still turning a catastrophically backtracking pattern into a
+    // RegexMatchTimeoutException instead of a hung thread.
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(30);
 
     private static readonly HashSet<string> CommonKeywords = new(StringComparer.OrdinalIgnoreCase)
     {

--- a/tests/Meziantou.Framework.SyntaxHighlighting.Tests/RegexTimeoutTests.cs
+++ b/tests/Meziantou.Framework.SyntaxHighlighting.Tests/RegexTimeoutTests.cs
@@ -1,0 +1,93 @@
+using System.Collections;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Meziantou.Framework.SyntaxHighlighting.Tests;
+
+/// <summary>
+/// Grammar patterns are matched against untrusted input. A pattern compiled without a match
+/// timeout that backtracks catastrophically hangs the calling thread with no way to recover, so
+/// every regex the engine builds must carry a finite timeout.
+/// </summary>
+public sealed class RegexTimeoutTests
+{
+    [Theory]
+    [InlineData("bash")]
+    [InlineData("bnf")]
+    [InlineData("cpp")]
+    [InlineData("csharp")]
+    [InlineData("css")]
+    [InlineData("dockerfile")]
+    [InlineData("dos")]
+    [InlineData("fsharp")]
+    [InlineData("graphql")]
+    [InlineData("html")]
+    [InlineData("http")]
+    [InlineData("ini")]
+    [InlineData("javascript")]
+    [InlineData("json")]
+    [InlineData("less")]
+    [InlineData("markdown")]
+    [InlineData("msil")]
+    [InlineData("nginx")]
+    [InlineData("php")]
+    [InlineData("powershell")]
+    [InlineData("razor")]
+    [InlineData("scss")]
+    [InlineData("sql")]
+    [InlineData("typescript")]
+    [InlineData("urlencoded")]
+    [InlineData("vbnet")]
+    [InlineData("x86asm")]
+    [InlineData("xml")]
+    [InlineData("yaml")]
+    public void EveryGrammarRegex_HasAFiniteMatchTimeout(string language)
+    {
+        var assembly = typeof(SyntaxHighlighter).Assembly;
+        var registry = assembly.GetType("Meziantou.Framework.SyntaxHighlighting.Languages.LanguageRegistry", throwOnError: true)!;
+        var root = registry.GetMethod("Get", BindingFlags.Public | BindingFlags.Static)!.Invoke(null, [language])!;
+
+        var infinite = new List<string>();
+        Collect(root, new HashSet<object>(ReferenceEqualityComparer.Instance), infinite);
+
+        Assert.Empty(infinite);
+    }
+
+    [Fact]
+    public void EveryBeginGuardRegex_HasAFiniteMatchTimeout()
+    {
+        var assembly = typeof(SyntaxHighlighter).Assembly;
+        var guards = assembly.GetType("Meziantou.Framework.SyntaxHighlighting.Engine.BeginGuards", throwOnError: true)!;
+
+        var regexes = guards
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(method => method.ReturnType == typeof(Regex) && method.GetParameters().Length is 0)
+            .Select(method => (Regex)method.Invoke(null, null)!)
+            .ToList();
+
+        Assert.NotEmpty(regexes);
+        Assert.Empty(regexes.Where(regex => regex.MatchTimeout == Regex.InfiniteMatchTimeout).Select(regex => regex.ToString()));
+    }
+
+    private static void Collect(object? compiledMode, HashSet<object> visited, List<string> infinite)
+    {
+        if (compiledMode is null || !visited.Add(compiledMode))
+            return;
+
+        var type = compiledMode.GetType();
+        foreach (var name in (string[])["BeginRe", "EndRe", "IllegalRe", "KeywordPatternRe"])
+        {
+            if (type.GetField(name)!.GetValue(compiledMode) is Regex regex && regex.MatchTimeout == Regex.InfiniteMatchTimeout)
+            {
+                infinite.Add($"{name}: {regex}");
+            }
+        }
+
+        foreach (var child in (IEnumerable)type.GetField("Contains")!.GetValue(compiledMode)!)
+        {
+            Collect(child, visited, infinite);
+        }
+
+        Collect(type.GetField("Starts")!.GetValue(compiledMode), visited, infinite);
+    }
+}


### PR DESCRIPTION
## Problem

Every grammar `Regex` was built with an explicitly infinite match timeout — `Engine/Compiler.cs:7` (`RegexTimeout = Timeout.InfiniteTimeSpan`, applied at `:108-116`) and `Engine/BeginGuards.cs:13,16` (`matchTimeoutMilliseconds: -1`).

These patterns run against untrusted input. A pattern that backtracks catastrophically — whether one that exists today or one introduced by a future grammar change — hangs the calling thread with no way to recover, and `SyntaxHighlighter.Highlight` takes no `CancellationToken`, so a caller has no remedy short of abandoning the thread.

## Changes

- `Compiler.RegexTimeout` → `TimeSpan.FromSeconds(30)`.
- The two `[GeneratedRegex]` guards in `BeginGuards` → `matchTimeoutMilliseconds: 30_000`.

### Why 30 seconds

I measured the slowest *single* regex match across the grammars to make sure the bound cannot fire on legitimate input:

| Input | Worst single match |
|---|---|
| ~50 KB of C#, CSS, YAML, C++, Markdown | **8 ms** |
| 48 KB of YAML prose (worst pattern in the codebase, `Languages/Yaml.cs:20`) | **4.7 s** |

30s leaves roughly 6× headroom over the worst legitimate case while still converting an unbounded hang into a `RegexMatchTimeoutException`. The value can be tightened once that YAML pattern is fixed.

## Scope — what this does and does not do

This bounds **one regex match**, not one `Highlight` call. It is defence in depth against catastrophic (exponential) backtracking.

It does **not** fix the separate finding that tokenization is quadratic: that cost comes from performing *many* individually-fast matches, so no per-match timeout can catch it. That is handled in its own PR.

## Verification

30 new tests in `RegexTimeoutTests.cs`: one per language asserting every compiled `BeginRe`/`EndRe`/`IllegalRe`/`KeywordPatternRe` has a finite `MatchTimeout`, plus one for the `BeginGuards` patterns.

Confirmed the tests are not vacuous — restoring `Timeout.InfiniteTimeSpan` fails 29 of 30.

Build clean with `-p:TreatWarningsAsErrors=true`; 4267 tests pass (4237 + 30).

## Follow-up

Exposing the timeout through `HighlightOptions` is the natural next step. I kept it a constant here so this PR stays independent of the `HighlightOptions` change in #2050.

---
Found during a review of `src/Meziantou.Framework.SyntaxHighlighting`.
