### PR TITLE
Apply the minimum age filter to list --upgradable

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
@@ -46,7 +46,7 @@ internal static class Program
         var filesOption = CreateFilesOption();
         var dependencyTypesOption = CreateDependencyTypesOption();
         var updateLockFilesOption = new Option<bool>("--update-lock-files") { Description = "Update lock files when dependencies are updated" };
-        var minimumAgeOption = new Option<int>("--minimum-age") { Description = "Minimum age in days for package versions to consider for update (default: 7). Use 0 or negative to disable filtering. Not applied to Docker images as registries don't expose publication dates.", DefaultValueFactory = _ => 7 };
+        var minimumAgeOption = CreateMinimumAgeOption();
 
         var updateCommand = new Command("update")
         {
@@ -80,6 +80,7 @@ internal static class Program
         var filesOption = CreateFilesOption();
         var dependencyTypesOption = CreateDependencyTypesOption();
         var upgradableOption = new Option<bool>("--upgradable") { Description = "Only list dependencies that can be upgraded" };
+        var minimumAgeOption = CreateMinimumAgeOption();
         var formatOption = new Option<OutputFormat>("--format")
         {
             Description = $"Output format. Available values: {nameof(OutputFormat.Text)}, {nameof(OutputFormat.Json)}",
@@ -93,6 +94,7 @@ internal static class Program
         listCommand.Options.Add(filesOption);
         listCommand.Options.Add(dependencyTypesOption);
         listCommand.Options.Add(upgradableOption);
+        listCommand.Options.Add(minimumAgeOption);
         listCommand.Options.Add(formatOption);
 
         listCommand.SetAction((parseResult, cancellationToken) =>
@@ -102,6 +104,7 @@ internal static class Program
                 parseResult.GetValue(filesOption),
                 parseResult.GetValue(dependencyTypesOption),
                 parseResult.GetValue(upgradableOption),
+                parseResult.GetValue(minimumAgeOption),
                 parseResult.GetValue(formatOption),
                 parseResult.InvocationConfiguration.Output,
                 parseResult.InvocationConfiguration.Error,
@@ -110,6 +113,12 @@ internal static class Program
 
         rootCommand.Subcommands.Add(listCommand);
     }
+
+    private static Option<int> CreateMinimumAgeOption() => new("--minimum-age")
+    {
+        Description = "Minimum age in days for package versions to consider for update (default: 7). Use 0 or negative to disable filtering. Not applied to Docker images as registries don't expose publication dates.",
+        DefaultValueFactory = _ => 7,
+    };
 
     private static Option<string?> CreateRootDirectoryOption() => new("--directory") { Description = "Root directory" };
 
@@ -203,7 +212,7 @@ internal static class Program
         return 0;
     }
 
-    private static async Task<int> ListAsync(string? rootDirectory, string[]? filePatterns, DependencyType[]? dependencyTypes, bool upgradable, OutputFormat format, TextWriter output, TextWriter error, CancellationToken cancellationToken)
+    private static async Task<int> ListAsync(string? rootDirectory, string[]? filePatterns, DependencyType[]? dependencyTypes, bool upgradable, int minimumAge, OutputFormat format, TextWriter output, TextWriter error, CancellationToken cancellationToken)
     {
         var globs = CreateGlobs(filePatterns, error);
         if (globs is null)
@@ -217,7 +226,7 @@ internal static class Program
         var filteredDependencies = FilterDependencies(dependencies, dependencyTypeSet);
         if (upgradable)
         {
-            filteredDependencies = await FilterUpgradableDependenciesAsync(filteredDependencies, cancellationToken).ConfigureAwait(false);
+            filteredDependencies = await FilterUpgradableDependenciesAsync(filteredDependencies, minimumAge, cancellationToken).ConfigureAwait(false);
         }
 
         if (format is OutputFormat.Json)
@@ -245,9 +254,10 @@ internal static class Program
         ];
     }
 
-    private static async Task<Dependency[]> FilterUpgradableDependenciesAsync(Dependency[] dependencies, CancellationToken cancellationToken)
+    private static async Task<Dependency[]> FilterUpgradableDependenciesAsync(Dependency[] dependencies, int minimumAge, CancellationToken cancellationToken)
     {
-        var updaters = CreatePackageUpdaters();
+        // Must match what 'update' would do, otherwise a version too recent to be applied is still listed
+        var updaters = CreatePackageUpdaters(minimumAge);
         var upgradableDependencies = new ConcurrentBag<Dependency>();
         await Parallel.ForEachAsync(
             dependencies.Where(static dependency => dependency.VersionLocation?.IsUpdatable is true),

--- a/src/Meziantou.Framework.DependencyScanning.Tool/readme.md
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/readme.md
@@ -55,6 +55,7 @@ Options:
   --files <files>                      Glob patterns to find files to scan
   --dependency-type <dependency-type>  Dependency types to include. Available values: Unknown, NuGet, Npm, PyPi, DockerImage, GitReference, DotNetSdk, DotNetTargetFramework, GitHubActions, AzureDevOpsVMPool, AzureDevOpsTask, AzureDevOpsTemplate, HelmChart, RubyGem, RenovateConfiguration, SwiftPackage, MSBuildProjectReference, DotNetAssemblyReference
   --upgradable                         Only list dependencies that can be upgraded
+  --minimum-age <minimum-age>          Minimum age in days for package versions to consider for update (default: 7). Use 0 or negative to disable filtering. Not applied to Docker images as registries don't expose publication dates. [default: 7]
   --format <Json|Text>                 Output format. Available values: Text, Json
   -?, -h, --help                       Show help and usage information
 ```


### PR DESCRIPTION
**Stack 1 of 3 · merges into `main` · must merge before #2213 and #2214**

`list --upgradable` and `update` disagreed about which versions are eligible.

`FilterUpgradableDependenciesAsync` called `CreatePackageUpdaters()` with the default `minimumAge` of 0, and `list` had no `--minimum-age` option at all. So a package whose only newer release shipped two days ago was reported as upgradable, and `update` — which defaults to `--minimum-age 7` — then refused to touch it.

`list --upgradable --format json` is the natural way to drive a dashboard or a merge gate; it disagreeing with `update` makes both untrustworthy, and doubles the network cost of investigating the discrepancy.

## What changed

`--minimum-age` is now an option on `list` too, with the same default of 7, built by a shared `CreateMinimumAgeOption` so the two commands cannot drift apart again. `ListAsync` passes it through to `FilterUpgradableDependenciesAsync`.

The generated help block in `readme.md` is regenerated accordingly (`dotnet run ./eng/update-all.cs`).

## Verification

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 49 passed, 0 failed (unchanged).
- `dotnet run ./eng/update-all.cs` — exits 1, meaning it rewrote `readme.md`; that regenerated file is included in the commit.

No new test: asserting the two commands agree needs a package whose newest release is inside the age window, which moves with the live registry. The shared option factory is what actually prevents the drift.


---

**Merge note:** conflicts with #2173, which adds a `TextWriter error` parameter to the same `FilterUpgradableDependenciesAsync` signature this PR gives an `int minimumAge` parameter. Whichever merges second needs a one-line rebase to carry both parameters. Since this PR is the bottom of a three-PR stack, rebasing it means `gh stack rebase --upstack && gh stack push`.