### PR TITLE
Escape vCard and iCalendar values and separate lines with CRLF

### DIFF
--- a/src/Meziantou.Framework.QRCode/QRCodePayload.cs
+++ b/src/Meziantou.Framework.QRCode/QRCodePayload.cs
@@ -64,58 +64,35 @@ public static class QRCodePayload
         ArgumentNullException.ThrowIfNull(lastName);
 
         var sb = new StringBuilder();
-        sb.AppendLine("BEGIN:VCARD");
-        sb.AppendLine("VERSION:3.0");
+        sb.Append("BEGIN:VCARD").Append(CrLf);
+        sb.Append("VERSION:3.0").Append(CrLf);
         sb.Append("N:");
-        sb.Append(lastName);
+        AppendVCardEscaped(sb, lastName);
         sb.Append(';');
-        sb.Append(firstName);
-        sb.AppendLine(";;;");
+        AppendVCardEscaped(sb, firstName);
+        sb.Append(";;;").Append(CrLf);
 
         sb.Append("FN:");
         if (firstName is not null)
         {
-            sb.Append(firstName);
+            AppendVCardEscaped(sb, firstName);
             sb.Append(' ');
         }
 
-        sb.AppendLine(lastName);
+        AppendVCardEscaped(sb, lastName);
+        sb.Append(CrLf);
 
-        if (phone is not null)
-        {
-            sb.Append("TEL:");
-            sb.AppendLine(phone);
-        }
-
-        if (email is not null)
-        {
-            sb.Append("EMAIL:");
-            sb.AppendLine(email);
-        }
-
-        if (organization is not null)
-        {
-            sb.Append("ORG:");
-            sb.AppendLine(organization);
-        }
-
-        if (title is not null)
-        {
-            sb.Append("TITLE:");
-            sb.AppendLine(title);
-        }
-
-        if (url is not null)
-        {
-            sb.Append("URL:");
-            sb.AppendLine(url);
-        }
+        AppendVCardProperty(sb, "TEL:", phone);
+        AppendVCardProperty(sb, "EMAIL:", email);
+        AppendVCardProperty(sb, "ORG:", organization);
+        AppendVCardProperty(sb, "TITLE:", title);
+        AppendVCardProperty(sb, "URL:", url);
 
         if (address is not null)
         {
             sb.Append("ADR:;;");
-            sb.Append(address);
-            sb.AppendLine(";;;;");
+            AppendVCardEscaped(sb, address);
+            sb.Append(";;;;").Append(CrLf);
         }
 
         sb.Append("END:VCARD");
@@ -214,28 +191,75 @@ public static class QRCodePayload
         ArgumentNullException.ThrowIfNull(summary);
 
         var sb = new StringBuilder();
-        sb.AppendLine("BEGIN:VEVENT");
-        sb.Append("SUMMARY:");
-        sb.AppendLine(summary);
-        sb.Append("DTSTART:");
-        sb.AppendLine(start.ToUniversalTime().ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture));
-        sb.Append("DTEND:");
-        sb.AppendLine(end.ToUniversalTime().ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture));
+        sb.Append("BEGIN:VEVENT").Append(CrLf);
+        AppendVCardProperty(sb, "SUMMARY:", summary);
+        sb.Append("DTSTART:").Append(start.ToUniversalTime().ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture)).Append(CrLf);
+        sb.Append("DTEND:").Append(end.ToUniversalTime().ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture)).Append(CrLf);
 
