### PR TITLE
Render binary bencode strings as hexadecimal instead of throwing from ToString

### DIFF
--- a/src/Meziantou.Framework.Bencode/BencodeString.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeString.cs
@@ -1,8 +1,12 @@
+using System.Text.Unicode;
+
 namespace Meziantou.Framework.Bencode;
 
 public sealed class BencodeString : BencodeValue, IEquatable<BencodeString>
 {
     private static readonly Encoding Utf8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    private const int MaxDiagnosticByteCount = 32;
 
     public BencodeString(ReadOnlyMemory<byte> value)
     {
@@ -13,6 +17,8 @@ public sealed class BencodeString : BencodeValue, IEquatable<BencodeString>
 
     public ReadOnlyMemory<byte> Value { get; }
 
+    /// <summary>Decodes the value as UTF-8.</summary>
+    /// <exception cref="DecoderFallbackException">The value is not valid UTF-8. Bencode strings hold arbitrary bytes, so use <see cref="ToString"/> when the value may be binary.</exception>
     public string ToUtf8String()
     {
         return Utf8Encoding.GetString(Value.Span);
@@ -41,5 +47,15 @@ public sealed class BencodeString : BencodeValue, IEquatable<BencodeString>
         writer.WriteString(Value.Span);
     }
 
-    public override string ToString() => ToUtf8String();
+    /// <summary>Returns a representation suitable for diagnostics. Bencode strings hold arbitrary bytes, so a value that is not valid UTF-8 is rendered as hexadecimal instead.</summary>
+    public override string ToString()
+    {
+        var span = Value.Span;
+        if (Utf8.IsValid(span))
+            return Utf8Encoding.GetString(span);
+
+        return span.Length <= MaxDiagnosticByteCount
+            ? "0x" + Convert.ToHexString(span)
+            : $"0x{Convert.ToHexString(span[..MaxDiagnosticByteCount])}... ({span.Length} bytes)";
+    }
 }

--- a/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
@@ -152,6 +152,55 @@ public sealed class BencodeDocumentTests
     }
 
     [Fact]
+    public void BencodeString_ToString_ValidUtf8_ReturnsTheText()
+    {
+        var value = new BencodeString("caf\u00e9"u8.ToArray());
+
+        Assert.Equal("caf\u00e9", value.ToString());
+    }
+
+    [Fact]
+    public void BencodeString_ToString_NonUtf8_ReturnsHexadecimalInsteadOfThrowing()
+    {
+        var value = new BencodeString(new byte[] { 0xFF, 0x00, 0x9A });
+
+        Assert.Equal("0xFF009A", value.ToString());
+    }
+
+    [Fact]
+    public void BencodeString_ToString_LongBinaryValue_IsTruncated()
+    {
+        var bytes = new byte[100];
+        Array.Fill(bytes, (byte)0xFF);
+
+        var text = new BencodeString(bytes).ToString();
+
+        Assert.Equal("0x" + new string('F', 64) + "... (100 bytes)", text);
+    }
+
+    [Fact]
+    public void BencodeString_ToUtf8String_NonUtf8_StillThrows()
+    {
+        var value = new BencodeString(new byte[] { 0xFF });
+
+        Assert.Throws<DecoderFallbackException>(() => value.ToUtf8String());
+    }
+
+    [Fact]
+    public void BencodeString_ToString_ParsedBinaryValue_DoesNotThrow()
+    {
+        var data = new List<byte>("d6:pieces20:"u8.ToArray());
+        data.AddRange([0x00, 0x01, 0x02, 0xFF, 0xFE]);
+        data.AddRange("0123456789abcde"u8.ToArray());
+        data.Add((byte)'e');
+
+        var dictionary = Assert.IsType<BencodeDictionary>(BencodeDocument.Parse(data.ToArray()).Root);
+        var pieces = dictionary[new BencodeString("pieces"u8.ToArray())];
+
+        Assert.Equal("0x000102FFFE303132333435363738396162636465", pieces.ToString());
+    }
+
+    [Fact]
     public void BencodeWriter_WriteDictionary()
     {
         var buffer = new ArrayBufferWriter<byte>();


### PR DESCRIPTION
## The problem

`BencodeString.ToString()` delegated to `ToUtf8String()` (`BencodeString.cs:44`), and `Utf8Encoding` is built with `throwOnInvalidBytes: true` (`:5`). Bencode strings hold arbitrary bytes, so `ToString()` threw for any binary value:

```
[tostring] THREW System.Text.DecoderFallbackException
```

That includes `pieces` — the concatenated SHA-1 digests, and the largest field in every torrent file.

`ToString()` is what runs in a debugger watch window, in `$"{value}"` interpolation, and in log statements. Throwing there turns a diagnostic into an exception at exactly the moment someone is trying to diagnose something.

## The change

`ToString()` now checks `Utf8.IsValid` first. Valid UTF-8 is returned as before, so nothing that worked previously changes. A value that is not valid UTF-8 is rendered as hexadecimal, truncated past 32 bytes with the total length appended:

```
0x000102FFFE303132333435363738396162636465
0xFFFFFF...FFFF... (100 bytes)
```

`ToUtf8String()` is deliberately left strict — validating the encoding is its job — and now says so in an XML doc that points binary callers at `ToString()`.

`Utf8.IsValid` replaces a try/catch so the common `pieces` path costs a scan rather than an exception. No public API change.

## Verification

`dotnet build /p:TreatWarningsAsErrors=true` clean; `dotnet test` green — 64 tests across net10.0 and net11.0, up from 54.

Three of the five new tests fail against `main` and pass here:

```
failed BencodeString_ToString_NonUtf8_ReturnsHexadecimalInsteadOfThrowing (2ms)
failed BencodeString_ToString_ParsedBinaryValue_DoesNotThrow (2ms)
failed BencodeString_ToString_LongBinaryValue_IsTruncated (0ms)
```

The other two pin the behaviour that must not change: valid UTF-8 still round-trips through `ToString()`, and `ToUtf8String()` still throws `DecoderFallbackException` on invalid bytes.

This is one half of a review finding. The other half — `TorrentFile.TryParse` throwing `DecoderFallbackException` instead of returning `false` for a legacy-encoded torrent — is fixed separately in the torrent layer.

Found by a project review of `src/Meziantou.Framework.Bencode`.
