### PR TITLE
Expose the full Restart Manager process information

### DIFF
--- a/ref/Meziantou.Framework.Win32.RestartManager.cs
+++ b/ref/Meziantou.Framework.Win32.RestartManager.cs
@@ -14,6 +14,7 @@ namespace Meziantou.Framework.Win32
         public void RegisterFiles(string[] paths) { }
         public bool IsResourcesLocked() => throw null;
         public System.Collections.Generic.IReadOnlyList<System.Diagnostics.Process> GetProcessesLockingResources() => throw null;
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Win32.RestartManagerProcessInfo> GetLockingProcesses() => throw null;
         public void Shutdown(Meziantou.Framework.Win32.RestartManagerShutdownType action) { }
         public void Shutdown(Meziantou.Framework.Win32.RestartManagerShutdownType action, Meziantou.Framework.Win32.RestartManagerWriteStatusCallback? statusCallback) { }
         public void Restart() { }
@@ -23,6 +24,44 @@ namespace Meziantou.Framework.Win32
         public static bool IsFileLocked(string path) => throw null;
         public static System.Collections.Generic.IReadOnlyList<System.Diagnostics.Process> GetProcessesLockingFile(string path) => throw null;
         public static System.Collections.Generic.IReadOnlyList<System.Diagnostics.Process> GetProcessesLockingFiles(string[] paths) => throw null;
+    }
+
+    [System.Flags]
+    public enum RestartManagerApplicationStatus
+    {
+        Unknown = 0,
+        Running = 1,
+        Stopped = 2,
+        StoppedOther = 4,
+        Restarted = 8,
+        ErrorOnStop = 16,
+        ErrorOnRestart = 32,
+        ShutdownMasked = 64,
+        RestartMasked = 128
+    }
+
+    public enum RestartManagerApplicationType
+    {
+        Unknown = 0,
+        MainWindow = 1,
+        OtherWindow = 2,
+        Service = 3,
+        Explorer = 4,
+        Console = 5,
+        Critical = 1000
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public sealed class RestartManagerProcessInfo
+    {
+        public int ProcessId { get => throw null; }
+        public System.DateTime StartTime { get => throw null; }
+        public string ApplicationName { get => throw null; }
+        public string ServiceShortName { get => throw null; }
+        public Meziantou.Framework.Win32.RestartManagerApplicationType ApplicationType { get => throw null; }
+        public Meziantou.Framework.Win32.RestartManagerApplicationStatus Status { get => throw null; }
+        public int TerminalServicesSessionId { get => throw null; }
+        public bool IsRestartable { get => throw null; }
     }
 
     [System.Flags]

--- a/src/Meziantou.Framework.Win32.RestartManager/FileTimeExtensions.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/FileTimeExtensions.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices.ComTypes;
+
+namespace Meziantou.Framework.Win32;
+
+internal static class FileTimeExtensions
+{
+    public static long ToFileTime(this FILETIME fileTime)
+    {
+        return ((long)(uint)fileTime.dwHighDateTime << 32) | (uint)fileTime.dwLowDateTime;
+    }
+
+    public static DateTime ToDateTime(this FILETIME fileTime)
+    {
+        return DateTime.FromFileTime(fileTime.ToFileTime());
+    }
+}

--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
@@ -128,6 +128,36 @@ public sealed class RestartManager : IDisposable
     /// <exception cref="Win32Exception">Thrown when the operation fails.</exception>
     public IReadOnlyList<Process> GetProcessesLockingResources()
     {
+        var (array, count) = GetList();
+        var processes = new List<Process>((int)count);
+        for (var i = 0; i < count; i++)
+        {
+            var process = TryGetProcess(array[i].Process);
+            if (process is not null)
+                processes.Add(process);
+        }
+
+        return processes;
+    }
+
+    /// <summary>Gets the applications and services that are currently using the registered resources.</summary>
+    /// <returns>A read-only list of <see cref="RestartManagerProcessInfo"/> describing each application or service.</returns>
+    /// <remarks>Unlike <see cref="GetProcessesLockingResources"/>, this method reports everything the Restart Manager knows about each application, including its name, type, status and whether it can be restarted, and it also reports applications that have already exited.</remarks>
+    /// <exception cref="Win32Exception">Thrown when the operation fails.</exception>
+    public IReadOnlyList<RestartManagerProcessInfo> GetLockingProcesses()
+    {
+        var (array, count) = GetList();
+        var result = new List<RestartManagerProcessInfo>((int)count);
+        for (var i = 0; i < count; i++)
+        {
+            result.Add(new RestartManagerProcessInfo(array[i]));
+        }
+
+        return result;
+    }
+
+    private (RM_PROCESS_INFO[] Array, uint Count) GetList()
+    {
         ObjectDisposedException.ThrowIf(_sessionHandle.IsClosed, this);
 
         uint arraySize = 10;
@@ -136,25 +166,12 @@ public sealed class RestartManager : IDisposable
             var array = new RM_PROCESS_INFO[arraySize];
             var result = PInvoke.RmGetList(_sessionHandle.SessionHandle, out var arrayCount, ref arraySize, array, out _);
             if (result == WIN32_ERROR.ERROR_SUCCESS)
-            {
-                var processes = new List<Process>((int)arrayCount);
-                for (var i = 0; i < arrayCount; i++)
-                {
-                    var process = TryGetProcess(array[i].Process);
-                    if (process is not null)
-                        processes.Add(process);
-                }
+                return (array, arrayCount);
 
-                return processes;
-            }
-            else if (result == WIN32_ERROR.ERROR_MORE_DATA)
-            {
-                arraySize = arrayCount;
-            }
-            else
-            {
+            if (result != WIN32_ERROR.ERROR_MORE_DATA)
                 throw new Win32Exception((int)result, $"RmGetList failed ({result})");
-            }
+
+            arraySize = arrayCount;
         }
     }
 
