### PR TITLE
Keep the torrent keys the model does not represent when writing

### DIFF
--- a/src/Meziantou.Framework.Bencode/BencodeDecoder.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeDecoder.cs
@@ -110,6 +110,7 @@ internal static class BencodeDecoder
     private static BencodeDictionary ParseDictionary(ReadOnlySpan<byte> data, ref int index, int depth)
     {
         EnsureDepth(depth);
+        var start = index;
         index++; // d
         var result = new BencodeDictionary();
 
@@ -121,6 +122,8 @@ internal static class BencodeDecoder
             if (data[index] == (byte)'e')
             {
                 index++;
+                result.SourceOffset = start;
+                result.SourceLength = index - start;
                 return result;
             }
 

--- a/src/Meziantou.Framework.Bencode/BencodeDictionary.cs
+++ b/src/Meziantou.Framework.Bencode/BencodeDictionary.cs
@@ -23,6 +23,12 @@ public sealed class BencodeDictionary : BencodeValue, IReadOnlyDictionary<Bencod
 
     public override BencodeValueKind Kind => BencodeValueKind.Dictionary;
 
+    /// <summary>Offset of the bytes this dictionary was decoded from, when it came from <see cref="BencodeDocument.Parse(ReadOnlySpan{byte})"/>.</summary>
+    internal int SourceOffset { get; set; }
+
+    /// <summary>Length of the bytes this dictionary was decoded from, or <c>0</c> when it was not decoded from a buffer.</summary>
+    internal int SourceLength { get; set; }
+
     public int Count => _entries.Count;
 
     public IEnumerable<BencodeString> Keys => _entries.Select(entry => entry.Key);

--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentDictionaryMerge.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentDictionaryMerge.cs
@@ -1,0 +1,67 @@
+namespace Meziantou.Framework.Bencode.Torrent;
+
+internal static class TorrentDictionaryMerge
+{
+    /// <summary>Rebuilds a metainfo dictionary from the model while carrying over the keys this model does not represent.</summary>
+    /// <param name="source">The dictionary the torrent was parsed from, or <see langword="null"/> when it was constructed in memory.</param>
+    /// <param name="modelled">The entries produced from the model, in the order they should be written.</param>
+    /// <param name="modelledKeys">Every key the model owns, including the ones <paramref name="modelled"/> currently omits.</param>
+    /// <remarks>
+    /// Torrents routinely carry keys outside BEP 3 ('source', 'md5sum', 'url-list', 'nodes', the BitTorrent v2 keys).
+    /// Rebuilding purely from the model silently drops them, so a parsed torrent cannot be written back out unchanged.
+    /// </remarks>
+    public static BencodeDictionary Merge(BencodeDictionary? source, IReadOnlyList<KeyValuePair<BencodeString, BencodeValue>> modelled, IReadOnlyList<BencodeString> modelledKeys)
+    {
+        var result = new BencodeDictionary();
+
+        if (source is not null)
+        {
+            foreach (var entry in source)
+            {
+                var replacement = FindValue(modelled, entry.Key);
+                if (replacement is not null)
+                {
+                    result.Add(entry.Key, replacement);
+                }
+                else if (!Contains(modelledKeys, entry.Key))
+                {
+                    result.Add(entry.Key, entry.Value);
+                }
+
+                // A modelled key the model no longer sets is intentionally dropped, so clearing a property removes it.
+            }
+        }
+
+        foreach (var entry in modelled)
+        {
+            if (!result.ContainsKey(entry.Key))
+            {
+                result.Add(entry.Key, entry.Value);
+            }
+        }
+
+        return result;
+    }
+
+    private static BencodeValue? FindValue(IReadOnlyList<KeyValuePair<BencodeString, BencodeValue>> entries, BencodeString key)
+    {
+        foreach (var entry in entries)
+        {
+            if (entry.Key.Equals(key))
+                return entry.Value;
+        }
+
+        return null;
+    }
+
+    private static bool Contains(IReadOnlyList<BencodeString> keys, BencodeString key)
+    {
+        foreach (var candidate in keys)
+        {
+            if (candidate.Equals(key))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentFile.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentFile.cs
@@ -21,20 +21,44 @@ public sealed class TorrentFile
 
     public DateTimeOffset? CreationDate { get; set; }
 
-    public TorrentInfo Info { get; set; } = new();
+    private TorrentInfo _info = new();
+    private ReadOnlyMemory<byte> _infoBytes;
+
+    /// <summary>The metainfo dictionary. Replacing it discards the parsed bytes, so the info-hash is recomputed from the model.</summary>
+    public TorrentInfo Info
+    {
+        get => _info;
+        set
+        {
+            _info = value;
+            _infoBytes = default;
+        }
+    }
 
     public static TorrentFile Parse(ReadOnlySpan<byte> data)
     {
         var root = BencodeDocument.Parse(data).Root;
-        return Parse(root);
+        var result = Parse(root);
+
+        if (root is BencodeDictionary rootDictionary
+            && rootDictionary.TryGetValue(InfoKey, out var infoValue)
+            && infoValue is BencodeDictionary { SourceLength: > 0 } infoDictionary)
+        {
+            result._infoBytes = data.Slice(infoDictionary.SourceOffset, infoDictionary.SourceLength).ToArray();
+        }
+
+        return result;
     }
 
     public static async ValueTask<TorrentFile> ParseAsync(Stream stream, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(stream);
 
-        var root = (await BencodeDocument.ParseAsync(stream, cancellationToken).ConfigureAwait(false)).Root;
-        return Parse(root);
+        // The whole file is buffered so the info dictionary can be hashed from the bytes it was parsed from.
+        // The decoded model is the same size anyway, so this does not change the order of memory used.
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+        return Parse(buffer.GetBuffer().AsSpan(0, (int)buffer.Length));
     }
 
     public static bool TryParse(ReadOnlySpan<byte> data, out TorrentFile? result)
@@ -65,17 +89,30 @@ public sealed class TorrentFile
         await stream.WriteAsync(data.AsMemory(), cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>Computes the BitTorrent v1 info-hash.</summary>
+    /// <remarks>For a parsed torrent this hashes the exact bytes the 'info' dictionary was read from, so keys this model does not represent still contribute to the hash.</remarks>
     [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash requires SHA-1.")]
     public byte[] GetInfoHashSha1()
     {
-        var data = Info.ToBencodeDictionary().ToUtf8ByteArray(canonical: true);
-        return SHA1.HashData(data);
+        return SHA1.HashData(GetInfoBytes().Span);
     }
 
+    /// <summary>Computes the SHA-256 of the 'info' dictionary.</summary>
+    /// <remarks>For a parsed torrent this hashes the exact bytes the 'info' dictionary was read from, so keys this model does not represent still contribute to the hash.</remarks>
     public byte[] GetInfoHashSha256()
     {
-        var data = Info.ToBencodeDictionary().ToUtf8ByteArray(canonical: true);
-        return SHA256.HashData(data);
+        return SHA256.HashData(GetInfoBytes().Span);
+    }
+
+    /// <summary>Returns the bytes to hash: the ones the torrent was parsed from when available, otherwise a canonical encoding of the model.</summary>
+    /// <remarks>
+    /// Re-encoding a parsed torrent would drop every 'info' key this model does not represent ('source', 'md5sum',
+    /// an explicit 'private 0', the BitTorrent v2 keys), and dropping any of them changes the hash, which is the
+    /// torrent's identity.
+    /// </remarks>
+    private ReadOnlyMemory<byte> GetInfoBytes()
+    {
+        return _infoBytes.IsEmpty ? Info.ToBencodeDictionary().ToUtf8ByteArray(canonical: true) : _infoBytes;
     }
 
     private static TorrentFile Parse(BencodeValue root)

--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentFile.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentFile.cs
@@ -10,6 +10,9 @@ public sealed class TorrentFile
     private static readonly BencodeString CommentKey = CreateKey("comment");
     private static readonly BencodeString CreatedByKey = CreateKey("created by");
     private static readonly BencodeString CreationDateKey = CreateKey("creation date");
+    private static readonly BencodeString[] ModelledKeys = [InfoKey, AnnounceKey, AnnounceListKey, CommentKey, CreatedByKey, CreationDateKey];
+
+    private BencodeDictionary? _source;
 
     public string? Announce { get; set; }
 
@@ -128,6 +131,8 @@ public sealed class TorrentFile
             Info = TorrentInfo.Parse(infoDictionary),
         };
 
+        result._source = dictionary;
+
         if (dictionary.TryGetValue(AnnounceKey, out var announceValue))
         {
             if (announceValue is not BencodeString announceText)
@@ -201,14 +206,14 @@ public sealed class TorrentFile
         if (Info is null)
             throw new FormatException("Torrent file must contain a non-null info object.");
 
-        var dictionary = new BencodeDictionary
+        var modelled = new List<KeyValuePair<BencodeString, BencodeValue>>
         {
-            { InfoKey, Info.ToBencodeDictionary() },
+            new(InfoKey, Info.ToBencodeDictionary()),
         };
 
         if (Announce is not null)
         {
-            dictionary.Add(AnnounceKey, new BencodeString(Encoding.UTF8.GetBytes(Announce)));
+            modelled.Add(new(AnnounceKey, new BencodeString(Encoding.UTF8.GetBytes(Announce))));
         }
 
         if (AnnounceList is not null)
@@ -231,25 +236,25 @@ public sealed class TorrentFile
                 tiers.Add(tierValues);
             }
 
-            dictionary.Add(AnnounceListKey, tiers);
+            modelled.Add(new(AnnounceListKey, tiers));
         }
 
         if (Comment is not null)
         {
-            dictionary.Add(CommentKey, new BencodeString(Encoding.UTF8.GetBytes(Comment)));
+            modelled.Add(new(CommentKey, new BencodeString(Encoding.UTF8.GetBytes(Comment))));
         }
 
         if (CreatedBy is not null)
         {
-            dictionary.Add(CreatedByKey, new BencodeString(Encoding.UTF8.GetBytes(CreatedBy)));
+            modelled.Add(new(CreatedByKey, new BencodeString(Encoding.UTF8.GetBytes(CreatedBy))));
         }
 
         if (CreationDate.HasValue)
         {
-            dictionary.Add(CreationDateKey, new BencodeInteger(CreationDate.Value.ToUnixTimeSeconds()));
+            modelled.Add(new(CreationDateKey, new BencodeInteger(CreationDate.Value.ToUnixTimeSeconds())));
         }
 
-        return dictionary;
+        return TorrentDictionaryMerge.Merge(_source, modelled, ModelledKeys);
     }
 
     private static BencodeString CreateKey(string value) => new(Encoding.UTF8.GetBytes(value));

--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentInfo.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentInfo.cs
@@ -9,6 +9,9 @@ public sealed class TorrentInfo
     private static readonly BencodeString LengthKey = CreateKey("length");
     private static readonly BencodeString FilesKey = CreateKey("files");
     private static readonly BencodeString PathKey = CreateKey("path");
+    private static readonly BencodeString[] ModelledKeys = [NameKey, PieceLengthKey, PiecesKey, PrivateKey, LengthKey, FilesKey];
+
+    private BencodeDictionary? _source;
 
     public string Name { get; set; } = "";
 
@@ -87,6 +90,7 @@ public sealed class TorrentInfo
             info.Files = files;
         }
 
+        info._source = dictionary;
         info.Validate();
         return info;
     }
@@ -95,21 +99,21 @@ public sealed class TorrentInfo
     {
         Validate();
 
-        var dictionary = new BencodeDictionary
+        var modelled = new List<KeyValuePair<BencodeString, BencodeValue>>
         {
-            { NameKey, new BencodeString(Encoding.UTF8.GetBytes(Name)) },
-            { PieceLengthKey, new BencodeInteger(PieceLength) },
-            { PiecesKey, new BencodeString(Pieces.ToArray()) },
+            new(NameKey, new BencodeString(Encoding.UTF8.GetBytes(Name))),
+            new(PieceLengthKey, new BencodeInteger(PieceLength)),
+            new(PiecesKey, new BencodeString(Pieces.ToArray())),
         };
 
         if (IsPrivate)
         {
-            dictionary.Add(PrivateKey, new BencodeInteger(1));
+            modelled.Add(new(PrivateKey, new BencodeInteger(1)));
         }
 
         if (Length.HasValue)
         {
-            dictionary.Add(LengthKey, new BencodeInteger(Length.Value));
+            modelled.Add(new(LengthKey, new BencodeInteger(Length.Value)));
         }
         else if (Files is not null)
         {
@@ -127,10 +131,10 @@ public sealed class TorrentInfo
                 });
             }
 
