### PR TITLE
Let cancellation escape the XML document loader

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Internals/XmlUtilities.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Internals/XmlUtilities.cs
@@ -30,8 +30,9 @@ internal static class XmlUtilities
             using var xmlReader = XmlReader.Create(stream, XmlSettings);
             return await XDocument.LoadAsync(xmlReader, loadOptions, cancellationToken).ConfigureAwait(false);
         }
-        catch
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            // An invalid document is not an error: the file is simply not a document this scanner can read
             return null;
         }
     }

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
@@ -89,6 +89,21 @@ public sealed class DependencyScannerTests
     }
 
     [Fact]
+    public async Task ScanDirectory_PropagatesCancellationFromXmlParsing()
+    {
+        await using var directory = TemporaryDirectory.Create();
+        await File.WriteAllTextAsync(directory.GetFullPath("test.csproj"), """
+            <Project><ItemGroup><PackageReference Include="A" Version="1.0.0" /></ItemGroup></Project>
+            """, XunitCancellationToken);
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+
+        var options = new ScannerOptions { DegreeOfParallelism = 1, Scanners = [new MsBuildReferencesDependencyScanner()] };
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => DependencyScanner.ScanDirectoryAsync(directory.FullPath, options, onDependencyFound: _ => { }, cancellationTokenSource.Token));
+    }
+
+    [Fact]
     public void DefaultScannersIncludeAllScanners()
     {
         var scanners = new ScannerOptions().Scanners.Select(t => t.GetType()).OrderBy(t => t.FullName, StringComparer.Ordinal).ToArray();


### PR DESCRIPTION
### The problem

```csharp
using var xmlReader = XmlReader.Create(stream, XmlSettings);
return await XDocument.LoadAsync(xmlReader, loadOptions, cancellationToken).ConfigureAwait(false);
}
catch
{
    return null;
}
```

The bare `catch` also catches `OperationCanceledException` from the `cancellationToken` it just passed in. Cancelling a scan while an XML file is parsing is turned into "this file has no dependencies", and the scan carries on to the next file and returns normally. A caller cannot tell a cancelled scan from a complete one, and gets partial results presented as final.

Swallowing *parse* errors is correct and deliberate — a file that is not valid XML is simply not a document this scanner can read. It is only the cancellation case that should get through.

### The change

`catch (Exception ex) when (ex is not OperationCanceledException)`. Deliberately still broad, so every input this used to tolerate is still tolerated.

### Scope note

My review claimed three locations for this. Only this one is real: the bare `catch` blocks in `YamlParserUtilities.LoadYamlDocument` and `AzureDevOpsScanner.ScanAsync` are wrapped around fully synchronous code with no cancellation token in scope, so there is no cancellation for them to swallow. They are left alone here. (`AzureDevOpsScanner`'s catch is broad enough to hide bugs in its own traversal, which is a separate readability concern, not this one.)

### Verification

New test `DependencyScannerTests.ScanDirectory_PropagatesCancellationFromXmlParsing`: scan a `.csproj` with an already-cancelled token and expect an `OperationCanceledException`.

Fails on `main` (the scan completes and reports nothing), passes here. Full project suite green: 81/81 on net10.0.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