-        if (location is not null)
-        {
-            sb.Append("LOCATION:");
-            sb.AppendLine(location);
-        }
-
-        if (description is not null)
-        {
-            sb.Append("DESCRIPTION:");
-            sb.AppendLine(description);
-        }
+        AppendVCardProperty(sb, "LOCATION:", location);
+        AppendVCardProperty(sb, "DESCRIPTION:", description);
 
         sb.Append("END:VEVENT");
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// vCard 3.0 and iCalendar both require CRLF between content lines (RFC 6350 and RFC 5545),
+    /// so the separator is written explicitly instead of through <see cref="StringBuilder.AppendLine()"/>,
+    /// whose separator depends on the platform.
+    /// </summary>
+    private const string CrLf = "\r\n";
+
+    private static void AppendVCardProperty(StringBuilder sb, string name, string? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        sb.Append(name);
+        AppendVCardEscaped(sb, value);
+        sb.Append(CrLf);
+    }
+
+    /// <summary>
+    /// Escapes a vCard 3.0 / iCalendar text value per RFC 6350 section 3.4 and RFC 5545 section 3.3.11.
+    /// </summary>
+    /// <remarks>
+    /// Without this, a value containing a new line injects arbitrary properties into the card, and
+    /// the far more common case of a name or address containing <c>;</c> or <c>,</c> silently
+    /// changes which structured component the text lands in.
+    /// </remarks>
+    private static void AppendVCardEscaped(StringBuilder sb, string? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\':
+                    sb.Append("\\\\");
+                    break;
+                case ';':
+                    sb.Append("\\;");
+                    break;
+                case ',':
+                    sb.Append("\\,");
+                    break;
+                case '\r':
+                    break;
+                case '\n':
+                    sb.Append("\\n");
+                    break;
+                default:
+                    sb.Append(c);
+                    break;
+            }
+        }
     }
 
     /// <summary>

--- a/tests/Meziantou.Framework.QRCode.Tests/QRCodePayloadTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/QRCodePayloadTests.cs
@@ -64,19 +64,10 @@ public class QRCodePayloadTests
             organization: "ACME", title: "Engineer",
             url: "https://example.com", address: "123 Main St");
 
-        Assert.Equal("""
-            BEGIN:VCARD
-            VERSION:3.0
-            N:Doe;John;;;
-            FN:John Doe
-            TEL:+1234567890
-            EMAIL:john@example.com
-            ORG:ACME
-            TITLE:Engineer
-            URL:https://example.com
-            ADR:;;123 Main St;;;;
-            END:VCARD
-            """, payload, ignoreLineEndingDifferences: true);
+        Assert.Equal(
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;John;;;\r\nFN:John Doe\r\nTEL:+1234567890\r\n" +
+            "EMAIL:john@example.com\r\nORG:ACME\r\nTITLE:Engineer\r\nURL:https://example.com\r\n" +
+            "ADR:;;123 Main St;;;;\r\nEND:VCARD", payload);
     }
 
     [Fact]
