### PR TITLE
Report the Restart Manager reboot reason to callers

### DIFF
--- a/ref/Meziantou.Framework.Win32.RestartManager.cs
+++ b/ref/Meziantou.Framework.Win32.RestartManager.cs
@@ -8,6 +8,7 @@ namespace Meziantou.Framework.Win32
     public sealed class RestartManager : System.IDisposable
     {
         public string SessionKey { get => throw null; }
+        public Meziantou.Framework.Win32.RestartManagerRebootReason RebootReason { get => throw null; }
         public static Meziantou.Framework.Win32.RestartManager CreateSession() => throw null;
         public static Meziantou.Framework.Win32.RestartManager JoinSession(string sessionKey) => throw null;
         public void RegisterFile(string path) { }
@@ -62,6 +63,17 @@ namespace Meziantou.Framework.Win32
         public Meziantou.Framework.Win32.RestartManagerApplicationStatus Status { get => throw null; }
         public int TerminalServicesSessionId { get => throw null; }
         public bool IsRestartable { get => throw null; }
+    }
+
+    [System.Flags]
+    public enum RestartManagerRebootReason
+    {
+        None = 0,
+        PermissionDenied = 1,
+        SessionMismatch = 2,
+        CriticalProcess = 4,
+        CriticalService = 8,
+        DetectedSelf = 16
     }
 
     [System.Flags]

--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
@@ -42,6 +42,15 @@ public sealed class RestartManager : IDisposable
     /// <summary>Gets the session key for this Restart Manager session.</summary>
     public string SessionKey { get; }
 
+    /// <summary>Gets the reason a system restart is required to free the registered resources.</summary>
+    /// <remarks>
+    /// This reflects the most recent call to <see cref="IsResourcesLocked"/>, <see cref="GetProcessesLockingResources"/>
+    /// or <see cref="GetLockingProcesses"/>, and is <see cref="RestartManagerRebootReason.None"/> until one of them runs.
+    /// When it is not <see cref="RestartManagerRebootReason.None"/>, calling <see cref="Shutdown(RestartManagerShutdownType)"/>
+    /// will not free the resources and the user should be prompted for a system restart instead.
+    /// </remarks>
+    public RestartManagerRebootReason RebootReason { get; private set; }
+
     private RestartManager(uint sessionHandle, string sessionKey)
     {
         _sessionHandle = new RestartManagerSessionHandle(sessionHandle);
@@ -116,9 +125,12 @@ public sealed class RestartManager : IDisposable
         // affected, and arrayCount reports the total number needed in both cases, so there is nothing to retry.
         uint arraySize = 1;
         var array = new RM_PROCESS_INFO[arraySize];
-        var result = PInvoke.RmGetList(_sessionHandle.SessionHandle, out var arrayCount, ref arraySize, array, out _);
+        var result = PInvoke.RmGetList(_sessionHandle.SessionHandle, out var arrayCount, ref arraySize, array, out var rebootReason);
         if (result is WIN32_ERROR.ERROR_SUCCESS or WIN32_ERROR.ERROR_MORE_DATA)
+        {
+            RebootReason = (RestartManagerRebootReason)rebootReason;
             return arrayCount > 0;
+        }
 
         throw new Win32Exception((int)result, $"RmGetList failed ({result})");
     }
