### PR TITLE
Stop throwing on HAR mime types that carry a charset

### DIFF
--- a/src/Meziantou.Framework.HttpArchive/HarEntryExtensions.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarEntryExtensions.cs
@@ -6,6 +6,8 @@ namespace Meziantou.Framework.HttpArchive;
 /// <summary>Provides extension methods for converting HAR entries to <see cref="HttpRequestMessage"/> and <see cref="HttpResponseMessage"/>.</summary>
 public static class HarEntryExtensions
 {
+    private const string ContentTypeHeaderName = "Content-Type";
+
     private static readonly HashSet<string> ContentHeaderNames = new(StringComparer.OrdinalIgnoreCase)
     {
         "Content-Disposition",
@@ -15,7 +17,7 @@ public static class HarEntryExtensions
         "Content-Location",
         "Content-MD5",
         "Content-Range",
-        "Content-Type",
+        ContentTypeHeaderName,
         "Expires",
         "Last-Modified",
         "Allow",
@@ -50,33 +52,16 @@ public static class HarEntryExtensions
         };
 
         HttpContent? content = null;
-
         if (request.PostData is not null)
         {
-            if (request.PostData.Text is not null)
-            {
-                content = new StringContent(request.PostData.Text, mediaType: new MediaTypeHeaderValue(request.PostData.MimeType));
-            }
-            else
-            {
-                content = new ByteArrayContent([]);
-            }
+            content = request.PostData.Text is not null
+                ? new ByteArrayContent(Encoding.UTF8.GetBytes(request.PostData.Text))
+                : new ByteArrayContent([]);
 
             message.Content = content;
         }
 
-        foreach (var header in request.Headers)
-        {
-            if (ContentHeaderNames.Contains(header.Name))
-            {
-                content?.Headers.TryAddWithoutValidation(header.Name, header.Value);
-            }
-            else
-            {
-                message.Headers.TryAddWithoutValidation(header.Name, header.Value);
-            }
-        }
-
+        CopyHeaders(request.Headers, message.Headers, content, request.PostData?.MimeType);
         return message;
     }
 
@@ -92,35 +77,64 @@ public static class HarEntryExtensions
             Version = ParseHttpVersion(response.HttpVersion),
         };
 
-        HttpContent content;
-        if (string.Equals(response.Content.Encoding, "base64", StringComparison.OrdinalIgnoreCase) && response.Content.Text is not null)
-        {
-            content = new ByteArrayContent(Convert.FromBase64String(response.Content.Text));
-        }
-        else if (response.Content.Text is not null)
-        {
-            content = new StringContent(response.Content.Text, mediaType: new MediaTypeHeaderValue(response.Content.MimeType));
-        }
-        else
-        {
-            content = new ByteArrayContent([]);
-        }
-
+        var content = CreateContent(response.Content);
         message.Content = content;
 
-        foreach (var header in response.Headers)
+        CopyHeaders(response.Headers, message.Headers, content, response.Content.MimeType);
+        return message;
+    }
+
+    private static ByteArrayContent CreateContent(HarContent harContent)
+    {
+        if (harContent.Text is null)
+            return new ByteArrayContent([]);
+
+        if (string.Equals(harContent.Encoding, "base64", StringComparison.OrdinalIgnoreCase) && TryDecodeBase64(harContent.Text, out var bytes))
+            return new ByteArrayContent(bytes);
+
+        return new ByteArrayContent(Encoding.UTF8.GetBytes(harContent.Text));
+    }
+
+    private static bool TryDecodeBase64(string text, [NotNullWhen(true)] out byte[]? bytes)
+    {
+        var buffer = new byte[((text.Length / 4) + 1) * 3];
+        if (Convert.TryFromBase64String(text, buffer, out var written))
+        {
+            bytes = buffer.AsSpan(0, written).ToArray();
+            return true;
+        }
+
+        bytes = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Copies the archived headers onto the message, routing entity headers to the content.
+    /// <paramref name="fallbackMimeType"/> is applied only when the archive contained no Content-Type header,
+    /// so the message never ends up with two of them.
+    /// </summary>
+    private static void CopyHeaders(List<HarHeader> headers, HttpHeaders messageHeaders, HttpContent? content, string? fallbackMimeType)
+    {
+        var hasContentType = false;
+        foreach (var header in headers)
         {
             if (ContentHeaderNames.Contains(header.Name))
             {
-                content.Headers.TryAddWithoutValidation(header.Name, header.Value);
+                if (content?.Headers.TryAddWithoutValidation(header.Name, header.Value) is true)
+                {
+                    hasContentType |= string.Equals(header.Name, ContentTypeHeaderName, StringComparison.OrdinalIgnoreCase);
+                }
             }
             else
             {
-                message.Headers.TryAddWithoutValidation(header.Name, header.Value);
+                messageHeaders.TryAddWithoutValidation(header.Name, header.Value);
             }
         }
 
-        return message;
+        if (content is not null && !hasContentType && !string.IsNullOrEmpty(fallbackMimeType))
+        {
+            content.Headers.TryAddWithoutValidation(ContentTypeHeaderName, fallbackMimeType);
+        }
     }
 
     private static Version ParseHttpVersion(string httpVersion)

--- a/tests/Meziantou.Framework.HttpArchive.Tests/HarEntryExtensionsTests.cs
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/HarEntryExtensionsTests.cs
@@ -215,4 +215,122 @@ public sealed class HarEntryExtensionsTests
         Assert.False(postData.TryGetRawData(out var rawData));
         Assert.Null(rawData);
     }
