### PR TITLE
Cover argument validation and a non-ASCII round trip in the LSA tests

### DIFF
--- a/tests/Meziantou.Framework.Win32.Lsa.Tests/LsaPrivateDataTests.cs
+++ b/tests/Meziantou.Framework.Win32.Lsa.Tests/LsaPrivateDataTests.cs
@@ -8,10 +8,7 @@ public sealed class LsaPrivateDataTests
     [Fact, RunIf(WindowsGroups.Administrator)]
     public void LsaPrivateData_SetGetRemove()
     {
-        // The project is multi-targeted, so multiple process can run in parallel
-        using var mutex = new Mutex(initiallyOwned: false, "MeziantouFrameworkLsaTests");
-        mutex.WaitOne();
-        try
+        WithLsaLock(() =>
         {
             // Set
             LsaPrivateData.SetValue("LsaPrivateDataTests", "test");
@@ -24,11 +21,7 @@ public sealed class LsaPrivateDataTests
             LsaPrivateData.RemoveValue("LsaPrivateDataTests");
             value = LsaPrivateData.GetValue("LsaPrivateDataTests");
             Assert.Null(value);
-        }
-        finally
-        {
-            mutex.ReleaseMutex();
-        }
+        });
     }
 
     [Fact, RunIf(WindowsGroups.Administrator)]
@@ -37,5 +30,71 @@ public sealed class LsaPrivateDataTests
         // Get
         var value = LsaPrivateData.GetValue("LsaPrivateDataTestsUnset");
         Assert.Null(value);
+    }
+
+    [Fact, RunIf(WindowsGroups.Administrator)]
+    public void LsaPrivateData_SetGetRemoveNonAsciiValue()
+    {
+        WithLsaLock(() =>
+        {
+            LsaPrivateData.SetValue("LsaPrivateDataTestsNonAscii", "\u00e9\u4e2d\u6587\ud83d\ude00");
+
+            var value = LsaPrivateData.GetValue("LsaPrivateDataTestsNonAscii");
+            Assert.Equal("\u00e9\u4e2d\u6587\ud83d\ude00", value);
+
+            LsaPrivateData.RemoveValue("LsaPrivateDataTestsNonAscii");
+            Assert.Null(LsaPrivateData.GetValue("LsaPrivateDataTestsNonAscii"));
+        });
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void SetValue_NullKey_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => LsaPrivateData.SetValue(key: null!, "test"));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetValue_NullKey_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => LsaPrivateData.GetValue(key: null!));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void RemoveValue_NullKey_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => LsaPrivateData.RemoveValue(key: null!));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void SetValue_EmptyKey_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => LsaPrivateData.SetValue("", "test"));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetValue_EmptyKey_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => LsaPrivateData.GetValue(""));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void RemoveValue_EmptyKey_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => LsaPrivateData.RemoveValue(""));
+    }
+
+    private static void WithLsaLock(Action action)
+    {
+        // The project is multi-targeted, so multiple process can run in parallel
+        using var mutex = new Mutex(initiallyOwned: false, "MeziantouFrameworkLsaTests");
+        mutex.WaitOne();
+        try
+        {
+            action();
+        }
+        finally
+        {
+            mutex.ReleaseMutex();
+        }
     }
 }


### PR DESCRIPTION
## The problem

`LsaPrivateDataTests` had two tests, both gated on `RunIf(WindowsGroups.Administrator)`, and the test project sets `MinimumExpectedTests` to `0` (correctly — everything skips off Windows). The combined effect is that a regression breaking all three public methods would still report green on any leg that is not an elevated Windows runner.

Nothing covered the argument validation at all, even though it runs before any P/Invoke and therefore needs Windows but **not** elevation.

## What changed

Six argument-validation tests, gated on `RunIf(TestOperatingSystems.Windows)` rather than `Administrator`, so they run on any Windows machine regardless of elevation:

- `SetValue` / `GetValue` / `RemoveValue` with a `null` key → `ArgumentNullException`
- `SetValue` / `GetValue` / `RemoveValue` with an empty key → `ArgumentException`

Plus one round-trip test for a non-ASCII value (`é中文😀`, including a surrogate pair) to cover the `Length / 2` char-count arithmetic on both the store and retrieve paths.

The mutex boilerplate moved into a `WithLsaLock` helper. The round-trip tests genuinely need it — the project is multi-targeted, so the `net10.0` and `net11.0` processes run concurrently and would race on the same key — and having it in two places invited it being forgotten in the third. `LsaPrivateData_SetGetRemove` is otherwise unchanged; the new test uses its own dedicated key.

## What I deliberately did not add

A round-trip test for an **empty-string** value. I do not know whether `LsaStorePrivateData` stores a zero-length secret or treats it as a delete, and I could not run anything against LSA to find out. Asserting a guessed outcome is worse than leaving the gap, so this one stays open — happy to add it if you know the answer.

## Verification

- Tests only — no production code touched.
- Builds clean for `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`, 0 warnings.
- `dotnet test` discovers 9 tests in the class, up from 2.
- **I could not execute them.** All 9 skip on macOS. CI is the first real run — and the six validation tests are the first in this project that do not need an elevated runner to execute.
