### PR TITLE
Authenticate GitHub tag requests and report rate limiting

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/GitHubActionsUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/GitHubActionsUpdater.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 
@@ -6,6 +7,9 @@ namespace Meziantou.Framework.DependencyScanning.Tool;
 
 internal sealed class GitHubActionsUpdater : PackageUpdater
 {
+    // Anonymous calls share a 60 requests/hour budget per IP, which a repository with a few dozen
+    // actions exhausts in a single run. A token raises that to 5000.
+    private static readonly string[] TokenEnvironmentVariables = ["GITHUB_TOKEN", "GH_TOKEN"];
     private static readonly HttpClient HttpClient = new();
     public override VersioningStrategy VersioningStrategy { get; set; } = GitHubActionsVersioningStrategy.Instance;
 
@@ -24,6 +28,10 @@ internal sealed class GitHubActionsUpdater : PackageUpdater
         request.Headers.TryAddWithoutValidation("X-GitHub-Api-Version", "2022-11-28");
         request.Headers.UserAgent.ParseAdd("Meziantou.Framework.DependencyScanning.Tool");
         request.Headers.Accept.ParseAdd("application/vnd.github+json");
+        if (GetToken() is { Length: > 0 } token)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
 
         var tagsWithDates = await GetTagsWithDatesAsync(request, cancellationToken).ConfigureAwait(false);
         if (tagsWithDates is null)
@@ -61,12 +69,31 @@ internal sealed class GitHubActionsUpdater : PackageUpdater
         return !string.IsNullOrWhiteSpace(owner) && !string.IsNullOrWhiteSpace(repository);
     }
 
+    private static string? GetToken()
+    {
+        foreach (var name in TokenEnvironmentVariables)
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            if (!string.IsNullOrEmpty(value))
+                return value;
+        }
+
+        return null;
+    }
+
     private static async Task<(string Tag, DateTime? PublishedDate)[]?> GetTagsWithDatesAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         try
         {
             using var response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-            if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest or HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.TooManyRequests)
+            if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.TooManyRequests)
+            {
+                // Without this the caller cannot tell "rate limited" from "no newer tag exists"
+                Console.Error.WriteLine($"GitHub API returned {(int)response.StatusCode} for '{request.RequestUri}'; GitHub Actions versions were not checked. Set GITHUB_TOKEN to raise the rate limit.");
+                return null;
+            }
+
+            if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest)
                 return null;
 
             response.EnsureSuccessStatusCode();


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2190**

`GitHubActionsUpdater` sent a `User-Agent` but no `Authorization` header, so every call used GitHub's anonymous budget of 60 requests/hour per IP. A repository with more than ~60 distinct actions exhausts that within a single run; on a shared CI runner the budget may already be spent before the tool starts.

Worse, `403` and `429` were folded into the same `return null` as `404`, which is indistinguishable from "no newer tag exists". The run continued and exited 0, so the user saw a clean, successful run in which no action was updated.

## What changed

- `GITHUB_TOKEN` (or `GH_TOKEN`) is read from the environment and sent as a bearer token, raising the limit to 5000 requests/hour. Absent, behaviour is unchanged.
- `401`, `403` and `429` are now reported on stderr — naming the URL, the status and the `GITHUB_TOKEN` remedy — instead of being silently swallowed. `404`/`400` still return quietly, since those genuinely mean "nothing to look at".

The warning goes to `Console.Error` to match how `NuGetPackageUpdater` and `NpmPackageUpdater` already report lock-file failures. Once #2173 lands there is a proper per-dependency error channel to route this through instead; that follow-up is deliberately not part of this PR.

## Verification

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 49 passed, 0 failed (unchanged).
- `dotnet run ./eng/update-all.cs` — no generated-file changes.

No new test: the token is read inside a `static readonly HttpClient` call path, so covering it offline needs an injectable `HttpMessageHandler`. That refactor is worth doing but is a larger change than this fix.
