### PR TITLE
Document that Clear does not erase the FixedStringBuilder buffer

### DIFF
--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
@@ -241,6 +241,13 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         AppendLine("}");
         AppendLine();
 
+        AppendLine("/// <summary>");
+        AppendLine("/// Resets this string to an empty string.");
+        AppendLine("/// </summary>");
+        AppendLine("/// <remarks>");
+        AppendLine("/// Only the length is reset. The characters that were written are not overwritten and stay in");
+        AppendLine("/// the underlying buffer. Do not rely on this method to erase sensitive data.");
+        AppendLine("/// </remarks>");
         AppendLine("public void Clear() => _length = 0;");
         AppendLine();
 

--- a/src/Meziantou.Framework.FixedStringBuilder/IFixedString.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder/IFixedString.cs
@@ -18,6 +18,11 @@ public interface IFixedString : ISpanFormattable
     /// <summary>
     /// Resets this string to an empty string.
     /// </summary>
+    /// <remarks>
+    /// Only the length is reset. The characters that were written are not overwritten: they stay in the underlying
+    /// buffer and remain readable through <see cref="GetUnsafeFullSpan"/>. Do not rely on this method to erase
+    /// sensitive data.
+    /// </remarks>
     void Clear();
 
     /// <summary>

--- a/tests/Meziantou.Framework.FixedStringBuilder.Tests/FixedStringBuilderTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Tests/FixedStringBuilderTests.cs
@@ -109,7 +109,7 @@ public sealed class FixedStringBuilderTests
         value.Clear();
 
         Assert.Equal(0, value.Length);
-        Assert.Equal("", value.ToString());
+        Assert.Equal("", value.ToString(null, null));
 
         // Documented behavior: Clear only resets the length, the characters stay in the underlying buffer.
         var fullSpan = ((IFixedString)value).GetUnsafeFullSpan();

--- a/tests/Meziantou.Framework.FixedStringBuilder.Tests/FixedStringBuilderTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Tests/FixedStringBuilderTests.cs
@@ -103,6 +103,20 @@ public sealed class FixedStringBuilderTests
     }
 
     [Fact]
+    public void ClearResetsTheLengthWithoutErasingTheBuffer()
+    {
+        FixedStringBuilder8 value = "abcdefgh";
+        value.Clear();
+
+        Assert.Equal(0, value.Length);
+        Assert.Equal("", value.ToString());
+
+        // Documented behavior: Clear only resets the length, the characters stay in the underlying buffer.
+        var fullSpan = ((IFixedString)value).GetUnsafeFullSpan();
+        Assert.Equal("abcdefgh", fullSpan.ToString());
+    }
+
+    [Fact]
     public void EqualsSupportsStringComparison()
     {
         FixedStringBuilder8 a = "AbC";


### PR DESCRIPTION
## The problem

`Clear()` is documented as *"Resets this string to an empty string."* (`IFixedString.cs:18-21`), which reads as a wipe. It only sets `_length = 0` (`FixedStringBuilderSourceGenerator.cs:188`) — the characters that were written stay in the buffer and remain readable through `IFixedString.GetUnsafeFullSpan()`.

Avoiding heap copies of short-lived text is a real reason to reach for a stack-allocated string type, so someone may well use one for a token or a short credential and assume `Clear()` erases it. It does not.

## The change

Documentation only, plus a test that pins the behavior.

- The `<remarks>` on `IFixedString.Clear()` now states that only the length is reset and that the method must not be relied on to erase sensitive data.
- The generated `Clear()` carries the same remark, so it shows up in IntelliSense on the concrete types (`FixedStringBuilder8` and friends), which is where people actually see it.

No behavior change. Zeroing the buffer unconditionally would add cost to the common reuse path, so if you want an erasing variant it is better as a separate `ClearAndZero()` — happy to follow up with that if you'd like it.

## Verification

- New `ClearResetsTheLengthWithoutErasingTheBuffer` asserts `Length == 0` and `ToString() == ""` after `Clear()`, and that the full unsafe span still contains the original characters — so the documented behavior is now enforced rather than just described.
- `Meziantou.Framework.FixedStringBuilder.Tests`: 13/13 pass. `Meziantou.Framework.FixedStringBuilder.Generator.Tests`: 8/8 pass.
- Release build with `/p:IsOfficialBuild=true` leaves `ref/` unchanged — XML docs are not part of the ref surface.
- `dotnet run ./eng/update-all.cs` produces no changes.

Found during a review of `Meziantou.Framework.FixedStringBuilder`.
