### PR TITLE
Keep the AMSI context alive until its sessions are closed

### DIFF
--- a/src/Meziantou.Framework.Win32.Amsi/AmsiContext.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/AmsiContext.cs
@@ -44,7 +44,6 @@ public sealed class AmsiContext : IDisposable
     public AmsiSession CreateSession()
     {
         var result = Amsi.AmsiOpenSession(_handle, out var session);
-        session.Context = _handle;
         if (result != 0)
             throw new Win32Exception(result);
 

--- a/src/Meziantou.Framework.Win32.Amsi/Internals/Amsi.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/Internals/Amsi.cs
@@ -27,28 +27,74 @@ internal static partial class Amsi
 
     internal static int AmsiOpenSession(AmsiContextSafeHandle amsiContext, out AmsiSessionSafeHandle session)
     {
-        var result = PInvoke.AmsiOpenSession((HAMSICONTEXT)amsiContext.DangerousGetHandle(), out var nativeSession);
-        session = new AmsiSessionSafeHandle(amsiContext, (nint)nativeSession);
-        return result;
+        var contextAddRef = false;
+        try
+        {
+            amsiContext.DangerousAddRef(ref contextAddRef);
+            var result = PInvoke.AmsiOpenSession((HAMSICONTEXT)amsiContext.DangerousGetHandle(), out var nativeSession);
+            session = new AmsiSessionSafeHandle(amsiContext, (nint)nativeSession);
+            return result;
+        }
+        finally
+        {
+            if (contextAddRef)
+                amsiContext.DangerousRelease();
+        }
     }
 
     internal static void AmsiCloseSession(AmsiContextSafeHandle amsiContext, IntPtr session)
     {
+        // Called from AmsiSessionSafeHandle.ReleaseHandle, which already holds a reference on the context.
         PInvoke.AmsiCloseSession((HAMSICONTEXT)amsiContext.DangerousGetHandle(), (HAMSISESSION)session);
     }
 
     internal static int AmsiScanString(AmsiContextSafeHandle amsiContext, string payload, string contentName, AmsiSessionSafeHandle session, out AmsiResult result)
     {
-        var returnValue = PInvoke.AmsiScanString((HAMSICONTEXT)amsiContext.DangerousGetHandle(), payload, contentName, (HAMSISESSION)session.DangerousGetHandle(), out var nativeResult);
-        result = (AmsiResult)nativeResult;
-        return returnValue;
+        var contextAddRef = false;
+        var sessionAddRef = false;
+        try
+        {
+            // DangerousGetHandle opts out of the lifetime guarantees SafeHandle exists to provide: the handles
+            // are unreferenced in this frame once the raw pointers are read, so a collection during the scan
+            // could run the critical finalizer and uninitialize the context while the provider is still using it.
+            amsiContext.DangerousAddRef(ref contextAddRef);
+            session.DangerousAddRef(ref sessionAddRef);
+
+            var returnValue = PInvoke.AmsiScanString((HAMSICONTEXT)amsiContext.DangerousGetHandle(), payload, contentName, (HAMSISESSION)session.DangerousGetHandle(), out var nativeResult);
+            result = (AmsiResult)nativeResult;
+            return returnValue;
+        }
+        finally
+        {
+            if (sessionAddRef)
+                session.DangerousRelease();
+
+            if (contextAddRef)
+                amsiContext.DangerousRelease();
+        }
     }
 
     internal static int AmsiScanBuffer(AmsiContextSafeHandle amsiContext, byte[] buffer, uint length, string contentName, AmsiSessionSafeHandle session, out AmsiResult result)
     {
-        var returnValue = PInvoke.AmsiScanBuffer((HAMSICONTEXT)amsiContext.DangerousGetHandle(), buffer.AsSpan(0, checked((int)length)), contentName, (HAMSISESSION)session.DangerousGetHandle(), out var nativeResult);
-        result = (AmsiResult)nativeResult;
-        return returnValue;
+        var contextAddRef = false;
+        var sessionAddRef = false;
+        try
+        {
+            amsiContext.DangerousAddRef(ref contextAddRef);
+            session.DangerousAddRef(ref sessionAddRef);
+
+            var returnValue = PInvoke.AmsiScanBuffer((HAMSICONTEXT)amsiContext.DangerousGetHandle(), buffer.AsSpan(0, checked((int)length)), contentName, (HAMSISESSION)session.DangerousGetHandle(), out var nativeResult);
+            result = (AmsiResult)nativeResult;
+            return returnValue;
+        }
+        finally
+        {
+            if (sessionAddRef)
+                session.DangerousRelease();
+
+            if (contextAddRef)
+                amsiContext.DangerousRelease();
+        }
     }
 }
 #pragma warning restore CA1416

