### PR TITLE
Reject a FixedStringBuilder capacity that would overflow the length counter

### DIFF
--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderAttributeAnalyzer.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderAttributeAnalyzer.cs
@@ -33,7 +33,15 @@ public sealed class FixedStringBuilderAttributeAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [MissingOrInvalidArgumentCount, ArgumentMustBeInt, LengthMustBePositive];
+    internal static readonly DiagnosticDescriptor LengthIsTooLarge = new(
+        id: "MFFSG0004",
+        title: "FixedStringBuilderAttribute length is too large",
+        messageFormat: "FixedStringBuilderAttribute length must be less than or equal to {0}",
+        category: "FixedStringBuilderGenerator",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [MissingOrInvalidArgumentCount, ArgumentMustBeInt, LengthMustBePositive, LengthIsTooLarge];
 
     public override void Initialize(AnalysisContext context)
     {
@@ -79,6 +87,10 @@ public sealed class FixedStringBuilderAttributeAnalyzer : DiagnosticAnalyzer
                 if (length <= 0)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(LengthMustBePositive, valueExpression.GetLocation()));
+                }
+                else if (length > FixedStringBuilderSourceGenerator.MaximumLength)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(LengthIsTooLarge, valueExpression.GetLocation(), FixedStringBuilderSourceGenerator.MaximumLength));
                 }
             }
         }

--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
@@ -8,6 +8,13 @@ namespace Meziantou.Framework.FixedStringBuilder.Generator;
 [Generator]
 public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
 {
+    /// <summary>
+    /// The largest capacity a fixed string can have. The generated type counts its characters in a
+    /// <see cref="short"/>, so a larger capacity would let the length overflow and produce a negative
+    /// <c>Length</c> instead of throwing.
+    /// </summary>
+    internal const int MaximumLength = short.MaxValue;
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         context.RegisterPostInitializationOutput(static context =>
@@ -68,7 +75,7 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
             if (attribute.ConstructorArguments.Length != 1)
                 continue;
 
-            if (attribute.ConstructorArguments[0].Value is int length and > 0)
+            if (attribute.ConstructorArguments[0].Value is int length and > 0 and <= MaximumLength)
             {
                 var fixedStringInterface = context.SemanticModel.Compilation.GetTypeByMetadataName("Meziantou.Framework.FixedStringBuilder.IFixedString`1");
                 var fixedStringNonGenericInterface = context.SemanticModel.Compilation.GetTypeByMetadataName("Meziantou.Framework.FixedStringBuilder.IFixedString");

--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/readme.md
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/readme.md
@@ -27,4 +27,5 @@ Generated fixed strings enforce capacity and throw `ArgumentException` when data
 | `MFFSG0001` | FixedStringBuilderGenerator | FixedStringBuilderAttribute requires one argument | Error | ✔️ |
 | `MFFSG0002` | FixedStringBuilderGenerator | FixedStringBuilderAttribute argument type is invalid | Error | ✔️ |
 | `MFFSG0003` | FixedStringBuilderGenerator | FixedStringBuilderAttribute length must be positive | Error | ✔️ |
+| `MFFSG0004` | FixedStringBuilderGenerator | FixedStringBuilderAttribute length is too large | Error | ✔️ |
 <!-- analyzer-rules -->

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
@@ -181,6 +181,38 @@ public sealed class FixedStringBuilderSourceGeneratorTests
         Assert.Equal("MFFSG0003", diagnostic.Id);
     }
 
+    [Fact]
+    public async Task AnalyzerReportsLengthAboveMaximum()
+    {
+        const string Source = """
+            [FixedStringBuilderAttribute(32768)]
+            public partial struct Sample
+            {
+            }
+            """;
+
+        var diagnostics = await AnalyzeAsync(Source);
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MFFSG0004", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task DoesNotGenerateWhenLengthIsAboveMaximum()
+    {
+        const string Source = """
+            [FixedStringBuilderAttribute(32768)]
+            public partial struct Sample
+            {
+            }
+            """;
+
+        var (runResult, _) = await GenerateAsync(Source);
+
+        // Only the two post-initialization sources: the type itself is not generated because its length would
+        // overflow the short used to count the characters.
+        Assert.HasCount(2, runResult.Results[0].GeneratedSources);
+    }
+
     private static async Task<(GeneratorDriverRunResult RunResult, Compilation Compilation)> GenerateAsync(string source)
     {
         var netcoreRef = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "8.0.0", "ref/net8.0/");


### PR DESCRIPTION
**Stack 1 of 2** · merges into `main` · must merge before #2287

## The problem

The analyzer rejected only `length <= 0` (`FixedStringBuilderAttributeAnalyzer.cs:79`) and the generator accepted any `int length and > 0` (`FixedStringBuilderSourceGenerator.cs:71`). But the generated type counts its characters in a `short` (`:153`), and the accumulate is an unchecked cast (`:202`, `:233`, `:249`, `:383`, `:399`).

So `[FixedStringBuilderAttribute(40000)]` compiled with **no diagnostic at all**, and then:

```
after append of 35000 chars: Length=-30536
AsSpan().Length=-30536
```

The bounds check in `AppendLiteral` passes (`35000 > 40000 - 0` is false), `_length += (short)35000` wraps, and the negative value flows into `MemoryMarshal.CreateSpan(ref …, _length)`. That produces a `Span<char>` with a negative `Length` — indexing or copying it is undefined behaviour, not a bounds-checked exception. Nothing in the API hints at the ceiling either: `MaxLength` and `Length` are both `int`.

## The change

- New diagnostic **`MFFSG0004`** (error): the length must be less than or equal to `short.MaxValue`.
- `GetTarget` applies the same bound, so the generator never emits an unsound type even if the diagnostic is suppressed.
- The limit lives in one place, `FixedStringBuilderSourceGenerator.MaximumLength`, documented with the reason it exists, so the analyzer and the generator cannot drift apart.

Widening `_length` to `int` was the alternative. It would cost 2 bytes on every instance including `FixedStringBuilder8`, which seemed the wrong trade for a type whose whole point is being small — happy to switch if you'd rather support larger capacities.

## Verification

- New `AnalyzerReportsLengthAboveMaximum` asserts `MFFSG0004` on `[FixedStringBuilderAttribute(32768)]`.
- New `DoesNotGenerateWhenLengthIsAboveMaximum` asserts the generator emits only the two post-initialization sources for an oversized length.
- `Meziantou.Framework.FixedStringBuilder.Generator.Tests`: 8/8 pass. `Meziantou.Framework.FixedStringBuilder.Tests`: 12/12 pass.
- `dotnet run ./eng/update-all.cs` regenerated the analyzer-rules table in `readme.md`; a second run is a no-op.
- Release build with `/p:IsOfficialBuild=true` leaves `ref/Meziantou.Framework.FixedStringBuilder.cs` unchanged — the built-in 8/16/32/64 types are all well under the limit.

Found during a review of `Meziantou.Framework.FixedStringBuilder`.
