### PR TITLE
Reject unsupported Micro QR error correction levels and expose the level used

### DIFF
--- a/ref/Meziantou.Framework.QRCode.cs
+++ b/ref/Meziantou.Framework.QRCode.cs
@@ -115,6 +115,7 @@ namespace Meziantou.Framework
     public sealed class QRCode
     {
         public Meziantou.Framework.QRCodeType Type { get => throw null; }
+        public Meziantou.Framework.ErrorCorrectionLevel ErrorCorrectionLevel { get => throw null; }
         public int Version { get => throw null; }
         public int Width { get => throw null; }
         public int Height { get => throw null; }

--- a/src/Meziantou.Framework.QRCode/Internal/MicroQR/MicroQREncoder.cs
+++ b/src/Meziantou.Framework.QRCode/Internal/MicroQR/MicroQREncoder.cs
@@ -16,7 +16,7 @@ internal static class MicroQREncoder
         var builder = new MicroQRMatrixBuilder(version);
         builder.Build(allCodewords, effectiveECLevel, bestMask);
 
-        return new QRCode(builder.Modules, version, QRCodeType.MicroQR);
+        return new QRCode(builder.Modules, version, QRCodeType.MicroQR, effectiveECLevel);
     }
 
     private static byte[] EncodeData(string data, int version, ErrorCorrectionLevel ecLevel, EncodingMode mode)

--- a/src/Meziantou.Framework.QRCode/Internal/MicroQR/MicroQRVersion.cs
+++ b/src/Meziantou.Framework.QRCode/Internal/MicroQR/MicroQRVersion.cs
@@ -159,7 +159,9 @@ internal static class MicroQRVersion
     {
         return (version, ecLevel) switch
         {
-            (1, _) => true, // M1 only has error detection, accept any EC level
+            // M1 carries error detection only, so it cannot satisfy a request for M or Q. Treating
+            // it as satisfying every level silently handed back a symbol with no error correction.
+            (1, ErrorCorrectionLevel.L) => true,
             (2, ErrorCorrectionLevel.L or ErrorCorrectionLevel.M) => true,
             (3, ErrorCorrectionLevel.L or ErrorCorrectionLevel.M) => true,
             (4, ErrorCorrectionLevel.L or ErrorCorrectionLevel.M or ErrorCorrectionLevel.Q) => true,

--- a/src/Meziantou.Framework.QRCode/Internal/RMQR/RMQREncoder.cs
+++ b/src/Meziantou.Framework.QRCode/Internal/RMQR/RMQREncoder.cs
@@ -18,7 +18,7 @@ internal static class RMQREncoder
         var builder = new RMQRMatrixBuilder(version);
         builder.Build(allCodewords, ecLevel);
 
-        return new QRCode(builder.Modules, version, QRCodeType.RMQR);
+        return new QRCode(builder.Modules, version, QRCodeType.RMQR, ecLevel);
     }
 
     private static byte[] EncodeData(string data, int version, ErrorCorrectionLevel ecLevel, EncodingMode mode)

--- a/src/Meziantou.Framework.QRCode/QRCode.cs
+++ b/src/Meziantou.Framework.QRCode/QRCode.cs
@@ -11,17 +11,26 @@ public sealed class QRCode
 {
     private readonly bool[,] _modules;
 
-    internal QRCode(bool[,] modules, int version, QRCodeType type)
+    internal QRCode(bool[,] modules, int version, QRCodeType type, ErrorCorrectionLevel errorCorrectionLevel)
     {
         _modules = modules;
         Version = version;
         Type = type;
+        ErrorCorrectionLevel = errorCorrectionLevel;
         Height = modules.GetLength(0);
         Width = modules.GetLength(1);
     }
 
     /// <summary>Gets the type of QR code.</summary>
     public QRCodeType Type { get; }
+
+    /// <summary>Gets the error correction level the symbol was built with.</summary>
+    /// <remarks>
+    /// This can differ from the requested level. Micro QR version M1 carries error detection only,
+    /// and is reported as <see cref="ErrorCorrectionLevel.L"/> because the enumeration has no
+    /// weaker member.
+    /// </remarks>
+    public ErrorCorrectionLevel ErrorCorrectionLevel { get; }
 
     /// <summary>Gets the QR code version.</summary>
     public int Version { get; }
@@ -100,6 +109,11 @@ public sealed class QRCode
             throw new ArgumentException("The data cannot be empty.", nameof(data));
         }
 
+        if (errorCorrectionLevel is ErrorCorrectionLevel.H)
+        {
+            throw new ArgumentOutOfRangeException(nameof(errorCorrectionLevel), errorCorrectionLevel, "Micro QR only supports EC levels L, M and Q.");
+        }
+
         return MicroQREncoder.Encode(data, errorCorrectionLevel);
     }
 
