### PR TITLE
Qualify TargetFramework lookups with the project namespace

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Scanners/MsBuildReferencesDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/MsBuildReferencesDependencyScanner.cs
@@ -157,21 +157,21 @@ public sealed partial class MsBuildReferencesDependencyScanner : DependencyScann
 
         foreach (var element in doc.Descendants(ns + "PropertyGroup"))
         {
-            foreach (var targetFrameworkElement in element.Elements("TargetFrameworkVersion"))
+            foreach (var targetFrameworkElement in element.Elements(ns + "TargetFrameworkVersion"))
             {
                 context.ReportDependency(this, name: null, targetFrameworkElement.Value.Trim(), DependencyType.DotNetTargetFramework,
                     nameLocation: null,
                     versionLocation: new XmlLocation(context.FileSystem, context.FullPath, targetFrameworkElement));
             }
 
-            foreach (var targetFrameworkElement in element.Elements("TargetFramework"))
+            foreach (var targetFrameworkElement in element.Elements(ns + "TargetFramework"))
             {
                 context.ReportDependency(this, name: null, targetFrameworkElement.Value.Trim(), DependencyType.DotNetTargetFramework,
                     nameLocation: null,
                     versionLocation: new XmlLocation(context.FileSystem, context.FullPath, targetFrameworkElement));
             }
 
-            foreach (var targetFrameworkElement in element.Elements("TargetFrameworks"))
+            foreach (var targetFrameworkElement in element.Elements(ns + "TargetFrameworks"))
             {
                 foreach (Match match in TargetFrameworksRegex().Matches(targetFrameworkElement.Value))
                 {

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -215,7 +215,7 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
             <Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
               <PropertyGroup>
-                <TargetFramework>netstandard2.0</TargetFramework>
+                <TargetFramework>2.0.0</TargetFramework>
                 <RootNamespace>Sample</RootNamespace>
               </PropertyGroup>
 
@@ -230,9 +230,45 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
 
         AddFile("test.csproj", Original);
         var result = await GetDependencies<MsBuildReferencesDependencyScanner>();
-        AssertContainDependency(result, (DependencyType.NuGet, "TestPackage", "4.2.1", 11, 45));
+        AssertContainDependency(result,
+            (DependencyType.NuGet, "TestPackage", "4.2.1", 11, 45),
+            (DependencyType.DotNetTargetFramework, null, "netstandard2.0", 0, 0));
 
         await UpdateDependencies(result, "dummy", "2.0.0");
+        AssertFileContentEqual("test.csproj", Expected, ignoreNewLines: true);
+    }
+
+    [Fact]
+    public async Task DotNetTargetFrameworkWithNamespace()
+    {
+        const string Original = """
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <TargetFramework>net472</TargetFramework>
+        <TargetFrameworks>net48</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    </PropertyGroup>
+</Project>
+""";
+        const string Expected = """
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <TargetFramework>net0.0</TargetFramework>
+        <TargetFrameworks>net0.0</TargetFrameworks>
+        <TargetFrameworks>net0.0;net0.0</TargetFrameworks>
+        <TargetFrameworkVersion>net0.0</TargetFrameworkVersion>
+    </PropertyGroup>
+</Project>
+""";
+
+        AddFile("test.csproj", Original);
+        var result = await GetDependencies<MsBuildReferencesDependencyScanner>();
+        AssertContainDependency(result,
+            (DependencyType.DotNetTargetFramework, null, "net472", 0, 0),
+            (DependencyType.DotNetTargetFramework, null, "v4.7.2", 0, 0));
+
+        await UpdateDependencies(result, "dummy", "net0.0");
         AssertFileContentEqual("test.csproj", Expected, ignoreNewLines: true);
     }
 


### PR DESCRIPTION
### The problem

`MsBuildReferencesDependencyScanner` qualifies the enclosing element with the document namespace but not the three inner lookups:

```csharp
foreach (var element in doc.Descendants(ns + "PropertyGroup"))   // qualified
{
    foreach (var e in element.Elements("TargetFrameworkVersion")) // NOT qualified
    foreach (var e in element.Elements("TargetFramework"))        // NOT qualified
    foreach (var e in element.Elements("TargetFrameworks"))       // NOT qualified
```

The implicit `string` → `XName` conversion produces a name in the *empty* namespace, which never matches a project declaring `xmlns="http://schemas.microsoft.com/developer/msbuild/2003"`. Every other lookup in the file uses `ns +`.

So no target framework is reported for a namespaced project. That is worth noting for `TargetFrameworkVersion` in particular, which is essentially only used *by* legacy namespaced projects — the branch was dead for every file it was written for. SDK-style projects were unaffected because `ns` is empty there.

### The change

Prefix the three lookups with `ns +`.

### Verification

New test `ScannerTests.DotNetTargetFrameworkWithNamespace` — the existing `DotNetTargetFramework` fixture with the legacy `xmlns` added. Fails on `main` (nothing detected, file unchanged), passes here.

`PackagesReferencesWithNamespaceDependencies` also changes, and that is the interesting part: its expected output had `<TargetFramework>netstandard2.0</TargetFramework>` surviving an "update every dependency" pass untouched. That expectation was encoding the bug. It now updates like any other detected dependency, and the test additionally asserts the target framework is found.

Full project suite green: 81/81 on net10.0.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
