### PR TITLE
Add TryGetRawData for HarContent to decode the standard encoding field

### DIFF
--- a/ref/Meziantou.Framework.HttpArchive.cs
+++ b/ref/Meziantou.Framework.HttpArchive.cs
@@ -62,6 +62,11 @@ namespace Meziantou.Framework.HttpArchive
         public System.Collections.Generic.Dictionary<string, System.Text.Json.JsonElement>? ExtensionData { get => throw null; set { } }
     }
 
+    public static class HarContentExtensions
+    {
+        public static bool TryGetRawData(this Meziantou.Framework.HttpArchive.HarContent? content, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out byte[]? rawData) => throw null;
+    }
+
     public sealed class HarCookie
     {
         [System.Text.Json.Serialization.JsonPropertyName("name")]

--- a/src/Meziantou.Framework.HttpArchive/HarContentExtensions.cs
+++ b/src/Meziantou.Framework.HttpArchive/HarContentExtensions.cs
@@ -1,0 +1,50 @@
+namespace Meziantou.Framework.HttpArchive;
+
+/// <summary>Provides helper methods for working with HAR response content payloads.</summary>
+public static class HarContentExtensions
+{
+    /// <summary>Gets the raw payload bytes represented by the HAR content.</summary>
+    /// <param name="content">The HAR content.</param>
+    /// <param name="rawData">The decoded raw bytes if available.</param>
+    /// <returns>
+    /// <see langword="true" /> when payload bytes are available; otherwise, <see langword="false" />.
+    /// Returns <see langword="false" /> when the text is not valid for the declared
+    /// <see cref="HarContent.Encoding"/>, or when that encoding is not understood, rather than reporting the
+    /// undecoded text as the payload.
+    /// </returns>
+    public static bool TryGetRawData(this HarContent? content, [NotNullWhen(true)] out byte[]? rawData)
+    {
+        if (content?.Text is null)
+        {
+            rawData = null;
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(content.Encoding))
+        {
+            if (!string.Equals(content.Encoding, "base64", StringComparison.OrdinalIgnoreCase))
+            {
+                rawData = null;
+                return false;
+            }
+
+            return TryDecodeBase64(content.Text, out rawData);
+        }
+
+        rawData = Encoding.UTF8.GetBytes(content.Text);
+        return true;
+    }
+
+    private static bool TryDecodeBase64(string text, [NotNullWhen(true)] out byte[]? bytes)
+    {
+        var buffer = new byte[((text.Length / 4) + 1) * 3];
+        if (Convert.TryFromBase64String(text, buffer, out var written))
+        {
+            bytes = buffer.AsSpan(0, written).ToArray();
+            return true;
+        }
+
+        bytes = null;
+        return false;
+    }
+}

--- a/tests/Meziantou.Framework.HttpArchive.Tests/HarContentExtensionsTests.cs
+++ b/tests/Meziantou.Framework.HttpArchive.Tests/HarContentExtensionsTests.cs
@@ -1,0 +1,50 @@
+namespace Meziantou.Framework.HttpArchive.Tests;
+
+public sealed class HarContentExtensionsTests
+{
+    [Fact]
+    public void TryGetRawData_PlainText()
+    {
+        var content = new HarContent { MimeType = "text/plain", Text = "hello" };
+
+        Assert.True(content.TryGetRawData(out var rawData));
+        Assert.Equal("hello"u8.ToArray(), rawData);
+    }
+
+    [Fact]
+    public void TryGetRawData_Base64()
+    {
+        var binaryData = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+        var content = new HarContent { MimeType = "image/png", Text = Convert.ToBase64String(binaryData), Encoding = "base64" };
+
+        Assert.True(content.TryGetRawData(out var rawData));
+        Assert.Equal(binaryData, rawData);
+    }
+
+    [Fact]
+    public void TryGetRawData_InvalidBase64()
+    {
+        var content = new HarContent { MimeType = "image/png", Text = "not!valid!base64", Encoding = "base64" };
+
+        Assert.False(content.TryGetRawData(out var rawData));
+        Assert.Null(rawData);
+    }
+
+    [Fact]
+    public void TryGetRawData_UnknownEncoding()
+    {
+        var content = new HarContent { MimeType = "text/plain", Text = "48656c6c6f", Encoding = "hex" };
+
+        Assert.False(content.TryGetRawData(out var rawData));
+        Assert.Null(rawData);
+    }
+
+    [Fact]
+    public void TryGetRawData_NoText()
+    {
+        var content = new HarContent { MimeType = "" };
+
+        Assert.False(content.TryGetRawData(out var rawData));
+        Assert.Null(rawData);
+    }
+}


### PR DESCRIPTION
Independent — branches from `main`, reviewable and mergeable in any order.

## The problem

An API-shape asymmetry, and the backwards way round. `HarPostData` had a public `TryGetRawData` helper built on a **Meziantou-specific extension field** (`x-meziantou-encoding`), while `HarContent` — which has a first-class `encoding` property in the HAR 1.2 spec — had no equivalent.

Callers who wanted response bytes had to reimplement the base64 branch themselves, duplicating logic that is easy to get wrong (the unguarded `Convert.FromBase64String` that this codebase itself got wrong is the illustration).

## What changed

Adds `HarContentExtensions.TryGetRawData(this HarContent?, out byte[]?)`, keyed on the standard `encoding` property:

- no encoding declared → UTF-8 bytes of `text`
- `"base64"` → decoded bytes, or `false` if the text is not valid base64
- any other encoding → `false`, rather than handing back undecoded text as the payload
- `text` is `null` → `false`

The contract deliberately matches `HarPostDataExtensions.TryGetRawData` so the two read the same way.

## Public API

New public type, so `ref/Meziantou.Framework.HttpArchive.cs` is regenerated and committed here — the diff is the five expected lines and nothing else.

## Follow-up, deliberately not in this PR

`ToHttpResponseMessage` still has its own inline base64 branch rather than calling this helper. Rewiring it would make this PR depend on #2154, which rewrites exactly that block. Once both have landed, that call site can be collapsed onto this helper as a small standalone cleanup.

## Verification

`dotnet test -p:TreatsWarningsAsErrors=true` → **76/76 green** on `net10.0` and `net11.0` (5 new tests).
