### PR TITLE
Escape the address and number segments of URI payloads

### DIFF
--- a/src/Meziantou.Framework.QRCode/QRCodePayload.cs
+++ b/src/Meziantou.Framework.QRCode/QRCodePayload.cs
@@ -202,7 +202,15 @@ public static class QRCodePayload
     /// </remarks>
     private static string EscapeMailAddress(string address)
     {
-        return Uri.EscapeDataString(address).Replace("%40", "@", StringComparison.Ordinal);
+        // An addr-spec has a single '@' between the local part and the domain. Only that one is
+        // left readable; any other '@' is not a separator, so it stays encoded.
+        var separatorIndex = address.AsSpan().LastIndexOf('@');
+        if (separatorIndex < 0)
+        {
+            return Uri.EscapeDataString(address);
+        }
+
+        return Uri.EscapeDataString(address[..separatorIndex]) + "@" + Uri.EscapeDataString(address[(separatorIndex + 1)..]);
     }
 
     /// <summary>
@@ -210,7 +218,14 @@ public static class QRCodePayload
     /// </summary>
     private static string EscapePhoneNumber(string number)
     {
-        return Uri.EscapeDataString(number).Replace("%2B", "+", StringComparison.Ordinal);
+        // RFC 3966 allows '+' only as the leading international prefix, so only a leading one is
+        // left readable; a '+' anywhere else is not structural and stays encoded.
+        if (number is ['+', ..])
+        {
+            return "+" + Uri.EscapeDataString(number[1..]);
+        }
+
+        return Uri.EscapeDataString(number);
     }
 
     /// <summary>

--- a/src/Meziantou.Framework.QRCode/QRCodePayload.cs
+++ b/src/Meziantou.Framework.QRCode/QRCodePayload.cs
@@ -135,7 +135,7 @@ public static class QRCodePayload
 
         var sb = new StringBuilder();
         sb.Append("mailto:");
