### PR TITLE
Follow the Link header when listing GitHub and Docker tags

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/DockerPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/DockerPackageUpdater.cs
@@ -8,6 +8,11 @@ namespace Meziantou.Framework.DependencyScanning.Tool;
 
 internal sealed class DockerPackageUpdater : PackageUpdater
 {
+    // Docker Hub answers with every tag at once, but GHCR, Harbor and ECR paginate; without following the
+    // Link header only the first page of tags is ever considered. No explicit page size is requested, so
+    // registries that already return everything keep doing so.
+    private const int MaxPages = 100;
+
     private static readonly HttpClient HttpClient = new();
     public override VersioningStrategy VersioningStrategy { get; set; } = DockerVersioningStrategy.Instance;
 
@@ -31,35 +36,46 @@ internal sealed class DockerPackageUpdater : PackageUpdater
         packageName = NormalizePackageName(packageName);
         var (registry, repository) = ParseImageName(packageName);
 
-        var tagsListUri = new UriBuilder(Uri.UriSchemeHttps, registry) { Path = $"v2/{repository}/tags/list" }.Uri;
-        using var initialResponse = await SendTagsListRequestAsync(tagsListUri, accessToken: null, cancellationToken).ConfigureAwait(false);
-        if (initialResponse.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest)
-            yield break;
-
-        if (initialResponse.StatusCode is HttpStatusCode.Unauthorized)
+        var nextUri = new UriBuilder(Uri.UriSchemeHttps, registry) { Path = $"v2/{repository}/tags/list" }.Uri;
+        string? accessToken = null;
+        for (var page = 0; page < MaxPages && nextUri is not null; page++)
         {
-            var accessToken = await GetRegistryTokenAsync(initialResponse, repository, cancellationToken).ConfigureAwait(false);
-            if (string.IsNullOrEmpty(accessToken))
+            var result = await GetTagsPageAsync(nextUri, repository, accessToken, cancellationToken).ConfigureAwait(false);
+            if (result is null)
                 yield break;
 
-            using var authenticatedResponse = await SendTagsListRequestAsync(tagsListUri, accessToken, cancellationToken).ConfigureAwait(false);
-            if (authenticatedResponse.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest)
-                yield break;
-
-            authenticatedResponse.EnsureSuccessStatusCode();
-            await foreach (var tag in ParseTagsAsync(authenticatedResponse, cancellationToken).ConfigureAwait(false))
+            foreach (var tag in result.Value.Tags)
             {
                 yield return tag;
             }
 
-            yield break;
+            accessToken = result.Value.AccessToken;
+            nextUri = result.Value.NextPage;
+        }
+    }
+
+    private static async Task<(List<string> Tags, Uri? NextPage, string? AccessToken)?> GetTagsPageAsync(Uri uri, string repository, string? accessToken, CancellationToken cancellationToken)
+    {
+        using var response = await SendTagsListRequestAsync(uri, accessToken, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest)
+            return null;
+
+        if (response.StatusCode is HttpStatusCode.Unauthorized)
+        {
+            accessToken = await GetRegistryTokenAsync(response, repository, cancellationToken).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(accessToken))
+                return null;
+
+            using var authenticatedResponse = await SendTagsListRequestAsync(uri, accessToken, cancellationToken).ConfigureAwait(false);
+            if (authenticatedResponse.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.BadRequest)
+                return null;
+
+            authenticatedResponse.EnsureSuccessStatusCode();
+            return (await ReadTagsAsync(authenticatedResponse, cancellationToken).ConfigureAwait(false), LinkHeader.TryGetNextPageUri(authenticatedResponse, uri), accessToken);
         }
 
-        initialResponse.EnsureSuccessStatusCode();
-        await foreach (var tag in ParseTagsAsync(initialResponse, cancellationToken).ConfigureAwait(false))
-        {
-            yield return tag;
-        }
+        response.EnsureSuccessStatusCode();
+        return (await ReadTagsAsync(response, cancellationToken).ConfigureAwait(false), LinkHeader.TryGetNextPageUri(response, uri), accessToken);
     }
 
     public override Task UpdateLockFileAsync(FullPath rootDirectory, IEnumerable<Dependency> updatedDependencies, CancellationToken cancellationToken) => Task.CompletedTask;
@@ -106,8 +122,9 @@ internal sealed class DockerPackageUpdater : PackageUpdater
         return await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
     }
 