@@ -164,9 +176,12 @@ public sealed class RestartManager : IDisposable
         while (true)
         {
             var array = new RM_PROCESS_INFO[arraySize];
-            var result = PInvoke.RmGetList(_sessionHandle.SessionHandle, out var arrayCount, ref arraySize, array, out _);
+            var result = PInvoke.RmGetList(_sessionHandle.SessionHandle, out var arrayCount, ref arraySize, array, out var rebootReason);
             if (result == WIN32_ERROR.ERROR_SUCCESS)
+            {
+                RebootReason = (RestartManagerRebootReason)rebootReason;
                 return (array, arrayCount);
+            }
 
             if (result != WIN32_ERROR.ERROR_MORE_DATA)
                 throw new Win32Exception((int)result, $"RmGetList failed ({result})");

--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManagerRebootReason.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManagerRebootReason.cs
@@ -1,0 +1,25 @@
+namespace Meziantou.Framework.Win32;
+
+/// <summary>Describes why a system restart is required to free the resources registered with a Restart Manager session.</summary>
+/// <remarks>Any value other than <see cref="None"/> means the Restart Manager cannot free the registered resources by shutting applications down, and that a system restart is required instead.</remarks>
+[Flags]
+public enum RestartManagerRebootReason
+{
+    /// <summary>A system restart is not required.</summary>
+    None = 0,
+
+    /// <summary>The current process does not have enough privileges to shut down one or more of the applications.</summary>
+    PermissionDenied = 0x1,
+
+    /// <summary>One or more of the applications is running in a different Terminal Services session.</summary>
+    SessionMismatch = 0x2,
+
+    /// <summary>One or more of the applications is a critical process.</summary>
+    CriticalProcess = 0x4,
+
+    /// <summary>One or more of the applications is a critical service.</summary>
+    CriticalService = 0x8,
+
+    /// <summary>The current process is using one of the registered resources itself.</summary>
+    DetectedSelf = 0x10,
+}

--- a/src/Meziantou.Framework.Win32.RestartManager/readme.md
+++ b/src/Meziantou.Framework.Win32.RestartManager/readme.md
@@ -99,6 +99,14 @@ The Restart Manager can shut down and restart applications that are locking reso
 using var session = RestartManager.CreateSession();
 session.RegisterFile(@"C:\path\to\file.txt");
 
+// A non-zero reboot reason means shutting applications down cannot free the resources,
+// and that a system restart is required instead. Check it before shutting anything down.
+if (session.IsResourcesLocked() && session.RebootReason != RestartManagerRebootReason.None)
+{
+    Console.WriteLine($"A system restart is required: {session.RebootReason}");
+    return;
+}
+
 // Shutdown applications with options
 session.Shutdown(RestartManagerShutdownType.ForceShutdown);
 

--- a/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
@@ -190,4 +190,29 @@ public class RestartManagerTests
             File.Delete(path);
         }
     }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void RebootReason_IsRefreshedWhenTheSessionIsQueried()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            using (File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                using var session = RestartManager.CreateSession();
+                session.RegisterFile(path);
+
+                Assert.Equal(RestartManagerRebootReason.None, session.RebootReason);
+
+                Assert.True(session.IsResourcesLocked());
+
+                // The session and the lock live in the same process, which is what DetectedSelf reports.
+                Assert.Equal(RestartManagerRebootReason.DetectedSelf, session.RebootReason);
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 }


### PR DESCRIPTION
Microsoft's "Using Restart Manager with a Primary Installer" procedure makes this the decision point of step 3:

> If the value of the *lpdwRebootReason* parameter that is returned by the **RmGetList** function is nonzero, the Restart Manager is unable to free a registered resource by the shutdown of an application or service. In this case, a system shutdown and restart is required to continue the installation.

Both `RmGetList` call sites passed `out _` and dropped that value on the floor. A caller would therefore call `session.Shutdown(ForceShutdown)`, get `ERROR_SUCCESS`, and still find the file locked — with nothing in the API to have warned them. That makes the shutdown half of this library impossible to use correctly, which is most of what distinguishes it from a plain "who locks this file" helper.

## What changed

Added a `RebootReason` property backed by a new `RestartManagerRebootReason` flags enum, refreshed by `IsResourcesLocked()`, `GetProcessesLockingResources()` and `GetLockingProcesses()`. `RM_REBOOT_REASON` was already listed in `NativeMethods.txt` and already generated — nothing was blocking this.

The readme's shutdown example now checks it before shutting anything down, since following the documented workflow is the entire point.

## Note for review

The property is refreshed as a side effect of querying, and is `None` until the first query — documented on the property, but it is an implicit contract and worth a look. The alternative was an `out` parameter on three methods, which is worse for the two that already return a list. Happy to switch if you disagree.

## Verification

- Builds clean on `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`, 0 warnings.
- `ref/` regenerated with `-c Release -p:IsOfficialBuild=true`; `dotnet run ./eng/update-all.cs` produces no further changes.
- Added `RebootReason_IsRefreshedWhenTheSessionIsQueried`.

**The assertion I am least sure of in this whole batch** is in that test: after locking a file from the test process itself and querying, it expects `DetectedSelf`. That follows from the documented meaning ("the current process is using one of the registered resources"), and the session and the lock really are in the same process — but I could not run it. If RM reports something else, this is the test that will say so.

---

**Stacked PR.** Merge order is bottom-up: #2124 → #2125 → #2126 → #2127. All four rewrite the same `RmGetList` region of `RestartManager.cs`, which is why they are a stack rather than independent PRs.

⚠️ **Tests were not run locally.** Every test in this project is `[RunIf(TestOperatingSystems.Windows)]` and this was authored on macOS, where they are all skipped. The `windows-2025-vs2026` CI leg is the first real execution.

From a review of `src/Meziantou.Framework.Win32.RestartManager`.