### PR TITLE
Cache the awaitable helper delegates by awaitable type

### DIFF
--- a/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
+++ b/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
@@ -12,6 +12,11 @@ namespace Meziantou.Framework;
 /// It supports both synchronous and asynchronous methods, including those returning Task, ValueTask,
 /// or any custom awaitable type that implements the awaitable pattern.
 /// </para>
+/// <para>
+/// <see cref="Create(MethodInfo)"/> compiles expression trees and is orders of magnitude more expensive
+/// than a single call to <see cref="Execute"/>. Create one executor per <see cref="MethodInfo"/> and
+/// cache it for the lifetime of the process rather than creating one per invocation.
+/// </para>
 /// </remarks>
 /// <example>
 /// Basic usage with synchronous and asynchronous methods:
@@ -37,6 +42,9 @@ public sealed class ObjectMethodExecutor
     private readonly object?[]? _parameterDefaultValues;
     private readonly MethodExecutorAsync? _executorAsync;
     private readonly MethodExecutor? _executor;
+
+    // Keyed weakly so a cached entry never keeps a plugin's Type (and its AssemblyLoadContext) alive.
+    private static readonly ConditionalWeakTable<Type, AwaitableHelpers> AwaitableHelpersCache = new();
 
     private static readonly ConstructorInfo ObjectMethodExecutorAwaitableConstructor =
         typeof(ObjectMethodExecutorAwaitable).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, [
@@ -263,19 +271,59 @@ public sealed class ObjectMethodExecutor
         }
 
         // Using the method return value, construct an ObjectMethodExecutorAwaitable based on
-        // the info we have about its implementation of the awaitable pattern. Note that all
-        // the funcs/actions we construct here are precompiled, so that only one instance of
-        // each is preserved throughout the lifetime of the ObjectMethodExecutor.
+        // the info we have about its implementation of the awaitable pattern. These funcs/actions
+        // depend only on the awaitable type, so they are compiled once and shared by every
+        // executor for a method returning that type.
 
+        var postCoercionMethodReturnType = coercedAwaitableInfo.CoercerResultType ?? methodInfo.ReturnType;
+        var helpers = GetAwaitableHelpers(postCoercionMethodReturnType, coercedAwaitableInfo.AwaitableInfo);
+
+        // If we need to pass the method call result through a coercer function to get an
+        // awaitable, then do so.
+        var coercedMethodCall = coercedAwaitableInfo.RequiresCoercion
+            ? Expression.Invoke(coercedAwaitableInfo.CoercerExpression!, methodCall)
+            : (Expression)methodCall;
+
+        // return new ObjectMethodExecutorAwaitable(
+        //     (object)coercedMethodCall,
+        //     getAwaiterFunc,
+        //     isCompletedFunc,
+        //     getResultFunc,
+        //     onCompletedFunc,
+        //     unsafeOnCompletedFunc);
+        var returnValueExpression = Expression.New(
+            ObjectMethodExecutorAwaitableConstructor,
+            Expression.Convert(coercedMethodCall, typeof(object)),
+            Expression.Constant(helpers.GetAwaiter),
+            Expression.Constant(helpers.IsCompleted),
+            Expression.Constant(helpers.GetResult),
+            Expression.Constant(helpers.OnCompleted),
+            Expression.Constant(helpers.UnsafeOnCompleted, typeof(Action<object, Action>)));
+
+        var lambda = Expression.Lambda<MethodExecutorAsync>(returnValueExpression, targetParameter, parametersParameter);
+        return lambda.Compile();
+    }
+
+    private static AwaitableHelpers GetAwaitableHelpers(Type awaitableType, AwaitableInfo awaitableInfo)
+    {
+        if (AwaitableHelpersCache.TryGetValue(awaitableType, out var cached))
+            return cached;
+
+        var helpers = CreateAwaitableHelpers(awaitableType, awaitableInfo);
+
+        // If another thread got there first, keep theirs and drop ours.
+        return AwaitableHelpersCache.GetValue(awaitableType, _ => helpers);
+    }
+
+    private static AwaitableHelpers CreateAwaitableHelpers(Type awaitableType, AwaitableInfo awaitableInfo)
+    {
         // var getAwaiterFunc = (object awaitable) =>
         //     (object)((CustomAwaitableType)awaitable).GetAwaiter();
         var customAwaitableParam = Expression.Parameter(typeof(object), "awaitable");
-        var awaitableInfo = coercedAwaitableInfo.AwaitableInfo;
-        var postCoercionMethodReturnType = coercedAwaitableInfo.CoercerResultType ?? methodInfo.ReturnType;
         var getAwaiterFunc = Expression.Lambda<Func<object, object>>(
             Expression.Convert(
                 Expression.Call(
-                    Expression.Convert(customAwaitableParam, postCoercionMethodReturnType),
+                    Expression.Convert(customAwaitableParam, awaitableType),
                     awaitableInfo.GetAwaiterMethod),
                 typeof(object)),
             customAwaitableParam).Compile();
@@ -350,30 +398,21 @@ public sealed class ObjectMethodExecutor
                 unsafeOnCompletedParam2).Compile();
         }
 
