### PR TITLE
Throw ObjectDisposedException instead of scanning with a disposed context

### DIFF
--- a/src/Meziantou.Framework.Win32.Amsi/AmsiContext.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/AmsiContext.cs
@@ -20,6 +20,16 @@ public sealed class AmsiContext : IDisposable
 
     private static readonly AmsiSessionSafeHandle DefaultSession = new();
 
+    private bool _disposed;
+
+    /// <summary>Gets a value indicating whether this context has been disposed.</summary>
+    /// <remarks>
+    /// Tracked separately from the handle: a session holds a reference on the handle, so
+    /// <see cref="System.Runtime.InteropServices.SafeHandle.IsClosed"/> stays <see langword="false"/>
+    /// after <see cref="Dispose"/> until every session is closed.
+    /// </remarks>
+    internal bool IsDisposed => _disposed;
+
     private AmsiContext(AmsiContextSafeHandle context)
     {
         _handle = context;
@@ -38,8 +48,10 @@ public sealed class AmsiContext : IDisposable
     /// <summary>Creates a new AMSI session for correlating multiple scan requests.</summary>
     /// <returns>A new <see cref="AmsiSession"/> instance.</returns>
     /// <exception cref="COMException">Thrown when the AMSI session cannot be opened.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the context has been disposed.</exception>
     public AmsiSession CreateSession()
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         Amsi.AmsiOpenSession(_handle, out var session).ThrowOnFailure();
         return new AmsiSession(this, session);
     }
@@ -49,8 +61,10 @@ public sealed class AmsiContext : IDisposable
     /// <param name="contentName">The name or identifier of the content being scanned.</param>
     /// <returns><see langword="true"/> if the content is detected as malware; otherwise, <see langword="false"/>.</returns>
     /// <exception cref="COMException">Thrown when the scan operation fails.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the context has been disposed.</exception>
     public bool IsMalware(string payload, string contentName)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         Amsi.AmsiScanString(_handle, payload, contentName, DefaultSession, out var result).ThrowOnFailure();
         return Amsi.AmsiResultIsMalware(result);
     }
@@ -60,14 +74,17 @@ public sealed class AmsiContext : IDisposable
     /// <param name="contentName">The name or identifier of the content being scanned.</param>
     /// <returns><see langword="true"/> if the content is detected as malware; otherwise, <see langword="false"/>.</returns>
     /// <exception cref="COMException">Thrown when the scan operation fails.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the context has been disposed.</exception>
     public bool IsMalware(byte[] payload, string contentName)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         Amsi.AmsiScanBuffer(_handle, payload, (uint)payload.Length, contentName, DefaultSession, out var result).ThrowOnFailure();
         return Amsi.AmsiResultIsMalware(result);
     }
 
     public void Dispose()
     {
+        _disposed = true;
         _handle.Dispose();
     }
 }

--- a/src/Meziantou.Framework.Win32.Amsi/AmsiSession.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/AmsiSession.cs
@@ -19,6 +19,7 @@ public sealed class AmsiSession : IDisposable
 {
     private readonly AmsiContext _context;
     private readonly AmsiSessionSafeHandle _sessionHandle;
+    private bool _disposed;
 
     internal AmsiSession(AmsiContext context, AmsiSessionSafeHandle session)
     {
@@ -31,8 +32,10 @@ public sealed class AmsiSession : IDisposable
     /// <param name="contentName">The name or identifier of the content being scanned.</param>
     /// <returns><see langword="true"/> if the content is detected as malware; otherwise, <see langword="false"/>.</returns>
     /// <exception cref="COMException">Thrown when the scan operation fails.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the session or its context has been disposed.</exception>
     public bool IsMalware(string payload, string contentName)
     {
+        ThrowIfDisposed();
         Amsi.AmsiScanString(_context._handle, payload, contentName, _sessionHandle, out var result).ThrowOnFailure();
         return Amsi.AmsiResultIsMalware(result);
     }
@@ -42,14 +45,26 @@ public sealed class AmsiSession : IDisposable
     /// <param name="contentName">The name or identifier of the content being scanned.</param>
     /// <returns><see langword="true"/> if the content is detected as malware; otherwise, <see langword="false"/>.</returns>
     /// <exception cref="COMException">Thrown when the scan operation fails.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown when the session or its context has been disposed.</exception>
     public bool IsMalware(byte[] payload, string contentName)
     {
+        ThrowIfDisposed();
         Amsi.AmsiScanBuffer(_context._handle, payload, (uint)payload.Length, contentName, _sessionHandle, out var result).ThrowOnFailure();
         return Amsi.AmsiResultIsMalware(result);
     }
 
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        // The session cannot outlive the context it correlates scans for, even though the underlying
+        // context handle is kept alive until this session is closed.
+        ObjectDisposedException.ThrowIf(_context.IsDisposed, _context);
+    }
+
     public void Dispose()
     {
+        _disposed = true;
         _sessionHandle.Dispose();
     }
 }

