### PR TITLE
Stop date range keywords from throwing on non-date and DateTime handlers

### DIFF
--- a/src/Meziantou.Framework.SimpleQueryLanguage/Ranges/RangeSyntax.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/Ranges/RangeSyntax.cs
@@ -36,93 +36,108 @@ internal static class RangeSyntax
 
     private static bool TryExpandRangeVariables<T>(string text, TimeProvider timeProvider, [MaybeNullWhen(false)] out RangeSyntax<T> value)
     {
+        // Every keyword below expands to a range of dates, so it cannot be represented for any other type.
+        // Returning false lets the caller fall back to the type's own parser instead of failing the cast.
+        if (typeof(T) != typeof(DateTime) && typeof(T) != typeof(DateTimeOffset) && typeof(T) != typeof(DateOnly))
+        {
+            value = default;
+            return false;
+        }
+
         var span = text.AsSpan().Trim();
         var utcNow = timeProvider.GetUtcNow();
+
         if (span.Equals("today", StringComparison.OrdinalIgnoreCase))
         {
-            var now = utcNow.UtcDateTime;
-            var start = new DateTime(now.Year, now.Month, now.Day);
-            var end = start.AddDays(1);
-            value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);
+            var start = StartOfDay(utcNow);
+            value = Between(start, start.AddDays(1));
             return true;
-
         }
         else if (span.Equals("yesterday", StringComparison.OrdinalIgnoreCase))
         {
-            var now = utcNow.UtcDateTime;
-            var end = new DateTime(now.Year, now.Month, now.Day);
-            var start = end.AddDays(-1);
-            value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);
+            var end = StartOfDay(utcNow);
+            value = Between(end.AddDays(-1), end);
             return true;
         }
-        else if (span.Trim().Equals("this week", StringComparison.OrdinalIgnoreCase))
+        else if (span.Equals("this week", StringComparison.OrdinalIgnoreCase))
         {
-            var now = utcNow;
-            var start = StartOfWeek(now);
-            var end = start.AddDays(7);
-            value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);
+            var start = StartOfWeek(utcNow);
+            value = Between(start, start.AddDays(7));
             return true;
         }
-        else if (span.Trim().Equals("this month", StringComparison.OrdinalIgnoreCase))
+        else if (span.Equals("this month", StringComparison.OrdinalIgnoreCase))
         {
-            var now = utcNow.UtcDateTime;
-            var start = new DateTime(now.Year, now.Month, 1);
-            var end = start.AddMonths(1);
-            value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);
+            var start = StartOfMonth(utcNow);
+            value = Between(start, start.AddMonths(1));
             return true;
         }
-        else if (span.Trim().Equals("last month", StringComparison.OrdinalIgnoreCase))
+        else if (span.Equals("last month", StringComparison.OrdinalIgnoreCase))
         {
-            var now = utcNow.UtcDateTime;
-            var end = new DateTime(now.Year, now.Month, 1);
-            var start = end.AddMonths(-1);
-            value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);
+            var end = StartOfMonth(utcNow);
+            value = Between(end.AddMonths(-1), end);
             return true;
         }
-        else if (span.Trim().Equals("this year", StringComparison.OrdinalIgnoreCase))
+        else if (span.Equals("this year", StringComparison.OrdinalIgnoreCase))
         {
-            var now = utcNow.UtcDateTime;
-            var start = new DateTime(now.Year, 1, 1);
-            var end = new DateTime(now.Year + 1, 1, 1);
-            value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);
+            var start = StartOfYear(utcNow);
+            value = Between(start, start.AddYears(1));
             return true;
         }
-        else if (span.Trim().Equals("last year", StringComparison.OrdinalIgnoreCase))
+        else if (span.Equals("last year", StringComparison.OrdinalIgnoreCase))
         {
-            var now = utcNow.UtcDateTime;
-            var end = new DateTime(now.Year, 1, 1);
-            var start = new DateTime(now.Year - 1, 1, 1);
-            value = new BinaryRangeSyntax<T>(ConvertValue(start), lowerBoundIncluded: true, ConvertValue(end), upperBoundIncluded: false);
+            var end = StartOfYear(utcNow);
+            value = Between(end.AddYears(-1), end);
             return true;
         }
 
         value = default;
         return false;
 
-        static T ConvertValue(object value)
+        static RangeSyntax<T> Between(DateTimeOffset lowerBound, DateTimeOffset upperBound)
         {
-            if (typeof(T) == typeof(DateTimeOffset) && value is DateTime dateTime)
-            {
-                return (T)(object)new DateTimeOffset(dateTime, TimeSpan.Zero);
-            }
-            else if (typeof(T) == typeof(DateOnly) && value is DateTime dateTime2)
-            {
-                return (T)(object)DateOnly.FromDateTime(dateTime2);
-            }
-
-            return (T)value;
+            return new BinaryRangeSyntax<T>(ConvertValue(lowerBound), lowerBoundIncluded: true, ConvertValue(upperBound), upperBoundIncluded: false);
         }