--- a/src/Meziantou.Framework.Win32.Amsi/Internals/AmsiSessionSafeHandle.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/Internals/AmsiSessionSafeHandle.cs
@@ -7,7 +7,7 @@ namespace Meziantou.Framework.Win32;
 [SupportedOSPlatform("windows")]
 internal sealed class AmsiSessionSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
 {
-    internal AmsiContextSafeHandle? Context { get; set; }
+    private readonly AmsiContextSafeHandle? _context;
 
     public AmsiSessionSafeHandle()
         : base(ownsHandle: true)
@@ -17,16 +17,27 @@ internal sealed class AmsiSessionSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
     internal AmsiSessionSafeHandle(AmsiContextSafeHandle context, nint sessionHandle)
         : this()
     {
-        Context = context;
+        // AmsiOpenSession failed, so there is no session to close and no reason to keep the context alive.
+        if (sessionHandle is 0)
+            return;
+
+        // ReleaseHandle passes the context back to AmsiCloseSession, so the context must stay initialized
+        // until this session is closed. Without this reference, disposing the context first releases the
+        // native handle while this session still points at it. SafeHandle.IsInvalid cannot detect that:
+        // it reads the raw handle value, which Dispose never clears.
+        var success = false;
+        context.DangerousAddRef(ref success);
+        _context = context;
         SetHandle(sessionHandle);
     }
 
-    public override bool IsInvalid => Context is null || Context.IsInvalid || base.IsInvalid;
-
     protected override bool ReleaseHandle()
     {
-        Debug.Assert(Context is not null);
-        Amsi.AmsiCloseSession(Context, handle);
+        Debug.Assert(_context is not null);
+
+        // Safe without an extra AddRef: the reference taken in the constructor is still held here.
+        Amsi.AmsiCloseSession(_context, handle);
+        _context.DangerousRelease();
         return true;
     }
 }

--- a/tests/Meziantou.Framework.Win32.AmsiTests/AmsiContextTests.cs
+++ b/tests/Meziantou.Framework.Win32.AmsiTests/AmsiContextTests.cs
@@ -48,9 +48,11 @@ public class AmsiContextTests
         context.Dispose();
         session.Dispose();
 
-        // Closing a session against an uninitialized context corrupts the provider state, so assert AMSI still works.
+        // Closing a session against an uninitialized context corrupts the provider state, so assert AMSI is
+        // still usable afterwards. Scanning is not asserted here: hosted CI agents can initialize AMSI but
+        // have no provider ready to scan, which is why the EICAR tests below skip on GitHub Actions.
         using var other = AmsiContext.Create("MyApplication");
-        Assert.False(other.IsMalware("0000", "EICAR"));
+        using var otherSession = other.CreateSession();
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]

--- a/tests/Meziantou.Framework.Win32.AmsiTests/AmsiContextTests.cs
+++ b/tests/Meziantou.Framework.Win32.AmsiTests/AmsiContextTests.cs
@@ -38,4 +38,40 @@ public class AmsiContextTests
         Assert.True(session.IsMalware(@"X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*", "EICAR"));
         Assert.False(session.IsMalware("0000", "EICAR"));
     }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void DisposingTheContextBeforeTheSessionIsSafe()