--- a/tests/Meziantou.Framework.Win32.AmsiTests/AmsiContextTests.cs
+++ b/tests/Meziantou.Framework.Win32.AmsiTests/AmsiContextTests.cs
@@ -76,4 +76,48 @@ public class AmsiContextTests
         session1.Dispose();
         session2.Dispose();
     }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void UsingADisposedContextThrows()
+    {
+        var context = AmsiContext.Create("MyApplication");
+        context.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => context.IsMalware("0000", "EICAR"));
+        Assert.Throws<ObjectDisposedException>(() => context.IsMalware([0, 0, 0, 0], "EICAR"));
+        Assert.Throws<ObjectDisposedException>(context.CreateSession);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void UsingADisposedSessionThrows()
+    {
+        using var context = AmsiContext.Create("MyApplication");
+        var session = context.CreateSession();
+        session.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => session.IsMalware("0000", "EICAR"));
+        Assert.Throws<ObjectDisposedException>(() => session.IsMalware([0, 0, 0, 0], "EICAR"));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void UsingASessionWhoseContextIsDisposedThrows()
+    {
+        var context = AmsiContext.Create("MyApplication");
+        using var session = context.CreateSession();
+        context.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => session.IsMalware("0000", "EICAR"));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void DisposingTwiceIsSafe()
+    {
+        var context = AmsiContext.Create("MyApplication");
+        var session = context.CreateSession();
+
+        session.Dispose();
+        session.Dispose();
+        context.Dispose();
+        context.Dispose();
+    }
 }


### PR DESCRIPTION
**Stack 3 of 4 · merges into `fix/amsi-hresult` (#2326) · merge after #2326.**

## The finding

Neither `Dispose` recorded that it ran, and the scan methods go straight to the interop layer, which reads the raw pointer with `DangerousGetHandle()`. That returns the stale pointer after the handle is closed, so:

```csharp
var context = AmsiContext.Create("app");
context.Dispose();
context.IsMalware("anything", "x");   // AmsiScanString with a freed HAMSICONTEXT
```

No exception, no failure code — the freed pointer just goes into the native call. Use-after-dispose is common enough in caller code (a shared context disposed by one path while another still holds it) that a library is expected to turn it into an `ObjectDisposedException`; here it became undefined native behaviour whose crash points at `amsi.dll` rather than at the caller's bug.

`AGENTS.md` also asks for `ObjectDisposedException.ThrowIf` where applicable.

## What changed

Guards on all four scan methods plus `CreateSession`, and on `AmsiSession` a check that the parent context is still alive.

**Note on why this uses an explicit flag rather than `SafeHandle.IsClosed`:** the obvious implementation is `ObjectDisposedException.ThrowIf(_handle.IsClosed, this)`, and it would be wrong. Layer 1 makes the session hold a reference on the context handle, and I verified that `SafeHandle.IsClosed` stays **`false`** after `Dispose()` while any reference is outstanding:

```
after Dispose while ref held: IsClosed=False
  >> ReleaseHandle -> AmsiUninitialize(0x1000)     <-- only after DangerousRelease
```

So `IsClosed` is not a reliable "was `Dispose` called" signal once ref-counting is in play. `AmsiContext` tracks disposal in a `_disposed` field and exposes it internally for `AmsiSession` to check.

## Verification

- Builds clean for `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`.
- 4 tests added (`[RunIf(TestOperatingSystems.Windows)]`): disposed context, disposed session, session whose context was disposed, and double-dispose.
- Public API surface unchanged.

⚠️ Like the rest of the stack, these tests have not been executed — macOS cannot load `amsi.dll`. The Windows CI leg is their first run.
