### PR TITLE
Remove the extension-method summaries from the CGroup2 partial declarations

### DIFF
--- a/ref/Meziantou.Framework.Unix.ControlGroups.cs
+++ b/ref/Meziantou.Framework.Unix.ControlGroups.cs
@@ -5,7 +5,6 @@
 namespace Meziantou.Framework.Unix.ControlGroups
 {
     [System.Runtime.Versioning.SupportedOSPlatform("linux")]
-    [System.Runtime.Versioning.SupportedOSPlatform("linux")]
     public sealed class CGroup2
     {
         public string Name { get => throw null; }

--- a/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.Cpuset.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.Cpuset.cs
@@ -1,10 +1,6 @@
-using System.Runtime.Versioning;
-
 namespace Meziantou.Framework.Unix.ControlGroups;
 
-/// <summary>Extension methods for cpuset controller on CGroup2.</summary>
-[SupportedOSPlatform("linux")]
-public partial class CGroup2
+public sealed partial class CGroup2
 {
     /// <summary>Sets the CPUs that tasks in this cgroup can use.</summary>
     /// <param name="cpus">Array of CPU numbers (e.g., [0, 1, 2] for CPUs 0-2).</param>

--- a/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.HugeTlb.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.HugeTlb.cs
@@ -1,7 +1,6 @@
 namespace Meziantou.Framework.Unix.ControlGroups;
 
-/// <summary>Extension methods for HugeTLB controller on CGroup2.</summary>
-public partial class CGroup2
+public sealed partial class CGroup2
 {
     /// <summary>Sets the HugeTLB usage limit for a specific page size.</summary>
     /// <param name="pageSize">The huge page size (e.g., "2MB", "1GB").</param>


### PR DESCRIPTION
## Finding

`CGroup2.Cpuset.cs` and `CGroup2.HugeTlb.cs` each carried

```csharp
/// <summary>Extension methods for … controller on CGroup2.</summary>
```

on a `partial class CGroup2` declaration whose members are ordinary instance methods, not extension methods. The summary also lands on the type in generated documentation, where it contradicted the summary on the primary declaration in `CGroup2.cs`, and it misleads a reader into looking for a static class that doesn't exist.

Two smaller inconsistencies in the same declarations:

- Both secondary partials said `public partial class` while the primary says `public sealed partial class`.
- `CGroup2.Cpuset.cs` repeated `[SupportedOSPlatform("linux")]`, which the primary declaration already applies. The attribute allows multiples, so this was legal — but it showed up **twice** on the type in the generated `ref/` file.

## Change

- Dropped the two misleading summaries. The type summary lives on the primary declaration in `CGroup2.cs`.
- Both secondary declarations now say `sealed`, matching the primary.
- Removed the duplicate `[SupportedOSPlatform("linux")]` and the now-unused `using System.Runtime.Versioning;`.

## Verification

`dotnet build -p:TreatWarningsAsErrors=true` clean for `net10.0` and `net11.0`.

`ref/` regenerated with a Release / `IsOfficialBuild=true` build. The whole generated diff is the removal of the duplicated attribute:

```diff
 namespace Meziantou.Framework.Unix.ControlGroups
 {
-    [System.Runtime.Versioning.SupportedOSPlatform("linux")]
     [System.Runtime.Versioning.SupportedOSPlatform("linux")]
     public sealed class CGroup2
```

No behavior change: `sealed` was already in effect via the primary declaration, and the type is still marked linux-only.
