### PR TITLE
Enumerate lock files tolerantly and restore every project type

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NuGetPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NuGetPackageUpdater.cs
@@ -52,20 +52,30 @@ internal sealed class NuGetPackageUpdater : PackageUpdater
         if (!updatedDependencies.Any(dep => dep.Type is DependencyType.NuGet))
             return;
 
-        var lockFiles = Directory.GetFiles(rootDirectory, "packages.lock.json", SearchOption.AllDirectories).Select(FullPath.FromPath);
-        foreach (var lockFile in lockFiles)
+        // Enumerated lazily and tolerantly: Directory.GetFiles materializes the whole tree eagerly and throws
+        // on the first directory it cannot read, which aborted the restore pass over a single bad permission.
+        var enumerationOptions = new EnumerationOptions
         {
-            var csprojs = Directory.GetFiles(lockFile.Parent, "*.csproj", SearchOption.TopDirectoryOnly);
-            foreach (var csproj in csprojs)
+            RecurseSubdirectories = true,
+            IgnoreInaccessible = true,
+            AttributesToSkip = FileAttributes.None,
+        };
+
+        foreach (var lockFilePath in Directory.EnumerateFiles(rootDirectory, "packages.lock.json", enumerationOptions))
+        {
+            var lockFile = FullPath.FromPath(lockFilePath);
+
+            // '*.*proj' rather than '*.csproj': F#, VB and the other MSBuild project types use lock files too.
+            foreach (var project in Directory.EnumerateFiles(lockFile.Parent, "*.*proj", SearchOption.TopDirectoryOnly))
             {
                 var result = await ProcessWrapper.Create("dotnet")
-                    .WithArguments("restore", csproj, "--no-cache")
+                    .WithArguments("restore", project, "--no-cache")
                     .WithValidation(ProcessValidationMode.None)
                     .ExecuteBufferedAsync(cancellationToken);
 
                 if (!result.ExitCode.IsSuccess)
                 {
-                    Console.WriteLine($"Unable to update lock file '{lockFile}':\n{result.Output}");
+                    Console.Error.WriteLine($"Unable to update lock file '{lockFile}':\n{result.Output}");
                 }
             }
         }


### PR DESCRIPTION
`NuGetPackageUpdater.UpdateLockFileAsync` discovered lock files with

```csharp
Directory.GetFiles(rootDirectory, "packages.lock.json", SearchOption.AllDirectories)
```

which has three problems:

- **`GetFiles` materializes eagerly and throws.** There is no `IgnoreInaccessible`, so one directory the process cannot read raises `UnauthorizedAccessException` and the whole restore pass is lost — after the version rewrites have already been written to disk.
- **`*.csproj` only.** F#, VB and the other MSBuild project types use `packages.lock.json` too; their lock files were found and then never restored.
- Diagnostics went to stdout, which pollutes `list --format json` piping.

## What changed

- `Directory.EnumerateFiles` with `EnumerationOptions { RecurseSubdirectories = true, IgnoreInaccessible = true }` — lazy, and an unreadable directory is skipped instead of aborting. `AttributesToSkip = FileAttributes.None` preserves the previous behaviour of not skipping hidden entries (the default would skip them, and on Unix .NET treats every dot-directory as hidden).
- `*.*proj` instead of `*.csproj`.
- Failures go to stderr.

Deliberately **not** changed: the pass still restores every project sitting next to a lock file rather than only the ones whose dependencies moved. Under Central Package Management the updated version lives in `Directory.Packages.props`, potentially far from the projects that consume it, so narrowing this by updated-dependency path would silently skip projects that genuinely need a restore. The redundancy is the safe side of that trade.

## Verification

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 49 passed, 0 failed (unchanged).
- `dotnet run ./eng/update-all.cs` — no generated-file changes.

No new test: exercising this needs a lock-file fixture plus a real `dotnet restore` (and, for the permission path, a directory the test process cannot read), neither of which the suite sets up today.
