### PR TITLE
Report torrent fields that are not valid UTF-8 as a format error

### DIFF
--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentField.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentField.cs
@@ -1,0 +1,22 @@
+namespace Meziantou.Framework.Bencode.Torrent;
+
+internal static class TorrentField
+{
+    /// <summary>Decodes a metainfo field as UTF-8, reporting invalid data as a <see cref="FormatException"/> like every other malformed field.</summary>
+    /// <remarks>
+    /// Bencode strings hold arbitrary bytes, and torrents produced with a legacy code page carry text that is not
+    /// valid UTF-8. Without this, decoding throws <see cref="DecoderFallbackException"/>, which escapes
+    /// <see cref="TorrentFile.TryParse"/> because it is not a <see cref="FormatException"/>.
+    /// </remarks>
+    public static string ToText(BencodeString value, string fieldName)
+    {
+        try
+        {
+            return value.ToUtf8String();
+        }
+        catch (DecoderFallbackException ex)
+        {
+            throw new FormatException($"The '{fieldName}' field is not valid UTF-8.", ex);
+        }
+    }
+}

--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentFile.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentFile.cs
@@ -96,7 +96,7 @@ public sealed class TorrentFile
             if (announceValue is not BencodeString announceText)
                 throw new FormatException("The 'announce' field must be a string.");
 
-            result.Announce = announceText.ToUtf8String();
+            result.Announce = TorrentField.ToText(announceText, "announce");
         }
 
         if (dictionary.TryGetValue(AnnounceListKey, out var announceListValue))
@@ -116,7 +116,7 @@ public sealed class TorrentFile
                     if (urlValue is not BencodeString urlText)
                         throw new FormatException("Each tracker URL must be a string.");
 
-                    urls.Add(urlText.ToUtf8String());
+                    urls.Add(TorrentField.ToText(urlText, "announce-list"));
                 }
 
                 tiers.Add(urls);
@@ -130,7 +130,7 @@ public sealed class TorrentFile
             if (commentValue is not BencodeString commentText)
                 throw new FormatException("The 'comment' field must be a string.");
 
-            result.Comment = commentText.ToUtf8String();
+            result.Comment = TorrentField.ToText(commentText, "comment");
         }
 
         if (dictionary.TryGetValue(CreatedByKey, out var createdByValue))
@@ -138,7 +138,7 @@ public sealed class TorrentFile
             if (createdByValue is not BencodeString createdByText)
                 throw new FormatException("The 'created by' field must be a string.");
 
-            result.CreatedBy = createdByText.ToUtf8String();
+            result.CreatedBy = TorrentField.ToText(createdByText, "created by");
         }
 
         if (dictionary.TryGetValue(CreationDateKey, out var creationDateValue))

--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentInfo.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentInfo.cs
@@ -74,7 +74,7 @@ public sealed class TorrentInfo
                     if (segmentValue is not BencodeString segmentString)
                         throw new FormatException("Each path segment must be a bencode string.");
 
-                    path.Add(segmentString.ToUtf8String());
+                    path.Add(TorrentField.ToText(segmentString, "path"));
                 }
 
                 files.Add(new TorrentInfoFile
@@ -193,7 +193,7 @@ public sealed class TorrentInfo
         if (!dictionary.TryGetValue(key, out var value) || value is not BencodeString text)
             throw new FormatException($"The required '{fieldName}' field is missing or not a string.");
 
-        return text.ToUtf8String();
+        return TorrentField.ToText(text, fieldName);
     }
 
     private static BencodeString GetRequiredByteString(BencodeDictionary dictionary, BencodeString key, string fieldName)

--- a/tests/Meziantou.Framework.Bencode.Tests/TorrentFileTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/TorrentFileTests.cs
@@ -43,6 +43,54 @@ public sealed class TorrentFileTests
     }
 
     [Fact]
