### PR TITLE
Warn that updating lock files executes code from the scanned repository

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Program.cs
@@ -45,7 +45,7 @@ internal static class Program
         var rootDirectoryOption = CreateRootDirectoryOption();
         var filesOption = CreateFilesOption();
         var dependencyTypesOption = CreateDependencyTypesOption();
-        var updateLockFilesOption = new Option<bool>("--update-lock-files") { Description = "Update lock files when dependencies are updated" };
+        var updateLockFilesOption = new Option<bool>("--update-lock-files") { Description = "Update lock files when dependencies are updated. Runs 'dotnet restore' and 'npm install', which execute MSBuild targets and npm install scripts from the scanned repository. Only use it on repositories you trust." };
         var minimumAgeOption = CreateMinimumAgeOption();
 
         var updateCommand = new Command("update")

--- a/src/Meziantou.Framework.DependencyScanning.Tool/readme.md
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/readme.md
@@ -16,6 +16,12 @@
     Meziantou.Framework.DependencyScanning.Tool update --directory .
     ````
 
+> [!WARNING]
+> `--update-lock-files` runs `dotnet restore` and `npm install` on the scanned repository. Both execute
+> code from that repository: `dotnet restore` evaluates MSBuild targets in the projects it restores, and
+> `npm install` runs the `preinstall`/`postinstall` scripts of the resolved dependency tree. Only use this
+> option on repositories you trust.
+
 You can show available options using:
 
 ````bash
@@ -73,7 +79,7 @@ Options:
   --directory <directory>              Root directory
   --files <files>                      Glob patterns to find files to scan
   --dependency-type <dependency-type>  Dependency types to include. Available values: Unknown, NuGet, Npm, PyPi, DockerImage, GitReference, DotNetSdk, DotNetTargetFramework, GitHubActions, AzureDevOpsVMPool, AzureDevOpsTask, AzureDevOpsTemplate, HelmChart, RubyGem, RenovateConfiguration, SwiftPackage, MSBuildProjectReference, DotNetAssemblyReference
-  --update-lock-files                  Update lock files when dependencies are updated
+  --update-lock-files                  Update lock files when dependencies are updated. Runs 'dotnet restore' and 'npm install', which execute MSBuild targets and npm install scripts from the scanned repository. Only use it on repositories you trust.
   --minimum-age <minimum-age>          Minimum age in days for package versions to consider for update (default: 7). Use 0 or negative to disable filtering. Versions whose publication date is unknown are skipped, except for Docker images as registries don't expose publication dates at all. [default: 7]
   -?, -h, --help                       Show help and usage information
 ```


### PR DESCRIPTION
**Stack 3 of 3 · merges into `fix/minimum-age-unknown-dates` (#2213) · merge #2212 and #2213 first**

`--update-lock-files` runs `dotnet restore` and `npm install` against whatever the scan found. Both are arbitrary-code-execution surfaces by design: MSBuild evaluates inline `Task`/`Exec` in the projects it restores, and npm runs `preinstall`/`postinstall` scripts from the resolved dependency tree.

There is no injection bug here — the risk is an undocumented capability. The tool's whole premise is pointing it at a directory, `--directory` accepts anything (a repository someone else contributed to, a vendored subtree), and neither `--help` nor the readme said that one flag makes it execute that repository's code.

## What changed

Documentation only, no behaviour change:

- The `--update-lock-files` description names both commands and says to use it only on trusted repositories.
- `readme.md` gains a warning callout with the specific mechanisms (MSBuild targets, npm lifecycle scripts).

Not done here, worth its own discussion: passing `--ignore-scripts` to npm by default with a flag to re-enable. That changes behaviour rather than documenting it, and would make lock files diverge from what a plain `npm install` produces.

## Verification

- `dotnet build ... -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test tests/Meziantou.Framework.DependencyScanning.Tool.Tests -f net10.0` — 51 passed, 0 failed (unchanged from the layer below).
- `dotnet run ./eng/update-all.cs` — exits 1 (files changed); the regenerated help block is in the commit.
