### PR TITLE
Keep updating the remaining dependencies when one registry call fails

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
@@ -177,6 +177,7 @@ internal static class Program
         var updaters = CreatePackageUpdaters(minimumAge);
 
         var updatedDependencies = new ConcurrentBag<Dependency>();
+        var failureCount = 0;
         var updatableDependencies = filteredDependencies.Where(static dependency => dependency.VersionLocation?.IsUpdatable is true);
         await Parallel.ForEachAsync(
             updatableDependencies,
@@ -186,12 +187,22 @@ internal static class Program
                 if (dependencyTypeSet is not null && !dependencyTypeSet.Contains(dependency.Type))
                     return;
 
-                string? updatedVersion = null;
-                foreach (var updater in updaters)
+                string? updatedVersion;
+                try
                 {
-                    updatedVersion = await updater.UpdateAsync(dependency, localCancellationToken).ConfigureAwait(false);
-                    if (updatedVersion is not null)
-                        break;
+                    updatedVersion = await UpdateDependencyAsync(updaters, dependency, localCancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (localCancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+#pragma warning disable CA1031 // One unreachable registry must not abort the whole run
+                catch (Exception ex)
+#pragma warning restore CA1031
+                {
+                    Interlocked.Increment(ref failureCount);
+                    error.WriteLine($"Unable to update {dependency}: {ex.Message}");
+                    return;
                 }
 
                 if (updatedVersion is not null)
@@ -205,11 +216,41 @@ internal static class Program
         {
             foreach (var updater in updaters)
             {
-                await updater.UpdateLockFileAsync(rootPath, updatedDependencies, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await updater.UpdateLockFileAsync(rootPath, updatedDependencies, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+#pragma warning disable CA1031 // A failing lock file must not hide the updates that succeeded
+                catch (Exception ex)
+#pragma warning restore CA1031
+                {
+                    failureCount++;
+                    error.WriteLine($"Unable to update lock files: {ex.Message}");
+                }
             }
         }
 
-        return 0;
+        output.WriteLine(failureCount is 0
+            ? $"{updatedDependencies.Count} dependencies updated"
+            : $"{updatedDependencies.Count} dependencies updated, {failureCount} failed");
+
+        return failureCount is 0 ? 0 : 1;
+    }
+
+    private static async Task<string?> UpdateDependencyAsync(PackageUpdater[] updaters, Dependency dependency, CancellationToken cancellationToken)
+    {
+        foreach (var updater in updaters)
+        {
+            var updatedVersion = await updater.UpdateAsync(dependency, cancellationToken).ConfigureAwait(false);
+            if (updatedVersion is not null)
+                return updatedVersion;
+        }
+
+        return null;
     }
 
     private static async Task<int> ListAsync(string? rootDirectory, string[]? filePatterns, DependencyType[]? dependencyTypes, bool upgradable, int minimumAge, OutputFormat format, TextWriter output, TextWriter error, CancellationToken cancellationToken)
@@ -226,7 +267,7 @@ internal static class Program
         var filteredDependencies = FilterDependencies(dependencies, dependencyTypeSet);
         if (upgradable)
         {
-            filteredDependencies = await FilterUpgradableDependenciesAsync(filteredDependencies, minimumAge, cancellationToken).ConfigureAwait(false);
+            filteredDependencies = await FilterUpgradableDependenciesAsync(filteredDependencies, minimumAge, error, cancellationToken).ConfigureAwait(false);
         }
 
         if (format is OutputFormat.Json)
@@ -254,7 +295,7 @@ internal static class Program
         ];
     }
 
-    private static async Task<Dependency[]> FilterUpgradableDependenciesAsync(Dependency[] dependencies, int minimumAge, CancellationToken cancellationToken)
+    private static async Task<Dependency[]> FilterUpgradableDependenciesAsync(Dependency[] dependencies, int minimumAge, TextWriter error, CancellationToken cancellationToken)
     {
         // Must match what 'update' would do, otherwise a version too recent to be applied is still listed
         var updaters = CreatePackageUpdaters(minimumAge);
@@ -264,13 +305,26 @@ internal static class Program
             new ParallelOptions { CancellationToken = cancellationToken, MaxDegreeOfParallelism = 1 },
             async (dependency, localCancellationToken) =>
             {
-                foreach (var updater in updaters)
+                try
                 {
-                    if (await updater.GetUpdatedVersionAsync(dependency, localCancellationToken).ConfigureAwait(false) is not null)
+                    foreach (var updater in updaters)
                     {
-                        upgradableDependencies.Add(dependency);
-                        break;
+                        if (await updater.GetUpdatedVersionAsync(dependency, localCancellationToken).ConfigureAwait(false) is not null)
+                        {
+                            upgradableDependencies.Add(dependency);
+                            break;
+                        }
                     }
+                }
+                catch (OperationCanceledException) when (localCancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+#pragma warning disable CA1031 // One unreachable registry must not abort the whole listing
+                catch (Exception ex)
+#pragma warning restore CA1031
+                {
+                    error.WriteLine($"Unable to check {dependency}: {ex.Message}");
                 }
             }).ConfigureAwait(false);
 

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
@@ -162,6 +162,39 @@ public sealed class FunctionalTests
     }
 
     [Fact]
+    public async Task UnreachableSourceDoesNotAbortTheRun()
+    {
+        await using var tempDir = TemporaryDirectory.Create();
+
+        await File.WriteAllTextAsync(tempDir.CreateEmptyFile("nuget.config"), """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="broken" value="https://nonexistent-feed.invalid/v3/index.json" />
+              </packageSources>
+            </configuration>
+            """, XunitCancellationToken);
+        await File.WriteAllTextAsync(tempDir.CreateEmptyFile("a.csproj"), """
+            <Project>
+                <ItemGroup>
+                    <PackageReference Include="Meziantou.Framework" Version="1.0.0" />
+                    <PackageReference Include="Newtonsoft.Json" Version="10.0.0" />
+                </ItemGroup>
+            </Project>
+            """, XunitCancellationToken);
+
+        var console = new ConsoleHelper(_testOutputHelper);
+        var result = await Program.MainImpl(["update", "--directory", tempDir.FullPath], console.ConfigureConsole);
+
+        Assert.Equal(1, result);
+        // The run continued past the first failure instead of throwing out of the command
+        Assert.Contains("Meziantou.Framework", console.Error);
+        Assert.Contains("Newtonsoft.Json", console.Error);
+        Assert.Contains("2 failed", console.Output);
+    }
+
+    [Fact]
     public async Task ListDependenciesAsJson()
     {
         await using var tempDir = TemporaryDirectory.Create();


### PR DESCRIPTION
Only `GitHubActionsUpdater` wrapped its HTTP call in a `try/catch`. Everywhere else `EnsureSuccessStatusCode`, `GetFromJsonAsync` and NuGet's `GetResourceAsync` threw straight through `Parallel.ForEachAsync` and out of the command.

**Reproduced before the fix** — one unreachable feed, two packages to update:

```
Unhandled exception: NuGet.Protocol.Core.Types.FatalProtocolException: Unable to load
the service index for source https://nonexistent-feed.invalid/v3/index.json.
 ---> System.Net.Http.HttpRequestException: nodename nor servname provided ...
   [~30 more frames]
```

Exit code 1, and **neither** project updated — the run aborted on the first dependency. Since `MaxDegreeOfParallelism` is 1, whichever dependency happens to be first decides whether anything gets done at all, and a mid-run failure leaves the working tree partially rewritten with no summary of what changed.

This is the unattended-CI use case: a 503 from a registry, an expired feed or a DNS blip turns a routine bump into a red build with a stack trace instead of a message.

## What changed

Each dependency is now attempted independently, in `update` and in `list --upgradable` alike:

- a failure writes a one-line message to stderr and the loop continues;
- `OperationCanceledException` is rethrown when the token is actually cancelled, so Ctrl-C still stops promptly (the shape `GitHubActionsUpdater` already used);
- `--update-lock-files` gets the same treatment, so a failing `dotnet restore` no longer hides the version updates that succeeded;
- `update` prints a closing summary and exits non-zero if anything failed, so CI still notices.

Same input, after:

```
2 dependencies found
Unable to update NuGet:Meziantou.Framework@1.0.0:...a.csproj: Unable to load the service index for source https://nonexistent-feed.invalid/v3/index.json.
Unable to update NuGet:Newtonsoft.Json@10.0.0:...a.csproj: Unable to load the service index for source https://nonexistent-feed.invalid/v3/index.json.
0 dependencies updated, 2 failed
```

The two `CA1031` suppressions are deliberate and commented: catching broadly is the point — an arbitrary registry failure must not take the process down.

Out of scope, worth a separate change: a dependency that fails on *one* configured source still fails overall, even when a later source would have answered. Making the per-source loop in `NuGetPackageUpdater` tolerant is a NuGet-specific fix.

## Verification

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 50 passed, 0 failed (was 49).
- `dotnet run ./eng/update-all.cs` — no generated-file changes.

New test `FunctionalTests.UnreachableSourceDoesNotAbortTheRun` points the tool at a `nuget.config` with a single unreachable feed and asserts both packages were attempted, the summary reports `2 failed`, and the exit code is 1.


---

**Merge note:** conflicts with #2212, which adds an `int minimumAge` parameter to the same `FilterUpgradableDependenciesAsync` signature this PR gives a `TextWriter error` parameter. Whichever merges second needs a one-line rebase to carry both parameters. Verified with `git merge-tree`; every other pair in this batch merges cleanly.