### PR TITLE
Reference Microsoft.CodeAnalysis.CSharp instead of the Microsoft.CodeAnalysis metapackage

### DIFF
--- a/src/Meziantou.Framework.ResxSourceGenerator/Meziantou.Framework.ResxSourceGenerator.csproj
+++ b/src/Meziantou.Framework.ResxSourceGenerator/Meziantou.Framework.ResxSourceGenerator.csproj
@@ -18,6 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.2.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## The change

This project referenced the `Microsoft.CodeAnalysis` **metapackage**, which pulls in CSharp, VisualBasic and Workspaces. Every other analyzer in this repository references `Microsoft.CodeAnalysis.CSharp` (or `.Common`):

| Project | Reference |
|---|---|
| `Meziantou.Framework.FullPath.Analyzer` | `Microsoft.CodeAnalysis.CSharp` 4.12.0 |
| `Meziantou.Framework.Assertions.Analyzer` | `Microsoft.CodeAnalysis.CSharp` 4.14.0 |
| `Meziantou.Framework.FastEnumGenerator` | `Microsoft.CodeAnalysis.CSharp` 4.14.0 |
| `Meziantou.Framework.Yaml.SourceGenerator` | `Microsoft.CodeAnalysis.CSharp` 5.6.0 |
| `Meziantou.Framework.ResxSourceGenerator` | **`Microsoft.CodeAnalysis` 4.2.0** |

The metapackage makes it possible to compile against APIs that are not loaded in the analyzer host, turning a mistake here into a runtime `TypeLoadException` in the consumer's compiler rather than a build error in this repo.

Swapped to `Microsoft.CodeAnalysis.CSharp` at the **same 4.2.0 version**, so the minimum supported Roslyn is unchanged. The build confirms nothing in this project was using the extra assemblies.

## Scope: what I deliberately left out

The review also flagged that this is the only analyzer project without `<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>`. I tried it, and it needs its own PRs rather than riding along here.

Setting the property alone is **inert** in this project: `Microsoft.CodeAnalysis.CSharp` 4.2.0 only brings `Microsoft.CodeAnalysis.Analyzers` **3.3.3** transitively, which predates RS1035. The build stays green and you get a false sense of coverage.

Adding an explicit `Microsoft.CodeAnalysis.Analyzers` 5.6.0 reference (as `Yaml.SourceGenerator` does) makes the rules real, and then two genuine problems surface:

- **RS1035** — `Environment.NewLine` at `ResxGenerator.cs:317`, `:533`, `:536`. Not a mechanical fix: `XElement.ToString()` writes newlines using `XmlWriterSettings.NewLineChars`, which itself defaults to `Environment.NewLine`. Both sides have to become explicit together, or the doc-comment `///` re-prefixing silently breaks on one platform.
- **RS1037** — `InvalidResx`, `InvalidPropertiesForResourceName` and `InconsistentProperties` (`ResxGeneratorAnalyzer.cs:10,18,26`) need the `CompilationEnd` custom tag, since they are reported from a `RegisterCompilationAction`. Without it these diagnostics can be dropped in IDE live analysis.

Both deserve their own change with their own tests. Once they land, enabling the rules becomes a clean follow-up.

## Verification

Build clean with 0 warnings / 0 errors on net11.0 and netstandard2.0. 38/38 unit tests and 16/16 generator tests pass.
