### PR TITLE
Resolve snapshot comparers by the stored format

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotComparerCollection.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotComparerCollection.cs
@@ -23,6 +23,9 @@ public sealed class SnapshotComparerCollection : IEnumerable<KeyValuePair<Snapsh
         _comparers[type] = comparer;
     }
 
+    /// <summary>Looks up a comparer registered for exactly this type, without falling back to a default.</summary>
+    internal bool TryGet(SnapshotType type, [NotNullWhen(true)] out ISnapshotComparer? comparer) => _comparers.TryGetValue(type, out comparer);
+
     public ISnapshotComparer Get(SnapshotType type)
     {
         if (_comparers.TryGetValue(type, out var comparer))

--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
@@ -99,7 +99,7 @@ internal static class SnapshotEngine
         {
             var actualFile = actualFiles[0];
             if (expectedFiles.TryGetValue(actualFile.FilePath, out var expectedData) &&
-                settings.Comparers.Get(type).Equals(expectedData, actualFile.Data))
+                GetComparer(settings, type, actualFile.Data).Equals(expectedData, actualFile.Data))
             {
                 return SnapshotComparisonResult.NoDifference;
             }
@@ -112,11 +112,11 @@ internal static class SnapshotEngine
         var missingPaths = actualPaths.Where(path => !expectedPaths.Contains(path)).ToArray();
         var extraPaths = expectedPaths.Where(path => !actualPaths.Contains(path)).ToArray();
 
-        var comparer = settings.Comparers.Get(type);
         var changedPaths = new List<FullPath>();
         foreach (var path in expectedPaths.Intersect(actualPaths))
         {
-            if (!comparer.Equals(expectedFiles[path], actualByPath[path]))
+            var actualData = actualByPath[path];
+            if (!GetComparer(settings, type, actualData).Equals(expectedFiles[path], actualData))
             {
                 changedPaths.Add(path);
             }
@@ -130,6 +130,25 @@ internal static class SnapshotEngine
         var message = BuildMessage(missingPaths, extraPaths, changedPaths);
         var pathsToUpdate = missingPaths.Concat(changedPaths).Distinct().ToArray();
         return new SnapshotComparisonResult(HasDifferences: true, message, FormatSummary(expectedPaths), FormatSummary(actualPaths), [.. changedPaths], missingPaths, extraPaths, pathsToUpdate);
+    }
+
+    /// <summary>
+    /// Resolves the comparer for a snapshot file. A serializer may store a different format than the one that
+    /// was requested - an animated GIF becomes PNG frames, a source generator result becomes C# files - and
+    /// the comparison is about the bytes that ended up on disk, so a comparer registered for the stored format
+    /// wins. The requested type stays as the fallback, so an explicit registration for it still applies when
+    /// nothing is registered for the stored format.
+    /// </summary>
+    private static ISnapshotComparer GetComparer(SnapshotSettings settings, SnapshotType requestedType, SnapshotData data)
+    {
+        if (!string.IsNullOrEmpty(data.Extension))
+        {
+            var storedType = SnapshotType.Create(data.Extension);
+            if (storedType != requestedType && settings.Comparers.TryGet(storedType, out var storedComparer))
+                return storedComparer;
+        }
+
+        return settings.Comparers.Get(requestedType);
     }
 
     private static string BuildMessage(

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -1297,6 +1297,59 @@ public sealed partial class SnapshotTests
         }
     }
 
