### PR TITLE
Parenthesize the expressions the FullPath code fixes generate

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/PathCombineWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathCombineWithFullPathAnalyzer.cs
@@ -11,7 +11,7 @@ public sealed class PathCombineWithFullPathAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathCombineWithFullPathDiagnosticId,
-        title: "Use '/' operator instead of Path.Combine or Path.Join",
+        title: "Use '/' operator instead of Path.Combine",
         messageFormat: "Use FullPath '/' operations instead of calling Path.{0}",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,
@@ -36,7 +36,9 @@ public sealed class PathCombineWithFullPathAnalyzer : DiagnosticAnalyzer
     private static void Analyze(OperationAnalysisContext context, FullPathContext analyzerContext)
     {
         var invocationOperation = (IInvocationOperation)context.Operation;
-        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" or "Join" } targetMethod)
+        // Path.Join is deliberately NOT included: it concatenates unconditionally, while the '/' operator
+        // (like Path.Combine) discards everything before a rooted segment
+        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" } targetMethod)
             return;
 
         if (!SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, analyzerContext.PathType))

--- a/src/Meziantou.Framework.FullPath.CodeFix/ExpressionSyntaxExtensions.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/ExpressionSyntaxExtensions.cs
@@ -1,0 +1,26 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Meziantou.Framework.Analyzers.FullPath;
+
+internal static class ExpressionSyntaxExtensions
+{
+    /// <summary>
+    /// Wraps the expression in parentheses unless it is already a primary expression.
+    /// </summary>
+    /// <remarks>
+    /// Generated code appends to the expression, either as the target of a member access or as an operand of the
+    /// <c>/</c> operator. Both bind tighter than most expressions, so an operand such as <c>a ? b : c</c> has to be
+    /// parenthesized to keep the meaning of the original code.
+    /// </remarks>
+    public static ExpressionSyntax Parenthesize(this ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            IdentifierNameSyntax or MemberAccessExpressionSyntax or InvocationExpressionSyntax or ElementAccessExpressionSyntax
+                or ParenthesizedExpressionSyntax or ThisExpressionSyntax or BaseExpressionSyntax or LiteralExpressionSyntax
+                or PredefinedTypeSyntax or QualifiedNameSyntax => expression,
+            _ => SyntaxFactory.ParenthesizedExpression(expression),
+        };
+    }
+}

--- a/src/Meziantou.Framework.FullPath.CodeFix/FullPathCodeFixProviderBase.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/FullPathCodeFixProviderBase.cs
@@ -69,7 +69,9 @@ public abstract class FullPathCodeFixProviderBase : CodeFixProvider
         if (!TryGetReplacementExpression(semanticModel, expressionSyntax, analyzerContext, cancellationToken, out var replacementExpression))
             return document;
 
-        replacementExpression = replacementExpression.WithTriviaFrom(expressionSyntax).WithAdditionalAnnotations(Formatter.Annotation);
+        replacementExpression = ParenthesizeForContext(replacementExpression, expressionSyntax)
+            .WithTriviaFrom(expressionSyntax)
+            .WithAdditionalAnnotations(Formatter.Annotation);
         var newRoot = root.ReplaceNode(expressionSyntax, replacementExpression);
         return document.WithSyntaxRoot(newRoot);
     }
@@ -86,7 +88,7 @@ public abstract class FullPathCodeFixProviderBase : CodeFixProvider
     {
         ExpressionSyntax result = SyntaxFactory.MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,
-            Parenthesize(fullPathExpression.WithoutTrivia()),
+            fullPathExpression.WithoutTrivia().Parenthesize(),
             SyntaxFactory.IdentifierName("IsEmpty"));
 
         if (negate)
@@ -97,15 +99,22 @@ public abstract class FullPathCodeFixProviderBase : CodeFixProvider
         return result;
     }
 
