### PR TITLE
Clear and fill the sensitive buffer without narrowing its size to int

### DIFF
--- a/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
+++ b/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
@@ -421,10 +421,10 @@ public sealed unsafe class SensitiveData<T> : IDisposable
                 SetHandle((IntPtr)NativeMemory.Alloc(byteCount));
 
                 _xorKey = (IntPtr)NativeMemory.Alloc(byteCount);
-                RandomNumberGenerator.Fill(new Span<byte>((void*)_xorKey, checked((int)byteCount)));
+                FillRandom((byte*)_xorKey, byteCount);
             }
 
-            GetAllocatedByteSpan().Clear();
+            NativeMemory.Clear((void*)handle, _allocatedBytes);
         }
 
         public Span<T> GetSpan()
@@ -500,7 +500,7 @@ public sealed unsafe class SensitiveData<T> : IDisposable
             switch (_protectionMode)
             {
                 case ProtectionMode.Windows when OperatingSystem.IsWindows():
-                    GetAllocatedByteSpan().Clear();
+                    NativeMemory.Clear((void*)handle, _allocatedBytes);
                     return WindowsHeap.Free(handle);
 
                 case ProtectionMode.Unix when OperatingSystem.IsLinux() || OperatingSystem.IsMacOS():
@@ -511,7 +511,7 @@ public sealed unsafe class SensitiveData<T> : IDisposable
 
                     if (!_unixMemoryProtected)
                     {
-                        GetAllocatedByteSpan().Clear();
+                        NativeMemory.Clear((void*)handle, _allocatedBytes);
 
                         if (_unixMemoryLocked)
                         {
@@ -523,11 +523,11 @@ public sealed unsafe class SensitiveData<T> : IDisposable
                     return SensitiveData.UnixMemoryProtection.Free(handle, _allocatedBytes);
 
                 case ProtectionMode.Xor:
-                    GetAllocatedByteSpan().Clear();
+                    NativeMemory.Clear((void*)handle, _allocatedBytes);
 
                     if (_xorKey != IntPtr.Zero)
                     {
-                        new Span<byte>((void*)_xorKey, checked((int)_byteCount)).Clear();
+                        NativeMemory.Clear((void*)_xorKey, _byteCount);
                         NativeMemory.Free((void*)_xorKey);
                         _xorKey = IntPtr.Zero;
                     }
@@ -542,17 +542,25 @@ public sealed unsafe class SensitiveData<T> : IDisposable
 
         private void XorWithKey()
         {
-            var data = new Span<byte>((void*)handle, (int)_allocatedBytes);
-            var key = new ReadOnlySpan<byte>((void*)_xorKey, (int)_allocatedBytes);
-            for (var i = 0; i < data.Length; i++)
+            var data = (byte*)handle;
+            var key = (byte*)_xorKey;
+            for (nuint i = 0; i < _allocatedBytes; i++)
             {
                 data[i] ^= key[i];
             }
         }
 
-        private Span<byte> GetAllocatedByteSpan()
+        // Span is limited to int.MaxValue elements, so the buffer is filled in chunks rather than
+        // narrowing the byte count to int.
+        private static void FillRandom(byte* destination, nuint byteCount)
         {
-            return new Span<byte>((void*)handle, checked((int)_allocatedBytes));
+            while (byteCount > 0)
+            {
+                var chunk = (int)Math.Min(byteCount, (nuint)int.MaxValue);
+                RandomNumberGenerator.Fill(new Span<byte>(destination, chunk));
+                destination += chunk;
+                byteCount -= (nuint)chunk;
+            }
         }
 
         private static void ThrowLastPInvokeError()

--- a/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
+++ b/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Security.Cryptography;
 using System.Text.Json;
 
 namespace Meziantou.Framework.Tests;
@@ -54,6 +55,16 @@ public sealed class SensitiveDataTests
         {
             expected[i] = (byte)i;
         }
+
+        using var data = SensitiveData.Create(expected);
+        Assert.Equal(expected, data.RevealToArray());
+    }
+
+    [Fact]
+    public void RevealToArray_BufferLargerThanOneMegabyte()
+    {
+        var expected = new byte[8 * 1024 * 1024];
+        RandomNumberGenerator.Fill(expected);
 
         using var data = SensitiveData.Create(expected);
         Assert.Equal(expected, data.RevealToArray());


### PR DESCRIPTION
## The problem

`_byteCount` is `count * sizeof(T)` as a `nuint`, which for a non-byte `T` exceeds `int.MaxValue`
well before the element count does - `SensitiveData.Create(new long[300_000_000])` is 2.4 GB, and
.NET allows arrays that large by default.

Every place the buffer was touched as a whole went through a `Span<byte>`, which caps at
`int.MaxValue`:

```csharp
private Span<byte> GetAllocatedByteSpan()
{
    return new Span<byte>((void*)handle, checked((int)_allocatedBytes));   // OverflowException
}
```

The first call is the **last line of `Allocate`**, after `SetHandle` has already run. So the
constructor threw with a live, non-invalid handle. The `SafeHandle` finalizer then ran
`ReleaseHandle`, which called `GetAllocatedByteSpan()` again and threw `OverflowException` a second
time - this time from inside a critical finalizer. An exception escaping a finalizer **terminates the
process**, at an arbitrary later GC, far from the call that caused it.

`XorWithKey` had the same narrowing without the `checked`, so above 2 GB it produced a negative
length and threw `ArgumentOutOfRangeException` from the `Span` constructor instead - two different
exceptions for the same condition, twenty lines apart.

## The change

Nothing that spans the whole buffer goes through `Span<byte>` any more:

- `GetAllocatedByteSpan()` is gone. The four clear sites use `NativeMemory.Clear(void*, nuint)`,
  which takes the byte count natively.
- `XorWithKey` loops over `nuint` with pointer indexing instead of building two spans.
- The XOR key fill is chunked in a new `FillRandom(byte*, nuint)` helper, because
  `RandomNumberGenerator.Fill` only takes a `Span<byte>`.

`ReleaseHandle` can no longer throw on any input, which was the part that actually mattered - the
other half of the failure was recoverable, the finalizer half was not.

## Verification

Existing tests cover the normal path (50/50 pass, 25 tests x net10.0 + net11.0), and one test is
added for an 8 MB buffer so the rewritten clear/fill/XOR code runs at a size beyond the 0-31 byte
cases the suite had.

**The >2 GB case itself is not tested, and cannot reasonably be** - it needs a multi-gigabyte
allocation in CI. The fix is by construction rather than by test: there is no `int` narrowing left in
the file, which is greppable and reviewable. Calling this out rather than implying coverage I do not
have.
