### PR TITLE
Encode PNG output as a two-colour palette and stream the rows

### DIFF
--- a/src/Meziantou.Framework.QRCode/BarcodePngRenderer.cs
+++ b/src/Meziantou.Framework.QRCode/BarcodePngRenderer.cs
@@ -39,9 +39,22 @@ public static class BarcodePngRenderer
 
         var width = GetTotalDimensionWithQuietZone(barcode.Width, options.QuietZoneModules, options.ModuleWidth, nameof(options.ModuleWidth));
         var height = GetTotalDimension(barcode.Height, options.ModuleHeight, nameof(options.ModuleHeight));
-        var imageData = CreateImageData(barcode, width, height, options);
 
-        PngWriter.WriteRgba(stream, width, height, imageData);
+        PngWriter.WritePalette(stream, width, height, options.LightColor, options.DarkColor, (row, y) =>
+        {
+            var sourceRow = y / options.ModuleHeight;
+            if (sourceRow < 0 || sourceRow >= barcode.Height)
+                return;
+
+            for (var x = 0; x < width; x++)
+            {
+                var sourceColumn = (x / options.ModuleWidth) - options.QuietZoneModules;
+                if (sourceColumn >= 0 && sourceColumn < barcode.Width && barcode[sourceRow, sourceColumn])
+                {
+                    row[x >> 3] |= (byte)(0x80 >> (x & 7));
+                }
+            }
+        });
     }
 
     private static int GetTotalDimensionWithQuietZone(int size, int quietZoneModules, int moduleSize, string parameterName)
@@ -60,38 +73,5 @@ public static class BarcodePngRenderer
             throw new ArgumentOutOfRangeException(parameterName, "The output image dimensions are too large.");
 
         return (int)value;
-    }
-
-    private static byte[] CreateImageData(Barcode barcode, int width, int height, BarcodePngOptions options)
-    {
-        var stride = (width * 4) + 1;
-        var dataLength = (long)stride * height;
-        if (dataLength > int.MaxValue)
-            throw new ArgumentOutOfRangeException(nameof(options), "The output image is too large.");
-
-        var result = new byte[(int)dataLength];
-        for (var row = 0; row < height; row++)
-        {
-            var rowOffset = row * stride;
-            var sourceRow = row / options.ModuleHeight;
-            for (var col = 0; col < width; col++)
-            {
-                var sourceCol = (col / options.ModuleWidth) - options.QuietZoneModules;
-                var isDark = sourceRow >= 0
-                    && sourceRow < barcode.Height
-                    && sourceCol >= 0
-                    && sourceCol < barcode.Width
-                    && barcode[sourceRow, sourceCol];
-
-                var color = isDark ? options.DarkColor : options.LightColor;
-                var pixelOffset = rowOffset + 1 + (col * 4);
-                result[pixelOffset] = color.Red;
-                result[pixelOffset + 1] = color.Green;
-                result[pixelOffset + 2] = color.Blue;
-                result[pixelOffset + 3] = color.Alpha;
-            }
-        }
-
-        return result;
     }
 }

--- a/src/Meziantou.Framework.QRCode/Internal/PngRowRenderer.cs
+++ b/src/Meziantou.Framework.QRCode/Internal/PngRowRenderer.cs
@@ -1,0 +1,11 @@
+namespace Meziantou.Framework.Internal;
+
+/// <summary>
+/// Fills one packed scanline of a two-colour indexed PNG.
+/// </summary>
+/// <param name="row">
+/// The packed scanline. It is cleared before each call and holds one bit per pixel, most
+/// significant bit leftmost; set a bit to make that pixel dark.
+/// </param>
+/// <param name="rowIndex">The zero-based row being rendered.</param>
+internal delegate void PngRowRenderer(Span<byte> row, int rowIndex);

--- a/src/Meziantou.Framework.QRCode/Internal/PngWriter.cs
+++ b/src/Meziantou.Framework.QRCode/Internal/PngWriter.cs
@@ -4,49 +4,99 @@ using System.IO.Compression;
 namespace Meziantou.Framework.Internal;
 
 /// <summary>
