### PR TITLE
Zero the decrypted LSA secret before freeing its buffer

### DIFF
--- a/src/Meziantou.Framework.Win32.Lsa/LsaPrivateData.cs
+++ b/src/Meziantou.Framework.Win32.Lsa/LsaPrivateData.cs
@@ -105,10 +105,16 @@ public static class LsaPrivateData
             if (privateData is null)
                 return null;
 
-            var value = new string(privateData->Buffer.Value, 0, privateData->Length / 2);
-            FreeMemory(privateData);
-
-            return value;
+            try
+            {
+                return new string(privateData->Buffer.Value, 0, privateData->Length / 2);
+            }
+            finally
+            {
+                // Mimic SecureZeroMemory so the decrypted secret does not stay readable in the freed block. SecureZeroMemory is not an exported function, neither is RtlSecureZeroMemory
+                new Span<byte>(privateData->Buffer.Value, privateData->Length).Clear();
+                FreeMemory(privateData);
+            }
         }
     }
 


### PR DESCRIPTION
## The problem

`LsaRetrievePrivateData` hands back an LSA-allocated buffer holding the **decrypted** secret. `GetValue` copied it into a managed `string` and called `LsaFreeMemory`:

```csharp
var value = new string(privateData->Buffer.Value, 0, privateData->Length / 2);
FreeMemory(privateData);

return value;
```

Two problems with that:

1. `LsaFreeMemory` releases the block but does not scrub it, so the plaintext stayed in the process heap until that memory happened to be reused — recoverable from a crash dump, a `MiniDumpWriteDump`, or a swapped-out page. Dump-scraping is a routine post-exploitation step, and this library exists to hold credentials.
2. There was no `try`/`finally`. If `new string(...)` threw — `OutOfMemoryException` on a large secret — `privateData` was never freed at all: a native leak that also still held the plaintext.

## What changed

The copy moved into a `try`, and the `finally` zeroes the buffer before freeing it. This is the same treatment `CredentialManager` already applies to its own credential buffer (`CredentialManager.cs:487`); `LsaPrivateData` was the inconsistent one, so the comment is worded to match.

## Note on scope

This does not make the retrieved secret safe end to end — `GetValue` still returns a `string`, which is immutable, unpinned, and impossible for the caller to clear. Closing that gap needs a `Span<char>` or callback-style overload, which is new public API and a separate decision. This PR is the half that costs nothing.

## Verification

- Builds clean for `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`, 0 warnings.
- No test added: asserting that freed native memory was zeroed means reading memory after `LsaFreeMemory` has returned it to LSA, which is undefined behaviour and would be a flaky test rather than a real one. The change is a straight refactor of the copy-and-free sequence.
- **The existing tests were not executed.** They are Windows-only and this was developed on macOS, where all 5 skip. CI is the first real run.
