### PR TITLE
Resolve a mapped package to its most specific source only

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/NuGetPackageSourceResolver.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/NuGetPackageSourceResolver.cs
@@ -5,6 +5,9 @@ namespace Meziantou.Framework.DependencyScanning.Tool;
 
 internal static class NuGetPackageSourceResolver
 {
+    private const int NoMatch = -1;
+    private const int ExactMatch = int.MaxValue;
+
     private static readonly StringComparer Comparer = OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
     public static NuGetSourceResolution Resolve(FullPath dependencyFile, string packageName)
@@ -99,16 +102,27 @@ internal static class NuGetPackageSourceResolver
         if (packageMappings.Count is 0)
             return [.. packageSources.Values];
 
+        // NuGet resolves a package to the source with the longest matching pattern, not to every source
+        // whose patterns happen to match. Querying them all would send an internally-mapped package name
+        // to a wildcard-mapped public feed, which is exactly what source mapping exists to prevent.
+        var bestScore = NoMatch;
         var matches = new List<string>();
         foreach (var (sourceName, patterns) in packageMappings)
         {
             if (!packageSources.TryGetValue(sourceName, out var sourceUrl))
                 continue;
 
-            if (IsMatch(packageName, patterns))
+            var score = GetMatchScore(packageName, patterns);
+            if (score is NoMatch || score < bestScore)
+                continue;
+
+            if (score > bestScore)
             {
-                matches.Add(sourceUrl);
+                bestScore = score;
+                matches.Clear();
             }
+
+            matches.Add(sourceUrl);
         }
 
         if (matches.Count is 0)
@@ -117,17 +131,33 @@ internal static class NuGetPackageSourceResolver
         return [.. matches.Distinct(Comparer)];
     }
 
-    private static bool IsMatch(string packageName, IReadOnlyCollection<string> patterns)
+    private static int GetMatchScore(string packageName, IReadOnlyCollection<string> patterns)
     {
+        var best = NoMatch;
         foreach (var pattern in patterns)
         {
-            if (GlobMatch(packageName, pattern))
+            var score = GetMatchScore(packageName, pattern);
+            if (score > best)
             {
-                return true;
+                best = score;
             }
         }
 
-        return false;
+        return best;
+    }
+
+    /// <summary>
+    /// Ranks how specifically <paramref name="pattern"/> matches <paramref name="packageName"/>: an exact
+    /// pattern outranks every wildcard, and among wildcards the longest literal prefix wins.
+    /// Returns <see cref="NoMatch"/> when the pattern does not match at all.
+    /// </summary>
+    private static int GetMatchScore(string packageName, string pattern)
+    {
+        var wildcardIndex = pattern.IndexOf('*', StringComparison.Ordinal);
+        if (wildcardIndex < 0)
+            return Comparer.Equals(packageName, pattern) ? ExactMatch : NoMatch;
+
+        return GlobMatch(packageName, pattern) ? wildcardIndex : NoMatch;
     }
 
     private static bool GlobMatch(string text, string pattern)

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
@@ -326,6 +326,100 @@ public sealed class FunctionalTests
     }
 
     [Fact]
