### PR TITLE
Avoid defensive copies by marking non-mutating FixedStringBuilder members readonly

### DIFF
--- a/ref/Meziantou.Framework.FixedStringBuilder.cs
+++ b/ref/Meziantou.Framework.FixedStringBuilder.cs
@@ -8,7 +8,7 @@ namespace Meziantou.Framework.FixedStringBuilder
     public struct FixedStringBuilder16 : Meziantou.Framework.FixedStringBuilder.IFixedString, Meziantou.Framework.FixedStringBuilder.IFixedString<Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16>, System.IEquatable<Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16>, System.IFormattable, System.ISpanFormattable
     {
         public static int MaxLength { get => throw null; }
-        public int Length { get => throw null; }
+        public readonly int Length { get => throw null; }
         public FixedStringBuilder16(int literalLength, int formattedCount) { }
         public FixedStringBuilder16(string value) { }
         public void Clear() { }
@@ -19,26 +19,26 @@ namespace Meziantou.Framework.FixedStringBuilder
         public void AppendFormatted<T>(T value, string? format) where T : System.ISpanFormattable { }
         public void AppendFormatted<T>(T value, int alignment) where T : System.ISpanFormattable { }
         public void AppendFormatted<T>(T value, int alignment, string? format) where T : System.ISpanFormattable { }
-        public bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16 other) => throw null;
-        public bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16 other, System.StringComparison comparison) => throw null;
+        public readonly bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16 other) => throw null;
+        public readonly bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16 other, System.StringComparison comparison) => throw null;
         public static bool operator ==(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16 left, Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16 right) => throw null;
         public static bool operator !=(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16 left, Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16 right) => throw null;
-        public override bool Equals(object? obj) => throw null;
-        public override int GetHashCode() => throw null;
+        public readonly override bool Equals(object? obj) => throw null;
+        public readonly override int GetHashCode() => throw null;
         [System.Diagnostics.CodeAnalysis.UnscopedRef]
         public readonly System.ReadOnlySpan<char> AsSpan() => throw null;
         System.Span<char> Meziantou.Framework.FixedStringBuilder.IFixedString.GetUnsafeFullSpan() => throw null;
         public static implicit operator Meziantou.Framework.FixedStringBuilder.FixedStringBuilder16(string value) => throw null;
-        public override string ToString() => throw null;
-        public string ToString(string? format, System.IFormatProvider? formatProvider) => throw null;
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) => throw null;
+        public readonly override string ToString() => throw null;
+        public readonly string ToString(string? format, System.IFormatProvider? formatProvider) => throw null;
+        public readonly bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) => throw null;
     }
 
     [System.Runtime.CompilerServices.InterpolatedStringHandler]
     public struct FixedStringBuilder32 : Meziantou.Framework.FixedStringBuilder.IFixedString, Meziantou.Framework.FixedStringBuilder.IFixedString<Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32>, System.IEquatable<Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32>, System.IFormattable, System.ISpanFormattable
     {
         public static int MaxLength { get => throw null; }
-        public int Length { get => throw null; }
+        public readonly int Length { get => throw null; }
         public FixedStringBuilder32(int literalLength, int formattedCount) { }
         public FixedStringBuilder32(string value) { }
         public void Clear() { }
@@ -49,26 +49,26 @@ namespace Meziantou.Framework.FixedStringBuilder
         public void AppendFormatted<T>(T value, string? format) where T : System.ISpanFormattable { }
         public void AppendFormatted<T>(T value, int alignment) where T : System.ISpanFormattable { }
         public void AppendFormatted<T>(T value, int alignment, string? format) where T : System.ISpanFormattable { }
-        public bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32 other) => throw null;
-        public bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32 other, System.StringComparison comparison) => throw null;
+        public readonly bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32 other) => throw null;
+        public readonly bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32 other, System.StringComparison comparison) => throw null;
         public static bool operator ==(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32 left, Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32 right) => throw null;
         public static bool operator !=(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32 left, Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32 right) => throw null;
-        public override bool Equals(object? obj) => throw null;
-        public override int GetHashCode() => throw null;
+        public readonly override bool Equals(object? obj) => throw null;
+        public readonly override int GetHashCode() => throw null;
         [System.Diagnostics.CodeAnalysis.UnscopedRef]
         public readonly System.ReadOnlySpan<char> AsSpan() => throw null;
         System.Span<char> Meziantou.Framework.FixedStringBuilder.IFixedString.GetUnsafeFullSpan() => throw null;
         public static implicit operator Meziantou.Framework.FixedStringBuilder.FixedStringBuilder32(string value) => throw null;
