### PR TITLE
Report the real host ports for a reused Apple container

### DIFF
--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleConfigurationDto.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleConfigurationDto.cs
@@ -7,4 +7,6 @@ internal sealed class AppleConfigurationDto
     public string? Id { get; set; }
     public string? Hostname { get; set; }
     public JsonElement Image { get; set; }
+    public Dictionary<string, string>? Labels { get; set; }
+    public List<ApplePublishedPortDto>? PublishedPorts { get; set; }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
@@ -20,11 +20,11 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
     // containers is the cheapest command that does.
     internal override IReadOnlyList<string> BuildProbeArguments() => ["ls", "-q"];
 
-    internal override Task<string> EnsureCreatedAsync(ContainerDefinition definition, CancellationToken cancellationToken)
+    internal override void PrepareDefinitionForCreate(ContainerDefinition definition)
     {
-        // Apple's container runtime does not support random-port assignment and does not
-        // report host port bindings in inspect output. Pre-assign free host ports so that
-        // GetMappedPort works correctly after the container starts.
+        // Apple's container runtime does not support random-port assignment, so a free host port has to be picked
+        // here. This only runs when a container is actually created: an adopted container keeps the host ports it was
+        // created with, and rewriting them would make GetMappedPort report ports nothing is listening on.
         var portsWithoutHostPort = new List<int>();
         foreach (var port in definition.Ports)
         {
@@ -37,8 +37,6 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
             definition.Ports.Remove(containerPort);
             definition.Ports.Add(GetFreeTcpPort(), containerPort);
         }
-
-        return base.EnsureCreatedAsync(definition, cancellationToken);
     }
 
     private static int GetFreeTcpPort()
@@ -222,20 +220,41 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
             State = ParseState(status),
             Status = status,
             IPAddress = slash >= 0 ? address![..slash] : address,
-            Ports = new Dictionary<int, int>(),
-            Labels = new Dictionary<string, string>(StringComparer.Ordinal),
+            Ports = GetPorts(result.Configuration?.PublishedPorts),
+            Labels = result.Configuration?.Labels ?? new Dictionary<string, string>(StringComparer.Ordinal),
         };
     }
 
     internal override IReadOnlyDictionary<int, int> ResolvePortMap(ContainerInfo info, ContainerDefinition definition)
     {
-        // Apple's runtime does not report host port bindings in inspect and has no random-port discovery,
-        // so the mapping is derived from the published ports (host defaults to the container port).
+        ArgumentNullException.ThrowIfNull(info);
+
+        // The runtime reports the bindings it actually created, which is the only source that is correct for a
+        // container adopted through ReuseId: its host ports were chosen by whichever run created it.
+        if (info.Ports.Count > 0)
+            return info.Ports;
+
+        // Older CLI versions do not report 'publishedPorts', so fall back to what the definition asked for.
         var map = new Dictionary<int, int>();
         foreach (var port in definition.Ports)
             map[port.Port] = port.HostPort ?? port.Port;
 
         return map;
+    }
+
+    private static Dictionary<int, int> GetPorts(List<ApplePublishedPortDto>? publishedPorts)
+    {
+        var ports = new Dictionary<int, int>();
+        if (publishedPorts is null)
+            return ports;
+
+        foreach (var port in publishedPorts)
+        {
+            if (port.Proto is null or "tcp" && port.HostPort > 0)
+                ports[port.ContainerPort] = port.HostPort;
+        }
+
+        return ports;
     }
 
     private static ContainerState ParseState(string? status)

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ApplePublishedPortDto.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ApplePublishedPortDto.cs
@@ -1,0 +1,8 @@
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+internal sealed class ApplePublishedPortDto
+{
+    public int ContainerPort { get; set; }
+    public int HostPort { get; set; }
+    public string? Proto { get; set; }
+}

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ExecutableContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ExecutableContainerRuntime.cs
@@ -150,6 +150,11 @@ internal abstract class ExecutableContainerRuntime : ContainerRuntime
 
     internal abstract ContainerInfo ParseInspect(string output);
 
+    /// <summary>Last chance to adjust the definition before a new container is created. Not called when an existing container is adopted through <see cref="ContainerDefinition.ReuseId"/>.</summary>
+    internal virtual void PrepareDefinitionForCreate(ContainerDefinition definition)
+    {
+    }
+
     internal override Task<string> EnsureCreatedAsync(ContainerDefinition definition, CancellationToken cancellationToken)
     {
         return EnsureCreatedCoreAsync(definition, cancellationToken);
@@ -162,6 +167,8 @@ internal abstract class ExecutableContainerRuntime : ContainerRuntime
         {
             return existingId;
         }
+
+        PrepareDefinitionForCreate(definition);
 
         var imageRef = await PrepareImageAsync(definition.Image, definition.PullPolicy, cancellationToken).ConfigureAwait(false);
         var args = BuildCreateArguments(definition, imageRef);

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerRuntimeAdapterTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/AppleContainerRuntimeAdapterTests.cs
@@ -57,7 +57,7 @@ public sealed class AppleContainerRuntimeAdapterTests
     }
 
     [Fact]
