### PR TITLE
Parse the rgba alpha component as a fraction instead of a byte

### DIFF
--- a/src/Meziantou.Framework.QRCode/Color.cs
+++ b/src/Meziantou.Framework.QRCode/Color.cs
@@ -257,13 +257,16 @@ public readonly partial struct Color : IEquatable<Color>
         return byte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
     }
 
+    /// <summary>
+    /// Parses the alpha component of an <c>rgba()</c> function.
+    /// </summary>
+    /// <remarks>
+    /// CSS alpha is a fraction between 0 and 1, so it is never parsed as a 0-255 byte. Trying the
+    /// byte form first made <c>rgba(0,0,0,1)</c> - the most common way to write opaque - resolve to
+    /// an alpha of 1, a colour that is 99.6% transparent, with no error raised.
+    /// </remarks>
     private static bool TryParseAlpha(string value, out byte alpha)
     {
-        if (TryParseByte(value, out alpha))
-        {
-            return true;
-        }
-
         if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var doubleValue)
             && doubleValue >= 0
             && doubleValue <= 1)

--- a/tests/Meziantou.Framework.QRCode.Tests/ColorTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/ColorTests.cs
@@ -1,0 +1,74 @@
+namespace Meziantou.Framework.Tests;
+
+public class ColorTests
+{
+    [Theory]
+    [InlineData("rgba(255,0,0,1)", 255, 255, 0, 0)]
+    [InlineData("rgba(0,0,0,1)", 255, 0, 0, 0)]
+    [InlineData("rgba(255,0,0,0)", 0, 255, 0, 0)]
+    [InlineData("rgba(17,34,51,0.5)", 128, 17, 34, 51)]
+    [InlineData("rgba(17,34,51,0.502)", 128, 17, 34, 51)]
+    [InlineData("rgba(1,2,3,0.25)", 64, 1, 2, 3)]
+    [InlineData("rgba(1,2,3,.5)", 128, 1, 2, 3)]
+    public void Parse_Rgba_TreatsAlphaAsAFraction(string value, byte alpha, byte red, byte green, byte blue)
+    {
+        var color = Color.Parse(value);
+
+        Assert.Equal(Color.FromArgb(alpha, red, green, blue), color);
+    }
+
+    [Theory]
+    [InlineData("rgba(0,0,0,2)")]
+    [InlineData("rgba(0,0,0,255)")]
+    [InlineData("rgba(0,0,0,-1)")]
+    [InlineData("rgba(0,0,0,abc)")]
+    public void TryParse_RgbaWithAlphaOutsideZeroToOne_Fails(string value)
+    {
+        Assert.False(Color.TryParse(value, out _));
+    }
+
+    [Fact]
+    public void Parse_RgbaWithAlphaOne_IsOpaque()
+    {
+        // rgba(r,g,b,1) is the most common way to write an opaque colour. Parsing the 1 as a
+        // 0-255 byte produced a colour that is 99.6% transparent, which renders an invisible
+        // QR code with no error raised anywhere.
+        Assert.Equal(Color.Black, Color.Parse("rgba(0,0,0,1)"));
+        Assert.Equal("#000000", Color.Parse("rgba(0,0,0,1)").ToCssString());
+    }
+
+    [Theory]
+    [InlineData("rgb(255,0,0)", 255, 0, 0)]
+    [InlineData("rgb(1, 2, 3)", 1, 2, 3)]
+    public void Parse_Rgb_IsOpaque(string value, byte red, byte green, byte blue)
+    {
+        Assert.Equal(Color.FromRgb(red, green, blue), Color.Parse(value));
+    }
+
+    [Theory]
+    [InlineData("#f00", 255, 255, 0, 0)]
+    [InlineData("#8f00", 136, 255, 0, 0)]
+    [InlineData("#ff0000", 255, 255, 0, 0)]
+    [InlineData("#80ff0000", 128, 255, 0, 0)]
+    public void Parse_Hex(string value, byte alpha, byte red, byte green, byte blue)
+    {
+        Assert.Equal(Color.FromArgb(alpha, red, green, blue), Color.Parse(value));
+    }
+
+    [Theory]
+    [InlineData("#000000")]
+    [InlineData("#80ff0000")]
+    [InlineData("rgba(17,34,51,0.502)")]
+    public void ToCssString_RoundTripsThroughParse(string value)
+    {
+        var color = Color.Parse(value);
+
+        Assert.Equal(color, Color.Parse(color.ToCssString()));
+    }
+
+    [Fact]
+    public void Parse_InvalidValue_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => Color.Parse("not a color"));
+    }
+}


### PR DESCRIPTION
## The problem

`Color.TryParseAlpha` (`Color.cs:260-277`) tried `byte.TryParse` before the fractional form:

```csharp
if (TryParseByte(value, out alpha)) return true;          // "1" → 1
if (double.TryParse(...) && d >= 0 && d <= 1) { ... }     // never reached for "1"
```

CSS `rgba()` alpha is a fraction between 0 and 1, so `1` means **fully opaque**. The byte
path wins for exactly the two most common values:

```
Color.Parse("rgba(255,0,0,1)")   → #01ff0000   (ToCssString: "rgba(255,0,0,0.004)")
Color.Parse("rgba(255,0,0,0.5)") → #80ff0000   (correct — the fractional path was reached)
```

`rgba(0,0,0,1)` is the single most common way to write opaque black. A caller who sets
`DarkColor` that way gets a QR code whose dark modules are 99.6 % transparent — invisible on
screen, blank on paper — and **no exception is raised anywhere**. It silently produces an
unscannable image.

The round trip was also asymmetric: `ToCssString` emits the fractional form, so
`Parse(c.ToCssString())` was lossless only by luck.

## The change

Parse the `rgba()` alpha component as a 0–1 fraction only, and drop the integer fast path.
Values outside 0–1 (`rgba(0,0,0,255)`, `rgba(0,0,0,2)`) now fail to parse rather than
resolving to something almost transparent.

If integer 0–255 alpha was intended as an extension, it needs a distinct syntax — it collides
with valid CSS at exactly the values `0` and `1`.

`rgb()` (no alpha) and all hex forms are unchanged; `TryParseByte` is still used for the
colour channels.

## Verification

334 tests pass on net10.0 and net11.0.

`Color` had **no parsing coverage at all** — it was only exercised indirectly through the
renderer snapshots — so this adds `ColorTests.cs` covering the rgba fraction, out-of-range
alpha rejection, `rgb()`, all four hex forms, and `ToCssString` round trips. (New file rather
than an existing one because there was no `Color` test file to add to.)

The `rgba(...)` strings in the committed SVG snapshots come from `ToCssString()`, which this
does not touch.
