### PR TITLE
Expose the new-side chunk on TextDiffEntry

### DIFF
--- a/ref/Meziantou.Framework.TextDiff.cs
+++ b/ref/Meziantou.Framework.TextDiff.cs
@@ -29,8 +29,11 @@ namespace Meziantou.Framework
     public readonly struct TextDiffEntry : System.IEquatable<Meziantou.Framework.TextDiffEntry>
     {
         public Meziantou.Framework.TextDiffOperation Operation { get => throw null; }
+        public string? OldText { get => throw null; }
+        public string? NewText { get => throw null; }
         public string Text { get => throw null; }
         public TextDiffEntry(Meziantou.Framework.TextDiffOperation operation, string text) { }
+        public TextDiffEntry(Meziantou.Framework.TextDiffOperation operation, string? oldText, string? newText) { }
         public bool Equals(Meziantou.Framework.TextDiffEntry other) => throw null;
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? obj) => throw null;
         public override int GetHashCode() => throw null;

--- a/src/Meziantou.Framework.TextDiff/TextDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiff.cs
@@ -68,7 +68,8 @@ public static class TextDiff
                 && !leftModified[lineLeft]
                 && !rightModified[lineRight])
             {
-                entries.Add(new TextDiffEntry(TextDiffOperation.Equal, oldChunks[lineLeft]));
+                // The comparison options can make two different chunks equal, so keep both sides.
+                entries.Add(new TextDiffEntry(TextDiffOperation.Equal, oldChunks[lineLeft], newChunks[lineRight]));
                 lineLeft++;
                 lineRight++;
             }

--- a/src/Meziantou.Framework.TextDiff/TextDiffEntry.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiffEntry.cs
@@ -8,20 +8,55 @@ public readonly struct TextDiffEntry : IEquatable<TextDiffEntry>
     public TextDiffEntry(TextDiffOperation operation, string text)
     {
         Operation = operation;
-        Text = text;
+        OldText = operation is TextDiffOperation.Insert ? null : text;
+        NewText = operation is TextDiffOperation.Delete ? null : text;
+    }
+
+    public TextDiffEntry(TextDiffOperation operation, string? oldText, string? newText)
+    {
+        Operation = operation;
+        OldText = oldText;
+        NewText = newText;
     }
 
     public TextDiffOperation Operation { get; }
 
-    public string Text { get; }
+    /// <summary>
+    /// Gets the chunk as it appears in the old text, or <see langword="null"/> when <see cref="Operation"/> is
+    /// <see cref="TextDiffOperation.Insert"/>.
+    /// </summary>
+    public string? OldText { get; }
+
+    /// <summary>
+    /// Gets the chunk as it appears in the new text, or <see langword="null"/> when <see cref="Operation"/> is
+    /// <see cref="TextDiffOperation.Delete"/>.
+    /// </summary>
+    /// <remarks>
+    /// When an option such as <see cref="TextDiffOptions.IgnoreCase"/> or <see cref="TextDiffOptions.IgnoreWhitespace"/>
+    /// makes two different chunks compare equal, an <see cref="TextDiffOperation.Equal"/> entry keeps both sides:
+    /// <see cref="OldText"/> and <see cref="NewText"/> then differ. Append <see cref="NewText"/> for
+    /// <see cref="TextDiffOperation.Equal"/> and <see cref="TextDiffOperation.Insert"/> entries to rebuild the new text.
+    /// </remarks>
+    public string? NewText { get; }
+
+    /// <summary>
+    /// Gets <see cref="OldText"/>, or <see cref="NewText"/> when <see cref="Operation"/> is
+    /// <see cref="TextDiffOperation.Insert"/>.
+    /// </summary>
+    /// <remarks>
+    /// For an <see cref="TextDiffOperation.Equal"/> entry this is the chunk from the <em>old</em> text, which is not
+    /// necessarily the chunk from the new text. Use <see cref="OldText"/> and <see cref="NewText"/> to rebuild either
+    /// side of the diff.
+    /// </remarks>
+    public string Text => (OldText ?? NewText)!;
 
     public bool Equals(TextDiffEntry other)
-        => Operation == other.Operation && Text == other.Text;
+        => Operation == other.Operation && OldText == other.OldText && NewText == other.NewText;
 
     public override bool Equals([NotNullWhen(true)] object? obj)
         => obj is TextDiffEntry other && Equals(other);
 
-    public override int GetHashCode() => HashCode.Combine(Operation, Text);
+    public override int GetHashCode() => HashCode.Combine(Operation, OldText, NewText);
 
     public static bool operator ==(TextDiffEntry left, TextDiffEntry right) => left.Equals(right);
 

--- a/src/Meziantou.Framework.TextDiff/readme.md
+++ b/src/Meziantou.Framework.TextDiff/readme.md
@@ -22,6 +22,22 @@ foreach (var entry in result.Entries)
 }
 ````
 
