### PR TITLE
Implement IEquatable on UnicodeCharacterInfo

### DIFF
--- a/ref/Meziantou.Framework.Unicode.cs
+++ b/ref/Meziantou.Framework.Unicode.cs
@@ -409,7 +409,7 @@ namespace Meziantou.Framework
         public static Meziantou.Framework.UnicodeBlock GetBlock(System.Text.Rune rune) => throw null;
     }
 
-    public readonly struct UnicodeCharacterInfo
+    public readonly struct UnicodeCharacterInfo : System.IEquatable<Meziantou.Framework.UnicodeCharacterInfo>
     {
         public System.Text.Rune Rune { get => throw null; }
         public string Name { get => throw null; }
@@ -433,6 +433,11 @@ namespace Meziantou.Framework
         public bool IsEmojiModifierBase { get => throw null; }
         public bool IsEmojiComponent { get => throw null; }
         public bool IsExtendedPictographic { get => throw null; }
+        public bool Equals(Meziantou.Framework.UnicodeCharacterInfo other) => throw null;
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) => throw null;
+        public override int GetHashCode() => throw null;
+        public static bool operator ==(Meziantou.Framework.UnicodeCharacterInfo left, Meziantou.Framework.UnicodeCharacterInfo right) => throw null;
+        public static bool operator !=(Meziantou.Framework.UnicodeCharacterInfo left, Meziantou.Framework.UnicodeCharacterInfo right) => throw null;
     }
 
     public static class UnicodeEmoji

--- a/src/Meziantou.Framework.Unicode/UnicodeCharacterInfo.cs
+++ b/src/Meziantou.Framework.Unicode/UnicodeCharacterInfo.cs
@@ -1,7 +1,7 @@
 namespace Meziantou.Framework;
 
 /// <summary>Represents Unicode character information.</summary>
-public readonly struct UnicodeCharacterInfo
+public readonly struct UnicodeCharacterInfo : IEquatable<UnicodeCharacterInfo>
 {
     private readonly sbyte _decimalDigitValue;
     private readonly sbyte _digitValue;
@@ -118,4 +118,22 @@ public readonly struct UnicodeCharacterInfo
 
     /// <summary>Gets a value indicating whether the character has the Extended_Pictographic property.</summary>
     public bool IsExtendedPictographic => (_emojiProperties & 0x20) != 0;
+
+    /// <summary>Determines whether this instance and another describe the same Unicode character.</summary>
+    /// <param name="other">The other character information.</param>
+    /// <returns><see langword="true"/> when both describe the same character; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Instances come from a fixed table keyed by <see cref="Rune"/>, so the scalar value identifies the
+    /// entry. <see cref="Name"/> is compared as well so that a <see langword="default"/> instance, which
+    /// carries the scalar value U+0000 and no name, is not equal to the real entry for U+0000.
+    /// </remarks>
+    public bool Equals(UnicodeCharacterInfo other) => Rune == other.Rune && string.Equals(Name, other.Name, StringComparison.Ordinal);
+
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is UnicodeCharacterInfo other && Equals(other);
+
+    public override int GetHashCode() => Rune.GetHashCode();
+
+    public static bool operator ==(UnicodeCharacterInfo left, UnicodeCharacterInfo right) => left.Equals(right);
+
+    public static bool operator !=(UnicodeCharacterInfo left, UnicodeCharacterInfo right) => !left.Equals(right);
 }

--- a/tests/Meziantou.Framework.Unicode.Tests/UnicodeTests.cs
+++ b/tests/Meziantou.Framework.Unicode.Tests/UnicodeTests.cs
@@ -112,6 +112,68 @@ public sealed class UnicodeTests
     }
 
     [Fact]