+    public async Task NuGetPackageSourceResolver_PackageSourceMapping_LongestPatternWinsOverWildcard()
+    {
+        await using var tempDir = TemporaryDirectory.Create();
+        var projectFile = tempDir.CreateEmptyFile("a.csproj");
+        await File.WriteAllTextAsync(projectFile, "<Project />", XunitCancellationToken);
+        await File.WriteAllTextAsync(tempDir.CreateEmptyFile("nuget.config"), """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+                <add key="private" value="https://private/v3/index.json" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="nuget">
+                  <package pattern="*" />
+                </packageSource>
+                <packageSource key="private">
+                  <package pattern="Contoso.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """, XunitCancellationToken);
+
+        var contoso = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Contoso.Library");
+        var newtonsoft = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Newtonsoft.Json");
+
+        // 'Contoso.*' is more specific than '*', so the public feed must not be queried for it
+        Assert.Equal(["https://private/v3/index.json"], contoso.PackageSources);
+        Assert.Equal(["https://api.nuget.org/v3/index.json"], newtonsoft.PackageSources);
+    }
+
+    [Fact]
+    public async Task NuGetPackageSourceResolver_PackageSourceMapping_ExactPatternWinsOverPrefix()
+    {
+        await using var tempDir = TemporaryDirectory.Create();
+        var projectFile = tempDir.CreateEmptyFile("a.csproj");
+        await File.WriteAllTextAsync(projectFile, "<Project />", XunitCancellationToken);
+        await File.WriteAllTextAsync(tempDir.CreateEmptyFile("nuget.config"), """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <add key="prefix" value="https://prefix/v3/index.json" />
+                <add key="exact" value="https://exact/v3/index.json" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="prefix">
+                  <package pattern="Contoso.*" />
+                </packageSource>
+                <packageSource key="exact">
+                  <package pattern="Contoso.Library" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """, XunitCancellationToken);
+
+        var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Contoso.Library");
+        var other = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Contoso.Other");
+
+        Assert.Equal(["https://exact/v3/index.json"], resolution.PackageSources);
+        Assert.Equal(["https://prefix/v3/index.json"], other.PackageSources);
+    }
+
+    [Fact]
+    public async Task NuGetPackageSourceResolver_PackageSourceMapping_EquallySpecificPatternsKeepEverySource()
+    {
+        await using var tempDir = TemporaryDirectory.Create();
+        var projectFile = tempDir.CreateEmptyFile("a.csproj");
+        await File.WriteAllTextAsync(projectFile, "<Project />", XunitCancellationToken);
+        await File.WriteAllTextAsync(tempDir.CreateEmptyFile("nuget.config"), """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <add key="first" value="https://first/v3/index.json" />
+                <add key="second" value="https://second/v3/index.json" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="first">
+                  <package pattern="Contoso.*" />
+                </packageSource>
+                <packageSource key="second">
+                  <package pattern="Contoso.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """, XunitCancellationToken);
+
+        var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Contoso.Library");
+
+        Assert.Equal(2, resolution.PackageSources.Count);
+        Assert.Contains("https://first/v3/index.json", resolution.PackageSources);
+        Assert.Contains("https://second/v3/index.json", resolution.PackageSources);
+    }
+
+    [Fact]
     public async Task NuGetPackageSourceResolver_PackageSourceMapping_UnmatchedPackageReturnsNoSource()
     {
         await using var tempDir = TemporaryDirectory.Create();


### PR DESCRIPTION
`ResolveSourcesForPackage` added **every** source whose `packageSourceMapping` patterns matched the package name. NuGet's rule is longest-match: the most specific pattern wins, and only the source(s) holding it are used. `PackageUpdater` then took the maximum version across the union, without recording which source it came from.

**Reproduced before the fix** — `fallback` mapped to `*`, `nuget` mapped to `Meziantou.*`:

```
Unhandled exception: NuGet.Protocol.Core.Types.FatalProtocolException: Unable to load
the service index for source https://nonexistent-feed.invalid/v3/index.json.
```

Real NuGet resolves `Meziantou.Framework` to `nuget` alone and never touches the wildcard source.

## Why it matters

The common enterprise layout is `<package pattern="*" />` on nuget.org plus `<package pattern="Contoso.*" />` on a private feed. Under that config the tool sent every internal package name to api.nuget.org — the precise leak source mapping exists to prevent — and if a public package shadowed an internal name with a higher version, that version got written into the project. Restore, which honours mapping correctly, then can't find it on the private feed and the build breaks.

The existing tests only used disjoint patterns (`Newtonsoft.*` vs `Contoso.*`), so nothing caught it.

## What changed

Each source is scored by its most specific matching pattern and only the best-scoring sources are returned:

- an exact pattern (no `*`) outranks every wildcard;
- among wildcards, the longest literal prefix before the `*` wins;
- sources that tie are all kept, since NuGet does allow one package to map to several sources.

Same input, after: only the mapped `nuget` source is contacted, and `Meziantou.Framework` updates to `6.0.1`.

## Verification

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 52 passed, 0 failed (was 49).
- `dotnet run ./eng/update-all.cs` — no generated-file changes.

Three new tests: `*` vs `Contoso.*` (the reported case, both directions), exact `Contoso.Library` vs prefix `Contoso.*`, and two sources sharing `Contoso.*` still yielding both.
