### PR TITLE
Take a ReadOnlySpan in SetCpusetMems to match SetCpusetCpus

### DIFF
--- a/ref/Meziantou.Framework.Unix.ControlGroups.cs
+++ b/ref/Meziantou.Framework.Unix.ControlGroups.cs
@@ -15,7 +15,7 @@ namespace Meziantou.Framework.Unix.ControlGroups
         public void SetCpusetCpusRaw(string cpuList) { }
         public int[]? GetCpusetCpus() => throw null;
         public int[]? GetCpusetCpusEffective() => throw null;
-        public void SetCpusetMems(params int[] nodes) { }
+        public void SetCpusetMems(params System.ReadOnlySpan<int> nodes) { }
         public void SetCpusetMemsRaw(string nodeList) { }
         public int[]? GetCpusetMems() => throw null;
         public int[]? GetCpusetMemsEffective() => throw null;

--- a/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.Cpuset.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.Cpuset.cs
@@ -51,10 +51,8 @@ public partial class CGroup2
 
     /// <summary>Sets the memory nodes that tasks in this cgroup can use.</summary>
     /// <param name="nodes">Array of memory node numbers.</param>
-    public void SetCpusetMems(params int[] nodes)
+    public void SetCpusetMems(params ReadOnlySpan<int> nodes)
     {
-        ArgumentNullException.ThrowIfNull(nodes);
-
         if (nodes.Length == 0)
         {
             SetCpusetMemsRaw("");


### PR DESCRIPTION
## Finding

`SetCpusetCpus` took `params ReadOnlySpan<int>` while its sibling `SetCpusetMems` took `params int[]`, for no reason visible in the code (`CGroup2.Cpuset.cs:11` vs `:54`). The two are the same operation against two different cgroup files, and callers hit an inconsistency where they'd expect symmetry.

The `int[]` overload also carried `ArgumentNullException.ThrowIfNull(nodes)`, which `AGENTS.md` — "trust the C# null annotations and don't add null checks when the type system says a value cannot be null" — says not to write.

## Change

`SetCpusetMems` now takes `params ReadOnlySpan<int>`, matching `SetCpusetCpus`. The null guard goes with it, since a span cannot be null. The private `ConvertToRanges` helper already accepted `ReadOnlySpan<int>`, so the body is otherwise unchanged.

## ⚠️ Breaking change

This is **source- and binary-breaking** on a published 2.0.0 package:

- Binary: the signature changes, so recompilation is required.
- Source: most call sites are unaffected — `SetCpusetMems(0, 1)` and `SetCpusetMems(array)` both still bind — but anything passing `null` explicitly, or relying on `int[]` overload resolution, will not compile.

You asked for the breaking findings as PRs, so here it is; it needs to land with a version bump you're comfortable with rather than merge quietly into 2.x.

## Verification

`dotnet build -p:TreatWarningsAsErrors=true` clean for `net10.0` and `net11.0`. `ref/` regenerated with a Release / `IsOfficialBuild=true` build; the whole generated diff is the one signature.

No test change — `SetCpusetMems` has no coverage today, and it can only be exercised against a real cgroupfs mount with the cpuset controller enabled.
