### PR TITLE
Document the LSA key-name prefixes and the DPAPI recommendation

### DIFF
--- a/src/Meziantou.Framework.Win32.Lsa/LsaPrivateData.cs
+++ b/src/Meziantou.Framework.Win32.Lsa/LsaPrivateData.cs
@@ -8,19 +8,30 @@ namespace Meziantou.Framework.Win32;
 
 /// <summary>
 /// Provides methods to interact with Local Security Authority (LSA) private data storage on Windows.
-/// LSA private data storage is a secure storage area for sensitive information like credentials and secrets.
+/// LSA private data storage keeps values encrypted on disk under a DACL that allows only the creator and administrators to read them.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Microsoft recommends <c>CryptProtectData</c> and <c>CryptUnprotectData</c> over the LSA private data functions unless you specifically need to manipulate LSA secrets.
+/// The stored data is not absolutely protected.
+/// </para>
+/// <para>
+/// The key name decides how far the secret reaches. A name starting with <c>L$</c> creates a local object that cannot be accessed remotely,
+/// <c>G$</c> a global object, and <c>M$</c> a machine object that only the operating system can read back.
+/// A name with none of those prefixes creates an object that <b>can be accessed remotely</b>, so prefer an <c>L$</c> prefix unless you need otherwise.
+/// </para>
+/// </remarks>
 /// <example>
 /// Store and retrieve a secret value:
 /// <code>
 /// // Store a secret value (requires administrator privileges)
-/// LsaPrivateData.SetValue("MySecretKey", "MySecretValue");
-/// 
+/// LsaPrivateData.SetValue("L$MySecretKey", "MySecretValue");
+///
 /// // Retrieve the value
-/// string? value = LsaPrivateData.GetValue("MySecretKey");
-/// 
+/// string? value = LsaPrivateData.GetValue("L$MySecretKey");
+///
 /// // Remove the value (requires administrator privileges)
-/// LsaPrivateData.RemoveValue("MySecretKey");
+/// LsaPrivateData.RemoveValue("L$MySecretKey");
 /// </code>
 /// </example>
 [SupportedOSPlatform("windows5.1.2600")]

--- a/src/Meziantou.Framework.Win32.Lsa/readme.md
+++ b/src/Meziantou.Framework.Win32.Lsa/readme.md
@@ -4,7 +4,9 @@
 
 ## Usage
 
-The LSA (Local Security Authority) private data storage is a secure Windows storage area that can be used to store sensitive data like credentials, secrets, and other private information. This library provides a simple .NET API to interact with LSA private data.
+The LSA (Local Security Authority) private data storage is a Windows storage area for sensitive data like credentials, secrets, and other private information. Values are encrypted before being stored, under a DACL that allows only the creator and administrators to read them. This library provides a simple .NET API to interact with LSA private data.
+
+Before using it, read [Security considerations](#security-considerations) below.
 
 **Note:** Administrator privileges are required to set or remove values in LSA private data storage.
 
@@ -14,7 +16,7 @@ The LSA (Local Security Authority) private data storage is a secure Windows stor
 using Meziantou.Framework.Win32;
 
 // Requires administrator privileges
-LsaPrivateData.SetValue("MySecretKey", "MySecretValue");
+LsaPrivateData.SetValue("L$MySecretKey", "MySecretValue");
 ```
 
 ### Retrieve a value
@@ -22,7 +24,7 @@ LsaPrivateData.SetValue("MySecretKey", "MySecretValue");
 ```csharp
 using Meziantou.Framework.Win32;
 
-string? value = LsaPrivateData.GetValue("MySecretKey");
+string? value = LsaPrivateData.GetValue("L$MySecretKey");
 if (value != null)
 {
     Console.WriteLine($"Retrieved value: {value}");
@@ -39,8 +41,24 @@ else
 using Meziantou.Framework.Win32;
 
 // Requires administrator privileges
-LsaPrivateData.RemoveValue("MySecretKey");
+LsaPrivateData.RemoveValue("L$MySecretKey");
 ```
+
+## Security considerations
+
+- **Consider DPAPI first.** Microsoft's own documentation for `LsaStorePrivateData` recommends [`CryptProtectData`](https://learn.microsoft.com/en-us/windows/desktop/api/dpapi/nf-dpapi-cryptprotectdata) and `CryptUnprotectData` instead, and says to use the LSA private data functions only when you need to manipulate LSA secrets specifically.
+- **The key name decides who can read the secret.** A prefix on the key name selects the object type:
+
+  | Prefix | Object type | Reach |
+  | --- | --- | --- |
+  | `L$` | local | Cannot be accessed remotely |
+  | `G$` | global | Can be accessed remotely |
+  | `M$` | machine | Can be read back only by the operating system |
+  | *(none)* | global | **Can be accessed remotely** |
+
+  A key with no prefix is remotely accessible. Prefer `L$` unless you specifically need otherwise — that is why the examples above use it.
+- **The data is not absolutely protected.** Microsoft states this directly: the value is encrypted at rest and the key is protected by a DACL, but LSA secrets are a well-known credential-theft target for anyone who already has administrator or SYSTEM access to the machine.
+- **The retrieved value is a `string`.** It cannot be cleared once you are done with it, and it stays readable in a process dump for as long as the garbage collector keeps it alive.
 
 ## Additional Resources
 


### PR DESCRIPTION
## The problem

`readme.md` described LSA private data as *"a secure Windows storage area that can be used to store sensitive data like credentials"* and left it there. Three things it did not say — all of them straight off Microsoft's own reference pages:

1. The [`LsaStorePrivateData`](https://learn.microsoft.com/en-us/windows/win32/api/ntsecapi/nf-ntsecapi-lsastoreprivatedata) page **opens** by telling callers not to use these functions, and to use `CryptProtectData`/`CryptUnprotectData` instead unless they specifically need to manipulate LSA secrets.
2. The key-name prefix decides the object's reach: `L$` is local-only, `G$` global, `M$` machine. A key with **no** prefix — which is exactly what every example in the readme and in the `<example>` XML block used (`"MySecretKey"`) — creates a secret that **can be accessed remotely**.
3. Microsoft's own wording: the data "is not absolutely protected".

Someone following the readme verbatim got a remotely-accessible secret while believing they had used the secure option. The library cannot change LSA's properties, but it can stop hiding them.

## What changed

- New **Security considerations** section in `readme.md`: the DPAPI recommendation, a table of the four key-name prefixes and what each one means for reach, the "not absolutely protected" caveat, and a note that the returned `string` cannot be cleared.
- Every example — readme and XML docs — now uses an `L$`-prefixed key, so copy-pasting gives you the local object rather than the remotely-accessible one.
- The class `<summary>` now says what the storage actually guarantees (encrypted at rest, DACL limited to creator and administrators) instead of the unqualified word "secure", with the prefix and DPAPI guidance in a `<remarks>` block.

Also folded in: the two trailing-whitespace characters on the blank `///` lines inside the `<example>` block, which violated `trim_trailing_whitespace = true` in `.editorconfig`. They sit inside the block this PR rewrites, so a separate PR for them would only have conflicted.

## Verification

- Documentation and comments only — no behaviour change.
- Builds clean for `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`, 0 warnings.
- `dotnet run ./eng/update-all.cs -- --step readme` produces no further changes, so this project's readme is not aggregated anywhere that needs regenerating.
- `grep -n ' $'` over both files returns nothing.
