### PR TITLE
Size the Unicode string read buffer from the whole string table

### DIFF
--- a/src/Meziantou.Framework.Unicode/UnicodeCharacterInfos.cs
+++ b/src/Meziantou.Framework.Unicode/UnicodeCharacterInfos.cs
@@ -33,7 +33,7 @@ internal static partial class UnicodeCharacterInfos
         var strings = new string[stringCount];
         for (var i = 0; i < strings.Length; i++)
         {
-            strings[i] = ReadString255LengthMax(stream);
+            strings[i] = ReadString(stream);
         }
 
         var entries = new Dictionary<Rune, UnicodeCharacterInfo>(capacity: entryCount);
@@ -92,13 +92,13 @@ internal static partial class UnicodeCharacterInfos
         return values[index];
     }
 
-    private static string ReadString255LengthMax(Stream stream)
+    private static string ReadString(Stream stream)
     {
         var length = ReadByte(stream);
         if (length == 0)
             return "";
 
-        Span<byte> buffer = stackalloc byte[MaxCharacterNameLength];
+        Span<byte> buffer = stackalloc byte[MaxSerializedStringLength];
         stream.ReadExactly(buffer[..length]);
         return Encoding.UTF8.GetString(buffer[..length]);
     }

--- a/src/Meziantou.Framework.Unicode/UnicodeCharacterInfos.g.cs
+++ b/src/Meziantou.Framework.Unicode/UnicodeCharacterInfos.g.cs
@@ -6,7 +6,7 @@
 //   - Total characters: 297334
 //   - Emoji characters: 1537
 //   - Compressed size: 992,905 bytes (6.7% of uncompressed)
-//   - Max character name length: 88 chars
+//   - Max serialized string length: 100 bytes
 //
 // Specification: https://www.unicode.org/reports/tr44/
 // DO NOT MODIFY THIS FILE MANUALLY - regenerate using the Unicode generator tool
@@ -16,5 +16,5 @@
 namespace Meziantou.Framework;
 internal static partial class UnicodeCharacterInfos
 {
-    private const int MaxCharacterNameLength = 128;
+    private const int MaxSerializedStringLength = 128;
 }