@@ -244,7 +261,7 @@ public sealed class RestartManager : IDisposable
     {
         try
         {
-            return process.StartTime.ToFileTime() != ToFileTime(startTime);
+            return process.StartTime.ToFileTime() != startTime.ToFileTime();
         }
         catch (Exception exception) when (exception is InvalidOperationException or Win32Exception)
         {
@@ -252,11 +269,6 @@ public sealed class RestartManager : IDisposable
             // dropping it here would hide a real lock holder, which is worse than the recycled-id race.
             return false;
         }
-    }
-
-    private static long ToFileTime(FILETIME fileTime)
-    {
-        return ((long)(uint)fileTime.dwHighDateTime << 32) | (uint)fileTime.dwLowDateTime;
     }
 
     private static unsafe WIN32_ERROR StartSession(out uint handle, Span<char> sessionKeyBuffer)

--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManagerApplicationStatus.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManagerApplicationStatus.cs
@@ -1,0 +1,33 @@
+namespace Meziantou.Framework.Win32;
+
+/// <summary>Describes the current status of an application that is using a resource registered with a Restart Manager session.</summary>
+[Flags]
+public enum RestartManagerApplicationStatus
+{
+    /// <summary>The status is not known.</summary>
+    Unknown = 0,
+
+    /// <summary>The application is running.</summary>
+    Running = 0x1,
+
+    /// <summary>The application has been stopped by the Restart Manager.</summary>
+    Stopped = 0x2,
+
+    /// <summary>The application has been stopped by a means other than the Restart Manager.</summary>
+    StoppedOther = 0x4,
+
+    /// <summary>The application has been restarted by the Restart Manager.</summary>
+    Restarted = 0x8,
+
+    /// <summary>The Restart Manager failed to stop the application.</summary>
+    ErrorOnStop = 0x10,
+
+    /// <summary>The Restart Manager failed to restart the application.</summary>
+    ErrorOnRestart = 0x20,
+
+    /// <summary>Shutdown of the application has been masked by a filter.</summary>
+    ShutdownMasked = 0x40,
+
+    /// <summary>Restart of the application has been masked by a filter.</summary>
+    RestartMasked = 0x80,
+}

--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManagerApplicationType.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManagerApplicationType.cs
@@ -1,0 +1,26 @@
+namespace Meziantou.Framework.Win32;
+
+/// <summary>Describes the type of an application that is using a resource registered with a Restart Manager session.</summary>
+public enum RestartManagerApplicationType
+{
+    /// <summary>The application cannot be classified. It may not respond to shutdown requests and may have to be forced to shut down.</summary>
+    Unknown = 0,
+
+    /// <summary>A Windows application that runs in its own process and has a top-level window.</summary>
+    MainWindow = 1,
+
+    /// <summary>A Windows application that does not run in its own process and does not have a top-level window.</summary>
+    OtherWindow = 2,
+
+    /// <summary>A Windows service.</summary>
+    Service = 3,
+
+    /// <summary>Windows Explorer.</summary>
+    Explorer = 4,
+
+    /// <summary>A console application.</summary>
+    Console = 5,
+
+    /// <summary>A critical process that must be shut down by a system restart.</summary>
+    Critical = 1000,
+}

