### PR TITLE
Preserve the last value of a row when it is empty

### DIFF
--- a/src/Meziantou.Framework.Csv/CsvReader.cs
+++ b/src/Meziantou.Framework.Csv/CsvReader.cs
@@ -133,7 +133,7 @@ public class CsvReader
         {
             var inQuote = false;
             var value = new StringBuilder();
-            var hasCell = false;
+            var hasPendingValue = false;
             ColumnNumber = 0;
             while (true)
             {
@@ -141,7 +141,7 @@ public class CsvReader
                 if (!c.HasValue)
                 {
                     endOfStream = true;
-                    if (hasCell)
+                    if (hasPendingValue)
                     {
                         rowValues.Add(value.ToString());
                     }
@@ -161,14 +161,14 @@ public class CsvReader
                     {
                         if (next == '\n')
                         {
-                            hasCell = true;
+                            hasPendingValue = true;
                             value.Append(c.Value);
                             c = await ReadCharAsync().ConfigureAwait(false);
                             ColumnNumber++;
                             if (!c.HasValue)
                             {
                                 endOfStream = true;
-                                if (hasCell)
+                                if (hasPendingValue)
                                 {
                                     rowValues.Add(value.ToString());
                                 }
@@ -185,7 +185,7 @@ public class CsvReader
                         if (next == Quote)
                         {
                             await ReadCharAsync().ConfigureAwait(false);
-                            hasCell = true;
+                            hasPendingValue = true;
                             value.Append(Quote.Value);
                         }
                         else
@@ -195,13 +195,13 @@ public class CsvReader
                     }
                     else
                     {
-                        hasCell = true;
+                        hasPendingValue = true;
                         value.Append(c.Value);
                     }
                 }
                 else if (c == '\n')
                 {
-                    if (hasCell)
+                    if (hasPendingValue)
                     {
                         rowValues.Add(value.ToString());
                     }
@@ -217,7 +217,7 @@ public class CsvReader
                         ColumnNumber++;
                     }
 
-                    if (hasCell)
+                    if (hasPendingValue)
                     {
                         rowValues.Add(value.ToString());
                     }
@@ -229,11 +229,12 @@ public class CsvReader
                 {
                     if (value.Length == 0)
                     {
+                        hasPendingValue = true;
                         inQuote = true;
                     }
                     else
                     {
-                        hasCell = true;
+                        hasPendingValue = true;
                         value.Append(c.Value);
                     }
                 }
@@ -241,11 +242,11 @@ public class CsvReader
                 {
                     rowValues.Add(value.ToString());
                     value.Clear();
-                    hasCell = false;
+                    hasPendingValue = true;
                 }
                 else
                 {
-                    hasCell = true;
+                    hasPendingValue = true;
                     value.Append(c.Value);
                 }
             }

--- a/tests/Meziantou.Framework.Csv.Tests/CsvReaderTests.cs
+++ b/tests/Meziantou.Framework.Csv.Tests/CsvReaderTests.cs
@@ -217,6 +217,102 @@ public class CsvReaderTests
         Assert.Equal(2, reader.RowNumber);
     }
 
+    [Theory]
+    [InlineData("a,b,", new[] { "a", "b", "" })]
+    [InlineData("a,b,\n", new[] { "a", "b", "" })]
+    [InlineData("a,b,\r\n", new[] { "a", "b", "" })]
+    [InlineData("a,b,\"\"", new[] { "a", "b", "" })]
+    [InlineData(",", new[] { "", "" })]
+    [InlineData(",,", new[] { "", "", "" })]
+    [InlineData("\"\"", new[] { "" })]
+    [InlineData("a,\"\",b", new[] { "a", "", "b" })]
+    [InlineData("\"a,b\",", new[] { "a,b", "" })]
+    [InlineData("a,b", new[] { "a", "b" })]
+    public async Task CsvReader_EmptyTrailingValueIsPreserved(string data, string[] expected)
+    {
+        using var sr = new StringReader(data);
+        var reader = new CsvReader(sr);
+
+        var row = await reader.ReadRowAsync();
+
+        Assert.NotNull(row);
+        Assert.Equal(expected, row.Values);
+    }
+
+    [Fact]
+    public async Task CsvReader_EmptyInputReturnsNoRow()
+    {
+        using var sr = new StringReader("");
+        var reader = new CsvReader(sr);
+
+        Assert.Null(await reader.ReadRowAsync());
+    }
+
+    [Fact]
+    public async Task CsvReader_TrailingNewLineDoesNotProduceAnExtraRow()
+    {
+        using var sr = new StringReader("a\nb\n");
+        var reader = new CsvReader(sr);
+
+        Assert.NotNull(await reader.ReadRowAsync());
+        Assert.NotNull(await reader.ReadRowAsync());
+        Assert.Null(await reader.ReadRowAsync());
+    }
+
+    [Fact]
+    public async Task CsvReader_BlankLineStillYieldsARowWithoutValues()
+    {
+        using var sr = new StringReader("a\n\nb");
+        var reader = new CsvReader(sr);
+
+        var row1 = await reader.ReadRowAsync();
+        Assert.NotNull(row1);
+        Assert.Equal(["a"], row1.Values);
+
+        var row2 = await reader.ReadRowAsync();
+        Assert.NotNull(row2);
+        Assert.Empty(row2.Values);
+
+        var row3 = await reader.ReadRowAsync();
+        Assert.NotNull(row3);
+        Assert.Equal(["b"], row3.Values);
+    }
+
+    [Fact]
+    public async Task CsvReader_EmptyTrailingValueIsAddressableByColumnName()
+    {
+        using var sr = new StringReader("A,B,C\n1,2,");
+        var reader = new CsvReader(sr) { HasHeaderRow = true };
+
+        var row = await reader.ReadRowAsync();
+
+        Assert.NotNull(row);
+        Assert.Equal(["1", "2", ""], row.Values);
+        Assert.Equal("", row["C"]);
+    }
+
+    [Fact]
+    public async Task CsvWriter_TrailingEmptyValue_RoundTripsThroughCsvReader()
+    {
+        using var sw = new StringWriter();
+        var writer = new CsvWriter(sw) { EndOfLine = "\n" };
+        await writer.WriteRowAsync("a", "b", "");
+        await writer.WriteRowAsync("", "", "");
+
+        using var sr = new StringReader(sw.ToString());
+        var reader = new CsvReader(sr);
+
+        var row1 = await reader.ReadRowAsync();
+        Assert.NotNull(row1);
+        Assert.Equal(["a", "b", ""], row1.Values);
+
+        var row2 = await reader.ReadRowAsync();
+        Assert.NotNull(row2);
+        Assert.Equal(["", "", ""], row2.Values);
+
+        Assert.Null(await reader.ReadRowAsync());
+    }
+
     private sealed class TruncatedCarriageReturnReader : TextReader
     {
         private readonly char[] _content = ['"', 'a', '\r'];


### PR DESCRIPTION
**Stack 2 of 2 · targets `fix/csv-row-number` · merge #2244 first.**

The reader silently dropped the last field of every row when that field was empty.

`hasCell` meant "at least one character was appended to the current cell". The four row-terminating paths — EOF (`:143`), EOF-after-CR (`:171`), `\n` (`:206`), `\r` (`:221`) — used it to decide whether to emit a final cell. But **an empty final cell is still a cell**. Separators mid-row added unconditionally (`:243`), so only the last field was affected:

| Input | Expected | Was |
|---|---|---|
| `a,b,` | 3 fields | **2** |
| `a,b,\n` | 3 fields | **2** |
| `a,b,""` | 3 fields | **2** |
| `,` | 2 fields | **1** |
| `,,` | 3 fields | **2** |
| `""` (whole row) | 1 field | **0** |

The `""` rows failed for the same reason from the other direction: opening a quote (`:233`) and closing it (`:194`) never touched `hasCell`, so a legitimately quoted empty value disappeared. A row consisting only of `""` vanished entirely — `rowValues` came back empty, which the end-of-stream guard reads as "no more rows".

### Why this is worse than a lost value

Positional indexing means the *next* thing the caller does throws. With `HasHeaderRow = true` and input `A,B,C\n1,2,`:

```csharp
row.Values.Count   // 2 — the empty C is gone
row["C"]           // ArgumentOutOfRangeException
```

`this[string]` resolves the name to index 2 and forwards to `this[int]`, whose guard fires — from an indexer documented to return `null` when a column is not found. Trailing empty fields are extremely common in real exports (an unset optional last column).

It also broke round-tripping through this library's own writer: `WriteRowAsync("a", "b", "")` emits `a,b,`, which read back as 2 values.

## What changed

`hasCell` becomes `hasPendingValue`, tracking **"a cell is open for this row"** rather than "characters were appended". Two places set it that previously did not:

- **Opening a quote** — a quoted value is a value even before any character lands in it, which fixes the `""` cases.
- **Consuming a separator** — a separator closes one cell *and opens the next*, so a trailing separator now correctly leaves an empty cell pending. This is the line that flipped: it used to set the flag to `false`.

The row terminators are otherwise untouched, and the quote/escape state machine is not modified at all.

**Blank lines are deliberately unchanged.** `a\n\nb` still yields three rows with the middle one having zero values. That is arguably wrong too, but it is a separate policy decision (skip the line, or emit one empty field?) and it is not this PR's to make. There is a test pinning the current behaviour so the choice stays visible.

## Verification

- `dotnet test /p:TreatsWarningsAsErrors=true` — 76 passed (38 × net10.0/net11.0), up from 38.
- 15 new tests: a 10-case theory over the table above plus `\r\n`, quoted values containing the separator, and the all-empty row; empty input still yielding no row; a trailing newline still not producing a phantom row; the blank-line characterization; `row["C"]` returning `""` instead of throwing; and a `CsvWriter` → `CsvReader` round trip of a row ending in an empty value.
- With **only #2244 applied** (this branch's parent), **20 of them fail**; with this layer, 0 fail. Layer 1's own tests still pass here, so the stack contract holds.
- `dotnet build /p:TreatsWarningsAsErrors=true` — succeeded, `ref/` unchanged. `dotnet run ./eng/update-all.cs` — no generated-file changes.

## Note

Field counts change for input that parses today, so this is a behavioural break on the shipped 5.0.0 package. `<Version>` is deliberately left alone for the bump bot.

Found by a review of `src/Meziantou.Framework.Csv`.
