### PR TITLE
Model the common torrent extension fields

### DIFF
--- a/ref/Meziantou.Framework.Bencode.cs
+++ b/ref/Meziantou.Framework.Bencode.cs
@@ -113,6 +113,12 @@ namespace Meziantou.Framework.Bencode.Torrent
         public string? Comment { get => throw null; set { } }
         public string? CreatedBy { get => throw null; set { } }
         public System.DateTimeOffset? CreationDate { get => throw null; set { } }
+        public System.Collections.Generic.IReadOnlyList<string>? UrlList { get => throw null; set { } }
+        public System.Collections.Generic.IReadOnlyList<string>? HttpSeeds { get => throw null; set { } }
+        public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Bencode.Torrent.TorrentNode>? Nodes { get => throw null; set { } }
+        public string? Encoding { get => throw null; set { } }
+        public string? Publisher { get => throw null; set { } }
+        public string? PublisherUrl { get => throw null; set { } }
         public Meziantou.Framework.Bencode.Torrent.TorrentInfo Info { get => throw null; set { } }
         public static Meziantou.Framework.Bencode.Torrent.TorrentFile Parse(System.ReadOnlySpan<byte> data) => throw null;
         public static System.Threading.Tasks.ValueTask<Meziantou.Framework.Bencode.Torrent.TorrentFile> ParseAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = null) => throw null;
@@ -131,11 +137,20 @@ namespace Meziantou.Framework.Bencode.Torrent
         public bool IsPrivate { get => throw null; set { } }
         public long? Length { get => throw null; set { } }
         public System.Collections.Generic.IReadOnlyList<Meziantou.Framework.Bencode.Torrent.TorrentInfoFile>? Files { get => throw null; set { } }
+        public string? Source { get => throw null; set { } }
+        public string? Md5Sum { get => throw null; set { } }
     }
 
     public sealed class TorrentInfoFile
     {
         public System.Collections.Generic.IReadOnlyList<string> Path { get => throw null; set { } }
         public long Length { get => throw null; set { } }
+        public string? Md5Sum { get => throw null; set { } }
+    }
+
+    public sealed class TorrentNode
+    {
+        public string Host { get => throw null; set { } }
+        public int Port { get => throw null; set { } }
     }
 }

--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentFile.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentFile.cs
@@ -10,6 +10,12 @@ public sealed class TorrentFile
     private static readonly BencodeString CommentKey = CreateKey("comment");
     private static readonly BencodeString CreatedByKey = CreateKey("created by");
     private static readonly BencodeString CreationDateKey = CreateKey("creation date");
+    private static readonly BencodeString UrlListKey = CreateKey("url-list");
+    private static readonly BencodeString HttpSeedsKey = CreateKey("httpseeds");
+    private static readonly BencodeString NodesKey = CreateKey("nodes");
+    private static readonly BencodeString EncodingKey = CreateKey("encoding");
+    private static readonly BencodeString PublisherKey = CreateKey("publisher");
+    private static readonly BencodeString PublisherUrlKey = CreateKey("publisher-url");
 
     public string? Announce { get; set; }
 
@@ -20,6 +26,25 @@ public sealed class TorrentFile
     public string? CreatedBy { get; set; }
 
     public DateTimeOffset? CreationDate { get; set; }
+
+    /// <summary>Web seed URLs from the 'url-list' key (BEP 19).</summary>
+    /// <remarks>BEP 19 allows a bare string as well as a list; both are read into this list, and it is always written back as a list.</remarks>
+    public IReadOnlyList<string>? UrlList { get; set; }
+
+    /// <summary>Web seed URLs from the 'httpseeds' key (BEP 17).</summary>
+    public IReadOnlyList<string>? HttpSeeds { get; set; }
+
+    /// <summary>DHT bootstrap nodes from the 'nodes' key (BEP 5).</summary>
+    public IReadOnlyList<TorrentNode>? Nodes { get; set; }
+
+    /// <summary>The 'encoding' key naming the code page the text fields were written with.</summary>
+    public string? Encoding { get; set; }
+
+    public string? Publisher { get; set; }
+
+    /// <summary>The 'publisher-url' key. Kept as text because the metainfo value is not guaranteed to be a well-formed URI.</summary>
+    [SuppressMessage("Design", "CA1056:URI-like properties should not be strings", Justification = "The value comes from the torrent and may not parse as a Uri; 'announce' is exposed the same way.")]
+    public string? PublisherUrl { get; set; }
 
     private TorrentInfo _info = new();
     private ReadOnlyMemory<byte> _infoBytes;
