### PR TITLE
Leave the shared scan stream open in RegexScanner

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Scanners/RegexScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/RegexScanner.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using Meziantou.Framework.DependencyScanning.Internals;
 using Meziantou.Framework.Globbing;
 
 namespace Meziantou.Framework.DependencyScanning.Scanners;
@@ -63,7 +64,7 @@ public sealed class RegexScanner : DependencyScanner
 
         _frozen = true;
 
-        using var sr = new StreamReader(context.Content);
+        using var sr = await StreamUtilities.CreateReaderAsync(context.Content, context.CancellationToken).ConfigureAwait(false);
         var text = await sr.ReadToEndAsync(context.CancellationToken).ConfigureAwait(false);
 
         foreach (Match match in regex.Matches(text))

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -955,6 +955,30 @@ jobs:
     }
 
     [Fact]
+    public async Task Regex_LeavesTheSharedStreamOpenForTheNextScanner()
+    {
+        AddFile("package.json", /*lang=json,strict*/ """
+{
+  "dependencies": {
+    "a": "1.0.0"
+  }
+}
+""");
+
+        var result = await GetDependencies<NpmPackageJsonDependencyScanner>([
+            new RegexScanner
+            {
+                FilePatterns = new GlobCollection(Glob.Parse("**/*", GlobDialect.Standard)),
+                DependencyType = DependencyType.DockerImage,
+                Regex = DockerImageWithVersionRegex(),
+            },
+            new NpmPackageJsonDependencyScanner(),
+        ]);
+
+        AssertContainDependency(result, (DependencyType.Npm, "a", "1.0.0", 0, 0));
+    }
+
+    [Fact]
     public async Task DotNetToolsDependencies()
     {
         const string Original = /*lang=json,strict*/ """


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/textlocation-first-line-column` · that PR must merge first.**

### The problem

```csharp
using var sr = new StreamReader(context.Content);
```

That `StreamReader` overload defaults `leaveOpen` to `false`, so disposing the reader disposes the stream. `ScanFileContext` caches the file stream in a `Lazy<Stream>` and hands the *same* stream to every scanner that claimed the file, so the next scanner's `ResetStream()` seeks a closed `FileStream` and `ObjectDisposedException: Cannot access a closed file` propagates out of `ScanDirectoryAsync` — the whole scan fails, not just the file.

Every other text scanner goes through `StreamUtilities.CreateReader`, which passes `leaveOpen: true`.

The readme documents `RegexScanner` as the extension point for custom formats, and the natural way to use it — appending it to the default scanner list — is exactly the broken configuration. Both existing `RegexScanner` tests run it as the only scanner, so nothing ever ran a second scanner behind it.

### The change

Use `StreamUtilities.CreateReaderAsync`, like the other text scanners. That leaves the stream open and, as a bonus, gives `RegexScanner` the BOM/encoding detection it was the only text scanner not to have.

### Verification

New test `ScannerTests.Regex_LeavesTheSharedStreamOpenForTheNextScanner`: a `RegexScanner` and `NpmPackageJsonDependencyScanner` both claim the same `package.json`, with the regex scanner first.

Fails on `main` with `ObjectDisposedException`. Passes here. Full project suite green: 82/82 on net10.0.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
