### PR TITLE
Stop using the assembly name as the project directory

### DIFF
--- a/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
+++ b/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
@@ -56,7 +56,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
             var generateResourcesTypeConfiguration = GetMetadataValue("GenerateResourcesType", globalName: null);
 
             var rootNamespace = rootNamespaceConfiguration ?? assemblyName ?? "";
-            var projectDir = projectDirConfiguration ?? assemblyName ?? "";
+            var projectDir = projectDirConfiguration ?? "";
             var defaultResourceName = defaultResourceNameConfiguration ?? ResxGeneratorCommon.ComputeResourceName(rootNamespace, projectDir, resxGroup.Key);
             var defaultNamespace = ResxGeneratorCommon.ComputeNamespace(rootNamespace, projectDir, resxGroup.Key);
 

--- a/src/Meziantou.Framework.ResxSourceGenerator/ResxGeneratorAnalyzer.cs
+++ b/src/Meziantou.Framework.ResxSourceGenerator/ResxGeneratorAnalyzer.cs
@@ -73,7 +73,7 @@ public sealed class ResxGeneratorAnalyzer : DiagnosticAnalyzer
             var generateResourcesTypeConfiguration = GetMetadataValue("GenerateResourcesType", globalName: null);
 
             var rootNamespace = rootNamespaceConfiguration ?? assemblyName ?? "";
-            var projectDir = projectDirConfiguration ?? assemblyName ?? "";
+            var projectDir = projectDirConfiguration ?? "";
             var defaultResourceName = defaultResourceNameConfiguration ?? ResxGeneratorCommon.ComputeResourceName(rootNamespace, projectDir, resxGroup.Key);
             var resourceName = resourceNameConfiguration ?? defaultResourceName;
             var generateResourcesType = ResxGeneratorCommon.ParseBoolean(generateResourcesTypeConfiguration, defaultValue: true);

