### PR TITLE
Reject control characters and out-of-range values in SepaPayment

### DIFF
--- a/src/Meziantou.Framework.QRCode/QRCodePayload.cs
+++ b/src/Meziantou.Framework.QRCode/QRCodePayload.cs
@@ -452,26 +452,68 @@ public static class QRCodePayload
             throw new ArgumentException("Only one of remittanceReference or remittanceText can be specified.", nameof(remittanceReference));
         }
 
+        ValidateSepaField(beneficiaryName, 70, nameof(beneficiaryName));
+        ValidateSepaField(iban, 34, nameof(iban));
+        ValidateSepaField(bic, 11, nameof(bic));
+        ValidateSepaField(remittanceReference, 35, nameof(remittanceReference));
+        ValidateSepaField(remittanceText, 140, nameof(remittanceText));
+        ValidateSepaField(information, 70, nameof(information));
+
+        if (amount is < 0.01m or > 999999999.99m)
+        {
+            throw new ArgumentOutOfRangeException(nameof(amount), amount, "The amount must be between 0.01 and 999999999.99.");
+        }
+
+        // EPC069-12 separates the twelve elements with a line feed, so the separator is written
+        // explicitly rather than through AppendLine, whose separator depends on the platform.
         var sb = new StringBuilder();
-        sb.AppendLine("BCD");         // Service Tag
-        sb.AppendLine("002");         // Version
-        sb.AppendLine("1");           // Character set (1 = UTF-8)
-        sb.AppendLine("SCT");         // Identification code
-        sb.AppendLine(bic ?? "");     // BIC
-        sb.AppendLine(beneficiaryName);
-        sb.AppendLine(iban);
-        sb.Append("EUR");
-        sb.AppendLine(amount.ToString("F2", CultureInfo.InvariantCulture));
+        sb.Append("BCD\n");                     // Service Tag
+        sb.Append("002\n");                     // Version
+        sb.Append("1\n");                       // Character set (1 = UTF-8)
+        sb.Append("SCT\n");                     // Identification code
+        sb.Append(bic).Append('\n');            // BIC
+        sb.Append(beneficiaryName).Append('\n');
+        sb.Append(iban).Append('\n');
+        sb.Append("EUR").Append(amount.ToString("F2", CultureInfo.InvariantCulture)).Append('\n');
 
         // Purpose (empty)
-        sb.AppendLine("");
+        sb.Append('\n');
 
         // Remittance reference (structured) or text (unstructured)
-        sb.AppendLine(remittanceReference ?? "");
-        sb.AppendLine(remittanceText ?? "");
+        sb.Append(remittanceReference).Append('\n');
+        sb.Append(remittanceText).Append('\n');
 
-        sb.Append(information ?? "");
+        sb.Append(information);
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Validates a single EPC element.
+    /// </summary>
+    /// <remarks>
+    /// EPC069-12 is positional and has no escape mechanism, so a control character in a value
+    /// cannot be represented. A line feed would shift every following element down by one and
+    /// silently redirect the payment, so the value is rejected rather than mangled.
+    /// </remarks>
+    private static void ValidateSepaField(string? value, int maxLength, string parameterName)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        foreach (var c in value)
+        {
+            if (char.IsControl(c))
+            {
+                throw new ArgumentException($"The value cannot contain control characters because the EPC format cannot escape them.", parameterName);
+            }
+        }
+
+        if (value.Length > maxLength)
+        {
+            throw new ArgumentException($"The value cannot exceed {maxLength} characters.", parameterName);
+        }
     }
 
     private static void AppendMeCardEscaped(StringBuilder sb, string value)

--- a/tests/Meziantou.Framework.QRCode.Tests/QRCodePayloadTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/QRCodePayloadTests.cs
@@ -375,20 +375,7 @@ public class QRCodePayloadTests
             bic: "COBADEFFXXX",
             remittanceText: "Donation");
 
