### PR TITLE
Derive the QR block structure from the block count so capacity and encoding agree

### DIFF
--- a/src/Meziantou.Framework.QRCode/Internal/QRCodeVersion.cs
+++ b/src/Meziantou.Framework.QRCode/Internal/QRCodeVersion.cs
@@ -12,13 +12,9 @@ internal static class QRCodeVersion
     /// </summary>
     public static int GetDataCodewords(int version, ErrorCorrectionLevel ecLevel)
     {
-        var totalCodewords = GetTotalCodewords(version);
-        var ecCodewordsPerBlock = GetECCodewordsPerBlock(version, ecLevel);
-        var (group1Blocks, _, group2Blocks, _) = GetBlockInfo(version, ecLevel);
-        var totalBlocks = group1Blocks + group2Blocks;
-        var totalECCodewords = ecCodewordsPerBlock * totalBlocks;
+        var (group1Blocks, group1DataCodewords, group2Blocks, group2DataCodewords) = GetBlockInfo(version, ecLevel);
 
-        return totalCodewords - totalECCodewords;
+        return (group1Blocks * group1DataCodewords) + (group2Blocks * group2DataCodewords);
     }
 
     /// <summary>
@@ -66,9 +62,9 @@ internal static class QRCodeVersion
             28, 28, 28, 28,    // V17
             30, 26, 28, 28,    // V18
             28, 26, 26, 26,    // V19
-            28, 26, 28, 28,    // V20
-            28, 26, 30, 28,    // V21
-            28, 28, 24, 30,    // V22
+            28, 26, 30, 28,    // V20
+            28, 26, 28, 30,    // V21
+            28, 28, 30, 24,    // V22
             30, 28, 30, 30,    // V23
             30, 28, 30, 30,    // V24
             26, 28, 30, 30,    // V25
@@ -93,192 +89,78 @@ internal static class QRCodeVersion
     }
 
     /// <summary>
-    /// Gets the block structure for a given version and EC level.
-    /// Returns (group1Blocks, group1DataCodewords, group2Blocks, group2DataCodewords).
+    /// Gets the number of Reed-Solomon blocks for a given version and EC level, per ISO/IEC 18004 Table 9.
     /// </summary>
