### PR TITLE
Reject cgroup names and page sizes that are not a single path segment

### DIFF
--- a/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.HugeTlb.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.HugeTlb.cs
@@ -8,7 +8,7 @@ public partial class CGroup2
     /// <param name="bytes">Maximum usage in bytes, or null for no limit.</param>
     public void SetHugeTlbMax(string pageSize, long? bytes)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(pageSize);
+        ValidateSegment(pageSize, nameof(pageSize));
         if (bytes.HasValue)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(bytes.Value, nameof(bytes));
@@ -24,7 +24,7 @@ public partial class CGroup2
     /// <returns>The limit in bytes, or null if set to max.</returns>
     public long? GetHugeTlbMax(string pageSize)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(pageSize);
+        ValidateSegment(pageSize, nameof(pageSize));
 
         var fileName = $"hugetlb.{pageSize}.max";
         var content = ReadFile(fileName);
@@ -47,7 +47,7 @@ public partial class CGroup2
     /// <returns>Current usage in bytes.</returns>
     public long? GetHugeTlbCurrent(string pageSize)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(pageSize);
+        ValidateSegment(pageSize, nameof(pageSize));
 
         var fileName = $"hugetlb.{pageSize}.current";
         var content = ReadFile(fileName);
@@ -66,7 +66,7 @@ public partial class CGroup2
     /// <returns>Number of limit hits.</returns>
     public long? GetHugeTlbEventsMax(string pageSize)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(pageSize);
+        ValidateSegment(pageSize, nameof(pageSize));
 
         var fileName = $"hugetlb.{pageSize}.events";
         var content = ReadFile(fileName);