-        Assert.Equal("""
-            BCD
-            002
-            1
-            SCT
-            COBADEFFXXX
-            Red Cross
-            DE89370400440532013000
-            EUR12.50
-
-
-            Donation
-
-            """, payload, ignoreLineEndingDifferences: true);
+        Assert.Equal("BCD\n002\n1\nSCT\nCOBADEFFXXX\nRed Cross\nDE89370400440532013000\nEUR12.50\n\n\nDonation\n", payload);
     }
 
     [Fact]
@@ -399,20 +386,7 @@ public class QRCodePayloadTests
             "NL91ABNA0417164300",
             100.00m);
 
-        Assert.Equal("""
-            BCD
-            002
-            1
-            SCT
-
-            John Doe
-            NL91ABNA0417164300
-            EUR100.00
-
-
-
-
-            """, payload, ignoreLineEndingDifferences: true);
+        Assert.Equal("BCD\n002\n1\nSCT\n\nJohn Doe\nNL91ABNA0417164300\nEUR100.00\n\n\n\n", payload);
     }
 
     [Fact]
@@ -424,20 +398,7 @@ public class QRCodePayloadTests
             50.00m,
             remittanceReference: "RF18539007547034");
 
-        Assert.Equal("""
-            BCD
-            002
-            1
-            SCT
-
-            Company
-            DE89370400440532013000
-            EUR50.00
-
-            RF18539007547034
-
-
-            """, payload, ignoreLineEndingDifferences: true);
+        Assert.Equal("BCD\n002\n1\nSCT\n\nCompany\nDE89370400440532013000\nEUR50.00\n\nRF18539007547034\n\n", payload);
     }
 
     [Fact]
@@ -458,6 +419,72 @@ public class QRCodePayloadTests
     public void SepaPayment_ThrowsWhenIbanIsNull()
     {
         Assert.Throws<ArgumentNullException>(() => QRCodePayload.SepaPayment("Name", null!, 10m));
+    }
+
+    [Theory]
+    [InlineData("Bob\nDE00ATTACKERIBAN0000\nEUR999.00")]
+    [InlineData("Bob\rDE00ATTACKERIBAN0000")]
+    [InlineData("Bob\r\nDE00ATTACKERIBAN0000")]
+    public void SepaPayment_ThrowsWhenBeneficiaryNameContainsANewLine(string beneficiaryName)
+    {
+        // EPC069-12 is positional: a new line in one element shifts every later element down,
+        // which lets a caller-supplied name replace the IBAN the payer sends money to.
+        Assert.Throws<ArgumentException>(() => QRCodePayload.SepaPayment(beneficiaryName, "DE89370400440532013000", 10m));
+    }
+
+    [Fact]
+    public void SepaPayment_ThrowsWhenIbanContainsANewLine()
+    {
+        Assert.Throws<ArgumentException>(() => QRCodePayload.SepaPayment("Name", "DE89370400440532013000\nEUR999.00", 10m));
+    }
+
+    [Fact]
+    public void SepaPayment_ThrowsWhenBicContainsANewLine()
+    {
+        Assert.Throws<ArgumentException>(() => QRCodePayload.SepaPayment("Name", "DE89370400440532013000", 10m, bic: "COBA\nDEFF"));
+    }
+
+    [Fact]
+    public void SepaPayment_ThrowsWhenRemittanceTextContainsANewLine()
+    {
+        Assert.Throws<ArgumentException>(() => QRCodePayload.SepaPayment("Name", "DE89370400440532013000", 10m, remittanceText: "Invoice\n1"));
+    }
+
+    [Fact]
+    public void SepaPayment_ThrowsWhenInformationContainsANewLine()
+    {
+        Assert.Throws<ArgumentException>(() => QRCodePayload.SepaPayment("Name", "DE89370400440532013000", 10m, information: "Thanks\nBye"));
+    }
+
+    [Fact]
+    public void SepaPayment_ThrowsWhenBeneficiaryNameIsTooLong()
+    {
+        Assert.Throws<ArgumentException>(() => QRCodePayload.SepaPayment(new string('a', 71), "DE89370400440532013000", 10m));
+    }
+
+    [Fact]
+    public void SepaPayment_ThrowsWhenRemittanceTextIsTooLong()
+    {
+        Assert.Throws<ArgumentException>(() => QRCodePayload.SepaPayment("Name", "DE89370400440532013000", 10m, remittanceText: new string('a', 141)));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(0.009)]
+    [InlineData(1000000000)]
+    public void SepaPayment_ThrowsWhenAmountIsOutOfRange(decimal amount)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => QRCodePayload.SepaPayment("Name", "DE89370400440532013000", amount));
+    }
+
+    [Fact]
+    public void SepaPayment_UsesLineFeedRegardlessOfPlatform()
+    {
+        var payload = QRCodePayload.SepaPayment("Name", "DE89370400440532013000", 10m);
+
+        Assert.DoesNotContain('\r', payload);
+        Assert.Equal(11, payload.Count(c => c == '\n'));
     }
 
     // Edge cases for encoding and special characters