-/// Writes a PNG container: signature, IHDR, IDAT and IEND, with the CRC32 each chunk needs.
+/// Writes a PNG container: signature, IHDR, PLTE, IDAT and IEND, with the CRC32 each chunk needs.
 /// </summary>
 internal static class PngWriter
 {
     private static readonly byte[] Signature = [137, 80, 78, 71, 13, 10, 26, 10];
     private static readonly byte[] IhdrChunkType = [73, 72, 68, 82];
+    private static readonly byte[] PlteChunkType = [80, 76, 84, 69];
+    private static readonly byte[] TrnsChunkType = [116, 82, 78, 83];
     private static readonly byte[] IdatChunkType = [73, 68, 65, 84];
     private static readonly byte[] IendChunkType = [73, 69, 78, 68];
     private static readonly uint[] Crc32Table = InitializeCrc32Table();
 
     /// <summary>
-    /// Writes a truecolour-with-alpha (8 bits per channel) PNG.
+    /// Writes a two-colour indexed PNG at one bit per pixel.
     /// </summary>
     /// <param name="stream">The destination stream.</param>
     /// <param name="width">The image width in pixels.</param>
     /// <param name="height">The image height in pixels.</param>
-    /// <param name="imageData">Scanlines, each prefixed with its filter type byte.</param>
-    public static void WriteRgba(Stream stream, int width, int height, ReadOnlySpan<byte> imageData)
+    /// <param name="lightColor">The colour for a clear bit.</param>
+    /// <param name="darkColor">The colour for a set bit.</param>
+    /// <param name="renderRow">
+    /// Fills one packed scanline. The span is cleared before each call and holds one bit per
+    /// pixel, most significant bit leftmost; set a bit to make that pixel dark.
+    /// </param>
+    /// <remarks>
+    /// QR codes and barcodes are two-colour images, so an indexed palette stores them at a
+    /// thirty-second of the bytes truecolour-with-alpha needs. Rows are streamed into the
+    /// compressor as they are produced rather than buffered, so peak memory does not scale with
+    /// the image size.
+    /// </remarks>
+    public static void WritePalette(Stream stream, int width, int height, Color lightColor, Color darkColor, PngRowRenderer renderRow)
     {
-        var compressedImageData = Compress(imageData);
+        var compressedImageData = CompressRows(width, height, renderRow);
 
         stream.Write(Signature);
 
         Span<byte> ihdrData = stackalloc byte[13];
         BinaryPrimitives.WriteUInt32BigEndian(ihdrData, (uint)width);
         BinaryPrimitives.WriteUInt32BigEndian(ihdrData[4..], (uint)height);
-        ihdrData[8] = 8;  // Bit depth
-        ihdrData[9] = 6;  // Colour type: truecolour with alpha
+        ihdrData[8] = 1;  // Bit depth
+        ihdrData[9] = 3;  // Colour type: indexed
         ihdrData[10] = 0; // Compression method
         ihdrData[11] = 0; // Filter method
         ihdrData[12] = 0; // Interlace method
-
         WriteChunk(stream, IhdrChunkType, ihdrData);
+
+        Span<byte> palette = [lightColor.Red, lightColor.Green, lightColor.Blue, darkColor.Red, darkColor.Green, darkColor.Blue];
+        WriteChunk(stream, PlteChunkType, palette);
+
+        if (lightColor.Alpha is not byte.MaxValue || darkColor.Alpha is not byte.MaxValue)
+        {
+            Span<byte> transparency = [lightColor.Alpha, darkColor.Alpha];
+            WriteChunk(stream, TrnsChunkType, transparency);
+        }
+
         WriteChunk(stream, IdatChunkType, compressedImageData);
         WriteChunk(stream, IendChunkType, ReadOnlySpan<byte>.Empty);
     }
 
-    private static byte[] Compress(ReadOnlySpan<byte> imageData)
+    private static byte[] CompressRows(int width, int height, PngRowRenderer renderRow)
     {
+        var bytesPerRow = (width + 7) / 8;
+        var current = new byte[bytesPerRow];
+        var previous = new byte[bytesPerRow];
+        var filtered = new byte[bytesPerRow + 1];
+
         using var output = new MemoryStream();
         using (var compressionStream = new ZLibStream(output, CompressionLevel.SmallestSize, leaveOpen: true))
         {
-            compressionStream.Write(imageData);
+            for (var row = 0; row < height; row++)
+            {
+                Array.Clear(current);
+                renderRow(current, row);
+
+                // The Up filter turns a row identical to the one above it into zeroes, which is
+                // the common case here because every module spans ModuleSize rows.
+                if (row is 0)
+                {
+                    filtered[0] = 0; // None
+                    current.CopyTo(filtered.AsSpan(1));
+                }
+                else
+                {
+                    filtered[0] = 2; // Up
+                    for (var i = 0; i < bytesPerRow; i++)
+                    {
+                        filtered[i + 1] = (byte)(current[i] - previous[i]);
+                    }
+                }
+
+                compressionStream.Write(filtered);
+                (previous, current) = (current, previous);
+            }
         }
 
         return output.ToArray();

--- a/src/Meziantou.Framework.QRCode/QRCodePngRenderer.cs
+++ b/src/Meziantou.Framework.QRCode/QRCodePngRenderer.cs
@@ -39,9 +39,22 @@ public static class QRCodePngRenderer
 
         var width = GetTotalDimension(qrCode.Width, options.QuietZoneModules, options.ModuleSize);
         var height = GetTotalDimension(qrCode.Height, options.QuietZoneModules, options.ModuleSize);
-        var imageData = CreateImageData(qrCode, width, height, options);
 
-        PngWriter.WriteRgba(stream, width, height, imageData);
+        PngWriter.WritePalette(stream, width, height, options.LightColor, options.DarkColor, (row, y) =>
+        {
+            var sourceRow = (y / options.ModuleSize) - options.QuietZoneModules;
+            if (sourceRow < 0 || sourceRow >= qrCode.Height)
+                return;
+
+            for (var x = 0; x < width; x++)
+            {
+                var sourceColumn = (x / options.ModuleSize) - options.QuietZoneModules;
+                if (sourceColumn >= 0 && sourceColumn < qrCode.Width && qrCode[sourceRow, sourceColumn])
+                {
+                    row[x >> 3] |= (byte)(0x80 >> (x & 7));
+                }
+            }
+        });
     }
 
     private static int GetTotalDimension(int size, int quietZoneModules, int moduleSize)
@@ -53,40 +66,5 @@ public static class QRCodePngRenderer
         }
 
         return (int)value;
