### PR TITLE
List only the selected dependency types when updating

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
@@ -171,8 +171,8 @@ internal static class Program
 
         WriteSearchScope(output, globs);
         var dependencies = await ScanDependenciesAsync(rootPath, globs, cancellationToken).ConfigureAwait(false);
-        WriteDependenciesAsText(output, dependencies);
         var filteredDependencies = FilterDependencies(dependencies, dependencyTypeSet);
+        WriteDependenciesAsText(output, filteredDependencies);
 
         var updaters = CreatePackageUpdaters(minimumAge);
 

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
@@ -104,6 +104,31 @@ public sealed class FunctionalTests
     }
 
     [Fact]
+    public async Task UpdateListsOnlyTheSelectedDependencyTypes()
+    {
+        await using var tempDir = TemporaryDirectory.Create();
+
+        await File.WriteAllTextAsync(tempDir.CreateEmptyFile("Dockerfile"), """
+            FROM nginx:1.27.1
+            """, XunitCancellationToken);
+        await File.WriteAllTextAsync(tempDir.CreateEmptyFile("package.json"), """
+            {
+            "dependencies": {
+                "npm": "8.0.0"
+              }
+            }
+            """, XunitCancellationToken);
+
+        var console = new ConsoleHelper(_testOutputHelper);
+        var result = await Program.MainImpl(["update", "--directory", tempDir.FullPath, "--dependency-type", "Npm"], console.ConfigureConsole);
+        Assert.Equal(0, result);
+
+        // The listing must match what is about to be updated, not everything that was scanned
+        Assert.Contains("1 dependencies found", console.Output);
+        Assert.DoesNotContain("DockerImage", console.Output);
+    }
+
+    [Fact]
     public async Task FilterDependencyType_DockerImage()
     {
         await using var tempDir = TemporaryDirectory.Create();


### PR DESCRIPTION
`update` printed the dependency list **before** applying `--dependency-type`, so `update --dependency-type Npm` listed every dependency in the repository and then updated only the npm ones. `list` prints the filtered set, so the two commands disagreed about what "N dependencies found" means.

Visible in a run over a directory holding one Dockerfile and one `package.json`:

```
$ tool update --directory . --dependency-type DockerImage
4 dependencies found
- DockerImage:mcr.microsoft.com/dotnet/aspnet@9.0:...
- DockerImage:nginx@1.27:...
- DockerImage:nginx@1.27.1:...
- node@20-alpine:...
```

...with the npm entries listed on other runs even though they were never candidates.

## What changed

`WriteDependenciesAsText` now runs after `FilterDependencies`, matching `ListAsync`. One line moved.

## Verification

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 50 passed, 0 failed (was 49).
- `dotnet run ./eng/update-all.cs` — no generated-file changes.

New test `UpdateListsOnlyTheSelectedDependencyTypes` scans a Dockerfile and a `package.json`, runs `update --dependency-type Npm`, and asserts the listing reports one dependency and never mentions `DockerImage`.
