### PR TITLE
Fix generated file name collisions in StronglyTypedIdSourceGenerator

### DIFF
--- a/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.cs
+++ b/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.cs
@@ -319,7 +319,35 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
         }
 
         Debug.Assert(writer.Indentation == 0);
-        context.AddSource(attribute.TypeName + ".g.cs", writer.ToSourceText());
+        context.AddSource(GetHintName(attribute.PartialTypeContext), writer.ToSourceText());
+    }
+
+    /// <summary>
+    /// Gets the name of the generated file for a type. Roslyn requires the name to be unique within a generator, so the fully-qualified name of the type is used instead of its short name.
+    /// </summary>
+    private static string GetHintName(PartialTypeContext context)
+    {
+        var sb = new StringBuilder();
+        if (!string.IsNullOrWhiteSpace(context.Namespace))
+        {
+            sb.Append(context.Namespace);
+            sb.Append('.');
+        }
+
+        AppendTypeNames(sb, context);
+        sb.Append(".g.cs");
+        return sb.ToString();
+
+        static void AppendTypeNames(StringBuilder sb, PartialTypeContext context)
+        {
+            if (context.Parent is not null)
+            {
+                AppendTypeNames(sb, context.Parent);
+                sb.Append('.');
+            }
+
+            sb.Append(context.Name);
+        }
     }
 
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Disposed manually")]

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
@@ -150,6 +150,54 @@ public sealed class StronglyTypedIdSourceGeneratorTests
     }
 
     [Fact]
