### PR TITLE
Index type definitions instead of scanning the metadata table on every lookup

### DIFF
--- a/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
+++ b/src/Meziantou.Framework.PublicApiGenerator/PublicApiModelReader.cs
@@ -22,6 +22,7 @@ internal static class PublicApiModelReader
     private static readonly Lock EnumMetadataCacheLock = new();
     private static readonly Dictionary<string, EnumMetadata?> EnumMetadataCache = new(StringComparer.Ordinal);
     private static readonly ConditionalWeakTable<MetadataReader, StrongBox<bool>> UpdatedMemorySafetyRulesCache = new();
+    private static readonly ConditionalWeakTable<MetadataReader, TypeDefinitionIndex> TypeDefinitionIndexCache = new();
 
     private static readonly HashSet<string> IrrelevantAttributes = new(StringComparer.Ordinal)
     {
@@ -336,12 +337,9 @@ internal static class PublicApiModelReader
 
     private static IEnumerable<TypeDefinitionHandle> EnumerateNestedTypes(MetadataReader metadataReader, TypeDefinitionHandle parentTypeHandle)
     {
-        foreach (var typeDefinitionHandle in metadataReader.TypeDefinitions)
+        foreach (var typeDefinitionHandle in metadataReader.GetTypeDefinition(parentTypeHandle).GetNestedTypes())
         {
             var typeDefinition = metadataReader.GetTypeDefinition(typeDefinitionHandle);
-            if (typeDefinition.GetDeclaringType() != parentTypeHandle)
-                continue;
-
             if (!IsExternallyVisibleNested(typeDefinition.Attributes))
                 continue;
 
@@ -2208,21 +2206,37 @@ internal static class PublicApiModelReader
             var typeReference = metadataReader.GetTypeReference((TypeReferenceHandle)handle);
             var namespaceName = typeReference.Namespace.IsNil ? string.Empty : metadataReader.GetString(typeReference.Namespace);
             var name = metadataReader.GetString(typeReference.Name);
-            foreach (var candidateHandle in metadataReader.TypeDefinitions)
-            {
-                var candidate = metadataReader.GetTypeDefinition(candidateHandle);
-                var candidateNamespace = candidate.Namespace.IsNil ? string.Empty : metadataReader.GetString(candidate.Namespace);
-                if (string.Equals(candidateNamespace, namespaceName, StringComparison.Ordinal) &&
-                    string.Equals(metadataReader.GetString(candidate.Name), name, StringComparison.Ordinal))
-                {
-                    typeDefinitionHandle = candidateHandle;
-                    return true;
-                }
-            }
+            return GetTypeDefinitionIndex(metadataReader).ByMetadataName.TryGetValue(BuildTypeKey(namespaceName, name), out typeDefinitionHandle);
         }
 
         typeDefinitionHandle = default;
         return false;
+    }
+
+    private static TypeDefinitionIndex GetTypeDefinitionIndex(MetadataReader metadataReader)
+    {
+        return TypeDefinitionIndexCache.GetValue(metadataReader, static reader =>
+        {
+            var byMetadataName = new Dictionary<string, TypeDefinitionHandle>(StringComparer.Ordinal);
+            var byDisplayName = new Dictionary<string, TypeDefinitionHandle>(StringComparer.Ordinal);
+            foreach (var typeDefinitionHandle in reader.TypeDefinitions)
+            {
+                var typeDefinition = reader.GetTypeDefinition(typeDefinitionHandle);
+                var namespaceName = typeDefinition.Namespace.IsNil ? string.Empty : reader.GetString(typeDefinition.Namespace);
+                var metadataName = reader.GetString(typeDefinition.Name);
+
+                // The first definition wins, which is what the previous linear scans did
+                byMetadataName.TryAdd(BuildTypeKey(namespaceName, metadataName), typeDefinitionHandle);
+                byDisplayName.TryAdd(BuildTypeKey(namespaceName, RemoveGenericArity(metadataName)), typeDefinitionHandle);
+            }
+
+            return new TypeDefinitionIndex(byMetadataName, byDisplayName);
+        });
+    }
+
+    private static string BuildTypeKey(string namespaceName, string typeName)
+    {
+        return string.IsNullOrEmpty(namespaceName) ? typeName : namespaceName + "." + typeName;
     }
 
     private static List<string> BuildAttributes(MetadataReader metadataReader, CustomAttributeHandleCollection attributes)
@@ -2682,23 +2696,7 @@ internal static class PublicApiModelReader
 
     private static bool TryResolveTypeDefinitionHandle(MetadataReader metadataReader, string fullTypeName, out TypeDefinitionHandle typeDefinitionHandle)
     {
-        var separator = fullTypeName.LastIndexOf('.', StringComparison.Ordinal);
-        var namespaceName = separator < 0 ? string.Empty : fullTypeName[..separator];
-        var typeName = separator < 0 ? fullTypeName : fullTypeName[(separator + 1)..];
-        foreach (var candidateHandle in metadataReader.TypeDefinitions)
-        {
-            var candidate = metadataReader.GetTypeDefinition(candidateHandle);
-            var candidateNamespace = candidate.Namespace.IsNil ? string.Empty : metadataReader.GetString(candidate.Namespace);
-            if (string.Equals(candidateNamespace, namespaceName, StringComparison.Ordinal) &&
-                string.Equals(RemoveGenericArity(metadataReader.GetString(candidate.Name)), typeName, StringComparison.Ordinal))
-            {
-                typeDefinitionHandle = candidateHandle;
-                return true;
-            }
-        }
-
-        typeDefinitionHandle = default;
-        return false;
+        return GetTypeDefinitionIndex(metadataReader).ByDisplayName.TryGetValue(fullTypeName, out typeDefinitionHandle);
     }
 
     private static bool TryReadObsoleteAttributeArguments(byte[] value, out string message, out bool? isError)
@@ -2860,6 +2858,10 @@ internal static class PublicApiModelReader
     }
 
     private static string EscapeIdentifier(string identifier) => CSharpIdentifierHelper.EscapeIdentifier(identifier);
