### PR TITLE
Correct the documented PostgreSQL image tag

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,23 @@
   "extends": [
     "github>meziantou/renovate-config"
   ],
+  "customManagers": [
+    {
+      // The shared preset only matches the ImageSource.FromRegistry(...) call, so the image named in the XML
+      // documentation right above it was left behind and drifted (postgres was documented as 17 while the code
+      // created an 18 container). Anchored on the 'using the <c>image:tag</c> image' wording so it cannot match
+      // the illustrative <c>redis:8</c> samples or <c>host:port</c> elsewhere in the documentation.
+      "customType": "regex",
+      "description": "Default container images named in the XML documentation of the ContainerDefinition factory methods",
+      "managerFilePatterns": [
+        "/^src/Meziantou\\.Framework\\.TemporaryContainers/Containers/.*Extensions\\.cs$/"
+      ],
+      "matchStrings": [
+        "using the <c>(?<depName>[^<]+):(?<currentValue>[^<@]+)</c> image"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "matchPackageNames": [ "/^Microsoft\\.Build\\..*/" ],

--- a/src/Meziantou.Framework.TemporaryContainers/Containers/Postgresql/ContainerDefinitionPostgreSqlExtensions.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Containers/Postgresql/ContainerDefinitionPostgreSqlExtensions.cs
@@ -8,7 +8,7 @@ public static class ContainerDefinitionPostgreSqlExtensions
     extension(ContainerDefinition)
     {
         /// <summary>Creates a definition pre-configured for a PostgreSQL container (port 5432, a default password, and a readiness wait strategy).</summary>
-        /// <returns>A PostgreSQL container definition using the <c>postgres:17</c> image.</returns>
+        /// <returns>A PostgreSQL container definition using the <c>postgres:18</c> image.</returns>
         public static PostgreSqlContainerDefinition CreatePostgreSql()
         {
             return CreatePostgreSql(ImageSource.FromRegistry("postgres:18"));


### PR DESCRIPTION
The XML doc on `CreatePostgreSql()` says the default image is `postgres:17`; the line below it uses `postgres:18`. The doc is what shows up in IntelliSense and on the API reference, so it's the version most people will read.

I checked the other three helpers while I was here — Redis (`redis:8.2`), MongoDB (`mongo:8`) and SQL Server (`mcr.microsoft.com/mssql/server:2025-latest`) all match their code. Only PostgreSQL had drifted.

## Verification

Doc comment only; `ref/` carries signatures without XML docs, so it is unchanged. Builds clean on both target frameworks with `/p:TreatWarningsAsErrors=true`.

Note: the `postgres:16` in `readme.md` is **not** drift — it illustrates the `CreatePostgreSql(ImageSource)` overload for overriding the image, not the default. Left alone.
