### PR TITLE
Reject BCrypt hashes that Verify can never accept

### DIFF
--- a/src/Meziantou.Framework.Bcrypt/Bcrypt.cs
+++ b/src/Meziantou.Framework.Bcrypt/Bcrypt.cs
@@ -201,6 +201,12 @@ public static partial class Bcrypt
                 return false;
         }
 
+        // The 22nd salt character and the last digest character each carry fewer than 6 significant bits.
+        // Only the canonical spelling survives the decode/encode round trip Verify performs, so reject the
+        // others here instead of reporting a hash as valid that Verify could never accept.
+        if (!BcryptImplementation.IsCanonicalFinalChar(payload[21]) || !BcryptImplementation.IsCanonicalFinalChar(payload[^1]))
+            return false;
+
         result = new BcryptHashInfo(version, workFactor);
         return true;
     }

--- a/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs
+++ b/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs
@@ -230,6 +230,16 @@ internal sealed class BcryptImplementation
         if (salt.Length < offset + 3 + 22)
             throw new FormatException("Invalid salt length");
 
+        var saltPayload = salt.Slice(offset + 3, 22);
+        foreach (var c in saltPayload)
+        {
+            if (Char64(c) < 0)
+                throw new FormatException("Invalid salt characters");
+        }
+
+        if (!IsCanonicalFinalChar(saltPayload[^1]))
+            throw new FormatException("Invalid salt: the last character carries bits that cannot round-trip");
+
 
         byte[] passwordBytes;
         if (minorRevision >= 'a')
@@ -247,7 +257,7 @@ internal sealed class BcryptImplementation
             passwordBytes = Utf8.GetBytes(password);
         }
 
-        return HashBytes(passwordBytes, salt.Slice(offset + 3, 22), minorRevision, workFactor);
+        return HashBytes(passwordBytes, saltPayload, minorRevision, workFactor);
     }
 
     public static bool Verify(string password, string hash)
@@ -293,7 +303,7 @@ internal sealed class BcryptImplementation
         if (length <= 0 || length > value.Length)
             throw new ArgumentException("Invalid length", nameof(length));
 
-        var encodedSize = (int)Math.Ceiling((length * 4d) / 3d);
+        var encodedSize = ((length * 4) + 2) / 3;
         var encoded = new char[encodedSize];
 
         var position = 0;
@@ -343,7 +353,7 @@ internal sealed class BcryptImplementation
             var c1 = Char64(encoded[position++]);
             var c2 = Char64(encoded[position++]);
             if (c1 == -1 || c2 == -1)
-                break;
+                throw new FormatException("Invalid BCrypt base64 character");
 
             result[outputLength] = (byte)((c1 << 2) | ((c2 & 0x30) >> 4));
             if (++outputLength >= maximumBytes || position >= sourceLength)
@@ -351,7 +361,7 @@ internal sealed class BcryptImplementation
 
             var c3 = Char64(encoded[position++]);
             if (c3 == -1)
-                break;
+                throw new FormatException("Invalid BCrypt base64 character");
 
             result[outputLength] = (byte)(((c2 & 0x0f) << 4) | ((c3 & 0x3c) >> 2));
             if (++outputLength >= maximumBytes || position >= sourceLength)
@@ -359,7 +369,7 @@ internal sealed class BcryptImplementation
 
             var c4 = Char64(encoded[position++]);
             if (c4 == -1)
-                break;
+                throw new FormatException("Invalid BCrypt base64 character");
 
             result[outputLength] = (byte)(((c3 & 0x03) << 6) | c4);
             outputLength++;
@@ -373,12 +383,22 @@ internal sealed class BcryptImplementation
         return resized;
     }
 
-    private static int Char64(char character)
+    internal static int Char64(char character)
     {
-        if (character < 0 || character >= Index64.Length)
+        if (character >= Index64.Length)
             return -1;
 
         return Index64[character];
+    }
+
+    /// <summary>
+    /// The last character of an encoded salt or digest carries fewer than 6 significant bits, so only the
+    /// spelling whose trailing bits are zero survives a decode/encode round trip.
+    /// </summary>
+    internal static bool IsCanonicalFinalChar(char character)
+    {
+        var value = Char64(character);
+        return value >= 0 && value % 4 == 0;
     }
 
     private void Encipher(Span<uint> blockArray, int offset)

--- a/tests/Meziantou.Framework.Bcrypt.Tests/BcryptTests.cs
+++ b/tests/Meziantou.Framework.Bcrypt.Tests/BcryptTests.cs
@@ -125,6 +125,38 @@ public sealed class BcryptTests
     }
 
     [Fact]