@@ -127,6 +141,6 @@ public sealed class QRCode
         var builder = new MatrixBuilder(version);
         builder.Build(allCodewords, errorCorrectionLevel, bestMask);
 
-        return new QRCode(builder.Modules, version, QRCodeType.Standard);
+        return new QRCode(builder.Modules, version, QRCodeType.Standard, errorCorrectionLevel);
     }
 }

--- a/tests/Meziantou.Framework.QRCode.Tests/MicroQRCodeTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/MicroQRCodeTests.cs
@@ -104,13 +104,44 @@ public class MicroQRCodeTests
         Assert.Throws<InvalidOperationException>(() => QRCode.CreateMicroQR(new string('A', 100)));
     }
 
-    [Fact]
-    public void CreateMicroQR_ECLevel_H_FallsBackToSupportedLevel()
+    [Theory]
+    [InlineData("ABCDEF")]
+    [InlineData("12345")]
+    [InlineData("1")]
+    public void CreateMicroQR_ECLevelH_Throws(string data)
     {
-        // H is not supported by any Micro QR version, but M1 accepts any EC level
-        // (it only supports error detection). For data that fits M1, H is silently resolved.
-        // For data that requires M2+, H should throw since no version supports it.
-        Assert.Throws<InvalidOperationException>(() => QRCode.CreateMicroQR("ABCDEF", ErrorCorrectionLevel.H));
+        // No Micro QR version supports H. This used to report "the data is too long", and for
+        // data small enough to fit M1 it silently returned a symbol with no error correction.
+        Assert.Throws<ArgumentOutOfRangeException>(() => QRCode.CreateMicroQR(data, ErrorCorrectionLevel.H));
+    }
+
+    [Fact]
+    public void CreateMicroQR_M1_ReportsTheLevelItActuallyUsed()
+    {
+        var qr = QRCode.CreateMicroQR("123", ErrorCorrectionLevel.L);
+
+        Assert.Equal(1, qr.Version);
+        Assert.Equal(ErrorCorrectionLevel.L, qr.ErrorCorrectionLevel);
+    }
+
+    [Theory]
+    [InlineData(ErrorCorrectionLevel.M)]
+    [InlineData(ErrorCorrectionLevel.Q)]
+    public void CreateMicroQR_LevelStrongerThanM1_SkipsM1(ErrorCorrectionLevel ecLevel)
+    {
+        // "123" fits M1, but M1 carries error detection only, so a request for M or Q has to
+        // move up to a version that genuinely provides it.
+        var qr = QRCode.CreateMicroQR("123", ecLevel);
+
+        Assert.True(qr.Version > 1);
+        Assert.Equal(ecLevel, qr.ErrorCorrectionLevel);
+    }
+
+    [Fact]
+    public void CreateMicroQR_ReportsTheRequestedLevel()
+    {
+        Assert.Equal(ErrorCorrectionLevel.M, QRCode.CreateMicroQR("HELLO", ErrorCorrectionLevel.M).ErrorCorrectionLevel);
+        Assert.Equal(ErrorCorrectionLevel.Q, QRCode.CreateMicroQR("12345678901", ErrorCorrectionLevel.Q).ErrorCorrectionLevel);
     }
 
     // ───── Determinism ─────

