### PR TITLE
Document the actual file name generated by the SingleFile layout

### DIFF
--- a/src/Meziantou.Framework.PublicApiGenerator.Tool/readme.md
+++ b/src/Meziantou.Framework.PublicApiGenerator.Tool/readme.md
@@ -32,7 +32,7 @@ When using multiple `--input` values, you can use `tfm=path` to set the target f
 
 `--output` is the output directory option.
 
-When using `--file-layout SingleFile`, you can use `--output-file` to set an explicit file path instead of generating `PublicApi.g.cs` in the output directory.
+When using `--file-layout SingleFile`, you can use `--output-file` to set an explicit file path instead of generating `<AssemblyName>.cs` in the output directory.
 
 ```bash
 Meziantou.Framework.PublicApiGenerator.Tool \


### PR DESCRIPTION
The CLI readme names the wrong default file for the `SingleFile` layout.

## The defect

`src/Meziantou.Framework.PublicApiGenerator.Tool/readme.md:35` said `--output-file` sets a path "instead of generating `PublicApi.g.cs` in the output directory". `PublicApiEmitter.BuildSingleFileName` returns `<AssemblyName>.cs`; `PublicApi.g.cs` is only used in the fallback case where the assembly name sanitizes to an empty string.

Checked against the built tool — generating for `Sample.dll` with `--output` and `--file-layout SingleFile` writes `Sample.cs`, not `PublicApi.g.cs`.

Someone following the readme adds the wrong path to `.gitignore` or to their diff check.

## The change

Documentation only — one line, now naming `<AssemblyName>.cs`.

The file name itself is left alone. It is also inconsistent with every other layout, which uses the `.g.cs` suffix, but changing it would move every consumer's generated file and belongs with a major version rather than a docs fix.

`dotnet run ./eng/update-all.cs` produced no changes: the edit is outside the generated `<!-- help -->` block.

Found during a review of the PublicApiGenerator projects.
