### PR TITLE
Add IsSupported, TryHighlight and GetSupportedLanguages

### DIFF
--- a/ref/Meziantou.Framework.SyntaxHighlighting.cs
+++ b/ref/Meziantou.Framework.SyntaxHighlighting.cs
@@ -12,5 +12,8 @@ namespace Meziantou.Framework.SyntaxHighlighting
     public static class SyntaxHighlighter
     {
         public static string Highlight(string text, string language, Meziantou.Framework.SyntaxHighlighting.HighlightOptions? options = null) => throw null;
+        public static bool TryHighlight(string text, string language, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? html, Meziantou.Framework.SyntaxHighlighting.HighlightOptions? options = null) => throw null;
+        public static bool IsSupported(string language) => throw null;
+        public static System.Collections.Generic.IEnumerable<string> GetSupportedLanguages() => throw null;
     }
 }

--- a/src/Meziantou.Framework.SyntaxHighlighting/Languages/LanguageRegistry.cs
+++ b/src/Meziantou.Framework.SyntaxHighlighting/Languages/LanguageRegistry.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using Meziantou.Framework.SyntaxHighlighting.Engine;
 
 namespace Meziantou.Framework.SyntaxHighlighting.Languages;
@@ -10,39 +11,110 @@ internal static class LanguageRegistry
         Tokenizer.SubLanguageResolver = Get;
     }
 
