### PR TITLE
Detect UTF-32 byte order marks before the UTF-16 ones

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Internals/StreamUtilities.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Internals/StreamUtilities.cs
@@ -2,6 +2,8 @@ namespace Meziantou.Framework.DependencyScanning.Internals;
 
 internal static class StreamUtilities
 {
+    private static readonly Encoding BigEndianUTF32 = new UTF32Encoding(bigEndian: true, byteOrderMark: true);
+
     public static StreamReader CreateReader(Stream stream, Encoding encoding)
     {
         return new StreamReader(stream, encoding, leaveOpen: true);
@@ -38,14 +40,18 @@ internal static class StreamUtilities
         if (buffer is [0xef, 0xbb, 0xbf, ..])
             return Encoding.UTF8;
 
+        // The UTF-32 BOMs must be tested before the UTF-16 ones: the UTF-32LE BOM starts with the UTF-16LE BOM
+        if (buffer is [0xff, 0xfe, 0x00, 0x00])
+            return Encoding.UTF32; //UTF-32LE
+
+        if (buffer is [0x00, 0x00, 0xfe, 0xff])
+            return BigEndianUTF32;
+
         if (buffer is [0xff, 0xfe, ..])
             return Encoding.Unicode; //UTF-16LE
 
         if (buffer is [0xfe, 0xff, ..])
             return Encoding.BigEndianUnicode; //UTF-16BE
-
-        if (buffer is [0x00, 0x00, 0xfe, 0xff, ..])
-            return Encoding.UTF32;
 
         return Encoding.Default;
     }

--- a/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tests/DependencyScannerTests.cs
@@ -298,6 +298,21 @@ public sealed class DependencyScannerTests
         Assert.Equal(Encoding.UTF8.WebName, encoding.WebName);
     }
 
+    [Theory]
+    [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'a' }, 65001)] // UTF-8
+    [InlineData(new byte[] { 0xFF, 0xFE, (byte)'a', 0x00 }, 1200)] // UTF-16LE
+    [InlineData(new byte[] { 0xFE, 0xFF, 0x00, (byte)'a' }, 1201)] // UTF-16BE
+    [InlineData(new byte[] { 0xFF, 0xFE, 0x00, 0x00 }, 12000)] // UTF-32LE
+    [InlineData(new byte[] { 0x00, 0x00, 0xFE, 0xFF }, 12001)] // UTF-32BE
+    public async Task GetEncodingAsync_DetectsBom(byte[] content, int expectedCodePage)
+    {
+        await using var stream = new MemoryStream(content);
+
+        var encoding = await StreamUtilities.GetEncodingAsync(stream, XunitCancellationToken);
+
+        Assert.Equal(expectedCodePage, encoding.CodePage);
+    }
+
     [Fact]
     public async Task CreateReaderAsync_DetectsUtf8Bom_WhenStreamReadsOneByteAtATime()
     {


### PR DESCRIPTION
### The problem

Two bugs in the BOM ladder in `StreamUtilities.GetEncodingAsync`:

1. **UTF-32LE is misdetected as UTF-16LE.** The UTF-32LE BOM is `FF FE 00 00`, which starts with the UTF-16LE BOM `FF FE`, and the 2-byte arm was tested first.
2. **UTF-32BE decodes as little-endian.** The `00 00 FE FF` arm matched the big-endian BOM but returned `Encoding.UTF32`, which is little-endian.

This matters mainly on the *write* side. `StreamReader` does its own BOM detection when reading, so reads mostly recovered; the detected encoding is what gets handed to `StreamUtilities.CreateWriter` in `TextLocation.UpdateCoreAsync`. Updating a dependency in a UTF-32 file therefore rewrote the whole file in the wrong encoding.

UTF-32 source files are rare, which is why this has not bitten — but the code reads as though it handles them, so it should.

### The change

Test the two 4-byte UTF-32 BOMs before the 2-byte UTF-16 ones, and return `new UTF32Encoding(bigEndian: true, byteOrderMark: true)` for the big-endian case.

### Verification

New theory `DependencyScannerTests.GetEncodingAsync_DetectsBom` asserting the code page for UTF-8, UTF-16LE, UTF-16BE, UTF-32LE and UTF-32BE.

The two UTF-32 cases fail on `main` (1200 instead of 12000, and 12000 instead of 12001); all five pass here. The UTF-16 cases pass on both, confirming the reordering did not disturb them. Full project suite green: 85/85 on net10.0.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
