### PR TITLE
Validate TextDiffOptions.Algorithm at the public entry points

### DIFF
--- a/src/Meziantou.Framework.TextDiff/TextDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiff.cs
@@ -11,13 +11,13 @@ public static class TextDiff
         ArgumentNullException.ThrowIfNull(newText);
 
         options ??= new TextDiffOptions();
+        ValidateOptions(options);
 
         var processedOld = options.IgnoreEndOfLine ? NormalizeLineEndings(oldText) : oldText;
         var processedNew = options.IgnoreEndOfLine ? NormalizeLineEndings(newText) : newText;
 
-        var chunker = options.Chunker ?? TextChunker.Lines;
-        var oldChunks = ToArray(chunker.Chunk(processedOld));
-        var newChunks = ToArray(chunker.Chunk(processedNew));
+        var oldChunks = ToArray(options.Chunker.Chunk(processedOld));
+        var newChunks = ToArray(options.Chunker.Chunk(processedNew));
 
         var comparer = BuildComparer(options);
         var diff = DiffAlgorithmDispatcher.Compute(options.Algorithm, oldChunks, newChunks, comparer);
@@ -32,6 +32,7 @@ public static class TextDiff
         ArgumentNullException.ThrowIfNull(chunkers);
 
         options ??= new TextDiffOptions();
+        ValidateOptions(options);
 
         var chunkerArray = ValidateChunkers(chunkers);
         var processedOld = options.IgnoreEndOfLine ? NormalizeLineEndings(oldText) : oldText;
@@ -39,6 +40,12 @@ public static class TextDiff
 
         var comparer = BuildComparer(options);
         return ComputeHierarchyDiffCore(processedOld, processedNew, chunkerArray, chunkerIndex: 0, options, comparer);
+    }
+
+    private static void ValidateOptions(TextDiffOptions options)
+    {
+        if (!Enum.IsDefined(options.Algorithm))
+            throw new ArgumentOutOfRangeException(nameof(options), options.Algorithm, $"'{nameof(TextDiffOptions.Algorithm)}' is not a valid {nameof(TextDiffAlgorithm)} value.");
     }
 
     private static IEqualityComparer<string> BuildComparer(TextDiffOptions options)

--- a/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
+++ b/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
@@ -585,6 +585,32 @@ public sealed class TextDiffTests
     }
 
     [Fact]
+    public void ComputeDiff_InvalidAlgorithm_ThrowsWithTheOptionsParamName()
+    {
+        var options = new TextDiffOptions { Algorithm = (TextDiffAlgorithm)99 };
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Diff.ComputeDiff("a", "b", options));
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Fact]
+    public void ComputeHierarchyDiff_InvalidAlgorithm_ThrowsWithTheOptionsParamName()
+    {
+        var options = new TextDiffOptions { Algorithm = (TextDiffAlgorithm)99 };
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(
+            () => Diff.ComputeHierarchyDiff("a", "b", [TextChunker.Lines, TextChunker.Words], options));
+        Assert.Equal("options", exception.ParamName);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllAlgorithms))]
+    public void ComputeDiff_DefinedAlgorithm_DoesNotThrow(TextDiffAlgorithm algorithm)
+    {
+        var result = Diff.ComputeDiff("a", "b", new TextDiffOptions { Algorithm = algorithm });
+
+        Assert.True(result.HasDifferences);
+    }
+
+    [Fact]
     public void ComputeHierarchyDiff_NullChunkers_Throws()
     {
         Assert.Throws<ArgumentNullException>(() => Diff.ComputeHierarchyDiff("a", "b", chunkers: null!));


### PR DESCRIPTION
Two small argument-handling problems at the public entry points, both in
`TextDiff.cs`.

## 1. An invalid `Algorithm` blamed a parameter the caller never passed

`ComputeDiff("a", "b", new TextDiffOptions { Algorithm = (TextDiffAlgorithm)7 })` threw
from `DiffAlgorithmDispatcher.cs:13` with `ParamName = "algorithm"`. The public method's
parameters are `oldText`, `newText` and `options` — there is no `algorithm` parameter for
the caller to go looking for.

`options.Algorithm` is now validated in both `ComputeDiff` and `ComputeHierarchyDiff`
before any work happens, and the exception names `options`. The dispatcher's `default`
arm stays as an unreachable guard, since the `switch` expression needs one anyway.

`ComputeHierarchyDiff` previously did not surface an invalid algorithm until it had
already normalized line endings and validated the chunkers; it now fails up front like
`ComputeDiff` does.

## 2. Dead null-check on a non-nullable property

```csharp
var chunker = options.Chunker ?? TextChunker.Lines;
```

`TextDiffOptions.Chunker` is declared non-nullable and initialized to `TextChunker.Lines`
(`TextDiffOptions.cs:11`), so the `??` was unreachable per the type system. What it did do
was silently accept `options.Chunker = null!` and quietly fall back to line chunking
instead of failing.

`AGENTS.md` says: *"Trust the C# null annotations and don't add null checks when the type
system says a value cannot be null."* The `??` is gone.

**Behaviour note:** a caller who forces `Chunker = null!` through the non-nullable property
now gets a `NullReferenceException` instead of silent line chunking. That is a deliberate
trade — the type system already says it cannot be null, and silently substituting a
different chunker hides the caller's bug rather than surfacing it.

## Verification

`dotnet test -c Release /p:TreatsWarningsAsErrors=true` → **204 passed, 0 failed** (192
before, +12 from the new tests across both target frameworks).

New tests:
- `ComputeDiff_InvalidAlgorithm_ThrowsWithTheOptionsParamName`
- `ComputeHierarchyDiff_InvalidAlgorithm_ThrowsWithTheOptionsParamName`
- `ComputeDiff_DefinedAlgorithm_DoesNotThrow` — over all four algorithms, so the new
  `Enum.IsDefined` guard cannot reject a valid one.

No new test accompanies the `??` removal: it is unreachable code, and the chunker paths it
guarded are already covered by `ComputeDiff_CustomChunker` and the corpus tests.

---

Found during a review of `Meziantou.Framework.TextDiff` (findings L3 and L4). Grouped into
one PR because both are argument handling in `ComputeDiff`, four lines apart.