-    /// <summary>Wraps the expression in parentheses unless it can already be used as the target of a member access.</summary>
-    private protected static ExpressionSyntax Parenthesize(ExpressionSyntax expression)
+    /// <summary>
+    /// Parenthesizes the replacement when the syntax it replaces sits in a position that binds tighter than it,
+    /// so that <c>!path.IsEmpty</c> substituted into <c>Path.IsPathRooted(p).ToString()</c> does not become
+    /// <c>!p.IsEmpty.ToString()</c>.
+    /// </summary>
+    private static ExpressionSyntax ParenthesizeForContext(ExpressionSyntax replacement, ExpressionSyntax replaced)
     {
-        return expression switch
+        var needsParentheses = replaced.Parent switch
         {
-            IdentifierNameSyntax or MemberAccessExpressionSyntax or InvocationExpressionSyntax or ElementAccessExpressionSyntax
-                or ParenthesizedExpressionSyntax or ThisExpressionSyntax or BaseExpressionSyntax or LiteralExpressionSyntax
-                or PredefinedTypeSyntax or QualifiedNameSyntax => expression,
-            _ => SyntaxFactory.ParenthesizedExpression(expression),
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Expression == replaced,
+            ElementAccessExpressionSyntax elementAccess => elementAccess.Expression == replaced,
+            ConditionalAccessExpressionSyntax conditionalAccess => conditionalAccess.Expression == replaced,
+            PostfixUnaryExpressionSyntax => true,
+            _ => false,
         };
+
+        return needsParentheses ? replacement.Parenthesize() : replacement;
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/FullPathCodeFixProviderBase.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/FullPathCodeFixProviderBase.cs
@@ -1,3 +1,4 @@
+using Meziantou.Framework.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathChangeExtensionWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathChangeExtensionWithFullPathCodeFixProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Meziantou.Framework.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathChangeExtensionWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathChangeExtensionWithFullPathCodeFixProvider.cs
@@ -91,7 +91,7 @@ public sealed class PathChangeExtensionWithFullPathCodeFixProvider : CodeFixProv
                 replacementExpression = SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
-                        fullPathExpression.WithoutTrivia(),
+                        fullPathExpression.WithoutTrivia().Parenthesize(),
                         SyntaxFactory.IdentifierName("ChangeExtension")),
                     SyntaxFactory.ArgumentList(
                     [

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathCombineWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathCombineWithFullPathCodeFixProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Meziantou.Framework.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -79,7 +80,7 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
         out ExpressionSyntax replacementExpression)
     {
         if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is not IInvocationOperation invocationOperation ||
-            invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" or "Join" } targetMethod ||
+            invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" } targetMethod ||
             !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) ||
             invocationOperation.Arguments.Length == 0)
         {
@@ -103,6 +104,17 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
             return false;
         }
 
+        // Arguments before the FullPath are discarded by the rewrite, because Path.Combine already discards
+        // everything before a rooted segment. Dropping them is only safe when evaluating them does nothing.
+        for (var i = 0; i < fullPathIndex; i++)
+        {
+            if (!IsSideEffectFree(invocationOperation.Arguments[i].Value))
+            {
+                replacementExpression = null!;
+                return false;
+            }
+        }
+
         var startOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[fullPathIndex].Value, fullPathType);
         if (startOperation.Syntax is not ExpressionSyntax expression)
         {
@@ -124,5 +136,17 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
         }
 
         return true;
+    }
+
+    /// <summary>Reports whether evaluating the operation can be skipped without changing the program.</summary>
+    private static bool IsSideEffectFree(IOperation operation)
+    {
+        return operation.UnwrapImplicitConversions() switch
+        {
+            ILiteralOperation or INameOfOperation or IDefaultValueOperation => true,
+            ILocalReferenceOperation or IParameterReferenceOperation => true,
+            IFieldReferenceOperation { Instance: var instance } => instance is null || IsSideEffectFree(instance),
+            _ => false,
+        };
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathCombineWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathCombineWithFullPathCodeFixProvider.cs
@@ -110,7 +110,7 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
             return false;
         }
 
-        replacementExpression = expression.WithoutTrivia();
+        replacementExpression = expression.WithoutTrivia().Parenthesize();
         for (var i = fullPathIndex + 1; i < invocationOperation.Arguments.Length; i++)
         {
             var nextOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[i].Value, fullPathType);
@@ -120,7 +120,7 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
                 return false;
             }
 
