### PR TITLE
Report null for memory.stat keys the kernel does not emit

### DIFF
--- a/ref/Meziantou.Framework.Unix.ControlGroups.cs
+++ b/ref/Meziantou.Framework.Unix.ControlGroups.cs
@@ -100,25 +100,25 @@ namespace Meziantou.Framework.Unix.ControlGroups
 
     public sealed class MemoryStat
     {
-        public long Anon { get => throw null; }
-        public long File { get => throw null; }
-        public long Kernel { get => throw null; }
-        public long KernelStack { get => throw null; }
-        public long PageTables { get => throw null; }
-        public long PerCpu { get => throw null; }
-        public long Sock { get => throw null; }
-        public long SwapCached { get => throw null; }
-        public long FileMapped { get => throw null; }
-        public long FileDirty { get => throw null; }
-        public long FileWriteback { get => throw null; }
-        public long InactiveAnon { get => throw null; }
-        public long ActiveAnon { get => throw null; }
-        public long InactiveFile { get => throw null; }
-        public long ActiveFile { get => throw null; }
-        public long Unevictable { get => throw null; }
-        public long SlabReclaimable { get => throw null; }
-        public long SlabUnreclaimable { get => throw null; }
-        public long Slab { get => throw null; }
+        public long? Anon { get => throw null; }
+        public long? File { get => throw null; }
+        public long? Kernel { get => throw null; }
+        public long? KernelStack { get => throw null; }
+        public long? PageTables { get => throw null; }
+        public long? PerCpu { get => throw null; }
+        public long? Sock { get => throw null; }
+        public long? SwapCached { get => throw null; }
+        public long? FileMapped { get => throw null; }
+        public long? FileDirty { get => throw null; }
+        public long? FileWriteback { get => throw null; }
+        public long? InactiveAnon { get => throw null; }
+        public long? ActiveAnon { get => throw null; }
+        public long? InactiveFile { get => throw null; }
+        public long? ActiveFile { get => throw null; }
+        public long? Unevictable { get => throw null; }
+        public long? SlabReclaimable { get => throw null; }
+        public long? SlabUnreclaimable { get => throw null; }
+        public long? Slab { get => throw null; }
         public long? PageSwapIn { get => throw null; }
         public long? PageSwapOut { get => throw null; }
         public long? PageFault { get => throw null; }

--- a/src/Meziantou.Framework.Unix.ControlGroups/MemoryStat.cs
+++ b/src/Meziantou.Framework.Unix.ControlGroups/MemoryStat.cs
@@ -1,64 +1,69 @@
 namespace Meziantou.Framework.Unix.ControlGroups;
 
 /// <summary>Represents memory statistics for a cgroup.</summary>
+/// <remarks>
+/// Every property is nullable because the set of keys <c>memory.stat</c> emits varies by kernel version and
+/// configuration. <see langword="null"/> means the running kernel did not report the value, which is distinct
+/// from it reporting zero.
+/// </remarks>
 public sealed class MemoryStat
 {
     /// <summary>Memory used in anonymous mappings (bytes).</summary>
-    public long Anon { get; private set; }
+    public long? Anon { get; private set; }
 
     /// <summary>Memory used to cache filesystem data (bytes).</summary>
-    public long File { get; private set; }
+    public long? File { get; private set; }
 
     /// <summary>Total kernel memory (bytes).</summary>
-    public long Kernel { get; private set; }
+    public long? Kernel { get; private set; }
 
     /// <summary>Memory allocated to kernel stacks (bytes).</summary>
-    public long KernelStack { get; private set; }
+    public long? KernelStack { get; private set; }
 
     /// <summary>Memory allocated for page tables (bytes).</summary>
-    public long PageTables { get; private set; }
+    public long? PageTables { get; private set; }
 
     /// <summary>Memory used for storing per-cpu kernel data structures (bytes).</summary>
-    public long PerCpu { get; private set; }
+    public long? PerCpu { get; private set; }
 
     /// <summary>Memory used in network transmission buffers (bytes).</summary>
-    public long Sock { get; private set; }
+    public long? Sock { get; private set; }
 
     /// <summary>Memory cached in swap (bytes).</summary>
-    public long SwapCached { get; private set; }
+    public long? SwapCached { get; private set; }
 
     /// <summary>Cached filesystem data mapped with mmap (bytes).</summary>
-    public long FileMapped { get; private set; }
+    public long? FileMapped { get; private set; }
 
     /// <summary>Cached filesystem data that was modified but not yet written back (bytes).</summary>
-    public long FileDirty { get; private set; }
+    public long? FileDirty { get; private set; }
 
     /// <summary>Cached filesystem data being written back to disk (bytes).</summary>
-    public long FileWriteback { get; private set; }
+    public long? FileWriteback { get; private set; }
 
     /// <summary>Inactive anonymous memory (bytes).</summary>
-    public long InactiveAnon { get; private set; }
+    public long? InactiveAnon { get; private set; }
 
     /// <summary>Active anonymous memory (bytes).</summary>
-    public long ActiveAnon { get; private set; }
+    public long? ActiveAnon { get; private set; }
 
     /// <summary>Inactive file-backed memory (bytes).</summary>
-    public long InactiveFile { get; private set; }
+    public long? InactiveFile { get; private set; }
 
     /// <summary>Active file-backed memory (bytes).</summary>
-    public long ActiveFile { get; private set; }
+    public long? ActiveFile { get; private set; }
 
     /// <summary>Unevictable memory (bytes).</summary>
-    public long Unevictable { get; private set; }
+    public long? Unevictable { get; private set; }
 
     /// <summary>Reclaimable slab memory (bytes).</summary>
-    public long SlabReclaimable { get; private set; }
+    public long? SlabReclaimable { get; private set; }
 
     /// <summary>Unreclaimable slab memory (bytes).</summary>
-    public long SlabUnreclaimable { get; private set; }
+    public long? SlabUnreclaimable { get; private set; }
 
     /// <summary>Total slab memory (bytes).</summary>
-    public long Slab { get; private set; }
+    public long? Slab { get; private set; }
 
     /// <summary>Number of pages swapped in.</summary>
     public long? PageSwapIn { get; private set; }

--- a/src/Meziantou.Framework.Unix.ControlGroups/readme.md
+++ b/src/Meziantou.Framework.Unix.ControlGroups/readme.md
@@ -19,7 +19,7 @@ A .NET library for managing Linux Control Groups v2 (cgroups v2).
 
 ## Requirements
 
-- Linux kernel 4.5+ with cgroup v2 enabled
+- Linux kernel 4.5+ with cgroup v2 enabled. Some APIs need a newer kernel: `AssociateThread`/`GetThreads` need 4.14, `Freeze`/`Unfreeze`/`IsFrozen` need 5.2, and `Kill` needs 5.14. The set of keys reported by `GetMemoryStat` also varies by version — for example `swapcached` needs 5.13 and `kernel` needs 6.0 — and `MemoryStat` reports `null` for anything the running kernel does not emit.
 - cgroup v2 filesystem mounted at `/sys/fs/cgroup` (default on most modern distributions)
 - Appropriate permissions to manage cgroups
 

--- a/tests/Meziantou.Framework.Unix.ControlGroups.Tests/CGroup2ParsingTests.cs
+++ b/tests/Meziantou.Framework.Unix.ControlGroups.Tests/CGroup2ParsingTests.cs
@@ -91,26 +91,35 @@ public sealed class CGroup2ParsingTests
     }
 
     [Fact]
-    public void MemoryStat_ShouldReportZeroForKeysTheKernelDoesNotEmit()
+    public void MemoryStat_ShouldReportNullForKeysTheKernelDoesNotEmit()
     {
-        // Documents a known limitation: 'kernel' (Linux 6.0+) and 'swapcached' (5.13+) are non-nullable,
-        // so an older kernel that never reports them is indistinguishable from one reporting zero bytes.
+        // 'kernel' needs Linux 6.0+ and 'swapcached' needs 5.13+, so an older kernel reports neither.
+        // That must be distinguishable from a cgroup genuinely using zero bytes.
         var stat = MemoryStat.Parse("anon 4096\nfile 8192\n");
 
         Assert.Equal(4096, stat.Anon);
-        Assert.Equal(0, stat.Kernel);
-        Assert.Equal(0, stat.SwapCached);
+        Assert.Null(stat.Kernel);
+        Assert.Null(stat.SwapCached);
         Assert.Null(stat.PageFault);
     }
 
     [Fact]
-    public void MemoryStat_ShouldReportZeroForValuesLargerThanInt64()
+    public void MemoryStat_ShouldReportZeroWhenTheKernelReportsZero()
     {
-        // Documents a known limitation: memory.stat counters are u64, but they are parsed into long,
-        // so a value above long.MaxValue silently leaves the field at its default.
-        var stat = MemoryStat.Parse("anon 18446744073709551615\n");
+        var stat = MemoryStat.Parse("anon 0\nkernel 0\n");
 
         Assert.Equal(0, stat.Anon);
+        Assert.Equal(0, stat.Kernel);
+    }
+
+    [Fact]
+    public void MemoryStat_ShouldReportNullForValuesLargerThanInt64()
+    {
+        // Documents a known limitation: memory.stat counters are u64, but they are parsed into long,
+        // so a value above long.MaxValue is treated as if the kernel had not reported it.
+        var stat = MemoryStat.Parse("anon 18446744073709551615\n");
+
+        Assert.Null(stat.Anon);
     }
 
     [Theory]


### PR DESCRIPTION
**Stack 2 of 2 · merges into `test/add-parser-tests` · merge after #2129**

## Finding

`MemoryStat.Parse` starts from a default instance and only assigns keys it finds. Nineteen properties were non-nullable `long` (default `0`) and four were `long?` (default `null`) — and the split did not track which keys are actually optional.

`kernel` was added to `memory.stat` in Linux 6.0 and `swapcached` in 5.13, but `MemoryStat.Kernel` and `MemoryStat.SwapCached` were non-nullable. On an older kernel a caller read `0` and could not tell it apart from a cgroup genuinely using no kernel memory. The same applied to any key a future kernel drops or renames.

Silently reporting zero bytes for a metric the kernel never reported is the failure mode a monitoring type must not have: it produces a plausible number rather than an absent one, and a dashboard cannot distinguish them.

`CpuStat` gets this right — `usage_usec`/`user_usec`/`system_usec` are always present and non-nullable, while the bandwidth-control keys that only appear when `cpu.max` is set are nullable. `MemoryStat` looked like the same design, but the nullability was assigned arbitrarily.

## Change

Every `memory.stat` property is now `long?`. Absence means absence, matching `CpuStat`'s principle. A `<remarks>` on the type states it.

The readme's "Linux kernel 4.5+" requirement is corrected in the same change, since it is the same class of inaccuracy: `AssociateThread`/`GetThreads` need 4.14, the freezer needs 5.2, `Kill` needs 5.14, and the `memory.stat` key set varies by version.

## ⚠️ Breaking change

**19 public properties change from `long` to `long?`.** This is source- and binary-breaking on a published 2.0.0 package. Anything doing arithmetic on `stat.Anon` or assigning it to a `long` will not compile until it handles the null case.

That is the point of the change — those call sites are exactly the ones silently treating "not reported" as "zero" — but it needs a version decision before it merges.

An alternative that preserves the surface would be to keep the `long` properties and add `HasKernel`-style presence flags, or expose the raw parsed dictionary alongside. I went with the nullable types because they make the wrong thing impossible rather than merely detectable; say the word if you'd rather have the additive version.

## Verification

`dotnet build -p:TreatWarningsAsErrors=true` clean for `net10.0` and `net11.0`. `ref/` regenerated with a Release / `IsOfficialBuild=true` build. `dotnet run ./eng/update-all.cs --step readme` reports no further changes.

Full suite, both TFMs: **44 passed, 0 failed, 24 skipped**. Three of #2129's tests are updated here — the two that documented the zero-versus-absent limitation now assert `null`, and a new `MemoryStat_ShouldReportZeroWhenTheKernelReportsZero` pins down the other half of the distinction. `MinimumExpectedTests` goes 21 → 22.
