### PR TITLE
Wait for an in-progress reveal before releasing the buffer in Dispose

### DIFF
--- a/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
+++ b/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
@@ -212,6 +212,7 @@ public static partial class SensitiveData
 public sealed unsafe class SensitiveData<T> : IDisposable
     where T : unmanaged
 {
+    [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed through the local returned by Interlocked.Exchange in Dispose")]
     private NativeMemorySafeHandle? _data;
 
     /// <summary>
@@ -234,8 +235,7 @@ public sealed unsafe class SensitiveData<T> : IDisposable
     /// <summary>Returns the length (in elements) of this buffer.</summary>
     public int GetLength()
     {
-        ThrowIfDisposed();
-        return _data.Length;
+        return GetHandle().Length;
     }
 
     /// <summary>
@@ -247,8 +247,7 @@ public sealed unsafe class SensitiveData<T> : IDisposable
     {
         get
         {
-            ThrowIfDisposed();
-            return _data.IsProtected;
+            return GetHandle().IsProtected;
         }
     }
 
@@ -260,19 +259,20 @@ public sealed unsafe class SensitiveData<T> : IDisposable
     /// <exception cref="ObjectDisposedException">This instance has already been disposed.</exception>
     public int RevealInto(Span<T> destination)
     {
-        ThrowIfDisposed();
-        lock (_data.SyncLock)
+        var data = GetHandle();
+        lock (data.SyncLock)
         {
-            _data.Unprotect();
+            ThrowIfReleased(data);
+            data.Unprotect();
             try
             {
-                var span = _data.GetSpan();
+                var span = data.GetSpan();
                 span.CopyTo(destination);
                 return span.Length;
             }
             finally
             {
-                _data.Protect();
+                data.Protect();
             }
         }
     }
@@ -283,17 +283,18 @@ public sealed unsafe class SensitiveData<T> : IDisposable
     /// <exception cref="ObjectDisposedException">This instance has already been disposed.</exception>
     public T[] RevealToArray()
     {
-        ThrowIfDisposed();
-        lock (_data.SyncLock)
+        var data = GetHandle();
+        lock (data.SyncLock)
         {
-            _data.Unprotect();
+            ThrowIfReleased(data);
+            data.Unprotect();
             try
             {
-                return _data.GetSpan().ToArray();
+                return data.GetSpan().ToArray();
             }
             finally
             {
-                _data.Protect();
+                data.Protect();
             }
         }
     }
@@ -307,18 +308,19 @@ public sealed unsafe class SensitiveData<T> : IDisposable
     public void RevealAndUse<TArg>(TArg arg, System.Buffers.ReadOnlySpanAction<T, TArg> spanAction)
     {
         ArgumentNullException.ThrowIfNull(spanAction);
-        ThrowIfDisposed();
-        lock (_data.SyncLock)
+        var data = GetHandle();
+        lock (data.SyncLock)
         {
-            _data.Unprotect();
+            ThrowIfReleased(data);
+            data.Unprotect();
             try
             {
-                var span = _data.GetSpan();
+                var span = data.GetSpan();
                 spanAction(span, arg);
             }
             finally
             {
-                _data.Protect();
+                data.Protect();
             }
         }
     }
@@ -328,18 +330,19 @@ public sealed unsafe class SensitiveData<T> : IDisposable
     /// <exception cref="ObjectDisposedException">This instance has already been disposed.</exception>
     public SensitiveData<T> Clone()
     {
-        ThrowIfDisposed();
-        lock (_data.SyncLock)
+        var data = GetHandle();
+        lock (data.SyncLock)
         {
-            _data.Unprotect();
+            ThrowIfReleased(data);
+            data.Unprotect();
             try
             {
-                var span = _data.GetSpan();
+                var span = data.GetSpan();
                 return new(span);
             }
             finally
             {
-                _data.Protect();
+                data.Protect();
             }
         }
     }
@@ -350,17 +353,35 @@ public sealed unsafe class SensitiveData<T> : IDisposable
     /// </summary>
     public void Dispose()
     {
-        if (_data is not null)
+        // Claim the handle atomically so two concurrent Dispose calls cannot both release it, and so
+        // a reveal that has not read the field yet observes null and throws instead of racing.
+        var data = Interlocked.Exchange(ref _data, value: null);
+        if (data is null)
+            return;
+
+        // Wait for a reveal in progress on another thread before releasing the memory. Without this,
+        // the buffer is unmapped while that thread still holds a span over it, which is an
+        // AccessViolationException the caller cannot catch rather than an ObjectDisposedException.
+        // Taking the lock also means that once Dispose returns, the contents really have been cleared.
+        lock (data.SyncLock)
         {
-            _data.Dispose();
-            _data = null;
+            data.Dispose();
         }
     }
 
-    [MemberNotNull(nameof(_data))]
-    private void ThrowIfDisposed()
+    private NativeMemorySafeHandle GetHandle()
     {
-        ObjectDisposedException.ThrowIf(_data is null, this);
+        // Read the field once: a concurrent Dispose sets it to null, and re-reading it mid-method
+        // would turn that race into a NullReferenceException.
+        var data = _data;
+        ObjectDisposedException.ThrowIf(data is null, this);
+        return data;
+    }
+
+    // Dispose may have released the handle between GetHandle and the lock being acquired.
+    private void ThrowIfReleased(NativeMemorySafeHandle data)
+    {
+        ObjectDisposedException.ThrowIf(data.IsClosed, this);
     }
 
     private sealed unsafe class NativeMemorySafeHandle : SafeHandle

--- a/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
+++ b/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
@@ -93,6 +93,62 @@ public sealed class SensitiveDataTests
     }
 
     [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The instance is disposed by the other thread the test starts")]
+    public void Dispose_DuringRevealOnAnotherThread_LetsTheRevealFinish()
+    {
+        var expected = new string('a', 4096);
+        var data = SensitiveData.Create(expected);
+        using var revealStarted = new ManualResetEventSlim();
+
+        var disposeThread = new Thread(() =>
+        {
+            revealStarted.Wait();
+            data.Dispose();
+        });
+
+        disposeThread.Start();
+
+        string? revealed = null;
+        data.RevealAndUse(arg: 0, (span, _) =>
+        {
+            revealStarted.Set();
+
+            // Give the other thread time to reach Dispose while this span is still alive.
+            Thread.Sleep(100);
+            revealed = new string(span);
+        });
+
+        Assert.True(disposeThread.Join(TimeSpan.FromSeconds(30)));
+        Assert.Equal(expected, revealed);
+        Assert.Throws<ObjectDisposedException>(() => data.RevealToString());
+    }
+
+    [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The instance is disposed by the threads the test starts")]
+    public void Dispose_ConcurrentCalls_ReleaseTheBufferExactlyOnce()
+    {
+        var data = SensitiveData.Create("foo");
+
+        var threads = new Thread[8];
+        for (var i = 0; i < threads.Length; i++)
+        {
+            threads[i] = new Thread(data.Dispose);
+        }
+
+        foreach (var thread in threads)
+        {
+            thread.Start();
+        }
+
+        foreach (var thread in threads)
+        {
+            Assert.True(thread.Join(TimeSpan.FromSeconds(30)));
+        }
+
+        Assert.Throws<ObjectDisposedException>(() => data.RevealToString());
+    }
+
+    [Fact]
     public void UnixPaths_CanRevealStringAndByteArray()
     {
         if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())


### PR DESCRIPTION
## The problem

Every reveal path took `_data.SyncLock`, but `Dispose()` took nothing. It called `_data.Dispose()`
and nulled the field. No reveal ever incremented the `SafeHandle` refcount - the handle is read
directly as the `handle` field from inside the subclass - so `Dispose` dropped the count to 0 and ran
`ReleaseHandle` immediately: `munmap` on Unix, `HeapFree` on Windows, `NativeMemory.Free` on the XOR
path. A span handed to a caller microseconds earlier now pointed at freed memory.

```csharp
var data = SensitiveData.Create(new string('a', 4096));
// thread B: data.Dispose()   while thread A is inside the callback
data.RevealAndUse(arg: 0, (span, _) => { /* ... */ _ = span[0]; });
```

On macOS/arm64 this is a `Fatal error. System.AccessViolationException` - **the process dies**, and
because it is an AV the caller cannot catch it or degrade gracefully. On Windows, where `HeapFree`
returns the block to a private heap rather than unmapping it, the more likely outcome is a silent
read of recycled heap memory.

There was a second, smaller variant of the same root cause: the reveal methods read the `_data` field
four separate times (`_data.SyncLock`, `_data.Unprotect()`, `_data.GetSpan()`, `_data.Protect()`). A
concurrent `Dispose` nulling it between two of those reads produced a `NullReferenceException`,
despite the `[MemberNotNull]` annotation on `ThrowIfDisposed` promising otherwise.

## The change

Three parts, all in `SensitiveData<T>`:

1. **`Dispose` claims the handle with `Interlocked.Exchange`.** Two concurrent `Dispose` calls can no
   longer both release it, and a reveal that has not yet read the field observes `null` and throws
   `ObjectDisposedException`.

2. **`Dispose` takes `SyncLock` before releasing.** A reveal already holding the lock finishes first.
   This also strengthens the contract in a way that matters for this library specifically: once
   `Dispose` returns, the buffer really has been cleared, rather than the free being deferred until
   some later moment.

3. **Each reveal reads the field once** into a local via `GetHandle()`, then re-checks
   `SafeHandle.IsClosed` after acquiring the lock. That closes the remaining window where `Dispose`
   won the race between the field read and the lock acquisition.

The two orderings are now both well defined: the reveal gets the lock first and `Dispose` waits, or
`Dispose` gets it first and the reveal throws `ObjectDisposedException`.

`ThrowIfDisposed` and its `[MemberNotNull]` annotation are gone, replaced by `GetHandle()` returning
the local it validated.

## Why not `DangerousAddRef`

`DangerousAddRef`/`DangerousRelease` is the other way to do this, and it avoids blocking `Dispose`
behind a long user callback. I chose the lock because it gives the stronger guarantee above - with
AddRef, `Dispose` returns while the secret is still in memory and the actual wipe happens later, on
whichever thread finishes last. For a type whose entire purpose is controlling how long a secret
stays readable, "Dispose returned, therefore it is gone" seemed worth the wait. Happy to switch if
you would rather have the non-blocking version.

## Verification

Two tests added: `Dispose` racing a 4 KB reveal on another thread (asserts the reveal returns the
right contents and that the instance is disposed afterwards), and eight threads calling `Dispose`
concurrently.

Confirmed they catch the bug: with the test changes applied but `SensitiveData.cs` reverted, the run
aborts with `Fatal error. System.AccessViolationException`. With the fix, 52/52 pass (26 tests x
net10.0 + net11.0).

`CA2213` is suppressed on the field (the analyzer cannot follow the dispose through
`Interlocked.Exchange`) and `CA2000` on the two tests (the instance is disposed by a thread the test
starts).

## Not covered

Calling `Dispose()` from *inside* your own `RevealAndUse` callback still fails the same way it does
today - `Lock` is reentrant, so the same thread walks straight through the gate and frees the buffer
under its own span. That is a distinct misuse from the cross-thread race this PR fixes, and the only
clean guards for it are either throwing from `Dispose` or tracking reveal depth, both of which are
design calls rather than bug fixes. Left alone deliberately.