-    }
-
-    private static byte[] CreateImageData(QRCode qrCode, int width, int height, QRCodePngOptions options)
-    {
-        var stride = (width * 4) + 1;
-        var dataLength = (long)stride * height;
-        if (dataLength > int.MaxValue)
-        {
-            throw new ArgumentOutOfRangeException("options.ModuleSize", "The output image is too large.");
-        }
-
-        var result = new byte[(int)dataLength];
-
-        for (var row = 0; row < height; row++)
-        {
-            var rowOffset = row * stride;
-            var sourceRow = (row / options.ModuleSize) - options.QuietZoneModules;
-            for (var col = 0; col < width; col++)
-            {
-                var sourceCol = (col / options.ModuleSize) - options.QuietZoneModules;
-                var isDark = sourceRow >= 0
-                    && sourceRow < qrCode.Height
-                    && sourceCol >= 0
-                    && sourceCol < qrCode.Width
-                    && qrCode[sourceRow, sourceCol];
-                var color = isDark ? options.DarkColor : options.LightColor;
-                var pixelOffset = rowOffset + 1 + (col * 4);
-                result[pixelOffset] = color.Red;
-                result[pixelOffset + 1] = color.Green;
-                result[pixelOffset + 2] = color.Blue;
-                result[pixelOffset + 3] = color.Alpha;
-            }
-        }
-
-        return result;
     }
 }

--- a/tests/Meziantou.Framework.QRCode.Tests/QRCodePngRendererTests.cs
+++ b/tests/Meziantou.Framework.QRCode.Tests/QRCodePngRendererTests.cs
@@ -48,9 +48,9 @@ public class QRCodePngRendererTests
         var qr = QRCode.Create("A", ErrorCorrectionLevel.L);
         var png = qr.ToPng();
 
