### PR TITLE
Make the FixedStringBuilder generator's pipeline model cacheable

### DIFF
--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
@@ -72,16 +72,39 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
             {
                 var fixedStringInterface = context.SemanticModel.Compilation.GetTypeByMetadataName("Meziantou.Framework.FixedStringBuilder.IFixedString`1");
                 var fixedStringNonGenericInterface = context.SemanticModel.Compilation.GetTypeByMetadataName("Meziantou.Framework.FixedStringBuilder.IFixedString");
-                return new FixedStringTypeInfo(targetTypeSymbol, length, fixedStringInterface is not null, fixedStringNonGenericInterface is not null);
+                return new FixedStringTypeInfo(
+                    Namespace: targetTypeSymbol.ContainingNamespace.IsGlobalNamespace ? null : targetTypeSymbol.ContainingNamespace.ToDisplayString(),
+                    FullyQualifiedName: targetTypeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                    Name: targetTypeSymbol.Name,
+                    TypeParameters: GetTypeParameters(targetTypeSymbol),
+                    Accessibility: GetAccessibility(targetTypeSymbol.DeclaredAccessibility),
+                    ContainingTypeDeclarations: GetContainingTypeDeclarations(targetTypeSymbol),
+                    Length: length,
+                    ImplementsIFixedStringGeneric: fixedStringInterface is not null,
+                    ImplementsIFixedStringNonGeneric: fixedStringNonGenericInterface is not null);
             }
         }
 
         return null;
     }
 
+    private static string GetContainingTypeDeclarations(INamedTypeSymbol symbol)
+    {
+        var containingTypes = new Stack<INamedTypeSymbol>();
+        for (var containingType = symbol.ContainingType; containingType is not null; containingType = containingType.ContainingType)
+        {
+            containingTypes.Push(containingType);
+        }
+
+        if (containingTypes.Count == 0)
+            return string.Empty;
+
+        return string.Join("\n", containingTypes.Select(static containingType => $"{GetAccessibility(containingType.DeclaredAccessibility)} partial {GetTypeKeyword(containingType)} {containingType.Name}{GetTypeParameters(containingType)}"));
+    }
+
     private static void Generate(SourceProductionContext context, FixedStringTypeInfo target)
     {
-        var hintName = target.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+        var hintName = target.FullyQualifiedName
             .Replace("global::", "", StringComparison.Ordinal)
             .Replace('<', '_')
             .Replace('>', '_')
@@ -105,9 +128,7 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         AppendLine("using System.Runtime.InteropServices;");
         AppendLine();
 
-        var namespaceName = target.Type.ContainingNamespace.IsGlobalNamespace
-            ? null
-            : target.Type.ContainingNamespace.ToDisplayString();
+        var namespaceName = target.Namespace;
         if (namespaceName is not null)
         {
             AppendLine($"namespace {namespaceName}");
@@ -115,21 +136,19 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
             indent++;
         }
 
-        var containingTypes = new Stack<INamedTypeSymbol>();
-        for (var containingType = target.Type.ContainingType; containingType is not null; containingType = containingType.ContainingType)
-        {
-            containingTypes.Push(containingType);
-        }
+        var containingTypeDeclarations = target.ContainingTypeDeclarations.Length == 0
+            ? []
+            : target.ContainingTypeDeclarations.Split('\n');
 
-        foreach (var containingType in containingTypes)
+        foreach (var containingTypeDeclaration in containingTypeDeclarations)
         {
-            AppendLine($"{GetAccessibility(containingType.DeclaredAccessibility)} partial {GetTypeKeyword(containingType)} {containingType.Name}{GetTypeParameters(containingType)}");
+            AppendLine(containingTypeDeclaration);
             AppendLine("{");
             indent++;
         }
 
-        var fullTypeName = target.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        var simpleTypeName = target.Type.Name + GetTypeParameters(target.Type);
+        var fullTypeName = target.FullyQualifiedName;
+        var simpleTypeName = target.Name + target.TypeParameters;
         var implementedInterfaces = new List<string>
         {
             $"global::System.IEquatable<{fullTypeName}>",
@@ -143,7 +162,7 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
 
         AppendLine("[global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Sequential)]");
         AppendLine("[global::System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute]");
-        AppendLine($"{GetAccessibility(target.Type.DeclaredAccessibility)} partial struct {target.Type.Name}{GetTypeParameters(target.Type)} : {string.Join(", ", implementedInterfaces)}");
+        AppendLine($"{target.Accessibility} partial struct {simpleTypeName} : {string.Join(", ", implementedInterfaces)}");
         AppendLine("{");
         indent++;
 
@@ -408,9 +427,8 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         indent--;
         AppendLine("}");
 
-        while (containingTypes.Count > 0)
+        for (var i = 0; i < containingTypeDeclarations.Length; i++)
         {
-            containingTypes.Pop();
             indent--;
             AppendLine("}");
         }
@@ -470,5 +488,20 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         return "<" + string.Join(", ", symbol.TypeParameters.Select(static t => t.Name)) + ">";
     }
 
-    private sealed record FixedStringTypeInfo(INamedTypeSymbol Type, int Length, bool ImplementsIFixedStringGeneric, bool ImplementsIFixedStringNonGeneric);
+    /// <summary>
+    /// The data needed to generate a fixed string. This flows through the incremental pipeline, so it must only
+    /// contain values that compare by value. In particular it must never hold a symbol or a syntax node: those
+    /// compare by reference and keep a <see cref="Compilation"/> alive, which stops the generator from caching
+    /// its output and makes it re-run on every keystroke.
+    /// </summary>
+    private sealed record FixedStringTypeInfo(
+        string? Namespace,
+        string FullyQualifiedName,
+        string Name,
+        string TypeParameters,
+        string Accessibility,
+        string ContainingTypeDeclarations,
+        int Length,
+        bool ImplementsIFixedStringGeneric,
+        bool ImplementsIFixedStringNonGeneric);
 }

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
@@ -181,6 +181,42 @@ public sealed class FixedStringBuilderSourceGeneratorTests
         Assert.Equal("MFFSG0003", diagnostic.Id);
     }
 