+    public void TryParse_NonUtf8Comment_ReturnsFalse()
+    {
+        var data = new List<byte>("d7:comment2:"u8.ToArray());
+        data.AddRange([0xFF, 0xFE]);
+        data.AddRange("4:infod6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:01234567890123456789ee"u8.ToArray());
+
+        var parsed = TorrentFile.TryParse(data.ToArray(), out var torrent);
+
+        Assert.False(parsed);
+        Assert.Null(torrent);
+    }
+
+    [Fact]
+    public void Parse_NonUtf8Name_ThrowsFormatException()
+    {
+        var data = new List<byte>("d4:infod6:lengthi123e4:name2:"u8.ToArray());
+        data.AddRange([0xFF, 0xFE]);
+        data.AddRange("12:piece lengthi16384e6:pieces20:01234567890123456789ee"u8.ToArray());
+
+        var exception = Assert.Throws<FormatException>(() => TorrentFile.Parse(data.ToArray()));
+        Assert.IsType<DecoderFallbackException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void Parse_NonUtf8PathSegment_ThrowsFormatException()
+    {
+        var data = new List<byte>("d4:infod5:filesld6:lengthi1e4:pathl2:"u8.ToArray());
+        data.AddRange([0xFF, 0xFE]);
+        data.AddRange("eee4:name4:test12:piece lengthi16384e6:pieces20:01234567890123456789ee"u8.ToArray());
+
+        Assert.Throws<FormatException>(() => TorrentFile.Parse(data.ToArray()));
+    }
+
+    [Fact]
+    public void Parse_NonAsciiUtf8Comment_IsStillSupported()
+    {
+        var data = new List<byte>("d7:comment"u8.ToArray());
+        var comment = Encoding.UTF8.GetBytes("caf\u00e9 \u2013 caf\u00e9");
+        data.AddRange(Encoding.ASCII.GetBytes(comment.Length + ":"));
+        data.AddRange(comment);
+        data.AddRange("4:infod6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:01234567890123456789ee"u8.ToArray());
+
+        var torrent = TorrentFile.Parse(data.ToArray());
+
+        Assert.Equal("caf\u00e9 \u2013 caf\u00e9", torrent.Comment);
+    }
+
+    [Fact]
     public async Task WriteToAsync_RoundTrip()
     {
         var torrent = TorrentFile.Parse(SingleFileTorrent);


### PR DESCRIPTION
## The problem

`BencodeString.ToUtf8String()` throws `DecoderFallbackException` on invalid UTF-8, and that is an `ArgumentException`, not a `FormatException`. The torrent layer called it unguarded for `announce` (`TorrentFile.cs:99`), `announce-list` (`:119`), `comment` (`:133`), `created by` (`:141`), `name` (`TorrentInfo.cs:196`) and every path segment (`TorrentInfo.cs:77`).

`TryParse` catches only `FormatException` (`TorrentFile.cs:47`), so a torrent carrying legacy-encoded metadata — cp1251, GBK, Shift-JIS, all common in the wild — escaped the `Try` contract entirely:

```
[tryparse] THREW System.Text.DecoderFallbackException: Unable to translate bytes [FF] at index 0 ...
```

A `TryParse` that throws is a crash in caller code that reasonably assumes it cannot.

## The change

A new internal `TorrentField.ToText` decodes each metainfo text field and translates `DecoderFallbackException` into `FormatException`, keeping the original as `InnerException`. Every decode site in the torrent layer goes through it.

That makes the exception contract uniform: `Parse` reports every malformed torrent as `FormatException`, and `TryParse` returns `false` for all of them, including this one.

Note what this does **not** do: a legacy-encoded torrent still fails to parse, it just fails predictably now. Reading those losslessly — honouring the `encoding` key, or exposing the raw bytes next to the decoded strings — is a larger question and is left for a separate change.

## Verification

`dotnet build /p:TreatWarningsAsErrors=true` clean; `dotnet test` green — 62 tests across net10.0 and net11.0, up from 54.

Three of the four new tests fail against `main` and pass here:

```
failed TorrentFileTests.TryParse_NonUtf8Comment_ReturnsFalse (1ms)
failed TorrentFileTests.Parse_NonUtf8Name_ThrowsFormatException (4ms)
failed TorrentFileTests.Parse_NonUtf8PathSegment_ThrowsFormatException (4ms)
```

The fourth, `Parse_NonAsciiUtf8Comment_IsStillSupported`, guards against over-rejecting: a comment with non-ASCII but valid UTF-8 still parses and round-trips to the same string.

This is one half of a review finding. The other half — `BencodeString.ToString()` throwing for binary values such as `pieces` — is fixed separately in the DOM layer.

Found by a project review of `src/Meziantou.Framework.Bencode`.
