### PR TITLE
Apply negation to the unhandled property handler

### DIFF
--- a/src/Meziantou.Framework.SimpleQueryLanguage/QueryBuilder.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/QueryBuilder.cs
@@ -302,7 +302,9 @@ public sealed class QueryBuilder<T>
 
         if (_unhandledPropertyFilter is not null)
         {
-            return v => _unhandledPropertyFilter(v, node.Key, op, node.Value);
+            return node.IsNegated
+                    ? v => !_unhandledPropertyFilter(v, node.Key, op, node.Value)
+                    : v => _unhandledPropertyFilter(v, node.Key, op, node.Value);
         }
 
         return CreatePredicate(new BoundTextQuery(node.IsNegated, $"{node.Key}:{node.Value}"));

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
@@ -657,6 +657,18 @@ public sealed class QueryBuilderTests
         Assert.Throws<NotSupportedException>(() => query.Evaluate(new() { StringValue = "dummy:10" }));
     }
 
+    [Theory]
+    [InlineData("dummy:10", true)]
+    [InlineData("-dummy:10", false)]
+    [InlineData("NOT dummy:10", false)]
+    public void UnhandledField_HandlerRespectsNegation(string query, bool expectedResult)
+    {
+        var queryBuilder = new QueryBuilder<Sample>();
+        queryBuilder.SetUnhandledPropertyHandler((obj, key, op, value) => true);
+
+        Assert.Equal(expectedResult, queryBuilder.Build(query).Evaluate(new Sample()));
+    }
+
     [Fact]
     public void EmptyQuery()
     {


### PR DESCRIPTION
`QueryBuilder<T>.CreatePredicate(BoundKeyValueQuery)` honours `node.IsNegated` in every branch except the one that calls the unhandled-property handler:

```csharp
if (_unhandledPropertyFilter is not null)
{
    return v => _unhandledPropertyFilter(v, node.Key, op, node.Value);   // node.IsNegated dropped
}
```

The registered-handler branch just above it negates, and the free-text fallback just below it passes `node.IsNegated` through. Only this one drops it.

With a handler that returns `true`, on `main`:

| Query | Result | Expected |
|---|---|---|
| `dummy:10` | `True` | `True` |
| `-dummy:10` | `True` | `False` |
| `NOT dummy:10` | `True` | `False` |

`ExpressionQueryBuilder<T>` gets this right (`ExpressionQueryBuilder.cs:188-193` — `-foo:bar` correctly returns 0 rows there), so the two builders disagree on the same query string.

## Why it matters

`SetUnhandledPropertyHandler` is how callers support dynamic or user-defined fields. A saved search whose whole point is `-label:wontfix` matches everything instead of excluding it. No exception, no diagnostic — just silently wrong results.

## What changed

Wrap the delegate the same way the branch above it already does.

## Verification

A theory added to `QueryBuilderTests` covering `dummy:10`, `-dummy:10` and `NOT dummy:10`. It fails on `main` for the two negated cases. Full suite green — 234 tests across net10.0 and net11.0, `-p:TreatWarningsAsErrors=true`.

No public API change.

Found during a review of the project; the report also covers eight other findings that are going out as separate PRs.
