### PR TITLE
Stop a hostile regex from escaping JSONPath evaluation as a timeout exception

### DIFF
--- a/src/Meziantou.Framework.JsonPath/Internals/JsonPathEvaluator.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/JsonPathEvaluator.cs
@@ -6,6 +6,13 @@ namespace Meziantou.Framework.Json.Internals;
 /// <summary>Evaluates a parsed JSONPath AST against a JSON value tree.</summary>
 internal static class JsonPathEvaluator
 {
+    /// <summary>
+    /// Backstop for a single <c>match()</c>/<c>search()</c> evaluation. <see cref="RegexOptions.NonBacktracking"/>
+    /// already guarantees linear time, so this only bounds pathologically long inputs. It is applied per node,
+    /// so it must stay small: a filter over a large array multiplies it by the node count.
+    /// </summary>
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
     public static JsonPathResult Evaluate(JsonPathExpression expression, JsonNode? root)
     {
         return Evaluate(expression, root, JsonPathEvaluationMode.Lax);
@@ -1001,16 +1008,7 @@ internal static class JsonPathEvaluator
             return false;
         }
 
-        try
-        {
-            var regex = ConvertIRegexpToRegex(pattern);
-            var fullPattern = $"^(?:{regex})$";
-            return Regex.IsMatch(str, fullPattern, RegexOptions.CultureInvariant, TimeSpan.FromSeconds(5));
-        }
-        catch (ArgumentException)
-        {
-            return false;
-        }
+        return IsRegexMatch(str, pattern, anchored: true);
     }
 
     private static bool EvaluateSearchFunction<TValue>(
@@ -1035,12 +1033,42 @@ internal static class JsonPathEvaluator
             return false;
         }
 
+        return IsRegexMatch(str, pattern, anchored: false);
+    }
+
+    /// <summary>
+    /// Runs an I-Regexp pattern (RFC 9485) against a string. Per RFC 9535 §2.4.6/§2.4.7, a pattern that
+    /// cannot be evaluated yields LogicalFalse rather than an error, so every failure mode returns
+    /// <see langword="false"/> instead of propagating out of <c>Evaluate</c>.
+    /// </summary>
+    /// <param name="input">The string to test.</param>
+    /// <param name="iRegexp">The I-Regexp pattern.</param>
+    /// <param name="anchored">Whether the pattern must match the whole string (<c>match()</c>) or any substring (<c>search()</c>).</param>
+    /// <returns><see langword="true"/> when the pattern matches; otherwise, <see langword="false"/>.</returns>
+    private static bool IsRegexMatch(string input, string iRegexp, bool anchored)
+    {
         try
         {
-            var regex = ConvertIRegexpToRegex(pattern);
-            return Regex.IsMatch(str, regex, RegexOptions.CultureInvariant, TimeSpan.FromSeconds(5));
+            var pattern = ConvertIRegexpToRegex(iRegexp);
+            if (anchored)
+            {
+                pattern = $"^(?:{pattern})$";
+            }
+
+            return Regex.IsMatch(input, pattern, RegexOptions.CultureInvariant | RegexOptions.NonBacktracking, RegexTimeout);
         }
         catch (ArgumentException)
+        {
+            // Not a valid .NET pattern.
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            // A construct NonBacktracking rejects (backreference, lookaround, atomic group). None of these
+            // are part of I-Regexp, so such a pattern is not a valid argument to match()/search() anyway.
+            return false;
+        }
+        catch (RegexMatchTimeoutException)
         {
             return false;
         }

--- a/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
@@ -422,6 +422,60 @@ public sealed class JsonPathEvaluateTests
         Assert.Equal(2, result.Count);
     }
 
