### PR TITLE
Return null instead of throwing when a row is shorter than its header

### DIFF
--- a/src/Meziantou.Framework.Csv/CsvRow.cs
+++ b/src/Meziantou.Framework.Csv/CsvRow.cs
@@ -46,7 +46,7 @@ public class CsvRow : IReadOnlyDictionary<string, string?>
 
     /// <summary>Gets the value of the column with the specified name.</summary>
     /// <param name="columnName">The name of the column.</param>
-    /// <returns>The value of the column, or <see langword="null"/> if the column is not found.</returns>
+    /// <returns>The value of the column, or <see langword="null"/> if the column is not found or the row has no value at the column's index.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="columnName"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">The CSV file has no header row.</exception>
     public virtual string? this[string columnName]
@@ -66,9 +66,9 @@ public class CsvRow : IReadOnlyDictionary<string, string?>
         }
     }
 
-    /// <summary>Gets the value of the specified column.</summary>
+    /// <summary>Gets the value of the specified column, or <see langword="null"/> if the row has no value at the column's index.</summary>
     /// <param name="column">The column.</param>
-    /// <returns>The value of the column.</returns>
+    /// <returns>The value of the column, or <see langword="null"/> if the row has fewer values than the column's index.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="column"/> is <see langword="null"/>.</exception>
     public virtual string? this[CsvColumn column]
     {
@@ -76,15 +76,19 @@ public class CsvRow : IReadOnlyDictionary<string, string?>
         {
             ArgumentNullException.ThrowIfNull(column);
 
-            return this[column.Index];
+            var index = column.Index;
+            if (index < 0 || index >= Values.Count)
+                return null;
+
+            return this[index];
         }
     }
 
-    IEnumerable<string> IReadOnlyDictionary<string, string?>.Keys => Columns is null ? Enumerable.Empty<string>() : Columns.Where(c => c.Name is not null).Select(c => c.Name!);
+    IEnumerable<string> IReadOnlyDictionary<string, string?>.Keys => Columns is null ? [] : Columns.Select(c => c.Name ?? "");
 
     IEnumerable<string> IReadOnlyDictionary<string, string?>.Values => Values;
 
-    int IReadOnlyCollection<KeyValuePair<string, string?>>.Count => Values.Count;
+    int IReadOnlyCollection<KeyValuePair<string, string?>>.Count => Columns?.Count ?? Values.Count;
 
     string? IReadOnlyDictionary<string, string?>.this[string key] => this[key];
 
@@ -98,11 +102,18 @@ public class CsvRow : IReadOnlyDictionary<string, string?>
 
     bool IReadOnlyDictionary<string, string?>.TryGetValue(string key, out string? value)
     {
-        var v = this[key];
-        if (v is not null)
+        ArgumentNullException.ThrowIfNull(key);
+
+        if (Columns is not null)
         {
-            value = v;
-            return true;
+            foreach (var column in Columns)
+            {
+                if (string.Equals(column.Name, key, StringComparison.Ordinal))
+                {
+                    value = this[column];
+                    return true;
+                }
+            }
         }
 
         value = default;

--- a/tests/Meziantou.Framework.Csv.Tests/CsvRowTests.cs
+++ b/tests/Meziantou.Framework.Csv.Tests/CsvRowTests.cs
@@ -14,4 +14,103 @@ public class CsvRowTests
         var actual = row.GetValueOrDefault("test", 0);
         Assert.Equal(42, actual);
     }
