### PR TITLE
Escape the credentials in the SQL Server and PostgreSQL connection strings

### DIFF
--- a/src/Meziantou.Framework.TemporaryContainers/Containers/Postgresql/PostgreSqlContainer.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/Postgresql/PostgreSqlContainer.cs
@@ -1,3 +1,5 @@
+using System.Data.Common;
+
 namespace Meziantou.Framework.TemporaryContainers;
 
 /// <summary>A temporary PostgreSQL container. Obtain one from <see cref="PostgreSqlContainerDefinition.CreateContainer"/>.</summary>
@@ -17,6 +19,17 @@ public sealed class PostgreSqlContainer : TemporaryContainer
         var username = Definition.Environment.GetValue("POSTGRES_USER") ?? "postgres";
         var password = Definition.Environment.GetValue("POSTGRES_PASSWORD") ?? "";
         var database = Definition.Environment.GetValue("POSTGRES_DB") ?? username;
-        return string.Create(CultureInfo.InvariantCulture, $"Host=127.0.0.1;Port={port};Username={username};Password={password};Database={database}");
+        // The credentials are caller-supplied, so they go through the builder: a value containing ';' would
+        // otherwise end the entry and have the rest of it parsed as further keywords.
+        var builder = new DbConnectionStringBuilder
+        {
+            ["Host"] = "127.0.0.1",
+            ["Port"] = port.ToString(CultureInfo.InvariantCulture),
+            ["Username"] = username,
+            ["Password"] = password,
+            ["Database"] = database,
+        };
+
+        return builder.ConnectionString;
     }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/SqlServer/SqlServerContainer.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/SqlServer/SqlServerContainer.cs
@@ -1,3 +1,5 @@
+using System.Data.Common;
+
 namespace Meziantou.Framework.TemporaryContainers;
 
 /// <summary>A temporary SQL Server container. Obtain one from <see cref="SqlServerContainerDefinition.CreateContainer"/>.</summary>
@@ -18,6 +20,19 @@ public sealed class SqlServerContainer : TemporaryContainer
         if (password is null)
             throw new InvalidOperationException("The SQL Server SA password is not configured.");
 
-        return string.Create(CultureInfo.InvariantCulture, $"Server=127.0.0.1,{port};Database=master;User Id=sa;Pwd={password};Encrypt=True;TrustServerCertificate=True;Connection Timeout=30");
+        // The password is caller-supplied, so it goes through the builder: a value containing ';' would otherwise
+        // end the entry and have the rest of it parsed as further keywords.
+        var builder = new DbConnectionStringBuilder
+        {
+            ["Server"] = string.Create(CultureInfo.InvariantCulture, $"127.0.0.1,{port}"),
+            ["Database"] = "master",
+            ["User Id"] = "sa",
+            ["Pwd"] = password,
+            ["Encrypt"] = "True",
+            ["TrustServerCertificate"] = "True",
+            ["Connection Timeout"] = "30",
+        };
+
+        return builder.ConnectionString;
     }
 }

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/PostgreSqlContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/PostgreSqlContainerTests.cs
@@ -61,6 +61,23 @@ public sealed class PostgreSqlContainerTests
         Assert.Equal(1, Convert.ToInt32(result, CultureInfo.InvariantCulture));
     }
 
+    [Fact]
+    public async Task StartAsync_ConnectionStringWorksWhenThePasswordContainsASeparator()
+    {
+        SkipOnNonCompatibleEnvironments();
+
+        var definition = ContainerDefinition.CreatePostgreSql();
+        definition.Environment.Add("POSTGRES_PASSWORD", "pa;ss=word");
+        await using var container = await StartWithRetryAsync(definition);
+
+        await using var connection = new NpgsqlConnection(container.GetConnectionString());
+        await connection.OpenAsync(XunitCancellationToken);
+        await using var command = new NpgsqlCommand("SELECT 1", connection);
+        var result = await command.ExecuteScalarAsync(XunitCancellationToken);
+
+        Assert.Equal(1, Convert.ToInt32(result, CultureInfo.InvariantCulture));
+    }
+
     private static Task<PostgreSqlContainer> StartWithRetryAsync(PostgreSqlContainerDefinition definition)
     {
         return ContainerTestHelper.StartWithRetryAsync(definition.CreateContainer, XunitCancellationToken);

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/SqlServerContainerTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/SqlServerContainerTests.cs
@@ -80,6 +80,22 @@ public sealed class SqlServerContainerTests
         Assert.Equal(1, Convert.ToInt32(result, CultureInfo.InvariantCulture));
     }
 