@@ -84,19 +75,69 @@ public class QRCodePayloadTests
     {
         var payload = QRCodePayload.VCard("Doe");
 
-        Assert.Equal("""
-            BEGIN:VCARD
-            VERSION:3.0
-            N:Doe;;;;
-            FN:Doe
-            END:VCARD
-            """, payload, ignoreLineEndingDifferences: true);
+        Assert.Equal("BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;;;;\r\nFN:Doe\r\nEND:VCARD", payload);
     }
 
     [Fact]
     public void VCard_ThrowsWhenLastNameIsNull()
     {
         Assert.Throws<ArgumentNullException>(() => QRCodePayload.VCard(null!));
+    }
+
+    [Fact]
+    public void VCard_EscapesStructuralCharactersInNames()
+    {
+        // A surname containing ';' previously produced a six-component N: field, so importers
+        // read "Jr" as the given name.
+        var payload = QRCodePayload.VCard("van der Berg; Jr", "Jan");
+
+        Assert.Equal(@"BEGIN:VCARD" + "\r\n" + @"VERSION:3.0" + "\r\n" + @"N:van der Berg\; Jr;Jan;;;" + "\r\n" + @"FN:Jan van der Berg\; Jr" + "\r\nEND:VCARD", payload);
+    }
+
+    [Fact]
+    public void VCard_EscapesCommasAndBackslashes()
+    {
+        var payload = QRCodePayload.VCard("Doe", address: @"1 Main St, Apt \ 2");
+
+        Assert.Contains(@"ADR:;;1 Main St\, Apt \\ 2;;;;", payload);
+    }
+
+    [Theory]
+    [InlineData("a@b.com\r\nTEL:+19999999999")]
+    [InlineData("a@b.com\nURL:https://evil.example")]
+    public void VCard_NewLineInAValueCannotInjectAProperty(string email)
+    {
+        var payload = QRCodePayload.VCard("Doe", "John", email: email);
+
+        // Exactly five content lines: BEGIN, VERSION, N, FN, EMAIL, END.
+        Assert.Equal(5, payload.Split("\r\n").Length - 1);
+        Assert.DoesNotContain("\r\nTEL:", payload);
+        Assert.DoesNotContain("\r\nURL:", payload);
+    }
+
+    [Fact]
+    public void VCard_UsesCarriageReturnLineFeedRegardlessOfPlatform()
+    {
+        var payload = QRCodePayload.VCard("Doe");
+
+        Assert.Equal(4, payload.Split("\r\n").Length - 1);
+        Assert.DoesNotContain("\n", payload.Replace("\r\n", "", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CalendarEvent_NewLineInSummaryCannotInjectASecondEvent()
+    {
+        var payload = QRCodePayload.CalendarEvent(
+            "Meeting\r\nEND:VEVENT\r\nBEGIN:VEVENT\r\nSUMMARY:Injected",
+            new DateTime(2025, 1, 1, 9, 0, 0, DateTimeKind.Utc),
+            new DateTime(2025, 1, 1, 10, 0, 0, DateTimeKind.Utc));
+
+        // The injected text survives as escaped content inside SUMMARY, so it is inert: what
+        // matters is that it never becomes a content line of its own.
+        var lines = payload.Split("\r\n");
+        Assert.Equal(1, lines.Count(line => line is "BEGIN:VEVENT"));
+        Assert.Equal(1, lines.Count(line => line is "END:VEVENT"));
+        Assert.Equal(5, lines.Length);
     }
 
     [Fact]
@@ -199,15 +240,9 @@ public class QRCodePayloadTests
             location: "Room 42",
             description: "Weekly sync");
 
-        Assert.Equal("""
-            BEGIN:VEVENT
-            SUMMARY:Team Meeting
-            DTSTART:20250615T140000Z
-            DTEND:20250615T150000Z
-            LOCATION:Room 42
-            DESCRIPTION:Weekly sync
-            END:VEVENT
-            """, payload, ignoreLineEndingDifferences: true);
+        Assert.Equal(
+            "BEGIN:VEVENT\r\nSUMMARY:Team Meeting\r\nDTSTART:20250615T140000Z\r\nDTEND:20250615T150000Z\r\n" +
+            "LOCATION:Room 42\r\nDESCRIPTION:Weekly sync\r\nEND:VEVENT", payload);
     }
 
     [Fact]
@@ -218,13 +253,7 @@ public class QRCodePayloadTests
             new DateTime(2025, 1, 1, 9, 0, 0, DateTimeKind.Utc),
             new DateTime(2025, 1, 1, 10, 0, 0, DateTimeKind.Utc));
 
-        Assert.Equal("""
-            BEGIN:VEVENT
-            SUMMARY:Meeting
-            DTSTART:20250101T090000Z
-            DTEND:20250101T100000Z
-            END:VEVENT
-            """, payload, ignoreLineEndingDifferences: true);
+        Assert.Equal("BEGIN:VEVENT\r\nSUMMARY:Meeting\r\nDTSTART:20250101T090000Z\r\nDTEND:20250101T100000Z\r\nEND:VEVENT", payload);
     }
 
     [Fact]
@@ -567,13 +596,8 @@ public class QRCodePayloadTests
             new DateTime(2025, 3, 1, 11, 0, 0, DateTimeKind.Utc),
             description: "Quarterly review");
 
-        Assert.Equal("""
-            BEGIN:VEVENT
-            SUMMARY:Review
-            DTSTART:20250301T100000Z
-            DTEND:20250301T110000Z
-            DESCRIPTION:Quarterly review
-            END:VEVENT
-            """, payload, ignoreLineEndingDifferences: true);
+        Assert.Equal(
+            "BEGIN:VEVENT\r\nSUMMARY:Review\r\nDTSTART:20250301T100000Z\r\nDTEND:20250301T110000Z\r\n" +
+            "DESCRIPTION:Quarterly review\r\nEND:VEVENT", payload);
     }
 }

