### PR TITLE
Reject bencode data nested deeper than the supported limit

### DIFF
--- a/src/Meziantou.Framework.Bencode/BencodeDecoder.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeDecoder.cs
@@ -2,17 +2,24 @@ namespace Meziantou.Framework.Bencode;
 
 internal static class BencodeDecoder
 {
+    /// <summary>The maximum number of nested lists and dictionaries a bencode document may contain.</summary>
+    /// <remarks>
+    /// Parsing is recursive, so an unbounded nesting depth would overflow the stack, which cannot be caught.
+    /// Real documents nest a handful of levels; this limit is far above any legitimate use.
+    /// </remarks>
+    public const int MaxDepth = 64;
+
     public static BencodeValue Parse(ReadOnlySpan<byte> data)
     {
         var index = 0;
-        var value = ParseValue(data, ref index);
+        var value = ParseValue(data, ref index, depth: 0);
         if (index != data.Length)
             throw new FormatException("Unexpected trailing data after bencode value.");
 
         return value;
     }
 
-    private static BencodeValue ParseValue(ReadOnlySpan<byte> data, ref int index)
+    private static BencodeValue ParseValue(ReadOnlySpan<byte> data, ref int index, int depth)
     {
         if (index >= data.Length)
             throw new FormatException("Unexpected end of bencode data.");
@@ -22,8 +29,8 @@ internal static class BencodeDecoder
         {
             (byte)'i' => ParseInteger(data, ref index),
             >= (byte)'0' and <= (byte)'9' => ParseString(data, ref index),
-            (byte)'l' => ParseList(data, ref index),
-            (byte)'d' => ParseDictionary(data, ref index),
+            (byte)'l' => ParseList(data, ref index, depth),
+            (byte)'d' => ParseDictionary(data, ref index, depth),
             _ => throw new FormatException($"Invalid bencode token '{(char)token}' at position {index}."),
         };
     }
@@ -80,8 +87,9 @@ internal static class BencodeDecoder
         return new BencodeString(bytes);
     }
 
-    private static BencodeList ParseList(ReadOnlySpan<byte> data, ref int index)
+    private static BencodeList ParseList(ReadOnlySpan<byte> data, ref int index, int depth)
     {
+        EnsureDepth(depth);
         index++; // l
         var result = new BencodeList();
         while (true)
@@ -95,12 +103,13 @@ internal static class BencodeDecoder
                 return result;
             }
 
-            result.Add(ParseValue(data, ref index));
+            result.Add(ParseValue(data, ref index, depth + 1));
         }
     }
 
-    private static BencodeDictionary ParseDictionary(ReadOnlySpan<byte> data, ref int index)
+    private static BencodeDictionary ParseDictionary(ReadOnlySpan<byte> data, ref int index, int depth)
     {
+        EnsureDepth(depth);
         index++; // d
         var result = new BencodeDictionary();
 
@@ -116,7 +125,7 @@ internal static class BencodeDecoder
             }
 
             var key = ParseString(data, ref index);
-            var value = ParseValue(data, ref index);
+            var value = ParseValue(data, ref index, depth + 1);
             try
             {
                 result.Add(key, value);
@@ -126,6 +135,12 @@ internal static class BencodeDecoder
                 throw new FormatException("Duplicate bencode dictionary key.", ex);
             }
         }
+    }
+
+    private static void EnsureDepth(int depth)
+    {
+        if (depth >= MaxDepth)
+            throw new FormatException($"Bencode data is nested too deeply. The maximum supported depth is {MaxDepth}.");
     }
 
     private static bool IsValidInteger(ReadOnlySpan<byte> value)

--- a/src/Meziantou.Framework.Bencode/BencodePipeReaderDecoder.cs
+++ b/src/Meziantou.Framework.Bencode/BencodePipeReaderDecoder.cs
@@ -22,7 +22,7 @@ internal sealed class BencodePipeReaderDecoder
         var decoder = new BencodePipeReaderDecoder(reader);
         try
         {
-            var value = await decoder.ParseValueAsync(cancellationToken).ConfigureAwait(false);
+            var value = await decoder.ParseValueAsync(depth: 0, cancellationToken).ConfigureAwait(false);
             await decoder.EnsureNoTrailingDataAsync(cancellationToken).ConfigureAwait(false);
             return value;
         }
