### PR TITLE
Compute the torrent info-hash from the bytes the info dictionary was parsed from

### DIFF
--- a/src/Meziantou.Framework.Bencode/BencodeDecoder.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeDecoder.cs
@@ -110,6 +110,7 @@ internal static class BencodeDecoder
     private static BencodeDictionary ParseDictionary(ReadOnlySpan<byte> data, ref int index, int depth)
     {
         EnsureDepth(depth);
+        var start = index;
         index++; // d
         var result = new BencodeDictionary();
 
@@ -121,6 +122,8 @@ internal static class BencodeDecoder
             if (data[index] == (byte)'e')
             {
                 index++;
+                result.SourceOffset = start;
+                result.SourceLength = index - start;
                 return result;
             }
 

--- a/src/Meziantou.Framework.Bencode/BencodeDictionary.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeDictionary.cs
@@ -23,6 +23,12 @@ public sealed class BencodeDictionary : BencodeValue, IReadOnlyDictionary<Bencod
 
     public override BencodeValueKind Kind => BencodeValueKind.Dictionary;
 
+    /// <summary>Offset of the bytes this dictionary was decoded from, when it came from <see cref="BencodeDocument.Parse(ReadOnlySpan{byte})"/>.</summary>
+    internal int SourceOffset { get; set; }
+
+    /// <summary>Length of the bytes this dictionary was decoded from, or <c>0</c> when it was not decoded from a buffer.</summary>
+    internal int SourceLength { get; set; }
+
     public int Count => _entries.Count;
 
     public IEnumerable<BencodeString> Keys => _entries.Select(entry => entry.Key);

--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentFile.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentFile.cs
@@ -21,20 +21,44 @@ public sealed class TorrentFile
 
     public DateTimeOffset? CreationDate { get; set; }
 
-    public TorrentInfo Info { get; set; } = new();
+    private TorrentInfo _info = new();
+    private ReadOnlyMemory<byte> _infoBytes;
+
+    /// <summary>The metainfo dictionary. Replacing it discards the parsed bytes, so the info-hash is recomputed from the model.</summary>
+    public TorrentInfo Info
+    {
+        get => _info;
+        set
+        {
+            _info = value;
+            _infoBytes = default;
+        }
+    }
 
     public static TorrentFile Parse(ReadOnlySpan<byte> data)
     {
         var root = BencodeDocument.Parse(data).Root;
-        return Parse(root);
+        var result = Parse(root);
+
+        if (root is BencodeDictionary rootDictionary
+            && rootDictionary.TryGetValue(InfoKey, out var infoValue)
+            && infoValue is BencodeDictionary { SourceLength: > 0 } infoDictionary)
+        {
+            result._infoBytes = data.Slice(infoDictionary.SourceOffset, infoDictionary.SourceLength).ToArray();
+        }
+
+        return result;
     }
 
     public static async ValueTask<TorrentFile> ParseAsync(Stream stream, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(stream);
 
-        var root = (await BencodeDocument.ParseAsync(stream, cancellationToken).ConfigureAwait(false)).Root;
-        return Parse(root);
+        // The whole file is buffered so the info dictionary can be hashed from the bytes it was parsed from.
+        // The decoded model is the same size anyway, so this does not change the order of memory used.
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+        return Parse(buffer.GetBuffer().AsSpan(0, (int)buffer.Length));
     }
 
     public static bool TryParse(ReadOnlySpan<byte> data, out TorrentFile? result)
@@ -65,17 +89,30 @@ public sealed class TorrentFile
         await stream.WriteAsync(data.AsMemory(), cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>Computes the BitTorrent v1 info-hash.</summary>
+    /// <remarks>For a parsed torrent this hashes the exact bytes the 'info' dictionary was read from, so keys this model does not represent still contribute to the hash.</remarks>
     [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash requires SHA-1.")]
     public byte[] GetInfoHashSha1()
     {
-        var data = Info.ToBencodeDictionary().ToUtf8ByteArray(canonical: true);
-        return SHA1.HashData(data);
+        return SHA1.HashData(GetInfoBytes().Span);
     }
 
+    /// <summary>Computes the SHA-256 of the 'info' dictionary.</summary>
+    /// <remarks>For a parsed torrent this hashes the exact bytes the 'info' dictionary was read from, so keys this model does not represent still contribute to the hash.</remarks>
     public byte[] GetInfoHashSha256()
     {
-        var data = Info.ToBencodeDictionary().ToUtf8ByteArray(canonical: true);
-        return SHA256.HashData(data);
+        return SHA256.HashData(GetInfoBytes().Span);
+    }
+
+    /// <summary>Returns the bytes to hash: the ones the torrent was parsed from when available, otherwise a canonical encoding of the model.</summary>
+    /// <remarks>
+    /// Re-encoding a parsed torrent would drop every 'info' key this model does not represent ('source', 'md5sum',
+    /// an explicit 'private 0', the BitTorrent v2 keys), and dropping any of them changes the hash, which is the
+    /// torrent's identity.
+    /// </remarks>
+    private ReadOnlyMemory<byte> GetInfoBytes()
+    {
+        return _infoBytes.IsEmpty ? Info.ToBencodeDictionary().ToUtf8ByteArray(canonical: true) : _infoBytes;
     }
 
     private static TorrentFile Parse(BencodeValue root)

--- a/tests/Meziantou.Framework.Bencode.Tests/TorrentFileTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/TorrentFileTests.cs
@@ -168,6 +168,81 @@ public sealed class TorrentFileTests
         Assert.Equal(SHA256.HashData(SingleFileInfo), torrent.GetInfoHashSha256());
     }
 
+    [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash is SHA-1.")]
+    [Theory]
+    [InlineData("d6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:012345678901234567896:source9:MyTrackere")]
+    [InlineData("d6:lengthi123e6:md5sum32:000102030405060708090a0b0c0d0e0f4:name8:file.txt12:piece lengthi16384e6:pieces20:01234567890123456789e")]
+    [InlineData("d6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:012345678901234567897:privatei0ee")]
+    public void GetInfoHash_UsesTheBytesTheInfoDictionaryWasParsedFrom(string info)
+    {
+        var infoBytes = Encoding.ASCII.GetBytes(info);
+        var torrent = TorrentFile.Parse(Encoding.ASCII.GetBytes("d8:announce14:https://t.test4:info" + info + "e"));
+
+        Assert.Equal(SHA1.HashData(infoBytes), torrent.GetInfoHashSha1());
+        Assert.Equal(SHA256.HashData(infoBytes), torrent.GetInfoHashSha256());
+    }
+
+    [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash is SHA-1.")]
+    [Fact]
+    public void GetInfoHash_NonCanonicalKeyOrder_UsesTheOriginalOrder()
+    {
+        var info = "d4:name8:file.txt6:lengthi123e12:piece lengthi16384e6:pieces20:01234567890123456789e";
+        var torrent = TorrentFile.Parse(Encoding.ASCII.GetBytes("d4:info" + info + "e"));
+
+        Assert.Equal(SHA1.HashData(Encoding.ASCII.GetBytes(info)), torrent.GetInfoHashSha1());
+    }
+
+    [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash is SHA-1.")]
+    [Fact]
+    public async Task GetInfoHashAsync_MatchesTheSynchronousParse()
+    {
+        var info = "d6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:012345678901234567896:source9:MyTrackere";
+        var content = Encoding.ASCII.GetBytes("d8:announce14:https://t.test4:info" + info + "e");
+
+        await using var stream = new MemoryStream(content);
+        var torrent = await TorrentFile.ParseAsync(stream);
+
+        Assert.Equal(SHA1.HashData(Encoding.ASCII.GetBytes(info)), torrent.GetInfoHashSha1());
+    }
+
+    [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash is SHA-1.")]
+    [Fact]
+    public void GetInfoHash_ConstructedTorrent_UsesTheCanonicalEncoding()
+    {
+        var torrent = new TorrentFile
+        {
+            Info = new TorrentInfo
+            {
+                Name = "file.txt",
+                PieceLength = 16384,
+                Pieces = "01234567890123456789"u8.ToArray(),
+                Length = 123,
+            },
+        };
+
+        Assert.Equal(SHA1.HashData(SingleFileInfo), torrent.GetInfoHashSha1());
+    }
+
+    [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash is SHA-1.")]
+    [Fact]
+    public void GetInfoHash_AfterReplacingInfo_UsesTheNewInfo()
+    {
+        var info = "d6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:012345678901234567896:source9:MyTrackere";
+        var torrent = TorrentFile.Parse(Encoding.ASCII.GetBytes("d4:info" + info + "e"));
+
+        Assert.Equal(SHA1.HashData(Encoding.ASCII.GetBytes(info)), torrent.GetInfoHashSha1());
+
+        torrent.Info = new TorrentInfo
+        {
+            Name = "file.txt",
+            PieceLength = 16384,
+            Pieces = "01234567890123456789"u8.ToArray(),
+            Length = 123,
+        };
+
+        Assert.Equal(SHA1.HashData(SingleFileInfo), torrent.GetInfoHashSha1());
+    }
+
     [Fact]
     public void ToArray_BothLengthAndFiles_Throws()
     {


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before the "preserve unknown keys" PR.**

## The problem

`GetInfoHashSha1()` and `GetInfoHashSha256()` (`TorrentFile.cs:69-79`) called `Info.ToBencodeDictionary()`, which rebuilds the dictionary from the six properties `TorrentInfo` models — `name`, `piece length`, `pieces`, `private`, `length`, `files`. Every other key inside `info` is discarded at parse time and absent at write time, so the hash is computed over a dictionary that is not the one the file contained.

Reproduced with a torrent whose `info` carries a `source` key (mktorrent `-s`, standard on private trackers):

```
info bytes:  d6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:012345678901234567896:source9:MyTrackere
expected:    91F9EFBB85756DFB27A09C5C950DDAC5A68517CD
actual:      5A47092756A964C26715F69510A7B35B63B3B01C   match=False
```

The same divergence hits `md5sum`, `name.utf-8`, `attr`, `sha256`, the BitTorrent v2 keys, and an explicit `private 0` — parsed into `IsPrivate = false` (`TorrentInfo.cs:45`) and then omitted entirely on write (`:105-108`). Non-canonical key order was lost too, since the re-encode always sorts.

The info-hash *is* the torrent's identity. A wrong one means a wrong magnet link, a tracker announce for a swarm that does not exist, and a peer handshake nobody answers — with no exception and no diagnostic.

The existing tests could not catch this: both fixtures contain exactly the four keys the model round-trips. I checked `files/ubuntu.torrent` — its info dictionary holds only `length`, `name`, `piece length`, `pieces`.

## The change

The synchronous decoder records the byte range each `BencodeDictionary` was decoded from (two `int`s per dictionary, no copying). `TorrentFile.Parse` slices those bytes for the `info` value and keeps them, and the hash methods use them.

- Constructed (not parsed) torrents fall back to the canonical encoding of the model, exactly as before.
- Assigning `Info` discards the parsed bytes, so a replaced info dictionary is hashed from the model rather than from stale bytes.
- `ParseAsync(Stream)` now buffers the file and goes through the same path, so both entry points agree. The decoded model is the same order of size, so peak memory does not change materially — but it does mean `TorrentFile.ParseAsync` no longer streams. `BencodeDocument.ParseAsync`, the general streaming API, is untouched.

`SourceOffset`/`SourceLength` are internal; the only public surface change is the two XML doc comments.

## Verification

`dotnet build /p:TreatWarningsAsErrors=true` clean; `dotnet test` green — 120 tests across net10.0 and net11.0.

Six of the new cases fail against `main` and pass here:

```
failed GetInfoHash_UsesTheBytesTheInfoDictionaryWasParsedFrom(info: "...6:source9:MyTracker...")
failed GetInfoHash_UsesTheBytesTheInfoDictionaryWasParsedFrom(info: "...6:md5sum32:...")
failed GetInfoHash_UsesTheBytesTheInfoDictionaryWasParsedFrom(info: "...7:privatei0e...")
failed GetInfoHash_NonCanonicalKeyOrder_UsesTheOriginalOrder
failed GetInfoHashAsync_MatchesTheSynchronousParse
failed GetInfoHash_AfterReplacingInfo_UsesTheNewInfo
```

Two more pin the behaviour that must not change: `GetInfoHash_ConstructedTorrent_UsesTheCanonicalEncoding`, and the existing `Parse_UbuntuTorrentResource`, which still asserts the real `e1fc140a6391357fa1cf08ddb70274f9c05eb88b` — now produced from the parsed bytes rather than from a re-encode.

## What this does not fix

Writing a parsed torrent back out still drops unknown keys, so `ToUtf8ByteArray`/`WriteToAsync` do not reproduce the original file. That is the next PR in this stack.

Found by a project review of `src/Meziantou.Framework.Bencode`.