+    [Fact]
+    public void Validate_UsesTheComparerRegisteredForTheStoredFormat()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var gif = CreateTwoFrameGif();
+
+        // The GIF serializer stores PNG frames, so the comparison is about PNG bytes even though the
+        // assertion asked for SnapshotType.Gif.
+        var settings = new SnapshotSettings
+        {
+            AutoDetectContinuousEnvironment = false,
+            SnapshotUpdateStrategy = SnapshotUpdateStrategy.OverwriteWithoutFailure,
+            AssertionExceptionCreator = new FixedAssertionExceptionBuilder(),
+            SnapshotPathStrategy = context => directory / ("snapshot_" + context.Index.ToString(CultureInfo.InvariantCulture) + ".verified.png"),
+        };
+        settings.Serializers.AddGifSerializer();
+
+        Snapshot.Validate(gif, SnapshotType.Gif, settings);
+
+        var comparer = new RecordingSnapshotComparer();
+        var compareSettings = settings with { SnapshotUpdateStrategy = SnapshotUpdateStrategy.Disallow };
+        compareSettings.Comparers.Set(SnapshotType.Png, comparer);
+
+        Snapshot.Validate(gif, SnapshotType.Gif, compareSettings);
+
+        Assert.True(comparer.InvocationCount > 0, "The comparer registered for PNG was not used.");
+    }
+
+    [Fact]
+    public void Validate_FallsBackToTheComparerForTheRequestedType()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var comparer = new RecordingSnapshotComparer();
+        var settings = CreateDeterministicSnapshotSettings(directory, "actual");
+        settings.Comparers.Set(SnapshotType.Default, comparer);
+        File.WriteAllText(directory.GetFullPath("snapshot.verified.txt"), "actual");
+
+        Snapshot.Validate("sample", settings);
+
+        Assert.True(comparer.InvocationCount > 0, "The comparer registered for the requested type was not used.");
+    }
+
+    private sealed class RecordingSnapshotComparer : ISnapshotComparer
+    {
+        public int InvocationCount { get; private set; }
+
+        public bool Equals(SnapshotData expected, SnapshotData actual)
+        {
+            InvocationCount++;
+            return expected.Data.AsSpan().SequenceEqual(actual.Data);
+        }
+    }
+
     private sealed class FixedAssertionExceptionBuilder : AssertionExceptionBuilder
     {
         public override Exception CreateException(string message)


### PR DESCRIPTION
> **Stack 1 of 2 · merges into `main` · must merge before the follow-up that aligns the
> `Add*` registration sets.**

Comparers were resolved by the *requested* `SnapshotType`, never by the format the
serializer actually produced:

```csharp
settings.Comparers.Get(type).Equals(expectedData, actualFile.Data)   // type == the caller's SnapshotType
```

`AddImageComparer()` registers `Bmp`, `Png`, `Jpeg`, `Tiff` — but not `Gif` or `Ico`. GIF
and ICO inputs are serialized to **PNG** files by `GifSnapshotSerializer` and
`IcoSnapshotSerializer`, yet the lookup key stayed `SnapshotType.Gif`/`SnapshotType.Ico`,
missed every registration, fell through to the `SnapshotType.None` default set in the
`SnapshotSettings` constructor (`SnapshotSettings.cs:105`), and landed on
`ByteArraySnapshotComparer`.

So this configuration silently did nothing:

```csharp
settings.Serializers.AddGifSerializer();
settings.Comparers.AddImageComparer(new ImageComparisonSettings { SimilarityThreshold = 0.99f });
Snapshot.Validate(gifBytes, SnapshotType.Gif, settings);   // still an exact byte comparison
```

The two formats that produce *re-encoded* PNG output — exactly where an encoder version
bump changes bytes without changing pixels — were the two getting exact byte comparison.
The same applies to the Roslyn generated-sources serializer, which stores `.cs` files.

## What changed

`SnapshotEngine` now resolves the comparer per file: if the serializer recorded an
extension and a comparer is registered for that stored format, it wins; otherwise the
requested type is used exactly as before. Both the single-file fast path and the
multi-file loop go through the same helper.

Keeping the requested type as the fallback means existing explicit registrations still
apply — this only changes behaviour where the stored format differs from the requested one
*and* a comparer is registered for the stored format.

Added `SnapshotComparerCollection.TryGet` (internal) for the "registered for exactly this
type, no fallback" lookup. No public API change, so `ref/` is untouched.

## Verification

- `Validate_UsesTheComparerRegisteredForTheStoredFormat` — confirmed it **fails** against
  the old code with "The comparer registered for PNG was not used", and passes with the fix.
- `Validate_FallsBackToTheComparerForTheRequestedType` — pins the fallback so the change
  cannot regress ordinary same-format snapshots.

```
dotnet build slnx/Meziantou.Framework.SnapshotTesting.slnx /p:TreatsWarningsAsErrors=true   # 0 warnings, 0 errors
dotnet test tests/Meziantou.Framework.SnapshotTesting.Tests --filter-not-class "*EndToEnd*" # 116/116 passed
```