@@ -32,15 +32,15 @@ internal sealed class BencodePipeReaderDecoder
         }
     }
 
-    private async ValueTask<BencodeValue> ParseValueAsync(CancellationToken cancellationToken)
+    private async ValueTask<BencodeValue> ParseValueAsync(int depth, CancellationToken cancellationToken)
     {
         var token = await PeekByteAsync(cancellationToken).ConfigureAwait(false);
         return token switch
         {
             (byte)'i' => await ParseIntegerAsync(cancellationToken).ConfigureAwait(false),
             >= (byte)'0' and <= (byte)'9' => await ParseStringAsync(cancellationToken).ConfigureAwait(false),
-            (byte)'l' => await ParseListAsync(cancellationToken).ConfigureAwait(false),
-            (byte)'d' => await ParseDictionaryAsync(cancellationToken).ConfigureAwait(false),
+            (byte)'l' => await ParseListAsync(depth, cancellationToken).ConfigureAwait(false),
+            (byte)'d' => await ParseDictionaryAsync(depth, cancellationToken).ConfigureAwait(false),
             null => throw new FormatException("Unexpected end of bencode data."),
             _ => throw new FormatException($"Invalid bencode token '{(char)token.GetValueOrDefault()}' at position {_position}."),
         };
@@ -112,8 +112,9 @@ internal sealed class BencodePipeReaderDecoder
         return new BencodeString(stringBytes);
     }
 
-    private async ValueTask<BencodeList> ParseListAsync(CancellationToken cancellationToken)
+    private async ValueTask<BencodeList> ParseListAsync(int depth, CancellationToken cancellationToken)
     {
+        EnsureDepth(depth);
         Consume(1); // l
         var result = new BencodeList();
         while (true)
@@ -128,12 +129,13 @@ internal sealed class BencodePipeReaderDecoder
                 return result;
             }
 
-            result.Add(await ParseValueAsync(cancellationToken).ConfigureAwait(false));
+            result.Add(await ParseValueAsync(depth + 1, cancellationToken).ConfigureAwait(false));
         }
     }
 
-    private async ValueTask<BencodeDictionary> ParseDictionaryAsync(CancellationToken cancellationToken)
+    private async ValueTask<BencodeDictionary> ParseDictionaryAsync(int depth, CancellationToken cancellationToken)
     {
+        EnsureDepth(depth);
         Consume(1); // d
         var result = new BencodeDictionary();
         while (true)
@@ -149,7 +151,7 @@ internal sealed class BencodePipeReaderDecoder
             }
 
             var key = await ParseStringAsync(cancellationToken).ConfigureAwait(false);
-            var value = await ParseValueAsync(cancellationToken).ConfigureAwait(false);
+            var value = await ParseValueAsync(depth + 1, cancellationToken).ConfigureAwait(false);
             try
             {
                 result.Add(key, value);
@@ -249,6 +251,12 @@ internal sealed class BencodePipeReaderDecoder
         var span = writer.GetSpan(1);
         span[0] = value;
         writer.Advance(1);
+    }
+
+    private static void EnsureDepth(int depth)
+    {
+        if (depth >= BencodeDecoder.MaxDepth)
+            throw new FormatException($"Bencode data is nested too deeply. The maximum supported depth is {BencodeDecoder.MaxDepth}.");
     }
 
     private static bool IsValidInteger(ReadOnlySpan<byte> value)

--- a/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
@@ -127,6 +127,68 @@ public sealed class BencodeDocumentTests
     }
 
     [Fact]
