### PR TITLE
Make the strict semantic versioning strategy reject a v prefix

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Versioning/SemanticVersioningStrategy.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Versioning/SemanticVersioningStrategy.cs
@@ -56,15 +56,13 @@ internal sealed class SemanticVersioningStrategy : VersioningStrategy
 
     private bool TryParseVersion(string? value, out SemanticVersion? version)
     {
-        value = Normalize(value);
+        version = null;
+
+        // SemanticVersion.TryParse skips a leading 'v' on its own, so stripping it here made no difference
+        // and 'Strict' silently accepted 'v1.0.0'. Rejecting it is what makes the two strategies differ.
+        if (!_allowVPrefix && value is ['v' or 'V', ..])
+            return false;
+
         return SemanticVersion.TryParse(value, out version);
-    }
-
-    private string? Normalize(string? value)
-    {
-        if (_allowVPrefix && value is ['v' or 'V', .. var version])
-            return version;
-
-        return value;
     }
 }

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
@@ -556,11 +556,24 @@ public sealed class FunctionalTests
 
     [Theory]
     [InlineData("v1.0.0", true)]
+    [InlineData("V1.0.0", true)]
     [InlineData("1.0.0", true)]
     [InlineData("latest", false)]
     public void SemanticVersioningStrategy_PrefixAllowed_IsSupportedVersion(string version, bool expectedResult)
     {
         var strategy = SemanticVersioningStrategy.PrefixAllowed;
+
+        Assert.Equal(expectedResult, strategy.IsSupportedVersion(version));
+    }
+
+    [Theory]
+    [InlineData("1.0.0", true)]
+    [InlineData("v1.0.0", false)]
+    [InlineData("V1.0.0", false)]
+    [InlineData("latest", false)]
+    public void SemanticVersioningStrategy_Strict_IsSupportedVersion(string version, bool expectedResult)
+    {
+        var strategy = SemanticVersioningStrategy.Strict;
 
         Assert.Equal(expectedResult, strategy.IsSupportedVersion(version));
     }


### PR DESCRIPTION
`SemanticVersioningStrategy.Strict` and `.PrefixAllowed` were behaviourally identical.

`Normalize` stripped a leading `v` only when `_allowVPrefix` was set — but `SemanticVersion.TryParse` already skips a leading `v`/`V` itself:

```csharp
var index = versionString[0] is 'v' or 'V' ? 1 : 0;
```

So `Strict.IsSupportedVersion("v1.0.0")` returned `true`, the flag changed nothing, and `PrefixAllowed` had no production caller. The one existing test (`SemanticVersioningStrategy_PrefixAllowed_IsSupportedVersion`) passed for both singletons, so nothing pinned the distinction.

A reader picking `Strict` reasonably expects `v`-prefixed input to be rejected. Small today; a trap as soon as someone relies on it.

## What changed

`TryParseVersion` rejects a leading `v`/`V` up front when the strategy is strict, instead of relying on a normalization step that `SemanticVersion.TryParse` renders moot.

No behaviour change for the only caller: `DotNetSdkUpdater` uses `Strict`, and `global.json` SDK versions are never `v`-prefixed.

## Verification

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 54 passed, 0 failed (was 49).
- `dotnet run ./eng/update-all.cs` — no generated-file changes.

New `SemanticVersioningStrategy_Strict_IsSupportedVersion` pins the rejection (it fails on the current code), and the `PrefixAllowed` theory gains an uppercase `V` case so the two are now covered as genuinely different.
