### PR TITLE
Emit the last container log line when it has no trailing newline

### DIFF
--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
@@ -328,6 +328,8 @@ internal sealed class DockerApiRuntime : ContainerRuntime
             if (buffer.Length == 0)
                 continue;
 
+            // TrimEnd mirrors what TryReadLine does for every other line, so the last one is not the only one that can
+            // come out with a trailing CR. It matters when the stream stops between the CR and the LF of a CRLF ending.
             var parsed = ParseLogLine(logStream, buffer.ToString().TrimEnd('\r'));
             if (parsed is not null)
                 yield return parsed;

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerApiRuntime.cs
@@ -299,7 +299,7 @@ internal sealed class DockerApiRuntime : ContainerRuntime
         return new InvalidOperationException(message);
     }
 
-    private static async IAsyncEnumerable<LogEntry> ReadMultiplexedLogsAsync(Stream stream, [EnumeratorCancellation] CancellationToken cancellationToken)
+    internal static async IAsyncEnumerable<LogEntry> ReadMultiplexedLogsAsync(Stream stream, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var buffers = new Dictionary<LogStream, StringBuilder>
         {
@@ -318,6 +318,19 @@ internal sealed class DockerApiRuntime : ContainerRuntime
                 if (parsed is not null)
                     yield return parsed;
             }
+        }
+
+        // The stream ended. Whatever is left was never terminated by a newline, but it is still a log line: a process
+        // that writes its readiness marker with 'printf' and no '\n', or that dies mid-line, would otherwise never be
+        // reported and every wait strategy watching for it would time out.
+        foreach (var (logStream, buffer) in buffers)
+        {
+            if (buffer.Length == 0)
+                continue;
+
+            var parsed = ParseLogLine(logStream, buffer.ToString().TrimEnd('\r'));
+            if (parsed is not null)
+                yield return parsed;
         }
     }
 

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiRuntimeTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiRuntimeTests.cs
@@ -40,6 +40,16 @@ public sealed class DockerApiRuntimeTests
     }
 
     [Fact]
