### PR TITLE
Do not suggest the FullPath factories when the result is concatenated

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/UseFullPathFactoryAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/UseFullPathFactoryAnalyzer.cs
@@ -43,6 +43,34 @@ public sealed class UseFullPathFactoryAnalyzer : DiagnosticAnalyzer
         if (analyzerContext.GetFullPathFactoryEquivalentTypeName(targetMethod) is not { } declaringTypeName)
             return;
 
+        if (IsConcatenated(invocationOperation))
+            return;
+
         context.ReportDiagnostic(Descriptor, invocationOperation, targetMethod.Name, declaringTypeName);
+    }
+
+    /// <summary>
+    /// Reports whether the result is appended to another string.
+    /// </summary>
+    /// <remarks>
+    /// The FullPath factories normalize the path, which removes the trailing directory separator that
+    /// <c>Path.GetTempPath</c> guarantees. Concatenating onto the result therefore produces a
+    /// different string, so the FullPath equivalent is not a drop-in replacement in that position.
+    /// </remarks>
+    private static bool IsConcatenated(IOperation operation)
+    {
+        var current = operation;
+        while (current.Parent is IConversionOperation { IsImplicit: true } conversionOperation)
+        {
+            current = conversionOperation;
+        }
+
+        return current.Parent switch
+        {
+            IBinaryOperation { OperatorKind: BinaryOperatorKind.Add } => true,
+            ICompoundAssignmentOperation { OperatorKind: BinaryOperatorKind.Add } => true,
+            IInterpolationOperation => true,
+            _ => false,
+        };
     }
 }

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseFullPathFactoryRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/UseFullPathFactoryRuleTests.cs
@@ -197,4 +197,40 @@ public sealed class UseFullPathFactoryRuleTests : FullPathAnalyzerTestBase
 
         await CreateAnalyzerTest<UseFullPathFactoryAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForPathGetTempPathInConcatenation()
+    {
+        var source = """
+            using System.IO;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M() => Path.GetTempPath() + "log.txt";
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseFullPathFactoryAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_ForPathGetTempPathInInterpolatedString()
+    {
+        var source = """
+            using System.IO;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M() => $"{Path.GetTempPath()}log.txt";
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<UseFullPathFactoryAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
 }


### PR DESCRIPTION
MFFP0024 suggests `Path.GetTempPath()` → `FullPath.GetTempPath()` and presents it as an equivalence. It is not one when the result is concatenated onto:

```csharp
// before
string tmp = Path.GetTempPath();        // "C:\Users\x\AppData\Local\Temp\"  — trailing separator guaranteed
var f = tmp + "log.txt";                // "…\Temp\log.txt"

// after applying the suggestion
string tmp = FullPath.GetTempPath();    // "C:\Users\x\AppData\Local\Temp"   — separator trimmed
var f = tmp + "log.txt";                // "…\Templog.txt"
```

`FullPath.GetTempPath()` routes through `FromPath`, which calls `Path.TrimEndingDirectorySeparator`. `Path.GetTempPath` documents the trailing separator, and concatenating onto it is a common idiom precisely because of that guarantee. The rewrite compiles cleanly and writes to the wrong place.

## What changed

The rule no longer reports when the result is an operand of a string concatenation, a `+=`, or an interpolated string. Everywhere else — assignment, return, argument — it reports as before.

## Why not fix this in FullPath instead

Preserving the trailing separator library-side is not possible: `FullPath` normalizes every path through `Path.TrimEndingDirectorySeparator` in `FromPath`, and its constructor asserts `Path.GetFullPath(path) == path`. A stored trailing separator would break that invariant for every path, not just temp ones. The difference between the two strings is real, so the analyzer has to stop claiming they are interchangeable in the position where it shows.

The related `Environment.GetFolderPath` half of this rule is addressed separately in #2336, which makes `FromPath("")` return `Empty` rather than throwing.

## Verification

Two negative tests added, for `+` concatenation and for interpolation. Both fail on `main` (the rule fires) and pass with the fix. The four existing positive tests are unchanged and still green; full analyzer suite green at 107 tests.