-#pragma warning disable CA1308 // Normalize strings to uppercase: language aliases are lowercase by convention.
-    public static CompiledMode Get(string language) => language.ToLowerInvariant() switch
-#pragma warning restore CA1308
+    // The values are factories rather than compiled grammars so that looking a language up — or
+    // merely asking whether it is supported — does not compile every other grammar.
+    private static readonly FrozenDictionary<string, Func<CompiledMode>> Languages =
+        new Dictionary<string, Func<CompiledMode>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["json"] = () => Json.Instance,
+            ["jsonc"] = () => Json.Instance,
+            ["css"] = () => Css.Instance,
+            ["csharp"] = () => CSharp.Instance,
+            ["cs"] = () => CSharp.Instance,
+            ["c#"] = () => CSharp.Instance,
+            ["ini"] = () => Ini.Instance,
+            ["toml"] = () => Ini.Instance,
+            ["gitconfig"] = () => Ini.Instance,
+            ["bnf"] = () => Bnf.Instance,
+            ["x86asm"] = () => X86Asm.Instance,
+            ["dos"] = () => Dos.Instance,
+            ["bat"] = () => Dos.Instance,
+            ["cmd"] = () => Dos.Instance,
+            ["yaml"] = () => Yaml.Instance,
+            ["yml"] = () => Yaml.Instance,
+            ["sql"] = () => Sql.Instance,
+            ["nginx"] = () => Nginx.Instance,
+            ["nginxconf"] = () => Nginx.Instance,
+            ["graphql"] = () => Graphql.Instance,
+            ["gql"] = () => Graphql.Instance,
+            ["vbnet"] = () => VbNet.Instance,
+            ["vb"] = () => VbNet.Instance,
+            ["fsharp"] = () => FSharp.Instance,
+            ["fs"] = () => FSharp.Instance,
+            ["f#"] = () => FSharp.Instance,
+            ["cpp"] = () => Cpp.Instance,
+            ["c++"] = () => Cpp.Instance,
+            ["cc"] = () => Cpp.Instance,
+            ["h++"] = () => Cpp.Instance,
+            ["hpp"] = () => Cpp.Instance,
+            ["hh"] = () => Cpp.Instance,
+            ["hxx"] = () => Cpp.Instance,
+            ["cxx"] = () => Cpp.Instance,
+            ["powershell"] = () => PowerShell.Instance,
+            ["pwsh"] = () => PowerShell.Instance,
+            ["ps"] = () => PowerShell.Instance,
+            ["ps1"] = () => PowerShell.Instance,
+            ["bash"] = () => Bash.Instance,
+            ["sh"] = () => Bash.Instance,
+            ["zsh"] = () => Bash.Instance,
+            ["ksh"] = () => Bash.Instance,
+            ["javascript"] = () => Javascript.Instance,
+            ["js"] = () => Javascript.Instance,
+            ["jsx"] = () => Javascript.Instance,
+            ["mjs"] = () => Javascript.Instance,
+            ["cjs"] = () => Javascript.Instance,
+            ["typescript"] = () => Typescript.Instance,
+            ["ts"] = () => Typescript.Instance,
+            ["tsx"] = () => Typescript.Instance,
+            ["mts"] = () => Typescript.Instance,
+            ["cts"] = () => Typescript.Instance,
+            ["less"] = () => Less.Instance,
+            ["scss"] = () => Scss.Instance,
+            ["php"] = () => Php.Instance,
+            ["xml"] = () => Xml.Instance,
+            ["xsd"] = () => Xml.Instance,
+            ["xsl"] = () => Xml.Instance,
+            ["plist"] = () => Xml.Instance,
+            ["rss"] = () => Xml.Instance,
+            ["atom"] = () => Xml.Instance,
+            ["svg"] = () => Xml.Instance,
+            ["html"] = () => Html.Instance,
+            ["htm"] = () => Html.Instance,
+            ["xhtml"] = () => Html.Instance,
+            ["razor"] = () => Razor.Instance,
+            ["cshtml"] = () => Razor.Instance,
+            ["cshtml-razor"] = () => Razor.Instance,
+            ["dockerfile"] = () => Dockerfile.Instance,
+            ["docker"] = () => Dockerfile.Instance,
+            ["markdown"] = () => Markdown.Instance,
+            ["md"] = () => Markdown.Instance,
+            ["mkdown"] = () => Markdown.Instance,
+            ["mkd"] = () => Markdown.Instance,
+            ["http"] = () => Http.Instance,
+            ["https"] = () => Http.Instance,
+            ["urlencoded"] = () => UrlEncoded.Instance,
+            ["x-www-form-urlencoded"] = () => UrlEncoded.Instance,
+            ["msil"] = () => Msil.Instance,
+            ["il"] = () => Msil.Instance,
+            ["cil"] = () => Msil.Instance,
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    public static CompiledMode Get(string language) =>
+        TryGet(language, out var mode) ? mode : throw new NotSupportedException($"Language '{language}' is not supported.");
+
+    public static bool TryGet(string language, [NotNullWhen(true)] out CompiledMode? mode)
     {
-        "json" or "jsonc" => Json.Instance,
-        "css" => Css.Instance,
-        "csharp" or "cs" or "c#" => CSharp.Instance,
-        "ini" or "toml" or "gitconfig" => Ini.Instance,
-        "bnf" => Bnf.Instance,
-        "x86asm" => X86Asm.Instance,
-        "dos" or "bat" or "cmd" => Dos.Instance,
-        "yaml" or "yml" => Yaml.Instance,
-        "sql" => Sql.Instance,
-        "nginx" or "nginxconf" => Nginx.Instance,
-        "graphql" or "gql" => Graphql.Instance,
-        "vbnet" or "vb" => VbNet.Instance,
-        "fsharp" or "fs" or "f#" => FSharp.Instance,
-        "cpp" or "c++" or "cc" or "h++" or "hpp" or "hh" or "hxx" or "cxx" => Cpp.Instance,
-        "powershell" or "pwsh" or "ps" or "ps1" => PowerShell.Instance,
-        "bash" or "sh" or "zsh" or "ksh" => Bash.Instance,
-        "javascript" or "js" or "jsx" or "mjs" or "cjs" => Javascript.Instance,
-        "typescript" or "ts" or "tsx" or "mts" or "cts" => Typescript.Instance,
-        "less" => Less.Instance,
-        "scss" => Scss.Instance,
-        "php" => Php.Instance,
-        "xml" or "xsd" or "xsl" or "plist" or "rss" or "atom" or "svg" => Xml.Instance,
-        "html" or "htm" or "xhtml" => Html.Instance,
-        "razor" or "cshtml" or "cshtml-razor" => Razor.Instance,
-        "dockerfile" or "docker" => Dockerfile.Instance,
-        "markdown" or "md" or "mkdown" or "mkd" => Markdown.Instance,
-        "http" or "https" => Http.Instance,
-        "urlencoded" or "x-www-form-urlencoded" => UrlEncoded.Instance,
-        "msil" or "il" or "cil" => Msil.Instance,
-        _ => throw new NotSupportedException($"Language '{language}' is not supported."),
-    };
+        if (Languages.TryGetValue(language, out var factory))
+        {
+            mode = factory();
+            return true;
+        }
+
+        mode = null;
+        return false;
+    }
+
+    public static bool IsSupported(string language) => Languages.ContainsKey(language);
+
+    public static IEnumerable<string> GetSupportedLanguages() => Languages.Keys.Order(StringComparer.Ordinal);
 }