-        public override string ToString() => throw null;
-        public string ToString(string? format, System.IFormatProvider? formatProvider) => throw null;
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) => throw null;
+        public readonly override string ToString() => throw null;
+        public readonly string ToString(string? format, System.IFormatProvider? formatProvider) => throw null;
+        public readonly bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) => throw null;
     }
 
     [System.Runtime.CompilerServices.InterpolatedStringHandler]
     public struct FixedStringBuilder64 : Meziantou.Framework.FixedStringBuilder.IFixedString, Meziantou.Framework.FixedStringBuilder.IFixedString<Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64>, System.IEquatable<Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64>, System.IFormattable, System.ISpanFormattable
     {
         public static int MaxLength { get => throw null; }
-        public int Length { get => throw null; }
+        public readonly int Length { get => throw null; }
         public FixedStringBuilder64(int literalLength, int formattedCount) { }
         public FixedStringBuilder64(string value) { }
         public void Clear() { }
@@ -79,26 +79,26 @@ namespace Meziantou.Framework.FixedStringBuilder
         public void AppendFormatted<T>(T value, string? format) where T : System.ISpanFormattable { }
         public void AppendFormatted<T>(T value, int alignment) where T : System.ISpanFormattable { }
         public void AppendFormatted<T>(T value, int alignment, string? format) where T : System.ISpanFormattable { }
-        public bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64 other) => throw null;
-        public bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64 other, System.StringComparison comparison) => throw null;
+        public readonly bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64 other) => throw null;
+        public readonly bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64 other, System.StringComparison comparison) => throw null;
         public static bool operator ==(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64 left, Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64 right) => throw null;
         public static bool operator !=(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64 left, Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64 right) => throw null;
-        public override bool Equals(object? obj) => throw null;
-        public override int GetHashCode() => throw null;
+        public readonly override bool Equals(object? obj) => throw null;
+        public readonly override int GetHashCode() => throw null;
         [System.Diagnostics.CodeAnalysis.UnscopedRef]
         public readonly System.ReadOnlySpan<char> AsSpan() => throw null;
         System.Span<char> Meziantou.Framework.FixedStringBuilder.IFixedString.GetUnsafeFullSpan() => throw null;
         public static implicit operator Meziantou.Framework.FixedStringBuilder.FixedStringBuilder64(string value) => throw null;
-        public override string ToString() => throw null;
-        public string ToString(string? format, System.IFormatProvider? formatProvider) => throw null;
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) => throw null;
+        public readonly override string ToString() => throw null;
+        public readonly string ToString(string? format, System.IFormatProvider? formatProvider) => throw null;
+        public readonly bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) => throw null;
     }
 
     [System.Runtime.CompilerServices.InterpolatedStringHandler]
     public struct FixedStringBuilder8 : Meziantou.Framework.FixedStringBuilder.IFixedString, Meziantou.Framework.FixedStringBuilder.IFixedString<Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8>, System.IEquatable<Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8>, System.IFormattable, System.ISpanFormattable
     {
         public static int MaxLength { get => throw null; }
-        public int Length { get => throw null; }
+        public readonly int Length { get => throw null; }
         public FixedStringBuilder8(int literalLength, int formattedCount) { }
         public FixedStringBuilder8(string value) { }
         public void Clear() { }
@@ -109,19 +109,19 @@ namespace Meziantou.Framework.FixedStringBuilder
         public void AppendFormatted<T>(T value, string? format) where T : System.ISpanFormattable { }
         public void AppendFormatted<T>(T value, int alignment) where T : System.ISpanFormattable { }
         public void AppendFormatted<T>(T value, int alignment, string? format) where T : System.ISpanFormattable { }
-        public bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8 other) => throw null;
-        public bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8 other, System.StringComparison comparison) => throw null;
+        public readonly bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8 other) => throw null;
+        public readonly bool Equals(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8 other, System.StringComparison comparison) => throw null;
         public static bool operator ==(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8 left, Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8 right) => throw null;
         public static bool operator !=(Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8 left, Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8 right) => throw null;
