### PR TITLE
Treat AMSI return values as HRESULT instead of Win32 error codes

### DIFF
--- a/src/Meziantou.Framework.Win32.Amsi/AmsiContext.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/AmsiContext.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
 namespace Meziantou.Framework.Win32;
@@ -28,25 +28,19 @@ public sealed class AmsiContext : IDisposable
     /// <summary>Creates a new AMSI context for the specified application.</summary>
     /// <param name="applicationName">The name of the application that will use the AMSI context.</param>
     /// <returns>A new <see cref="AmsiContext"/> instance.</returns>
-    /// <exception cref="Win32Exception">Thrown when the AMSI context cannot be initialized.</exception>
+    /// <exception cref="COMException">Thrown when the AMSI context cannot be initialized.</exception>
     public static AmsiContext Create(string applicationName)
     {
-        var result = Amsi.AmsiInitialize(applicationName, out var context);
-        if (result != 0)
-            throw new Win32Exception(result);
-
+        Amsi.AmsiInitialize(applicationName, out var context).ThrowOnFailure();
         return new AmsiContext(context);
     }
 
     /// <summary>Creates a new AMSI session for correlating multiple scan requests.</summary>
     /// <returns>A new <see cref="AmsiSession"/> instance.</returns>
-    /// <exception cref="Win32Exception">Thrown when the AMSI session cannot be opened.</exception>
+    /// <exception cref="COMException">Thrown when the AMSI session cannot be opened.</exception>
     public AmsiSession CreateSession()
     {
-        var result = Amsi.AmsiOpenSession(_handle, out var session);
-        if (result != 0)
-            throw new Win32Exception(result);
-
+        Amsi.AmsiOpenSession(_handle, out var session).ThrowOnFailure();
         return new AmsiSession(this, session);
     }
 
@@ -54,13 +48,10 @@ public sealed class AmsiContext : IDisposable
     /// <param name="payload">The string content to scan.</param>
     /// <param name="contentName">The name or identifier of the content being scanned.</param>
     /// <returns><see langword="true"/> if the content is detected as malware; otherwise, <see langword="false"/>.</returns>
-    /// <exception cref="Win32Exception">Thrown when the scan operation fails.</exception>
+    /// <exception cref="COMException">Thrown when the scan operation fails.</exception>
     public bool IsMalware(string payload, string contentName)
     {
-        var returnValue = Amsi.AmsiScanString(_handle, payload, contentName, DefaultSession, out var result);
-        if (returnValue != 0)
-            throw new Win32Exception(returnValue);
-
+        Amsi.AmsiScanString(_handle, payload, contentName, DefaultSession, out var result).ThrowOnFailure();
         return Amsi.AmsiResultIsMalware(result);
     }
 
@@ -68,13 +59,10 @@ public sealed class AmsiContext : IDisposable
     /// <param name="payload">The byte buffer to scan.</param>
     /// <param name="contentName">The name or identifier of the content being scanned.</param>
     /// <returns><see langword="true"/> if the content is detected as malware; otherwise, <see langword="false"/>.</returns>
-    /// <exception cref="Win32Exception">Thrown when the scan operation fails.</exception>
+    /// <exception cref="COMException">Thrown when the scan operation fails.</exception>
     public bool IsMalware(byte[] payload, string contentName)
     {
-        var returnValue = Amsi.AmsiScanBuffer(_handle, payload, (uint)payload.Length, contentName, DefaultSession, out var result);
-        if (returnValue != 0)
-            throw new Win32Exception(returnValue);
-
+        Amsi.AmsiScanBuffer(_handle, payload, (uint)payload.Length, contentName, DefaultSession, out var result).ThrowOnFailure();
         return Amsi.AmsiResultIsMalware(result);
     }
 

--- a/src/Meziantou.Framework.Win32.Amsi/AmsiSession.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/AmsiSession.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
 namespace Meziantou.Framework.Win32;
@@ -30,13 +30,10 @@ public sealed class AmsiSession : IDisposable
     /// <param name="payload">The string content to scan.</param>
     /// <param name="contentName">The name or identifier of the content being scanned.</param>
     /// <returns><see langword="true"/> if the content is detected as malware; otherwise, <see langword="false"/>.</returns>
