### PR TITLE
Report Azure DevOps repository metadata as strings

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Scanners/AzureDevOpsScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/AzureDevOpsScanner.cs
@@ -118,8 +118,8 @@ public sealed class AzureDevOpsScanner : DependencyScanner
                     var type = GetProperty(repository, "type", StringComparison.Ordinal);
                     if (string.Equals(GetScalarValue(type), "git", StringComparison.OrdinalIgnoreCase))
                     {
-                        var endpoint = GetProperty(repository, "endpoint", StringComparison.Ordinal);
-                        var alias = GetProperty(repository, "repository", StringComparison.Ordinal);
+                        var endpoint = GetScalarValue(GetProperty(repository, "endpoint", StringComparison.Ordinal));
+                        var alias = GetScalarValue(GetProperty(repository, "repository", StringComparison.Ordinal));
                         var name = GetProperty(repository, "name", StringComparison.Ordinal);
                         var version = GetProperty(repository, "ref", StringComparison.Ordinal);
                         if (name is not null)

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -1311,16 +1311,23 @@ jobs:
               repositories:
               - repository: dummy
                 name: repo
+                endpoint: myendpoint
                 ref: 'main'
                 type: git
             """);
         var result = await GetDependencies<AzureDevOpsScanner>();
+
+        var dependency = Assert.Single(result, d => d.Type == DependencyType.GitReference);
+        Assert.Equal("dummy", dependency.Metadata["repository"]);
+        Assert.Equal("myendpoint", dependency.Metadata["endpoint"]);
+
         await UpdateDependencies(result, "dummy", "1.2.3");
         AssertFileContentEqual("sample.yml", """
             resources:
               repositories:
               - repository: dummy
                 name: dummy1
+                endpoint: myendpoint
                 ref: '1.2.3'
                 type: git
             """, ignoreNewLines: true);


### PR DESCRIPTION
### The problem

When `AzureDevOpsScanner` reports a `resources.repositories` entry, it puts the raw YAML nodes into the dependency metadata:

```csharp
var endpoint = GetProperty(repository, "endpoint", StringComparison.Ordinal);   // YamlElement?
var alias = GetProperty(repository, "repository", StringComparison.Ordinal);    // YamlElement?
...
metadata: [
    KeyValuePair.Create<string, object?>("endpoint", endpoint),
    KeyValuePair.Create<string, object?>("repository", alias),
]);
```

Every sibling value in the same call goes through `GetScalarValue(...)` first; these two do not. `Dependency.Metadata` is `IDictionary<string, object?>` on a public type, so a consumer doing `(string)dep.Metadata["endpoint"]` gets an `InvalidCastException`, and `.ToString()` gets whatever `YamlValue` renders. It also put a `Meziantou.Framework.Yaml.Model` parse-tree type into this library's public surface.

### The change

Wrap both in `GetScalarValue`, matching the `name` and `version` arguments two lines above.

### Verification

The metadata was not covered by any test. `ScannerTests.AzureDevOpsResourcesRepositoryDependencies` now includes an `endpoint` in the fixture and asserts both metadata values are the expected strings.

Fails on `main` (`Assert.Equal` gets a `YamlValue`), passes here. Full project suite green: 80/80 on net10.0.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
