### PR TITLE
Match the process start time before reporting a locking process

### DIFF
--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Versioning;
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -139,15 +140,9 @@ public sealed class RestartManager : IDisposable
                 var processes = new List<Process>((int)arrayCount);
                 for (var i = 0; i < arrayCount; i++)
                 {
-                    try
-                    {
-                        var process = Process.GetProcessById((int)array[i].Process.dwProcessId);
-                        if (process is not null)
-                            processes.Add(process);
-                    }
-                    catch
-                    {
-                    }
+                    var process = TryGetProcess(array[i].Process);
+                    if (process is not null)
+                        processes.Add(process);
                 }
 
                 return processes;
@@ -219,6 +214,49 @@ public sealed class RestartManager : IDisposable
         var result = PInvoke.RmCancelCurrentTask(_sessionHandle.SessionHandle);
         if (result != WIN32_ERROR.ERROR_SUCCESS)
             throw new Win32Exception((int)result, $"RmCancelCurrentTask failed ({result})");
+    }
+
+    private static Process? TryGetProcess(RM_UNIQUE_PROCESS uniqueProcess)
+    {
+        Process process;
+        try
+        {
+            process = Process.GetProcessById((int)uniqueProcess.dwProcessId);
+        }
+        catch (ArgumentException)
+        {
+            // The process exited between RmGetList and now.
+            return null;
+        }
+
+        if (HasDifferentStartTime(process, uniqueProcess.ProcessStartTime))
+        {
+            process.Dispose();
+            return null;
+        }
+
+        return process;
+    }
+
+    // Windows recycles process ids, so the id alone does not identify a process: the one running now may not
+    // be the one RmGetList saw. RM_UNIQUE_PROCESS carries the start time precisely to tell those apart.
+    private static bool HasDifferentStartTime(Process process, FILETIME startTime)
+    {
+        try
+        {
+            return process.StartTime.ToFileTime() != ToFileTime(startTime);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or Win32Exception)
+        {
+            // The start time is not readable, typically for a protected or system process. Keep the process:
+            // dropping it here would hide a real lock holder, which is worse than the recycled-id race.
+            return false;
+        }
+    }
+
+    private static long ToFileTime(FILETIME fileTime)
+    {
+        return ((long)(uint)fileTime.dwHighDateTime << 32) | (uint)fileTime.dwLowDateTime;
     }
 
     private static unsafe WIN32_ERROR StartSession(out uint handle, Span<char> sessionKeyBuffer)


### PR DESCRIPTION
`GetProcessesLockingResources` identified each locking process by PID alone:

```csharp
var process = Process.GetProcessById((int)array[i].Process.dwProcessId);
```

`RM_UNIQUE_PROCESS` carries two fields, and the second was discarded:

```csharp
internal partial struct RM_UNIQUE_PROCESS
{
    internal uint dwProcessId;
    internal FILETIME ProcessStartTime;   // discarded
}
```

The start time is why the struct is called *unique*. Windows recycles PIDs aggressively, so a PID captured by `RmGetList` can belong to a different process by the time `Process.GetProcessById` runs microseconds later — and the method would then return a real, live, completely unrelated process and report it as holding a lock on the file. Callers of `GetProcessesLockingFile` typically go on to kill or prompt about what comes back, so a wrong answer is worse than none.

A bare `catch { }` compounded it, swallowing every failure including the `ArgumentException` that `GetProcessById` throws for an exited process — so the list could be silently shorter than the true set of lock holders.

## What changed

Process lookup moved into `TryGetProcess`, which compares `ProcessStartTime` against `Process.StartTime` and drops mismatches (disposing the `Process` it opened). The catch narrowed to `ArgumentException`, the case it was actually there for. The dead `if (process is not null)` on a non-nullable return went too — `AGENTS.md` asks that the null annotations be trusted.

## The one judgment call worth reviewing

When the start time **cannot be read** — `Process.StartTime` throws `Win32Exception` "Access is denied" for protected and some system processes — the process is **kept**, not dropped:

```csharp
catch (Exception exception) when (exception is InvalidOperationException or Win32Exception)
{
    // Keep the process: dropping it would hide a real lock holder, which is worse than the recycled-id race.
    return false;
}
```

Dropping on failure would have been the tidier-looking code, but it would mean a file locked by a SYSTEM service silently disappears from the results — trading a narrow race for a broad, silent regression. This keeps current behavior whenever the check is not answerable.

## Verification

- Builds clean on `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`, 0 warnings. No `ref/` change.
- **No new test.** The existing `GetProcessesLockingFile` test is the guard here: it now runs through the start-time comparison, so if `Process.StartTime.ToFileTime()` did not round-trip against RM's `FILETIME` exactly, every process would be dropped and that test would fail with an empty list. That round-trip is the part I could not verify from macOS, and it is precisely what CI will settle.

---

**Stacked PR.** Merge order is bottom-up: #2124 → #2125 → #2126 → #2127. All four rewrite the same `RmGetList` region of `RestartManager.cs`, which is why they are a stack rather than independent PRs.

⚠️ **Tests were not run locally.** Every test in this project is `[RunIf(TestOperatingSystems.Windows)]` and this was authored on macOS, where they are all skipped. The `windows-2025-vs2026` CI leg is the first real execution.

From a review of `src/Meziantou.Framework.Win32.RestartManager`.