### PR TITLE
Fix generated file name collisions in the FixedStringBuilder generator

### DIFF
--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
@@ -104,15 +104,52 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
 
     private static void Generate(SourceProductionContext context, FixedStringTypeInfo target)
     {
-        var hintName = target.FullyQualifiedName
-            .Replace("global::", "", StringComparison.Ordinal)
-            .Replace('<', '_')
-            .Replace('>', '_')
-            .Replace('.', '_')
-            .Replace('+', '_') + ".g.cs";
-
         var source = GenerateSource(target);
-        context.AddSource(hintName, SourceText.From(source, Encoding.UTF8));
+        context.AddSource(ComputeHintName(target.FullyQualifiedName), SourceText.From(source, Encoding.UTF8));
+    }
+
+    /// <summary>
+    /// Computes the name of the generated file for a type. Replacing the characters that cannot appear in a hint
+    /// name is not injective: <c>A.B.C</c> and <c>A.B_C</c> both sanitize to <c>A_B_C</c>. A duplicate hint name
+    /// makes <see cref="SourceProductionContext.AddSource(string, SourceText)"/> throw, which takes down the whole
+    /// generator and leaves every type without its members, so a hash of the original name is appended to keep the
+    /// result unique. The types are generated one at a time, so a shared set of already-used names is not an
+    /// option here: it would make the output depend on the order the types are processed in.
+    /// </summary>
+    private static string ComputeHintName(string fullyQualifiedName)
+    {
+        var name = fullyQualifiedName.Replace("global::", "", StringComparison.Ordinal);
+
+        var sb = new StringBuilder(name.Length + 14);
+        foreach (var c in name)
+        {
+            sb.Append(char.IsLetterOrDigit(c) ? c : '_');
+        }
+
+        sb.Append('.');
+        sb.Append(GetStableHash(name).ToString("x8", CultureInfo.InvariantCulture));
+        sb.Append(".g.cs");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// FNV-1a. <see cref="string.GetHashCode()"/> is randomized per process, which would make the name of the
+    /// generated files change between builds.
+    /// </summary>
+    private static uint GetStableHash(string value)
+    {
+        unchecked
+        {
+            var hash = 2166136261;
+            foreach (var c in value)
+            {
+                hash ^= c;
+                hash *= 16777619;
+            }
+
+            return hash;
+        }
     }
 
     private static string GenerateSource(FixedStringTypeInfo target)

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
@@ -182,6 +182,36 @@ public sealed class FixedStringBuilderSourceGeneratorTests
     }
 
     [Fact]
+    public async Task GeneratesBothTypesWhenTheirSanitizedNamesCollide()
+    {
+        // "A.B.C" and "A.B_C" both sanitize to "A_B_C"
+        const string Source = """
+            namespace A.B
+            {
+                [FixedStringBuilderAttribute(4)]
+                public partial struct C;
+            }
+
+            namespace A
+            {
+                [FixedStringBuilderAttribute(4)]
+                public partial struct B_C;
+            }
+            """;
+
+        var (runResult, compilation) = await GenerateAsync(Source);
+        Assert.Empty(runResult.Diagnostics);
+
+        var hintNames = runResult.Results[0].GeneratedSources.Select(static source => source.HintName).ToArray();
+        Assert.HasCount(4, hintNames);
+        Assert.HasCount(hintNames.Length, hintNames.Distinct(StringComparer.Ordinal));
+
+        using var peStream = new MemoryStream();
+        var emitResult = compilation.Emit(peStream);
+        Assert.True(emitResult.Success, string.Join('\n', emitResult.Diagnostics));
+    }
+
+    [Fact]
     public async Task OutputIsCachedWhenAnUnrelatedFileChanges()
     {
         const string Target = """


### PR DESCRIPTION
**Stack 2 of 2** · merges into `fix/generator-cacheable-model` · must merge after #2283

## The problem

The hint name was the fully-qualified type name with `.`, `<`, `>` and `+` all replaced by `_` (`FixedStringBuilderSourceGenerator.cs:84-89`). That mapping is not injective: `A.B.C` and `A.B_C` both become `A_B_C`, and `AddSource` throws on a duplicate.

The blast radius is larger than the two types involved — the exception aborts the whole `SourceOutput` node, so **neither** struct gets its members:

```
warning CS8785: Generator 'FixedStringBuilderSourceGenerator' failed to generate source.
  Exception was of type 'ArgumentException' with message
  'The hintName 'A_B_C.g.cs' of the added source file must be unique within a generator.'
```

The user then sees a cascade of "does not contain a definition for `AppendLiteral`" errors on types that look perfectly correct, with no indication that a naming coincidence elsewhere in the assembly is the cause.

## The change

`ComputeHintName` sanitizes the name as before and appends an 8-hex-digit FNV-1a hash of the original fully-qualified name, so distinct types always get distinct files.

Two notes on the approach:

- `ResxGenerator.GetHintName` solves the same problem with a shared `HashSet` and a numeric suffix. That works there because it emits every file inside one callback; here the types are generated one at a time by `RegisterSourceOutput`, so shared mutable state would make the output depend on processing order. Collecting the types into a single batch would fix that but would undo the caching work in #2283.
- `string.GetHashCode()` is randomized per process, so it would make generated file names change between builds. Hence the explicit FNV-1a.

Generated *file* names change for every type as a result. They are not API — they show up in the IDE's generated-files node and in `EmitCompilerGeneratedFiles` output.

## Verification

- New test `GeneratesBothTypesWhenTheirSanitizedNamesCollide` declares `A.B.C` and `A.B_C`, asserts the driver reports no diagnostics, that all four hint names are distinct, and that the result emits. Confirmed it **fails on the pre-change generator** (`Assert.Empty()` on driver diagnostics — the CS8785 crash), and passes after.
- `Meziantou.Framework.FixedStringBuilder.Generator.Tests`: 8/8 pass. `Meziantou.Framework.FixedStringBuilder.Tests`: 12/12 pass.
- Release build with `/p:IsOfficialBuild=true` leaves `ref/Meziantou.Framework.FixedStringBuilder.cs` unchanged.

Found during a review of `Meziantou.Framework.FixedStringBuilder`.
