### PR TITLE
Count nested reveals so only the outermost one changes the protection

### DIFF
--- a/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
+++ b/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
@@ -376,6 +376,13 @@ public sealed unsafe class SensitiveData<T> : IDisposable
         private bool _unixMemoryProtected;
         private bool _isProtected;
 
+        // Number of reveals currently in progress. Reveals nest: a callback passed to RevealAndUse can
+        // reach another reveal on the same instance, and Lock is reentrant so the nested call is allowed
+        // straight through. Only the outermost reveal may touch the platform protection - an inner one
+        // that unprotected again would decrypt already-decrypted bytes on Windows, and an inner one that
+        // re-protected on exit would revoke the page while the outer caller still holds a span over it.
+        private int _revealCount;
+
         public NativeMemorySafeHandle()
             : base(invalidHandleValue: Invalid, ownsHandle: true)
         {
@@ -437,6 +444,15 @@ public sealed unsafe class SensitiveData<T> : IDisposable
             if (_allocatedBytes == 0)
                 return;
 
+            // An outer reveal is still in progress, so the contents must stay accessible.
+            // The count is only decremented once the platform call below has succeeded, so a
+            // failure to re-protect leaves the count untouched rather than losing a level.
+            if (_revealCount > 1)
+            {
+                _revealCount--;
+                return;
+            }
+
             if (OperatingSystem.IsWindows() && _protectionMode is ProtectionMode.Windows)
             {
                 WindowsHeap.ProtectMemory(handle, _allocatedBytes);
@@ -460,12 +476,23 @@ public sealed unsafe class SensitiveData<T> : IDisposable
                 XorWithKey();
                 _isProtected = true;
             }
+
+            _revealCount = 0;
         }
 
         public void Unprotect()
         {
             if (_allocatedBytes == 0)
                 return;
+
+            // The contents are already accessible because an outer reveal is in progress. Unprotecting
+            // again would decrypt already-decrypted bytes on Windows and re-apply the XOR key on the
+            // fallback path, handing the caller ciphertext instead of the secret.
+            if (_revealCount > 0)
+            {
+                _revealCount++;
+                return;
+            }
 
             if (OperatingSystem.IsWindows() && _protectionMode is ProtectionMode.Windows)
             {
@@ -474,15 +501,18 @@ public sealed unsafe class SensitiveData<T> : IDisposable
             }
             else if ((OperatingSystem.IsLinux() || OperatingSystem.IsMacOS()) && _protectionMode is ProtectionMode.Unix)
             {
-                if (!_unixMemoryProtected)
-                    return;
-
-                if (!SensitiveData.UnixMemoryProtection.TryProtect(handle, _allocatedBytes, MemoryProtectionReadWrite))
+                // Skip the syscall when a previous Protect failed and left the pages readable,
+                // but still count the reveal so the matching Protect re-applies the protection.
+                if (_unixMemoryProtected)
                 {
-                    ThrowLastPInvokeError();
+                    if (!SensitiveData.UnixMemoryProtection.TryProtect(handle, _allocatedBytes, MemoryProtectionReadWrite))
+                    {
+                        ThrowLastPInvokeError();
+                    }
+
+                    _unixMemoryProtected = false;
                 }
 
-                _unixMemoryProtected = false;
                 _isProtected = false;
             }
             else if (_protectionMode is ProtectionMode.Xor)
@@ -490,6 +520,8 @@ public sealed unsafe class SensitiveData<T> : IDisposable
                 XorWithKey();
                 _isProtected = false;
             }
+
+            _revealCount = 1;
         }
 
         protected override bool ReleaseHandle()

--- a/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
+++ b/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
@@ -82,6 +82,85 @@ public sealed class SensitiveDataTests
     }
 
     [Fact]