-            replacementExpression = SyntaxFactory.BinaryExpression(SyntaxKind.DivideExpression, replacementExpression, nextExpression.WithoutTrivia());
+            replacementExpression = SyntaxFactory.BinaryExpression(SyntaxKind.DivideExpression, replacementExpression, nextExpression.WithoutTrivia().Parenthesize());
         }
 
         return true;

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetDirectoryNameWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetDirectoryNameWithFullPathCodeFixProvider.cs
@@ -89,7 +89,7 @@ public sealed class PathGetDirectoryNameWithFullPathCodeFixProvider : CodeFixPro
             {
                 replacementExpression = SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    fullPathExpression.WithoutTrivia(),
+                    fullPathExpression.WithoutTrivia().Parenthesize(),
                     SyntaxFactory.IdentifierName("Parent"));
                 return true;
             }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetDirectoryNameWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetDirectoryNameWithFullPathCodeFixProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Meziantou.Framework.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetDirectoryNameWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetDirectoryNameWithFullPathCodeFixProvider.cs
@@ -83,6 +83,12 @@ public sealed class PathGetDirectoryNameWithFullPathCodeFixProvider : CodeFixPro
             SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) &&
             invocationOperation.Arguments.Length == 1)
         {
+            if (!ResultStaysCompilable(invocationOperation))
+            {
+                replacementExpression = null!;
+                return false;
+            }
+
             var fullPathOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[0].Value, fullPathType);
             if (SymbolEqualityComparer.Default.Equals(fullPathOperation.Type, fullPathType) &&
                 fullPathOperation.Syntax is ExpressionSyntax fullPathExpression)
@@ -97,5 +103,30 @@ public sealed class PathGetDirectoryNameWithFullPathCodeFixProvider : CodeFixPro
 
         replacementExpression = null!;
         return false;
+    }
+
+    /// <summary>
+    /// Reports whether replacing the invocation with a FullPath-typed expression leaves the surrounding code valid.
+    /// </summary>
+    /// <remarks>
+    /// FullPath converts implicitly to string, so a string-typed slot keeps compiling. A receiver position does not,
+    /// because the members being invoked belong to string, and a 'var' initializer would change the inferred type.
+    /// </remarks>
+    private static bool ResultStaysCompilable(IOperation operation)
+    {
+        var current = operation;
+        while (current.Parent is IConversionOperation { IsImplicit: true } conversionOperation)
+        {
+            current = conversionOperation;
+        }
+
+        return current.Parent switch
+        {
+            IInvocationOperation invocationOperation => invocationOperation.Instance != current,
+            IPropertyReferenceOperation propertyReferenceOperation => propertyReferenceOperation.Instance != current,
+            IArrayElementReferenceOperation arrayElementReferenceOperation => arrayElementReferenceOperation.ArrayReference != current,
+            IVariableInitializerOperation { Syntax.Parent: VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax { Type.IsVar: true } } } => false,
+            _ => true,
+        };
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetExtensionWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetExtensionWithFullPathCodeFixProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Meziantou.Framework.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetExtensionWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetExtensionWithFullPathCodeFixProvider.cs
@@ -89,7 +89,7 @@ public sealed class PathGetExtensionWithFullPathCodeFixProvider : CodeFixProvide
             {
                 replacementExpression = SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    fullPathExpression.WithoutTrivia(),
+                    fullPathExpression.WithoutTrivia().Parenthesize(),
                     SyntaxFactory.IdentifierName("Extension"));
                 return true;
             }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetFileNameWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetFileNameWithFullPathCodeFixProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Meziantou.Framework.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetFileNameWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetFileNameWithFullPathCodeFixProvider.cs
@@ -89,7 +89,7 @@ public sealed class PathGetFileNameWithFullPathCodeFixProvider : CodeFixProvider
             {
                 replacementExpression = SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    fullPathExpression.WithoutTrivia(),
+                    fullPathExpression.WithoutTrivia().Parenthesize(),
                     SyntaxFactory.IdentifierName("Name"));
                 return true;
             }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetFileNameWithoutExtensionWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetFileNameWithoutExtensionWithFullPathCodeFixProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Meziantou.Framework.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetFileNameWithoutExtensionWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetFileNameWithoutExtensionWithFullPathCodeFixProvider.cs
@@ -89,7 +89,7 @@ public sealed class PathGetFileNameWithoutExtensionWithFullPathCodeFixProvider :
             {
                 replacementExpression = SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    fullPathExpression.WithoutTrivia(),
+                    fullPathExpression.WithoutTrivia().Parenthesize(),
                     SyntaxFactory.IdentifierName("NameWithoutExtension"));
                 return true;
             }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetFullPathOnFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetFullPathOnFullPathCodeFixProvider.cs