-    public static (int Group1Blocks, int Group1DataCodewords, int Group2Blocks, int Group2DataCodewords) GetBlockInfo(int version, ErrorCorrectionLevel ecLevel)
+    public static int GetBlockCount(int version, ErrorCorrectionLevel ecLevel)
     {
-        // Packed as: group1Blocks, group1DataCW, group2Blocks, group2DataCW
-        // Index: (version-1) * 4 + ecLevel, each entry is 4 bytes
-        ReadOnlySpan<byte> group1Blocks =
+        // Rows: version 1-40, Columns: L, M, Q, H
+        ReadOnlySpan<byte> table =
         [
             1, 1, 1, 1,       // V1
             1, 1, 1, 1,       // V2
             1, 1, 2, 2,       // V3
             1, 2, 2, 4,       // V4
-            1, 2, 2, 2,       // V5
+            1, 2, 4, 4,       // V5
             2, 4, 4, 4,       // V6
-            2, 4, 2, 4,       // V7
-            2, 2, 4, 4,       // V8
-            2, 3, 4, 4,       // V9
-            2, 4, 6, 6,       // V10
-            4, 1, 4, 3,       // V11
-            2, 6, 4, 7,       // V12
-            4, 8, 8, 12,      // V13
-            3, 4, 11, 11,     // V14
-            5, 5, 5, 11,      // V15
-            5, 7, 15, 3,      // V16
-            1, 10, 1, 2,      // V17
-            5, 9, 17, 2,      // V18
-            3, 3, 17, 9,      // V19
-            3, 3, 15, 15,     // V20
-            4, 17, 17, 19,    // V21
-            2, 17, 7, 34,     // V22
-            4, 4, 11, 16,     // V23
-            6, 6, 11, 30,     // V24
-            8, 8, 7, 22,      // V25
-            10, 19, 28, 33,   // V26
-            8, 22, 8, 12,     // V27
-            3, 3, 26, 11,     // V28
-            7, 21, 7, 23,     // V29
-            5, 19, 10, 15,    // V30
-            13, 2, 29, 42,    // V31
-            17, 10, 10, 23,   // V32
-            17, 14, 29, 44,   // V33
-            13, 14, 44, 59,   // V34
-            12, 12, 39, 22,   // V35
-            6, 6, 46, 2,      // V36
-            17, 29, 49, 24,   // V37
-            4, 13, 48, 42,    // V38
-            20, 40, 43, 10,   // V39
-            19, 18, 34, 20,   // V40
+            2, 4, 6, 5,       // V7
+            2, 4, 6, 6,       // V8
+            2, 5, 8, 8,       // V9
+            4, 5, 8, 8,       // V10
+            4, 5, 8, 11,      // V11
+            4, 8, 10, 11,     // V12
+            4, 9, 12, 16,     // V13
+            4, 9, 16, 16,     // V14
+            6, 10, 12, 18,    // V15
+            6, 10, 17, 16,    // V16
+            6, 11, 16, 19,    // V17
+            6, 13, 18, 21,    // V18
+            7, 14, 21, 25,    // V19
+            8, 16, 20, 25,    // V20
+            8, 17, 23, 25,    // V21
+            9, 17, 23, 34,    // V22
+            9, 18, 25, 30,    // V23
+            10, 20, 27, 32,   // V24
+            12, 21, 29, 35,   // V25
+            12, 23, 34, 37,   // V26
+            12, 25, 34, 40,   // V27
+            13, 26, 35, 42,   // V28
+            14, 28, 38, 45,   // V29
+            15, 29, 40, 48,   // V30
+            16, 31, 43, 51,   // V31
+            17, 33, 45, 54,   // V32
+            18, 35, 48, 57,   // V33
+            19, 37, 51, 60,   // V34
+            19, 38, 53, 63,   // V35
+            20, 40, 56, 66,   // V36
+            21, 43, 59, 70,   // V37
+            22, 45, 62, 74,   // V38
+            24, 47, 65, 77,   // V39
+            25, 49, 68, 81,   // V40
         ];
 
-        ReadOnlySpan<byte> group1DataCW =
-        [
-            19, 16, 13, 9,    // V1
-            34, 28, 22, 16,   // V2
-            55, 44, 17, 13,   // V3
-            80, 32, 24, 9,    // V4
-            108, 43, 15, 11,  // V5
-            68, 27, 19, 15,   // V6
-            78, 31, 14, 13,   // V7
-            97, 38, 18, 14,   // V8
-            116, 36, 16, 12,  // V9
-            68, 43, 19, 15,   // V10
-            81, 50, 22, 12,   // V11
-            92, 36, 20, 14,   // V12
-            107, 37, 20, 11,  // V13
-            115, 40, 16, 12,  // V14
-            87, 41, 24, 12,   // V15
-            98, 45, 19, 15,   // V16
-            107, 46, 22, 14,  // V17
-            120, 43, 22, 14,  // V18
-            113, 44, 21, 13,  // V19
-            107, 41, 24, 15,  // V20
-            116, 42, 22, 16,  // V21
-            111, 46, 24, 13,  // V22
-            121, 47, 24, 15,  // V23
-            117, 45, 24, 16,  // V24
-            106, 47, 24, 15,  // V25
-            114, 46, 22, 16,  // V26
-            122, 45, 23, 15,  // V27
-            117, 45, 24, 15,  // V28
-            116, 45, 23, 15,  // V29
-            115, 45, 24, 15,  // V30
-            115, 46, 24, 15,  // V31
-            115, 46, 24, 15,  // V32
-            115, 46, 24, 15,  // V33
-            115, 46, 24, 15,  // V34
-            121, 47, 24, 15,  // V35
-            121, 47, 24, 15,  // V36
-            122, 46, 24, 15,  // V37
-            122, 46, 24, 15,  // V38
-            117, 47, 24, 15,  // V39
-            118, 47, 24, 15,  // V40
-        ];
+        return table[((version - 1) * 4) + (int)ecLevel];
+    }
 
