### PR TITLE
Bound the allocations the streaming bencode decoder makes from declared sizes

### DIFF
--- a/src/Meziantou.Framework.Bencode/BencodePipeReaderDecoder.cs
+++ b/src/Meziantou.Framework.Bencode/BencodePipeReaderDecoder.cs
@@ -5,6 +5,16 @@ namespace Meziantou.Framework.Bencode;
 
 internal sealed class BencodePipeReaderDecoder
 {
+    // long.MinValue is 20 characters including the sign, and int.MaxValue is 10 digits. The decoder reads these
+    // digits from the stream before it can validate them, so the runs must be bounded or a peer can make the
+    // decoder buffer without limit by never sending a terminator.
+    private const int MaxIntegerDigits = 20;
+    private const int MaxStringLengthDigits = 10;
+
+    // A declared string length is attacker-controlled, so the payload buffer starts small and grows with the data
+    // that actually arrives instead of being sized from the declaration.
+    private const int InitialStringBufferSize = 64 * 1024;
+
     private readonly PipeReader _reader;
     private ReadOnlySequence<byte> _buffer;
     private bool _hasPendingReadResult;
@@ -60,6 +70,9 @@ internal sealed class BencodePipeReaderDecoder
             if (next == (byte)'e')
                 break;
 
+            if (integerText.WrittenCount == MaxIntegerDigits)
+                throw new FormatException("Invalid bencode integer format.");
+
             AppendByte(integerText, next.Value);
         }
 
@@ -84,6 +97,9 @@ internal sealed class BencodePipeReaderDecoder
 
             if (next is >= (byte)'0' and <= (byte)'9')
             {
+                if (lengthText.WrittenCount == MaxStringLengthDigits)
+                    throw new FormatException("Invalid bencode string length.");
+
                 AppendByte(lengthText, next.Value);
                 continue;
             }
@@ -105,10 +121,7 @@ internal sealed class BencodePipeReaderDecoder
         if (!int.TryParse(lengthString, CultureInfo.InvariantCulture, out var stringLength) || stringLength < 0)
             throw new FormatException("Invalid bencode string length.");
 
-        var stringBytes = new byte[stringLength];
-        if (!await TryReadExactlyAsync(stringBytes.AsMemory(), cancellationToken).ConfigureAwait(false))
-            throw new FormatException("Unexpected end of bencode string data.");
-
+        var stringBytes = await ReadStringDataAsync(stringLength, cancellationToken).ConfigureAwait(false);
         return new BencodeString(stringBytes);
     }
 
@@ -170,24 +183,24 @@ internal sealed class BencodePipeReaderDecoder
             throw new FormatException("Unexpected trailing data after bencode value.");
     }
 