@@ -178,6 +203,57 @@ public sealed class TorrentFile
             result.CreatedBy = TorrentField.ToText(createdByText, "created by");
         }
 
+        if (dictionary.TryGetValue(UrlListKey, out var urlListValue))
+        {
+            // BEP 19 allows either a single URL or a list of them.
+            result.UrlList = urlListValue switch
+            {
+                BencodeString single => [TorrentField.ToText(single, "url-list")],
+                BencodeList list => ReadStringList(list, "url-list"),
+                _ => throw new FormatException("The 'url-list' field must be a string or a list of strings."),
+            };
+        }
+
+        if (dictionary.TryGetValue(HttpSeedsKey, out var httpSeedsValue))
+        {
+            if (httpSeedsValue is not BencodeList httpSeeds)
+                throw new FormatException("The 'httpseeds' field must be a list.");
+
+            result.HttpSeeds = ReadStringList(httpSeeds, "httpseeds");
+        }
+
+        if (dictionary.TryGetValue(NodesKey, out var nodesValue))
+        {
+            if (nodesValue is not BencodeList nodes)
+                throw new FormatException("The 'nodes' field must be a list.");
+
+            result.Nodes = ReadNodes(nodes);
+        }
+
+        if (dictionary.TryGetValue(EncodingKey, out var encodingValue))
+        {
+            if (encodingValue is not BencodeString encodingText)
+                throw new FormatException("The 'encoding' field must be a string.");
+
+            result.Encoding = TorrentField.ToText(encodingText, "encoding");
+        }
+
+        if (dictionary.TryGetValue(PublisherKey, out var publisherValue))
+        {
+            if (publisherValue is not BencodeString publisherText)
+                throw new FormatException("The 'publisher' field must be a string.");
+
+            result.Publisher = TorrentField.ToText(publisherText, "publisher");
+        }
+
+        if (dictionary.TryGetValue(PublisherUrlKey, out var publisherUrlValue))
+        {
+            if (publisherUrlValue is not BencodeString publisherUrlText)
+                throw new FormatException("The 'publisher-url' field must be a string.");
+
+            result.PublisherUrl = TorrentField.ToText(publisherUrlText, "publisher-url");
+        }
+
         if (dictionary.TryGetValue(CreationDateKey, out var creationDateValue))
         {
             if (creationDateValue is not BencodeInteger creationDateInteger)
@@ -208,7 +284,7 @@ public sealed class TorrentFile
 
         if (Announce is not null)
         {
-            dictionary.Add(AnnounceKey, new BencodeString(Encoding.UTF8.GetBytes(Announce)));
+            dictionary.Add(AnnounceKey, ToBencodeString(Announce));
         }
 
         if (AnnounceList is not null)
@@ -225,7 +301,7 @@ public sealed class TorrentFile
                     if (string.IsNullOrEmpty(url))
                         throw new FormatException("Announce-list URLs cannot be null or empty.");
 
-                    tierValues.Add(new BencodeString(Encoding.UTF8.GetBytes(url)));
+                    tierValues.Add(ToBencodeString(url));
                 }
 
                 tiers.Add(tierValues);
@@ -236,12 +312,12 @@ public sealed class TorrentFile
 
         if (Comment is not null)
         {
-            dictionary.Add(CommentKey, new BencodeString(Encoding.UTF8.GetBytes(Comment)));
+            dictionary.Add(CommentKey, ToBencodeString(Comment));
         }
 
         if (CreatedBy is not null)
         {
-            dictionary.Add(CreatedByKey, new BencodeString(Encoding.UTF8.GetBytes(CreatedBy)));
+            dictionary.Add(CreatedByKey, ToBencodeString(CreatedBy));
         }
 
         if (CreationDate.HasValue)
@@ -249,8 +325,110 @@ public sealed class TorrentFile
             dictionary.Add(CreationDateKey, new BencodeInteger(CreationDate.Value.ToUnixTimeSeconds()));
         }
 