--- a/tools/Meziantou.Framework.Unicode.Generator/Program.cs
+++ b/tools/Meziantou.Framework.Unicode.Generator/Program.cs
@@ -390,11 +390,19 @@ async Task WriteUnicodeCharacterInfosFile(List<(int Start, int End, string Name)
     if (WriteUnicodeDataBinaryIfChanged(unicodeDataPath, unicodeDataBytes, unicodeDataEntries))
         outputUpdated = true;
 
-    var maxNameLength = unicodeDataEntries.Max(entry => entry.Name.Length);
-    var maxNameLengthPowerOfTwo = NextPowerOfTwo(maxNameLength);
+    // The reader uses a single stack buffer for every string in the table, not just names,
+    // and the serialized length prefix is a UTF-8 byte count. Bound both accordingly.
+    var maxStringByteLength = unicodeDataEntries.Max(entry => Math.Max(
+        Encoding.UTF8.GetByteCount(entry.Name),
+        Math.Max(
+            Math.Max(GetByteCount(entry.DecompositionMapping), GetByteCount(entry.NumericValue)),
+            Math.Max(GetByteCount(entry.Unicode1Name), GetByteCount(entry.IsoComment)))));
+    var maxStringByteLengthPowerOfTwo = NextPowerOfTwo(maxStringByteLength);
 
-    if (maxNameLengthPowerOfTwo > 256)
-        throw new InvalidOperationException("Max character name length exceeds 256: " + maxNameLengthPowerOfTwo);
+    if (maxStringByteLengthPowerOfTwo > 256)
+        throw new InvalidOperationException("Max serialized string length exceeds 256: " + maxStringByteLengthPowerOfTwo);
+
+    static int GetByteCount(string? value) => value is null ? 0 : Encoding.UTF8.GetByteCount(value);
 
     var emojiCount = unicodeDataEntries.Count(e => e.EmojiProperties != EmojiProperties.None);
     var compressedSize = unicodeDataBytes.Length;
@@ -409,7 +417,7 @@ async Task WriteUnicodeCharacterInfosFile(List<(int Start, int End, string Name)
         //   - Total characters: {{unicodeDataEntries.Count}}
         //   - Emoji characters: {{emojiCount}}
         //   - Compressed size: {{compressedSize:N0}} bytes ({{compressionRatio * 100d:F1}}% of uncompressed)
-        //   - Max character name length: {{maxNameLength}} chars
+        //   - Max serialized string length: {{maxStringByteLength}} bytes
         //
         // Specification: https://www.unicode.org/reports/tr44/
         // DO NOT MODIFY THIS FILE MANUALLY - regenerate using the Unicode generator tool
@@ -419,7 +427,7 @@ async Task WriteUnicodeCharacterInfosFile(List<(int Start, int End, string Name)
         namespace Meziantou.Framework;
         internal static partial class UnicodeCharacterInfos
         {
-            private const int MaxCharacterNameLength = {{maxNameLengthPowerOfTwo}};
+            private const int MaxSerializedStringLength = {{maxStringByteLengthPowerOfTwo}};
         }
         """);
 
@@ -533,14 +541,14 @@ static byte[] BuildUnicodeDataBinary(List<UnicodeDataEntry> entries)
             entry.EmojiProperties));
     }
 
-    var maxStringLength = strings.Count == 0 ? 0 : strings.Max(s => s.Length);
+    var maxStringLength = strings.Count == 0 ? 0 : strings.Max(s => Encoding.UTF8.GetByteCount(s));
     if (maxStringLength > 255)
-        throw new InvalidOperationException("A string exceeds the maximum length of 255 characters.");
+        throw new InvalidOperationException("A string exceeds the maximum length of 255 bytes.");
 
     if (strings.Count > 65536 - 1)
         throw new InvalidOperationException("Too many strings: " + strings.Count);
 
-    Console.WriteLine($"Serialized {serialized.Count} UnicodeData entries with {strings.Count} unique strings (max length: {maxStringLength})");
+    Console.WriteLine($"Serialized {serialized.Count} UnicodeData entries with {strings.Count} unique strings (max length: {maxStringLength} bytes)");
 
     using (var compressed = new MemoryStream())
     {


### PR DESCRIPTION
`ReadString255LengthMax` reads **every** string in the serialized string table into a single
stack buffer:

```csharp
Span<byte> buffer = stackalloc byte[MaxCharacterNameLength];  // 128
stream.ReadExactly(buffer[..length]);                          // length is a byte: 0-255
```

But `MaxCharacterNameLength` was generated as `NextPowerOfTwo(entries.Max(e => e.Name.Length))`
— **from names only, and in UTF-16 chars**. The table also holds `DecompositionMapping`,
`NumericValue`, `Unicode1Name` and `IsoComment` (`Program.cs:495-502`), and the length prefix
is a UTF-8 byte count.

Decoding the shipped `Resources/UnicodeData.bin.gz`:

| quantity | value |
|---|---|
| longest **name** (what the bound was derived from) | 88 bytes |
| longest **string in the table** (what the bound must cover) | **100 bytes** — a decomposition mapping on U+FDFA |
| generated constant | 128 |

So the constant was bounding a quantity 12 bytes larger than the one it was computed from,
and only power-of-two rounding provided the margin. Cross 128 and `buffer[..length]` throws
`ArgumentOutOfRangeException` **inside a static field initializer** — surfacing as
`TypeInitializationException` on the first call to any character-metadata or emoji API. Failed
static constructors are cached, so the type stays poisoned for the process lifetime. A
24-code-point compatibility decomposition (130 bytes) is enough; today's longest is 18.

Nothing in the pipeline could catch it. Every guard is set at 255, and the generator's *own*
copy of the reader (`Program.cs:834`) stackallocs 255 — so it round-trips its own bad output
cleanly and reports success, while the only reader that actually ships uses 128.

## What changed

- The bound is now the max UTF-8 byte length across **all five** serialized string fields,
  not `Name.Length`. The guard message and threshold move with it.
- `Program.cs:536-538` compared `s.Length` (UTF-16 chars) against a 255 **byte** limit, while
  the writer at `:997-1003` correctly measured bytes. Both now measure bytes. All strings are
  ASCII today so the two coincide — but for a reason external to this code.
- Renamed `MaxCharacterNameLength` to `MaxSerializedStringLength` and
  `ReadString255LengthMax` to `ReadString` in the shipped reader; both names described
  something other than what the code does. The generator's own reader keeps its name, where
  the 255 is accurate.

**No behavioural change today.** `NextPowerOfTwo(100)` and `NextPowerOfTwo(88)` are both 128,
so the emitted constant is byte-identical and the binary resource is untouched. The values
only diverge in exactly the scenario this fixes.

## Verification

```
dotnet run --project tools/Meziantou.Framework.Unicode.Generator
```

Exit code **0** (the generator's "nothing changed" convention) against live unicode.org data,
and it reports `47281 unique strings (max length: 100 bytes)`. The regenerated
`UnicodeCharacterInfos.g.cs` is identical to the committed one, confirming the new derivation
produces the same constant on current data.

`dotnet test ... /p:TreatsWarningsAsErrors=true` — 32 passed, 0 failed.
`dotnet build` on the generator — 0 warnings, 0 errors.

The reader's error paths are not unit-testable today: `UnicodeCharacterInfos` is `internal`
with no `InternalsVisibleTo`, and there is no generator test project. Both are tracked
separately.

Found by a project review of `src/Meziantou.Framework.Unicode`.
