### PR TITLE
Fix crash when hashing an empty password with the legacy $2$ revision

### DIFF
--- a/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs
+++ b/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs
@@ -232,15 +232,16 @@ internal sealed class BcryptImplementation
         byte[] passwordBytes;
         if (minorRevision >= 'a')
         {
-            // For the 'a' revision and later, the password is null-terminated. This allows for correct handling of passwords that contain embedded null characters.
-            // For the 'b', 'x', and 'y' revisions, the password is not null-terminated, and any embedded null characters are treated as part of the password.
+            // The 'a' revision and later append a NUL terminator to the password before it is used as key material.
+            // Unlike the C implementations, the password is not truncated at an embedded NUL: .NET strings are not
+            // NUL-terminated, so every byte of the password takes part in the hash.
             passwordBytes = new byte[Utf8.GetByteCount(password) + 1];
             Utf8.GetBytes(password, passwordBytes);
             passwordBytes[^1] = 0; // Null terminator
         }
         else
         {
-            // For the original '2' revision, the password is not null-terminated, and any embedded null characters are treated as part of the password.
+            // The original '2' revision uses the password as-is, with no NUL terminator.
             passwordBytes = Utf8.GetBytes(password);
         }
 
@@ -255,7 +256,7 @@ internal sealed class BcryptImplementation
         return Verify(password.AsSpan(), hash.AsSpan());
     }
 