+    [Theory]
+    [InlineData("match")]
+    [InlineData("search")]
+    public void Evaluate_Function_CatastrophicBacktrackingPattern_DoesNotThrow(string function)
+    {
+        // '(a|aa)+$' against a non-matching string is the classic exponential-backtracking case. Before
+        // NonBacktracking it spun for the full timeout and then threw RegexMatchTimeoutException straight
+        // out of Evaluate -- including in Lax mode, which documents that errors produce no match.
+        var doc = JsonNode.Parse($$"""[{"s": "{{new string('a', 40)}}b"}]""");
+        var path = JsonPath.Parse($"$[?{function}(@.s, '(a|aa)+$')]");
+
+        var lax = path.Evaluate(doc, JsonPathEvaluationMode.Lax);
+        var strict = path.Evaluate(doc, JsonPathEvaluationMode.Strict);
+
+        Assert.Empty(lax);
+        Assert.Empty(strict);
+    }
+
+    [Fact]
+    public void Evaluate_Function_CatastrophicBacktrackingPattern_CompletesQuickly()
+    {
+        var array = new JsonArray();
+        for (var i = 0; i < 50; i++)
+        {
+            array.Add(new JsonObject { ["s"] = new string('a', 40) + "b" });
+        }
+
+        var path = JsonPath.Parse("$[?match(@.s, '(a|aa)+$')]");
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var result = path.Evaluate(array);
+        stopwatch.Stop();
+
+        Assert.Empty(result);
+
+        // The old backtracking engine took ~5s per element, so 50 elements would have needed ~250s.
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10), $"Evaluation took {stopwatch.Elapsed}.");
+    }
+
+    [Theory]
+    // The pattern is written as it appears inside the JSONPath string literal, so a backslash intended for
+    // the regex engine has to be escaped for the JSONPath lexer first.
+    [InlineData("(")]                  // not a valid pattern at all
+    [InlineData("a{2,1}")]             // invalid quantifier range
+    [InlineData(@"(a)\\1")]            // backreference: not part of I-Regexp, unsupported by NonBacktracking
+    [InlineData("(?=a)b")]             // lookahead: likewise
+    public void Evaluate_Function_UnusablePattern_YieldsNoMatch(string pattern)
+    {
+        var doc = JsonNode.Parse("""[{"s": "aa"}]""");
+        var path = JsonPath.Parse($"$[?match(@.s, '{pattern}')]");
+
+        Assert.Empty(path.Evaluate(doc, JsonPathEvaluationMode.Lax));
+        Assert.Empty(path.Evaluate(doc, JsonPathEvaluationMode.Strict));
+    }
+
     [Fact]
     public void Evaluate_Function_Value()
     {


### PR DESCRIPTION
> **Stack 1 of 2** · merges into `main` · must merge before #2251

`EvaluateMatchFunction` and `EvaluateSearchFunction` wrapped `Regex.IsMatch(..., TimeSpan.FromSeconds(5))` in `catch (ArgumentException)`. `RegexMatchTimeoutException` derives from `TimeoutException`, not `ArgumentException`, so it was never caught and propagated straight out of `JsonPath.Evaluate`.

## What happens

```csharp
var doc  = JsonNode.Parse("""[{"s": "aaaaaaaa…b"}]""");   // 40 a's, then b
var path = JsonPath.Parse("$[?match(@.s, '(a|aa)+$')]");
path.Evaluate(doc, JsonPathEvaluationMode.Lax);           // throws after ~5s
```

Two problems:

1. **It contradicts the documented contract.** `JsonPathEvaluationMode.Lax` says "Path errors … produce no match", and none of the `Evaluate` overloads declare an exception for the Lax path. The obvious defensive handler, `catch (JsonPathEvaluationException)`, does not catch this.
2. **The timeout is per node.** A filter over a 1,000-element array budgets ~5,000 seconds before the first exception surfaces, so it works as a request-timeout exhaustion primitive even when the exception *is* handled. Both directions are reachable: a hostile pattern over benign data, and a benign pattern over hostile data.

## What changed

`match()` and `search()` now share one `IsRegexMatch` helper that returns `false` for every failure mode, matching RFC 9535 §2.4.6/§2.4.7 — a pattern that cannot be evaluated yields `LogicalFalse` rather than an error.

The substantive change is `RegexOptions.NonBacktracking`, which makes catastrophic backtracking *structurally impossible* rather than merely bounded — the timeout alone would not have fixed the wall-clock problem, since `N × timeout` still grows with the document. NonBacktracking rejects backreferences, lookarounds, and atomic groups, but **none of those are part of I-Regexp (RFC 9485)**, so a pattern using them was never a valid `match()`/`search()` argument; it now yields no match instead of an exception. The timeout drops from 5s to 1s and stays only as a backstop for pathologically long inputs.

That this is a safe swap is worth checking rather than assuming, so: **the full 703-case Compliance Test Suite passes with NonBacktracking enabled**, including the `\p{Lu}` / `\P{Lu}` unicode-character-class cases and the surrogate-pair `.` cases, which were the ones most at risk.

## Verification

- `dotnet test -f net10.0 -p:TreatWarningsAsErrors=true` → **812 passed, 0 failed** (805 before, +7 new).
- The 703-case Compliance Test Suite is part of that run and passes in full.
- New tests: the `(a|aa)+$` case in both `match()` and `search()` and in both evaluation modes (must return no match, not throw); a 50-element array asserting the whole evaluation finishes well under 10s where the old code needed ~250s; and four unusable patterns (malformed, invalid quantifier, backreference, lookahead) that must degrade to no-match.
- Benchmark, 100k-element array, `match(@, 'hello world [0-9]+')`, Release, warm, best of 3: **71ms → 64ms**, allocation unchanged at 82.6MB. #2251 on top of this takes it to 39ms / 58.2MB.
- `dotnet run ./eng/update-all.cs` → clean, no generated-file changes.
