### PR TITLE
Encode the dictionary with ToUtf8ByteArray in the bencode readme sample

### DIFF
--- a/src/Meziantou.Framework.Bencode/readme.md
+++ b/src/Meziantou.Framework.Bencode/readme.md
@@ -23,7 +23,7 @@ var dictionary = (BencodeDictionary)document.Root;
 var cow = (BencodeString)dictionary[new BencodeString("cow"u8.ToArray())];
 Console.WriteLine(cow.ToUtf8String()); // moo
 
-var encoded = dictionary.ToArray();
+var encoded = dictionary.ToUtf8ByteArray(); // d3:cow3:moo4:spam4:eggse
 
 await using var stream = File.Create("output.bencode");
 await dictionary.WriteToAsync(stream);

--- a/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
@@ -102,6 +102,20 @@ public sealed class BencodeDocumentTests
     }
 
     [Fact]
+    public void ReadmeSample_ParseThenEncodeADictionary()
+    {
+        var data = "d3:cow3:moo4:spam4:eggse"u8.ToArray();
+        var document = BencodeDocument.Parse(data);
+
+        var dictionary = (BencodeDictionary)document.Root;
+        var cow = (BencodeString)dictionary[new BencodeString("cow"u8.ToArray())];
+        Assert.Equal("moo", cow.ToUtf8String());
+
+        var encoded = dictionary.ToUtf8ByteArray();
+        Assert.Equal("d3:cow3:moo4:spam4:eggse", Encoding.ASCII.GetString(encoded));
+    }
+
+    [Fact]
     public void BencodeValueToArray_CanonicalFalse_PreservesInsertionOrder()
     {
         BencodeValue value = new BencodeDictionary


### PR DESCRIPTION
## The problem

The readme's first example (`src/Meziantou.Framework.Bencode/readme.md:26`) read:

```csharp
var encoded = dictionary.ToArray();
```

`BencodeDictionary` implements `IReadOnlyDictionary<,>`, so that binds to `Enumerable.ToArray` and yields `KeyValuePair<BencodeString, BencodeValue>[]` — not the encoded bytes the surrounding text implies. Confirmed by compiling the snippet with the type spelled out:

```
error CS0029: Cannot implicitly convert type
'KeyValuePair<BencodeString, BencodeValue>[]' to 'byte[]'
```

`ToArray()` returning encoded bytes exists only on `BencodeDocument` (`BencodeDocument.cs:42`), not on `BencodeValue`. Because of `var`, the mistake compiles silently and hands the reader an array of entries where they expected a payload — and it is the first thing a new user copies.

## The change

Use the extension that actually encodes, and show the expected output:

```csharp
var encoded = dictionary.ToUtf8ByteArray(); // d3:cow3:moo4:spam4:eggse
```

`ReadmeSample_ParseThenEncodeADictionary` runs the corrected snippet end to end and asserts those bytes, so the example stays honest if the API moves.

## Verification

`dotnet build /p:TreatWarningsAsErrors=true` clean; `dotnet test` green — 56 tests across net10.0 and net11.0, up from 54.

Found by a project review of `src/Meziantou.Framework.Bencode`.
