### PR TITLE
Qualify the EditorBrowsable attribute on the generated Culture property

### DIFF
--- a/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
+++ b/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
@@ -167,7 +167,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
+        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
 
         " + AppendNotNullIfNotNull("defaultValue") + @"

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
@@ -123,6 +123,25 @@ public sealed class ResxGeneratorTest
     }
 
     [Fact]
+    public async Task GeneratedCodeQualifiesEveryFrameworkTypeReference()
+    {
+        // A consumer can declare a type or namespace named System, so nothing in the generated code may rely on it
+        var element = new XElement("root", new XElement("data", new XAttribute("name", "Sample"), new XElement("value", "Value")));
+        var result = await GenerateFiles([("test.resx", element.ToString())], new OptionProvider
+        {
+            Namespace = "test",
+            ResourceName = "test",
+        });
+
+        var fileContent = result.GeneratedFileRoot.ToFullString();
+        for (var index = fileContent.IndexOf("System.", StringComparison.Ordinal); index >= 0; index = fileContent.IndexOf("System.", index + 1, StringComparison.Ordinal))
+        {
+            var qualified = index >= 8 && fileContent.AsSpan(index - 8, 8).SequenceEqual("global::".AsSpan());
+            Assert.True(qualified, "Unqualified reference: " + fileContent[Math.Max(0, index - 40)..Math.Min(fileContent.Length, index + 40)]);
+        }
+    }
+
+    [Fact]
     public async Task GenerateProperties_WithFormatParameterMetadata()
     {
         XNamespace generatorNamespace = "https://meziantou.net/meziantou.framework/resxgenerator";


### PR DESCRIPTION
## The bug

Every type reference in the generated code is `global::`-qualified — except one. `ResxGenerator.cs:170` emitted:

```csharp
[System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
public static global::System.Globalization.CultureInfo? Culture { get; set; }
```

while the identical attribute on `ResourceManager` twelve lines earlier is fully qualified.

A consumer with a type or namespace named `System` in scope — which is exactly what the `global::` convention throughout this file exists to guard against — gets a compile error inside generated code they never wrote.

## What changed

Added the two missing `global::` prefixes.

## Verification

Added `GeneratedCodeQualifiesEveryFrameworkTypeReference`, which walks the generated output and asserts that every occurrence of `System.` is immediately preceded by `global::`. That covers the whole emitted surface rather than just this one attribute, so a future unqualified reference anywhere in the boilerplate fails the test too.

Confirmed it fails when the fix is reverted, and 40/40 unit tests pass with it on net10.0 and net11.0.
