### PR TITLE
Stop rewriting ASCII characters in ReplaceConfusablesCharacters

### DIFF
--- a/src/Meziantou.Framework.Unicode/Unicode.Confusables.g.cs
+++ b/src/Meziantou.Framework.Unicode/Unicode.Confusables.g.cs
@@ -3,12 +3,13 @@
 // Data source: https://www.unicode.org/Public/UCD/latest/security/confusables.txt
 // Last modified: 2025-08-16T00:45:12.0000000+00:00
 // Statistics:
-//   - Total confusable mappings: 6565
-//   - Single-character replacements: 4462
-//   - Multi-character replacements: 2103
+//   - Total confusable mappings: 6557
+//   - Single-character replacements: 4457
+//   - Multi-character replacements: 2100
 //
 // Specification: https://www.unicode.org/reports/tr39/
-// Purpose: Helps detect visually confusable characters that may be used in security attacks
+// Purpose: Maps non-ASCII characters to the ASCII-ish character they resemble.
+    //          ASCII sources are excluded so ordinary text is never rewritten.
 // DO NOT MODIFY THIS FILE MANUALLY - regenerate using the Unicode generator tool
 
 #nullable enable
@@ -30,16 +31,8 @@ internal static class UnicodeConfusablesData
 
     private static Dictionary<Rune, string> Create()
     {
-        return new Dictionary<Rune, string>(capacity: 6565)
+        return new Dictionary<Rune, string>(capacity: 6557)
         {
-            [new Rune(0x22)] = "\u0027\u0027",
-            [new Rune(0x25)] = "\u00BA\u002F\u2080",
-            [new Rune(0x30)] = "\u004F",
-            [new Rune(0x31)] = "\u006C",
-            [new Rune(0x49)] = "\u006C",
-            [new Rune(0x60)] = "\u0027",
-            [new Rune(0x6D)] = "\u0072\u006E",
-            [new Rune(0x7C)] = "\u006C",
             [new Rune(0xA0)] = "\u0020",
             [new Rune(0xA2)] = "\u0063\u0338",
             [new Rune(0xA5)] = "\u0059\u0335",

--- a/src/Meziantou.Framework.Unicode/Unicode.cs
+++ b/src/Meziantou.Framework.Unicode/Unicode.cs
@@ -3,10 +3,18 @@ namespace Meziantou.Framework;
 /// <summary>Provides Unicode helper methods.</summary>
 public static partial class Unicode
 {
-    /// <summary>Replaces confusable Unicode characters using the Unicode confusables table.</summary>
+    /// <summary>Replaces characters that look like another character with their canonical form.</summary>
     /// <param name="str">The text to normalize.</param>
-    /// <returns>The text with confusable characters replaced.</returns>
-    /// <seealso href="https://unicode.org/reports/tr39/" />
+    /// <returns>The normalized text. Characters that are already ASCII are returned unchanged.</returns>
+    /// <remarks>
+    /// The mapping is derived from the Unicode confusables table, excluding sources that are already
+    /// ASCII, so ordinary text such as <c>"Item 1 of 10"</c> is returned unchanged.
+    /// <para>
+    /// The result is displayable text, not a comparison key. It is deliberately not the skeleton
+    /// defined by UTS #39: the input is not normalized and the mapping is applied in a single pass,
+    /// so two strings that a reader would consider confusable can still produce different results.
+    /// </para>
+    /// </remarks>
     public static string ReplaceConfusablesCharacters(string str)
     {
         ArgumentNullException.ThrowIfNull(str);
@@ -46,10 +54,10 @@ public static partial class Unicode
         return sb.ToString();
     }
 
-    /// <summary>Replaces a confusable Unicode character using the Unicode confusables table.</summary>
+    /// <summary>Replaces a character that looks like another character with its canonical form.</summary>
     /// <param name="rune">The character to normalize.</param>
-    /// <returns>The replacement text for the character.</returns>
-    /// <seealso href="https://unicode.org/reports/tr39/" />
+    /// <returns>The replacement text, or the character itself when it has no replacement.</returns>
+    /// <remarks>ASCII characters are never replaced.</remarks>
     public static string ReplaceConfusablesCharacters(Rune rune)
     {
         if (UnicodeConfusablesData.TryGetReplacement(rune, out var replacement))
@@ -58,10 +66,13 @@ public static partial class Unicode
         return rune.ToString();
     }
 
-    /// <summary>Replaces a confusable Unicode character using the Unicode confusables table.</summary>
+    /// <summary>Replaces a character that looks like another character with its canonical form.</summary>
     /// <param name="value">The character to normalize.</param>
-    /// <returns>The replacement text for the character.</returns>
-    /// <seealso href="https://unicode.org/reports/tr39/" />
+    /// <returns>The replacement text, or the character itself when it has no replacement.</returns>
+    /// <remarks>
+    /// ASCII characters are never replaced. A <see cref="char"/> cannot represent a code point above
+    /// U+FFFF, so use the <see cref="Rune"/> or <see cref="string"/> overload to normalize those.
+    /// </remarks>
     public static string ReplaceConfusablesCharacters(char value)
     {
         if (!Rune.TryCreate(value, out var rune))
@@ -73,10 +84,10 @@ public static partial class Unicode
         return rune.ToString();
     }
 
-    /// <summary>Determines whether a Unicode character has a confusable replacement.</summary>
+    /// <summary>Determines whether a Unicode character has a replacement in the confusables table.</summary>
     /// <param name="rune">The Unicode scalar value to inspect.</param>
-    /// <returns><see langword="true"/> when the character is confusable; otherwise <see langword="false"/>.</returns>
-    /// <seealso href="https://unicode.org/reports/tr39/" />
+    /// <returns><see langword="true"/> when the character has a replacement; otherwise <see langword="false"/>.</returns>
+    /// <remarks>Always returns <see langword="false"/> for ASCII characters, which are never replaced.</remarks>
     public static bool IsConfusableCharacter(Rune rune)
     {
         return UnicodeConfusablesData.TryGetReplacement(rune, out _);

--- a/src/Meziantou.Framework.Unicode/readme.md
+++ b/src/Meziantou.Framework.Unicode/readme.md
@@ -1,6 +1,6 @@
 # Meziantou.Framework.Unicode
 
-This package provides Unicode helpers for normalizing confusable characters using the Unicode confusables table.
+This package provides Unicode helpers for normalizing characters that look like other characters, using the Unicode confusables table.
 
 ```csharp
 using Meziantou.Framework;
@@ -10,6 +10,17 @@ var normalized = Unicode.ReplaceConfusablesCharacters(input);
 
 Console.WriteLine(normalized); // "paypal"
 ```
+
+Characters that are already ASCII are never replaced, so ordinary text passes through untouched:
+
+```csharp
+Unicode.ReplaceConfusablesCharacters("Item 1 of 10"); // "Item 1 of 10"
+```
+
+> The result is displayable text, not a comparison key. This is deliberately **not** the
+> `skeleton` algorithm from [UTS #39](https://unicode.org/reports/tr39/): the input is not
+> normalized and the mapping is applied in a single pass, so it is not sufficient on its own
+> to decide whether two strings are confusable.
 
 This package also exposes Unicode character metadata from the Unicode data table:
 

--- a/tests/Meziantou.Framework.Unicode.Tests/UnicodeTests.cs
+++ b/tests/Meziantou.Framework.Unicode.Tests/UnicodeTests.cs
@@ -38,6 +38,31 @@ public sealed class UnicodeTests
         Assert.Equal("\uD800", output);
     }
 
+    [Theory]
+    [InlineData("Item 1 of 10")]
+    [InlineData("100% done")]
+    [InlineData("a|b`c\"d")]
+    [InlineData("Hello, World!")]
+    public void ReplaceConfusablesCharacters_LeavesAsciiUnchanged(string input)
+    {
+        Assert.Same(input, Unicode.ReplaceConfusablesCharacters(input));
+    }
+
+    [Fact]
+    public void ReplaceConfusablesCharacters_StillFoldsNonAsciiLookAlikes()
+    {
+        Assert.Equal("paypal", Unicode.ReplaceConfusablesCharacters("\u0440\u0430\u0443\u0440\u0430l"));
+    }
+
+    [Fact]
+    public void IsConfusableCharacter_IsFalseForAscii()
+    {
+        foreach (var c in "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz|`%\"")
+        {
+            Assert.False(Unicode.IsConfusableCharacter(new Rune(c)), $"U+{(int)c:X4} should not be confusable");
+        }
+    }
+
     [Fact]
     public void IsConfusableCharacter_ReturnsExpectedValue()
     {

--- a/tools/Meziantou.Framework.Unicode.Generator/Program.cs
+++ b/tools/Meziantou.Framework.Unicode.Generator/Program.cs
@@ -104,6 +104,7 @@ static async Task<(List<Entry> entries, string lastModified)> LoadConfusablesEnt
     var entries = new Dictionary<Rune, Entry>();
     var lineCount = 0;
     var processedLines = 0;
+    var skippedAsciiSources = 0;
     foreach (var rawLine in content.Split('\n'))
     {
         lineCount++;
@@ -127,13 +128,22 @@ static async Task<(List<Entry> entries, string lastModified)> LoadConfusablesEnt
         var source = ParseSingleRune(parts[0]);
         var target = ParseCodePointSequence(parts[1]);
 
+        // ASCII is the alphabet this table normalizes toward, so an ASCII source is already
+        // in its canonical form. Folding it (0 -> O, 1 -> l, m -> rn, ...) would corrupt
+        // ordinary text without making anything less confusable.
+        if (source.Value < 0x80)
+        {
+            skippedAsciiSources++;
+            continue;
+        }
+
         if (!entries.TryAdd(source, new Entry(source, target)))
             throw new InvalidOperationException("Duplicated source mapping: U+" + source.Value.ToString("X", CultureInfo.InvariantCulture));
 
         processedLines++;
     }
 
-    Console.WriteLine($"  Loaded {entries.Count} confusable mappings from {lineCount} lines ({processedLines} data lines)");
+    Console.WriteLine($"  Loaded {entries.Count} confusable mappings from {lineCount} lines ({processedLines} data lines, {skippedAsciiSources} ASCII sources skipped)");
     return (entries.Values.ToList(), lastModified);
 }
 
@@ -1186,7 +1196,8 @@ async Task WriteConfusableCharactersFile(List<Entry> confusableEntries, string c
     //   - Multi-character replacements: {{multiCharMappings.ToString(CultureInfo.InvariantCulture)}}
     //
     // Specification: https://www.unicode.org/reports/tr39/
-    // Purpose: Helps detect visually confusable characters that may be used in security attacks
+    // Purpose: Maps non-ASCII characters to the ASCII-ish character they resemble.
+        //          ASCII sources are excluded so ordinary text is never rewritten.
     // DO NOT MODIFY THIS FILE MANUALLY - regenerate using the Unicode generator tool
 
     #nullable enable


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2109**

The confusables table contains eight sources below U+0080, and they were applied
unconditionally:

| source | replacement |
|---|---|
| `"` | `''` |
| `%` | `º/₀` |
| `0` | `O` |
| `1` | `l` |
| `I` | `l` |
| `` ` `` | `'` |
| `m` | `rn` |
| `\|` | `l` |

So `Unicode.ReplaceConfusablesCharacters("Item 1 of 10")` returned **`"ltern l of lO"`**.

The XML doc said the method returns "The text with confusable characters replaced" and the
readme example ends with `Console.WriteLine(normalized)`, both presenting the result as
displayable text. A caller following the readme to normalize a username, filename or display
name before **storing** it corrupted nearly every realistic input, silently and irreversibly.

The reason this stayed hidden is that the readme's own example string, `"paypal"`, happens to
contain none of the eight.

## What changed

ASCII is the alphabet this table normalizes *toward*, so an ASCII source is already in its
canonical form and folding it cannot make anything less confusable. `LoadConfusablesEntries`
now skips sources below U+0080, and the generated table drops from 6,565 to 6,557 entries.

`Unicode.ReplaceConfusablesCharacters("раураl")` still returns `"paypal"` — every Cyrillic,
Greek and other non-ASCII look-alike is untouched by this change.

Docs are corrected to match:

- The `<seealso href="https://unicode.org/reports/tr39/" />` references are removed. This was
  never the `skeleton` algorithm from UTS #39 — that is defined as
  `toNFD(toConfusable(toNFD(X)))` applied to a fixed point, while this is a single pass over
  un-normalized input — and with ASCII sources excluded it is further from it still. Citing
  the spec invited callers to use this for homograph detection, which it does not do
  correctly.
- The XML docs and readme now say the result is displayable text, not a comparison key, and
  say so explicitly rather than by omission.
- The generated file's `Purpose:` header line, which claimed the table "helps detect visually
  confusable characters that may be used in security attacks", is updated.

A proper UTS #39 skeleton API for the security use case is worth adding separately; this PR
deliberately does not pretend the existing method is one.

`<Version>` is intentionally left at 2.0.1 — the generator bumps it automatically on any data
change, and that bump is reverted here since version bumps go through the bot's own PRs.

## Verification

`dotnet test ... /p:TreatsWarningsAsErrors=true` — **44 passed** (22 facts x 2 TFMs), up from
32, 0 failed.

New facts: four ASCII strings returned by reference (`Assert.Same`, which also pins the
no-allocation fast path), the Cyrillic `paypal` fold still working, and
`IsConfusableCharacter` returning false across the printable ASCII range.

The generator was run against live unicode.org data and reports
`6557 confusable mappings ... 8 ASCII sources skipped`; the generated diff is exactly those
eight entries plus the header statistics.

Found by a project review of `src/Meziantou.Framework.Unicode`.
