### PR TITLE
Compile a literal match/search pattern once per JSONPath instead of per node

### DIFF
--- a/src/Meziantou.Framework.JsonPath/Internals/Ast/FunctionCallExpression.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/Ast/FunctionCallExpression.cs
@@ -1,7 +1,21 @@
+using System.Text.RegularExpressions;
+
 namespace Meziantou.Framework.Json.Internals;
 
 internal sealed class FunctionCallExpression : LogicalExpression
 {
+    /// <summary>
+    /// Cached <see cref="Regex"/> for a <c>match()</c>/<c>search()</c> call whose pattern is a literal, which is
+    /// the overwhelmingly common case. A miss stores <see cref="RegexCacheEntry.Unusable"/> so an invalid pattern
+    /// is not re-translated per node either.
+    /// </summary>
+    /// <remarks>
+    /// A parsed <see cref="JsonPath"/> is documented as thread-safe and reusable. Publishing this field races
+    /// benignly: <see cref="RegexCacheEntry"/> is immutable, reference assignment is atomic, and the worst case
+    /// is that two threads each build an equivalent entry and one wins.
+    /// </remarks>
+    private RegexCacheEntry? _regexCache;
+
     public FunctionCallExpression(string name, FunctionArgument[] arguments, FunctionExpressionType resultType)
     {
         Name = name;
@@ -16,4 +30,32 @@ internal sealed class FunctionCallExpression : LogicalExpression
     public FunctionArgument[] Arguments { get; }
 
     public FunctionExpressionType ResultType { get; }
+
+    /// <summary>Gets the cached regex for this call, building it with <paramref name="factory"/> on first use.</summary>
+    /// <param name="factory">Builds the entry from the literal pattern.</param>
+    /// <returns>The cached entry.</returns>
+    public RegexCacheEntry GetOrCreateRegex(Func<string, RegexCacheEntry> factory)
+    {
+        var cached = _regexCache;
+        if (cached is not null)
+        {
+            return cached;
+        }
+
+        var pattern = (string)Arguments[1].Value!;
+        cached = factory(pattern);
+        _regexCache = cached;
+        return cached;
+    }
+
+    /// <summary>An immutable compiled-pattern result: either a usable <see cref="Regex"/> or a known failure.</summary>
+    public sealed class RegexCacheEntry
+    {
+        /// <summary>A pattern that cannot be evaluated, which RFC 9535 maps to LogicalFalse.</summary>
+        public static readonly RegexCacheEntry Unusable = new(regex: null);
+
+        public RegexCacheEntry(Regex? regex) => Regex = regex;
+
+        public Regex? Regex { get; }
+    }
 }

--- a/src/Meziantou.Framework.JsonPath/Internals/JsonPathEvaluator.cs
+++ b/src/Meziantou.Framework.JsonPath/Internals/JsonPathEvaluator.cs
@@ -1008,7 +1008,7 @@ internal static class JsonPathEvaluator
             return false;
         }
 
-        return IsRegexMatch(str, pattern, anchored: true);
+        return IsRegexMatch(func, str, pattern, anchored: true);
     }
 
     private static bool EvaluateSearchFunction<TValue>(
@@ -1033,7 +1033,7 @@ internal static class JsonPathEvaluator
             return false;
         }
 
-        return IsRegexMatch(str, pattern, anchored: false);
+        return IsRegexMatch(func, str, pattern, anchored: false);
     }
 
     /// <summary>
@@ -1041,11 +1041,35 @@ internal static class JsonPathEvaluator
     /// cannot be evaluated yields LogicalFalse rather than an error, so every failure mode returns
     /// <see langword="false"/> instead of propagating out of <c>Evaluate</c>.
     /// </summary>
+    /// <param name="func">The call being evaluated, used to cache the compiled pattern.</param>
     /// <param name="input">The string to test.</param>
     /// <param name="iRegexp">The I-Regexp pattern.</param>
     /// <param name="anchored">Whether the pattern must match the whole string (<c>match()</c>) or any substring (<c>search()</c>).</param>
     /// <returns><see langword="true"/> when the pattern matches; otherwise, <see langword="false"/>.</returns>
-    private static bool IsRegexMatch(string input, string iRegexp, bool anchored)
+    private static bool IsRegexMatch(FunctionCallExpression func, string input, string iRegexp, bool anchored)
+    {
+        // The pattern is a literal in almost every real query, so translate and compile it once per AST node
+        // rather than once per node visited. A computed pattern falls back to the per-call path.
+        var regex = func.Arguments[1].Kind is FunctionArgumentKind.Literal && func.Arguments[1].Value is string
+            ? func.GetOrCreateRegex(p => CreateRegex(p, anchored)).Regex
+            : CreateRegex(iRegexp, anchored).Regex;
+
+        if (regex is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return regex.IsMatch(input);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static FunctionCallExpression.RegexCacheEntry CreateRegex(string iRegexp, bool anchored)
     {
         try
         {
@@ -1055,22 +1079,19 @@ internal static class JsonPathEvaluator
                 pattern = $"^(?:{pattern})$";
             }
 
-            return Regex.IsMatch(input, pattern, RegexOptions.CultureInvariant | RegexOptions.NonBacktracking, RegexTimeout);
+            return new FunctionCallExpression.RegexCacheEntry(
+                new Regex(pattern, RegexOptions.CultureInvariant | RegexOptions.NonBacktracking, RegexTimeout));
         }
         catch (ArgumentException)
         {
             // Not a valid .NET pattern.
-            return false;
+            return FunctionCallExpression.RegexCacheEntry.Unusable;
         }
         catch (NotSupportedException)
         {
             // A construct NonBacktracking rejects (backreference, lookaround, atomic group). None of these
             // are part of I-Regexp, so such a pattern is not a valid argument to match()/search() anyway.
-            return false;
-        }
-        catch (RegexMatchTimeoutException)
-        {
-            return false;
+            return FunctionCallExpression.RegexCacheEntry.Unusable;
         }
     }
 

--- a/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
+++ b/tests/Meziantou.Framework.JsonPath.Tests/JsonPathEvaluateTests.cs
@@ -460,6 +460,45 @@ public sealed class JsonPathEvaluateTests
         Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10), $"Evaluation took {stopwatch.Elapsed}.");
     }
 
