### PR TITLE
Add invariant and range/block coverage to the Unicode tests

### DIFF
--- a/tests/Meziantou.Framework.Unicode.Tests/UnicodeTests.cs
+++ b/tests/Meziantou.Framework.Unicode.Tests/UnicodeTests.cs
@@ -166,4 +166,126 @@ public sealed class UnicodeTests
         Assert.False(info.Value.IsEmojiModifier);
         Assert.False(info.Value.IsEmojiModifierBase);
     }
+
+    [Fact]
+    public void AllCharacters_MatchesGeneratedEntryCount()
+    {
+        Assert.Equal(297334, Unicode.AllCharacters.Count);
+    }
+
+    [Theory]
+    [InlineData(0x4E00, "<CJK Ideograph>")]
+    [InlineData(0xAC00, "<Hangul Syllable>")]
+    [InlineData(0xE000, "<Private Use>")]
+    [InlineData(0x20000, "<CJK Ideograph Extension B>")]
+    [InlineData(0xF0000, "<Plane 15 Private Use>")]
+    public void GetCharacterInfo_ResolvesRangeExpandedCodePoints(int codePoint, string expectedName)
+    {
+        var info = Unicode.GetCharacterInfo(new Rune(codePoint));
+
+        Assert.NotNull(info);
+        Assert.Equal(expectedName, info.Value.Name);
+    }
+
+    [Fact]
+    public void AllCharacters_HaveConsistentBlockAndName()
+    {
+        var failures = new List<string>();
+        foreach (var info in Unicode.AllCharacters)
+        {
+            if (failures.Count >= 10)
+                break;
+
+            if (!ReferenceEquals(UnicodeBlocks.GetBlock(info.Rune), info.Block))
+            {
+                failures.Add($"U+{info.Rune.Value:X4}: block {info.Block.Name} != {UnicodeBlocks.GetBlock(info.Rune).Name}");
+            }
+            else if (!info.Block.Contains(info.Rune))
+            {
+                failures.Add($"U+{info.Rune.Value:X4}: not contained in block {info.Block.Name}");
+            }
+            else if (string.IsNullOrEmpty(info.Name))
+            {
+                failures.Add($"U+{info.Rune.Value:X4}: empty name");
+            }
+        }
+
+        Assert.Empty(failures);
+    }
+
+    [Fact]
+    public void UnicodeRange_RejectsInvalidBounds()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new UnicodeRange(-1, 10));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new UnicodeRange(0x110000, 0x110000));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new UnicodeRange(0, -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new UnicodeRange(0, 0x110000));
+        Assert.Throws<ArgumentException>(() => new UnicodeRange(10, 5));
+    }
+
+    [Fact]
+    public void UnicodeRange_LengthAndContainsAreInclusive()
+    {
+        var range = new UnicodeRange(0x40, 0x4F);
+
+        Assert.Equal(16, range.Length);
+        Assert.Equal(1, new UnicodeRange(0x41, 0x41).Length);
+        Assert.True(range.Contains(0x40));
+        Assert.True(range.Contains(0x4F));
+        Assert.True(range.Contains(new Rune(0x45)));
+        Assert.False(range.Contains(0x3F));
+        Assert.False(range.Contains(0x50));
+    }
+
+    [Fact]
+    public void UnicodeRange_EqualityIsStructural()
+    {
+        var a = new UnicodeRange(0, 0x7F);
+        var b = new UnicodeRange(0, 0x7F);
+        var c = new UnicodeRange(0, 0x80);
+
+        Assert.Equal(a, b);
+        Assert.True(a == b);
+        Assert.False(a != b);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        Assert.NotEqual(a, c);
+        Assert.True(a != c);
+        Assert.Equal<object>(a, b);
+        Assert.NotEqual<object>("not a range", a);
+    }
+
+    [Fact]
+    public void UnicodeRange_ToStringUsesCodePointNotation()
+    {
+        Assert.Equal("U+0000..U+007F", new UnicodeRange(0, 0x7F).ToString());
+        Assert.Equal("U+10000..U+10FFFF", new UnicodeRange(0x10000, 0x10FFFF).ToString());
+    }
+
+    [Fact]
+    public void UnicodeBlocks_GetBlockMatchesBlockRange()
+    {
+        Assert.Same(UnicodeBlocks.BasicLatin, UnicodeBlocks.GetBlock(0x41));
+        Assert.Same(UnicodeBlocks.BasicLatin, UnicodeBlocks.GetBlock(new Rune('A')));
+        Assert.Same(UnicodeBlocks.Latin1Supplement, UnicodeBlocks.GetBlock(0x80));
+        Assert.Same(UnicodeBlocks.Unknown, UnicodeBlocks.GetBlock(-1));
+        Assert.Same(UnicodeBlocks.Unknown, UnicodeBlocks.GetBlock(0x110000));
+        Assert.Same(UnicodeBlocks.Unknown, UnicodeBlocks.GetBlock(int.MinValue));
+    }
+
+    [Fact]
+    public void UnicodeBlock_ExposesNameRangeAndEquality()
+    {
+        var block = UnicodeBlocks.BasicLatin;
+
+        Assert.Equal("Basic Latin", block.Name);
+        Assert.Equal(new UnicodeRange(0, 0x7F), block.Range);
+        Assert.True(block.Contains(0x41));
+        Assert.True(block.Contains(new Rune('A')));
+        Assert.False(block.Contains(0x80));
+        Assert.Equal("Basic Latin (U+0000..U+007F)", block.ToString());
+        Assert.Equal(block, UnicodeBlocks.BasicLatin);
+        Assert.NotEqual(block, UnicodeBlocks.Latin1Supplement);
+        Assert.False(block.Equals(null));
+        Assert.Equal(block.GetHashCode(), UnicodeBlocks.BasicLatin.GetHashCode());
+    }
 }


