### PR TITLE
Unbox value-type receivers so struct mutations are not discarded

### DIFF
--- a/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
+++ b/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
@@ -194,7 +194,7 @@ public sealed class ObjectMethodExecutor
         MethodCallExpression methodCall;
         if (!methodInfo.IsStatic)
         {
-            var instanceCast = Expression.Convert(targetParameter, targetTypeInfo.AsType());
+            var instanceCast = GetTargetExpression(targetParameter, targetTypeInfo);
             methodCall = Expression.Call(instanceCast, methodInfo, parameters);
         }
         else
@@ -228,6 +228,19 @@ public sealed class ObjectMethodExecutor
         };
     }
 
+    private static UnaryExpression GetTargetExpression(ParameterExpression targetParameter, TypeInfo targetTypeInfo)
+    {
+        var targetType = targetTypeInfo.AsType();
+
+        // For a value type, Expression.Convert emits "unbox.any", which copies the struct out of the box.
+        // A method that mutates the receiver would then mutate that copy and the caller would observe
+        // nothing. Expression.Unbox emits "unbox", which yields a managed pointer into the boxed data, so
+        // mutations are applied in place. This matches what MethodInfo.Invoke does.
+        return targetType.IsValueType
+            ? Expression.Unbox(targetParameter, targetType)
+            : Expression.Convert(targetParameter, targetType);
+    }
+
     private static MethodExecutorAsync GetExecutorAsync(
         MethodInfo methodInfo,
         TypeInfo targetTypeInfo,
@@ -254,7 +267,7 @@ public sealed class ObjectMethodExecutor
         MethodCallExpression methodCall;
         if (!methodInfo.IsStatic)
         {
-            var instanceCast = Expression.Convert(targetParameter, targetTypeInfo.AsType());
+            var instanceCast = GetTargetExpression(targetParameter, targetTypeInfo);
             methodCall = Expression.Call(instanceCast, methodInfo, parameters);
         }
         else

--- a/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
+++ b/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
@@ -27,6 +27,54 @@ public sealed class ObjectMethodExecutorTests
     }
 
     [Fact]
+    public void MutatingStructMethod_AppliesMutationToBoxedInstance()
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(MutableCounter).GetMethod(nameof(MutableCounter.Increment))!);
+        object target = new MutableCounter();
+
+        executor.Execute(target, []);
+
+        Assert.Equal(1, ((MutableCounter)target).Value);
+    }
+
+    [Fact]
+    public async Task MutatingStructMethod_AppliesMutationToBoxedInstance_Async()
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(MutableCounter).GetMethod(nameof(MutableCounter.IncrementAsync))!);
+        object target = new MutableCounter();
+
+        await executor.ExecuteAsync(target, []);
+
+        Assert.Equal(1, ((MutableCounter)target).Value);
+    }
+
+    [Fact]
+    public void MutatingStructMethod_MatchesMethodInfoInvoke()
+    {
+        var methodInfo = typeof(MutableCounter).GetMethod(nameof(MutableCounter.Increment))!;
+        object viaInvoke = new MutableCounter();
+        methodInfo.Invoke(viaInvoke, parameters: null);
+
+        object viaExecutor = new MutableCounter();
+        ObjectMethodExecutor.Create(methodInfo).Execute(viaExecutor, []);
+
+        Assert.Equal(((MutableCounter)viaInvoke).Value, ((MutableCounter)viaExecutor).Value);
+    }
+
+    private struct MutableCounter
+    {
+        public int Value;
+
+        public void Increment() => Value++;
+
+        public Task IncrementAsync()
+        {
+            Value++;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
     public void SyncInt32Test()
     {
         var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32")!);


### PR DESCRIPTION
`ObjectMethodExecutor` silently discarded any mutation made by a method whose declaring type is a value type.

## The defect

`GetExecutor` and `GetExecutorAsync` both built the receiver with:

```csharp
var instanceCast = Expression.Convert(targetParameter, targetTypeInfo.AsType());
```

For a value type, `Expression.Convert` emits `unbox.any`, which copies the struct out of the box. The method then ran against that copy and the copy was discarded. No exception, no warning — just a different answer than `MethodInfo.Invoke` gives for the same inputs:

```csharp
struct Counter { public int Value; public void Increment() => Value++; }

object boxed = new Counter();
executor.Execute(boxed, []);      // ((Counter)boxed).Value == 0   <- mutation lost
methodInfo.Invoke(boxed, null);   // ((Counter)boxed).Value == 1   <- mutation applied
```

This matters because the library's whole purpose is to be a faster stand-in for `MethodInfo.Invoke`. Anyone swapping `Invoke` for `ObjectMethodExecutor` to speed up a dispatch loop got silently wrong results for value-type receivers, with no signal to investigate.

## The change

Both call sites now go through a shared `GetTargetExpression` helper that uses `Expression.Unbox` for value types. `Expression.Unbox` emits plain `unbox`, which yields a managed pointer into the boxed data, so the call mutates in place. Reference types keep using `Expression.Convert`.

The return type is `UnaryExpression` rather than `Expression` because both factory methods return it and CA1859 is enforced here.

## Verification

Three tests added to `ObjectMethodExecutorTests.cs` covering the sync path, the async path (`GetExecutorAsync` had the same line), and direct equivalence with `MethodInfo.Invoke`.

- All three **fail on `main`** and pass with this change — confirmed by reverting only the source file and re-running.
- Full suite green: 34 passed (17 × net10.0/net11.0), 0 failed.
- No public API change, so `ref/` is unchanged.

Found during a review of `Meziantou.Framework.ObjectMethodExecutor`.
