### PR TITLE
Only report FixedStringBuilder diagnostics on the generator's own attribute

### DIFF
--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderAttributeAnalyzer.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderAttributeAnalyzer.cs
@@ -54,9 +54,14 @@ public sealed class FixedStringBuilderAttributeAnalyzer : DiagnosticAnalyzer
                 if (!IsCandidate(attributeSyntax.Name))
                     continue;
 
-                var symbolInfo = context.SemanticModel.GetSymbolInfo(attributeSyntax, context.CancellationToken).Symbol as IMethodSymbol;
-                if (symbolInfo is not null &&
-                    (symbolInfo.ContainingType.Name is not "FixedStringBuilderAttribute" || !symbolInfo.ContainingType.ContainingNamespace.IsGlobalNamespace))
+                var symbolInfo = context.SemanticModel.GetSymbolInfo(attributeSyntax, context.CancellationToken);
+
+                // The symbol does not bind when the arguments do not match any constructor, which is exactly what
+                // MFFSG0001 reports, so the candidates are considered too. Without a symbol to check the attribute
+                // against, an unrelated attribute that happens to be named FixedStringBuilder would be reported on.
+                if ((symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault()) is not IMethodSymbol attributeConstructor ||
+                    attributeConstructor.ContainingType.Name is not "FixedStringBuilderAttribute" ||
+                    !attributeConstructor.ContainingType.ContainingNamespace.IsGlobalNamespace)
                 {
                     continue;
                 }

--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderAttributeAnalyzer.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderAttributeAnalyzer.cs
@@ -39,10 +39,19 @@ public sealed class FixedStringBuilderAttributeAnalyzer : DiagnosticAnalyzer
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterSyntaxNodeAction(static context => AnalyzeTypeDeclaration(context), SyntaxKind.StructDeclaration);
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Resolve the attribute once per compilation so each declaration can be compared against the symbol
+            // itself. When the generator did not run there is no attribute and nothing to analyze.
+            var attributeSymbol = context.Compilation.GetTypeByMetadataName("FixedStringBuilderAttribute");
+            if (attributeSymbol is null)
+                return;
+
+            context.RegisterSyntaxNodeAction(context => AnalyzeTypeDeclaration(context, attributeSymbol), SyntaxKind.StructDeclaration);
+        });
     }
 
-    private static void AnalyzeTypeDeclaration(SyntaxNodeAnalysisContext context)
+    private static void AnalyzeTypeDeclaration(SyntaxNodeAnalysisContext context, INamedTypeSymbol attributeSymbol)
     {
         if (context.Node is not TypeDeclarationSyntax typeDeclarationSyntax)
             return;
@@ -51,17 +60,12 @@ public sealed class FixedStringBuilderAttributeAnalyzer : DiagnosticAnalyzer
         {
             foreach (var attributeSyntax in attributeList.Attributes)
             {
-                if (!IsCandidate(attributeSyntax.Name))
-                    continue;
-
                 var symbolInfo = context.SemanticModel.GetSymbolInfo(attributeSyntax, context.CancellationToken);
 
                 // The symbol does not bind when the arguments do not match any constructor, which is exactly what
-                // MFFSG0001 reports, so the candidates are considered too. Without a symbol to check the attribute
-                // against, an unrelated attribute that happens to be named FixedStringBuilder would be reported on.
+                // MFFSG0001 reports, so the candidates are considered too.
                 if ((symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault()) is not IMethodSymbol attributeConstructor ||
-                    attributeConstructor.ContainingType.Name is not "FixedStringBuilderAttribute" ||
-                    !attributeConstructor.ContainingType.ContainingNamespace.IsGlobalNamespace)
+                    !SymbolEqualityComparer.Default.Equals(attributeConstructor.ContainingType, attributeSymbol))
                 {
                     continue;
                 }
@@ -87,18 +91,5 @@ public sealed class FixedStringBuilderAttributeAnalyzer : DiagnosticAnalyzer
                 }
             }
         }
-    }
-
-    private static bool IsCandidate(NameSyntax nameSyntax)
-    {
-        var name = nameSyntax switch
-        {
-            IdentifierNameSyntax identifierNameSyntax => identifierNameSyntax.Identifier.ValueText,
-            QualifiedNameSyntax qualifiedNameSyntax => qualifiedNameSyntax.Right.Identifier.ValueText,
-            AliasQualifiedNameSyntax aliasQualifiedNameSyntax => aliasQualifiedNameSyntax.Name.Identifier.ValueText,
-            _ => null,
-        };
-
-        return name is "FixedStringBuilder" or "FixedStringBuilderAttribute";
     }
 }

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
@@ -272,6 +272,24 @@ public sealed class FixedStringBuilderSourceGeneratorTests
         Assert.Empty(diagnostics);
     }
 
