### PR TITLE
Create one channel consumer per degree of parallelism

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/DependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/DependencyScanner.cs
@@ -226,7 +226,14 @@ public abstract class DependencyScanner
         // Parse files
         var tasks = new Task[options.DegreeOfParallelism + 1];
         tasks[0] = enumeratorTask;
-        Array.Fill(tasks, Task.Run(async () =>
+        for (var i = 1; i < tasks.Length; i++)
+        {
+            tasks[i] = Task.Run(ScanFilesFromChannelAsync, cancellationToken);
+        }
+
+        return Task.WhenAll(tasks);
+
+        async Task ScanFilesFromChannelAsync()
         {
             var reader = filesToScanChannel.Reader;
             var scanners = options.EnabledScanners;
@@ -254,9 +261,7 @@ public abstract class DependencyScanner
                     }
                 }
             }
-        }, cancellationToken), startIndex: 1, options.DegreeOfParallelism);
-
-        return Task.WhenAll(tasks);
+        }
     }
 
     /// <summary>Determines whether this scanner should scan the specified file.</summary>

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
@@ -89,6 +89,20 @@ public sealed class DependencyScannerTests
     }
 
     [Fact]
+    public async Task ScanDirectory_ScansFilesConcurrently()
+    {
+        await using var directory = TemporaryDirectory.Create();
+        directory.CreateEmptyFile("file1.txt");
+        directory.CreateEmptyFile("file2.txt");
+
+        var scanner = new ConcurrencyProbeScanner(expectedConcurrency: 2);
+        var options = new ScannerOptions { DegreeOfParallelism = 2, Scanners = [scanner] };
+        await DependencyScanner.ScanDirectoryAsync(directory.FullPath, options, onDependencyFound: _ => { }, XunitCancellationToken);
+
+        Assert.True(scanner.ReachedExpectedConcurrency);
+    }
+
+    [Fact]
     public void DefaultScannersIncludeAllScanners()
     {
         var scanners = new ScannerOptions().Scanners.Select(t => t.GetType()).OrderBy(t => t.FullName, StringComparer.Ordinal).ToArray();
@@ -419,6 +433,30 @@ public sealed class DependencyScannerTests
         }
 
         protected override bool ShouldScanFileCore(CandidateFileContext file) => false;
+    }
+
+    private sealed class ConcurrencyProbeScanner(int expectedConcurrency) : DependencyScanner
+    {
+        private readonly TaskCompletionSource _reachedExpectedConcurrency = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _currentConcurrency;
+
+        public bool ReachedExpectedConcurrency => _reachedExpectedConcurrency.Task.IsCompletedSuccessfully;
+
+        protected internal override IReadOnlyCollection<DependencyType> SupportedDependencyTypes { get; } = [];
+
+        public override async ValueTask ScanAsync(ScanFileContext context)
+        {
+            if (Interlocked.Increment(ref _currentConcurrency) >= expectedConcurrency)
+            {
+                _reachedExpectedConcurrency.TrySetResult();
+            }
+
+            // Wait for the other workers to pick up a file, without blocking the scan forever when they never do
+            await Task.WhenAny(_reachedExpectedConcurrency.Task, Task.Delay(TimeSpan.FromSeconds(5), context.CancellationToken)).ConfigureAwait(false);
+            Interlocked.Decrement(ref _currentConcurrency);
+        }
+
+        protected override bool ShouldScanFileCore(CandidateFileContext file) => true;
     }
 
     private sealed class ScanThrowScanner : DependencyScanner


### PR DESCRIPTION
### The problem

`ScanDirectoryParallelAsync` builds its pool of channel consumers with `Array.Fill`:

```csharp
Array.Fill(tasks, Task.Run(async () => { ... }, cancellationToken), startIndex: 1, options.DegreeOfParallelism);
```

`Array.Fill`'s `value` is an ordinary argument, so `Task.Run` is evaluated **once** and the same `Task` reference is copied into all N slots. Only one consumer ever drains the channel, and `Task.WhenAll` then waits on that same task N times.

`DegreeOfParallelism` has therefore had no effect on `ScanDirectoryAsync` — every file is scanned serially, regardless of the value. Measured on 200 files with 10 ms of scan work each and `DegreeOfParallelism = 8`: **2686 ms**, i.e. exactly the serial time. Eight consumers would be ≈350 ms.

### The change

Create one task per worker in a loop, with the consumer body moved to a local function so it reads the same as before.

### Verification

New test `DependencyScannerTests.ScanDirectory_ScansFilesConcurrently`: two files, `DegreeOfParallelism = 2`, and a probe scanner that signals once two files are being scanned at the same time. The probe waits on that signal with a 5 s ceiling, so it never hangs the suite when the workers do not materialise.

- Fails on `main` (the second file is only picked up after the first gives up at the 5 s ceiling).
- Passes with this change.
- Full project suite green: 81/81 on net10.0.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