+        if (UrlList is not null)
+        {
+            dictionary.Add(UrlListKey, WriteStringList(UrlList, "url-list"));
+        }
+
+        if (HttpSeeds is not null)
+        {
+            dictionary.Add(HttpSeedsKey, WriteStringList(HttpSeeds, "httpseeds"));
+        }
+
+        if (Nodes is not null)
+        {
+            var nodes = new BencodeList();
+            foreach (var node in Nodes)
+            {
+                if (node is null)
+                    throw new FormatException("Nodes cannot be null.");
+
+                if (string.IsNullOrEmpty(node.Host))
+                    throw new FormatException("A node host cannot be null or empty.");
+
+                if (node.Port is < 0 or > 65535)
+                    throw new FormatException("A node port is out of range.");
+
+                nodes.Add(new BencodeList([ToBencodeString(node.Host), new BencodeInteger(node.Port)]));
+            }
+
+            dictionary.Add(NodesKey, nodes);
+        }
+
+        if (Encoding is not null)
+        {
+            dictionary.Add(EncodingKey, ToBencodeString(Encoding));
+        }
+
+        if (Publisher is not null)
+        {
+            dictionary.Add(PublisherKey, ToBencodeString(Publisher));
+        }
+
+        if (PublisherUrl is not null)
+        {
+            dictionary.Add(PublisherUrlKey, ToBencodeString(PublisherUrl));
+        }
+
         return dictionary;
     }
 
-    private static BencodeString CreateKey(string value) => new(Encoding.UTF8.GetBytes(value));
+    private static BencodeList WriteStringList(IReadOnlyList<string> values, string fieldName)
+    {
+        var result = new BencodeList();
+        foreach (var value in values)
+        {
+            if (string.IsNullOrEmpty(value))
+                throw new FormatException($"A '{fieldName}' entry cannot be null or empty.");
+
+            result.Add(ToBencodeString(value));
+        }
+
+        return result;
+    }
+
+    private static List<string> ReadStringList(BencodeList list, string fieldName)
+    {
+        var result = new List<string>(list.Count);
+        foreach (var value in list)
+        {
+            if (value is not BencodeString text)
+                throw new FormatException($"Each '{fieldName}' entry must be a string.");
+
+            result.Add(TorrentField.ToText(text, fieldName));
+        }
+
+        return result;
+    }
+
+    private static List<TorrentNode> ReadNodes(BencodeList list)
+    {
+        var result = new List<TorrentNode>(list.Count);
+        foreach (var value in list)
+        {
+            if (value is not BencodeList { Count: 2 } node)
+                throw new FormatException("Each 'nodes' entry must be a list holding a host and a port.");
+
+            if (node[0] is not BencodeString host)
+                throw new FormatException("The host of a 'nodes' entry must be a string.");
+
+            if (node[1] is not BencodeInteger port)
+                throw new FormatException("The port of a 'nodes' entry must be an integer.");
+
+            if (port.Value is < 0 or > 65535)
+                throw new FormatException("The port of a 'nodes' entry is out of range.");
+
+            result.Add(new TorrentNode
+            {
+                Host = TorrentField.ToText(host, "nodes"),
+                Port = (int)port.Value,
+            });
+        }
+
+        return result;
+    }
+
+    private static BencodeString CreateKey(string value) => ToBencodeString(value);
+
+    private static BencodeString ToBencodeString(string value) => new(System.Text.Encoding.UTF8.GetBytes(value));
 }

--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentInfo.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentInfo.cs
@@ -9,6 +9,8 @@ public sealed class TorrentInfo
     private static readonly BencodeString LengthKey = CreateKey("length");
     private static readonly BencodeString FilesKey = CreateKey("files");
     private static readonly BencodeString PathKey = CreateKey("path");
+    private static readonly BencodeString SourceKey = CreateKey("source");
+    private static readonly BencodeString Md5SumKey = CreateKey("md5sum");
 
     public string Name { get; set; } = "";
 
@@ -21,6 +23,12 @@ public sealed class TorrentInfo
     public long? Length { get; set; }
 
     public IReadOnlyList<TorrentInfoFile>? Files { get; set; }
+
+    /// <summary>The 'source' key many private trackers add to make the info-hash unique to them.</summary>
+    public string? Source { get; set; }
+
+    /// <summary>The 'md5sum' of a single-file torrent's content, when the torrent carries one.</summary>
+    public string? Md5Sum { get; set; }
 
     internal static TorrentInfo Parse(BencodeDictionary dictionary)
     {
@@ -43,6 +51,22 @@ public sealed class TorrentInfo
                 throw new FormatException("The 'private' field must be an integer.");
 
             info.IsPrivate = privateInteger.Value != 0;
+        }
+
+        if (dictionary.TryGetValue(SourceKey, out var sourceValue))
+        {
+            if (sourceValue is not BencodeString sourceText)
+                throw new FormatException("The 'source' field must be a string.");
+
+            info.Source = TorrentField.ToText(sourceText, "source");
+        }
+
+        if (dictionary.TryGetValue(Md5SumKey, out var md5Value))
+        {
+            if (md5Value is not BencodeString md5Text)
+                throw new FormatException("The 'md5sum' field must be a string.");
+
+            info.Md5Sum = TorrentField.ToText(md5Text, "md5sum");
         }
 
         if (dictionary.TryGetValue(LengthKey, out var lengthValue))
