### PR TITLE
Require exactly one argument before suggesting FullPath.CreateParentDirectory

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/UseCreateParentDirectoryAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/UseCreateParentDirectoryAnalyzer.cs
@@ -45,7 +45,9 @@ public sealed class UseCreateParentDirectoryAnalyzer : DiagnosticAnalyzer
         if (!SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, analyzerContext.DirectoryType))
             return;
 
-        if (invocationOperation.Arguments.Length == 0)
+        // CreateParentDirectory() takes no options, so the Directory.CreateDirectory(path, unixCreateMode)
+        // overload cannot be rewritten without dropping the requested mode
+        if (invocationOperation.Arguments.Length != 1)
             return;
 
         // CreateParentDirectory returns void, so the DirectoryInfo must not be used

--- a/src/Meziantou.Framework.FullPath.CodeFix/UseCreateParentDirectoryCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/UseCreateParentDirectoryCodeFixProvider.cs
@@ -21,7 +21,7 @@ public sealed class UseCreateParentDirectoryCodeFixProvider : FullPathCodeFixPro
         CancellationToken cancellationToken,
         out ExpressionSyntax replacementExpression)
     {
-        if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is IInvocationOperation { Arguments.Length: > 0 } invocationOperation &&
+        if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is IInvocationOperation { Arguments.Length: 1 } invocationOperation &&
             invocationOperation.TargetMethod is { IsStatic: true, Name: "CreateDirectory" } targetMethod &&
             SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, analyzerContext.DirectoryType) &&
             analyzerContext.UnwrapToFullPath(invocationOperation.Arguments[0].Value) is IPropertyReferenceOperation { Property.Name: "Parent", Instance: { } instance } property &&

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseCreateParentDirectoryRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseCreateParentDirectoryRuleTests.cs
@@ -130,4 +130,26 @@ public sealed class UseCreateParentDirectoryRuleTests : FullPathAnalyzerTestBase
 
         await CreateAnalyzerTest<DirectoryGetParentWithFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForCreateDirectoryWithUnixFileMode()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static void M(FullPath fullPath)
+                    {
+                        Directory.CreateDirectory(fullPath.Parent, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseCreateParentDirectoryAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
 }


### PR DESCRIPTION
MFFP0022 suggests replacing `Directory.CreateDirectory(fullPath.Parent)` with `fullPath.CreateParentDirectory()`. Both the analyzer and the code fix guarded only on "at least one argument" and then looked exclusively at `Arguments[0]`, so the two-argument overload matched too:

```csharp
// before — reports MFFP0022, fix offered
Directory.CreateDirectory(file.Parent, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);

// after applying the fix — the mode is gone
file.CreateParentDirectory();
```

`FullPath.CreateParentDirectory()` takes no options and calls the single-argument `Directory.CreateDirectory`, so the directory is created with the process default mode less umask instead of `0700`. It compiles, and the mode argument simply is not in the diff any more.

That is a permissions regression on Linux and macOS produced by a one-click fix.

## What changed

`Arguments.Length == 0` → `!= 1` in the analyzer, and `Arguments.Length: > 0` → `: 1` in the code fix provider. Every sibling analyzer in this project already uses an exact `Arguments.Length != N` guard; this rule was the only outlier.

## Verification

Negative test added for the `UnixFileMode` overload. It fails on `main` (the rule fires) and passes with the fix. Existing MFFP0022 tests unchanged and still green; full analyzer suite green at 106 tests.
