### PR TITLE
Give CGroup2 value equality and a cached root

### DIFF
--- a/ref/Meziantou.Framework.Unix.ControlGroups.cs
+++ b/ref/Meziantou.Framework.Unix.ControlGroups.cs
@@ -6,7 +6,7 @@ namespace Meziantou.Framework.Unix.ControlGroups
 {
     [System.Runtime.Versioning.SupportedOSPlatform("linux")]
     [System.Runtime.Versioning.SupportedOSPlatform("linux")]
-    public sealed class CGroup2
+    public sealed class CGroup2 : System.IEquatable<Meziantou.Framework.Unix.ControlGroups.CGroup2>
     {
         public string Name { get => throw null; }
         public Meziantou.Framework.Unix.ControlGroups.CGroup2? Parent { get => throw null; }
@@ -57,6 +57,11 @@ namespace Meziantou.Framework.Unix.ControlGroups
         public void Kill() { }
         public Meziantou.Framework.Unix.ControlGroups.CpuStat? GetCpuStat() => throw null;
         public Meziantou.Framework.Unix.ControlGroups.MemoryStat? GetMemoryStat() => throw null;
+        public bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] Meziantou.Framework.Unix.ControlGroups.CGroup2? other) => throw null;
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) => throw null;
+        public override int GetHashCode() => throw null;
+        public static bool operator ==(Meziantou.Framework.Unix.ControlGroups.CGroup2? left, Meziantou.Framework.Unix.ControlGroups.CGroup2? right) => throw null;
+        public static bool operator !=(Meziantou.Framework.Unix.ControlGroups.CGroup2? left, Meziantou.Framework.Unix.ControlGroups.CGroup2? right) => throw null;
         public override string ToString() => throw null;
         public void SetHugeTlbMax(string pageSize, long? bytes) { }
         public long? GetHugeTlbMax(string pageSize) => throw null;

--- a/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
@@ -5,9 +5,10 @@ namespace Meziantou.Framework.Unix.ControlGroups;
 
 /// <summary>Represents a cgroup v2 control group for managing and limiting resource usage of processes.</summary>
 [SupportedOSPlatform("linux")]
-public sealed partial class CGroup2
+public sealed partial class CGroup2 : IEquatable<CGroup2>
 {
     private const string CGroupV2MountPoint = "/sys/fs/cgroup";
+    private const string RootName = "/";
 
     private readonly string _path;
 
@@ -27,20 +28,11 @@ public sealed partial class CGroup2
     {
         Name = name;
         Parent = parent;
-
-        if (parent is null)
-        {
-            // Root level cgroup or absolute path
-            _path = name.StartsWith('/', StringComparison.Ordinal) ? name : System.IO.Path.Combine(CGroupV2MountPoint, name);
-        }
-        else
-        {
-            _path = System.IO.Path.Combine(parent._path, name);
-        }
+        _path = parent is null ? CGroupV2MountPoint : System.IO.Path.Combine(parent._path, name);
     }
 
     /// <summary>Gets the root cgroup.</summary>
-    public static CGroup2 Root => new(CGroupV2MountPoint, parent: null);
+    public static CGroup2 Root { get; } = new(RootName, parent: null);
 
     /// <summary>Gets an existing child cgroup without creating it.</summary>
     /// <param name="name">The name of the child cgroup.</param>
@@ -528,6 +520,26 @@ public sealed partial class CGroup2
     }
 
     #endregion
+
+    /// <summary>Determines whether the specified cgroup refers to the same path as this instance.</summary>
+    /// <param name="other">The cgroup to compare with this instance.</param>
+    public bool Equals([NotNullWhen(true)] CGroup2? other) => other is not null && string.Equals(_path, other._path, StringComparison.Ordinal);
+
+    /// <inheritdoc />
+    public override bool Equals([NotNullWhen(true)] object? obj) => Equals(obj as CGroup2);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(_path);
+
+    /// <summary>Determines whether two cgroups refer to the same path.</summary>
+    /// <param name="left">The first cgroup to compare.</param>
+    /// <param name="right">The second cgroup to compare.</param>
+    public static bool operator ==(CGroup2? left, CGroup2? right) => left is null ? right is null : left.Equals(right);
+
+    /// <summary>Determines whether two cgroups refer to different paths.</summary>
+    /// <param name="left">The first cgroup to compare.</param>
+    /// <param name="right">The second cgroup to compare.</param>
+    public static bool operator !=(CGroup2? left, CGroup2? right) => !(left == right);
 
     /// <summary>Returns a string representation of this cgroup.</summary>
     public override string ToString() => _path;

