### PR TITLE
Parse nullable value types in ValueConverter

### DIFF
--- a/src/Meziantou.Framework.SimpleQueryLanguage/ValueConverter.cs
+++ b/src/Meziantou.Framework.SimpleQueryLanguage/ValueConverter.cs
@@ -7,9 +7,14 @@ internal static class ValueConverter
 {
     public static bool TryParseValue<TValue>(string value, [MaybeNullWhen(false)] out TValue result)
     {
-        if (typeof(TValue).IsEnum)
+        // A boxed Nullable<T> is a boxed T, so parsing the underlying type and casting back to TValue
+        // works for every type below. Without this, Nullable<T> falls all the way through to
+        // Convert.ChangeType, which throws for a null-able target and silently yields "no match".
+        var type = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);
+
+        if (type.IsEnum)
         {
-            if (Enum.TryParse(typeof(TValue), value, ignoreCase: true, out var parsedEnum))
+            if (Enum.TryParse(type, value, ignoreCase: true, out var parsedEnum))
             {
                 result = (TValue)parsedEnum;
                 return true;
@@ -19,7 +24,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(DateTimeOffset))
+        if (type == typeof(DateTimeOffset))
         {
             if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces, out var parsedValue))
             {
@@ -31,7 +36,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(DateTime))
+        if (type == typeof(DateTime))
         {
             if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces, out var parsedValue))
             {
@@ -43,7 +48,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(DateOnly))
+        if (type == typeof(DateOnly))
         {
             if (DateOnly.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var parsedValue))
             {
@@ -55,7 +60,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(TimeOnly))
+        if (type == typeof(TimeOnly))
         {
             if (TimeOnly.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var parsedValue))
             {
@@ -67,7 +72,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(long))
+        if (type == typeof(long))
         {
             if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -79,7 +84,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(ulong))
+        if (type == typeof(ulong))
         {
             if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -91,7 +96,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(int))
+        if (type == typeof(int))
         {
             if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -103,7 +108,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(uint))
