### PR TITLE
Write paths relative to the project directory in the generated debug header

### DIFF
--- a/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
+++ b/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
@@ -82,10 +82,10 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
 
             var content = $@"
 // Debug info:
-// key: {resxGroup.Key}
-// files: {string.Join(", ", resxGroup.Select(f => f.Path))}
+// key: {ToDisplayPath(projectDir, resxGroup.Key)}
+// files: {string.Join(", ", resxGroup.Select(f => ToDisplayPath(projectDir, f.Path)))}
 // RootNamespace (metadata): {rootNamespaceConfiguration}
-// ProjectDir (metadata): {projectDirConfiguration}
+// ProjectDir (metadata): {(projectDirConfiguration is null ? "<not set>" : "<set>")}
 // Namespace / DefaultResourcesNamespace (metadata): {namespaceConfiguration}
 // DefaultResourceName (metadata): {defaultResourceNameConfiguration}
 // ResourceName (metadata): {resourceNameConfiguration}
@@ -95,7 +95,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
 // GenerateResources (metadata): {generateResourcesTypeConfiguration}
 // AssemblyName: {assemblyName}
 // RootNamespace (computed): {rootNamespace}
-// ProjectDir (computed): {projectDir}
+// ProjectDir (computed): {(string.IsNullOrEmpty(projectDir) ? "<empty>" : "<set>")}
 // defaultNamespace: {defaultNamespace}
 // defaultResourceName: {defaultResourceName}
 // Namespace: {ns}
@@ -109,6 +109,35 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
 
             context.AddSource(GetHintName(hintNames, projectDir, resxGroup.Key), SourceText.From(content, Encoding.UTF8));
         }
+    }
+
+    /// <summary>
+    /// Formats a path for the debug header. The generated text is embedded in the PDB, so an absolute path would
+    /// leak the layout of the build machine and make the same commit produce different output on another machine.
+    /// </summary>
+    private static string ToDisplayPath(string projectDir, string path)
+    {
+        if (!string.IsNullOrEmpty(projectDir))
+        {
+            try
+            {
+                var fullProjectDir = Path.GetFullPath(projectDir);
+                if (fullProjectDir[^1] != Path.DirectorySeparatorChar)
+                {
+                    fullProjectDir += Path.DirectorySeparatorChar;
+                }
+
+                var fullPath = Path.GetFullPath(path);
+                if (fullPath.StartsWith(fullProjectDir, StringComparison.Ordinal))
+                    return fullPath[fullProjectDir.Length..].Replace('\\', '/');
+            }
+            catch (ArgumentException)
+            {
+                // The path cannot be rooted, fall back to the file name
+            }
+        }
+
+        return Path.GetFileName(path);
     }
 
     private static string GetHintName(HashSet<string> hintNames, string projectDir, string resourcePath)

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
@@ -310,6 +310,23 @@ public sealed class ResxGeneratorTest
     }
 
     [Fact]
+    public async Task DebugHeaderDoesNotContainAbsolutePaths()
+    {
+        // The generated text ends up in the PDB, so it must be identical whatever the directory the project sits in
+        var projectDir = FullPath.GetTempPath() / "dir" / "proj";
+        var result = await GenerateFiles([(projectDir / "Folder1" / "test.resx", new XElement("root").ToString())], new OptionProvider
+        {
+            ProjectDir = projectDir,
+            RootNamespace = "proj",
+        });
+
+        var fileContent = result.GeneratedFileRoot.ToFullString();
+        Assert.DoesNotContain(projectDir.Value, fileContent, ignoreCase: true);
+        Assert.Contains("// key: Folder1/test", fileContent);
+        Assert.Contains("// files: Folder1/test.resx", fileContent);
+    }
+
+    [Fact]
     public async Task ComputeNamespace_RootDir()
     {
         var result = await GenerateFiles([(FullPath.GetTempPath() / "dir" / "proj" / "test.resx", new XElement("root").ToString())], new OptionProvider


### PR DESCRIPTION
## The bug

Every generated file is unconditionally prefixed with a `// Debug info:` block (`ResxGenerator.cs:83-107`) containing `resxGroup.Key`, the full path of every contributing resx file, and the computed `ProjectDir` — all absolute paths from the build machine:

```
// key: /Users/someone/src/MyApp/Folder1/test
// files: /Users/someone/src/MyApp/Folder1/test.resx
// ProjectDir (computed): /Users/someone/src/MyApp/
```

Roslyn embeds generated source text into the PDB, and that text is **not** subject to `/pathmap`. So two builds of the same commit on different machines produce byte-different generated sources and PDBs, which defeats reproducible-build verification and ships local directory layout — including usernames — in the symbols. It is also unavoidable noise for anyone using `EmitCompilerGeneratedFiles`.

## What changed

The header stays, but paths in it are now written relative to the project directory, with separators normalized to `/` so Windows and Linux produce identical text:

```
// key: Folder1/test
// files: Folder1/test.resx
// ProjectDir (computed): <set>
```

A new `ToDisplayPath` helper does the rooting, falling back to the bare file name when the path is outside the project directory or the project directory isn't usable. The two `ProjectDir` lines become `<set>` / `<not set>` / `<empty>` markers, since the value itself is inherently machine-specific and the relative paths already convey the relationship it was there to show.

### Alternative worth considering

The other option from the review was to keep the header verbatim but gate it behind an opt-in MSBuild property, which preserves full debuggability and removes the noise entirely. I went with relative paths because it keeps the header useful by default — it exists to debug exactly the resource-name and namespace problems the other open resx PRs are about — and because it needs no new props surface. Happy to switch if you'd rather have the opt-in.

## Verification

Added `DebugHeaderDoesNotContainAbsolutePaths`, which generates from a resx under a temp project directory and asserts the absolute project directory appears nowhere in the output, while `// key: Folder1/test` and `// files: Folder1/test.resx` do.

40/40 unit tests pass on net10.0 and net11.0.
