### PR TITLE
Extract the duplicated PNG container writer

### DIFF
--- a/src/Meziantou.Framework.QRCode/BarcodePngRenderer.cs
+++ b/src/Meziantou.Framework.QRCode/BarcodePngRenderer.cs
@@ -1,5 +1,4 @@
-using System.Buffers.Binary;
-using System.IO.Compression;
+using Meziantou.Framework.Internal;
 
 namespace Meziantou.Framework;
 
@@ -8,12 +7,6 @@ namespace Meziantou.Framework;
 /// </summary>
 public static class BarcodePngRenderer
 {
-    private static readonly byte[] PngSignature = [137, 80, 78, 71, 13, 10, 26, 10];
-    private static readonly byte[] IhdrChunkType = [73, 72, 68, 82];
-    private static readonly byte[] IdatChunkType = [73, 68, 65, 84];
-    private static readonly byte[] IendChunkType = [73, 69, 78, 68];
-    private static readonly uint[] Crc32Table = InitializeCrc32Table();
-
     /// <summary>Renders the barcode as PNG bytes with default options.</summary>
     public static byte[] ToPng(this Barcode barcode)
     {
@@ -47,9 +40,8 @@ public static class BarcodePngRenderer
         var width = GetTotalDimensionWithQuietZone(barcode.Width, options.QuietZoneModules, options.ModuleWidth, nameof(options.ModuleWidth));
         var height = GetTotalDimension(barcode.Height, options.ModuleHeight, nameof(options.ModuleHeight));
         var imageData = CreateImageData(barcode, width, height, options);
-        var compressedImageData = CompressImageData(imageData);
 
-        WritePng(stream, width, height, compressedImageData);
+        PngWriter.WriteRgba(stream, width, height, imageData);
     }
 
     private static int GetTotalDimensionWithQuietZone(int size, int quietZoneModules, int moduleSize, string parameterName)
@@ -101,83 +93,5 @@ public static class BarcodePngRenderer
         }
 
         return result;
-    }
-
-    private static byte[] CompressImageData(ReadOnlySpan<byte> imageData)
-    {
-        using var output = new MemoryStream();
-        using (var compressionStream = new ZLibStream(output, CompressionLevel.SmallestSize, leaveOpen: true))
-        {
-            compressionStream.Write(imageData);
-        }
-
-        return output.ToArray();
-    }
-
-    private static void WritePng(Stream stream, int width, int height, ReadOnlySpan<byte> compressedImageData)
-    {
-        stream.Write(PngSignature);
-
-        Span<byte> ihdrData = stackalloc byte[13];
-        BinaryPrimitives.WriteUInt32BigEndian(ihdrData, (uint)width);
-        BinaryPrimitives.WriteUInt32BigEndian(ihdrData[4..], (uint)height);
-        ihdrData[8] = 8;
-        ihdrData[9] = 6;
-        ihdrData[10] = 0;
-        ihdrData[11] = 0;
-        ihdrData[12] = 0;
-
-        WriteChunk(stream, IhdrChunkType, ihdrData);
-        WriteChunk(stream, IdatChunkType, compressedImageData);
-        WriteChunk(stream, IendChunkType, ReadOnlySpan<byte>.Empty);
-    }
-
-    private static void WriteChunk(Stream stream, ReadOnlySpan<byte> chunkType, ReadOnlySpan<byte> data)
-    {
-        Span<byte> uintBuffer = stackalloc byte[4];
-        BinaryPrimitives.WriteUInt32BigEndian(uintBuffer, (uint)data.Length);
-        stream.Write(uintBuffer);
-        stream.Write(chunkType);
-        stream.Write(data);
-
-        var crc = ComputeCrc32(chunkType, data);
-        BinaryPrimitives.WriteUInt32BigEndian(uintBuffer, crc);
-        stream.Write(uintBuffer);
-    }
-
-    private static uint ComputeCrc32(ReadOnlySpan<byte> chunkType, ReadOnlySpan<byte> data)
-    {
-        var crc = uint.MaxValue;
-        crc = UpdateCrc32(crc, chunkType);
-        crc = UpdateCrc32(crc, data);
-
-        return ~crc;
-    }
-
-    private static uint UpdateCrc32(uint crc, ReadOnlySpan<byte> data)
-    {
-        foreach (var value in data)
-        {
-            crc = Crc32Table[(int)((crc ^ value) & 0xFF)] ^ (crc >> 8);
-        }
-
-        return crc;
-    }
-
-    private static uint[] InitializeCrc32Table()
-    {
-        var table = new uint[256];
-        for (uint index = 0; index < table.Length; index++)
-        {
-            var crc = index;
-            for (var bit = 0; bit < 8; bit++)
-            {
-                crc = (crc & 1) == 0 ? (crc >> 1) : (0xEDB88320u ^ (crc >> 1));
-            }
-
-            table[index] = crc;
-        }
-
-        return table;
     }
 }

