### PR TITLE
Keep the counting filter's hash accumulator at the hash-half width

### DIFF
--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilter.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilter.cs
@@ -71,7 +71,7 @@ public abstract partial class CountingBloomFilter
     private protected int GetEstimatedCountHash(Hash32 hash) => GetEstimatedCountHashCore32(hash.Hash1, hash.Hash2);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void AddHashCore(ulong hash1, ulong hash2)
+    private void AddHashCore(uint hash1, uint hash2)
     {
         var counterCount = (ulong)Counters.CounterCount;
         var combined = hash1;
@@ -86,7 +86,7 @@ public abstract partial class CountingBloomFilter
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void RemoveHashCore(ulong hash1, ulong hash2)
+    private void RemoveHashCore(uint hash1, uint hash2)
     {
         var counterCount = (ulong)Counters.CounterCount;
         var combined = hash1;
@@ -101,7 +101,7 @@ public abstract partial class CountingBloomFilter
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int GetEstimatedCountHashCore(ulong hash1, ulong hash2)
+    private int GetEstimatedCountHashCore(uint hash1, uint hash2)
     {
         var counterCount = (ulong)Counters.CounterCount;
         var combined = hash1;
@@ -166,6 +166,9 @@ public abstract partial class CountingBloomFilter
         return result;
     }
 
+    // Each Reduce overload shifts by the width of its hash argument, so the accumulator passed in must
+    // keep the width of the hash halves it came from. Widening a 32-bit half to ulong would select the
+    // 64-bit overload and shift the whole hash away, mapping every value to index 0.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static long Reduce(ulong hash, ulong range) => (long)(((UInt128)hash * range) >> 64);
 

--- a/tests/Meziantou.Framework.BloomFilters.Tests/BloomFilterTests.cs
+++ b/tests/Meziantou.Framework.BloomFilters.Tests/BloomFilterTests.cs
@@ -251,6 +251,40 @@ public sealed class BloomFilterTests
         Assert.All(unsignedValues, value => Assert.False(filter.MayContain(value)));
     }
 
+    [Theory]
+    [InlineData(nameof(CountingBloomFilter.CreateXXHash128))]
+    [InlineData(nameof(CountingBloomFilter.CreateXXHash64))]
+    [InlineData(nameof(CountingBloomFilter.CreateXXHash3))]
+    [InlineData(nameof(CountingBloomFilter.CreateCrc64))]
+    public void CountingBloomFilter_FalsePositiveRate_StaysNearTarget(string createMethodName)
+    {
+        const int ItemCount = 10_000;
+        const int ProbeCount = 100_000;
+        const double FalsePositiveProbability = 0.01;
+
+        var size = CountingBloomFilterSize.CreateOptimalSize(ItemCount, FalsePositiveProbability);
+        var filter = (ICountingBloomFilter)typeof(CountingBloomFilter).GetMethod(createMethodName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!.Invoke(null, [size])!;
+        for (var value = 0; value < ItemCount; value++)
+        {
+            filter.Add(value);
+        }
+
+        var falsePositiveCount = 0;
+        for (var value = ItemCount; value < ItemCount + ProbeCount; value++)
+        {
+            if (filter.MayContain(value))
+            {
+                falsePositiveCount++;
+            }
+        }
+
+        Assert.InRange((double)falsePositiveCount / ProbeCount, 0, FalsePositiveProbability * 3);
+
+        // A value inserted once must not be reported as inserted thousands of times. When every hash
+        // reduces to the same counter, this returns the total number of increments issued instead.
+        Assert.InRange(filter.GetEstimatedCount(0), 1, 5);
+    }
+
     [Fact]
     public void CountingBloomFilterSize_CreateOptimalSize_MatchesBloomFilterSize()
     {


### PR DESCRIPTION
## The problem

`CountingBloomFilter.AddHash(Hash64)` forwards `Hash64`'s two **`uint`** halves into `AddHashCore(ulong hash1, ulong hash2)`. The implicit widening makes the accumulator a `ulong`, so overload resolution picks

```csharp
private static long Reduce(ulong hash, ulong range) => (long)(((UInt128)hash * range) >> 64);
```

With `hash < 2^32` and `range < 2^32` that product never reaches 2^64, so **the reduction always returns 0**. Every value maps to counter index 0, for every 64-bit algorithm.

Measured at `CountingBloomFilterSize.CreateOptimalSize(10_000, 0.01)` — 95,851 counters, k=7 — after inserting 1,000 distinct values (7,000 increments issued):

| Factory | non-zero counters | false-positive rate | `GetEstimatedCount` for an item added once |
|---|---|---|---|
| `CreateXXHash128` | 6,734 / 95,851 | 1.02% | 1 |
| `CreateXXHash64` | **1** / 95,851 | **100.00%** | 70,000 |
| `CreateXXHash3` | **1** / 95,851 | **100.00%** | 70,000 |
| `CreateCrc64` | **1** / 95,851 | **100.00%** | 70,000 |

The user-visible damage, using the algorithm the readme's counting example picks:

```csharp
var f = CountingBloomFilter.CreateXXHash3(CountingBloomFilterSize.CreateOptimalSize(10_000, 0.01));
f.Add("alice");
f.MayContain("bob");   // true  — never added
f.Remove("bob");       // decrements alice's counters
f.MayContain("alice"); // false — silently lost
```

That last line breaks the one guarantee a Bloom filter makes: false positives are allowed, false negatives are not.

`BloomFilter` does not have this bug — `AddHash(Hash64)` there keeps the accumulator at `uint` (`var combined = hash.Hash1;`) and picks the `Reduce(uint, ulong)` overload correctly. Only the `CountingBloomFilter` refactor into `…Core` helpers widened the parameters.

## The change

Narrow `AddHashCore`, `RemoveHashCore` and `GetEstimatedCountHashCore` from `(ulong, ulong)` to `(uint, uint)`, so `Hash64`'s halves keep their own width and select `Reduce(uint, ulong)` — matching what `BloomFilter` already does. Plus a comment at the `Reduce` overloads explaining why the parameter widths are load-bearing, since the failure mode is silent and the compiler is happy either way.

## Scope

This fixes the **64-bit** algorithms only: `CreateXXHash64`, `CreateXXHash3`, `CreateCrc64`.

`CreateXXHash32` / `CreateCrc32` have the same shape one size down — `Hash32`'s `ushort` halves widened into `AddHashCore32(uint, uint)`, reaching only 11 distinct counters — but the right fix there is to give the 32-bit hash more entropy in `Hash32` itself rather than to narrow another helper, so it is a separate PR that touches `Hash32.cs` and leaves this file alone. The two are independent and can merge in either order.

## Verification

New `CountingBloomFilter_FalsePositiveRate_StaysNearTarget` inserts 10,000 values into a filter sized for a 1% false-positive rate, probes 100,000 absent values, and asserts the observed rate stays under 3%. It also asserts `GetEstimatedCount` for a value inserted once stays in 1..5 — on the broken code it returns the total increment count. Inputs are fixed integers, so the test is deterministic, not statistical.

Confirmed it catches the bug: with this commit's source change reverted, the three 64-bit cases fail and `CreateXXHash128` (the control) passes. With the fix, all four pass.

`dotnet test` — **992 passed, 0 failed** (496 × net10.0/net11.0), warnings as errors. `dotnet run ./eng/update-all.cs` reports no changes.
