### PR TITLE
Report unsupported FixedStringBuilder target types instead of generating nothing

### DIFF
--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderAttributeAnalyzer.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderAttributeAnalyzer.cs
@@ -41,7 +41,23 @@ public sealed class FixedStringBuilderAttributeAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [MissingOrInvalidArgumentCount, ArgumentMustBeInt, LengthMustBePositive, LengthIsTooLarge];
+    internal static readonly DiagnosticDescriptor TypeMustBePartial = new(
+        id: "MFFSG0005",
+        title: "FixedStringBuilderAttribute requires a partial struct",
+        messageFormat: "'{0}' must be partial for the members to be generated",
+        category: "FixedStringBuilderGenerator",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor TypeMustNotBeReadOnlyOrRef = new(
+        id: "MFFSG0006",
+        title: "FixedStringBuilderAttribute does not support readonly or ref structs",
+        messageFormat: "'{0}' must not be a readonly struct or a ref struct",
+        category: "FixedStringBuilderGenerator",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [MissingOrInvalidArgumentCount, ArgumentMustBeInt, LengthMustBePositive, LengthIsTooLarge, TypeMustBePartial, TypeMustNotBeReadOnlyOrRef];
 
     public override void Initialize(AnalysisContext context)
     {
@@ -67,6 +83,18 @@ public sealed class FixedStringBuilderAttributeAnalyzer : DiagnosticAnalyzer
                     (symbolInfo.ContainingType.Name is not "FixedStringBuilderAttribute" || !symbolInfo.ContainingType.ContainingNamespace.IsGlobalNamespace))
                 {
                     continue;
+                }
+
+                // The generator silently skips a type it cannot add members to, so the mistake has to be reported here.
+                if (!typeDeclarationSyntax.Modifiers.Any(SyntaxKind.PartialKeyword))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(TypeMustBePartial, typeDeclarationSyntax.Identifier.GetLocation(), typeDeclarationSyntax.Identifier.ValueText));
+                }
+                else if (typeDeclarationSyntax.Modifiers.Any(SyntaxKind.ReadOnlyKeyword) || typeDeclarationSyntax.Modifiers.Any(SyntaxKind.RefKeyword))
+                {
+                    // A fixed string builder is mutable and implements interfaces, so the generated members do not
+                    // compile inside a readonly struct or a ref struct.
+                    context.ReportDiagnostic(Diagnostic.Create(TypeMustNotBeReadOnlyOrRef, typeDeclarationSyntax.Identifier.GetLocation(), typeDeclarationSyntax.Identifier.ValueText));
                 }
 
                 var arguments = attributeSyntax.ArgumentList?.Arguments;

--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
@@ -67,6 +67,11 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         if (!declaration.Modifiers.Any(SyntaxKind.PartialKeyword))
             return null;
 
+        // The generated members are mutable and implement interfaces, so they would not compile in these shapes.
+        // The analyzer reports MFFSG0006 for them.
+        if (declaration.Modifiers.Any(SyntaxKind.ReadOnlyKeyword) || declaration.Modifiers.Any(SyntaxKind.RefKeyword))
+            return null;
+
         if (context.TargetSymbol is not INamedTypeSymbol targetTypeSymbol)
             return null;
 

--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/readme.md
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/readme.md
@@ -28,4 +28,6 @@ Generated fixed strings enforce capacity and throw `ArgumentException` when data
 | `MFFSG0002` | FixedStringBuilderGenerator | FixedStringBuilderAttribute argument type is invalid | Error | ✔️ |
 | `MFFSG0003` | FixedStringBuilderGenerator | FixedStringBuilderAttribute length must be positive | Error | ✔️ |
 | `MFFSG0004` | FixedStringBuilderGenerator | FixedStringBuilderAttribute length is too large | Error | ✔️ |
+| `MFFSG0005` | FixedStringBuilderGenerator | FixedStringBuilderAttribute requires a partial struct | Error | ✔️ |
+| `MFFSG0006` | FixedStringBuilderGenerator | FixedStringBuilderAttribute does not support readonly or ref structs | Error | ✔️ |
 <!-- analyzer-rules -->

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
@@ -213,6 +213,55 @@ public sealed class FixedStringBuilderSourceGeneratorTests
         Assert.HasCount(2, runResult.Results[0].GeneratedSources);
     }
 
