### PR TITLE
Add the missing cgroup limit getters

### DIFF
--- a/ref/Meziantou.Framework.Unix.ControlGroups.cs
+++ b/ref/Meziantou.Framework.Unix.ControlGroups.cs
@@ -36,13 +36,18 @@ namespace Meziantou.Framework.Unix.ControlGroups
         public int? GetCpuWeight() => throw null;
         public void SetCpuMax(long? maxMicroseconds, long periodMicroseconds = 100000L) { }
         public void RemoveCpuMax() { }
+        public Meziantou.Framework.Unix.ControlGroups.CpuMax? GetCpuMax() => throw null;
         public void SetMemoryMax(long? bytes) { }
         public long? GetMemoryMax() => throw null;
         public void SetMemoryHigh(long? bytes) { }
+        public long? GetMemoryHigh() => throw null;
         public void SetMemoryLow(long? bytes) { }
+        public long? GetMemoryLow() => throw null;
         public void SetMemoryMin(long? bytes) { }
+        public long? GetMemoryMin() => throw null;
         public long? GetMemoryCurrent() => throw null;
         public void SetSwapMax(long? bytes) { }
+        public long? GetSwapMax() => throw null;
         public void SetIoWeight(int major, int minor, int weight) { }
         public void SetDefaultIoWeight(int weight) { }
         public void SetIoMax(int major, int minor, long? readBytesPerSecond = null, long? writeBytesPerSecond = null, long? readIopsPerSecond = null, long? writeIopsPerSecond = null) { }
@@ -61,6 +66,24 @@ namespace Meziantou.Framework.Unix.ControlGroups
         public long? GetHugeTlbMax(string pageSize) => throw null;
         public long? GetHugeTlbCurrent(string pageSize) => throw null;
         public long? GetHugeTlbEventsMax(string pageSize) => throw null;
+    }
+
+    public readonly struct CpuMax : System.IEquatable<Meziantou.Framework.Unix.ControlGroups.CpuMax>
+    {
+        public long? MaxMicroseconds { get => throw null; init { } }
+        public long PeriodMicroseconds { get => throw null; init { } }
+        public CpuMax(long? MaxMicroseconds, long PeriodMicroseconds) { }
+        #nullable disable
+        public override string ToString() => throw null;
+        #nullable restore
+        public static bool operator !=(Meziantou.Framework.Unix.ControlGroups.CpuMax left, Meziantou.Framework.Unix.ControlGroups.CpuMax right) => throw null;
+        public static bool operator ==(Meziantou.Framework.Unix.ControlGroups.CpuMax left, Meziantou.Framework.Unix.ControlGroups.CpuMax right) => throw null;
+        public override int GetHashCode() => throw null;
+        #nullable disable
+        public override bool Equals(object obj) => throw null;
+        #nullable restore
+        public bool Equals(Meziantou.Framework.Unix.ControlGroups.CpuMax other) => throw null;
+        public void Deconstruct(out long? MaxMicroseconds, out long PeriodMicroseconds) => throw null;
     }
 
     public sealed class CpuStat

--- a/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/CGroup2.cs
@@ -227,6 +227,30 @@ public sealed partial class CGroup2
         WriteFile("cpu.max", "max");
     }
 
+    /// <summary>Gets the CPU maximum bandwidth limit.</summary>
+    /// <returns>The quota and period, or <see langword="null"/> when the value cannot be read.</returns>
+    public CpuMax? GetCpuMax()
+    {
+        var content = ReadFile("cpu.max");
+        if (string.IsNullOrWhiteSpace(content))
+            return null;
+
+        var parts = content.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length is not 2)
+            return null;
+
+        if (!long.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var period))
+            return null;
+
+        if (parts[0].Equals("max", StringComparison.OrdinalIgnoreCase))
+            return new CpuMax(MaxMicroseconds: null, period);
+
+        if (long.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var max))
+            return new CpuMax(max, period);
+
+        return null;
+    }
+
     #endregion
 
     #region Memory Controller
@@ -245,21 +269,7 @@ public sealed partial class CGroup2
     }
 
     /// <summary>Gets the memory maximum limit in bytes.</summary>
-    public long? GetMemoryMax()
-    {
-        var content = ReadFile("memory.max");
-        if (string.IsNullOrWhiteSpace(content))
-            return null;
-
-        content = content.Trim();
-        if (content.Equals("max", StringComparison.OrdinalIgnoreCase))
-            return null;
-
-        if (long.TryParse(content, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
-            return value;
-
-        return null;
-    }
+    public long? GetMemoryMax() => ReadLimit("memory.max");
 
     /// <summary>Sets the memory high limit (soft limit with throttling).</summary>
     /// <param name="bytes">High memory limit in bytes, or null for no limit.</param>
@@ -274,6 +284,10 @@ public sealed partial class CGroup2
         WriteFile("memory.high", value);
     }
 
+    /// <summary>Gets the memory high limit in bytes.</summary>
+    /// <returns>The limit, or <see langword="null"/> when there is no limit.</returns>
+    public long? GetMemoryHigh() => ReadLimit("memory.high");
+
     /// <summary>Sets the memory low limit (best-effort protection).</summary>
     /// <param name="bytes">Low memory limit in bytes, or null for no protection.</param>
     public void SetMemoryLow(long? bytes)
@@ -287,6 +301,10 @@ public sealed partial class CGroup2
         WriteFile("memory.low", value);
     }
 
