### PR TITLE
Return the default id instead of null when a JSON object has no Value property

### DIFF
--- a/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.Newtonsoft.Json.cs
+++ b/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.Newtonsoft.Json.cs
@@ -72,6 +72,13 @@ public partial class StronglyTypedIdSourceGenerator
                         }
                     }
 
+                    // The object may not contain the 'Value' property, in which case the default value is returned.
+                    // Returning null would throw a NullReferenceException when the id is a value type.
+                    using (writer.BeginBlock("if (!valueRead)"))
+                    {
+                        writer.WriteLine($"return default({context.TypeName});");
+                    }
+
                     writer.WriteLine("return value;");
                 }
 

--- a/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
@@ -226,6 +226,27 @@ public sealed partial class StronglyTypedIdTests
     }
 
     [Fact]
+    public void NewtonsoftJson_Int32_ParseObjectWithoutValue()
+    {
+        var value = Newtonsoft.Json.JsonConvert.DeserializeObject<IdInt32>("{}");
+        Assert.Equal(default, value);
+    }
+
+    [Fact]
+    public void NewtonsoftJson_Int32_ParseObjectWithUnknownProperties()
+    {
+        var value = Newtonsoft.Json.JsonConvert.DeserializeObject<IdInt32>(@"{ ""a"": {}, ""b"": false }");
+        Assert.Equal(default, value);
+    }
+
+    [Fact]
+    public void SystemTextJson_Int32_ParseObjectWithoutValue()
+    {
+        var value = System.Text.Json.JsonSerializer.Deserialize<IdInt32>("{}");
+        Assert.Equal(default, value);
+    }
+
+    [Fact]
     public void NewtonsoftJson_IdRecordStructInt32_ParseNull()
     {
         Assert.Throws<JsonSerializationException>(() => Newtonsoft.Json.JsonConvert.DeserializeObject<IdRecordStructInt32>("null"));


### PR DESCRIPTION
The generated `Newtonsoft.Json` converter declares `object? value = null` and returns it unchanged when the JSON object contains no `"Value"` property:

```csharp
object? value = null;
bool valueRead = false;
reader.Read();
while (reader.TokenType != JsonToken.EndObject) { /* ... */ }
return value;   // still null when the object had no "Value" property
```

Newtonsoft then unboxes that `null` into a value-type id, which throws:

```csharp
JsonConvert.DeserializeObject<IdInt32>("{}");   // System.NullReferenceException
```

It is a raw `NullReferenceException`, not a `JsonSerializationException`, so `catch (JsonException)` error handling does not see it. In an ASP.NET Core app using `AddNewtonsoftJson`, a body containing `{"orderId": {}}` becomes a 500 instead of a 400 — from a two-character payload any client can send.

The System.Text.Json converter already returns `default` for the same input, so the two serializers disagreed.

## What changed

The generated converter now returns `default(TId)` when no `"Value"` property was read, matching the System.Text.Json behavior:

```csharp
if (!valueRead)
{
    return default(IdInt32);
}

return value;
```

For reference-type ids this is unchanged (`default` is `null`, which is what was returned before).

## Verification

Three tests added next to the existing `NewtonsoftJson_*_ParseNull` tests:

- `NewtonsoftJson_Int32_ParseObjectWithoutValue` — `{}`
- `NewtonsoftJson_Int32_ParseObjectWithUnknownProperties` — `{ "a": {}, "b": false }`
- `SystemTextJson_Int32_ParseObjectWithoutValue` — pins the System.Text.Json side so the two cannot drift apart again

Both Newtonsoft tests fail on `main` with `NullReferenceException`; the System.Text.Json one already passed, which is what made the divergence visible.

Full suites pass: 89 in `Meziantou.Framework.StronglyTypedId.GeneratorTests` (86 + these 3) and 728 in `Meziantou.Framework.StronglyTypedId.Tests`.
