### PR TITLE
Rebuild form request bodies recorded as params instead of text

### DIFF
--- a/src/Meziantou.Framework.HttpArchive/HarEntryExtensions.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarEntryExtensions.cs
@@ -54,6 +54,11 @@ public static class HarEntryExtensions
     /// <summary>Creates an <see cref="HttpRequestMessage"/> from a HAR request.</summary>
     /// <param name="request">The HAR request to convert.</param>
     /// <returns>An <see cref="HttpRequestMessage"/> representing the HAR request.</returns>
+    /// <remarks>
+    /// When the archive recorded the body as <c>params</c> instead of <c>text</c>, a
+    /// <c>application/x-www-form-urlencoded</c> body is rebuilt from the parameters. Multipart bodies cannot be
+    /// rebuilt this way because the original boundary is not part of the archive; they convert to an empty body.
+    /// </remarks>
     public static HttpRequestMessage ToHttpRequestMessage(this HarRequest request)
     {
         var message = new HttpRequestMessage
@@ -66,15 +71,61 @@ public static class HarEntryExtensions
         HttpContent? content = null;
         if (request.PostData is not null)
         {
-            content = request.PostData.Text is not null
-                ? new ByteArrayContent(Encoding.UTF8.GetBytes(request.PostData.Text))
-                : new ByteArrayContent([]);
-
-            message.Content = content;
+            content = CreateRequestContent(request.PostData);
         }
+        else if (HasContentHeader(request.Headers))
+        {
+            // The body was not captured, but the entity headers describing it were: keep somewhere to put them.
+            content = new ByteArrayContent([]);
+        }
+
+        message.Content = content;
 
         CopyHeaders(request.Headers, message.Headers, content, request.PostData?.MimeType);
         return message;
+    }
+
+    private static ByteArrayContent CreateRequestContent(HarPostData postData)
+    {
+        if (postData.Text is not null)
+            return new ByteArrayContent(Encoding.UTF8.GetBytes(postData.Text));
+
+        if (postData.Params is { Count: > 0 } parameters &&
+            postData.MimeType.StartsWith("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase))
+        {
+            return new ByteArrayContent(Encoding.UTF8.GetBytes(BuildFormUrlEncodedBody(parameters)));
+        }
+
+        return new ByteArrayContent([]);
+    }
+
+    private static string BuildFormUrlEncodedBody(List<HarPostDataParameter> parameters)
+    {
+        // Archives store the parameters already percent-encoded, exactly as they were split out of the body,
+        // so they are joined back as-is rather than re-encoded.
+        var builder = new StringBuilder();
+        foreach (var parameter in parameters)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append('&');
+            }
+
+            builder.Append(parameter.Name).Append('=').Append(parameter.Value);
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool HasContentHeader(List<HarHeader> headers)
+    {
+        foreach (var header in headers)
+        {
+            if (!WireOnlyHeaderNames.Contains(header.Name) && ContentHeaderNames.Contains(header.Name))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>Creates an <see cref="HttpResponseMessage"/> from a HAR response.</summary>

--- a/tests/Meziantou.Framework.HttpArchive.Tests/HarEntryExtensionsTests.cs
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/HarEntryExtensionsTests.cs
@@ -448,6 +448,121 @@ public sealed class HarEntryExtensionsTests
         Assert.Equal(body.Length, message.Content.Headers.ContentLength);
     }
 
+    [Fact]
+    public async Task ToHttpRequestMessage_RebuildsBodyFromParams()
+    {
+        var request = new HarRequest
+        {
+            Method = "POST",
+            Url = "https://example.com/login",
+            HttpVersion = "http/2.0",
+            PostData = new HarPostData
+            {
+                MimeType = "application/x-www-form-urlencoded;charset=UTF-8",
+                Params =
+                [
+                    new HarPostDataParameter { Name = "username", Value = "someone%40example.com" },
+                    new HarPostDataParameter { Name = "remember", Value = "on" },
+                ],
+            },
+        };
+
+        using var message = request.ToHttpRequestMessage();
+
+        Assert.NotNull(message.Content);
+        Assert.Equal("username=someone%40example.com&remember=on", await message.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task ToHttpRequestMessage_TextWinsOverParams()
+    {
+        var request = new HarRequest
+        {
+            Method = "POST",
+            Url = "https://example.com/login",
+            HttpVersion = "http/2.0",
+            PostData = new HarPostData
+            {
+                MimeType = "application/x-www-form-urlencoded",
+                Text = "a=1&b=2",
+                Params = [new HarPostDataParameter { Name = "ignored", Value = "x" }],
+            },
+        };
+
+        using var message = request.ToHttpRequestMessage();
+
+        Assert.NotNull(message.Content);
+        Assert.Equal("a=1&b=2", await message.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task ToHttpRequestMessage_MultipartParamsProduceAnEmptyBody()
+    {
+        var request = new HarRequest
+        {
+            Method = "POST",
+            Url = "https://example.com/upload",
+            HttpVersion = "http/2.0",
+            PostData = new HarPostData
+            {
+                MimeType = "multipart/form-data; boundary=----WebKitFormBoundaryABC",
+                Params = [new HarPostDataParameter { Name = "file", FileName = "a.txt", ContentType = "text/plain" }],
+            },
+        };
+
+        using var message = request.ToHttpRequestMessage();
+
+        Assert.NotNull(message.Content);
+        Assert.Empty(await message.Content.ReadAsByteArrayAsync());
+    }
+
+    [Fact]
+    public void ToHttpRequestMessage_KeepsContentHeadersWhenBodyWasNotCaptured()
+    {
+        var request = new HarRequest
+        {
+            Method = "POST",
+            Url = "https://example.com/upload",
+            HttpVersion = "http/2.0",
+            Headers = [new HarHeader { Name = "Content-Type", Value = "application/octet-stream" }],
+        };
+
+        using var message = request.ToHttpRequestMessage();
+
+        Assert.NotNull(message.Content);
+        Assert.Equal("application/octet-stream", message.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public void ToHttpRequestMessage_NoContentHeadersLeavesContentNull()
+    {
+        var request = new HarRequest
+        {
+            Method = "GET",
+            Url = "https://example.com/",
+            HttpVersion = "http/2.0",
+            Headers = [new HarHeader { Name = "Accept", Value = "*/*" }],
+        };
+
+        using var message = request.ToHttpRequestMessage();
+
+        Assert.Null(message.Content);
+    }
+
+    [Fact]
+    public async Task RealWorldHar_FormPostKeepsItsBody()
+    {
+        var document = LoadChromeHar();
+        var entry = document.Log.Entries.Single(e => e.Request.Url.EndsWith("/login", StringComparison.Ordinal));
+
+        Assert.Null(entry.Request.PostData!.Text);
+
+        using var message = entry.ToHttpRequestMessage();
+
+        Assert.NotNull(message.Content);
+        Assert.Equal("username=someone%40example.com&password=redacted&remember=on", await message.Content.ReadAsStringAsync());
+    }
+
     private static HarDocument LoadChromeHar()
     {
         using var stream = typeof(HarEntryExtensionsTests).Assembly.GetManifestResourceStream("files/chrome-devtools.har")!;


### PR DESCRIPTION
Stack 3 of 4 · merges into `fix/har-replay-headers` (#2155) · must merge after #2154, #2155

> The dependency on #2155 is ordering only — this change and #2155 both build on #2154 but not on each other. A stack has to be linear, so they were ordered by severity.

## The problems

**`postData.params` was parsed but never used.** `HarPostDataParameter` is a fully modelled public type that affected nothing — `Params` was referenced nowhere in `src/` or `tests/`. The HAR spec lets a producer record a body as `params` *instead of* `text`; when it does, `postData.Text is null`, so the converter attached an empty body and returned without complaint. Silent data loss on exactly the requests where the body matters most, and a caller replaying the entry gets a 400 with no clue why.

**Content headers vanished when the body was not captured.** Producers routinely omit `postData` for large or binary uploads while still recording `Content-Type` in `headers`. `content` stayed `null` and `content?.Headers` made the copy a no-op, so those headers were silently discarded.

## What changed

- A form body is rebuilt from `params` when the mime type is `application/x-www-form-urlencoded`. Parameters are joined **as recorded**, not re-encoded: archives store them already percent-encoded, exactly as they were split out of the body, so joining them back is lossless. Re-encoding would turn `someone%40example.com` into `someone%2540example.com`.
- `text` still wins over `params` when both are present.
- When there is no `postData` but the request does carry entity headers, an empty content is attached so those headers have somewhere to land. A request with neither still converts with `Content` as `null`.

## Deliberate limitation

**Multipart bodies are not rebuilt** — they still convert to an empty body, now documented in the XML docs rather than silent.

The original boundary is not part of the archive. Generating a fresh one would force the generated `Content-Type` to override the recorded header, which contradicts the "recorded header wins" rule established in #2154 — and getting that wrong produces a body whose boundary does not match its own header, which is worse than an empty body. It needs a design decision rather than a quiet default, so it is left out of this PR.

## Verification

`dotnet test -p:TreatsWarningsAsErrors=true` → **100/100 green** on `net10.0` and `net11.0` (6 new tests). The fixture's `params`-only login post now reconstructs `username=someone%40example.com&password=redacted&remember=on`.
