### PR TITLE
Document the TextDiff public API

### DIFF
--- a/src/Meziantou.Framework.TextDiff/TextChunker.cs
+++ b/src/Meziantou.Framework.TextDiff/TextChunker.cs
@@ -2,12 +2,43 @@ using System.Buffers;
 
 namespace Meziantou.Framework;
 
+/// <summary>Splits a text into the chunks that a diff compares against each other. Derive from this type and
+/// override <see cref="Chunk"/> to supply a custom chunking strategy.</summary>
 public class TextChunker
 {
+    /// <summary>
+    /// Gets a chunker that splits on line terminators, keeping the terminator at the end of each chunk so the
+    /// text can be rebuilt exactly.
+    /// </summary>
+    /// <remarks>
+    /// A text that ends with a line terminator produces a final empty chunk, and an empty text produces a single
+    /// empty chunk. This is what makes the chunks concatenate back to the original text; <see cref="Words"/> and
+    /// <see cref="Characters"/> produce no chunks at all for an empty text.
+    /// </remarks>
     public static TextChunker Lines { get; } = new LineChunker();
+
+    /// <summary>
+    /// Gets a chunker that alternates between runs of non-whitespace and runs of whitespace, so that whitespace
+    /// is preserved in its own chunks.
+    /// </summary>
     public static TextChunker Words { get; } = new WordChunker();
+
+    /// <summary>Gets a chunker that produces one chunk per <see cref="char"/>.</summary>
+    /// <remarks>
+    /// Chunks are UTF-16 code units, not grapheme clusters: a surrogate pair is split into two chunks.
+    /// </remarks>
     public static TextChunker Characters { get; } = new CharacterChunker();
 
+    /// <summary>Splits <paramref name="value"/> into chunks.</summary>
+    /// <param name="value">The text to split.</param>
+    /// <returns>
+    /// The chunks, in order. Concatenating them should reproduce <paramref name="value"/> exactly, otherwise the
+    /// diff cannot be used to rebuild either text.
+    /// </returns>
+    /// <remarks>
+    /// The base implementation delegates to <see cref="Lines"/>. A derived chunker that does not override this
+    /// method therefore produces line chunks rather than failing.
+    /// </remarks>
     public virtual IEnumerable<string> Chunk(ReadOnlySpan<char> value)
         => Lines.Chunk(value);
 

--- a/src/Meziantou.Framework.TextDiff/TextDiff.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiff.cs
@@ -1,10 +1,19 @@
 namespace Meziantou.Framework;
 
+/// <summary>Computes the differences between two texts.</summary>
 public static class TextDiff
 {
     private static readonly IEqualityComparer<string> OrdinalWhitespaceComparer = new WhitespaceTrimmingComparer(StringComparer.Ordinal);
     private static readonly IEqualityComparer<string> OrdinalIgnoreCaseWhitespaceComparer = new WhitespaceTrimmingComparer(StringComparer.OrdinalIgnoreCase);
 
+
+    /// <summary>Computes the differences between <paramref name="oldText"/> and <paramref name="newText"/>.</summary>
+    /// <param name="oldText">The original text.</param>
+    /// <param name="newText">The modified text.</param>
+    /// <param name="options">The chunking and comparison options. Defaults to a line diff using
+    /// <see cref="TextDiffAlgorithm.Myers"/> with no option ignored.</param>
+    /// <returns>The chunks of both texts in order, each tagged with what happened to it.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="oldText"/> or <paramref name="newText"/> is <see langword="null"/>.</exception>
     public static TextDiffResult ComputeDiff(string oldText, string newText, TextDiffOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(oldText);
@@ -25,6 +34,25 @@ public static class TextDiff
         return BuildResult(oldChunks, newChunks, diff);
     }
 
+
+    /// <summary>
+    /// Computes the differences between <paramref name="oldText"/> and <paramref name="newText"/>, refining each
+    /// changed chunk with the next chunker in <paramref name="chunkers"/>.
+    /// </summary>
+    /// <param name="oldText">The original text.</param>
+    /// <param name="newText">The modified text.</param>
+    /// <param name="chunkers">
+    /// The chunking levels, coarsest first — for example <c>[TextChunker.Lines, TextChunker.Words]</c>. At least
+    /// two are required; use <see cref="ComputeDiff"/> for a single level. <see cref="TextDiffOptions.Chunker"/>
+    /// is not used by this overload.
+    /// </param>
+    /// <param name="options">The comparison options. Defaults to <see cref="TextDiffAlgorithm.Myers"/> with no
+    /// option ignored.</param>
+    /// <returns>The chunks produced by the first chunker, each of which may carry a finer diff of its own.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="oldText"/>, <paramref name="newText"/> or
+    /// <paramref name="chunkers"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="chunkers"/> holds fewer than two chunkers, or one of
+    /// them is <see langword="null"/>.</exception>
     public static TextDiffHierarchyResult ComputeHierarchyDiff(string oldText, string newText, IReadOnlyList<TextChunker> chunkers, TextDiffOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(oldText);

--- a/src/Meziantou.Framework.TextDiff/TextDiffHierarchyEntry.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiffHierarchyEntry.cs
@@ -1,5 +1,6 @@
 namespace Meziantou.Framework;
 
+/// <summary>One chunk of a hierarchy diff, with the finer diff of its two sides when there is a deeper chunking level.</summary>
 public sealed class TextDiffHierarchyEntry
 {
     public TextDiffHierarchyEntry(TextDiffHierarchyOperation operation, string? oldText, string? newText, IReadOnlyList<TextDiffHierarchyEntry>? children = null)
@@ -10,11 +11,26 @@ public sealed class TextDiffHierarchyEntry
         Children = children ?? [];
     }
 
+
+    /// <summary>Gets what happened to this chunk between the two texts.</summary>
     public TextDiffHierarchyOperation Operation { get; }
 
+    /// <summary>
+    /// Gets the chunk as it appears in the old text, or <see langword="null"/> when <see cref="Operation"/> is
+    /// <see cref="TextDiffHierarchyOperation.Insert"/>.
+    /// </summary>
     public string? OldText { get; }
 
+    /// <summary>
+    /// Gets the chunk as it appears in the new text, or <see langword="null"/> when <see cref="Operation"/> is
+    /// <see cref="TextDiffHierarchyOperation.Delete"/>.
+    /// </summary>
     public string? NewText { get; }
 
+    /// <summary>
+    /// Gets the diff of <see cref="OldText"/> against <see cref="NewText"/> at the next chunking level. Empty
+    /// unless <see cref="Operation"/> is <see cref="TextDiffHierarchyOperation.Replace"/> and a finer chunker
+    /// was supplied.
+    /// </summary>
     public IReadOnlyList<TextDiffHierarchyEntry> Children { get; }
 }

--- a/src/Meziantou.Framework.TextDiff/TextDiffHierarchyOperation.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiffHierarchyOperation.cs
@@ -1,9 +1,20 @@
 namespace Meziantou.Framework;
 
+/// <summary>Specifies what happened to a chunk between the old and the new text at one level of a hierarchy diff.</summary>
 public enum TextDiffHierarchyOperation
 {
+    /// <summary>The chunk is present in both texts.</summary>
     Equal,
+
+    /// <summary>The chunk is only present in the new text.</summary>
     Insert,
+
+    /// <summary>The chunk is only present in the old text.</summary>
     Delete,
+
+    /// <summary>
+    /// A chunk of the old text was replaced by a chunk of the new text. When a finer chunker is available,
+    /// <see cref="TextDiffHierarchyEntry.Children"/> holds the diff of the two chunks at that level.
+    /// </summary>
     Replace,
 }

--- a/src/Meziantou.Framework.TextDiff/TextDiffHierarchyResult.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiffHierarchyResult.cs
@@ -1,5 +1,7 @@
 namespace Meziantou.Framework;
 
+/// <summary>The result of <see cref="TextDiff.ComputeHierarchyDiff"/>: the chunks produced by the first chunker,
+/// each of which may carry a finer diff of its own.</summary>
 public sealed class TextDiffHierarchyResult
 {
     internal TextDiffHierarchyResult(IReadOnlyList<TextDiffHierarchyEntry> entries, bool hasDifferences)
@@ -8,7 +10,10 @@ public sealed class TextDiffHierarchyResult
         HasDifferences = hasDifferences;
     }
 
+
+    /// <summary>Gets the chunks of both texts at the outermost chunking level, in order.</summary>
     public IReadOnlyList<TextDiffHierarchyEntry> Entries { get; }
 
+    /// <summary>Gets a value indicating whether the two texts differ under the comparison options that were used.</summary>
     public bool HasDifferences { get; }
 }

--- a/src/Meziantou.Framework.TextDiff/TextDiffOperation.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiffOperation.cs
@@ -1,8 +1,14 @@
 namespace Meziantou.Framework;
 
+/// <summary>Specifies what happened to a chunk between the old and the new text.</summary>
 public enum TextDiffOperation
 {
+    /// <summary>The chunk is present in both texts.</summary>
     Equal,
+
+    /// <summary>The chunk is only present in the new text.</summary>
     Insert,
+
+    /// <summary>The chunk is only present in the old text.</summary>
     Delete,
 }

--- a/src/Meziantou.Framework.TextDiff/TextDiffOptions.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiffOptions.cs
@@ -8,11 +8,38 @@ public sealed class TextDiffOptions
     /// </summary>
     public TextDiffAlgorithm Algorithm { get; set; } = TextDiffAlgorithm.Myers;
 
+
+    /// <summary>
+    /// Gets or sets how the texts are split into the chunks that are compared against each other.
+    /// Defaults to <see cref="TextChunker.Lines"/>.
+    /// </summary>
     public TextChunker Chunker { get; set; } = TextChunker.Lines;
 
+    /// <summary>
+    /// Gets or sets a value indicating whether two chunks that differ only in casing are considered equal.
+    /// The comparison is ordinal, so casing rules are not culture-sensitive.
+    /// </summary>
     public bool IgnoreCase { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the leading and trailing whitespace of a chunk is ignored
+    /// when comparing chunks.
+    /// </summary>
+    /// <remarks>
+    /// Only the <em>edges</em> of a chunk are trimmed; whitespace inside a chunk remains significant. With the
+    /// default <see cref="TextChunker.Lines"/> chunker, <c>"a  b"</c> and <c>"a b"</c> are still different. Use
+    /// <see cref="TextChunker.Words"/> to make internal whitespace insignificant: it puts each run of whitespace
+    /// in its own chunk, which trimming then reduces to an empty one.
+    /// </remarks>
     public bool IgnoreWhitespace { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether line terminators are normalized to <c>"\n"</c> before the texts
+    /// are chunked, so that <c>"\r\n"</c>, <c>"\r"</c> and <c>"\n"</c> compare equal.
+    /// </summary>
+    /// <remarks>
+    /// The normalization happens before chunking, so the entries of the result carry the normalized text rather
+    /// than the original line terminators.
+    /// </remarks>
     public bool IgnoreEndOfLine { get; set; }
 }

--- a/src/Meziantou.Framework.TextDiff/TextDiffResult.cs
+++ b/src/Meziantou.Framework.TextDiff/TextDiffResult.cs
@@ -1,5 +1,7 @@
 namespace Meziantou.Framework;
 
+/// <summary>The result of <see cref="TextDiff.ComputeDiff"/>: the chunks of both texts in order, each tagged with
+/// what happened to it.</summary>
 public sealed class TextDiffResult
 {
     internal TextDiffResult(IReadOnlyList<TextDiffEntry> entries, bool hasDifferences)
@@ -8,8 +10,11 @@ public sealed class TextDiffResult
         HasDifferences = hasDifferences;
     }
 
+
+    /// <summary>Gets the chunks of both texts, in order.</summary>
     public IReadOnlyList<TextDiffEntry> Entries { get; }
 
+    /// <summary>Gets a value indicating whether the two texts differ under the comparison options that were used.</summary>
     public bool HasDifferences { get; }
 
     public override string ToString()

--- a/src/Meziantou.Framework.TextDiff/readme.md
+++ b/src/Meziantou.Framework.TextDiff/readme.md
@@ -34,7 +34,17 @@ var options = new TextDiffOptions
 };
 
 var result = TextDiff.ComputeDiff("Hello   world\r\n", "hello world\n", options);
+// result.HasDifferences == false
 ````
+
+`IgnoreWhitespace` trims the **edges** of each chunk; whitespace inside a chunk stays
+significant. `Chunker = TextChunker.Words` is what makes the two texts above compare equal:
+it puts each run of whitespace in its own chunk, which trimming then reduces to an empty
+one. With the default `TextChunker.Lines`, `"Hello   world"` and `"hello world"` are a
+single chunk each and still differ.
+
+`IgnoreEndOfLine` normalizes line terminators *before* chunking, so the entries of the
+result carry `\n` rather than the original `\r\n`.
 
 ## Compute a hierarchical diff with multiple chunking levels
 
@@ -74,3 +84,19 @@ Available algorithms:
 - `TextDiffAlgorithm.Patience`: best for human-readable output in reviews, even if edits are not always minimal.
 - `TextDiffAlgorithm.Histogram`: good practical choice for large or repetitive texts when performance is important.
 - `TextDiffAlgorithm.HuntSzymanski`: useful for large inputs with relatively sparse matches.
+
+### Cost
+
+All four algorithms trim the common prefix and suffix first, so the cost below is driven by the
+part that actually differs — two revisions of the same file are cheap whatever you pick.
+
+| Algorithm | Cost | Degrades when |
+|---|---|---|
+| `Myers` | `O(D²)`, `D` = edit distance | the two texts have little in common: 50 000 fully different lines take seconds |
+| `Patience` | anchor search, `Myers` on unanchored regions | no chunk is unique, so it falls back to `Myers` |
+| `Histogram` | anchor search, `Myers` on unanchored regions | every shared chunk is very frequent, so it falls back to `Myers` |
+| `HuntSzymanski` | `O(r log n)`, `r` = matching pairs | many duplicate chunks, which makes `r` quadratic |
+
+There is no work limit: a diff of two large, unrelated texts runs to completion however long it
+takes. Character-level diffs reach these sizes quickly, since every character is a chunk — prefer
+`ComputeHierarchyDiff` so the character diff only runs on chunks that already changed.


### PR DESCRIPTION
The package ships with almost no XML documentation: `TextDiffAlgorithm` and
`TextDiffOptions.Algorithm` were the only documented members. Neither `ComputeDiff` nor
`ComputeHierarchyDiff` had a doc comment, and IntelliSense is the primary documentation
surface for a NuGet package.

That gap hid two behaviours that surprise callers, both now written down.

## 1. `IgnoreWhitespace` only trims chunk edges — and the README example hid it

`IgnoreWhitespace` calls `Trim()`, so internal whitespace stays significant:

```
'a  b'    vs 'a b'   IgnoreWhitespace -> HasDifferences = True
'a\tb'    vs 'a b'   IgnoreWhitespace -> HasDifferences = True
'  a b  ' vs 'a b'   IgnoreWhitespace -> HasDifferences = False
```

The README's own example pairs `"Hello   world\r\n"` with `"hello world\n"` under
`IgnoreWhitespace = true` and implies they match. They do — but only because that snippet
*also* sets `Chunker = TextChunker.Words`, which isolates each whitespace run into its own
chunk so trimming reduces it to `""`. Drop the `Chunker` line, keep the three flags, and the
same call returns `HasDifferences = True`.

A reader who takes the three flags as the point of the example and leaves the chunker at its
default gets the opposite of what the section demonstrates. The README now says which line is
doing the work, and `TextDiffOptions.IgnoreWhitespace` says the same in IntelliSense.

This documents the existing behaviour rather than changing it — "ignore whitespace" meaning
internal whitespace too (as `diff -w` does) would be a behavioural change and belongs in its
own PR.

## 2. Algorithm cost

The README recommended algorithms without saying what any of them cost, so there was no way
to choose knowingly. A new **Cost** table gives the complexity of each and the input shape
that degrades it, and notes that there is no work limit — a diff of two large unrelated texts
runs to completion however long it takes. Character-level diffs reach that size quickly, so
the table points at `ComputeHierarchyDiff` as the way to keep the character diff scoped to
chunks that already changed.

## Also documented

- `TextChunker.Lines` produces a **trailing empty chunk** for a text ending in a line
  terminator, and a single empty chunk for empty input — while `Words` and `Characters`
  produce nothing for empty input. That asymmetry is deliberate (it is what makes the chunks
  concatenate back to the original text) but nothing said so.
- `TextChunker.Chunk`'s base implementation delegates to `Lines`, so a derived chunker that
  forgets to override it silently produces line chunks.
- `TextChunker.Characters` chunks UTF-16 code units, not grapheme clusters.
- `ComputeHierarchyDiff` requires **at least two** chunkers, and ignores
  `TextDiffOptions.Chunker`. Both were only discoverable by hitting the `ArgumentException`.
- `IgnoreEndOfLine` normalizes *before* chunking, so the entries carry the normalized text.
- `TextDiffOperation`, `TextDiffHierarchyOperation`, `TextDiffResult`,
  `TextDiffHierarchyResult` and `TextDiffHierarchyEntry` members.

## Deliberately not included

`TextDiffEntry.cs` is untouched. #2147 rewrites that file to add `OldText`/`NewText` and
documents the members there, so documenting them here would only produce a conflict. If
#2147 is closed rather than merged, `TextDiffEntry` needs a follow-up.

## Verification

Documentation only — no code changed, and `ref/Meziantou.Framework.TextDiff.cs` is unchanged.

`dotnet build -c Release /p:TreatsWarningsAsErrors=true` succeeds with no warnings, so every
`<see cref="..."/>` resolves. `dotnet test -c Release /p:TreatsWarningsAsErrors=true` →
**192 passed, 0 failed**. `dotnet run ./eng/update-all.cs` reports no changes.

---

Found during a review of `Meziantou.Framework.TextDiff` (findings L5, M1, L1, and the
documentation half of M2). Grouped into one PR because separate ones would collide in
`TextDiffOptions.cs`, `TextChunker.cs` and `readme.md`.
