### PR TITLE
Drop the loop that could never iterate in IsResourcesLocked

### DIFF
--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
@@ -111,18 +111,15 @@ public sealed class RestartManager : IDisposable
     {
         ObjectDisposedException.ThrowIf(_sessionHandle.IsClosed, this);
 
+        // A single-element buffer is enough here. ERROR_MORE_DATA already means more than one process is
+        // affected, and arrayCount reports the total number needed in both cases, so there is nothing to retry.
         uint arraySize = 1;
-        while (true)
-        {
-            var array = new RM_PROCESS_INFO[arraySize];
-            var result = PInvoke.RmGetList(_sessionHandle.SessionHandle, out var arrayCount, ref arraySize, array, out _);
-            if (result is WIN32_ERROR.ERROR_SUCCESS or WIN32_ERROR.ERROR_MORE_DATA)
-            {
-                return arrayCount > 0;
-            }
+        var array = new RM_PROCESS_INFO[arraySize];
+        var result = PInvoke.RmGetList(_sessionHandle.SessionHandle, out var arrayCount, ref arraySize, array, out _);
+        if (result is WIN32_ERROR.ERROR_SUCCESS or WIN32_ERROR.ERROR_MORE_DATA)
+            return arrayCount > 0;
 
-            throw new Win32Exception((int)result, $"RmGetList failed ({result})");
-        }
+        throw new Win32Exception((int)result, $"RmGetList failed ({result})");
     }
 
     /// <summary>Gets a list of processes that are currently locking the registered resources.</summary>

--- a/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
@@ -140,4 +140,28 @@ public class RestartManagerTests
 
         Assert.Throws<ObjectDisposedException>(() => _ = session.IsResourcesLocked());
     }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void IsResourcesLocked_ReflectsTheCurrentStateOfRegisteredFiles()
+    {
+        var unlockedPath = Path.GetTempFileName();
+        var lockedPath = Path.GetTempFileName();
+        try
+        {
+            using var session = RestartManager.CreateSession();
+            session.RegisterFiles([unlockedPath, lockedPath]);
+
+            Assert.False(session.IsResourcesLocked());
+
+            using (File.Open(lockedPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                Assert.True(session.IsResourcesLocked());
+            }
+        }
+        finally
+        {
+            File.Delete(unlockedPath);
+            File.Delete(lockedPath);
+        }
+    }
 }


### PR DESCRIPTION
`IsResourcesLocked` wrapped its single `RmGetList` call in a `while (true)` whose body either returns (on `ERROR_SUCCESS` or `ERROR_MORE_DATA`) or throws. There was no path back to the top, so the loop could never run a second time. It looks like it was copied from `GetProcessesLockingResources`, where the retry loop *is* load-bearing, without the retry case being removed.

## What changed

Deleted the loop and kept the single call. Behavior is identical.

The one-element buffer that made the loop look suspicious is actually deliberate and correct, so it now says so in a comment: `ERROR_MORE_DATA` already means more than one process is affected, and `pnProcInfoNeeded` reports the total in both cases — so there is nothing to retry and no reason to size the buffer up just to count.

## Verification

- Builds clean on `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`, 0 warnings. No `ref/` change.
- Added `IsResourcesLocked_ReflectsTheCurrentStateOfRegisteredFiles`, which registers two files on a manual session and asserts the result flips from `false` to `true` when one is locked. `IsResourcesLocked` previously had no direct coverage — only indirect coverage through `IsFileLocked`.

---

**Stacked PR.** Merge order is bottom-up: #2124 → #2125 → #2126 → #2127. All four rewrite the same `RmGetList` region of `RestartManager.cs`, which is why they are a stack rather than independent PRs.

⚠️ **Tests were not run locally.** Every test in this project is `[RunIf(TestOperatingSystems.Windows)]` and this was authored on macOS, where they are all skipped. The `windows-2025-vs2026` CI leg is the first real execution.

From a review of `src/Meziantou.Framework.Win32.RestartManager`.