+
+        static T ConvertValue(DateTimeOffset value)
+        {
+            if (typeof(T) == typeof(DateTimeOffset))
+                return (T)(object)value;
+
+            if (typeof(T) == typeof(DateOnly))
+                return (T)(object)DateOnly.FromDateTime(value.UtcDateTime);
+
+            // UtcDateTime yields DateTimeKind.Utc, matching what ValueConverter produces for an explicit date
+            return (T)(object)value.UtcDateTime;
+        }
+    }
+
+    private static DateTimeOffset StartOfDay(DateTimeOffset dt)
+    {
+        var utc = dt.UtcDateTime;
+        return new DateTimeOffset(utc.Year, utc.Month, utc.Day, 0, 0, 0, TimeSpan.Zero);
+    }
+
+    private static DateTimeOffset StartOfMonth(DateTimeOffset dt)
+    {
+        var utc = dt.UtcDateTime;
+        return new DateTimeOffset(utc.Year, utc.Month, 1, 0, 0, 0, TimeSpan.Zero);
+    }
+
+    private static DateTimeOffset StartOfYear(DateTimeOffset dt)
+    {
+        var utc = dt.UtcDateTime;
+        return new DateTimeOffset(utc.Year, 1, 1, 0, 0, 0, TimeSpan.Zero);
     }
 
     private static DateTimeOffset StartOfWeek(DateTimeOffset dt)
     {
-        var diff = dt.DayOfWeek - DayOfWeek.Monday;
+        var start = StartOfDay(dt);
+        var diff = start.DayOfWeek - DayOfWeek.Monday;
         if (diff < 0)
         {
             diff += 7;
         }
 
-        dt = dt.AddDays(-1 * diff);
-        return new DateTimeOffset(dt.Year, dt.Month, dt.Day, 0, 0, 0, TimeSpan.Zero);
+        return start.AddDays(-diff);
     }
 }

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/QueryBuilderTests.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Meziantou.Framework.SimpleQueryLanguage.Ranges;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Meziantou.Framework.SimpleQueryLanguage.Tests;
@@ -655,6 +656,67 @@ public sealed class QueryBuilderTests
         var query = queryBuilder.Build("dummy:10");
 
         Assert.Throws<NotSupportedException>(() => query.Evaluate(new() { StringValue = "dummy:10" }));
+    }
+
+    [Theory]
+    [InlineData("today")]
+    [InlineData("yesterday")]
+    [InlineData("this week")]
+    [InlineData("this month")]
+    [InlineData("last month")]
+    [InlineData("this year")]
+    [InlineData("last year")]
+    public void DateKeyword_OnNonDateHandler_DoesNotMatch(string keyword)
+    {
+        var queryBuilder = new QueryBuilder<Sample>();
+        queryBuilder.AddRangeHandler<int>("age", (obj, range) => range.IsInRange(obj.Int32Value));
+        var query = queryBuilder.Build($"age:\"{keyword}\"");
+
+        Assert.False(query.Evaluate(new Sample { Int32Value = 42 }));
+    }
+
+    // 2026-03-15 is a Sunday, so "this week" is 2026-03-09..2026-03-16
+    [Theory]
+    [InlineData("today", true)]
+    [InlineData("yesterday", false)]
+    [InlineData("this week", true)]
+    [InlineData("this month", true)]
+    [InlineData("last month", false)]
+    [InlineData("this year", true)]
+    [InlineData("last year", false)]
+    public void DateKeyword_OnDateTimeHandler_IsSupported(string keyword, bool expectedResult)
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero));
+
+        var queryBuilder = new QueryBuilder<Sample>(timeProvider);
+        queryBuilder.AddRangeHandler<DateTime>("date", (obj, range) => range.IsInRange(obj.DateTimeValue));
+        var query = queryBuilder.Build($"date:\"{keyword}\"");
+
+        Assert.Equal(expectedResult, query.Evaluate(new Sample { DateTimeValue = new DateTime(2026, 3, 15, 8, 0, 0, DateTimeKind.Utc) }));
+    }
+
+    [Fact]
+    public void DateKeyword_OnDateTimeHandler_ProducesUtcBounds()
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero));
+
+        BinaryRangeSyntax<DateTime>? capturedRange = null;
+        var queryBuilder = new QueryBuilder<Sample>(timeProvider);
+        queryBuilder.AddRangeHandler<DateTime>("date", (obj, range) =>
+        {
+            capturedRange = Assert.IsType<BinaryRangeSyntax<DateTime>>(range);
+            return true;
+        });
+
+        queryBuilder.Build("date:today").Evaluate(new Sample());
+
+        Assert.NotNull(capturedRange);
+        Assert.Equal(new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc), capturedRange.LowerBound);
+        Assert.Equal(DateTimeKind.Utc, capturedRange.LowerBound.Kind);
+        Assert.Equal(new DateTime(2026, 3, 16, 0, 0, 0, DateTimeKind.Utc), capturedRange.UpperBound);
+        Assert.Equal(DateTimeKind.Utc, capturedRange.UpperBound.Kind);
     }
 
     [Fact]