+    public void Parse_DeeplyNestedLists_ThrowsInsteadOfOverflowingTheStack()
+    {
+        var data = new byte[200_000];
+        Array.Fill(data, (byte)'l');
+
+        var exception = Assert.Throws<FormatException>(() => BencodeDocument.Parse(data));
+        Assert.Contains("nested too deeply", exception.Message);
+    }
+
+    [Fact]
+    public async Task ParseAsync_DeeplyNestedLists_ThrowsInsteadOfOverflowingTheStack()
+    {
+        var data = new byte[200_000];
+        Array.Fill(data, (byte)'l');
+
+        var pipe = new Pipe();
+        var parseTask = BencodeDocument.ParseAsync(pipe.Reader).AsTask();
+        await pipe.Writer.WriteAsync(data);
+        await pipe.Writer.CompleteAsync();
+
+        var exception = await Assert.ThrowsAsync<FormatException>(() => parseTask);
+        Assert.Contains("nested too deeply", exception.Message);
+
+        await pipe.Reader.CompleteAsync();
+    }
+
+    [Theory]
+    [InlineData(64, true)]
+    [InlineData(65, false)]
+    public void Parse_NestingDepthBoundary(int depth, bool expectedSuccess)
+    {
+        var data = Encoding.ASCII.GetBytes(new string('l', depth) + new string('e', depth));
+
+        if (expectedSuccess)
+        {
+            Assert.IsType<BencodeList>(BencodeDocument.Parse(data).Root);
+        }
+        else
+        {
+            Assert.Throws<FormatException>(() => BencodeDocument.Parse(data));
+        }
+    }
+
+    [Theory]
+    [InlineData(64, true)]
+    [InlineData(65, false)]
+    public async Task ParseAsync_NestingDepthBoundary(int depth, bool expectedSuccess)
+    {
+        var data = Encoding.ASCII.GetBytes(string.Concat(Enumerable.Repeat("d1:a", depth)) + "1:b" + new string('e', depth));
+
+        await using var stream = new MemoryStream(data);
+        if (expectedSuccess)
+        {
+            Assert.IsType<BencodeDictionary>((await BencodeDocument.ParseAsync(stream)).Root);
+        }
+        else
+        {
+            await Assert.ThrowsAsync<FormatException>(async () => await BencodeDocument.ParseAsync(stream));
+        }
+    }
+
+    [Fact]
     public void Parse_InvalidData_Throws()
     {
         var data = Encoding.ASCII.GetBytes("i-0e");


### PR DESCRIPTION
## The problem

`BencodeDecoder.ParseValue` → `ParseList` → `ParseValue` recursed once per nesting level with no depth limit, in both the synchronous decoder (`BencodeDecoder.cs:15-29`, `:83-99`, `:102-128`) and the streaming one (`BencodePipeReaderDecoder.cs:35-47`, `:115-133`, `:135-162`).

A document consisting only of `l` bytes overflows the stack. Measured on this machine, the failure happens at ~24,880 frames — roughly **25 KB of input**:

```
Stack overflow.
Repeated 24880 times:
   at Meziantou.Framework.Bencode.BencodeDecoder.ParseList(System.ReadOnlySpan<Byte>, Int32 ByRef)
```

The streaming decoder fails the same way: its awaits complete synchronously while data is buffered, so the state machines chain on the stack.

A .NET stack overflow is not catchable. `TorrentFile.TryParse` cannot return `false`, a `catch (Exception)` in the host cannot contain it, and the process dies — so a 25 KB torrent kills every other in-flight request too.

## The change

Thread a `depth` counter through `ParseValue`/`ParseList`/`ParseDictionary` in both decoders and throw `FormatException` past `BencodeDecoder.MaxDepth` (64, the same default `System.Text.Json` uses). Real torrents nest three or four levels, so this is far above any legitimate document.

The limit is a single `const` on `BencodeDecoder` that the streaming decoder references, so the two decoders can't drift. No public API change.

## Verification

`dotnet build /p:TreatWarningsAsErrors=true` clean; `dotnet test` green — 66 tests across net10.0 and net11.0, up from 54.

New tests in `BencodeDocumentTests`:

- `Parse_DeeplyNestedLists_ThrowsInsteadOfOverflowingTheStack` and the `ParseAsync` counterpart — 200 KB of `l` now raises `FormatException` instead of taking the process down. Before this change these tests crash the test host rather than fail.
- `Parse_NestingDepthBoundary` / `ParseAsync_NestingDepthBoundary` — 64 levels parse, 65 are rejected, pinning the limit on both decoders.

Found by a project review of `src/Meziantou.Framework.Bencode`.