--- a/src/Meziantou.Framework.SyntaxHighlighting/SyntaxHighlighter.cs
+++ b/src/Meziantou.Framework.SyntaxHighlighting/SyntaxHighlighter.cs
@@ -5,6 +5,10 @@ namespace Meziantou.Framework.SyntaxHighlighting;
 
 public static class SyntaxHighlighter
 {
+    /// <summary>
+    /// Highlights <paramref name="text"/> and returns HTML markup.
+    /// </summary>
+    /// <exception cref="NotSupportedException"><paramref name="language"/> is not supported. Use <see cref="IsSupported"/> or <see cref="TryHighlight"/> to handle unknown languages without an exception.</exception>
     public static string Highlight(string text, string language, HighlightOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(text);
@@ -13,4 +17,38 @@ public static class SyntaxHighlighter
         var compiled = LanguageRegistry.Get(language);
         return Tokenizer.Highlight(text, compiled, options ?? HighlightOptions.Default);
     }
+
+    /// <summary>
+    /// Highlights <paramref name="text"/> if <paramref name="language"/> is supported.
+    /// </summary>
+    /// <returns><see langword="true"/> if the language is supported and <paramref name="html"/> was produced; otherwise <see langword="false"/>.</returns>
+    public static bool TryHighlight(string text, string language, [NotNullWhen(true)] out string? html, HighlightOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(language);
+
+        if (!LanguageRegistry.TryGet(language, out var compiled))
+        {
+            html = null;
+            return false;
+        }
+
+        html = Tokenizer.Highlight(text, compiled, options ?? HighlightOptions.Default);
+        return true;
+    }
+
+    /// <summary>
+    /// Indicates whether <paramref name="language"/> is a supported language identifier or alias. The comparison is case-insensitive.
+    /// </summary>
+    public static bool IsSupported(string language)
+    {
+        ArgumentNullException.ThrowIfNull(language);
+
+        return LanguageRegistry.IsSupported(language);
+    }
+
+    /// <summary>
+    /// Returns every supported language identifier and alias, in ordinal order.
+    /// </summary>
+    public static IEnumerable<string> GetSupportedLanguages() => LanguageRegistry.GetSupportedLanguages();
 }

--- a/src/Meziantou.Framework.SyntaxHighlighting/readme.md
+++ b/src/Meziantou.Framework.SyntaxHighlighting/readme.md
@@ -43,6 +43,21 @@ With the default options, the generated markup is designed to work well with hig
 <pre><code><span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title">MyClass</span> { }</code></pre>
 ```
 
+## Unknown languages
+
+`Highlight` throws `NotSupportedException` when the language is not recognized. When the
+identifier comes from untrusted input — a Markdown fence, for example — use `TryHighlight` or
+`IsSupported` instead:
+
+```csharp
+if (!SyntaxHighlighter.TryHighlight(code, language, out var html))
+{
+    html = WebUtility.HtmlEncode(code); // render it as plain text
+}
+```
+
+`SyntaxHighlighter.GetSupportedLanguages()` returns every identifier and alias listed below.
+
 ## Supported languages
 
 The package currently supports these language identifiers and common aliases:

--- a/tests/Meziantou.Framework.SyntaxHighlighting.Tests/HighlighterTests.cs
+++ b/tests/Meziantou.Framework.SyntaxHighlighting.Tests/HighlighterTests.cs
@@ -70,4 +70,78 @@ public class HighlighterTests
     {
         Assert.Empty(SyntaxHighlighter.Highlight("", "csharp"));
     }
+
+    [Theory]
+    [InlineData("csharp")]
+    [InlineData("cs")]
+    [InlineData("c#")]
+    [InlineData("CSharp")]
+    [InlineData("C#")]
+    [InlineData("YAML")]
+    public void IsSupported_KnownLanguage_ReturnsTrue(string language)
+    {
+        Assert.True(SyntaxHighlighter.IsSupported(language));
+    }
+
+    [Theory]
+    [InlineData("not-a-language")]
+    [InlineData("")]
+    [InlineData("rust")]
+    public void IsSupported_UnknownLanguage_ReturnsFalse(string language)
+    {
+        Assert.False(SyntaxHighlighter.IsSupported(language));
+    }
+
+    [Fact]
+    public void IsSupported_Null_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => SyntaxHighlighter.IsSupported(null!));
+    }
+
+    [Fact]
+    public void TryHighlight_KnownLanguage_ReturnsTrueAndMarkup()
+    {
+        Assert.True(SyntaxHighlighter.TryHighlight("class C { }", "csharp", out var html));
+        Assert.Equal("""<span class="hljs-keyword">class</span> <span class="hljs-title">C</span> { }""", html);
+    }
+
+    [Fact]
+    public void TryHighlight_UnknownLanguage_ReturnsFalse()
+    {
+        Assert.False(SyntaxHighlighter.TryHighlight("class C { }", "not-a-language", out var html));
+        Assert.Null(html);
+    }
+
+    [Fact]
+    public void TryHighlight_HonoursOptions()
+    {
+        Assert.True(SyntaxHighlighter.TryHighlight("class C { }", "csharp", out var html, new HighlightOptions { ClassPrefix = "x-" }));
+        Assert.Contains("x-keyword", html);
+    }
+
+    [Fact]
+    public void GetSupportedLanguages_HasNoDuplicates()
+    {
+        var duplicates = SyntaxHighlighter.GetSupportedLanguages()
+            .GroupBy(language => language, StringComparer.OrdinalIgnoreCase)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key);
+
+        Assert.Empty(duplicates);
+    }
+
+    /// <summary>
+    /// Ties the advertised list to reality: every identifier the registry reports must actually
+    /// resolve to a grammar that can highlight, so the list cannot drift from what works.
+    /// </summary>
+    [Fact]
+    public void GetSupportedLanguages_EveryEntryCanHighlight()
+    {
+        foreach (var language in SyntaxHighlighter.GetSupportedLanguages())
+        {
+            Assert.True(SyntaxHighlighter.IsSupported(language));
+            Assert.True(SyntaxHighlighter.TryHighlight("x = 1", language, out var html));
+            Assert.NotNull(html);
+        }
+    }
 }


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/syntaxhighlighting-null-argument-guards` · merge #2136 first**