--- a/src/Meziantou.Framework.ResxSourceGenerator/ResxGeneratorCommon.cs
+++ b/src/Meziantou.Framework.ResxSourceGenerator/ResxGeneratorCommon.cs
@@ -68,7 +68,9 @@ internal static class ResxGeneratorCommon
 
     internal static string? ComputeResourceName(string rootNamespace, string projectDir, string resourcePath)
     {
-        var fullProjectDir = EnsureEndSeparator(Path.GetFullPath(projectDir));
+        if (TryGetFullDirectoryPath(projectDir) is not string fullProjectDir)
+            return Path.GetFileNameWithoutExtension(resourcePath);
+
         var fullResourcePath = Path.GetFullPath(resourcePath);
 
         if (fullProjectDir == fullResourcePath)
@@ -85,7 +87,9 @@ internal static class ResxGeneratorCommon
 
     internal static string? ComputeNamespace(string rootNamespace, string projectDir, string resourcePath)
     {
-        var fullProjectDir = EnsureEndSeparator(Path.GetFullPath(projectDir));
+        if (TryGetFullDirectoryPath(projectDir) is not string fullProjectDir)
+            return null;
+
         var fullResourcePath = EnsureEndSeparator(Path.GetDirectoryName(Path.GetFullPath(resourcePath))!);
 
         if (fullProjectDir == fullResourcePath)
@@ -106,10 +110,10 @@ internal static class ResxGeneratorCommon
     /// </summary>
     internal static string ComputeHintName(string projectDir, string resourcePath)
     {
-        var fullProjectDir = EnsureEndSeparator(Path.GetFullPath(projectDir));
+        var fullProjectDir = TryGetFullDirectoryPath(projectDir);
         var fullResourcePath = Path.GetFullPath(resourcePath);
 
-        var name = fullResourcePath.StartsWith(fullProjectDir, StringComparison.Ordinal)
+        var name = fullProjectDir is not null && fullResourcePath.StartsWith(fullProjectDir, StringComparison.Ordinal)
             ? fullResourcePath[fullProjectDir.Length..]
             : Path.GetFileName(resourcePath);
 
@@ -127,6 +131,26 @@ internal static class ResxGeneratorCommon
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Resolves a directory to a rooted path ending with a separator, or returns <see langword="null"/> when the
+    /// value cannot be one. The project directory is unset in projects that reference the analyzer directly
+    /// instead of importing the props shipped in the package.
+    /// </summary>
+    private static string? TryGetFullDirectoryPath(string directory)
+    {
+        if (string.IsNullOrEmpty(directory))
+            return null;
+
+        try
+        {
+            return EnsureEndSeparator(Path.GetFullPath(directory));
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
     }
 
     private static string EnsureEndSeparator(string path)

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
@@ -310,6 +310,22 @@ public sealed class ResxGeneratorTest
     }
 
     [Fact]
+    public async Task GenerationSucceedsWhenProjectDirIsNotProvided()
+    {
+        // The project directory is only set by the props shipped in the package, so a project referencing the
+        // analyzer directly leaves it unset. The assembly name must not be used as a directory in that case.
+        var element = new XElement("root", new XElement("data", new XAttribute("name", "Sample"), new XElement("value", "Value")));
+        var result = await GenerateFiles([(FullPath.GetTempPath() / "elsewhere" / "test.resx", element.ToString())], new OptionProvider
+        {
+            Namespace = "test",
+        });
+
+        var fileContent = result.GeneratedFileRoot.ToFullString();
+        Assert.Contains("// ResourceName: test", fileContent);
+        Assert.Equal("test.resx.g.cs", result.GeneratedFileName);
+    }
+
+    [Fact]
     public async Task ComputeNamespace_RootDir()
     {
         var result = await GenerateFiles([(FullPath.GetTempPath() / "dir" / "proj" / "test.resx", new XElement("root").ToString())], new OptionProvider


### PR DESCRIPTION
## The bug

`ResxGenerator.cs:59` and `ResxGeneratorAnalyzer.cs:76` both read:

```csharp
var rootNamespace = rootNamespaceConfiguration ?? assemblyName ?? "";
var projectDir = projectDirConfiguration ?? assemblyName ?? "";   // <-- assembly name used as a directory
```

The first line is correct. The second looks like a copy of it: when the `ProjectDir` metadata is absent, the **assembly name** is used as a directory path and resolved with `Path.GetFullPath` against the compiler's working directory.

Two consequences:

1. The resx path never starts with that bogus prefix, so `ComputeResourceName` falls through to `Path.GetFileNameWithoutExtension` and produces an unrooted resource name that won't match the embedded manifest resource — `MissingManifestResourceException` at runtime.
2. If `ProjectDir` **and** `AssemblyName` are both absent, `projectDir` is `""` and `Path.GetFullPath("")` throws `ArgumentException`, crashing the generator.

The props shipped in the package always set `ProjectDir`, which is why this has not surfaced for packaged consumers. It bites projects that reference the analyzer directly via `OutputItemType="Analyzer"` — a documented way to consume generators, and what this repo's own test projects do.

## What changed

- Dropped the `?? assemblyName` on both lines, so an unset `ProjectDir` is simply empty.
- Added `TryGetFullDirectoryPath`, which returns `null` for an empty or unusable directory instead of throwing, and routed `ComputeResourceName`, `ComputeNamespace` and `ComputeHintName` through it.

### This is behaviour-preserving on purpose

Worth checking while reviewing: today `projectDir` is the assembly name, which essentially never matches the resx path, so `ComputeResourceName` already lands on the `Path.GetFileNameWithoutExtension` fallback. With `projectDir` empty it lands on the *same* fallback. So the observable output is unchanged — what goes away is the nonsensical path and the crash.

## Scope: MFRG0003 is still unreachable

The review paired this with finding #6 — `MFRG0003 "Couldn't compute resource name"` is documented and enabled, but `ComputeResourceName` never returns `null`, so the diagnostic is dead code (`ResxGeneratorAnalyzer.cs:80-83`, `ResxGenerator.cs:70-73`).

I planned to fix both here and backed that out. Making `ComputeResourceName` return `null` when it cannot produce a rooted name breaks **six existing tests** that generate successfully with no `ProjectDir` (`GenerateInternalClasses`, `GeneratePublicClasses`, `GenerateProperties`, …). That is not a test problem — it is the tests correctly pinning current behaviour. Turning "generate a class with a probably-wrong resource name" into "generate nothing plus a warning" converts a runtime failure into a compile error in consumer code, and that is your call to make as the package owner, not a drive-by.

So `MFRG0003` stays dead in this PR and wants its own change with a deliberate decision about the fallback.

## Verification

Added `GenerationSucceedsWhenProjectDirIsNotProvided`, which generates from a resx outside any known project directory with no `ProjectDir` set and asserts the resource name and hint name still come out as before.

40/40 unit tests and 16/16 generator tests pass on net10.0 and net11.0 — including the six that would have broken under the wider change.