-            dictionary.Add(FilesKey, files);
+            modelled.Add(new(FilesKey, files));
         }
 
-        return dictionary;
+        return TorrentDictionaryMerge.Merge(_source, modelled, ModelledKeys);
     }
 
     private void Validate()

--- a/tests/Meziantou.Framework.Bencode.Tests/TorrentFileTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/TorrentFileTests.cs
@@ -243,6 +243,89 @@ public sealed class TorrentFileTests
         Assert.Equal(SHA1.HashData(SingleFileInfo), torrent.GetInfoHashSha1());
     }
 
+    [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash is SHA-1.")]
+    [Fact]
+    public void ToUtf8ByteArray_PreservesKeysTheModelDoesNotRepresent()
+    {
+        var content = Encoding.ASCII.GetBytes("d8:announce14:https://t.test5:nodesll4:hosti1eee4:infod6:lengthi123e6:md5sum4:abcd4:name8:file.txt12:piece lengthi16384e6:pieces20:012345678901234567896:source9:MyTrackere8:url-listl20:https://seed.test/abee");
+        var original = TorrentFile.Parse(content);
+
+        var roundTrip = TorrentFile.Parse(original.ToUtf8ByteArray());
+
+        Assert.Equal(original.GetInfoHashSha1(), roundTrip.GetInfoHashSha1());
+
+        var root = Assert.IsType<BencodeDictionary>(BencodeDocument.Parse(original.ToUtf8ByteArray()).Root);
+        Assert.Contains(Key("url-list"), root);
+        Assert.Contains(Key("nodes"), root);
+
+        var info = Assert.IsType<BencodeDictionary>(root[Key("info")]);
+        Assert.Equal("MyTracker", Assert.IsType<BencodeString>(info[Key("source")]).ToUtf8String());
+        Assert.Equal("abcd", Assert.IsType<BencodeString>(info[Key("md5sum")]).ToUtf8String());
+    }
+
+    [Fact]
+    public void ToUtf8ByteArray_ModelledFieldsStillWinOverTheParsedValue()
+    {
+        var original = TorrentFile.Parse(SingleFileTorrent);
+        original.Comment = "replaced";
+        original.Info.Name = "renamed.txt";
+
+        var roundTrip = TorrentFile.Parse(original.ToUtf8ByteArray());
+
+        Assert.Equal("replaced", roundTrip.Comment);
+        Assert.Equal("renamed.txt", roundTrip.Info.Name);
+        Assert.Equal("https://t.test", roundTrip.Announce);
+    }
+
+    [Fact]
+    public void ToUtf8ByteArray_ClearedFieldIsRemoved()
+    {
+        var original = TorrentFile.Parse(SingleFileTorrent);
+        Assert.NotNull(original.CreationDate);
+        original.CreationDate = null;
+
+        var root = Assert.IsType<BencodeDictionary>(BencodeDocument.Parse(original.ToUtf8ByteArray()).Root);
+
+        Assert.DoesNotContain(Key("creation date"), root);
+        Assert.Contains(Key("announce"), root);
+    }
+
+    [Fact]
+    public void ToUtf8ByteArray_ConstructedTorrent_WritesOnlyModelledKeys()
+    {
+        var torrent = new TorrentFile
+        {
+            Announce = "https://t.test",
+            Info = new TorrentInfo
+            {
+                Name = "file.txt",
+                PieceLength = 16384,
+                Pieces = "01234567890123456789"u8.ToArray(),
+                Length = 123,
+            },
+        };
+
+        var root = Assert.IsType<BencodeDictionary>(BencodeDocument.Parse(torrent.ToUtf8ByteArray()).Root);
+
+        Assert.Equal(2, root.Count);
+        Assert.Contains(Key("announce"), root);
+        Assert.Contains(Key("info"), root);
+    }
+
+    [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash is SHA-1.")]
+    [Fact]
+    public async Task WriteToAsync_UbuntuTorrent_KeepsTheInfoHash()
+    {
+        await using var stream = OpenUbuntuTorrentResourceStream();
+        var torrent = await TorrentFile.ParseAsync(stream);
+
+        var roundTrip = TorrentFile.Parse(torrent.ToUtf8ByteArray());
+
+        Assert.Equal(Convert.FromHexString("e1fc140a6391357fa1cf08ddb70274f9c05eb88b"), roundTrip.GetInfoHashSha1());
+    }
+
+    private static BencodeString Key(string value) => new(Encoding.UTF8.GetBytes(value));
+
     [Fact]
     public void ToArray_BothLengthAndFiles_Throws()
     {

--- a/tests/Meziantou.Framework.Bencode.Tests/TorrentFileTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/TorrentFileTests.cs
@@ -168,6 +168,81 @@ public sealed class TorrentFileTests
         Assert.Equal(SHA256.HashData(SingleFileInfo), torrent.GetInfoHashSha256());
     }
 
+    [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash is SHA-1.")]
+    [Theory]
+    [InlineData("d6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:012345678901234567896:source9:MyTrackere")]
+    [InlineData("d6:lengthi123e6:md5sum32:000102030405060708090a0b0c0d0e0f4:name8:file.txt12:piece lengthi16384e6:pieces20:01234567890123456789e")]
+    [InlineData("d6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:012345678901234567897:privatei0ee")]
+    public void GetInfoHash_UsesTheBytesTheInfoDictionaryWasParsedFrom(string info)
+    {
+        var infoBytes = Encoding.ASCII.GetBytes(info);
+        var torrent = TorrentFile.Parse(Encoding.ASCII.GetBytes("d8:announce14:https://t.test4:info" + info + "e"));
+
+        Assert.Equal(SHA1.HashData(infoBytes), torrent.GetInfoHashSha1());
+        Assert.Equal(SHA256.HashData(infoBytes), torrent.GetInfoHashSha256());
+    }
+
+    [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash is SHA-1.")]
+    [Fact]
+    public void GetInfoHash_NonCanonicalKeyOrder_UsesTheOriginalOrder()
+    {
+        var info = "d4:name8:file.txt6:lengthi123e12:piece lengthi16384e6:pieces20:01234567890123456789e";
+        var torrent = TorrentFile.Parse(Encoding.ASCII.GetBytes("d4:info" + info + "e"));
+
+        Assert.Equal(SHA1.HashData(Encoding.ASCII.GetBytes(info)), torrent.GetInfoHashSha1());
+    }
+
+    [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash is SHA-1.")]
+    [Fact]
+    public async Task GetInfoHashAsync_MatchesTheSynchronousParse()
+    {
+        var info = "d6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:012345678901234567896:source9:MyTrackere";
+        var content = Encoding.ASCII.GetBytes("d8:announce14:https://t.test4:info" + info + "e");
+
+        await using var stream = new MemoryStream(content);
+        var torrent = await TorrentFile.ParseAsync(stream);
+
+        Assert.Equal(SHA1.HashData(Encoding.ASCII.GetBytes(info)), torrent.GetInfoHashSha1());
+    }
+
+    [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash is SHA-1.")]
+    [Fact]
+    public void GetInfoHash_ConstructedTorrent_UsesTheCanonicalEncoding()
+    {
+        var torrent = new TorrentFile
+        {
+            Info = new TorrentInfo
+            {
+                Name = "file.txt",
+                PieceLength = 16384,
+                Pieces = "01234567890123456789"u8.ToArray(),
+                Length = 123,
+            },
+        };
+
+        Assert.Equal(SHA1.HashData(SingleFileInfo), torrent.GetInfoHashSha1());
+    }
+
+    [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash is SHA-1.")]
+    [Fact]
+    public void GetInfoHash_AfterReplacingInfo_UsesTheNewInfo()
+    {
+        var info = "d6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:012345678901234567896:source9:MyTrackere";
+        var torrent = TorrentFile.Parse(Encoding.ASCII.GetBytes("d4:info" + info + "e"));
+
+        Assert.Equal(SHA1.HashData(Encoding.ASCII.GetBytes(info)), torrent.GetInfoHashSha1());
+
+        torrent.Info = new TorrentInfo
+        {
+            Name = "file.txt",
+            PieceLength = 16384,
+            Pieces = "01234567890123456789"u8.ToArray(),
+            Length = 123,
+        };
+
+        Assert.Equal(SHA1.HashData(SingleFileInfo), torrent.GetInfoHashSha1());
+    }
+
     [Fact]
     public void ToArray_BothLengthAndFiles_Throws()
     {


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/bencode-info-hash-source-bytes` (#2322) · must merge after it.**

## The problem

`TorrentFile` models six top-level keys and `TorrentInfo` six info keys, and both rebuilt their dictionary purely from those properties (`TorrentFile.cs:162-216`, `TorrentInfo.cs:94-134`). Everything else the file carried was read past at parse time and absent at write time: `url-list` (web seeds, BEP 19), `httpseeds`, `nodes` (DHT bootstrap, BEP 5), `encoding`, and inside `info` — `source`, `md5sum`, `name.utf-8`, `attr`, the BitTorrent v2 keys.

The readme presents exactly this as the supported workflow — parse `file.torrent`, `WriteToAsync` to `copy.torrent`. The "copy" is not a copy: it has lost its web seeds and DHT nodes, and before #2322 it also had a different info-hash.

## The change

Parsing keeps the dictionary each object came from. On write, `TorrentDictionaryMerge.Merge` walks the source in order and, for each entry:

- a key the model owns and currently sets → the model's value wins,
- a key the model owns but no longer sets → dropped, so clearing a property removes the key,
- anything else → carried over verbatim.

Modelled keys the source did not contain are appended afterwards. A torrent constructed in memory has no source, so it writes exactly what it did before.

One asymmetry worth knowing: an explicit `private 0` parses to `IsPrivate = false` and is therefore written as *absent* rather than as `0`. Those two are semantically identical, and since #2322 the info-hash comes from the parsed bytes, so this no longer affects the torrent's identity.

## Verification

`dotnet build /p:TreatWarningsAsErrors=true` clean; `dotnet test` green — 130 tests across net10.0 and net11.0.

`ToUtf8ByteArray_PreservesKeysTheModelDoesNotRepresent` fails against the layer below and passes here:

```
failed ToUtf8ByteArray_PreservesKeysTheModelDoesNotRepresent (7ms)
```

It parses a torrent carrying `url-list`, `nodes`, `source` and `md5sum`, writes it, and asserts all four survive and that the round-tripped info-hash matches the original. Four more tests cover the rest of the contract: modelled fields still override the parsed value, a cleared field is removed, a constructed torrent writes only modelled keys, and the ubuntu fixture keeps `e1fc140a6391357fa1cf08ddb70274f9c05eb88b` through a full write/re-parse cycle.

Found by a project review of `src/Meziantou.Framework.Bencode`.
