### PR TITLE
Remove the duplicated runtime parse helpers

### DIFF
--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/AppleContainerRuntime.cs
@@ -70,7 +70,10 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
 
             case ArchiveImage archive:
                 var loadResult = await Cli.RunBufferedAsync(["image", "load", "-i", archive.ArchivePath], cancellationToken).ConfigureAwait(false);
-                return ParseLoadedImage(loadResult.StandardOutput);
+                // Apple's load output is not documented, so an unrecognised shape falls back to the raw output
+                // rather than failing outright.
+                return ContainerImageOutputParser.TryParseLoadedImage(loadResult.StandardOutput)
+                    ?? loadResult.StandardOutput.Trim();
 
             case ExistingImage existing:
                 return existing.ImageId;
@@ -342,24 +345,5 @@ internal sealed class AppleContainerRuntime : ExecutableContainerRuntime
             builder.Append(char.IsAsciiLetterOrDigit(ch) || ch is '_' or '.' or '-' ? ch : '-');
 
         return builder.ToString();
-    }
-
-    private static string ParseLoadedImage(string output)
-    {
-        const string Marker = "Loaded image";
-        foreach (var line in output.Split('\n'))
-        {
-            var trimmed = line.Trim();
-            var markerIndex = trimmed.IndexOf(Marker, StringComparison.OrdinalIgnoreCase);
-            if (markerIndex < 0)
-                continue;
-
-            var rest = trimmed[(markerIndex + Marker.Length)..];
-            var colonIndex = rest.IndexOf(':', StringComparison.Ordinal);
-            if (colonIndex >= 0)
-                return rest[(colonIndex + 1)..].Trim();
-        }
-
-        return output.Trim();
     }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerInfoParser.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerInfoParser.cs
@@ -72,6 +72,7 @@ internal static class DockerContainerInfoParser
         if (!DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var result))
             return null;
 
+        // Runtimes report the zero date for events that never happened (for example FinishedAt on a running container).
         return result.UtcDateTime.Year <= 1 ? null : result;
     }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/DockerContainerRuntime.cs
@@ -55,7 +55,8 @@ internal sealed class DockerContainerRuntime : ExecutableContainerRuntime
 
             case ArchiveImage archive:
                 var loadResult = await Cli.RunBufferedAsync(["load", "-i", archive.ArchivePath], cancellationToken).ConfigureAwait(false);
-                return ParseLoadedImage(loadResult.StandardOutput);
+                return ContainerImageOutputParser.TryParseLoadedImage(loadResult.StandardOutput)
+                    ?? throw new InvalidOperationException("Unable to determine the image reference from the load output: " + loadResult.StandardOutput);
 
             case ExistingImage existing:
                 return existing.ImageId;
@@ -218,26 +219,6 @@ internal sealed class DockerContainerRuntime : ExecutableContainerRuntime
         }
 
         await base.CopyFromContainerAsync(id, source, destination, cancellationToken).ConfigureAwait(false);
-    }
-
-    private static string ParseLoadedImage(string output)
-    {
-        // Output looks like: "Loaded image: repo:tag" or "Loaded image ID: sha256:...".
-        const string Marker = "Loaded image";
-        foreach (var line in output.Split('\n'))
-        {
-            var trimmed = line.Trim();
-            var markerIndex = trimmed.IndexOf(Marker, StringComparison.OrdinalIgnoreCase);
-            if (markerIndex < 0)
-                continue;
-
-            var rest = trimmed[(markerIndex + Marker.Length)..];
-            var colonIndex = rest.IndexOf(':', StringComparison.Ordinal);
-            if (colonIndex >= 0)
-                return rest[(colonIndex + 1)..].Trim();
-        }
-
-        throw new InvalidOperationException("Unable to determine the image reference from the load output: " + output);
     }
 
     private static bool IsContainerId(string value)

--- a/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ExecutableContainerRuntime.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/ContainerRuntimes/ExecutableContainerRuntime.cs
@@ -388,16 +388,4 @@ internal abstract class ExecutableContainerRuntime : ContainerRuntime
     {
         return value.Replace("'", "''", StringComparison.Ordinal);
     }
-
-    protected static DateTimeOffset? ParseDate(string? value)
-    {
-        if (string.IsNullOrEmpty(value))
-            return null;
-
-        if (!DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var result))
-            return null;
-
-        // Runtimes report the zero date for events that never happened (for example FinishedAt on a running container).
-        return result.UtcDateTime.Year <= 1 ? null : result;
-    }
 }

