### PR TITLE
Use the custom parser for range comparison operators

### DIFF
--- a/src/Meziantou.Framework.SimpleQueryLanguage/QueryBuilder.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/QueryBuilder.cs
@@ -180,7 +180,7 @@ public sealed class QueryBuilder<T>
         else
         {
             // field>=1
-            if (ValueConverter.TryParseValue<TValue>(value, out var parsedValue))
+            if (tryParseValue(value, out var parsedValue))
             {
                 var range = new UnaryRangeSyntax<TValue>(op, parsedValue);
                 return predicate(obj, range);

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
@@ -657,6 +657,34 @@ public sealed class QueryBuilderTests
         Assert.Throws<NotSupportedException>(() => query.Evaluate(new() { StringValue = "dummy:10" }));
     }
 
+    [Theory]
+    [InlineData("size:medium", true)]
+    [InlineData("size>small", true)]
+    [InlineData("size>large", false)]
+    [InlineData("size>=medium", true)]
+    [InlineData("size<large", true)]
+    [InlineData("size<=small", false)]
+    public void RangeHandler_UsesCustomParserForComparisonOperators(string query, bool expectedResult)
+    {
+        var queryBuilder = new QueryBuilder<Sample>();
+        queryBuilder.AddRangeHandler<int>("size", (obj, range) => range.IsInRange(obj.Int32Value), TryParseSize);
+
+        Assert.Equal(expectedResult, queryBuilder.Build(query).Evaluate(new Sample { Int32Value = 2 }));
+
+        static bool TryParseSize(string value, out int result)
+        {
+            result = value switch
+            {
+                "small" => 1,
+                "medium" => 2,
+                "large" => 3,
+                _ => 0,
+            };
+
+            return result is not 0;
+        }
+    }
+
     [Fact]
     public void EmptyQuery()
     {


### PR DESCRIPTION
`AddRangeHandler<TValue>(key, predicate, tryParseValue)` lets a caller supply a parser for their own value type. `ConvertRangePredicate` threads that parser into the `EqualTo` and `NotEqualTo` branches, then ignores it in the branch handling `<`, `<=`, `>` and `>=`, which called `ValueConverter.TryParseValue<TValue>` directly.

Reproduced with a parser that records its calls:

```
AddRangeHandler<int>("n", …, customParser);

Build("n:abc").Evaluate(item)   =>  custom parser called with "abc"
Build("n>abc").Evaluate(item)   =>  custom parser NOT called; result false
```

`ValueConverter` cannot parse the caller's domain values, so it returns `false` and the predicate silently returns `false`.

## Why it matters

The custom parser is how a caller supports domain values — `size>large`, `priority>=p2`, `version>v1.2`. Those all silently return `false` while the `:` form works, which reads as "ranges are broken for my type" rather than "one line uses the wrong parser".

## What changed

Use the `tryParseValue` parameter that is already in scope. When the caller passes no parser, `AddRangeHandler` still substitutes `ValueConverter.TryParseValue`, so the default path is unchanged.

## Verification

A theory added to `QueryBuilderTests` using a `small`/`medium`/`large` parser across `:`, `>`, `>=`, `<` and `<=`. The four comparison cases fail on `main`. Full suite green — 240 tests across net10.0 and net11.0, `-p:TreatWarningsAsErrors=true`.

No public API change.

Found during a review of the project; the report also covers eight other findings that are going out as separate PRs.
