### PR TITLE
Rename the Micro QR mask evaluation to say it is a score, not a penalty

### DIFF
--- a/src/Meziantou.Framework.QRCode/Internal/MicroQR/MicroQREncoder.cs
+++ b/src/Meziantou.Framework.QRCode/Internal/MicroQR/MicroQREncoder.cs
@@ -73,6 +73,14 @@ internal static class MicroQREncoder
         return result;
     }
 
+    /// <summary>
+    /// Picks the mask with the highest score, per ISO/IEC 18004 section 7.8.3.2.
+    /// </summary>
+    /// <remarks>
+    /// Micro QR maximises its mask score, unlike standard QR which minimises a penalty. Flipping
+    /// this comparison to match <see cref="MaskEvaluator.FindBestMask"/> would silently degrade
+    /// every Micro QR symbol.
+    /// </remarks>
     private static int FindBestMask(byte[] codewords, int version, ErrorCorrectionLevel ecLevel)
     {
         var bestMask = 0;
@@ -82,7 +90,7 @@ internal static class MicroQREncoder
         {
             var builder = new MicroQRMatrixBuilder(version);
             builder.Build(codewords, ecLevel, mask);
-            var score = MicroQRMatrixBuilder.EvaluateMaskPenalty(builder.Modules, builder.Size);
+            var score = MicroQRMatrixBuilder.EvaluateMaskScore(builder.Modules, builder.Size);
 
             if (score > bestScore)
             {

--- a/src/Meziantou.Framework.QRCode/Internal/MicroQR/MicroQRMatrixBuilder.cs
+++ b/src/Meziantou.Framework.QRCode/Internal/MicroQR/MicroQRMatrixBuilder.cs
@@ -203,7 +203,15 @@ internal sealed class MicroQRMatrixBuilder
     // Count dark modules in last row and last column (outside finder/timing area).
     // Score = min(darkLastRow, darkLastCol) * 16 + max(darkLastRow, darkLastCol)
     // Best mask = highest score.
-    public static int EvaluateMaskPenalty(bool[,] modules, int size)
+    /// <summary>
+    /// Scores a masked Micro QR symbol per ISO/IEC 18004 section 7.8.3.2.
+    /// </summary>
+    /// <remarks>
+    /// This is a score, not a penalty: Micro QR selects the mask with the <b>highest</b> value,
+    /// which is the opposite of the standard QR rule in <see cref="MaskEvaluator"/>. The score
+    /// favours dark modules along the right and lower edges.
+    /// </remarks>
+    public static int EvaluateMaskScore(bool[,] modules, int size)
     {
         var darkInLastRow = 0;
         var darkInLastCol = 0;


### PR DESCRIPTION
**No behaviour change** — naming and documentation only.

## The problem

`MicroQRMatrixBuilder.EvaluateMaskPenalty` (`:206-232`) is *maximised* by
`MicroQREncoder.FindBestMask` (`:76-95`):

```csharp
var score = MicroQRMatrixBuilder.EvaluateMaskPenalty(builder.Modules, builder.Size);
if (score > bestScore)   // note: >
```

This is **correct**. ISO/IEC 18004 §7.8.3.2 selects the Micro QR mask with the *highest*
`min × 16 + max` edge score — the opposite of the standard QR rule, where a penalty is
minimised.

But the name says "penalty", and the sibling `MaskEvaluator.FindBestMask` sitting next to it
genuinely minimises:

```csharp
if (penalty < bestPenalty)   // standard QR — correct for a penalty
```

So the code reads as an inconsistency. The next person to notice it and "fix" the `>` would
silently degrade every Micro QR symbol the library produces — and nothing would fail, because
the result is still a valid symbol, just a worse-scoring mask. The snapshots would be
regenerated and the change would look clean.

I flagged this while auditing the Micro QR encoder: I had to go back to the spec to convince
myself the `>` was not a bug.

## The change

- `EvaluateMaskPenalty` → `EvaluateMaskScore`
- Doc comments on both the scorer and `FindBestMask` stating that Micro QR maximises, citing
  §7.8.3.2, and warning that flipping the comparison to match `MaskEvaluator` would degrade
  every symbol.

Both members are `internal`, so this is not an API change.

## Verification

312 tests pass on net10.0 and net11.0, including every Micro QR snapshot — the selected masks
are byte-for-byte identical, which is the point.