--- a/tests/Meziantou.Framework.Unix.ControlGroups.Tests/CGroup2IdentityTests.cs
+++ b/tests/Meziantou.Framework.Unix.ControlGroups.Tests/CGroup2IdentityTests.cs
@@ -1,0 +1,65 @@
+namespace Meziantou.Framework.Unix.ControlGroups.Tests;
+
+/// <summary>Identity and equality do not touch the file system, so these run on every OS without privileges.</summary>
+public sealed class CGroup2IdentityTests
+{
+    [Fact]
+    public void Root_ShouldBeNamedAsASegmentNotAPath()
+    {
+        Assert.Equal("/", CGroup2.Root.Name);
+    }
+
+    [Fact]
+    public void Root_ShouldStillResolveToTheMountPoint()
+    {
+        Assert.Equal("/sys/fs/cgroup", CGroup2.Root.ToString());
+    }
+
+    [Fact]
+    public void Root_ShouldHaveNoParent()
+    {
+        Assert.Null(CGroup2.Root.Parent);
+    }
+
+    [Fact]
+    public void Root_ShouldReturnTheSameInstanceOnEveryAccess()
+    {
+        Assert.Same(CGroup2.Root, CGroup2.Root);
+    }
+
+    [Fact]
+    public void Equals_ShouldCompareByPath()
+    {
+        var root = CGroup2.Root;
+        Assert.Equal(root, CGroup2.Root);
+        Assert.Equal(root.GetHashCode(), CGroup2.Root.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_ShouldReturnFalseForNull()
+    {
+        Assert.False(CGroup2.Root.Equals(null));
+        Assert.False(CGroup2.Root.Equals(obj: null));
+    }
+
+    [Fact]
+    public void EqualityOperators_ShouldCompareByPath()
+    {
+        var root = CGroup2.Root;
+        CGroup2? nothing = null;
+
+        var sameIsEqual = root == CGroup2.Root;
+        var sameIsNotEqual = root != CGroup2.Root;
+        var valueEqualsNull = root == nothing;
+        var valueDiffersFromNull = root != nothing;
+        var nullEqualsNull = nothing == null;
+        var nullDiffersFromNull = nothing != null;
+
+        Assert.True(sameIsEqual);
+        Assert.False(sameIsNotEqual);
+        Assert.False(valueEqualsNull);
+        Assert.True(valueDiffersFromNull);
+        Assert.True(nullEqualsNull);
+        Assert.False(nullDiffersFromNull);
+    }
+}


### PR DESCRIPTION
## Findings

Two related problems around `CGroup2`'s identity (`CGroup2.cs:26-43`).

**`Root` allocated a new instance per access, and the type had no value equality.** `Root` was a property returning `new(...)` on every read, and `CGroup2` inherited reference equality. So `CGroup2.Root.Equals(CGroup2.Root)` was `false`, two instances for the same path never compared equal, and a `HashSet<CGroup2>` grew instead of deduplicating. The type is conceptually a value — an immutable path — so this is the opposite of what a caller expects.

**`Root.Name` returned a full path.** `Root` was constructed as `new(CGroupV2MountPoint, parent: null)`, so `CGroup2.Root.Name` was `"/sys/fs/cgroup"` — from a property documented as "the name of the cgroup". Every other instance returned a bare segment, so code building a display string or a nested path from `Name` hit a special case with no reason to expect one.

## Change

- `Root` is now `public static CGroup2 Root { get; } = new(RootName, parent: null)` — initialized once. Safe because the instance is immutable.
- `Root.Name` is now `"/"`. The mount point stays in the private path, so `Root.ToString()` is unchanged at `/sys/fs/cgroup`.
- The constructor no longer has the "name may be an absolute path" branch. That branch existed only to build `Root`, and dropping it means a name can no longer silently become the whole path.
- Implements `IEquatable<CGroup2>` over the path with matching `GetHashCode`, `Equals(object)`, and `==`/`!=`.

## ⚠️ Behavior change

**`CGroup2.Root.Name` changes from `"/sys/fs/cgroup"` to `"/"`.** Anything reading `Root.Name` and expecting a path will see different output. `ToString()` is unchanged, so callers using that for display are unaffected. The old value contradicted the property's own doc comment, which is why I fixed it rather than preserving it — but it is a visible change on a published 2.0.0 package, so flagging it explicitly.

Everything else here is additive.

## Verification

`dotnet build -p:TreatWarningsAsErrors=true` clean for `net10.0` and `net11.0`. `ref/` regenerated with a Release / `IsOfficialBuild=true` build.

New `CGroup2IdentityTests` — 7 tests, all passing, and like the name-validation tests they need no privileges or Linux, so they run in CI.

One existing assertion improves as a side effect: `CGroup2Tests.cs:69` (`Assert.Equal(_testRoot, child.Parent)`) previously passed only because those happened to be the same reference; it now tests what it reads as.
