### PR TITLE
Read JSON files that are not encoded in UTF-8

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Internals/JsonNodeDocument.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Internals/JsonNodeDocument.cs
@@ -20,6 +20,17 @@ internal sealed class JsonNodeDocument
 
     public static async ValueTask<JsonNodeDocument> ParseAsync(Stream stream, CancellationToken cancellationToken)
     {
+        var encoding = await StreamUtilities.GetEncodingAsync(stream, cancellationToken).ConfigureAwait(false);
+        stream.Seek(0, SeekOrigin.Begin);
+
+        // System.Text.Json only reads UTF-8, so anything else has to be transcoded first
+        if (encoding.CodePage != Encoding.UTF8.CodePage)
+        {
+            using var reader = StreamUtilities.CreateReader(stream, encoding);
+            var text = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+            return new JsonNodeDocument(ParseNode(text));
+        }
+
         var root = await JsonNode.ParseAsync(stream, nodeOptions: null, documentOptions: JsonDocumentOptions, cancellationToken: cancellationToken).ConfigureAwait(false) ?? throw new JsonException("Expected a JSON value.");
         return new JsonNodeDocument(root);
     }

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/ScannerTests.cs
@@ -52,6 +52,44 @@ public sealed partial class ScannerTests(ITestOutputHelper testOutputHelper) : I
     }
 
     [Theory]
+    [InlineData("utf-8")]
+    [InlineData("utf-8-bom")]
+    [InlineData("utf-16le")]
+    [InlineData("utf-16be")]
+    public async Task NpmPackageJsonDependencies_Encodings(string encodingName)
+    {
+        Encoding encoding = encodingName switch
+        {
+            "utf-8" => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            "utf-8-bom" => new UTF8Encoding(encoderShouldEmitUTF8Identifier: true),
+            "utf-16le" => new UnicodeEncoding(bigEndian: false, byteOrderMark: true),
+            _ => new UnicodeEncoding(bigEndian: true, byteOrderMark: true),
+        };
+
+        const string Content = /*lang=json,strict*/ """
+{
+  "dependencies": {
+    "a": "1.0.0"
+  }
+}
+""";
+        const string Expected = /*lang=json,strict*/ """
+{
+  "dependencies": {
+    "a": "2.0.0"
+  }
+}
+""";
+        AddFile("package.json", [.. encoding.GetPreamble(), .. encoding.GetBytes(Content)]);
+
+        var result = await GetDependencies<NpmPackageJsonDependencyScanner>();
+        AssertContainDependency(result, (DependencyType.Npm, "a", "1.0.0", 0, 0));
+
+        await UpdateDependencies(result, "dummy", "2.0.0");
+        AssertFileContentEqual("package.json", Expected, ignoreNewLines: true);
+    }
+
+    [Theory]
     [InlineData("http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd")]
     [InlineData("http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd")]
     [InlineData("http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd")]


### PR DESCRIPTION
### The problem

`JsonNodeDocument.ParseAsync` hands the raw stream to `JsonNode.ParseAsync`. `System.Text.Json` only accepts UTF-8, so a UTF-16 or UTF-32 file throws `JsonException` — which every JSON scanner catches and ignores. The file is reported as having no dependencies, with no error to notice.

This affects all six JSON scanners: `package.json`, `global.json`, `dotnet-tools.json`, `project.json`, `Package.resolved` and the Renovate configs.

It stands out because `StreamUtilities.GetEncodingAsync` exists precisely to detect these BOMs, and every *text* and *XML* scanner already goes through it. The JSON path was the one that opted out — while `JsonLocation.UpdateCoreAsync`, on the write side, already detects and preserves the encoding.

### The change

Detect the encoding first. UTF-8 (with or without BOM, including the BOM-less `Encoding.Default` case) keeps the existing streaming fast path unchanged; anything else is transcoded through a `StreamReader` and parsed with the existing `ParseNode`.

### Verification

New theory `ScannerTests.NpmPackageJsonDependencies_Encodings` over UTF-8, UTF-8 with BOM, UTF-16LE and UTF-16BE. Each case is a full round trip: scan, assert the dependency is found, update the version, and assert the resulting file content — so it covers reading *and* that the update preserves the file's encoding.

The two UTF-16 cases fail on `main` (nothing is detected); all four pass here. Full project suite green: 84/84 on net10.0.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