-    private static async IAsyncEnumerable<string> ParseTagsAsync(HttpResponseMessage response, [EnumeratorCancellation] CancellationToken cancellationToken)
+    private static async Task<List<string>> ReadTagsAsync(HttpResponseMessage response, CancellationToken cancellationToken)
     {
+        var tags = new List<string>();
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
         if (document.RootElement.TryGetProperty("tags", out var tagsElement) && tagsElement.ValueKind is JsonValueKind.Array)
@@ -117,10 +134,12 @@ internal sealed class DockerPackageUpdater : PackageUpdater
                 var tag = tagElement.GetString();
                 if (!string.IsNullOrEmpty(tag))
                 {
-                    yield return tag;
+                    tags.Add(tag);
                 }
             }
         }
+
+        return tags;
     }
 
     private static async Task<string?> GetRegistryTokenAsync(HttpResponseMessage unauthorizedResponse, string repository, CancellationToken cancellationToken)

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/GitHubActionsUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/GitHubActionsUpdater.cs
@@ -10,6 +10,10 @@ internal sealed class GitHubActionsUpdater : PackageUpdater
     // Anonymous calls share a 60 requests/hour budget per IP, which a repository with a few dozen
     // actions exhausts in a single run. A token raises that to 5000.
     private static readonly string[] TokenEnvironmentVariables = ["GITHUB_TOKEN", "GH_TOKEN"];
+    // GitHub does not document its tag ordering, so on a repository with more than one page of tags the
+    // newest release can sit behind the Link header rather than in the first response.
+    private const int MaxPages = 10;
+
     private static readonly HttpClient HttpClient = new();
     public override VersioningStrategy VersioningStrategy { get; set; } = GitHubActionsVersioningStrategy.Instance;
 
@@ -23,8 +27,25 @@ internal sealed class GitHubActionsUpdater : PackageUpdater
         if (!TryParseRepository(dependency.Name, out var owner, out var repository))
             yield break;
 
-        var tagsUri = new Uri($"https://api.github.com/repos/{owner}/{repository}/tags?per_page=100");
-        using var request = new HttpRequestMessage(HttpMethod.Get, tagsUri);
+        var nextUri = new Uri($"https://api.github.com/repos/{owner}/{repository}/tags?per_page=100");
+        for (var page = 0; page < MaxPages && nextUri is not null; page++)
+        {
+            var result = await GetTagsWithDatesAsync(nextUri, cancellationToken).ConfigureAwait(false);
+            if (result is null)
+                yield break;
+
+            foreach (var (tag, date) in result.Value.Tags)
+            {
+                yield return new PackageVersion(tag, date);
+            }
+
+            nextUri = result.Value.NextPage;
+        }
+    }
+
+    private static HttpRequestMessage CreateTagsRequest(Uri uri)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, uri);
         request.Headers.TryAddWithoutValidation("X-GitHub-Api-Version", "2022-11-28");
         request.Headers.UserAgent.ParseAdd("Meziantou.Framework.DependencyScanning.Tool");
         request.Headers.Accept.ParseAdd("application/vnd.github+json");
@@ -33,14 +54,7 @@ internal sealed class GitHubActionsUpdater : PackageUpdater
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
 
-        var tagsWithDates = await GetTagsWithDatesAsync(request, cancellationToken).ConfigureAwait(false);
-        if (tagsWithDates is null)
-            yield break;
-
-        foreach (var (tag, date) in tagsWithDates)
-        {
-            yield return new PackageVersion(tag, date);
-        }
+        return request;
     }
 
     public override Task UpdateLockFileAsync(FullPath rootDirectory, IEnumerable<Dependency> updatedDependencies, CancellationToken cancellationToken) => Task.CompletedTask;
@@ -81,10 +95,11 @@ internal sealed class GitHubActionsUpdater : PackageUpdater
         return null;
     }
 
