### PR TITLE
Fall back to the config credentials when a credential helper is missing

### DIFF
--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerRegistryAuthProvider.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerRegistryAuthProvider.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Text;
 using System.Text.Json;
 using Meziantou.Framework;
@@ -155,12 +156,11 @@ internal sealed class DockerRegistryAuthProvider
                 Password = credentials.Secret,
             };
         }
-        catch (FileNotFoundException)
+        catch (Exception ex) when (ex is Win32Exception or IOException or InvalidOperationException)
         {
-            return null;
-        }
-        catch (DirectoryNotFoundException)
-        {
+            // The helper is an optimization: a config naming one that is not installed (a config copied between
+            // machines, or Docker Desktop uninstalled but its config left behind) must fall through to 'auths'
+            // rather than fail the pull. Starting a missing executable raises Win32Exception, not FileNotFoundException.
             return null;
         }
     }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRegistryAuthProviderTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRegistryAuthProviderTests.cs
@@ -55,6 +55,44 @@ public sealed class DockerRegistryAuthProviderTests
         Assert.Equal("registry.example.com", payload.ServerAddress);
     }
 
+    [Fact]
+    public async Task GetRegistryAuthHeaderValueAsync_ReturnsNullWhenTheCredentialHelperIsMissing()
+    {
+        var config = new DockerApiModels.AuthConfigFile
+        {
+            CredsStore = MissingHelperName(),
+        };
+
+        var provider = new DockerRegistryAuthProvider(overrideConfiguration: config);
+
+        Assert.Null(await provider.GetRegistryAuthHeaderValueAsync("redis:8", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetRegistryAuthHeaderValueAsync_FallsBackToAuthsWhenTheCredentialHelperIsMissing()
+    {
+        var config = new DockerApiModels.AuthConfigFile
+        {
+            CredsStore = MissingHelperName(),
+            Auths = new Dictionary<string, DockerApiModels.AuthEntry>(StringComparer.Ordinal)
+            {
+                ["https://index.docker.io/v1/"] = new DockerApiModels.AuthEntry
+                {
+                    Auth = Convert.ToBase64String(Encoding.UTF8.GetBytes("john:secret")),
+                },
+            },
+        };
+
+        var provider = new DockerRegistryAuthProvider(overrideConfiguration: config);
+        var header = await provider.GetRegistryAuthHeaderValueAsync("redis:8", CancellationToken.None);
+
+        Assert.NotNull(header);
+        Assert.Equal("john", DecodeHeader(header!).Username);
+    }
+
+    /// <summary>A helper name that cannot resolve to an executable, so 'docker-credential-&lt;name&gt;' is guaranteed to be missing.</summary>
+    private static string MissingHelperName() => "meziantou-tc-missing-" + Guid.NewGuid().ToString("N");
+
     [Theory]
     [InlineData("redis:8", "index.docker.io")]
     [InlineData("library/redis:8", "index.docker.io")]


### PR DESCRIPTION
`ResolveCredentialsFromHelperAsync` guarded against a missing helper binary with `catch (FileNotFoundException)` and `catch (DirectoryNotFoundException)`. Neither is what .NET throws — launching a nonexistent executable raises `System.ComponentModel.Win32Exception`:

```
System.ComponentModel.Win32Exception: An error occurred trying to start process
    'docker-credential-doesnotexist' … No such file or directory
  is FileNotFoundException: False
  is DirectoryNotFoundException: False
```

`ProcessWrapper` raises `Win32Exception` on its own failure path too, so both routes escape. The two catch clauses were dead code and the exception propagated out of `PullImageAsync` → `StartAsync`.

A `~/.docker/config.json` naming a helper that isn't installed is common: a config copied between machines, Docker Desktop uninstalled but its config left behind, or a CI image with `credsStore` baked in. The result was an unhandled `Win32Exception` whenever an image actually needed pulling, naming a `docker-credential-*` binary with no hint that the cause was registry auth. This is reachable through the Docker Engine API runtime, which is the one `ContainerRuntime.Auto` prefers.

## What changed

Catch `Win32Exception`, plus `IOException` and `InvalidOperationException` defensively, and return `null`. The credential helper is an optimization, not a requirement — falling through to the `auths` section of the config is the correct behavior, and matches what the `docker` CLI does.

No public API change, so `ref/` is unchanged.

## Verification

Two tests added, covering both outcomes of the fall-through:

- `GetRegistryAuthHeaderValueAsync_ReturnsNullWhenTheCredentialHelperIsMissing` — nothing else configured.
- `GetRegistryAuthHeaderValueAsync_FallsBackToAuthsWhenTheCredentialHelperIsMissing` — credentials still resolve from `auths`.

Both **fail on `main`** with exactly the `Win32Exception` above, and pass with this change. `DockerRegistryAuthProviderTests` 8/8 green.

Note this path had no test coverage at all before, which is why the dead catch clauses went unnoticed.