@@ -82,6 +82,12 @@ public sealed class PathGetFullPathOnFullPathCodeFixProvider : CodeFixProvider
             SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) &&
             invocationOperation.Arguments.Length >= 1)
         {
+            if (!ResultStaysCompilable(invocationOperation))
+            {
+                replacementExpression = null!;
+                return false;
+            }
+
             var argument = invocationOperation.Arguments[0].Value;
             if (SymbolEqualityComparer.Default.Equals(FullPathAnalyzerCommon.UnwrapToFullPath(argument, fullPathType).Type, fullPathType) &&
                 argument.Syntax is ExpressionSyntax fullPathExpression)
@@ -93,5 +99,30 @@ public sealed class PathGetFullPathOnFullPathCodeFixProvider : CodeFixProvider
 
         replacementExpression = null!;
         return false;
+    }
+
+    /// <summary>
+    /// Reports whether replacing the invocation with a FullPath-typed expression leaves the surrounding code valid.
+    /// </summary>
+    /// <remarks>
+    /// FullPath converts implicitly to string, so a string-typed slot keeps compiling. A receiver position does not,
+    /// because the members being invoked belong to string, and a 'var' initializer would change the inferred type.
+    /// </remarks>
+    private static bool ResultStaysCompilable(IOperation operation)
+    {
+        var current = operation;
+        while (current.Parent is IConversionOperation { IsImplicit: true } conversionOperation)
+        {
+            current = conversionOperation;
+        }
+
+        return current.Parent switch
+        {
+            IInvocationOperation invocationOperation => invocationOperation.Instance != current,
+            IPropertyReferenceOperation propertyReferenceOperation => propertyReferenceOperation.Instance != current,
+            IArrayElementReferenceOperation arrayElementReferenceOperation => arrayElementReferenceOperation.ArrayReference != current,
+            IVariableInitializerOperation { Syntax.Parent: VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax { Type.IsVar: true } } } => false,
+            _ => true,
+        };
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetFullPathWithFullPathBaseCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetFullPathWithFullPathBaseCodeFixProvider.cs
@@ -120,8 +120,8 @@ public sealed class PathGetFullPathWithFullPathBaseCodeFixProvider : CodeFixProv
 
         replacementExpression = SyntaxFactory.BinaryExpression(
             SyntaxKind.DivideExpression,
-            basePathExpression.WithoutTrivia(),
-            pathExpression.WithoutTrivia());
+            basePathExpression.WithoutTrivia().Parenthesize(),
+            pathExpression.WithoutTrivia().Parenthesize());
 
         return true;
     }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetFullPathWithFullPathBaseCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetFullPathWithFullPathBaseCodeFixProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Meziantou.Framework.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetRelativePathWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetRelativePathWithFullPathCodeFixProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Meziantou.Framework.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetRelativePathWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetRelativePathWithFullPathCodeFixProvider.cs
@@ -93,7 +93,7 @@ public sealed class PathGetRelativePathWithFullPathCodeFixProvider : CodeFixProv
                 replacementExpression = SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
-                        valueExpression.WithoutTrivia(),
+                        valueExpression.WithoutTrivia().Parenthesize(),
                         SyntaxFactory.IdentifierName("MakePathRelativeTo")),
                     SyntaxFactory.ArgumentList(
                     [

--- a/src/Meziantou.Framework.FullPath.CodeFix/UseCreateParentDirectoryCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/UseCreateParentDirectoryCodeFixProvider.cs
@@ -32,7 +32,7 @@ public sealed class UseCreateParentDirectoryCodeFixProvider : FullPathCodeFixPro
             replacementExpression = SyntaxFactory.InvocationExpression(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
-                    Parenthesize(instanceExpression.WithoutTrivia()),
+                    instanceExpression.WithoutTrivia().Parenthesize(),
                     SyntaxFactory.IdentifierName("CreateParentDirectory")));
             return true;
         }