--- a/src/Meziantou.Framework.TemporaryContainers/Internals/ContainerImageOutputParser.cs
+++ b/src/Meziantou.Framework.TemporaryContainers/Internals/ContainerImageOutputParser.cs
@@ -1,0 +1,25 @@
+namespace Meziantou.Framework.TemporaryContainers.Internals;
+
+internal static class ContainerImageOutputParser
+{
+    private const string LoadedImageMarker = "Loaded image";
+
+    /// <summary>Reads the image reference out of the output of an image load, which looks like <c>Loaded image: repo:tag</c> or <c>Loaded image ID: sha256:...</c>. Returns <see langword="null"/> when the output has no such line; callers decide whether that is an error.</summary>
+    public static string? TryParseLoadedImage(string output)
+    {
+        foreach (var line in output.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            var markerIndex = trimmed.IndexOf(LoadedImageMarker, StringComparison.OrdinalIgnoreCase);
+            if (markerIndex < 0)
+                continue;
+
+            var rest = trimmed[(markerIndex + LoadedImageMarker.Length)..];
+            var colonIndex = rest.IndexOf(':', StringComparison.Ordinal);
+            if (colonIndex >= 0)
+                return rest[(colonIndex + 1)..].Trim();
+        }
+
+        return null;
+    }
+}

--- a/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRuntimeAdapterTests.cs
+++ b/tests/Meziantou.Framework.TemporaryContainers.Tests/DockerRuntimeAdapterTests.cs
@@ -212,6 +212,24 @@ public sealed class DockerRuntimeAdapterTests
         Assert.Equal(unchecked((int)3221225786u), container.ExitCode);
     }
 
+    [Theory]
+    [InlineData("Loaded image: repo/app:1.2", "repo/app:1.2")]
+    [InlineData("Loaded image ID: sha256:abc123", "sha256:abc123")]
+    [InlineData("some noise\nLoaded image: repo/app:latest\nmore noise", "repo/app:latest")]
+    [InlineData("  Loaded image: repo/app:latest  ", "repo/app:latest")]
+    public void TryParseLoadedImage_ReadsTheImageReference(string output, string expected)
+    {
+        Assert.Equal(expected, ContainerImageOutputParser.TryParseLoadedImage(output));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("something went wrong")]
+    public void TryParseLoadedImage_ReturnsNullWithoutAMarker(string output)
+    {
+        Assert.Null(ContainerImageOutputParser.TryParseLoadedImage(output));
+    }
+
     /// <summary>Writes a CLI that exits with <paramref name="exitCode"/> whatever it is asked to do, so the outcome of the probe can be forced.</summary>
     private static string CreateStubCli(int exitCode)
     {


### PR DESCRIPTION
Two helpers existed twice in `ContainerRuntimes/`.

**`ParseDate`** — `ExecutableContainerRuntime.ParseDate` and `DockerContainerInfoParser.ParseDate` were character-identical, and the one on `ExecutableContainerRuntime` had **no callers at all** (`grep` finds only its own declaration). Deleted. Its comment explaining the zero-date case was the better of the two, so it moves onto the copy that is actually used:

```csharp
// Runtimes report the zero date for events that never happened (for example FinishedAt on a running container).
return result.UtcDateTime.Year <= 1 ? null : result;
```

**`ParseLoadedImage`** — `DockerContainerRuntime` and `AppleContainerRuntime` had identical bodies except for the last line: Docker throws when no `Loaded image` line is found, Apple returns the raw output. The scanning logic now lives once, in `ContainerImageOutputParser.TryParseLoadedImage`, which returns `null` for an unrecognized shape and lets each call site decide:

```csharp
// Docker
return ContainerImageOutputParser.TryParseLoadedImage(loadResult.StandardOutput)
    ?? throw new InvalidOperationException("Unable to determine the image reference from the load output: " + loadResult.StandardOutput);

// Apple
return ContainerImageOutputParser.TryParseLoadedImage(loadResult.StandardOutput)
    ?? loadResult.StandardOutput.Trim();
```

Behavior is unchanged on both paths — the difference is now visible at the call sites instead of buried at the bottom of two near-identical methods.

**A question for you, deliberately not answered here:** I could not find a reason for the divergence, and it means a garbled `image load` output silently becomes an image reference on Apple's runtime and a clear error on Docker's. Apple's load output isn't documented, so I left the lenient fallback alone and commented it rather than changing behavior in a refactor. If the leniency isn't deliberate, unifying on the throwing path is now a one-line change.

No public API change (`ParseDate` was `protected` on an `internal` class), so `ref/` is unchanged.

## Verification

Added six cases for `TryParseLoadedImage` to `DockerRuntimeAdapterTests`, covering both documented output shapes (`Loaded image: repo:tag`, `Loaded image ID: sha256:…`), surrounding noise, leading/trailing whitespace, and the two no-marker cases that now return `null`.

35/35 green locally across `DockerRuntimeAdapterTests`, `AppleContainerRuntimeAdapterTests` and `DockerContainerTests` — the last of which exercises the real archive-load path.