+
+    private sealed record TypeDefinitionIndex(
+        Dictionary<string, TypeDefinitionHandle> ByMetadataName,
+        Dictionary<string, TypeDefinitionHandle> ByDisplayName);
 
     private sealed record EnumMetadata(
         bool IsFlags,


### PR DESCRIPTION
Three metadata lookups walked the full `TypeDefinitions` table on every call.

## The defect

- `EnumerateNestedTypes` scanned every type definition in the assembly to find one type's nested types, comparing `GetDeclaringType()` against the parent. It is called recursively for every visible type, so the cost was O(n²) in type count.
- `TryResolveTypeDefinitionHandle` scanned the whole table for a type by name. It is reached from `IsEnumType` for **every attribute argument**, so an assembly with many attributes paid for it repeatedly.
- `TryGetTypeDefinition` did the same scan when resolving a base type for a constructor initializer.

## The change

- `EnumerateNestedTypes` now uses `TypeDefinition.GetNestedTypes()`, which reads the `NestedClass` table directly. The visibility and `<`-name filters are unchanged, and the caller already sorts by name, so the result is identical.
- The two by-name lookups share one index built once per `MetadataReader`, held in a `ConditionalWeakTable` alongside the existing `UpdatedMemorySafetyRulesCache`. Two dictionaries are needed because the callers key differently: one on the raw metadata name (``List`1``) and one on the display name (`List`). `TryAdd` keeps the first definition, matching what the linear scans returned.

No behaviour change — this is a pure lookup-strategy swap.

## Measurements

Generating for `System.Private.CoreLib.dll` (17 MB, ~4600 type definitions, 36 676 lines of output), Release build, five runs each:

| | runs (ms) | median |
|---|---|---|
| before | 2011, 2358, 2589, 2095, 2238 | 2238 |
| after | 1652, 1618, 1637, 1765, 1683 | 1652 |

About 26% faster, with non-overlapping ranges. A first single-run comparison showed no difference at all — that was build and JIT noise, which is why the table above uses five runs.

## Verification

- Output for `System.Private.CoreLib.dll` is **byte-identical** before and after (`diff -q`), which is the real correctness check for this change.
- Full suite: 99/99 passing.
- No `ref/` baseline changes, as expected for identical output.
- `dotnet run ./eng/update-all.cs` produced no changes.

Found during a review of the PublicApiGenerator projects.