+    [Fact]
+    public async Task AnalyzerReportsThroughAnAlias()
+    {
+        // The attribute is the generator's one, so it must be analyzed even though the name is not written out.
+        const string Source = """
+            using Aliased = FixedStringBuilderAttribute;
+
+            [Aliased(0)]
+            public partial struct Sample
+            {
+            }
+            """;
+
+        var diagnostics = await AnalyzeAsync(Source);
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal("MFFSG0003", diagnostic.Id);
+    }
+
     private static async Task<(GeneratorDriverRunResult RunResult, Compilation Compilation)> GenerateAsync(string source)
     {
         var netcoreRef = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "8.0.0", "ref/net8.0/");

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
@@ -247,6 +247,31 @@ public sealed class FixedStringBuilderSourceGeneratorTests
         Assert.All(outputs, static output => Assert.Equal(IncrementalStepRunReason.Cached, output.Reason));
     }
 
+    [Fact]
+    public async Task AnalyzerIgnoresAnUnrelatedAttributeThatDoesNotBind()
+    {
+        // Other.FixedStringBuilderAttribute has no parameterless constructor, so the attribute does not bind to a
+        // symbol. It is still not the generator's attribute and must not be reported on.
+        const string Source = """
+            namespace Other
+            {
+                [System.AttributeUsage(System.AttributeTargets.Struct)]
+                public sealed class FixedStringBuilderAttribute : System.Attribute
+                {
+                    public FixedStringBuilderAttribute(string name) { }
+                }
+            }
+
+            [Other.FixedStringBuilder]
+            public partial struct Sample
+            {
+            }
+            """;
+
+        var diagnostics = await AnalyzeAsync(Source);
+        Assert.Empty(diagnostics);
+    }
+
     private static async Task<(GeneratorDriverRunResult RunResult, Compilation Compilation)> GenerateAsync(string source)
     {
         var netcoreRef = await NuGetHelpers.GetNuGetReferences("Microsoft.NETCore.App.Ref", "8.0.0", "ref/net8.0/");


### PR DESCRIPTION
## The problem

The analyzer decided whether an attribute was *its* attribute using a syntactic name filter plus a name-and-namespace string comparison, and only applied that check when the symbol resolved:

```csharp
if (!IsCandidate(attributeSyntax.Name))      // matches the identifier text
    continue;

var symbolInfo = ... .Symbol as IMethodSymbol;
if (symbolInfo is not null && (symbolInfo.ContainingType.Name is not "FixedStringBuilderAttribute" || ...))
    continue;
```

Two defects fell out of that.

**False positive.** When the symbol did not bind, `symbolInfo` was `null`, the guard was skipped, and `MFFSG0001`/`0002`/`0003` were reported on an attribute belonging to someone else:

```csharp
namespace Other
{
    public sealed class FixedStringBuilderAttribute : System.Attribute
    {
        public FixedStringBuilderAttribute(string name) { }
    }
}

[Other.FixedStringBuilder]     // does not bind -> MFFSG0001 on an unrelated attribute
public partial struct Sample;
```

**False negative.** Because the syntactic filter matched on the written identifier, the generator's own attribute used through an alias was skipped entirely — `[Aliased(0)]` reported nothing where `MFFSG0003` was due.

## The change

Per review feedback: resolve the attribute **once** in `RegisterCompilationStartAction` and compare symbols.

```csharp
context.RegisterCompilationStartAction(context =>
{
    var attributeSymbol = context.Compilation.GetTypeByMetadataName("FixedStringBuilderAttribute");
    if (attributeSymbol is null)
        return;

    context.RegisterSyntaxNodeAction(context => AnalyzeTypeDeclaration(context, attributeSymbol), SyntaxKind.StructDeclaration);
});
```

and at each declaration:

```csharp
if ((symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault()) is not IMethodSymbol attributeConstructor ||
    !SymbolEqualityComparer.Default.Equals(attributeConstructor.ContainingType, attributeSymbol))
{
    continue;
}
```

No name or namespace strings are compared any more. Notes:

- **`IsCandidate` is gone.** Keeping it as a syntactic fast path would have preserved the alias false negative, which is the whole point of comparing symbols. The cost is a `GetSymbolInfo` per attribute on struct declarations — happy to reinstate it as a pre-filter if you would rather have the throughput and accept that aliases go unanalyzed.
- **`CandidateSymbols` is still consulted**, because not binding is exactly what `MFFSG0001` reports: `[FixedStringBuilderAttribute]` with no argument matches no constructor. Requiring `symbolInfo.Symbol` alone would silence a diagnostic that should fire.
- When the generator has not run there is no attribute symbol, so the whole analysis is skipped up front rather than per declaration.

## Verification

- New `AnalyzerIgnoresAnUnrelatedAttributeThatDoesNotBind` — confirmed it **fails on the pre-change analyzer** (a diagnostic was reported), passes after.
- New `AnalyzerReportsThroughAnAlias` — confirmed it **fails on the pre-change analyzer** (nothing reported for `[Aliased(0)]`), passes after.
- `AnalyzerReportsMissingValue` still passes, which is the check that the `CandidateSymbols` fallback did not silence the real diagnostic.
- `Meziantou.Framework.FixedStringBuilder.Generator.Tests`: 10/10 pass.
- Release build with `/p:IsOfficialBuild=true` leaves `ref/` unchanged. `dotnet run ./eng/update-all.cs` produces no changes.

Note: this touches `AnalyzeTypeDeclaration`, as do #2286 and #2287. Those add checks inside the loop while this reshapes registration and the guard, so whichever lands second is worth a glance.

Found during a review of `Meziantou.Framework.FixedStringBuilder`.
