### PR TITLE
Stop treating Path.Join as Path.Combine in the redundant FromPath rule

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/RedundantFromPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/RedundantFromPathAnalyzer.cs
@@ -67,7 +67,10 @@ public sealed class RedundantFromPathAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (innerMethod.Name is "Combine" or "Join")
+        // Path.Join is deliberately NOT included: it concatenates unconditionally, while FullPath.Combine
+        // (like Path.Combine) discards everything before a rooted segment. It also has ReadOnlySpan<char>
+        // overloads that FullPath.Combine does not provide.
+        if (innerMethod.Name is "Combine")
         {
             context.ReportDiagnostic(Descriptor, invocationOperation, "FullPath.Combine");
         }

--- a/src/Meziantou.Framework.FullPath.CodeFix/RedundantFromPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/RedundantFromPathCodeFixProvider.cs
@@ -62,7 +62,7 @@ public sealed class RedundantFromPathCodeFixProvider : FullPathCodeFixProviderBa
         }
 
         // FullPath.FromPath(Path.Combine(path1, path2)) -> FullPath.Combine(path1, path2)
-        if (innerInvocation.TargetMethod.Name is "Combine" or "Join")
+        if (innerInvocation.TargetMethod.Name is "Combine")
         {
             if (expressionSyntax is not InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax fromPathAccess })
                 return false;

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/RedundantFromPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/RedundantFromPathRuleTests.cs
@@ -137,4 +137,49 @@ public sealed class RedundantFromPathRuleTests : FullPathAnalyzerTestBase
 
         await CreateAnalyzerTest<RedundantFromPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForFromPathWithPathJoin()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M(string path1, string path2)
+                    {
+                        return FullPath.FromPath(Path.Join(path1, path2));
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<RedundantFromPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForFromPathWithPathJoinOverSpans()
+    {
+        var source = """
+            using System;
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static FullPath M(string path1, string path2)
+                    {
+                        return FullPath.FromPath(Path.Join(path1.AsSpan(), path2.AsSpan()));
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<RedundantFromPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
 }


### PR DESCRIPTION
MFFP0019 rewrites `FullPath.FromPath(Path.Combine(a, b))` to `FullPath.Combine(a, b)`. It matched `Path.Join` as well, which is wrong twice over.

**Semantics.** `Path.Join` concatenates unconditionally; `Path.Combine` — and therefore `FullPath.Combine` — discards everything before a rooted segment. So the fix silently changed the result:

```csharp
FullPath.FromPath(Path.Join(root, segment))   // root + "/" + segment
FullPath.Combine(root, segment)               // just segment, when segment is rooted
```

**Compilation.** The fixer reuses the inner argument list verbatim, and the analyzer checked only the method *name*, never the parameter types. `Path.Join` has `ReadOnlySpan<char>` overloads that `FullPath.Combine` does not:

```csharp
FullPath.FromPath(Path.Join(dir.AsSpan(), file.AsSpan()))
// →  FullPath.Combine(dir.AsSpan(), file.AsSpan())  →  CS1503
```

`Path.Join`'s span overloads are the allocation-free idiom, so this was a guaranteed build break for the callers most likely to use it.

## What changed

`Join` is dropped from the rule. `Path.Combine` has no span overloads and all four of its string overloads map onto an existing `FullPath.Combine`, so restricting to `Combine` resolves the overload-resolution problem and the semantic one together — no separate arity or parameter-type check needed.

`Path.Join` now simply reports nothing here. Reporting it would require a different suggestion than `FullPath.Combine`, which is out of scope for this fix.

## Verification

Two negative tests added, for `Path.Join(string, string)` and for the span overload. Both fail on `main` (the rule fires) and pass with the fix. No existing test covered `Join`, so nothing else changed. Full analyzer suite green at 107 tests.
