### PR TITLE
Annotate the FSharpAsync coercion path with RequiresDynamicCode

### DIFF
--- a/ref/Meziantou.Framework.ObjectMethodExecutor.cs
+++ b/ref/Meziantou.Framework.ObjectMethodExecutor.cs
@@ -5,6 +5,7 @@
 namespace Meziantou.Framework
 {
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ObjectMethodExecutor performs reflection on arbitrary types.")]
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("ObjectMethodExecutor compiles expression trees and may construct generic types at runtime.")]
     public sealed class ObjectMethodExecutor
     {
         public bool IsMethodAsync { get => throw null; }

--- a/src/Meziantou.Framework.ObjectMethodExecutor/CoercedAwaitableInfo.cs
+++ b/src/Meziantou.Framework.ObjectMethodExecutor/CoercedAwaitableInfo.cs
@@ -23,6 +23,7 @@ internal readonly struct CoercedAwaitableInfo
         AwaitableInfo = coercedAwaitableInfo;
     }
 
+    [RequiresDynamicCode("Coercing FSharpAsync<T> to Task<T> constructs generic types and methods at runtime.")]
     public static bool IsTypeAwaitable(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)] Type type,
         out CoercedAwaitableInfo info)

--- a/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
+++ b/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutor.cs
@@ -32,6 +32,7 @@ namespace Meziantou.Framework;
 /// </code>
 /// </example>
 [RequiresUnreferencedCode("ObjectMethodExecutor performs reflection on arbitrary types.")]
+[RequiresDynamicCode("ObjectMethodExecutor compiles expression trees and may construct generic types at runtime.")]
 public sealed class ObjectMethodExecutor
 {
     private readonly object?[]? _parameterDefaultValues;

--- a/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutorFSharpSupport.cs
+++ b/src/Meziantou.Framework.ObjectMethodExecutor/ObjectMethodExecutorFSharpSupport.cs
@@ -21,6 +21,7 @@ internal static class ObjectMethodExecutorFSharpSupport
     private static PropertyInfo? s_fsharpOptionOfCancellationTokenNoneProperty;
 
     [UnconditionalSuppressMessage("Trimmer", "IL2060", Justification = "Reflecting over the async FSharpAsync<> contract.")]
+    [RequiresDynamicCode("Coercing FSharpAsync<T> to Task<T> constructs generic types and methods at runtime.")]
     public static bool TryBuildCoercerFromFSharpAsyncToAwaitable(
         Type possibleFSharpAsyncType,
         [NotNullWhen(true)] out Expression? coerceToAwaitableExpression,
@@ -63,6 +64,7 @@ internal static class ObjectMethodExecutorFSharpSupport
         return true;
     }
 
+    [RequiresDynamicCode("Coercing FSharpAsync<T> to Task<T> constructs generic types and methods at runtime.")]
     private static bool IsFSharpAsyncOpenGenericType(Type? possibleFSharpAsyncGenericType)
     {
         if (possibleFSharpAsyncGenericType == null)
@@ -92,6 +94,7 @@ internal static class ObjectMethodExecutorFSharpSupport
     [UnconditionalSuppressMessage("Trimmer", "IL2026", Justification = "Reflecting over the async FSharpAsync<> contract")]
     [UnconditionalSuppressMessage("Trimmer", "IL2055", Justification = "Reflecting over the async FSharpAsync<> contract")]
     [UnconditionalSuppressMessage("Trimmer", "IL2072", Justification = "Reflecting over the async FSharpAsync<> contract")]
+    [RequiresDynamicCode("Coercing FSharpAsync<T> to Task<T> constructs generic types and methods at runtime.")]
     private static bool TryPopulateFSharpValueCaches(Type possibleFSharpAsyncGenericType)
     {
         var assembly = possibleFSharpAsyncGenericType.Assembly;


### PR DESCRIPTION
The F# coercion path calls APIs that require dynamic code, and nothing on the public surface said so.

## The defect

Building this project with the AOT analyzer enabled reports **20 IL3050 diagnostics**, all reachable from `Create`:

- `Type.MakeGenericType` — `ObjectMethodExecutorFSharpSupport.cs:41`, `:105`, `:109`
- `MethodInfo.MakeGenericMethod` — `:50`
- non-generic `Expression.Lambda` — `:53`

`CoercedAwaitableInfo.IsTypeAwaitable` reaches this path for *every* return type that is not directly awaitable, so it is not confined to F# callers.

`MakeGenericType(typeof(Task<>), someValueType)` throws at runtime for an instantiation the AOT compiler did not statically root. The class carried `[RequiresUnreferencedCode]`, which covers trimming, but nothing covered dynamic code — so a consumer publishing Native AOT hit it from a package they did not write, with no annotation pointing at the cause.

Worth noting what is *not* affected: the generic `Expression.Lambda<TDelegate>(...).Compile()` used throughout `ObjectMethodExecutor.cs` is not AOT-annotated and produces no diagnostic. The hazard is specific to the F# coercer.

## The change

`[RequiresDynamicCode]` on the three members in `ObjectMethodExecutorFSharpSupport`, on `CoercedAwaitableInfo.IsTypeAwaitable`, and on the `ObjectMethodExecutor` class itself — the same placement the existing `[RequiresUnreferencedCode]` uses. Consumers now get IL3050 at their own call site instead of a runtime failure.

The project's `IsTrimmable=false` is left alone; that is managed by `eng/update-all.cs` and is consistent with 37 other projects here. This PR only annotates the surface.

## Verification

Because `-p:IsAotCompatible=true` on the command line propagates into referenced `netstandard2.0` analyzer projects and fails them with NETSDK1210, I scoped the property to this project's csproj alone for the comparison:

| | IL3050 |
|---|---|
| `origin/main` | **20** |
| this branch | **0**, build succeeded |

Then reverted the csproj. Also verified: normal build clean (0 warnings with `TreatWarningsAsErrors`), suite green at 28 passed (14 × net10.0/net11.0), and `dotnet run ./eng/update-all.cs` exits 0 with no further changes.

No runtime tests accompany this one — the change is annotations, which have no observable runtime behavior. The regenerated `ref/Meziantou.Framework.ObjectMethodExecutor.cs` is what pins it: the attribute is now part of the checked-in public surface, so removing it shows up as an API diff and CI's `PublicApiGeneratorVerifyNoChangeOnBuild` catches it.

Package `<Version>` deliberately untouched.

Found during a review of `Meziantou.Framework.ObjectMethodExecutor`.
