### PR TITLE
Annotate unsafeOnCompletedMethod as nullable to match its runtime value

### DIFF
--- a/ref/Meziantou.Framework.ObjectMethodExecutor.cs
+++ b/ref/Meziantou.Framework.ObjectMethodExecutor.cs
@@ -20,7 +20,7 @@ namespace Meziantou.Framework
         public readonly struct Awaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
         {
             public bool IsCompleted { get => throw null; }
-            public Awaiter(object customAwaiter, System.Func<object, bool> isCompletedMethod, System.Func<object, object?> getResultMethod, System.Action<object, System.Action> onCompletedMethod, System.Action<object, System.Action> unsafeOnCompletedMethod) { }
+            public Awaiter(object customAwaiter, System.Func<object, bool> isCompletedMethod, System.Func<object, object?> getResultMethod, System.Action<object, System.Action> onCompletedMethod, System.Action<object, System.Action>? unsafeOnCompletedMethod) { }
             public object? GetResult() => throw null;
             public void OnCompleted(System.Action continuation) { }
             public void UnsafeOnCompleted(System.Action continuation) { }

--- a/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutorAwaitable.cs
+++ b/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutorAwaitable.cs
@@ -15,7 +15,7 @@ public readonly struct ObjectMethodExecutorAwaitable
     private readonly Func<object, bool> _isCompletedMethod;
     private readonly Func<object, object?> _getResultMethod;
     private readonly Action<object, Action> _onCompletedMethod;
-    private readonly Action<object, Action> _unsafeOnCompletedMethod;
+    private readonly Action<object, Action>? _unsafeOnCompletedMethod;
 
     // Perf note: since we're requiring the customAwaitable to be supplied here as an object,
     // this will trigger a further allocation if it was a value type (i.e., to box it). We can't
@@ -41,7 +41,7 @@ public readonly struct ObjectMethodExecutorAwaitable
         Func<object, bool> isCompletedMethod,
         Func<object, object?> getResultMethod,
         Action<object, Action> onCompletedMethod,
-        Action<object, Action> unsafeOnCompletedMethod)
+        Action<object, Action>? unsafeOnCompletedMethod)
     {
         _customAwaitable = customAwaitable;
         _getAwaiterMethod = getAwaiterMethod;
@@ -67,20 +67,20 @@ public readonly struct ObjectMethodExecutorAwaitable
         private readonly Func<object, bool> _isCompletedMethod;
         private readonly Func<object, object?> _getResultMethod;
         private readonly Action<object, Action> _onCompletedMethod;
-        private readonly Action<object, Action> _unsafeOnCompletedMethod;
+        private readonly Action<object, Action>? _unsafeOnCompletedMethod;
 
         /// <summary>Initializes a new instance of the <see cref="Awaiter"/> struct.</summary>
         /// <param name="customAwaiter">The custom awaiter to wrap.</param>
         /// <param name="isCompletedMethod">The method to check if the operation is completed.</param>
         /// <param name="getResultMethod">The method to retrieve the result.</param>
         /// <param name="onCompletedMethod">The method to schedule continuations.</param>
-        /// <param name="unsafeOnCompletedMethod">The method to schedule continuations without capturing context.</param>
+        /// <param name="unsafeOnCompletedMethod">The method to schedule continuations without capturing context, or <see langword="null"/> if the underlying awaiter does not implement <see cref="ICriticalNotifyCompletion"/>.</param>
         public Awaiter(
             object customAwaiter,
             Func<object, bool> isCompletedMethod,
             Func<object, object?> getResultMethod,
             Action<object, Action> onCompletedMethod,
-            Action<object, Action> unsafeOnCompletedMethod)
+            Action<object, Action>? unsafeOnCompletedMethod)
         {
             _customAwaiter = customAwaiter;
             _isCompletedMethod = isCompletedMethod;

--- a/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
+++ b/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
@@ -97,6 +97,29 @@ public sealed class ObjectMethodExecutorTests
     }
 
     [Fact]