@@ -77,11 +101,21 @@ public sealed class TorrentInfo
                     path.Add(TorrentField.ToText(segmentString, "path"));
                 }
 
-                files.Add(new TorrentInfoFile
+                var file = new TorrentInfoFile
                 {
                     Length = fileLength,
                     Path = path,
-                });
+                };
+
+                if (fileDictionary.TryGetValue(Md5SumKey, out var fileMd5Value))
+                {
+                    if (fileMd5Value is not BencodeString fileMd5Text)
+                        throw new FormatException("The 'md5sum' field must be a string.");
+
+                    file.Md5Sum = TorrentField.ToText(fileMd5Text, "md5sum");
+                }
+
+                files.Add(file);
             }
 
             info.Files = files;
@@ -107,6 +141,16 @@ public sealed class TorrentInfo
             dictionary.Add(PrivateKey, new BencodeInteger(1));
         }
 
+        if (Source is not null)
+        {
+            dictionary.Add(SourceKey, new BencodeString(Encoding.UTF8.GetBytes(Source)));
+        }
+
+        if (Md5Sum is not null)
+        {
+            dictionary.Add(Md5SumKey, new BencodeString(Encoding.UTF8.GetBytes(Md5Sum)));
+        }
+
         if (Length.HasValue)
         {
             dictionary.Add(LengthKey, new BencodeInteger(Length.Value));
@@ -120,11 +164,18 @@ public sealed class TorrentInfo
                     throw new FormatException("Torrent file entries cannot be null.");
 
                 var path = new BencodeList(file.Path.Select(segment => (BencodeValue)new BencodeString(Encoding.UTF8.GetBytes(segment))));
-                files.Add(new BencodeDictionary
+                var fileDictionary = new BencodeDictionary
                 {
                     { LengthKey, new BencodeInteger(file.Length) },
                     { PathKey, path },
-                });
+                };
+
+                if (file.Md5Sum is not null)
+                {
+                    fileDictionary.Add(Md5SumKey, new BencodeString(Encoding.UTF8.GetBytes(file.Md5Sum)));
+                }
+
+                files.Add(fileDictionary);
             }
 
             dictionary.Add(FilesKey, files);

--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentInfoFile.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentInfoFile.cs
@@ -5,4 +5,7 @@ public sealed class TorrentInfoFile
     public IReadOnlyList<string> Path { get; set; } = [];
 
     public long Length { get; set; }
+
+    /// <summary>The 'md5sum' of this file, when the torrent carries one.</summary>
+    public string? Md5Sum { get; set; }
 }

--- a/src/Meziantou.Framework.Bencode/Torrent/TorrentNode.cs
+++ b/src/Meziantou.Framework.Bencode/Torrent/TorrentNode.cs
@@ -1,0 +1,9 @@
+namespace Meziantou.Framework.Bencode.Torrent;
+
+/// <summary>A DHT bootstrap node from the 'nodes' key (BEP 5).</summary>
+public sealed class TorrentNode
+{
+    public string Host { get; set; } = "";
+
+    public int Port { get; set; }
+}

--- a/tests/Meziantou.Framework.Bencode.Tests/TorrentFileTests.cs
+++ b/tests/Meziantou.Framework.Bencode.Tests/TorrentFileTests.cs
@@ -260,6 +260,107 @@ public sealed class TorrentFileTests
     }
 
     [Fact]