+    [Fact]
+    public async Task StartAsync_ConnectionStringWorksWhenThePasswordContainsASeparator()
+    {
+        SkipOnNonCompatibleEnvironments();
+
+        var definition = ContainerDefinition.CreateSqlServer();
+        definition.SaPassword = "Pa;ss=w0rd!";
+        await using var container = await StartWithRetryAsync(definition);
+
+        await using var connection = await OpenConnectionWithRetryAsync(container.GetConnectionString());
+        await using var command = new SqlCommand("SELECT 1", connection);
+        var result = await command.ExecuteScalarAsync(XunitCancellationToken);
+
+        Assert.Equal(1, Convert.ToInt32(result, CultureInfo.InvariantCulture));
+    }
+
     private static Task<SqlServerContainer> StartWithRetryAsync(SqlServerContainerDefinition definition)
     {
         return ContainerTestHelper.StartWithRetryAsync(definition.CreateContainer, XunitCancellationToken);


### PR DESCRIPTION
`SqlServerContainer.GetConnectionString()` and `PostgreSqlContainer.GetConnectionString()` built their connection strings by raw interpolation. A `;` in the password ends the value, and everything after it is parsed as further keywords:

```
d.SaPassword = "Passw0rd;Encrypt=False";
  built:  …;User Id=sa;Pwd=Passw0rd;Encrypt=False;Encrypt=True;TrustServerCertificate=True;…
  parsed: Pwd = 'Passw0rd'          <-- password silently truncated

POSTGRES_PASSWORD = "pa;ss"
  built:  …;Password=pa;ss;Database=postgres
  parsed: Password = 'pa'           <-- password silently truncated
```

The *generated* password is safe — `ContainerCredentialGenerator`'s symbol set (`!@$%*+-_.?`) excludes `;`, `'`, `"` and `=`. This only bites when the caller supplies the password, which the readme explicitly documents (`sqlDefinition.SaPassword = "…"`) and which is the normal way to set `POSTGRES_PASSWORD`. The symptom is an authentication failure with a correct-looking password.

Beyond truncation, a password read from configuration can inject keywords ahead of the library's own `Encrypt=True` / `TrustServerCertificate=True`, which is a narrow but real transport-security downgrade.

## What changed

Both methods now build through `DbConnectionStringBuilder`, which quotes values that need it. `MongoDbContainer` already did the equivalent with `Uri.EscapeDataString`; this brings the other two in line.

The builder preserves key casing and insertion order and only quotes when necessary, so the ordinary connection string is byte-identical to what the readme documents:

```
Server=127.0.0.1,1433;Database=master;User Id=sa;Pwd=Abc1!xyz;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30
```

and a password containing a separator now round-trips instead of truncating:

```
Server=127.0.0.1,1433;…;Pwd="Passw0rd;Encrypt=False";Encrypt=True;…
     round-trip Pwd = 'Passw0rd;Encrypt=False'
```

No public API change, so `ref/` is unchanged.

## Verification

Added `StartAsync_ConnectionStringWorksWhenThePasswordContainsASeparator` to both test classes. They start a real container with a separator in the password and open an actual connection, so they pin the end-to-end behavior rather than the string shape.

On `main`'s library code the PostgreSQL one **fails** with `System.ArgumentException: Couldn't set ss (Parameter 'ss')` — Npgsql parsing the `ss=word` fragment as a keyword, which is the injection above. Passes with this change; `PostgreSqlContainerTests` 5/5 green locally.

The SQL Server test could not run locally (no arm64 image for the default `mssql/server` tag) and will first execute on CI.
