### PR TITLE
Check for null before serializing a reference type id to BSON

### DIFF
--- a/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.MongoDB.cs
+++ b/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.MongoDB.cs
@@ -41,6 +41,16 @@ public partial class StronglyTypedIdSourceGenerator
             WriteNewMember(writer, context, addNewLine: true, InheritDocComment);
             using (writer.BeginBlock($"public override void Serialize(global::MongoDB.Bson.Serialization.BsonSerializationContext context, global::MongoDB.Bson.Serialization.BsonSerializationArgs args, {context.TypeName}{(context.IsReferenceType ? "?" : "")} value)"))
             {
+                // The null check must be done before using 'value', whatever the underlying type is.
+                if (context.IsReferenceType)
+                {
+                    using (writer.BeginBlock($"if (value == null)"))
+                    {
+                        writer.WriteLine($"context.Writer.WriteNull();");
+                        writer.WriteLine($"return;");
+                    }
+                }
+
                 if (context.IdType is IdType.System_Half)
                 {
                     writer.WriteLine($"var serializer = global::MongoDB.Bson.Serialization.BsonSerializer.LookupSerializer<float>();");
@@ -53,15 +63,6 @@ public partial class StronglyTypedIdSourceGenerator
                 }
                 else
                 {
-                    if (context.IsReferenceType)
-                    {
-                        using (writer.BeginBlock($"if (value == null)"))
-                        {
-                            writer.WriteLine($"context.Writer.WriteNull();");
-                            writer.WriteLine($"return;");
-                        }
-                    }
-
                     if (context.IsValueTypeNullable)
                     {
                         using (writer.BeginBlock($"if (value.Value == null)"))

--- a/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
@@ -471,6 +471,26 @@ public sealed partial class StronglyTypedIdTests
         Assert.Equal(Guid.Empty, clone.Value);
     }
 
+    [Fact]
+    public void Bson_Half_Class_Null() => Assert.Null(BsonClone<IdClassHalf?>(null));
+
+    [Fact]
+    public void Bson_Int128_Class_Null() => Assert.Null(BsonClone<IdClassInt128?>(null));
+
+    [Fact]
+    public void Bson_UInt128_Class_Null() => Assert.Null(BsonClone<IdClassUInt128?>(null));
+
+    [Fact]
+    public void Bson_BigInteger_Class_Null() => Assert.Null(BsonClone<IdClassBigInteger?>(null));
+
+    [Fact]
+    public void Bson_Int128_Class_Value()
+    {
+        var instance = IdClassInt128.FromInt128(Int128.MaxValue);
+        var clone = BsonClone(instance);
+        Assert.Equal(Int128.MaxValue, clone.Value);
+    }
+
     [return: NotNullIfNotNull(nameof(value))]
     private static T? BsonClone<T>(T value)
     {
@@ -612,6 +632,18 @@ public sealed partial class StronglyTypedIdTests
 
     [StronglyTypedId(typeof(ulong))]
     private sealed partial class IdClassUInt64 { }
+
+    [StronglyTypedId(typeof(Half))]
+    private sealed partial class IdClassHalf { }
+
+    [StronglyTypedId(typeof(Int128))]
+    private sealed partial class IdClassInt128 { }
+
+    [StronglyTypedId(typeof(UInt128))]
+    private sealed partial class IdClassUInt128 { }
+
+    [StronglyTypedId(typeof(BigInteger))]
+    private sealed partial class IdClassBigInteger { }
 
     [StronglyTypedId(typeof(int))]
     private partial struct IdCtorDefined


### PR DESCRIPTION
In the generated BSON serializer, the reference-type null guard sat inside the final `else` branch, after the wide-numeric types had already been handled:

```csharp
if (context.IdType is IdType.System_Half)          // dereferences value.Value
else if (Int128 or UInt128 or BigInteger)          // dereferences value.ValueAsString
else
{
    if (context.IsReferenceType) { if (value == null) { WriteNull(); return; } }   // only here
    ...
}
```

So a null class-based id whose underlying type is `Half`, `Int128`, `UInt128` or `BigInteger` threw:

```csharp
BsonSerializer.Serialize(writer, (IdClassInt128?)null);   // System.NullReferenceException
```

The same test against `IdClassInt32` correctly wrote `null`, and `Deserialize` already handled the null case up front for reference types — so the two directions disagreed, and only for 4 of the 21 supported underlying types. A null id on an optional document field is ordinary, and the failure surfaces as an opaque NRE inside the driver, which reads like a driver bug rather than a generator one.

## What changed

The null check is hoisted above the type-specific branching, so it applies to every underlying type — mirroring what `Deserialize` already does.

## Verification

The runtime test project had no class-based ids for the wide numeric types, which is why this went unnoticed. Added `IdClassHalf`, `IdClassInt128`, `IdClassUInt128` and `IdClassBigInteger`, plus tests next to the existing `Bson_Guid_Class_Null`:

- `Bson_Half_Class_Null`, `Bson_Int128_Class_Null`, `Bson_UInt128_Class_Null`, `Bson_BigInteger_Class_Null` — all four fail on `main` with `NullReferenceException`
- `Bson_Int128_Class_Value` — round-trips `Int128.MaxValue`, so the null fix cannot regress the non-null path (passes on `main` too)

Full suites pass: 91 in `Meziantou.Framework.StronglyTypedId.GeneratorTests` (86 + these 5) and 728 in `Meziantou.Framework.StronglyTypedId.Tests`.
