### PR TITLE
Emit a translatable, null-safe Contains for string handlers

### DIFF
--- a/ref/Meziantou.Framework.SimpleQueryLanguage.cs
+++ b/ref/Meziantou.Framework.SimpleQueryLanguage.cs
@@ -6,7 +6,7 @@ namespace Meziantou.Framework.SimpleQueryLanguage
 {
     public sealed class ExpressionQueryBuilder<T>
     {
-        public void AddHandler(string key, System.Linq.Expressions.Expression<System.Func<T, string?>> selector, System.StringComparison comparisonType = 5) { }
+        public void AddHandler(string key, System.Linq.Expressions.Expression<System.Func<T, string?>> selector, System.StringComparison? comparisonType = null) { }
         public void AddHandler<TValue>(string key, System.Linq.Expressions.Expression<System.Func<T, TValue>> selector, Meziantou.Framework.SimpleQueryLanguage.ScalarParser<TValue>? tryParseValue = null) { }
         public void AddHandler(string key, Meziantou.Framework.SimpleQueryLanguage.KeyValueOperator op, System.Func<string, System.Linq.Expressions.Expression<System.Func<T, bool>>> handler) { }
         public void AddHandler(string key, System.Func<string, System.Linq.Expressions.Expression<System.Func<T, bool>>> handler) { }

--- a/src/Meziantou.Framework.SimpleQueryLanguage/ExpressionQueryBuilder.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/ExpressionQueryBuilder.cs
@@ -31,22 +31,40 @@ public sealed class ExpressionQueryBuilder<T>
         _handlers.Add(new ExpressionFilterKey(key.ToLowerInvariant(), op), handler);
     }
 
-    /// <summary>Registers a handler for a string property with equality comparison.</summary>
+    /// <summary>Registers a handler for a string property using a "contains" comparison.</summary>
     /// <param name="key">The property key to handle.</param>
     /// <param name="selector">Expression selecting the string property.</param>
-    /// <param name="comparisonType">The string comparison type to use.</param>
-    public void AddHandler(string key, Expression<Func<T, string?>> selector, StringComparison comparisonType = StringComparison.OrdinalIgnoreCase)
+    /// <param name="comparisonType">
+    /// The string comparison to use, or <see langword="null"/> to emit a plain <see cref="string.Contains(string)"/> call.
+    /// Most LINQ providers, including Entity Framework Core, cannot translate the <see cref="StringComparison"/> overload
+    /// of <see cref="string.Contains(string, StringComparison)"/>, so passing a value here makes the query usable in memory only.
+    /// When left <see langword="null"/>, case sensitivity is decided by the underlying provider — the database collation for EF Core,
+    /// and an ordinal comparison for LINQ to Objects.
+    /// </param>
+    public void AddHandler(string key, Expression<Func<T, string?>> selector, StringComparison? comparisonType = null)
     {
         Expression<Func<T, bool>> CreatePredicate(string value)
         {
             var box = new QueryValueStore<string>(value);
             var valueExpression = Expression.PropertyOrField(Expression.Constant(box), nameof(QueryValueStore<string>.Value));
 
-            var comparisonExpression = Expression.Constant(comparisonType);
-            var containsMethod = typeof(string).GetMethod(nameof(string.Contains), [typeof(string), typeof(StringComparison)])!;
-            var body = Expression.Call(selector.Body, containsMethod, valueExpression, comparisonExpression);
+            Expression body;
+            if (comparisonType is null)
+            {
+                var containsMethod = typeof(string).GetMethod(nameof(string.Contains), [typeof(string)])!;
+                body = Expression.Call(selector.Body, containsMethod, valueExpression);
+            }
+            else
+            {
+                var containsMethod = typeof(string).GetMethod(nameof(string.Contains), [typeof(string), typeof(StringComparison)])!;
+                body = Expression.Call(selector.Body, containsMethod, valueExpression, Expression.Constant(comparisonType.Value));
+            }
 
-            return Expression.Lambda<Func<T, bool>>(body, selector.Parameters);
+            // The selected property is nullable, so guard the call. EF Core folds this into the generated SQL,
+            // and in memory it stops a null property from throwing.
+            var notNull = Expression.NotEqual(selector.Body, Expression.Constant(value: null, typeof(string)));
+
+            return Expression.Lambda<Func<T, bool>>(Expression.AndAlso(notNull, body), selector.Parameters);
         }
 
         AddHandlerCore(key, KeyValueOperator.EqualTo, CreatePredicate);

--- a/src/Meziantou.Framework.SimpleQueryLanguage/readme.md
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/readme.md
@@ -45,7 +45,9 @@ The `ExpressionQueryBuilder<T>` class creates `Expression<Func<T, bool>>` object
 // Define a query builder for your entity
 var queryBuilder = new ExpressionQueryBuilder<Person>();
 
-// Add handlers for string properties (uses Contains for partial matching)
+// Add handlers for string properties (uses Contains for partial matching).
+// Case sensitivity follows the provider: the database collation for EF Core, ordinal for LINQ to Objects.
+// Pass a StringComparison to force one, but note that EF Core cannot translate it.
 queryBuilder.AddHandler("name", person => person.FullName);
 
 // Add handlers for comparable types (supports range and comparison operators)

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ExpressionQueryBuilderTests.cs
@@ -168,6 +168,71 @@ public sealed class ExpressionQueryBuilderTests
         Assert.Null(query.Predicate);
     }
 
+    [Fact]
+    public void StringHandler_MatchesSubstring()
+    {
+        var queryBuilder = new ExpressionQueryBuilder<Sample>();
+        queryBuilder.AddHandler("name", item => item.StringValue);
+        var query = queryBuilder.Build("name:John");
+
+        var items = new[]
+        {
+            new Sample { StringValue = "John Doe" },
+            new Sample { StringValue = "Jane Doe" },
+        }.AsQueryable();
+        var result = query.Apply(items).ToList();
+
+        Assert.Single(result);
+        Assert.Equal("John Doe", result[0].StringValue);
+    }
+
+    [Fact]
+    public void StringHandler_NullProperty_DoesNotThrow()
+    {
+        var queryBuilder = new ExpressionQueryBuilder<Sample>();
+        queryBuilder.AddHandler("name", item => item.StringValue);
+        var query = queryBuilder.Build("name:John");
+
+        var items = new[]
+        {
+            new Sample { StringValue = null },
+            new Sample { StringValue = "John Doe" },
+        }.AsQueryable();
+        var result = query.Apply(items).ToList();
+
+        Assert.Single(result);
+        Assert.Equal("John Doe", result[0].StringValue);
+    }
+
+    [Fact]
+    public void StringHandler_DoesNotEmitStringComparison()
+    {
+        var queryBuilder = new ExpressionQueryBuilder<Sample>();
+        queryBuilder.AddHandler("name", item => item.StringValue);
+        var query = queryBuilder.Build("name:John");
+
+        // string.Contains(string, StringComparison) is not translatable by Entity Framework Core
+        Assert.DoesNotContain(nameof(StringComparison.OrdinalIgnoreCase), query.Predicate!.ToString());
+    }
+
+    [Fact]
+    public void StringHandler_ExplicitComparisonType_IgnoresCase()
+    {
+        var queryBuilder = new ExpressionQueryBuilder<Sample>();
+        queryBuilder.AddHandler("name", item => item.StringValue, StringComparison.OrdinalIgnoreCase);
+        var query = queryBuilder.Build("name:john");
+
+        var items = new[]
+        {
+            new Sample { StringValue = "John Doe" },
+            new Sample { StringValue = null },
+        }.AsQueryable();
+        var result = query.Apply(items).ToList();
+
+        Assert.Single(result);
+        Assert.Equal("John Doe", result[0].StringValue);
+    }
+
     private sealed class Sample
     {
         public int Int32Value { get; set; }


### PR DESCRIPTION
`ExpressionQueryBuilder<T>` exists to produce expressions EF Core can translate to SQL. Its string handler produced one it cannot.

`AddHandler(key, selector, comparisonType = StringComparison.OrdinalIgnoreCase)` emitted:

```
o => o.StringValue.Contains(value(QueryValueStore`1[System.String]).Value, OrdinalIgnoreCase)
```

EF Core does not translate the `StringComparison` overload of `string.Contains`, so `dbContext.People.Apply(query).ToListAsync()` throws `InvalidOperationException: The LINQ expression … could not be translated`. This is the call the package readme leads with.

The selector is also typed `Expression<Func<T, string?>>` and the call was emitted with no null guard, so under LINQ to Objects a null property throws:

```
items = [ { StringValue = "John" }, { StringValue = null } ];
query.Apply(items).ToList();   // NullReferenceException
```

The existing suite is green on `main` because it never exercises this overload, and because in-memory queryables translate everything.

## What changed

Emit `x.Prop != null && x.Prop.Contains(value)` by default. EF Core folds the null check into the generated SQL, and in memory it stops null properties from throwing.

`comparisonType` becomes `StringComparison?`, defaulting to `null`:

- `null` (the new default) → plain `Contains(string)`. Translatable everywhere.
- non-null → the `StringComparison` overload, as before, for callers who deliberately want it in memory. The XML doc says plainly that this is in-memory only.

Keeping the parameter rather than deleting it preserves the escape hatch and stays source-compatible for callers who never passed it. Happy to drop it entirely instead if you would rather not carry an untranslatable option at all.

## Behaviour change

Matching is no longer case-insensitive by default. Case sensitivity now follows the provider — the database collation under EF Core (case-insensitive on a default SQL Server collation, case-sensitive on a default PostgreSQL one), ordinal under LINQ to Objects. Callers who relied on `OrdinalIgnoreCase` in memory now pass it explicitly. `readme.md` updated to say so.

`ref/` regenerated and committed. The signature change is binary-breaking for callers who passed `comparisonType` positionally.

## Verification

Four tests added to `ExpressionQueryBuilderTests`: substring matching, a null property that no longer throws, an assertion that the default expression carries no `StringComparison` argument, and the explicit-`OrdinalIgnoreCase` path still ignoring case. Full suite green — 236 tests across net10.0 and net11.0, `-p:TreatWarningsAsErrors=true`.

## What this PR does not prove

There is no EF Core reference anywhere in the repository, so nothing here runs against a translating provider — the tests assert the *shape* of the expression, not that SQL Server accepts it. A SQLite-in-memory test project running the readme's examples end to end is the thing that would actually close this gap, and it is worth doing separately.

Found during a review of the project; the report also covers eight other findings that are going out as separate PRs.
