### PR TITLE
Make the HAR model nullable so archives with an explicit null still parse

### DIFF
--- a/ref/Meziantou.Framework.HttpArchive.cs
+++ b/ref/Meziantou.Framework.HttpArchive.cs
@@ -7,9 +7,9 @@ namespace Meziantou.Framework.HttpArchive
     public sealed class HarBrowser
     {
         [System.Text.Json.Serialization.JsonPropertyName("name")]
-        public string Name { get => throw null; set { } }
+        public string? Name { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("version")]
-        public string Version { get => throw null; set { } }
+        public string? Version { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("comment")]
         public string? Comment { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonExtensionData]
@@ -35,7 +35,7 @@ namespace Meziantou.Framework.HttpArchive
         [System.Text.Json.Serialization.JsonPropertyName("lastAccess")]
         public System.DateTimeOffset LastAccess { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("eTag")]
-        public string ETag { get => throw null; set { } }
+        public string? ETag { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("hitCount")]
         public int HitCount { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("comment")]
@@ -51,7 +51,7 @@ namespace Meziantou.Framework.HttpArchive
         [System.Text.Json.Serialization.JsonPropertyName("compression")]
         public long? Compression { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("mimeType")]
-        public string MimeType { get => throw null; set { } }
+        public string? MimeType { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("text")]
         public string? Text { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("encoding")]
@@ -70,9 +70,9 @@ namespace Meziantou.Framework.HttpArchive
     public sealed class HarCookie
     {
         [System.Text.Json.Serialization.JsonPropertyName("name")]
-        public string Name { get => throw null; set { } }
+        public string? Name { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("value")]
-        public string Value { get => throw null; set { } }
+        public string? Value { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("path")]
         public string? Path { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("domain")]
@@ -92,9 +92,9 @@ namespace Meziantou.Framework.HttpArchive
     public sealed class HarCreator
     {
         [System.Text.Json.Serialization.JsonPropertyName("name")]
-        public string Name { get => throw null; set { } }
+        public string? Name { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("version")]
-        public string Version { get => throw null; set { } }
+        public string? Version { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("comment")]
         public string? Comment { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonExtensionData]
@@ -104,7 +104,7 @@ namespace Meziantou.Framework.HttpArchive
     public sealed class HarDocument
     {
         [System.Text.Json.Serialization.JsonPropertyName("log")]
-        public Meziantou.Framework.HttpArchive.HarLog Log { get => throw null; set { } }
+        public Meziantou.Framework.HttpArchive.HarLog? Log { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonExtensionData]
         public System.Collections.Generic.Dictionary<string, System.Text.Json.JsonElement>? ExtensionData { get => throw null; set { } }
         public static Meziantou.Framework.HttpArchive.HarDocument Parse(string json) => throw null;
@@ -124,13 +124,13 @@ namespace Meziantou.Framework.HttpArchive
         [System.Text.Json.Serialization.JsonPropertyName("time")]
         public double Time { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("request")]
-        public Meziantou.Framework.HttpArchive.HarRequest Request { get => throw null; set { } }
+        public Meziantou.Framework.HttpArchive.HarRequest? Request { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("response")]
-        public Meziantou.Framework.HttpArchive.HarResponse Response { get => throw null; set { } }
+        public Meziantou.Framework.HttpArchive.HarResponse? Response { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("cache")]
-        public Meziantou.Framework.HttpArchive.HarCache Cache { get => throw null; set { } }
+        public Meziantou.Framework.HttpArchive.HarCache? Cache { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("timings")]
-        public Meziantou.Framework.HttpArchive.HarTimings Timings { get => throw null; set { } }
+        public Meziantou.Framework.HttpArchive.HarTimings? Timings { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("serverIPAddress")]
         public string? ServerIPAddress { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("connection")]
@@ -152,9 +152,9 @@ namespace Meziantou.Framework.HttpArchive
     public sealed class HarHeader
     {
         [System.Text.Json.Serialization.JsonPropertyName("name")]
-        public string Name { get => throw null; set { } }
+        public string? Name { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("value")]
-        public string Value { get => throw null; set { } }
+        public string? Value { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("comment")]
         public string? Comment { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonExtensionData]
@@ -164,15 +164,15 @@ namespace Meziantou.Framework.HttpArchive
     public sealed class HarLog
     {
         [System.Text.Json.Serialization.JsonPropertyName("version")]
-        public string Version { get => throw null; set { } }
+        public string? Version { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("creator")]
-        public Meziantou.Framework.HttpArchive.HarCreator Creator { get => throw null; set { } }
+        public Meziantou.Framework.HttpArchive.HarCreator? Creator { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("browser")]
         public Meziantou.Framework.HttpArchive.HarBrowser? Browser { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("pages")]
         public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarPage>? Pages { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("entries")]
-        public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarEntry> Entries { get => throw null; set { } }
+        public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarEntry>? Entries { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("comment")]
         public string? Comment { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonExtensionData]
@@ -184,11 +184,11 @@ namespace Meziantou.Framework.HttpArchive
         [System.Text.Json.Serialization.JsonPropertyName("startedDateTime")]
         public System.DateTimeOffset StartedDateTime { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("id")]
-        public string Id { get => throw null; set { } }
+        public string? Id { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("title")]
-        public string Title { get => throw null; set { } }
+        public string? Title { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("pageTimings")]
-        public Meziantou.Framework.HttpArchive.HarPageTimings PageTimings { get => throw null; set { } }
+        public Meziantou.Framework.HttpArchive.HarPageTimings? PageTimings { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("comment")]
         public string? Comment { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonExtensionData]
@@ -210,7 +210,7 @@ namespace Meziantou.Framework.HttpArchive
     public sealed class HarPostData
     {
         [System.Text.Json.Serialization.JsonPropertyName("mimeType")]
-        public string MimeType { get => throw null; set { } }
+        public string? MimeType { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("params")]
         public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarPostDataParameter>? Params { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("text")]
@@ -246,9 +246,9 @@ namespace Meziantou.Framework.HttpArchive
     public sealed class HarQueryParameter
     {
         [System.Text.Json.Serialization.JsonPropertyName("name")]
-        public string Name { get => throw null; set { } }
+        public string? Name { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("value")]
-        public string Value { get => throw null; set { } }
+        public string? Value { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("comment")]
         public string? Comment { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonExtensionData]
@@ -258,17 +258,17 @@ namespace Meziantou.Framework.HttpArchive
     public sealed class HarRequest
     {
         [System.Text.Json.Serialization.JsonPropertyName("method")]
-        public string Method { get => throw null; set { } }
+        public string? Method { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("url")]
-        public string Url { get => throw null; set { } }
+        public string? Url { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("httpVersion")]
-        public string HttpVersion { get => throw null; set { } }
+        public string? HttpVersion { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("cookies")]
-        public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarCookie> Cookies { get => throw null; set { } }
+        public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarCookie>? Cookies { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("headers")]
-        public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarHeader> Headers { get => throw null; set { } }
+        public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarHeader>? Headers { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("queryString")]
-        public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarQueryParameter> QueryString { get => throw null; set { } }
+        public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarQueryParameter>? QueryString { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("postData")]
         public Meziantou.Framework.HttpArchive.HarPostData? PostData { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("headersSize")]
@@ -286,17 +286,17 @@ namespace Meziantou.Framework.HttpArchive
         [System.Text.Json.Serialization.JsonPropertyName("status")]
         public int Status { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("statusText")]
-        public string StatusText { get => throw null; set { } }
+        public string? StatusText { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("httpVersion")]
-        public string HttpVersion { get => throw null; set { } }
+        public string? HttpVersion { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("cookies")]
-        public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarCookie> Cookies { get => throw null; set { } }
+        public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarCookie>? Cookies { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("headers")]
-        public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarHeader> Headers { get => throw null; set { } }
+        public System.Collections.Generic.List<Meziantou.Framework.HttpArchive.HarHeader>? Headers { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("content")]
-        public Meziantou.Framework.HttpArchive.HarContent Content { get => throw null; set { } }
+        public Meziantou.Framework.HttpArchive.HarContent? Content { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("redirectURL")]
-        public string RedirectUrl { get => throw null; set { } }
+        public string? RedirectUrl { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("headersSize")]
         public long HeadersSize { get => throw null; set { } }
         [System.Text.Json.Serialization.JsonPropertyName("bodySize")]

--- a/src/Meziantou.Framework.Http.Recording/HarHttpRecordingStore.cs
+++ b/src/Meziantou.Framework.Http.Recording/HarHttpRecordingStore.cs
@@ -24,9 +24,13 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
 
         await using var stream = File.OpenRead(_filePath);
         var doc = await HarDocument.ParseAsync(stream, cancellationToken).ConfigureAwait(false);
+        if (doc.Log?.Entries is not { } harEntries)
+        {
+            return [];
+        }
 
-        var entries = new List<HttpRecordingEntry>(doc.Log.Entries.Count);
-        foreach (var harEntry in doc.Log.Entries)
+        var entries = new List<HttpRecordingEntry>(harEntries.Count);
+        foreach (var harEntry in harEntries)
         {
             entries.Add(ConvertFromHarEntry(harEntry));
         }
@@ -43,14 +47,21 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
             Directory.CreateDirectory(directory);
         }
 
-        var doc = new HarDocument();
-        doc.Log.Version = "1.2";
-        doc.Log.Creator = new HarCreator { Name = "Meziantou.Framework.Http.Recording", Version = "1.0.0" };
-
+        var harEntries = new List<HarEntry>(entries.Count);
         foreach (var entry in entries)
         {
-            doc.Log.Entries.Add(ConvertToHarEntry(entry));
+            harEntries.Add(ConvertToHarEntry(entry));
         }
+
+        var doc = new HarDocument
+        {
+            Log = new HarLog
+            {
+                Version = "1.2",
+                Creator = new HarCreator { Name = "Meziantou.Framework.Http.Recording", Version = "1.0.0" },
+                Entries = harEntries,
+            },
+        };
 
         await using var stream = File.Create(_filePath);
         await doc.WriteToAsync(stream, indented: true, cancellationToken).ConfigureAwait(false);
@@ -58,133 +69,95 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
 
     private static HttpRecordingEntry ConvertFromHarEntry(HarEntry harEntry)
     {
+        var request = harEntry.Request;
+        var response = harEntry.Response;
+
         var entry = new HttpRecordingEntry
         {
-            Method = harEntry.Request.Method,
-            RequestUri = harEntry.Request.Url,
-            StatusCode = harEntry.Response.Status,
+            Method = request?.Method ?? "",
+            RequestUri = request?.Url ?? "",
+            StatusCode = response?.Status ?? 0,
             RecordedAt = harEntry.StartedDateTime,
+            RequestHeaders = ConvertFromHarHeaders(request?.Headers),
+            ResponseHeaders = ConvertFromHarHeaders(response?.Headers),
         };
 
-        // Request headers
-        if (harEntry.Request.Headers.Count > 0)
-        {
-            entry.RequestHeaders = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
-            foreach (var header in harEntry.Request.Headers)
-            {
-                if (entry.RequestHeaders.TryGetValue(header.Name, out var existing))
-                {
-                    entry.RequestHeaders[header.Name] = [.. existing, header.Value];
-                }
-                else
-                {
-                    entry.RequestHeaders[header.Name] = [header.Value];
-                }
-            }
-        }
-
         // Request body
-        if (harEntry.Request.PostData.TryGetRawData(out var requestBody))
+        if (request?.PostData.TryGetRawData(out var requestBody) is true)
         {
             entry.RequestBody = requestBody;
         }
 
-        // Response headers
-        if (harEntry.Response.Headers.Count > 0)
-        {
-            entry.ResponseHeaders = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
-            foreach (var header in harEntry.Response.Headers)
-            {
-                if (entry.ResponseHeaders.TryGetValue(header.Name, out var existing))
-                {
-                    entry.ResponseHeaders[header.Name] = [.. existing, header.Value];
-                }
-                else
-                {
-                    entry.ResponseHeaders[header.Name] = [header.Value];
-                }
-            }
-        }
-
         // Response body
-        if (harEntry.Response.Content.Text is not null)
+        if (response?.Content?.Text is { } responseText)
         {
-            if (string.Equals(harEntry.Response.Content.Encoding, "base64", StringComparison.OrdinalIgnoreCase))
-            {
-                entry.ResponseBody = Convert.FromBase64String(harEntry.Response.Content.Text);
-            }
-            else
-            {
-                entry.ResponseBody = System.Text.Encoding.UTF8.GetBytes(harEntry.Response.Content.Text);
-            }
+            entry.ResponseBody = string.Equals(response.Content.Encoding, "base64", StringComparison.OrdinalIgnoreCase)
+                ? Convert.FromBase64String(responseText)
+                : System.Text.Encoding.UTF8.GetBytes(responseText);
         }
 
         return entry;
     }
 
+    /// <summary>Groups the archived headers by name. Headers without a name are skipped: there is nothing to look them up by.</summary>
+    private static Dictionary<string, string[]>? ConvertFromHarHeaders(List<HarHeader>? headers)
+    {
+        if (headers is null || headers.Count is 0)
+            return null;
+
+        var result = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var header in headers)
+        {
+            if (header.Name is not { } name)
+                continue;
+
+            var value = header.Value ?? "";
+            result[name] = result.TryGetValue(name, out var existing) ? [.. existing, value] : [value];
+        }
+
+        return result.Count is 0 ? null : result;
+    }
+
     private static HarEntry ConvertToHarEntry(HttpRecordingEntry entry)
     {
-        var harEntry = new HarEntry
+        var request = new HarRequest
         {
-            StartedDateTime = entry.RecordedAt,
-            Request =
-            {
-                Method = entry.Method,
-                Url = entry.RequestUri,
-            },
-            Response =
-            {
-                Status = entry.StatusCode,
-                StatusText = "",
-            },
+            Method = entry.Method,
+            Url = entry.RequestUri,
+            Headers = ConvertToHarHeaders(entry.RequestHeaders),
         };
 
-        // Request headers
-        if (entry.RequestHeaders is not null)
+        var response = new HarResponse
         {
-            foreach (var (name, values) in entry.RequestHeaders)
-            {
-                foreach (var value in values)
-                {
-                    harEntry.Request.Headers.Add(new HarHeader { Name = name, Value = value });
-                }
-            }
-        }
+            Status = entry.StatusCode,
+            StatusText = "",
+            Headers = ConvertToHarHeaders(entry.ResponseHeaders),
+        };
 
         // Request body
         if (entry.RequestBody is { Length: > 0 })
         {
             var contentType = GetContentType(entry.RequestHeaders);
 
-            harEntry.Request.PostData = new HarPostData
+            var postData = new HarPostData
             {
                 MimeType = contentType,
             };
 
             if (IsTextMediaType(contentType) && TryDecodeUtf8(entry.RequestBody, out var requestText))
             {
-                harEntry.Request.PostData.Text = requestText;
+                postData.Text = requestText;
             }
             else
             {
-                harEntry.Request.PostData.Text = Convert.ToBase64String(entry.RequestBody);
-                harEntry.Request.PostData.ExtensionData = new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal)
+                postData.Text = Convert.ToBase64String(entry.RequestBody);
+                postData.ExtensionData = new Dictionary<string, System.Text.Json.JsonElement>(StringComparer.Ordinal)
                 {
                     [HarPostDataExtensions.DefaultEncodingExtensionName] = System.Text.Json.JsonDocument.Parse("\"base64\"").RootElement.Clone(),
                 };
             }
-        }
 
-        // Response headers
-        if (entry.ResponseHeaders is not null)
-        {
-            foreach (var (name, values) in entry.ResponseHeaders)
-            {
-                foreach (var value in values)
-                {
-                    harEntry.Response.Headers.Add(new HarHeader { Name = name, Value = value });
-                }
-            }
+            request.PostData = postData;
         }
 
         // Response body
@@ -192,7 +165,7 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
         {
             var mimeType = GetContentType(entry.ResponseHeaders);
 
-            harEntry.Response.Content = new HarContent
+            var content = new HarContent
             {
                 Size = entry.ResponseBody.Length,
                 MimeType = mimeType,
@@ -200,16 +173,40 @@ public sealed class HarHttpRecordingStore : IHttpRecordingStore
 
             if (IsTextMediaType(mimeType) && TryDecodeUtf8(entry.ResponseBody, out var responseText))
             {
-                harEntry.Response.Content.Text = responseText;
+                content.Text = responseText;
             }
             else
             {
-                harEntry.Response.Content.Encoding = "base64";
-                harEntry.Response.Content.Text = Convert.ToBase64String(entry.ResponseBody);
+                content.Encoding = "base64";
+                content.Text = Convert.ToBase64String(entry.ResponseBody);
+            }
+
+            response.Content = content;
+        }
+
+        return new HarEntry
+        {
+            StartedDateTime = entry.RecordedAt,
+            Request = request,
+            Response = response,
+        };
+    }
+
+    private static List<HarHeader> ConvertToHarHeaders(Dictionary<string, string[]>? headers)
+    {
+        var result = new List<HarHeader>();
+        if (headers is not null)
+        {
+            foreach (var (name, values) in headers)
+            {
+                foreach (var value in values)
+                {
+                    result.Add(new HarHeader { Name = name, Value = value });
+                }
             }
         }
 
-        return harEntry;
+        return result;
     }
 
     private static string GetContentType(Dictionary<string, string[]>? headers)

--- a/src/Meziantou.Framework.HttpArchive/HarBrowser.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarBrowser.cs
@@ -8,11 +8,11 @@ public sealed class HarBrowser
 {
     /// <summary>Gets or sets the name of the browser.</summary>
     [JsonPropertyName("name")]
-    public string Name { get; set; } = "";
+    public string? Name { get; set; } = "";
 
     /// <summary>Gets or sets the version of the browser.</summary>
     [JsonPropertyName("version")]
-    public string Version { get; set; } = "";
+    public string? Version { get; set; } = "";
 
     /// <summary>Gets or sets a comment provided by the user or the application.</summary>
     [JsonPropertyName("comment")]

--- a/src/Meziantou.Framework.HttpArchive/HarCacheEntry.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarCacheEntry.cs
@@ -16,7 +16,7 @@ public sealed class HarCacheEntry
 
     /// <summary>Gets or sets the ETag.</summary>
     [JsonPropertyName("eTag")]
-    public string ETag { get; set; } = "";
+    public string? ETag { get; set; } = "";
 
     /// <summary>Gets or sets the number of times the cache entry has been opened.</summary>
     [JsonPropertyName("hitCount")]

--- a/src/Meziantou.Framework.HttpArchive/HarContent.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarContent.cs
@@ -16,7 +16,7 @@ public sealed class HarContent
 
     /// <summary>Gets or sets the MIME type of the response text.</summary>
     [JsonPropertyName("mimeType")]
-    public string MimeType { get; set; } = "";
+    public string? MimeType { get; set; } = "";
 
     /// <summary>Gets or sets the response body sent from the server or loaded from the browser cache.</summary>
     [JsonPropertyName("text")]

--- a/src/Meziantou.Framework.HttpArchive/HarCookie.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarCookie.cs
@@ -8,11 +8,11 @@ public sealed class HarCookie
 {
     /// <summary>Gets or sets the name of the cookie.</summary>
     [JsonPropertyName("name")]
-    public string Name { get; set; } = "";
+    public string? Name { get; set; } = "";
 
     /// <summary>Gets or sets the cookie value.</summary>
     [JsonPropertyName("value")]
-    public string Value { get; set; } = "";
+    public string? Value { get; set; } = "";
 
     /// <summary>Gets or sets the path pertaining to the cookie.</summary>
     [JsonPropertyName("path")]

--- a/src/Meziantou.Framework.HttpArchive/HarCreator.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarCreator.cs
@@ -8,11 +8,11 @@ public sealed class HarCreator
 {
     /// <summary>Gets or sets the name of the application that created the log.</summary>
     [JsonPropertyName("name")]
-    public string Name { get; set; } = "";
+    public string? Name { get; set; } = "";
 
     /// <summary>Gets or sets the version of the application that created the log.</summary>
     [JsonPropertyName("version")]
-    public string Version { get; set; } = "";
+    public string? Version { get; set; } = "";
 
     /// <summary>Gets or sets a comment provided by the user or the application.</summary>
     [JsonPropertyName("comment")]

--- a/src/Meziantou.Framework.HttpArchive/HarDocument.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarDocument.cs
@@ -8,7 +8,7 @@ public sealed class HarDocument
 {
     /// <summary>Gets or sets the log object containing all HAR data.</summary>
     [JsonPropertyName("log")]
-    public HarLog Log { get; set; } = new();
+    public HarLog? Log { get; set; } = new();
 
     /// <summary>Parses a HAR document from a JSON string.</summary>
     /// <param name="json">The JSON string to parse.</param>

--- a/src/Meziantou.Framework.HttpArchive/HarEntry.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarEntry.cs
@@ -20,19 +20,19 @@ public sealed class HarEntry
 
     /// <summary>Gets or sets the detailed info about the request.</summary>
     [JsonPropertyName("request")]
-    public HarRequest Request { get; set; } = new();
+    public HarRequest? Request { get; set; } = new();
 
     /// <summary>Gets or sets the detailed info about the response.</summary>
     [JsonPropertyName("response")]
-    public HarResponse Response { get; set; } = new();
+    public HarResponse? Response { get; set; } = new();
 
     /// <summary>Gets or sets the info about cache usage.</summary>
     [JsonPropertyName("cache")]
-    public HarCache Cache { get; set; } = new();
+    public HarCache? Cache { get; set; } = new();
 
     /// <summary>Gets or sets the detailed timing info about request/response round trip.</summary>
     [JsonPropertyName("timings")]
-    public HarTimings Timings { get; set; } = new();
+    public HarTimings? Timings { get; set; } = new();
 
     /// <summary>Gets or sets the IP address of the server that was connected.</summary>
     [JsonPropertyName("serverIPAddress")]

--- a/src/Meziantou.Framework.HttpArchive/HarEntryExtensions.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarEntryExtensions.cs
@@ -40,17 +40,21 @@ public static class HarEntryExtensions
     /// <summary>Creates an <see cref="HttpRequestMessage"/> from a HAR entry.</summary>
     /// <param name="entry">The HAR entry to convert.</param>
     /// <returns>An <see cref="HttpRequestMessage"/> representing the HAR request.</returns>
+    /// <exception cref="InvalidOperationException">The entry does not contain a request.</exception>
     public static HttpRequestMessage ToHttpRequestMessage(this HarEntry entry)
     {
-        return entry.Request.ToHttpRequestMessage();
+        var request = entry.Request ?? throw new InvalidOperationException("The HAR entry does not contain a request.");
+        return request.ToHttpRequestMessage();
     }
 
     /// <summary>Creates an <see cref="HttpResponseMessage"/> from a HAR entry.</summary>
     /// <param name="entry">The HAR entry to convert.</param>
     /// <returns>An <see cref="HttpResponseMessage"/> representing the HAR response.</returns>
+    /// <exception cref="InvalidOperationException">The entry does not contain a response.</exception>
     public static HttpResponseMessage ToHttpResponseMessage(this HarEntry entry)
     {
-        return entry.Response.ToHttpResponseMessage();
+        var response = entry.Response ?? throw new InvalidOperationException("The HAR entry does not contain a response.");
+        return response.ToHttpResponseMessage();
     }
 
     /// <summary>Creates an <see cref="HttpRequestMessage"/> from a HAR request.</summary>
@@ -61,12 +65,13 @@ public static class HarEntryExtensions
     /// <c>application/x-www-form-urlencoded</c> body is rebuilt from the parameters. Multipart bodies cannot be
     /// rebuilt this way because the original boundary is not part of the archive; they convert to an empty body.
     /// </remarks>
+    /// <exception cref="InvalidOperationException">The request does not contain a method or a URL.</exception>
     public static HttpRequestMessage ToHttpRequestMessage(this HarRequest request)
     {
         var message = new HttpRequestMessage
         {
-            Method = new HttpMethod(request.Method),
-            RequestUri = new Uri(request.Url),
+            Method = new HttpMethod(request.Method ?? throw new InvalidOperationException("The HAR request does not contain a method.")),
+            RequestUri = new Uri(request.Url ?? throw new InvalidOperationException("The HAR request does not contain a URL.")),
             Version = ParseHttpVersion(request.HttpVersion),
         };
 
@@ -86,9 +91,9 @@ public static class HarEntryExtensions
         CopyHeaders(request.Headers, message.Headers, content, request.PostData?.MimeType);
 
         // Some tools record cookies only in the structured list, without the header that carried them.
-        if (request.Cookies.Count > 0 && !message.Headers.Contains(CookieHeaderName))
+        if (request.Cookies is { Count: > 0 } cookies && !message.Headers.Contains(CookieHeaderName))
         {
-            message.Headers.TryAddWithoutValidation(CookieHeaderName, BuildCookieHeader(request.Cookies));
+            message.Headers.TryAddWithoutValidation(CookieHeaderName, BuildCookieHeader(cookies));
         }
 
         return message;
@@ -100,7 +105,7 @@ public static class HarEntryExtensions
             return new ByteArrayContent(Encoding.UTF8.GetBytes(postData.Text));
 
         if (postData.Params is { Count: > 0 } parameters &&
-            postData.MimeType.StartsWith("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase))
+            postData.MimeType?.StartsWith("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase) is true)
         {
             return new ByteArrayContent(Encoding.UTF8.GetBytes(BuildFormUrlEncodedBody(parameters)));
         }
@@ -126,11 +131,17 @@ public static class HarEntryExtensions
         return builder.ToString();
     }
 
-    private static bool HasContentHeader(List<HarHeader> headers)
+    private static bool HasContentHeader(List<HarHeader>? headers)
     {
+        if (headers is null)
+            return false;
+
         foreach (var header in headers)
         {
-            if (!WireOnlyHeaderNames.Contains(header.Name) && ContentHeaderNames.Contains(header.Name))
+            if (header.Name is not { } name)
+                continue;
+
+            if (!WireOnlyHeaderNames.Contains(name) && ContentHeaderNames.Contains(name))
                 return true;
         }
 
@@ -152,11 +163,11 @@ public static class HarEntryExtensions
         var content = CreateContent(response.Content);
         message.Content = content;
 
-        CopyHeaders(response.Headers, message.Headers, content, response.Content.MimeType);
+        CopyHeaders(response.Headers, message.Headers, content, response.Content?.MimeType);
 
-        if (response.Cookies.Count > 0 && !message.Headers.Contains(SetCookieHeaderName))
+        if (response.Cookies is { Count: > 0 } cookies && !message.Headers.Contains(SetCookieHeaderName))
         {
-            foreach (var cookie in response.Cookies)
+            foreach (var cookie in cookies)
             {
                 message.Headers.TryAddWithoutValidation(SetCookieHeaderName, BuildSetCookieHeader(cookie));
             }
@@ -214,15 +225,15 @@ public static class HarEntryExtensions
         return builder.ToString();
     }
 
-    private static ByteArrayContent CreateContent(HarContent harContent)
+    private static ByteArrayContent CreateContent(HarContent? harContent)
     {
-        if (harContent.Text is null)
+        if (harContent?.Text is not { } text)
             return new ByteArrayContent([]);
 
-        if (string.Equals(harContent.Encoding, "base64", StringComparison.OrdinalIgnoreCase) && TryDecodeBase64(harContent.Text, out var bytes))
+        if (string.Equals(harContent.Encoding, "base64", StringComparison.OrdinalIgnoreCase) && TryDecodeBase64(text, out var bytes))
             return new ByteArrayContent(bytes);
 
-        return new ByteArrayContent(Encoding.UTF8.GetBytes(harContent.Text));
+        return new ByteArrayContent(Encoding.UTF8.GetBytes(text));
     }
 
     private static bool TryDecodeBase64(string text, [NotNullWhen(true)] out byte[]? bytes)
@@ -241,26 +252,26 @@ public static class HarEntryExtensions
     /// <summary>
     /// Copies the archived headers onto the message, routing entity headers to the content.
     /// <paramref name="fallbackMimeType"/> is applied only when the archive contained no Content-Type header,
-    /// so the message never ends up with two of them.
+    /// so the message never ends up with two of them. Headers without a name are skipped.
     /// </summary>
-    private static void CopyHeaders(List<HarHeader> headers, HttpHeaders messageHeaders, HttpContent? content, string? fallbackMimeType)
+    private static void CopyHeaders(List<HarHeader>? headers, HttpHeaders messageHeaders, HttpContent? content, string? fallbackMimeType)
     {
         var hasContentType = false;
-        foreach (var header in headers)
+        foreach (var header in headers ?? [])
         {
-            if (WireOnlyHeaderNames.Contains(header.Name))
+            if (header.Name is not { } name || WireOnlyHeaderNames.Contains(name))
                 continue;
 
-            if (ContentHeaderNames.Contains(header.Name))
+            if (ContentHeaderNames.Contains(name))
             {
-                if (content?.Headers.TryAddWithoutValidation(header.Name, header.Value) is true)
+                if (content?.Headers.TryAddWithoutValidation(name, header.Value) is true)
                 {
-                    hasContentType |= string.Equals(header.Name, ContentTypeHeaderName, StringComparison.OrdinalIgnoreCase);
+                    hasContentType |= string.Equals(name, ContentTypeHeaderName, StringComparison.OrdinalIgnoreCase);
                 }
             }
             else
             {
-                messageHeaders.TryAddWithoutValidation(header.Name, header.Value);
+                messageHeaders.TryAddWithoutValidation(name, header.Value);
             }
         }
 
@@ -270,7 +281,7 @@ public static class HarEntryExtensions
         }
     }
 
-    private static Version ParseHttpVersion(string httpVersion)
+    private static Version ParseHttpVersion(string? httpVersion)
     {
         return httpVersion switch
         {

--- a/src/Meziantou.Framework.HttpArchive/HarHeader.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarHeader.cs
@@ -8,11 +8,11 @@ public sealed class HarHeader
 {
     /// <summary>Gets or sets the header name.</summary>
     [JsonPropertyName("name")]
-    public string Name { get; set; } = "";
+    public string? Name { get; set; } = "";
 
     /// <summary>Gets or sets the header value.</summary>
     [JsonPropertyName("value")]
-    public string Value { get; set; } = "";
+    public string? Value { get; set; } = "";
 
     /// <summary>Gets or sets a comment provided by the user or the application.</summary>
     [JsonPropertyName("comment")]

--- a/src/Meziantou.Framework.HttpArchive/HarLog.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarLog.cs
@@ -8,11 +8,11 @@ public sealed class HarLog
 {
     /// <summary>Gets or sets the version number of the HAR format. Defaults to "1.2".</summary>
     [JsonPropertyName("version")]
-    public string Version { get; set; } = "1.2";
+    public string? Version { get; set; } = "1.2";
 
     /// <summary>Gets or sets information about the application that created the log.</summary>
     [JsonPropertyName("creator")]
-    public HarCreator Creator { get; set; } = new();
+    public HarCreator? Creator { get; set; } = new();
 
     /// <summary>Gets or sets information about the browser that created the log.</summary>
     [JsonPropertyName("browser")]
@@ -26,7 +26,7 @@ public sealed class HarLog
     /// <summary>Gets or sets the list of exported HTTP requests.</summary>
     [JsonPropertyName("entries")]
     [SuppressMessage("Design", "CA1002:Do not expose generic lists")]
-    public List<HarEntry> Entries { get; set; } = [];
+    public List<HarEntry>? Entries { get; set; } = [];
 
     /// <summary>Gets or sets a comment provided by the user or the application.</summary>
     [JsonPropertyName("comment")]

--- a/src/Meziantou.Framework.HttpArchive/HarPage.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarPage.cs
@@ -12,15 +12,15 @@ public sealed class HarPage
 
     /// <summary>Gets or sets the unique identifier of a page. Entries use it to refer to the parent page.</summary>
     [JsonPropertyName("id")]
-    public string Id { get; set; } = "";
+    public string? Id { get; set; } = "";
 
     /// <summary>Gets or sets the page title.</summary>
     [JsonPropertyName("title")]
-    public string Title { get; set; } = "";
+    public string? Title { get; set; } = "";
 
     /// <summary>Gets or sets detailed timing info about the page load.</summary>
     [JsonPropertyName("pageTimings")]
-    public HarPageTimings PageTimings { get; set; } = new();
+    public HarPageTimings? PageTimings { get; set; } = new();
 
     /// <summary>Gets or sets a comment provided by the user or the application.</summary>
     [JsonPropertyName("comment")]

--- a/src/Meziantou.Framework.HttpArchive/HarPostData.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarPostData.cs
@@ -8,7 +8,7 @@ public sealed class HarPostData
 {
     /// <summary>Gets or sets the MIME type of the posted data.</summary>
     [JsonPropertyName("mimeType")]
-    public string MimeType { get; set; } = "";
+    public string? MimeType { get; set; } = "";
 
     /// <summary>Gets or sets the list of posted parameters (in case of URL encoded parameters).</summary>
     [JsonPropertyName("params")]

--- a/src/Meziantou.Framework.HttpArchive/HarQueryParameter.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarQueryParameter.cs
@@ -8,11 +8,11 @@ public sealed class HarQueryParameter
 {
     /// <summary>Gets or sets the parameter name.</summary>
     [JsonPropertyName("name")]
-    public string Name { get; set; } = "";
+    public string? Name { get; set; } = "";
 
     /// <summary>Gets or sets the parameter value.</summary>
     [JsonPropertyName("value")]
-    public string Value { get; set; } = "";
+    public string? Value { get; set; } = "";
 
     /// <summary>Gets or sets a comment provided by the user or the application.</summary>
     [JsonPropertyName("comment")]

--- a/src/Meziantou.Framework.HttpArchive/HarRequest.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarRequest.cs
@@ -8,31 +8,31 @@ public sealed class HarRequest
 {
     /// <summary>Gets or sets the request method (GET, POST, ...).</summary>
     [JsonPropertyName("method")]
-    public string Method { get; set; } = "";
+    public string? Method { get; set; } = "";
 
     /// <summary>Gets or sets the absolute URL of the request (fragments are not included).</summary>
     [JsonPropertyName("url")]
     [SuppressMessage("Design", "CA1056:URI-like properties should not be strings")]
-    public string Url { get; set; } = "";
+    public string? Url { get; set; } = "";
 
     /// <summary>Gets or sets the request HTTP version.</summary>
     [JsonPropertyName("httpVersion")]
-    public string HttpVersion { get; set; } = "";
+    public string? HttpVersion { get; set; } = "";
 
     /// <summary>Gets or sets the list of cookie objects.</summary>
     [JsonPropertyName("cookies")]
     [SuppressMessage("Design", "CA1002:Do not expose generic lists")]
-    public List<HarCookie> Cookies { get; set; } = [];
+    public List<HarCookie>? Cookies { get; set; } = [];
 
     /// <summary>Gets or sets the list of header objects.</summary>
     [JsonPropertyName("headers")]
     [SuppressMessage("Design", "CA1002:Do not expose generic lists")]
-    public List<HarHeader> Headers { get; set; } = [];
+    public List<HarHeader>? Headers { get; set; } = [];
 
     /// <summary>Gets or sets the list of query string parameter objects.</summary>
     [JsonPropertyName("queryString")]
     [SuppressMessage("Design", "CA1002:Do not expose generic lists")]
-    public List<HarQueryParameter> QueryString { get; set; } = [];
+    public List<HarQueryParameter>? QueryString { get; set; } = [];
 
     /// <summary>Gets or sets the posted data info.</summary>
     [JsonPropertyName("postData")]

--- a/src/Meziantou.Framework.HttpArchive/HarResponse.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarResponse.cs
@@ -12,30 +12,30 @@ public sealed class HarResponse
 
     /// <summary>Gets or sets the response status description.</summary>
     [JsonPropertyName("statusText")]
-    public string StatusText { get; set; } = "";
+    public string? StatusText { get; set; } = "";
 
     /// <summary>Gets or sets the response HTTP version.</summary>
     [JsonPropertyName("httpVersion")]
-    public string HttpVersion { get; set; } = "";
+    public string? HttpVersion { get; set; } = "";
 
     /// <summary>Gets or sets the list of cookie objects.</summary>
     [JsonPropertyName("cookies")]
     [SuppressMessage("Design", "CA1002:Do not expose generic lists")]
-    public List<HarCookie> Cookies { get; set; } = [];
+    public List<HarCookie>? Cookies { get; set; } = [];
 
     /// <summary>Gets or sets the list of header objects.</summary>
     [JsonPropertyName("headers")]
     [SuppressMessage("Design", "CA1002:Do not expose generic lists")]
-    public List<HarHeader> Headers { get; set; } = [];
+    public List<HarHeader>? Headers { get; set; } = [];
 
     /// <summary>Gets or sets the details about the response body.</summary>
     [JsonPropertyName("content")]
-    public HarContent Content { get; set; } = new();
+    public HarContent? Content { get; set; } = new();
 
     /// <summary>Gets or sets the redirection target URL from the Location response header.</summary>
     [JsonPropertyName("redirectURL")]
     [SuppressMessage("Design", "CA1056:URI-like properties should not be strings")]
-    public string RedirectUrl { get; set; } = "";
+    public string? RedirectUrl { get; set; } = "";
 
     /// <summary>Gets or sets the total number of bytes from the start of the HTTP response message until (and including) the double CRLF before the body. Use -1 if the info is not available.</summary>
     [JsonPropertyName("headersSize")]

--- a/src/Meziantou.Framework.HttpArchive/readme.md
+++ b/src/Meziantou.Framework.HttpArchive/readme.md
@@ -15,6 +15,13 @@
 dotnet add package Meziantou.Framework.HttpArchive
 ```
 
+## Nullability
+
+Producers do not always honor the HAR schema: an archive can hold an explicit `null` for any field. The model is
+nullable throughout so those archives still parse, and it is up to the caller to decide what an absent value means.
+A property left out of the JSON keeps its default (`""` for strings, an empty list for collections); only an explicit
+`null` yields `null`.
+
 ## Parse a HAR file
 
 ```c#
@@ -23,9 +30,9 @@ using Meziantou.Framework.HttpArchive;
 await using var stream = File.OpenRead("traffic.har");
 var document = await HarDocument.ParseAsync(stream);
 
-foreach (var entry in document.Log.Entries)
+foreach (var entry in document.Log?.Entries ?? [])
 {
-    Console.WriteLine($"{entry.Request.Method} {entry.Request.Url} -> {entry.Response.Status}");
+    Console.WriteLine($"{entry.Request?.Method} {entry.Request?.Url} -> {entry.Response?.Status}");
 }
 ```
 
@@ -34,28 +41,35 @@ foreach (var entry in document.Log.Entries)
 ```c#
 using Meziantou.Framework.HttpArchive;
 
-var document = new HarDocument();
-document.Log.Version = "1.2";
-document.Log.Creator = new HarCreator
+var document = new HarDocument
 {
-    Name = "MyTool",
-    Version = "1.0.0",
+    Log = new HarLog
+    {
+        Version = "1.2",
+        Creator = new HarCreator
+        {
+            Name = "MyTool",
+            Version = "1.0.0",
+        },
+        Entries =
+        [
+            new HarEntry
+            {
+                StartedDateTime = DateTimeOffset.UtcNow,
+                Request = new HarRequest
+                {
+                    Method = "GET",
+                    Url = "https://example.com/api/data",
+                },
+                Response = new HarResponse
+                {
+                    Status = 200,
+                    StatusText = "OK",
+                },
+            },
+        ],
+    },
 };
-
-document.Log.Entries.Add(new HarEntry
-{
-    StartedDateTime = DateTimeOffset.UtcNow,
-    Request =
-    {
-        Method = "GET",
-        Url = "https://example.com/api/data",
-    },
-    Response =
-    {
-        Status = 200,
-        StatusText = "OK",
-    },
-});
 
 await using var stream = File.Create("output.har");
 await document.WriteToAsync(stream, indented: true);
@@ -67,8 +81,10 @@ await document.WriteToAsync(stream, indented: true);
 using Meziantou.Framework.HttpArchive;
 
 var document = HarDocument.Parse(File.ReadAllText("traffic.har"));
-var entry = document.Log.Entries[0];
+var entry = document.Log!.Entries![0];
 
+// Throws InvalidOperationException when the archived entry has no request/response,
+// or when the request declares no method or URL.
 using var request = entry.ToHttpRequestMessage();
 using var response = entry.ToHttpResponseMessage();
 ```

--- a/tests/Meziantou.Framework.Http.Recording.Tests/HarHttpRecordingStoreTests.cs
+++ b/tests/Meziantou.Framework.Http.Recording.Tests/HarHttpRecordingStoreTests.cs
@@ -128,8 +128,8 @@ public sealed class HarHttpRecordingStoreTests
         await using (var stream = File.OpenRead(filePath))
         {
             var harDocument = await HarDocument.ParseAsync(stream, CancellationToken.None);
-            var harEntry = Assert.Single(harDocument.Log.Entries);
-            Assert.Equal("base64", harEntry.Response.Content.Encoding);
+            var harEntry = Assert.Single(harDocument.Log!.Entries!);
+            Assert.Equal("base64", harEntry.Response!.Content!.Encoding);
         }
 
         var loaded = await store.LoadAsync(CancellationToken.None);
@@ -165,8 +165,8 @@ public sealed class HarHttpRecordingStoreTests
         await using (var stream = File.OpenRead(filePath))
         {
             var harDocument = await HarDocument.ParseAsync(stream, CancellationToken.None);
-            var harEntry = Assert.Single(harDocument.Log.Entries);
-            var postData = harEntry.Request.PostData;
+            var harEntry = Assert.Single(harDocument.Log!.Entries!);
+            var postData = harEntry.Request!.PostData;
             Assert.NotNull(postData);
             Assert.Equal(Convert.ToBase64String(requestBody), postData.Text);
             Assert.NotNull(postData.ExtensionData);

--- a/tests/Meziantou.Framework.HttpArchive.Tests/HarDocumentTests.cs
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/HarDocumentTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Meziantou.Framework.HttpArchive.Tests;
 
 public sealed class HarDocumentTests
@@ -108,12 +110,12 @@ public sealed class HarDocumentTests
     {
         var doc = HarDocument.Parse(MinimalHar);
 
-        Assert.Equal("1.2", doc.Log.Version);
-        Assert.Equal("TestApp", doc.Log.Creator.Name);
-        Assert.Equal("1.0", doc.Log.Creator.Version);
-        Assert.Null(doc.Log.Browser);
-        Assert.Null(doc.Log.Pages);
-        Assert.Empty(doc.Log.Entries);
+        Assert.Equal("1.2", doc.Log!.Version);
+        Assert.Equal("TestApp", doc.Log!.Creator!.Name);
+        Assert.Equal("1.0", doc.Log!.Creator!.Version);
+        Assert.Null(doc.Log!.Browser);
+        Assert.Null(doc.Log!.Pages);
+        Assert.Empty(doc.Log!.Entries!);
     }
 
     [Fact]
@@ -121,53 +123,53 @@ public sealed class HarDocumentTests
     {
         var doc = HarDocument.Parse(CompleteHar);
 
-        Assert.Equal("1.2", doc.Log.Version);
-        Assert.Equal("WebInspector", doc.Log.Creator.Name);
-        Assert.Equal("Chrome", doc.Log.Browser?.Name);
-        Assert.Equal("120.0", doc.Log.Browser?.Version);
+        Assert.Equal("1.2", doc.Log!.Version);
+        Assert.Equal("WebInspector", doc.Log!.Creator!.Name);
+        Assert.Equal("Chrome", doc.Log!.Browser?.Name);
+        Assert.Equal("120.0", doc.Log!.Browser?.Version);
 
-        Assert.NotNull(doc.Log.Pages);
-        var page = Assert.Single(doc.Log.Pages);
+        Assert.NotNull(doc.Log!.Pages);
+        var page = Assert.Single(doc.Log!.Pages);
         Assert.Equal("page_1", page.Id);
         Assert.Equal("Test Page", page.Title);
-        Assert.Equal(1500, page.PageTimings.OnContentLoad);
-        Assert.Equal(2500, page.PageTimings.OnLoad);
+        Assert.Equal(1500, page.PageTimings!.OnContentLoad);
+        Assert.Equal(2500, page.PageTimings!.OnLoad);
 
-        var entry = Assert.Single(doc.Log.Entries);
+        var entry = Assert.Single(doc.Log!.Entries!);
         Assert.Equal("page_1", entry.Pageref);
         Assert.Equal(150.5, entry.Time);
         Assert.Equal("93.184.216.34", entry.ServerIPAddress);
         Assert.Equal("443", entry.Connection);
 
-        Assert.Equal("GET", entry.Request.Method);
-        Assert.Equal("https://example.com/api/data", entry.Request.Url);
-        Assert.Equal("HTTP/1.1", entry.Request.HttpVersion);
-        Assert.Equal(200, entry.Request.HeadersSize);
-        Assert.HasCount(2, entry.Request.Headers);
-        var cookie = Assert.Single(entry.Request.Cookies);
+        Assert.Equal("GET", entry.Request!.Method);
+        Assert.Equal("https://example.com/api/data", entry.Request!.Url);
+        Assert.Equal("HTTP/1.1", entry.Request!.HttpVersion);
+        Assert.Equal(200, entry.Request!.HeadersSize);
+        Assert.HasCount(2, entry.Request!.Headers!);
+        var cookie = Assert.Single(entry.Request!.Cookies!);
         Assert.Equal("session", cookie.Name);
         Assert.Equal("abc123", cookie.Value);
         Assert.Equal("/", cookie.Path);
         Assert.True(cookie.HttpOnly);
         Assert.True(cookie.Secure);
-        var queryParam = Assert.Single(entry.Request.QueryString);
+        var queryParam = Assert.Single(entry.Request!.QueryString!);
         Assert.Equal("page", queryParam.Name);
         Assert.Equal("1", queryParam.Value);
 
-        Assert.Equal(200, entry.Response.Status);
-        Assert.Equal("OK", entry.Response.StatusText);
-        Assert.Equal(42, entry.Response.Content.Size);
-        Assert.Equal(0, entry.Response.Content.Compression);
-        Assert.Equal("application/json", entry.Response.Content.MimeType);
-        Assert.Equal("{\"key\":\"value\"}", entry.Response.Content.Text);
+        Assert.Equal(200, entry.Response!.Status);
+        Assert.Equal("OK", entry.Response!.StatusText);
+        Assert.Equal(42, entry.Response!.Content!.Size);
+        Assert.Equal(0, entry.Response!.Content!.Compression);
+        Assert.Equal("application/json", entry.Response!.Content!.MimeType);
+        Assert.Equal("{\"key\":\"value\"}", entry.Response!.Content!.Text);
 
-        Assert.Equal(0.5, entry.Timings.Blocked);
-        Assert.Equal(10.0, entry.Timings.Dns);
-        Assert.Equal(25.0, entry.Timings.Connect);
-        Assert.Equal(1.0, entry.Timings.Send);
-        Assert.Equal(100.0, entry.Timings.Wait);
-        Assert.Equal(14.0, entry.Timings.Receive);
-        Assert.Equal(12.0, entry.Timings.Ssl);
+        Assert.Equal(0.5, entry.Timings!.Blocked);
+        Assert.Equal(10.0, entry.Timings!.Dns);
+        Assert.Equal(25.0, entry.Timings!.Connect);
+        Assert.Equal(1.0, entry.Timings!.Send);
+        Assert.Equal(100.0, entry.Timings!.Wait);
+        Assert.Equal(14.0, entry.Timings!.Receive);
+        Assert.Equal(12.0, entry.Timings!.Ssl);
     }
 
     [Fact]
@@ -177,17 +179,17 @@ public sealed class HarDocumentTests
         var json = doc.ToJsonString();
         var doc2 = HarDocument.Parse(json);
 
-        Assert.Equal(doc.Log.Version, doc2.Log.Version);
-        Assert.Equal(doc.Log.Creator.Name, doc2.Log.Creator.Name);
-        Assert.Equal(doc.Log.Browser?.Name, doc2.Log.Browser?.Name);
-        Assert.HasCount(doc.Log.Entries.Count, doc2.Log.Entries);
+        Assert.Equal(doc.Log!.Version, doc2.Log!.Version);
+        Assert.Equal(doc.Log!.Creator!.Name, doc2.Log!.Creator!.Name);
+        Assert.Equal(doc.Log!.Browser?.Name, doc2.Log!.Browser?.Name);
+        Assert.HasCount(doc.Log!.Entries!.Count, doc2.Log!.Entries!);
 
-        var entry1 = doc.Log.Entries[0];
-        var entry2 = doc2.Log.Entries[0];
-        Assert.Equal(entry1.Request.Url, entry2.Request.Url);
-        Assert.Equal(entry1.Response.Status, entry2.Response.Status);
-        Assert.Equal(entry1.Response.Content.Text, entry2.Response.Content.Text);
-        Assert.Equal(entry1.Timings.Wait, entry2.Timings.Wait);
+        var entry1 = doc.Log!.Entries![0];
+        var entry2 = doc2.Log!.Entries![0];
+        Assert.Equal(entry1.Request!.Url, entry2.Request!.Url);
+        Assert.Equal(entry1.Response!.Status, entry2.Response!.Status);
+        Assert.Equal(entry1.Response!.Content!.Text, entry2.Response!.Content!.Text);
+        Assert.Equal(entry1.Timings!.Wait, entry2.Timings!.Wait);
     }
 
     [Fact]
@@ -196,8 +198,8 @@ public sealed class HarDocumentTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(CompleteHar));
         var doc = await HarDocument.ParseAsync(stream);
 
-        Assert.Equal("1.2", doc.Log.Version);
-        Assert.Single(doc.Log.Entries);
+        Assert.Equal("1.2", doc.Log!.Version);
+        Assert.Single(doc.Log!.Entries!);
     }
 
     [Fact]
@@ -206,8 +208,8 @@ public sealed class HarDocumentTests
         var stream = new MemoryStream(Encoding.UTF8.GetBytes(CompleteHar));
         var doc = HarDocument.Parse(stream);
 
-        Assert.Equal("1.2", doc.Log.Version);
-        Assert.Single(doc.Log.Entries);
+        Assert.Equal("1.2", doc.Log!.Version);
+        Assert.Single(doc.Log!.Entries!);
     }
 
     [Fact]
@@ -238,8 +240,8 @@ public sealed class HarDocumentTests
         stream.Position = 0;
 
         var doc2 = HarDocument.Parse(stream);
-        Assert.Equal("1.2", doc2.Log.Version);
-        Assert.Equal("TestApp", doc2.Log.Creator.Name);
+        Assert.Equal("1.2", doc2.Log!.Version);
+        Assert.Equal("TestApp", doc2.Log!.Creator!.Name);
     }
 
     [Fact]
@@ -251,7 +253,7 @@ public sealed class HarDocumentTests
         stream.Position = 0;
 
         var doc2 = HarDocument.Parse(stream);
-        Assert.Equal("1.2", doc2.Log.Version);
+        Assert.Equal("1.2", doc2.Log!.Version);
     }
 
     [Fact]
@@ -304,7 +306,7 @@ public sealed class HarDocumentTests
             """;
 
         var doc = HarDocument.Parse(Har);
-        var timings = doc.Log.Entries[0].Timings;
+        var timings = doc.Log!.Entries![0].Timings!;
 
         Assert.Equal(-1, timings.Blocked);
         Assert.Equal(-1, timings.Dns);
@@ -314,8 +316,8 @@ public sealed class HarDocumentTests
         Assert.Equal(9, timings.Receive);
         Assert.Equal(-1, timings.Ssl);
 
-        Assert.Equal(-1, doc.Log.Entries[0].Request.HeadersSize);
-        Assert.Equal(-1, doc.Log.Entries[0].Request.BodySize);
+        Assert.Equal(-1, doc.Log!.Entries![0].Request!.HeadersSize);
+        Assert.Equal(-1, doc.Log!.Entries![0].Request!.BodySize);
     }
 
     [Fact]
@@ -364,7 +366,7 @@ public sealed class HarDocumentTests
             """;
 
         var doc = HarDocument.Parse(Har);
-        Assert.Equal("https://www.example.com", doc.Log.Entries[0].Response.RedirectUrl);
+        Assert.Equal("https://www.example.com", doc.Log!.Entries![0].Response!.RedirectUrl);
 
         var json = doc.ToJsonString();
         Assert.Contains("\"redirectURL\"", json);
@@ -414,15 +416,15 @@ public sealed class HarDocumentTests
             """;
 
         var doc = HarDocument.Parse(Har);
-        var entry = doc.Log.Entries[0];
+        var entry = doc.Log!.Entries![0];
 
         Assert.NotNull(entry.ExtensionData);
         Assert.Contains("_priority", entry.ExtensionData);
         Assert.Equal("High", entry.ExtensionData["_priority"].GetString());
         Assert.Equal("xhr", entry.ExtensionData["_resourceType"].GetString());
 
-        Assert.NotNull(entry.Response.Content.ExtensionData);
-        Assert.Equal(1234, entry.Response.Content.ExtensionData["_transferSize"].GetInt32());
+        Assert.NotNull(entry.Response!.Content!.ExtensionData);
+        Assert.Equal(1234, entry.Response!.Content!.ExtensionData["_transferSize"].GetInt32());
 
         var json = doc.ToJsonString();
         Assert.Contains("_priority", json);
@@ -475,7 +477,7 @@ public sealed class HarDocumentTests
             """;
 
         var doc = HarDocument.Parse(Har);
-        var postData = doc.Log.Entries[0].Request.PostData;
+        var postData = doc.Log!.Entries![0].Request!.PostData;
 
         Assert.NotNull(postData);
         Assert.Equal("application/json", postData.MimeType);
@@ -531,11 +533,90 @@ public sealed class HarDocumentTests
             """;
 
         var doc = HarDocument.Parse(Har);
-        var cache = doc.Log.Entries[0].Cache;
+        var cache = doc.Log!.Entries![0].Cache!;
 
         Assert.Null(cache.BeforeRequest);
         Assert.NotNull(cache.AfterRequest);
         Assert.Equal("\"abc123\"", cache.AfterRequest.ETag);
         Assert.Equal(5, cache.AfterRequest.HitCount);
+    }
+
+    [Fact]
+    public void Parse_NullLog_IsAllowed()
+    {
+        var document = HarDocument.Parse("""{"log":null}""");
+
+        Assert.Null(document.Log);
+    }
+
+    [Fact]
+    public void Parse_NullOnStringProperty_IsAllowed()
+    {
+        var json = """{"log":{"version":"1.2","entries":[{"request":{"method":null,"url":null}}]}}""";
+
+        var document = HarDocument.Parse(json);
+
+        var request = Assert.Single(document.Log!.Entries!).Request;
+        Assert.NotNull(request);
+        Assert.Null(request.Method);
+        Assert.Null(request.Url);
+    }
+
+    [Fact]
+    public void Parse_NullOnCollectionProperty_IsAllowed()
+    {
+        var json = """{"log":{"version":"1.2","entries":[{"request":{"headers":null}}]}}""";
+
+        var document = HarDocument.Parse(json);
+
+        var request = Assert.Single(document.Log!.Entries!).Request;
+        Assert.NotNull(request);
+        Assert.Null(request.Headers);
+    }
+
+    [Fact]
+    public void Parse_NullOnNestedObjectProperty_IsAllowed()
+    {
+        var json = """{"log":{"version":"1.2","entries":[{"request":null,"response":null}]}}""";
+
+        var document = HarDocument.Parse(json);
+
+        var entry = Assert.Single(document.Log!.Entries!);
+        Assert.Null(entry.Request);
+        Assert.Null(entry.Response);
+    }
+
+    [Fact]
+    public void Parse_NullOnNullableProperty_IsAllowed()
+    {
+        var json = """{"log":{"version":"1.2","comment":null,"browser":null,"entries":[]}}""";
+
+        var document = HarDocument.Parse(json);
+
+        Assert.Null(document.Log!.Comment);
+        Assert.Null(document.Log.Browser);
+    }
+
+    [Fact]
+    public void Parse_MissingProperty_KeepsTheDefault()
+    {
+        var document = HarDocument.Parse("""{"log":{"version":"1.2","entries":[{}]}}""");
+
+        var entry = Assert.Single(document.Log!.Entries!);
+        Assert.NotNull(entry.Request);
+        Assert.Equal("", entry.Request.Method);
+        Assert.Empty(entry.Request.Headers!);
+    }
+
+    [Fact]
+    public void ToJsonString_OmitsPropertiesThatWereNullInTheSource()
+    {
+        var document = HarDocument.Parse("""{"log":{"version":"1.2","entries":[{"request":{"method":null,"headers":null}}]}}""");
+
+        using var json = JsonDocument.Parse(document.ToJsonString());
+
+        var request = json.RootElement.GetProperty("log").GetProperty("entries")[0].GetProperty("request");
+        Assert.False(request.TryGetProperty("method", out _));
+        Assert.False(request.TryGetProperty("headers", out _));
     }
 }

--- a/tests/Meziantou.Framework.HttpArchive.Tests/HarEntryExtensionsTests.cs
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/HarEntryExtensionsTests.cs
@@ -270,9 +270,9 @@ public sealed class HarEntryExtensionsTests
     {
         var document = LoadChromeHar();
 
-        Assert.HasCount(6, document.Log.Entries);
+        Assert.HasCount(6, document.Log!.Entries!);
 
-        foreach (var entry in document.Log.Entries)
+        foreach (var entry in document.Log!.Entries!)
         {
             using var request = entry.ToHttpRequestMessage();
             using var response = entry.ToHttpResponseMessage();
@@ -287,7 +287,7 @@ public sealed class HarEntryExtensionsTests
     {
         var document = LoadChromeHar();
 
-        foreach (var entry in document.Log.Entries)
+        foreach (var entry in document.Log!.Entries!)
         {
             using var response = entry.ToHttpResponseMessage();
             if (response.Content.Headers.TryGetValues("Content-Type", out var values))
@@ -418,9 +418,9 @@ public sealed class HarEntryExtensionsTests
     public async Task RealWorldHar_GzippedEntryHasConsistentContentLength()
     {
         var document = LoadChromeHar();
-        var entry = document.Log.Entries[0];
+        var entry = document.Log!.Entries![0];
 
-        Assert.Equal("648", entry.Response.Headers.Single(h => string.Equals(h.Name, "content-length", StringComparison.OrdinalIgnoreCase)).Value);
+        Assert.Equal("648", entry.Response!.Headers!.Single(h => string.Equals(h.Name, "content-length", StringComparison.OrdinalIgnoreCase)).Value);
 
         using var message = entry.ToHttpResponseMessage();
         var body = await message.Content.ReadAsByteArrayAsync();
@@ -553,9 +553,9 @@ public sealed class HarEntryExtensionsTests
     public async Task RealWorldHar_FormPostKeepsItsBody()
     {
         var document = LoadChromeHar();
-        var entry = document.Log.Entries.Single(e => e.Request.Url.EndsWith("/login", StringComparison.Ordinal));
+        var entry = document.Log!.Entries!.Single(e => e.Request!.Url!.EndsWith("/login", StringComparison.Ordinal));
 
-        Assert.Null(entry.Request.PostData!.Text);
+        Assert.Null(entry.Request!.PostData!.Text);
 
         using var message = entry.ToHttpRequestMessage();
 
@@ -636,13 +636,85 @@ public sealed class HarEntryExtensionsTests
     public void RealWorldHar_DoesNotDuplicateRecordedCookieHeaders()
     {
         var document = LoadChromeHar();
-        var entry = document.Log.Entries[0];
+        var entry = document.Log!.Entries![0];
 
         using var request = entry.ToHttpRequestMessage();
         using var response = entry.ToHttpResponseMessage();
 
         Assert.Equal("session=abc123; theme=dark", Assert.Single(request.Headers.GetValues("Cookie")));
         Assert.Single(response.Headers.GetValues("Set-Cookie"));
+    }
+
+    [Fact]
+    public void ToHttpRequestMessage_NullRequest_Throws()
+    {
+        var entry = new HarEntry { Request = null };
+
+        Assert.Throws<InvalidOperationException>(entry.ToHttpRequestMessage);
+    }
+
+    [Fact]
+    public void ToHttpResponseMessage_NullResponse_Throws()
+    {
+        var entry = new HarEntry { Response = null };
+
+        Assert.Throws<InvalidOperationException>(entry.ToHttpResponseMessage);
+    }
+
+    [Fact]
+    public void ToHttpRequestMessage_NullMethod_Throws()
+    {
+        var request = new HarRequest { Method = null, Url = "https://example.com/" };
+
+        Assert.Throws<InvalidOperationException>(request.ToHttpRequestMessage);
+    }
+
+    [Fact]
+    public void ToHttpRequestMessage_NullUrl_Throws()
+    {
+        var request = new HarRequest { Method = "GET", Url = null };
+
+        Assert.Throws<InvalidOperationException>(request.ToHttpRequestMessage);
+    }
+
+    [Fact]
+    public async Task ToHttpRequestMessage_NullHeadersCookiesAndMimeType()
+    {
+        var request = new HarRequest
+        {
+            Method = "POST",
+            Url = "https://example.com/",
+            HttpVersion = null,
+            Headers = null,
+            Cookies = null,
+            PostData = new HarPostData { MimeType = null, Text = "body" },
+        };
+
+        using var message = request.ToHttpRequestMessage();
+
+        Assert.Equal(new Version(1, 1), message.Version);
+        Assert.NotNull(message.Content);
+        Assert.Null(message.Content.Headers.ContentType);
+        Assert.Equal("body", await message.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ToHttpResponseMessage_NullContentHeadersAndCookies()
+    {
+        var response = new HarResponse
+        {
+            Status = 204,
+            StatusText = null,
+            Content = null,
+            Headers = null,
+            Cookies = null,
+        };
+
+        using var message = response.ToHttpResponseMessage();
+
+        Assert.Equal(HttpStatusCode.NoContent, message.StatusCode);
+        Assert.NotNull(message.Content);
+        Assert.Empty(await message.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken));
     }
 
     private static HarDocument LoadChromeHar()


### PR DESCRIPTION
Stack 1 of 2 · merges into `main` · must merge before #2165

> Updated after review: the first version made the parser reject an explicit `null`. Per feedback, it now makes the model nullable instead, so more documents parse. Rebased onto current `main` and squashed to a single commit; #2165 is rebased on top of it.

## The problem

`System.Text.Json` writes `null` into a non-nullable reference property without complaint, so the model's annotations were not enforced by anything. Verified against the library before the fix:

- `{"log":null}` → `HarDocument.Parse` **succeeds**, `doc.Log` is `null`, and `doc.Log.Entries` throws `NullReferenceException`
- `{"log":{"entries":[{"request":{"method":null,"url":null,"headers":null},"response":null}]}}` → parses fine; `Request.Method`, `Request.Headers` and `Response` are all `null`, and `ToHttpRequestMessage()` throws `ArgumentNullException`

Callers were told by the type system that `document.Log.Entries` needed no null check. An archive from a buggy producer turned that into a `NullReferenceException` deep in user code with no indication the input was at fault.

## What changed

Every reference-typed property on the model is now nullable, so the annotations describe what the parser actually produces. Nothing is rejected: an archive that writes `null` anywhere still parses, and the possible `null` shows up at compile time rather than as a `NullReferenceException` at run time.

Unaffected:
- **Missing** properties still keep their initializer defaults (`Method` stays `""`, `Headers` stays an empty list). Only an explicit `null` yields `null`.
- On write, `DefaultIgnoreCondition.WhenWritingNull` omits those properties, so a document built in code serializes exactly as before.
- A top-level `null` document still surfaces as the existing `InvalidOperationException`.

The conversion helpers gained the matching null handling:
- `ToHttpRequestMessage()` / `ToHttpResponseMessage()` on `HarEntry` throw `InvalidOperationException` when the entry carries no request or response, and `ToHttpRequestMessage()` on `HarRequest` does the same when there is no method or URL — those cannot be reconstructed.
- A `null` (or empty) `mimeType` now falls back to the `StringContent` default instead of throwing out of `MediaTypeHeaderValue`.
- `null` header lists and headers without a name are skipped.

`HarHttpRecordingStore` reads through the nullable model and builds its documents up front rather than mutating the initializer defaults.

## Tradeoff

This is the alternative that the first version of this PR considered and did not take. It costs API churn — `ref/Meziantou.Framework.HttpArchive.cs` shows 36 properties changing shape, and callers that walk the graph now need `?.` or `!`, which the repo's own tests and readme show. In exchange no input is ever rejected, which is the priority for a format whose producers do not reliably follow the schema.

## Verification

`dotnet test -p:TreatsWarningsAsErrors=true` → **150/150 green** on `Meziantou.Framework.HttpArchive.Tests` and **76/76** on `Meziantou.Framework.Http.Recording.Tests`, across `net10.0` and `net11.0`. 13 new tests cover the null shapes that now parse, the missing-property defaults, the write path, and the conversion helpers' new exceptions. `dotnet run ./eng/update-all.cs` reports no further changes; `ref/` is regenerated and committed.