+    public async Task GenerateTypesWithSameNameInDifferentNamespaces()
+    {
+        var sourceCode = """
+            namespace A
+            {
+                [Meziantou.Framework.Annotations.StronglyTypedId(typeof(int))]
+                public partial struct Test {}
+            }
+
+            namespace B
+            {
+                [Meziantou.Framework.Annotations.StronglyTypedId(typeof(int))]
+                public partial struct Test {}
+            }
+            """;
+
+        var result = await GenerateFiles(sourceCode);
+        Assert.Empty(result.GeneratorResult.Diagnostics);
+        Assert.Equal(2, result.GeneratorResult.GeneratedTrees.Length);
+
+        AssertGeneratedTypes(result, ["A.Test", "B.Test"]);
+    }
+
+    [Fact]
+    public async Task GenerateNestedTypesWithSameNameInDifferentContainingTypes()
+    {
+        var sourceCode = """
+            public partial class A
+            {
+                [Meziantou.Framework.Annotations.StronglyTypedId(typeof(int))]
+                public partial struct Test {}
+            }
+
+            public partial class B
+            {
+                [Meziantou.Framework.Annotations.StronglyTypedId(typeof(int))]
+                public partial struct Test {}
+            }
+            """;
+
+        var result = await GenerateFiles(sourceCode);
+        Assert.Empty(result.GeneratorResult.Diagnostics);
+        Assert.Equal(2, result.GeneratorResult.GeneratedTrees.Length);
+
+        AssertGeneratedTypes(result, ["A+Test", "B+Test"]);
+    }
+
+    [Fact]
     public async Task DummyAttribute()
     {
         var sourceCode = """
@@ -1108,6 +1156,31 @@ public sealed class StronglyTypedIdSourceGeneratorTests
         var generated = runResult.GeneratedTrees.Length > 0 ? (await runResult.GeneratedTrees[0].GetRootAsync(XunitCancellationToken)).ToFullString() : "<no file generated>";
         Assert.True(compilationOutput.Success);
         Assert.Empty(compilationOutput.Diagnostics);
+    }
+
+    /// <summary>Loads the generated assembly and ensures the members are generated for every expected type.</summary>
+    private static void AssertGeneratedTypes((GeneratorDriverRunResult GeneratorResult, Compilation OutputCompilation, byte[]? Assembly, byte[] Symbols) result, string[] typeNames)
+    {
+        Assert.NotNull(result.Assembly);
+
+        var alc = new AssemblyLoadContext("test", isCollectible: true);
+        try
+        {
+            var assembly = alc.LoadFromStream(new MemoryStream(result.Assembly), new MemoryStream(result.Symbols));
+            foreach (var typeName in typeNames)
+            {
+                var type = assembly.GetType(typeName);
+                Assert.NotNull(type);
+
+                var from = (MethodInfo)type.GetMember("FromInt32").Single();
+                var instance = from.Invoke(null, [10]);
+                Assert.Equal("10", System.Text.Json.JsonSerializer.Serialize(instance));
+            }
+        }
+        finally
+        {
+            alc.Unload();
+        }
     }
 
     private static Task TestGeneratedAssembly([StringSyntax("c#-test")] string sourceCode, Action<Type> assert)

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
@@ -168,7 +168,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
 
         var result = await GenerateFiles(sourceCode);
         Assert.Empty(result.GeneratorResult.Diagnostics);
-        Assert.Equal(2, result.GeneratorResult.GeneratedTrees.Length);
+        Assert.HasCount(2, result.GeneratorResult.GeneratedTrees);
 
         AssertGeneratedTypes(result, ["A.Test", "B.Test"]);
     }
@@ -192,7 +192,7 @@ public sealed class StronglyTypedIdSourceGeneratorTests
 
         var result = await GenerateFiles(sourceCode);
         Assert.Empty(result.GeneratorResult.Diagnostics);
-        Assert.Equal(2, result.GeneratorResult.GeneratedTrees.Length);
+        Assert.HasCount(2, result.GeneratorResult.GeneratedTrees);
 
         AssertGeneratedTypes(result, ["A+Test", "B+Test"]);
     }


### PR DESCRIPTION
`Execute` used the type's **short** name as the Roslyn hint name:

```csharp
context.AddSource(attribute.TypeName + ".g.cs", writer.ToSourceText());
```

Two strongly-typed IDs sharing a short name — the normal case when namespaces separate bounded contexts (`A.OrderId` / `B.OrderId`) — make the second `AddSource` throw:

```
ArgumentException: The hintName 'Test.g.cs' of the added source file must be unique within a generator.
```

Roslyn catches that, reports only **`warning CS8785`**, and discards **everything** the generator produced — the run yields zero generated sources, not one fewer. Every ID in the compilation silently loses its constructor, `Value`, `Parse`, equality members and converters, so the user sees a wall of `CS1061`/`CS0117` errors on members they never wrote, while the actual cause is a warning that is easy to miss or `NoWarn`-suppressed.

The same collision happens for a top-level `Foo` next to a nested `Outer.Foo`, and for `Outer1.Foo` next to `Outer2.Foo`.

## What changed

The hint name is now built from the fully-qualified name — namespace, then each containing type outermost-first, then the type name. Because C# guarantees fully-qualified type names are unique within a compilation, the hint name is unique too.

`PartialTypeContext` already carries the namespace and the parent chain, so no new data had to be threaded through.

## Verification

Two tests added next to the existing namespace/nesting tests, both of which fail on `main` with the `CS8785` warning and pass here:

- `GenerateTypesWithSameNameInDifferentNamespaces` — `A.Test` + `B.Test`
- `GenerateNestedTypesWithSameNameInDifferentContainingTypes` — `A.Test` + `B.Test` as nested types

Both assert two generated trees, no driver diagnostics, and that each generated type actually works after loading the emitted assembly.

Full suites pass: 730 in `Meziantou.Framework.StronglyTypedId.Tests` (728 + these 2) and 86 in `Meziantou.Framework.StronglyTypedId.GeneratorTests`. `dotnet run ./eng/update-all.cs` is a no-op.

## Note

Generic types are out of scope here — `Outer<T>.Foo` and a non-generic `Outer.Foo` would still produce the same hint name, because `PartialTypeContext.Name` carries no arity. That is not a regression (today they collide too), and it becomes unreachable once generic types are rejected outright, which is done in a separate independent PR.
