### PR TITLE
Trust the null annotations on the raw cpuset setters

### DIFF
--- a/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.Cpuset.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.Cpuset.cs
@@ -24,7 +24,7 @@ public partial class CGroup2
     /// <param name="cpuList">CPU list in cgroup format.</param>
     public void SetCpusetCpusRaw(string cpuList)
     {
-        WriteFile("cpuset.cpus", cpuList ?? "");
+        WriteFile("cpuset.cpus", cpuList);
     }
 
     /// <summary>Gets the CPUs that tasks in this cgroup can use.</summary>
@@ -69,7 +69,7 @@ public partial class CGroup2
     /// <param name="nodeList">Memory node list in cgroup format.</param>
     public void SetCpusetMemsRaw(string nodeList)
     {
-        WriteFile("cpuset.mems", nodeList ?? "");
+        WriteFile("cpuset.mems", nodeList);
     }
 
     /// <summary>Gets the memory nodes that tasks in this cgroup can use.</summary>


### PR DESCRIPTION
## Finding

`SetCpusetCpusRaw(string cpuList)` and `SetCpusetMemsRaw(string nodeList)` declared non-nullable parameters and then wrote `cpuList ?? ""` anyway (`CGroup2.Cpuset.cs:27,72`).

`AGENTS.md` says to trust the C# null annotations rather than add defensive checks. The guard was also actively misleading: coercing `null` to `""` routes it into the "write an empty string" path, which is a silent no-op on cgroupfs, so a `null` slipping in from a non-annotated caller would fail quietly instead of loudly.

## Change

Deleted both `?? ""` operators and let the annotations stand.

## Verification

`dotnet build -p:TreatWarningsAsErrors=true` clean for `net10.0` and `net11.0`. No public API change — the parameters were already non-nullable — so `ref/` is untouched.
