### PR TITLE
Reject torrent path segments that escape the destination directory

### DIFF
--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentInfo.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentInfo.cs
@@ -138,6 +138,8 @@ public sealed class TorrentInfo
         if (string.IsNullOrEmpty(Name))
             throw new FormatException("Torrent info must contain a non-empty name.");
 
+        ValidatePathSegment(Name, "name");
+
         if (PieceLength <= 0)
             throw new FormatException("Torrent info must contain a positive piece length.");
 
@@ -173,11 +175,23 @@ public sealed class TorrentInfo
 
                 foreach (var segment in file.Path)
                 {
-                    if (string.IsNullOrEmpty(segment))
-                        throw new FormatException("Path segments cannot be null or empty.");
+                    ValidatePathSegment(segment, "path");
                 }
             }
         }
+    }
+
+    /// <summary>Rejects the segments BEP 3 forbids, because clients build a file path out of these values.</summary>
+    private static void ValidatePathSegment(string segment, string fieldName)
+    {
+        if (string.IsNullOrEmpty(segment))
+            throw new FormatException($"The '{fieldName}' field cannot contain a null or empty segment.");
+
+        if (segment is "." or "..")
+            throw new FormatException($"The '{fieldName}' field cannot contain a '.' or '..' segment.");
+
+        if (segment.AsSpan().ContainsAny('/', '\\'))
+            throw new FormatException($"The '{fieldName}' field cannot contain a directory separator.");
     }
 
     private static long GetRequiredInteger(BencodeDictionary dictionary, BencodeString key, string fieldName)

--- a/tests/Meziantou.Framework.Bencode.Tests/TorrentFileTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/TorrentFileTests.cs
@@ -42,6 +42,59 @@ public sealed class TorrentFileTests
         Assert.Null(torrent);
     }
 
+    [Theory]
+    [InlineData("l2:..4:.ssh6:id_rsae")]
+    [InlineData("l1:.6:id_rsae")]
+    [InlineData("l3:a/be")]
+    [InlineData("l4:a\\\\be")]
+    public void Parse_UnsafePathSegment_Throws(string pathList)
+    {
+        Assert.Throws<FormatException>(() => TorrentFile.Parse(MultiFileTorrent(pathList)));
+    }
+
+    [Theory]
+    [InlineData("2:..")]
+    [InlineData("1:.")]
+    [InlineData("3:a/b")]
+    public void Parse_UnsafeName_Throws(string name)
+    {
+        Assert.Throws<FormatException>(() => TorrentFile.Parse(MultiFileTorrent("l8:file.bine", name)));
+    }
+
+    [Theory]
+    [InlineData("l7:a:b.mp3e", "a:b.mp3")]
+    [InlineData("l3:..ae", "..a")]
+    [InlineData("l7:sub dir8:file.bine", "sub dir")]
+    public void Parse_LegitimatePathSegment_IsAccepted(string pathList, string expectedFirstSegment)
+    {
+        var torrent = TorrentFile.Parse(MultiFileTorrent(pathList));
+
+        Assert.NotNull(torrent.Info.Files);
+        Assert.Equal(expectedFirstSegment, torrent.Info.Files[0].Path[0]);
+    }
+
+    [Fact]
+    public void ToUtf8ByteArray_UnsafePathSegment_Throws()
+    {
+        var torrent = new TorrentFile
+        {
+            Info = new TorrentInfo
+            {
+                Name = "test",
+                PieceLength = 16,
+                Pieces = "01234567890123456789"u8.ToArray(),
+                Files = [new TorrentInfoFile { Length = 1, Path = ["..", "escaped.bin"] }],
+            },
+        };
+
+        Assert.Throws<FormatException>(() => torrent.ToUtf8ByteArray());
+    }
+
+    private static byte[] MultiFileTorrent(string pathList, string name = "4:test")
+    {
+        return Encoding.ASCII.GetBytes($"d4:infod5:filesld6:lengthi1e4:path{pathList}ee4:name{name}12:piece lengthi16384e6:pieces20:01234567890123456789ee");
+    }
+
     [Fact]
     public async Task WriteToAsync_RoundTrip()
     {


### PR DESCRIPTION
## The problem

`TorrentInfo.Validate()` rejected null and empty path segments (`TorrentInfo.cs:174-178`) and nothing else, so `..` passed straight through. `TorrentInfoFile.Path` is typed and named as a file path, so the natural next step in a downloader is `Path.Combine(destination, ...file.Path)` — which then escapes the download directory.

Reproduced end to end with a torrent whose `path` is `["..", "..", ".ssh", "id_rsa"]`:

```
[path] segments=[.., .., .ssh, id_rsa] -> /.ssh/id_rsa      (base was /downloads)
```

Segments containing a directory separator were unchecked too, and so was `name`, which clients use as the destination directory for a multi-file torrent.

BEP 3 explicitly requires rejecting `.` and `..` here. This library is the layer that has already decided to interpret the list as a path, so it is the right layer to enforce it — leaving it to every consumer means every consumer gets it wrong once.

## The change

`ValidatePathSegment` rejects empty segments, `.`, `..`, and any segment containing `/` or `\`. It runs over every `path` segment and over `name`.

The rule is deliberately narrow — the BEP-mandated set plus the backslash that Windows also treats as a separator. Notably it does **not** reject colons: they are legal in filenames on Linux and appear in real torrents, so rejecting them would break valid data to defend a Windows-only edge.

Validation runs on both paths, so an unsafe torrent is refused when parsed *and* when written.

## Verification

`dotnet build /p:TreatWarningsAsErrors=true` clean; `dotnet test` green — 76 tests across net10.0 and net11.0, up from 54.

All eight new rejection cases fail against `main` and pass here:

```
failed Parse_UnsafePathSegment_Throws(pathList: "l2:..4:.ssh6:id_rsae")
failed Parse_UnsafePathSegment_Throws(pathList: "l1:.6:id_rsae")
failed Parse_UnsafePathSegment_Throws(pathList: "l3:a/be")
failed Parse_UnsafePathSegment_Throws(pathList: "l4:a\\be")
failed Parse_UnsafeName_Throws(name: "2:..") / ("1:.") / ("3:a/b")
failed ToUtf8ByteArray_UnsafePathSegment_Throws
```

`Parse_LegitimatePathSegment_IsAccepted` guards the other direction with three cases that must keep working: `a:b.mp3`, `..a` (a name that merely starts with dots), and `sub dir`. The existing ubuntu torrent fixture still parses.

Found by a project review of `src/Meziantou.Framework.Bencode`.