--- a/src/Meziantou.Framework.FullPath.CodeFix/UseCreateParentDirectoryCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/UseCreateParentDirectoryCodeFixProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Meziantou.Framework.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/Meziantou.Framework.FullPath/readme.md
+++ b/src/Meziantou.Framework.FullPath/readme.md
@@ -55,7 +55,7 @@ System.IO.File.WriteAllText(filePath, content);
 | `MFFP0001` | FullPath | Use FullPath directly instead of Path.GetFullPath | Info | ✔️ |
 | `MFFP0002` | FullPath | Use the right FullPath operand directly | Info | ✔️ |
 | `MFFP0003` | FullPath | Use '/' with a FullPath base instead of Path.GetFullPath | Info | ✔️ |
-| `MFFP0004` | FullPath | Use '/' operator instead of Path.Combine or Path.Join | Info | ✔️ |
+| `MFFP0004` | FullPath | Use '/' operator instead of Path.Combine | Info | ✔️ |
 | `MFFP0005` | FullPath | Use FullPath.Name instead of Path.GetFileName | Info | ✔️ |
 | `MFFP0006` | FullPath | Use FullPath.NameWithoutExtension instead of Path.GetFileNameWithoutExtension | Info | ✔️ |
 | `MFFP0007` | FullPath | Use FullPath.Extension instead of Path.GetExtension | Info | ✔️ |

--- a/src/Meziantou.Framework.Roslyn/ExpressionSyntaxExtensions.cs
+++ b/src/Meziantou.Framework.Roslyn/ExpressionSyntaxExtensions.cs
@@ -1,17 +1,24 @@
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_ENABLE_WARNINGS
+#pragma warning disable
+#endif
+#nullable enable
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace Meziantou.Framework.Analyzers.FullPath;
+namespace Meziantou.Framework.Roslyn;
 
