### PR TITLE
Pin the module patterns of every barcode symbology

### DIFF
--- a/tests/Meziantou.Framework.QRCode.Tests/BarCode128Tests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/BarCode128Tests.cs
@@ -228,4 +228,17 @@ public class BarCode128Tests
 
         return (width, height);
     }
+
+    // ───── Module patterns ─────
+    //
+    // Produced from this encoder's output and confirmed to decode back to the payload with an
+    // external reader (ZXing) while the tests were written.
+
+    [Theory]
+    [InlineData("SKU-123456", "110100100001101110100010110001110110111011101001101110010111011110101100111001000101100011100010110111011010001100011101011")]
+    [InlineData("12345678", "1101001110010110011100100010110001110001011011000010100100011101101100011101011")]
+    public void CreateCode128_ProducesTheExpectedModules(string data, string expected)
+    {
+        Assert.Equal(expected, BarcodeModulePattern.Render(Barcode.CreateCode128(data)));
+    }
 }

--- a/tests/Meziantou.Framework.QRCode.Tests/BarCode39Tests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/BarCode39Tests.cs
@@ -203,4 +203,30 @@ public class BarCode39Tests
 
         return (width, height);
     }
+
+    // ───── Module patterns ─────
+    //
+    // The expected patterns were produced from this encoder's output and each one was confirmed
+    // to decode back to the documented payload with an external reader (ZXing) while the tests
+    // were written. Pinning the modules keeps a change that still renders a plausible-looking
+    // barcode, but an unreadable one, from passing.
+
+    [Theory]
+    [InlineData("ABC-123", "10010110110101101010010110101101001011011011010010101001010110110110100101011010110010101101101100101010100101101101")]
+    [InlineData("A", "10010110110101101010010110100101101101")]
+    public void CreateCode39_ProducesTheExpectedModules(string data, string expected)
+    {
+        Assert.Equal(expected, BarcodeModulePattern.Render(Barcode.CreateCode39(data)));
+    }
+
+    [Fact]
+    public void CreateCode39_WithChecksum_ProducesTheExpectedModules()
+    {
+        // Decodes as "ABC-123" once the reader validates and strips the Mod 43 check digit.
+        var barcode = Barcode.CreateCode39("ABC-123", includeChecksum: true);
+
+        Assert.Equal(
+            "100101101101011010100101101011010010110110110100101010010101101101101001010110101100101011011011001010101100110101010100101101101",
+            BarcodeModulePattern.Render(barcode));
+    }
 }

--- a/tests/Meziantou.Framework.QRCode.Tests/BarCodeAdditionalTypesTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/BarCodeAdditionalTypesTests.cs
@@ -402,4 +402,66 @@ public class BarCodeAdditionalTypesTests
             }
         }
     }
+
+    // ───── Module patterns ─────
+    //
+    // Produced from this encoder's output and each confirmed to decode back to the documented
+    // payload with an external reader (ZXing) while the tests were written. These symbologies had
+    // no coverage beyond image snapshots, so a wrong parity or check digit would have rendered
+    // cleanly and gone unnoticed.
+
+    [Fact]
+    public void CreateCode93_ProducesTheExpectedModules()
+    {
+        // Decodes as "ABC123".
+        Assert.Equal(
+            "1010111101101010001101001001101000101010010001010001001010000101011011001000010101010111101",
+            BarcodeModulePattern.Render(Barcode.CreateCode93("ABC123")));
+    }
+
+    [Fact]
+    public void CreateEan8_ProducesTheExpectedModules()
+    {
+        // Decodes as "55123457" - the encoder appends the check digit.
+        Assert.Equal(
+            "1010110001011000100110010010011010101000010101110010011101000100101",
+            BarcodeModulePattern.Render(Barcode.CreateEan8("5512345")));
+    }
+
+    [Fact]
+    public void CreateEan13_ProducesTheExpectedModules()
+    {
+        // Decodes as "4006381333931". The first digit is carried by the left-group parity rather
+        // than by a symbol of its own, so a wrong parity row silently changes the leading digit.
+        Assert.Equal(
+            "10100011010100111010111101111010001001011001101010100001010000101000010111010010000101100110101",
+            BarcodeModulePattern.Render(Barcode.CreateEan13("400638133393")));
+    }
+
+    [Fact]
+    public void CreateUpcA_ProducesTheExpectedModules()
+    {
+        // Decodes as "036000291452".
+        Assert.Equal(
+            "10100011010111101010111100011010001101000110101010110110011101001100110101110010011101101100101",
+            BarcodeModulePattern.Render(Barcode.CreateUpcA("03600029145")));
+    }
+
+    [Fact]
+    public void CreateCodabar_ProducesTheExpectedModules()
+    {
+        // Decodes as "A40156B" when the reader is asked to keep the start and stop guards.
+        Assert.Equal(
+            "10110010010101101001010101001101010110010110101001010010101101001001011",
+            BarcodeModulePattern.Render(Barcode.CreateCodabar("40156", startCharacter: 'A', stopCharacter: 'B')));
+    }
+
+    [Fact]
+    public void CreateItf_ProducesTheExpectedModules()
+    {
+        // Decodes as "12345678".
+        Assert.Equal(
+            "101011101000101011100011101110100010100011101000111000101010001010111000111011101",
+            BarcodeModulePattern.Render(Barcode.CreateItf("12345678")));
+    }
 }

