### PR TITLE
Document marking snapshot directories as binary in git

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/readme.md
+++ b/src/Meziantou.Framework.SnapshotTesting/readme.md
@@ -53,6 +53,24 @@ Notes:
 - If a single assertion serializes multiple files, an index suffix (`_0`, `_1`, ...) is appended.
 - If names are too long (or already end with `.verified` / `.actual`), a stable hash is added.
 
+## Storing snapshots in git
+
+Snapshots are often binary: PNG frames from the GIF/ICO serializers, whatever the ImageSharp and
+SkiaSharp backends emit, and `.bin` for any value whose extension is unknown. Add an entry to your
+`.gitattributes` so git never applies line-ending conversion to them:
+
+```gitattributes
+**/__snapshots__/** -text
+```
+
+Without it, a repository using the default `core.autocrlf=true` on Windows rewrites the line endings
+of every binary snapshot on checkout. The symptom is snapshots that pass for whoever approved them
+and fail for everyone else. PNG files fail to decode outright rather than mis-comparing, because the
+PNG signature contains a `CR LF` pair specifically to catch this, but the reported error
+("Unsupported image format") does not point at the cause.
+
+## Snapshot naming
+
 You can choose how snapshot names are generated using `SnapshotSettings.SnapshotNamingStrategy`:
 
 - `SnapshotNamingStrategies.TestName`


### PR DESCRIPTION
The package writes binary snapshots — PNG from the GIF/ICO serializers, `.bin` for
unrecognised extensions (`SnapshotSettings.cs:151`), plus whatever the ImageSharp and
SkiaSharp backends emit — but the readme never tells consumers to keep git away from them.

A consumer repository on Windows with the default `core.autocrlf=true` and no
`.gitattributes` entry has every binary snapshot line-ending mangled on checkout. The
symptom is baffling: snapshots pass for whoever approved them and fail for everyone else,
with a diff that looks like noise.

This repository is immune — its `.gitattributes` is `* -text` — which is exactly why the
problem is invisible from the inside.

## What changed

Added a "Storing snapshots in git" section to the core readme recommending:

```gitattributes
**/__snapshots__/** -text
```

with a short explanation of the failure mode, including the detail that PNG snapshots fail
to *decode* rather than mis-compare (the PNG signature carries a `CR LF` pair precisely to
detect this), and that the resulting "Unsupported image format" message does not point at
the cause.

Also gave the naming-strategy paragraph that followed it its own `## Snapshot naming`
heading, since it was previously trailing off the end of the file-naming section.

## Scope

Documentation only.
