### PR TITLE
Collect every histogram anchor from a single occurrence table

### DIFF
--- a/src/Meziantou.Framework.TextDiff/Anchor.cs
+++ b/src/Meziantou.Framework.TextDiff/Anchor.cs
@@ -1,0 +1,10 @@
+using System.Runtime.InteropServices;
+
+namespace Meziantou.Framework;
+
+/// <summary>
+/// A pair of chunks, one on each side, that an anchor-based algorithm has decided to treat as a match and
+/// diff around.
+/// </summary>
+[StructLayout(LayoutKind.Auto)]
+internal readonly record struct Anchor(int LeftIndex, int RightIndex);

--- a/src/Meziantou.Framework.TextDiff/DiffAlgorithmHelpers.cs
+++ b/src/Meziantou.Framework.TextDiff/DiffAlgorithmHelpers.cs
@@ -4,6 +4,8 @@ namespace Meziantou.Framework;
 
 internal static class DiffAlgorithmHelpers
 {
+    private const int StackAllocationThreshold = 128;
+
     internal static void ApplySubDiff(DiffComputationResult subDiff, bool[] leftModified, int leftOffset, bool[] rightModified, int rightOffset)
     {
         Array.Copy(subDiff.LeftModified, 0, leftModified, leftOffset, subDiff.LeftLength);
@@ -19,6 +21,71 @@ internal static class DiffAlgorithmHelpers
         {
             var middle = low + ((high - low) / 2);
             if (span[middle] < value)
+            {
+                low = middle + 1;
+            }
+            else
+            {
+                high = middle;
+            }
+        }
+
+        return low;
+    }
+
+    /// <summary>
+    /// Reduces candidate anchors, already ordered by their left index, to the longest subsequence whose right
+    /// indexes also increase. Anchors that cross each other cannot all be kept: an anchor pair is only usable
+    /// when it preserves the order of both sides.
+    /// </summary>
+    internal static List<Anchor> LongestIncreasingSubsequenceByRight(List<Anchor> candidates)
+    {
+        var count = candidates.Count;
+        var tailsBuffer = count <= StackAllocationThreshold ? stackalloc int[StackAllocationThreshold] : new int[count];
+        var previousBuffer = count <= StackAllocationThreshold ? stackalloc int[StackAllocationThreshold] : new int[count];
+
+        var tails = tailsBuffer[..count];
+        var previous = previousBuffer[..count];
+        previous.Fill(-1);
+        var length = 0;
+
+        var candidatesSpan = CollectionsMarshal.AsSpan(candidates);
+        for (var i = 0; i < count; i++)
+        {
+            var position = LowerBoundByRight(candidatesSpan, tails, length, candidatesSpan[i].RightIndex);
+            if (position > 0)
+            {
+                previous[i] = tails[position - 1];
+            }
+
+            tails[position] = i;
+            if (position == length)
+            {
+                length++;
+            }
+        }
+
+        var result = new List<Anchor>(length);
+        var index = tails[length - 1];
+        while (index >= 0)
+        {
+            result.Add(candidatesSpan[index]);
+            index = previous[index];
+        }
+
+        result.Reverse();
+        return result;
+    }
+
+    private static int LowerBoundByRight(ReadOnlySpan<Anchor> candidates, ReadOnlySpan<int> tails, int length, int rightIndex)
+    {
+        var low = 0;
+        var high = length;
+        while (low < high)
+        {
+            var middle = low + ((high - low) / 2);
+            var value = candidates[tails[middle]].RightIndex;
+            if (value < rightIndex)
             {
                 low = middle + 1;
             }

--- a/src/Meziantou.Framework.TextDiff/HistogramDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/HistogramDiff.cs
@@ -4,6 +4,11 @@ namespace Meziantou.Framework;
 
 internal static class HistogramDiff
 {
+    // A token that occurs this often on both sides anchors the region badly: it splits it at an
+    // arbitrary one of its many occurrences and the result is worse than not anchoring at all. Give up
+    // on the region and let the fallback algorithm handle it, as git's histogram diff does.
+    private const int MaxAnchorScore = 64;
+
     internal static DiffComputationResult Compute(string[] left, string[] right, IEqualityComparer<string> comparer)
     {
         var leftModified = new bool[left.Length];
@@ -26,10 +31,13 @@ internal static class HistogramDiff
         bool[] leftModified,
         bool[] rightModified)
     {
-        // Each level consumes a single anchor, so recursing on both sides of it made the recursion
-        // depth proportional to the number of anchors. The region after the anchor is a tail call:
-        // iterate on it instead of recursing, which leaves only the region before the anchor on the
-        // stack. Recursing on both sides overflowed the stack on a few thousand changed chunks.
+        // Each pass keeps every anchor it can find instead of a single one. Consuming one anchor per
+        // occurrence table made the search quadratic: the table was rebuilt over the whole remaining
+        // region for each anchor, so a region with k anchors cost O(region * k).
+        //
+        // The region after the last anchor is a tail call, so iterate on it and leave only the gaps
+        // between anchors on the stack. Recursing on it too overflowed the stack on a few thousand
+        // changed chunks.
         while (true)
         {
             while (leftStart < leftEnd && rightStart < rightEnd && comparer.Equals(left[leftStart], right[rightStart]))
@@ -51,18 +59,21 @@ internal static class HistogramDiff
             if (leftStart >= leftEnd || rightStart >= rightEnd)
                 return;
 
-            var anchor = FindBestAnchor(left, leftStart, leftEnd, right, rightStart, rightEnd, comparer);
-            if (anchor is null)
+            var anchors = FindAnchors(left, leftStart, leftEnd, right, rightStart, rightEnd, comparer);
+            if (anchors.Count == 0)
             {
                 ApplyMyers(left, leftStart, leftEnd, right, rightStart, rightEnd, comparer, leftModified, rightModified);
                 return;
             }
 
-            ComputeRange(left, leftStart, anchor.Value.LeftIndex, right, rightStart, anchor.Value.RightIndex, comparer, leftModified, rightModified);
-            leftModified[anchor.Value.LeftIndex] = false;
-            rightModified[anchor.Value.RightIndex] = false;
-            leftStart = anchor.Value.LeftIndex + 1;
-            rightStart = anchor.Value.RightIndex + 1;
+            foreach (var anchor in anchors)
+            {
+                ComputeRange(left, leftStart, anchor.LeftIndex, right, rightStart, anchor.RightIndex, comparer, leftModified, rightModified);
+                leftModified[anchor.LeftIndex] = false;
+                rightModified[anchor.RightIndex] = false;
+                leftStart = anchor.LeftIndex + 1;
+                rightStart = anchor.RightIndex + 1;
+            }
         }
     }
 
@@ -85,19 +96,20 @@ internal static class HistogramDiff
         DiffAlgorithmHelpers.ApplySubDiff(subDiff, leftModified, leftStart, rightModified, rightStart);
     }
 
-    private static Anchor? FindBestAnchor(string[] left, int leftStart, int leftEnd, string[] right, int rightStart, int rightEnd, IEqualityComparer<string> comparer)
+    private static List<Anchor> FindAnchors(string[] left, int leftStart, int leftEnd, string[] right, int rightStart, int rightEnd, IEqualityComparer<string> comparer)
     {
-        // A single map holds the occurrence counts on both sides and the first right-hand position of
-        // each token. This replaces a second dictionary and the List<int> that used to be allocated per
+        // A single map holds the occurrence counts on both sides and the first position of each token on
+        // each side. This replaces a second dictionary and the List<int> that used to be allocated per
         // distinct token, which dominated the allocations of this pass.
         var stats = new Dictionary<string, TokenStats>(comparer);
-        for (var i = leftStart; i < leftEnd; i++)
+        for (var i = leftEnd - 1; i >= leftStart; i--)
         {
             ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(stats, left[i], out _);
             entry.LeftCount++;
+            entry.FirstLeftIndex = i;
         }
 
-        // Walking backwards leaves the smallest index of each token in FirstRightIndex.
+        // Walking backwards leaves the smallest index of each token in FirstLeftIndex/FirstRightIndex.
         for (var i = rightEnd - 1; i >= rightStart; i--)
         {
             ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(stats, right[i], out _);
@@ -105,30 +117,43 @@ internal static class HistogramDiff
             entry.FirstRightIndex = i;
         }
 
-        Anchor? best = null;
+        // The histogram rule: anchor on the least frequent token the two sides share.
         var bestScore = int.MaxValue;
+        foreach (var entry in stats.Values)
+        {
+            if (entry.LeftCount is 0 || entry.RightCount is 0)
+                continue;
+
+            var score = entry.LeftCount + entry.RightCount;
+            if (score < bestScore)
+            {
+                bestScore = score;
+            }
+        }
+
+        if (bestScore > MaxAnchorScore)
+            return [];
+
+        // Walking the range in order yields the candidates already sorted by left index, which is what
+        // the longest-increasing-subsequence pass needs.
+        var candidates = new List<Anchor>();
         for (var leftIndex = leftStart; leftIndex < leftEnd; leftIndex++)
         {
             var entry = stats[left[leftIndex]];
-            if (entry.RightCount is 0)
+            if (entry.RightCount is 0 || entry.LeftCount + entry.RightCount != bestScore)
                 continue;
 
-            // leftIndex only increases and ties are won by the smallest leftIndex, so an anchor found
-            // later can only replace the current best with a strictly lower score.
-            var score = entry.LeftCount + entry.RightCount;
-            if (score >= bestScore)
+            // Keep one candidate per token so a repeated token cannot contribute several crossing pairs.
+            if (entry.FirstLeftIndex != leftIndex)
                 continue;
 
-            best = new Anchor(leftIndex, entry.FirstRightIndex);
-            bestScore = score;
-
-            // 2 is the lowest reachable score: the token occurs exactly once on each side. Nothing
-            // later in the range can beat it, so stop scanning.
-            if (score is 2)
-                break;
+            candidates.Add(new Anchor(leftIndex, entry.FirstRightIndex));
         }
 
-        return best;
+        if (candidates.Count == 0)
+            return candidates;
+
+        return DiffAlgorithmHelpers.LongestIncreasingSubsequenceByRight(candidates);
     }
 
     [StructLayout(LayoutKind.Auto)]
@@ -136,9 +161,7 @@ internal static class HistogramDiff
     {
         public int LeftCount;
         public int RightCount;
+        public int FirstLeftIndex;
         public int FirstRightIndex;
     }
-
-    [StructLayout(LayoutKind.Auto)]
-    private readonly record struct Anchor(int LeftIndex, int RightIndex);
 }

--- a/src/Meziantou.Framework.TextDiff/PatienceDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/PatienceDiff.cs
@@ -114,7 +114,7 @@ internal static class PatienceDiff
         if (pairs.Count == 0)
             return pairs;
 
-        return LongestIncreasingSubsequenceByRight(pairs);
+        return DiffAlgorithmHelpers.LongestIncreasingSubsequenceByRight(pairs);
     }
 
     private static Dictionary<string, int> FindUniquePositions(string[] values, int start, int end, IEqualityComparer<string> comparer)
@@ -129,69 +129,4 @@ internal static class PatienceDiff
 
         return result;
     }