### PR DESCRIPTION
`RangeSyntax.TryExpandRangeVariables<T>` runs for **every** `T`, before the type's own parser gets a chance. It builds date bounds and hands them to a local `ConvertValue(object)` that special-cased `DateTimeOffset` and `DateOnly` and otherwise did a blind `(T)value` — an unguarded unboxing cast that requires an exact type match.

Two ways that throws today:

**1. Any date keyword against a non-date handler.**

```csharp
queryBuilder.AddRangeHandler<int>("age", (o, r) => r.IsInRange(o.Age));
queryBuilder.Build("age:today").Evaluate(item);
// InvalidCastException: Unable to cast object of type 'System.DateTime' to type 'System.Int32'.
```

A user typing `age:today` into a search box gets a 500. Every *other* unparsable value in this library degrades to "no match" — this one throws.

**2. `this week` against a plain `DateTime` handler.**

The `this week` branch computed its bounds as `DateTimeOffset` (via `StartOfWeek`) while every other branch produced `DateTime`. `ConvertValue` only unwrapped `DateTime`, so:

```csharp
queryBuilder.AddRangeHandler<DateTime>("date", (o, r) => r.IsInRange(o.Date));
queryBuilder.Build("date:\"this week\"").Evaluate(item);
// InvalidCastException: Unable to cast object of type 'System.DateTimeOffset' to type 'System.DateTime'.
```

The existing date tests only cover `DateTimeOffset` and `DateOnly` handlers, which is why this went unnoticed.

There was also a latent inconsistency in the same method: bounds were built with `new DateTime(y, m, d)`, which is `DateTimeKind.Unspecified`, while `ValueConverter.TryParseValue<DateTime>` uses `AdjustToUniversal` and yields `Kind == Utc` (asserted in `ValueParserTests`). `Comparer<DateTime>.Default` ignores `Kind`, so nothing was observably broken — but `date:today` and `date:2026-03-15` were comparing against differently-kinded values, and anyone later adding `ToUniversalTime()` or a custom `IComparer<DateTime>` would get a silent timezone-sized shift in the keywords only.

## What changed

- Bail out early when `T` is not `DateTime`, `DateTimeOffset` or `DateOnly`, so the caller falls through to the type's own parser and then to the normal no-match path. `TimeOnly` is deliberately included in the bail-out: a "today" range is meaningless for a time of day.
- Compute every bound as a UTC `DateTimeOffset` and convert once in a single total `ConvertValue`, which removes the `this week` mismatch by construction. `value.UtcDateTime` yields `DateTimeKind.Utc`, so the bounds now match what the parser produces — the latent inconsistency goes away as a side effect of the same rewrite.
- Extract `StartOfDay` / `StartOfMonth` / `StartOfYear` alongside the existing `StartOfWeek`, all working off `UtcDateTime` so they are correct whatever offset the `TimeProvider` returns.

Week boundaries are unchanged — still Monday-start — and so are all existing range semantics.

## Verification

Three tests added to `QueryBuilderTests`:

- all seven keywords against an `int` range handler now return `false` instead of throwing (all seven throw on `main`);
- all seven keywords against a `DateTime` range handler, with a `FakeTimeProvider` pinned to Sunday 2026-03-15, asserting membership rather than just absence of a crash (`this week` throws on `main`, and `yesterday` / `last month` / `last year` correctly exclude);
- `date:today` on a `DateTime` handler produces `2026-03-15T00:00:00Z`..`2026-03-16T00:00:00Z` with `Kind == Utc` on both bounds.

Full suite green — 258 tests across net10.0 and net11.0, `-p:TreatWarningsAsErrors=true`.

No public API change.

## Scope note

The review this came from listed the `Kind` mismatch as a separate low-severity finding, intended for its own PR. Fixing the casts properly means rewriting the same conversion, and that rewrite sets `Kind` correctly by construction — splitting them would have meant knowingly leaving the method half-fixed. So they are one change here.

Found during a review of the project; the report also covers seven other findings that are going out as separate PRs.
