### PR TITLE
Move a child process instead of the test host in the cgroup test

### DIFF
--- a/tests/Meziantou.Framework.Unix.ControlGroups.Tests/CGroup2Tests.cs
+++ b/tests/Meziantou.Framework.Unix.ControlGroups.Tests/CGroup2Tests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Meziantou.Xunit;
 
 namespace Meziantou.Framework.Unix.ControlGroups.Tests;
@@ -46,14 +47,15 @@ public sealed class CGroup2Tests : IDisposable
         // Cleanup: remove test cgroup
         try
         {
-            if (_testRoot is not null && _testRoot.Exists())
+            if (_testRoot.Exists())
             {
                 _testRoot.Delete();
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // Ignore cleanup errors
+            // A cgroup that still holds processes cannot be removed. Report it instead of leaking it silently.
+            _testOutputHelper.WriteLine($"Cannot delete the test cgroup '{_testRoot}': {ex}");
         }
     }
 
@@ -90,18 +92,23 @@ public sealed class CGroup2Tests : IDisposable
     [Fact]
     public void AddProcess_ShouldAddProcessToCGroup()
     {
-        // Arrange
-        var currentPid = Environment.ProcessId;
+        // Move a short-lived child process, never the test host: a failed assertion must not leave the
+        // runner confined to the test cgroup, where it would break sibling tests and block cleanup.
+        using var process = Process.Start("sleep", "30");
+        try
+        {
+            // Act
+            _testRoot.AssociateProcess(process);
 
-        // Act
-        _testRoot.AssociateProcess(currentPid);
-
-        // Assert
-        var processes = _testRoot.GetProcesses().ToList();
-        Assert.Contains(currentPid, processes);
-
-        // Note: Moving back to root is done in cleanup
-        CGroup2.Root.AssociateProcess(currentPid);
+            // Assert
+            var processes = _testRoot.GetProcesses().ToList();
+            Assert.Contains(process.Id, processes);
+        }
+        finally
+        {
+            process.Kill();
+            process.WaitForExit();
+        }
     }
 
     [Fact]


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2122**

## Finding

`AddProcess_ShouldAddProcessToCGroup` moved the **test runner's own process** into the test cgroup, asserted, and then moved it back — but the move back was the last statement, after the assertion (`CGroup2Tests.cs:90-105`).

If `Assert.Contains` failed, the exception propagated and the runner process stayed inside `_testRoot`. `Dispose` then called `_testRoot.Delete()`, which fails because the cgroup is non-empty, and the failure was swallowed by the bare `catch` at `:54-57`. The result was a leaked cgroup **and** a test process still confined by it for the rest of the run — including any test executing concurrently in the same assembly, which would also be inside it.

So a single assertion failure turned into cascading unexplained failures in unrelated tests, plus a cgroup left behind on the machine. Since these tests only ever run on a developer's box, those leaked directories accumulate there.

## Change

- The test now starts a short-lived `sleep` child process and moves **that** into the cgroup. A failure can no longer confine the runner.
- Cleanup is in a `finally`, so the child is killed and reaped — and therefore leaves the cgroup — on every path.
- `Dispose` reports a failed cleanup through `ITestOutputHelper` instead of swallowing it entirely. A cgroup that cannot be deleted is a real signal, and silently discarding it is what made the original failure mode invisible.
- Dropped the `_testRoot is not null` check: the field is non-nullable, and `AGENTS.md` says to trust the annotations.

## Verification

`dotnet build -p:TreatWarningsAsErrors=true` clean for `net10.0` and `net11.0`.

**I could not execute this test.** It is skipped unless running as root on Linux with cgroup v2 outside GitHub Actions, and this was developed on macOS. The change is mechanical — swap the PID, wrap in `finally` — but it needs one run on a privileged Linux box to confirm the `sleep` child is actually visible in `cgroup.procs` before the kill.