@@ -534,20 +561,7 @@ public class QRCodePayloadTests
     {
         var payload = QRCodePayload.SepaPayment("Doe", "DE89370400440532013000", 25.00m, information: "Thank you");
 
-        Assert.Equal("""
-            BCD
-            002
-            1
-            SCT
-
-            Doe
-            DE89370400440532013000
-            EUR25.00
-
-
-
-            Thank you
-            """, payload, ignoreLineEndingDifferences: true);
+        Assert.Equal("BCD\n002\n1\nSCT\n\nDoe\nDE89370400440532013000\nEUR25.00\n\n\n\nThank you", payload);
     }
 
     [Fact]


### PR DESCRIPTION
## The problem

`QRCodePayload.SepaPayment` builds an EPC069-12 payload — twelve **positional**,
line-separated elements — with no validation or escaping of caller-supplied values
(`QRCodePayload.cs:445-475`).

A line feed in any field shifts every later element down by one. Because the format has
exactly twelve elements, the genuine values fall past the end and are ignored:

```csharp
QRCodePayload.SepaPayment(
    "Bob\nDE00ATTACKERIBAN000000\nEUR999.00\n\n\nUrgent",
    "DE89370400440532013000",
    10.00m);
```

```
BCD / 002 / 1 / SCT / (bic) / Bob / DE00ATTACKERIBAN000000 / EUR999.00 / / / Urgent
   ← a complete, well-formed EPC payment for 999 EUR to the attacker's IBAN
DE89370400440532013000 / EUR10.00 / / /      ← real IBAN and amount, past element 12, ignored
```

The caller gets **no error** and a payload that scans cleanly in a banking app — the payer
sees a legitimate-looking transfer to the wrong account. The same hole existed in `bic`,
`iban`, `remittanceReference`, `remittanceText` and `information`.

This matters wherever a payee name, reference or note comes from outside the developer's
control: donation pages, invoicing SaaS, marketplaces, anything multi-tenant. Every other
builder in this file (`Wifi`, `MeCard`, and the query parameters of `Email` and `Bitcoin`)
already escapes its delimiters, so a caller has good reason to assume this one does too.

## The change

- **Reject** control characters in every EPC element rather than stripping them. EPC069-12
  has no escape mechanism, so a control character is unrepresentable — silently mangling a
  payment field would be worse than throwing.
- Enforce the field lengths the XML documentation already promised (name ≤ 70, remittance
  text ≤ 140, information ≤ 70, reference ≤ 35, BIC ≤ 11, IBAN ≤ 34).
- Enforce the documented amount range of 0.01–999999999.99.
- Write the element separator as an explicit `\n`. EPC069-12 **requires LF**, but
  `AppendLine` emits `Environment.NewLine`, so the payload was CRLF on Windows and LF
  elsewhere — the same input produced different bytes per platform.

## Verification

326 tests pass. New coverage: newline injection in each of the five caller-controlled
fields, the length limits, the amount range, and an assertion that the payload contains no
`\r` and exactly eleven `\n`.

The four existing payload assertions dropped `ignoreLineEndingDifferences: true` and now
pin the exact LF bytes — that flag was hiding the platform dependence.
