### PR TITLE
Return an empty relative directory instead of throwing on unrelated paths

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/CandidateFileContext.cs
+++ b/src/Meziantou.Framework.DependencyScanning/CandidateFileContext.cs
@@ -6,6 +6,8 @@ namespace Meziantou.Framework.DependencyScanning;
 [StructLayout(LayoutKind.Auto)]
 public readonly ref struct CandidateFileContext
 {
+    private static readonly char[] DirectorySeparators = [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar];
+
     public CandidateFileContext(ReadOnlySpan<char> rootDirectory, ReadOnlySpan<char> directory, ReadOnlySpan<char> fileName)
     {
         RootDirectory = rootDirectory;
@@ -58,6 +60,20 @@ public readonly ref struct CandidateFileContext
         return false;
     }
 
-    /// <summary>Gets the directory path relative to the root directory.</summary>
-    public ReadOnlySpan<char> RelativeDirectory => Directory.SequenceEqual(RootDirectory) ? "" : Directory[(RootDirectory.Length + 1)..];
+    /// <summary>Gets the directory path relative to the root directory, or an empty span when the directory is not under the root directory.</summary>
+    public ReadOnlySpan<char> RelativeDirectory
+    {
+        get
+        {
+            var root = RootDirectory.TrimEnd(DirectorySeparators);
+            var directory = Directory.TrimEnd(DirectorySeparators);
+            if (directory.Length <= root.Length || !directory.StartsWith(root, StringComparison.Ordinal))
+                return "";
+
+            if (Array.IndexOf(DirectorySeparators, directory[root.Length]) < 0)
+                return "";
+
+            return directory[(root.Length + 1)..];
+        }
+    }
 }

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
@@ -88,6 +88,22 @@ public sealed class DependencyScannerTests
         });
     }
 
+    [Theory]
+    [InlineData("/root", "/root", "")]
+    [InlineData("/root/", "/root", "")]
+    [InlineData("/root", "/root/", "")]
+    [InlineData("/root", "/root/sub", "sub")]
+    [InlineData("/root/", "/root/sub", "sub")]
+    [InlineData("/root", "/root/sub/nested", "sub/nested")]
+    [InlineData("/root", "/rootother", "")]
+    [InlineData("/root", "/other", "")]
+    public void CandidateFileContext_RelativeDirectory(string rootDirectory, string directory, string expected)
+    {
+        var context = new CandidateFileContext(rootDirectory, directory, "file.txt");
+
+        Assert.Equal(expected, context.RelativeDirectory.ToString());
+    }
+
     [Fact]
     public void DefaultScannersIncludeAllScanners()
     {


### PR DESCRIPTION
### The problem

```csharp
public ReadOnlySpan<char> RelativeDirectory =>
    Directory.SequenceEqual(RootDirectory) ? "" : Directory[(RootDirectory.Length + 1)..];
```

With a root of `/a/b/` and a directory of `/a/b`, the two are not sequence-equal, so it slices from index 6 of a 4-character span and throws `ArgumentOutOfRangeException`. The same happens for any directory that is not actually under the root.

The directory walk never hit this because `FileSystemEntry.RootDirectory` is normalised by the runtime. It is reachable from the public `DependencyScanner.ShouldScanFile(rootDirectory, fullPath)` overload, where passing a directory path with a trailing separator is an entirely ordinary thing to do — and the resulting exception says nothing about paths.

`RenovateExtendsDependencyScanner` is the only in-box reader today, but this is a public property on a public struct that third-party scanners are meant to use.

### The change

Normalise trailing separators on both sides, require the directory to be a strict descendant of the root on a separator boundary, and return an empty span when it is not. That also fixes a prefix bug the old code shared: a root of `/root` and a directory of `/rootother` used to produce `ther`.

Comparison stays `Ordinal`, as before — this change is not trying to alter case sensitivity.

### Verification

New theory `DependencyScannerTests.CandidateFileContext_RelativeDirectory` covering equal paths, trailing separators on either side, nested directories, the `/root` vs `/rootother` prefix case, and an unrelated directory. Written with `/`, which is the directory separator on Unix and the alternate separator on Windows, so it holds on both.

3 of the 8 cases fail on `main` (two throw, one returns `ther`); all 8 pass here. Full project suite green: 88/88 on net10.0. No `ref/` drift — the property signature is unchanged.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
