### PR TITLE
Fix the generated code sample in the readme

### DIFF
--- a/src/Meziantou.Framework.StronglyTypedId/readme.md
+++ b/src/Meziantou.Framework.StronglyTypedId/readme.md
@@ -21,13 +21,13 @@ public partial struct ProjectId { }
 [System.ComponentModel.TypeConverterAttribute(typeof(ProjectIdTypeConverter))]
 [System.Text.Json.Serialization.JsonConverterAttribute(typeof(ProjectIdJsonConverter))]
 [Newtonsoft.Json.JsonConverterAttribute(typeof(ProjectIdNewtonsoftJsonConverter))]
-[MongoDB.Bson.Serialization.Attributes.BsonSerializerAttribute(typeof(ProjectIdMongoDBBsonSerializer))]
+[MongoDB.Bson.Serialization.Attributes.BsonSerializerAttribute(typeof(ProjectIdBsonConverter))]
 public partial struct ProjectId :
     System.IEquatable<ProjectId>,
     System.IParsable<ProjectId>,        // .NET 7+
     System.ISpanParsable<ProjectId>,    // .NET 7+
     IStronglyTypedId,                   // When Meziantou.Framework.StronglyTypedId.Interfaces is referenced
-    IStronglyTypedId<ProjectId>,        // When Meziantou.Framework.StronglyTypedId.Interfaces is referenced
+    IStronglyTypedId<int>,              // When Meziantou.Framework.StronglyTypedId.Interfaces is referenced
     IComparable, IComparable<ProjectId> // When at least one of the interface is explicitly defined by the user
 {
     public int Value { get; }
@@ -47,7 +47,7 @@ public partial struct ProjectId :
     public static bool operator !=(ProjectId a, ProjectId b);
     public override string ToString();
 
-    private partial class CustomerIdTypeConverter : System.ComponentModel.TypeConverter
+    private partial class ProjectIdTypeConverter : System.ComponentModel.TypeConverter
     {
         public override bool CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType);
         public override object? ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value);
@@ -56,14 +56,14 @@ public partial struct ProjectId :
     }
 
     // Generated only when System.Text.Json is accessible
-    private partial class CustomerIdJsonConverter : System.Text.Json.Serialization.JsonConverter<ProjectId>
+    private partial class ProjectIdJsonConverter : System.Text.Json.Serialization.JsonConverter<ProjectId>
     {
         public override void Write(System.Text.Json.Utf8JsonWriter writer, ProjectId value, System.Text.Json.JsonSerializerOptions options);
         public override ProjectId Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);
     }
 
     // Generated only when Newtonsoft.Json is accessible
-    private partial class CustomerIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
+    private partial class ProjectIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
     {
         public override bool CanRead { get; }
         public override bool CanWrite { get; }
@@ -73,7 +73,7 @@ public partial struct ProjectId :
     }
 
     // Generated only when MongoDB.Bson.Serialization.Serializers.SerializerBase is accessible
-    private partial class ProjectIdMongoDBBsonSerializer : MongoDB.Bson.Serialization.Serializers.SerializerBase<ProjectId>
+    private partial class ProjectIdBsonConverter : MongoDB.Bson.Serialization.Serializers.SerializerBase<ProjectId>
     {
         public override ProjectId Deserialize(MongoDB.Bson.Serialization.BsonDeserializationContext context, MongoDB.Bson.Serialization.BsonDeserializationArgs args);
         public override void Serialize(MongoDB.Bson.Serialization.BsonSerializationContext context, MongoDB.Bson.Serialization.BsonSerializationArgs args, ProjectId value);
@@ -177,11 +177,11 @@ public partial struct ProjectId : IComparable { }
 public partial struct ProjectId : IComparable<ProjectId>
 {
 	public int CompareTo(object? other);
-	public int CompareTo(ProjectId? other);
-	public static bool operator <(ProjectId? left, ProjectId? right);
-	public static bool operator <=(IdInt32Comparable? left, IdInt32Comparable? right);
-	public static bool operator >(IdInt32Comparable? left, IdInt32Comparable? right);
-	public static bool operator >=(IdInt32Comparable? left, IdInt32Comparable? right);
+	public int CompareTo(ProjectId other);
+	public static bool operator <(ProjectId left, ProjectId right);
+	public static bool operator <=(ProjectId left, ProjectId right);
+	public static bool operator >(ProjectId left, ProjectId right);
+	public static bool operator >=(ProjectId left, ProjectId right);
 }
 ````
 

--- a/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.StronglyTypedId.Tests/StronglyTypedIdSourceGeneratorTests.cs
@@ -897,6 +897,42 @@ public sealed class StronglyTypedIdSourceGeneratorTests
     }
 
     [Fact]
