### PR TITLE
Advance RowNumber for every row instead of only at end of stream

### DIFF
--- a/src/Meziantou.Framework.Csv/CsvReader.cs
+++ b/src/Meziantou.Framework.Csv/CsvReader.cs
@@ -27,6 +27,7 @@ public class CsvReader
     private bool _hasBufferedChar;
     private char _bufferedChar;
     private bool _endOfStreamReached;
+    private bool _hasParsedRow;
 
     /// <summary>Gets or sets the character used to separate values in a row. Default is a comma (,).</summary>
     public char Separator { get; set; } = DefaultSeparatorCharacter;
@@ -145,7 +146,6 @@ public class CsvReader
                         rowValues.Add(value.ToString());
                     }
 
-                    RowNumber++;
                     break;
                 }
 
@@ -173,7 +173,6 @@ public class CsvReader
                                     rowValues.Add(value.ToString());
                                 }
 
-                                RowNumber++;
                                 break;
                             }
                         }
@@ -254,6 +253,13 @@ public class CsvReader
 
         if (rowValues.Count == 0 && endOfStream)
             return null;
+
+        if (_hasParsedRow)
+        {
+            RowNumber++;
+        }
+
+        _hasParsedRow = true;
 
         var columns = _columns;
         if (HasHeaderRow && columns is null)

--- a/tests/Meziantou.Framework.Csv.Tests/CsvReaderTests.cs
+++ b/tests/Meziantou.Framework.Csv.Tests/CsvReaderTests.cs
@@ -158,6 +158,65 @@ public class CsvReaderTests
         Assert.Null(await reader.ReadRowAsync());
     }
 
+    [Fact]
+    public async Task CsvReader_RowNumberIsTheZeroBasedIndexOfTheRowJustReturned()
+    {
+        using var sr = new StringReader("a\nb\nc");
+        var reader = new CsvReader(sr);
+
+        await reader.ReadRowAsync();
+        Assert.Equal(0, reader.RowNumber);
+
+        await reader.ReadRowAsync();
+        Assert.Equal(1, reader.RowNumber);
+
+        await reader.ReadRowAsync();
+        Assert.Equal(2, reader.RowNumber);
+    }
+
+    [Fact]
+    public async Task CsvReader_RowNumberDoesNotAdvancePastTheLastRow()
+    {
+        using var sr = new StringReader("a\nb");
+        var reader = new CsvReader(sr);
+
+        await reader.ReadRowAsync();
+        await reader.ReadRowAsync();
+        Assert.Equal(1, reader.RowNumber);
+
+        Assert.Null(await reader.ReadRowAsync());
+        Assert.Equal(1, reader.RowNumber);
+    }
+
+    [Fact]
+    public async Task CsvReader_RowNumberCountsTheHeaderRow()
+    {
+        using var sr = new StringReader("A,B\n1,2\n3,4");
+        var reader = new CsvReader(sr) { HasHeaderRow = true };
+
+        await reader.ReadRowAsync();
+        Assert.Equal(1, reader.RowNumber);
+
+        await reader.ReadRowAsync();
+        Assert.Equal(2, reader.RowNumber);
+    }
+
+    [Fact]
+    public async Task CsvReader_RowNumberIsIndependentOfTheLineTerminator()
+    {
+        using var sr = new StringReader("a\r\nb\rc");
+        var reader = new CsvReader(sr);
+
+        await reader.ReadRowAsync();
+        Assert.Equal(0, reader.RowNumber);
+
+        await reader.ReadRowAsync();
+        Assert.Equal(1, reader.RowNumber);
+
+        await reader.ReadRowAsync();
+        Assert.Equal(2, reader.RowNumber);
+    }
+
     private sealed class TruncatedCarriageReturnReader : TextReader
     {
         private readonly char[] _content = ['"', 'a', '\r'];


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2245.**

`RowNumber` is public, documented as "the current row number (0-based)", and is exactly what you reach for when reporting a validation error back to a user ("bad value on row 47"). It reported the wrong row every time.

`RowNumber++` appeared at only two sites (`CsvReader.cs:148` and `:176`), both on **end-of-stream** paths. It was missing from the `\n` path (`:203-212`) and the `\r` path (`:214-228`), so the counter advanced only when the parser hit the end of the input:

```csharp
// input "a\nb\nc"
await reader.ReadRowAsync();   // RowNumber == 0
await reader.ReadRowAsync();   // RowNumber == 0   <-- still
await reader.ReadRowAsync();   // RowNumber == 1
```

For a file ending in a newline it reported 0 for every row. `LineNumber` is maintained correctly on all four paths, which is what makes this look like an oversight rather than a decision.

## What changed

The two scattered increments are removed and replaced by a **single** site, placed after the "no row here" guard so it runs once per row that is actually produced:

```csharp
if (rowValues.Count == 0 && endOfStream)
    return null;

if (_hasParsedRow)
{
    RowNumber++;
}

_hasParsedRow = true;
```

`RowNumber` is now the **0-based index of the row just returned**, which is what the existing doc comment already claimed — so no doc change is needed and the property still starts at 0.

Two consequences worth stating explicitly:

- **The header row counts.** With `HasHeaderRow = true` the header is row 0, so the first data row reports 1. That keeps `RowNumber` a physical position in the file, which is what makes it useful in an error message. It falls out of the header path naturally, because `ReadRowAsync` recurses (`:263`) and the header goes through the same increment.
- **It does not run past the end.** The guard returns before the increment, so reading past the last row leaves `RowNumber` on the last real row rather than advancing into nothing.

## Verification

- `dotnet test /p:TreatsWarningsAsErrors=true` — 46 passed (23 × net10.0/net11.0), up from 38.
- 4 new tests: the 0-based sequence over three rows, no advance past the last row, the header-counts case, and the same sequence driven by `\r\n` and bare `\r` to prove it no longer depends on which terminator ends the row.
- Reverting only `CsvReader.cs` and re-running turns **8 of them red**.
- `dotnet build /p:TreatsWarningsAsErrors=true` — succeeded, `ref/` unchanged. `dotnet run ./eng/update-all.cs` — no generated-file changes.

## Note

`RowNumber` also has a public **setter** that nothing in the library reads back and no test exercises. I left it alone rather than guess — if it is not deliberate, `private set` would match `LineNumber` and `ColumnNumber` and this is the natural PR to do it in.

Found by a review of `src/Meziantou.Framework.Csv`.
