### PR TITLE
Register the image backends once instead of inside a test

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting.ImageSharp/readme.md
+++ b/src/Meziantou.Framework.SnapshotTesting.ImageSharp/readme.md
@@ -7,24 +7,46 @@
 Call `AddImageSharp()` on your `SnapshotSettings` to register the ImageSharp serializer and comparer:
 
 ```csharp
+using System.Runtime.CompilerServices;
+using Meziantou.Framework.SnapshotTesting;
+using Meziantou.Framework.SnapshotTesting.ImageSharp;
+
+internal static class SnapshotConfiguration
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        SnapshotSettings.Default.AddImageSharp();
+    }
+}
+```
+
+Then validate images from your tests:
+
+```csharp
 public sealed class SampleTests
 {
     [Fact]
     public void ValidateImage()
     {
-        SnapshotSettings.Default.AddImageSharp();
-
         using var image = Image.Load("sample.png");
         Snapshot.Validate(image, SnapshotType.Png);
     }
 }
 ```
 
+> [!IMPORTANT]
+> Register once for the whole test assembly, not inside a test method. `SnapshotSettings.Default` is
+> shared by every test in the process and its collections are not safe for concurrent modification, so
+> calling `AddImageSharp()` from a test races against any other test that is serializing a snapshot at
+> the same time. Repeated calls also append a serializer and a converter every time.
+
 ## Image comparison
 
 By default, images are compared pixel-by-pixel (exact comparison). To allow minor rendering differences, configure a [Structural Similarity Index (SSIM)](https://en.wikipedia.org/wiki/Structural_similarity_index_measure) threshold:
 
 ```csharp
+// In the module initializer shown above
 SnapshotSettings.Default.AddImageSharp(new ImageComparisonSettings
 {
     SimilarityThreshold = 0.99f, // 0.0 = completely different, 1.0 = identical

--- a/src/Meziantou.Framework.SnapshotTesting.SkiaSharp/readme.md
+++ b/src/Meziantou.Framework.SnapshotTesting.SkiaSharp/readme.md
@@ -7,18 +7,39 @@
 Call `AddSkiaSharp()` on your `SnapshotSettings` to register the SkiaSharp serializer and comparer:
 
 ```csharp
+using System.Runtime.CompilerServices;
+using Meziantou.Framework.SnapshotTesting;
+using Meziantou.Framework.SnapshotTesting.SkiaSharp;
+
+internal static class SnapshotConfiguration
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        SnapshotSettings.Default.AddSkiaSharp();
+    }
+}
+```
+
+Then validate images from your tests:
+
+```csharp
 public sealed class SampleTests
 {
     [Fact]
     public void ValidateImage()
     {
-        SnapshotSettings.Default.AddSkiaSharp();
-
         using var bitmap = SKBitmap.Decode("sample.png");
         Snapshot.Validate(bitmap, SnapshotType.Png);
     }
 }
 ```
+
+> [!IMPORTANT]
+> Register once for the whole test assembly, not inside a test method. `SnapshotSettings.Default` is
+> shared by every test in the process and its collections are not safe for concurrent modification, so
+> calling `AddSkiaSharp()` from a test races against any other test that is serializing a snapshot at
+> the same time. Repeated calls also append a serializer and a converter every time.
 
 Note that SkiaSharp requires the native libraries to be available at runtime. They are included in the `SkiaSharp` package for Windows and macOS. On Linux, add a reference to [`SkiaSharp.NativeAssets.Linux`](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Linux).
 
@@ -27,6 +48,7 @@ Note that SkiaSharp requires the native libraries to be available at runtime. Th
 By default, images are compared pixel-by-pixel (exact comparison). To allow minor rendering differences, configure a [Structural Similarity Index (SSIM)](https://en.wikipedia.org/wiki/Structural_similarity_index_measure) threshold:
 
 ```csharp
+// In the module initializer shown above
 SnapshotSettings.Default.AddSkiaSharp(new ImageComparisonSettings
 {
     SimilarityThreshold = 0.99f, // 0.0 = completely different, 1.0 = identical


### PR DESCRIPTION
The ImageSharp and SkiaSharp readmes showed registration inside a test method:

```csharp
[Fact]
public void ValidateImage()
{
    SnapshotSettings.Default.AddImageSharp();   // readme, verbatim
    ...
}
```

`SnapshotSettings.Default` is a mutable static shared by every test in the process, and its
collections are plain `List<T>` with no synchronization. `AddImageSharp` reaches
`ConfigureHumanReadableSerializer`, which rebuilds the serializer list non-atomically:

```csharp
settings.Serializers.Clear();
foreach (var item in serializers)
    settings.Serializers.Add(item);
```

while another test may be inside `SnapshotSerializerCollection.Serialize`:

```csharp
for (var i = _serializers.Count - 1; i >= 0; i--)
{
    var serializer = _serializers[i];   // after a concurrent Clear()
```

`Count` is read once at loop entry, so a `Clear()` landing between those two lines throws
`ArgumentOutOfRangeException` from the indexer. xunit v3 parallelises test collections by
default, so reproducing this needs nothing more than two test classes both following the
readme.

Neither `AddImageSharp` nor `AddSkiaSharp` is idempotent either, so calling them per-test
appends another serializer and another converter to the global default on every call.

## What changed

Both readmes now show a `[ModuleInitializer]` that registers once per test assembly, with
the test method reduced to the assertion, plus an `[!IMPORTANT]` note explaining why. The
SSIM snippets are marked as belonging in that same initializer.

This is the pattern the **Roslyn readme already uses** (`…Roslyn/readme.md:10-22`) — my
review said all three readmes had the problem, which was wrong. Roslyn was already correct;
this brings the other two in line with it.

## Scope

Documentation only — no code changes. Hardening the collections themselves so global
mutation is actually safe is a larger design change, tracked separately.
