### PR TITLE
Stop sizing the resource-registration buffer on the stack

### DIFF
--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -87,7 +86,7 @@ public sealed class RestartManager : IDisposable
         ArgumentNullException.ThrowIfNull(path);
 
         string[] resources = [path];
-        var result = RegisterResources(SessionHandle, resources);
+        var result = PInvoke.RmRegisterResources(SessionHandle, resources, rgApplications: default, rgsServiceNames: default);
         if (result != WIN32_ERROR.ERROR_SUCCESS)
             throw new Win32Exception((int)result, $"RmRegisterResources failed ({result})");
     }
@@ -100,7 +99,7 @@ public sealed class RestartManager : IDisposable
     {
         ArgumentNullException.ThrowIfNull(paths);
 
-        var result = RegisterResources(SessionHandle, paths);
+        var result = PInvoke.RmRegisterResources(SessionHandle, paths, rgApplications: default, rgsServiceNames: default);
         if (result != WIN32_ERROR.ERROR_SUCCESS)
             throw new Win32Exception((int)result, $"RmRegisterResources failed ({result})");
     }
@@ -209,35 +208,6 @@ public sealed class RestartManager : IDisposable
             var result = PInvoke.RmStartSession(&localHandle, 0, new PWSTR(sessionKeyBufferPtr));
             handle = localHandle;
             return result;
-        }
-    }
-
-    private static unsafe WIN32_ERROR RegisterResources(uint sessionHandle, string[] paths)
-    {
-        if (paths.Length == 0)
-            return PInvoke.RmRegisterResources(sessionHandle, 0, (PCWSTR*)null, 0, (RM_UNIQUE_PROCESS*)null, 0, (PCWSTR*)null);
-
-        var handles = new GCHandle[paths.Length];
-        try
-        {
-            var pathPointers = stackalloc PCWSTR[paths.Length];
-            for (var i = 0; i < paths.Length; i++)
-            {
-                handles[i] = GCHandle.Alloc(paths[i], GCHandleType.Pinned);
-                pathPointers[i] = new PCWSTR((char*)handles[i].AddrOfPinnedObject());
-            }
-
-            return PInvoke.RmRegisterResources(sessionHandle, (uint)paths.Length, pathPointers, 0, (RM_UNIQUE_PROCESS*)null, 0, (PCWSTR*)null);
-        }
-        finally
-        {
-            foreach (var handle in handles)
-            {
-                if (handle.IsAllocated)
-                {
-                    handle.Free();
-                }
-            }
         }
     }
 

--- a/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
@@ -59,4 +59,31 @@ public class RestartManagerTests
             File.Delete(path);
         }
     }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void RegisterFiles_WithManyPaths()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        try
+        {
+            var paths = new string[2000];
+            for (var i = 0; i < paths.Length; i++)
+            {
+                paths[i] = Path.Combine(directory.FullName, $"file{i}.txt");
+            }
+
+            File.WriteAllText(paths[^1], "");
+            using (File.Open(paths[^1], FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                using var session = RestartManager.CreateSession();
+                session.RegisterFiles(paths);
+
+                Assert.Contains(_currentProcessId, session.GetProcessesLockingResources().Select(process => process.Id));
+            }
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
 }


### PR DESCRIPTION
`RegisterResources` sized its pointer array on the stack from a caller-supplied array length:

```csharp
var pathPointers = stackalloc PCWSTR[paths.Length];
```

`PCWSTR` is pointer-sized, so on x64 this is `8 × paths.Length` bytes against a 1 MB default stack (main thread and thread-pool threads alike). At roughly 131,000 paths the stack is exhausted, and a `StackOverflowException` in .NET cannot be caught — the runtime terminates the process immediately, with no chance to log or unwind. `RegisterFiles(string[])` is public and a large file list is exactly the Restart Manager's use case, so caller input reached that `stackalloc` unchecked.

## What changed

Deleted the hand-written marshalling helper and called the friendly overload CsWin32 already generates:

```csharp
PInvoke.RmRegisterResources(SessionHandle, paths, rgApplications: default, rgsServiceNames: default);
```

It does the identical `GCHandle`-pin-per-string work, but backs the pointer array with `ArrayPool<PCWSTR>.Shared` instead of the stack, so the length is bounded by the heap. It also handles the empty case correctly (`Rent(0)` plus `fixed` yields a null pointer with `nFiles = 0`), which made the `paths.Length == 0` special case redundant. `System.Runtime.InteropServices` went with it — `GCHandle` was its only use.

Net: 30 lines deleted, marshalling now maintained by CsWin32 rather than by hand. No public API change.

## Verification

- Builds clean on `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`, 0 warnings.
- `dotnet run ./eng/update-all.cs` produces no further changes.
- Added `RegisterFiles_WithManyPaths`, which registers 2000 paths in one call and asserts the locking process is found.

**The new test does not reproduce the original crash.** Doing that needs ~131k paths, which would mean a 131k-resource registry write in CI — the Restart Manager docs explicitly warn that `RmRegisterResources` "performs relatively expensive write operations". The test covers the batch path; the crash is removed by construction, since there is no longer a stack allocation to overflow.

⚠️ **Tests were not run locally.** Every test in this project is `[RunIf(TestOperatingSystems.Windows)]` and this was authored on macOS, where all four are skipped. The `windows-2025-vs2026` CI leg is the first real execution.

Found by a review of `src/Meziantou.Framework.Win32.RestartManager` (High severity finding).