-    private static async Task<(string Tag, DateTime? PublishedDate)[]?> GetTagsWithDatesAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    private static async Task<((string Tag, DateTime? PublishedDate)[] Tags, Uri? NextPage)?> GetTagsWithDatesAsync(Uri uri, CancellationToken cancellationToken)
     {
         try
         {
+            using var request = CreateTagsRequest(uri);
             using var response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.TooManyRequests)
             {
@@ -132,7 +147,7 @@ internal sealed class GitHubActionsUpdater : PackageUpdater
                 result.Add((name, publishedDate));
             }
 
-            return [.. result];
+            return ([.. result], LinkHeader.TryGetNextPageUri(response, uri));
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/LinkHeader.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/LinkHeader.cs
@@ -1,0 +1,36 @@
+namespace Meziantou.Framework.DependencyScanning.Tool;
+
+/// <summary>Reads the <c>rel="next"</c> entry of an RFC 8288 <c>Link</c> response header, which both the
+/// GitHub API and Docker registries use to paginate their tag listings.</summary>
+internal static class LinkHeader
+{
+    public static Uri? TryGetNextPageUri(HttpResponseMessage response, Uri requestUri)
+    {
+        if (!response.Headers.TryGetValues("Link", out var headerValues))
+            return null;
+
+        foreach (var headerValue in headerValues)
+        {
+            // Splitting on ',' is enough for the URLs GitHub and Docker registries produce; a comma inside
+            // a quoted parameter value would need a full RFC 8288 parser.
+            foreach (var link in headerValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (link.Length is 0 || link[0] is not '<')
+                    continue;
+
+                var urlEnd = link.IndexOf('>', StringComparison.Ordinal);
+                if (urlEnd < 0)
+                    continue;
+
+                var parameters = link[(urlEnd + 1)..];
+                if (!parameters.Contains("rel=\"next\"", StringComparison.OrdinalIgnoreCase) && !parameters.Contains("rel=next", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (Uri.TryCreate(requestUri, link[1..urlEnd], out var nextUri))
+                    return nextUri;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
@@ -584,6 +584,31 @@ public sealed class FunctionalTests
         Assert.Equal(expectedResult, strategy.IsCompatibleVersion(currentVersion, candidateVersion));
     }
 
+    [Theory]
+    // GitHub sends absolute URLs and several relations in one header
+    [InlineData("<https://api.github.com/repositories/1/tags?page=2>; rel=\"next\", <https://api.github.com/repositories/1/tags?page=9>; rel=\"last\"", "https://api.github.com/repositories/1/tags?page=2")]
+    // Docker registries send a relative URL that has to be resolved against the request
+    [InlineData("</v2/library/nginx/tags/list?n=100&last=1.27>; rel=\"next\"", "https://registry-1.docker.io/v2/library/nginx/tags/list?n=100&last=1.27")]
+    // The last page only advertises relations other than 'next'
+    [InlineData("<https://api.github.com/repositories/1/tags?page=1>; rel=\"prev\", <https://api.github.com/repositories/1/tags?page=1>; rel=\"first\"", null)]
+    public void LinkHeader_TryGetNextPageUri(string headerValue, string? expected)
+    {
+        using var response = new HttpResponseMessage();
+        response.Headers.TryAddWithoutValidation("Link", headerValue);
+
+        var result = LinkHeader.TryGetNextPageUri(response, new Uri("https://registry-1.docker.io/v2/library/nginx/tags/list"));
+
+        Assert.Equal(expected, result?.ToString());
+    }
+
+    [Fact]
+    public void LinkHeader_TryGetNextPageUri_NoHeader()
+    {
+        using var response = new HttpResponseMessage();
+
+        Assert.Null(LinkHeader.TryGetNextPageUri(response, new Uri("https://registry-1.docker.io/v2/library/nginx/tags/list")));
+    }
+
     private static async Task<IReadOnlyList<Dependency>> ScanDependencies(TemporaryDirectory temporaryDirectory)
     {
         var deps = (await DependencyScanner.ScanDirectoryAsync(temporaryDirectory.FullPath, options: null, XunitCancellationToken)).ToList();


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/github-actions-auth` (#2189) · merge that one first**

Neither tag listing followed pagination:

- `GitHubActionsUpdater` requested `?per_page=100` and never read the `Link: rel="next"` header. GitHub does not document its tag ordering, so for a repository with more than 100 tags the newest release may simply be absent from the candidate set — the tool then reports "up to date" against a stale maximum.
- `DockerPackageUpdater` called `v2/<repo>/tags/list` and read only that response. Docker Hub answers with every tag at once, but GHCR, Harbor and most ECR deployments paginate.

## What changed

A small shared `LinkHeader.TryGetNextPageUri` parses the RFC 8288 `rel="next"` entry and resolves relative URLs (which Docker registries use) against the request URI. Both updaters now loop until there is no next page, with a page cap as a backstop — 10 pages for GitHub at `per_page=100`, 100 for Docker.

Deliberately **not** sending an explicit `n=` to Docker registries: registries that already return every tag in one response must keep doing so, otherwise a page cap would shrink the candidate list instead of growing it. Verified that `nginx:1.27.1` still resolves to `1.31.4` through Docker Hub after the change.

`ParseTagsAsync` became `ReadTagsAsync` returning a list, so the per-page fetch is an ordinary `Task` and the iterator stays readable; the 401-then-token-retry flow moved into that helper and now reuses the token across pages instead of re-fetching it.

## Verification

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 53 passed, 0 failed (49 on the layer below).
- `dotnet run ./eng/update-all.cs` — no generated-file changes.
- End to end: `nginx:1.27.1` → `1.31.4` (Docker Hub, unchanged) and `actions/checkout@v2` → `v7` (GitHub, paginated).

Four new tests cover `LinkHeader.TryGetNextPageUri`: GitHub's absolute multi-relation header, a Docker relative URL resolved against the request, a last page advertising only `prev`/`first`, and no header at all.
