### PR TITLE
Stop EncoderFallbackException escaping from Bcrypt.Verify

### DIFF
--- a/src/Meziantou.Framework.Bcrypt/Bcrypt.cs
+++ b/src/Meziantou.Framework.Bcrypt/Bcrypt.cs
@@ -44,6 +44,7 @@ public static partial class Bcrypt
     /// <param name="workFactor">The BCrypt work factor. Must be between <see cref="MinWorkFactor"/> and <see cref="MaxWorkFactor"/>.</param>
     /// <param name="version">The BCrypt revision to generate.</param>
     /// <returns>The BCrypt hash string.</returns>
+    /// <exception cref="ArgumentException"><paramref name="password"/> cannot be encoded as UTF-8 because it contains an unpaired surrogate.</exception>
     public static string HashPassword(string password, int workFactor = DefaultWorkFactor, BcryptVersion version = BcryptVersion.Revision2B)
     {
         ArgumentNullException.ThrowIfNull(password);
@@ -55,6 +56,7 @@ public static partial class Bcrypt
     /// <param name="workFactor">The BCrypt work factor. Must be between <see cref="MinWorkFactor"/> and <see cref="MaxWorkFactor"/>.</param>
     /// <param name="version">The BCrypt revision to generate.</param>
     /// <returns>The BCrypt hash string.</returns>
+    /// <exception cref="ArgumentException"><paramref name="password"/> cannot be encoded as UTF-8 because it contains an unpaired surrogate.</exception>
     public static string HashPassword(ReadOnlySpan<char> password, int workFactor = DefaultWorkFactor, BcryptVersion version = BcryptVersion.Revision2B)
     {
         return HashPassword(password, GenerateSalt(workFactor, version));
@@ -64,6 +66,7 @@ public static partial class Bcrypt
     /// <param name="password">The password to hash.</param>
     /// <param name="salt">The BCrypt salt string.</param>
     /// <returns>The BCrypt hash string.</returns>
+    /// <exception cref="ArgumentException"><paramref name="password"/> cannot be encoded as UTF-8 because it contains an unpaired surrogate.</exception>
     public static string HashPassword(string password, string salt)
     {
         ArgumentNullException.ThrowIfNull(password);
@@ -76,6 +79,7 @@ public static partial class Bcrypt
     /// <param name="password">The password to hash.</param>
     /// <param name="salt">The BCrypt salt string.</param>
     /// <returns>The BCrypt hash string.</returns>
+    /// <exception cref="ArgumentException"><paramref name="password"/> cannot be encoded as UTF-8 because it contains an unpaired surrogate.</exception>
     public static string HashPassword(ReadOnlySpan<char> password, ReadOnlySpan<char> salt)
     {
         return BcryptImplementation.HashPassword(password, salt);
@@ -86,6 +90,7 @@ public static partial class Bcrypt
     /// <param name="hash">The BCrypt hash string.</param>
     /// <returns><see langword="true"/> if the password matches; otherwise, <see langword="false"/>.</returns>
     /// <exception cref="NotSupportedException"><paramref name="hash"/> uses the <c>$2x$</c> revision, which cannot be verified correctly.</exception>
+    /// <remarks>A <paramref name="password"/> that cannot be encoded as UTF-8 reports a mismatch rather than throwing.</remarks>
     public static bool Verify(string password, string hash)
     {
         ArgumentNullException.ThrowIfNull(password);
@@ -99,6 +104,7 @@ public static partial class Bcrypt
     /// <param name="hash">The BCrypt hash string.</param>
     /// <returns><see langword="true"/> if the password matches; otherwise, <see langword="false"/>.</returns>
     /// <exception cref="NotSupportedException"><paramref name="hash"/> uses the <c>$2x$</c> revision, which cannot be verified correctly.</exception>
+    /// <remarks>A <paramref name="password"/> that cannot be encoded as UTF-8 reports a mismatch rather than throwing.</remarks>
     public static bool Verify(ReadOnlySpan<char> password, ReadOnlySpan<char> hash)
     {
         if (!TryParseHash(hash, out _))

--- a/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs
+++ b/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs
@@ -232,22 +232,32 @@ internal sealed class BcryptImplementation
 
 
         byte[] passwordBytes;
-        if (minorRevision >= 'a')
+        try
         {
-            // The 'a' revision and later append a NUL terminator to the password before it is used as key material.
-            // Unlike the C implementations, the password is not truncated at an embedded NUL: .NET strings are not
-            // NUL-terminated, so every byte of the password takes part in the hash.
-            passwordBytes = new byte[Utf8.GetByteCount(password) + 1];
-            Utf8.GetBytes(password, passwordBytes);
-            passwordBytes[^1] = 0; // Null terminator
+            passwordBytes = GetPasswordBytes(password, minorRevision);
         }
-        else
+        catch (EncoderFallbackException ex)
         {
-            // The original '2' revision uses the password as-is, with no NUL terminator.
-            passwordBytes = Utf8.GetBytes(password);
+            throw new ArgumentException("The password cannot be encoded as UTF-8. It contains an unpaired surrogate.", nameof(password), ex);
         }
 
         return HashBytes(passwordBytes, salt.Slice(offset + 3, 22), minorRevision, workFactor);
+    }
+
+    private static byte[] GetPasswordBytes(ReadOnlySpan<char> password, char minorRevision)
+    {
+        // The original '2' revision uses the password as-is, with no NUL terminator.
+        if (minorRevision < 'a')
+            return Utf8.GetBytes(password);
+
+        // The 'a' revision and later append a NUL terminator to the password before it is used as key material.
+        // Unlike the C implementations, the password is not truncated at an embedded NUL: .NET strings are not
+        // NUL-terminated, so every byte of the password takes part in the hash.
+        var passwordBytes = new byte[Utf8.GetByteCount(password) + 1];
+        Utf8.GetBytes(password, passwordBytes);
+        passwordBytes[^1] = 0; // Null terminator
+
+        return passwordBytes;
     }
 
     public static bool Verify(string password, string hash)
@@ -260,8 +270,22 @@ internal sealed class BcryptImplementation
 
     public static bool Verify(ReadOnlySpan<char> password, ReadOnlySpan<char> hash)
     {
+        string computedHash;
+        try
+        {
+            computedHash = HashPassword(password, hash);
+        }
+        catch (ArgumentException ex) when (ex.InnerException is EncoderFallbackException)
+        {
+            // A password that cannot be encoded as UTF-8 can never have produced a stored hash, so report
+            // a mismatch instead of letting the exception escape a method that returns bool. This is
+            // deliberately checked after HashPassword has validated the hash itself, so an unsupported
+            // revision still fails loudly even when the password is also invalid.
+            return false;
+        }
+
         var hashBytes = Utf8.GetBytes(hash);
-        var computedHashBytes = Utf8.GetBytes(HashPassword(password, hash));
+        var computedHashBytes = Utf8.GetBytes(computedHash);
         return CryptographicOperations.FixedTimeEquals(hashBytes, computedHashBytes);
     }
 

--- a/tests/Meziantou.Framework.Bcrypt.Tests/BcryptTests.cs
+++ b/tests/Meziantou.Framework.Bcrypt.Tests/BcryptTests.cs
@@ -182,6 +182,72 @@ public sealed class BcryptTests
     }
 
     [Fact]
+    public void Verify_PasswordWithUnpairedSurrogate_ReturnsFalse()
+    {
+        // Unpaired surrogates used to escape as EncoderFallbackException from a method returning bool.
+        const string Hash = "$2b$04$2Siw3Nv3Q/gTOIPetAyPr.GNj3aO0lb1E5E9UumYGKjP9BYqlNWJe";
+
+        foreach (var password in UnpairedSurrogatePasswords())
+        {
+            Assert.False(Bcrypt.Verify(password, Hash));
+            Assert.False(Bcrypt.Verify(password.AsSpan(), Hash.AsSpan()));
+        }
+    }
+
+    [Fact]
+    public void HashPassword_PasswordWithUnpairedSurrogate_ThrowsArgumentException()
+    {
+        var salt = Bcrypt.GenerateSalt(4);
+
+        foreach (var password in UnpairedSurrogatePasswords())
+        {
+            // Guard against the inputs silently becoming encodable and making the assertions below vacuous.
+            Assert.Throws<EncoderFallbackException>(() => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true).GetByteCount(password));
+
+            Assert.Equal("password", Assert.Throws<ArgumentException>(() => Bcrypt.HashPassword(password, workFactor: 4)).ParamName);
+            Assert.Equal("password", Assert.Throws<ArgumentException>(() => Bcrypt.HashPassword(password, salt)).ParamName);
+        }
+    }
+
+    [Fact]
+    public void Verify_UnpairedSurrogateAgainstUnsupportedRevision_StillReportsTheRevision()
+    {
+        // The hash is validated before the password is encoded, so an unsupported revision fails loudly
+        // even when the password is itself invalid: the revision is a property of stored data and the
+        // caller needs to learn about it.
+        const string Hash2X = "$2x$12$DB3BUbYa/SsEL7kCOVji0OauTkPkB5Y1OeyfxJHM7jvMrbml5sgD2";
+
+        foreach (var password in UnpairedSurrogatePasswords())
+        {
+            Assert.Throws<NotSupportedException>(() => Bcrypt.Verify(password, Hash2X));
+        }
+    }
+
+    // Built in code rather than through [InlineData]: xunit round-trips theory data through UTF-8,
+    // which replaces unpaired surrogates with U+FFFD and would make these tests vacuous.
+    private static string[] UnpairedSurrogatePasswords() =>
+    [
+        "\ud800",
+        "\udc00",
+        "ab\ud800cd",
+        "ab\udc00cd",
+        "trailing\ud83d",
+    ];
+
+    [Theory]
+    [InlineData("caf\u00e9")]
+    [InlineData("\u4f60\u597d\u4e16\u754c")]
+    [InlineData("\ud83d\ude00 emoji")]
+    [InlineData("\u00ff\u00ffabc")]
+    public void HashPassword_NonAsciiPassword_RoundTrips(string password)
+    {
+        var hash = Bcrypt.HashPassword(password, workFactor: 4);
+
+        Assert.True(Bcrypt.Verify(password, hash));
+        Assert.False(Bcrypt.Verify(password + "x", hash));
+    }
+
+    [Fact]
     public void NeedsRehash_ReturnsExpectedValue()
     {
         var hash = Bcrypt.HashPassword("password", workFactor: 6, version: BcryptVersion.Revision2A);


### PR DESCRIPTION
Stack 2 of 2 · merges into `fix/bcrypt-empty-password-crash` · merge #2337 first

## Finding

A password containing an unpaired surrogate threw out of `Bcrypt.Verify`, which is documented to
return `bool`:

```
Bcrypt.Verify("ab\ud800cd", validHash)
    -> System.Text.EncoderFallbackException: Unable to translate Unicode character \uD800 at index 2
Bcrypt.HashPassword("ab\ud800cd", 4)
    -> same
```

.NET strings can hold unpaired surrogates, and one arriving from a JSON body, a form post, or a
truncated client-side field is routine. An unauthenticated caller could force an unhandled exception
on the login path with a one-character payload; on a registration path it failed *after* the user
had committed to a password. No `<exception>` documentation warned of it.

## Changes

The strict UTF-8 encoder is kept. A replacement fallback (U+FFFD) is what most bcrypt libraries do,
but it lets two different malformed passwords hash identically, so the contract is made explicit
instead:

- `Bcrypt.Verify` reports a mismatch for an un-encodable password. Such a password can never have
  produced a stored hash, so `false` is the correct answer and the method stays total.
- `Bcrypt.HashPassword` throws `ArgumentException` (`ParamName` = `"password"`) rather than storing
  a hash that cannot be reproduced.
- Both documented with `<exception>` / `<remarks>` across all six overloads.
- Password-to-bytes conversion extracted into `GetPasswordBytes`, giving the failure a single point
  to catch.

## On the tests

The first attempt used `[InlineData("\ud800")]` and **passed against the unfixed code**. xunit
round-trips theory data through UTF-8, which replaces unpaired surrogates with U+FFFD, so the test
never carried the bug:

```
PROBE len=3 chars=[FFFD,FFFD,FFFD]
PROBE len=7 chars=[0061,0062,FFFD,FFFD,FFFD,0063,0064]
```

The surrogates are now built in code, and each input is asserted to be genuinely un-encodable
(`Assert.Throws<EncoderFallbackException>`) so the test cannot quietly regress to a no-op.

Both new tests were confirmed to fail against this branch with the fix backed out, and to pass with
it. This PR also adds the first non-ASCII round-trip coverage in the suite — every pre-existing
vector is pure ASCII, which is why the whole UTF-8 path was untested.

## Verification

- `dotnet test -p:TreatWarningsAsErrors=true` — 124 passed, 0 failed (62 × net10.0/net11.0).
- `dotnet run ./eng/update-all.cs` — no generated files changed.

Note: this touches the XML doc blocks on `HashPassword`, which #2346 also edits. Whichever lands
second may want a trivial rebase.
