### PR TITLE
Avoid allocating when no confusable character is present

### DIFF
--- a/src/Meziantou.Framework.Unicode/Unicode.cs
+++ b/src/Meziantou.Framework.Unicode/Unicode.cs
@@ -19,13 +19,15 @@ public static partial class Unicode
     {
         ArgumentNullException.ThrowIfNull(str);
 
-        if (str.Length == 0)
+        var start = IndexOfFirstConfusable(str);
+        if (start < 0)
             return str;
 
-        var sb = new StringBuilder(str.Length);
-        var index = 0;
-        var hasReplacement = false;
+        // Some replacements are longer than their source, so leave a little room to grow.
+        var sb = new StringBuilder(str.Length + 16);
+        sb.Append(str, 0, start);
 
+        var index = start;
         while (index < str.Length)
         {
             if (!Rune.TryGetRuneAt(str, index, out var rune))
@@ -38,20 +40,39 @@ public static partial class Unicode
             if (UnicodeConfusablesData.TryGetReplacement(rune, out var replacement))
             {
                 sb.Append(replacement);
-                hasReplacement = true;
             }
             else
             {
-                sb.Append(rune);
+                // Append from the source string rather than the Rune: there is no
+                // StringBuilder.Append(Rune) overload before .NET 11, so appending the Rune
+                // would box it and allocate a string for every character on net10.0.
+                sb.Append(str, index, rune.Utf16SequenceLength);
             }
 
             index += rune.Utf16SequenceLength;
         }
 
-        if (!hasReplacement)
-            return str;
-
         return sb.ToString();
+    }
+
+    private static int IndexOfFirstConfusable(string str)
+    {
+        var index = 0;
+        while (index < str.Length)
+        {
+            if (!Rune.TryGetRuneAt(str, index, out var rune))
+            {
+                index++;
+                continue;
+            }
+
+            if (UnicodeConfusablesData.TryGetReplacement(rune, out _))
+                return index;
+
+            index += rune.Utf16SequenceLength;
+        }
+
+        return -1;
     }
 
     /// <summary>Replaces a character that looks like another character with its canonical form.</summary>

--- a/tests/Meziantou.Framework.Unicode.Tests/UnicodeTests.cs
+++ b/tests/Meziantou.Framework.Unicode.Tests/UnicodeTests.cs
@@ -64,6 +64,33 @@ public sealed class UnicodeTests
     }
 
     [Fact]
+    public void ReplaceConfusablesCharacters_ExpandsMultiCharacterReplacements()
+    {
+        Assert.Equal("c\u0338", Unicode.ReplaceConfusablesCharacters("\u00A2"));
+    }
+
+    [Fact]
+    public void ReplaceConfusablesCharacters_HandlesAstralCodePoints()
+    {
+        Assert.Equal("xAy", Unicode.ReplaceConfusablesCharacters("x\U0001D400y"));
+    }
+
+    [Fact]
+    public void ReplaceConfusablesCharacters_PreservesTheScannedPrefix()
+    {
+        Assert.Equal("abca", Unicode.ReplaceConfusablesCharacters("abc\u0430"));
+    }
+
+    [Fact]
+    public void ReplaceConfusablesCharacters_HandlesEmptyAndLoneSurrogates()
+    {
+        Assert.Same("", Unicode.ReplaceConfusablesCharacters(""));
+        Assert.Same("\uD800", Unicode.ReplaceConfusablesCharacters("\uD800"));
+        Assert.Equal("a\uD800", Unicode.ReplaceConfusablesCharacters("a\uD800"));
+        Assert.Equal("A\uD800", Unicode.ReplaceConfusablesCharacters("\u0410\uD800"));
+    }
+
+    [Fact]
     public void IsConfusableCharacter_ReturnsExpectedValue()
     {
         Assert.True(Unicode.IsConfusableCharacter(new Rune('\u0410')));


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/confusables-ascii-passthrough` · merge #2108 first**

`ReplaceConfusablesCharacters(string)` allocated on every call, including the overwhelmingly
common one where nothing is confusable and the original instance is returned:

1. `new StringBuilder(str.Length)` was allocated unconditionally, filled character by
   character, then thrown away when `hasReplacement` stayed false.
2. `sb.Append(rune)` — **`StringBuilder.Append(Rune)` was added in .NET 11 and does not exist
   in .NET 10** (verified by reflecting over `StringBuilder` on both runtimes). The package
   multi-targets both, so on the net10.0 asset that call bound to `Append(object)`, boxing
   every non-confusable scalar and allocating a string from `Rune.ToString()`. Confirmed in
   the compiled net10.0 IL: `box System.Text.Rune` followed by `callvirt
   StringBuilder::Append(object)`. The net11.0 asset took the non-boxing path — the same
   source, silently allocating very differently per target.

Measured before, net10.0 Release, 20,000 iterations: a 19-char clean ASCII string cost
**1,024 B/call**; 198 chars cost **9,976 B/call**. Roughly 89% of that was boxing plus
`ToString()`.

## What changed

Scan first, then build. `IndexOfFirstConfusable` walks the string and returns the index of the
first character with a replacement, or -1. On -1 the original instance is returned having
allocated nothing at all. Otherwise the already-scanned prefix is copied in one
`Append(string, int, int)` and the loop continues from there.

The non-replacement branch now appends from the source string rather than the `Rune`. The
source characters are already in hand, so re-encoding the scalar was pointless — and it
removes any dependence on which `Append` overloads a given target framework has.

The capacity hint also allows for growth: 2,100 of the 6,557 mappings expand to more than one
character, so `str.Length` was guaranteed to regrow on replacement-heavy input.

## Verification

`dotnet test ... /p:TreatsWarningsAsErrors=true` — **52 passed** (26 facts x 2 TFMs), 0 failed,
with this layer applied on top of #2108.

Allocation measured against the built library on net10.0 Release, 20,000 iterations each:

| input | before | after |
|---|---|---|
| 19-char clean ASCII | 1,024 B/call | **0 B/call** |
| 198-char clean ASCII | 9,976 B/call | **0 B/call** |
| `"Item 1 of 10"` | — | **0 B/call** |
| Cyrillic `"раураl"` (does replace) | — | 160 B/call |

New facts cover the paths the previous suite never exercised: a multi-character expansion
(U+00A2 to `c` + U+0338), an astral key through the string overload
(`"x\U0001D400y"` to `"xAy"`, which pins the `+= Utf16SequenceLength` advance of 2), the
scanned prefix being preserved, and the empty string and lone-surrogate cases.

Found by a project review of `src/Meziantou.Framework.Unicode`.