+    public void Parse_ExtensionFields()
+    {
+        var content = Encoding.ASCII.GetBytes("d8:encoding5:UTF-84:infod6:lengthi123e6:md5sum4:abcd4:name8:file.txt12:piece lengthi16384e6:pieces20:012345678901234567896:source9:MyTrackere5:nodesll9:127.0.0.1i6881eel4:hosti1eee9:publisher7:someone13:publisher-url19:https://pub.test/ab8:url-listl20:https://seed.test/abee");
+
+        var torrent = TorrentFile.Parse(content);
+
+        Assert.Equal(["https://seed.test/ab"], torrent.UrlList);
+        Assert.Equal("UTF-8", torrent.Encoding);
+        Assert.Equal("someone", torrent.Publisher);
+        Assert.Equal("https://pub.test/ab", torrent.PublisherUrl);
+        Assert.Equal("MyTracker", torrent.Info.Source);
+        Assert.Equal("abcd", torrent.Info.Md5Sum);
+
+        Assert.NotNull(torrent.Nodes);
+        Assert.Equal(2, torrent.Nodes.Count);
+        Assert.Equal("127.0.0.1", torrent.Nodes[0].Host);
+        Assert.Equal(6881, torrent.Nodes[0].Port);
+        Assert.Equal("host", torrent.Nodes[1].Host);
+        Assert.Equal(1, torrent.Nodes[1].Port);
+    }
+
+    [Fact]
+    public void Parse_UrlListAsASingleString_IsReadAsAOneItemList()
+    {
+        var content = Encoding.ASCII.GetBytes("d4:infod6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:01234567890123456789e8:url-list20:https://seed.test/abe");
+
+        var torrent = TorrentFile.Parse(content);
+
+        Assert.Equal(["https://seed.test/ab"], torrent.UrlList);
+    }
+
+    [Fact]
+    public void Parse_HttpSeeds()
+    {
+        var content = Encoding.ASCII.GetBytes("d9:httpseedsl20:https://seed.test/abe4:infod6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:01234567890123456789ee");
+
+        var torrent = TorrentFile.Parse(content);
+
+        Assert.Equal(["https://seed.test/ab"], torrent.HttpSeeds);
+    }
+
+    [Fact]
+    public void Parse_PerFileMd5Sum()
+    {
+        var content = Encoding.ASCII.GetBytes("d4:infod5:filesld6:lengthi1e6:md5sum4:abcd4:pathl8:file.bineee4:name4:test12:piece lengthi16384e6:pieces20:01234567890123456789ee");
+
+        var torrent = TorrentFile.Parse(content);
+
+        Assert.NotNull(torrent.Info.Files);
+        Assert.Equal("abcd", torrent.Info.Files[0].Md5Sum);
+    }
+
+    [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "BitTorrent v1 info-hash is SHA-1.")]
+    [Fact]
+    public void RoundTrip_ExtensionFields_ArePreserved()
+    {
+        var content = Encoding.ASCII.GetBytes("d8:encoding5:UTF-89:httpseedsl20:https://seed.test/cde4:infod6:lengthi123e6:md5sum4:abcd4:name8:file.txt12:piece lengthi16384e6:pieces20:012345678901234567896:source9:MyTrackere5:nodesll9:127.0.0.1i6881eee9:publisher7:someone13:publisher-url19:https://pub.test/ab8:url-listl20:https://seed.test/abee");
+        var original = TorrentFile.Parse(content);
+        Assert.NotNull(original.UrlList);
+        Assert.NotNull(original.HttpSeeds);
+
+        var roundTrip = TorrentFile.Parse(original.ToUtf8ByteArray());
+
+        Assert.Equal(original.UrlList, roundTrip.UrlList);
+        Assert.Equal(original.HttpSeeds, roundTrip.HttpSeeds);
+        Assert.Equal(original.Encoding, roundTrip.Encoding);
+        Assert.Equal(original.Publisher, roundTrip.Publisher);
+        Assert.Equal(original.PublisherUrl, roundTrip.PublisherUrl);
+        Assert.Equal(original.Info.Source, roundTrip.Info.Source);
+        Assert.Equal(original.Info.Md5Sum, roundTrip.Info.Md5Sum);
+        Assert.Equal(original.GetInfoHashSha1(), roundTrip.GetInfoHashSha1());
+
+        Assert.NotNull(roundTrip.Nodes);
+        Assert.Equal("127.0.0.1", roundTrip.Nodes[0].Host);
+        Assert.Equal(6881, roundTrip.Nodes[0].Port);
+    }
+
+    [Theory]
+    [InlineData("8:url-listi1e")]
+    [InlineData("9:httpseeds20:https://seed.test/ab")]
+    [InlineData("5:nodesl9:127.0.0.1e")]
+    [InlineData("5:nodesll9:127.0.0.1i70000eee")]
+    [InlineData("5:nodesll9:127.0.0.14:portee")]
+    [InlineData("8:encodingi1e")]
+    public void Parse_MalformedExtensionField_Throws(string field)
+    {
+        var content = Encoding.ASCII.GetBytes("d" + field + "4:infod6:lengthi123e4:name8:file.txt12:piece lengthi16384e6:pieces20:01234567890123456789ee");
+
+        Assert.Throws<FormatException>(() => TorrentFile.Parse(content));
+    }
+
+    [Fact]
+    public void ToUtf8ByteArray_NodePortOutOfRange_Throws()
+    {
+        var torrent = TorrentFile.Parse(SingleFileTorrent);
+        torrent.Nodes = [new TorrentNode { Host = "127.0.0.1", Port = 70000 }];
+
+        Assert.Throws<FormatException>(() => torrent.ToUtf8ByteArray());
+    }
+
+    [Fact]
     public void ToArray_BothLengthAndFiles_Throws()
     {
         var torrent = new TorrentFile


### PR DESCRIPTION
Replaces #2323, which carried unknown keys through the write path instead of modelling them. Modelling them makes the values *readable* — before this, a caller could not get at the web seeds or the tracker source without parsing the bencode themselves.

## The problem

`TorrentFile` modelled six top-level keys and `TorrentInfo` six info keys. Common, well-specified extension keys were read past at parse time and absent at write time, so a parsed torrent could neither expose them nor write them back.

## The change

New properties, each parsed and written:

| Key | Property | Spec |
|---|---|---|
| `url-list` | `TorrentFile.UrlList` | BEP 19 |
| `httpseeds` | `TorrentFile.HttpSeeds` | BEP 17 |
| `nodes` | `TorrentFile.Nodes` (new `TorrentNode`) | BEP 5 |
| `encoding` | `TorrentFile.Encoding` | convention |
| `publisher`, `publisher-url` | `TorrentFile.Publisher`, `.PublisherUrl` | convention |
| `info.source` | `TorrentInfo.Source` | private trackers |
| `info.md5sum` | `TorrentInfo.Md5Sum` | BEP 3 |
| `files[].md5sum` | `TorrentInfoFile.Md5Sum` | BEP 3 |

Notes on the two that needed a decision:

- **`url-list`** is a bare string *or* a list of strings under BEP 19. Both parse into the list; it is always written back as a list, so a torrent that used the string form is written with the list form. That is top-level, so the info-hash is unaffected.
- **`nodes`** is a list of `[host, port]` pairs, so it gets a small `TorrentNode` type. Ports outside 0–65535 are rejected on both parse and write.

`PublisherUrl` stays a `string` rather than a `Uri` (CA1056 suppressed with a justification): the value comes from the torrent and is not guaranteed to parse, and `Announce` is already exposed the same way. Inside `TorrentFile` the new `Encoding` property shadows `System.Text.Encoding`, so UTF-8 encoding now goes through a small `ToBencodeString` helper, which also removes some repetition.

`ref/Meziantou.Framework.Bencode.cs` is regenerated. All additions are new members — nothing existing changed shape.

## Known limitation

Keys outside the modelled set are still dropped when a parsed torrent is written back out — `azureus_properties`, `libtorrent_resume`, `info.attr`, `info.sha256`, `info.symlink path`, `name.utf-8`, the BitTorrent v2 keys, and any future BEP extension. #2322 already landed, so the info-hash comes from the parsed bytes and is correct regardless; but `ToUtf8ByteArray`/`WriteToAsync` still do not reproduce such a torrent byte for byte.

BitTorrent v2 (`meta version`, `file tree`, `piece layers`) is deliberately out of scope: `TorrentInfo.Validate` hard-requires v1 `pieces`, so supporting it is a redesign rather than added properties.

## Verification

`dotnet build /p:TreatWarningsAsErrors=true` clean; `dotnet test` green — 168 tests across net10.0 and net11.0, up from 148.

The 14 new cases exercise every field: a torrent carrying all of them, `url-list` in its single-string form, `httpseeds`, per-file `md5sum`, a full write/re-parse cycle asserting each property and the info-hash survive, six malformed-input cases (`url-list` as an integer, `httpseeds` as a string, a `nodes` entry that is not a pair, an out-of-range port, a non-integer port, `encoding` as an integer), and an out-of-range port on the write path. Against `main` the test project does not compile at all, since none of these members exist.

Found by a project review of `src/Meziantou.Framework.Bencode`.
