### PR TITLE
Name the assertion method to use in the MFAS0005 message

### DIFF
--- a/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzer.cs
+++ b/src/Meziantou.Framework.Assertions.Analyzer/Rules/CountAssertionAnalyzer.cs
@@ -20,7 +20,7 @@ public sealed class CountAssertionAnalyzer : DiagnosticAnalyzer
     public static readonly DiagnosticDescriptor UseHasCountDescriptor = new(
         id: RuleIdentifiers.UseHasCountAssertionDiagnosticId,
         title: "Use specialized count assertions",
-        messageFormat: "Use a specialized count assertion method",
+        messageFormat: "Use Assert.{0}(expected, actual) to report the actual count",
         category: "Assertions",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
@@ -53,7 +53,7 @@ public sealed class CountAssertionAnalyzer : DiagnosticAnalyzer
         }
         else
         {
-            context.ReportDiagnostic(UseHasCountDescriptor, match.CountOperation);
+            context.ReportDiagnostic(UseHasCountDescriptor, match.CountOperation, match.AssertionMethodName);
         }
     }
 }

--- a/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CountAssertionRuleTests.cs
+++ b/tests/Meziantou.Framework.Assertions.Analyzer.Tests/CountAssertionRuleTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis.Testing;
 using CountAssertionAnalyzerType = Meziantou.Framework.Analyzers.Assertions.CountAssertionAnalyzer;
 using CountAssertionCodeFixProviderType = Meziantou.Framework.Analyzers.Assertions.CountAssertionCodeFixProvider;
 
@@ -1213,5 +1214,37 @@ public sealed class CountAssertionRuleTests : AssertionsAnalyzerTestBase
             """;
 
         await CreateCodeFixTest<CountAssertionAnalyzerType, CountAssertionCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Theory]
+    [InlineData("Assert.Equal(3, {|#0:collection.Count|});", "HasCount")]
+    [InlineData("Assert.NotEqual(3, {|#0:collection.Count|});", "DoesNotHaveCount")]
+    [InlineData("Assert.True({|#0:collection.Count|} < 3);", "HasCountLessThan")]
+    [InlineData("Assert.True({|#0:collection.Count|} <= 3);", "HasCountLessThanOrEqual")]
+    [InlineData("Assert.True({|#0:collection.Count|} > 3);", "HasCountGreaterThan")]
+    [InlineData("Assert.True({|#0:collection.Count|} >= 3);", "HasCountGreaterThanOrEqual")]
+    public async Task Analyzer_MessageIndicatesTheAssertionMethodToUse(string assertion, string expectedAssertionMethodName)
+    {
+        var source = $$"""
+            using System.Collections.Generic;
+            using Meziantou.Framework.Assertions;
+
+            namespace Sample;
+
+            public static class TestClass
+            {
+                public static void M(List<int> collection)
+                {
+                    {{assertion}}
+                }
+            }
+            """;
+
+        var test = CreateAnalyzerTest<CountAssertionAnalyzerType>(source);
+        test.ExpectedDiagnostics.Add(new DiagnosticResult(CountAssertionAnalyzerType.UseHasCountDescriptor)
+            .WithLocation(0)
+            .WithMessage($"Use Assert.{expectedAssertionMethodName}(expected, actual) to report the actual count"));
+
+        await test.RunAsync(XunitCancellationToken);
     }
 }


### PR DESCRIPTION
## What

`MFAS0005` reported the same message for every match:

> MFAS0005: Use a specialized count assertion method

It now names the method that applies:

| code | message |
| --- | --- |
| `Assert.Equal(3, collection.Count)` | Use Assert.**HasCount**(expected, actual) to report the actual count |
| `Assert.NotEqual(3, collection.Count)` | Use Assert.**DoesNotHaveCount**(expected, actual) to report the actual count |
| `Assert.True(collection.Count < 3)` | Use Assert.**HasCountLessThan**(expected, actual) to report the actual count |
| `Assert.True(collection.Count <= 3)` | Use Assert.**HasCountLessThanOrEqual**(expected, actual) to report the actual count |
| `Assert.True(collection.Count > 3)` | Use Assert.**HasCountGreaterThan**(expected, actual) to report the actual count |
| `Assert.True(collection.Count >= 3)` | Use Assert.**HasCountGreaterThanOrEqual**(expected, actual) to report the actual count |

## Why

The old message did not tell the user which of the six count assertions to reach for, which matters most outside the IDE (build logs, CI output) where the code fix is not one keystroke away.

The analyzer already computed the method name to build the code fix — it just was not passed as a message argument. `MFAS0004`, declared directly above it in the same file, already did exactly that (`"Use Assert.{0} for count checks against zero"`), so this only makes the two consistent.

## Notes for reviewers

- The wording follows the convention used across this analyzer set, e.g. `"Use Assert.InRange(actual, low, high) to report the value and the range"`.
- Only `messageFormat` changed. The rule id, title, category, severity and the code fix are untouched, so the readme rules table (which lists titles) needs no update.
- The existing tests use `{|MFAS0005:...|}` markup, which verifies the diagnostic id and location but not the message text, so the message was previously unverified. Added a theory covering all six method names.

## Verification

- `dotnet build ... /p:TreatsWarningsAsErrors=true` — 0 warnings, 0 errors
- `dotnet test tests/Meziantou.Framework.Assertions.Analyzer.Tests` — 209/209 pass (45 in `CountAssertionRuleTests`, including the 6 new cases)
- `dotnet run ./eng/update-all.cs` — no generated file changes