### PR TITLE
Compute the correct column for a text location on the first line

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Locations/TextLocation.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Locations/TextLocation.cs
@@ -109,20 +109,21 @@ internal sealed class TextLocation : Location, ILocationLineInfo
 
     internal static TextLocation FromIndex(IFileSystem fileSystem, string filePath, string text, int index, int length)
     {
-        var line = 1;
-        var lineIndex = 0;
-        for (var i = 0; i < text.Length; i++)
-        {
-            if (i == index)
-                return new TextLocation(fileSystem, filePath, line, index - lineIndex, length);
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(index, text.Length);
 
+        var line = 1;
+        var lineStartIndex = 0;
+        for (var i = 0; i < index; i++)
+        {
             if (text[i] == '\n')
             {
-                lineIndex = i;
+                lineStartIndex = i + 1;
                 line++;
             }
         }
 
-        throw new ArgumentException("Index was not found in the text", nameof(index));
+        // LineNumber and LinePosition are 1-based
+        return new TextLocation(fileSystem, filePath, line, index - lineStartIndex + 1, length);
     }
 }

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -898,6 +898,33 @@ jobs:
     }
 
     [Fact]
+    public async Task Regex_FirstLine()
+    {
+        const string Original = """
+            image: node:10
+            image: alpine:3
+            """;
+        const string Expected = """
+            image: dummy1:2.0.0
+            image: dummy2:2.0.0
+            """;
+
+        AddFile("custom/sample.yml", Original);
+        var result = await GetDependencies<RegexScanner>([new RegexScanner()
+        {
+            FilePatterns = new GlobCollection(Glob.Parse("**/*", GlobDialect.Standard)),
+            DependencyType = DependencyType.DockerImage,
+            Regex = DockerImageWithVersionRegex(),
+        }]);
+        AssertContainDependency(result,
+            (DependencyType.DockerImage, "node", "10", 1, 13),
+            (DependencyType.DockerImage, "alpine", "3", 2, 15));
+
+        await UpdateDependencies(result, "dummy", "2.0.0");
+        AssertFileContentEqual("custom/sample.yml", Expected, ignoreNewLines: false);
+    }
+
+    [Fact]
     public async Task Regex_OptionalVersion()
     {
         const string Original = """


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before the `RegexScanner` stream fix stacked on top of it.**

### The problem

`TextLocation.FromIndex` records the newline's own index as the start of the next line:

```csharp
if (text[i] == '\n')
{
    lineIndex = i;      // index OF the newline, not of the next line
    line++;
}
```

and then returns `index - lineIndex` as a **1-based** column. For lines 2 and beyond the two errors cancel out (`index - nlIndex` == `index - (nlIndex + 1) + 1`), so the result is right by accident. On line 1 `lineIndex` is still `0` and the column comes out one too small.

`RegexScanner` is the only caller. A match on line 1 therefore gets a location one character to the left, and `UpdateVersionAsync` either throws `DependencyScannerException: Expected value not found at the location` (when `oldValue` is supplied, which is what `Dependency.UpdateVersionAsync` does) or writes at the wrong offset. Both existing `RegexScanner` tests happen to put their match on line 2, which is why this survived.

`FromIndex` also threw `ArgumentException` for `index == text.Length`, a legitimate end-of-text position.

### The change

Walk only up to `index`, track the index *after* the newline, and add the 1-based adjustment explicitly. Range-check `index` up front so an out-of-range value gets `ArgumentOutOfRangeException` rather than a loop that falls off the end.

### Verification

New test `ScannerTests.Regex_FirstLine`: two matches, one on each line, asserting both columns (1,13) and (2,15) and then updating both.

Fails on `main` with `DependencyScannerException` on the line-1 update. Passes here. The existing `Regex` test's assertion of `(…, 2, 15)` is unchanged, confirming lines 2+ are unaffected. Full project suite green: 81/81 on net10.0.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
