### PR TITLE
Skip versions whose publication date could not be determined

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
@@ -116,7 +116,7 @@ internal static class Program
 
     private static Option<int> CreateMinimumAgeOption() => new("--minimum-age")
     {
-        Description = "Minimum age in days for package versions to consider for update (default: 7). Use 0 or negative to disable filtering. Not applied to Docker images as registries don't expose publication dates.",
+        Description = "Minimum age in days for package versions to consider for update (default: 7). Use 0 or negative to disable filtering. Versions whose publication date is unknown are skipped, except for Docker images as registries don't expose publication dates at all.",
         DefaultValueFactory = _ => 7,
     };
 

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/DockerPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/DockerPackageUpdater.cs
@@ -18,6 +18,9 @@ internal sealed class DockerPackageUpdater : PackageUpdater
 
     protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.DockerImage && dependency.Name is not null;
 
+    // Registries expose no publication date for a tag, so --minimum-age cannot apply here
+    protected override bool VersionsHavePublicationDates => false;
+
     protected override async IAsyncEnumerable<PackageVersion> GetVersionsAsync(Dependency dependency, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // Docker registry API doesn't provide simple access to published dates

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NuGetPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NuGetPackageUpdater.cs
@@ -108,9 +108,11 @@ internal sealed class NuGetPackageUpdater : PackageUpdater
         {
             metadata = await metadataResource.GetMetadataAsync(packageName, includePrerelease: true, includeUnlisted: false, cache, NullLogger.Instance, cancellationToken).ConfigureAwait(false);
         }
-        catch
+        catch (FatalProtocolException)
         {
-            // If metadata retrieval fails, fallback to non-metadata version retrieval
+            // The source has no usable metadata resource (a V2 feed, typically): fall back to the plain
+            // version list. Narrow on purpose - a bare catch also swallowed cancellation, and it turned a
+            // transient failure into a silent loss of publication dates, which disables --minimum-age.
         }
 
         if (metadata is null)

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/PackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/PackageUpdater.cs
@@ -6,6 +6,13 @@ internal abstract class PackageUpdater
     public int MinimumAge { get; set; }
     public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
 
+    /// <summary>
+    /// Whether this source reports a publication date for its versions. When it does, a version that comes
+    /// back without one means the age could not be verified, so <see cref="MinimumAge"/> must reject it
+    /// rather than silently let it through.
+    /// </summary>
+    protected virtual bool VersionsHavePublicationDates => true;
+
     public virtual async Task<string?> UpdateAsync(Dependency dependency, CancellationToken cancellationToken)
     {
         var updatedVersion = await GetUpdatedVersionAsync(dependency, cancellationToken).ConfigureAwait(false);
@@ -38,11 +45,18 @@ internal abstract class PackageUpdater
                 continue;
 
             // Filter by minimum age if enabled
-            if (minimumAgeTimeSpan.HasValue && publishedDate.HasValue)
+            if (minimumAgeTimeSpan.HasValue)
             {
-                var age = now - publishedDate.Value;
-                if (age < minimumAgeTimeSpan.Value)
+                if (publishedDate.HasValue)
+                {
+                    var age = now - publishedDate.Value;
+                    if (age < minimumAgeTimeSpan.Value)
+                        continue;
+                }
+                else if (VersionsHavePublicationDates)
+                {
                     continue;
+                }
             }
 
             if (rawMaxVersion is null || versioningStrategy.CompareVersions(version, rawMaxVersion) > 0)

--- a/src/Meziantou.Framework.DependencyScanning.Tool/readme.md
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/readme.md
@@ -55,7 +55,7 @@ Options:
   --files <files>                      Glob patterns to find files to scan
   --dependency-type <dependency-type>  Dependency types to include. Available values: Unknown, NuGet, Npm, PyPi, DockerImage, GitReference, DotNetSdk, DotNetTargetFramework, GitHubActions, AzureDevOpsVMPool, AzureDevOpsTask, AzureDevOpsTemplate, HelmChart, RubyGem, RenovateConfiguration, SwiftPackage, MSBuildProjectReference, DotNetAssemblyReference
   --upgradable                         Only list dependencies that can be upgraded
-  --minimum-age <minimum-age>          Minimum age in days for package versions to consider for update (default: 7). Use 0 or negative to disable filtering. Not applied to Docker images as registries don't expose publication dates. [default: 7]
+  --minimum-age <minimum-age>          Minimum age in days for package versions to consider for update (default: 7). Use 0 or negative to disable filtering. Versions whose publication date is unknown are skipped, except for Docker images as registries don't expose publication dates at all. [default: 7]
   --format <Json|Text>                 Output format. Available values: Text, Json
   -?, -h, --help                       Show help and usage information
 ```
@@ -74,7 +74,7 @@ Options:
   --files <files>                      Glob patterns to find files to scan
   --dependency-type <dependency-type>  Dependency types to include. Available values: Unknown, NuGet, Npm, PyPi, DockerImage, GitReference, DotNetSdk, DotNetTargetFramework, GitHubActions, AzureDevOpsVMPool, AzureDevOpsTask, AzureDevOpsTemplate, HelmChart, RubyGem, RenovateConfiguration, SwiftPackage, MSBuildProjectReference, DotNetAssemblyReference
   --update-lock-files                  Update lock files when dependencies are updated
-  --minimum-age <minimum-age>          Minimum age in days for package versions to consider for update (default: 7). Use 0 or negative to disable filtering. Not applied to Docker images as registries don't expose publication dates. [default: 7]
+  --minimum-age <minimum-age>          Minimum age in days for package versions to consider for update (default: 7). Use 0 or negative to disable filtering. Versions whose publication date is unknown are skipped, except for Docker images as registries don't expose publication dates at all. [default: 7]
   -?, -h, --help                       Show help and usage information
 ```
 <!-- help -->

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/MinimumAgeTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/MinimumAgeTests.cs
@@ -53,7 +53,7 @@ public sealed class MinimumAgeTests
     }
 
     [Fact]
-    public async Task VersionsWithoutPublishDate_AreNotFiltered()
+    public async Task VersionsWithoutPublishDate_AreNotFiltered_WhenTheSourceHasNoDates()
     {
         // Some sources (e.g. Docker) don't expose a publication date; those versions must remain eligible.
         var versions = new[]
@@ -61,7 +61,38 @@ public sealed class MinimumAgeTests
             new PackageVersion("2.0.0", PublishedDate: null),
         };
 
+        var (result, _, location) = await RunUpdateAsync(versions, minimumAge: 7, versionsHavePublicationDates: false);
+
+        Assert.Equal("2.0.0", result);
+        Assert.Equal("2.0.0", location.UpdatedValue);
+    }
+
+    [Fact]
+    public async Task VersionsWithoutPublishDate_AreSkipped_WhenTheSourceNormallyHasDates()
+    {
+        // A missing date from a source that normally reports them means the age could not be verified,
+        // so the version must not silently bypass the filter.
+        var versions = new[]
+        {
+            new PackageVersion("2.0.0", PublishedDate: null),
+            new PackageVersion("1.5.0", Now.UtcDateTime.AddDays(-30)),
+        };
+
         var (result, _, location) = await RunUpdateAsync(versions, minimumAge: 7);
+
+        Assert.Equal("1.5.0", result);
+        Assert.Equal("1.5.0", location.UpdatedValue);
+    }
+
+    [Fact]
+    public async Task VersionsWithoutPublishDate_AreNotFiltered_WhenFilteringIsDisabled()
+    {
+        var versions = new[]
+        {
+            new PackageVersion("2.0.0", PublishedDate: null),
+        };
+
+        var (result, _, location) = await RunUpdateAsync(versions, minimumAge: 0);
 
         Assert.Equal("2.0.0", result);
         Assert.Equal("2.0.0", location.UpdatedValue);
@@ -72,7 +103,7 @@ public sealed class MinimumAgeTests
     {
         var location = new RecordingLocation();
         var dependency = new Dependency("Sample.Package", "1.0.0", DependencyType.NuGet, nameLocation: null, versionLocation: location);
-        var updater = new FakePackageUpdater([new PackageVersion("2.0.0", PublishedDate: null)]);
+        var updater = new FakePackageUpdater([new PackageVersion("2.0.0", PublishedDate: null)], versionsHavePublicationDates: false);
 
         var result = await updater.GetUpdatedVersionAsync(dependency, XunitCancellationToken);
 
@@ -94,12 +125,12 @@ public sealed class MinimumAgeTests
         Assert.Equal("2.0.0", location.UpdatedValue);
     }
 
-    private static async Task<(string? Result, Dependency Dependency, RecordingLocation Location)> RunUpdateAsync(PackageVersion[] versions, int minimumAge)
+    private static async Task<(string? Result, Dependency Dependency, RecordingLocation Location)> RunUpdateAsync(PackageVersion[] versions, int minimumAge, bool versionsHavePublicationDates = true)
     {
         var location = new RecordingLocation();
         var dependency = new Dependency("Sample.Package", "1.0.0", DependencyType.NuGet, nameLocation: null, versionLocation: location);
 
-        var updater = new FakePackageUpdater(versions)
+        var updater = new FakePackageUpdater(versions, versionsHavePublicationDates)
         {
             MinimumAge = minimumAge,
             TimeProvider = new FakeTimeProvider(Now),
@@ -109,9 +140,11 @@ public sealed class MinimumAgeTests
         return (result, dependency, location);
     }
 
-    private sealed class FakePackageUpdater(PackageVersion[] versions) : PackageUpdater
+    private sealed class FakePackageUpdater(PackageVersion[] versions, bool versionsHavePublicationDates = true) : PackageUpdater
     {
         public override VersioningStrategy VersioningStrategy { get; set; } = NuGetVersioningStrategy.Instance;
+
+        protected override bool VersionsHavePublicationDates => versionsHavePublicationDates;
 
         protected override bool IsSupported(Dependency dependency) => true;
 


### PR DESCRIPTION
**Stack 2 of 3 · merges into `fix/list-minimum-age` (#2212) · merge that one first**

`--minimum-age` was silently inert whenever a source returned no publication date:

```csharp
if (minimumAgeTimeSpan.HasValue && publishedDate.HasValue)
```

For NuGet that is not only the "registry has no dates" case the help text described. It is also **every** version returned by the `FindPackageByIdResource` fallback, which was taken whenever `GetMetadataAsync` threw — and the `catch` there was bare, swallowing 401s, transient 5xx and cancellation alike.

`--minimum-age` exists to avoid adopting a package within days of publication, the window in which a compromised or broken release is typically pulled. A transient metadata failure downgraded that safety control to a no-op without telling anyone.

## What changed

- `PackageUpdater.VersionsHavePublicationDates` (default `true`) says whether a source is expected to report dates. When it is, a version arriving without one means the age *could not be verified*, so it is skipped rather than waved through. `DockerPackageUpdater` overrides it to `false`, which keeps the documented Docker exemption exact instead of accidental.
- The bare `catch` in `NuGetPackageUpdater` is narrowed to `FatalProtocolException`, the exception that actually means "this source has no usable metadata resource" (a V2 feed). It no longer swallows cancellation.
- The `--minimum-age` description now says what the code does, and `readme.md` is regenerated.

Behaviour change worth calling out: when a NuGet feed's metadata endpoint fails, versions from the fallback path are no longer eligible while `--minimum-age > 0`. That is the intended direction — no dates means no age guarantee — but it will produce fewer updates against feeds that only support the V2 protocol.

## Verification

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 51 passed, 0 failed (49 on the layer below).
- `dotnet run ./eng/update-all.cs` — exits 1 (files changed); the regenerated `readme.md` is in the commit.

`VersionsWithoutPublishDate_AreNotFiltered` is split into three cases: undated versions stay eligible when the source has no dates (Docker), are skipped when the source normally has them, and stay eligible when filtering is off entirely.