+    /// <summary>Gets the memory low limit in bytes.</summary>
+    /// <returns>The protection level, or <see langword="null"/> when there is no protection.</returns>
+    public long? GetMemoryLow() => ReadLimit("memory.low");
+
     /// <summary>Sets the memory min limit (hard protection).</summary>
     /// <param name="bytes">Min memory limit in bytes, or null for no protection.</param>
     public void SetMemoryMin(long? bytes)
@@ -299,6 +317,10 @@ public sealed partial class CGroup2
         var value = bytes.HasValue ? bytes.Value.ToString(CultureInfo.InvariantCulture) : "0";
         WriteFile("memory.min", value);
     }
+
+    /// <summary>Gets the memory min limit in bytes.</summary>
+    /// <returns>The protection level, or <see langword="null"/> when there is no protection.</returns>
+    public long? GetMemoryMin() => ReadLimit("memory.min");
 
     /// <summary>Gets the current memory usage in bytes.</summary>
     public long? GetMemoryCurrent()
@@ -325,6 +347,10 @@ public sealed partial class CGroup2
         var value = bytes.HasValue ? bytes.Value.ToString(CultureInfo.InvariantCulture) : "max";
         WriteFile("memory.swap.max", value);
     }
+
+    /// <summary>Gets the swap maximum limit in bytes.</summary>
+    /// <returns>The limit, or <see langword="null"/> when there is no limit.</returns>
+    public long? GetSwapMax() => ReadLimit("memory.swap.max");
 
     #endregion
 
@@ -417,21 +443,7 @@ public sealed partial class CGroup2
     }
 
     /// <summary>Gets the maximum number of processes allowed.</summary>
-    public long? GetPidsMax()
-    {
-        var content = ReadFile("pids.max");
-        if (string.IsNullOrWhiteSpace(content))
-            return null;
-
-        content = content.Trim();
-        if (content.Equals("max", StringComparison.OrdinalIgnoreCase))
-            return null;
-
-        if (long.TryParse(content, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
-            return value;
-
-        return null;
-    }
+    public long? GetPidsMax() => ReadLimit("pids.max");
 
     /// <summary>Gets the current number of processes.</summary>
     public long? GetPidsCurrent()
@@ -523,6 +535,25 @@ public sealed partial class CGroup2
         {
             return "";
         }
+    }
+
+    /// <summary>Reads an interface file holding a single limit, where "max" means unlimited.</summary>
+    /// <param name="fileName">The name of the interface file.</param>
+    /// <returns>The limit, or <see langword="null"/> when the cgroup is unlimited.</returns>
+    private long? ReadLimit(string fileName)
+    {
+        var content = ReadFile(fileName);
+        if (string.IsNullOrWhiteSpace(content))
+            return null;
+
+        content = content.Trim();
+        if (content.Equals("max", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        if (long.TryParse(content, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+            return value;
+
+        return null;
     }
 
     private void WriteFile(string fileName, string content)

--- a/src/Meziantou.Framework.Unix.ControlGroups/CpuMax.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/CpuMax.cs
@@ -1,0 +1,9 @@
+using System.Runtime.InteropServices;
+
+namespace Meziantou.Framework.Unix.ControlGroups;
+
+/// <summary>Represents the CPU bandwidth limit of a cgroup.</summary>
+/// <param name="MaxMicroseconds">Maximum time in microseconds the cgroup can run during one period, or <see langword="null"/> when the cgroup is unlimited.</param>
+/// <param name="PeriodMicroseconds">Length of the accounting period in microseconds.</param>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct CpuMax(long? MaxMicroseconds, long PeriodMicroseconds);


### PR DESCRIPTION
**Stack 3 of 4 · merges into `fix/setter-argument-validation` · merge after #2113, before #2115**

## Finding

Roughly half the setters had no corresponding getter, so state written through the library could not be read back through it:

| setter | getter |
|---|---|
| `SetCpuMax` | — |
| `SetMemoryHigh` | — |
| `SetMemoryLow` | — |
| `SetMemoryMin` | — |
| `SetSwapMax` | — |

That asymmetry is what made #2112 (`RemoveCpuMax` clobbering the period) unrecoverable rather than merely annoying — there was no way to read the period, before or after.

## Change

Adds `GetCpuMax`, `GetMemoryHigh`, `GetMemoryLow`, `GetMemoryMin` and `GetSwapMax`.

`cpu.max` holds two values, so `GetCpuMax` returns a new `CpuMax` readonly record struct (`MaxMicroseconds`, `PeriodMicroseconds`) rather than forcing two reads or a bare tuple. That is the one new public type here.

The four memory getters are each a single `long?` following `GetMemoryMax`'s existing shape. Rather than paste that 14-line body four more times, they share a private `ReadLimit(fileName)` helper — and `GetMemoryMax` and `GetPidsMax`, which were already that exact body, now use it too. That is a deliberate call: the alternative was shipping five more copies of the same code.

Everything here is additive — no existing signature or behavior changes.

## Verification

`dotnet build -p:TreatWarningsAsErrors=true` clean for `net10.0` and `net11.0`. `ref/` regenerated with a Release / `IsOfficialBuild=true` build; the generated diff is the five new members plus the `CpuMax` struct.

No automated test: every one of these reads a real cgroupfs interface file, which is not reachable from a unit test.
