### PR TITLE
Make TryGetRawData return false instead of throwing on bad input

### DIFF
--- a/src/Meziantou.Framework.HttpArchive/HarPostDataExtensions.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarPostDataExtensions.cs
@@ -12,7 +12,11 @@ public static class HarPostDataExtensions
     /// <param name="postData">The HAR post data.</param>
     /// <param name="rawData">The decoded raw bytes if available.</param>
     /// <param name="encodingExtensionName">The extension field name containing the encoding metadata.</param>
-    /// <returns><see langword="true" /> when payload bytes are available; otherwise, <see langword="false" />.</returns>
+    /// <returns>
+    /// <see langword="true" /> when payload bytes are available; otherwise, <see langword="false" />.
+    /// Returns <see langword="false" /> when the text is not valid for the declared encoding, or when the
+    /// declared encoding is not understood, rather than reporting the undecoded text as the payload.
+    /// </returns>
     public static bool TryGetRawData(this HarPostData? postData, [NotNullWhen(true)] out byte[]? rawData, string encodingExtensionName = DefaultEncodingExtensionName)
     {
         if (postData?.Text is null)
@@ -21,15 +25,32 @@ public static class HarPostDataExtensions
             return false;
         }
 
-        if (TryGetEncoding(postData, encodingExtensionName, out var encoding) &&
-            string.Equals(encoding, "base64", StringComparison.OrdinalIgnoreCase))
+        if (TryGetEncoding(postData, encodingExtensionName, out var encoding))
         {
-            rawData = Convert.FromBase64String(postData.Text);
-            return true;
+            if (!string.Equals(encoding, "base64", StringComparison.OrdinalIgnoreCase))
+            {
+                rawData = null;
+                return false;
+            }
+
+            return TryDecodeBase64(postData.Text, out rawData);
         }
 
         rawData = Encoding.UTF8.GetBytes(postData.Text);
         return true;
+    }
+
+    private static bool TryDecodeBase64(string text, [NotNullWhen(true)] out byte[]? bytes)
+    {
+        var buffer = new byte[((text.Length / 4) + 1) * 3];
+        if (Convert.TryFromBase64String(text, buffer, out var written))
+        {
+            bytes = buffer.AsSpan(0, written).ToArray();
+            return true;
+        }
+
+        bytes = null;
+        return false;
     }
 
     private static bool TryGetEncoding(HarPostData postData, string encodingExtensionName, out string? encoding)

--- a/tests/Meziantou.Framework.HttpArchive.Tests/HarEntryExtensionsTests.cs
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/HarEntryExtensionsTests.cs
@@ -179,6 +179,55 @@ public sealed class HarEntryExtensionsTests
     }
 
     [Fact]
+    public void PostData_TryGetRawData_InvalidBase64()
+    {
+        var postData = new HarPostData
+        {
+            Text = "not!valid!base64",
+            ExtensionData = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+            {
+                [HarPostDataExtensions.DefaultEncodingExtensionName] = JsonDocument.Parse("\"base64\"").RootElement.Clone(),
+            },
+        };
+
+        Assert.False(postData.TryGetRawData(out var rawData));
+        Assert.Null(rawData);
+    }
+
+    [Fact]
+    public void PostData_TryGetRawData_UnknownEncoding()
+    {
+        var postData = new HarPostData
+        {
+            Text = "48656c6c6f",
+            ExtensionData = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+            {
+                [HarPostDataExtensions.DefaultEncodingExtensionName] = JsonDocument.Parse("\"hex\"").RootElement.Clone(),
+            },
+        };
+
+        Assert.False(postData.TryGetRawData(out var rawData));
+        Assert.Null(rawData);
+    }
+
+    [Fact]
+    public void PostData_TryGetRawData_CustomEncodingExtensionName()
+    {
+        var binaryData = new byte[] { 0x00, 0xFF };
+        var postData = new HarPostData
+        {
+            Text = Convert.ToBase64String(binaryData),
+            ExtensionData = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+            {
+                ["_encoding"] = JsonDocument.Parse("\"base64\"").RootElement.Clone(),
+            },
+        };
+
+        Assert.True(postData.TryGetRawData(out var rawData, "_encoding"));
+        Assert.Equal(binaryData, rawData);
+    }
+
+    [Fact]
     public void PostData_TryGetRawData_Utf8()
     {
         var postData = new HarPostData


### PR DESCRIPTION
Independent — branches from `main`, reviewable and mergeable in any order.

## The problem

`HarPostDataExtensions.TryGetRawData` is a `Try` method: `bool` return, `[NotNullWhen(true)]` out parameter. Callers reasonably assume it does not throw. It did, for exactly the input it exists to validate.

**It threw on malformed base64.** `Convert.FromBase64String` was called unguarded on text straight out of the file, so a truncated or corrupted archive — a common state, since these files are large and frequently hand-edited to redact secrets — produced `FormatException`. Callers who correctly guarded with `if (postData.TryGetRawData(out var raw))` still crashed.

**It reported success with the wrong bytes for an encoding it did not understand.** If the encoding extension field held anything other than `"base64"` (`"hex"`, `"gzip"`, …) the method fell through to `Encoding.UTF8.GetBytes(postData.Text)` and returned `true`. The caller received the *encoded* text as bytes with no indication the declared encoding had been ignored. Wrong data reported as valid is worse than a clean failure.

## What changed

- `Convert.TryFromBase64String` instead of `Convert.FromBase64String`; invalid base64 now returns `false`.
- An encoding that is present but not understood returns `false`. The UTF-8 path is reserved for the no-encoding-declared case, which is what the absence of the field actually means.
- The documented return contract now states both conditions.

Behaviour is unchanged for the two cases that already worked: no encoding declared → UTF-8 bytes, and `"base64"` with valid text → decoded bytes.

## Note

`HarEntryExtensions` carries a similar private base64 helper (added in #2154 for the response path). Both are small and self-contained; folding them into one internal helper is left as a follow-up so these PRs stay independent of each other.

## Verification

`dotnet test -p:TreatsWarningsAsErrors=true` → **72/72 green** on `net10.0` and `net11.0` (3 new tests). The three pre-existing `PostData_TryGetRawData_*` tests still pass unchanged.
