### PR TITLE
Enumerate the MSBuild item groups once per project file

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning/Scanners/MsBuildReferencesDependencyScanner.cs
+++ b/src/Meziantou.Framework.DependencyScanning/Scanners/MsBuildReferencesDependencyScanner.cs
@@ -33,7 +33,8 @@ public sealed partial class MsBuildReferencesDependencyScanner : DependencyScann
             return;
 
         var ns = doc.Root.GetDefaultNamespace();
-        var itemGroups = doc.Descendants(ns + "ItemGroup");
+        // Materialized once: the query below is enumerated five times, and each enumeration walks the whole document
+        var itemGroups = doc.Descendants(ns + "ItemGroup").ToArray();
         foreach (var package in itemGroups.Elements(ns + "PackageReference").Concat(itemGroups.Elements(ns + "PackageDownload")).Concat(itemGroups.Elements(ns + "GlobalPackageReference")))
         {
             var nameAttribute = package.Attribute(IncludeXName);


### PR DESCRIPTION
### The problem

```csharp
var itemGroups = doc.Descendants(ns + "ItemGroup");
```

That is a lazy query, and it is enumerated five times — three times in the `.Concat` chain for `PackageReference` / `PackageDownload` / `GlobalPackageReference`, then again for `PackageVersion` and for `ProjectReference`. Each enumeration walks the entire document, so every `.csproj`, `.props` and `.targets` file in a repository gets five full tree walks where one would do.

### The change

Materialize it once with `ToArray()`. `Elements(XName)` still works the same over the array.

No behaviour change: the same elements are visited in the same order.

### Verification

This is a pure refactor with no behaviour change, so it adds no test. Behaviour is pinned by the existing MSBuild tests, which cover every one of the five enumerations — `MsBuildReferencesDependencies` (`PackageReference`, `PackageVersion`, `PackageDownload`, `GlobalPackageReference`, `ProjectReference`), `MsBuildSdkReferencesDependencies` and `PackagesReferencesWithNamespaceDependencies` — and assert exact updated file contents. All pass unchanged.

Full project suite green: 80/80 on net10.0, building with `/p:TreatWarningsAsErrors=true`.

Found by a project review of `Meziantou.Framework.DependencyScanning`.
