### PR TITLE
Accept Docker tags and npm ranges that omit version components

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Versioning/DockerVersioningStrategy.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Versioning/DockerVersioningStrategy.cs
@@ -12,15 +12,15 @@ internal sealed class DockerVersioningStrategy : VersioningStrategy
 
     public override bool IsSupportedVersion(string? version)
     {
-        return TryGetSemanticVersion(version, out _, out _);
+        return TryGetSemanticVersion(version, out _, out _, out _);
     }
 
     public override int CompareVersions(string? x, string? y)
     {
-        if (!TryGetSemanticVersion(x, out var left, out _))
+        if (!TryGetSemanticVersion(x, out var left, out _, out _))
             throw new ArgumentException($"Version '{x}' is not a valid docker version", nameof(x));
 
-        if (!TryGetSemanticVersion(y, out var right, out _))
+        if (!TryGetSemanticVersion(y, out var right, out _, out _))
             throw new ArgumentException($"Version '{y}' is not a valid docker version", nameof(y));
 
         return left!.CompareTo(right);
@@ -28,31 +28,37 @@ internal sealed class DockerVersioningStrategy : VersioningStrategy
 
     public override bool IsCompatibleVersion(string? currentVersion, string candidateVersion)
     {
-        if (!TryGetSemanticVersion(currentVersion, out var current, out var currentSuffix))
+        if (!TryGetSemanticVersion(currentVersion, out var current, out var currentSuffix, out var currentComponentCount))
             return false;
 
-        if (!TryGetSemanticVersion(candidateVersion, out var candidate, out var candidateSuffix))
+        if (!TryGetSemanticVersion(candidateVersion, out var candidate, out var candidateSuffix, out var candidateComponentCount))
             return false;
 
         if (!string.Equals(currentSuffix, candidateSuffix, StringComparison.Ordinal))
             return false;
 
+        // The candidate is written back verbatim as the image tag, so it must have the same shape as the
+        // current tag: '8.0' must not be replaced by '8.1.2', which pins the image far more tightly.
+        if (currentComponentCount != candidateComponentCount)
+            return false;
+
         return candidate > current;
     }
 
-    private static bool TryGetSemanticVersion(string? value, out SemanticVersion? semanticVersion, out string? suffix)
+    private static bool TryGetSemanticVersion(string? value, out SemanticVersion? semanticVersion, out string? suffix, out int componentCount)
     {
         semanticVersion = null;
         suffix = null;
+        componentCount = 0;
 
         if (string.IsNullOrEmpty(value))
             return false;
 
         var hyphenIndex = value.IndexOf('-', StringComparison.Ordinal);
         if (hyphenIndex < 0)
-            return SemanticVersion.TryParse(value, out semanticVersion);
+            return PartialSemanticVersion.TryParse(value, out semanticVersion, out componentCount);
 
         suffix = value[(hyphenIndex + 1)..];
-        return SemanticVersion.TryParse(value[..hyphenIndex], out semanticVersion);
+        return PartialSemanticVersion.TryParse(value[..hyphenIndex], out semanticVersion, out componentCount);
     }
 }

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Versioning/GitHubActionsVersioningStrategy.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Versioning/GitHubActionsVersioningStrategy.cs
@@ -70,40 +70,6 @@ internal sealed class GitHubActionsVersioningStrategy : VersioningStrategy
             value = suffix;
         }
 
-        var firstSuffixIndex = value.IndexOfAny(['-', '+']);
-        var numericPart = firstSuffixIndex >= 0 ? value[..firstSuffixIndex] : value;
-        componentCount = numericPart.Count(c => c == '.') + 1;
-        if (componentCount is < 1 or > 3)
-            return false;
-
-        if (numericPart.Split('.').Any(static part => !int.TryParse(part, NumberStyles.None, CultureInfo.InvariantCulture, out _)))
-            return false;
-
-        var normalizedVersion = NormalizeToThreeComponents(value, componentCount);
-
-        if (!SemanticVersion.TryParse(normalizedVersion, out var parsedVersion))
-            return false;
-
-        version = parsedVersion;
-        return true;
-    }
-
-    private static string NormalizeToThreeComponents(string value, int componentCount)
-    {
-        if (componentCount is 3)
-            return value;
-
-        var firstSuffixIndex = value.IndexOfAny(['-', '+']);
-        var core = firstSuffixIndex >= 0 ? value[..firstSuffixIndex] : value;
-        var suffix = firstSuffixIndex >= 0 ? value[firstSuffixIndex..] : string.Empty;
-
-        var sb = new StringBuilder(core);
-        for (var i = componentCount; i < 3; i++)
-        {
-            sb.Append(".0");
-        }
-
-        sb.Append(suffix);
-        return sb.ToString();
+        return PartialSemanticVersion.TryParse(value, out version, out componentCount);
     }
 }

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Versioning/NpmVersioningStrategy.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Versioning/NpmVersioningStrategy.cs
@@ -93,6 +93,8 @@ internal sealed class NpmVersioningStrategy : VersioningStrategy
             value = suffix;
         }
 