-        // If we need to pass the method call result through a coercer function to get an
-        // awaitable, then do so.
-        var coercedMethodCall = coercedAwaitableInfo.RequiresCoercion
-            ? Expression.Invoke(coercedAwaitableInfo.CoercerExpression!, methodCall)
-            : (Expression)methodCall;
+        return new AwaitableHelpers(getAwaiterFunc, isCompletedFunc, getResultFunc, onCompletedFunc, unsafeOnCompletedFunc);
+    }
 
-        // return new ObjectMethodExecutorAwaitable(
-        //     (object)coercedMethodCall,
-        //     getAwaiterFunc,
-        //     isCompletedFunc,
-        //     getResultFunc,
-        //     onCompletedFunc,
-        //     unsafeOnCompletedFunc);
-        var returnValueExpression = Expression.New(
-            ObjectMethodExecutorAwaitableConstructor,
-            Expression.Convert(coercedMethodCall, typeof(object)),
-            Expression.Constant(getAwaiterFunc),
-            Expression.Constant(isCompletedFunc),
-            Expression.Constant(getResultFunc),
-            Expression.Constant(onCompletedFunc),
-            Expression.Constant(unsafeOnCompletedFunc, typeof(Action<object, Action>)));
-
-        var lambda = Expression.Lambda<MethodExecutorAsync>(returnValueExpression, targetParameter, parametersParameter);
-        return lambda.Compile();
+    private sealed class AwaitableHelpers(
+        Func<object, object> getAwaiter,
+        Func<object, bool> isCompleted,
+        Func<object, object> getResult,
+        Action<object, Action> onCompleted,
+        Action<object, Action>? unsafeOnCompleted)
+    {
+        public Func<object, object> GetAwaiter { get; } = getAwaiter;
+        public Func<object, bool> IsCompleted { get; } = isCompleted;
+        public Func<object, object> GetResult { get; } = getResult;
+        public Action<object, Action> OnCompleted { get; } = onCompleted;
+        public Action<object, Action>? UnsafeOnCompleted { get; } = unsafeOnCompleted;
     }
 
     private static MethodExecutorAsync GetExecutorAsyncFromSync(MethodExecutor executor)

--- a/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
+++ b/tests/Meziantou.Framework.ObjectMethodExecutor.Tests/ObjectMethodExecutorTests.cs
@@ -119,6 +119,29 @@ public sealed class ObjectMethodExecutorTests
     }
 
     [Fact]