--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManagerProcessInfo.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManagerProcessInfo.cs
@@ -1,0 +1,45 @@
+using System.Runtime.Versioning;
+using Windows.Win32.System.RestartManager;
+
+namespace Meziantou.Framework.Win32;
+
+/// <summary>Describes an application or service that is using a resource registered with a Restart Manager session.</summary>
+[SupportedOSPlatform("windows")]
+public sealed class RestartManagerProcessInfo
+{
+    internal RestartManagerProcessInfo(RM_PROCESS_INFO processInfo)
+    {
+        ProcessId = (int)processInfo.Process.dwProcessId;
+        StartTime = processInfo.Process.ProcessStartTime.ToDateTime();
+        ApplicationName = processInfo.strAppName.ToString();
+        ServiceShortName = processInfo.strServiceShortName.ToString();
+        ApplicationType = (RestartManagerApplicationType)processInfo.ApplicationType;
+        Status = (RestartManagerApplicationStatus)processInfo.AppStatus;
+        TerminalServicesSessionId = (int)processInfo.TSSessionId;
+        IsRestartable = processInfo.bRestartable;
+    }
+
+    /// <summary>Gets the identifier of the process.</summary>
+    public int ProcessId { get; }
+
+    /// <summary>Gets the time at which the process started. Windows recycles process identifiers, so only the combination of <see cref="ProcessId"/> and <see cref="StartTime"/> identifies a process.</summary>
+    public DateTime StartTime { get; }
+
+    /// <summary>Gets the friendly name of the application.</summary>
+    public string ApplicationName { get; }
+
+    /// <summary>Gets the short name of the service, or an empty string when the process is not a service.</summary>
+    public string ServiceShortName { get; }
+
+    /// <summary>Gets the type of the application.</summary>
+    public RestartManagerApplicationType ApplicationType { get; }
+
+    /// <summary>Gets the current status of the application.</summary>
+    public RestartManagerApplicationStatus Status { get; }
+
+    /// <summary>Gets the Terminal Services session identifier in which the process is running.</summary>
+    public int TerminalServicesSessionId { get; }
+
+    /// <summary>Gets a value indicating whether the Restart Manager can restart the application after shutting it down.</summary>
+    public bool IsRestartable { get; }
+}

--- a/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Diagnostics;
 using Meziantou.Xunit;
 
 namespace Meziantou.Framework.Win32.Tests;
@@ -162,6 +163,31 @@ public class RestartManagerTests
         {
             File.Delete(unlockedPath);
             File.Delete(lockedPath);
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetLockingProcesses_ReportsTheDetailsOfTheLockingProcess()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            using (File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                using var session = RestartManager.CreateSession();
+                session.RegisterFile(path);
+
+                var info = Assert.Single(session.GetLockingProcesses(), item => item.ProcessId == _currentProcessId);
+                Assert.NotEmpty(info.ApplicationName);
+
+                using var currentProcess = Process.GetCurrentProcess();
+                var difference = (currentProcess.StartTime - info.StartTime).Duration();
+                Assert.True(difference < TimeSpan.FromSeconds(1), $"Expected {currentProcess.StartTime:O} but got {info.StartTime:O}");
+            }
+        }
+        finally
+        {
+            File.Delete(path);
         }
     }
 }


### PR DESCRIPTION
`RmGetList` fills an `RM_PROCESS_INFO` per locking process carrying `strAppName`, `strServiceShortName`, `ApplicationType`, `AppStatus`, `TSSessionId` and `bRestartable`. The wrapper read one field — `dwProcessId` — threw the rest away, and then called `Process.GetProcessById` to re-derive a subset of it, more expensively and (before #2125) racily.

Three concrete losses. A caller could not tell a **service** from an application, which changes what you can safely do about it. A caller could not see **`bRestartable`**, which is exactly the input needed to choose between `ForceShutdown` and `ShutdownOnlyRegistered`. And a process that had already exited yielded nothing at all, even though RM had its name.

## What changed

Added `GetLockingProcesses()` returning `IReadOnlyList<RestartManagerProcessInfo>`, a projection of the native struct, with `RestartManagerApplicationType` and `RestartManagerApplicationStatus` mirroring the RM enums.

This is **additive**. `GetProcessesLockingResources()` is unchanged and still returns `IReadOnlyList<Process>`; both now share an extracted `GetList()` helper that owns the `ERROR_MORE_DATA` retry, so the buffer-growth logic exists once instead of twice.

## Why it is worth adding rather than changing

The existing shape is `IReadOnlyList<Process>`, pinned in `ref/`. None of the above can be added to it without a breaking change, so a second method is the only additive route. It also sidesteps a wart in the existing one: `Process` is `IDisposable`, and handing back a list of them transfers ownership of native handles without documenting it — `RestartManagerProcessInfo` is a plain value with nothing to dispose.

## Verification

- Builds clean on `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`, 0 warnings.
- `ref/` regenerated with `-c Release -p:IsOfficialBuild=true`; `dotnet run ./eng/update-all.cs` produces no further changes.
- Added `GetLockingProcesses_ReportsTheDetailsOfTheLockingProcess`, asserting the current process appears with a non-empty `ApplicationName` and a `StartTime` within a second of `Process.GetCurrentProcess().StartTime` — which also exercises the `FILETIME` conversion that #2125 depends on.

`ApplicationType` is deliberately **not** asserted: how RM classifies a test host is not something I want to bake into a test.

---

**Stacked PR.** Merge order is bottom-up: #2124 → #2125 → #2126 → #2127. All four rewrite the same `RmGetList` region of `RestartManager.cs`, which is why they are a stack rather than independent PRs.

⚠️ **Tests were not run locally.** Every test in this project is `[RunIf(TestOperatingSystems.Windows)]` and this was authored on macOS, where they are all skipped. The `windows-2025-vs2026` CI leg is the first real execution.

From a review of `src/Meziantou.Framework.Win32.RestartManager`.