-        ReadOnlySpan<byte> group2Blocks =
-        [
-            0, 0, 0, 0,       // V1
-            0, 0, 0, 0,       // V2
-            0, 0, 0, 0,       // V3
-            0, 0, 0, 0,       // V4
-            0, 0, 2, 2,       // V5
-            0, 0, 0, 0,       // V6
-            0, 0, 4, 1,       // V7
-            0, 2, 2, 2,       // V8
-            0, 2, 4, 4,       // V9
-            2, 1, 2, 2,       // V10
-            0, 4, 4, 8,       // V11
-            2, 2, 6, 4,       // V12
-            0, 1, 4, 4,       // V13
-            1, 5, 5, 5,       // V14
-            1, 5, 7, 7,       // V15
-            1, 3, 2, 13,      // V16
-            5, 1, 15, 17,     // V17
-            1, 4, 1, 19,      // V18
-            4, 11, 4, 16,     // V19
-            5, 13, 5, 10,     // V20
-            4, 0, 6, 6,       // V21
-            7, 0, 16, 0,      // V22
-            5, 14, 14, 14,    // V23
-            4, 14, 16, 2,     // V24
-            4, 13, 22, 13,    // V25
-            2, 4, 6, 4,       // V26
-            4, 3, 26, 28,     // V27
-            10, 23, 2, 31,    // V28
-            7, 7, 34, 26,     // V29
-            10, 10, 32, 32,   // V30
-            3, 29, 2, 1,      // V31
-            0, 23, 32, 23,    // V32
-            1, 21, 14, 3,     // V33
-            6, 23, 7, 1,      // V34
-            7, 26, 7, 41,     // V35
-            14, 34, 10, 64,   // V36
-            4, 14, 10, 46,    // V37
-            18, 32, 14, 32,   // V38
-            4, 7, 22, 67,     // V39
-            6, 31, 34, 61,    // V40
-        ];
+    /// <summary>
+    /// Gets the block structure for a given version and EC level.
+    /// Returns (group1Blocks, group1DataCodewords, group2Blocks, group2DataCodewords).
+    /// </summary>
+    /// <remarks>
+    /// ISO/IEC 18004 distributes the data codewords as evenly as possible across the blocks, so the
+    /// split is fully determined by the total codeword count, the EC codewords per block and the
+    /// block count. Deriving it here keeps <see cref="GetDataCodewords"/> and this method from
+    /// disagreeing, which previously produced symbols the error correction encoder could not build.
+    /// </remarks>
+    public static (int Group1Blocks, int Group1DataCodewords, int Group2Blocks, int Group2DataCodewords) GetBlockInfo(int version, ErrorCorrectionLevel ecLevel)
+    {
+        var totalBlocks = GetBlockCount(version, ecLevel);
+        var dataCodewords = GetTotalCodewords(version) - (GetECCodewordsPerBlock(version, ecLevel) * totalBlocks);
 
-        ReadOnlySpan<byte> group2DataCW =
-        [
-            0, 0, 0, 0,       // V1
-            0, 0, 0, 0,       // V2
-            0, 0, 0, 0,       // V3
-            0, 0, 0, 0,       // V4
-            0, 0, 16, 12,     // V5
-            0, 0, 0, 0,       // V6
-            0, 0, 15, 14,     // V7
-            0, 39, 19, 15,    // V8
-            0, 37, 17, 13,    // V9
-            69, 44, 20, 16,   // V10
-            0, 51, 23, 13,    // V11
-            93, 37, 21, 15,   // V12
-            0, 38, 21, 12,    // V13
-            116, 41, 17, 13,  // V14
-            88, 42, 25, 13,   // V15
-            99, 46, 20, 16,   // V16
-            108, 47, 23, 15,  // V17
-            121, 44, 23, 15,  // V18
-            114, 45, 22, 14,  // V19
-            108, 42, 25, 16,  // V20
-            117, 0, 23, 17,   // V21
-            112, 0, 25, 0,    // V22
-            122, 48, 25, 16,  // V23
-            118, 46, 25, 17,  // V24
-            107, 48, 25, 16,  // V25
-            115, 47, 23, 17,  // V26
-            123, 46, 24, 16,  // V27
-            118, 46, 25, 16,  // V28
-            117, 46, 24, 16,  // V29
-            116, 46, 25, 16,  // V30
-            116, 47, 25, 16,  // V31
-            0, 47, 25, 16,    // V32
-            116, 47, 25, 16,  // V33
-            116, 47, 25, 16,  // V34
-            122, 48, 25, 16,  // V35
-            122, 48, 25, 16,  // V36
-            123, 47, 25, 16,  // V37
-            123, 47, 25, 16,  // V38
-            118, 48, 25, 16,  // V39
-            119, 48, 25, 16,  // V40
-        ];
+        var group2Blocks = dataCodewords % totalBlocks;
+        var group1Blocks = totalBlocks - group2Blocks;
+        var group1DataCodewords = dataCodewords / totalBlocks;
 
-        var idx = ((version - 1) * 4) + (int)ecLevel;
-
-        return (group1Blocks[idx], group1DataCW[idx], group2Blocks[idx], group2DataCW[idx]);
+        return (group1Blocks, group1DataCodewords, group2Blocks, group1DataCodewords + 1);
     }
 
     /// <summary>

