### PR TITLE
Keep the CPU period when removing the bandwidth limit

### DIFF
--- a/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
@@ -211,10 +211,11 @@ public sealed partial class CGroup2
         WriteFile("cpu.max", $"{maxStr} {periodMicroseconds.ToString(CultureInfo.InvariantCulture)}");
     }
 
-    /// <summary>Removes the CPU maximum bandwidth limit.</summary>
+    /// <summary>Removes the CPU maximum bandwidth limit. The period is left unchanged.</summary>
     public void RemoveCpuMax()
     {
-        SetCpuMax(null, 100000);
+        // cpu.max accepts "max" on its own, which clears the quota and keeps the configured period.
+        WriteFile("cpu.max", "max");
     }
 
     #endregion


### PR DESCRIPTION
**Stack 1 of 4 · merges into `main` · must merge before #2113, #2114, #2115**

## Finding

`RemoveCpuMax()` was implemented as `SetCpuMax(null, 100000)`, which writes `"max 100000"` to `cpu.max` — **both** fields (`CGroup2.cs:214-218`).

A caller who configured `SetCpuMax(50_000, 50_000)` — a 50 ms period, chosen for latency reasons — and later called `RemoveCpuMax()` got the quota removed *and* the period silently reset from 50 ms to 100 ms. Nothing in the method name or its doc comment ("Removes the CPU maximum bandwidth limit.") suggested the period was touched, and there was no `GetCpuMax()` to read it back, so the original value was unrecoverable through this API.

Period length controls the granularity of throttling, so a workload tuned for a short period sees longer stalls after what the caller believed was a pure "remove the cap" operation.

## Change

`cpu.max` accepts `"max"` on its own, which clears the quota and leaves the period untouched. `RemoveCpuMax` now writes exactly that instead of round-tripping through `SetCpuMax`. The doc comment says the period is preserved.

## Verification

`dotnet build -p:TreatWarningsAsErrors=true` clean for `net10.0` and `net11.0`. No public API change, so `ref/` is untouched.

Not covered by an automated test: the write path is only reachable against a real cgroupfs mount, and this project's integration tests are skipped unless run as root on Linux outside CI. #2114 adds `GetCpuMax()`, which makes this verifiable by round-trip on a Linux box: `SetCpuMax(50_000, 50_000)` → `RemoveCpuMax()` → `GetCpuMax()` should report `PeriodMicroseconds = 50_000`.