--- a/tests/Meziantou.Framework.QRCode.Tests/QRCodeTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/QRCodeTests.cs
@@ -374,6 +374,16 @@ public class QRCodeTests
         Assert.Throws<ArgumentException>(() => QRCode.Create(Array.Empty<byte>(), ErrorCorrectionLevel.M));
     }
 
+    [Theory]
+    [InlineData(ErrorCorrectionLevel.L)]
+    [InlineData(ErrorCorrectionLevel.M)]
+    [InlineData(ErrorCorrectionLevel.Q)]
+    [InlineData(ErrorCorrectionLevel.H)]
+    public void Create_ReportsTheErrorCorrectionLevel(ErrorCorrectionLevel ecLevel)
+    {
+        Assert.Equal(ecLevel, QRCode.Create("HELLO WORLD", ecLevel).ErrorCorrectionLevel);
+    }
+
     [Fact]
     public void Create_DataTooLong_ThrowsInvalidOperationException()
     {

--- a/tests/Meziantou.Framework.QRCode.Tests/RMQRCodeTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/RMQRCodeTests.cs
@@ -207,4 +207,12 @@ public class RMQRCodeTests
 
         return sb.ToString();
     }
+
+    [Theory]
+    [InlineData(ErrorCorrectionLevel.M)]
+    [InlineData(ErrorCorrectionLevel.H)]
+    public void CreateRMQR_ReportsTheErrorCorrectionLevel(ErrorCorrectionLevel ecLevel)
+    {
+        Assert.Equal(ecLevel, QRCode.CreateRMQR("HELLO", ecLevel).ErrorCorrectionLevel);
+    }
 }


### PR DESCRIPTION
## The problem

`MicroQRVersion.IsECLevelSupported` returned `true` for **every** level on M1
(`Internal/MicroQR/MicroQRVersion.cs:158-168`), and `ResolveECLevel` then rewrote the request
to `L`. Micro QR M1 carries **error detection only** — there is no error correction in it at all.

```csharp
QRCode.CreateMicroQR("12345", ErrorCorrectionLevel.H);
// → M1, 11x11, no error correction whatsoever. No warning, no way to tell.

QRCode.CreateMicroQR("123456", ErrorCorrectionLevel.H);
// → InvalidOperationException: "The data is too long to be encoded in a Micro QR code."
```

The second message is wrong: six digits fit comfortably in M2/M3/M4. The actual problem is
that **no Micro QR version has an H level**, so the caller goes looking for a size problem
that does not exist.

And `QRCode` exposed `Version` and `Type` but not the error correction level
(`ref/Meziantou.Framework.QRCode.cs:115-127`), so the downgrade in the first case was
undetectable by the caller. Someone asking for H is asking for damage tolerance; getting a
detection-only symbol back with no signal defeats the reason they chose it.

## The change

- **Reject `H` up front** with `ArgumentOutOfRangeException`, exactly as `RMQREncoder` already
  rejects `L` and `Q` (`Internal/RMQR/RMQREncoder.cs:7-10`). That precedent was already in the
  codebase.
- **Only select M1 when `L` was requested.** A request for `M` or `Q` now moves up to a version
  that genuinely provides that level instead of quietly dropping to detection-only. This only
  affects numeric payloads of ≤ 5 digits — anything longer or non-numeric already skipped M1.
- **Add `QRCode.ErrorCorrectionLevel`**, reporting the level the symbol was actually built with,
  for standard QR, Micro QR and rMQR.

M1 is still reported as `L` because `ErrorCorrectionLevel` has no member weaker than `L`;
that caveat is documented on the property rather than papered over. Introducing a
"detection only" member is a larger API change than belongs in this PR.

## Verification

324 tests pass on net10.0 and net11.0.

`CreateMicroQR_ECLevel_H_FallsBackToSupportedLevel` was documenting the old behaviour in its
own comment ("For data that fits M1, H is silently resolved"). Replaced with a theory asserting
H throws for payloads that fit M1 and for payloads that do not.

`ref/Meziantou.Framework.QRCode.cs` regenerated for the new property (Release build with
`IsOfficialBuild=true`).