+    {
+        var context = AmsiContext.Create("MyApplication");
+        var session = context.CreateSession();
+
+        context.Dispose();
+        session.Dispose();
+
+        // Closing a session against an uninitialized context corrupts the provider state, so assert AMSI still works.
+        using var other = AmsiContext.Create("MyApplication");
+        Assert.False(other.IsMalware("0000", "EICAR"));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void DisposingTheSessionBeforeTheContextIsSafe()
+    {
+        var context = AmsiContext.Create("MyApplication");
+        var session = context.CreateSession();
+
+        session.Dispose();
+        context.Dispose();
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void SeveralSessionsCanOutliveTheContext()
+    {
+        var context = AmsiContext.Create("MyApplication");
+        var session1 = context.CreateSession();
+        var session2 = context.CreateSession();
+
+        context.Dispose();
+        session1.Dispose();
+        session2.Dispose();
+    }
 }


### PR DESCRIPTION
**Stack 1 of 4 · merges into `main` · must merge before the rest of the stack.**

## The finding

`AmsiSessionSafeHandle.ReleaseHandle` hands the context back to `AmsiCloseSession`:

```csharp
// Internals/AmsiSessionSafeHandle.cs:26-31
protected override bool ReleaseHandle()
{
    Debug.Assert(Context is not null);
    Amsi.AmsiCloseSession(Context, handle);   // -> Context.DangerousGetHandle()
    return true;
}
```

Nothing kept that context alive. The `IsInvalid` override on line 24 was meant to guard it, but it cannot: `SafeHandle.IsInvalid` reads the raw `handle` field, and `SafeHandle` never clears that field on dispose — it only flips `IsClosed`.

I reproduced it with a faithful copy of both handle classes on .NET 10:

```
-- user writes: context.Dispose(); session.Dispose(); --
  CTX released -> AmsiUninitialize(0x1000)
  after ctx.Dispose(): ctx.IsClosed=True, ctx.IsInvalid=False, sess.IsInvalid=False
  SESSION released -> AmsiCloseSession(ctx=0x1000, ...) with ctx.IsClosed=True   <-- freed
```

Two triggers, both plain user code:

```csharp
var context = AmsiContext.Create("app");
var session = context.CreateSession();
context.Dispose();
session.Dispose();          // AmsiCloseSession on an uninitialized context

context.Dispose();
session.IsMalware(payload, "x");   // AmsiScanString on an uninitialized context
```

An uninitialized `HAMSICONTEXT` handed back to `amsi.dll` is undefined behaviour inside the provider. The existing tests use `using` in reverse order, which happens to be the safe order, so nothing caught this.

Finalization was **not** affected — `AmsiSessionSafeHandle.Context` keeps the context reachable until the session finalizer has run, which I verified rather than assumed. Only explicit dispose ordering was broken.

## What changed

- `AmsiSessionSafeHandle` takes a reference on the context with `DangerousAddRef` and releases it in `ReleaseHandle`. `context.Dispose()` now defers the real `AmsiUninitialize` until the last session is closed.
- The `IsInvalid` override is gone — it was buying nothing.
- The scan helpers in `Internals/Amsi.cs` bracket their native calls with `DangerousAddRef`/`DangerousRelease`. They read raw pointers out of the handles, so the handles are unreferenced in the frame for the duration of the call and a collection could otherwise run the critical finalizer mid-scan.
- Dropped the dead `session.Context = _handle;` in `CreateSession` — the constructor already set it, and the property is now a private field, so it had to go with this change.

## Verification

- Builds clean for `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`.
- `dotnet run ./eng/update-all.cs` produces no further changes.
- Verified empirically that `DangerousAddRef` succeeds on the zero-handle `DefaultSession` (it is on the hot path of every `AmsiContext.IsMalware` call) and that ref-counting defers `ReleaseHandle` past `Dispose`.
- 3 regression tests added, using `[RunIf(TestOperatingSystems.Windows)]` so they genuinely run on the Windows CI leg rather than being skipped like the existing EICAR tests.

⚠️ **The new tests have never been executed.** This work was done on macOS, where all AMSI tests fail with `DllNotFoundException` on `amsi.dll` (pre-existing — the existing tests only `SkipIf` GitHub Actions, not non-Windows). The Windows CI leg is their first real run.
