### PR TITLE
Report an error instead of generating invalid code for generic strongly-typed ids

### DIFF
--- a/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdAnalyzer.cs
+++ b/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdAnalyzer.cs
@@ -33,7 +33,16 @@ public sealed class StronglyTypedIdAnalyzer : DiagnosticAnalyzer
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(UnsupportedType, UnsupportedGuidGenerationStrategy, UnusedGuidGenerationStrategy);
+    private static readonly DiagnosticDescriptor UnsupportedGenericType = new(
+        id: "MFSTID0004",
+        title: "Generic types are not supported",
+        messageFormat: "The type '{0}' cannot be a strongly-typed id because it is generic or nested in a generic type",
+        category: "StronglyTypedId",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "An attribute argument cannot use a type parameter (CS0416), so the generated converters could not be associated with the type.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(UnsupportedType, UnsupportedGuidGenerationStrategy, UnusedGuidGenerationStrategy, UnsupportedGenericType);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -85,6 +94,17 @@ public sealed class StronglyTypedIdAnalyzer : DiagnosticAnalyzer
             var typeSymbol = TryGetIdTypeSymbol(attribute, nonGenericAttribute, genericAttribute);
             if (typeSymbol is null)
                 continue;
+
+            if (StronglyTypedIdSourceGenerator.IsGenericTypeOrNestedInGenericType(symbol))
+            {
+                var location = attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken).GetLocation() ?? symbol.Locations.FirstOrDefault();
+                if (location is not null)
+                {
+                    context.ReportDiagnostic(UnsupportedGenericType, location, symbol.ToDisplayString());
+                }
+
+                continue;
+            }
 
             var idType = StronglyTypedIdSourceGenerator.GetIdType(context.Compilation, typeSymbol);
             if (idType is StronglyTypedIdSourceGenerator.IdType.Unknown)

--- a/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.cs
+++ b/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.cs
@@ -118,6 +118,10 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
         {
             var semanticModel = ctx.SemanticModel;
 
+            // Generic types are not supported. The analyzer reports MFSTID0004.
+            if (ctx.TargetSymbol is not INamedTypeSymbol targetSymbol || IsGenericTypeOrNestedInGenericType(targetSymbol))
+                return null;
+
             foreach (var attribute in ctx.Attributes)
             {
                 var attributeSyntax = attribute.ApplicationSyntaxReference!.GetSyntax(cancellationToken);
@@ -380,6 +384,20 @@ public sealed partial class StronglyTypedIdSourceGenerator : IIncrementalGenerat
         {
             writer.WriteLine(GeneratedCodeAttribute);
         }
+    }
+
+    /// <summary>
+    /// Indicates whether the type is generic or is nested in a generic type. The generated code cannot support those types as an attribute argument cannot use a type parameter (CS0416), so the converters could not be associated with the type.
+    /// </summary>
+    internal static bool IsGenericTypeOrNestedInGenericType(INamedTypeSymbol symbol)
+    {
+        for (var current = symbol; current is not null; current = current.ContainingType)
+        {
+            if (current.Arity > 0)
+                return true;
+        }
+
+        return false;
     }
 
     internal static IdType GetIdType(Compilation compilation, ITypeSymbol symbol)

--- a/src/Meziantou.Framework.StronglyTypedId/readme.md
+++ b/src/Meziantou.Framework.StronglyTypedId/readme.md
@@ -199,4 +199,5 @@ public partial struct ProjectId : IComparable<ProjectId>
 | `MFSTID0001` | StronglyTypedId | Not supported type | Error | ✔️ |
 | `MFSTID0002` | StronglyTypedId | Guid generation strategy is not supported by the target framework | Error | ✔️ |
 | `MFSTID0003` | StronglyTypedId | Guid generation strategy is only applicable to Guid | Warning | ✔️ |
+| `MFSTID0004` | StronglyTypedId | Generic types are not supported | Error | ✔️ |
 <!-- analyzer-rules -->

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
@@ -177,6 +177,56 @@ public sealed class StronglyTypedIdSourceGeneratorTests
     }
 
     [Fact]
