### PR TITLE
Scan Dockerfile and Containerfile name variants

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Scanners/DockerfileDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/DockerfileDependencyScanner.cs
@@ -6,6 +6,9 @@ namespace Meziantou.Framework.DependencyScanning.Scanners;
 /// <summary>Scans Dockerfile and Containerfile for Docker image dependencies in FROM and COPY --from instructions.</summary>
 public sealed partial class DockerfileDependencyScanner : DependencyScanner
 {
+    private static readonly string[] FileNames = ["Dockerfile", "Containerfile"];
+    private static readonly string[] Extensions = [".Dockerfile", ".Containerfile"];
+
     protected internal override IReadOnlyCollection<DependencyType> SupportedDependencyTypes { get; } = [DependencyType.DockerImage];
 
     public override async ValueTask ScanAsync(ScanFileContext context)
@@ -39,7 +42,25 @@ public sealed partial class DockerfileDependencyScanner : DependencyScanner
 
     protected override bool ShouldScanFileCore(CandidateFileContext context)
     {
-        return context.HasFileName("Dockerfile", ignoreCase: true);
+        // <name>.Dockerfile
+        if (context.HasExtension(Extensions, ignoreCase: true))
+            return true;
+
+        foreach (var fileName in FileNames)
+        {
+            if (context.HasFileName(fileName, ignoreCase: true))
+                return true;
+
+            // Dockerfile.<name>
+            if (context.FileName.Length > fileName.Length &&
+                context.FileName[fileName.Length] is '.' &&
+                context.FileName.StartsWith(fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     [GeneratedRegex(@"^FROM\s*(?<ImageName>[^\s]+):(?<Version>[^\s]+)(\s+AS\s+\w+)?\s*$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 10000)]

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -554,6 +554,35 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
         AssertFileContentEqual("Dockerfile", Expected, ignoreNewLines: false);
     }
 
+    [Theory]
+    [InlineData("Dockerfile")]
+    [InlineData("dockerfile")]
+    [InlineData("Dockerfile.prod")]
+    [InlineData("app.Dockerfile")]
+    [InlineData("Containerfile")]
+    [InlineData("Containerfile.prod")]
+    [InlineData("app.Containerfile")]
+    public async Task DockerfileFileNames(string fileName)
+    {
+        AddFile(fileName, "FROM a.com/b:1.2.2\n");
+
+        var result = await GetDependencies<DockerfileDependencyScanner>();
+
+        AssertContainDependency(result, (DependencyType.DockerImage, "a.com/b", "1.2.2", 1, 14));
+    }
+
+    [Theory]
+    [InlineData("NotADockerfile")]
+    [InlineData("readme.txt")]
+    public async Task DockerfileFileNames_NotScanned(string fileName)
+    {
+        AddFile(fileName, "FROM a.com/b:1.2.2\n");
+
+        var result = await GetDependencies<DockerfileDependencyScanner>();
+
+        Assert.Empty(result);
+    }
+
     [Fact]
     public async Task GlobalJsonFromDependencies()
     {


### PR DESCRIPTION
### The problem

```csharp
protected override bool ShouldScanFileCore(CandidateFileContext context)
    => context.HasFileName("Dockerfile", ignoreCase: true);
```

An exact match, so `Dockerfile.prod`, `app.Dockerfile` and `Containerfile` were all skipped and their base images were invisible to a scan. The class doc comment already claimed "Scans Dockerfile and Containerfile", so the code and the documentation disagreed.

`Dockerfile.<variant>` and `<service>.Dockerfile` are the standard layout for multi-image repos and Compose setups; `Containerfile` is the Podman/Buildah name.

### The change

Match, case-insensitively: `Dockerfile` and `Containerfile` exactly, `<name>.Dockerfile` / `<name>.Containerfile` by extension, and `Dockerfile.<suffix>` / `Containerfile.<suffix>` by prefix.

The prefix form is deliberately permissive — `Dockerfile.md` will now be scanned. There is no way to tell `Dockerfile.prod` from `Dockerfile.md` by name, and this matches what Docker itself accepts via `-f` and what Dependabot matches (`Dockerfile*`). Scanning an extra file is cheap; missing every `Dockerfile.prod` in a repo is not.

### Verification

Two new theories in `ScannerTests`:

- `DockerfileFileNames` — 7 cases covering both base names, the prefix form, the extension form, and lowercase.
- `DockerfileFileNames_NotScanned` — `NotADockerfile` and `readme.txt` stay unscanned, so the prefix match does not degenerate into "any name containing Dockerfile".

5 of the 9 cases fail on `main`; all 9 pass here. Full project suite green: 89/89 on net10.0.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
