### PR TITLE
Return false instead of throwing when a string id constructor rejects the value

### DIFF
--- a/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.Members.cs
+++ b/src/Meziantou.Framework.StronglyTypedId/StronglyTypedIdSourceGenerator.Members.cs
@@ -419,8 +419,19 @@ public partial class StronglyTypedIdSourceGenerator
                     {
                         if (isReadOnlySpan)
                         {
-                            writer.WriteLine($"result = new {context.TypeName}(value.ToString());");
-                            writer.WriteLine("return true;");
+                            // The constructor may be defined by the user and may throw when the value is not valid
+                            using (writer.BeginBlock("try"))
+                            {
+                                writer.WriteLine($"result = new {context.TypeName}(value.ToString());");
+                                writer.WriteLine("return true;");
+                            }
+
+                            using (writer.BeginBlock("catch"))
+                            {
+                            }
+
+                            writer.WriteLine("result = default;");
+                            writer.WriteLine("return false;");
                         }
                         else
                         {

--- a/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
@@ -664,8 +664,7 @@ public sealed partial class StronglyTypedIdTests
     {
         private IdInt32Validated(int value)
         {
-            if (value < 0)
-                throw new ArgumentOutOfRangeException(nameof(value));
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
 
             _value = value;
         }

--- a/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.GeneratorTests/StronglyTypedIdTests.cs
@@ -180,6 +180,31 @@ public sealed partial class StronglyTypedIdTests
     }
 
     [Fact]
+    public void String_TryParse_ValidatingConstructor_ReturnsFalse()
+    {
+        Assert.False(IdStringValidated.TryParse("", out _));
+    }
+
+    [Fact]
+    public void String_TryParse_ReadOnlySpan_ValidatingConstructor_ReturnsFalse()
+    {
+        Assert.False(IdStringValidated.TryParse("".AsSpan(), out _));
+    }
+
+    [Fact]
+    public void String_TryParse_ValidatingConstructor_ReturnsTrueForValidValue()
+    {
+        Assert.True(IdStringValidated.TryParse("test", out var result));
+        Assert.Equal("test", result.Value);
+    }
+
+    [Fact]
+    public void Int32_TryParse_ValidatingConstructor_ReturnsFalse()
+    {
+        Assert.False(IdInt32Validated.TryParse("-1", out _));
+    }
+
+    [Fact]
     public void String_TryParse_ReadOnlySpan()
     {
         Assert.True(IdString.TryParse("test".AsSpan(), out var value));
@@ -618,6 +643,30 @@ public sealed partial class StronglyTypedIdTests
     {
         public IdCtorDefined(int value)
         {
+            _value = value;
+        }
+    }
+
+    [StronglyTypedId(typeof(string))]
+    private partial struct IdStringValidated
+    {
+        private IdStringValidated(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentException("The value cannot be empty", nameof(value));
+
+            _value = value;
+        }
+    }
+
+    [StronglyTypedId(typeof(int))]
+    private partial struct IdInt32Validated
+    {
+        private IdInt32Validated(int value)
+        {
+            if (value < 0)
+                throw new ArgumentOutOfRangeException(nameof(value));
+
             _value = value;
         }
     }


### PR DESCRIPTION
`TryParse` wraps the constructor call in `try`/`catch` for every underlying type except one: the `ReadOnlySpan<char>` overload for `string` ids constructed unguarded.

```csharp
result = new IdString(value.ToString());
return true;
```

The `string` overload does have a guard, but it is unreachable on any target with `Span`: `ValueTypeHasParseReadOnlySpan` is true for `string` whenever `ReadOnlySpan<char>` exists, so `TryParse(string)` delegates to the span overload. The guarded code only runs on frameworks without `Span` — so in practice string ids had no protection at all, while `int` ids did.

## What happens

```csharp
[StronglyTypedId(typeof(string))]
public partial struct IdStringValidated
{
    private IdStringValidated(string value)
    {
        if (string.IsNullOrEmpty(value))
            throw new ArgumentException("The value cannot be empty", nameof(value));

        _value = value;
    }
}

IdStringValidated.TryParse("", out _);   // throws ArgumentException
```

The equivalent `int` id with a validating constructor correctly returns `false`. Returning `false` rather than throwing is the entire contract of the `Try*` pattern — callers write `if (!Id.TryParse(s, out var id)) return BadRequest();` on that basis — and it also makes the generated `IParsable<T>.TryParse` violate its documented contract. String ids are the ones most likely to carry validation (non-empty, length, charset), so the gap hit the case where it matters most.

## What changed

The span branch now guards the constructor call the same way the numeric branches do, falling through to `result = default; return false;`.

The `string`-overload guard is deliberately left in place: it is still reachable on targets without `Span` (`netstandard2.0`), where `TryParse(string)` does not delegate.

## Verification

Two new id types with validating constructors (`IdStringValidated`, `IdInt32Validated`) and four tests next to the existing `String_Parse` tests:

- `String_TryParse_ValidatingConstructor_ReturnsFalse` — fails on `main` with `ArgumentException`
- `String_TryParse_ReadOnlySpan_ValidatingConstructor_ReturnsFalse` — fails on `main` with `ArgumentException`
- `String_TryParse_ValidatingConstructor_ReturnsTrueForValidValue` — the valid path still succeeds and returns the value
- `Int32_TryParse_ValidatingConstructor_ReturnsFalse` — pins the numeric behavior that was already correct, so the two cannot diverge again

Full suites pass: 90 in `Meziantou.Framework.StronglyTypedId.GeneratorTests` (86 + these 4) and 728 in `Meziantou.Framework.StronglyTypedId.Tests`.
