### PR TITLE
Remove the unused XML save helper

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Internals/XmlUtilities.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Internals/XmlUtilities.cs
@@ -36,26 +36,6 @@ internal static class XmlUtilities
         }
     }
 
-    public static async Task SaveDocumentWithoutClosingStream(Stream stream, XDocument document, CancellationToken cancellationToken)
-    {
-        var settings = new XmlWriterSettings
-        {
-            OmitXmlDeclaration = document.Declaration is null,
-            CloseOutput = false,
-            Async = true,
-            Indent = false,
-        };
-        var xmlWriter = XmlWriter.Create(stream, settings);
-        try
-        {
-            await document.SaveAsync(xmlWriter, cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            await xmlWriter.DisposeAsync().ConfigureAwait(false);
-        }
-    }
-
     public static string CreateXPath(XElement element)
     {
         var current = element;


### PR DESCRIPTION
### The problem

`XmlUtilities.SaveDocumentWithoutClosingStream` has no callers. It is `internal`, and the two assemblies with `InternalsVisibleTo` access (`Meziantou.Framework.DependencyScanning.Tests` and `DependencyScanningBenchmarks`) do not use it either — a repo-wide grep finds only the definition.

It also carries a latent bug if anyone ever did revive it: it writes into the stream without `SetLength(0)`, so saving a shorter document over a longer one would leave the tail of the old content behind. That is exactly the mistake `TextLocation`, `JsonLocation` and `XmlLocation` each avoid explicitly, and it is the kind of thing that is easy to reach for without noticing.

### The change

Delete it. The XML write path that is actually used goes through `XmlLocation.UpdateCoreAsync`, which truncates correctly.

### Verification

Repo-wide grep for the symbol returns only the definition. Builds clean with `/p:TreatWarningsAsErrors=true` (so no using directive is left dangling — `System.Xml` is still needed by `XmlReaderSettings` and `XmlNodeType`). Full project suite green: 80/80 on net10.0.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
