### PR TITLE
Expand the 32-bit hash to 64 bits before deriving filter positions

### DIFF
--- a/src/Meziantou.Framework.BloomFilters/BloomFilter.cs
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilter.cs
@@ -123,7 +123,4 @@ public abstract partial class BloomFilter
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static long Reduce(uint hash, ulong range) => (long)(((UInt128)hash * range) >> 32);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static long Reduce(ushort hash, ulong range) => (long)(((UInt128)hash * range) >> 16);
 }

--- a/src/Meziantou.Framework.BloomFilters/Hash32.cs
+++ b/src/Meziantou.Framework.BloomFilters/Hash32.cs
@@ -5,13 +5,31 @@ namespace Meziantou.Framework.BloomFilters;
 [StructLayout(LayoutKind.Auto)]
 internal readonly struct Hash32
 {
-    public readonly ushort Hash1;
-    public readonly ushort Hash2;
+    public readonly uint Hash1;
+    public readonly uint Hash2;
 
     public Hash32(uint value)
     {
-        Hash1 = (ushort)value;
-        var hash2 = (ushort)(value >> 16);
-        Hash2 = hash2 == 0 ? (ushort)0x9E37 : hash2; // Golden ratio
+        // Splitting a 32-bit hash into two 16-bit halves leaves only 16 bits of index entropy, which caps
+        // the number of reachable positions at 65,536 whatever the filter size is. Expand the hash to
+        // 64 bits first so both halves are full width.
+        var expanded = Expand(value);
+        Hash1 = (uint)expanded;
+        var hash2 = (uint)(expanded >> 32);
+
+        // The i-th position is derived as Hash1 + i * Hash2 in modular arithmetic, so an even step has a
+        // cycle shorter than the word size and revisits positions. Keep the step odd for a full period.
+        Hash2 = hash2 == 0 ? 0x9E3779B9U : hash2 | 1; // Golden ratio
+    }
+
+    /// <summary>
+    /// Spreads a 32-bit value over 64 bits using the splitmix64 finalizer.
+    /// </summary>
+    private static ulong Expand(uint value)
+    {
+        var result = value + 0x9E3779B97F4A7C15UL;
+        result = (result ^ (result >> 30)) * 0xBF58476D1CE4E5B9UL;
+        result = (result ^ (result >> 27)) * 0x94D049BB133111EBUL;
+        return result ^ (result >> 31);
     }
 }

--- a/tests/Meziantou.Framework.BloomFilters.Tests/BloomFilterTests.cs
+++ b/tests/Meziantou.Framework.BloomFilters.Tests/BloomFilterTests.cs
@@ -114,6 +114,66 @@ public sealed class BloomFilterTests
         Assert.InRange(filter.GetEstimateCount(), ItemCount * 0.95, ItemCount * 1.05);
     }
 