-    private async ValueTask<bool> TryReadExactlyAsync(Memory<byte> destination, CancellationToken cancellationToken)
+    private async ValueTask<ReadOnlyMemory<byte>> ReadStringDataAsync(int length, CancellationToken cancellationToken)
     {
-        var offset = 0;
-        while (offset < destination.Length)
-        {
-            if (_buffer.IsEmpty)
-            {
-                if (!await ReadMoreAsync(cancellationToken).ConfigureAwait(false))
-                    return false;
-            }
+        if (length is 0)
+            return ReadOnlyMemory<byte>.Empty;
 
-            var bytesToCopy = (int)Math.Min(_buffer.Length, destination.Length - offset);
-            _buffer.Slice(0, bytesToCopy).CopyTo(destination.Span[offset..(offset + bytesToCopy)]);
+        var destination = new ArrayBufferWriter<byte>(Math.Min(length, InitialStringBufferSize));
+        while (destination.WrittenCount < length)
+        {
+            if (_buffer.IsEmpty && !await ReadMoreAsync(cancellationToken).ConfigureAwait(false))
+                throw new FormatException("Unexpected end of bencode string data.");
+
+            var bytesToCopy = (int)Math.Min(_buffer.Length, length - destination.WrittenCount);
+            _buffer.Slice(0, bytesToCopy).CopyTo(destination.GetSpan(bytesToCopy));
             Consume(bytesToCopy);
-            offset += bytesToCopy;
+            destination.Advance(bytesToCopy);
         }
 
-        return true;
+        return destination.WrittenMemory;
     }
 
     private async ValueTask<byte?> TryReadByteAsync(CancellationToken cancellationToken)

--- a/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
@@ -149,6 +149,28 @@ public sealed class BencodeDocumentTests
 
         var exception = await Assert.ThrowsAsync<FormatException>(() => parseTask);
         Assert.Contains("nested too deeply", exception.Message);
+    }
+
+    [Fact]
+    public async Task ParseAsync_DeclaredStringLengthIsNotAllocatedBeforeTheDataArrives()
+    {
+        var pipe = new Pipe();
+        await pipe.Writer.WriteAsync("2000000000:"u8.ToArray());
+        await pipe.Writer.CompleteAsync();
+
+        // Every byte is already buffered, so the parse runs synchronously on this thread and the counter is reliable.
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        try
+        {
+            await BencodeDocument.ParseAsync(pipe.Reader);
+            Assert.Fail("Expected a FormatException.");
+        }
+        catch (FormatException)
+        {
+        }
+
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.True(allocated < 1024 * 1024, $"An 11-byte document allocated {allocated} bytes.");
 
         await pipe.Reader.CompleteAsync();
     }
@@ -186,6 +208,90 @@ public sealed class BencodeDocumentTests
         {
             await Assert.ThrowsAsync<FormatException>(async () => await BencodeDocument.ParseAsync(stream));
         }
+    }
+
+    [Fact]
+    public async Task ParseAsync_UnterminatedIntegerDigits_AreRejectedInsteadOfBuffered()
+    {
+        var pipe = new Pipe();
+        var parseTask = BencodeDocument.ParseAsync(pipe.Reader).AsTask();
+
+        var digits = new byte[1024];
+        Array.Fill(digits, (byte)'1');
+        await pipe.Writer.WriteAsync("i"u8.ToArray());
+        await pipe.Writer.WriteAsync(digits);
+
+        await Assert.ThrowsAsync<FormatException>(() => parseTask.WaitAsync(TimeSpan.FromSeconds(30)));
+
+        await pipe.Writer.CompleteAsync();
+        await pipe.Reader.CompleteAsync();
+    }
+
+    [Fact]
+    public async Task ParseAsync_UnterminatedStringLengthDigits_AreRejectedInsteadOfBuffered()
+    {
+        var pipe = new Pipe();
+        var parseTask = BencodeDocument.ParseAsync(pipe.Reader).AsTask();
+
+        var digits = new byte[1024];
+        Array.Fill(digits, (byte)'1');
+        await pipe.Writer.WriteAsync(digits);
+
+        await Assert.ThrowsAsync<FormatException>(() => parseTask.WaitAsync(TimeSpan.FromSeconds(30)));
+
+        await pipe.Writer.CompleteAsync();
+        await pipe.Reader.CompleteAsync();
+    }
+
+    [Fact]
+    public async Task ParseAsync_StringSpanningMultipleReads_IsReadCompletely()
+    {
+        var payload = new byte[300_000];
+        for (var i = 0; i < payload.Length; i++)
+        {
+            payload[i] = (byte)(i % 256);
+        }
+
+        var pipe = new Pipe();
+        var parseTask = BencodeDocument.ParseAsync(pipe.Reader).AsTask();
+
+        await pipe.Writer.WriteAsync(Encoding.ASCII.GetBytes(payload.Length + ":"));
+        for (var offset = 0; offset < payload.Length; offset += 10_000)
+        {
+            await pipe.Writer.WriteAsync(payload.AsMemory(offset, Math.Min(10_000, payload.Length - offset)));
+        }
+
+        await pipe.Writer.CompleteAsync();
+
+        var value = Assert.IsType<BencodeString>((await parseTask).Root);
+        Assert.True(value.Value.Span.SequenceEqual(payload));
+
+        await pipe.Reader.CompleteAsync();
+    }
+
+    [Fact]
+    public async Task ParseAsync_TruncatedStringData_Throws()
+    {
+        var pipe = new Pipe();
+        await pipe.Writer.WriteAsync("10:abc"u8.ToArray());
+        await pipe.Writer.CompleteAsync();
+
+        await Assert.ThrowsAsync<FormatException>(async () => await BencodeDocument.ParseAsync(pipe.Reader));
+
+        await pipe.Reader.CompleteAsync();
+    }
+
+    [Fact]
+    public async Task ParseAsync_EmptyString_IsSupported()
+    {
+        var pipe = new Pipe();
+        await pipe.Writer.WriteAsync("0:"u8.ToArray());
+        await pipe.Writer.CompleteAsync();
+
+        var value = Assert.IsType<BencodeString>((await BencodeDocument.ParseAsync(pipe.Reader)).Root);
+        Assert.True(value.Value.IsEmpty);
+
+        await pipe.Reader.CompleteAsync();
     }
 
     [Fact]