-
-    private static List<Anchor> LongestIncreasingSubsequenceByRight(List<Anchor> pairs)
-    {
-        const int StackAllocationThreshold = 128;
-
-        var count = pairs.Count;
-        var tailsBuffer = count <= StackAllocationThreshold ? stackalloc int[StackAllocationThreshold] : new int[count];
-        var previousBuffer = count <= StackAllocationThreshold ? stackalloc int[StackAllocationThreshold] : new int[count];
-
-        var tails = tailsBuffer[..count];
-        var previous = previousBuffer[..count];
-        previous.Fill(-1);
-        var length = 0;
-
-        var pairsSpan = CollectionsMarshal.AsSpan(pairs);
-        for (var i = 0; i < count; i++)
-        {
-            var position = LowerBoundByRight(pairsSpan, tails, length, pairsSpan[i].RightIndex);
-            if (position > 0)
-            {
-                previous[i] = tails[position - 1];
-            }
-
-            tails[position] = i;
-            if (position == length)
-            {
-                length++;
-            }
-        }
-
-        var result = new List<Anchor>(length);
-        var index = tails[length - 1];
-        while (index >= 0)
-        {
-            result.Add(pairsSpan[index]);
-            index = previous[index];
-        }
-
-        result.Reverse();
-        return result;
-    }
-
-    private static int LowerBoundByRight(ReadOnlySpan<Anchor> pairs, ReadOnlySpan<int> tails, int length, int rightIndex)
-    {
-        var low = 0;
-        var high = length;
-        while (low < high)
-        {
-            var middle = low + ((high - low) / 2);
-            var value = pairs[tails[middle]].RightIndex;
-            if (value < rightIndex)
-            {
-                low = middle + 1;
-            }
-            else
-            {
-                high = middle;
-            }
-        }
-
-        return low;
-    }
-
-    [StructLayout(LayoutKind.Auto)]
-    private readonly record struct Anchor(int LeftIndex, int RightIndex);
 }