+    [Theory]
+    [InlineData(nameof(BloomFilter.CreateXXHash32))]
+    [InlineData(nameof(BloomFilter.CreateCrc32))]
+    public void BloomFilter32_FalsePositiveRate_StaysNearTarget(string createMethodName)
+    {
+        const int ItemCount = 10_000;
+        const int ProbeCount = 100_000;
+        const double FalsePositiveProbability = 0.01;
+
+        var size = BloomFilterSize.CreateOptimalSize(ItemCount, FalsePositiveProbability);
+        var filter = (IBloomFilter)typeof(BloomFilter).GetMethod(createMethodName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!.Invoke(null, [size])!;
+        for (var value = 0; value < ItemCount; value++)
+        {
+            filter.Add(value);
+        }
+
+        var falsePositiveCount = 0;
+        for (var value = ItemCount; value < ItemCount + ProbeCount; value++)
+        {
+            if (filter.MayContain(value))
+            {
+                falsePositiveCount++;
+            }
+        }
+
+        Assert.InRange((double)falsePositiveCount / ProbeCount, 0, FalsePositiveProbability * 3);
+
+        // Too few reachable positions also skews the set-bit count the estimate is derived from.
+        Assert.InRange(filter.GetEstimateCount(), ItemCount * 0.9, ItemCount * 1.1);
+    }
+
+    [Theory]
+    [InlineData(nameof(CountingBloomFilter.CreateXXHash32))]
+    [InlineData(nameof(CountingBloomFilter.CreateCrc32))]
+    public void CountingBloomFilter32_FalsePositiveRate_StaysNearTarget(string createMethodName)
+    {
+        const int ItemCount = 10_000;
+        const int ProbeCount = 100_000;
+        const double FalsePositiveProbability = 0.01;
+
+        var size = CountingBloomFilterSize.CreateOptimalSize(ItemCount, FalsePositiveProbability);
+        var filter = (ICountingBloomFilter)typeof(CountingBloomFilter).GetMethod(createMethodName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!.Invoke(null, [size])!;
+        for (var value = 0; value < ItemCount; value++)
+        {
+            filter.Add(value);
+        }
+
+        var falsePositiveCount = 0;
+        for (var value = ItemCount; value < ItemCount + ProbeCount; value++)
+        {
+            if (filter.MayContain(value))
+            {
+                falsePositiveCount++;
+            }
+        }
+
+        Assert.InRange((double)falsePositiveCount / ProbeCount, 0, FalsePositiveProbability * 3);
+        Assert.InRange(filter.GetEstimatedCount(0), 1, 5);
+    }
+
     [Fact]
     public void XXHash32_AddRange_ThenMayContain_ReturnsTrue()
     {


### PR DESCRIPTION
## The problem

`Hash32` splits a 32-bit hash into two **`ushort`** halves. `BloomFilter.AddHash(Hash32)` then infers a `ushort` accumulator (`var combined = hash.Hash1;`), `combined += hash.Hash2` truncates mod 2^16, and `Reduce(ushort, ulong)` shifts by 16. The whole index pipeline runs at 16-bit width, so **at most 65,536 distinct positions exist no matter how large the bit array is**.

On a 10,000,000-bit filter with k=1, inserting 2,000,000 distinct integers sets exactly 65,536 bits — the ceiling — against ~1,813,000 for the 64/128-bit variants.

False-positive rate against a 1% target:

| items | `CreateXXHash32` | `CreateCrc32` | `CreateXXHash3` (reference) |
|---|---|---|---|
| 1,000 | 0.96% | 1.04% | 1.04% |
| 10,000 | **5.32%** | **5.32%** | 1.04% |
| 100,000 | **99.97%** | **100.00%** | 1.02% |

`GetEstimateCount()` is wrong in the same proportion — a 32-bit filter holding 100,000 items reports ~9,700.

This is the worst failure shape: acceptable at the readme's 1,000-item example, then silently falling apart an order of magnitude later with no error.

## The change

Expand the 32-bit hash to 64 bits with the splitmix64 finalizer before splitting it, and hold the halves as `uint`. `Reduce(ushort, ulong)` in `BloomFilter` becomes unreachable and is removed; the `Add`/`MayContain` loop bodies are untouched — `var combined` now simply infers `uint` and binds to the existing `Reduce(uint, ulong)`.

While rewriting the derivation, the new step is forced odd (`hash2 | 1`). The positions are `Hash1 + i * Hash2` in modular arithmetic, so an even step has a cycle shorter than the word size and revisits positions — a value could set as few as 2 of its 7 bits. The existing zero-substitution constants are already odd, so they are unchanged.

The expansion does not create entropy that a 32-bit hash lacks: two inputs that collide at 32 bits still collide completely. That is inherent to choosing a 32-bit algorithm. What it fixes is that a *single* hash value can now address the whole filter instead of 1/65,536 of it.

## Also fixes the 32-bit counting filters

`CountingBloomFilter.AddHash(Hash32)` forwards into `AddHashCore32(uint, uint)` and reduces with `Reduce(uint, ulong)`. That code is already correct — it was being fed `ushort` values, which is why only 11 of 95,851 counters were reachable and the false-positive rate was 100%. Widening `Hash32`'s fields fixes it with no change to `CountingBloomFilter.cs`.

The 64-bit counting algorithms have a different bug in that file (`ulong` parameters selecting the wrong `Reduce`); that is #2141, which touches only `CountingBloomFilter.cs`. The two PRs are independent and can merge in either order.

## Verification

After this change, on a 10,000,000-bit filter with k=1 and 2,000,000 distinct inserts: `CreateXXHash32` reaches **1,812,609** distinct positions (was 65,536), `CreateCrc32` **1,812,828** — in line with the 64/128-bit variants.

False-positive rate after the fix:

| items | `CreateXXHash32` | `CreateCrc32` |
|---|---|---|
| 10,000 | 0.95% | 0.98% |
| 100,000 | **0.97%** | **0.99%** |

Two new tests, `BloomFilter32_FalsePositiveRate_StaysNearTarget` and `CountingBloomFilter32_FalsePositiveRate_StaysNearTarget`, insert 10,000 values into a filter sized for 1%, probe 100,000 absent values, and assert the observed rate stays under 3%; the plain-filter one also asserts `GetEstimateCount()` lands within 10% of the true count. Inputs are fixed integers, so they are deterministic rather than statistical.

Confirmed they catch the bug: with this commit's source changes reverted, all four cases fail. With the fix, all four pass.

`dotnet test` — **992 passed, 0 failed** (496 × net10.0/net11.0), warnings as errors. `dotnet run ./eng/update-all.cs` reports no changes.