-        var (width, height, _, _) = ParsePng(png);
-        Assert.Equal(290, width);
-        Assert.Equal(290, height);
+        var parsed = ParsePng(png);
+        Assert.Equal(290, parsed.Width);
+        Assert.Equal(290, parsed.Height);
     }
 
     [Theory]
@@ -69,9 +69,9 @@ public class QRCodePngRendererTests
         var qr = QRCode.CreateMicroQR("123", ErrorCorrectionLevel.L);
         var png = qr.ToPng(new QRCodePngOptions { ModuleSize = 2, QuietZoneModules = 1 });
 
-        var (width, height, _, _) = ParsePng(png);
-        Assert.Equal((11 + 2) * 2, width);
-        Assert.Equal((11 + 2) * 2, height);
+        var parsed = ParsePng(png);
+        Assert.Equal((11 + 2) * 2, parsed.Width);
+        Assert.Equal((11 + 2) * 2, parsed.Height);
     }
 
     [Fact]
@@ -80,9 +80,9 @@ public class QRCodePngRendererTests
         var qr = QRCode.CreateRMQR("AB", ErrorCorrectionLevel.M);
         var png = qr.ToPng(new QRCodePngOptions { ModuleSize = 3, QuietZoneModules = 0 });
 
-        var (width, height, _, _) = ParsePng(png);
-        Assert.Equal(27 * 3, width);
-        Assert.Equal(11 * 3, height);
+        var parsed = ParsePng(png);
+        Assert.Equal(27 * 3, parsed.Width);
+        Assert.Equal(11 * 3, parsed.Height);
     }
 
     [Fact]
@@ -113,19 +113,20 @@ public class QRCodePngRendererTests
             LightColor = Color.FromArgb(0x40, 0xaa, 0xbb, 0xcc),
         }));
 
-        var width = normal.Width;
-        var pixelIndex = 1;
-        var expectedNormalPixel = qr[0, 0] ? (byte)0 : (byte)255;
-        var expectedCustomPixel = qr[0, 0] ? new byte[] { 0x11, 0x22, 0x33, 0x7f } : [0xaa, 0xbb, 0xcc, 0x40];
-
-        Assert.Equal(width, custom.Width);
+        Assert.Equal(normal.Width, custom.Width);
         Assert.Equal(normal.Height, custom.Height);
-        Assert.Equal((byte)6, custom.ColorType);
-        Assert.Equal(expectedNormalPixel, normal.ImageData[pixelIndex]);
-        Assert.Equal(expectedCustomPixel[0], custom.ImageData[pixelIndex]);
-        Assert.Equal(expectedCustomPixel[1], custom.ImageData[pixelIndex + 1]);
-        Assert.Equal(expectedCustomPixel[2], custom.ImageData[pixelIndex + 2]);
-        Assert.Equal(expectedCustomPixel[3], custom.ImageData[pixelIndex + 3]);
+
+        // Indexed, one bit per pixel: the colours live in PLTE and tRNS, and a set bit means dark.
+        Assert.Equal((byte)3, custom.ColorType);
+        Assert.Equal((byte)1, custom.BitDepth);
+        Assert.Equal(new byte[] { 0xaa, 0xbb, 0xcc, 0x11, 0x22, 0x33 }, custom.Palette);
+        Assert.Equal(new byte[] { 0x40, 0x7f }, custom.Transparency);
+        Assert.Equal(qr[0, 0], custom.IsSet(0, 0));
+
+        // The default colours are opaque, so no tRNS chunk is written at all.
+        Assert.Equal(new byte[] { 0xff, 0xff, 0xff, 0x00, 0x00, 0x00 }, normal.Palette);
+        Assert.Empty(normal.Transparency);
+        Assert.Equal(qr[0, 0], normal.IsSet(0, 0));
     }
 
     [Fact]
@@ -177,12 +178,27 @@ public class QRCodePngRendererTests
         Assert.Throws<ArgumentNullException>(() => qr.ToPng(options: null!));
     }
 
