### PR TITLE
Mark the FixedStringBuilder throw helpers as not returning

### DIFF
--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
@@ -227,7 +227,7 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         AppendLine("if (!value.TryFormat(span, out var charsWritten, ReadOnlySpan<char>.Empty, null))");
         AppendLine("{");
         indent++;
-        AppendLine("ThrowValueTooLong();");
+        AppendLine("ThrowFormattedValueTooLong();");
         indent--;
         AppendLine("}");
         AppendLine("_length += (short)charsWritten;");
@@ -243,7 +243,7 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         AppendLine("if (!value.TryFormat(span, out var charsWritten, format, null))");
         AppendLine("{");
         indent++;
-        AppendLine("ThrowValueTooLong();");
+        AppendLine("ThrowFormattedValueTooLong();");
         indent--;
         AppendLine("}");
         AppendLine("_length += (short)charsWritten;");
@@ -403,7 +403,12 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         AppendLine("}");
         AppendLine();
 
+        AppendLine("[global::System.Diagnostics.CodeAnalysis.DoesNotReturn]");
         AppendLine("private static void ThrowValueTooLong() => throw new ArgumentException(\"The value is too long to fit in this fixed string.\");");
+        AppendLine();
+
+        AppendLine("[global::System.Diagnostics.CodeAnalysis.DoesNotReturn]");
+        AppendLine("private static void ThrowFormattedValueTooLong() => throw new ArgumentException(\"The formatted value does not fit in the remaining capacity of this fixed string.\");");
 
         indent--;
         AppendLine("}");


### PR DESCRIPTION
## The problem

Two small things in the generated throw helper (`FixedStringBuilderSourceGenerator.cs:406`, called from `:227`, `:243`).

**No `[DoesNotReturn]`.** The compiler cannot see that the method never returns, so it cannot prune the fall-through and the JIT gets no hint that the path is cold.

**Misattributed message.** `AppendFormatted<T>` treated *any* `false` from `value.TryFormat` as "the value is too long":

```csharp
if (!value.TryFormat(span, out var charsWritten, format, null))
{
    ThrowValueTooLong();   // "The value is too long to fit in this fixed string."
}
```

`TryFormat` returning `false` is documented to mean the destination was too small, but the message claims to know more than the call site actually does, and it reads oddly when the destination is empty because the buffer is already full.

## The change

- `[global::System.Diagnostics.CodeAnalysis.DoesNotReturn]` on the throw helpers.
- The two `AppendFormatted<T>` paths now call a dedicated `ThrowFormattedValueTooLong`, whose message names what is actually known: *"The formatted value does not fit in the remaining capacity of this fixed string."* `AppendLiteral` and the alignment path keep `ThrowValueTooLong`, where the length really is the cause.

The exception **type** is unchanged (`ArgumentException`) on every path; only the message text differs, and only for the `AppendFormatted<T>` overloads. Shout if you'd rather keep a single message for all four call sites.

## Verification

- `Meziantou.Framework.FixedStringBuilder.Tests`: 12/12 pass (including `AppendFormattedThrowsWhenValueIsTooLong`, which asserts the exception type). `Meziantou.Framework.FixedStringBuilder.Generator.Tests`: 6/6 pass.
- Release build with `/p:IsOfficialBuild=true` leaves `ref/` unchanged — both helpers are private.
- `dotnet run ./eng/update-all.cs` produces no changes.

Found during a review of `Meziantou.Framework.FixedStringBuilder`.