+## Rebuild either side of the diff
+
+`Text` is the chunk from the old text (from the new text for an `Insert`). When a comparison
+option such as `IgnoreCase` makes two *different* chunks compare equal, `OldText` and
+`NewText` give the exact chunk from each side:
+
+````csharp
+var oldText = string.Concat(result.Entries
+    .Where(e => e.Operation is TextDiffOperation.Equal or TextDiffOperation.Delete)
+    .Select(e => e.OldText));
+
+var newText = string.Concat(result.Entries
+    .Where(e => e.Operation is TextDiffOperation.Equal or TextDiffOperation.Insert)
+    .Select(e => e.NewText));
+````
+
 ## Configure chunking and comparison
 
 ````csharp

--- a/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
+++ b/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
@@ -472,6 +472,103 @@ public sealed class TextDiffTests
     }
 
     // IgnoreCase tests
+    [Theory]
+    [MemberData(nameof(AllAlgorithms))]
+    [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Generating test inputs, and the fixed seed keeps the cases reproducible.")]
+    public void ComputeDiff_AllAlgorithms_IgnoreOptions_ReconstructsOldAndNewText(TextDiffAlgorithm algorithm)
+    {
+        var random = new Random(20260827);
+
+        foreach (var chunker in new[] { TextChunker.Lines, TextChunker.Words, TextChunker.Characters })
+        {
+            foreach (var ignoreCase in new[] { false, true })
+            {
+                foreach (var ignoreWhitespace in new[] { false, true })
+                {
+                    foreach (var ignoreEndOfLine in new[] { false, true })
+                    {
+                        var options = new TextDiffOptions
+                        {
+                            Algorithm = algorithm,
+                            Chunker = chunker,
+                            IgnoreCase = ignoreCase,
+                            IgnoreWhitespace = ignoreWhitespace,
+                            IgnoreEndOfLine = ignoreEndOfLine,
+                        };
+
+                        for (var iteration = 0; iteration < 10; iteration++)
+                        {
+                            var oldText = CreateNoisyText(random);
+                            var newText = CreateNoisyText(random);
+
+                            var result = Diff.ComputeDiff(oldText, newText, options);
+
+                            // IgnoreEndOfLine normalizes the input before chunking, so that is what the entries carry.
+                            var expectedOld = ignoreEndOfLine ? oldText.ReplaceLineEndings("\n") : oldText;
+                            var expectedNew = ignoreEndOfLine ? newText.ReplaceLineEndings("\n") : newText;
+
+                            Assert.Equal(expectedOld, ReconstructOldText(result));
+                            Assert.Equal(expectedNew, ReconstructNewText(result));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void ComputeDiff_IgnoreCase_EqualEntryKeepsBothSides()
+    {
+        var result = Diff.ComputeDiff("Hello\nWORLD", "hello\nworld", new TextDiffOptions { IgnoreCase = true });
+
+        Assert.False(result.HasDifferences);
+        Assert.Collection(
+            result.Entries,
+            entry =>
+            {
+                Assert.Equal(TextDiffOperation.Equal, entry.Operation);
+                Assert.Equal("Hello\n", entry.OldText);
+                Assert.Equal("hello\n", entry.NewText);
+                Assert.Equal("Hello\n", entry.Text);
+            },
+            entry =>
+            {
+                Assert.Equal(TextDiffOperation.Equal, entry.Operation);
+                Assert.Equal("WORLD", entry.OldText);
+                Assert.Equal("world", entry.NewText);
+                Assert.Equal("WORLD", entry.Text);
+            });
+    }
+
+    [Fact]
+    public void TextDiffEntry_DeleteAndInsert_ExposeOnlyTheirOwnSide()
+    {
+        var result = Diff.ComputeDiff("removed\ncommon", "added\ncommon");
+
+        var deleted = Assert.Single(result.Entries, e => e.Operation == TextDiffOperation.Delete);
+        Assert.Equal("removed\n", deleted.OldText);
+        Assert.Null(deleted.NewText);
+        Assert.Equal("removed\n", deleted.Text);
+
+        var inserted = Assert.Single(result.Entries, e => e.Operation == TextDiffOperation.Insert);
+        Assert.Null(inserted.OldText);
+        Assert.Equal("added\n", inserted.NewText);
+        Assert.Equal("added\n", inserted.Text);
+    }
+
+    [Fact]
+    public void TextDiffEntry_EqualityDistinguishesTheNewSide()
+    {
+        var a = new TextDiffEntry(TextDiffOperation.Equal, "Hello", "hello");
+        var b = new TextDiffEntry(TextDiffOperation.Equal, "Hello", "hello");
+        var c = new TextDiffEntry(TextDiffOperation.Equal, "Hello", "Hello");
+
+        Assert.Equal(a, b);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        Assert.NotEqual(a, c);
+        Assert.True(a != c);
+    }
+
     [Fact]
     public void ComputeDiff_IgnoreCase_NoDifferences()
     {
@@ -766,7 +863,7 @@ public sealed class TextDiffTests
         {
             if (entry.Operation is TextDiffOperation.Equal or TextDiffOperation.Delete)
             {
-                sb.Append(entry.Text);
+                sb.Append(entry.OldText);
             }
         }
 
@@ -780,7 +877,7 @@ public sealed class TextDiffTests
         {
             if (entry.Operation is TextDiffOperation.Equal or TextDiffOperation.Insert)
             {
-                sb.Append(entry.Text);
+                sb.Append(entry.NewText);
             }
         }
 
@@ -827,6 +924,27 @@ public sealed class TextDiffTests
         }
 
         return lines;
+    }
+
+    [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Generating test inputs, and the fixed seed keeps the cases reproducible.")]
+    private static string CreateNoisyText(Random random)
+    {
+        var builder = new StringBuilder();
+        var lineCount = random.Next(0, 8);
+        for (var line = 0; line < lineCount; line++)
+        {
+            var wordCount = random.Next(0, 4);
+            for (var word = 0; word < wordCount; word++)
+            {
+                var token = "tok" + random.Next(3).ToString(CultureInfo.InvariantCulture);
+                builder.Append(random.Next(2) is 0 ? token.ToUpperInvariant() : token);
+                builder.Append(' ', random.Next(1, 4));
+            }
+
+            builder.Append(random.Next(2) is 0 ? "\r\n" : "\n");
+        }
+
+        return builder.ToString();
     }
 
     private sealed record DiffCorpusCase(string Name, string OldText, string NewText, bool HasDifferences);


### PR DESCRIPTION
`TextDiffEntry` carried a single `Text`, and `BuildResult` filled it from the **old**
chunk for `Equal` entries (`TextDiff.cs:71`). So the standard way to render the right-hand
side of a diff — walk the entries and append `Equal` + `Insert` — did not reproduce the new
text whenever a comparison option made two *different* chunks compare equal.

```csharp
var result = TextDiff.ComputeDiff("Hello\nWORLD", "hello\nworld",
    new TextDiffOptions { IgnoreCase = true });

// entries: Equal:'Hello\n', Equal:'WORLD'
// Equal + Insert  =>  "Hello\nWORLD"   but the new text is "hello\nworld"
```

`IgnoreWhitespace` is worse than cosmetic: it makes chunks of *different lengths* compare
equal, so the reconstructed text comes out structurally wrong, with line breaks in the
wrong places. `IgnoreEndOfLine` normalizes before chunking, so the original `\r\n` never
appears in any entry.

Fuzzing 4 000 random inputs across all four algorithms and all three chunkers with random
ignore-option combinations reproduced this in **1 718 cases**. The same 4 000 inputs with
no ignore-options pass 100 %, which is why the existing suite never caught it — every
reconstruction assertion ran with default options.

## What changed

`TextDiffEntry` now mirrors `TextDiffHierarchyEntry`, which already had this right:

| | `OldText` | `NewText` |
|---|---|---|
| `Equal` | old chunk | new chunk |
| `Delete` | old chunk | `null` |
| `Insert` | `null` | new chunk |

`Text` is kept and unchanged — it returns `OldText`, or `NewText` for `Insert`, exactly as
before — so existing callers compile and behave identically. The API addition is purely
additive; `ref/Meziantou.Framework.TextDiff.cs` shows two new properties and one new
constructor.

Two behaviour changes worth calling out for review:

- **`Equals`/`GetHashCode` now include `NewText`.** Two `Equal` entries that agreed on the
  old chunk but differed on the new one used to compare equal; they no longer do. This is
  the point of the fix, but it is observable.
- **The existing two-argument constructor** sets the sides its operation implies
  (`Equal` → both, `Delete` → old only, `Insert` → new only), so `new TextDiffEntry(Equal, "A\n")`
  keeps meaning what it meant.

`ToString()` is deliberately untouched.

## Verification

`dotnet test -c Release /p:TreatsWarningsAsErrors=true` → **206 passed, 0 failed** (192
before, +14 from the new tests across both target frameworks).

I confirmed the new tests actually catch the bug by reverting the one-line fix in
`BuildResult` and re-running: `ComputeDiff_AllAlgorithms_IgnoreOptions_ReconstructsOldAndNewText`
fails for **all four** algorithms and `ComputeDiff_IgnoreCase_EqualEntryKeepsBothSides`
fails too.

New tests:
- `ComputeDiff_AllAlgorithms_IgnoreOptions_ReconstructsOldAndNewText` — the coverage gap
  that let this through. Runs the reconstruction invariant over algorithm × chunker × all
  eight ignore-option combinations, on generated input with mixed case, runs of spaces,
  mixed `\r\n`/`\n` and empty lines.
- `ComputeDiff_IgnoreCase_EqualEntryKeepsBothSides` — the minimal repro above.
- `TextDiffEntry_DeleteAndInsert_ExposeOnlyTheirOwnSide` — pins the `null` side.
- `TextDiffEntry_EqualityDistinguishesTheNewSide` — pins the equality change.

`ReconstructOldText`/`ReconstructNewText` in the test suite now read `OldText`/`NewText`
instead of `Text`, so every existing corpus and randomized test exercises the new
properties too.

`ref/Meziantou.Framework.TextDiff.cs` regenerated with a Release `IsOfficialBuild` build.

---

Found during a review of `Meziantou.Framework.TextDiff` (findings H1 and M3). M3 — "the
test suite never checks reconstruction with ignore-options" — is folded in here rather than
split out, because that coverage *is* the test that proves this fix.
