### PR TITLE
Document the ImageSharp licence and describe the backend packages

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting.ImageSharp/Meziantou.Framework.SnapshotTesting.ImageSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Description>Enables verification of objects using file-based snapshots</Description>
+    <Description>Enables verification of SixLabors.ImageSharp images using file-based snapshots</Description>
     <Version>2.0.4</Version>
   </PropertyGroup>
 

--- a/src/Meziantou.Framework.SnapshotTesting.ImageSharp/readme.md
+++ b/src/Meziantou.Framework.SnapshotTesting.ImageSharp/readme.md
@@ -2,6 +2,19 @@
 
 `Meziantou.Framework.SnapshotTesting.ImageSharp` extends [`Meziantou.Framework.SnapshotTesting`](https://www.nuget.org/packages/Meziantou.Framework.SnapshotTesting) with support for [SixLabors.ImageSharp](https://github.com/SixLabors/ImageSharp) images, enabling snapshot validation of `Image` objects stored as PNG, JPEG, BMP, TIFF, or WebP files.
 
+## Licensing
+
+This package is MIT-licensed, but it takes a hard dependency on
+[SixLabors.ImageSharp](https://github.com/SixLabors/ImageSharp), which since v3 is published under the
+[Six Labors Split License](https://github.com/SixLabors/ImageSharp/blob/main/LICENSE): AGPL-3.0 unless you
+hold a commercial licence. Installing this package therefore brings that obligation with it, and your build
+will emit a "No Six Labors license found" warning until you set `SixLaborsLicenseKey`, set
+`SixLaborsLicenseFile`, or add a `sixlabors.lic` file.
+
+If that does not suit your project,
+[`Meziantou.Framework.SnapshotTesting.SkiaSharp`](https://www.nuget.org/packages/Meziantou.Framework.SnapshotTesting.SkiaSharp)
+offers the same image snapshot support on top of SkiaSharp, which is MIT-licensed.
+
 ## Setup
 
 Call `AddImageSharp()` on your `SnapshotSettings` to register the ImageSharp serializer and comparer:

--- a/src/Meziantou.Framework.SnapshotTesting.SkiaSharp/Meziantou.Framework.SnapshotTesting.SkiaSharp.csproj
+++ b/src/Meziantou.Framework.SnapshotTesting.SkiaSharp/Meziantou.Framework.SnapshotTesting.SkiaSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Meziantou.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <Description>Enables verification of objects using file-based snapshots</Description>
+    <Description>Enables verification of SkiaSharp images using file-based snapshots</Description>
     <Version>1.0.1</Version>
   </PropertyGroup>
 


### PR DESCRIPTION
Two small packaging problems in the image backend packages.

## The ImageSharp licence obligation is undocumented

`Meziantou.Framework.SnapshotTesting.ImageSharp` is published under this repository's MIT
licence but takes a hard `PackageReference` on `SixLabors.ImageSharp` 4.1.0. ImageSharp v3
and later use the Six Labors Split License: AGPL-3.0 unless the consumer holds a commercial
licence. A consumer installing an MIT-badged package transitively picks that up, and the
readme said nothing about it.

This is easy to miss from inside the repository, because `Directory.Build.targets:14-16`
sets:

```xml
<PackageReference Update="SixLabors.ImageSharp">
  <IncludeAssets>compile;runtime</IncludeAssets>
</PackageReference>
```

Excluding the `build` assets means SixLabors' own targets are never imported here, so the
"No Six Labors license found" warning never appears in this build. Consumers of the
published package resolve ImageSharp with default assets and *do* see it — confirmed by
building a scratch project against SixLabors.ImageSharp 4.1.0, which emits:

```
warning : No Six Labors license found. Set $(SixLaborsLicenseKey), set $(SixLaborsLicenseFile),
          or add a 'sixlabors.lic' file to the project/workspace.
```

Added a "Licensing" section to the readme naming the licence, explaining the warning and
the three ways to clear it, and pointing at the SkiaSharp package as the
permissively-licensed alternative (SkiaSharp is MIT).

## The backend packages had the core package's description

Both `.csproj` files carried "Enables verification of objects using file-based snapshots",
copy-pasted from the core package, which is what NuGet shows on the listing page. Replaced
with descriptions of what each package actually does.

## Scope

Documentation and NuGet metadata only — no code changes, no behaviour change.
