### PR TITLE
Report an undecodable ImageSharp snapshot as a difference

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting.ImageSharp/ImageSharpSnapshotComparer.cs
+++ b/src/Meziantou.Framework.SnapshotTesting.ImageSharp/ImageSharpSnapshotComparer.cs
@@ -8,23 +8,36 @@ internal sealed class ImageSharpSnapshotComparer(ImageComparisonSettings? settin
 {
     public bool Equals(SnapshotData expected, SnapshotData actual)
     {
+        ArgumentNullException.ThrowIfNull(expected);
+        ArgumentNullException.ThrowIfNull(actual);
+
         // Identical bytes decode to identical pixels, so an exact comparison matches, SSIM is 1.0 and both
         // hash distances are 0 - every configured threshold is satisfied. This is the case for every passing
         // image snapshot test, and it avoids decoding both images.
         if (expected.Data.AsSpan().SequenceEqual(actual.Data))
             return true;
 
-        using var expectedImage = Image.Load<Rgba32>(expected.Data);
-        using var actualImage = Image.Load<Rgba32>(actual.Data);
+        try
+        {
+            using var expectedImage = Image.Load<Rgba32>(expected.Data);
+            using var actualImage = Image.Load<Rgba32>(actual.Data);
 
-        if (expectedImage.Width != actualImage.Width || expectedImage.Height != actualImage.Height)
+            if (expectedImage.Width != actualImage.Width || expectedImage.Height != actualImage.Height)
+                return false;
+
+            var threshold = settings?.SimilarityThreshold;
+            if (threshold is null)
+                return ExactEquals(expectedImage, actualImage);
+
+            return ComputeMeanSsim(expectedImage, actualImage) >= threshold.Value;
+        }
+        catch (ImageFormatException)
+        {
+            // A snapshot that cannot be decoded is a snapshot that does not match. Letting the exception
+            // escape would report a corrupt verified file as a library crash instead of a mismatch, which is
+            // what the built-in ImageComparer and SkiaSharpSnapshotComparer already do.
             return false;
-
-        var threshold = settings?.SimilarityThreshold;
-        if (threshold is null)
-            return ExactEquals(expectedImage, actualImage);
-
-        return ComputeMeanSsim(expectedImage, actualImage) >= threshold.Value;
+        }
     }
 
     private static bool ExactEquals(Image<Rgba32> expected, Image<Rgba32> actual)


### PR DESCRIPTION
`ImageSharpSnapshotComparer.Equals` decodes both sides with no error handling:

```csharp
using var expectedImage = Image.Load<Rgba32>(expected.Data);
using var actualImage = Image.Load<Rgba32>(actual.Data);
```

`Image.Load` throws `UnknownImageFormatException` or `InvalidImageContentException` for
data it cannot decode. Neither was caught, so a corrupt or wrong-format `.verified` file
crashed the test with an ImageSharp exception instead of reporting a snapshot mismatch.

The other two comparers in the repository already get this right:

- `ImageComparer.cs:63-70` catches and returns `false`.
- `SkiaSharpSnapshotComparer.cs:41-57` relies on `SKCodec.Create` returning `null` and
  handles the `null`.

So the three comparers behaved differently on identical input. This one also skipped the
`ArgumentNullException.ThrowIfNull` guards the built-in comparer has.

## What changed

- Wrapped the decode and comparison in `catch (ImageFormatException) { return false; }`.
  Verified against SixLabors.ImageSharp 4.1.0 that `ImageFormatException` is the base of
  both `UnknownImageFormatException` and `InvalidImageContentException`, so this covers
  every documented decode failure without catching unrelated exceptions.
- Added the two null guards, matching `ISnapshotComparer`'s other implementations.

## Verification

```
dotnet build slnx/Meziantou.Framework.SnapshotTesting.ImageSharp.slnx /p:TreatsWarningsAsErrors=true   # 0 warnings, 0 errors
```

**This package has no test project**, so the change is verified by build and by the
exception-hierarchy check described above, not by a test. That gap is the subject of a
separate issue — the two image backend packages are both published (ImageSharp 2.0.4,
SkiaSharp 1.0.1) with no tests at all, and this fix is exactly the kind of thing a handful
of tests would have caught.