### PR DESCRIPTION
## The problem

The streaming decoder sized allocations from numbers that come out of the data being parsed, before any of the corresponding payload had arrived.

**1. The declared string length was allocated up front** (`BencodePipeReaderDecoder.cs:108`): `new byte[stringLength]` ran before `TryReadExactlyAsync` discovered there was no such data. Feeding a `PipeReader` the 11 bytes `2000000000:` and nothing else:

```
input=11 bytes, allocated=1907 MB
```

That is a ~190,000,000× amplification from one tiny write. The synchronous decoder does not have this bug — `BencodeDecoder.cs:75` checks the remaining length before slicing, because the whole document is already in memory.

**2. Digit runs were buffered without limit** (`:53-64` for integers, `:78-95` for string lengths): both loops appended into a growing `ArrayBufferWriter<byte>` and only validated after the terminator arrived. A peer that sends `i` followed by digits and never sends `e` grows memory indefinitely — 64 MB of digits took the process to 160 MB RSS with the parse still running.

Either one lets a peer exhaust memory from a trivially small amount of sent data.

## The change

- `ReadStringDataAsync` replaces `TryReadExactlyAsync`. The payload buffer starts at `min(declaredLength, 64 KB)` and grows with the bytes that actually arrive, so allocation tracks real data rather than the declaration. It returns `ReadOnlyMemory<byte>` straight from the writer, so there is no extra copy on the way into `BencodeString`; the cost is that a string can retain up to 2× its length from the growth doubling.
- Digit runs are capped at 20 for integers (`long.MinValue` is 20 characters with its sign) and 10 for string lengths (`int.MaxValue` is 10 digits). Anything longer was already invalid — now it is rejected as it is read instead of after it is buffered.

No public API change; both types are internal.

## Verification

`dotnet build /p:TreatWarningsAsErrors=true` clean; `dotnet test` green — 66 tests across net10.0 and net11.0, up from 54.

I confirmed the three regression tests fail against `main`'s decoder and pass with this change:

```
failed ParseAsync_DeclaredStringLengthIsNotAllocatedBeforeTheDataArrives (5ms)
failed ParseAsync_UnterminatedStringLengthDigits_AreRejectedInsteadOfBuffered (30s)
failed ParseAsync_UnterminatedIntegerDigits_AreRejectedInsteadOfBuffered (30s)
```

The two digit-flood tests time out on `main` because the parse simply never finishes — they carry a 30s `WaitAsync` so a regression fails rather than hangs. The allocation test buffers the whole document before parsing, so the parse runs synchronously on the test thread and `GC.GetAllocatedBytesForCurrentThread` is a reliable measure; the 1 MB threshold is generous against ~2 GB before the change.

Three further tests cover the rewritten read path rather than the bug: a 300 KB string split across many pipe writes, a truncated string, and the empty-string case.

Found by a project review of `src/Meziantou.Framework.Bencode`.