--- a/tests/Meziantou.Framework.QRCode.Tests/QRCodeTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/QRCodeTests.cs
@@ -401,9 +401,18 @@ public class QRCodeTests
     [Fact]
     public void Create_AlphanumericDataTooLong_ThrowsInvalidOperationException()
     {
-        var longData = new string('A', 660);
+        // Version 40-Q holds 2420 alphanumeric characters.
+        var longData = new string('A', 2421);
 
         Assert.Throws<InvalidOperationException>(() => QRCode.Create(longData, ErrorCorrectionLevel.Q));
+    }
+
+    [Fact]
+    public void Create_AlphanumericAtMaximumCapacity_Succeeds()
+    {
+        var qr = QRCode.Create(new string('A', 2420), ErrorCorrectionLevel.Q);
+
+        Assert.Equal(40, qr.Version);
     }
 
     // ───── Determinism ─────
@@ -510,5 +519,89 @@ public class QRCodeTests
         }
 
         return version;
+    }
+
+    // ───── Capacity tables (ISO/IEC 18004 Table 7/9) ─────
+
+    /// <summary>
+    /// Maximum byte-mode payload for each version, indexed by L, M, Q, H.
+    /// </summary>
+    private static readonly int[][] ByteCapacities =
+    [
+        [17, 14, 11, 7], [32, 26, 20, 14], [53, 42, 32, 24], [78, 62, 46, 34],
+        [106, 84, 60, 44], [134, 106, 74, 58], [154, 122, 86, 64], [192, 152, 108, 84],
+        [230, 180, 130, 98], [271, 213, 151, 119], [321, 251, 177, 137], [367, 287, 203, 155],
+        [425, 331, 241, 177], [458, 362, 258, 194], [520, 412, 292, 220], [586, 450, 322, 250],
+        [644, 504, 364, 280], [718, 560, 394, 310], [792, 624, 442, 338], [858, 666, 482, 382],
+        [929, 711, 509, 403], [1003, 779, 565, 439], [1091, 857, 611, 461], [1171, 911, 661, 511],
+        [1273, 997, 715, 535], [1367, 1059, 751, 593], [1465, 1125, 805, 625], [1528, 1190, 868, 658],
+        [1628, 1264, 908, 698], [1732, 1370, 982, 742], [1840, 1452, 1030, 790], [1952, 1538, 1112, 842],
+        [2068, 1628, 1168, 898], [2188, 1722, 1228, 958], [2303, 1809, 1283, 983], [2431, 1911, 1351, 1051],
+        [2563, 1989, 1423, 1093], [2699, 2099, 1499, 1139], [2809, 2213, 1579, 1219], [2953, 2331, 1663, 1273],
+    ];
+
+    public static TheoryData<int, ErrorCorrectionLevel> AllVersionsAndErrorCorrectionLevels()
+    {
+        var data = new TheoryData<int, ErrorCorrectionLevel>();
+        foreach (var ecLevel in new[] { ErrorCorrectionLevel.L, ErrorCorrectionLevel.M, ErrorCorrectionLevel.Q, ErrorCorrectionLevel.H })
+        {
+            for (var version = 1; version <= 40; version++)
+            {
+                data.Add(version, ecLevel);
+            }
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(AllVersionsAndErrorCorrectionLevels))]
+    public void Create_AtMaximumCapacity_SelectsExpectedVersion(int version, ErrorCorrectionLevel ecLevel)
+    {
+        var capacity = ByteCapacities[version - 1][(int)ecLevel];
+        var payload = new byte[capacity];
+        for (var i = 0; i < payload.Length; i++)
+        {
+            payload[i] = (byte)('0' + (i % 10));
+        }
+
+        var qr = QRCode.Create(payload, ecLevel);
+
+        Assert.Equal(version, qr.Version);
+        Assert.Equal(17 + (version * 4), qr.Size);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllVersionsAndErrorCorrectionLevels))]
+    public void Create_OneByteOverCapacity_MovesToTheNextVersion(int version, ErrorCorrectionLevel ecLevel)
+    {
+        var payload = new byte[ByteCapacities[version - 1][(int)ecLevel] + 1];
+
+        if (version == 40)
+        {
+            Assert.Throws<InvalidOperationException>(() => QRCode.Create(payload, ecLevel));
+            return;
+        }
+
+        Assert.Equal(version + 1, QRCode.Create(payload, ecLevel).Version);
+    }
+
+    [Theory]
+    [InlineData(ErrorCorrectionLevel.L)]
+    [InlineData(ErrorCorrectionLevel.M)]
+    [InlineData(ErrorCorrectionLevel.Q)]
+    [InlineData(ErrorCorrectionLevel.H)]
+    public void Create_VersionSelectionIsMonotonicInPayloadLength(ErrorCorrectionLevel ecLevel)
+    {
+        // A non-monotonic capacity table lets DetermineVersion skip versions, which produces a
+        // needlessly large symbol for some lengths and no symbol at all for others.
+        var maximum = ByteCapacities[^1][(int)ecLevel];
+        var previousVersion = 0;
+        for (var length = 1; length <= maximum; length++)
+        {
+            var version = QRCode.Create(new byte[length], ecLevel).Version;
+            Assert.True(version >= previousVersion, $"Payload of {length} bytes selected version {version} after version {previousVersion}.");
+            previousVersion = version;
+        }
     }
 }


