### PR TITLE
Pass a StringComparison to WhitespaceTrimmingComparer

### DIFF
--- a/src/Meziantou.Framework.TextDiff/TextDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiff.cs
@@ -2,8 +2,8 @@ namespace Meziantou.Framework;
 
 public static class TextDiff
 {
-    private static readonly IEqualityComparer<string> OrdinalWhitespaceComparer = new WhitespaceTrimmingComparer(StringComparer.Ordinal);
-    private static readonly IEqualityComparer<string> OrdinalIgnoreCaseWhitespaceComparer = new WhitespaceTrimmingComparer(StringComparer.OrdinalIgnoreCase);
+    private static readonly IEqualityComparer<string> OrdinalWhitespaceComparer = new WhitespaceTrimmingComparer(StringComparison.Ordinal);
+    private static readonly IEqualityComparer<string> OrdinalIgnoreCaseWhitespaceComparer = new WhitespaceTrimmingComparer(StringComparison.OrdinalIgnoreCase);
 
     public static TextDiffResult ComputeDiff(string oldText, string newText, TextDiffOptions? options = null)
     {
@@ -231,9 +231,9 @@ public static class TextDiff
         return chunkerArray;
     }
 
-    private sealed class WhitespaceTrimmingComparer(StringComparer inner) : IEqualityComparer<string>
+    private sealed class WhitespaceTrimmingComparer(StringComparison comparison) : IEqualityComparer<string>
     {
-        private readonly StringComparison _comparison = inner == StringComparer.OrdinalIgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        private readonly StringComparison _comparison = comparison;
 
         public bool Equals(string? x, string? y)
         {


### PR DESCRIPTION
`WhitespaceTrimmingComparer` took a `StringComparer` but never used it to compare
anything. It only reference-compared it against the `OrdinalIgnoreCase` singleton to
recover a `StringComparison`, then discarded it:

```csharp
private sealed class WhitespaceTrimmingComparer(StringComparer inner) : IEqualityComparer<string>
{
    private readonly StringComparison _comparison = inner == StringComparer.OrdinalIgnoreCase
        ? StringComparison.OrdinalIgnoreCase
        : StringComparison.Ordinal;
```

Any `StringComparer` other than that exact singleton — `StringComparer.Create(culture, ignoreCase)`,
`StringComparer.InvariantCultureIgnoreCase`, a custom one — silently degraded to `Ordinal`.

Nothing is broken today: the class is private and both call sites
(`TextDiff.cs:5-6`) pass the exact singletons the check expects. This is a latent
trap, not a live bug — the signature invites passing any comparer and quietly
ignores it.

## What changed

The constructor takes a `StringComparison` directly, which is the only thing the
class ever wanted. The reference comparison is gone, and with it the possibility
of a caller's comparer being ignored.

## Verification

No behaviour change — the two call sites resolve to exactly the same
`StringComparison` values they did before.

`dotnet test -c Release /p:TreatsWarningsAsErrors=true` → **192 passed, 0 failed.**

Both comparer paths are already covered by existing tests, so no new test accompanies
this one: `ComputeDiff_IgnoreWhitespace_NoDifferences` exercises the `Ordinal` path and
`ComputeDiff_IgnoreCaseAndWhitespace` the `OrdinalIgnoreCase` path.

---

Found during a review of `Meziantou.Framework.TextDiff` (finding L2).