+    [Fact]
+    public async Task OutputIsCachedWhenAnUnrelatedFileChanges()
+    {
+        const string Target = """
+            [FixedStringBuilderAttribute(10)]
+            public partial struct FixedStringBuilder10;
+            """;
+
+        var netcoreRef = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "8.0.0", "ref/net8.0/");
+        var references = netcoreRef.Select(static location => MetadataReference.CreateFromFile(location)).ToArray();
+
+        Compilation CreateCompilation(string unrelatedSource) => CSharpCompilation.Create(
+            "compilation",
+            [CSharpSyntaxTree.ParseText(Target, ParseOptions), CSharpSyntaxTree.ParseText(unrelatedSource, ParseOptions)],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+
+        ISourceGenerator generator = new FixedStringBuilderSourceGenerator().AsSourceGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            [generator],
+            parseOptions: ParseOptions,
+            driverOptions: new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps: true));
+
+        driver = driver.RunGenerators(CreateCompilation("internal sealed class Unrelated { }"));
+        driver = driver.RunGenerators(CreateCompilation("internal sealed class Unrelated { private int _field; }"));
+
+        var outputs = driver.GetRunResult().Results[0].TrackedSteps
+            .Where(static step => step.Key.StartsWith("SourceOutput", StringComparison.Ordinal))
+            .SelectMany(static step => step.Value)
+            .SelectMany(static step => step.Outputs)
+            .ToArray();
+
+        Assert.NotEmpty(outputs);
+        Assert.All(outputs, static output => Assert.Equal(IncrementalStepRunReason.Cached, output.Reason));
+    }
+
     private static async Task<(GeneratorDriverRunResult RunResult, Compilation Compilation)> GenerateAsync(string source)
     {
         var netcoreRef = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "8.0.0", "ref/net8.0/");


### PR DESCRIPTION
**Stack 1 of 2** · merges into `main` · must merge before #2284

## The problem

`FixedStringTypeInfo`, the value that flows through the incremental pipeline, held an `INamedTypeSymbol` (`FixedStringBuilderSourceGenerator.cs:473`, populated at `:75`). Roslyn symbols compare by reference and are tied to a specific `Compilation`, so the record's synthesized `Equals` never reported two runs as equal and every downstream step re-executed.

Measured with `trackIncrementalGeneratorSteps: true`, editing a file in the compilation that has nothing to do with the generated types:

| pipeline model | `SourceOutput` run reason |
| --- | --- |
| `INamedTypeSymbol` (before) | `Modified` |
| value model (after) | `Cached` |

In the IDE this runs on every keystroke, and `GenerateSource` emits one line per character of capacity — so a project with a handful of `[FixedStringBuilderAttribute(256)]` types re-materialized thousands of lines of source per edit and then re-parsed them. Holding symbols also keeps old `Compilation` objects reachable across generator runs, which is the usual cause of "Visual Studio memory grows over a long session" reports against a generator.

## The change

`GetTarget` now projects the symbol into an equatable value model — namespace, fully-qualified name, name, type parameters, accessibility, and the containing-type chain — and `INamedTypeSymbol` never leaves the transform. `GenerateSource` reads only those values; nothing else about it changed.

The containing-type chain is stored as a newline-joined string of pre-rendered declaration headers. `ImmutableArray<string>` would be the more natural shape, but it compares by underlying-array reference inside a record, which would have reintroduced exactly this bug.

## Verification

- New test `OutputIsCachedWhenAnUnrelatedFileChanges` asserts every `SourceOutput` step reports `IncrementalStepRunReason.Cached` after an unrelated edit. Confirmed it **fails on the pre-change generator** with `Expected: Cached / Actual: Modified`, and passes after.
- `Meziantou.Framework.FixedStringBuilder.Generator.Tests`: 7/7 pass. `Meziantou.Framework.FixedStringBuilder.Tests`: 12/12 pass.
- Release build with `/p:IsOfficialBuild=true` leaves `ref/Meziantou.Framework.FixedStringBuilder.cs` unchanged — the generated output is byte-identical, this is a pipeline-shape change only.
- `dotnet run ./eng/update-all.cs` produces no changes.

Found during a review of `Meziantou.Framework.FixedStringBuilder`.
