### PR TITLE
Stop inflating PNG image data past the size the header allows

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/Images/PngImageLoader.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/Images/PngImageLoader.cs
@@ -267,14 +267,27 @@ internal static class PngImageLoader
     /// <summary>Inflates the concatenated IDAT chunks.</summary>
     /// <param name="compressedStream">The concatenated IDAT chunks, positioned at the first byte.</param>
     /// <param name="expectedLength">
-    /// The image data size computed from the header, used to size the output buffer. A malformed image may
-    /// inflate to a different size, in which case the stream simply grows as usual.
+    /// The image data size computed from the validated header. Inflating is stopped one byte past it: the
+    /// header already says how much data the image can hold, so anything beyond that is malformed and the
+    /// caller reports the size mismatch. Copying the whole stream instead would let a corrupt file inflate
+    /// to an arbitrary size and exhaust memory before the size is ever checked.
     /// </param>
     private static MemoryStream DecompressPngIdatData(Stream compressedStream, int expectedLength)
     {
         using var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress, leaveOpen: true);
         var output = new MemoryStream(expectedLength);
-        zlibStream.CopyTo(output);
+
+        // One byte past the expected size is enough to tell "exactly right" from "too long".
+        var limit = (long)expectedLength + 1;
+        var buffer = new byte[Math.Min(limit, 81920)];
+        while (output.Length < limit)
+        {
+            var read = zlibStream.Read(buffer, 0, (int)Math.Min(buffer.Length, limit - output.Length));
+            if (read == 0)
+                break;
+
+            output.Write(buffer, 0, read);
+        }
 
         return output;
     }

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/ImageTestData.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/ImageTestData.cs
@@ -247,6 +247,42 @@ internal static class ImageTestData
         return stream.ToArray();
     }
 
+    /// <summary>
+    /// Writes a PNG whose IDAT payload is supplied verbatim, so the inflated size can deliberately disagree
+    /// with what the IHDR dimensions imply.
+    /// </summary>
+    public static byte[] CreatePngWithRawImageData(int width, int height, byte bitDepth, byte colorType, byte[] rawImageData)
+    {
+        ArgumentNullException.ThrowIfNull(rawImageData);
+
+        byte[] compressedData;
+        using (var compressedStream = new MemoryStream())
+        {
+            using (var zlib = new ZLibStream(compressedStream, CompressionLevel.SmallestSize, leaveOpen: true))
+            {
+                zlib.Write(rawImageData);
+            }
+
+            compressedData = compressedStream.ToArray();
+        }
+
+        using var stream = new MemoryStream();
+        stream.Write([137, 80, 78, 71, 13, 10, 26, 10]);
+
+        Span<byte> ihdrData = stackalloc byte[13];
+        BinaryPrimitives.WriteUInt32BigEndian(ihdrData, (uint)width);
+        BinaryPrimitives.WriteUInt32BigEndian(ihdrData[4..], (uint)height);
+        ihdrData[8] = bitDepth;
+        ihdrData[9] = colorType;
+        ihdrData[10] = 0;
+        ihdrData[11] = 0;
+        ihdrData[12] = 0;
+        WritePngChunk(stream, "IHDR"u8, ihdrData);
+        WritePngChunk(stream, "IDAT"u8, compressedData);
+        WritePngChunk(stream, "IEND"u8, ReadOnlySpan<byte>.Empty);
+        return stream.ToArray();
+    }
+
     public static byte[] CreateIcoWithPngEntries(params byte[][] pngImages)
     {
         ArgumentNullException.ThrowIfNull(pngImages);

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/PngImageLoaderTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/PngImageLoaderTests.cs
@@ -108,4 +108,19 @@ public sealed class PngImageLoaderTests
 
         Assert.Equal([new Argb(0xFF101010u), new Argb(0x80202020u)], image.Pixels.ToArray());
     }
+
+    [Fact]
+    public void Load_StopsInflatingOnceTheImageDataIsLongerThanTheHeaderAllows()
+    {
+        // The header describes a 1x1 RGBA image (5 bytes of filtered image data) while the IDAT inflates to
+        // 64 MiB of zeros. Reading the whole stream would materialize all of it before the size is checked.
+        const int InflatedSize = 64 * 1024 * 1024;
+        var imageData = ImageTestData.CreatePngWithRawImageData(width: 1, height: 1, bitDepth: 8, colorType: 6, new byte[InflatedSize]);
+
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        Assert.Throws<InvalidDataException>(() => Image.Load(imageData));
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        Assert.True(allocated < 4 * 1024 * 1024, $"Decoding allocated {allocated} bytes for a 1x1 image.");
+    }
 }


### PR DESCRIPTION
`DecompressPngIdatData` used `expectedLength` only to *size* the output buffer, then copied
the whole inflated stream:

```csharp
var output = new MemoryStream(expectedLength);
zlibStream.CopyTo(output);
```

The existing doc comment acknowledged it — "A malformed image may inflate to a different
size, in which case the stream simply grows as usual" — and the size check only happens
afterwards, at `PngImageLoader.cs:220`. So a corrupt or deliberately crafted `.verified.png`
could inflate to an arbitrary size and exhaust memory before anything checked it.

Snapshot files are largely trusted input, which is why this is a robustness issue rather
than a vulnerability — but the bound is nearly free.

## What changed

Inflate at most `expectedLength + 1` bytes. One byte past the expected size is enough to
distinguish "exactly right" from "too long", and the existing equality check at line 220
then reports the mismatch as `InvalidDataException` exactly as before.

## Verification

Added `Load_StopsInflatingOnceTheImageDataIsLongerThanTheHeaderAllows`: a PNG whose IHDR
describes a 1×1 RGBA image (5 bytes of filtered data) while its IDAT inflates to 64 MiB of
zeros, asserting both the `InvalidDataException` and that decoding allocates under 4 MiB.

Measured against the old code, the same input allocated **134,285,760 bytes** for a 1×1
image; with the cap the test passes well inside the 4 MiB bound.

Also added `ImageTestData.CreatePngWithRawImageData`, which writes a PNG with a verbatim
IDAT payload so the inflated size can deliberately disagree with the IHDR dimensions —
the existing `CreatePng` helper validates that they match.

```
dotnet build slnx/Meziantou.Framework.SnapshotTesting.slnx /p:TreatsWarningsAsErrors=true   # 0 warnings, 0 errors
dotnet test tests/Meziantou.Framework.SnapshotTesting.Tests --filter-not-class "*EndToEnd*" # 115/115 passed
```
