### PR TITLE
Fix inaccurate ecosystem list and non-compiling sample in the readme

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/ScannerOptions.cs
+++ b/src/Meziantou.Framework.DependencyScanning/ScannerOptions.cs
@@ -11,7 +11,7 @@ namespace Meziantou.Framework.DependencyScanning;
 /// {
 ///     DegreeOfParallelism = 8,
 ///     RecurseSubdirectories = true,
-///     IncludedDependencyTypes = [DependencyType.NuGet, DependencyType.Npm].ToImmutableHashSet()
+///     IncludedDependencyTypes = [DependencyType.NuGet, DependencyType.Npm]
 /// };
 /// var dependencies = await DependencyScanner.ScanDirectoryAsync("C:\\MyProject", options, cancellationToken);
 /// </code>

--- a/src/Meziantou.Framework.DependencyScanning/readme.md
+++ b/src/Meziantou.Framework.DependencyScanning/readme.md
@@ -5,7 +5,7 @@ A .NET library for scanning source code directories and files to discover and ma
 ## Features
 
 - **Multi-format Support**: Scan dependencies from various project files and configuration formats
-- **Multiple Package Ecosystems**: NuGet, npm, PyPI, Docker, Ruby Gems, Helm Charts, and more
+- **Multiple Package Ecosystems**: NuGet, npm, PyPI, Docker, Swift packages, Helm Charts, and more
 - **Parallel Scanning**: High-performance parallel file scanning with configurable degree of parallelism
 - **Dependency Updates**: Locate and update dependency versions programmatically
 - **Customizable Scanning**: Filter by file patterns, dependency types, and custom predicates
@@ -26,7 +26,6 @@ The library can detect the following dependency types:
 - **AzureDevOpsTask** - Azure DevOps pipeline tasks
 - **AzureDevOpsTemplate** - Azure DevOps pipeline templates
 - **HelmChart** - Helm chart dependencies
-- **RubyGem** - Ruby gems
 - **RenovateConfiguration** - Renovate configuration extends
 - **SwiftPackage** - Swift Package Manager dependencies
 - **MSBuildProjectReference** - MSBuild project references
@@ -86,13 +85,13 @@ var dependencies = await DependencyScanner.ScanDirectoryAsync(
 var options = new ScannerOptions
 {
     // Only scan for specific dependency types
-    IncludedDependencyTypes = [DependencyType.NuGet, DependencyType.Npm].ToImmutableHashSet(),
+    IncludedDependencyTypes = [DependencyType.NuGet, DependencyType.Npm],
 };
 
 // Or exclude specific types
 var options2 = new ScannerOptions
 {
-    ExcludedDependencyTypes = [DependencyType.DockerImage].ToImmutableHashSet(),
+    ExcludedDependencyTypes = [DependencyType.DockerImage],
 };
 ```
 


### PR DESCRIPTION
Two documentation inaccuracies in `Meziantou.Framework.DependencyScanning`.

### 1. Ruby Gems support that does not exist

The readme listed `RubyGem` under supported dependency types and named "Ruby Gems" among the supported ecosystems. `DependencyType.RubyGem` exists in the enum, but no scanner ever reports it — grep confirms the member has no producer. Setting `IncludedDependencyTypes = [DependencyType.RubyGem]` yields an empty scanner list and zero results, with nothing to explain why.

Removed both claims. The enum member is left alone: it is public API, and removing it would be a breaking change for no benefit.

`Meziantou.Framework.DependencyScanning.Tool/readme.md` also lists `RubyGem` in its `--dependency-type` help, but that file is generated by `eng/update-all.cs` from the enum, so it is correct to leave it as is. Ran `dotnet run ./eng/update-all.cs`; no regeneration was needed.

### 2. The `IncludedDependencyTypes` sample does not compile

```csharp
IncludedDependencyTypes = [DependencyType.NuGet, DependencyType.Npm].ToImmutableHashSet(),
```

`error CS9176: There is no target type for the collection expression` — a collection expression has no type in receiver position. Since the property is already `ImmutableHashSet<DependencyType>`, the assignment target supplies the type and the `.ToImmutableHashSet()` is both wrong and unnecessary:

```csharp
IncludedDependencyTypes = [DependencyType.NuGet, DependencyType.Npm],
```

Fixed in the readme (both the included and excluded samples) and in the same idiom in the `ScannerOptions` XML doc example. Verified the corrected form compiles and runs.

Full project suite green: 80/80 on net10.0.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
