### PR TITLE
Match the optionalDependencies section name exactly

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Scanners/NpmPackageJsonDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/NpmPackageJsonDependencyScanner.cs
@@ -13,7 +13,7 @@ public sealed class NpmPackageJsonDependencyScanner : DependencyScanner
         "dependencies",
         "devDependencies",
         "peerDependencies",
-        "optionaldependencies",
+        "optionalDependencies",
     ];
 
     protected internal override IReadOnlyCollection<DependencyType> SupportedDependencyTypes { get; } = [DependencyType.Npm];

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -23,6 +23,12 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
   "devDependencies": {
     "b": "1.2.3",
     "c": null
+  },
+  "peerDependencies": {
+    "d": "3.1.4"
+  },
+  "optionalDependencies": {
+    "e": "4.1.5"
   }
 }
 """;
@@ -37,6 +43,12 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
   "devDependencies": {
     "b": "2.0.0",
     "c": null
+  },
+  "peerDependencies": {
+    "d": "2.0.0"
+  },
+  "optionalDependencies": {
+    "e": "2.0.0"
   }
 }
 """;
@@ -45,7 +57,9 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
         var result = await GetDependencies<NpmPackageJsonDependencyScanner>();
         AssertContainDependency(result,
             (DependencyType.Npm, "a", "1.0.0", 0, 0),
-            (DependencyType.Npm, "b", "1.2.3", 0, 0));
+            (DependencyType.Npm, "b", "1.2.3", 0, 0),
+            (DependencyType.Npm, "d", "3.1.4", 0, 0),
+            (DependencyType.Npm, "e", "4.1.5", 0, 0));
 
         await UpdateDependencies(result, "dummy", "2.0.0");
         AssertFileContentEqual("package.json", Expected, ignoreNewLines: true);


### PR DESCRIPTION
### The problem

`NpmPackageJsonDependencyScanner` looks up its four dependency sections by name:

```csharp
"dependencies",
"devDependencies",
"peerDependencies",
"optionaldependencies",   // <-- all lowercase
```

Lookup goes through `JsonObject.TryGetPropertyValue`, which is case-sensitive by default, and npm's key is `optionalDependencies`. So that section was never scanned — the entry matched nothing while the real property was skipped. The other three are cased correctly and worked.

Optional dependencies are still installed and still carry vulnerabilities, so an audit built on this silently under-reported, with no error to notice.

### The change

Fix the casing.

### Verification

`ScannerTests.NpmPackageJsonDependencies` now covers all four sections — the fixture gains a `peerDependencies` entry (previously untested too, though it worked) and an `optionalDependencies` entry, and both are asserted as found and as updated.

Fails on `main` (`d` and `e` are not reported), passes here. Full project suite green: 80/80 on net10.0.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
