### PR TITLE
Return Empty instead of throwing for FullPath.FromPath with an empty path

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -441,6 +441,10 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         // A path that resolves to nothing already returns Empty below; an empty input is the same case, and
         // Path.GetFullPath would throw before reaching it. Environment.GetFolderPath returns "" for a folder
         // that is not defined on the platform, which makes this a routine input rather than a caller error.
+        //
+        // Empty rather than CurrentDirectory: "" means "no path", not "the current directory". Resolving it against
+        // the current directory would turn an undefined special folder into a real, writable location. "." is the
+        // spelling for the current directory, and Path.GetFullPath("") throws rather than treating the two alike.
         if (path is { Length: 0 })
             return Empty;
 

--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -435,9 +435,15 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
     public static FullPath CurrentDirectory() => FromPath(Environment.CurrentDirectory);
 
     /// <summary>Creates a <see cref="FullPath"/> from a string path by converting it to an absolute path.</summary>
-    /// <param name="path">The path to convert. Can be relative or absolute.</param>
+    /// <param name="path">The path to convert. Can be relative or absolute. An empty string returns <see cref="Empty"/>.</param>
     public static FullPath FromPath(string path)
     {
+        // A path that resolves to nothing already returns Empty below; an empty input is the same case, and
+        // Path.GetFullPath would throw before reaching it. Environment.GetFolderPath returns "" for a folder
+        // that is not defined on the platform, which makes this a routine input rather than a caller error.
+        if (path is { Length: 0 })
+            return Empty;
+
         // '\' is a regular file name character on Unix, so a path such as @"\\?\a" is a relative file name there, not a device path
         if (OperatingSystem.IsWindows() && PathInternal.IsExtended(path))
         {

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -14,6 +14,14 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public void FromPath_EmptyString_ReturnsEmpty()
+    {
+        Assert.True(FullPath.FromPath("").IsEmpty);
+        Assert.Equal(FullPath.Empty, FullPath.FromPath(""));
+        Assert.Equal(FullPath.Empty, FullPath.FromPath(string.Empty));
+    }
+
+    [Fact]
     public void Properties()
     {
         var path = FullPath.FromPath("test") / "a" / "b.txt";

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -22,6 +22,22 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public void FromPath_EmptyString_IsNotTheCurrentDirectory()
+    {
+        Assert.NotEqual(FullPath.CurrentDirectory(), FullPath.FromPath(""));
+        Assert.Equal(FullPath.CurrentDirectory(), FullPath.FromPath("."));
+    }
+
+    [Fact]
+    public void FromPath_RoundTripsTheStringRepresentation()
+    {
+        Assert.Equal(FullPath.Empty, FullPath.FromPath(FullPath.Empty.Value));
+
+        var path = FullPath.FromPath("test");
+        Assert.Equal(path, FullPath.FromPath(path.Value));
+    }
+
+    [Fact]
     public void Properties()
     {
         var path = FullPath.FromPath("test") / "a" / "b.txt";


### PR DESCRIPTION
`FullPath.FromPath("")` threw `ArgumentException: The value cannot be an empty string. (Parameter 'path')`, because `Path.GetFullPath("")` throws before `FromPath` reaches its own empty check a few lines below.

That makes `FullPath.GetFolderPath` unsafe on exactly the machines where it matters:

```csharp
// Environment.GetFolderPath returns "" when the folder is not defined on the platform —
// routine for MyMusic, MyVideos, CommonDesktopDirectory in containers and on servers.
var music = FullPath.GetFolderPath(Environment.SpecialFolder.MyMusic);  // threw
```

`FullPath.GetFolderPath` is `FromPath(Environment.GetFolderPath(folder))`, so a documented empty result became an unhandled exception. Code that probed special folders and guarded with `if (dir.Length == 0)` had its guard rendered unreachable. It fails in CI and container environments rather than on the developer's box, so it ships green.

## What changed

`FromPath` returns `Empty` for an empty input. This is the same outcome the method already produced one branch later for a path that *resolves* to nothing (`FromPath("/")` → `Empty`) — an empty input is that same case, it just never got there.

`path is { Length: 0 }` rather than `path.Length == 0` deliberately: a `null` argument still falls through to `Path.GetFullPath` and throws `ArgumentNullException` exactly as before, rather than turning into a `NullReferenceException`.

## Behavior change

This is a public behavior change to a shipped package. `FromPath("")` goes from throwing to returning `Empty`. No test in the repo pinned the throw, and `IsEmpty` already existed as the way to detect this state, but it is worth a deliberate look.

It also resolves the second half of a review finding: MFFP0024 suggests `Environment.GetFolderPath` → `FullPath.GetFolderPath`, which was previously not a safe rewrite for this reason.

## Verification

Test added asserting `FromPath("")`, `FromPath(string.Empty)` and `FullPath.Empty` agree. It fails on `main` with the `ArgumentException` above and passes with the fix. Full `Meziantou.Framework.FullPath` suite green — 164 run, 56 skipped (Windows-only), 0 failed. `dotnet run ./eng/update-all.cs` produces no further changes.