+
+    [Fact]
+    public void RealWorldHar_EveryEntryConvertsWithoutThrowing()
+    {
+        var document = LoadChromeHar();
+
+        Assert.HasCount(6, document.Log.Entries);
+
+        foreach (var entry in document.Log.Entries)
+        {
+            using var request = entry.ToHttpRequestMessage();
+            using var response = entry.ToHttpResponseMessage();
+
+            Assert.NotNull(request.RequestUri);
+            Assert.NotNull(response.Content);
+        }
+    }
+
+    [Fact]
+    public void RealWorldHar_ContentTypeIsNeverDuplicated()
+    {
+        var document = LoadChromeHar();
+
+        foreach (var entry in document.Log.Entries)
+        {
+            using var response = entry.ToHttpResponseMessage();
+            if (response.Content.Headers.TryGetValues("Content-Type", out var values))
+            {
+                Assert.Single(values);
+            }
+        }
+    }
+
+    [Fact]
+    public void ToHttpResponseMessage_MimeTypeWithCharset()
+    {
+        var response = new HarResponse
+        {
+            Status = 200,
+            HttpVersion = "http/2.0",
+            Content = new HarContent { MimeType = "text/html; charset=utf-8", Text = "<h1>Hi</h1>" },
+        };
+
+        using var message = response.ToHttpResponseMessage();
+
+        Assert.Equal("text/html; charset=utf-8", Assert.Single(message.Content.Headers.GetValues("Content-Type")));
+    }
+
+    [Fact]
+    public void ToHttpResponseMessage_EmptyMimeType()
+    {
+        var response = new HarResponse
+        {
+            Status = 304,
+            HttpVersion = "http/2.0",
+            Content = new HarContent { MimeType = "" },
+        };
+
+        using var message = response.ToHttpResponseMessage();
+
+        Assert.False(message.Content.Headers.Contains("Content-Type"));
+    }
+
+    [Fact]
+    public void ToHttpResponseMessage_HeaderWinsOverMimeType()
+    {
+        var response = new HarResponse
+        {
+            Status = 200,
+            HttpVersion = "http/2.0",
+            Headers = [new HarHeader { Name = "Content-Type", Value = "application/json; charset=utf-8" }],
+            Content = new HarContent { MimeType = "application/json", Text = "{}" },
+        };
+
+        using var message = response.ToHttpResponseMessage();
+
+        Assert.Equal("application/json; charset=utf-8", Assert.Single(message.Content.Headers.GetValues("Content-Type")));
+    }
+
+    [Fact]
+    public async Task ToHttpResponseMessage_InvalidBase64FallsBackToRawText()
+    {
+        var response = new HarResponse
+        {
+            Status = 200,
+            HttpVersion = "http/2.0",
+            Content = new HarContent { MimeType = "image/png", Text = "not!valid!base64", Encoding = "base64" },
+        };
+
+        using var message = response.ToHttpResponseMessage();
+
+        Assert.Equal("not!valid!base64", await message.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public void ToHttpRequestMessage_PostDataMimeTypeWithCharset()
+    {
+        var request = new HarRequest
+        {
+            Method = "POST",
+            Url = "https://example.com/login",
+            HttpVersion = "http/2.0",
+            PostData = new HarPostData { MimeType = "application/x-www-form-urlencoded;charset=UTF-8", Text = "a=1" },
+        };
+
+        using var message = request.ToHttpRequestMessage();
+
+        Assert.NotNull(message.Content);
+        Assert.Single(message.Content.Headers.GetValues("Content-Type"));
+        Assert.Equal("application/x-www-form-urlencoded", message.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("UTF-8", message.Content.Headers.ContentType?.CharSet);
+    }
+
+    private static HarDocument LoadChromeHar()
+    {
+        using var stream = typeof(HarEntryExtensionsTests).Assembly.GetManifestResourceStream("files/chrome-devtools.har")!;
+        return HarDocument.Parse(stream);
+    }
 }

--- a/tests/Meziantou.Framework.HttpArchive.Tests/Meziantou.Framework.HttpArchive.Tests.csproj
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/Meziantou.Framework.HttpArchive.Tests.csproj
@@ -8,4 +8,10 @@
     <ProjectReference Include="../../src/Meziantou.Framework.HttpArchive/Meziantou.Framework.HttpArchive.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="files/**/*">
+        <LogicalName>$([System.String]::new('%(RelativeDir)').Replace('\','/'))%(FileName)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/tests/Meziantou.Framework.HttpArchive.Tests/files/chrome-devtools.har
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/files/chrome-devtools.har
@@ -1,0 +1,366 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2026-08-27T09:14:22.115Z",
+        "id": "page_1",
+        "title": "https://example.com/",
+        "pageTimings": {
+          "onContentLoad": 312.4,
+          "onLoad": 498.7
+        }
+      }
+    ],
+    "entries": [
+      {
+        "_initiator": { "type": "other" },
+        "_priority": "VeryHigh",
+        "_resourceType": "document",
+        "cache": {},
+        "connection": "184623",
+        "pageref": "page_1",
+        "request": {
+          "method": "GET",
+          "url": "https://example.com/",
+          "httpVersion": "http/2.0",
+          "headers": [
+            { "name": ":method", "value": "GET" },
+            { "name": ":authority", "value": "example.com" },
+            { "name": "accept", "value": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8" },
+            { "name": "accept-encoding", "value": "gzip, deflate, br" },
+            { "name": "cookie", "value": "session=abc123; theme=dark" },
+            { "name": "user-agent", "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36" }
+          ],
+          "queryString": [],
+          "cookies": [
+            { "name": "session", "value": "abc123", "path": "/", "domain": "example.com", "expires": "2026-09-27T09:14:22.000Z", "httpOnly": true, "secure": true },
+            { "name": "theme", "value": "dark", "path": "/", "domain": "example.com", "httpOnly": false, "secure": false }
+          ],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "",
+          "httpVersion": "http/2.0",
+          "headers": [
+            { "name": "content-encoding", "value": "gzip" },
+            { "name": "content-length", "value": "648" },
+            { "name": "content-type", "value": "text/html; charset=utf-8" },
+            { "name": "date", "value": "Thu, 27 Aug 2026 09:14:22 GMT" },
+            { "name": "set-cookie", "value": "session=abc123; Path=/; Secure; HttpOnly; SameSite=Lax" },
+            { "name": "vary", "value": "Accept-Encoding" }
+          ],
+          "cookies": [
+            { "name": "session", "value": "abc123", "path": "/", "httpOnly": true, "secure": true }
+          ],
+          "content": {
+            "size": 1256,
+            "compression": 608,
+            "mimeType": "text/html; charset=utf-8",
+            "text": "<!doctype html>\n<html lang=\"en\">\n<head><meta charset=\"utf-8\"><title>Example Domain</title></head>\n<body><h1>Example Domain</h1><p>Café — naïve façade</p></body>\n</html>\n"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 648,
+          "_transferSize": 892
+        },
+        "serverIPAddress": "93.184.216.34",
+        "startedDateTime": "2026-08-27T09:14:22.115Z",
+        "time": 142.53,
+        "timings": {
+          "blocked": 1.23,
+          "dns": -1,
+          "ssl": -1,
+          "connect": -1,
+          "send": 0.11,
+          "wait": 138.94,
+          "receive": 2.25,
+          "_blocked_queueing": 0.82
+        }
+      },
+      {
+        "_initiator": { "type": "script" },
+        "_priority": "High",
+        "_resourceType": "fetch",
+        "cache": {},
+        "connection": "184623",
+        "pageref": "page_1",
+        "request": {
+          "method": "GET",
+          "url": "https://example.com/api/items?page=2&sort=name",
+          "httpVersion": "http/2.0",
+          "headers": [
+            { "name": "accept", "value": "application/json, text/plain, */*" },
+            { "name": "authorization", "value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.redacted.redacted" },
+            { "name": "content-type", "value": "application/json" }
+          ],
+          "queryString": [
+            { "name": "page", "value": "2" },
+            { "name": "sort", "value": "name" }
+          ],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "",
+          "httpVersion": "http/2.0",
+          "headers": [
+            { "name": "content-encoding", "value": "br" },
+            { "name": "content-length", "value": "97" },
+            { "name": "content-type", "value": "application/json; charset=utf-8" }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 184,
+            "compression": 87,
+            "mimeType": "application/json; charset=utf-8",
+            "text": "{\"items\":[{\"id\":1,\"name\":\"Alpha\"},{\"id\":2,\"name\":\"Beta\"}],\"page\":2,\"total\":2}"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 97,
+          "_transferSize": 341
+        },
+        "serverIPAddress": "93.184.216.34",
+        "startedDateTime": "2026-08-27T09:14:22.512Z",
+        "time": 48.19,
+        "timings": {
+          "blocked": 0.44,
+          "dns": -1,
+          "ssl": -1,
+          "connect": -1,
+          "send": 0.09,
+          "wait": 46.81,
+          "receive": 0.85,
+          "_blocked_queueing": 0.21
+        }
+      },
+      {
+        "_initiator": { "type": "other" },
+        "_priority": "High",
+        "_resourceType": "document",
+        "cache": {},
+        "connection": "184623",
+        "pageref": "page_1",
+        "request": {
+          "method": "POST",
+          "url": "https://example.com/login",
+          "httpVersion": "http/2.0",
+          "headers": [
+            { "name": "content-type", "value": "application/x-www-form-urlencoded" },
+            { "name": "content-length", "value": "43" },
+            { "name": "origin", "value": "https://example.com" }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded;charset=UTF-8",
+            "params": [
+              { "name": "username", "value": "someone%40example.com" },
+              { "name": "password", "value": "redacted" },
+              { "name": "remember", "value": "on" }
+            ]
+          },
+          "headersSize": -1,
+          "bodySize": 43
+        },
+        "response": {
+          "status": 302,
+          "statusText": "",
+          "httpVersion": "http/2.0",
+          "headers": [
+            { "name": "location", "value": "https://example.com/dashboard" },
+            { "name": "content-length", "value": "0" },
+            { "name": "set-cookie", "value": "session=zzz999; Path=/; Secure; HttpOnly" }
+          ],
+          "cookies": [
+            { "name": "session", "value": "zzz999", "path": "/", "httpOnly": true, "secure": true }
+          ],
+          "content": {
+            "size": 0,
+            "mimeType": "x-unknown"
+          },
+          "redirectURL": "https://example.com/dashboard",
+          "headersSize": -1,
+          "bodySize": 0,
+          "_transferSize": 214
+        },
+        "serverIPAddress": "93.184.216.34",
+        "startedDateTime": "2026-08-27T09:14:23.004Z",
+        "time": 91.72,
+        "timings": {
+          "blocked": 0.61,
+          "dns": -1,
+          "ssl": -1,
+          "connect": -1,
+          "send": 0.14,
+          "wait": 90.11,
+          "receive": 0.86,
+          "_blocked_queueing": 0.33
+        }
+      },
+      {
+        "_initiator": { "type": "parser" },
+        "_priority": "Low",
+        "_resourceType": "image",
+        "cache": {},
+        "connection": "184623",
+        "pageref": "page_1",
+        "request": {
+          "method": "GET",
+          "url": "https://example.com/pixel.png",
+          "httpVersion": "http/2.0",
+          "headers": [
+            { "name": "accept", "value": "image/avif,image/webp,*/*" }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "",
+          "httpVersion": "http/2.0",
+          "headers": [
+            { "name": "content-type", "value": "image/png" },
+            { "name": "content-length", "value": "68" }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 68,
+            "mimeType": "image/png",
+            "text": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+            "encoding": "base64"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 68,
+          "_transferSize": 289
+        },
+        "serverIPAddress": "93.184.216.34",
+        "startedDateTime": "2026-08-27T09:14:23.221Z",
+        "time": 12.06,
+        "timings": {
+          "blocked": 0.29,
+          "dns": -1,
+          "ssl": -1,
+          "connect": -1,
+          "send": 0.05,
+          "wait": 11.4,
+          "receive": 0.32,
+          "_blocked_queueing": 0.11
+        }
+      },
+      {
+        "_initiator": { "type": "parser" },
+        "_priority": "Low",
+        "_resourceType": "stylesheet",
+        "cache": {
+          "beforeRequest": {
+            "expires": "2026-08-28T09:14:22.000Z",
+            "lastAccess": "2026-08-27T09:10:02.000Z",
+            "eTag": "\"9a8b7c6d\"",
+            "hitCount": 3
+          }
+        },
+        "connection": "184623",
+        "pageref": "page_1",
+        "request": {
+          "method": "GET",
+          "url": "https://example.com/site.css",
+          "httpVersion": "http/2.0",
+          "headers": [
+            { "name": "if-none-match", "value": "\"9a8b7c6d\"" }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 304,
+          "statusText": "",
+          "httpVersion": "http/2.0",
+          "headers": [
+            { "name": "etag", "value": "\"9a8b7c6d\"" },
+            { "name": "cache-control", "value": "max-age=86400" }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 0,
+            "mimeType": ""
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 0,
+          "_transferSize": 118
+        },
+        "serverIPAddress": "93.184.216.34",
+        "startedDateTime": "2026-08-27T09:14:23.318Z",
+        "time": 8.41,
+        "timings": {
+          "blocked": 0.18,
+          "dns": -1,
+          "ssl": -1,
+          "connect": -1,
+          "send": 0.04,
+          "wait": 8.02,
+          "receive": 0.17,
+          "_blocked_queueing": 0.07
+        }
+      },
+      {
+        "_initiator": { "type": "script" },
+        "_priority": "Low",
+        "_resourceType": "xhr",
+        "cache": {},
+        "pageref": "page_1",
+        "request": {
+          "method": "GET",
+          "url": "https://blocked.example.net/tracker.js",
+          "httpVersion": "",
+          "headers": [],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 0,
+          "statusText": "",
+          "httpVersion": "",
+          "headers": [],
+          "cookies": [],
+          "content": {
+            "size": 0,
+            "mimeType": "x-unknown"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": 0,
+          "_error": "net::ERR_BLOCKED_BY_CLIENT"
+        },
+        "startedDateTime": "2026-08-27T09:14:23.402Z",
+        "time": 0.83,
+        "timings": {
+          "blocked": 0.83,
+          "dns": -1,
+          "ssl": -1,
+          "connect": -1,
+          "send": 0,
+          "wait": 0,
+          "receive": 0
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Stack 1 of 4 · merges into `main` · must merge before #2155, #2156, #2157

## The problem

`HarEntryExtensions` built its `HttpContent` with `new MediaTypeHeaderValue(mimeType)`. That constructor accepts a **bare** media type only — unlike `MediaTypeHeaderValue.Parse`, it rejects parameters. HAR producers write the full header value into `mimeType`, so:

- `"mimeType": "text/html; charset=utf-8"` (Chrome, Firefox, Edge, Playwright) → `FormatException: The format of value 'text/html; charset=utf-8' is invalid.`
- `"mimeType": ""` (spec-legal for 304 / empty bodies, and the property default) → `ArgumentException: The value cannot be an empty string.`

`ToHttpResponseMessage` — the API the readme leads with — therefore threw on essentially every real archive. The response path was unguarded: any entry with a non-null, non-base64 `content.text` reached it.

A second defect was hiding underneath: the content was constructed with a media type *and* the header loop then added the archive's own `Content-Type`, because `Content-Type` is in `ContentHeaderNames`. `TryAddWithoutValidation` appends rather than replaces, so every converted message carried:

```
Content-Type: application/json, application/json; charset=utf-8
```

The typed `content.Headers.ContentType` property returns only the first value, which is why the existing tests passed while producing a malformed message.

## What changed

- Content is now built as `ByteArrayContent`, which has no default `Content-Type`, instead of `StringContent` with a typed media type.
- `CopyHeaders` tracks whether the archive supplied a `Content-Type`, and falls back to `mimeType` only when it did not — so there is exactly one, and the recorded header wins.
- The base64 decode in `ToHttpResponseMessage` now uses `Convert.TryFromBase64String` and falls back to treating the text literally, instead of throwing `FormatException` on a corrupted archive. (Part of the finding covering `Convert.FromBase64String`; the `HarPostDataExtensions` half is a separate PR.)

## Test fixture

Adds `tests/.../files/chrome-devtools.har` and wires up the `files/**` embedded-resource convention already used by `Meziantou.Framework.Bencode.Tests`.

The fixture reproduces the shapes real DevTools output has and the hand-written test fixtures did not: charset-qualified mime types, an empty `mimeType` on a 304, `gzip`/`br` `Content-Encoding` with a `Content-Length` describing the compressed body, a `params`-only form post, a base64 image, a `status: 0` blocked request, `statusText: ""` on HTTP/2, and vendor `_`-prefixed fields.

It is **synthesized**, not a genuine export — labelled as such so nobody assumes otherwise. Swapping in a real scrubbed export later would strengthen it without changing the tests.

## Verification

`dotnet test -p:TreatsWarningsAsErrors=true` → **80/80 green** on `net10.0` and `net11.0` (was 66/66; 7 new tests). Every entry in the fixture now converts to both a request and a response message without throwing, and no converted message carries a duplicate `Content-Type`.