-    public void ResolvesPortMapFromDefinition()
+    public void ResolvesPortMapFromDefinitionWhenTheRuntimeReportsNoBinding()
     {
         var runtime = CreateRuntime();
         var definition = new ContainerDefinition(new RegistryImage("nginx"));
@@ -69,5 +69,33 @@ public sealed class AppleContainerRuntimeAdapterTests
 
         Assert.Equal(8080, map[8080]);
         Assert.Equal(15432, map[5432]);
+    }
+
+    [Fact]
+    public void ResolvesPortMapFromInspectWhenAvailable()
+    {
+        var runtime = CreateRuntime();
+
+        // A container adopted through ReuseId: the definition asks for one mapping, the runtime reports another.
+        var definition = new ContainerDefinition(new RegistryImage("nginx"));
+        definition.Ports.Add(53437, 8080);
+
+        var info = runtime.ParseInspect("""
+            [{
+              "id": "meziantou-tc-app",
+              "status": { "state": "running" },
+              "configuration": {
+                "id": "meziantou-tc-app",
+                "labels": { "meziantou.tc.reuse": "app" },
+                "publishedPorts": [
+                  { "containerPort": 8080, "hostPort": 53432, "proto": "tcp" }
+                ]
+              }
+            }]
+            """);
+
+        Assert.Equal(53432, info.Ports[8080]);
+        Assert.Equal("app", info.Labels["meziantou.tc.reuse"]);
+        Assert.Equal(53432, runtime.ResolvePortMap(info, definition)[8080]);
     }
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/ContainerRuntimeTestsBase.cs
@@ -411,12 +411,14 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
     {
         var reuseId = "meziantou-tc-test-" + Guid.NewGuid().ToString("N");
         string firstId;
+        int firstPort;
 
         var firstDefinition = CreateHttpServerDefinition();
         firstDefinition.ReuseId = reuseId;
         await using (var first = await StartWithRetryAsync(firstDefinition))
         {
             firstId = first.Id;
+            firstPort = first.GetMappedPort(8080);
         }
 
         try
@@ -427,6 +429,11 @@ public abstract class ContainerRuntimeTestsBase : IAsyncLifetime
             await second.EnsureCreatedAsync(XunitCancellationToken);
 
             Assert.Equal(firstId, second.Id);
+
+            // The adopted container keeps the host ports it was created with, so the second run has to report those
+            // and not a freshly picked mapping.
+            await second.StartAsync(XunitCancellationToken);
+            Assert.Equal(firstPort, second.GetMappedPort(8080));
         }
         finally
         {


### PR DESCRIPTION
`AppleContainerRuntime.EnsureCreatedAsync` pre-assigned free host ports to every port without one, and *then* called `base.EnsureCreatedAsync` — which is where the `ReuseId` lookup happens. So on the reuse path the definition had already been rewritten with brand-new ports that have nothing to do with the container being adopted. `ResolvePortMap` derived the map from `definition.Ports`, so `GetMappedPort` returned a port nothing is bound to:

```
first run  -> id=meziantou-tc  mapped host port = 53432
second run -> adopted id=meziantou-tc (same container: True)
second run -> mapped host port = 53437  <-- must equal 53432
```

`ReuseId` exists so a container survives across runs, so the second run is the normal case. Because `CreateRedis`/`CreatePostgreSql`/`CreateMongoDb`/`CreateSqlServer` all register `Wait.ForPort`, this doesn't fail fast — `StartAsync` spins in `PortWaitStrategy`'s retry loop for the full 300 s `StartupTimeout` before throwing `TimeoutException`, which reads like a slow image rather than a mapping bug.

## What changed

The comment on `ResolvePortMap` claimed the runtime "does not report host port bindings in inspect". That is no longer true — `container inspect` reports them under `configuration.publishedPorts`:

```json
"publishedPorts": [
  { "containerPort": 8080, "count": 1, "hostAddress": "0.0.0.0", "hostPort": 54999, "proto": "tcp" }
]
```

So the fix reads the bindings the runtime actually created rather than inferring them:

- `AppleConfigurationDto` gains `publishedPorts` (new `ApplePublishedPortDto`) and `labels`; `ParseInspect` now fills `ContainerInfo.Ports` and `ContainerInfo.Labels` instead of returning empty dictionaries for both.
- `ResolvePortMap` returns the reported bindings when there are any, and keeps the definition-derived map as a fallback for CLI versions that don't report them.
- `ExecutableContainerRuntime` gains a `PrepareDefinitionForCreate` hook, called only on the path that actually creates a container. `AppleContainerRuntime` moves its port pre-assignment there and drops its `EnsureCreatedAsync` override, so adopting a container no longer mutates the definition's ports at all.

Picking a free host port is still needed — Apple's runtime has no random-port assignment — it just no longer happens for containers we didn't create.

No public API change, so `ref/` is unchanged.

## Verification

- `Reuse_AdoptsExistingContainer` previously stopped at `EnsureCreatedAsync`, which is why this was invisible. It now starts the adopted container and asserts the mapped port matches the first run's. On `main`'s library code that test **fails after 5m03s** — it waits out the whole `StartupTimeout`, reproducing the reported symptom exactly.
- Added `ResolvesPortMapFromInspectWhenAvailable` covering the parse and the reuse case; renamed the existing test to `ResolvesPortMapFromDefinitionWhenTheRuntimeReportsNoBinding` to say what it now pins.
- 40/40 green locally across `AppleContainer*`, `DockerContainerTests` and `DockerRuntimeAdapterTests`.
