### PR TITLE
Use one minimum work factor and keep salt errors as FormatException

### DIFF
--- a/src/Meziantou.Framework.Bcrypt/Bcrypt.cs
+++ b/src/Meziantou.Framework.Bcrypt/Bcrypt.cs
@@ -67,6 +67,7 @@ public static partial class Bcrypt
     /// <param name="salt">The BCrypt salt string.</param>
     /// <returns>The BCrypt hash string.</returns>
     /// <exception cref="ArgumentException"><paramref name="password"/> cannot be encoded as UTF-8 because it contains an unpaired surrogate.</exception>
+    /// <exception cref="FormatException"><paramref name="salt"/> is not a valid BCrypt salt: bad revision, a work factor outside <see cref="MinWorkFactor"/>..<see cref="MaxWorkFactor"/>, or a malformed payload.</exception>
     public static string HashPassword(string password, string salt)
     {
         ArgumentNullException.ThrowIfNull(password);
@@ -80,6 +81,7 @@ public static partial class Bcrypt
     /// <param name="salt">The BCrypt salt string.</param>
     /// <returns>The BCrypt hash string.</returns>
     /// <exception cref="ArgumentException"><paramref name="password"/> cannot be encoded as UTF-8 because it contains an unpaired surrogate.</exception>
+    /// <exception cref="FormatException"><paramref name="salt"/> is not a valid BCrypt salt: bad revision, a work factor outside <see cref="MinWorkFactor"/>..<see cref="MaxWorkFactor"/>, or a malformed payload.</exception>
     public static string HashPassword(ReadOnlySpan<char> password, ReadOnlySpan<char> salt)
     {
         return BcryptImplementation.HashPassword(password, salt);

--- a/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs
+++ b/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs
@@ -224,7 +224,7 @@ internal sealed class BcryptImplementation
 
         var workFactor = (tens * 10) + ones;
 
-        if (workFactor is < 1 or > Bcrypt.MaxWorkFactor)
+        if (workFactor is < Bcrypt.MinWorkFactor or > Bcrypt.MaxWorkFactor)
             throw new FormatException("Salt rounds out of range");
 
         if (salt.Length < offset + 3 + 22)
@@ -546,8 +546,6 @@ internal sealed class BcryptImplementation
             throw new ArgumentException("Bad salt length", nameof(saltBytes));
 
         var rounds = 1u << workFactor;
-        if (rounds < 1)
-            throw new ArgumentException("Bad number of rounds", nameof(workFactor));
 
         var cdata = new uint[BfCryptCiphertext.Length];
         Array.Copy(BfCryptCiphertext, cdata, BfCryptCiphertext.Length);
@@ -555,7 +553,7 @@ internal sealed class BcryptImplementation
         InitializeKey();
         EksKey(saltBytes, inputBytes);
 
-        for (var i = 0; i != rounds; i++)
+        for (var i = 0u; i < rounds; i++)
         {
             Key(inputBytes);
             Key(saltBytes);

--- a/tests/Meziantou.Framework.Bcrypt.Tests/BcryptTests.cs
+++ b/tests/Meziantou.Framework.Bcrypt.Tests/BcryptTests.cs
@@ -213,6 +213,33 @@ public sealed class BcryptTests
         Assert.False(Bcrypt.Verify("dEe6XfVGrrfSH", Hash[..^10]));
     }
 
+    [Theory]
+    [InlineData("$2b$00$DCq7YPn5Rq63x1Lad4cll.")]
+    [InlineData("$2b$01$DCq7YPn5Rq63x1Lad4cll.")]
+    [InlineData("$2b$03$DCq7YPn5Rq63x1Lad4cll.")]
+    [InlineData("$2b$32$DCq7YPn5Rq63x1Lad4cll.")]
+    [InlineData("$2b$xx$DCq7YPn5Rq63x1Lad4cll.")]
+    public void HashPassword_SaltWithWorkFactorOutOfRange_ThrowsFormatException(string salt)
+    {
+        // Work factors 1 to 3 used to pass the salt parser and then fail inside CryptRaw with
+        // ArgumentException naming a private parameter ("workFactor").
+        Assert.Throws<FormatException>(() => Bcrypt.HashPassword("abc", salt));
+        Assert.Throws<FormatException>(() => Bcrypt.HashPassword("abc".AsSpan(), salt.AsSpan()));
+    }
+
+    [Theory]
+    [InlineData(Bcrypt.MinWorkFactor)]
+    [InlineData(Bcrypt.MinWorkFactor + 1)]
+    public void HashPassword_SaltAtMinimumWorkFactor_Succeeds(int workFactor)
+    {
+        var salt = Bcrypt.GenerateSalt(workFactor);
+
+        var hash = Bcrypt.HashPassword("abc", salt);
+
+        Assert.True(Bcrypt.Verify("abc", hash));
+        Assert.Equal(workFactor, Bcrypt.ParseHash(hash).WorkFactor);
+    }
+
     [Fact]
     public void Verify_PasswordWithUnpairedSurrogate_ReturnsFalse()
     {


### PR DESCRIPTION
Stack 2 of 2 · merges into `fix/bcrypt-salt-validation` · merge #2345 first

## Finding

The library carried two different minimum work factors — `Bcrypt.MinWorkFactor` is 4, but the salt
parser admitted costs 1 to 3 and left `CryptRaw` to reject them. Two inputs of the same kind produced
different exception types, and the `ArgumentException` named parameters the caller never passed:

| Call | Thrown |
|---|---|
| `HashPassword("abc", "$2b$00$…")` | `FormatException: Salt rounds out of range` |
| `HashPassword("abc", "$2b$01$…")` | `ArgumentException: Bad number of rounds (Parameter 'workFactor')` |

Neither `HashPassword(password, salt)` overload documented any exception, so a caller guarding with
`catch (FormatException)` — the documented contract everywhere else on this type — would let
`ArgumentException` escape, and the wrong parameter name sends debugging in the wrong direction.

## Changes

- The salt parser uses `Bcrypt.MinWorkFactor`, so every out-of-range cost is a `FormatException`
  raised before `CryptRaw` is reached.
- Documented `FormatException` on both `HashPassword(password, salt)` overloads.
- Removed the unreachable `rounds < 1` check — `rounds` is a `uint` from `1u << workFactor` with
  `workFactor` already range-checked, so it can never be zero.
- The round loop counter is now `uint` and uses `<` rather than `!=`. As an `int` it overflowed past
  `int.MaxValue` at work factor 31 (an accepted value) and never equalled `2^31`, so the loop could
  not terminate. Academic at that cost — it would not finish this century regardless — but free.

## Verification

- `dotnet test -p:TreatWarningsAsErrors=true` — 126 passed, 0 failed (63 × net10.0/net11.0).
- `dotnet run ./eng/update-all.cs` — no generated files changed.

Note: this touches the XML doc block on `HashPassword`, which #2338 also edits. Whichever lands
second may want a trivial rebase.
