### PR TITLE
Escape resx names and resource file names written into generated string literals

### DIFF
--- a/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
+++ b/src/Meziantou.Framework.ResxSourceGenerator/ResxGenerator.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 
@@ -156,7 +157,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
             {
                 if (resourceMan is null)
                 {
-                    resourceMan = new global::System.Resources.ResourceManager(""" + resourceName + @""", typeof(" + className + @").Assembly);
+                    resourceMan = new global::System.Resources.ResourceManager(" + ToLiteral(resourceName) + @", typeof(" + className + @").Assembly);
                 }
 
                 return resourceMan;
@@ -322,7 +323,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
         {
             get
             {
-                return GetString(""" + entry.Name + @""");
+                return GetString(" + ToLiteral(entry.Name) + @");
             }
         }
 ");
@@ -347,7 +348,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
         /// " + formatComment + @"
         public static string? Format" + ToCSharpNameIdentifier(entry.Name) + "(global::System.Globalization.CultureInfo? provider, " + inParams + @")
         {
-            return GetString(culture: provider, name: """ + entry.Name + @""", args: new object?[] { " + callParams + @" });
+            return GetString(culture: provider, name: " + ToLiteral(entry.Name) + @", args: new object?[] { " + callParams + @" });
         }
 ");
 
@@ -355,7 +356,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
         /// " + formatComment + @"
         public static string? Format" + ToCSharpNameIdentifier(entry.Name) + "(" + inParams + @")
         {
-            return GetString(name: """ + entry.Name + @""", args: new object?[] { " + callParams + @" });
+            return GetString(name: " + ToLiteral(entry.Name) + @", args: new object?[] { " + callParams + @" });
         }
 ");
                         }
@@ -368,7 +369,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
         {
             get
             {
-                return (global::" + entry.FullTypeName + @"?)GetObject(""" + entry.Name + @""");
+                return (global::" + entry.FullTypeName + @"?)GetObject(" + ToLiteral(entry.Name) + @");
             }
         }
 ");
@@ -388,7 +389,7 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
                 if (string.IsNullOrEmpty(entry.Name))
                     continue;
 
-                sb.AppendLine("        public const string @" + ToCSharpNameIdentifier(entry.Name) + " = \"" + entry.Name + "\";");
+                sb.AppendLine("        public const string @" + ToCSharpNameIdentifier(entry.Name) + " = " + ToLiteral(entry.Name) + ";");
             }
 
             sb.AppendLine("    }");
@@ -534,6 +535,15 @@ public sealed partial class ResxGenerator : IIncrementalGenerator
         }
 
         return string.Join(Environment.NewLine + "        /// ", elements);
+    }
+
+    /// <summary>
+    /// Formats a value read from the resx file as a C# string literal, quotes included. Resource names and
+    /// resource file names are arbitrary text, so they cannot be concatenated into the generated source as-is.
+    /// </summary>
+    private static string ToLiteral(string value)
+    {
+        return SymbolDisplay.FormatLiteral(value, quote: true);
     }
 
     private static string EscapeCSharpIdentifier(string name)

--- a/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
+++ b/tests/Meziantou.Framework.ResxSourceGenerator.Tests/ResxGeneratorTest.cs
@@ -122,6 +122,43 @@ public sealed class ResxGeneratorTest
         Assert.Contains("public static global::System.Drawing.Bitmap? @Image1", fileContent);
     }
 
+    [Theory]
+    [InlineData("He\"llo")]
+    [InlineData(@"a\tb")]
+    [InlineData(@"Path\To")]
+    [InlineData("Line1\nLine2")]
+    public async Task ResourceNamesWithSpecialCharactersAreEscaped(string name)
+    {
+        var element = new XElement("root",
+            new XElement("data", new XAttribute("name", name), new XElement("value", "Value {0}")));
+
+        var result = await GenerateFiles([("test.resx", element.ToString())], new OptionProvider
+        {
+            Namespace = "test",
+            ResourceName = "test",
+        });
+
+        // The literal must round-trip to the exact key of the resx entry, otherwise the lookup silently returns null
+        var fileContent = result.GeneratedFileRoot.ToFullString();
+        var literal = SymbolDisplay.FormatLiteral(name, quote: true);
+        Assert.Contains("GetString(" + literal + ")", fileContent);
+        Assert.Contains(" = " + literal + ";", fileContent);
+    }
+
+    [Fact]
+    public async Task ResourceFileNameWithSpecialCharactersIsEscaped()
+    {
+        var element = new XElement("root", new XElement("data", new XAttribute("name", "Sample"), new XElement("value", "Value")));
+        var result = await GenerateFiles([("test.resx", element.ToString())], new OptionProvider
+        {
+            Namespace = "test",
+            ResourceName = @"My\Resource""Name",
+        });
+
+        var fileContent = result.GeneratedFileRoot.ToFullString();
+        Assert.Contains("new global::System.Resources.ResourceManager(" + SymbolDisplay.FormatLiteral(@"My\Resource""Name", quote: true), fileContent);
+    }
+
     [Fact]
     public async Task GenerateProperties_WithFormatParameterMetadata()
     {


### PR DESCRIPTION
> **Stack 1 of 3** · merges into `main` · must merge before #2118 and #2119.

## The bug

Resource names read from the resx file were concatenated straight between quotes into the generated source — `ResxGenerator.cs:325`, `:350`, `:358`, `:371`, `:391`, and `resourceName` at `:159`. Resx keys are free-form text, so this has two distinct failure modes, both verified against the real generator:

**A name containing `"`** produces uncompilable code. `He"llo` emitted:

```csharp
return GetString("He"llo");
public const string @He_llo = "He"llo";
```

**A name containing a valid escape sequence compiles, and is wrong.** `a\tb` emitted `GetString("a\tb")`, which builds with **zero errors** and looks up the 3-character key `a<TAB>b` instead of the 4-character key `a\tb` that is actually in the resx. `ResourceManager` returns `null`, so the property silently yields `null` at runtime.

The second one is the reason this is first in the stack: no build error, no diagnostic, just a resource that comes back empty in production. The generated `{ClassName}Names` constants are wrong the same way, so "use the constant instead of a magic string" doesn't save you either.

## What changed

Added a `ToLiteral` helper over `SymbolDisplay.FormatLiteral(value, quote: true)` — already available from the `Microsoft.CodeAnalysis` reference — and routed all six emission sites through it. One helper, applied everywhere a resx-derived value lands inside a literal.

## Verification

- `ResourceNamesWithSpecialCharactersAreEscaped` — a theory over `He"llo`, `a\tb`, `Path\To` and `Line1\nLine2`, asserting the emitted literal round-trips to the exact resx key in both the lookup call and the `Names` constant.
- `ResourceFileNameWithSpecialCharactersIsEscaped` — same for the `ResourceName` metadata flowing into the `ResourceManager` constructor.

All four theory cases fail against the old concatenation. 48/48 unit tests pass on net10.0 and net11.0.
