### PR TITLE
Bound the YAML key scan to the simple-key limit

### DIFF
--- a/src/Meziantou.Framework.SyntaxHighlighting/Languages/Yaml.cs
+++ b/src/Meziantou.Framework.SyntaxHighlighting/Languages/Yaml.cs
@@ -12,14 +12,22 @@ internal static class Yaml
         string[] literals = ["true", "false", "yes", "no", "null"];
         const string UriChars = @"[\w#;/?:@&=+$,.~*'()[\]]+";
 
+        // The run class contains both ' ' and ':', so an unbounded `*` lets a candidate key span a
+        // whole line and then backtrack over it looking for the terminating ':'. Repeated at every
+        // start position that is quadratic in the line length, which makes a single long line (a
+        // multi-word description value, for example) pathologically slow. YAML restricts a simple
+        // key to 1024 characters, so bounding the run keeps every real key matching while making
+        // the scan linear.
+        const string KeyRun = @"[\w*@ :()\./-]{0,1024}";
+
         var key = new Mode
         {
             Scope = "attr",
             Variants =
             [
-                new Mode { Begin = @"[\w*@][\w*@ :()\./-]*:(?=[ \t]|$)" },
-                new Mode { Begin = @"""[\w*@][\w*@ :()\./-]*"":(?=[ \t]|$)" },
-                new Mode { Begin = @"'[\w*@][\w*@ :()\./-]*':(?=[ \t]|$)" },
+                new Mode { Begin = @"[\w*@]" + KeyRun + @":(?=[ \t]|$)" },
+                new Mode { Begin = @"""[\w*@]" + KeyRun + @""":(?=[ \t]|$)" },
+                new Mode { Begin = @"'[\w*@]" + KeyRun + @"':(?=[ \t]|$)" },
             ],
         };
 

--- a/tests/Meziantou.Framework.SyntaxHighlighting.Tests/YamlHighlighterTests.cs
+++ b/tests/Meziantou.Framework.SyntaxHighlighting.Tests/YamlHighlighterTests.cs
@@ -1,4 +1,4 @@
-namespace Meziantou.Framework.SyntaxHighlighting.Tests;
+﻿namespace Meziantou.Framework.SyntaxHighlighting.Tests;
 
 public class YamlHighlighterTests
 {
@@ -1295,5 +1295,35 @@ name: alice
 <span class="hljs-attr">name:</span> <span class="hljs-string">alice</span>
 
 """);
+    }
+
+    [Fact]
+    public void Key_FollowedByLongSingleLineValue_IsStillHighlighted()
+    {
+        var code = "desc: " + string.Join(' ', Enumerable.Repeat("word", 500));
+
+        var result = SyntaxHighlighter.Highlight(code, "yaml");
+
+        Assert.StartsWith("""<span class="hljs-attr">desc:</span>""", result);
+    }
+
+    [Fact]
+    public void Key_AtTheYamlSimpleKeyLimit_IsHighlighted()
+    {
+        var code = new string('k', 1024) + ": value";
+
+        var result = SyntaxHighlighter.Highlight(code, "yaml");
+
+        Assert.StartsWith("""<span class="hljs-attr">""", result);
+    }
+
+    [Fact]
+    public void Key_BeyondTheYamlSimpleKeyLimit_IsNotHighlighted()
+    {
+        var code = new string('k', 1100) + ": value";
+
+        var result = SyntaxHighlighter.Highlight(code, "yaml");
+
+        Assert.DoesNotContain("hljs-attr", result);
     }
 }


### PR DESCRIPTION
## Problem

The YAML key patterns (`Languages/Yaml.cs:20-22`) use an unbounded run whose character class contains both `' '` and `':'`:

```
[\w*@][\w*@ :()\./-]*:(?=[ \t]|$)
```

A candidate key can therefore span an entire line, and the engine then backtracks across it looking for the terminating `:`. Repeated at every start position, that is **O(line²)**.

The class contains no `\n`, so a run cannot cross a line — which means normal YAML is unaffected. What triggers it is a **single long line**, and that is not exotic: a multi-word description value does it.

| Input | Before |
|---|---|
| 29 KB, ordinary short lines | 620 ms |
| `desc:` + 8 KB of words on one line | **> 60 s** |

## Changes

Bounds the run at 1024 characters. YAML restricts a simple key to 1024 characters, so this is the spec's own limit rather than an arbitrary number: every conformant key still matches, and the scan becomes linear.

## Verification

All 4237 pre-existing tests pass unchanged, including the flow-mapping cases (`data: {a: 1, b: 2}`) that rule out simply anchoring the pattern to the start of a line.

Spot-checked the key shapes the class is built for — all unchanged:

```
key: value              key with spaces: value      data: {a: 1, b: 2}
"quoted key": v         'single key': v             a.b/c-d: v        *anchor: v
```

3 new tests in `YamlHighlighterTests.cs`: a key followed by a long single-line value is still highlighted; a 1024-character key is highlighted; a 1100-character key is not.

Build clean with `-p:TreatWarningsAsErrors=true`; 4240 tests pass (4237 + 3).

## Honest sizing — this is not the whole story

On its own this is roughly a **2–3× improvement** (the >60 s case becomes ~27 s). The dominant remaining cost is that the tokenizer re-scans from every token position, which is a separate finding with its own PR.

The two compound, and that is where the real win is. With both applied:

| Input | Before | This PR | Both |
|---|---|---|---|
| 29 KB, short lines | 620 ms | 671 ms | **21 ms** |
| `desc:` + 8 KB on one line | > 60 s | 27 s | **42 ms** |
| 48 KB, all one line | > 70 s | — | **238 ms** |

If only one of the two lands, it should be the tokenizer one.

## Correction to the original review

My review report cited "35.7 ms for a single scan of a 2.9 KB prose input" for this pattern. That measurement was correct but the input had no newlines, which is not representative of YAML — with normal line breaks the same pattern costs 3.5 ms on a 96 KB document. The finding stands, but it is specifically about long single lines, not YAML documents in general.

---
Found during a review of `src/Meziantou.Framework.SyntaxHighlighting`.
