### PR TITLE
Remove the unused npm repository converter that could loop forever

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NpmPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NpmPackageUpdater.cs
@@ -1,6 +1,5 @@
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using Meziantou.Framework;
 
@@ -9,13 +8,7 @@ namespace Meziantou.Framework.DependencyScanning.Tool;
 internal sealed class NpmPackageUpdater : PackageUpdater
 {
     private static readonly HttpClient HttpClient = new();
-    private static readonly JsonSerializerOptions DefaultJsonOptions = new()
-    {
-        Converters =
-        {
-            new NpmPackageRepositoryJsonConverter(),
-        },
-    };
+
     public override VersioningStrategy VersioningStrategy { get; set; } = NpmVersioningStrategy.Instance;
 
     protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.Npm;
@@ -41,7 +34,7 @@ internal sealed class NpmPackageUpdater : PackageUpdater
             yield break;
 
         packageResponse.EnsureSuccessStatusCode();
-        var package = await packageResponse.Content.ReadFromJsonAsync<NpmPackage>(options: DefaultJsonOptions, cancellationToken).ConfigureAwait(false);
+        var package = await packageResponse.Content.ReadFromJsonAsync<NpmPackage>(cancellationToken).ConfigureAwait(false);
         if (package is null)
             yield break;
 
@@ -115,9 +108,6 @@ internal sealed class NpmPackageUpdater : PackageUpdater
         [JsonPropertyName("homepage")]
         public string? Homepage { get; set; }
 
-        [JsonPropertyName("repository")]
-        public NpmPackageRepository[]? Repository { get; set; }
-
         [JsonPropertyName("versions")]
         public IReadOnlyDictionary<string, NpmPackageVersion> Versions { get; set; } = null!;
 
@@ -144,78 +134,9 @@ internal sealed class NpmPackageUpdater : PackageUpdater
         [JsonPropertyName("description")]
         public string? Description { get; set; }
 
-        [JsonPropertyName("repository")]
-        public NpmPackageRepository[]? Repository { get; set; }
-
         public override string ToString()
         {
             return Id;
-        }
-    }
-
-    private sealed class NpmPackageRepository
-    {
-        [JsonPropertyName("type")]
-        public string Type { get; set; } = null!;
-
-        [JsonPropertyName("url")]
-        public string Url { get; set; } = null!;
-    }
-
-    private sealed class NpmPackageRepositoryJsonConverter : JsonConverter<NpmPackageRepository[]>
-    {
-        public override bool HandleNull => false;
-
-        public override NpmPackageRepository[]? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            if (reader.TokenType is JsonTokenType.StartArray)
-            {
-                reader.Read();
-                var result = new List<NpmPackageRepository>();
-                while (reader.TokenType is not JsonTokenType.EndArray)
-                {
-                    var item = ReadSingleItem(ref reader);
-                    if (item is not null)
-                    {
-                        result.Add(item);
-                    }
-
-                    if (reader.TokenType is JsonTokenType.EndObject)
-                    {
-                        reader.Read();
-                    }
-                }
-
-                return [.. result];
-            }
-
-            var value = ReadSingleItem(ref reader);
-            if (value is not null)
-                return [value];
-
-            throw new NotSupportedException($"Token {reader.TokenType} is not supported");
-        }
-
-        private static NpmPackageRepository? ReadSingleItem(ref Utf8JsonReader reader)
-        {
-            // Repository can be a string or an object
-            if (reader.TokenType is JsonTokenType.StartObject)
-            {
-                return JsonSerializer.Deserialize<NpmPackageRepository>(ref reader);
-            }
-
-            if (reader.TokenType is JsonTokenType.String)
-            {
-                var str = reader.GetString();
-                return new NpmPackageRepository { Url = str! };
-            }
-
-            throw new NotSupportedException($"Token {reader.TokenType} is not supported");
-        }
-
-        public override void Write(Utf8JsonWriter writer, NpmPackageRepository[]? value, JsonSerializerOptions options)
-        {
-            throw new NotSupportedException();
         }
     }
 }


### PR DESCRIPTION
`NpmPackageRepositoryJsonConverter` hangs forever on a packument whose `repository` is an array of strings.

In the array branch, `ReadSingleItem` advances the reader for a `StartObject` element (`JsonSerializer.Deserialize` leaves it on `EndObject`, which the following `if` consumes) but **not** for a `String` element. The loop condition then re-tests the same `String` token forever.

Reproduced by running the converter's own code against sample documents, with a loop guard added:

| `repository` value | result |
|---|---|
| `{"type":"git","url":"…"}` | ok |
| `"https://…"` | ok |
| `[{"type":"git","url":"…"}]` | ok |
| `["https://…"]` | **infinite loop** — guard tripped at 1000 iterations |
| `[null]` | `NotSupportedException`, aborting the run |

An infinite loop in a CLI is a hung CI job burning a runner until timeout, with no output.

I could **not** reproduce it against registry.npmjs.org — a sample of thirteen old packages all carry object- or string-form `repository`. So this is latent rather than known-live. It stays reachable from any registry serving un-normalized metadata, which the tool explicitly supports through `.npmrc` (Verdaccio, Artifactory pass-through).

## What changed

Deleted it. `NpmPackage.Repository`, `NpmPackageVersion.Repository`, the `NpmPackageRepository` type and its converter are never read — only `Versions` and `Time` are used — so the converter existed solely to parse a field nothing consumes. Removing it takes out ~65 lines along with the hang and the `NotSupportedException`, and `repository` is now simply ignored as an unknown property. `DefaultJsonOptions` went with it, since the converter was its only entry.

Noted while in here but **not** changed, to keep this a pure deletion: `NpmPackage.Versions` is declared `null!`, so a registry response without a `versions` object would `NullReferenceException` in the `foreach` below it.

## Verification

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 49 passed, 0 failed (unchanged).
- `dotnet run ./eng/update-all.cs` — no generated-file changes.

No new test: the deleted code was unreachable from any public entry point, and the remaining parsing needs an injectable `HttpMessageHandler` to exercise offline. The existing npm end-to-end tests still pass, which is what confirms nothing depended on the removed field.