--- a/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
@@ -47,6 +47,8 @@ public sealed partial class CGroup2
     /// <returns>The child cgroup.</returns>
     public CGroup2? GetChild(string name)
     {
+        ValidateSegment(name, nameof(name));
+
         if (!Directory.Exists(System.IO.Path.Combine(_path, name)))
             return null;
 
@@ -58,6 +60,8 @@ public sealed partial class CGroup2
     /// <returns>The child cgroup.</returns>
     public CGroup2 CreateOrGetChild(string name)
     {
+        ValidateSegment(name, nameof(name));
+
         var child = new CGroup2(name, this);
         Directory.CreateDirectory(child._path);
         return child;
@@ -478,6 +482,18 @@ public sealed partial class CGroup2
     #endregion
 
     #region Helper Methods
+
+    /// <summary>Ensures a caller-provided value is a single path segment, so it cannot escape the cgroup hierarchy.</summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="paramName">The name of the parameter being validated.</param>
+    /// <exception cref="ArgumentException">The value is empty, is a relative path segment, or contains a directory separator.</exception>
+    internal static void ValidateSegment(string value, string paramName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value, paramName);
+
+        if (value is "." or ".." || value.AsSpan().ContainsAny('/', '\0'))
+            throw new ArgumentException($"'{value}' must be a single path segment and cannot be '.', '..', or contain '/'", paramName);
+    }
 
     private string ReadFile(string fileName)
     {

--- a/tests/Meziantou.Framework.Unix.ControlGroups.Tests/CGroup2NameValidationTests.cs
+++ b/tests/Meziantou.Framework.Unix.ControlGroups.Tests/CGroup2NameValidationTests.cs
@@ -1,0 +1,48 @@
+namespace Meziantou.Framework.Unix.ControlGroups.Tests;
+
+/// <summary>Name validation happens before any file system access, so these run on every OS without privileges.</summary>
+public sealed class CGroup2NameValidationTests
+{
+    [Theory]
+    [InlineData("/tmp/evil")]
+    [InlineData("../../../tmp/evil")]
+    [InlineData("..")]
+    [InlineData(".")]
+    [InlineData("a/b")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CreateOrGetChild_ShouldRejectNamesThatAreNotASingleSegment(string name)
+    {
+        Assert.ThrowsAny<ArgumentException>(() => CGroup2.Root.CreateOrGetChild(name));
+    }
+
+    [Theory]
+    [InlineData("/tmp/evil")]
+    [InlineData("../../../tmp/evil")]
+    [InlineData("a/b")]
+    public void GetChild_ShouldRejectNamesThatAreNotASingleSegment(string name)
+    {
+        Assert.ThrowsAny<ArgumentException>(() => CGroup2.Root.GetChild(name));
+    }
+
+    [Theory]
+    [InlineData("2MB/../../../etc/passwd")]
+    [InlineData("../../2MB")]
+    [InlineData("")]
+    public void HugeTlb_ShouldRejectPageSizesThatAreNotASingleSegment(string pageSize)
+    {
+        Assert.ThrowsAny<ArgumentException>(() => CGroup2.Root.SetHugeTlbMax(pageSize, 1024));
+        Assert.ThrowsAny<ArgumentException>(() => CGroup2.Root.GetHugeTlbMax(pageSize));
+        Assert.ThrowsAny<ArgumentException>(() => CGroup2.Root.GetHugeTlbCurrent(pageSize));
+        Assert.ThrowsAny<ArgumentException>(() => CGroup2.Root.GetHugeTlbEventsMax(pageSize));
+    }
+
+    [Theory]
+    [InlineData("myapp")]
+    [InlineData("worker.1")]
+    [InlineData("test_cgroup_0")]
+    public void ValidateSegment_ShouldAcceptOrdinaryNames(string name)
+    {
+        CGroup2.ValidateSegment(name, nameof(name));
+    }
+}


### PR DESCRIPTION
## Finding

`CGroup2` built its path with `Path.Combine` and never validated the caller-supplied name (`CGroup2.cs:26-64`). `Path.Combine` returns the second argument whole when it is rooted, and does not collapse `..`:

| `name` passed to `CreateOrGetChild` | resulting path |
|---|---|
| `/etc/cron.d/x` | `/etc/cron.d/x` |
| `../../../tmp/evil` | `/tmp/evil` |
| `..` | `/sys/fs` |

`Directory.CreateDirectory` and `Directory.Delete` both normalise before acting, so `CGroup2.Root.CreateOrGetChild(nameFromConfig)` created a directory at an attacker-chosen path — in a process that, by this library's own requirements, is running as root. `Delete()` then removed any empty directory on the system.

There was a second, quieter consequence. Once the path left cgroupfs, `WriteFile` no longer wrote to a kernel interface file: `File.WriteAllText` *creates* a regular file. `AssociateProcess(pid)` would write the PID into a plain text file named `cgroup.procs` and return normally, so the caller believed a process was confined when it was not.

The same applied to `pageSize`, which `CGroup2.HugeTlb.cs` interpolated straight into the file name (`hugetlb.{pageSize}.max`).

## Change

Adds `CGroup2.ValidateSegment`, which rejects `null`/empty/whitespace, `.`, `..`, and any value containing `/` or `\0` — a cgroup name is a single directory component, so this costs nothing in expressiveness. It is called from the three places that accept a caller-supplied segment:

- `GetChild(string name)`
- `CreateOrGetChild(string name)`
- the four HugeTLB methods, replacing the weaker `ArgumentException.ThrowIfNullOrWhiteSpace(pageSize)` guard

Validation happens before any file system access, so the guard cannot be reached with a partially applied side effect.

## Verification

`dotnet build -p:TreatWarningsAsErrors=true` clean for `net10.0` and `net11.0`; `dotnet run ./eng/update-all.cs` reports no changes. No public API change (`ValidateSegment` is `internal`), so `ref/` is untouched.

New `CGroup2NameValidationTests` — 16 tests, all passing. Because validation short-circuits before touching the file system, **these run on every OS and need no privileges**, so unlike the rest of this project's suite they actually execute in CI.
