### PR TITLE
Report the real bound in the storage index validation message

### DIFF
--- a/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
+++ b/src/Meziantou.Framework.BloomFilters/SegmentedBitStorage.cs
@@ -84,10 +84,10 @@ internal sealed class SegmentedBitStorage
     {
         if ((ulong)bitIndex >= (ulong)BitCount)
         {
-            ThrowInvalidBitIndex(bitIndex);
+            ThrowInvalidBitIndex(bitIndex, BitCount);
         }
 
         [DoesNotReturn]
-        static void ThrowInvalidBitIndex(long bitIndex) => throw new ArgumentOutOfRangeException(nameof(bitIndex), $"Bit index must be between 0 and {long.MaxValue} (inclusive). Actual value: {bitIndex}");
+        static void ThrowInvalidBitIndex(long bitIndex, long bitCount) => throw new ArgumentOutOfRangeException(nameof(bitIndex), $"Bit index must be between 0 and {bitCount - 1} (inclusive). Actual value: {bitIndex}");
     }
 }

--- a/src/Meziantou.Framework.BloomFilters/SegmentedCounterStorage.cs
+++ b/src/Meziantou.Framework.BloomFilters/SegmentedCounterStorage.cs
@@ -81,10 +81,10 @@ internal sealed class SegmentedCounterStorage
     {
         if ((ulong)counterIndex >= (ulong)CounterCount)
         {
-            ThrowInvalidCounterIndex(counterIndex);
+            ThrowInvalidCounterIndex(counterIndex, CounterCount);
         }
 
         [DoesNotReturn]
-        static void ThrowInvalidCounterIndex(long counterIndex) => throw new ArgumentOutOfRangeException(nameof(counterIndex), $"Counter index must be between 0 and {long.MaxValue} (inclusive). Actual value: {counterIndex}");
+        static void ThrowInvalidCounterIndex(long counterIndex, long counterCount) => throw new ArgumentOutOfRangeException(nameof(counterIndex), $"Counter index must be between 0 and {counterCount - 1} (inclusive). Actual value: {counterIndex}");
     }
 }


### PR DESCRIPTION
## The problem

The debug-only bounds check reports a range that is never the real one:

```csharp
throw new ArgumentOutOfRangeException(nameof(bitIndex), $"Bit index must be between 0 and {long.MaxValue} (inclusive). Actual value: {bitIndex}")
```

The guard above it tests `(ulong)bitIndex >= (ulong)BitCount`, so the valid range is `0 .. BitCount - 1`. Printing `long.MaxValue` tells the reader nothing except that the index is a `long` — and the value it should be showing, the filter's actual size, is the one piece of information needed to tell an off-by-one apart from a reduction that produced garbage.

`SegmentedCounterStorage` has the same message with `CounterCount`.

## The change

Pass the bound into the throw helper and interpolate it. The helper is `static` (so it can't close over the instance property), hence the extra parameter rather than a direct property read.

## Verification

No test. `ValidateBitIndex` is `[Conditional("DEBUG")]` on an `internal` type, and `Reduce` is provably in range for every valid filter size — `(hash * range) >> width < range` holds for all inputs — so the branch is unreachable from the public API by construction. There is nothing to assert from a test project that sees only the public surface. The message exists for whoever is debugging a future change to the reduction, which is exactly when the real bound matters.

Verified it compiles in both configurations, since the call site only exists in `Debug`: `dotnet build -c Debug` succeeds with warnings as errors, and `dotnet test -c Release` gives **984 passed, 0 failed** (492 × net10.0/net11.0). `dotnet run ./eng/update-all.cs` reports no changes.