+        if (type == typeof(uint))
         {
             if (uint.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -115,7 +120,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(short))
+        if (type == typeof(short))
         {
             if (short.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -127,7 +132,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(ushort))
+        if (type == typeof(ushort))
         {
             if (ushort.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -139,7 +144,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(byte))
+        if (type == typeof(byte))
         {
             if (byte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -151,7 +156,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(sbyte))
+        if (type == typeof(sbyte))
         {
             if (sbyte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -163,7 +168,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(double))
+        if (type == typeof(double))
         {
             if (double.TryParse(value, NumberStyles.AllowThousands | NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -175,7 +180,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(float))
+        if (type == typeof(float))
         {
             if (float.TryParse(value, NumberStyles.AllowThousands | NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -187,7 +192,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(Half))
+        if (type == typeof(Half))
         {
             if (Half.TryParse(value, NumberStyles.AllowThousands | NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -199,7 +204,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(decimal))
+        if (type == typeof(decimal))
         {
             if (decimal.TryParse(value, NumberStyles.AllowThousands | NumberStyles.Float, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -211,7 +216,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(IntPtr))
+        if (type == typeof(IntPtr))
         {
             if (IntPtr.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -223,7 +228,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(BigInteger))
+        if (type == typeof(BigInteger))
         {
             if (BigInteger.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -235,7 +240,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(Int128))
+        if (type == typeof(Int128))
         {
             if (Int128.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -247,7 +252,7 @@ internal static class ValueConverter
             return false;
         }
 
-        if (typeof(TValue) == typeof(UInt128))
+        if (type == typeof(UInt128))
         {
             if (UInt128.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedValue))
             {
@@ -260,7 +265,7 @@ internal static class ValueConverter
         }
 
         // Try find TryParse(string, IFormatProvider, out TValue) method
-        var methodInfo = GetStaticMethodFromHierarchy(typeof(TValue), "TryParse", [typeof(string), typeof(IFormatProvider), typeof(TValue).MakeByRefType()], ValidateReturnType);
+        var methodInfo = GetStaticMethodFromHierarchy(type, "TryParse", [typeof(string), typeof(IFormatProvider), type.MakeByRefType()], ValidateReturnType);
         if (methodInfo != null)
         {
             var parameters = new object?[] { value, CultureInfo.InvariantCulture, null };
@@ -276,7 +281,7 @@ internal static class ValueConverter
         }
 
         // Try find TryParse(string, out TValue) method
-        methodInfo = GetStaticMethodFromHierarchy(typeof(TValue), "TryParse", [typeof(string), typeof(TValue).MakeByRefType()], ValidateReturnType);
+        methodInfo = GetStaticMethodFromHierarchy(type, "TryParse", [typeof(string), type.MakeByRefType()], ValidateReturnType);
         if (methodInfo != null)
         {
             var parameters = new object?[] { value, null };
@@ -294,7 +299,7 @@ internal static class ValueConverter
         // Fallback to ChangeType
         try
         {
-            result = (TValue)Convert.ChangeType(value, typeof(TValue), CultureInfo.InvariantCulture);
+            result = (TValue)Convert.ChangeType(value, type, CultureInfo.InvariantCulture);
             return true;
         }
         catch

--- a/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ValueParserTests.cs
+++ b/tests/Meziantou.Framework.SimpleQueryLanguage.Tests/ValueParserTests.cs
@@ -82,6 +82,49 @@ public class ValueParserTests
         Assert.False(ValueConverter.TryParseValue<CustomTypeWithTryParse>("", out _));
     }
 
+    [Fact]
+    public void ParseNullableInt32()
+    {
+        Assert.True(ValueConverter.TryParseValue<int?>("10", out var result));
+        Assert.Equal(10, result);
+    }
+
+    [Fact]
+    public void ParseNullableInt32_Invalid()
+    {
+        Assert.False(ValueConverter.TryParseValue<int?>("not-a-number", out _));
+    }
+
+    [Fact]
+    public void ParseNullableDateTimeOffset()
+    {
+        Assert.True(ValueConverter.TryParseValue<DateTimeOffset?>("2022-01-01", out var result));
+        Assert.Equal(new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero), result);
+    }
+
+    [Fact]
+    public void ParseNullableEnum()
+    {
+        Assert.True(ValueConverter.TryParseValue<DayOfWeek?>("monday", out var result));
+        Assert.Equal(DayOfWeek.Monday, result);
+    }
+
+    [Fact]
+    public void ParseNullableCustomTypeWithTryParse()
+    {
+        Assert.True(ValueConverter.TryParseValue<CustomStructWithTryParse?>("test", out var result));
+        Assert.NotNull(result);
+    }
+
+    private readonly struct CustomStructWithTryParse
+    {
+        public static bool TryParse(string value, out CustomStructWithTryParse result)
+        {
+            result = default;
+            return !string.IsNullOrEmpty(value);
+        }
+    }
+
     private sealed class CustomTypeWithTryParse
     {
         public static bool TryParse(string value, out CustomTypeWithTryParse? result)


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2106.**

`ValueConverter.TryParseValue<TValue>` had no `Nullable<T>` branch. For `int?` it fell past every type-specific fast path, found no `int?.TryParse` by reflection, and reached `Convert.ChangeType(value, typeof(int?))` — which throws `InvalidCastException` and is swallowed by the `catch` at the end of the method. The result: a silent `false`.

That is how `ExpressionQueryBuilder<T>.AddHandler<int?>("id", o => o.Value)` ends up matching nothing at all, even for plain equality:

```
Build("id:10").Apply(items).Count()  =>  0     // items include Value = 10
```

No exception, no log, no diagnostic — the filter just returns an empty result set. Nullable columns are the norm in EF Core entities, so this is easy to hit and hard to spot.

## What changed

Unwrap `Nullable.GetUnderlyingType(typeof(TValue))` once at the top and test the unwrapped type throughout. A boxed `Nullable<T>` is just a boxed `T`, so every existing `result = (TValue)(object)parsedValue` assignment already works unchanged.

This is a mechanical substitution — `typeof(TValue) ==` becomes `type ==` in all 20 branches, plus the enum check, the two reflection lookups and the `Convert.ChangeType` fallback. It reuses every existing fast path, so `DateTimeOffset?` still gets the `AssumeUniversal | AdjustToUniversal` styles and a nullable user-defined struct still gets its `TryParse` found. No new reflection is introduced, so the trimming and AOT story is unchanged.

## Verification

Five tests added to `ValueParserTests`: `int?` valid and invalid, `DateTimeOffset?`, `DayOfWeek?` (exercising the enum path through the unwrap), and a nullable user-defined struct with a `TryParse` method (exercising the reflection path). All five fail on `main`. Full suite green — 238 tests across net10.0 and net11.0, `-p:TreatWarningsAsErrors=true`.

No public API change.

This PR fixes the *parsing* half of the nullable problem. The handler-registration half — `int?` never getting the `<`, `<=`, `>`, `>=` operators registered — is #2106 on top of this, because its tests only pass once this is in.

Found during a review of the project; the report also covers seven other findings that are going out as separate PRs.
