### PR TITLE
Rebuild cookie headers from the archived cookie lists

### DIFF
--- a/src/Meziantou.Framework.HttpArchive/HarEntryExtensions.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarEntryExtensions.cs
@@ -7,6 +7,8 @@ namespace Meziantou.Framework.HttpArchive;
 public static class HarEntryExtensions
 {
     private const string ContentTypeHeaderName = "Content-Type";
+    private const string CookieHeaderName = "Cookie";
+    private const string SetCookieHeaderName = "Set-Cookie";
 
     private static readonly HashSet<string> ContentHeaderNames = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -82,6 +84,13 @@ public static class HarEntryExtensions
         message.Content = content;
 
         CopyHeaders(request.Headers, message.Headers, content, request.PostData?.MimeType);
+
+        // Some tools record cookies only in the structured list, without the header that carried them.
+        if (request.Cookies.Count > 0 && !message.Headers.Contains(CookieHeaderName))
+        {
+            message.Headers.TryAddWithoutValidation(CookieHeaderName, BuildCookieHeader(request.Cookies));
+        }
+
         return message;
     }
 
@@ -144,7 +153,65 @@ public static class HarEntryExtensions
         message.Content = content;
 
         CopyHeaders(response.Headers, message.Headers, content, response.Content.MimeType);
+
+        if (response.Cookies.Count > 0 && !message.Headers.Contains(SetCookieHeaderName))
+        {
+            foreach (var cookie in response.Cookies)
+            {
+                message.Headers.TryAddWithoutValidation(SetCookieHeaderName, BuildSetCookieHeader(cookie));
+            }
+        }
+
         return message;
+    }
+
+    private static string BuildCookieHeader(List<HarCookie> cookies)
+    {
+        var builder = new StringBuilder();
+        foreach (var cookie in cookies)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append("; ");
+            }
+
+            builder.Append(cookie.Name).Append('=').Append(cookie.Value);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string BuildSetCookieHeader(HarCookie cookie)
+    {
+        var builder = new StringBuilder();
+        builder.Append(cookie.Name).Append('=').Append(cookie.Value);
+
+        if (!string.IsNullOrEmpty(cookie.Path))
+        {
+            builder.Append("; Path=").Append(cookie.Path);
+        }
+
+        if (!string.IsNullOrEmpty(cookie.Domain))
+        {
+            builder.Append("; Domain=").Append(cookie.Domain);
+        }
+
+        if (cookie.Expires is { } expires)
+        {
+            builder.Append("; Expires=").Append(expires.UtcDateTime.ToString("R", CultureInfo.InvariantCulture));
+        }
+
+        if (cookie.HttpOnly is true)
+        {
+            builder.Append("; HttpOnly");
+        }
+
+        if (cookie.Secure is true)
+        {
+            builder.Append("; Secure");
+        }
+
+        return builder.ToString();
     }
 
     private static ByteArrayContent CreateContent(HarContent harContent)

--- a/tests/Meziantou.Framework.HttpArchive.Tests/HarEntryExtensionsTests.cs
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/HarEntryExtensionsTests.cs
@@ -563,6 +563,88 @@ public sealed class HarEntryExtensionsTests
         Assert.Equal("username=someone%40example.com&password=redacted&remember=on", await message.Content.ReadAsStringAsync());
     }
 