-    private static (int Width, int Height, byte ColorType, byte[] ImageData) ParsePng(byte[] data)
+    private sealed record ParsedPng(int Width, int Height, byte BitDepth, byte ColorType, byte[] Palette, byte[] Transparency, byte[] ImageData)
+    {
+        /// <summary>Gets whether the pixel at the given position uses palette entry 1.</summary>
+        public bool IsSet(int row, int column)
+        {
+            var bytesPerRow = ((Width * BitDepth) + 7) / 8;
+            var rowOffset = (row * (bytesPerRow + 1)) + 1;
+
+            return (ImageData[rowOffset + (column >> 3)] & (0x80 >> (column & 7))) != 0;
+        }
+    }
+
+    private static ParsedPng ParsePng(byte[] data)
     {
         var offset = 8;
         var width = 0;
         var height = 0;
+        byte bitDepth = 0;
         byte colorType = 0;
+        var palette = Array.Empty<byte>();
+        var transparency = Array.Empty<byte>();
         using var idatData = new MemoryStream();
 
         while (offset < data.Length)
@@ -195,7 +211,16 @@ public class QRCodePngRendererTests
             {
                 width = BinaryPrimitives.ReadInt32BigEndian(chunkData[..4]);
                 height = BinaryPrimitives.ReadInt32BigEndian(chunkData[4..8]);
+                bitDepth = chunkData[8];
                 colorType = chunkData[9];
+            }
+            else if (chunkType.SequenceEqual("PLTE"u8))
+            {
+                palette = chunkData.ToArray();
+            }
+            else if (chunkType.SequenceEqual("tRNS"u8))
+            {
+                transparency = chunkData.ToArray();
             }
             else if (chunkType.SequenceEqual("IDAT"u8))
             {
@@ -214,6 +239,6 @@ public class QRCodePngRendererTests
         using var imageData = new MemoryStream();
         zlib.CopyTo(imageData);
 
-        return (width, height, colorType, imageData.ToArray());
+        return new ParsedPng(width, height, bitDepth, colorType, palette, transparency, imageData.ToArray());
     }
 }


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/png-writer-extract` (#2308) · merge #2308 first**

## The problem

QR codes and barcodes are two-colour images, but the renderers expanded every module to 32-bit
RGBA and materialized the entire image before compressing it
(`QRCodePngRenderer.cs:66-99`, `BarcodePngRenderer.cs:73-104`).

Measured on a version 40 symbol at the default `ModuleSize = 10`:

```
1850x1850 px → 91,324-byte file, 14,415,040 bytes allocated, 108 ms
```

14 MB of large-object-heap traffic to emit 91 KB. A web endpoint generating QR codes on demand
pays that per request, and the `dataLength > int.MaxValue` guard meant the ceiling was a 2 GB
single allocation. `ToPng` then copied the compressed stream again via `stream.ToArray()`.

## The change

- **Colour type 3 at one bit per pixel** with a two-entry `PLTE`. `tRNS` is written only when a
  colour is translucent, so the common opaque case does not carry the chunk at all.
- **Up filter** (type 2) instead of None. Every module spans `ModuleSize` rows, so identical
  consecutive rows collapse to zeroes and deflate away.
- **Rows streamed into the compressor** as they are produced. Peak memory is now two scanline
  buffers — 232 bytes each for the image above — rather than the whole image.

Same symbol after:

```
1850x1850 px → 16,148-byte file, 107,240 bytes allocated, 9 ms
```

**5.7× smaller output, 134× less allocation, 12× faster.**

## Verification

312 tests pass on net10.0 and net11.0.

The snapshot comparer decodes PNGs to ARGB and compares pixel content rather than raw bytes, so
**every existing PNG snapshot still matches** — the images are unchanged, only the encoding is.
That is the strongest available evidence for this change, and no snapshot needed regenerating.

`ToPng_CustomColors_UsesConfiguredRgb` inspected raw RGBA scanline bytes, which no longer exist.
Rewritten to assert the `PLTE` and `tRNS` chunks directly plus the pixel bit — a more precise
test of the same property, and it now also pins that opaque colours emit no `tRNS`.