--- a/src/Meziantou.Framework.QRCode/Internal/PngWriter.cs
+++ b/src/Meziantou.Framework.QRCode/Internal/PngWriter.cs
@@ -1,0 +1,103 @@
+using System.Buffers.Binary;
+using System.IO.Compression;
+
+namespace Meziantou.Framework.Internal;
+
+/// <summary>
+/// Writes a PNG container: signature, IHDR, IDAT and IEND, with the CRC32 each chunk needs.
+/// </summary>
+internal static class PngWriter
+{
+    private static readonly byte[] Signature = [137, 80, 78, 71, 13, 10, 26, 10];
+    private static readonly byte[] IhdrChunkType = [73, 72, 68, 82];
+    private static readonly byte[] IdatChunkType = [73, 68, 65, 84];
+    private static readonly byte[] IendChunkType = [73, 69, 78, 68];
+    private static readonly uint[] Crc32Table = InitializeCrc32Table();
+
+    /// <summary>
+    /// Writes a truecolour-with-alpha (8 bits per channel) PNG.
+    /// </summary>
+    /// <param name="stream">The destination stream.</param>
+    /// <param name="width">The image width in pixels.</param>
+    /// <param name="height">The image height in pixels.</param>
+    /// <param name="imageData">Scanlines, each prefixed with its filter type byte.</param>
+    public static void WriteRgba(Stream stream, int width, int height, ReadOnlySpan<byte> imageData)
+    {
+        var compressedImageData = Compress(imageData);
+
+        stream.Write(Signature);
+
+        Span<byte> ihdrData = stackalloc byte[13];
+        BinaryPrimitives.WriteUInt32BigEndian(ihdrData, (uint)width);
+        BinaryPrimitives.WriteUInt32BigEndian(ihdrData[4..], (uint)height);
+        ihdrData[8] = 8;  // Bit depth
+        ihdrData[9] = 6;  // Colour type: truecolour with alpha
+        ihdrData[10] = 0; // Compression method
+        ihdrData[11] = 0; // Filter method
+        ihdrData[12] = 0; // Interlace method
+
+        WriteChunk(stream, IhdrChunkType, ihdrData);
+        WriteChunk(stream, IdatChunkType, compressedImageData);
+        WriteChunk(stream, IendChunkType, ReadOnlySpan<byte>.Empty);
+    }
+
+    private static byte[] Compress(ReadOnlySpan<byte> imageData)
+    {
+        using var output = new MemoryStream();
+        using (var compressionStream = new ZLibStream(output, CompressionLevel.SmallestSize, leaveOpen: true))
+        {
+            compressionStream.Write(imageData);
+        }
+
+        return output.ToArray();
+    }
+
+    private static void WriteChunk(Stream stream, ReadOnlySpan<byte> chunkType, ReadOnlySpan<byte> data)
+    {
+        Span<byte> uintBuffer = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(uintBuffer, (uint)data.Length);
+        stream.Write(uintBuffer);
+        stream.Write(chunkType);
+        stream.Write(data);
+
+        var crc = ComputeCrc32(chunkType, data);
+        BinaryPrimitives.WriteUInt32BigEndian(uintBuffer, crc);
+        stream.Write(uintBuffer);
+    }
+
+    private static uint ComputeCrc32(ReadOnlySpan<byte> chunkType, ReadOnlySpan<byte> data)
+    {
+        var crc = uint.MaxValue;
+        crc = UpdateCrc32(crc, chunkType);
+        crc = UpdateCrc32(crc, data);
+
+        return ~crc;
+    }
+
+    private static uint UpdateCrc32(uint crc, ReadOnlySpan<byte> data)
+    {
+        foreach (var value in data)
+        {
+            crc = Crc32Table[(int)((crc ^ value) & 0xFF)] ^ (crc >> 8);
+        }
+
+        return crc;
+    }
+
+    private static uint[] InitializeCrc32Table()
+    {
+        var table = new uint[256];
+        for (uint index = 0; index < table.Length; index++)
+        {
+            var crc = index;
+            for (var bit = 0; bit < 8; bit++)
+            {
+                crc = (crc & 1) == 0 ? (crc >> 1) : (0xEDB88320u ^ (crc >> 1));
+            }
+
+            table[index] = crc;
+        }
+
+        return table;
+    }
+}

--- a/src/Meziantou.Framework.QRCode/QRCodePngRenderer.cs
+++ b/src/Meziantou.Framework.QRCode/QRCodePngRenderer.cs
@@ -1,5 +1,4 @@
-using System.Buffers.Binary;
-using System.IO.Compression;
+using Meziantou.Framework.Internal;
 
 namespace Meziantou.Framework;
 
