### PR TITLE
Probe the xunit v3 assert assembly when creating assertion exceptions

### DIFF
--- a/src/Meziantou.Framework.InlineSnapshotTesting/AssertionExceptionBuilder.cs
+++ b/src/Meziantou.Framework.InlineSnapshotTesting/AssertionExceptionBuilder.cs
@@ -15,16 +15,18 @@ public class AssertionExceptionBuilder
     {
         // Try to find the current runner exception.
         // These exceptions are better formatted in the test output.
-        var xunitAssertionType = Type.GetType("Xunit.Sdk.XunitException, xunit.assert");
-        if (xunitAssertionType != null)
+        // xunit v3 renamed the assert assembly, so both names must be probed.
+        var xunitAssertionType = Type.GetType("Xunit.Sdk.XunitException, xunit.v3.assert") ??
+                                 Type.GetType("Xunit.Sdk.XunitException, xunit.assert");
+        if (xunitAssertionType is not null)
             return (Exception)Activator.CreateInstance(xunitAssertionType, message)!;
 
         var nunitAssertionType = Type.GetType("NUnit.Framework.AssertionException, nunit.framework");
-        if (nunitAssertionType != null)
+        if (nunitAssertionType is not null)
             return (Exception)Activator.CreateInstance(nunitAssertionType, message)!;
 
         var msTestV2AssertionType = Type.GetType("Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException, Microsoft.VisualStudio.TestPlatform.TestFramework");
-        if (msTestV2AssertionType != null)
+        if (msTestV2AssertionType is not null)
             return (Exception)Activator.CreateInstance(msTestV2AssertionType, message)!;
 
         return new InlineSnapshotAssertionException(message);

--- a/src/Meziantou.Framework.SnapshotTesting/AssertionExceptionBuilder.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/AssertionExceptionBuilder.cs
@@ -15,16 +15,18 @@ public class AssertionExceptionBuilder
     {
         // Try to find the current runner exception.
         // These exceptions are better formatted in the test output.
-        var xunitAssertionType = Type.GetType("Xunit.Sdk.XunitException, xunit.assert");
-        if (xunitAssertionType != null)
+        // xunit v3 renamed the assert assembly, so both names must be probed.
+        var xunitAssertionType = Type.GetType("Xunit.Sdk.XunitException, xunit.v3.assert") ??
+                                 Type.GetType("Xunit.Sdk.XunitException, xunit.assert");
+        if (xunitAssertionType is not null)
             return (Exception)Activator.CreateInstance(xunitAssertionType, message)!;
 
         var nunitAssertionType = Type.GetType("NUnit.Framework.AssertionException, nunit.framework");
-        if (nunitAssertionType != null)
+        if (nunitAssertionType is not null)
             return (Exception)Activator.CreateInstance(nunitAssertionType, message)!;
 
         var msTestV2AssertionType = Type.GetType("Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException, Microsoft.VisualStudio.TestPlatform.TestFramework");
-        if (msTestV2AssertionType != null)
+        if (msTestV2AssertionType is not null)
             return (Exception)Activator.CreateInstance(msTestV2AssertionType, message)!;
 
         return new SnapshotAssertionException(message);

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Meziantou.Framework.SnapshotTesting.MergeTools;
+using Xunit.Sdk;
 
 namespace Meziantou.Framework.SnapshotTesting.Tests;
 
@@ -912,6 +913,15 @@ public sealed partial class SnapshotTests
         Assert.Contains("To update snapshots automatically, re-run the test with SNAPSHOTTESTING_STRATEGY=Overwrite (or OverwriteWithoutFailure).", exception.Message);
         Assert.True(File.Exists(actualPath0));
         Assert.True(File.Exists(actualPath1));
+    }
+
+    [Fact]
+    public void DefaultAssertionExceptionBuilder_UsesTheXunitExceptionType()
+    {
+        var exception = AssertionExceptionBuilder.Default.CreateException("the message");
+
+        Assert.IsType<XunitException>(exception);
+        Assert.Equal("the message", exception.Message);
     }
 
     [Theory]


### PR DESCRIPTION
`AssertionExceptionBuilder.CreateException` looks up the xunit exception type with:

```csharp
var xunitAssertionType = Type.GetType("Xunit.Sdk.XunitException, xunit.assert");
```

xunit v3 renamed the assert assembly to `xunit.v3.assert`, so under xunit v3 this
`Type.GetType` returns `null`, the NUnit and MSTest probes also fail, and every snapshot
assertion falls back to `SnapshotAssertionException` — losing the runner-specific
formatting the class exists to provide.

This is the primary target: the readme advertises xunit v3 support
(`src/Meziantou.Framework.SnapshotTesting/readme.md:95`) and this repository's own test
projects run on xunit v3.

## What changed

- Probe `xunit.v3.assert` first, falling back to `xunit.assert` for consumers still on
  xunit v2, in both `Meziantou.Framework.SnapshotTesting` and
  `Meziantou.Framework.InlineSnapshotTesting` (the file is duplicated between the two
  packages).
- Replaced the three `!= null` checks with `is not null`, per `AGENTS.md`.
- Added `SnapshotTests.DefaultAssertionExceptionBuilder_UsesTheXunitExceptionType`.

## Why there was no test

Every existing test substitutes `FixedAssertionExceptionBuilder`
(`SnapshotTests.cs:1172`, `:1186`), which returns `SnapshotAssertionException`
unconditionally — so the fallback and the working path were indistinguishable and the
default builder was never exercised. The new test covers the default builder directly.

## Verification

Confirmed the new test fails against the old code (returns `SnapshotAssertionException`)
and passes with the fix.

```
dotnet build slnx/Meziantou.Framework.SnapshotTesting.slnx /p:TreatsWarningsAsErrors=true   # 0 warnings, 0 errors
dotnet test tests/Meziantou.Framework.SnapshotTesting.Tests --filter-not-class "*EndToEnd*" # 115/115 passed
```
