### PR TITLE
Annotate the AMSI wrapper with the Windows version it actually requires

### DIFF
--- a/ref/Meziantou.Framework.Win32.Amsi.cs
+++ b/ref/Meziantou.Framework.Win32.Amsi.cs
@@ -4,7 +4,7 @@
 
 namespace Meziantou.Framework.Win32
 {
-    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows10.0.10240")]
     public sealed class AmsiContext : System.IDisposable
     {
         public static Meziantou.Framework.Win32.AmsiContext Create(string applicationName) => throw null;
@@ -14,7 +14,7 @@ namespace Meziantou.Framework.Win32
         public void Dispose() { }
     }
 
-    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows10.0.10240")]
     public sealed class AmsiSession : System.IDisposable
     {
         public bool IsMalware(string payload, string contentName) => throw null;

--- a/src/Meziantou.Framework.Win32.Amsi/AmsiContext.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/AmsiContext.cs
@@ -13,7 +13,7 @@ namespace Meziantou.Framework.Win32;
 /// }
 /// </code>
 /// </example>
-[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("windows10.0.10240")]
 public sealed class AmsiContext : IDisposable
 {
     internal readonly AmsiContextSafeHandle _handle;

--- a/src/Meziantou.Framework.Win32.Amsi/AmsiSession.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/AmsiSession.cs
@@ -14,7 +14,7 @@ namespace Meziantou.Framework.Win32;
 /// }
 /// </code>
 /// </example>
-[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("windows10.0.10240")]
 public sealed class AmsiSession : IDisposable
 {
     private readonly AmsiContext _context;

--- a/src/Meziantou.Framework.Win32.Amsi/Internals/Amsi.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/Internals/Amsi.cs
@@ -4,8 +4,7 @@ using Windows.Win32.System.Antimalware;
 
 namespace Meziantou.Framework.Win32;
 
-[SupportedOSPlatform("windows")]
-#pragma warning disable CA1416 // The containing APIs are Windows-only.
+[SupportedOSPlatform("windows10.0.10240")]
 internal static partial class Amsi
 {
     internal static bool AmsiResultIsMalware(AmsiResult result)
@@ -51,4 +50,3 @@ internal static partial class Amsi
         return returnValue;
     }
 }
-#pragma warning restore CA1416

--- a/src/Meziantou.Framework.Win32.Amsi/Internals/AmsiContextSafeHandle.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/Internals/AmsiContextSafeHandle.cs
@@ -3,7 +3,7 @@ using Microsoft.Win32.SafeHandles;
 
 namespace Meziantou.Framework.Win32;
 
-[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("windows10.0.10240")]
 internal sealed class AmsiContextSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
 {
     public AmsiContextSafeHandle()

--- a/src/Meziantou.Framework.Win32.Amsi/Internals/AmsiSessionSafeHandle.cs
+++ b/src/Meziantou.Framework.Win32.Amsi/Internals/AmsiSessionSafeHandle.cs
@@ -4,7 +4,7 @@ using Microsoft.Win32.SafeHandles;
 
 namespace Meziantou.Framework.Win32;
 
-[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("windows10.0.10240")]
 internal sealed class AmsiSessionSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
 {
     internal AmsiContextSafeHandle? Context { get; set; }


### PR DESCRIPTION
**Independent — branches off `main`, merges in any order.**

## The finding

The CsWin32-generated P/Invokes are annotated `[SupportedOSPlatform("windows10.0.10240")]`, but the wrapper claimed plain `"windows"`. The resulting CA1416 was silenced for the whole of `Internals/Amsi.cs`:

```csharp
[SupportedOSPlatform("windows")]
#pragma warning disable CA1416 // The containing APIs are Windows-only.
```

The comment does not describe the actual mismatch, which is about the Windows *version*, not the platform. Practical impact today is nil — `net10.0`/`net11.0` already require Windows 10 1607+, above the AMSI floor. The cost is that a file-wide suppression will also swallow the next genuine CA1416 in that file.

## What changed

`[SupportedOSPlatform("windows10.0.10240")]` on `AmsiContext`, `AmsiSession`, `Amsi`, and both SafeHandles, matching the generated annotations. The `#pragma` pair is deleted.

## Verification

I checked that the suppression is genuinely no longer needed rather than just confirming a green build:

| state | CA1416 diagnostics |
|---|---|
| old `"windows"` attribute, pragma removed | **32** |
| new `"windows10.0.10240"` attribute, pragma removed | **0** |

Measured with `/p:RunAnalyzers=true /p:EnableNETAnalyzers=true /p:AnalysisMode=All`. The first row confirms the analyzer is actually live, so the second row means something.

Builds clean for `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`. `ref/` regenerated (Release + `IsOfficialBuild`); the only change is the attribute on the two public types.

## Note on merge order

Conflicts with #2328 in `ref/Meziantou.Framework.Win32.Amsi.cs` only. That file is generated — whichever lands second should be resolved by regenerating:

```
dotnet build src/Meziantou.Framework.Win32.Amsi/Meziantou.Framework.Win32.Amsi.csproj -c Release /p:IsOfficialBuild=true
```

Clean against every other branch in this set, including the bottom of the stack.
