### PR TITLE
Read the registry credentials from DOCKER_CONFIG when it is set

### DIFF
--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerRegistryAuthProvider.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerRegistryAuthProvider.cs
@@ -61,12 +61,20 @@ internal sealed class DockerRegistryAuthProvider
 
     private static DockerApiModels.AuthConfigFile? LoadConfiguration()
     {
-        var configPath = FullPath.GetFolderPath(Environment.SpecialFolder.UserProfile) / ".docker" / "config.json";
+        var configPath = GetConfigurationDirectory(Environment.GetEnvironmentVariable("DOCKER_CONFIG")) / "config.json";
         if (!File.Exists(configPath))
             return null;
 
         using var stream = File.OpenRead(configPath);
         return JsonSerializer.Deserialize(stream, DockerApiJsonContext.Default.AuthConfigFile);
+    }
+
+    /// <summary>The directory the credentials are read from: <c>DOCKER_CONFIG</c> when it is set, <c>~/.docker</c> otherwise. CI systems that isolate credentials into a per-job directory rely on the environment variable.</summary>
+    internal static FullPath GetConfigurationDirectory(string? dockerConfigEnvironmentVariable)
+    {
+        return string.IsNullOrWhiteSpace(dockerConfigEnvironmentVariable)
+            ? FullPath.GetFolderPath(Environment.SpecialFolder.UserProfile) / ".docker"
+            : FullPath.FromPath(dockerConfigEnvironmentVariable);
     }
 
     private static string? GetCredentialHelper(DockerApiModels.AuthConfigFile config, string registry)

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRegistryAuthProviderTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRegistryAuthProviderTests.cs
@@ -65,6 +65,25 @@ public sealed class DockerRegistryAuthProviderTests
         Assert.Equal(expectedRegistry, DockerRegistryAuthProvider.GetRegistryFromImageName(imageName));
     }
 
+    [Fact]
+    public void GetConfigurationDirectory_UsesDockerConfigWhenSet()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "meziantou-tc-docker-config");
+
+        Assert.Equal(FullPath.FromPath(directory), DockerRegistryAuthProvider.GetConfigurationDirectory(directory));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetConfigurationDirectory_FallsBackToTheUserProfileWhenDockerConfigIsNotSet(string? dockerConfig)
+    {
+        var expected = FullPath.GetFolderPath(Environment.SpecialFolder.UserProfile) / ".docker";
+
+        Assert.Equal(expected, DockerRegistryAuthProvider.GetConfigurationDirectory(dockerConfig));
+    }
+
     private static DockerApiModels.RegistryAuthHeader DecodeHeader(string value)
     {
         var json = Encoding.UTF8.GetString(Convert.FromBase64String(value));


### PR DESCRIPTION
`LoadConfiguration` hardcoded the credentials path to `<UserProfile>/.docker/config.json`. Docker resolves `$DOCKER_CONFIG` first; the variable was not read anywhere in the project.

CI systems that isolate credentials into a per-job `DOCKER_CONFIG` directory — a common hardening pattern, and what `docker login` writes to when the variable is set — got no credentials at all. Private-image pulls then fail through the Docker Engine API runtime while succeeding through the `docker` CLI on the same agent.

## What changed

`GetConfigurationDirectory` returns `DOCKER_CONFIG` when it is set to something non-blank, and `~/.docker` otherwise. It takes the variable's value as a parameter rather than reading the environment itself, so it can be tested without mutating process-global state that would race with parallel tests.

No public API change, so `ref/` is unchanged.

## Verification

- `GetConfigurationDirectory_UsesDockerConfigWhenSet`
- `GetConfigurationDirectory_FallsBackToTheUserProfileWhenDockerConfigIsNotSet`, covering `null`, `""` and whitespace.

`DockerRegistryAuthProviderTests` 10/10 green.
