### PR TITLE
Do not generate Parse(string) when the type already defines it

### DIFF
--- a/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.Members.cs
+++ b/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.Members.cs
@@ -298,28 +298,31 @@ public partial class StronglyTypedIdSourceGenerator
         }
 
         // Parse
-        WriteNewMember(
-            XmlSummary("Converts the string representation of a ", XmlSeeCref(context.TypeName), " to the equivalent ", XmlSeeCref(context.TypeName), " type."),
-            XmlParam("value", "The string to convert."),
-            XmlReturn("A new instance that contains the value that was parsed"));
-        using (writer.BeginBlock($"public static {context.TypeName} Parse(string value)"))
+        if (!context.IsParseDefined_String)
         {
-            using (writer.BeginBlock($"if (TryParse(value, out var result))"))
+            WriteNewMember(
+                XmlSummary("Converts the string representation of a ", XmlSeeCref(context.TypeName), " to the equivalent ", XmlSeeCref(context.TypeName), " type."),
+                XmlParam("value", "The string to convert."),
+                XmlReturn("A new instance that contains the value that was parsed"));
+            using (writer.BeginBlock($"public static {context.TypeName} Parse(string value)"))
             {
-                if (!context.SupportNotNullWhenAttribute)
+                using (writer.BeginBlock($"if (TryParse(value, out var result))"))
                 {
-                    writer.WriteLine($"#nullable disable");
+                    if (!context.SupportNotNullWhenAttribute)
+                    {
+                        writer.WriteLine($"#nullable disable");
+                    }
+
+                    writer.WriteLine($"return result;");
+
+                    if (!context.SupportNotNullWhenAttribute)
+                    {
+                        writer.WriteLine($"#nullable enable");
+                    }
                 }
 
-                writer.WriteLine($"return result;");
-
-                if (!context.SupportNotNullWhenAttribute)
-                {
-                    writer.WriteLine($"#nullable enable");
-                }
+                writer.WriteLine($"throw new global::System.FormatException($\"value '{{value}}' is not valid\");");
             }
-
-            writer.WriteLine($"throw new global::System.FormatException($\"value '{{value}}' is not valid\");");
         }
 
         // TryParse

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
@@ -268,6 +268,25 @@ public sealed class StronglyTypedIdSourceGeneratorTests
     }
 
     [Fact]
+    public async Task GenerateStruct_UserDefinedParse()
+    {
+        var sourceCode = """
+            [Meziantou.Framework.Annotations.StronglyTypedIdAttribute(typeof(int))]
+            public partial struct Test
+            {
+                public static Test Parse(string value) => FromInt32(int.Parse(value, global::System.Globalization.CultureInfo.InvariantCulture) * 2);
+            }
+            """;
+
+        await TestGeneratedAssembly(sourceCode, type =>
+        {
+            var parseMethod = type.GetMethod("Parse", [typeof(string)])!;
+            var instance = parseMethod.Invoke(null, ["21"]);
+            Assert.Equal(42, type.GetProperty("Value")!.GetValue(instance));
+        });
+    }
+
+    [Fact]
     public async Task GenerateStruct_Guid_New_DefaultStrategy()
     {
         var sourceCode = """


### PR DESCRIPTION
`AttributeInfo` detects a user-defined `Parse(string)` and stores it in `IsParseDefined_String` — the flag is even compared in `Equals` and mixed into `GetHashCode` — but nothing ever read it. The `Parse(string)` block was emitted unconditionally.

Every sibling flag is honoured: `IsParseDefined_ReadOnlySpan` guards the span overload, `IsTryParseDefined_String` guards `TryParse`. This was the one hole in a design otherwise built around respecting user-supplied members (20 of them).

## What happens

```csharp
[StronglyTypedId(typeof(int))]
public partial struct Test
{
    public static Test Parse(string value) => FromInt32(int.Parse(value));
}
```

```
error CS0111: Type 'Test' already defines a member called 'Parse' with the same parameter types
error CS0121: The call is ambiguous between ... 'Test.Parse(string)' and 'Test.Parse(string)'   (x3)
```

The three `CS0121`s come from the generator's own code — `ReadAsPropertyName`, the `TypeConverter`, and `IParsable<T>.Parse` all call `Parse(...)` and can no longer resolve it. They bury the actual `CS0111`, and the errors point into generated code the user cannot edit.

Writing a custom `Parse` to add validation or a custom format is the natural extension point, which is what makes this worth fixing rather than documenting.

## What changed

One guard, matching the surrounding code:

```csharp
if (!context.IsParseDefined_String)
{
    // emit Parse(string)
}
```

When the user supplies `Parse(string)`, the generated converters and `IParsable<T>.Parse` now bind to it — which is the point of defining one.

## Verification

`GenerateStruct_UserDefinedParse` added next to the existing `GenerateStruct_Guid_UserDefinedNew`, which is the same scenario for `New()`. It defines a `Parse` that doubles its input, then asserts `Parse("21").Value == 42` — proving the user's implementation is the one that survives, not just that the code compiles. It fails on `main` with `CS0111`.

Full suites pass: 729 in `Meziantou.Framework.StronglyTypedId.Tests` (728 + this one) and 86 in `Meziantou.Framework.StronglyTypedId.GeneratorTests`.