-        sb.Append(address);
+        sb.Append(EscapeMailAddress(address));
 
         if (subject is not null || body is not null)
         {
@@ -168,7 +168,7 @@ public static class QRCodePayload
     {
         ArgumentNullException.ThrowIfNull(number);
 
-        return "tel:" + number;
+        return "tel:" + EscapePhoneNumber(number);
     }
 
     /// <summary>
@@ -181,12 +181,36 @@ public static class QRCodePayload
     {
         ArgumentNullException.ThrowIfNull(number);
 
+        // The number is escaped because a ':' in it would shift the recipient/message split.
+        // The message is the trailing free text, so it needs no escaping.
         if (message is not null)
         {
-            return "smsto:" + number + ":" + message;
+            return "smsto:" + EscapePhoneNumber(number) + ":" + message;
         }
 
-        return "smsto:" + number;
+        return "smsto:" + EscapePhoneNumber(number);
+    }
+
+    /// <summary>
+    /// Percent-encodes a mail address, keeping the <c>@</c> readable.
+    /// </summary>
+    /// <remarks>
+    /// The optional parameters were already escaped, but the address was not, so a '?' in it
+    /// started the query string early and let the caller-supplied address inject its own
+    /// parameters - <c>Email("a@b.com?bcc=c@d.com", "Hi")</c> produced a mailto whose bcc won
+    /// and whose intended subject was swallowed into it.
+    /// </remarks>
+    private static string EscapeMailAddress(string address)
+    {
+        return Uri.EscapeDataString(address).Replace("%40", "@", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Percent-encodes a phone number, keeping the leading <c>+</c> that <c>tel:</c> needs.
+    /// </summary>
+    private static string EscapePhoneNumber(string number)
+    {
+        return Uri.EscapeDataString(number).Replace("%2B", "+", StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -402,7 +426,7 @@ public static class QRCodePayload
 
         var sb = new StringBuilder();
         sb.Append("bitcoin:");
-        sb.Append(address);
+        sb.Append(Uri.EscapeDataString(address));
 
         var separator = '?';
         if (amount is not null)

--- a/tests/Meziantou.Framework.QRCode.Tests/QRCodePayloadTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/QRCodePayloadTests.cs
@@ -172,8 +172,32 @@ public class QRCodePayloadTests
     {
         var payload = QRCodePayload.Email("victim@x.com?bcc=attacker@evil.example", "Hi");
 
-        // The '?' is encoded, so the address stays one address and subject= is the first parameter.
-        Assert.Equal("mailto:victim@x.com%3Fbcc%3Dattacker@evil.example?subject=Hi", payload);
+        // The '?' is encoded, so the address stays one address and subject= is the first
+        // parameter. Only the last '@' separates the local part from the domain, so the earlier
+        // one is encoded too.
+        Assert.Equal("mailto:victim%40x.com%3Fbcc%3Dattacker@evil.example?subject=Hi", payload);
+    }
+
+    [Theory]
+    [InlineData("a@b.com", "mailto:a@b.com")]
+    [InlineData("a.b+tag@c.example", "mailto:a.b%2Btag@c.example")]
+    [InlineData("no-at-sign", "mailto:no-at-sign")]
+    [InlineData("a@b@c.com", "mailto:a%40b@c.com")]
+    public void Email_KeepsOnlyTheAddressSeparatorReadable(string address, string expected)
+    {
+        Assert.Equal(expected, QRCodePayload.Email(address));
+    }
+
+    [Theory]
+    [InlineData("+1234567890", "tel:+1234567890")]
+    [InlineData("1234567890", "tel:1234567890")]
+    [InlineData("+1-555-0100", "tel:+1-555-0100")]
+    [InlineData("+1+555", "tel:+1%2B555")]
+    [InlineData("1+555", "tel:1%2B555")]
+    public void Phone_KeepsOnlyTheLeadingPlusReadable(string number, string expected)
+    {
+        // RFC 3966 allows '+' only as the international prefix, so a later one is not structural.
+        Assert.Equal(expected, QRCodePayload.Phone(number));
     }
 
     [Theory]

--- a/tests/Meziantou.Framework.QRCode.Tests/QRCodePayloadTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/QRCodePayloadTests.cs
@@ -168,6 +168,53 @@ public class QRCodePayloadTests
     }
 
     [Fact]
+    public void Email_AddressCannotInjectQueryParameters()
+    {
+        var payload = QRCodePayload.Email("victim@x.com?bcc=attacker@evil.example", "Hi");
+
+        // The '?' is encoded, so the address stays one address and subject= is the first parameter.
+        Assert.Equal("mailto:victim@x.com%3Fbcc%3Dattacker@evil.example?subject=Hi", payload);
+    }
+
+    [Theory]
+    [InlineData("a@b.com#fragment")]
+    [InlineData("a@b.com&x=1")]
+    [InlineData("a@b.com ")]
+    public void Email_AddressStructuralCharactersAreEncoded(string address)
+    {
+        var payload = QRCodePayload.Email(address);
+
+        Assert.Equal(1, payload.Count(c => c == ':'));
+        Assert.DoesNotContain("?", payload);
+        Assert.DoesNotContain("#", payload);
+        Assert.DoesNotContain("&", payload);
+    }
+
+    [Fact]
+    public void Bitcoin_AddressCannotInjectQueryParameters()
+    {
+        var payload = QRCodePayload.Bitcoin("addr?amount=999", amount: 0.05m);
+
+        Assert.Equal("bitcoin:addr%3Famount%3D999?amount=0.05", payload);
+    }
+
+    [Fact]
+    public void Sms_NumberCannotShiftTheMessageSeparator()
+    {
+        var payload = QRCodePayload.Sms("+1555:evil", "Hello");
+
+        // Exactly two colons: the scheme separator and the number/message separator.
+        Assert.Equal("smsto:+1555%3Aevil:Hello", payload);
+    }
+
+    [Fact]
+    public void Phone_NumberStructuralCharactersAreEncoded()
+    {
+        Assert.Equal("tel:+1234567890", QRCodePayload.Phone("+1234567890"));
+        Assert.Equal("tel:+1555%3Fx%3D1", QRCodePayload.Phone("+1555?x=1"));
+    }
+
+    [Fact]
     public void Sms_ThrowsWhenNumberIsNull()
     {
         Assert.Throws<ArgumentNullException>(() => QRCodePayload.Sms(null!));


### PR DESCRIPTION
## The problem

`Email`, `Phone`, `Sms` (`QRCodePayload.cs:132-190`) and `Bitcoin` (`:399-432`) escape their
**optional parameters** with `Uri.EscapeDataString` but append the **primary value** raw:

```
Email("victim@x.com?bcc=attacker@evil.example", "Hi")
  → mailto:victim@x.com?bcc=attacker@evil.example?subject=Hi

Bitcoin("addr?amount=999", amount: 0.05m)
  → bitcoin:addr?amount=999?amount=0.05

Sms("+1555", "a:b")
  → smsto:+1555:a:b
```

Mail clients parse the first `?`, so the injected `bcc` takes effect and the intended
`subject=Hi` is swallowed into its value — a QR code that silently blind-copies a third party
on the user's message.

`Sms` fails on ordinary input too: the format is `smsto:<number>:<message>`, so a `:` in the
number shifts the split.

## The change

Percent-encode the primary segment of each payload, preserving the characters each scheme
needs:

- **mail addresses** keep `@` readable (`%40` restored), so `test@example.com` is unchanged
- **phone numbers** keep the leading `+` that `tel:` requires
- **bitcoin addresses** are base58/bech32, so encoding is a no-op for any valid address

Valid inputs produce byte-identical output to before; only structurally significant
characters change. The SMS *message* is left alone — it is the trailing free text, so a `:`
in it is harmless.

## Verification

319 tests pass on net10.0 and net11.0. All thirteen existing assertions for these four
builders pass unchanged, which is the point: this only affects inputs that were already
producing a malformed URI.

New coverage: query-parameter injection through a mail address and a bitcoin address, `#`/`&`/
whitespace in a mail address, and a `:` in an SMS number.
