### PR TITLE
Report malformed image data as invalid data rather than overflow

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/Images/BmpImageLoader.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/BmpImageLoader.cs
@@ -55,7 +55,9 @@ internal static class BmpImageLoader
         var rowWithoutPadding = checked(width * bytesPerPixel);
         var rowStride = checked((rowWithoutPadding + 3) & ~3);
         var pixelDataSize = checked(rowStride * absoluteHeight);
-        if (pixelDataOffset + pixelDataSize > data.Length)
+        // Subtract rather than add: pixelDataOffset is already known to be inside the buffer, so this cannot
+        // overflow, whereas pixelDataOffset + pixelDataSize can and would then pass the check.
+        if (pixelDataSize > data.Length - pixelDataOffset)
             throw new InvalidDataException("The BMP pixel data is truncated.");
 
         var pixels = new Argb[checked(width * absoluteHeight)];

--- a/src/Meziantou.Framework.SnapshotTesting/Images/Image.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/Image.cs
@@ -33,7 +33,34 @@ internal sealed class Image : IEquatable<Image>
         return Load(data);
     }
 
+    /// <summary>
+    /// Decodes an image. Callers treat a decode failure as "these two snapshots differ", so every way a
+    /// malformed file can fail has to arrive as <see cref="InvalidDataException" /> or
+    /// <see cref="NotSupportedException" />. The decoders narrow file-supplied 32-bit values with checked
+    /// casts and index into the data with offsets derived from them, so an arithmetic or range failure is a
+    /// statement about the file rather than a bug.
+    /// </summary>
     internal static Image Load(ReadOnlySpan<byte> data)
+    {
+        try
+        {
+            return LoadCore(data);
+        }
+        catch (OverflowException ex)
+        {
+            throw new InvalidDataException("The image data contains an out-of-range value.", ex);
+        }
+        catch (IndexOutOfRangeException ex)
+        {
+            throw new InvalidDataException("The image data is truncated or inconsistent.", ex);
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            throw new InvalidDataException("The image data is truncated or inconsistent.", ex);
+        }
+    }
+
+    private static Image LoadCore(ReadOnlySpan<byte> data)
     {
         if (BmpImageLoader.IsBmp(data))
             return BmpImageLoader.Load(data);

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/BmpImageLoaderTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/BmpImageLoaderTests.cs
@@ -1,3 +1,5 @@
+using System.Buffers.Binary;
+
 namespace Meziantou.Framework.SnapshotTesting.Tests;
 
 public sealed class BmpImageLoaderTests
@@ -61,5 +63,30 @@ public sealed class BmpImageLoaderTests
         Assert.Equal(bmpImage.Height, pngImage.Height);
         Assert.Equal(bmpImage.Pixels.ToArray(), pngImage.Pixels.ToArray());
         Assert.Equal(bmpImage, pngImage);
+    }
+
+    [Fact]
+    public void Image_Load_ReportsInvalidDataForAnOutOfRangePixelDataOffset()
+    {
+        var imageData = ImageTestData.CreateBmp24(width: 1, height: 1, pixels: [0xFF112233u], pixelsPerMeter: 2835);
+
+        // The pixel data offset is a raw uint in the file header; the loader narrows it with a checked cast,
+        // which would otherwise surface as OverflowException.
+        BinaryPrimitives.WriteUInt32LittleEndian(imageData.AsSpan(10), uint.MaxValue);
+
+        var exception = Assert.Throws<InvalidDataException>(() => Image.Load(imageData));
+        Assert.IsType<OverflowException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void ImageComparer_ReportsADifferenceForCorruptImageData()
+    {
+        var expected = ImageTestData.CreateBmp24(width: 1, height: 1, pixels: [0xFF112233u], pixelsPerMeter: 2835);
+        var actual = ImageTestData.CreateBmp24(width: 1, height: 1, pixels: [0xFF112233u], pixelsPerMeter: 2835);
+        BinaryPrimitives.WriteUInt32LittleEndian(actual.AsSpan(10), uint.MaxValue);
+
+        var equal = ImageComparer.Instance.Equals(new SnapshotData("bmp", expected), new SnapshotData("bmp", actual));
+
+        Assert.False(equal);
     }
 }


### PR DESCRIPTION
`ImageComparer.Equals` treats a decode failure as "these snapshots differ", but its catch
list covers exactly two exception types:

```csharp
catch (InvalidDataException) { return false; }
catch (NotSupportedException) { return false; }
```

The decoders narrow file-supplied 32-bit values with `checked` casts, which throw
`OverflowException`. The shortest reproduction is a BMP whose pixel-data offset field
(bytes 10-13) is `FF FF FF FF`:

```csharp
var pixelDataOffset = checked((int)ReadUInt32LittleEndian(data, 10));   // BmpImageLoader.cs:27
```

`4294967295` does not fit in `int`, so the `OverflowException` propagates out of
`ImageComparer.Equals`, out of `SnapshotEngine.Compare`, and out of `Snapshot.Validate`.
The same shape exists at `TiffImageLoader.cs:67` (first IFD offset), `:188` (strip
offsets) and `IcoImageLoader.cs:97` (colors used).

A corrupted `.verified` image — a bad merge, a partial checkout, a file mangled by a
checkout filter — should read as "the snapshot does not match", which is actionable.
Instead it read as `System.OverflowException: Arithmetic operation resulted in an overflow`
with a stack inside an internal decoder.

Memory safety was never at risk: all reads go through bounds-checked spans. This is purely
about which exception reaches the user.

## What changed

- `Image.Load` now wraps the decoder dispatch and translates `OverflowException`,
  `IndexOutOfRangeException` and `ArgumentOutOfRangeException` into `InvalidDataException`,
  preserving the original as `InnerException`. Doing it at this one boundary covers every
  decoder, present and future, without a blanket catch in the comparer that would also
  swallow genuine bugs.
- Fixed a real overflow in the BMP bounds check itself: `pixelDataOffset + pixelDataSize >
  data.Length` can wrap to a negative value and pass. It now subtracts instead, which
  cannot overflow because `pixelDataOffset` is already known to be inside the buffer.

## Verification

Two tests added:

- `Image_Load_ReportsInvalidDataForAnOutOfRangePixelDataOffset` — asserts
  `InvalidDataException` **and** that the inner exception is the `OverflowException`, which
  confirms the failure was previously escaping rather than being avoided.
- `ImageComparer_ReportsADifferenceForCorruptImageData` — asserts the comparer returns
  `false` instead of throwing.

```
dotnet build slnx/Meziantou.Framework.SnapshotTesting.slnx /p:TreatsWarningsAsErrors=true   # 0 warnings, 0 errors
dotnet test tests/Meziantou.Framework.SnapshotTesting.Tests --filter-not-class "*EndToEnd*" # 116/116 passed
```
