### PR TITLE
Store FixedStringBuilder characters in an inline array and make AsSpan ref-safe

### DIFF
--- a/ref/Meziantou.Framework.FixedStringBuilder.cs
+++ b/ref/Meziantou.Framework.FixedStringBuilder.cs
@@ -25,6 +25,7 @@ namespace Meziantou.Framework.FixedStringBuilder
         public static bool operator !=(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16 left, Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16 right) => throw null;
         public override bool Equals(object? obj) => throw null;
         public override int GetHashCode() => throw null;
+        [System.Diagnostics.CodeAnalysis.UnscopedRef]
         public readonly System.ReadOnlySpan<char> AsSpan() => throw null;
         System.Span<char> Meziantou.Framework.FixedStringBuilder.IFixedString.GetUnsafeFullSpan() => throw null;
         public static implicit operator Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16(string value) => throw null;
@@ -54,6 +55,7 @@ namespace Meziantou.Framework.FixedStringBuilder
         public static bool operator !=(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32 left, Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32 right) => throw null;
         public override bool Equals(object? obj) => throw null;
         public override int GetHashCode() => throw null;
+        [System.Diagnostics.CodeAnalysis.UnscopedRef]
         public readonly System.ReadOnlySpan<char> AsSpan() => throw null;
         System.Span<char> Meziantou.Framework.FixedStringBuilder.IFixedString.GetUnsafeFullSpan() => throw null;
         public static implicit operator Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32(string value) => throw null;
@@ -83,6 +85,7 @@ namespace Meziantou.Framework.FixedStringBuilder
         public static bool operator !=(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64 left, Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64 right) => throw null;
         public override bool Equals(object? obj) => throw null;
         public override int GetHashCode() => throw null;
+        [System.Diagnostics.CodeAnalysis.UnscopedRef]
         public readonly System.ReadOnlySpan<char> AsSpan() => throw null;
         System.Span<char> Meziantou.Framework.FixedStringBuilder.IFixedString.GetUnsafeFullSpan() => throw null;
         public static implicit operator Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64(string value) => throw null;
@@ -112,6 +115,7 @@ namespace Meziantou.Framework.FixedStringBuilder
         public static bool operator !=(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8 left, Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8 right) => throw null;
         public override bool Equals(object? obj) => throw null;
         public override int GetHashCode() => throw null;
+        [System.Diagnostics.CodeAnalysis.UnscopedRef]
         public readonly System.ReadOnlySpan<char> AsSpan() => throw null;
         System.Span<char> Meziantou.Framework.FixedStringBuilder.IFixedString.GetUnsafeFullSpan() => throw null;
         public static implicit operator Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8(string value) => throw null;

--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
@@ -161,6 +161,7 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         AppendLine("#nullable enable");
         AppendLine("using System;");
         AppendLine("using System.ComponentModel;");
+        AppendLine("using System.Diagnostics.CodeAnalysis;");
         AppendLine("using System.Runtime.CompilerServices;");
         AppendLine("using System.Runtime.InteropServices;");
         AppendLine();
@@ -207,13 +208,18 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         AppendLine();
 
         AppendLine("private short _length;");
-        AppendLine("#pragma warning disable CS0169, CS0649");
-        for (var i = 0; i < target.Length; i++)
-        {
-            AppendLine($"private char _c{i};");
-        }
+        AppendLine("private Storage _storage;");
+        AppendLine();
 
-        AppendLine("#pragma warning restore CS0169, CS0649");
+        AppendLine($"[global::System.Runtime.CompilerServices.InlineArray({target.Length})]");
+        AppendLine("private struct Storage");
+        AppendLine("{");
+        indent++;
+        AppendLine("#pragma warning disable CS0169");
+        AppendLine("private char _element0;");
+        AppendLine("#pragma warning restore CS0169");
+        indent--;
+        AppendLine("}");
         AppendLine();
 
         AppendLine($"public {simpleTypeName}(int literalLength, int formattedCount)");
@@ -358,7 +364,8 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         AppendLine("}");
         AppendLine();
 