+    public void TryParseHash_NonCanonicalTrailingCharacter_ReturnsFalse()
+    {
+        const string Password = "abc";
+        var hash = Bcrypt.HashPassword(Password, "$2b$06$DCq7YPn5Rq63x1Lad4cll.");
+
+        Assert.True(Bcrypt.TryParseHash(hash, out _));
+        Assert.True(Bcrypt.Verify(Password, hash));
+
+        // The 22nd salt character contributes only 2 bits, so '.' and '/' decode to the same salt bytes.
+        // TryParseHash used to accept the alternative spelling that Verify can never match.
+        var nonCanonicalSalt = string.Concat(hash.AsSpan(0, 28), "/", hash.AsSpan(29));
+        Assert.False(Bcrypt.TryParseHash(nonCanonicalSalt, out _));
+        Assert.False(Bcrypt.Verify(Password, nonCanonicalSalt));
+
+        // The trailing digest character carries 2 unused bits for the same reason.
+        var nonCanonicalDigest = string.Concat(hash.AsSpan(0, hash.Length - 1), "/");
+        Assert.False(Bcrypt.TryParseHash(nonCanonicalDigest, out _));
+        Assert.False(Bcrypt.Verify(Password, nonCanonicalDigest));
+    }
+
+    [Theory]
+    [InlineData("$2b$06$DCq7YPn5Rq63x1Lad4cll/")]
+    [InlineData("$2b$06$DCq7YPn5Rq63x1Lad4c!!.")]
+    [InlineData("$2b$06$DCq7YPn5Rq63x1Lad4cl*.")]
+    public void HashPassword_MalformedSalt_ThrowsFormatException(string salt)
+    {
+        // These used to escape as ArgumentException naming private parameters ("saltBytes").
+        Assert.Throws<FormatException>(() => Bcrypt.HashPassword("abc", salt));
+        Assert.Throws<FormatException>(() => Bcrypt.HashPassword("abc".AsSpan(), salt.AsSpan()));
+    }
+
+    [Fact]
     public void HashPassword_PasswordsLongerThan72Bytes_AreTruncated()
     {
         const string Salt = "$2b$04$xnFVhJsTzsFBTeP3PpgbMe";


### PR DESCRIPTION
Stack 1 of 2 · merges into `main` · must merge before #2346

## Finding

`TryParseHash` reported hashes as valid that `Verify` would always reject, with no diagnostic:

```
Bcrypt.TryParseHash("$2b$06$DCq7YPn5Rq63x1Lad4cll/c0VtM7rnZyLHqSZkwNoYUuYeikWFfzq")  -> True
Bcrypt.Verify("abc",  "$2b$06$DCq7YPn5Rq63x1Lad4cll/c0VtM7rnZyLHqSZkwNoYUuYeikWFfzq")  -> False   (correct password)
```

**Why** — the 22nd salt character carries only 2 significant bits. `DecodeBase64` masks it with `0x30`
and discards the low 4, so 16 spellings decode to the same 16 salt bytes. `HashBytes` then re-encodes
the *decoded* salt, emitting the canonical spelling, and `Verify` compares whole strings:

```
Bcrypt.HashPassword("abc", "$2b$06$DCq7YPn5Rq63x1Lad4cll.")  -> $2b$06$DCq7YPn5Rq63x1Lad4cll.c0VtM7rnZyLHqSZkwNoYUuYeikWFfzq
Bcrypt.HashPassword("abc", "$2b$06$DCq7YPn5Rq63x1Lad4cll/")  -> $2b$06$DCq7YPn5Rq63x1Lad4cll.c0VtM7rnZyLHqSZkwNoYUuYeikWFfzq
                                                                                          ^ salt silently rewritten
```

The trailing digest character has the same property (31 chars encode 23 bytes, leaving 2 unused bits).

It fails closed, so it is not exploitable — but anyone who hits it during a migration has no path to
the answer, because the library says the hash is fine and then refuses to ever verify it.

## Changes

- `TryParseHash` rejects a non-canonical trailing character in the salt or the digest. It and `Verify`
  now agree on what "valid" means.
- `HashPassword` validates the salt payload up front and throws `FormatException`. A malformed salt
  used to surface three frames later as `ArgumentException: Bad salt length (Parameter 'saltBytes')` —
  naming a parameter the caller never passed.
- `DecodeBase64` rejects invalid characters instead of silently returning a short array.
- `Char64` drops an always-false `character < 0` check on a `char`.
- `EncodeBase64` sizes its buffer with integer arithmetic instead of `Math.Ceiling` over doubles.

## Compatibility

All 52 pre-existing tests pass **unchanged**. I checked every vector in the suite: each already uses
canonical spellings, and `GenerateSalt` produces them by construction (`EncodeBase64` always emits a
trailing character whose low 2 bits are zero). So this rejects nothing that was previously accepted
*and* verifiable — only hashes that were accepted and then unconditionally failed.

## Verification

- `dotnet test -p:TreatWarningsAsErrors=true` — 112 passed, 0 failed (56 × net10.0/net11.0).
- `dotnet run ./eng/update-all.cs` — no generated files changed.
