### PR TITLE
Recognize script and three-letter subtags when grouping satellite resx files

### DIFF
--- a/src/Meziantou.Framework.ResxSourceGenerator/ResxGeneratorCommon.cs
+++ b/src/Meziantou.Framework.ResxSourceGenerator/ResxGeneratorCommon.cs
@@ -137,6 +137,12 @@ internal static class ResxGeneratorCommon
         return path + Path.DirectorySeparatorChar;
     }
 
+    // Matches the shape of a BCP-47 culture name: a 2 or 3 letter language, an optional 4 letter script,
+    // and an optional region that is either 2 letters or 3 digits (zh, fil, zh-Hans, fr-FR, sr-Latn-RS, es-419).
+    // The shape is checked instead of asking CultureInfo so that grouping does not depend on the ICU version
+    // of the machine running the compiler.
+    private const string CultureNamePattern = "^[a-zA-Z]{2,3}(-[a-zA-Z]{4})?(-([a-zA-Z]{2}|[0-9]{3}))?$";
+
     private static string GetResourceName(string path)
     {
         var pathWithoutExtension = Path.Combine(Path.GetDirectoryName(path)!, Path.GetFileNameWithoutExtension(path));
@@ -144,7 +150,7 @@ internal static class ResxGeneratorCommon
         if (indexOf < 0)
             return pathWithoutExtension;
 
-        return Regex.IsMatch(pathWithoutExtension[(indexOf + 1)..], "^[a-zA-Z]{2}(-[a-zA-Z]{2})?$", RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1))
+        return Regex.IsMatch(pathWithoutExtension[(indexOf + 1)..], CultureNamePattern, RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1))
             ? pathWithoutExtension[0..indexOf]
             : pathWithoutExtension;
     }

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
@@ -309,6 +309,52 @@ public sealed class ResxGeneratorTest
             });
     }
 
+    [Theory]
+    [InlineData("fr")]
+    [InlineData("fil")]
+    [InlineData("fr-FR")]
+    [InlineData("zh-Hans")]
+    [InlineData("sr-Latn-RS")]
+    [InlineData("es-419")]
+    public async Task SatelliteResxFilesAreGroupedWithTheNeutralFile(string culture)
+    {
+        var element = new XElement("root", new XElement("data", new XAttribute("name", "Sample"), new XElement("value", "Value")));
+
+        var result = await GenerateFiles(
+            [
+                (FullPath.GetTempPath() / "proj" / "Messages.resx", element.ToString()),
+                (FullPath.GetTempPath() / "proj" / $"Messages.{culture}.resx", element.ToString()),
+            ], new OptionProvider
+            {
+                ProjectDir = FullPath.GetTempPath() / "proj",
+                RootNamespace = "Test",
+            });
+
+        Assert.Equal("Messages.resx.g.cs", result.GeneratedFileName);
+    }
+
+    [Theory]
+    [InlineData("Backup")]
+    [InlineData("v2")]
+    [InlineData("Design")]
+    public async Task NonCultureSuffixesAreTheirOwnResource(string suffix)
+    {
+        var element = new XElement("root", new XElement("data", new XAttribute("name", "Sample"), new XElement("value", "Value")));
+
+        var result = await GenerateFiles(
+            [
+                (FullPath.GetTempPath() / "proj" / "Messages.resx", element.ToString()),
+                (FullPath.GetTempPath() / "proj" / $"Messages.{suffix}.resx", element.ToString()),
+            ], new OptionProvider
+            {
+                ProjectDir = FullPath.GetTempPath() / "proj",
+                RootNamespace = "Test",
+            });
+
+        var fileNames = result.GeneratedTrees.Select(tree => Path.GetFileName(tree.FilePath)).Order(StringComparer.Ordinal);
+        Assert.Equal(new[] { $"Messages.{suffix}.resx.g.cs", "Messages.resx.g.cs" }.Order(StringComparer.Ordinal), fileNames);
+    }
+
     [Fact]
     public async Task ComputeNamespace_RootDir()
     {


### PR DESCRIPTION
## The bug

`ResxGeneratorCommon.GetResourceName` (`ResxGeneratorCommon.cs:147`) decided whether a trailing filename segment was a culture with:

```
^[a-zA-Z]{2}(-[a-zA-Z]{2})?$
```

That matches `fr` and `fr-FR`, but not `zh-Hans`, `zh-Hant-TW`, `sr-Latn-RS`, `fil`, `haw` or `es-419`. Any satellite resx using one of those was not grouped with its neutral file — it became a resource of its own.

Given `Res.resx`, `Res.fr-FR.resx` and `Res.zh-Hans.resx`, the generator emitted **two** files instead of one: `Res.resx.g.cs` and `Res.zh-Hans.resx.g.cs`.

Two consequences for the consumer:

1. A spurious `Res_zh_Hans` class appears in their API surface.
2. Its `ResourceManager` is built with a base name that has no matching neutral resource, so every lookup through it throws `MissingManifestResourceException` at runtime.

## What changed

Widened the pattern to the shape of a BCP-47 culture name — 2 or 3 letter language, optional 4 letter script, optional region that is either 2 letters or 3 digits — and pulled it into a named constant with a comment explaining the choice.

### Why a shape check and not `CultureInfo`

Asking `CultureInfo.GetCultureInfo` whether a segment is a real culture would be more precise, but it makes resx **grouping depend on the ICU version of the machine running the compiler**. Two developers on different OS versions would get different generated code from the same source tree. For a source generator that trade is not worth it, so the check stays purely lexical and deterministic.

### The trade-off worth reviewing

The design here has always been "a trailing segment shaped like a culture *is* a culture", and widening the shape widens the false positives with it. Concretely: `Messages.Bar.resx` (3 letters) is now grouped into `Messages.resx`, where before it was its own resource. `Messages.Ab.resx` already behaved that way, so this is the same class of risk rather than a new one — but it is a behaviour change and it is the part of this PR worth pushing back on if you'd rather match MSBuild's known-culture list instead.

## Verification

Two theories added to `ResxGeneratorTest.cs`:

- `SatelliteResxFilesAreGroupedWithTheNeutralFile` — `fr`, `fil`, `fr-FR`, `zh-Hans`, `sr-Latn-RS`, `es-419` each produce exactly one generated file.
- `NonCultureSuffixesAreTheirOwnResource` — `Backup`, `v2`, `Design` still produce two, so the widening is bounded.

Checked that the new tests fail against the old pattern: exactly the 4 cases it cannot express (`fil`, `zh-Hans`, `sr-Latn-RS`, `es-419`) fail, and `fr`, `fr-FR` plus all three non-culture suffixes pass. With the fix, 56/56 unit tests and 16/16 generator tests pass on net10.0 and net11.0.
