### PR TITLE
Validate the bencode writer state before ending a container

### DIFF
--- a/src/Meziantou.Framework.Bencode/BencodeWriter.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeWriter.cs
@@ -60,9 +60,7 @@ public sealed class BencodeWriter
 
     public void WriteEndList()
     {
-        var state = PopContainer(ContainerKind.List);
-        WriteByte((byte)'e');
-        CompleteRootContainerIfNeeded(state);
+        EndContainer(ContainerKind.List);
     }
 
     public void WriteStartDictionary()
@@ -93,12 +91,7 @@ public sealed class BencodeWriter
 
     public void WriteEndDictionary()
     {
-        var state = PopContainer(ContainerKind.Dictionary);
-        if (!state.ExpectingDictionaryKey)
-            throw new InvalidOperationException("Cannot end a dictionary while expecting a value for the last key.");
-
-        WriteByte((byte)'e');
-        CompleteRootContainerIfNeeded(state);
+        EndContainer(ContainerKind.Dictionary);
     }
 
     public void Complete()
@@ -141,18 +134,30 @@ public sealed class BencodeWriter
         return false;
     }
 
-    private ContainerState PopContainer(ContainerKind expectedContainerKind)
+    private void EndContainer(ContainerKind expectedContainerKind)
     {
+        // Every check runs before the writer state is touched, so a rejected call leaves the container open
+        // and the caller can recover from the InvalidOperationException.
         if (_containers.Count == 0)
-            throw new InvalidOperationException($"Cannot end a {expectedContainerKind.ToString().ToLowerInvariant()} because no container is open.");
+            throw new InvalidOperationException($"Cannot end a {Describe(expectedContainerKind)} because no container is open.");
 
         var state = _containers[^1];
         if (state.Kind != expectedContainerKind)
-            throw new InvalidOperationException($"Cannot end a {expectedContainerKind.ToString().ToLowerInvariant()} while inside a {state.Kind.ToString().ToLowerInvariant()}.");
+            throw new InvalidOperationException($"Cannot end a {Describe(expectedContainerKind)} while inside a {Describe(state.Kind)}.");
+
+        if (state.Kind is ContainerKind.Dictionary && !state.ExpectingDictionaryKey)
+            throw new InvalidOperationException("Cannot end a dictionary while expecting a value for the last key.");
 
         _containers.RemoveAt(_containers.Count - 1);
-        return state;
+        WriteByte((byte)'e');
+
+        if (_containers.Count == 0)
+        {
+            _isComplete = true;
+        }
     }
+
+    private static string Describe(ContainerKind kind) => kind.ToString().ToLowerInvariant();
 
     private ContainerState GetCurrentContainer()
     {
@@ -160,17 +165,6 @@ public sealed class BencodeWriter
             throw new InvalidOperationException("No container is currently open.");
 
         return _containers[^1];
-    }
-
-    private void CompleteRootContainerIfNeeded(ContainerState state)
-    {
-        if (_containers.Count != 0)
-            return;
-
-        if (state.Kind is ContainerKind.Dictionary && !state.ExpectingDictionaryKey)
-            throw new InvalidOperationException("Cannot complete a dictionary with a missing value.");
-
-        _isComplete = true;
     }
 
     private void WriteStringCore(ReadOnlySpan<byte> value)

--- a/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/BencodeDocumentTests.cs
@@ -331,6 +331,48 @@ public sealed class BencodeDocumentTests
     }
 
     [Fact]
+    public void BencodeWriter_WriteEndDictionaryWhileExpectingValue_LeavesTheDictionaryOpen()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new BencodeWriter(buffer);
+        writer.WriteStartDictionary();
+        writer.WriteUtf8Key("a");
+
+        Assert.Throws<InvalidOperationException>(() => writer.WriteEndDictionary());
+
+        writer.WriteInteger(1);
+        writer.WriteEndDictionary();
+        writer.Complete();
+
+        Assert.Equal("d1:ai1ee", Encoding.ASCII.GetString(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void BencodeWriter_WriteEndListWhileInsideADictionary_LeavesTheDictionaryOpen()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new BencodeWriter(buffer);
+        writer.WriteStartDictionary();
+        writer.WriteUtf8Key("a");
+        writer.WriteInteger(1);
+
+        Assert.Throws<InvalidOperationException>(() => writer.WriteEndList());
+
+        writer.WriteEndDictionary();
+        writer.Complete();
+
+        Assert.Equal("d1:ai1ee", Encoding.ASCII.GetString(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void BencodeWriter_WriteEndDictionaryWithoutAnOpenContainer_Throws()
+    {
+        var writer = new BencodeWriter(new ArrayBufferWriter<byte>());
+
+        Assert.Throws<InvalidOperationException>(() => writer.WriteEndDictionary());
+    }
+
+    [Fact]
     public void BencodeWriter_WriteMultipleRootValues_Throws()
     {
         var writer = new BencodeWriter(new ArrayBufferWriter<byte>());


### PR DESCRIPTION
## The problem

`WriteEndDictionary` popped the container *before* validating it (`BencodeWriter.cs:94-102` via `PopContainer` at `:153`):

```csharp
var state = PopContainer(ContainerKind.Dictionary);   // already removed
if (!state.ExpectingDictionaryKey)
    throw new InvalidOperationException(...);          // ...then rejected
```

The exception is an `InvalidOperationException`, which by contract is recoverable — but the writer has already forgotten the open dictionary. A caller that catches it and continues then hits "Only one root bencode value can be written", because the writer believes the root value is finished.

Relatedly, the dictionary branch in `CompleteRootContainerIfNeeded` (`:170-171`) was unreachable: `WriteEndDictionary` throws first in that case, and `WriteEndList` never passes a dictionary state.

## The change

Both end methods now delegate to one `EndContainer`, which runs every check — container open, kind matches, no dangling dictionary key — before touching `_containers` or the output. `PopContainer` and `CompleteRootContainerIfNeeded` are gone, along with the dead branch; the net effect is 24 lines removed for 18 added.

Behaviour on the success path is unchanged, and the rejected calls throw exactly the same exception type and messages as before — they just no longer corrupt the writer on the way out.

## Verification

`dotnet build /p:TreatWarningsAsErrors=true` clean; `dotnet test` green — 90 tests across net10.0 and net11.0.

`BencodeWriter_WriteEndDictionaryWhileExpectingValue_LeavesTheDictionaryOpen` fails against `main` and passes here:

```
failed BencodeWriter_WriteEndDictionaryWhileExpectingValue_LeavesTheDictionaryOpen (2ms)
```

It catches the rejected `WriteEndDictionary`, then writes the missing value and closes the dictionary properly, asserting the output is `d1:ai1ee`. Two further tests cover the paths that already behaved correctly and must keep doing so: ending a list while inside a dictionary, and ending a dictionary with no container open. The existing writer-misuse tests are unchanged and still pass.

Found by a project review of `src/Meziantou.Framework.Bencode`.
