### PR TITLE
Limit JSONPath filter expression nesting to prevent a stack overflow

### DIFF
--- a/src/Meziantou.Framework.JsonPath/Internals/JsonPathParser.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/JsonPathParser.cs
@@ -9,13 +9,23 @@ namespace Meziantou.Framework.Json.Internals;
 [StructLayout(LayoutKind.Auto)]
 internal ref struct JsonPathParser
 {
+    /// <summary>
+    /// Maximum nesting depth of filter expressions and function calls. The parser is recursive, so an
+    /// unbounded nesting level would overflow the stack, which cannot be caught and terminates the process.
+    /// The value matches <see cref="System.Text.Json.JsonDocumentOptions.MaxDepth"/>'s default and is far
+    /// above any practical query.
+    /// </summary>
+    private const int MaxNestingDepth = 64;
+
     private JsonPathLexer _lexer;
     private JsonPathToken _current;
+    private int _depth;
 
     private JsonPathParser(ReadOnlySpan<char> input)
     {
         _lexer = new JsonPathLexer(input);
         _current = _lexer.NextToken();
+        _depth = 0;
     }
 
     public static JsonPathExpression Parse(ReadOnlySpan<char> input)
@@ -298,6 +308,19 @@ internal ref struct JsonPathParser
 
     // basic-expr = paren-expr / comparison-expr / test-expr
     private LogicalExpression ParseBasicExpression()
+    {
+        EnterNestingLevel();
+        try
+        {
+            return ParseBasicExpressionCore();
+        }
+        finally
+        {
+            _depth--;
+        }
+    }
+
+    private LogicalExpression ParseBasicExpressionCore()
     {
         // paren-expr = [logical-not-op S] "(" S logical-expr S ")"
         // test-expr = [logical-not-op S] (filter-query / function-expr)
@@ -606,6 +629,21 @@ internal ref struct JsonPathParser
     // function-expr = function-name "(" S [function-argument *(S "," S function-argument)] S ")"
     private FunctionCallExpression ParseFunctionCallExpression()
     {
+        // Nested function arguments recurse back into this method without going through
+        // ParseBasicExpression, so this entry point needs its own guard.
+        EnterNestingLevel();
+        try
+        {
+            return ParseFunctionCallExpressionCore();
+        }
+        finally
+        {
+            _depth--;
+        }
+    }
+
+    private FunctionCallExpression ParseFunctionCallExpressionCore()
+    {
         var name = _current.StringValue!;
         var pos = _current.Position;
         Advance(); // consume function name
@@ -776,6 +814,14 @@ internal ref struct JsonPathParser
     private void Advance()
     {
         _current = _lexer.NextToken();
+    }
+
+    private void EnterNestingLevel()
+    {
+        if (++_depth > MaxNestingDepth)
+        {
+            throw new FormatException($"Filter expression nesting exceeds the maximum depth of {MaxNestingDepth} at position {_current.Position}.");
+        }
     }
 
     private static long GetLongValue(JsonPathToken token)

--- a/src/Meziantou.Framework.JsonPath/readme.md
+++ b/src/Meziantou.Framework.JsonPath/readme.md
@@ -65,3 +65,10 @@ Full RFC 9535 compliance:
 - **Filter expressions**: comparisons (`==`, `!=`, `<`, `<=`, `>`, `>=`), logical operators (`&&`, `||`, `!`), existence tests, parenthesized grouping
 - **Built-in functions**: `length()`, `count()`, `match()`, `search()`, `value()`
 - **Normalized paths**: canonical path output per RFC 9535 §2.7
+
+## Limits
+
+Filter expressions, nested filter selectors, and function arguments may nest up to 64 levels deep. Beyond that,
+`Parse` throws a `FormatException` and `TryParse` returns `false`. The parser is recursive, so this bound is what
+keeps a hostile or machine-generated expression from exhausting the stack; 64 matches the default `MaxDepth` of
+`System.Text.Json` and is far above any practical query.

--- a/tests/Meziantou.Framework.JsonPath.Tests/JsonPathParseTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/JsonPathParseTests.cs
@@ -76,4 +76,41 @@ public sealed class JsonPathParseTests
         var path = JsonPath.Parse(expression);
         Assert.Equal(expression, path.ToString());
     }
+
+    [Theory]
+    [MemberData(nameof(DeeplyNestedExpressions), 5_000)]
+    public void TryParse_DeeplyNestedExpression_ReturnsFalseInsteadOfOverflowingTheStack(string expression)
+    {
+        Assert.False(JsonPath.TryParse(expression, out var result));
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(DeeplyNestedExpressions), 8)]
+    public void TryParse_ModeratelyNestedExpression_StaysWithinTheDepthLimit(string expression)
+    {
+        Assert.True(JsonPath.TryParse(expression, out var result));
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void Parse_ManyConjuncts_IsNotTreatedAsNesting()
+    {
+        // '&&' chains are parsed iteratively, so a flat chain must not consume nesting budget.
+        var expression = "$[?" + string.Join(" && ", Enumerable.Range(0, 500).Select(i => $"@.a{i}")) + "]";
+        Assert.True(JsonPath.TryParse(expression, out _));
+    }
+
+    public static TheoryData<string> DeeplyNestedExpressions(int depth)
+    {
+        return
+        [
+            // paren-expr recursion
+            "$[?" + new string('(', depth) + "@.a" + new string(')', depth) + "]",
+            // nested filter-selector recursion
+            "$[?" + string.Concat(Enumerable.Repeat("@.a[?", depth)) + "@.b" + new string(']', depth) + "]",
+            // nested function-argument recursion
+            "$[?length(" + string.Concat(Enumerable.Repeat("length(", depth)) + "@" + new string(')', depth) + ")==1]",
+        ];
+    }
 }


### PR DESCRIPTION
`JsonPathParser` is a recursive-descent parser with no bound on nesting depth. A sufficiently nested filter expression exhausts the stack, and `StackOverflowException` cannot be caught in .NET — the runtime fails fast and the process dies. `JsonPath.TryParse` is documented as the safe, non-throwing entry point, so a caller who does the right thing gets no protection at all.

## What happens

Reproduced against the built assembly. There are **three** independent recursion paths, and they crash at very different depths — the cheapest needs under 2.5 KB of input on a typical 1 MB-stack server thread:

| Nesting | Path through the parser | Crashes at (1 MB stack) | Input size |
|---|---|---|---|
| `$[?@.a[?@.a[?…]]]` | `ParseFilterSelector` → … → `ParseBracketedSelection` → `ParseFilterSelector` | **< 500 levels** | **~2.5 KB** |
| `$[?((((…@.a…))))]` | `ParseBasicExpression` → `ParseLogicalOrExpression` → `ParseBasicExpression` | ~1,000 levels | ~3 KB |
| `$[?length(length(…))]` | `ParseFunctionCallExpression` → `ParseValueTypeArgument` → `ParseFunctionCallExpression` | < 2,000 levels | ~16 KB |

The third path is worth calling out: it does **not** go through `ParseBasicExpression`, so guarding only the obvious recursion point would have left it open.

On the 8 MB main thread the thresholds are roughly 8× higher, so this is not reproducible in a console app at the sizes above — it needs a thread-pool-sized stack, which is what any ASP.NET Core request runs on.

Any service that accepts a JSONPath from a request body, a query string, a user-authored rule, or a tenant-supplied config file can be killed by a single small request, taking every in-flight request on the process with it.

## What changed

A single `_depth` counter on the parser, checked at both recursion entry points — `ParseBasicExpression` (covers paren nesting and nested filter selectors) and `ParseFunctionCallExpression` (covers nested function arguments). Over the limit, it throws `FormatException`, which `TryParse` already converts to `false` — so the API now behaves the way its documentation always claimed.

The limit is **64**, matching the default `JsonDocumentOptions.MaxDepth` in `System.Text.Json`. Both entry points decrement in a `finally`, so sibling expressions do not accumulate depth — a flat `@.a0 && @.a1 && … ` chain of 500 conjuncts is parsed iteratively and is unaffected (there is a test for exactly this, since getting it wrong would reject legitimate queries).

`readme.md` gains a short "Limits" section, since this is a real behavioural change: expressions nested deeper than 64 that used to parse are now rejected.

## Verification

- `dotnet test -f net10.0 -p:TreatWarningsAsErrors=true` → **812 passed, 0 failed** (805 before this change, +7 new).
- The 703-case JSONPath Compliance Test Suite is part of that run and still passes in full — no legitimately-nested CTS case is caught by the new limit.
- New tests cover all three recursion paths at depth 5,000 (must return `false`, and would crash the test host if the guard were missing), all three at depth 8 (must still parse), and the flat-conjunct case.
- `dotnet run ./eng/update-all.cs` → clean, no generated-file changes. The change is internal, so `ref/` is unaffected.