+    public async Task ReadMultiplexedLogsAsync_DoesNotEndTheTrailingLineWithACarriageReturn()
+    {
+        // A container writing CRLF endings that is killed between the CR and the LF. TryReadLine already drops the CR
+        // from every complete line, so the trailing one must not be the only line that keeps it.
+        var entries = await ReadAllAsync((LogStream.Stdout, "starting\r\nSERVER READY\r"));
+
+        Assert.Equal(["starting", "SERVER READY"], entries.Select(entry => entry.Message));
+    }
+
+    [Fact]
     public async Task ReadMultiplexedLogsAsync_KeepsTheTimestampOfTheTrailingLine()
     {
         var entries = await ReadAllAsync((LogStream.Stdout, "2026-08-27T10:11:12.0000000Z SERVER READY"));

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiRuntimeTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerApiRuntimeTests.cs
@@ -1,0 +1,80 @@
+using System.Buffers.Binary;
+using System.Text;
+using Meziantou.Framework.TemporaryContainers.Internals;
+
+namespace Meziantou.Framework.TemporaryContainers.Tests;
+
+public sealed class DockerApiRuntimeTests
+{
+    [Fact]
+    public async Task ReadMultiplexedLogsAsync_SplitsFramesIntoLines()
+    {
+        var entries = await ReadAllAsync(
+            (LogStream.Stdout, "first\nsecond\n"),
+            (LogStream.Stderr, "boom\n"));
+
+        Assert.Equal(["first", "second", "boom"], entries.Select(entry => entry.Message));
+        Assert.Equal([LogStream.Stdout, LogStream.Stdout, LogStream.Stderr], entries.Select(entry => entry.Stream));
+    }
+
+    [Fact]
+    public async Task ReadMultiplexedLogsAsync_JoinsALineSplitAcrossFrames()
+    {
+        var entries = await ReadAllAsync(
+            (LogStream.Stdout, "SERVER "),
+            (LogStream.Stdout, "READY\n"));
+
+        Assert.Equal("SERVER READY", Assert.Single(entries).Message);
+    }
+
+    [Fact]
+    public async Task ReadMultiplexedLogsAsync_YieldsTheTrailingLineWithoutANewline()
+    {
+        // A container that writes its readiness marker with 'printf' and no '\n' still has to be reported, otherwise
+        // Wait.ForLogMessage waits out the whole StartupTimeout for a message that was actually printed.
+        var entries = await ReadAllAsync(
+            (LogStream.Stdout, "starting\n"),
+            (LogStream.Stdout, "SERVER READY"));
+
+        Assert.Equal(["starting", "SERVER READY"], entries.Select(entry => entry.Message));
+    }
+
+    [Fact]
+    public async Task ReadMultiplexedLogsAsync_KeepsTheTimestampOfTheTrailingLine()
+    {
+        var entries = await ReadAllAsync((LogStream.Stdout, "2026-08-27T10:11:12.0000000Z SERVER READY"));
+
+        var entry = Assert.Single(entries);
+        Assert.Equal("SERVER READY", entry.Message);
+        Assert.Equal(DateTimeOffset.Parse("2026-08-27T10:11:12.0000000Z", CultureInfo.InvariantCulture), entry.Timestamp);
+    }
+
+    private static async Task<List<LogEntry>> ReadAllAsync(params (LogStream Stream, string Text)[] frames)
+    {
+        using var stream = new MemoryStream(BuildFrames(frames));
+
+        var entries = new List<LogEntry>();
+        await foreach (var entry in DockerApiRuntime.ReadMultiplexedLogsAsync(stream, CancellationToken.None))
+            entries.Add(entry);
+
+        return entries;
+    }
+
+    /// <summary>Builds the stream the Docker API returns for a container without a TTY: each payload is prefixed by an 8-byte header whose first byte is the stream and whose last four bytes are the big-endian payload length.</summary>
+    private static byte[] BuildFrames((LogStream Stream, string Text)[] frames)
+    {
+        var result = new List<byte>();
+        foreach (var (logStream, text) in frames)
+        {
+            var payload = Encoding.UTF8.GetBytes(text);
+            var header = new byte[8];
+            header[0] = logStream is LogStream.Stderr ? (byte)2 : (byte)1;
+            BinaryPrimitives.WriteInt32BigEndian(header.AsSpan(4), payload.Length);
+
+            result.AddRange(header);
+            result.AddRange(payload);
+        }
+
+        return [.. result];
+    }
+}


### PR DESCRIPTION
`ReadMultiplexedLogsAsync` accumulates frame text per stream and only emits on `\n` (`TryReadLine`). When the stream ended, whatever remained in the buffer was discarded rather than flushed.

A container whose readiness marker is written without a trailing newline — a `printf` without `\n`, or a process that dies mid-line — therefore never produced that entry. `Wait.ForLogMessage` then waits out the full `StartupTimeout` and reports a timeout for a message that was actually printed.

## What changed

After the frame loop completes, any non-empty remainder of each stream's buffer is emitted as a final `LogEntry`, through the same `ParseLogLine` as every other line, so the timestamp prefix is still stripped and preserved.

`ReadMultiplexedLogsAsync` becomes `internal` so it can be tested directly. It is pure stream-in / entries-out, which makes it worth pinning: this decoder had no coverage at all.

No public API change, so `ref/` is unchanged.

## Verification

New `DockerApiRuntimeTests` builds synthetic Docker frames (8-byte header, big-endian payload length) and covers four cases:

- `SplitsFramesIntoLines` — multiple lines, stdout and stderr routed correctly.
- `JoinsALineSplitAcrossFrames` — one line arriving in two frames.
- `YieldsTheTrailingLineWithoutANewline` — the fix.
- `KeepsTheTimestampOfTheTrailingLine` — the trailing line goes through the same parsing as the rest.

With the flush removed and everything else identical, the two trailing-line tests fail and the other two pass, so they pin this behavior specifically. 4/4 green with the fix.

New test file rather than an addition to an existing one: there was no test class for `DockerApiRuntime`, and folding stream-decoding tests into `DockerApiCreateRequestBuilderTests` would have misnamed both. Happy to merge them if you'd rather.