-    public static unsafe bool Verify(ReadOnlySpan<char> password, ReadOnlySpan<char> hash)
+    public static bool Verify(ReadOnlySpan<char> password, ReadOnlySpan<char> hash)
     {
         var hashBytes = Utf8.GetBytes(hash);
         var computedHashBytes = Utf8.GetBytes(HashPassword(password, hash));
@@ -425,6 +426,12 @@ internal sealed class BcryptImplementation
 
     private static uint StreamToWord(ReadOnlySpan<byte> data, ref int offset)
     {
+        // Only a legacy '$2$' hash combined with an empty password can produce empty key material: every other
+        // revision appends a NUL terminator. The C implementations read out of bounds here, so no reference
+        // result exists; treat the stream as zero bytes so hashing stays total instead of throwing.
+        if (data.IsEmpty)
+            return 0;
+
         uint word = 0;
         for (var i = 0; i < 4; i++)
         {

--- a/src/Meziantou.Framework.Bcrypt/EncodingExtensions.cs
+++ b/src/Meziantou.Framework.Bcrypt/EncodingExtensions.cs
@@ -4,16 +4,15 @@ namespace Meziantou.Framework;
 
 internal static class EncodingExtensions
 {
-    public unsafe static byte[] GetBytes(this Encoding encoding, ReadOnlySpan<char> s)
+    public static byte[] GetBytes(this Encoding encoding, ReadOnlySpan<char> s)
     {
         var count = encoding.GetByteCount(s);
+        if (count is 0)
+            return [];
+
         var buffer = new byte[count];
-        fixed (byte* ptr = buffer)
-        fixed (char* ptr2 = s)
-        {
-            var result = encoding.GetBytes(ptr2, s.Length, ptr, count);
-            Debug.Assert(result == count);
-        }
+        var written = encoding.GetBytes(s, buffer);
+        Debug.Assert(written == count);
 
         return buffer;
     }

--- a/tests/Meziantou.Framework.Bcrypt.Tests/BcryptTests.cs
+++ b/tests/Meziantou.Framework.Bcrypt.Tests/BcryptTests.cs
@@ -119,6 +119,36 @@ public sealed class BcryptTests
         Assert.False(Bcrypt.Verify(differentInFirst72Bytes, hash72));
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("a")]
+    [InlineData("password")]
+    public void HashPassword_LegacyRevision2_RoundTrips(string password)
+    {
+        const string Salt = "$2$06$DCq7YPn5Rq63x1Lad4cll.";
+
+        var hash = Bcrypt.HashPassword(password, Salt);
+
+        Assert.StartsWith("$2$06$", hash);
+        Assert.HasCount(59, hash);
+        Assert.True(Bcrypt.Verify(password, hash));
+    }
+
+    [Fact]
+    public void Verify_EmptyPasswordAgainstLegacyRevision2Hash_DoesNotThrow()
+    {
+        // An empty password used to throw ArgumentNullException here: the '$2$' revision appends no NUL
+        // terminator, so it is the only revision that can produce zero-length key material.
+        // Zero-length key material yields the same all-zero key schedule as the single NUL byte the 'a'
+        // revision appends, so this digest matches the well-known '$2a$06$' vector for an empty password.
+        const string Hash = "$2$06$DCq7YPn5Rq63x1Lad4cll.TV4S6ytwfsfvkgY8jIucDrjc8deX1s.";
+
+        Assert.True(Bcrypt.TryParseHash(Hash, out _));
+        Assert.True(Bcrypt.Verify("", Hash));
+        Assert.True(Bcrypt.Verify("".AsSpan(), Hash.AsSpan()));
+        Assert.False(Bcrypt.Verify("not-empty", Hash));
+    }
+
     [Fact]
     public void Verify_InvalidLengthHash_ReturnsFalse()
     {


### PR DESCRIPTION
Stack 1 of 2 · merges into `main` · must merge before #2338

## Finding

`Bcrypt.Verify("", legacy2DollarHash)` threw `ArgumentNullException` instead of returning a result.

```
Bcrypt.TryParseHash("$2$06$DCq7YPn5Rq63x1Lad4cll.TV4S6ytwfsfvkgY8jIucDrjc8deX1s.", out _)  -> True
Bcrypt.Verify("",   "$2$06$DCq7YPn5Rq63x1Lad4cll.TV4S6ytwfsfvkgY8jIucDrjc8deX1s.")
    -> System.ArgumentNullException: Array cannot be null. (Parameter 'chars')
```

`TryParseHash` accepts the hash as valid, so a caller had no way to see it coming. A login endpoint
receiving a blank password against a legacy `$2$` row returned a 500 rather than "invalid
credentials" — reachable by an unauthenticated caller, and it distinguished `$2$` rows from others
by response code.

**Root cause** — `$2$` is the only revision that appends no NUL terminator, so an empty password
produces zero-length key material. `EncodingExtensions.GetBytes` took `fixed` over a zero-length
array, which yields a null pointer, and `Encoding.GetBytes(char*, int, byte*, int)` rejects null.

A **second crash sat behind it**: with the encoding fixed, `StreamToWord` read `data[0]` and computed
`% data.Length` on an empty span — `IndexOutOfRangeException`, then `DivideByZeroException`. Fixing
only the encoding helper would have swapped one crash for another.

## Changes

- `EncodingExtensions.GetBytes` uses the safe span API and returns an empty array for empty input.
  The `unsafe` block is gone.
- `StreamToWord` treats empty key material as zero bytes. The C implementations read out of bounds
  here (jBCrypt throws `ArrayIndexOutOfBoundsException`), so no reference result exists.
- Dropped the `unsafe` modifier from `BcryptImplementation.Verify`, which contains no pointer code.
- Corrected the comment describing NUL termination per revision. It claimed `b`, `x` and `y` are
  *not* NUL-terminated, but the `minorRevision >= 'a'` guard means they are — and it credited
  NUL-termination with handling embedded NULs, which is backwards.

## A note on the chosen behaviour

Zero-length key material yields the same all-zero key schedule as the single NUL byte the `a`
revision appends. So `$2$` + `""` produces the same digest as `$2a$` + `""`, and the new test asserts
against the well-known `$2a$06$DCq7YPn5Rq63x1Lad4cll.` vector. This keeps hashing total — `Verify`
must not throw for a well-formed hash and an arbitrary password — at the cost of defining behaviour
no reference implementation defines. Happy to make it throw a documented exception instead if you'd
rather the case stay undefined.

## Verification

- `dotnet test -p:TreatWarningsAsErrors=true` — 124 passed, 0 failed (62 × net10.0/net11.0).
- `dotnet run ./eng/update-all.cs` — no generated files changed; the public API surface is untouched,
  so `ref/Meziantou.Framework.Bcrypt.cs` is unchanged.

Found by a review of `src/Meziantou.Framework.Bcrypt`; behaviour reproduced against the compiled
assembly before and after.
