### PR TITLE
Make clearing a cgroup setting actually issue a write

### DIFF
--- a/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
@@ -500,7 +500,11 @@ public sealed partial class CGroup2
     private void WriteFile(string fileName, string content)
     {
         var filePath = System.IO.Path.Combine(_path, fileName);
-        File.WriteAllText(filePath, content);
+
+        // cgroup interface files are only updated by a write(2). File.WriteAllText issues no write at all when
+        // content is empty, and the O_TRUNC implied by FileMode.Create does not clear the value held by kernfs.
+        // Appending a newline (what 'echo' does) keeps clearing a setting from silently doing nothing.
+        File.WriteAllText(filePath, content + "\n");
     }
 
     #endregion


### PR DESCRIPTION
## Finding

`File.WriteAllText(path, "")` performs **no `write(2)` at all**. For empty content with a BOM-less UTF-8 encoder the implementation returns immediately after opening the handle.

On a regular file this is invisible, because `FileMode.Create` implies `O_TRUNC`. On cgroupfs it is not: kernfs holds the value in the kernel object, `O_TRUNC` does not touch it, and only a `write(2)` changes it.

So every method that clears a setting by writing an empty string opened the file, wrote nothing, closed it, and returned successfully while the previous value stayed in force:

- `SetCpusetCpus()` (no arguments) and `SetCpusetCpusRaw("")`
- `SetCpusetMems()` (no arguments) and `SetCpusetMemsRaw("")`
- `SetControllers()` (no arguments)

The caller had no way to detect it. Code that releases a CPU pinning before handing a cgroup to the next workload left the old pinning in place, and a resource-isolation API silently failing to *un*-apply a restriction shows up as a starved or hung workload with no error anywhere.

## Change

`WriteFile` now appends a newline, which is what `echo` does and what every kernel-side example assumes. A zero-length payload becomes a one-byte write, so clearing a setting reaches the kernel. Trailing newlines are accepted by every cgroup v2 interface file.

## Verification

`dotnet build -p:TreatWarningsAsErrors=true` clean for both target frameworks. No public API change, so `ref/` is untouched.

The .NET half was verified empirically on .NET 10 rather than by inspection, using a FIFO — which ignores `O_TRUNC`, so only a real write is observable:

```
[empty-string write] reader got 0 byte(s)
[non-empty write]    reader got 1 byte(s)
```

The cgroupfs half rests on kernfs semantics; I could not execute it, since this was developed on macOS. **Worth a manual check on a Linux box**: set a cpuset, call `SetCpusetCpus()`, and confirm `cpuset.cpus` is now empty. There is no automated test because `CGroup2` can only be rooted at `/sys/fs/cgroup`, so the write path is not reachable from a unit test.
