### PR TITLE
Reject queries that would overflow the stack or explode into disjunctive normal form

### DIFF
--- a/ref/Meziantou.Framework.SimpleQueryLanguage.cs
+++ b/ref/Meziantou.Framework.SimpleQueryLanguage.cs
@@ -52,6 +52,12 @@ namespace Meziantou.Framework.SimpleQueryLanguage
         public Meziantou.Framework.SimpleQueryLanguage.Query<T> Build(string query) => throw null;
     }
 
+    public sealed class QueryTooComplexException : System.Exception
+    {
+        public QueryTooComplexException(string? message) { }
+        public QueryTooComplexException(string? message, System.Exception? innerException) { }
+    }
+
     public sealed class Query<T>
     {
         public string Text { get => throw null; }

--- a/src/Meziantou.Framework.SimpleQueryLanguage/Binding/BoundQuery.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/Binding/BoundQuery.cs
@@ -1,5 +1,6 @@
 using System.CodeDom.Compiler;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Meziantou.Framework.SimpleQueryLanguage.Syntax;
 
 namespace Meziantou.Framework.SimpleQueryLanguage.Binding;
@@ -7,20 +8,70 @@ namespace Meziantou.Framework.SimpleQueryLanguage.Binding;
 /// <summary>Represents a bound query node in the query tree after semantic analysis.</summary>
 public abstract class BoundQuery
 {
+    /// <summary>
+    /// The largest number of disjunctions a query may expand to. Converting to disjunctive normal form
+    /// distributes AND over OR, so the term count grows exponentially with the number of OR groups.
+    /// </summary>
+    private const int MaxDisjunctions = 8192;
+
     /// <summary>Creates a disjunctive normal form representation of the query syntax tree.</summary>
     /// <param name="syntax">The query syntax tree to bind.</param>
     /// <returns>A list of disjunctions, where each disjunction is a list of conjunctions.</returns>
+    /// <exception cref="QueryTooComplexException">The query nests expressions too deeply, or expands to too many disjunctions.</exception>
     public static IReadOnlyList<IReadOnlyList<BoundQuery>> Create(QuerySyntax syntax)
     {
         ArgumentNullException.ThrowIfNull(syntax);
 
-        var result = CreateInternal(syntax);
-        var dnf = ToDisjunctiveNormalForm(result);
-        return Flatten(dnf);
+        try
+        {
+            var result = CreateInternal(syntax);
+            EnsureDisjunctionCountIsSupported(result);
+
+            var dnf = ToDisjunctiveNormalForm(result);
+            return Flatten(dnf);
+        }
+        catch (InsufficientExecutionStackException ex)
+        {
+            throw new QueryTooComplexException("The query nests expressions too deeply to be evaluated", ex);
+        }
+    }
+
+    /// <summary>
+    /// Computes how many disjunctions <see cref="ToDisjunctiveNormalForm"/> would produce, without
+    /// materializing them, so an oversized query is rejected before any work is done.
+    /// </summary>
+    private static void EnsureDisjunctionCountIsSupported(BoundQuery node)
+    {
+        var count = CountDisjunctions(node, isNegated: false);
+        if (count > MaxDisjunctions)
+            throw new QueryTooComplexException($"The query expands to more than {MaxDisjunctions} disjunctions. Reduce the number of OR groups combined with AND.");
+    }
+
+    private static int CountDisjunctions(BoundQuery node, bool isNegated)
+    {
+        RuntimeHelpers.EnsureSufficientExecutionStack();
+
+        // Negation swaps AND and OR, so it also swaps how the term count grows.
+        return node switch
+        {
+            BoundNegatedQuery negatedQuery => CountDisjunctions(negatedQuery.Query, !isNegated),
+            BoundAndQuery andQuery when isNegated => Add(CountDisjunctions(andQuery.Left, isNegated: true), CountDisjunctions(andQuery.Right, isNegated: true)),
+            BoundAndQuery andQuery => Multiply(CountDisjunctions(andQuery.Left, isNegated: false), CountDisjunctions(andQuery.Right, isNegated: false)),
+            BoundOrQuery orQuery when isNegated => Multiply(CountDisjunctions(orQuery.Left, isNegated: true), CountDisjunctions(orQuery.Right, isNegated: true)),
+            BoundOrQuery orQuery => Add(CountDisjunctions(orQuery.Left, isNegated: false), CountDisjunctions(orQuery.Right, isNegated: false)),
+            _ => 1,
+        };
+
+        // Saturating arithmetic: the exact count can overflow an int, and anything past the limit is equally rejected.
+        static int Add(int a, int b) => (int)Math.Min((long)a + b, MaxDisjunctions + 1L);
+
+        static int Multiply(int a, int b) => (int)Math.Min((long)a * b, MaxDisjunctions + 1L);
     }
 
     private static BoundQuery CreateInternal(QuerySyntax syntax)
     {
+        RuntimeHelpers.EnsureSufficientExecutionStack();
+
         return syntax.Kind switch
         {
             QuerySyntaxKind.TextQuery => CreateTextExpression((TextQuerySyntax)syntax),
@@ -84,6 +135,8 @@ public abstract class BoundQuery
 
     private static BoundQuery ToDisjunctiveNormalForm(BoundQuery node)
     {
+        RuntimeHelpers.EnsureSufficientExecutionStack();
+
         if (node is BoundNegatedQuery negated)
             return ToDisjunctiveNormalForm(Negate(negated.Query));
 
@@ -136,6 +189,8 @@ public abstract class BoundQuery
 
     private static BoundQuery Negate(BoundQuery node)
     {
+        RuntimeHelpers.EnsureSufficientExecutionStack();
+
         return node switch
         {
             BoundKeyValueQuery kevValue => NegateKevValueQuery(kevValue),

--- a/src/Meziantou.Framework.SimpleQueryLanguage/QueryTooComplexException.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/QueryTooComplexException.cs
@@ -1,0 +1,24 @@
+namespace Meziantou.Framework.SimpleQueryLanguage;
+
+/// <summary>Exception thrown when a query is too complex to be parsed or evaluated.</summary>
+/// <remarks>
+/// A query can be too complex because it nests expressions too deeply, or because converting it to
+/// disjunctive normal form would produce an impractical number of terms. Queries coming from an
+/// untrusted source should be built inside a <see langword="try"/> block that handles this exception.
+/// </remarks>
+public sealed class QueryTooComplexException : Exception
+{
+    public QueryTooComplexException()
+    {
+    }
+
+    public QueryTooComplexException(string? message)
+        : base(message)
+    {
+    }
+
+    public QueryTooComplexException(string? message, Exception? innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Meziantou.Framework.SimpleQueryLanguage/Syntax/QuerySyntax.Parser.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/Syntax/QuerySyntax.Parser.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace Meziantou.Framework.SimpleQueryLanguage.Syntax;
 
 public partial class QuerySyntax
@@ -121,6 +123,10 @@ public partial class QuerySyntax
 
         private QuerySyntax ParsePrimaryExpression()
         {
+            // Parenthesized and negated expressions recurse, so a deeply nested query would otherwise
+            // overflow the stack and kill the process. This turns that into a catchable exception.
+            RuntimeHelpers.EnsureSufficientExecutionStack();
+
             return Current.Kind switch
             {
                 QuerySyntaxKind.NotKeyword => ParseNotExpression(),

--- a/src/Meziantou.Framework.SimpleQueryLanguage/Syntax/QuerySyntax.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/Syntax/QuerySyntax.cs
@@ -8,13 +8,21 @@ public abstract partial class QuerySyntax : QueryNodeOrToken
     /// <summary>Parses a query string into a syntax tree.</summary>
     /// <param name="text">The query string to parse.</param>
     /// <returns>The root node of the parsed syntax tree.</returns>
+    /// <exception cref="QueryTooComplexException">The query nests expressions too deeply to be parsed.</exception>
     public static QuerySyntax Parse(string text)
     {
         ArgumentNullException.ThrowIfNull(text);
 
         var tokens = Lexer.Tokenize(text).Where(t => t.Kind != QuerySyntaxKind.WhitespaceToken);
         var parser = new Parser(tokens);
-        return parser.Parse();
+        try
+        {
+            return parser.Parse();
+        }
+        catch (InsufficientExecutionStackException ex)
+        {
+            throw new QueryTooComplexException("The query nests expressions too deeply to be parsed", ex);
+        }
     }
 
     public override string ToString()

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
@@ -825,6 +825,64 @@ public sealed class QueryBuilderTests
         Assert.False(query.Evaluate(new Sample { Int32Value = 2, StringValue = "sample" }));
     }
 
+    [Fact]
+    public void DeeplyNestedParentheses_ThrowsQueryTooComplex()
+    {
+        var query = new string('(', 100_000) + "a" + new string(')', 100_000);
+
+        var queryBuilder = new QueryBuilder<Sample>();
+        queryBuilder.SetTextFilterHandler((obj, value) => true);
+
+        Assert.Throws<QueryTooComplexException>(() => queryBuilder.Build(query));
+    }
+
+    [Fact]
+    public void VeryLongConjunction_ThrowsQueryTooComplex()
+    {
+        var query = string.Join(' ', Enumerable.Range(0, 100_000).Select(i => "term" + i.ToString(CultureInfo.InvariantCulture)));
+
+        var queryBuilder = new QueryBuilder<Sample>();
+        queryBuilder.SetTextFilterHandler((obj, value) => true);
+
+        Assert.Throws<QueryTooComplexException>(() => queryBuilder.Build(query));
+    }
+
+    [Fact]
+    public void ManyOrGroupsCombinedWithAnd_ThrowsQueryTooComplex()
+    {
+        // Converting to disjunctive normal form would produce 2^30 terms
+        var query = string.Join(" AND ", Enumerable.Range(0, 30).Select(i => $"(a{i}:1 OR b{i}:2)"));
+
+        var queryBuilder = new QueryBuilder<Sample>();
+        queryBuilder.SetTextFilterHandler((obj, value) => true);
+
+        Assert.Throws<QueryTooComplexException>(() => queryBuilder.Build(query));
+    }
+
+    [Fact]
+    public void ModeratelyComplexQuery_IsStillSupported()
+    {
+        // 2^10 disjunctions is well within the limit and must keep working
+        var query = string.Join(" AND ", Enumerable.Range(0, 10).Select(i => $"(int32:{i} OR int32:{i + 100})"));
+
+        var queryBuilder = new QueryBuilder<Sample>();
+        queryBuilder.AddHandler<int>("int32", (obj, value) => obj.Int32Value == value);
+
+        Assert.False(queryBuilder.Build(query).Evaluate(new Sample { Int32Value = 0 }));
+    }
+
+    [Fact]
+    public void LongFreeTextQuery_IsStillSupported()
+    {
+        // A user pasting a long sentence into a search box must not be rejected
+        var query = string.Join(' ', Enumerable.Repeat("word", 500));
+
+        var queryBuilder = new QueryBuilder<Sample>();
+        queryBuilder.SetTextFilterHandler((obj, value) => obj.StringValue == value);
+
+        Assert.True(queryBuilder.Build(query).Evaluate(new Sample { StringValue = "word" }));
+    }
+
     private static QueryBuilder<Sample> CreateDateTimeOffsetRangeQueryBuilder(DateTimeOffset utcNow)
     {
         var timeProvider = new FakeTimeProvider();


### PR DESCRIPTION
`Meziantou.Framework.SimpleQueryLanguage` parses end-user search queries, so the query string is untrusted input. Two unbounded operations in the pipeline let a small query take the process down.

### 1. Unbounded recursion → uncatchable `StackOverflowException`

`Parser.ParsePrimaryExpression` recurses for parentheses and `NOT`, and `BoundQuery.CreateInternal` / `ToDisjunctiveNormalForm` / `Negate` recurse over the whole tree. Neither had a limit. Measured on `main`, Release, default 1 MB stack:

| Input | Result |
|---|---|
| `"("×3200 + "a" + ")"×3200` (~6.4 KB) | parses |
| `"("×6400 + "a" + ")"×6400` (~13 KB) | **process killed** in `ParseParenthesizedExpression` |
| 6,000 space-separated words (~35 KB) | binds |
| 8,000 space-separated words (~45 KB) | **process killed** in `BoundQuery.Create` |

Thresholds are several times lower in a Debug build. `StackOverflowException` cannot be caught in .NET — the runtime tears the process down, so a `try`/`catch` around `Build()` does not help and neither does an ASP.NET Core exception filter.

Note the long-conjunction case is not deep *nesting*: `ParseAndExpression` builds a left-deep tree in a loop, so 8,000 flat terms produce a spine 8,000 nodes deep that only the binder recurses over.

### 2. Exponential DNF expansion

`ToDisjunctiveNormalForm` distributes AND over OR with no ceiling, so the term count is 2^n in the number of OR groups. Measured on `main`, Release:

| OR groups | Query length | `QueryBuilder.Build` |
|---|---|---|
| 12 | 227 chars | 35 ms |
| 14 | 269 chars | 386 ms |
| 16 | 311 chars | 1,359 ms |
| 18 | **353 chars** | **10,499 ms** |

Each additional group roughly quadruples the cost. This happens at `Build` time, before any item is evaluated, so a caller cannot cheaply pre-validate around it.

## What changed

**Recursion** — `RuntimeHelpers.EnsureSufficientExecutionStack()` at each recursion site (the same approach Roslyn uses in its own parser and binder). `QuerySyntax.Parse` and `BoundQuery.Create` translate the resulting `InsufficientExecutionStackException` into a new public `QueryTooComplexException`.

This deliberately avoids an arbitrary depth limit. A fixed cap would have to reject long *flat* queries too, because a 500-word free-text query produces a 500-deep left spine — and pasting a paragraph into a search box is a legitimate thing to do. The stack probe rejects only what would actually have crashed.

**DNF size** — a new `CountDisjunctions` pre-pass computes the expansion size in O(nodes) with saturating arithmetic and no allocation, so an oversized query is rejected before a single node is materialized. Negation is accounted for by swapping the AND/OR growth rules, matching what `ToDisjunctiveNormalForm` does via `Negate`. The limit is `MaxDisjunctions = 8192`, which allows 13 OR groups (~100 ms) and rejects 14 or more.

## Behaviour change

Queries that previously crashed the process, or ran for minutes, now throw `QueryTooComplexException` from `QueryBuilder<T>.Build` / `ExpressionQueryBuilder<T>.Build` / `QuerySyntax.Parse` / `BoundQuery.Create`. Callers accepting untrusted input should catch it and return a "query too complex" response. No previously-working query is rejected — see the two `_IsStillSupported` tests.

Public API addition: `QueryTooComplexException`. `ref/` regenerated and committed.

## Verification

Five tests added to `QueryBuilderTests`: 100,000 nested parentheses, 100,000 flat terms and 30 OR groups all throw `QueryTooComplexException` instead of crashing; a 10-OR-group query and a 500-word free-text query still evaluate correctly. Full suite green — 238 tests across net10.0 and net11.0, `-p:TreatWarningsAsErrors=true`.

Found during a review of the project; the report also covers eight other findings that are going out as separate PRs.
