### PR TITLE
Reject optimal sizes that overflow instead of saturating them

### DIFF
--- a/src/Meziantou.Framework.BloomFilters/BloomFilterSize.cs
+++ b/src/Meziantou.Framework.BloomFilters/BloomFilterSize.cs
@@ -24,8 +24,16 @@ public readonly struct BloomFilterSize
         ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(falsePositiveProbability, 1);
 
         const double Ln2 = 0.6931471805599453d; // Math.Log(2)
-        var bitCount = (long)Math.Ceiling(-expectedItemCount * Math.Log(falsePositiveProbability) / (Ln2 * Ln2));
-        var hashCount = (int)Math.Ceiling((double)bitCount / expectedItemCount * Ln2);
+        var exactBitCount = Math.Ceiling(-expectedItemCount * Math.Log(falsePositiveProbability) / (Ln2 * Ln2));
+
+        // A double-to-long conversion saturates rather than overflowing, so without this check an
+        // oversized request silently returns long.MaxValue and, because the hash count is derived from
+        // it, a hash count of 1 instead of the correct value.
+        if (exactBitCount >= (double)long.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(expectedItemCount), expectedItemCount, "The optimal size for these parameters exceeds the maximum supported size. Lower expectedItemCount or raise falsePositiveProbability.");
+
+        var bitCount = (long)exactBitCount;
+        var hashCount = (int)Math.Ceiling(exactBitCount / expectedItemCount * Ln2);
 
         return new BloomFilterSize(bitCount, hashCount);
     }

--- a/src/Meziantou.Framework.BloomFilters/CountingBloomFilterSize.cs
+++ b/src/Meziantou.Framework.BloomFilters/CountingBloomFilterSize.cs
@@ -24,8 +24,16 @@ public readonly struct CountingBloomFilterSize
         ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(falsePositiveProbability, 1);
 
         const double Ln2 = 0.6931471805599453d; // Math.Log(2)
-        var counterCount = (long)Math.Ceiling(-expectedItemCount * Math.Log(falsePositiveProbability) / (Ln2 * Ln2));
-        var hashCount = (int)Math.Ceiling((double)counterCount / expectedItemCount * Ln2);
+        var exactCounterCount = Math.Ceiling(-expectedItemCount * Math.Log(falsePositiveProbability) / (Ln2 * Ln2));
+
+        // A double-to-long conversion saturates rather than overflowing, so without this check an
+        // oversized request silently returns long.MaxValue and, because the hash count is derived from
+        // it, a hash count of 1 instead of the correct value.
+        if (exactCounterCount >= (double)long.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(expectedItemCount), expectedItemCount, "The optimal size for these parameters exceeds the maximum supported size. Lower expectedItemCount or raise falsePositiveProbability.");
+
+        var counterCount = (long)exactCounterCount;
+        var hashCount = (int)Math.Ceiling(exactCounterCount / expectedItemCount * Ln2);
 
         return new CountingBloomFilterSize(counterCount, hashCount);
     }

--- a/tests/Meziantou.Framework.BloomFilters.Tests/BloomFilterTests.cs
+++ b/tests/Meziantou.Framework.BloomFilters.Tests/BloomFilterTests.cs
@@ -283,6 +283,30 @@ public sealed class BloomFilterTests
         Assert.Throws<ArgumentOutOfRangeException>(() => CountingBloomFilterSize.CreateOptimalSize(expectedItemCount, falsePositiveProbability));
     }
 
+    [Theory]
+    [InlineData(2_000_000_000_000_000_000L, 0.01)]
+    [InlineData(long.MaxValue, 0.01)]
+    [InlineData(long.MaxValue, 0.5)]
+    public void CreateOptimalSize_SizeExceedingLongMaxValue_Throws(long expectedItemCount, double falsePositiveProbability)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => BloomFilterSize.CreateOptimalSize(expectedItemCount, falsePositiveProbability));
+        Assert.Throws<ArgumentOutOfRangeException>(() => CountingBloomFilterSize.CreateOptimalSize(expectedItemCount, falsePositiveProbability));
+    }
+
+    [Fact]
+    public void CreateOptimalSize_LargestSupportedItemCount_KeepsHashCountCorrect()
+    {
+        const long ExpectedItemCount = 900_000_000_000_000_000L;
+
+        var size = BloomFilterSize.CreateOptimalSize(ExpectedItemCount, 0.01);
+        var countingSize = CountingBloomFilterSize.CreateOptimalSize(ExpectedItemCount, 0.01);
+
+        Assert.Equal(7, size.HashCount);
+        Assert.Equal(7, countingSize.HashCount);
+        Assert.InRange(size.BitCount, ExpectedItemCount * 9, ExpectedItemCount * 10);
+        Assert.Equal(size.BitCount, countingSize.CounterCount);
+    }
+
     private static IEnumerable<object> GetValues()
     {
         return


### PR DESCRIPTION
## The problem

`CreateOptimalSize` computes the bit count in `double` and casts to `long`. .NET **saturates** out-of-range floating-point-to-integer conversions rather than overflowing, so an oversized request returns a wrong answer with no error:

```csharp
var size = BloomFilterSize.CreateOptimalSize(long.MaxValue, 0.01);
// size.BitCount  == 9223372036854775807   (saturated)
// size.HashCount == 1                     (should be 7)
```

The hash count is the part that bites. It is derived from the already-saturated bit count:

```csharp
var hashCount = (int)Math.Ceiling((double)bitCount / expectedItemCount * Ln2);
```

so saturation silently corrupts it too — `k` collapses toward 1 as the requested size grows. A caller who computes `expectedItemCount` from a large upstream value gets a filter configured for a completely different false-positive rate than the one they asked for.

Passing the saturated size on to a factory then allocates a 134-million-entry jagged array and 8 GiB segments until the process is OOM-killed. I reproduced this: the run terminated with no exception surfaced, so there is nothing to catch or diagnose.

Both size structs have the identical code and the identical bug.

## The change

Keep the computed size in `double`, reject it before the cast, and derive the hash count from the unsaturated value so it stays correct for every size that is accepted.

The bound is `>= (double)long.MaxValue` rather than `>`, because `(double)long.MaxValue` rounds up to exactly 2^63 — one past the largest representable `long` — and would itself saturate on the way back.

## Scope

This fixes the silent wrong answer. It deliberately does **not** try to reject sizes that are merely too large to allocate: `CreateOptimalSize(100_000_000_000_000_000, 0.01)` returns an honest, in-range `BitCount` that will still exhaust memory at construction time. Capping that would mean picking an allocation policy, which is a separate decision from "don't return numbers that aren't the answer".

## Verification

`CreateOptimalSize_SizeExceedingLongMaxValue_Throws` covers three saturating inputs against both structs. `CreateOptimalSize_LargestSupportedItemCount_KeepsHashCountCorrect` pins the other side — 900,000,000,000,000,000 items at 1% is just under the limit, and must still return `HashCount == 7` with a bit count in the expected 9-10 bits/item band — so the new check can't drift into rejecting valid sizes.

Confirmed the tests catch the bug: with this commit's source changes reverted, all three throwing cases fail. With the fix, all pass.

`dotnet test` — **992 passed, 0 failed** (496 × net10.0/net11.0), warnings as errors. `dotnet run ./eng/update-all.cs` reports no changes.