+
+    [Fact]
+    public async Task RaggedRow_ValueOfMissingColumnIsNull()
+    {
+        var row = await ReadSingleRowWithHeaderAsync("A,B,C\n1,2");
+
+        Assert.Equal("1", row["A"]);
+        Assert.Equal("2", row["B"]);
+        Assert.Null(row["C"]);
+        Assert.Null(row["unknown"]);
+    }
+
+    [Fact]
+    public async Task RaggedRow_TryGetValueDoesNotThrow()
+    {
+        var row = (IReadOnlyDictionary<string, string?>)await ReadSingleRowWithHeaderAsync("A,B,C\n1,2");
+
+        Assert.True(row.TryGetValue("C", out var value));
+        Assert.Null(value);
+
+        Assert.True(row.TryGetValue("A", out var a));
+        Assert.Equal("1", a);
+
+        Assert.False(row.TryGetValue("unknown", out var unknown));
+        Assert.Null(unknown);
+    }
+
+    [Fact]
+    public async Task RaggedRow_ContainsKeyAgreesWithTryGetValue()
+    {
+        var row = (IReadOnlyDictionary<string, string?>)await ReadSingleRowWithHeaderAsync("A,B,C\n1,2");
+
+        foreach (var key in new[] { "A", "B", "C", "unknown" })
+        {
+            Assert.Equal(row.ContainsKey(key), row.TryGetValue(key, out _));
+        }
+    }
+
+    [Fact]
+    public async Task RaggedRow_CountAgreesWithKeysAndEnumeration()
+    {
+        var row = (IReadOnlyDictionary<string, string?>)await ReadSingleRowWithHeaderAsync("A,B,C\n1,2");
+
+        Assert.Equal(3, row.Count);
+        Assert.Equal(["A", "B", "C"], row.Keys);
+    }
+
+    [Fact]
+    public async Task RaggedRow_EnumerationDoesNotThrow()
+    {
+        var row = (IReadOnlyDictionary<string, string?>)await ReadSingleRowWithHeaderAsync("A,B,C\n1,2");
+
+        Assert.Equal(
+            [
+                new KeyValuePair<string, string?>("A", "1"),
+                new KeyValuePair<string, string?>("B", "2"),
+                new KeyValuePair<string, string?>("C", null),
+            ],
+            row.ToList());
+    }
+
+    [Fact]
+    public async Task CompleteRow_DictionaryViewIsConsistent()
+    {
+        var row = (IReadOnlyDictionary<string, string?>)await ReadSingleRowWithHeaderAsync("A,B\n1,2");
+
+        Assert.Equal(2, row.Count);
+        Assert.Equal(["A", "B"], row.Keys);
+        Assert.Equal(["1", "2"], row.Values);
+        Assert.True(row.TryGetValue("B", out var b));
+        Assert.Equal("2", b);
+    }
+
+    [Fact]
+    public void RowWithoutHeader_ValueByColumnOutOfRangeIsNull()
+    {
+        var row = new CsvRow(columns: null, ["1", "2"]);
+
+        Assert.Null(row[new CsvColumn("C", 2)]);
+        Assert.Equal("1", row[new CsvColumn("A", 0)]);
+    }
+
+    [Fact]
+    public void IndexerByPositionStillThrowsOutOfRange()
+    {
+        var row = new CsvRow(columns: null, ["1", "2"]);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => row[2]);
+        Assert.Throws<ArgumentOutOfRangeException>(() => row[-1]);
+    }
+
+    private static async Task<CsvRow> ReadSingleRowWithHeaderAsync(string csv)
+    {
+        using var sr = new StringReader(csv);
+        var reader = new CsvReader(sr) { HasHeaderRow = true };
+        var row = await reader.ReadRowAsync();
+        Assert.NotNull(row);
+        return row;
+    }
 }


### PR DESCRIPTION
`CsvRow` advertises itself as an `IReadOnlyDictionary<string, string?>`, but every name-based member routed through `this[column.Index]` (`CsvRow.cs:79`), which throws once the row has fewer values than the header has columns. With header `A,B,C` and a row of two values:

```csharp
dict.ContainsKey("C")        // true
dict.TryGetValue("C", out _) // throws ArgumentOutOfRangeException
foreach (var kvp in dict)    // throws after yielding A and B
dict.Count                   // 2   (from Values)
dict.Keys.Count()            // 3   (from Columns)
```

Three separate contract violations:

- **`TryGetValue` throws.** The entire point of the `Try` prefix is that it does not. Code written against the interface has no way to defend against this.
- **`ContainsKey` returns `true` for a key that then throws.** The worst combination: the guard you would naturally write does not help.
- **`Count` disagrees with `Keys`.** LINQ operators and serializers that trust one or the other silently produce wrong results.

Ragged rows are normal in real-world CSV, and they also arrive from well-formed input via the trailing-empty-field defect fixed separately in #2245 — so `row["LastColumn"]` throwing is reachable today from an ordinary file.

## What changed

`this[CsvColumn]` is the single source of every throw, so the bounds check goes there: an index outside the row's values now returns `null`, matching what `this[string]` already promised for an unknown column. It still delegates to the virtual `this[int]` for in-range indices, so subclasses keep their override.

That alone fixes `foreach` and the name indexer. On top of it:

- `TryGetValue` no longer routes through the indexer's null-means-missing signal. It looks the key up in `Columns` and returns `true` whenever the column exists — so it agrees with `ContainsKey` — with `value` set to `null` when the row is short.
- `Count` and `Keys` are both column-based when a header is present, so `Count`, `Keys`, and the enumerator all agree. Behaviour without a header is deliberately untouched: `Count` stays `Values.Count` and `Keys` stays empty.

`this[int]` still throws `ArgumentOutOfRangeException` — it is the positional accessor and that is correct.

## Verification

- `dotnet test /p:TreatsWarningsAsErrors=true` — 54 passed (27 × net10.0/net11.0), up from 38.
- 8 new tests in `CsvRowTests.cs` covering the ragged case for the name indexer, `TryGetValue`, `ContainsKey`/`TryGetValue` agreement, `Count`/`Keys` agreement, and enumeration; plus a headerless case and a guard that positional indexing still throws.
- Reverting only `CsvRow.cs` and re-running turns **12 of them red**.
- `dotnet build /p:TreatsWarningsAsErrors=true` — succeeded, `ref/` unchanged (no signature changes). `dotnet run ./eng/update-all.cs` — no generated-file changes.

Found by a review of `src/Meziantou.Framework.Csv`.

