### PR TITLE
Warn that HAR files contain credentials

### DIFF
--- a/src/Meziantou.Framework.HttpArchive/readme.md
+++ b/src/Meziantou.Framework.HttpArchive/readme.md
@@ -2,6 +2,13 @@
 
 `Meziantou.Framework.HttpArchive` provides a .NET model for the HAR 1.2 (HTTP Archive) format, with parsing, serialization, and helpers to convert HAR entries to `HttpRequestMessage` / `HttpResponseMessage`.
 
+> [!WARNING]
+> **HAR files contain credentials.** An archive records `Authorization` headers, `Cookie` and `Set-Cookie`
+> values, bearer tokens, API keys and complete request bodies exactly as they were sent. Treat a `.har` as a
+> secret: do not attach one to a bug report, support ticket or issue, and do not commit one, without removing
+> the sensitive entries first. This library reads and writes what the file contains and does not redact
+> anything for you.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Independent — documentation only, branches from `main`.

## Why

HAR files are one of the standard ways credentials leak in practice: an archive captures `Authorization` headers, `Cookie` / `Set-Cookie` values, bearer tokens, API keys and full request bodies verbatim, and the usual vehicles are support-ticket attachments and bug reports.

The readme's examples read a `.har` and write one back out with no mention of this. A HAR library is the right place to say it.

## What changed

A warning callout below the intro, before the install instructions. Documentation only — no code, no API change.

## Not in this PR

The review that produced this also suggested a `HarDocument.Redact(...)` / `RemoveSensitiveData()` helper. That is a new public feature with real design questions — which headers, which cookies, which post-data fields, and configurable by whom — rather than a fix to existing behaviour, so it is deliberately left out and is worth its own issue if you want it.