+    public async Task AwaiterImplementingOnlyINotifyCompletion()
+    {
+        var executor = ObjectMethodExecutor.Create(typeof(Test).GetMethod("NotifyOnlyAwaitable")!);
+
+        Assert.True(executor.IsMethodAsync);
+        Assert.Equal(42, await executor.ExecuteAsync(new Test(), []));
+    }
+
+    private sealed class NotifyOnlyAwaitable
+    {
+        public NotifyOnlyAwaiter GetAwaiter() => new();
+
+        internal sealed class NotifyOnlyAwaiter : INotifyCompletion
+        {
+            public bool IsCompleted => false;
+
+            public int GetResult() => 42;
+
+            public void OnCompleted(Action continuation) => ThreadPool.QueueUserWorkItem(_ => continuation());
+        }
+    }
+
+    [Fact]
     public async Task AsyncValueTaskTests()
     {
         var validator = new Validator();
@@ -179,6 +202,8 @@ public sealed class ObjectMethodExecutorTests
         }
 
         public ValueTask<int> ValueTaskInt32() => ValueTask.FromResult(1);
+
+        public NotifyOnlyAwaitable NotifyOnlyAwaitable() => new();
 
         public async ValueTask AsyncValueTask(Validator validator)
         {


### PR DESCRIPTION
`_unsafeOnCompletedMethod` was declared non-nullable but is genuinely `null` at runtime. Only a `??` kept that from being a `NullReferenceException`, and nothing tested it.

## The defect

`AwaitableInfo.AwaiterUnsafeOnCompletedMethod` is `null` whenever the awaiter implements `INotifyCompletion` but not `ICriticalNotifyCompletion`. That `null` flows through `Expression.Constant(unsafeOnCompletedFunc, typeof(Action<object, Action>))` into fields and constructor parameters declared `Action<object, Action>` — non-nullable.

The only thing standing between that and an NRE is line 123 of `ObjectMethodExecutorAwaitable.cs`:

```csharp
var underlyingMethodToUse = _unsafeOnCompletedMethod ?? _onCompletedMethod;
```

The path is live — awaiting a method that returns an `INotifyCompletion`-only awaitable works today. But it had no test: the only custom-awaitable test, `AsyncCustomAwaiter`, uses `YieldAwaitable`, whose awaiter *does* implement `ICriticalNotifyCompletion`.

That combination is the hazard. `AGENTS.md` says "Trust the C# null annotations and don't add null checks when the type system says a value cannot be null" — so a reviewer or analyzer applying the repo's own rule would delete that `??` as dead code, and the suite would stay green.

I checked what that would actually cost. With the `??` replaced by `_unsafeOnCompletedMethod!`, the NRE fires on the continuation thread, so it does not surface as a test failure — it comes out as an **unhandled exception that takes down the test host**, and two tests never report at all.

## The change

Annotate the truth. Both fields and both constructor parameters become `Action<object, Action>?`, which is how upstream ASP.NET Core declares them, and the XML doc says when `null` is expected. No behavior change — the `??` was already doing the right thing; this stops the type system from claiming otherwise.

`Awaiter`'s constructor is public, so this is a public signature change. It is annotation-only and binary compatible, and `ref/` is regenerated accordingly.

## Verification

One test added covering an awaitable whose awaiter implements only `INotifyCompletion`, driven through `ExecuteAsync` with `IsCompleted` returning `false` so the `UnsafeOnCompleted` path is actually taken.

To be clear about what this test does and does not do: it **passes on `main`** — the `??` already works, so this is not a regression test. Its job is to make the hazard above impossible to reintroduce silently. It fails (loudly, by killing the host) the moment the fallback is removed.

- Full suite green: 30 passed (15 × net10.0/net11.0), 0 failed.
- `ref/Meziantou.Framework.ObjectMethodExecutor.cs` regenerated — one parameter gains `?`.
- Package `<Version>` deliberately untouched.

Found during a review of `Meziantou.Framework.ObjectMethodExecutor`.
