### PR TITLE
Quote written values containing a newline or an embedded quote

### DIFF
--- a/src/Meziantou.Framework.Csv/CsvWriter.cs
+++ b/src/Meziantou.Framework.Csv/CsvWriter.cs
@@ -115,7 +115,7 @@ public class CsvWriter
             if (Quote.HasValue)
             {
                 var quote = Quote.Value;
-                if (value[0] != quote && value.IndexOf(Separator, StringComparison.Ordinal) < 0)
+                if (!RequiresQuoting(value, quote))
                 {
                     await writer.WriteAsync(value).ConfigureAwait(false);
                 }
@@ -144,5 +144,20 @@ public class CsvWriter
                 await writer.WriteAsync(value).ConfigureAwait(false);
             }
         }
+    }
+
+    private bool RequiresQuoting(string value, char quote)
+    {
+        ReadOnlySpan<char> specialCharacters = [quote, Separator, '\r', '\n'];
+        if (value.AsSpan().IndexOfAny(specialCharacters) >= 0)
+            return true;
+
+        foreach (var c in EndOfLine)
+        {
+            if (value.Contains(c, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Meziantou.Framework.Csv.Tests/CsvWriterTests.cs
+++ b/tests/Meziantou.Framework.Csv.Tests/CsvWriterTests.cs
@@ -90,9 +90,84 @@ public class CsvWriterTests
         while ((csvRow = await reader.ReadRowAsync()) is not null)
         {
             rowIndex++;
-            Assert.EqualUnordered(rows[rowIndex], csvRow.Values.ToList());
+            Assert.Equal(rows[rowIndex], csvRow.Values.ToList());
         }
 
         Assert.Equal(rows.Count - 1, rowIndex);
+    }
+
+    [Fact]
+    public async Task CsvWriterAsync_EscapeValueContainingLineFeed()
+    {
+        using var sw = new StringWriter();
+        var writer = new CsvWriter(sw) { EndOfLine = "\n" };
+        await writer.WriteRowAsync("a\nb", "c");
+        await writer.WriteRowAsync("d", "e");
+        Assert.Equal("\"a\nb\",c\nd,e", sw.ToString());
+    }
+
+    [Fact]
+    public async Task CsvWriterAsync_EscapeValueContainingCarriageReturn()
+    {
+        using var sw = new StringWriter();
+        var writer = new CsvWriter(sw) { EndOfLine = "\n" };
+        await writer.WriteRowAsync("a\r\nb", "c");
+        Assert.Equal("\"a\r\nb\",c", sw.ToString());
+    }
+
+    [Fact]
+    public async Task CsvWriterAsync_EscapeValueWithQuoteInTheMiddle()
+    {
+        using var sw = new StringWriter();
+        var writer = new CsvWriter(sw);
+        await writer.WriteRowAsync("a\"b", "c");
+        Assert.Equal("\"a\"\"b\",c", sw.ToString());
+    }
+
+    [Fact]
+    public async Task CsvWriterAsync_EscapeValueWithQuoteAtTheEnd()
+    {
+        using var sw = new StringWriter();
+        var writer = new CsvWriter(sw);
+        await writer.WriteRowAsync("ab\"", "c");
+        Assert.Equal("\"ab\"\"\",c", sw.ToString());
+    }
+
+    [Fact]
+    public async Task CsvWriterAsync_EscapeValueContainingCustomEndOfLine()
+    {
+        using var sw = new StringWriter();
+        var writer = new CsvWriter(sw) { EndOfLine = "|" };
+        await writer.WriteRowAsync("a|b", "c");
+        Assert.Equal("\"a|b\",c", sw.ToString());
+    }
+
+    [Theory]
+    [InlineData("a\nb")]
+    [InlineData("a\r\nb")]
+    [InlineData("a\rb")]
+    [InlineData("a\"b")]
+    [InlineData("a,b")]
+    [InlineData("\"")]
+    [InlineData("a\n\"b\",c")]
+    public async Task CsvWriterAsync_SpecialCharacters_RoundTripThroughCsvReader(string value)
+    {
+        using var sw = new StringWriter();
+        var writer = new CsvWriter(sw) { EndOfLine = "\n" };
+        await writer.WriteRowAsync(value, "next");
+        await writer.WriteRowAsync("second", "row");
+
+        using var sr = new StringReader(sw.ToString());
+        var reader = new CsvReader(sr);
+
+        var row1 = await reader.ReadRowAsync();
+        Assert.NotNull(row1);
+        Assert.Equal([value, "next"], row1.Values);
+
+        var row2 = await reader.ReadRowAsync();
+        Assert.NotNull(row2);
+        Assert.Equal(["second", "row"], row2.Values);
+
+        Assert.Null(await reader.ReadRowAsync());
     }
 }


### PR DESCRIPTION
`CsvWriter` decided whether to quote a value with this predicate (`CsvWriter.cs:118`):

```csharp
if (value[0] != quote && value.IndexOf(Separator, StringComparison.Ordinal) < 0)
```

It looks at only the **first** character and the separator, so two classes of value were written unescaped.

### A value containing a line break corrupts the file

```csharp
await writer.WriteRowAsync("a\nb", "c");   // EndOfLine = "\n"
await writer.WriteRowAsync("d", "e");
// produced: "a\nb,c\nd,e"
```

Two rows in, **three** rows out — and the first one has the wrong field count. Reading that back through `CsvReader` yields `["a"]`, `["b","c"]`, `["d","e"]`. Every other CSV parser, Excel included, sees the same three rows. Any user-supplied text field (an address, a comment, a description) triggers it, and the corruption is invisible until someone reads the file back.

### A quote after position 0 is not escaped

`WriteRowAsync("a\"b", "c")` emitted `a"b,c`. RFC 4180 §2.7 requires a field containing a double quote to be quoted with the inner quote doubled — `"a""b",c`. `CsvReader` is lenient enough to read the unquoted form back correctly, so this one is an interop problem rather than data loss: a file this library writes may not be readable by the tool it was written for.

## What changed

The predicate moves into `RequiresQuoting`, which quotes when the value contains the quote character **anywhere**, the separator, `\r`, `\n`, or any character of the configured `EndOfLine`. `EndOfLine` is settable, so it is checked explicitly rather than assumed to be a line break. The escaping loop itself was already correct and is unchanged.

## Verification

- `dotnet test /p:TreatsWarningsAsErrors=true` — 62 passed (31 × net10.0/net11.0), up from 38.
- 12 new tests: line feed, CRLF, quote in the middle, quote at the end, a custom non-newline `EndOfLine`, and a 7-case round-trip theory asserting that `CsvWriter` → `CsvReader` preserves the value **and** the row count.
- Reverting only `CsvWriter.cs` and re-running turns **16 of them red**, so they pin the actual defect.
- `dotnet run ./eng/update-all.cs` — no generated-file changes. No public API change, so `ref/` is untouched.

## Note

This changes bytes on the wire for values that were previously emitted bare, so it is a behavioural break on the shipped 5.0.0 package. `<Version>` is deliberately left alone for the bump bot.

Found by a review of `src/Meziantou.Framework.Csv`.
