### PR TITLE
Memoize pattern scans so tokenization is no longer quadratic

### DIFF
--- a/src/Meziantou.Framework.SyntaxHighlighting/Engine/Tokenizer.cs
+++ b/src/Meziantou.Framework.SyntaxHighlighting/Engine/Tokenizer.cs
@@ -37,10 +37,12 @@ internal static class Tokenizer
         var bufferStart = 0;
         var index = 0;
         var lastBeginIndex = -1;
+        // Memoizes the next match of each pattern for this run. See ScanCache/NextMatch.
+        var scanCache = new Dictionary<Regex, (int From, Match? Match)>(ReferenceEqualityComparer.Instance);
 
         while (true)
         {
-            var hit = FindNextHit(input, index, stack, beginCaptures);
+            var hit = FindNextHit(input, index, stack, beginCaptures, scanCache);
             if (hit is null)
                 break;
 
@@ -92,7 +94,32 @@ internal static class Tokenizer
         return emitter.ToHtml();
     }
 
-    private static Hit? FindNextHit(string input, int from, List<CompiledMode> stack, List<string?> beginCaptures)
+    /// <summary>
+    /// The leftmost match of <paramref name="re"/> at an index &gt;= <paramref name="from"/>,
+    /// memoized for the duration of one highlight run.
+    /// </summary>
+    /// <remarks>
+    /// The engine asks for the next match of every candidate pattern after every token, and each
+    /// of those calls re-scans the rest of the input, which makes tokenization quadratic in the
+    /// document size. A match already found at index <c>i</c> while scanning from <c>f</c> is
+    /// still the leftmost match for any start in <c>[f, i]</c> — there is nothing in between, or
+    /// it would have been found first — so the scan can be skipped until the cursor passes it.
+    /// A pattern that did not match from <c>f</c> cannot match from any later start either.
+    /// The cursor can move backwards (ReturnBegin/ReturnEnd), so a start before the memoized
+    /// scan origin falls through to a real scan.
+    /// </remarks>
+    private static Match? NextMatch(Regex re, string input, int from, Dictionary<Regex, (int From, Match? Match)> cache)
+    {
+        if (cache.TryGetValue(re, out var cached) && from >= cached.From && (cached.Match is null || cached.Match.Index >= from))
+            return cached.Match;
+
+        var match = re.Match(input, from);
+        var result = match.Success ? match : null;
+        cache[re] = (from, result);
+        return result;
+    }
+
+    private static Hit? FindNextHit(string input, int from, List<CompiledMode> stack, List<string?> beginCaptures, Dictionary<Regex, (int From, Match? Match)> cache)
     {
         Hit? best = null;
         var top = stack[^1];
@@ -101,24 +128,28 @@ internal static class Tokenizer
         {
             if (child.BeginRe is null)
                 continue;
-            var m = child.BeginRe.Match(input, from);
+            var m = NextMatch(child.BeginRe, input, from, cache);
             // For guarded modes (hljs's `on:begin` veto), walk forward through
             // candidate matches until one is accepted by the guard. The next start
             // is bounded the same way MatchEnd bounds its cursor: a zero-width
             // candidate at the very end of the input would otherwise ask Regex.Match
             // to start past the end of the string, which throws.
-            while (m.Success && child.BeginGuard is not null && !BeginGuards.Accept(child.BeginGuard, m, input))
+            while (m is not null && child.BeginGuard is not null && !BeginGuards.Accept(child.BeginGuard, m, input))
             {
                 var next = m.Index + Math.Max(1, m.Length);
                 if (next > input.Length)
                 {
-                    m = Match.Empty;
+                    m = null;
                     break;
                 }
 
-                m = child.BeginRe.Match(input, next);
+                var candidate = child.BeginRe.Match(input, next);
+                m = candidate.Success ? candidate : null;
+                // Remember the accepted candidate, not the vetoed one, so the next lookup
+                // for this pattern resumes from the same answer.
+                cache[child.BeginRe] = (from, m);
             }
-            if (!m.Success)
+            if (m is null)
                 continue;
             if (best is null || m.Index < best.Value.Index)
                 best = new Hit(m.Index, m.Length, HitKind.Begin, child, -1, m);
@@ -130,7 +161,7 @@ internal static class Tokenizer
             var frame = stack[depth];
             if (frame.EndRe is not null)
             {
-                var m = MatchEnd(frame, beginCaptures[depth], input, from);
+                var m = MatchEnd(frame, beginCaptures[depth], input, from, cache);
                 if (m is not null && (best is null || m.Index < best.Value.Index))
                 {
                     best = new Hit(m.Index, m.Length, HitKind.End, frame, depth, m);
@@ -142,8 +173,8 @@ internal static class Tokenizer
 
         if (top.IllegalRe is not null)
         {
-            var m = top.IllegalRe.Match(input, from);
-            if (m.Success && (best is null || m.Index < best.Value.Index))
+            var m = NextMatch(top.IllegalRe, input, from, cache);
+            if (m is not null && (best is null || m.Index < best.Value.Index))
                 best = new Hit(m.Index, m.Length, HitKind.Illegal, Child: null, -1, m);
         }
 
@@ -154,14 +185,13 @@ internal static class Tokenizer
     /// For modes with EndSameAsBegin, scan forward through end candidates and skip any
     /// whose group-1 capture doesn't match the value captured at begin time.
     /// </summary>
-    private static Match? MatchEnd(CompiledMode frame, string? beginCapture, string input, int from)
+    private static Match? MatchEnd(CompiledMode frame, string? beginCapture, string input, int from, Dictionary<Regex, (int From, Match? Match)> cache)
     {
         if (frame.EndRe is null)
             return null;
         if (!frame.EndSameAsBegin)
         {
-            var m = frame.EndRe.Match(input, from);
-            return m.Success ? m : null;
+            return NextMatch(frame.EndRe, input, from, cache);
         }
 
         var expected = beginCapture.AsSpan();

--- a/tests/Meziantou.Framework.SyntaxHighlighting.Tests/LargeInputTests.cs
+++ b/tests/Meziantou.Framework.SyntaxHighlighting.Tests/LargeInputTests.cs
@@ -1,0 +1,53 @@
+namespace Meziantou.Framework.SyntaxHighlighting.Tests;
+
+/// <summary>
+/// Every other test in this project highlights a snippet of a few dozen bytes, so none of them
+/// notice how the tokenizer scales. This one does: it highlights a document of a realistic size
+/// and fails if that takes an unreasonable amount of time. The budget is deliberately loose — the
+/// point is to catch a return to super-linear scanning, not to measure throughput.
+/// </summary>
+public sealed class LargeInputTests
+{
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(10);
+
+    [Theory]
+    [InlineData("bash")]
+    [InlineData("bnf")]
+    [InlineData("cpp")]
+    [InlineData("csharp")]
+    [InlineData("css")]
+    [InlineData("dockerfile")]
+    [InlineData("dos")]
+    [InlineData("fsharp")]
+    [InlineData("graphql")]
+    [InlineData("html")]
+    [InlineData("http")]
+    [InlineData("ini")]
+    [InlineData("javascript")]
+    [InlineData("json")]
+    [InlineData("less")]
+    [InlineData("markdown")]
+    [InlineData("msil")]
+    [InlineData("nginx")]
+    [InlineData("php")]
+    [InlineData("powershell")]
+    [InlineData("razor")]
+    [InlineData("scss")]
+    [InlineData("sql")]
+    [InlineData("typescript")]
+    [InlineData("urlencoded")]
+    [InlineData("vbnet")]
+    [InlineData("x86asm")]
+    [InlineData("xml")]
+    [InlineData("yaml")]
+    public async Task Highlight_LargeDocument_CompletesInReasonableTime(string language)
+    {
+        const string Line = "public int Method(int a) { return a + 1; } /* note */ \"text\" 'c' <T> @name #tag\n";
+        var code = string.Concat(Enumerable.Repeat(Line, 800));
+
+        var highlight = Task.Run(() => SyntaxHighlighter.Highlight(code, language));
+        var finished = await Task.WhenAny(highlight, Task.Delay(Budget)) == highlight;
+
+        Assert.True(finished, $"Highlighting {code.Length} characters of '{language}' did not finish within {Budget.TotalSeconds:F0}s.");
+    }
+}


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/syntaxhighlighting-guard-loop-bound` · merge #2132 first**

## Problem

`FindNextHit` (`Engine/Tokenizer.cs:95-141`) re-scans the remaining input **from scratch, for every child mode, after every token**. `child.BeginRe.Match(input, from)` and the end-regex walk up the stack each restart at the cursor and scan forward to the next match. With *t* tokens and *c* child modes that is O(t · c · n) — quadratic in document size. Upstream highlight.js avoids this by compiling all child `begin` patterns into one alternated regex driven by `lastIndex`.

The effect on ordinary files is severe. Highlighting this repository's own sources:

| Language | Input | Time on `main` |
|---|---|---|
| C# (`RegexRoundTripFuzzTests.cs`) | 6.3 KB | 104 ms |
| SCSS | 27.5 KB | 20.7 s |
| TypeScript | 36.5 KB | 49.9 s |
| YAML | 11.5 KB | **> 120 s** |

Doubling the input multiplies time by 4–5×. The existing suite never noticed because all 4237 fixtures are a few dozen bytes and the whole run takes 1.7 s.

## Changes

Memoize each pattern's next match for the duration of one run.

A match found at index `i` while scanning from `f` is still the leftmost match for any start in `[f, i]` — there is nothing in between, or it would have been found first — so the scan can be skipped until the cursor passes it. A pattern that did not match from `f` cannot match from any later start either.

Two subtleties, both handled and commented in the code:

- The cursor can move **backwards** (`ReturnBegin`/`ReturnEnd`), so a start before the memoized scan origin falls through to a real scan.
- The cache is keyed by the `Regex` instance, not the mode — a mode's begin/end/illegal patterns are different regexes and must not share a slot. (Keying by mode was a bug in my first draft; it silently changed output on `#!/bin/bash` and Markdown headings.)

`EndSameAsBegin` end-matching is left on the uncached path, since it filters candidates by capture value.

## Verification

**Output is byte-identical.** I compared this engine against `main`'s over 1,270 inputs — every `.cs`/`.css`/`.json`/`.yml`/`.md`/`.csproj`/`.editorconfig` file in this repository under 8 KB, plus adversarial edge cases across all 29 languages:

```
mismatches: 0 / 1270
total  baseline=2.15s  memoized=0.48s   speedup=4.5x
```

On a 64 KB document:

| Language | `main` | This PR |
|---|---|---|
| TypeScript | 49.4 s | **55 ms** |
| JavaScript | 40.4 s | **49 ms** |
| YAML | 25.8 s | **22 ms** |
| PowerShell | 25.6 s | **20 ms** |
| C++ | 10.0 s | **27 ms** |
| C# | 3.1 s | **39 ms** |

Growth is now near-linear rather than quadratic.

`LargeInputTests` adds one theory case per language: highlight a 64 KB document, fail if it takes over 10 seconds. The budget is deliberately loose — it catches a return to super-linear scanning, not throughput. On `main` it would fail for TypeScript, JavaScript, YAML, PowerShell and C++; here every language finishes in 3–55 ms, and the whole suite still runs in 1.7 s.

Build clean with `-p:TreatWarningsAsErrors=true -p:ContinuousIntegrationBuild=true`; 4269 tests pass (4237 + 3 from #2132 + 29).

## Note on the alternative

Combining each mode's child `begin` patterns into a single alternated regex, as upstream does, would be faster still, but it is a much larger change and needs the group-numbering rework in `Compiler.CountCapturingGroups`. This gets most of the win for ~40 lines.

---
Found during a review of `src/Meziantou.Framework.SyntaxHighlighting`.