-        return SemanticVersion.TryParse(value, out semanticVersion);
+        // Ranges such as '^1.1' or '~7' omit components. Unlike Docker tags the shape is not preserved:
+        // registry versions are always complete, and 'npm update --save' also writes the full version back.
+        return PartialSemanticVersion.TryParse(value, out semanticVersion, out _);
     }
 }

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Versioning/PartialSemanticVersion.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Versioning/PartialSemanticVersion.cs
@@ -1,0 +1,56 @@
+using Meziantou.Framework.Versioning;
+
+namespace Meziantou.Framework.DependencyScanning.Tool;
+
+/// <summary>
+/// Parses versions that may omit the minor or the patch component, such as the Docker tag <c>8.0</c>
+/// or the npm range <c>~7</c>. <see cref="SemanticVersion.TryParse(string, out SemanticVersion)"/> requires
+/// all three components, so those values would otherwise be rejected as unsupported.
+/// </summary>
+internal static class PartialSemanticVersion
+{
+    /// <summary>Parses <paramref name="value"/>, padding the missing components with zeros.</summary>
+    /// <param name="componentCount">The number of numeric components present in <paramref name="value"/>, so callers can write an updated version back in the same shape.</param>
+    public static bool TryParse(string? value, out SemanticVersion? version, out int componentCount)
+    {
+        version = null;
+        componentCount = 0;
+
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var firstSuffixIndex = value.IndexOfAny(['-', '+']);
+        var numericPart = firstSuffixIndex >= 0 ? value[..firstSuffixIndex] : value;
+        componentCount = numericPart.Count(c => c == '.') + 1;
+        if (componentCount > 3)
+            return false;
+
+        if (numericPart.Split('.').Any(static part => !int.TryParse(part, NumberStyles.None, CultureInfo.InvariantCulture, out _)))
+            return false;
+
+        if (!SemanticVersion.TryParse(PadToThreeComponents(value, componentCount), out var parsedVersion))
+            return false;
+
+        version = parsedVersion;
+        return true;
+    }
+
+    private static string PadToThreeComponents(string value, int componentCount)
+    {
+        if (componentCount is 3)
+            return value;
+
+        var firstSuffixIndex = value.IndexOfAny(['-', '+']);
+        var core = firstSuffixIndex >= 0 ? value[..firstSuffixIndex] : value;
+        var suffix = firstSuffixIndex >= 0 ? value[firstSuffixIndex..] : string.Empty;
+
+        var sb = new StringBuilder(core);
+        for (var i = componentCount; i < 3; i++)
+        {
+            sb.Append(".0");
+        }
+
+        sb.Append(suffix);
+        return sb.ToString();
+    }
+}

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
@@ -528,6 +528,35 @@ public sealed class FunctionalTests
         Assert.Equal("^2.0.0", strategy.GetUpdateReferenceText("^1.0.0", "2.0.0"));
         Assert.Equal("~2.0.0", strategy.GetUpdateReferenceText("~1.0.0", "2.0.0"));
         Assert.Equal("2.0.0", strategy.GetUpdateReferenceText("1.0.0", "2.0.0"));
+
+        // A partial range keeps its prefix and gains the full version, like 'npm update --save'
+        Assert.Equal("^1.9.4", strategy.GetUpdateReferenceText("^1.1", "1.9.4"));
+        Assert.Equal("~7.7.4", strategy.GetUpdateReferenceText("~7", "7.7.4"));
+    }
+
+    [Theory]
+    [InlineData("1.0.0", true)]
+    [InlineData("^1.1", true)]
+    [InlineData("~7", true)]
+    [InlineData(">=2.4", true)]
+    [InlineData("v1.2", true)]
+    [InlineData("1.x", false)]
+    [InlineData("*", false)]
+    [InlineData("latest", false)]
+    [InlineData("", false)]
+    public void NpmVersioningStrategy_IsSupportedVersion(string version, bool expectedResult)
+    {
+        Assert.Equal(expectedResult, NpmVersioningStrategy.Instance.IsSupportedVersion(version));
+    }
+
+    [Theory]
+    [InlineData("^1.1", "1.9.4", true)]
+    [InlineData("~7", "7.7.4", true)]
+    [InlineData("^1.1", "1.1.0", false)]
+    [InlineData("^2", "1.9.4", false)]
+    public void NpmVersioningStrategy_IsCompatibleVersion(string currentVersion, string candidateVersion, bool expectedResult)
+    {
+        Assert.Equal(expectedResult, NpmVersioningStrategy.Instance.IsCompatibleVersion(currentVersion, candidateVersion));
     }
 
     [Theory]