+    public void RevealAndUse_NestedRevealLeavesTheOuterSpanReadable()
+    {
+        using var data = SensitiveData.Create("foo");
+
+        string? nested = null;
+        string? outerAfterNested = null;
+        data.RevealAndUse(arg: data, (span, secret) =>
+        {
+            nested = secret.RevealToString();
+            outerAfterNested = new string(span);
+        });
+
+        Assert.Equal("foo", nested);
+        Assert.Equal("foo", outerAfterNested);
+        Assert.True(data.IsProtected);
+    }
+
+    [Fact]
+    public void RevealInto_NestedInsideRevealAndUse_CopiesTheSecret()
+    {
+        using var data = SensitiveData.Create("foo");
+
+        var buffer = new char[3];
+        data.RevealAndUse(arg: data, (span, secret) => secret.RevealInto(buffer));
+
+        Assert.Equal("foo", new string(buffer));
+    }
+
+    [Fact]
+    public void RevealAndUse_NestedReveals_RestoreProtectionOnlyAtTheOutermostLevel()
+    {
+        using var data = SensitiveData.Create("foo");
+
+        data.RevealAndUse(arg: data, (outerSpan, secret) =>
+        {
+            Assert.False(secret.IsProtected);
+            secret.RevealAndUse(arg: secret, (middleSpan, middle) =>
+            {
+                middle.RevealAndUse(arg: middle, static (innerSpan, inner) =>
+                {
+                    Assert.False(inner.IsProtected);
+                    Assert.Equal("foo", new string(innerSpan));
+                });
+
+                Assert.False(middle.IsProtected);
+                Assert.Equal("foo", new string(middleSpan));
+            });
+
+            Assert.False(secret.IsProtected);
+            Assert.Equal("foo", new string(outerSpan));
+        });
+
+        Assert.True(data.IsProtected);
+        Assert.Equal("foo", data.RevealToString());
+    }
+
+    [Fact]
+    public void Clone_InsideRevealAndUse_ProducesAnIndependentCopy()
+    {
+        using var data = SensitiveData.Create("foo");
+
+        SensitiveData<char>? clone = null;
+        data.RevealAndUse(arg: data, (span, secret) =>
+        {
+            clone = secret.Clone();
+            Assert.Equal("foo", new string(span));
+        });
+
+        Assert.NotNull(clone);
+        using (clone)
+        {
+            Assert.Equal("foo", clone.RevealToString());
+        }
+
+        Assert.True(data.IsProtected);
+        Assert.Equal("foo", data.RevealToString());
+    }
+
+    [Fact]
     public void Clone_CreatesIndependentCopy()
     {
         var original = SensitiveData.Create("foo");


### PR DESCRIPTION
## The problem

`System.Threading.Lock` is reentrant, and `_isProtected` was a plain bool with no notion of nesting.
So a reveal that happens *inside* another reveal on the same instance took the lock again and ran a
second `Unprotect`/`Protect` pair against a buffer that was already unprotected.

That is not an exotic call shape. `RevealAndUse` exists so callers can do work with the secret in
scope, and a helper reached from inside the callback that does `secret.RevealToString()` is enough:

```csharp
using var data = SensitiveData.Create("foo");
data.RevealAndUse(arg: data, (span, secret) =>
{
    _ = secret.RevealToString();   // nested reveal - re-protects the page on exit
    _ = span[0];                   // outer span is now inaccessible
});
```

The outcome differed per platform, and all three were wrong:

- **Linux/macOS** - the inner reveal's `Protect()` restored `PROT_NONE` while the outer caller still
  held a span over the buffer. The next read from that span was an `AccessViolationException`. It is
  an AV, so it is not catchable and no `finally` runs - **the process dies**.
- **Windows** - the inner `Unprotect()` called `CryptUnprotectMemory` on already-decrypted bytes.
  There is no authentication tag, so it "succeeded" and produced garbage. The inner caller silently
  received ciphertext-derived bytes **as if they were the secret**. State repaired itself on unwind,
  so nothing ever surfaced the error.
- **XOR fallback platforms** - same as Windows: the second XOR re-encrypted, the inner caller read
  ciphertext, and the damage was invisible.

For a library whose job is to hand back a secret, silently returning ciphertext is arguably the worse
of the two.

## The change

`NativeMemorySafeHandle` now counts the reveals in progress. Only the outermost one touches the
platform protection:

- `Unprotect()` increments and returns early when a reveal is already open.
- `Protect()` decrements and returns early while an outer reveal is still open.
- The count is only updated *after* the platform call succeeds, so a failed `mprotect` leaves the
  count untouched rather than losing a nesting level.

The constructor's initial `Protect()` still works unchanged: the count is 0, so it falls through to
the platform call and stays at 0.

`_isProtected` is kept as-is and stays accurate at every point, because it is only assigned on the
paths that actually make a platform call. The Unix branch of `Unprotect` was restructured from an
early `return` into a nested `if` so it can skip the syscall without also skipping the bookkeeping -
same behaviour, one less way to fall out of the method early.

## Verification

Four tests added, covering the nested `RevealToString`, nested `RevealInto`, three levels of nested
`RevealAndUse` asserting `IsProtected` at each level, and `Clone()` called from inside a callback.

Checked that they actually catch the bug: with the test changes applied but `SensitiveData.cs`
reverted to its previous state, the run aborts with

```
Fatal error.
System.AccessViolationException: Attempted to read or write protected memory.
```

With the fix, 56/56 pass (28 tests x net10.0 + net11.0).

**Note on what is verified where:** the crash and the fix were reproduced on macOS/arm64. The Windows
ciphertext-corruption half of this is reasoned from the `CryptProtectMemory`/`CryptUnprotectMemory`
contract, not reproduced - the new tests assert the revealed value is `"foo"` rather than garbage, so
CI on Windows is what actually confirms that half.