### PR DESCRIPTION
The Unicode character database is regenerated weekly and unattended by
`update-unicode-confusables.yml`, which auto-commits and opens a PR. The test suite that
gates it asserts on **four** code points out of 297,334 — U+0041, U+0030, U+00BD and
U+1F600 — and every one of them is written as an explicit line in `UnicodeData.txt`.

**No test touched a range-expanded code point**, yet 256,864 entries (86.4% of the table)
exist only because the generator expands `UnicodeData.txt`'s `, First>` / `, Last>` range
markers into one record per code point — all of CJK, Hangul and both Private Use planes.

Concretely: `Program.cs:191` matches `name.EndsWith(", First>")`. If upstream ever changed
that spacing to `, First >`, both marker lines would become ordinary entries, ~256,000 code
points would silently vanish, **no exception would be thrown**, and every test would still
pass. `GetCharacterInfo(new Rune(0x4E00))`, `(0xAC00)` and `(0xE000)` would all return null.

`UnicodeRange` and `UnicodeBlock` also had zero tests anywhere in the repo, despite being
shipped public types with a `ref/` API baseline — the baseline pins their signatures but
nothing pinned their behaviour.

## What changed

Tests only. No production code is touched.

- `AllCharacters_MatchesGeneratedEntryCount` — pins the entry count at 297,334. This must be
  bumped in the same PR as any data refresh, which is the point: it forces a human to look at
  the delta instead of rubber-stamping a green CI run.
- `GetCharacterInfo_ResolvesRangeExpandedCodePoints` — five range-derived code points
  (CJK URO, Hangul, BMP PUA, CJK Ext B, Plane 15 PUA) with their expected names.
- `AllCharacters_HaveConsistentBlockAndName` — one pass over all 297,334 entries asserting
  each entry's `Block` is the same instance `UnicodeBlocks.GetBlock` returns, that the block
  actually contains the rune, and that the name is non-empty. Accumulates up to 10 offenders
  so a failure names the code points.
- `UnicodeRange` — constructor guards, inclusive `Length`/`Contains` boundaries, structural
  equality and hash agreement, `ToString` above and below U+FFFF.
- `UnicodeBlocks.GetBlock` — a known block, a boundary, and the `Unknown` fallback for
  negative, `int.MinValue` and `> 0x10FFFF`.
- `UnicodeBlock` — name, range, `Contains`, equality, hash and `ToString`.

## Verification

`dotnet test tests/Meziantou.Framework.Unicode.Tests /p:TreatsWarningsAsErrors=true`

- before: 32 passed (16 facts x net10.0 + net11.0)
- after: **58 passed** (29 x 2), 0 failed, 0 skipped

The block-consistency pass reports 0 mismatches, 0 unknown blocks and 0 empty names against
the currently shipped data.

Found by a project review of `src/Meziantou.Framework.Unicode`.