+    public async Task GenericType_ReportedByAnalyzer()
+    {
+        var sourceCode = """
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(int))]
+            public partial struct Test<T> { }
+            """;
+
+        var result = await GenerateFiles(sourceCode, mustCompile: false);
+        Assert.Empty(result.GeneratorResult.Diagnostics);
+        Assert.Empty(result.GeneratorResult.GeneratedTrees);
+
+        var diagnostics = await Analyze(sourceCode);
+        Assert.Collection(diagnostics, diag => Assert.Equal("MFSTID0004", diag.Id));
+    }
+
+    [Fact]
+    public async Task GenericContainingType_ReportedByAnalyzer()
+    {
+        var sourceCode = """
+            public partial class Outer<T>
+            {
+                [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(int))]
+                public partial struct Test { }
+            }
+            """;
+
+        var result = await GenerateFiles(sourceCode, mustCompile: false);
+        Assert.Empty(result.GeneratorResult.Diagnostics);
+        Assert.Empty(result.GeneratorResult.GeneratedTrees);
+
+        var diagnostics = await Analyze(sourceCode);
+        Assert.Collection(diagnostics, diag => Assert.Equal("MFSTID0004", diag.Id));
+    }
+
+    [Fact]
+    public async Task NonGenericTypeNestedInNonGenericType_NotReported()
+    {
+        var sourceCode = """
+            public partial class Outer
+            {
+                [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(int))]
+                public partial struct Test { }
+            }
+            """;
+
+        var diagnostics = await Analyze(sourceCode);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public async Task MultipleAttribute()
     {
         var sourceCode = """


### PR DESCRIPTION
An id nested in a generic type silently generated its members into a **different type**:

```csharp
public partial class Outer<T>
{
    [StronglyTypedId<int>]
    public partial struct Foo { }
}
```

`PartialTypeContext` stores only `typeSymbol.Name`, so the generator emitted `partial class Outer { partial struct Foo { ... } }`. `Outer` (arity 0) and `Outer<T>` (arity 1) are different types, so this **compiles without error** — it just creates a new `Outer` class nobody asked for, while the real `Outer<T>.Foo` gets none of the generated members. The user then sees "`Foo` does not contain a definition for `FromInt32`" pointing at their own call sites, while `Foo.g.cs` visibly contains that exact method.

A generic id type itself (`[StronglyTypedId<int>] partial struct Foo<T>`) has the same root cause and additionally collides on the generated file name.

## Why reject rather than support

Emitting `Outer<T>` is easy, but the generated converters cannot follow. C# forbids an attribute argument that references an enclosing type parameter:

```
error CS0416: 'Outer<T>.FooJsonConverter': an attribute argument cannot use type parameters
```

So `[TypeConverter]`, `[JsonConverter]`, `[BsonSerializer]` and `[Newtonsoft.Json.JsonConverter]` can never be applied to an id nested in a generic type. Any "support" would silently drop serialization support for those ids — a worse failure than the one being fixed, because it only shows up at runtime. Rejecting keeps the contract honest: every generated id gets the full set of members and converters, or none at all.

## What changed

- New analyzer rule **`MFSTID0004`** (Error): *"The type '{0}' cannot be a strongly-typed id because it is generic or nested in a generic type"*, with the CS0416 rationale in the description.
- The generator skips those types, so it no longer emits code into a phantom type. This mirrors how the unsupported-id-type case (`MFSTID0001`) is already split between generator and analyzer.
- `IsGenericTypeOrNestedInGenericType` walks the containing-type chain and is shared by both.
- Readme analyzer-rules table regenerated by `dotnet run ./eng/update-all.cs`.

## Verification

Three tests added next to `UnsupportedType_ReportedByAnalyzer`, all failing on `main`:

- `GenericType_ReportedByAnalyzer` — `struct Test<T>`: nothing generated, `MFSTID0004` reported
- `GenericContainingType_ReportedByAnalyzer` — `Outer<T>.Test`: nothing generated, `MFSTID0004` reported
- `NonGenericTypeNestedInNonGenericType_NotReported` — regression guard so ordinary nesting stays clean

Full suites pass: 731 in `Meziantou.Framework.StronglyTypedId.Tests` and 86 in `Meziantou.Framework.StronglyTypedId.GeneratorTests`.

## Compatibility

This turns code that previously compiled (while silently doing the wrong thing) into a build error. That is intentional — the affected ids never worked — but it is a behavior change for anyone who has such a type today.
