### PR TITLE
Name RmJoinSession in the JoinSession failure message

### DIFF
--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
@@ -73,7 +73,7 @@ public sealed class RestartManager : IDisposable
     {
         var result = PInvoke.RmJoinSession(out var handle, sessionKey);
         if (result != WIN32_ERROR.ERROR_SUCCESS)
-            throw new Win32Exception((int)result, $"RmStartSession failed ({result})");
+            throw new Win32Exception((int)result, $"RmJoinSession failed ({result})");
 
         return new RestartManager(handle, sessionKey);
     }

--- a/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Meziantou.Xunit;
 
 namespace Meziantou.Framework.Win32.Tests;
@@ -58,5 +59,12 @@ public class RestartManagerTests
         {
             File.Delete(path);
         }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void JoinSession_WithUnknownKey_ReportsTheFailingFunction()
+    {
+        var exception = Assert.Throws<Win32Exception>(() => RestartManager.JoinSession("00000000000000000000000000000000"));
+        Assert.StartsWith("RmJoinSession failed", exception.Message);
     }
 }


### PR DESCRIPTION
`JoinSession` reported the wrong function name when it failed:

```csharp
var result = PInvoke.RmJoinSession(out var handle, sessionKey);
if (result != WIN32_ERROR.ERROR_SUCCESS)
    throw new Win32Exception((int)result, $"RmStartSession failed ({result})");
```

The call that failed was `RmJoinSession`. The message was copy-pasted from `CreateSession`, so anyone debugging a join failure was sent to the wrong API — and `RmStartSession` and `RmJoinSession` fail for genuinely different reasons (`ERROR_MAX_SESSIONS_REACHED` vs. a bad or expired session key).

## What changed

One string. The other five call sites in the file already name their function correctly.

## Verification

- Builds clean on `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`, 0 warnings.
- `dotnet run ./eng/update-all.cs` produces no further changes. No `ref/` change.
- Added `JoinSession_WithUnknownKey_ReportsTheFailingFunction`, which joins with a well-formed but unknown session key and asserts the message names `RmJoinSession`.

⚠️ **Tests were not run locally** — every test here is `[RunIf(TestOperatingSystems.Windows)]` and this was authored on macOS. The `windows-2025-vs2026` CI leg is the first real execution. Worth a glance on this one: the test assumes the Restart Manager rejects an unknown 32-character session key, which is the documented behavior but is not something I could confirm by running it.

Found by a review of `src/Meziantou.Framework.Win32.RestartManager` (Low severity finding).
