### PR TITLE
Test the argument's own type in the FullPath.Equals(string) rule

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/FullPathEqualsStringAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FullPathEqualsStringAnalyzer.cs
@@ -53,8 +53,10 @@ public sealed class FullPathEqualsStringAnalyzer : DiagnosticAnalyzer
         if (invocationOperation.Instance is not { } instance || !analyzerContext.IsFullPathType(instance.Type))
             return;
 
-        // An 'object' argument may hold a boxed FullPath at run time, a string never can
-        if (analyzerContext.UnwrapToFullPath(invocationOperation.Arguments[0].Value).Type?.SpecialType != SpecialType.System_String)
+        // An 'object' argument may hold a boxed FullPath at run time, a string never can.
+        // Only the conversion to 'object' is unwrapped: UnwrapToFullPath would also strip 'Value', 'RawValue',
+        // 'ToString()' and the explicit cast, hiding the string argument behind the FullPath it came from.
+        if (invocationOperation.Arguments[0].Value.UnwrapImplicitConversions().Type?.SpecialType != SpecialType.System_String)
             return;
 
         context.ReportDiagnostic(Descriptor, invocationOperation);

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/FullPathEqualsStringRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/FullPathEqualsStringRuleTests.cs
@@ -108,4 +108,88 @@ public sealed class FullPathEqualsStringRuleTests : FullPathAnalyzerTestBase
 
         await CreateAnalyzerTest<FullPathEqualsStringAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForEqualsWithFullPathValue()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(FullPath fullPath, FullPath other)
+                    {
+                        return {|MFFP0016:fullPath.Equals(other.Value)|};
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<FullPathEqualsStringAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForEqualsWithFullPathRawValue()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(FullPath fullPath, FullPath other)
+                    {
+                        return {|MFFP0016:fullPath.Equals(other.RawValue)|};
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<FullPathEqualsStringAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForEqualsWithFullPathToString()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(FullPath fullPath, FullPath other)
+                    {
+                        return {|MFFP0016:fullPath.Equals(other.ToString())|};
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<FullPathEqualsStringAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_ForEqualsWithFullPathExplicitCast()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(FullPath fullPath, FullPath other)
+                    {
+                        return {|MFFP0016:fullPath.Equals((string)other)|};
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<FullPathEqualsStringAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
 }


### PR DESCRIPTION
MFFP0016 is a Warning-level rule that reports `FullPath.Equals(object)` calls whose argument is a `string`, because those always return `false`. It missed the most natural way to write the mistake:

```csharp
fullPath.Equals(other.Value)      // always false — reported nothing
fullPath.Equals(other.RawValue)   // always false — reported nothing
fullPath.Equals(other.ToString()) // always false — reported nothing
fullPath.Equals((string)other)    // always false — reported nothing
```

The check ran `UnwrapToFullPath` on the argument before testing `SpecialType == System_String`. That shared helper strips `.Value`, `.RawValue`, `ToString()` and the explicit cast back to the underlying `FullPath` — which is what makes every *other* rule in the set work, and is exactly what breaks this one. The type test saw `FullPath` and bailed.

The comment on the line above it — "An 'object' argument may hold a boxed FullPath at run time, a string never can" — shows the intent was always to test the argument's **static** type.

## What changed

`UnwrapToFullPath` → `UnwrapImplicitConversions` (already in `Meziantou.Framework.Roslyn`). That still strips the implicit conversion to `object`, which is needed to see through the `Equals(object)` parameter, but leaves the `FullPath`-to-`string` accessors alone.

## Verification

Four positive tests added, one per spelling. All four fail on `main` and pass with the fix. The existing negative tests still pass unchanged — `Equals(otherFullPath)` and `Equals(objectValue)` are unaffected, since unwrapping the boxing conversion still yields a non-`string` type.

Full analyzer suite green at 109 tests.