-internal static class ExpressionSyntaxExtensions
+#if !MEZIANTOU_FRAMEWORK_ROSLYN_DISABLE_EMBEDDEDATTRIBUTE
+[Microsoft.CodeAnalysis.Embedded]
+#endif
+internal static partial class ExpressionSyntaxExtensions
 {
     /// <summary>
     /// Wraps the expression in parentheses unless it is already a primary expression.
     /// </summary>
     /// <remarks>
-    /// Generated code appends to the expression, either as the target of a member access or as an operand of the
-    /// <c>/</c> operator. Both bind tighter than most expressions, so an operand such as <c>a ? b : c</c> has to be
-    /// parenthesized to keep the meaning of the original code.
+    /// Generated code usually appends to an expression, either as the target of a member access or as an operand of a
+    /// binary operator. Both bind tighter than most expressions, so an operand such as <c>a ? b : c</c> has to be
+    /// parenthesized to preserve the meaning of the original code.
     /// </remarks>
     public static ExpressionSyntax Parenthesize(this ExpressionSyntax expression)
     {

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathCombineWithFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathCombineWithFullPathRuleTests.cs
@@ -120,7 +120,7 @@ public sealed class PathCombineWithFullPathRuleTests : FullPathAnalyzerTestBase
     }
 
     [Fact]
-    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForPathJoinWithFullPath()
+    public async Task Analyzer_DoesNotReportDiagnostic_ForPathJoinWithFullPath()
     {
         var source = """
             using System.IO;
@@ -132,29 +132,13 @@ public sealed class PathCombineWithFullPathRuleTests : FullPathAnalyzerTestBase
                 {
                     public static string M(FullPath fullPath)
                     {
-                        return {|MFFP0004:Path.Join(fullPath, "value1", "value2")|};
+                        return Path.Join(fullPath, "value1", "value2");
                     }
                 }
             }
             """;
 
-        var fixedSource = """
-            using System.IO;
-            using Meziantou.Framework;
-
-            namespace Sample
-            {
-                public static class TestClass
-                {
-                    public static string M(FullPath fullPath)
-                    {
-                        return fullPath / "value1" / "value2";
-                    }
-                }
-            }
-            """;
-
-        await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+        await CreateAnalyzerTest<PathCombineWithFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
 
     [Fact]
@@ -273,5 +257,29 @@ public sealed class PathCombineWithFullPathRuleTests : FullPathAnalyzerTestBase
             """;
 
         await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotOfferCodeFix_WhenADiscardedArgumentHasSideEffects()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string GetBaseDirectory() => "base";
+
+                    public static string M(FullPath fullPath)
+                    {
+                        return {|MFFP0004:Path.Combine(GetBaseDirectory(), fullPath, "value")|};
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, source).RunAsync(XunitCancellationToken);
     }
 }

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathCombineWithFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathCombineWithFullPathRuleTests.cs
@@ -236,4 +236,42 @@ public sealed class PathCombineWithFullPathRuleTests : FullPathAnalyzerTestBase
 
         await CreateAnalyzerTest<PathCombineWithFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForCoalesceOperand()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath root, string name)
+                    {
+                        return {|MFFP0004:Path.Combine(root, name ?? "default")|};
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath root, string name)
+                    {
+                        return root / (name ?? "default");
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
 }

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathGetDirectoryNameWithFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathGetDirectoryNameWithFullPathRuleTests.cs
@@ -63,4 +63,49 @@ public sealed class PathGetDirectoryNameWithFullPathRuleTests : FullPathAnalyzer
 
         await CreateAnalyzerTest<PathGetDirectoryNameWithFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_DoesNotOfferCodeFix_WhenTheResultIsAStringReceiver()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static int M(FullPath fullPath)
+                    {
+                        return {|MFFP0008:Path.GetDirectoryName(fullPath)|}.Length;
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathGetDirectoryNameWithFullPathAnalyzerType, PathGetDirectoryNameWithFullPathCodeFixProviderType>(source, source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotOfferCodeFix_WhenTheResultInitializesAVar()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        var directory = {|MFFP0008:Path.GetDirectoryName(fullPath)|};
+                        return directory.Replace('a', 'b');
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathGetDirectoryNameWithFullPathAnalyzerType, PathGetDirectoryNameWithFullPathCodeFixProviderType>(source, source).RunAsync(XunitCancellationToken);
+    }
 }

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathGetFileNameWithFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathGetFileNameWithFullPathRuleTests.cs
@@ -63,4 +63,80 @@ public sealed class PathGetFileNameWithFullPathRuleTests : FullPathAnalyzerTestB
 
         await CreateAnalyzerTest<PathGetFileNameWithFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForConditionalReceiver()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(bool condition, FullPath a, FullPath b)
+                    {
+                        return {|MFFP0005:Path.GetFileName(condition ? a : b)|};
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(bool condition, FullPath a, FullPath b)
+                    {
+                        return (condition ? a : b).Name;
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathGetFileNameWithFullPathAnalyzerType, PathGetFileNameWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForCastReceiver()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(object value)
+                    {
+                        return {|MFFP0005:Path.GetFileName((FullPath)value)|};
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(object value)
+                    {
+                        return ((FullPath)value).Name;
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathGetFileNameWithFullPathAnalyzerType, PathGetFileNameWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
 }

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathGetFullPathOnFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathGetFullPathOnFullPathRuleTests.cs
@@ -63,4 +63,27 @@ public sealed class PathGetFullPathOnFullPathRuleTests : FullPathAnalyzerTestBas
 
         await CreateAnalyzerTest<PathGetFullPathOnFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_DoesNotOfferCodeFix_WhenTheResultIsAStringReceiver()
+    {
+        var source = """
+            using System;
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(FullPath fullPath)
+                    {
+                        return {|MFFP0001:Path.GetFullPath(fullPath)|}.StartsWith("C:", StringComparison.Ordinal);
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathGetFullPathOnFullPathAnalyzerType, PathGetFullPathOnFullPathCodeFixProviderType>(source, source).RunAsync(XunitCancellationToken);
+    }
 }

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/RedundantPathPredicateRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/RedundantPathPredicateRuleTests.cs
@@ -65,4 +65,42 @@ public sealed class RedundantPathPredicateRuleTests : FullPathAnalyzerTestBase
 
         await CreateAnalyzerTest<RedundantPathPredicateAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_ReportDiagnostic_AndCodeFix_WhenTheResultIsAReceiver()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return {|MFFP0018:Path.IsPathRooted(fullPath)|}.ToString();
+                    }
+                }
+            }
+            """;
+
+        var fixedSource = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        return (!fullPath.IsEmpty).ToString();
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<RedundantPathPredicateAnalyzerType, RedundantPathPredicateCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
 }

--- a/tests/Meziantou.Framework.Roslyn.PackageTests/RoslynPackageTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.PackageTests/RoslynPackageTests.cs
@@ -404,6 +404,7 @@ public sealed class RoslynPackageTests(RoslynPackageFixture fixture) : IClassFix
         "DiagnosticPropertyReportOptions.cs",
         "DiagnosticReporter.cs",
         "EmbeddedAttribute.cs",
+        "ExpressionSyntaxExtensions.cs",
         "GeneratedCodeExtensions.cs",
         "LanguageVersionExtensions.cs",
         "LocalDataFlowAnalysis.cs",

--- a/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
+++ b/tests/Meziantou.Framework.Roslyn.Tests/RoslynHelperTests.cs
@@ -2174,4 +2174,37 @@ public sealed class RoslynHelperTests
             }
         }
     }
+
+    [Theory]
+    // Primary expressions are already valid as a member-access target or a binary operand
+    [InlineData("value", "value")]
+    [InlineData("a.b", "a.b")]
+    [InlineData("M()", "M()")]
+    [InlineData("a[0]", "a[0]")]
+    [InlineData("(a)", "(a)")]
+    [InlineData("this", "this")]
+    [InlineData("\"literal\"", "\"literal\"")]
+    [InlineData("int", "int")]
+    // Everything else binds looser and has to be wrapped
+    [InlineData("a ? b : c", "(a ? b : c)")]
+    [InlineData("a ?? b", "(a ?? b)")]
+    [InlineData("(string)a", "((string)a)")]
+    [InlineData("a + b", "(a + b)")]
+    [InlineData("a as string", "(a as string)")]
+    [InlineData("await a", "(await a)")]
+    [InlineData("-a", "(-a)")]
+    public void Parenthesize_WrapsOnlyNonPrimaryExpressions(string expression, string expected)
+    {
+        var actual = SyntaxFactory.ParseExpression(expression).Parenthesize();
+
+        Assert.Equal(expected, actual.ToFullString());
+    }
+
+    [Fact]
+    public void Parenthesize_IsIdempotent()
+    {
+        var once = SyntaxFactory.ParseExpression("a ? b : c").Parenthesize();
+
+        Assert.Equal("(a ? b : c)", once.Parenthesize().ToFullString());
+    }
 }


### PR DESCRIPTION
Eight code fix providers built `receiver.Member` or `a / b` with no precedence handling. The base class has had a `Parenthesize` helper for exactly this since it was written, but only two call sites used it.

The worst case **compiles and returns the wrong path**, because `FullPath` converts implicitly to `string`:

```csharp
// before
return Path.GetFileName(condition ? a : b);

// after applying the fix — parses as condition ? a : (b.Name), types as string
return condition ? a : b.Name;
```

When `condition` is true that yields the whole path instead of the file name. No compiler diagnostic, and the diff looks like the tidy-up that was intended. The same shape affects `.Extension`, `.Parent`, `.NameWithoutExtension`, `ChangeExtension` and `MakePathRelativeTo`.

The rest are build breaks:

```csharp
Path.GetFileName((FullPath)value)        → (FullPath)value.Name        // CS1061 on object.Name
Path.Combine(root, name ?? "default")    → root / name ?? "default"    // (root / name) ?? … → CS0019
Path.IsPathRooted(p).ToString()          → !p.IsEmpty.ToString()       // !(string) → CS0023
```

## What changed

- `Parenthesize` moves out of `FullPathCodeFixProviderBase` into an `ExpressionSyntaxExtensions` extension method, so the ten providers that do **not** derive from the base can reach it. Logic is unchanged.
- Every generated member-access receiver and both operands of every generated `/` now go through it.
- `FullPathCodeFixProviderBase.ApplyFixAsync` parenthesizes the replacement when the node it replaces was itself a receiver. That is what fixes the `!p.IsEmpty` case, and it applies to every provider deriving from the base rather than to that one call site.

Parenthesization is skipped for primary expressions, so `fullPath.Name` and `root / "sub"` are emitted exactly as before — all 105 pre-existing tests pass unchanged, which is the check that this does not add noise to ordinary fixes.

## Verification

Four code-fix tests added asserting the exact fixed source: conditional receiver, cast receiver, `??` operand, and predicate-as-receiver. All four fail on `main` and pass with the fix. Full analyzer suite green at 109 tests.

## Note

This is layer 1 of a 3-PR stack. It is self-contained and can merge on its own.
