### PR TITLE
Do not replay Content-Length and Content-Encoding onto the rebuilt body

### DIFF
--- a/src/Meziantou.Framework.HttpArchive/HarEntryExtensions.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarEntryExtensions.cs
@@ -23,6 +23,18 @@ public static class HarEntryExtensions
         "Allow",
     };
 
+    /// <summary>
+    /// Headers that describe the bytes as they travelled on the wire. The reconstructed content holds the
+    /// decoded body from <c>content.text</c>, so replaying these would describe bytes that are no longer there:
+    /// a stale Content-Length makes the send fail outright. The recorded values remain available on
+    /// <see cref="HarResponse.Content"/>, <see cref="HarRequest.BodySize"/> and the header lists.
+    /// </summary>
+    private static readonly HashSet<string> WireOnlyHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Content-Length",
+        "Content-Encoding",
+    };
+
     /// <summary>Creates an <see cref="HttpRequestMessage"/> from a HAR entry.</summary>
     /// <param name="entry">The HAR entry to convert.</param>
     /// <returns>An <see cref="HttpRequestMessage"/> representing the HAR request.</returns>
@@ -118,6 +130,9 @@ public static class HarEntryExtensions
         var hasContentType = false;
         foreach (var header in headers)
         {
+            if (WireOnlyHeaderNames.Contains(header.Name))
+                continue;
+
             if (ContentHeaderNames.Contains(header.Name))
             {
                 if (content?.Headers.TryAddWithoutValidation(header.Name, header.Value) is true)

--- a/tests/Meziantou.Framework.HttpArchive.Tests/HarEntryExtensionsTests.cs
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/HarEntryExtensionsTests.cs
@@ -377,6 +377,77 @@ public sealed class HarEntryExtensionsTests
         Assert.Equal("UTF-8", message.Content.Headers.ContentType?.CharSet);
     }
 
+    [Fact]
+    public void ToHttpResponseMessage_DoesNotReplayRecordedContentLength()
+    {
+        var response = new HarResponse
+        {
+            Status = 200,
+            HttpVersion = "http/2.0",
+            Headers =
+            [
+                new HarHeader { Name = "Content-Length", Value = "648" },
+                new HarHeader { Name = "Content-Type", Value = "text/plain" },
+            ],
+            Content = new HarContent { MimeType = "text/plain", Text = "hello" },
+        };
+
+        using var message = response.ToHttpResponseMessage();
+
+        Assert.Equal(5, message.Content.Headers.ContentLength);
+        Assert.Equal("5", Assert.Single(message.Content.Headers.GetValues("Content-Length")));
+    }
+
+    [Fact]
+    public void ToHttpResponseMessage_DoesNotReplayContentEncoding()
+    {
+        var response = new HarResponse
+        {
+            Status = 200,
+            HttpVersion = "http/2.0",
+            Headers = [new HarHeader { Name = "Content-Encoding", Value = "gzip" }],
+            Content = new HarContent { MimeType = "text/plain", Text = "already decoded" },
+        };
+
+        using var message = response.ToHttpResponseMessage();
+
+        Assert.False(message.Content.Headers.Contains("Content-Encoding"));
+    }
+
+    [Fact]
+    public async Task RealWorldHar_GzippedEntryHasConsistentContentLength()
+    {
+        var document = LoadChromeHar();
+        var entry = document.Log.Entries[0];
+
+        Assert.Equal("648", entry.Response.Headers.Single(h => string.Equals(h.Name, "content-length", StringComparison.OrdinalIgnoreCase)).Value);
+
+        using var message = entry.ToHttpResponseMessage();
+        var body = await message.Content.ReadAsByteArrayAsync();
+
+        Assert.Equal(body.Length, message.Content.Headers.ContentLength);
+        Assert.False(message.Content.Headers.Contains("Content-Encoding"));
+    }
+
+    [Fact]
+    public async Task ToHttpRequestMessage_RecordedContentLengthDoesNotBreakSending()
+    {
+        var request = new HarRequest
+        {
+            Method = "POST",
+            Url = "https://example.com/upload",
+            HttpVersion = "http/1.1",
+            Headers = [new HarHeader { Name = "Content-Length", Value = "99999" }],
+            PostData = new HarPostData { MimeType = "text/plain", Text = "abc" },
+        };
+
+        using var message = request.ToHttpRequestMessage();
+
+        Assert.NotNull(message.Content);
+        var body = await message.Content.ReadAsByteArrayAsync();
+        Assert.Equal(body.Length, message.Content.Headers.ContentLength);
+    }
+
     private static HarDocument LoadChromeHar()
     {
         using var stream = typeof(HarEntryExtensionsTests).Assembly.GetManifestResourceStream("files/chrome-devtools.har")!;


### PR DESCRIPTION
Stack 2 of 4 · merges into `fix/har-content-type` (#2154) · must merge after #2154

## The problem

`Content-Length` and `Content-Encoding` were forwarded verbatim from the archive onto the reconstructed content — but the reconstructed body is not the body those headers describe. HAR stores `content.text` **decoded**, while `Content-Length` was recorded for the compressed on-the-wire body.

`HttpContentHeaders.ContentLength` (the typed property) hides this by returning the computed length, but the header collection keeps the archived value and that is what goes on the wire. Verified against a real socket before the fix:

```
client: HttpRequestException: Sent 3 request content bytes, but Content-Length promised 99999.
<server received nothing>
```

Every gzip/brotli entry hits this — which is most HTML, JS and JSON — as does any entry whose body the capturing tool truncated or omitted. Since replaying captured traffic is the reason to convert an entry into an `HttpRequestMessage` at all, this made the primary use case fail at send time, with an error pointing at the caller rather than at the archive.

`Content-Encoding` has the same defect in the other direction: it advertises a compression that is no longer applied to the reconstructed bytes.

## What changed

A `WireOnlyHeaderNames` set, skipped in `CopyHeaders`. `HttpContent` computes the correct `Content-Length` itself. The recorded values are not lost — they remain on `HarResponse.Content.Size`, `HarRequest.BodySize`, and in the `Headers` lists.

`ContentHeaderNames` is left intact: it is an accurate description of which entity headers .NET routes to `HttpContentHeaders`, and is worth keeping correct independently of which ones we choose to replay.

## Verification

`dotnet test -p:TreatsWarningsAsErrors=true` → **88/88 green** on `net10.0` and `net11.0` (4 new tests). The fixture's gzipped entry records `content-length: 648` and now converts to a message whose `ContentLength` matches the actual decoded body, with no `Content-Encoding`.