+    public async Task GeneratedConverterTypeNames()
+    {
+        // These names are part of the public surface of the generated types and are documented in the readme
+        var sourceCode = """
+            [Meziantou.Framework.Annotations.StronglyTypedId(typeof(int))]
+            public partial struct ProjectId { }
+
+            namespace Meziantou.Framework
+            {
+                public interface IStronglyTypedId { string ValueAsString { get; } System.Type UnderlyingType { get; } }
+                public interface IStronglyTypedId<T> : IStronglyTypedId { T Value { get; } }
+            }
+            """;
+        var compilation = await CreateCompilation(sourceCode,
+        [
+            new NuGetReference("Microsoft.NETCore.App.Ref", NetCoreVersion, "ref/"),
+            new NuGetReference("Newtonsoft.Json", "13.0.4", "lib/netstandard2.0/"),
+            new NuGetReference("MongoDB.Bson", "2.18.0", "lib/netstandard2.1/"),
+        ]);
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(generators: [InstantiateGenerator()]);
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics, XunitCancellationToken);
+        Assert.Empty(diagnostics);
+
+        var type = outputCompilation.GetTypeByMetadataName("ProjectId");
+        Assert.NotNull(type);
+        Assert.NotEmpty(type.GetTypeMembers("ProjectIdTypeConverter"));
+        Assert.NotEmpty(type.GetTypeMembers("ProjectIdJsonConverter"));
+        Assert.NotEmpty(type.GetTypeMembers("ProjectIdNewtonsoftJsonConverter"));
+        Assert.NotEmpty(type.GetTypeMembers("ProjectIdBsonConverter"));
+
+        // IStronglyTypedId<T> is parameterized with the underlying type, not with the id type
+        Assert.Contains(type.AllInterfaces, i => i.Name == "IStronglyTypedId" && i.TypeArguments is [{ SpecialType: SpecialType.System_Int32 }]);
+    }
+
+    [Fact]
     public async Task TestIncrementalSupport()
     {
         var generator = InstantiateGenerator();


### PR DESCRIPTION
The readme's "generated code" sample is the NuGet package description — for most users it is the only documentation they read, and the surrounding `<!-- generated code -->` markers imply it is machine-verified. It is not, and it had drifted from what the generator actually emits. Checked line by line against real output:

| Documented | Actually generated |
| --- | --- |
| `IStronglyTypedId<ProjectId>` | `IStronglyTypedId<int>` — parameterized by the **underlying** type |
| `ProjectIdMongoDBBsonSerializer` | `ProjectIdBsonConverter` |
| `CustomerIdTypeConverter` | `ProjectIdTypeConverter` |
| `CustomerIdJsonConverter` | `ProjectIdJsonConverter` |
| `CustomerIdNewtonsoftJsonConverter` | `ProjectIdNewtonsoftJsonConverter` |

The three `CustomerId*` names are copy-paste from a different example. The `IStronglyTypedId<ProjectId>` one is the most misleading, since it misrepresents what the interface means.

The `IComparable` example had also drifted: it leaked `IdInt32Comparable` (a type name from the test suite) into four operator signatures, and showed nullable annotations (`ProjectId?`) that the generator only emits for reference types — the example declares a `struct`.

## What changed

Readme only, plus one test. No generator changes.

## Verification

`GeneratedConverterTypeNames` added: it runs the generator against a `ProjectId` struct with System.Text.Json, Newtonsoft.Json and MongoDB.Bson referenced, then asserts the four nested converter types exist under exactly the documented names, and that the implemented interface is `IStronglyTypedId<int>` rather than `IStronglyTypedId<ProjectId>`.

That is what confirmed the corrections rather than my reading of the source. It also pins names that are part of the public surface of every generated id, so a future rename fails a test instead of silently invalidating the docs again.

Full suites pass: 729 in `Meziantou.Framework.StronglyTypedId.Tests` (728 + this one) and 86 in `Meziantou.Framework.StronglyTypedId.GeneratorTests`. `dotnet run ./eng/update-all.cs` reports no changes.

## Follow-up worth considering

The markers are already in place, so this block could be generated from a golden-file test over real generator output the way `eng/update-all.cs` maintains the analyzer-rules table — making the sample self-correcting instead of a second thing to remember. Left out of this PR to keep it a docs fix.
