### PR TITLE
Validate the query argument in both Build methods

### DIFF
--- a/src/Meziantou.Framework.SimpleQueryLanguage/ExpressionQueryBuilder.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/ExpressionQueryBuilder.cs
@@ -114,6 +114,8 @@ public sealed class ExpressionQueryBuilder<T>
     /// <returns>A compiled expression query that can be applied to an <see cref="IQueryable{T}"/>.</returns>
     public ExpressionQuery<T> Build(string query)
     {
+        ArgumentNullException.ThrowIfNull(query);
+
         if (string.IsNullOrWhiteSpace(query))
             return new ExpressionQuery<T>(query, predicate: null);
 

--- a/src/Meziantou.Framework.SimpleQueryLanguage/QueryBuilder.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/QueryBuilder.cs
@@ -224,6 +224,8 @@ public sealed class QueryBuilder<T>
     /// <returns>A compiled query that can be evaluated against objects.</returns>
     public Query<T> Build(string query)
     {
+        ArgumentNullException.ThrowIfNull(query);
+
         var predicate = CreatePredicate(query);
         return new Query<T>(query, predicate);
     }

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
@@ -168,6 +168,15 @@ public sealed class ExpressionQueryBuilderTests
         Assert.Null(query.Predicate);
     }
 
+    [Fact]
+    public void Build_NullQuery_ThrowsArgumentNullException()
+    {
+        var queryBuilder = new ExpressionQueryBuilder<Sample>();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => queryBuilder.Build(query: null!));
+        Assert.Equal("query", exception.ParamName);
+    }
+
     private sealed class Sample
     {
         public int Int32Value { get; set; }

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
@@ -658,6 +658,15 @@ public sealed class QueryBuilderTests
     }
 
     [Fact]
+    public void Build_NullQuery_ThrowsArgumentNullException()
+    {
+        var queryBuilder = new QueryBuilder<Sample>();
+
+        var exception = Assert.Throws<ArgumentNullException>(() => queryBuilder.Build(query: null!));
+        Assert.Equal("query", exception.ParamName);
+    }
+
+    [Fact]
     public void EmptyQuery()
     {
         var queryBuilder = new QueryBuilder<Sample>();


### PR DESCRIPTION
Neither `Build` method validates its argument, and they fail differently:

- `QueryBuilder<T>.Build(null)` throws `NullReferenceException` from `query.Length` in `CreatePredicate`. `QuerySyntax.Parse` guards its own argument properly (`QuerySyntax.cs:13`) — `Build` just never reaches it.
- `ExpressionQueryBuilder<T>.Build(null)` throws `ArgumentNullException` with `paramName: "text"`, which is `ExpressionQuery<T>`'s constructor parameter leaking out. A caller sees a parameter name that does not exist on the method they called.

Neither produces a wrong result, but both turn a caller's typo into a confusing diagnostic.

## What changed

`ArgumentNullException.ThrowIfNull(query)` at the top of both methods, so each reports `"query"`.

## Verification

One test per builder asserting the exception type and `ParamName`. Both fail on `main` — the first with `NullReferenceException`, the second with `ParamName == "text"`. Full suite green — 232 tests across net10.0 and net11.0, `-p:TreatWarningsAsErrors=true`.

No public API change.

## Not included

The review that turned this up also flagged the duplicate-handler-registration behaviour in the same area: `AddHandlerCore` uses `Dictionary.Add`, so registering a key twice throws `ArgumentException: An item with the same key has already been added. Key: ExpressionFilterKey { Key = id, Operator = EqualTo }` — exposing a private record struct in a user-facing message — while the public `AddHandler(string, KeyValueOperator, Func<…>)` overload uses the indexer and silently overwrites. The two registration paths disagree about whether re-registering is legal. That is a policy decision rather than a fix, so it is left out of this PR.

Found during a review of the project; the report also covers eight other findings that are going out as separate PRs.
