### PR TITLE
Escape Unicode block names before emitting them into generated code

### DIFF
--- a/tools/Meziantou.Framework.Unicode.Generator/Program.cs
+++ b/tools/Meziantou.Framework.Unicode.Generator/Program.cs
@@ -464,6 +464,47 @@ static Rune ParseSingleRune(string input)
     return new Rune(value);
 }
 
+// Values below come from files downloaded at build time, so they must never be
+// interpolated into generated source without escaping.
+static string EscapeStringLiteral(string value)
+{
+    var sb = new StringBuilder(value.Length);
+    foreach (var c in value)
+    {
+        switch (c)
+        {
+            case '\\':
+                sb.Append("\\\\");
+                break;
+
+            case '"':
+                sb.Append("\\\"");
+                break;
+
+            default:
+                if (char.IsControl(c))
+                {
+                    sb.Append(CultureInfo.InvariantCulture, $"\\u{(int)c:X4}");
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+
+                break;
+        }
+    }
+
+    return sb.ToString();
+}
+
+static string EscapeXmlText(string value)
+{
+    return value.Replace("&", "&amp;", StringComparison.Ordinal)
+        .Replace("<", "&lt;", StringComparison.Ordinal)
+        .Replace(">", "&gt;", StringComparison.Ordinal);
+}
+
 static string EscapeString(string value)
 {
     var sb = new StringBuilder();
@@ -1229,8 +1270,8 @@ async Task WriteUnicodeBlocksFile(List<(int Start, int End, string Name)> blockR
     {
         var propertyName = ToPropertyName(name);
         var codePointCount = end - start + 1;
-        sb.AppendLine(CultureInfo.InvariantCulture, $"    /// <summary>{name} (U+{start:X4}..U+{end:X4}, {codePointCount:N0} code points).</summary>");
-        sb.AppendLine(CultureInfo.InvariantCulture, $"    public static UnicodeBlock {propertyName} {{ get; }} = UnicodeBlock.CreateInternal(\"{name}\", new UnicodeRange(0x{start:X}, 0x{end:X}));");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"    /// <summary>{EscapeXmlText(name)} (U+{start:X4}..U+{end:X4}, {codePointCount:N0} code points).</summary>");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"    public static UnicodeBlock {propertyName} {{ get; }} = UnicodeBlock.CreateInternal(\"{EscapeStringLiteral(name)}\", new UnicodeRange(0x{start:X}, 0x{end:X}));");
         sb.AppendLine();
     }
 
@@ -1305,7 +1346,12 @@ async Task WriteUnicodeBlocksFile(List<(int Start, int End, string Name)> blockR
                 sb.Append(c);
             }
         }
-        return sb.ToString();
+
+        var propertyName = sb.ToString();
+        if (propertyName.Length == 0 || !char.IsLetter(propertyName[0]))
+            throw new InvalidOperationException($"Block name '{blockName}' does not yield a valid C# identifier");
+
+        return propertyName;
     }
 }
 


### PR DESCRIPTION
`WriteUnicodeBlocksFile` interpolates the Unicode block name — read verbatim from the
`Blocks.txt` file downloaded at build time (`Program.cs:288-289`) — straight into generated
C# with no escaping:

```csharp
sb.AppendLine(..., $"    /// <summary>{name} (U+{start:X4}..U+{end:X4}, ...).</summary>");
sb.AppendLine(..., $"    public static UnicodeBlock {propertyName} {{ get; }} = UnicodeBlock.CreateInternal(\"{name}\", ...);");
```

A name containing a double quote closes the string literal and injects arbitrary C# into
`UnicodeBlocks.g.cs`. The weekly `update-unicode-confusables.yml` job then auto-commits that
file and opens a PR; once merged it ships in the NuGet package and runs in every consumer's
process on first touch of `UnicodeBlocks`. A payload hidden inside a large generated data
diff is unlikely to be caught in review.

The generator already knows to do this — `EscapeString` at `Program.cs:467` is applied to
confusable replacement values at `:1171`. Block names were simply missed.

**Precondition, stated plainly:** exploiting this requires controlling what unicode.org
serves over HTTPS. That is a steep bar, and this is hardening rather than a live hole. But
the fix costs nothing and the failure mode is code execution in CI and in the shipped package.

## What changed

- `EscapeStringLiteral` — escapes `\`, `"` and control characters for use inside a C# string
  literal. Deliberately *not* `EscapeString`, which escapes every character as `\uXXXX`; that
  is right for confusable replacement values but would render all 346 block names unreadable.
- `EscapeXmlText` — escapes `&`, `<` and `>` for the XML doc comment, the second injection
  point on the line above.
- `ToPropertyName` now throws when a block name does not yield a valid C# identifier. The
  identifier was already safe (non-alphanumerics are stripped), but a name like `"123"` or
  `"!!!"` would previously emit uncompilable source; now it fails with a clear message.

The `GetBlock` switch arms use `propertyName`, which was already sanitized, so they are
untouched.

## Verification

There is no test project for the generator, so this is verified by running it end to end
against live unicode.org data:

```
dotnet run --project tools/Meziantou.Framework.Unicode.Generator
```

Exit code **0** — the generator's convention for "nothing changed" — and `git status` shows
only `Program.cs` modified. All 346 current block names pass through both escapers unchanged
and `UnicodeBlocks.g.cs` is byte-identical, which is exactly the intended outcome: the fix is
a no-op on well-formed data and only bites on hostile input.

`dotnet build ... /p:TreatsWarningsAsErrors=true` — 0 warnings, 0 errors.

Adding a test project for the generator is tracked separately; it is a prerequisite for unit
testing this and is a larger restructuring job, since the generator is top-level statements
with local functions.

Found by a project review of `src/Meziantou.Framework.Unicode`.
