### PR TITLE
Resolve the MSBuild task without MinimumTargetFramework in cross-targeting builds

### DIFF
--- a/src/Meziantou.Framework.PublicApiGenerator.MSBuild/buildMultiTargeting/Meziantou.Framework.PublicApiGenerator.MSBuild.targets
+++ b/src/Meziantou.Framework.PublicApiGenerator.MSBuild/buildMultiTargeting/Meziantou.Framework.PublicApiGenerator.MSBuild.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <_PublicApiGeneratorTaskAssemblyPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'tasks', '$(MinimumTargetFramework)', 'Meziantou.Framework.PublicApiGenerator.MSBuild.dll'))</_PublicApiGeneratorTaskAssemblyPath>
+    <_PublicApiGeneratorTaskAssemblyPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'tasks', 'Meziantou.Framework.PublicApiGenerator.MSBuild.dll'))</_PublicApiGeneratorTaskAssemblyPath>
     <_PublicApiGeneratorResolvedOutputPath Condition="'$(PublicApiGeneratorOutputPath)' != ''">$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(PublicApiGeneratorOutputPath)'))</_PublicApiGeneratorResolvedOutputPath>
     <_PublicApiGeneratorEnabled Condition="'$(PublicApiGeneratorGenerateOnBuild)' == 'true' or '$(PublicApiGeneratorVerifyNoChangeOnBuild)' == 'true'">true</_PublicApiGeneratorEnabled>
   </PropertyGroup>

--- a/tests/Meziantou.Framework.PublicApiGenerator.MSBuild.Tests/PublicApiGeneratorMsBuildTests.cs
+++ b/tests/Meziantou.Framework.PublicApiGenerator.MSBuild.Tests/PublicApiGeneratorMsBuildTests.cs
@@ -163,6 +163,45 @@ public sealed class PublicApiGeneratorMsBuildTests(PublicApiGeneratorMsBuildPack
     }
 
     [Fact]
+    public async Task GenerateOnBuild_MultiTarget_ConsumerDefinesMinimumTargetFramework()
+    {
+        await using var temporaryDirectory = TemporaryDirectory.Create();
+        var projectDirectory = temporaryDirectory.CreateDirectory("multi-minimum-tfm");
+        CreateGlobalJson(projectDirectory, fixture.DotnetSdkVersion);
+        CreateNuGetConfig(projectDirectory, fixture.PackagesDirectory);
+
+        // MinimumTargetFramework is defined by several custom SDKs. The task must be resolved regardless of its value.
+        temporaryDirectory.CreateTextFile("multi-minimum-tfm/Sample.csproj", $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFrameworks>net10.0;net11.0</TargetFrameworks>
+                <MinimumTargetFramework>net10.0</MinimumTargetFramework>
+                <PublicApiGeneratorOutputPath>obj/PublicApi/PublicApi.g.cs</PublicApiGeneratorOutputPath>
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="Meziantou.Framework.PublicApiGenerator.MSBuild" Version="{{fixture.PackageVersion}}" PrivateAssets="all" />
+              </ItemGroup>
+            </Project>
+            """);
+        temporaryDirectory.CreateTextFile("multi-minimum-tfm/Sample.cs", """
+            public class Sample
+            {
+                public void A()
+                {
+                }
+            }
+            """);
+
+        await RunDotNetCommand(projectDirectory, ["restore", "--disable-build-servers"], expectedExitCode: 0);
+        await RunDotNetCommand(projectDirectory, ["build", "--no-restore", "--disable-build-servers", "-nologo"], expectedExitCode: 0);
+
+        var generatedFilePath = projectDirectory / "obj" / "PublicApi" / "PublicApi.g.cs";
+        Assert.True(File.Exists(generatedFilePath));
+        Assert.Contains("public void A() { }", await File.ReadAllTextAsync(generatedFilePath, XunitCancellationToken));
+    }
+
+    [Fact]
     public async Task GenerateOnBuild_MissingOutputPath_FailsBuild()
     {
         await using var temporaryDirectory = TemporaryDirectory.Create();


### PR DESCRIPTION
Cross-targeting projects that define a `MinimumTargetFramework` property fail their build with `MSB4036`.

## The defect

`buildMultiTargeting/Meziantou.Framework.PublicApiGenerator.MSBuild.targets:3` resolved the task assembly through a consumer-visible property:

```xml
$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'tasks', '$(MinimumTargetFramework)', '...dll'))
```

The package has no per-framework subfolder — `Meziantou.Framework.PublicApiGenerator.MSBuild.csproj:20-23` packs the task to `tasks/`, and the packed nupkg contains exactly `tasks/Meziantou.Framework.PublicApiGenerator.MSBuild.dll`. The path only resolved because `MinimumTargetFramework` is normally empty and `NormalizePath` collapses the empty segment.

Set the property — as any project built on a custom SDK that defines it does, including this repository's own — and `Exists(...)` on the `UsingTask` goes false, the task is never registered, and the build fails:

```
buildMultiTargeting/Meziantou.Framework.PublicApiGenerator.MSBuild.targets(37,5):
error MSB4036: The "GeneratePublicApiTask" task was not found.
```

Cross-targeting is the only case `buildMultiTargeting/` exists for, so the whole multi-target path is affected. `build/…targets` already used the correct `tasks/` path, which is why single-target builds were unaffected.

## The change

Drop `$(MinimumTargetFramework)` from the path so both targets files agree on `../tasks/`.

Adds `GenerateOnBuild_MultiTarget_ConsumerDefinesMinimumTargetFramework`, which builds a `net10.0;net11.0` consumer with the property set. The existing multi-target test could not catch this: its consumer is a plain `Microsoft.NET.Sdk` project, so the property is empty and the broken path silently resolved.

## Verification

- New test fails on `main` with the `MSB4036` above; passes with the fix.
- Full suite: 9/9 passing (`dotnet test … MSBuild.Tests -f net10.0`).
- `dotnet run ./eng/update-all.cs` produced no changes.

Found during a review of the PublicApiGenerator projects.