--- a/tests/Meziantou.Framework.QRCode.Tests/BarcodeModulePattern.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/BarcodeModulePattern.cs
@@ -1,0 +1,18 @@
+namespace Meziantou.Framework.Tests;
+
+internal static class BarcodeModulePattern
+{
+    /// <summary>
+    /// Renders a barcode as one character per module, <c>1</c> for a bar and <c>0</c> for a space.
+    /// </summary>
+    public static string Render(Barcode barcode)
+    {
+        var sb = new StringBuilder(barcode.Width);
+        for (var column = 0; column < barcode.Width; column++)
+        {
+            sb.Append(barcode[0, column] ? '1' : '0');
+        }
+
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
## The problem

The barcode encoders had **no coverage beyond image snapshots**. Every test rendered to SVG or
PNG and compared against a committed file, so the suite recorded what the encoder *did*, not
whether the result was readable.

That matters here because these eight symbologies are built from hand-entered tables and
hand-written checksum algorithms — Code 93's extended-ASCII shift mapping, EAN‑13's left-group
parity rows, the UPC/EAN check digit, Code 39's Mod 43 check digit, Code 128's code-set
switching. A wrong entry in any of them renders a barcode that looks completely normal and that
no scanner can read. The snapshot would be regenerated and the change would look clean.

## The change

Pins the exact module pattern for all eight symbologies: Code 39 (with and without the Mod 43
check digit), Code 93, Code 128 in both code sets, EAN‑8, EAN‑13, UPC‑A, Codabar and ITF.

The expected patterns come from this encoder's output, and **each one was confirmed to decode
back to the documented payload with an external reader while the tests were written** — so the
values being pinned are known-readable rather than merely current. The payload each pattern
decodes to is recorded in a comment beside it:

```csharp
[Fact]
public void CreateEan13_ProducesTheExpectedModules()
{
    // Decodes as "4006381333931". The first digit is carried by the left-group parity rather
    // than by a symbol of its own, so a wrong parity row silently changes the leading digit.
    Assert.Equal("101000110101001110101111011110100010010110011010101000010100001010000101110100100001011001101 01", ...);
}
```

**The reader is not taken as a dependency.** No package reference is added, and nothing in the
test project imports it.

## What this does and does not give you

It is still a golden-value test: it will catch any change to the emitted modules, and it tells
a reviewer what those modules are supposed to mean. It does **not** re-verify readability on
every run — if someone deliberately regenerates a pattern, nothing checks that the new one
decodes. Live decoding in CI would close that gap, at the cost of the dependency.

Module patterns rather than more image snapshots because they are readable in a diff, are
independent of renderer settings, and put the decoded payload next to the bits it comes from.

## Verification

323 tests pass on net10.0 and net11.0. `dotnet run ./eng/update-all.cs` is clean.

Originally opened stacked on #2298; with the external reader out of the test project this no
longer depends on it, so it now targets `main` and the two can merge in either order.
