### PR TITLE
Stop the streaming bencode parse when the pending read is canceled

### DIFF
--- a/src/Meziantou.Framework.Bencode/BencodePipeReaderDecoder.cs
+++ b/src/Meziantou.Framework.Bencode/BencodePipeReaderDecoder.cs
@@ -223,6 +223,9 @@ internal sealed class BencodePipeReaderDecoder
             _buffer = readResult.Buffer;
             _hasPendingReadResult = true;
 
+            if (readResult.IsCanceled)
+                throw new OperationCanceledException("The bencode read was canceled.");
+
             if (!_buffer.IsEmpty)
                 return true;
 

--- a/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
@@ -189,6 +189,37 @@ public sealed class BencodeDocumentTests
     }
 
     [Fact]
+    public async Task ParseAsync_CancelPendingRead_StopsTheParse()
+    {
+        var pipe = new Pipe();
+        var parseTask = BencodeDocument.ParseAsync(pipe.Reader).AsTask();
+        await pipe.Writer.WriteAsync("l"u8.ToArray());
+
+        pipe.Reader.CancelPendingRead();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => parseTask.WaitAsync(TimeSpan.FromSeconds(30)));
+
+        await pipe.Writer.CompleteAsync();
+        await pipe.Reader.CompleteAsync();
+    }
+
+    [Fact]
+    public async Task ParseAsync_CancellationToken_StopsTheParse()
+    {
+        using var cts = new CancellationTokenSource();
+        var pipe = new Pipe();
+        var parseTask = BencodeDocument.ParseAsync(pipe.Reader, cts.Token).AsTask();
+        await pipe.Writer.WriteAsync("l"u8.ToArray());
+
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => parseTask.WaitAsync(TimeSpan.FromSeconds(30)));
+
+        await pipe.Writer.CompleteAsync();
+        await pipe.Reader.CompleteAsync();
+    }
+
+    [Fact]
     public void Parse_InvalidData_Throws()
     {
         var data = Encoding.ASCII.GetBytes("i-0e");


### PR DESCRIPTION
## The problem

`ReadMoreAsync` (`BencodePipeReaderDecoder.cs:214-230`) inspected `_buffer.IsEmpty` and `readResult.IsCompleted` but never `readResult.IsCanceled`, so a cancelled read looked exactly like "no data yet" and the loop called `ReadAsync` again.

`PipeReader.CancelPendingRead()` is the documented way to unblock a consumer — for shutdown, or an idle timeout on a connection. Against this decoder it does nothing: the parse task never completes and the reader leaks.

Reproduced by cancelling mid-parse:

```
[cancel] CancelPendingRead ignored - parse still hanging after 2s
```

The `CancellationToken` path was never affected — it propagates out of `ReadAsync` — it is specifically the pipe's own cancellation signal that was swallowed.

## The change

Check `readResult.IsCanceled` after the read result is stored and throw `OperationCanceledException`. The result is stored first so the `finally` in `ParseAsync` still calls `AdvanceTo` with the correct positions on the way out.

## Verification

`dotnet build /p:TreatWarningsAsErrors=true` clean; `dotnet test` green — 58 tests across net10.0 and net11.0, up from 54.

`ParseAsync_CancelPendingRead_StopsTheParse` fails against `main` and passes here:

```
failed ParseAsync_CancelPendingRead_StopsTheParse (30s 004ms)
```

It hangs on `main`, so the assertion carries a 30s `WaitAsync` — a regression fails the test rather than wedging the run. `ParseAsync_CancellationToken_StopsTheParse` covers the token path, which already worked, so the two cancellation routes stay covered together.

Found by a project review of `src/Meziantou.Framework.Bencode`.