-        AppendLine("public readonly ReadOnlySpan<char> AsSpan() => MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in _c0), _length);");
+        AppendLine("[UnscopedRef]");
+        AppendLine("public readonly ReadOnlySpan<char> AsSpan() => ((ReadOnlySpan<char>)_storage).Slice(0, _length);");
         AppendLine();
         if (target.ImplementsIFixedStringNonGeneric)
         {
@@ -392,7 +399,10 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         AppendLine("}");
         AppendLine();
 
-        AppendLine("private Span<char> AsUnsafeFullSpan() => MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in _c0), MaxLength);");
+        // Unlike AsSpan, this one has to launder the ref: the explicit IFixedString.GetUnsafeFullSpan
+        // implementation returns it, and an interface member cannot be [UnscopedRef]. That is the escape hatch
+        // IFixedString.GetUnsafeFullSpan is documented to be.
+        AppendLine("private Span<char> AsUnsafeFullSpan() => MemoryMarshal.CreateSpan(ref Unsafe.As<Storage, char>(ref Unsafe.AsRef(in _storage)), MaxLength);");
         AppendLine();
         AppendLine("private Span<char> AsRemainingSpan() => AsUnsafeFullSpan().Slice(_length);");
         AppendLine();

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
@@ -50,8 +50,9 @@ public sealed class FixedStringBuilderSourceGeneratorTests
         Assert.Contains("internal partial class FixedStringBuilderAttribute", allGeneratedSources);
         Assert.Contains("internal sealed partial class EmbeddedAttribute", allGeneratedSources);
         Assert.Contains("public static int MaxLength => 10;", allGeneratedSources);
-        Assert.Contains("private char _c0;", allGeneratedSources);
-        Assert.Contains("public readonly ReadOnlySpan<char> AsSpan() => MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in _c0), _length);", allGeneratedSources);
+        Assert.Contains("[global::System.Runtime.CompilerServices.InlineArray(10)]", allGeneratedSources);
+        Assert.Contains("private Storage _storage;", allGeneratedSources);
+        Assert.Contains("public readonly ReadOnlySpan<char> AsSpan() => ((ReadOnlySpan<char>)_storage).Slice(0, _length);", allGeneratedSources);
         Assert.Contains("public bool Equals(FixedStringBuilder10 other, StringComparison comparison)", allGeneratedSources);
 
         using var peStream = new MemoryStream();
@@ -245,6 +246,32 @@ public sealed class FixedStringBuilderSourceGeneratorTests
 
         Assert.NotEmpty(outputs);
         Assert.All(outputs, static output => Assert.Equal(IncrementalStepRunReason.Cached, output.Reason));
+    }
+
+    [Fact]
+    public async Task AsSpanCannotOutliveTheValueItPointsInto()
+    {
+        const string Source = """
+            [FixedStringBuilderAttribute(10)]
+            public partial struct FixedStringBuilder10
+            {
+            }
+
+            public static class Harness
+            {
+                public static System.ReadOnlySpan<char> Escape()
+                {
+                    FixedStringBuilder10 value = "abcd";
+                    return value.AsSpan();
+                }
+            }
+            """;
+
+        var (_, compilation) = await GenerateAsync(Source);
+
+        var errors = compilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
+        var error = Assert.Single(errors);
+        Assert.Equal("CS8168", error.Id);
     }
 
     private static async Task<(GeneratorDriverRunResult RunResult, Compilation Compilation)> GenerateAsync(string source)


### PR DESCRIPTION
**Stack 1 of 3** · merges into `main` · must merge before #2295 and #2296
**⚠️ Source-breaking** — see below.

## The problem

`AsSpan()` handed out a span the compiler could not prove was still alive:

```csharp
public readonly ReadOnlySpan<char> AsSpan() => MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in _c0), _length);
```

`Unsafe.AsRef<T>(scoped in T)` exists precisely to launder a ref out of its scope, so ref-safety analysis stops tracking the connection to `this`. This compiled with no error and no warning:

```csharp
static ReadOnlySpan<char> Escape()
{
    FixedStringBuilder8 sb = default;
    sb.AppendLiteral("abcd");
    return sb.AsSpan();     // span over a stack slot that is about to die
}
```

Run against the shipped library, after the caller overwrote the reclaimed frame, that span read `len=4 content=[泬 ᠀]` instead of `abcd`. `AsSpan()` is the natural way to read a fixed string, carries no "unsafe" in its name, and had no lifetime warning — unlike `IFixedString.GetUnsafeFullSpan`, whose remarks call the hazard out explicitly.

Separately, storage was one `private char _cN;` field per character. `[FixedStringBuilderAttribute(256)]` emitted 256 field declarations, all needing a `#pragma warning disable CS0169, CS0649` bracket because none is ever referenced by name — and taking the address of `_c0` is *why* the ref had to be laundered in the first place.

## The change

Both problems have one fix: a single `[InlineArray(N)]` field.

```csharp
private Storage _storage;

[global::System.Runtime.CompilerServices.InlineArray(N)]
private struct Storage
{
    private char _element0;
}

[UnscopedRef]
public readonly ReadOnlySpan<char> AsSpan() => ((ReadOnlySpan<char>)_storage).Slice(0, _length);
```

The compiler's inline-array→span conversion is ref-safety-tracked, so the `Escape()` sample above is now `CS8168: Cannot return local 'sb' by reference`. The generated file is also a constant size regardless of capacity, and the pragma is gone.

**`AsUnsafeFullSpan` deliberately keeps the laundering.** The explicit `IFixedString.GetUnsafeFullSpan()` implementation returns it, and an interface member cannot be `[UnscopedRef]` — making it safe is `CS8170: Struct members cannot return 'this' or other instance members by reference`. That is the right outcome: the safe-named method gets compiler enforcement, and the method documented as an escape hatch keeps being one. There is a comment in the generator saying so.

### Breaking change

`[UnscopedRef]` correctly rejects call sites that compile today — any code returning `AsSpan()` out of the scope that owns the value. That code was already broken at runtime; it just failed silently. This is a source break, so it belongs in a major version. Say the word if you'd rather hold it.

`[InlineArray]` also requires consumers to target .NET 8+. The library is `net10.0;net11.0` so that costs nothing here, but the generator ships standalone and could be used from an older TFM — worth a note in the readme, or a TFM check in the generator, if you want to support that.

## Verification

- New `AsSpanCannotOutliveTheValueItPointsInto` compiles the `Escape()` shape through the generator and asserts a single `CS8168`. Confirmed it **fails on the pre-change generator** — the escape compiled with zero errors — and passes after.
- `Meziantou.Framework.FixedStringBuilder.Tests`: 12/12 pass. `Meziantou.Framework.FixedStringBuilder.Generator.Tests`: 9/9 pass, including `GetUnsafeFullSpanReturnsFixedCapacity` and `ImplementsIFixedStringWhenInterfaceExists`, which exercise the laundered path.
- `ref/Meziantou.Framework.FixedStringBuilder.cs` regenerated: the only surface change is `[UnscopedRef]` on `AsSpan()` for the four built-in types. Storage is private, so nothing else moved.
- `dotnet run ./eng/update-all.cs` produces no changes.

Found during a review of `Meziantou.Framework.FixedStringBuilder`.
