### PR TITLE
Guard the public Highlight arguments against null

### DIFF
--- a/src/Meziantou.Framework.SyntaxHighlighting/SyntaxHighlighter.cs
+++ b/src/Meziantou.Framework.SyntaxHighlighting/SyntaxHighlighter.cs
@@ -7,6 +7,9 @@ public static class SyntaxHighlighter
 {
     public static string Highlight(string text, string language, HighlightOptions? options = null)
     {
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(language);
+
         var compiled = LanguageRegistry.Get(language);
         return Tokenizer.Highlight(text, compiled, options ?? HighlightOptions.Default);
     }

--- a/tests/Meziantou.Framework.SyntaxHighlighting.Tests/HighlighterTests.cs
+++ b/tests/Meziantou.Framework.SyntaxHighlighting.Tests/HighlighterTests.cs
@@ -42,4 +42,32 @@ public class HighlighterTests
         Assert.DoesNotContain("hljs-keyword", customResult);
         Assert.Equal(defaultResult, defaultResult2);
     }
+
+    [Fact]
+    public void Highlight_NullText_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => SyntaxHighlighter.Highlight(text: null!, "csharp"));
+
+        Assert.Equal("text", exception.ParamName);
+    }
+
+    [Fact]
+    public void Highlight_NullLanguage_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => SyntaxHighlighter.Highlight("class C { }", language: null!));
+
+        Assert.Equal("language", exception.ParamName);
+    }
+
+    [Fact]
+    public void Highlight_UnknownLanguage_ThrowsNotSupportedException()
+    {
+        Assert.Throws<NotSupportedException>(() => SyntaxHighlighter.Highlight("class C { }", "not-a-language"));
+    }
+
+    [Fact]
+    public void Highlight_EmptyText_ReturnsEmptyString()
+    {
+        Assert.Empty(SyntaxHighlighter.Highlight("", "csharp"));
+    }
 }


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2135**

## Problem

Neither parameter of the only public method is guarded. `text: null` happens to produce a reasonable `ArgumentNullException` from a framework call further in — but it names the *internal* parameter:

```
text=null  -> System.ArgumentNullException: Value cannot be null. (Parameter 'input')
lang=null  -> System.NullReferenceException: Object reference not set to an instance of an object.
```

`language: null` gives a bare `NullReferenceException` from `language.ToLowerInvariant()` in `LanguageRegistry.Get`.

## Changes

`ArgumentNullException.ThrowIfNull` for both parameters at the public entry point. This also makes the `text` exception report `text` rather than the internal `input`.

## Verification

4 new tests in `HighlighterTests.cs` — null `text` and null `language` (asserting the `ParamName`), unknown language throwing `NotSupportedException`, and empty text returning an empty string. Before this change the project had **no** `Assert.Throws` anywhere, so all of these error paths were untested.

Build clean with `-p:TreatWarningsAsErrors=true -p:ContinuousIntegrationBuild=true`; all tests pass.

No public API shape change, so `ref/` is untouched.

---
Found during a review of `src/Meziantou.Framework.SyntaxHighlighting`.