@@ -8,12 +7,6 @@ namespace Meziantou.Framework;
 /// </summary>
 public static class QRCodePngRenderer
 {
-    private static readonly byte[] PngSignature = [137, 80, 78, 71, 13, 10, 26, 10];
-    private static readonly byte[] IhdrChunkType = [73, 72, 68, 82];
-    private static readonly byte[] IdatChunkType = [73, 68, 65, 84];
-    private static readonly byte[] IendChunkType = [73, 69, 78, 68];
-    private static readonly uint[] Crc32Table = InitializeCrc32Table();
-
     /// <summary>Renders the QR code as PNG bytes with default options.</summary>
     public static byte[] ToPng(this QRCode qrCode)
     {
@@ -47,9 +40,8 @@ public static class QRCodePngRenderer
         var width = GetTotalDimension(qrCode.Width, options.QuietZoneModules, options.ModuleSize);
         var height = GetTotalDimension(qrCode.Height, options.QuietZoneModules, options.ModuleSize);
         var imageData = CreateImageData(qrCode, width, height, options);
-        var compressedImageData = CompressImageData(imageData);
 
-        WritePng(stream, width, height, compressedImageData);
+        PngWriter.WriteRgba(stream, width, height, imageData);
     }
 
     private static int GetTotalDimension(int size, int quietZoneModules, int moduleSize)
@@ -96,83 +88,5 @@ public static class QRCodePngRenderer
         }
 
         return result;
-    }
-
-    private static byte[] CompressImageData(ReadOnlySpan<byte> imageData)
-    {
-        using var output = new MemoryStream();
-        using (var compressionStream = new ZLibStream(output, CompressionLevel.SmallestSize, leaveOpen: true))
-        {
-            compressionStream.Write(imageData);
-        }
-
-        return output.ToArray();
-    }
-
-    private static void WritePng(Stream stream, int width, int height, ReadOnlySpan<byte> compressedImageData)
-    {
-        stream.Write(PngSignature);
-
-        Span<byte> ihdrData = stackalloc byte[13];
-        BinaryPrimitives.WriteUInt32BigEndian(ihdrData, (uint)width);
-        BinaryPrimitives.WriteUInt32BigEndian(ihdrData[4..], (uint)height);
-        ihdrData[8] = 8;
-        ihdrData[9] = 6;
-        ihdrData[10] = 0;
-        ihdrData[11] = 0;
-        ihdrData[12] = 0;
-
-        WriteChunk(stream, IhdrChunkType, ihdrData);
-        WriteChunk(stream, IdatChunkType, compressedImageData);
-        WriteChunk(stream, IendChunkType, ReadOnlySpan<byte>.Empty);
-    }
-
-    private static void WriteChunk(Stream stream, ReadOnlySpan<byte> chunkType, ReadOnlySpan<byte> data)
-    {
-        Span<byte> uintBuffer = stackalloc byte[4];
-        BinaryPrimitives.WriteUInt32BigEndian(uintBuffer, (uint)data.Length);
-        stream.Write(uintBuffer);
-        stream.Write(chunkType);
-        stream.Write(data);
-
-        var crc = ComputeCrc32(chunkType, data);
-        BinaryPrimitives.WriteUInt32BigEndian(uintBuffer, crc);
-        stream.Write(uintBuffer);
-    }
-
-    private static uint ComputeCrc32(ReadOnlySpan<byte> chunkType, ReadOnlySpan<byte> data)
-    {
-        var crc = uint.MaxValue;
-        crc = UpdateCrc32(crc, chunkType);
-        crc = UpdateCrc32(crc, data);
-
-        return ~crc;
-    }
-
-    private static uint UpdateCrc32(uint crc, ReadOnlySpan<byte> data)
-    {
-        foreach (var value in data)
-        {
-            crc = Crc32Table[(int)((crc ^ value) & 0xFF)] ^ (crc >> 8);
-        }
-
-        return crc;
-    }
-
-    private static uint[] InitializeCrc32Table()
-    {
-        var table = new uint[256];
-        for (uint index = 0; index < table.Length; index++)
-        {
-            var crc = index;
-            for (var bit = 0; bit < 8; bit++)
-            {
-                crc = (crc & 1) == 0 ? (crc >> 1) : (0xEDB88320u ^ (crc >> 1));
-            }
-
-            table[index] = crc;
-        }
-
-        return table;
     }
 }


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2309**

**No behaviour change** — every PNG snapshot is byte identical.

## The problem

`QRCodePngRenderer` (`:11-15,101-177`) and `BarcodePngRenderer` (`:11-15,106-182`) held
byte-identical copies of the entire PNG container implementation:

- `PngSignature` and the four chunk-type arrays
- `CompressImageData`, `WritePng`, `WriteChunk`
- `ComputeCrc32`, `UpdateCrc32`, `InitializeCrc32Table`

About 120 lines each, including **two separate 256-entry CRC tables** built and held for the
lifetime of the process.

Any change to how this library writes PNG has to be made twice and kept in sync — which is
exactly what #2309 needs to do.

## The change

Moves the container writing into `Internal/PngWriter.cs`.

Scanline generation stays in each renderer, because the two genuinely differ: QR codes carry a
quiet zone on all four sides, barcodes only on the left and right. Unifying that too would have
meant an abstraction over the module source for no benefit at this step.

## Verification

312 tests pass on net10.0 and net11.0. Every PNG snapshot matches, which for a pure extraction
is the assertion that matters.