+    [Fact]
+    public async Task AnalyzerReportsNonPartialType()
+    {
+        const string Source = """
+            [FixedStringBuilderAttribute(4)]
+            public struct Sample
+            {
+            }
+            """;
+
+        var diagnostics = await AnalyzeAsync(Source);
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MFFSG0005", diagnostic.Id);
+    }
+
+    [Theory]
+    [InlineData("readonly partial")]
+    [InlineData("ref partial")]
+    public async Task AnalyzerReportsReadOnlyOrRefType(string modifiers)
+    {
+        var source = $$"""
+            [FixedStringBuilderAttribute(4)]
+            public {{modifiers}} struct Sample
+            {
+            }
+            """;
+
+        var diagnostics = await AnalyzeAsync(source);
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MFFSG0006", diagnostic.Id);
+    }
+
+    [Theory]
+    [InlineData("public struct Sample { }")]
+    [InlineData("public readonly partial struct Sample { }")]
+    [InlineData("public ref partial struct Sample { }")]
+    public async Task DoesNotGenerateForUnsupportedTypeShapes(string declaration)
+    {
+        var source = $$"""
+            [FixedStringBuilderAttribute(4)]
+            {{declaration}}
+            """;
+
+        var (runResult, _) = await GenerateAsync(source);
+
+        // Only the two post-initialization sources: the members would not compile in these shapes.
+        Assert.HasCount(2, runResult.Results[0].GeneratedSources);
+    }
+
     private static async Task<(GeneratorDriverRunResult RunResult, Compilation Compilation)> GenerateAsync(string source)
     {
         var netcoreRef = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "8.0.0", "ref/net8.0/");


### PR DESCRIPTION
**Stack 2 of 2** · merges into `fix/analyzer-max-length` · must merge after #2286

## The problem

Two ways to misuse the attribute produced no useful diagnostic.

**Not `partial`.** `GetTarget` returns `null` and nothing is reported (`FixedStringBuilderSourceGenerator.cs:60-61`):

```
driverDiags:   (none)
compileErrors: CS1061: 'NotPartial' does not contain a definition for 'Length'
```

If the type is never used there is no error at all — the attribute just silently does nothing. Forgetting `partial` is the most common mistake with attribute-driven generators, and the error that does appear points at the *use site* rather than the declaration that is wrong.

**`readonly` or `ref` struct.** The generator emitted its half anyway, producing code that cannot compile:

```
hints:         …, Ro.g.cs
compileErrors: CS8340: Instance fields of readonly structs must be readonly.
```

The error lands on generated code the user did not write and cannot fix, with no hint that removing `readonly` from their own declaration is the answer.

## The change

- **`MFFSG0005`** (error): the type must be `partial`.
- **`MFFSG0006`** (error): the type must not be a `readonly struct` or a `ref struct` — a fixed string builder is mutable by design and implements interfaces.
- `GetTarget` now also skips `readonly`/`ref` structs, so the generator no longer emits code that cannot compile.

Both diagnostics are reported on the type identifier, so the squiggle is on the declaration that needs changing.

## Verification

- New `AnalyzerReportsNonPartialType` (`MFFSG0005`) and `AnalyzerReportsReadOnlyOrRefType` (`MFFSG0006`, for `readonly partial` and `ref partial`).
- New `DoesNotGenerateForUnsupportedTypeShapes` asserts the generator emits only the two post-initialization sources for all three shapes.
- `Meziantou.Framework.FixedStringBuilder.Generator.Tests`: 14/14 pass. `Meziantou.Framework.FixedStringBuilder.Tests`: 12/12 pass.
- `dotnet run ./eng/update-all.cs` regenerated the analyzer-rules table; a second run is a no-op.
- Release build with `/p:IsOfficialBuild=true` leaves `ref/Meziantou.Framework.FixedStringBuilder.cs` unchanged.

Found during a review of `Meziantou.Framework.FixedStringBuilder`.
