### PR TITLE
Make argument validation consistent across the renderers and encoders

### DIFF
--- a/src/Meziantou.Framework.QRCode/Internal/Barcode/CodabarEncoder.cs
+++ b/src/Meziantou.Framework.QRCode/Internal/Barcode/CodabarEncoder.cs
@@ -70,10 +70,9 @@ internal static class CodabarEncoder
 
     private static void AppendCharacter(List<bool> modules, char character)
     {
-        if (!CharacterEncodings.TryGetValue(character, out var encoding))
-        {
-            throw new ArgumentException($"The character '{character}' is not supported by Codabar.", nameof(character));
-        }
+        // Encode has already validated the payload and normalized the guards, so a missing
+        // entry here means the table and the validation disagree.
+        var encoding = CharacterEncodings[character];
 
         var isDark = true;
         for (var i = 0; i < 7; i++)

--- a/src/Meziantou.Framework.QRCode/QRCodeConsoleRenderer.cs
+++ b/src/Meziantou.Framework.QRCode/QRCodeConsoleRenderer.cs
@@ -48,8 +48,9 @@ public static class QRCodeConsoleRenderer
     {
         ArgumentNullException.ThrowIfNull(qrCode);
         ArgumentNullException.ThrowIfNull(options);
-        ArgumentOutOfRangeException.ThrowIfLessThan(options.ModuleWidth, 1, nameof(options));
-        ArgumentOutOfRangeException.ThrowIfLessThan(options.ModuleHeight, 1, nameof(options));
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.ModuleWidth, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.ModuleHeight, 1);
+        ArgumentOutOfRangeException.ThrowIfNegative(options.QuietZoneModules);
 
         var quietZone = options.QuietZoneModules;
         var moduleWidth = options.ModuleWidth;

--- a/src/Meziantou.Framework.QRCode/QRCodeSvgRenderer.cs
+++ b/src/Meziantou.Framework.QRCode/QRCodeSvgRenderer.cs
@@ -17,13 +17,11 @@ public static class QRCodeSvgRenderer
         ArgumentNullException.ThrowIfNull(qrCode);
         ArgumentNullException.ThrowIfNull(options);
 
-        var moduleSize = options.ModuleSize;
-        if (moduleSize <= 0)
-            throw new ArgumentOutOfRangeException("options.ModuleSize", options.ModuleSize, "ModuleSize must be greater than 0.");
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.ModuleSize, 1);
+        ArgumentOutOfRangeException.ThrowIfNegative(options.QuietZoneModules);
 
+        var moduleSize = options.ModuleSize;
         var quietZone = options.QuietZoneModules;
-        if (quietZone < 0)
-            throw new ArgumentOutOfRangeException("options.QuietZoneModules", options.QuietZoneModules, "QuietZoneModules must be greater than or equal to 0.");
 
         var totalWidth = ((long)qrCode.Width + (2L * quietZone)) * moduleSize;
         var totalHeight = ((long)qrCode.Height + (2L * quietZone)) * moduleSize;

--- a/tests/Meziantou.Framework.QRCode.Tests/QRCodeConsoleRendererTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/QRCodeConsoleRendererTests.cs
@@ -277,4 +277,14 @@ public class QRCodeConsoleRendererTests
             """);
     }
 
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void ToConsoleString_NegativeQuietZone_Throws(int quietZoneModules)
+    {
+        // This used to return an empty string, while every other renderer threw.
+        var qr = QRCode.Create("HELLO", ErrorCorrectionLevel.L);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => qr.ToConsoleString(new QRCodeConsoleOptions { QuietZoneModules = quietZoneModules }));
+    }
 }


### PR DESCRIPTION
Three low-severity findings that are the same pattern — argument validation that disagrees
with the rest of the package — so they land together rather than as three one-line PRs.

## 1. The console renderer silently accepted a negative quiet zone

`QRCodeConsoleRenderer.ToConsoleString` (`:47-58`) validated `ModuleWidth` and `ModuleHeight`
but not `QuietZoneModules`. A negative value made `totalHeight` negative, the render loop never
ran, and the method returned an **empty string**:

```csharp
qr.ToConsoleString(new QRCodeConsoleOptions { QuietZoneModules = -100 });  // ""
```

Every other renderer calls `ArgumentOutOfRangeException.ThrowIfNegative` for the same option.
Now this one does too.

## 2. The SVG renderer hand-rolled checks the barcode renderers do with helpers

`QRCodeSvgRenderer` (`:22,26`) threw with string-literal parameter names while
`BarcodeSvgRenderer` (`:19-21`) uses `ArgumentOutOfRangeException.ThrowIfLessThan` /
`ThrowIfNegative`. `7081b63b4` already migrated the rest of the repo to these helpers, and
`AGENTS.md` asks for `nameof` over literals.

Converted `ModuleSize` and `QuietZoneModules`. `CallerArgumentExpression` yields the same
`options.ModuleSize` parameter name, so the thrown exceptions are unchanged — the two existing
tests for these pass untouched.

**`LogoSizePercent` deliberately keeps its explicit check.** Its message names the valid range
("LogoSizePercent must be between 1 and 100"), which the helper's generic message does not, and
that message is pinned by an `InlineSnapshot` test. Converting it would have been a downgrade,
so the file keeps one hand-rolled check on purpose.

## 3. Codabar reported a private parameter name

`CodabarEncoder.AppendCharacter` (`:75`) threw `ArgumentException(..., nameof(character))`.
`character` is a private helper's parameter; the caller passed `data`. The branch is also
unreachable — `Encode` validates the payload and normalizes the guards before calling it — so
the lookup is now a direct indexer with a comment explaining why a miss would be a table bug
rather than bad input.

## Verification

314 tests pass on net10.0 and net11.0. Adds the missing negative-quiet-zone test for the
console renderer; the SVG cases were already covered.
