### PR TITLE
Annotate RestartManager with the Windows version it actually requires

### DIFF
--- a/ref/Meziantou.Framework.Win32.RestartManager.cs
+++ b/ref/Meziantou.Framework.Win32.RestartManager.cs
@@ -4,7 +4,7 @@
 
 namespace Meziantou.Framework.Win32
 {
-    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows6.0.6000")]
     public sealed class RestartManager : System.IDisposable
     {
         public string SessionKey { get => throw null; }

--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
@@ -6,8 +6,6 @@ using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.System.RestartManager;
 
-#pragma warning disable CA1416 // RestartManager is Windows-only
-
 namespace Meziantou.Framework.Win32;
 
 /// <summary>Provides a wrapper around the Windows Restart Manager API to detect which processes are locking files and manage application restarts.</summary>
@@ -36,7 +34,7 @@ namespace Meziantou.Framework.Win32;
 /// }
 /// </code>
 /// </example>
-[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("windows6.0.6000")]
 public sealed class RestartManager : IDisposable
 {
     private uint SessionHandle { get; }
@@ -276,5 +274,3 @@ public sealed class RestartManager : IDisposable
         return restartManager.GetProcessesLockingResources();
     }
 }
-
-#pragma warning restore CA1416


### PR DESCRIPTION
The class was annotated `[SupportedOSPlatform("windows")]` — all Windows versions — while every `PInvoke` member CsWin32 generates is `[SupportedOSPlatform("windows6.0.6000")]`. That mismatch is a real `CA1416` violation, and a `#pragma warning disable CA1416` spanning the whole file is what kept the build green. Its comment ("RestartManager is Windows-only") describes a different problem than the one it was actually suppressing.

## What changed

Tightened the class attribute to `[SupportedOSPlatform("windows6.0.6000")]` and deleted both pragma lines. `ref/` regenerated accordingly.

## Verification

Both halves were checked by building, not by inspection:

- Removing the pragma **alone** produces 9 `CA1416` errors — one per native call site (`RmJoinSession`, `RmGetList` ×2, `RmShutdown`, `RmRestart`, `RmStartSession`, `RmRegisterResources` ×2, `RmEndSession`).
- Removing the pragma **and** tightening the attribute builds clean: `0 Warning(s), 0 Error(s)` on `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`.
- `ref/` regenerated with `-c Release -p:IsOfficialBuild=true`; `dotnet run ./eng/update-all.cs` produces no further changes.

**No test accompanies this one.** The defect is a compile-time annotation, so the build *is* the test — there is no runtime behavior to assert. Flagging it explicitly since `CONTRIBUTING.md` asks for tests with each change.

## Why it is worth doing

The readme already states the real requirement ("requires Windows Vista or later", `readme.md:107`), so the attribute was simply understating it and consumers got no analyzer signal. The larger cost was the blanket suppression: spanning all 280 lines, it would silently absorb any *future* platform mismatch introduced in this file too.

Practical impact on consumers is small — .NET 10 already requires a Windows version well past 6.0.6000 — so this mostly buys back the analyzer rather than changing what compiles.

Found by a review of `src/Meziantou.Framework.Win32.RestartManager` (Medium severity finding).
