### PR TITLE
Stop the FullPath return-value walk at lambdas

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs
@@ -68,14 +68,15 @@ internal sealed class FullPathContext(Compilation compilation)
 
     /// <summary>
     /// Walks <paramref name="operation"/> and reports whether it contains at least one <see langword="return"/> with a
-    /// value, and whether every such value is a <c>FullPath</c>. Nested local functions are not walked.
+    /// value, and whether every such value is a <c>FullPath</c>. Nested local functions and lambdas are not walked.
     /// </summary>
     public void AnalyzeReturnOperations(IOperation operation, ref bool hasReturnValue, ref bool allReturnsAreFullPath)
     {
         if (!allReturnsAreFullPath)
             return;
 
-        if (operation is ILocalFunctionOperation)
+        // A lambda or a local function has its own return statements; they are not the enclosing member's
+        if (operation is ILocalFunctionOperation or IAnonymousFunctionOperation)
             return;
 
         if (operation is IReturnOperation returnOperation && returnOperation.ReturnedValue is not null)

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/MethodShouldReturnFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/MethodShouldReturnFullPathRuleTests.cs
@@ -112,4 +112,53 @@ public sealed class MethodShouldReturnFullPathRuleTests : FullPathAnalyzerTestBa
 
         await CreateAnalyzerTest<MethodShouldReturnFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_WhenTheMethodContainsALambdaReturningAnotherType()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string {|MFFP0011:M|}(FullPath root, IEnumerable<string> names)
+                    {
+                        var first = names.First(n => n.Length > 0);
+                        return root / first;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<MethodShouldReturnFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_NoDiagnostic_WhenOnlyALambdaReturnsFullPathValues()
+    {
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath root, IEnumerable<string> names)
+                    {
+                        var paths = names.Select(n => root / n).ToList();
+                        throw new InvalidOperationException(string.Join(", ", paths));
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<MethodShouldReturnFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
 }


### PR DESCRIPTION
`FullPathContext.AnalyzeReturnOperations` stops its walk at `ILocalFunctionOperation` but not at `IAnonymousFunctionOperation`. Roslyn models a lambda body as a nested `IBlockOperation` containing `IReturnOperation`, so a lambda's returns were counted as the enclosing member's. That makes MFFP0011 and MFFP0012 misfire in both directions on any method containing a lambda.

**False negative** — reports nothing, because the lambda's `bool` return sets `allReturnsAreFullPath = false`:

```csharp
public static string M(FullPath root, IEnumerable<string> names)
{
    var first = names.First(n => n.Length > 0);
    return root / first;   // every real return IS a FullPath
}
```

The same code written with a local function *is* reported, which made the behaviour look arbitrary.

**False positive** — reported as "returns FullPath values and should return FullPath", even though `M` never returns:

```csharp
public static string M(FullPath root, IEnumerable<string> names)
{
    var paths = names.Select(n => root / n).ToList();
    throw new InvalidOperationException(string.Join(", ", paths));
}
```

Since LINQ lambdas are everywhere, the false negative silently suppressed both rules across most real codebases.

## What changed

One added operation kind in the existing guard, plus the doc comment that documented the old behaviour.

## Verification

Two regression tests added, one per direction. Both fail on `main` and pass with the fix; full analyzer suite green at 107 tests.
