### PR TITLE
Allow CsvRow to be derived from outside the assembly

### DIFF
--- a/ref/Meziantou.Framework.Csv.cs
+++ b/ref/Meziantou.Framework.Csv.cs
@@ -37,6 +37,7 @@ namespace Meziantou.Framework.Csv
         public string? this[int index] { get => throw null; }
         public string? this[string columnName] { get => throw null; }
         public string? this[Meziantou.Framework.Csv.CsvColumn column] { get => throw null; }
+        protected internal CsvRow(System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Csv.CsvColumn>? columns, System.Collections.Generic.IReadOnlyList<string> values) { }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;
     }
 

--- a/src/Meziantou.Framework.Csv/CsvRow.cs
+++ b/src/Meziantou.Framework.Csv/CsvRow.cs
@@ -24,7 +24,10 @@ public class CsvRow : IReadOnlyDictionary<string, string?>
     /// <summary>Gets the values of the row.</summary>
     public IReadOnlyList<string> Values { get; }
 
-    internal CsvRow(IReadOnlyList<CsvColumn>? columns, IReadOnlyList<string> values)
+    /// <summary>Initializes a new instance of the <see cref="CsvRow"/> class.</summary>
+    /// <param name="columns">The columns of the row, or <see langword="null"/> if the CSV file has no header row.</param>
+    /// <param name="values">The values of the row.</param>
+    protected internal CsvRow(IReadOnlyList<CsvColumn>? columns, IReadOnlyList<string> values)
     {
         Values = values;
         Columns = columns;

--- a/tests/Meziantou.Framework.Csv.Tests/CsvReaderTests.cs
+++ b/tests/Meziantou.Framework.Csv.Tests/CsvReaderTests.cs
@@ -194,4 +194,31 @@ public class CsvReaderTests
             return Task.FromResult(Read(buffer, index, count));
         }
     }
+
+    [Fact]
+    public async Task CsvReader_CreateRowAndCreateColumnCanBeOverridden()
+    {
+        using var sr = new StringReader("A,B\n1,2");
+        var reader = new CustomReader(sr) { HasHeaderRow = true };
+
+        var row = await reader.ReadRowAsync();
+
+        var customRow = Assert.IsType<CustomRow>(row);
+        Assert.Equal("1", customRow["A"]);
+        Assert.NotNull(customRow.Columns);
+        Assert.IsType<CustomColumn>(customRow.Columns[0]);
+    }
+
+    private sealed class CustomColumn(string? name, int index) : CsvColumn(name, index);
+
+    private sealed class CustomRow(IReadOnlyList<CsvColumn>? columns, IReadOnlyList<string> values)
+        : CsvRow(columns, values);
+
+    private sealed class CustomReader(TextReader reader) : CsvReader(reader)
+    {
+        protected override CsvColumn CreateColumn(string name, int index) => new CustomColumn(name, index);
+
+        protected override CsvRow CreateRow(IReadOnlyList<CsvColumn>? columns, IReadOnlyList<string> values)
+            => new CustomRow(columns, values);
+    }
 }


### PR DESCRIPTION
`CsvReader.CreateRow` is `protected virtual` and carries this doc comment (`CsvReader.cs:278`):

> This method can be overridden to create custom row types.

`CsvRow`'s three indexers are `virtual` for the same reason. But `CsvRow`'s only constructor was `internal` (`CsvRow.cs:27`), so **no external assembly could derive from `CsvRow` at all**. A consumer follows the doc comment, overrides `CreateRow`, and then cannot write the type it is supposed to return:

```
error CS1729: 'CsvRow' does not contain a constructor that takes 2 arguments
```

The in-repo tests only construct `CsvRow` directly because of `[assembly: InternalsVisibleTo("Meziantou.Framework.Csv.Tests")]` (`Properties/AssemblyInfo.cs:3`), which is why this never surfaced. `ref/Meziantou.Framework.Csv.cs` confirms no constructor was exported. The `virtual` modifiers on `CsvRow`'s indexers were dead weight for the same reason.

## What changed

The constructor becomes `protected internal` and gets an XML doc comment. `protected internal` is the accessibility this needs and `protected` alone is not: `CsvReader.CreateRow` calls `new CsvRow(...)` without deriving from `CsvRow`, so it needs the `internal` half, while an external subclass needs the `protected` half for its `: base(...)` call.

It also keeps direct construction closed. External code can subclass `CsvRow` but still cannot do `new CsvRow(columns, values)`, so rows continue to come from a reader.

This is purely additive to the public surface — `ref/Meziantou.Framework.Csv.cs` gains one line and nothing changes meaning.

## Verification

- `dotnet test /p:TreatsWarningsAsErrors=true` — 40 passed (20 × net10.0/net11.0), up from 38.
- New test `CsvReader_CreateRowAndCreateColumnCanBeOverridden` exercises the documented extension point end to end: a derived reader overriding both `CreateColumn` and `CreateRow`, asserting the derived types come back out of `ReadRowAsync`.
- Because the test assembly has `InternalsVisibleTo`, it cannot prove the external case — so that was checked separately by compiling a **separate assembly** against the built library. It now compiles and runs (`external subclass OK: TypedRow, A=x`), and direct construction from that assembly still fails with `error CS0122: ... is inaccessible due to its protection level`, which is the intent.
- `dotnet build /p:TreatsWarningsAsErrors=true` — succeeded; `ref/` regenerated and committed. `dotnet run ./eng/update-all.cs` — no further generated-file changes.

## Alternative

If extensibility here is not actually wanted, the coherent opposite is to seal `CsvRow`, drop the `virtual` modifiers from its indexers, and delete the "can be overridden" language from `CreateRow`. Happy to switch to that — the current half-open state is the only outcome that helps nobody.

Found by a review of `src/Meziantou.Framework.Csv`.
