### PR TITLE
Stop treating WSL and containers as continuous integration

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/SnapshotEngine.cs
@@ -32,11 +32,12 @@ internal static class SnapshotEngine
         if (!comparison.HasDifferences && !settings.ForceUpdateSnapshots)
             return;
 
+        var blockedByAutoDetection = settings.AutoDetectContinuousEnvironment && SnapshotSettings.IsRunningOnContinuousIntegration();
         if (!settings.SnapshotUpdateStrategy.CanUpdateSnapshotInternal(settings, callerContext.SourceFilePath, comparison.ExpectedSummary, comparison.ActualSummary))
         {
             if (comparison.HasDifferences)
             {
-                ThrowAssertion(settings, comparison.Message);
+                ThrowAssertion(settings, comparison.Message, blockedByAutoDetection);
             }
 
             return;
@@ -51,7 +52,8 @@ internal static class SnapshotEngine
 
         if (comparison.HasDifferences && settings.SnapshotUpdateStrategy.MustReportError(settings, callerContext.SourceFilePath))
         {
-            ThrowAssertion(settings, comparison.Message);
+            // Getting here means the update was allowed, so the guidance must not blame auto-detection.
+            ThrowAssertion(settings, comparison.Message, blockedByAutoDetection: false);
         }
     }
 
@@ -184,21 +186,35 @@ internal static class SnapshotEngine
             }
         }
 
-        AppendResolutionGuidance(sb);
-
         return sb.ToString().TrimEnd();
     }
 
-    private static void AppendResolutionGuidance(StringBuilder sb)
+    /// <summary>
+    /// Builds the guidance appended to a failure. It has to know whether the environment detection suppressed
+    /// updates: when it did, SNAPSHOTTESTING_STRATEGY is ignored, and telling the user to set it sends them
+    /// down a path that cannot work.
+    /// </summary>
+    internal static string BuildResolutionGuidance(bool blockedByAutoDetection)
     {
-        sb.AppendLine();
+        var sb = new StringBuilder();
         sb.AppendLine("Resolution guidance:");
         sb.AppendLine("  - Compare each Verified/Actual pair listed above.");
         sb.AppendLine("  - If the new behavior is correct, copy each .actual file to its .verified file.");
-        sb.AppendLine("  - To update snapshots automatically, re-run the test with SNAPSHOTTESTING_STRATEGY=Overwrite (or OverwriteWithoutFailure).");
+
+        if (blockedByAutoDetection)
+        {
+            sb.AppendLine("  - Snapshot updates are disabled because a continuous integration, continuous testing or LLM environment was detected, so SNAPSHOTTESTING_STRATEGY has no effect here.");
+            sb.AppendLine("    Approve the .actual files with the Meziantou.Framework.SnapshotTesting.Tool package, or set SnapshotSettings.AutoDetectContinuousEnvironment to false to update them from this environment.");
+        }
+        else
+        {
+            sb.AppendLine("  - To update snapshots automatically, re-run the test with SNAPSHOTTESTING_STRATEGY=Overwrite (or OverwriteWithoutFailure).");
+        }
+
         sb.AppendLine("  - If the old behavior is correct, fix the test or production code so output matches the .verified files.");
         sb.AppendLine("  - Remove unexpected .verified files when they are no longer expected.");
         sb.AppendLine("  - Re-run the test.");
+        return sb.ToString();
     }
 
     private static string? FormatSummary(IEnumerable<FullPath> paths)
@@ -474,9 +490,13 @@ internal static class SnapshotEngine
         }
     }
 
-    private static void ThrowAssertion(SnapshotSettings settings, string message)
+    private static void ThrowAssertion(SnapshotSettings settings, string message, bool blockedByAutoDetection)
     {
-        throw settings.AssertionExceptionCreator.CreateException(message);
+        var sb = new StringBuilder(message);
+        sb.AppendLine();
+        sb.AppendLine();
+        sb.Append(BuildResolutionGuidance(blockedByAutoDetection));
+        throw settings.AssertionExceptionCreator.CreateException(sb.ToString().TrimEnd());
     }
 
     private readonly record struct SnapshotComparisonResult(

--- a/src/Meziantou.Framework.SnapshotTesting/common/BuildServerDetector.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/common/BuildServerDetector.cs
@@ -1,5 +1,10 @@
 namespace Meziantou.Framework;
 
+/// <summary>
+/// Detects an unattended build. WSL and containers are deliberately not treated as one: both are ordinary
+/// local development environments, and a build server running inside a container sets one of the variables
+/// below anyway.
+/// </summary>
 internal static class BuildServerDetector
 {
     private static bool HasEnvironmentVariable(string name) => Environment.GetEnvironmentVariable(name) is not null;
@@ -13,9 +18,7 @@ internal static class BuildServerDetector
         || HasEnvironmentVariable("GITLAB_CI")
         || HasEnvironmentVariable("GO_SERVER_URL")
         || HasEnvironmentVariable("TRAVIS_BUILD_ID")
-        || HasEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER")
         || HasEnvironmentVariable("APPVEYOR")
-        || HasEnvironmentVariable("WSL_DISTRO_NAME")
         || HasEnvironmentVariable("BuildRunner", "MyGet")
         || HasEnvironmentVariable("TF_BUILD", "True")
         ;

--- a/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.SnapshotTesting.Tests/SnapshotTests.cs
@@ -1297,6 +1297,27 @@ public sealed partial class SnapshotTests
         }
     }
 
