### PR TITLE
Throw from ExecuteAsync instead of silently not awaiting async void methods

### DIFF
--- a/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
+++ b/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
@@ -68,10 +68,13 @@ public sealed class ObjectMethodExecutor
         {
             _executorAsync = GetExecutorAsync(methodInfo, targetTypeInfo, coercedAwaitableInfo);
         }
+        else if (IsAsyncVoidMethod(methodInfo))
+        {
+            _executorAsync = GetAsyncVoidExecutorAsync(methodInfo);
+        }
         else
         {
             _executorAsync = GetExecutorAsyncFromSync(_executor);
-
         }
 
         _parameterDefaultValues = parameterDefaultValues;
@@ -154,6 +157,7 @@ public sealed class ObjectMethodExecutor
     /// <param name="target">The object whose method is to be executed.</param>
     /// <param name="parameters">Parameters to pass to the method.</param>
     /// <returns>An object that you can "await" to get the method return value.</returns>
+    /// <exception cref="InvalidOperationException">The configured method is an <c>async void</c> method, which cannot be awaited. Use <see cref="Execute"/> instead.</exception>
     public ObjectMethodExecutorAwaitable ExecuteAsync(object? target, object?[]? parameters)
     {
         Debug.Assert(_executorAsync is not null, "Async execution is not supported.");
@@ -374,6 +378,20 @@ public sealed class ObjectMethodExecutor
 
         var lambda = Expression.Lambda<MethodExecutorAsync>(returnValueExpression, targetParameter, parametersParameter);
         return lambda.Compile();
+    }
+
+    private static bool IsAsyncVoidMethod(MethodInfo methodInfo)
+    {
+        return methodInfo.ReturnType == typeof(void) && methodInfo.GetCustomAttribute<AsyncStateMachineAttribute>() is not null;
+    }
+
+    private static MethodExecutorAsync GetAsyncVoidExecutorAsync(MethodInfo methodInfo)
+    {
+        var methodName = $"{methodInfo.DeclaringType?.FullName}.{methodInfo.Name}";
+        return delegate
+        {
+            throw new InvalidOperationException($"'{methodName}' is an async void method, so there is no awaitable to observe. Awaiting the result of {nameof(ExecuteAsync)} would return before the method completed, and any exception it throws would be raised on the synchronization context instead of surfacing here. Use {nameof(Execute)} to start it, or change the method to return Task.");
+        };
     }
 
     private static MethodExecutorAsync GetExecutorAsyncFromSync(MethodExecutor executor)

--- a/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
+++ b/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
@@ -65,6 +65,46 @@ public sealed class ObjectMethodExecutorTests
     }
 
     [Fact]
+    public void AsyncVoid_IsNotReportedAsAsync()
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncVoid")!);
+
+        Assert.False(executor.IsMethodAsync);
+    }
+
+    [Fact]
+    public void AsyncVoid_ExecuteAsyncThrows()
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncVoid")!);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => executor.ExecuteAsync(new Test(), [new Validator()]));
+        Assert.Contains("async void", exception.Message);
+    }
+
+    [Fact]
+    public void AsyncVoid_ExecuteStartsTheMethod()
+    {
+        var validator = new Validator();
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncVoid")!);
+
+        var result = executor.Execute(new Test(), [validator]);
+
+        Assert.Null(result);
+        Assert.True(validator.HasBeenInvoked);
+    }
+
+    [Fact]
+    public async Task PlainVoid_IsStillExecutableAsync()
+    {
+        var validator = new Validator();
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncVoid")!);
+
+        await executor.ExecuteAsync(new Test(), [validator]);
+
+        Assert.True(validator.HasBeenInvoked);
+    }
+
+    [Fact]
     public async Task AsyncTaskInt32Tests()
     {
         var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32")!);
@@ -187,6 +227,14 @@ public sealed class ObjectMethodExecutorTests
         }
 
         public YieldAwaitable AsyncCustomAwaiter() => Task.Yield();
+
+#pragma warning disable MA0155 // Do not use async void methods - this is the shape under test
+        public async void AsyncVoid(Validator validator)
+        {
+            validator.Invoked();
+            await Task.Delay(1);
+        }
+#pragma warning restore MA0155
     }
 #pragma warning restore CA1822
 }


### PR DESCRIPTION
**Stack 1 of 2 · targets `main` · merge this before #2229.**

---

`await executor.ExecuteAsync(...)` on an `async void` method returned immediately without running the method to completion, and said nothing about it.

## The defect

An `async void` method has return type `void`, so `CoercedAwaitableInfo.IsTypeAwaitable` reports "not awaitable", `IsMethodAsync` is `false`, and `ExecuteAsync` routed through `GetExecutorAsyncFromSync`, which wraps the *immediate* return in `Task.FromResult`:

```csharp
IsMethodAsync == false
await executor.ExecuteAsync(instance, []);   // returns at once
// the method's post-await work has not run
```

For every other shape — `Task`, `Task<T>`, `ValueTask`, custom awaitables — `await ExecuteAsync(...)` does run the method to completion. `async void` was the one case where it quietly did not. Worse, an unhandled exception in an `async void` body goes to the `SynchronizationContext` and tears down the process rather than surfacing at the `await`, so the failure does not even land near the caller.

Callers driving user-supplied handlers by reflection are exactly the people who hit this.

## The change

`ExecuteAsync` now throws `InvalidOperationException` for `async void` methods, naming the method and explaining both consequences.

The detection is `ReturnType == typeof(void)` plus the compiler-emitted `[AsyncStateMachine]`, evaluated once in the constructor. The throwing delegate is built there and stored as `_executorAsync`, so there is no added check on any normal call path.

**`Execute` is deliberately left working.** Starting an `async void` method synchronously is what an ordinary C# caller does, and it is a legitimate use of this library — the problem is only that there is no awaitable to observe. Throwing from `Create` would have blocked that valid path too.

`IsMethodAsync` stays `false`, which is accurate: the method genuinely is not awaitable. So the documented `if (IsMethodAsync) ExecuteAsync else Execute` pattern keeps working unchanged and never reaches the new throw — it fires only for code that calls `ExecuteAsync` directly, which is the broken usage.

## Verification

Four tests added to `ObjectMethodExecutorTests.cs`: `IsMethodAsync` is `false`, `ExecuteAsync` throws, `Execute` still starts the method, and a plain (non-async) `void` method is still awaitable through `ExecuteAsync` — that last one guards the `else` branch this change moved past.

- `AsyncVoid_ExecuteAsyncThrows` **fails on `main`** and passes here; the other three pass on both, which is the point for the two that pin existing behavior.
- Full suite green: 36 passed (18 × net10.0/net11.0), 0 failed.
- No public API change, so `ref/` is unchanged.

The test fixture needs `#pragma warning disable MA0155` because the `async void` shape is the thing under test.

Found during a review of `Meziantou.Framework.ObjectMethodExecutor`.
