### PR TITLE
Expose GetDefaultValueForParameter so the parameterDefaultValues overload has an effect

### DIFF
--- a/ref/Meziantou.Framework.ObjectMethodExecutor.cs
+++ b/ref/Meziantou.Framework.ObjectMethodExecutor.cs
@@ -12,6 +12,7 @@ namespace Meziantou.Framework
         public static Meziantou.Framework.ObjectMethodExecutor Create(System.Reflection.MethodInfo methodInfo, object[]? parameterDefaultValues) => throw null;
         public object? Execute(object? target, object?[]? parameters) => throw null;
         public Meziantou.Framework.ObjectMethodExecutorAwaitable ExecuteAsync(object? target, object?[]? parameters) => throw null;
+        public object? GetDefaultValueForParameter(int index) => throw null;
     }
 
     public readonly struct ObjectMethodExecutorAwaitable

--- a/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
+++ b/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
@@ -74,6 +74,9 @@ public sealed class ObjectMethodExecutor
 
         }
 
+        if (parameterDefaultValues is not null && parameterDefaultValues.Length != MethodParameters.Length)
+            throw new ArgumentException($"Expected {MethodParameters.Length} default value(s) for '{methodInfo.Name}', but got {parameterDefaultValues.Length}", nameof(parameterDefaultValues));
+
         _parameterDefaultValues = parameterDefaultValues;
     }
 
@@ -102,7 +105,7 @@ public sealed class ObjectMethodExecutor
 
     /// <summary>Creates an executor for the specified method with parameter default values.</summary>
     /// <param name="methodInfo">The method to be invoked.</param>
-    /// <param name="parameterDefaultValues">The default values for the method parameters.</param>
+    /// <param name="parameterDefaultValues">The default values for the method parameters, readable afterwards through <see cref="GetDefaultValueForParameter"/>. Must contain exactly one entry per parameter.</param>
     /// <returns>An <see cref="ObjectMethodExecutor"/> that can invoke the specified method.</returns>
     public static ObjectMethodExecutor Create(MethodInfo methodInfo, object?[]? parameterDefaultValues)
     {
@@ -160,7 +163,17 @@ public sealed class ObjectMethodExecutor
         return _executorAsync(target, parameters);
     }
 
-    private object? GetDefaultValueForParameter(int index)
+    /// <summary>Gets the default value supplied for the parameter at <paramref name="index"/>.</summary>
+    /// <remarks>
+    /// Callers use this to build the <c>parameters</c> array passed to <see cref="Execute"/> or
+    /// <see cref="ExecuteAsync"/> when they have no value of their own for a parameter. The executor
+    /// itself never consults these values.
+    /// </remarks>
+    /// <param name="index">The zero-based index of the parameter.</param>
+    /// <returns>The default value supplied for that parameter when the executor was created.</returns>
+    /// <exception cref="InvalidOperationException">No parameter default values were supplied to <see cref="Create(MethodInfo, object[])"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is negative or not less than the number of parameters.</exception>
+    public object? GetDefaultValueForParameter(int index)
     {
         if (_parameterDefaultValues is null)
             throw new InvalidOperationException($"Cannot call {nameof(GetDefaultValueForParameter)}, because no parameter default values were supplied.");

--- a/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
+++ b/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
@@ -43,6 +43,40 @@ public sealed class ObjectMethodExecutorTests
     }
 
     [Fact]
+    public void GetDefaultValueForParameter_ReturnsSuppliedValues()
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32WithParam")!, [42]);
+
+        Assert.Equal(42, executor.GetDefaultValueForParameter(0));
+    }
+
+    [Fact]
+    public void GetDefaultValueForParameter_ThrowsWhenNoDefaultsSupplied()
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32WithParam")!);
+
+        Assert.Throws<InvalidOperationException>(() => executor.GetDefaultValueForParameter(0));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(1)]
+    public void GetDefaultValueForParameter_ThrowsWhenIndexOutOfRange(int index)
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32WithParam")!, [42]);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => executor.GetDefaultValueForParameter(index));
+    }
+
+    [Fact]
+    public void Create_ThrowsWhenDefaultValueCountDoesNotMatchParameterCount()
+    {
+        var methodInfo = typeof(Test).GetMethod("SyncInt32WithParam")!;
+
+        Assert.Throws<ArgumentException>(() => ObjectMethodExecutor.Create(methodInfo, [1, 2]));
+    }
+
+    [Fact]
     public async Task StaticAsyncTaskTests()
     {
         var validator = new Validator();


### PR DESCRIPTION
`ObjectMethodExecutor.Create(methodInfo, parameterDefaultValues)` accepted its second argument and then did nothing with it.

## The defect

`parameterDefaultValues` was stored in `_parameterDefaultValues` and read by exactly one member — `private object? GetDefaultValueForParameter(int index)` — which was private and had no callers anywhere in the repository. Neither `Execute` nor `ExecuteAsync` consulted it. The array was dead weight held for the lifetime of every executor.

So a shipped, versioned public overload took input and dropped it, and the natural reading of the API was wrong:

```csharp
// int Optional(int i = 99)
var e = ObjectMethodExecutor.Create(mi, [42]);
e.Execute(target, []);   // IndexOutOfRangeException - not 42, and not 99
```

In upstream ASP.NET Core (where this type was ported from) the equivalent `GetDefaultValueForParameter` is public and MVC's parameter binder calls it to build the arguments array. The member that gave this parameter its purpose did not come across with it.

## The change

Restores the upstream contract — `GetDefaultValueForParameter` becomes public, and the overload means what it means upstream: the executor stores the defaults so callers can read them back while assembling the `parameters` array. The executor itself still never consults them, which is now stated in the XML docs on both members.

`Create` also validates the array length. Without that, making the getter public would ship a latent bug: the bounds check used `MethodParameters.Length`, so for a short array an index the check accepted would still throw `IndexOutOfRangeException` off the array itself. A mismatch now fails fast at `Create` with a message naming the method and both counts.

This is additive — nothing that compiles today stops compiling, except a `Create` call passing a wrong-length defaults array, which never worked in the first place.

## Alternatives considered

- **Have `Execute` fill in the defaults for a short `parameters` array.** More intuitive, but a behavior change, and it overlaps the arity validation in a separate PR from the same review.
- **`[Obsolete]` the overload and remove it in 3.0.** Honest about it never having worked, but a deprecation on a shipped API when the upstream design is right there.

## Verification

Five test cases added to `ObjectMethodExecutorTests.cs`: values round-trip, `InvalidOperationException` when no defaults were supplied, `ArgumentOutOfRangeException` at both ends of the range, and the new length-mismatch guard.

- Full suite green: 38 passed (19 × net10.0/net11.0), 0 failed.
- `ref/Meziantou.Framework.ObjectMethodExecutor.cs` regenerated — one added line for the new public member.
- Package `<Version>` deliberately untouched.

Found during a review of `Meziantou.Framework.ObjectMethodExecutor`.