+    public void UnicodeCharacterInfo_EqualityIsStructural()
+    {
+        Assert.True(Unicode.TryGetCharacterInfo(new Rune('A'), out var a));
+        Assert.True(Unicode.TryGetCharacterInfo(new Rune('A'), out var b));
+        Assert.True(Unicode.TryGetCharacterInfo(new Rune('B'), out var c));
+
+        Assert.Equal(a, b);
+        Assert.True(a == b);
+        Assert.False(a != b);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+
+        Assert.NotEqual(a, c);
+        Assert.True(a != c);
+        Assert.NotEqual<object>("not a character", a);
+    }
+
+    [Fact]
+    public void UnicodeCharacterInfo_DefaultIsNotEqualToTheEntryForNull()
+    {
+        Assert.True(Unicode.TryGetCharacterInfo(new Rune(0), out var nul));
+
+        Assert.Equal(new Rune(0), nul.Rune);
+        Assert.Equal(default, default(UnicodeCharacterInfo).Rune);
+        Assert.NotEqual(default, nul);
+    }
+
+    [Fact]
+    public void UnicodeCharacterInfo_HashCodeDistinguishesCharacters()
+    {
+        var seen = new Dictionary<int, Rune>();
+        var collisions = new List<string>();
+        for (var codePoint = 0; codePoint < 1000; codePoint++)
+        {
+            if (!Unicode.TryGetCharacterInfo(new Rune(codePoint), out var info))
+                continue;
+
+            var hash = info.GetHashCode();
+            if (seen.TryGetValue(hash, out var existing))
+            {
+                collisions.Add($"U+{existing.Value:X4} collides with U+{info.Rune.Value:X4}");
+            }
+            else
+            {
+                seen[hash] = info.Rune;
+            }
+        }
+
+        Assert.Empty(collisions);
+    }
+
+    [Fact]
+    public void UnicodeCharacterInfo_DeduplicatesInAHashSet()
+    {
+        Assert.True(Unicode.TryGetCharacterInfo(new Rune('A'), out var a));
+        Assert.True(Unicode.TryGetCharacterInfo(new Rune('A'), out var duplicate));
+
+        var set = new HashSet<UnicodeCharacterInfo> { a, duplicate };
+
+        Assert.Single(set);
+    }
+
+    [Fact]
     public void IsEmoji_ReturnsExpectedValue()
     {
         Assert.True(UnicodeEmoji.IsEmoji(new Rune(0x1F600)));


### PR DESCRIPTION
`UnicodeCharacterInfo` is a public struct returned by `GetCharacterInfo`,
`TryGetCharacterInfo` and `AllCharacters`, and it overrode neither `Equals` nor
`GetHashCode` and implemented no interface.

Because the struct contains reference fields the CLR cannot use the fast bitwise hash and
falls back to hashing the **first field** — which is `private readonly sbyte
_decimalDigitValue` (line 6), holding 11 possible values (-1 and 0-9). Measured against the
shipped assembly before this change:

- `GetCharacterInfo('A')`, `('B')` and `(U+1F600)` all returned hash code `-326204284`
- 5,000 distinct characters produced **11** distinct hash codes
- filling a `HashSet<UnicodeCharacterInfo>` with those 5,000 took **13,023 ms** (quadratic)
- each reflection-based `ValueType.Equals` cost ~1.7 us

So any `Distinct()`, `GroupBy` or `HashSet` over `AllCharacters` (297,334 items) was a hang,
not a slowdown. Nothing flagged it because CA1815 is disabled repo-wide.

## What changed

Implements `IEquatable<UnicodeCharacterInfo>` with `Equals`, `GetHashCode`, `==` and `!=`,
matching the shape `UnicodeRange` already has.

**On the equality key:** the obvious choice is `Rune` alone, since instances come from a fixed
table keyed by `Rune`. That is subtly wrong — `default(UnicodeCharacterInfo).Rune` is
`default(Rune)`, i.e. U+0000, so a `default` instance would compare **equal** to the real entry
for U+0000, which is a live entry in the table. `Equals` therefore compares `Rune` **and**
`Name` (ordinal); `GetHashCode` stays on `Rune` alone, which is valid since equal instances
always share a scalar value, and costs at most one collision.

Adding an interface and these overrides to an existing struct is source- and
binary-compatible, so this is shippable in 2.x. `ref/Meziantou.Framework.Unicode.cs` is
regenerated and included.

Note that `Equals` semantics narrow from "all 17 fields match" (the old reflection behaviour)
to "same code point and name". For instances obtained from the table those are equivalent,
since the table has one entry per scalar value.

## Verification

`dotnet test ... /p:TreatsWarningsAsErrors=true` — **40 passed** (20 facts x 2 TFMs), up from
32, 0 failed.

Four new facts:

- structural equality, operators and hash agreement for the same character
- `default` is not equal to the real U+0000 entry — the case that rules out a `Rune`-only key
- **no two of the 989 characters below U+03E8 share a hash code**; this is the regression test
  for the collapse above, and it fails with hundreds of listed collisions without the fix
- a `HashSet` deduplicates two lookups of the same character

`dotnet build src/Meziantou.Framework.Unicode` — 0 warnings, 0 errors, `ref/` regenerated.

Found by a project review of `src/Meziantou.Framework.Unicode`.
