### PR TITLE
Validate the arguments of SetCpuMax and SetIoMax

### DIFF
--- a/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
@@ -346,7 +346,7 @@ public sealed partial class CGroup2
         WriteFile("io.weight", $"default {weight.ToString(CultureInfo.InvariantCulture)}");
     }
 
-    /// <summary>Sets IO bandwidth limits for a device.</summary>
+    /// <summary>Sets IO bandwidth limits for a device. When every limit is null, the limits of the device are removed.</summary>
     /// <param name="major">Device major number.</param>
     /// <param name="minor">Device minor number.</param>
     /// <param name="readBytesPerSecond">Read bandwidth limit in bytes per second, or null for no limit.</param>
@@ -356,7 +356,10 @@ public sealed partial class CGroup2
     public void SetIoMax(int major, int minor, long? readBytesPerSecond = null, long? writeBytesPerSecond = null, long? readIopsPerSecond = null, long? writeIopsPerSecond = null)
     {
         if (readBytesPerSecond is null && writeBytesPerSecond is null && readIopsPerSecond is null && writeIopsPerSecond is null)
-            throw new ArgumentException("At least one limit must be provided. Use RemoveIoMax to clear the limits of a device.", nameof(readBytesPerSecond));
+        {
+            RemoveIoMax(major, minor);
+            return;
+        }
 
         var sb = new StringBuilder();
         sb.Append($"{major.ToString(CultureInfo.InvariantCulture)}:{minor.ToString(CultureInfo.InvariantCulture)}");

--- a/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
@@ -205,6 +205,11 @@ public sealed partial class CGroup2
     /// <param name="periodMicroseconds">Period in microseconds (default is 100000 = 100ms).</param>
     public void SetCpuMax(long? maxMicroseconds, long periodMicroseconds = 100000)
     {
+        if (maxMicroseconds.HasValue)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(maxMicroseconds.Value, nameof(maxMicroseconds));
+        }
+
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(periodMicroseconds, nameof(periodMicroseconds));
 
         var maxStr = maxMicroseconds.HasValue ? maxMicroseconds.Value.ToString(CultureInfo.InvariantCulture) : "max";
@@ -350,6 +355,9 @@ public sealed partial class CGroup2
     /// <param name="writeIopsPerSecond">Write IOPS limit, or null for no limit.</param>
     public void SetIoMax(int major, int minor, long? readBytesPerSecond = null, long? writeBytesPerSecond = null, long? readIopsPerSecond = null, long? writeIopsPerSecond = null)
     {
+        if (readBytesPerSecond is null && writeBytesPerSecond is null && readIopsPerSecond is null && writeIopsPerSecond is null)
+            throw new ArgumentException("At least one limit must be provided. Use RemoveIoMax to clear the limits of a device.", nameof(readBytesPerSecond));
+
         var sb = new StringBuilder();
         sb.Append($"{major.ToString(CultureInfo.InvariantCulture)}:{minor.ToString(CultureInfo.InvariantCulture)}");
 


### PR DESCRIPTION
**Stack 2 of 4 · merges into `fix/removecpumax-period` · merge after #2112, before #2114 and #2115**

## Finding

Every nullable-`long` setter in this class guards with `ArgumentOutOfRangeException.ThrowIfNegative` — `SetMemoryMax`, `SetMemoryHigh`, `SetMemoryLow`, `SetMemoryMin`, `SetSwapMax`, `SetPidsMax`. `SetCpuMax` did not (`CGroup2.cs:206-212`); it guarded only `periodMicroseconds`.

So `SetCpuMax(-5)` formatted `"-5 100000"` and handed it to the kernel, which rejects it with `EINVAL` surfacing as an `IOException` — a different and much less useful exception than the identical mistake produces on `SetMemoryMax`.

Relatedly, `SetIoMax(8, 0)` with all four limits left `null` wrote the bare device string `"8:0"` with no key/value pairs at all, which is also `EINVAL`. There was no way to reach that call intending anything sensible.

## Change

- `SetCpuMax` validates `maxMicroseconds` with `ArgumentOutOfRangeException.ThrowIfNegative`, matching its siblings.
- `SetIoMax` throws `ArgumentException` when no limit is supplied, and points at `RemoveIoMax` — which is what a caller wanting to clear a device's limits actually needs.

Both are argument-validation only; no change to what gets written when the arguments are valid.

## Verification

`dotnet build -p:TreatWarningsAsErrors=true` clean for `net10.0` and `net11.0`. No public API change, so `ref/` is untouched.

## Why this is stacked

`SetCpuMax`, `RemoveCpuMax` and (in #2114) `GetCpuMax` live in the same ~15 lines of `CGroup2.cs`. As independent PRs off `main` these would conflict on merge, so they're a stack rather than three parallel branches.