+    [Fact]
+    public void Evaluate_Function_Match_NonLiteralPattern_IsNotCached()
+    {
+        // The pattern comes from the document, so it differs per node and must bypass the per-AST cache.
+        var doc = JsonNode.Parse("""[{"s": "foo", "p": "f.o"}, {"s": "bar", "p": "z.z"}, {"s": "baz", "p": "b.z"}]""");
+        var path = JsonPath.Parse("$[?match(@.s, @.p)]");
+
+        var result = path.Evaluate(doc);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("foo", result[0].Value!.AsObject()["s"]!.GetValue<string>());
+        Assert.Equal("baz", result[1].Value!.AsObject()["s"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Evaluate_Function_Match_CachedRegex_IsStableAcrossReuseAndThreads()
+    {
+        // A parsed JsonPath is documented as reusable and thread-safe, and the regex cache is populated lazily.
+        var doc = JsonNode.Parse("""[{"a": "foo"}, {"a": "bar"}, {"a": "foobar"}]""");
+        var path = JsonPath.Parse("""$[?search(@.a, "foo")]""");
+
+        Assert.Equal(2, path.Evaluate(doc).Count);
+        Assert.Equal(2, path.Evaluate(doc).Count);
+
+        var counts = new int[32];
+        Parallel.For(0, counts.Length, i => counts[i] = path.Evaluate(doc).Count);
+        Assert.All(counts, count => Assert.Equal(2, count));
+    }
+
+    [Fact]
+    public void Evaluate_Function_Match_UnusablePatternIsCachedToo()
+    {
+        var doc = JsonNode.Parse("""[{"s": "aa"}, {"s": "bb"}]""");
+        var path = JsonPath.Parse("$[?match(@.s, '(')]");
+
+        Assert.Empty(path.Evaluate(doc));
+        Assert.Empty(path.Evaluate(doc));
+    }
+
     [Theory]
     // The pattern is written as it appears inside the JSONPath string literal, so a backslash intended for
     // the regex engine has to be escaped for the JSONPath lexer first.


### PR DESCRIPTION
> **Stack 2 of 2** · merges into `fix/jsonpath-regex-timeout` (#2250) · merge #2250 first

Follow-up to #2250, which this builds on textually — both rewrite the same block in `EvaluateMatchFunction`/`EvaluateSearchFunction`, so they are stacked rather than independent.

## What happens

For every node tested, `match()`/`search()` walked the I-Regexp pattern and rebuilt it through a `StringBuilder` (sized `iregexp.Length * 2`), then `match()` interpolated `$"^(?:{pattern})$"` on top, and handed the result to the static `Regex.IsMatch` — whose internal cache holds only 15 entries. The pattern is a literal in the AST in essentially every real query, so all of that is the same work repeated once per node.

## What changed

`FunctionCallExpression` gained a lazily-populated `RegexCacheEntry` holding the compiled `Regex`, used when the pattern argument is a literal. A computed pattern — `$[?match(@.s, @.p)]`, where the pattern comes from the document and differs per node — still goes through the per-call path.

An unusable pattern caches `RegexCacheEntry.Unusable` rather than nothing, so an invalid pattern is not re-translated per node either.

**On thread safety:** a parsed `JsonPath` is documented as immutable and safe to share, and this adds a mutable field to the AST. The race is benign by construction — `RegexCacheEntry` is immutable, reference assignment is atomic, and the worst case is two threads each building an equivalent entry with one winning. No lock, so the hot path stays a single field read. There is a `Parallel.For` test covering it.

## Verification

- `dotnet test -f net10.0 -p:TreatWarningsAsErrors=true` → **815 passed, 0 failed** (812 with #2250 alone, +3 new).
- The 703-case Compliance Test Suite is part of that run and passes in full.
- New tests: a non-literal pattern that must bypass the cache and still match per node; cache stability across sequential reuse and 32 parallel evaluations of one `JsonPath`; and an unusable pattern evaluated twice.
- Benchmark, 100k-element array, `match(@, 'hello world [0-9]+')`, Release, warm, best of 3:

  | | time | allocated |
  |---|---|---|
  | `main` | 71ms | 82.6MB |
  | with #2250 | 64ms | 82.6MB |
  | with this PR | **39ms** | **58.2MB** |

  The remaining 58MB is normalized-path construction in the evaluator, which is a separate finding and not touched here.
- `dotnet run ./eng/update-all.cs` → clean, no generated-file changes.
