### PR TITLE
Remove the container on dispose even when log forwarding fails

### DIFF
--- a/src/Meziantou.Framework.TemporaryContainers/TemporaryContainer.Logging.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/TemporaryContainer.Logging.cs
@@ -34,8 +34,10 @@ public partial class TemporaryContainer
             cts.Cancel();
             await task.ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+        catch
         {
+            // Forwarding logs is best-effort. A pump that faulted must not break the lifecycle operation that stops it,
+            // and it must never keep the container from being removed on dispose.
         }
         finally
         {
@@ -61,6 +63,12 @@ public partial class TemporaryContainer
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            // Expected: the container is stopping.
+        }
+        catch
+        {
+            // The runtime stopped streaming, or the logger itself threw. A logger backed by a test output helper does
+            // that as soon as the test that owns it completes, which is exactly when the container is being disposed.
         }
     }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/TemporaryContainer.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/TemporaryContainer.cs
@@ -120,14 +120,13 @@ public partial class TemporaryContainer : IAsyncDisposable
             return;
 
         _disposed = true;
-        await StopForwardingLogsAsync().ConfigureAwait(false);
-
-        if (_id is null || _definition.ReuseId is not null)
-            return;
 
         try
         {
-            await Runtime.DeleteAsync(_id, CancellationToken.None).ConfigureAwait(false);
+            await StopForwardingLogsAsync().ConfigureAwait(false);
+
+            if (_id is not null && _definition.ReuseId is null)
+                await Runtime.DeleteAsync(_id, CancellationToken.None).ConfigureAwait(false);
         }
         catch
         {

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -2,6 +2,7 @@ using System.Net.Sockets;
 using System.Text.Json;
 using Meziantou.Extensions.Logging.Xunit.v3;
 using Meziantou.Xunit;
+using Microsoft.Extensions.Logging;
 
 namespace Meziantou.Framework.TemporaryContainers.Tests;
 
@@ -404,6 +405,35 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
             await container.DeleteAsync(XunitCancellationToken);
             Assert.False(await container.ExistsAsync(XunitCancellationToken));
         }, XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_RemovesTheContainerWhenTheLoggerThrows()
+    {
+        var definition = CreateHttpServerDefinition();
+        definition.Logging.Logger = new ThrowingLogger();
+
+        var container = await StartWithRetryAsync(definition);
+        var id = container.Id;
+
+        // Let the forwarding pump reach the logger, so the failure is in flight when the container is disposed.
+        await Task.Delay(TimeSpan.FromSeconds(1), XunitCancellationToken);
+
+        await container.DisposeAsync();
+
+        Assert.False(await Runtime.ExistsAsync(id, XunitCancellationToken));
+    }
+
+    /// <summary>Mimics a logger backed by xunit's test output helper, which throws once the test that owns it has completed.</summary>
+    private sealed class ThrowingLogger : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => throw new InvalidOperationException("There is no currently active test.");
     }
 
     [Fact]


### PR DESCRIPTION
`TemporaryContainer.DisposeAsync` awaited `StopForwardingLogsAsync()` **outside** its `try`, so anything the log-forwarding pump raised propagated out of `DisposeAsync` before `Runtime.DeleteAsync` ever ran. `ForwardLogsAsync` only swallowed `OperationCanceledException`, so a logger that throws was enough to trigger it.

The container is then leaked permanently: `_disposed` is already `true` and the forwarding fields have already been nulled, so a second `DisposeAsync` returns at the guard clause and never retries the delete.

This contradicts the documented contract on that method — *"Cleanup is best-effort and never throws"* — and it fires in the library's primary use case. `CreateHttpServerDefinition` in our own test base sets `Logging.Logger = XUnitLogger.CreateLogger()`, and a logger backed by xunit's `ITestOutputHelper` throws `InvalidOperationException: There is no currently active test` as soon as the owning test completes — which is exactly when the container is disposed.

Reproduced before the fix:

```
started db00663c4772…
DisposeAsync THREW: InvalidOperationException: There is no currently active test.
second DisposeAsync completed
RESULT: CONTAINER LEAKED (db00663c4772)
```

`StopAsync`, `KillAsync`, `DeleteAsync` and `RestartAsync` had the same exposure, since they all await `StopForwardingLogsAsync()` first.

## What changed

- `ForwardLogsAsync` no longer lets a failure escape the pump. Cancellation stays an explicitly expected case; anything else (the runtime stopping the stream, or the logger itself throwing) is swallowed, because a best-effort background pump must not decide whether a lifecycle call succeeds.
- `StopForwardingLogsAsync` broadens its catch for the same reason, so a task that faulted for a reason the pump could not intercept still cannot surface through a lifecycle method.
- `DisposeAsync` moves the `StopForwardingLogsAsync()` call inside the existing `try`, so a future regression in shutdown still cannot skip container removal.

No public API change, so `ref/` is unchanged.

## Verification

Added `DisposeAsync_RemovesTheContainerWhenTheLoggerThrows` to `ContainerRuntimeTestsBase`, so it runs against every runtime the agent supports. It starts a container with a logger that throws on every write, waits for the pump to hit it, disposes, and asserts the container is gone.

Confirmed the test pins the bug: it **fails** on `main`'s library code (and leaks a container while doing so) and passes with this change. Full `DockerContainerTests` class green locally — 11/11.