### PR DESCRIPTION
## The problem

`QRCodeVersion.GetDataCodewords` derived the data codeword count arithmetically
(`GetTotalCodewords − ecPerBlock × blocks`) while `GetBlockInfo` returned a separate,
hand-entered block split. The two disagreed for **19 of the 160 (version, EC level)
combinations**, so `ErrorCorrectionEncoder.AddErrorCorrection` either tripped its own
consistency check (`Internal/ErrorCorrectionEncoder.cs:35-38`) or read past the end of the
data array.

`GetECCodewordsPerBlock` was also wrong for V20‑Q, V21‑Q, V21‑H, V22‑Q and V22‑H.

The result: `QRCode.Create` threw `InvalidOperationException("The data is too long to be
encoded in a QR code.")` on ordinary, in-capacity payloads.

```csharp
QRCode.Create(new string('a', 1400), ErrorCorrectionLevel.H);
// InvalidOperationException: The data is too long to be encoded in a QR code.
```

Sweeping every valid byte length through `QRCode.Create`, before this change:

| EC level | Byte lengths that threw | Failing ranges |
|---|---|---|
| L | 0 / 2 953 | — |
| M | 106 / 2 331 (4.5 %) | 1265–1370 |
| **Q** | **949 / 1 663 (57 %)** | 443–703, 806–1493 |
| **H** | **611 / 1 273 (48 %)** | 383–453, 659–1198 |

A second symptom: because the derived capacity was wrong, the capacity sequence was
non‑monotonic and `DetermineVersion`'s "first version that fits" loop skipped versions.
`Create(1199 bytes, H)` returned a **version 39** symbol where version 34 was correct —
165×165 instead of 149×149.

Present since the package was introduced in #1228.

## The change

ISO/IEC 18004 distributes data codewords as evenly as possible across the blocks, so the
split is fully determined by the total codeword count, the EC codewords per block, and the
block count. This stores only the block count and derives the rest:

```csharp
var group2Blocks = dataCodewords % totalBlocks;
var group1Blocks = totalBlocks - group2Blocks;
var group1DataCodewords = dataCodewords / totalBlocks;
```

`GetDataCodewords` now derives from `GetBlockInfo` rather than running a parallel
calculation, so the two cannot diverge again.

## Verification

The committed tests pin every version and EC level against the **byte capacities in ISO/IEC
18004 Table 7**. Capacity is computed from the codeword tables, so a wrong entry changes a
capacity and fails the test — the assertions are anchored to the standard, not to this
library's own output.

- `Create_AtMaximumCapacity_SelectsExpectedVersion` and
  `Create_OneByteOverCapacity_MovesToTheNextVersion` — `[Theory]` over all 160 combinations.
- `Create_VersionSelectionIsMonotonicInPayloadLength` — guards the non-monotonicity.

`Create_AlphanumericDataTooLong_ThrowsInvalidOperationException` was asserting that 660
alphanumeric characters at Q throws. It only threw because of this bug; the real V40‑Q limit
is 2420. Corrected, and paired with a test that 2420 succeeds.

637 tests pass on net10.0 and net11.0. `dotnet run ./eng/update-all.cs` is clean.

**Checked additionally while developing, not in CI:** all 8 220 valid byte lengths across the
four EC levels now encode (0 failures, down from 1 666), and all 160 combinations were
round-tripped through an external decoder at their exact ISO capacity — 160/160 decoded back
to the original bytes. That reader was used to derive and confirm the tables; it is
deliberately **not** taken as a test dependency, so CI does not repeat that check.
