### PR TITLE
Expose RmCancelCurrentTask and document the status callback contract

### DIFF
--- a/ref/Meziantou.Framework.Win32.RestartManager.cs
+++ b/ref/Meziantou.Framework.Win32.RestartManager.cs
@@ -18,6 +18,7 @@ namespace Meziantou.Framework.Win32
         public void Shutdown(Meziantou.Framework.Win32.RestartManagerShutdownType action, Meziantou.Framework.Win32.RestartManagerWriteStatusCallback? statusCallback) { }
         public void Restart() { }
         public void Restart(Meziantou.Framework.Win32.RestartManagerWriteStatusCallback? statusCallback) { }
+        public void CancelCurrentTask() { }
         public void Dispose() { }
         public static bool IsFileLocked(string path) => throw null;
         public static System.Collections.Generic.IReadOnlyList<System.Diagnostics.Process> GetProcessesLockingFile(string path) => throw null;

--- a/src/Meziantou.Framework.Win32.RestartManager/NativeMethods.txt
+++ b/src/Meziantou.Framework.Win32.RestartManager/NativeMethods.txt
@@ -4,6 +4,7 @@ RmRegisterResources
 RmGetList
 RmShutdown
 RmRestart
+RmCancelCurrentTask
 RmEndSession
 
 RM_PROCESS_INFO

--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
@@ -173,7 +173,7 @@ public sealed class RestartManager : IDisposable
 
     /// <summary>Shuts down applications and services that are using the registered resources.</summary>
     /// <param name="action">The shutdown options to use.</param>
-    /// <param name="statusCallback">An optional callback to receive progress updates during the shutdown operation.</param>
+    /// <param name="statusCallback">An optional callback to receive progress updates during the shutdown operation. The callback is invoked by native code and must not throw; use <see cref="CancelCurrentTask"/> from another thread to stop the operation instead.</param>
     /// <exception cref="Win32Exception">Thrown when the shutdown operation fails.</exception>
     public void Shutdown(RestartManagerShutdownType action, RestartManagerWriteStatusCallback? statusCallback)
     {
@@ -191,7 +191,7 @@ public sealed class RestartManager : IDisposable
     }
 
     /// <summary>Restarts applications and services that were shut down by the Restart Manager and that were registered for restart.</summary>
-    /// <param name="statusCallback">An optional callback to receive progress updates during the restart operation.</param>
+    /// <param name="statusCallback">An optional callback to receive progress updates during the restart operation. The callback is invoked by native code and must not throw; use <see cref="CancelCurrentTask"/> from another thread to stop the operation instead.</param>
     /// <exception cref="Win32Exception">Thrown when the restart operation fails.</exception>
     public void Restart(RestartManagerWriteStatusCallback? statusCallback)
     {
@@ -199,6 +199,20 @@ public sealed class RestartManager : IDisposable
         var result = PInvoke.RmRestart(SessionHandle, 0, callback);
         if (result != WIN32_ERROR.ERROR_SUCCESS)
             throw new Win32Exception((int)result, $"RmRestart failed ({result})");
+    }
+
+    /// <summary>Cancels the <see cref="Shutdown(RestartManagerShutdownType)"/> or <see cref="Restart()"/> operation that is currently running on this session.</summary>
+    /// <remarks>
+    /// <see cref="Shutdown(RestartManagerShutdownType)"/> and <see cref="Restart()"/> block until they complete, so this method
+    /// has to be called from another thread while one of them is running. It can only be called by the session that was created
+    /// with <see cref="CreateSession"/>, not by a session joined with <see cref="JoinSession(string)"/>.
+    /// </remarks>
+    /// <exception cref="Win32Exception">Thrown when the cancellation fails.</exception>
+    public void CancelCurrentTask()
+    {
+        var result = PInvoke.RmCancelCurrentTask(SessionHandle);
+        if (result != WIN32_ERROR.ERROR_SUCCESS)
+            throw new Win32Exception((int)result, $"RmCancelCurrentTask failed ({result})");
     }
 
     private static unsafe WIN32_ERROR StartSession(out uint handle, Span<char> sessionKeyBuffer)


### PR DESCRIPTION
`Shutdown` and `Restart` marshal a user delegate as `RM_WRITE_STATUS_CALLBACK` and hand it to native code, but nothing said what happens if that callback throws. It is a plausible thing for a caller to try, because a progress callback is exactly where someone reaches for cancellation — and the result is an exception unwinding out of a managed callback back through `rstrtmgr.dll`'s frames, mid-shutdown, while the Restart Manager holds its locks and has already terminated some processes. The state it leaves behind is not defined and not recoverable by the caller.

The Restart Manager has a proper answer for this — `RmCancelCurrentTask` — which the wrapper did not expose, so the callback was the only lever available.

## What changed

- Exposed `CancelCurrentTask()`, adding `RmCancelCurrentTask` to `NativeMethods.txt`.
- Documented the callback contract on both `Shutdown` and `Restart` overloads: the callback must not throw, and `CancelCurrentTask` is the supported way to stop the operation.
- Documented the two constraints the Win32 docs place on it: `Shutdown`/`Restart` block, so cancellation has to come from another thread; and only the session created by `CreateSession` may cancel, not one joined via `JoinSession`.

## ⚠️ No test, and no runtime verification at all

This is the weakest-verified PR of the batch and I would rather say so than bury it.

Testing `CancelCurrentTask` meaningfully requires an in-flight `RmShutdown` — that is, actually shutting down real processes on the CI machine — which is not something I am willing to add to this suite. Nor could I check the shape of the no-op case (calling it with nothing running): asserting a specific return code there would be a guess about `rstrtmgr.dll` behavior I have no way to confirm from macOS, and a guessed assertion is worse than no assertion.

So: the signature and the marshalling are verified by the compiler and by CsWin32's own metadata, the documented constraints come from the Win32 docs, and **the call itself has never been executed**. If you would rather not take an unexercised P/Invoke, the doc half of this change stands on its own and I can drop the method.

## Verification

- Builds clean on `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`, 0 warnings.
- `ref/` regenerated with `-c Release -p:IsOfficialBuild=true` — one added line. `dotnet run ./eng/update-all.cs` produces no further changes.

Purely additive to the public surface. Found by a review of `src/Meziantou.Framework.Win32.RestartManager` (Low severity finding).
