### PR TITLE
Pass a null SystemName to LsaOpenPolicy for the local system

### DIFF
--- a/src/Meziantou.Framework.Win32.Lsa/LsaPrivateData.cs
+++ b/src/Meziantou.Framework.Win32.Lsa/LsaPrivateData.cs
@@ -44,7 +44,6 @@ public static class LsaPrivateData
             throw new ArgumentException($"{nameof(key)} must not be empty", nameof(key));
 
         var objectAttributes = new LSA_OBJECT_ATTRIBUTES();
-        var localsystem = new LSA_UNICODE_STRING();
         var secretName = new LSA_UNICODE_STRING();
         fixed (char* keyPtr = key)
         fixed (char* valuePtr = value)
@@ -64,7 +63,7 @@ public static class LsaPrivateData
                 };
             }
 
-            using var lsaPolicyHandle = GetLsaPolicy(in objectAttributes, ref localsystem);
+            using var lsaPolicyHandle = GetLsaPolicy(in objectAttributes);
             var result = PInvoke.LsaStorePrivateData(lsaPolicyHandle, in secretName, lusSecretData);
 
             var winErrorCode = PInvoke.LsaNtStatusToWinError(result);
@@ -84,7 +83,6 @@ public static class LsaPrivateData
             throw new ArgumentException($"{nameof(key)} must not be empty", nameof(key));
 
         var objectAttributes = new LSA_OBJECT_ATTRIBUTES();
-        var localsystem = new LSA_UNICODE_STRING();
         var secretName = new LSA_UNICODE_STRING();
         fixed (char* keyPtr = key)
         {
@@ -93,7 +91,7 @@ public static class LsaPrivateData
             secretName.Length = (ushort)(key.Length * 2);
 
             // Get LSA policy
-            using var lsaPolicyHandle = GetLsaPolicy(in objectAttributes, ref localsystem);
+            using var lsaPolicyHandle = GetLsaPolicy(in objectAttributes);
             var result = PInvoke.LsaRetrievePrivateData(lsaPolicyHandle, in secretName, out var privateData);
             if (result == NTSTATUS.STATUS_OBJECT_NAME_NOT_FOUND)
                 return null;
@@ -112,9 +110,10 @@ public static class LsaPrivateData
         }
     }
 
-    private static unsafe LsaCloseSafeHandle GetLsaPolicy(in LSA_OBJECT_ATTRIBUTES objectAttributes, ref LSA_UNICODE_STRING localSystem)
+    private static unsafe LsaCloseSafeHandle GetLsaPolicy(in LSA_OBJECT_ATTRIBUTES objectAttributes)
     {
-        var ntsResult = PInvoke.LsaOpenPolicy(localSystem, in objectAttributes, PInvoke.POLICY_GET_PRIVATE_INFORMATION, out var lsaPolicyHandle);
+        // A null SystemName means the local system
+        var ntsResult = PInvoke.LsaOpenPolicy(SystemName: null, in objectAttributes, PInvoke.POLICY_GET_PRIVATE_INFORMATION, out var lsaPolicyHandle);
         var winErrorCode = PInvoke.LsaNtStatusToWinError(ntsResult);
         if (winErrorCode != 0)
             throw new Win32Exception((int)winErrorCode, "LsaOpenPolicy failed: " + winErrorCode.ToString(CultureInfo.InvariantCulture));


### PR DESCRIPTION
> **Stack 1 of 2** · merges into `main` · the follow-up PR targets this branch and must merge after it.

## The problem

`GetLsaPolicy` carried two parameters that did nothing useful.

**`SystemName` was never actually null.** CsWin32 generates the friendly overload as:

```csharp
internal static unsafe NTSTATUS LsaOpenPolicy([Optional] LSA_UNICODE_STRING? SystemName, ...)
{
    LSA_UNICODE_STRING SystemNameLocal = SystemName ?? default;
    ...
    PInvoke.LsaOpenPolicy(SystemName.HasValue ? &SystemNameLocal : null, ...);
}
```

The caller passed a default-constructed `LSA_UNICODE_STRING`, so `HasValue` was `true` and LSA received a **pointer to a zeroed struct** where the documentation asks for `NULL` to mean "the local system". It works — the `Buffer` inside is null — but it depends on LSA treating the two as equivalent, which is not something the docs promise.

**`ref localSystem` conveyed nothing.** The generated overload takes the value as a nullable struct, so the `ref` could not propagate anything back, and the parameter was never mutated. It just required each caller to declare a `localsystem` local that existed only to be passed.

## What changed

- `GetLsaPolicy` passes `SystemName: null`, which is what the documentation asks for.
- The `localSystem` parameter and the two `localsystem` locals in `SetValue` and `GetValue` are gone.

Net negative lines, no behaviour change intended.

## Verification

- Builds clean for `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`, 0 warnings.
- No test added: this is the same call with the documented spelling of the same argument, and there is no observable behaviour to assert. The existing round-trip test covers the path.
- **The tests were not executed.** They are Windows-only and this was developed on macOS, where they all skip. CI is the first real run — and since this touches the call every public method goes through, the existing `LsaPrivateData_SetGetRemove` passing on CI is the real check that `null` and a zeroed struct are in fact equivalent to LSA.