-    /// <exception cref="Win32Exception">Thrown when the scan operation fails.</exception>
+    /// <exception cref="COMException">Thrown when the scan operation fails.</exception>
     public bool IsMalware(string payload, string contentName)
     {
-        var returnValue = Amsi.AmsiScanString(_context._handle, payload, contentName, _sessionHandle, out var result);
-        if (returnValue != 0)
-            throw new Win32Exception(returnValue);
-
+        Amsi.AmsiScanString(_context._handle, payload, contentName, _sessionHandle, out var result).ThrowOnFailure();
         return Amsi.AmsiResultIsMalware(result);
     }
 
@@ -44,13 +41,10 @@ public sealed class AmsiSession : IDisposable
     /// <param name="payload">The byte buffer to scan.</param>
     /// <param name="contentName">The name or identifier of the content being scanned.</param>
     /// <returns><see langword="true"/> if the content is detected as malware; otherwise, <see langword="false"/>.</returns>
-    /// <exception cref="Win32Exception">Thrown when the scan operation fails.</exception>
+    /// <exception cref="COMException">Thrown when the scan operation fails.</exception>
     public bool IsMalware(byte[] payload, string contentName)
     {
-        var returnValue = Amsi.AmsiScanBuffer(_context._handle, payload, (uint)payload.Length, contentName, _sessionHandle, out var result);
-        if (returnValue != 0)
-            throw new Win32Exception(returnValue);
-
+        Amsi.AmsiScanBuffer(_context._handle, payload, (uint)payload.Length, contentName, _sessionHandle, out var result).ThrowOnFailure();
         return Amsi.AmsiResultIsMalware(result);
     }
 

--- a/src/Meziantou.Framework.Win32.Amsi/Internals/Amsi.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/Internals/Amsi.cs
@@ -1,5 +1,6 @@
 using System.Runtime.Versioning;
 using Windows.Win32;
+using Windows.Win32.Foundation;
 using Windows.Win32.System.Antimalware;
 
 namespace Meziantou.Framework.Win32;
@@ -13,10 +14,13 @@ internal static partial class Amsi
         return result >= AmsiResult.AMSI_RESULT_DETECTED;
     }
 
-    internal static int AmsiInitialize(string appName, out AmsiContextSafeHandle amsiContext)
+    internal static HRESULT AmsiInitialize(string appName, out AmsiContextSafeHandle amsiContext)
     {
         var result = PInvoke.AmsiInitialize(appName, out var context);
-        amsiContext = new AmsiContextSafeHandle((nint)context);
+
+        // Only take ownership of the handle the call actually produced: on failure the out parameter
+        // carries no handle the caller is allowed to pass back to AmsiUninitialize.
+        amsiContext = result.Failed ? new AmsiContextSafeHandle() : new AmsiContextSafeHandle((nint)context);
         return result;
     }
 
@@ -25,14 +29,14 @@ internal static partial class Amsi
         PInvoke.AmsiUninitialize((HAMSICONTEXT)amsiContext);
     }
 
-    internal static int AmsiOpenSession(AmsiContextSafeHandle amsiContext, out AmsiSessionSafeHandle session)
+    internal static HRESULT AmsiOpenSession(AmsiContextSafeHandle amsiContext, out AmsiSessionSafeHandle session)
     {
         var contextAddRef = false;
         try
         {
             amsiContext.DangerousAddRef(ref contextAddRef);
             var result = PInvoke.AmsiOpenSession((HAMSICONTEXT)amsiContext.DangerousGetHandle(), out var nativeSession);
-            session = new AmsiSessionSafeHandle(amsiContext, (nint)nativeSession);
+            session = result.Failed ? new AmsiSessionSafeHandle() : new AmsiSessionSafeHandle(amsiContext, (nint)nativeSession);
             return result;
         }
         finally
@@ -48,7 +52,7 @@ internal static partial class Amsi
         PInvoke.AmsiCloseSession((HAMSICONTEXT)amsiContext.DangerousGetHandle(), (HAMSISESSION)session);
     }
 