+    [Fact]
+    public void ResolutionGuidance_PointsAtTheStrategyVariable_WhenUpdatesAreAllowed()
+    {
+        var guidance = SnapshotEngine.BuildResolutionGuidance(blockedByAutoDetection: false);
+
+        Assert.Contains("To update snapshots automatically, re-run the test with SNAPSHOTTESTING_STRATEGY=Overwrite (or OverwriteWithoutFailure).", guidance);
+        Assert.DoesNotContain("SNAPSHOTTESTING_STRATEGY has no effect here", guidance);
+    }
+
+    [Fact]
+    public void ResolutionGuidance_DoesNotPointAtTheStrategyVariable_WhenAutoDetectionBlocksUpdates()
+    {
+        var guidance = SnapshotEngine.BuildResolutionGuidance(blockedByAutoDetection: true);
+
+        // Telling the user to set SNAPSHOTTESTING_STRATEGY here would send them down a path that cannot work.
+        Assert.DoesNotContain("re-run the test with SNAPSHOTTESTING_STRATEGY=Overwrite", guidance);
+        Assert.Contains("SNAPSHOTTESTING_STRATEGY has no effect here", guidance);
+        Assert.Contains("Meziantou.Framework.SnapshotTesting.Tool", guidance);
+        Assert.Contains("AutoDetectContinuousEnvironment", guidance);
+    }
+
     private sealed class FixedAssertionExceptionBuilder : AssertionExceptionBuilder
     {
         public override Exception CreateException(string message)


### PR DESCRIPTION
`BuildServerDetector.Detected` returned `true` whenever `WSL_DISTRO_NAME` or
`DOTNET_RUNNING_IN_CONTAINER` was set, and `CanUpdateSnapshotInternal` short-circuits
*before* consulting the strategy:

```csharp
if (settings.AutoDetectContinuousEnvironment && SnapshotSettings.IsRunningOnContinuousIntegration())
    return false;

return CanUpdateSnapshot(settings, path, expectedSnapshot, actualSnapshot);
```

So a developer working in WSL2 or a devcontainer — ordinary local development, not CI —
got `SNAPSHOTTESTING_STRATEGY=Overwrite` ignored, `OverwriteWithoutFailure` ignored,
`SnapshotSettings.ForceUpdateSnapshots = true` ignored, and merge tools never launched
(`MergeTool.cs:52-59` gates on the same detector).

And the failure message said, unconditionally:

> `- To update snapshots automatically, re-run the test with SNAPSHOTTESTING_STRATEGY=Overwrite (or OverwriteWithoutFailure).`

The one instruction printed was the one that could not work in the environment where it was
printed, with no hint that auto-detection was the cause and no mention of the approve tool,
which *is* the working escape hatch (the `.actual` files are still written —
`SnapshotEngine.cs:30`).

## What changed

**1. Removed `WSL_DISTRO_NAME` and `DOTNET_RUNNING_IN_CONTAINER` from the detector.**
Neither implies an unattended build. A build server running inside a container still sets
`CI`, `GITHUB_ACTION`, `TF_BUILD` or one of the others, so real CI detection is unaffected.

**2. Made the guidance tell the truth.** The resolution guidance is no longer baked into the
message at comparison time; it is built at throw time, when the engine knows whether
auto-detection suppressed the update. When it did, the message now names the cause and
points at the approve tool and at `AutoDetectContinuousEnvironment` instead of at
`SNAPSHOTTESTING_STRATEGY`.

This also fixes the same problem for genuine CI, where the old message was equally
misleading.

## Open question for you

I deliberately did **not** change the precedence: auto-detection still overrides an
explicitly-set strategy. There is a reasonable argument that an explicit
`SNAPSHOTTESTING_STRATEGY` or `ForceUpdateSnapshots = true` should win over a heuristic —
the user has stated intent. That is a behaviour decision rather than a bug fix, so I left it
alone and made the current behaviour visible instead. Say the word and I will follow up.

## Scope

`common/BuildServerDetector.cs` is compiled into `Meziantou.Framework.InlineSnapshotTesting`
too (`Meziantou.Framework.InlineSnapshotTesting.csproj:14`), so the detector change applies
to both packages.

## Verification

Extracted `BuildResolutionGuidance(bool)` so both branches are directly testable — the
detectors cache their result in a static initializer, so the environment itself cannot be
varied within a test run. Two tests assert that the blocked branch does not mention
`SNAPSHOTTESTING_STRATEGY` and does mention the tool, and that the allowed branch is
unchanged.

```
dotnet build slnx/Meziantou.Framework.SnapshotTesting.slnx /p:TreatsWarningsAsErrors=true   # 0 warnings, 0 errors
dotnet test tests/Meziantou.Framework.SnapshotTesting.Tests                                 # 158/158 passed (full suite, end-to-end included)
```

The full suite matters here: `SnapshotEndToEndTests` asserts on real failure output, and the
pre-existing `Validate_ErrorMessageIncludesVerifiedAndActualPaths_ForAllChangedFiles` pins
the exact guidance string for the non-blocked path.