--- a/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
+++ b/tests/Meziantou.Framework.TextDiff.Tests/TextDiffTests.cs
@@ -89,9 +89,9 @@ public sealed class TextDiffTests
             JoinLines("A", "A", "B", "C"),
             [
                 new TextDiffEntry(TextDiffOperation.Equal, "A\n"),
-                new TextDiffEntry(TextDiffOperation.Insert, "A\n"),
-                new TextDiffEntry(TextDiffOperation.Equal, "B\n"),
-                new TextDiffEntry(TextDiffOperation.Delete, "A\n"),
+                new TextDiffEntry(TextDiffOperation.Delete, "B\n"),
+                new TextDiffEntry(TextDiffOperation.Equal, "A\n"),
+                new TextDiffEntry(TextDiffOperation.Insert, "B\n"),
                 new TextDiffEntry(TextDiffOperation.Equal, "C"),
             ]),
         new(
@@ -137,9 +137,9 @@ public sealed class TextDiffTests
             JoinLines("a", "c", "b", "d"),
             [
                 new TextDiffEntry(TextDiffOperation.Equal, "a\n"),
-                new TextDiffEntry(TextDiffOperation.Insert, "c\n"),
-                new TextDiffEntry(TextDiffOperation.Equal, "b\n"),
-                new TextDiffEntry(TextDiffOperation.Delete, "c\n"),
+                new TextDiffEntry(TextDiffOperation.Delete, "b\n"),
+                new TextDiffEntry(TextDiffOperation.Equal, "c\n"),
+                new TextDiffEntry(TextDiffOperation.Insert, "b\n"),
                 new TextDiffEntry(TextDiffOperation.Equal, "d"),
             ]),
         new(
@@ -370,6 +370,62 @@ public sealed class TextDiffTests
         thread.Join();
 
         Assert.NotNull(result);
+        Assert.Equal(oldText, ReconstructOldText(result));
+        Assert.Equal(newText, ReconstructNewText(result));
+    }
+
+    [Fact]
+    public void ComputeDiff_Histogram_ManyAnchors_IsNotQuadraticInTheAnchorCount()
+    {
+        // Rebuilding the occurrence table to consume a single anchor made this input cost O(n * anchors):
+        // it took over 30s at this size and ~11.6s at 20k lines. Collecting every anchor from one pass
+        // brings it to a few tens of milliseconds, so the budget below only trips on a real regression.
+        const int Count = 50_000;
+        var oldLines = new string[Count];
+        var newLines = new string[Count];
+        for (var i = 0; i < Count; i++)
+        {
+            var suffix = i.ToString(CultureInfo.InvariantCulture);
+            oldLines[i] = "u" + suffix;
+            newLines[i] = (i % 2 is 0 ? "u" : "v") + suffix;
+        }
+
+        var oldText = JoinLines(oldLines);
+        var newText = JoinLines(newLines);
+
+        TextDiffResult? result = null;
+        var thread = new Thread(() => result = Diff.ComputeDiff(oldText, newText, new TextDiffOptions { Algorithm = TextDiffAlgorithm.Histogram }));
+        thread.Start();
+
+        Assert.True(thread.Join(TimeSpan.FromSeconds(20)), "The histogram anchor search did not complete in 20s.");
+        Assert.NotNull(result);
+        Assert.Equal(oldText, ReconstructOldText(result));
+        Assert.Equal(newText, ReconstructNewText(result));
+    }
+
+    [Fact]
+    [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Generating test inputs, and the fixed seed keeps the cases reproducible.")]
+    public void ComputeDiff_Histogram_HighlyRepetitiveInput_FallsBackToMyers()
+    {
+        // Every token occurs hundreds of times on each side, so the best anchor scores far above
+        // MaxAnchorScore and the region is handed to the fallback algorithm instead of being anchored
+        // on a token that appears everywhere.
+        const int Count = 2_000;
+        var random = new Random(20260827);
+        var oldLines = new string[Count];
+        var newLines = new string[Count];
+        for (var i = 0; i < Count; i++)
+        {
+            oldLines[i] = "line" + random.Next(3).ToString(CultureInfo.InvariantCulture);
+            newLines[i] = "line" + random.Next(3).ToString(CultureInfo.InvariantCulture);
+        }
+
+        var oldText = JoinLines(oldLines);
+        var newText = JoinLines(newLines);
+
+        var result = Diff.ComputeDiff(oldText, newText, new TextDiffOptions { Algorithm = TextDiffAlgorithm.Histogram });
+
+        Assert.True(result.HasDifferences);
         Assert.Equal(oldText, ReconstructOldText(result));
         Assert.Equal(newText, ReconstructNewText(result));
     }


### PR DESCRIPTION
`HistogramDiff.FindBestAnchor` built a fresh `Dictionary<string, TokenStats>` over the
**entire remaining** left and right range, then consumed exactly **one** anchor from it
(`leftStart = anchor.LeftIndex + 1`) and rebuilt the table on the next iteration. A region
with *k* anchors therefore cost `O(region * k)`.

Measured on "every second line changed" — an ordinary shape: a renamed identifier, a
reformatted file:

| lines/side | before | after |
|---|---:|---:|
| 5 000 | 399 ms | **3 ms** |
| 20 000 | 11 591 ms | **12 ms** |
| 50 000 | > 30 000 ms (timed out) | **18 ms** |

Histogram was the slowest of the four algorithms at every size, on the workload the README
recommends it for. It is now the fastest or tied-fastest.

This was **not** a regression from `67fe2e16d` ("Fix stack overflow in Histogram diff on
inputs with many anchors"). That commit turned the after-anchor recursion into iteration;
the pre-fix recursive version rebuilt the table over the same ranges and had the same total
cost. The quadratic behaviour was original to the design.

## What changed

`FindBestAnchor` becomes `FindAnchors`: one pass over the region collects the occurrence
counts, and **every** candidate at the best score is kept rather than just the first. The
candidates run through a longest-increasing-subsequence pass so the anchors that survive are
monotonic on both sides, then `ComputeRange` recurses into the gaps between them. Each region
now builds its table once.

The tail-iteration from `67fe2e16d` is preserved: only the gaps between anchors go on the
stack, never the region after the last anchor. `ComputeDiff_Histogram_ManyAnchors_DoesNotOverflowTheStack`
still passes on its 512 KB thread.

`MaxAnchorScore` (64, the value git's histogram diff uses) hands a region to the Myers
fallback when the least frequent shared token still occurs ~32 times per side. Anchoring on
a token that appears everywhere splits the region arbitrarily. On realistic input this never
fires; it is a safeguard, not a tuning knob.

The longest-increasing-subsequence pass and the `Anchor` type moved from `PatienceDiff` into
`DiffAlgorithmHelpers`/`Anchor.cs` so both algorithms share one copy. That is a mechanical
extraction required by this fix, not an unrelated change — `PatienceDiff`'s behaviour is
unchanged. `Anchor` needed its own file to satisfy MA0048.

## Output change

Two golden expectations moved. On `A B A C -> A A B C` and `a b c d -> a c b d`, Histogram
now splits the way Patience and Hunt-Szymanski already do. Both the old and new output
contain **three** `Equal` chunks — same minimality, different but equally valid anchor — and
the new output is consistent with the other anchor-based algorithms rather than with Myers.

## On diff quality

The review that prompted this PR also claimed Histogram produced ~30 % worse diffs than the
other algorithms (finding H3). **That finding was wrong, and this PR does not act on it.**
The 30 % gap only appeared on random lines drawn from a 6-token alphabet, which is not text.
Re-measured on realistic input:

| corpus | Myers | Patience | Histogram | Hunt-Szymanski |
|---|---:|---:|---:|---:|
| 147 real C# file pairs, realistic edits | 19 670 | 19 670 | 19 668 | 19 670 |
| 300 prose word-level diffs | 39 924 | 39 919 | 39 919 | 39 924 |

(equal chunks; higher is tighter). Histogram is within 0.01 % of Myers on both. Tightening
the anchor threshold to recover the synthetic number would have made Histogram behave
identically to Patience, deleting the reason both algorithms exist. Left alone deliberately.

## Verification

`dotnet test -c Release /p:TreatsWarningsAsErrors=true` → **196 passed, 0 failed** (192
before, +4 from the new tests across both target frameworks).

I confirmed the new perf guard catches the old behaviour by restoring the previous
`HistogramDiff`/`PatienceDiff`/`DiffAlgorithmHelpers` and re-running it: it fails on both
target frameworks with *"The histogram anchor search did not complete in 20s."*

New tests:
- `ComputeDiff_Histogram_ManyAnchors_IsNotQuadraticInTheAnchorCount` — 50 000 lines under a
  20 s budget. Takes ~18 ms with this change; the old code exceeded 30 s.
- `ComputeDiff_Histogram_HighlyRepetitiveInput_FallsBackToMyers` — 2 000 lines over a
  3-token alphabet, which is what drives the `MaxAnchorScore` fallback.

`ref/` is unchanged: every type touched here is internal. `dotnet run ./eng/update-all.cs`
reports no changes.

---

Found during a review of `Meziantou.Framework.TextDiff` (finding H2; H3 retracted above).
