### PR TITLE
Skip malformed packages.config files instead of failing the scan

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Scanners/PackagesConfigDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/PackagesConfigDependencyScanner.cs
@@ -31,7 +31,7 @@ public sealed partial class PackagesConfigDependencyScanner : DependencyScanner
 
     public override async ValueTask ScanAsync(ScanFileContext context)
     {
-        var doc = await XmlUtilities.LoadDocumentWithoutClosingStreamAsync(context.Content, context.CancellationToken).ConfigureAwait(false);
+        var doc = await XmlUtilities.TryLoadDocumentWithoutClosingStream(context.Content, context.CancellationToken).ConfigureAwait(false);
         if (doc is null)
             return;
 

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -523,6 +523,32 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
     }
 
     [Fact]
+    public async Task PackagesConfigInvalidXml()
+    {
+        AddFile("packages.config", """<packages><package id="a" version="1.0.0">""");
+
+        var result = await GetDependencies<PackagesConfigDependencyScanner>();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task PackagesConfigInvalidXmlDoesNotStopTheScan()
+    {
+        AddFile("packages.config", """<packages><package id="a" version="1.0.0">""");
+        AddFile("Chart.yaml", """
+            dependencies:
+              - name: mariadb
+                version: 7.x.x
+                repository: https://example.com/charts
+            """);
+
+        var result = await GetDependencies<HelmChartDependencyScanner>();
+
+        AssertContainDependency(result, (DependencyType.HelmChart, "https://example.com/charts", "7.x.x", 0, 0));
+    }
+
+    [Fact]
     public async Task DockerfileFromDependencies()
     {
         const string Original = """


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before the query-hoisting PR stacked on top of it.**

### The problem

`PackagesConfigDependencyScanner` is the only scanner calling the throwing loader:

```csharp
var doc = await XmlUtilities.LoadDocumentWithoutClosingStreamAsync(context.Content, context.CancellationToken);
if (doc is null)   // never null; the call throws instead
    return;
```

A truncated `packages.config` throws `XmlException` straight out of `ScanAsync`. Scanner exceptions propagate by design (`DependencyScannerTests.ReportScanException` asserts exactly that), so one malformed file discards the results for **every other file in the tree**.

`NuSpecDependencyScanner` and `MsBuildReferencesDependencyScanner` handle the same situation with `TryLoadDocumentWithoutClosingStream` and return early. Scanners run over repositories the caller does not control, where a half-written or templated config file is routine, so "skip the file" is the right behaviour here — this is not a change to the framework's exception contract, just to which category a malformed input falls into.

### The change

Use `TryLoadDocumentWithoutClosingStream`. The existing `if (doc is null) return;` was already written for it and now actually does something.

### Verification

Two new tests in `ScannerTests`:

- `PackagesConfigInvalidXml` — a truncated `packages.config` yields no dependencies instead of throwing.
- `PackagesConfigInvalidXmlDoesNotStopTheScan` — a truncated `packages.config` next to a valid `Chart.yaml`; the Helm chart is still reported.

Both fail on `main` with `XmlException: Unexpected end of file`. Both pass here. Full project suite green: 82/82 on net10.0.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