-        public override bool Equals(object? obj) => throw null;
-        public override int GetHashCode() => throw null;
+        public readonly override bool Equals(object? obj) => throw null;
+        public readonly override int GetHashCode() => throw null;
         [System.Diagnostics.CodeAnalysis.UnscopedRef]
         public readonly System.ReadOnlySpan<char> AsSpan() => throw null;
         System.Span<char> Meziantou.Framework.FixedStringBuilder.IFixedString.GetUnsafeFullSpan() => throw null;
         public static implicit operator Meziantou.Framework.FixedStringBuilder.FixedStringBuilder8(string value) => throw null;
-        public override string ToString() => throw null;
-        public string ToString(string? format, System.IFormatProvider? formatProvider) => throw null;
-        public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) => throw null;
+        public readonly override string ToString() => throw null;
+        public readonly string ToString(string? format, System.IFormatProvider? formatProvider) => throw null;
+        public readonly bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) => throw null;
     }
 
     public interface IFixedString : System.IFormattable, System.ISpanFormattable

--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
@@ -239,7 +239,7 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         AppendLine("}");
         AppendLine();
 
-        AppendLine("public int Length");
+        AppendLine("public readonly int Length");
         AppendLine("{");
         indent++;
         AppendLine("get => _length;");
@@ -335,19 +335,19 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         AppendLine("}");
         AppendLine();
 
-        AppendLine($"public bool Equals({simpleTypeName} other) => _length == other._length && AsSpan().SequenceEqual(other.AsSpan());");
+        AppendLine($"public readonly bool Equals({simpleTypeName} other) => _length == other._length && AsSpan().SequenceEqual(other.AsSpan());");
         AppendLine();
-        AppendLine($"public bool Equals({simpleTypeName} other, StringComparison comparison) => new string(AsSpan()).Equals(new string(other.AsSpan()), comparison);");
+        AppendLine($"public readonly bool Equals({simpleTypeName} other, StringComparison comparison) => new string(AsSpan()).Equals(new string(other.AsSpan()), comparison);");
         AppendLine();
         AppendLine($"public static bool operator ==({simpleTypeName} left, {simpleTypeName} right) => left.Equals(right);");
         AppendLine();
         AppendLine($"public static bool operator !=({simpleTypeName} left, {simpleTypeName} right) => !left.Equals(right);");
         AppendLine();
 
-        AppendLine("public override bool Equals(object? obj) => obj is " + simpleTypeName + " other && Equals(other);");
+        AppendLine("public override readonly bool Equals(object? obj) => obj is " + simpleTypeName + " other && Equals(other);");
         AppendLine();
 
-        AppendLine("public override int GetHashCode()");
+        AppendLine("public override readonly int GetHashCode()");
         AppendLine("{");
         indent++;
         AppendLine("var hash = unchecked((int)2166136261);");
@@ -375,13 +375,13 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
 
         AppendLine($"public static implicit operator {simpleTypeName}(string value) => new(value);");
         AppendLine();
-        AppendLine("public override string ToString() => ToString(null, null);");
+        AppendLine("public override readonly string ToString() => ToString(null, null);");
         AppendLine();
-        AppendLine("public string ToString(string? format, IFormatProvider? formatProvider) => _length == 0 ? string.Empty : new string(AsSpan());");
+        AppendLine("public readonly string ToString(string? format, IFormatProvider? formatProvider) => _length == 0 ? string.Empty : new string(AsSpan());");
         AppendLine();
 
         AppendLine("[EditorBrowsable(EditorBrowsableState.Never)]");
-        AppendLine("public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)");
+        AppendLine("public readonly bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)");
         AppendLine("{");
         indent++;
         AppendLine("if (destination.Length < _length)");

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
@@ -53,7 +53,7 @@ public sealed class FixedStringBuilderSourceGeneratorTests
         Assert.Contains("[global::System.Runtime.CompilerServices.InlineArray(10)]", allGeneratedSources);
         Assert.Contains("private Storage _storage;", allGeneratedSources);
         Assert.Contains("public readonly ReadOnlySpan<char> AsSpan() => ((ReadOnlySpan<char>)_storage).Slice(0, _length);", allGeneratedSources);
-        Assert.Contains("public bool Equals(FixedStringBuilder10 other, StringComparison comparison)", allGeneratedSources);
+        Assert.Contains("public readonly bool Equals(FixedStringBuilder10 other, StringComparison comparison)", allGeneratedSources);
 
         using var peStream = new MemoryStream();
         var emitResult = compilation.Emit(peStream);

