### PR TITLE
Stop skipping nameless dependencies so global.json SDK versions update

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/DockerPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/DockerPackageUpdater.cs
@@ -11,7 +11,7 @@ internal sealed class DockerPackageUpdater : PackageUpdater
     private static readonly HttpClient HttpClient = new();
     public override VersioningStrategy VersioningStrategy { get; set; } = DockerVersioningStrategy.Instance;
 
-    protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.DockerImage;
+    protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.DockerImage && dependency.Name is not null;
 
     protected override async IAsyncEnumerable<PackageVersion> GetVersionsAsync(Dependency dependency, [EnumeratorCancellation] CancellationToken cancellationToken)
     {

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/GitHubActionsUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/GitHubActionsUpdater.cs
@@ -9,7 +9,7 @@ internal sealed class GitHubActionsUpdater : PackageUpdater
     private static readonly HttpClient HttpClient = new();
     public override VersioningStrategy VersioningStrategy { get; set; } = GitHubActionsVersioningStrategy.Instance;
 
-    protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.GitHubActions;
+    protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.GitHubActions && dependency.Name is not null;
 
     protected override async IAsyncEnumerable<PackageVersion> GetVersionsAsync(Dependency dependency, [EnumeratorCancellation] CancellationToken cancellationToken)
     {

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NpmPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NpmPackageUpdater.cs
@@ -18,7 +18,7 @@ internal sealed class NpmPackageUpdater : PackageUpdater
     };
     public override VersioningStrategy VersioningStrategy { get; set; } = NpmVersioningStrategy.Instance;
 
-    protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.Npm;
+    protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.Npm && dependency.Name is not null;
 
     protected override async IAsyncEnumerable<PackageVersion> GetVersionsAsync(Dependency dependency, [EnumeratorCancellation] CancellationToken cancellationToken)
     {

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NuGetPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NuGetPackageUpdater.cs
@@ -11,7 +11,7 @@ internal sealed class NuGetPackageUpdater : PackageUpdater
     private const string NuGetOrgSource = "https://api.nuget.org/v3/index.json";
     public override VersioningStrategy VersioningStrategy { get; set; } = NuGetVersioningStrategy.Instance;
 
-    protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.NuGet;
+    protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.NuGet && dependency.Name is not null;
 
     protected override async IAsyncEnumerable<PackageVersion> GetVersionsAsync(Dependency dependency, [EnumeratorCancellation] CancellationToken cancellationToken)
     {

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/PackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/PackageUpdater.cs
@@ -18,10 +18,10 @@ internal abstract class PackageUpdater
 
     public async Task<string?> GetUpdatedVersionAsync(Dependency dependency, CancellationToken cancellationToken)
     {
-        if (dependency.Name is null || !IsSupported(dependency))
+        if (!IsSupported(dependency))
             return null;
 
-        var versioningStrategy = VersioningStrategy ?? throw new InvalidOperationException($"{nameof(VersioningStrategy)} cannot be null");
+        var versioningStrategy = VersioningStrategy;
         if (!versioningStrategy.IsSupportedVersion(dependency.Version))
             return null;
 

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
@@ -36,6 +36,44 @@ public sealed class FunctionalTests
     }
 
     [Fact]
+    public async Task UpdateDotNetSdk()
+    {
+        await using var tempDir = TemporaryDirectory.Create();
+
+        var path = tempDir.CreateEmptyFile("global.json");
+        await File.WriteAllTextAsync(path, """
+            {
+              "sdk": {
+                "version": "8.0.404"
+              }
+            }
+            """, XunitCancellationToken);
+
+        var console = new ConsoleHelper(_testOutputHelper);
+        var result = await Program.MainImpl(["update", "--directory", tempDir.FullPath, "--dependency-type", "DotNetSdk"], console.ConfigureConsole);
+        Assert.Equal(0, result);
+
+        var dependencies = await DependencyScanner.ScanDirectoryAsync(tempDir.FullPath, options: null, XunitCancellationToken);
+        var sdk = Assert.Single(dependencies, static dep => dep.Type is DependencyType.DotNetSdk);
+        Assert.True(SemanticVersion.Parse(sdk.Version!) > SemanticVersion.Parse("8.0.404"));
+    }
+
+    [Theory]
+    [InlineData(DependencyType.NuGet)]
+    [InlineData(DependencyType.Npm)]
+    [InlineData(DependencyType.DockerImage)]
+    [InlineData(DependencyType.GitHubActions)]
+    public async Task UpdatersRequiringAPackageNameIgnoreNamelessDependencies(DependencyType dependencyType)
+    {
+        var dependency = new Dependency(name: null, "1.0.0", dependencyType, nameLocation: null, versionLocation: null);
+
+        foreach (var updater in new PackageUpdater[] { new NuGetPackageUpdater(), new NpmPackageUpdater(), new DockerPackageUpdater(), new GitHubActionsUpdater() })
+        {
+            Assert.Null(await updater.GetUpdatedVersionAsync(dependency, XunitCancellationToken));
+        }
+    }
+
+    [Fact]
     public async Task FilterDependencyType()
     {
         await using var tempDir = TemporaryDirectory.Create();

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/MinimumAgeTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/MinimumAgeTests.cs
@@ -80,6 +80,20 @@ public sealed class MinimumAgeTests
         Assert.Null(location.UpdatedValue);
     }
 
+    [Fact]
+    public async Task DependencyWithoutNameIsUpdated()
+    {
+        // global.json reports its SDK version without a name; such dependencies must still be considered.
+        var location = new RecordingLocation();
+        var dependency = new Dependency(name: null, "1.0.0", DependencyType.DotNetSdk, nameLocation: null, versionLocation: location);
+        var updater = new FakePackageUpdater([new PackageVersion("2.0.0", PublishedDate: null)]);
+
+        var result = await updater.UpdateAsync(dependency, XunitCancellationToken);
+
+        Assert.Equal("2.0.0", result);
+        Assert.Equal("2.0.0", location.UpdatedValue);
+    }
+
     private static async Task<(string? Result, Dependency Dependency, RecordingLocation Location)> RunUpdateAsync(PackageVersion[] versions, int minimumAge)
     {
         var location = new RecordingLocation();


### PR DESCRIPTION
`DotNetSdkUpdater` has never run. `PackageUpdater.GetUpdatedVersionAsync` opened with

```csharp
if (dependency.Name is null || !IsSupported(dependency))
    return null;
```

and `DotNetGlobalJsonDependencyScanner` reports SDK dependencies with `name: null` — an SDK version has no package name. Every `DotNetSdk` dependency therefore returned `null` before its updater was ever consulted, so the whole of `DotNetSdkUpdater` (the release-index fetch, the `latest-release-date` age handling) was dead code.

**Reproduced before the fix:** a directory containing `{ "sdk": { "version": "8.0.404" } }`, run through `update --minimum-age 0`, listed the dependency, changed nothing and exited 0. The release index currently offers `10.0.400`, `9.0.317` and `8.0.424`, all of which pass `IsCompatibleVersion`.

## What changed

The name requirement belongs to the updaters that actually need a name, not to the base class. `IsSupported` on the NuGet, npm, Docker and GitHub Actions updaters now also requires `dependency.Name is not null`; `DotNetSdkUpdater` doesn't, so it finally gets asked.

Also removed the adjacent `VersioningStrategy ?? throw new InvalidOperationException(...)` on the following line — `VersioningStrategy` is a non-nullable property, so the guard was unreachable.

Note this makes `global.json` follow the newest SDK across major versions (`8.0.404` → `10.0.400`), consistent with how the other updaters treat major bumps. Constraining it to the pinned channel would be a separate change.

## Verification

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 55 passed, 0 failed (was 49).
- `dotnet run ./eng/update-all.cs` — no generated-file changes.

New tests:
- `MinimumAgeTests.DependencyWithoutNameIsUpdated` — offline regression test for the guard itself.
- `FunctionalTests.UpdateDotNetSdk` — end-to-end, asserts `global.json` moves past `8.0.404`.
- `FunctionalTests.UpdatersRequiringAPackageNameIgnoreNamelessDependencies` — the four name-requiring updaters still ignore a nameless dependency (offline; they return before any network call).