+    [Fact]
+    public void ToHttpRequestMessage_SynthesizesCookieHeaderFromCookieList()
+    {
+        var request = new HarRequest
+        {
+            Method = "GET",
+            Url = "https://example.com/",
+            HttpVersion = "http/2.0",
+            Cookies =
+            [
+                new HarCookie { Name = "session", Value = "abc123" },
+                new HarCookie { Name = "theme", Value = "dark" },
+            ],
+        };
+
+        using var message = request.ToHttpRequestMessage();
+
+        Assert.Equal("session=abc123; theme=dark", Assert.Single(message.Headers.GetValues("Cookie")));
+    }
+
+    [Fact]
+    public void ToHttpRequestMessage_KeepsTheRecordedCookieHeader()
+    {
+        var request = new HarRequest
+        {
+            Method = "GET",
+            Url = "https://example.com/",
+            HttpVersion = "http/2.0",
+            Headers = [new HarHeader { Name = "Cookie", Value = "session=fromheader" }],
+            Cookies = [new HarCookie { Name = "session", Value = "fromlist" }],
+        };
+
+        using var message = request.ToHttpRequestMessage();
+
+        Assert.Equal("session=fromheader", Assert.Single(message.Headers.GetValues("Cookie")));
+    }
+
+    [Fact]
+    public void ToHttpResponseMessage_SynthesizesSetCookieHeaders()
+    {
+        var response = new HarResponse
+        {
+            Status = 200,
+            HttpVersion = "http/2.0",
+            Cookies =
+            [
+                new HarCookie
+                {
+                    Name = "session",
+                    Value = "abc123",
+                    Path = "/",
+                    Domain = "example.com",
+                    Expires = new DateTimeOffset(2026, 9, 27, 9, 14, 22, TimeSpan.Zero),
+                    HttpOnly = true,
+                    Secure = true,
+                },
+                new HarCookie { Name = "theme", Value = "dark" },
+            ],
+            Content = new HarContent { MimeType = "text/plain", Text = "ok" },
+        };
+
+        using var message = response.ToHttpResponseMessage();
+
+        var values = message.Headers.GetValues("Set-Cookie").ToList();
+        Assert.HasCount(2, values);
+        Assert.Equal("session=abc123; Path=/; Domain=example.com; Expires=Sun, 27 Sep 2026 09:14:22 GMT; HttpOnly; Secure", values[0]);
+        Assert.Equal("theme=dark", values[1]);
+    }
+
+    [Fact]
+    public void RealWorldHar_DoesNotDuplicateRecordedCookieHeaders()
+    {
+        var document = LoadChromeHar();
+        var entry = document.Log.Entries[0];
+
+        using var request = entry.ToHttpRequestMessage();
+        using var response = entry.ToHttpResponseMessage();
+
+        Assert.Equal("session=abc123; theme=dark", Assert.Single(request.Headers.GetValues("Cookie")));
+        Assert.Single(response.Headers.GetValues("Set-Cookie"));
+    }
+
     private static HarDocument LoadChromeHar()
     {
         using var stream = typeof(HarEntryExtensionsTests).Assembly.GetManifestResourceStream("files/chrome-devtools.har")!;


### PR DESCRIPTION
Stack 4 of 4 · merges into `fix/har-request-body` (#2156) · must merge last

> Ordering only — this builds on #2154, not on #2155 or #2156. A stack has to be linear, so it was placed last as the lowest-severity layer. **This is the most droppable PR in the stack**; closing it does not affect the three below.

## The problem

`request.Cookies` and `response.Cookies` were never read by either converter. Entries whose producer recorded cookies only in the structured array — without a matching `Cookie` / `Set-Cookie` header — converted to a message with no cookies at all, so a replayed request silently lost its session.

Most tools write both forms, so this usually goes unnoticed; it is a Low finding for that reason.

## What changed

- `Cookie` is synthesized from `request.Cookies` **only when the archive contained no `Cookie` header**, so the recorded header always wins and the message never ends up with two.
- One `Set-Cookie` per entry in `response.Cookies`, under the same condition, with `Path`, `Domain`, `Expires` (RFC 1123), `HttpOnly` and `Secure` rendered when present.

## Verification

`dotnet test -p:TreatsWarningsAsErrors=true` → **108/108 green** on `net10.0` and `net11.0` (4 new tests). The fixture's first entry records cookies in *both* forms; the test asserts the converted message carries exactly one `Cookie` and one `Set-Cookie`, taken from the headers.