--- a/tests/Meziantou.Framework.FixedStringBuilder.Tests/FixedStringBuilderTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Tests/FixedStringBuilderTests.cs
@@ -1,9 +1,46 @@
+using System.Reflection;
 using Meziantou.Framework.FixedStringBuilder;
 
 namespace Meziantou.Framework.Tests;
 
 public sealed class FixedStringBuilderTests
 {
+    [Theory]
+    [InlineData("get_Length")]
+    [InlineData("Equals")]
+    [InlineData("GetHashCode")]
+    [InlineData("ToString")]
+    [InlineData("TryFormat")]
+    [InlineData("AsSpan")]
+    public void NonMutatingMembersAreReadOnly(string methodName)
+    {
+        // A non-readonly member forces a defensive copy of the whole struct when it is called on a readonly
+        // field or through an "in" parameter.
+        var methods = typeof(FixedStringBuilder64)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(method => method.Name == methodName)
+            .ToArray();
+
+        Assert.NotEmpty(methods);
+        Assert.All(methods, static method => Assert.Contains(
+            method.GetCustomAttributesData(),
+            static attribute => attribute.AttributeType.FullName == "System.Runtime.CompilerServices.IsReadOnlyAttribute"));
+    }
+
+    [Fact]
+    public void MutatingMembersAreNotReadOnly()
+    {
+        var methods = typeof(FixedStringBuilder64)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(static method => method.Name is "Clear" or "AppendLiteral")
+            .ToArray();
+
+        Assert.NotEmpty(methods);
+        Assert.All(methods, static method => Assert.DoesNotContain(
+            method.GetCustomAttributesData(),
+            static attribute => attribute.AttributeType.FullName == "System.Runtime.CompilerServices.IsReadOnlyAttribute"));
+    }
+
     [Fact]
     public void MaxLengthValues()
     {


### PR DESCRIPTION
**Stack 2 of 3** · merges into `fix/inline-array-storage` · after #2294, before #2296

## The problem

Only `AsSpan()` was `readonly`. `Length`, both `Equals` overloads, `Equals(object)`, `GetHashCode`, both `ToString` overloads and `TryFormat` were not — so calling any of them through a `readonly` field or an `in` parameter copied the whole struct first.

From the IL of a sample using the shipped `FixedStringBuilder64` (130 bytes):

```il
// static int LenIn(in FixedStringBuilder64 v) => v.Length;
ldarg.0
ldobj  FixedStringBuilder64      // <-- full 130-byte defensive copy
stloc.0
ldloca.s 0
call   instance int32 FixedStringBuilder64::get_Length()

// static int SpanLen(in FixedStringBuilder64 v) => v.AsSpan().Length;   (AsSpan is readonly)
ldarg.0
call   instance ReadOnlySpan`1<char> FixedStringBuilder64::AsSpan()   // <-- no copy
```

This is the one performance issue that directly contradicts the package's purpose: a `readonly FixedStringBuilder64` field copies 130 bytes on every `Length` read. The contrast with `AsSpan()` in the same type shows the fix was already understood, just not applied consistently.

## The change

`readonly` on every member that does not mutate: `Length`, `Equals(T)`, `Equals(T, StringComparison)`, `Equals(object)`, `GetHashCode`, `ToString()`, `ToString(string?, IFormatProvider?)` and `TryFormat`. The mutating members (`Clear`, `AppendLiteral`, every `AppendFormatted`) are deliberately left alone.

Purely additive — no signature changes, no source break.

## Verification

- New theory `NonMutatingMembersAreReadOnly` asserts each of those members carries `IsReadOnlyAttribute` in the emitted metadata, which is what actually governs the defensive copy — not the source text.
- New `MutatingMembersAreNotReadOnly` asserts `Clear` and `AppendLiteral` did *not* pick it up, so the change cannot over-apply.
- `Meziantou.Framework.FixedStringBuilder.Tests`: 19/19 pass. `Meziantou.Framework.FixedStringBuilder.Generator.Tests`: 9/9 pass.
- `ref/Meziantou.Framework.FixedStringBuilder.cs` regenerated: 32 members gain `readonly` across the four built-in types.
- `dotnet run ./eng/update-all.cs` produces no changes.

Found during a review of `Meziantou.Framework.FixedStringBuilder`.