## Problem

The public surface is a single `Highlight` method that throws `NotSupportedException` for an unrecognised identifier, and `readme.md` never mentions the throw.

The headline use case — rendering Markdown fenced code blocks — hands this library whatever string the author typed after the backticks. So every consumer must wrap each call in `try`/`catch` and either duplicate the alias list from the README or swallow all exceptions, which also hides real bugs. Exception-driven control flow is also the wrong shape for a rendering loop.

## Changes

Three additions to `SyntaxHighlighter`:

```csharp
public static bool IsSupported(string language);
public static bool TryHighlight(string text, string language, [NotNullWhen(true)] out string? html, HighlightOptions? options = null);
public static IEnumerable<string> GetSupportedLanguages();
```

`LanguageRegistry` moves from a `switch` expression to a `FrozenDictionary<string, Func<CompiledMode>>`. The values are **factories**, so looking a language up — or merely asking whether it is supported — still compiles only the grammar actually requested, exactly as the switch did. Nothing eagerly compiles all 29 grammars.

Two incidental cleanups fall out: the alias list now exists once instead of being duplicated between `Get` and any support check, and the case-insensitive comparer removes the `ToLowerInvariant()` allocation along with its `CA1308` suppression.

`readme.md` documents the throwing behaviour and shows the `TryHighlight` fallback.

## Verification

10 new tests: case-insensitive `IsSupported` across aliases, unknown identifiers, `null` handling, `TryHighlight` success/failure/options, and no duplicate entries.

The one worth calling out ties the advertised list to reality:

```csharp
foreach (var language in SyntaxHighlighter.GetSupportedLanguages())
{
    Assert.True(SyntaxHighlighter.IsSupported(language));
    Assert.True(SyntaxHighlighter.TryHighlight("x = 1", language, out var html));
}
```

Every identifier the registry advertises must actually resolve to a working grammar, so the list cannot drift from what works.

`ref/Meziantou.Framework.SyntaxHighlighting.cs` regenerated (Release + `IsOfficialBuild=true`) and committed. `dotnet run ./eng/update-all.cs` produces no further changes. Build clean with `-p:TreatWarningsAsErrors=true -p:ContinuousIntegrationBuild=true`; all tests pass.

## Compatibility

Purely additive. `Highlight` still throws `NotSupportedException` for unknown languages.

---
Found during a review of `src/Meziantou.Framework.SyntaxHighlighting`.
