### PR TITLE
Bound the begin-guard retry loop to the input length

### DIFF
--- a/src/Meziantou.Framework.SyntaxHighlighting/Engine/Tokenizer.cs
+++ b/src/Meziantou.Framework.SyntaxHighlighting/Engine/Tokenizer.cs
@@ -103,10 +103,20 @@ internal static class Tokenizer
                 continue;
             var m = child.BeginRe.Match(input, from);
             // For guarded modes (hljs's `on:begin` veto), walk forward through
-            // candidate matches until one is accepted by the guard.
+            // candidate matches until one is accepted by the guard. The next start
+            // is bounded the same way MatchEnd bounds its cursor: a zero-width
+            // candidate at the very end of the input would otherwise ask Regex.Match
+            // to start past the end of the string, which throws.
             while (m.Success && child.BeginGuard is not null && !BeginGuards.Accept(child.BeginGuard, m, input))
             {
-                m = child.BeginRe.Match(input, m.Index + Math.Max(1, m.Length));
+                var next = m.Index + Math.Max(1, m.Length);
+                if (next > input.Length)
+                {
+                    m = Match.Empty;
+                    break;
+                }
+
+                m = child.BeginRe.Match(input, next);
             }
             if (!m.Success)
                 continue;

--- a/tests/Meziantou.Framework.SyntaxHighlighting.Tests/JavaScriptHighlighterTests.cs
+++ b/tests/Meziantou.Framework.SyntaxHighlighting.Tests/JavaScriptHighlighterTests.cs
@@ -1,4 +1,4 @@
-namespace Meziantou.Framework.SyntaxHighlighting.Tests;
+﻿namespace Meziantou.Framework.SyntaxHighlighting.Tests;
 
 public class JavaScriptHighlighterTests
 {
@@ -3334,6 +3334,18 @@ const a = 1;
 """,
 """
 <span class="hljs-comment">// just a comment</span>
+""");
+    }
+
+    [Fact]
+    public void JsxTag_OpeningTagIsTreatedAsMarkup()
+    {
+        AssertHighlighter("javascript",
+"""
+const el = <div>hello</div>;
+""",
+"""
+<span class="hljs-keyword">const</span> el = <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">div</span>&gt;</span>hello<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span></span>;
 """);
     }
 }

--- a/tests/Meziantou.Framework.SyntaxHighlighting.Tests/TypeScriptHighlighterTests.cs
+++ b/tests/Meziantou.Framework.SyntaxHighlighting.Tests/TypeScriptHighlighterTests.cs
@@ -1,4 +1,4 @@
-namespace Meziantou.Framework.SyntaxHighlighting.Tests;
+﻿namespace Meziantou.Framework.SyntaxHighlighting.Tests;
 
 public class TypeScriptHighlighterTests
 {
@@ -3224,6 +3224,30 @@ const x = 1;
 """,
 """
 <span class="hljs-comment">/// &lt;reference path=&quot;./foo.d.ts&quot; /&gt;</span>
+""");
+    }
+
+    [Fact]
+    public void JsxTag_SelfClosingTagIsTreatedAsMarkup()
+    {
+        AssertHighlighter("typescript",
+"""
+const el = <Foo bar={1} />;
+""",
+"""
+<span class="hljs-keyword">const</span> el = <span class="language-xml"><span class="hljs-tag">&lt;<span class="hljs-name">Foo</span> <span class="hljs-attr">bar</span>=<span class="hljs-string">{1}</span> /&gt;</span></span>;
+""");
+    }
+
+    [Fact]
+    public void JsxTag_GenericArrowFunctionIsNotTreatedAsMarkup()
+    {
+        AssertHighlighter("typescript",
+"""
+const f = <T,>(x: T) => x;
+""",
+"""
+<span class="hljs-keyword">const</span> f = &lt;T,&gt;<span class="hljs-function">(<span class="hljs-params"><span class="hljs-attr">x</span>: T</span>) =&gt;</span> x;
 """);
     }
 }


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2133**

## Problem

The begin-guard retry loop in `Engine/Tokenizer.cs:107-110` advances with:

```csharp
m = child.BeginRe.Match(input, m.Index + Math.Max(1, m.Length));
```

If a guarded pattern ever produced a zero-width match at the very end of the input, the start index becomes `input.Length + 1` and `Regex.Match` throws `ArgumentOutOfRangeException`. The equivalent loop in `MatchEnd` (`:158-170`) already guards this with `while (cursor <= input.Length)`; this one did not.

**This is not reachable today.** The only guard is `"jsxTag"` (`Languages/Javascript.cs:70`, `Languages/Typescript.cs:72`), whose pattern `<[A-Za-z0-9\\._:-]+` always matches at least two characters. It is a trap for the next guard added, and the loop is rewritten by #2133, so it is worth closing first.

## Changes

Bound the next start the same way `MatchEnd` does, and treat "no candidate fits" as no match rather than falling through with a vetoed one.

## Verification

Because the crash is unreachable through the public API, there is no failing-test-to-passing-test to show — I could not construct one without a zero-width guarded pattern, which no grammar has.

What I did add is coverage for the guard's *accept* path, which had none: the existing TypeScript tests exercise the reject path well (`Box<T>`, `<T>(x: T)`), but nothing asserted that a real JSX tag is treated as markup. Three tests now pin both sides:

- `<div>hello</div>` in JavaScript → sub-language XML
- `<Foo bar={1} />` in TypeScript → sub-language XML
- `<T,>(x: T) => x` in TypeScript → *not* markup

Build clean with `-p:TreatWarningsAsErrors=true -p:ContinuousIntegrationBuild=true`; 4240 tests pass (4237 + 3).

---
Found during a review of `src/Meziantou.Framework.SyntaxHighlighting`.
