### PR TITLE
Validate the parameter count in Execute and ExecuteAsync

### DIFF
--- a/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
+++ b/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
@@ -35,6 +35,7 @@ namespace Meziantou.Framework;
 public sealed class ObjectMethodExecutor
 {
     private readonly object?[]? _parameterDefaultValues;
+    private readonly string _methodName;
     private readonly MethodExecutorAsync? _executorAsync;
     private readonly MethodExecutor? _executor;
 
@@ -53,6 +54,7 @@ public sealed class ObjectMethodExecutor
         ArgumentNullException.ThrowIfNull(methodInfo);
 
         MethodParameters = methodInfo.GetParameters();
+        _methodName = $"{methodInfo.DeclaringType?.FullName}.{methodInfo.Name}";
         MethodReturnType = methodInfo.ReturnType;
 
         var isAwaitable = CoercedAwaitableInfo.IsTypeAwaitable(MethodReturnType, out var coercedAwaitableInfo);
@@ -132,8 +134,11 @@ public sealed class ObjectMethodExecutor
     /// <param name="target">The object whose method is to be executed.</param>
     /// <param name="parameters">Parameters to pass to the method.</param>
     /// <returns>The method return value.</returns>
+    /// <exception cref="ArgumentException"><paramref name="parameters"/> does not contain one entry per method parameter.</exception>
     public object? Execute(object? target, object?[]? parameters)
     {
+        ValidateParameters(parameters);
+
         Debug.Assert(_executor is not null, "Sync execution is not supported.");
         return _executor(target, parameters);
     }
@@ -157,9 +162,12 @@ public sealed class ObjectMethodExecutor
     /// <param name="target">The object whose method is to be executed.</param>
     /// <param name="parameters">Parameters to pass to the method.</param>
     /// <returns>An object that you can "await" to get the method return value.</returns>
+    /// <exception cref="ArgumentException"><paramref name="parameters"/> does not contain one entry per method parameter.</exception>
     /// <exception cref="InvalidOperationException">The configured method is an <c>async void</c> method, which cannot be awaited. Use <see cref="Execute"/> instead.</exception>
     public ObjectMethodExecutorAwaitable ExecuteAsync(object? target, object?[]? parameters)
     {
+        ValidateParameters(parameters);
+
         Debug.Assert(_executorAsync is not null, "Async execution is not supported.");
         return _executorAsync(target, parameters);
     }
@@ -407,5 +415,15 @@ public sealed class ObjectMethodExecutor
                 (taskAwaiter, action) => ((TaskAwaiter<object?>)taskAwaiter).OnCompleted(action),
                 (taskAwaiter, action) => ((TaskAwaiter<object?>)taskAwaiter).UnsafeOnCompleted(action));
         };
+    }
+
+    private void ValidateParameters(object?[]? parameters)
+    {
+        // The compiled delegate indexes and unboxes the array with no guard, so a wrong-sized array
+        // surfaces as IndexOutOfRangeException or NullReferenceException from generated code with no
+        // useful frame. Check the count here so the caller learns which method it got wrong.
+        var actual = parameters?.Length ?? 0;
+        if (actual != MethodParameters.Length)
+            throw new ArgumentException($"'{_methodName}' takes {MethodParameters.Length} parameter(s), but {actual} were supplied", nameof(parameters));
     }
 }

--- a/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
+++ b/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
@@ -121,6 +121,55 @@ public sealed class ObjectMethodExecutorTests
     }
 
     [Fact]
+    public void Execute_ThrowsWhenTooFewParameters()
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32WithParam")!);
+
+        var exception = Assert.Throws<ArgumentException>(() => executor.Execute(new Test(), []));
+        Assert.Contains("SyncInt32WithParam", exception.Message);
+    }
+
+    [Fact]
+    public void Execute_ThrowsWhenTooManyParameters()
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32WithParam")!);
+
+        Assert.Throws<ArgumentException>(() => executor.Execute(new Test(), [1, 2]));
+    }
+
+    [Fact]
+    public void Execute_ThrowsWhenParametersIsNullAndMethodTakesParameters()
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32WithParam")!);
+
+        Assert.Throws<ArgumentException>(() => executor.Execute(new Test(), parameters: null));
+    }
+
+    [Fact]
+    public void Execute_AllowsNullParametersForParameterlessMethod()
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("SyncInt32")!);
+
+        Assert.Equal(1, executor.Execute(new Test(), parameters: null));
+    }
+
+    [Fact]
+    public void ExecuteAsync_ThrowsWhenParameterCountIsWrong()
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32WithParam")!);
+
+        Assert.Throws<ArgumentException>(() => executor.ExecuteAsync(new Test(), []));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AllowsNullParametersForParameterlessMethod()
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32")!);
+
+        Assert.Equal(1, await executor.ExecuteAsync(new Test(), parameters: null));
+    }
+
+    [Fact]
     public async Task AsyncTaskInt32WithParamTests()
     {
         var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32WithParam")!);


### PR DESCRIPTION
**Stack 2 of 2 · targets `fix/reject-async-void` · merge #2225 first.**

Both PRs add an `<exception>` tag at the same spot in `ExecuteAsync`'s docs, so they cannot land independently. The diff shown here is layer 2 only.

---

A wrong-sized `parameters` array produced a bare `IndexOutOfRangeException` or `NullReferenceException` from generated code, with no frame pointing at the caller's mistake.

## The defect

The compiled delegate indexes and unboxes `parameters[i]` with no guard. Against an executor for `int SyncInt32WithParam(int i)`:

| call | before |
|---|---|
| `Execute(target, [])` | `IndexOutOfRangeException: Index was outside the bounds of the array.` |
| `Execute(target, null)` | `NullReferenceException` |
| `Execute(target, [1, 2])` | *silently ignored the extra argument* |

`parameters` is declared `object?[]?`, so passing `null` is an advertised call — and it threw `NullReferenceException` for any method with at least one parameter. None of these named the method or the argument. `MethodInfo.Invoke`, by contrast, raises `TargetParameterCountException`.

## The change

`Execute` and `ExecuteAsync` now check the count once, up front, and throw `ArgumentException` naming the method and both counts. This also closes the silent case: passing too many arguments used to be ignored and is now rejected.

`parameters: null` keeps working for a parameterless method — it is treated as zero arguments, which is what it did before and what callers rely on. There is a test pinning that in both `Execute` and `ExecuteAsync`.

The check is one length comparison against `MethodParameters`, which was previously only reachable from a method with no callers.

## Deliberately not included

Passing `null` for a value-type parameter (`Execute(target, [null])`) still throws `NullReferenceException` from the unboxing conversion. Producing a good message there needs a per-parameter type check on every call, and `Execute` is a ~15 ns operation — that seemed worth raising separately rather than folding in here. Happy to add it if you'd rather have the diagnostic than the nanoseconds.

## Verification

Six tests added to `ObjectMethodExecutorTests.cs` — too few, too many, `null` with parameters, `null` without parameters, and the `ExecuteAsync` equivalents.

- The four throw-tests **fail on `main`** and pass here. The two that pin the existing `null`-array behavior pass on both, which is their job.
- Full suite green on top of layer 1: 48 passed (24 × net10.0/net11.0), 0 failed.
- No public API change, so `ref/` is unchanged.

Found during a review of `Meziantou.Framework.ObjectMethodExecutor`.