--- a/tests/Meziantou.Framework.QRCode.Tests/QRCodePayloadTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/QRCodePayloadTests.cs
@@ -109,8 +109,8 @@ public class QRCodePayloadTests
     {
         var payload = QRCodePayload.VCard("Doe", "John", email: email);
 
-        // Exactly five content lines: BEGIN, VERSION, N, FN, EMAIL, END.
-        Assert.Equal(5, payload.Split("\r\n").Length - 1);
+        // Six content lines - BEGIN, VERSION, N, FN, EMAIL, END - so five separators.
+        Assert.HasCount(6, payload.Split("\r\n"));
         Assert.DoesNotContain("\r\nTEL:", payload);
         Assert.DoesNotContain("\r\nURL:", payload);
     }
@@ -120,7 +120,7 @@ public class QRCodePayloadTests
     {
         var payload = QRCodePayload.VCard("Doe");
 
-        Assert.Equal(4, payload.Split("\r\n").Length - 1);
+        Assert.HasCount(5, payload.Split("\r\n"));
         Assert.DoesNotContain("\n", payload.Replace("\r\n", "", StringComparison.Ordinal));
     }
 
@@ -135,9 +135,9 @@ public class QRCodePayloadTests
         // The injected text survives as escaped content inside SUMMARY, so it is inert: what
         // matters is that it never becomes a content line of its own.
         var lines = payload.Split("\r\n");
-        Assert.Equal(1, lines.Count(line => line is "BEGIN:VEVENT"));
-        Assert.Equal(1, lines.Count(line => line is "END:VEVENT"));
-        Assert.Equal(5, lines.Length);
+        Assert.Single(lines, line => line is "BEGIN:VEVENT");
+        Assert.Single(lines, line => line is "END:VEVENT");
+        Assert.HasCount(5, lines);
     }
 
     [Fact]


### PR DESCRIPTION
## The problem

`VCard` (`QRCodePayload.cs:62-123`) and `CalendarEvent` (`:212-239`) appended caller-supplied
values raw, with no escaping.

**Property injection.** A new line in any field opens a new content line:

```csharp
QRCodePayload.VCard("Doe", "John", email: "a@b.com\r\nTEL:+19999999999\r\nURL:https://evil.example")
// EMAIL:a@b.com
// TEL:+19999999999          ← injected
// URL:https://evil.example  ← injected

QRCodePayload.CalendarEvent("Meeting\r\nEND:VEVENT\r\nBEGIN:VEVENT\r\nSUMMARY:Injected", ...)
// produces two VEVENTs
```

Scanning a contact QR is a one-tap "add to address book" on every phone, so an injected
`TEL:` or `URL:` lands in the victim's contacts looking like it came from the real person.

**The benign case is more likely to bite first.** `;` and `,` are structural in vCard:

```csharp
QRCodePayload.VCard("van der Berg; Jr", "Jan")
// N:van der Berg; Jr;Jan;;;   ← six components where the standard defines five
```

Most importers then read "Jr" as the given name. This affects every user with a surname
containing `;` or `,`, with no error and no workaround.

**Wrong line separator.** RFC 6350 and RFC 5545 both require CRLF between content lines, but
`AppendLine` emits `Environment.NewLine` — so the output was LF-only on Linux and macOS, and
the same input produced different bytes per platform.

## The change

- Escape every caller-supplied value per RFC 6350 §3.4 and RFC 5545 §3.3.11
  (`\` → `\\`, `;` → `\;`, `,` → `\,`, newline → `\n`), exactly as `AppendMeCardEscaped`
  already did for MeCard. The structural separators the builder itself writes stay unescaped,
  so this is a per-value helper rather than a pass over the finished string.
- Write the line separator as an explicit `\r\n`.

Injected text now survives as escaped content *inside* the value it was passed to, which is
inert — it never becomes a content line of its own.

## Verification

318 tests pass on net10.0 and net11.0. New coverage: `;` and `,` and `\` escaping, newline
injection into a vCard property, newline injection into a VEVENT summary, and CRLF assertions.

The five affected assertions dropped `ignoreLineEndingDifferences: true` and now pin the exact
CRLF bytes — that flag was hiding the platform dependence.