+    public async Task DistinctMethodsSharingAnAwaitableType_DoNotInterfere()
+    {
+        var first = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32")!);
+        var second = ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32WithParam")!);
+
+        Assert.Equal(1, await first.ExecuteAsync(new Test(), []));
+        Assert.Equal(12, await second.ExecuteAsync(new Test(), [12]));
+        Assert.Equal(1, await first.ExecuteAsync(new Test(), []));
+    }
+
+    [Fact]
+    public async Task DistinctAwaitableTypes_AreNotConfused()
+    {
+        var validator = new Validator();
+
+        Assert.Equal(1, await ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskInt32")!).ExecuteAsync(new Test(), []));
+        Assert.Equal(1, await ObjectMethodExecutor.Create(typeof(Test).GetMethod("ValueTaskInt32")!).ExecuteAsync(new Test(), []));
+        Assert.Equal("s", await ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTaskString")!).ExecuteAsync(new Test(), []));
+        Assert.Null(await ObjectMethodExecutor.Create(typeof(Test).GetMethod("AsyncTask")!).ExecuteAsync(new Test(), [validator]));
+        Assert.True(validator.HasBeenInvoked);
+    }
+
+    [Fact]
     public async Task FSharpAsync()
     {
         var executor = ObjectMethodExecutor.Create(typeof(FSharpTests.Say).GetMethod("get_int32")!);
@@ -171,6 +194,8 @@ public sealed class ObjectMethodExecutorTests
         }
 
         public Task<int> AsyncTaskInt32() => Task.FromResult(1);
+
+        public Task<string> AsyncTaskString() => Task.FromResult("s");
 
         public async Task<int> AsyncTaskInt32WithParam(int i)
         {


### PR DESCRIPTION
`Create` compiled six expression trees for every async method, five of which did not depend on the method at all.

## The defect

`GetExecutorAsync` built `getAwaiterFunc`, `isCompletedFunc`, `getResultFunc`, `onCompletedFunc` and `unsafeOnCompletedFunc` from scratch on every call, and `Compile()`d each one. All five are derived purely from the awaitable/awaiter type — nothing in them varies by method — so a thousand methods returning `Task<int>` compiled the same five delegates a thousand times.

Measured on the built assembly, Release, before this change:

| operation | cost |
|---|---|
| `Create` for an `async Task<int>` method | **~3.34 ms** each |
| `Create` for a sync method | ~0.10 ms each |
| `Execute` on a sync method | ~15 ns each |

`Create` for an async method was roughly 200,000× one `Execute`. Nothing cached it, and nothing said it needed caching — the XML docs said the class "creates optimized delegates ... avoiding repeated reflection overhead" and both the doc example and the readme show `Create` immediately followed by the call. Code following that shape inside a request handler is orders of magnitude slower than `MethodInfo.Invoke` while reading like an optimization.

## The change

The five delegates move into `CreateAwaitableHelpers` and are cached by the awaitable type they are derived from.

Measured after, same machine and harness:

| operation | before | after |
|---|---|---|
| `Create` (async) | 3.34 ms | **0.441 ms** (~7.6× faster) |
| `Create` (sync) | 0.10 ms | 0.071 ms (unchanged, noise) |
| `Execute` | ~15 ns | ~12.6 ns (unchanged) |

The cache is a `ConditionalWeakTable<Type, AwaitableHelpers>`, not a `ConcurrentDictionary`. A static dictionary keyed by `Type` would root plugin types and keep their `AssemblyLoadContext` from unloading — a real leak for exactly the reflection-heavy plugin hosts that use this library. A weak table lets an entry go when its type does. On a race, the loser's helpers are discarded and the winner's are returned.

The XML docs now also say plainly that `Create` is expensive and that executors are meant to be cached per `MethodInfo`. That does not make an uncached caller fast, but it stops the docs from implying otherwise.

## Verification

Two tests added covering the risk this change introduces — that executors now *share* delegates where they previously had their own:

- `DistinctMethodsSharingAnAwaitableType_DoNotInterfere` — two different methods both returning `Task<int>`, interleaved, each still returning its own result.
- `DistinctAwaitableTypes_AreNotConfused` — `Task<int>`, `ValueTask<int>`, `Task<string>` and non-generic `Task` in one test, so a mis-keyed entry would surface as a wrong value or a cast failure.

- Full suite green: 32 passed (16 × net10.0/net11.0), 0 failed.
- No public API change, so `ref/` is unchanged.

Found during a review of `Meziantou.Framework.ObjectMethodExecutor`.