@@ -535,6 +564,18 @@ public sealed class FunctionalTests
     [InlineData("1.0.0-alpine", "1.0.1-slim", false)]
     [InlineData("1.0.0", "1.0.1-alpine", false)]
     [InlineData("1.0.0", "1.1.0", true)]
+    // Two- and one-component tags are the common shape for official images
+    [InlineData("1.27", "1.31", true)]
+    [InlineData("9.0", "10.0", true)]
+    [InlineData("20-alpine", "24-alpine", true)]
+    [InlineData("20-alpine", "24-slim", false)]
+    // The candidate is written back as the tag, so the number of components must not change
+    [InlineData("1.27", "1.31.4", false)]
+    [InlineData("1.27.1", "1.31", false)]
+    [InlineData("20-alpine", "24.1-alpine", false)]
+    // Still not a version
+    [InlineData("latest", "1.0.0", false)]
+    [InlineData("1.0.0", "latest", false)]
     public void DockerVersioningStrategy_IsCompatibleVersion(string currentVersion, string candidateVersion, bool expectedResult)
     {
         var strategy = DockerVersioningStrategy.Instance;


### PR DESCRIPTION
Docker tags and npm ranges that omit the minor or patch component were silently skipped. Both strategies delegate `IsSupportedVersion` to `SemanticVersion.TryParse`, which requires all three components, so `PackageUpdater.GetUpdatedVersionAsync` returned `null` without a word.

**Reproduced before the fix** — exit code 0, no diagnostic:

```
FROM nginx:1.27                          -> not updated
FROM nginx:1.27.1                        -> updated to 1.31.4
FROM mcr.microsoft.com/dotnet/aspnet:9.0 -> not updated
FROM node:20-alpine                      -> not updated

"left-pad": "^1.1"    -> not updated
"lodash":   "4.17.20" -> updated to 4.18.1
"semver":   "~7"      -> not updated
```

These are the dominant shapes in the wild — official .NET, Node and nginx images are almost always pinned as `9.0`, `20-alpine` or `1.27`, and npm ranges are routinely `^18` or `~7`. On a typical repository the tool reported success while leaving most Docker and npm dependencies untouched.

## What changed

`GitHubActionsVersioningStrategy` already solved this privately, so its logic is extracted into `PartialSemanticVersion.TryParse`, which pads the missing components and reports how many were present. All three strategies now share it.

The two ecosystems then differ, deliberately:

- **Docker** — the candidate *is* the tag that gets written back, so `IsCompatibleVersion` now also requires the component count to match. `1.27` moves to `1.31`, never to `1.31.4`; a two-component pin stays a two-component pin. The existing suffix rule (`-alpine` must match `-alpine`) is unchanged.
- **npm** — registry versions are always complete, so matching component counts would block every update. Instead the current value may be partial and the full version is written back under the existing prefix: `^1.1` → `^1.9.4`, `~7` → `~7.7.4`. That is what `npm update --save` does too.

Also removed the `componentCount is < 1` half of a guard in the extracted code — `componentCount` is `Count('.') + 1`, so it can never be below 1.

## Verification

Same input after the fix, each dependency keeping its original shape:

```
FROM nginx:1.31
FROM nginx:1.31.4
FROM mcr.microsoft.com/dotnet/aspnet:10.0
FROM node:26-alpine

"left-pad": "^1.3.0"
"lodash":   "4.18.1"
"semver":   "~7.8.5"
```

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 71 passed, 0 failed (was 49).
- `dotnet run ./eng/update-all.cs` — no generated-file changes.

22 new test cases: partial and shape-preserving rows on `DockerVersioningStrategy_IsCompatibleVersion`, plus `NpmVersioningStrategy_IsSupportedVersion` and `NpmVersioningStrategy_IsCompatibleVersion` covering `^1.1`, `~7`, `>=2.4` and the values that must stay unsupported (`1.x`, `*`, `latest`).
