### PR TITLE
Honor cancellation between resx groups and resx files

### DIFF
--- a/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
+++ b/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
@@ -35,6 +35,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
 
         foreach (var resxGroup in resxGroups)
         {
+            context.CancellationToken.ThrowIfCancellationRequested();
             var hasError = false;
 
             string? GetMetadataValue(string name, string? globalName)
@@ -415,6 +416,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
         var entries = new List<ResxEntry>();
         foreach (var entry in resxGroug.OrderBy(file => file.Path, StringComparer.Ordinal))
         {
+            context.CancellationToken.ThrowIfCancellationRequested();
             var content = entry.GetText(context.CancellationToken);
             if (content is null)
                 continue;

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
@@ -402,6 +402,49 @@ public sealed class ResxGeneratorTest
         Assert.Empty(diagnostics);
     }
 
+    [Fact]
+    public async Task GenerationStopsWhenCancellationIsRequested()
+    {
+        using var cts = new CancellationTokenSource();
+        var element = new XElement("root", new XElement("data", new XAttribute("name", "Sample"), new XElement("value", "Value")));
+        var compilation = await CreateCompilation();
+
+        // The first group cancels while it is being read, so the remaining groups must not be generated
+        AdditionalText[] additionalTexts =
+        [
+            new CancellingAdditionalText("a.resx", element.ToString(), cts),
+            new TestAdditionalText("b.resx", element.ToString()),
+        ];
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: [new ResxGenerator().AsSourceGenerator()],
+            additionalTexts: additionalTexts,
+            optionsProvider: new OptionProvider { Namespace = "test", ResourceName = "test" });
+
+        Assert.Throws<OperationCanceledException>(() => driver.RunGenerators(compilation, cts.Token));
+    }
+
+    private sealed class CancellingAdditionalText : AdditionalText
+    {
+        private readonly CancellationTokenSource _cancellationTokenSource;
+        private readonly SourceText _text;
+
+        public CancellingAdditionalText(string path, string text, CancellationTokenSource cancellationTokenSource)
+        {
+            Path = path;
+            _text = SourceText.From(text);
+            _cancellationTokenSource = cancellationTokenSource;
+        }
+
+        public override string Path { get; }
+
+        public override SourceText GetText(CancellationToken cancellationToken = default)
+        {
+            _cancellationTokenSource.Cancel();
+            return _text;
+        }
+    }
+
     private sealed class OptionProvider : AnalyzerConfigOptionsProvider
     {
         public string? ProjectDir { get; set; }


### PR DESCRIPTION
## The bug

`ResxGenerator.Execute` threaded `context.CancellationToken` into `AdditionalText.GetText`, but never checked it itself. The loop over resx groups (`ResxGenerator.cs:36-111`) and the loop over the files in a group (`LoadResourceFiles`, `ResxGenerator.cs:416`) both ran to completion regardless of whether the compilation had been cancelled.

Keystrokes in the IDE cancel and restart generator passes constantly. Work that ignores cancellation keeps parsing XML and building source text for a result that is already going to be thrown away, which shows up as editor latency on projects with many or large resx files.

## What changed

Two `context.CancellationToken.ThrowIfCancellationRequested()` calls: one at the top of the group loop in `Execute`, one at the top of the file loop in `LoadResourceFiles`.

Deliberately **not** added to the per-entry loop in `GenerateCode`. The per-group and per-file checks already bound the work to one resx file, and leaving that method alone keeps this PR from colliding with the emission changes in the other open resx PRs.

## Verification

Added `GenerationStopsWhenCancellationIsRequested`. It drives the generator over two resx groups where the first group's `AdditionalText.GetText` cancels the token as a side effect, then asserts `RunGenerators` throws `OperationCanceledException` rather than going on to generate the second group.

The check that mattered here was the negative one: Roslyn's driver could plausibly have noticed the cancellation by itself and made the test pass regardless. It does not — with both `ThrowIfCancellationRequested` calls removed, the test fails. So it is testing this change and not the host.

40/40 unit tests pass on net10.0 and net11.0.
