### PR TITLE
Document the actual behaviour of the CsvReader position properties

### DIFF
--- a/src/Meziantou.Framework.Csv/CsvReader.cs
+++ b/src/Meziantou.Framework.Csv/CsvReader.cs
@@ -37,10 +37,12 @@ public class CsvReader
     /// <summary>Gets or sets a value indicating whether the first row contains column headers.</summary>
     public bool HasHeaderRow { get; set; }
 
-    /// <summary>Gets the current column number being read (1-based).</summary>
+    /// <summary>Gets the number of characters read since the beginning of the current row.</summary>
+    /// <remarks>This is a character position, not the index of the field being read. It counts every character consumed by the current row, including the characters of a multi-line quoted value, and it is reset to 0 at the start of each row.</remarks>
     public int ColumnNumber { get; private set; }
 
-    /// <summary>Gets the current line number being read (1-based).</summary>
+    /// <summary>Gets the number of line terminators consumed so far.</summary>
+    /// <remarks>This is 0 while the first line is being read, and is incremented as each line ends. Line terminators inside a quoted value are counted, so this tracks the physical line in the input rather than the number of rows returned. See <see cref="RowNumber"/> for the row.</remarks>
     public int LineNumber { get; private set; }
 
     /// <summary>Gets or sets the current row number (0-based).</summary>
@@ -50,6 +52,7 @@ public class CsvReader
     public TextReader BaseReader { get; }
 
     /// <summary>Gets a value indicating whether the end of the stream has been reached.</summary>
+    /// <remarks>Reading this property can block: when the internal buffer is empty it queries the underlying <see cref="TextReader"/> synchronously, even though the rest of this type is asynchronous. Prefer testing whether <see cref="ReadRowAsync"/> returned <see langword="null"/>.</remarks>
     public bool EndOfStream
     {
         get

--- a/tests/Meziantou.Framework.Csv.Tests/CsvReaderTests.cs
+++ b/tests/Meziantou.Framework.Csv.Tests/CsvReaderTests.cs
@@ -60,6 +60,50 @@ public class CsvReaderTests
     }
 
     [Fact]
+    public async Task CsvReader_ColumnNumberCountsCharactersNotFields()
+    {
+        using var sr = new StringReader("A,B,C\nvalue");
+        var reader = new CsvReader(sr);
+
+        Assert.Equal(0, reader.ColumnNumber);
+
+        await reader.ReadRowAsync();
+        Assert.Equal(6, reader.ColumnNumber);
+
+        await reader.ReadRowAsync();
+        Assert.Equal(5, reader.ColumnNumber);
+    }
+
+    [Fact]
+    public async Task CsvReader_LineNumberCountsConsumedLineTerminators()
+    {
+        using var sr = new StringReader("a\nb\nc");
+        var reader = new CsvReader(sr);
+
+        Assert.Equal(0, reader.LineNumber);
+
+        await reader.ReadRowAsync();
+        Assert.Equal(1, reader.LineNumber);
+
+        await reader.ReadRowAsync();
+        Assert.Equal(2, reader.LineNumber);
+
+        await reader.ReadRowAsync();
+        Assert.Equal(2, reader.LineNumber);
+    }
+
+    [Fact]
+    public async Task CsvReader_LineNumberCountsLineTerminatorsInsideQuotedValues()
+    {
+        using var sr = new StringReader("\"a\nb\",c");
+        var reader = new CsvReader(sr);
+
+        await reader.ReadRowAsync();
+
+        Assert.Equal(1, reader.LineNumber);
+    }
+
+    [Fact]
     public async Task CsvReader_MultiLineQuotedValue()
     {
         var sb = new StringBuilder();


### PR DESCRIPTION
Three `CsvReader` properties have doc comments that do not describe what the code does. These are the properties a consumer reaches for when building an error message pointing at bad input, so a wrong description sends the user to the wrong place in their file.

### `ColumnNumber` — documented "1-based", actually a character count

> Gets the current column number being read (1-based).

It is incremented once per **character** (`CsvReader.cs:152`), not per field. After reading the row `A,B,C` it reports **6**, not 3. Telling a user "the problem is at column 6" of a three-column row is worse than saying nothing.

### `LineNumber` — documented "1-based", actually 0-based

> Gets the current line number being read (1-based).

It starts at 0 and is only incremented once a line terminator is consumed, so it reads 0 for the whole of the first line and reaches 1 only when that line ends.

### `EndOfStream` — silently synchronous

Once the internal buffer is drained the property falls back to `streamReader.EndOfStream` (`CsvReader.cs:67`) or `BaseReader.Peek()` (`CsvReader.cs:69`), both of which block while filling the underlying reader. A caller polling it in a loop over a network stream blocks the calling thread — the exact thing the library's async design exists to avoid. The value is correct; nothing warns that getting it is not free.

## What changed

Documentation only — no behaviour change, no public API change, `ref/` untouched.

`ColumnNumber` is now described as the character position within the current row, explicitly *not* the field index, and notes that it counts through multi-line quoted values and resets per row. `LineNumber` is described as the count of consumed line terminators, noting that terminators inside a quoted value are counted so it tracks the physical input line. `EndOfStream` gains a `<remarks>` warning that reading it can block, pointing at `ReadRowAsync() is null` as the async-friendly alternative.

The other reading of this is that the *names* are wrong rather than the docs. I did not rename anything: `ColumnNumber` is public API and changing its meaning in place would silently break anyone relying on the current values. If a genuine field index is wanted, that is better added as a new property.

## Verification

- Three new characterization tests pin each documented claim — `ColumnNumber` reporting 6 then 5 for `A,B,C\nvalue`, `LineNumber` walking 0→1→2 and stopping, and `LineNumber` counting a terminator inside a quoted value.
- They pass against **unmodified** parsing code, which is the point: they demonstrate the new prose matches the existing behaviour rather than describing an aspiration.
- `dotnet test /p:TreatsWarningsAsErrors=true` — 44 passed (22 × net10.0/net11.0), up from 38.
- `dotnet build /p:TreatsWarningsAsErrors=true` — succeeded. `dotnet run ./eng/update-all.cs` — no generated-file changes.

Found by a review of `src/Meziantou.Framework.Csv`.
