### PR TITLE
Resolve npm from PATH and run it where the lock file lives

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NpmPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NpmPackageUpdater.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -56,27 +57,39 @@ internal sealed class NpmPackageUpdater : PackageUpdater
 
     public override async Task UpdateLockFileAsync(FullPath rootDirectory, IEnumerable<Dependency> updatedDependencies, CancellationToken cancellationToken)
     {
-        var files = updatedDependencies
-            .Where(dep => dep.Type is DependencyType.Npm && dep.VersionLocation is not null)
-            .Select(dep => FullPath.FromPath(dep.VersionLocation!.FilePath))
-            .Distinct()
-            .ToArray();
-
-        foreach (var file in files)
+        var lockFiles = new HashSet<FullPath>();
+        foreach (var dependency in updatedDependencies)
         {
-            var lockFile = TryFindLockFile(file.Parent, "package-lock.json");
+            if (dependency.Type is not DependencyType.Npm || dependency.VersionLocation is null)
+                continue;
+
+            var lockFile = TryFindLockFile(FullPath.FromPath(dependency.VersionLocation.FilePath).Parent, "package-lock.json");
             if (!lockFile.IsEmpty)
             {
-                var result = await ProcessWrapper.Create(OperatingSystem.IsWindows() ? @"C:\Program Files\nodejs\npm.cmd" : "npm")
-                    .WithWorkingDirectory(file.Parent)
-                    .WithArguments("install", "--no-audit", "--force")
+                lockFiles.Add(lockFile);
+            }
+        }
+
+        foreach (var lockFile in lockFiles)
+        {
+            try
+            {
+                // npm has to run where the lock file lives. In an npm-workspaces repository the lock file
+                // sits at the root, and running in a sub-package would create a second one there.
+                var result = await ProcessWrapper.Create(OperatingSystem.IsWindows() ? "npm.cmd" : "npm")
+                    .WithWorkingDirectory(lockFile.Parent)
+                    .WithArguments("install", "--no-audit")
                     .WithValidation(ProcessValidationMode.None)
                     .ExecuteBufferedAsync(cancellationToken);
 
                 if (!result.ExitCode.IsSuccess)
                 {
-                    Console.WriteLine($"Unable to update lock file '{lockFile}':\n{result.Output}");
+                    Console.Error.WriteLine($"Unable to update lock file '{lockFile}':\n{result.Output}");
                 }
+            }
+            catch (Win32Exception ex)
+            {
+                Console.Error.WriteLine($"Unable to run npm to update lock file '{lockFile}': {ex.Message}");
             }
         }
     }


### PR DESCRIPTION
Three problems in `NpmPackageUpdater.UpdateLockFileAsync`, all on the `--update-lock-files` path.

**1. Hardcoded Windows path.** The executable was `C:\Program Files\nodejs\npm.cmd`. Installations via nvm-windows, Chocolatey, Scoop, winget or a per-user MSI are not there, and `Process.Start` then throws `Win32Exception` — which `ProcessValidationMode.None` does **not** suppress, since that only relaxes exit-code validation. The exception escaped the command and took the whole run with it.

**2. Wrong working directory.** `TryFindLockFile` walks *up* from `package.json` to find `package-lock.json`, but `npm install` ran in the `package.json` directory. In an npm-workspaces repository the lock file lives at the root, so npm ran in a sub-package and could create a second lock file there instead of updating the real one.

**3. `--force`.** It tells npm to ignore peer-dependency conflicts, which can produce a lock file that `npm ci` later refuses.

## What changed

- Resolve `npm` (`npm.cmd` on Windows) from `PATH`, and catch `Win32Exception` so "npm is not installed" is a one-line message rather than a crash.
- Run once per distinct lock file, in that lock file's own directory. Previously it ran once per updated `package.json`, which also meant repeated installs for several packages sharing one lock file.
- Drop `--force`; `--no-audit` is kept.
- Diagnostics go to stderr rather than stdout, so `list --format json` piping stays clean.

## Verification

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 49 passed, 0 failed (unchanged).
- `dotnet run ./eng/update-all.cs` — no generated-file changes.

No new test: covering this needs a real `npm` on the test machine and a writable workspace fixture, which the suite does not currently set up. The Windows path bug in particular cannot be reproduced on the CI matrix without one. Worth adding if you want an npm-tagged integration test; I did not want to introduce that dependency inside this fix.