-    internal static int AmsiScanString(AmsiContextSafeHandle amsiContext, string payload, string contentName, AmsiSessionSafeHandle session, out AmsiResult result)
+    internal static HRESULT AmsiScanString(AmsiContextSafeHandle amsiContext, string payload, string contentName, AmsiSessionSafeHandle session, out AmsiResult result)
     {
         var contextAddRef = false;
         var sessionAddRef = false;
@@ -74,7 +78,7 @@ internal static partial class Amsi
         }
     }
 
-    internal static int AmsiScanBuffer(AmsiContextSafeHandle amsiContext, byte[] buffer, uint length, string contentName, AmsiSessionSafeHandle session, out AmsiResult result)
+    internal static HRESULT AmsiScanBuffer(AmsiContextSafeHandle amsiContext, byte[] buffer, uint length, string contentName, AmsiSessionSafeHandle session, out AmsiResult result)
     {
         var contextAddRef = false;
         var sessionAddRef = false;


### PR DESCRIPTION
**Stack 2 of 4 · merges into `fix/amsi-handle-lifetime` (#2325) · merge after #2325.**

## The finding

Every AMSI function returns an `HRESULT` — confirmed both in the [docs](https://learn.microsoft.com/en-us/windows/win32/api/amsi/nf-amsi-amsiscanstring) ("If this function succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT** error code") and in the CsWin32-generated signatures. The wrapper widened that to `int` and did this at all six call sites:

```csharp
if (result != 0)
    throw new Win32Exception(result);
```

Two separate defects:

1. **Wrong success test.** HRESULT success is `result >= 0`, not `result == 0`. A non-`S_OK` success such as `S_FALSE` would throw on a call that actually succeeded, discarding a valid scan result.
2. **Wrong error domain.** `Win32Exception(int)` interprets its argument as a `GetLastError()` code, so `NativeErrorCode` ends up holding an HRESULT and callers cannot branch on it.

CI on #2325 produced a live example of this. A scan on a hosted agent failed and surfaced as:

```
System.ComponentModel.Win32Exception : The device is not ready.
   at AmsiContext.IsMalware(String payload, String contentName) in AmsiContext.cs:line 62
```

AMSI returned `HRESULT_FROM_WIN32(ERROR_NOT_READY)` = `0x80070015`. To be precise about what does and does not go wrong here: `FormatMessage` *did* resolve that value, so the message text is correct — that part of my original description was overstated. What is wrong is `NativeErrorCode`, which holds `0x80070015` (2147942421) rather than `21`, so `catch (Win32Exception e) when (e.NativeErrorCode == ERROR_NOT_READY)` does not match. And the message only survives because this HRESULT happens to be `FACILITY_WIN32`; a provider-specific or `FACILITY_ITF` HRESULT has no system message-table entry and degrades to `Unknown error (0x…)`.

This is the entire error-reporting surface of the package, and AMSI failing is not exotic — no registered provider, AMSI disabled by policy, or a provider rejecting the content all arrive here.

## What changed

- The interop helpers return CsWin32's `HRESULT` instead of widening to `int`, and the public methods call `.ThrowOnFailure()`. This matches the convention already used in the repo at `src/Meziantou.Framework.FullPath/FullPath.cs:731`; every other `Win32Exception` in the repo is paired with `Marshal.GetLastWin32Error()`, so AMSI was the outlier.
- `AmsiInitialize`/`AmsiOpenSession` no longer wrap the `out` parameter in an owning `SafeHandle` when the call failed — on failure it carries no handle that may legally be passed back to `AmsiUninitialize`/`AmsiCloseSession`.

## Behaviour change for callers

Failures now throw what `Marshal.ThrowExceptionForHR` produces — `COMException` for provider HRESULTs, or a mapped BCL type (`E_INVALIDARG` → `ArgumentException`, `E_OUTOFMEMORY` → `OutOfMemoryException`) — instead of `Win32Exception`. The `<exception>` docs were updated to `COMException`.

This is a breaking change for anyone catching `Win32Exception`. The package is at `3.0.0`; flagging it in case you want a major bump or a release note. I did not touch `<Version>` since `eng/update-versions.cs` owns that.

## Verification

- Builds clean for `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`.
- Public API surface unchanged (`ref/` regenerates identically) — only the thrown exception type differs, which the ref file does not capture.
- No new tests: the change is on error paths that need a failing AMSI provider to reach, which I cannot produce on macOS. Called out in the stack summary as a coverage gap rather than papered over.

