### PR TITLE
Cover the XOR protection fallback and assert the contents are transformed at rest

### DIFF
--- a/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
+++ b/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
@@ -222,13 +222,41 @@ public sealed unsafe class SensitiveData<T> : IDisposable
     /// The newly-returned <see cref="SensitiveData{T}"/> instance maintains its own copy of the data separate from <paramref name="contents"/>.
     /// </remarks>
     internal SensitiveData(ReadOnlySpan<T> contents)
+        : this(contents, forceXorProtection: false)
+    {
+    }
+
+    private SensitiveData(ReadOnlySpan<T> contents, bool forceXorProtection)
     {
         // Use unmanaged memory so the data remains at a stable address
         // and can be cleared during Dispose.
         _data = new NativeMemorySafeHandle();
-        _data.Allocate(contents.Length);
+        _data.Allocate(contents.Length, forceXorProtection);
         contents.CopyTo(_data.GetSpan());
         _data.Protect();
+    }
+
+    /// <summary>
+    /// Creates an instance that uses the XOR fallback protection whatever the platform.
+    /// Windows, Linux and macOS all select one of the other modes, so without this the fallback
+    /// is executed by no test on any platform CI runs on.
+    /// </summary>
+    internal static SensitiveData<T> CreateWithXorProtection(ReadOnlySpan<T> contents) => new(contents, forceXorProtection: true);
+
+    /// <summary>
+    /// Copies the bytes as they are stored while protected, so tests can assert the contents are
+    /// really transformed at rest rather than only that <see cref="IsProtected"/> was set.
+    /// Returns <see langword="false"/> under the Unix protection, where the pages are
+    /// <c>PROT_NONE</c> and reading them would fault instead of returning anything.
+    /// </summary>
+    internal bool TryGetBytesAtRest(out byte[] bytes)
+    {
+        var data = _data;
+        ObjectDisposedException.ThrowIf(data is null, this);
+        lock (data.SyncLock)
+        {
+            return data.TryCopyBytesAtRest(out bytes);
+        }
     }
 
     /// <summary>Returns the length (in elements) of this buffer.</summary>
@@ -390,7 +418,7 @@ public sealed unsafe class SensitiveData<T> : IDisposable
 
         public override bool IsInvalid => handle == Invalid;
 
-        public void Allocate(int count)
+        public void Allocate(int count, bool forceXorProtection)
         {
             Length = count;
             var byteCount = (nuint)count * (nuint)sizeof(T);
@@ -399,7 +427,7 @@ public sealed unsafe class SensitiveData<T> : IDisposable
             if (byteCount == 0)
                 return;
 
-            if (OperatingSystem.IsWindows())
+            if (!forceXorProtection && OperatingSystem.IsWindows())
             {
                 _protectionMode = ProtectionMode.Windows;
                 _allocatedBytes = WindowsHeap.GetAlignedSize(byteCount);
@@ -407,7 +435,7 @@ public sealed unsafe class SensitiveData<T> : IDisposable
                 if (handle == IntPtr.Zero)
                     ThrowOutOfMemory();
             }
-            else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+            else if (!forceXorProtection && (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS()))
             {
                 _protectionMode = ProtectionMode.Unix;
                 _allocatedBytes = SensitiveData.UnixMemoryProtection.GetAlignedSize(byteCount);
@@ -430,6 +458,19 @@ public sealed unsafe class SensitiveData<T> : IDisposable
         public Span<T> GetSpan()
         {
             return new Span<T>((void*)handle, Length);
+        }
+
+        public bool TryCopyBytesAtRest(out byte[] bytes)
+        {
+            // Reading PROT_NONE pages faults, so the Unix protection cannot be observed this way.
+            if (_protectionMode is ProtectionMode.Unix)
+            {
+                bytes = [];
+                return false;
+            }
+
+            bytes = new ReadOnlySpan<byte>((void*)handle, checked((int)_allocatedBytes)).ToArray();
+            return true;
         }
 
         public void Protect()

--- a/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
+++ b/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
@@ -105,6 +105,108 @@ public sealed class SensitiveDataTests
         Assert.Equal(new byte[] { 1, 2, 3, 4 }, bytes.RevealToArray());
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(15)]
+    [InlineData(16)]
+    [InlineData(17)]
+    [InlineData(31)]
+    public void XorProtection_RoundTripsVariousLengths(int length)
+    {
+        var expected = new byte[length];
+        for (var i = 0; i < expected.Length; i++)
+        {
+            expected[i] = (byte)i;
+        }
+
+        using var data = SensitiveData<byte>.CreateWithXorProtection(expected);
+        Assert.True(data.IsProtected);
+        Assert.Equal(expected, data.RevealToArray());
+        Assert.True(data.IsProtected);
+    }
+
+    [Fact]
+    public void XorProtection_StoresTransformedBytesAtRest()
+    {
+        var plaintext = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+        using var data = SensitiveData<byte>.CreateWithXorProtection(plaintext);
+
+        Assert.True(data.TryGetBytesAtRest(out var atRest));
+        Assert.NotEqual(plaintext, atRest);
+        Assert.Equal(plaintext, data.RevealToArray());
+    }
+
+    [Fact]
+    public void DefaultProtection_StoresTransformedBytesAtRest()
+    {
+        var plaintext = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+
+        using var data = SensitiveData.Create(plaintext);
+
+        // The Unix protection makes the pages unreadable, so there is nothing to compare against.
+        if (!data.TryGetBytesAtRest(out var atRest))
+            return;
+
+        Assert.NotEqual(plaintext, atRest);
+        Assert.Equal(plaintext, data.RevealToArray());
+    }
+
+    [Fact]
+    public void RevealInto_DestinationTooSmall_ThrowsAndLeavesTheInstanceUsable()
+    {
+        using var data = SensitiveData.Create("foo");
+
+        Assert.Throws<ArgumentException>(() => data.RevealInto(new char[2]));
+
+        Assert.True(data.IsProtected);
+        Assert.Equal("foo", data.RevealToString());
+    }
+
+    [Fact]
+    public void Create_FromReadOnlySpan()
+    {
+        ReadOnlySpan<byte> buffer = [1, 2, 3, 4, 5];
+
+        using var data = SensitiveData.Create(buffer);
+
+        Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, data.RevealToArray());
+    }
+
+    [Fact]
+    public void ConcurrentReveals_AllReturnTheSecret()
+    {
+        using var data = SensitiveData.Create("foo");
+
+        var results = new string[8];
+        var threads = new Thread[results.Length];
+        for (var i = 0; i < threads.Length; i++)
+        {
+            var index = i;
+            threads[index] = new Thread(() =>
+            {
+                for (var iteration = 0; iteration < 200; iteration++)
+                {
+                    results[index] = data.RevealToString();
+                }
+            });
+        }
+
+        foreach (var thread in threads)
+        {
+            thread.Start();
+        }
+
+        foreach (var thread in threads)
+        {
+            Assert.True(thread.Join(TimeSpan.FromSeconds(30)));
+        }
+
+        Assert.All(results, result => Assert.Equal("foo", result));
+        Assert.True(data.IsProtected);
+    }
+
     [Fact]
     [SuppressMessage("Design", "MA0150:Do not call the default object.ToString explicitly")]
     public void ToStringDoesNotRevealValue()


### PR DESCRIPTION
## The problem

Two gaps, same root cause - nothing asserted that the protection was *actually applied*.

**`IsProtected` only reports bookkeeping.** It is `_allocatedBytes == 0 || _isProtected`, and
`_isProtected` is a bool assigned by the very methods under test. So
`ProtectionIsAppliedAtRestAndLiftedWhileRevealing` proved that `Protect()` sets a field - not that
`CryptProtectMemory` ran, not that the page is `PROT_NONE`, not that the bytes at rest differ from
the plaintext. A refactor that deleted the `CryptProtectMemory` call but kept the flag assignment
passed the whole suite. The XML doc on `IsProtected` claims it exists "so tests can assert the
protection is actually in effect rather than only that the contents round-trip", which overstated
what it delivered.

**The XOR fallback was executed by no test on any platform.** Branch selection is
`IsWindows()` -> `IsLinux() || IsMacOS()` -> else XOR, and `Allocate` offered no seam, so Windows CI
takes the first branch, Linux and macOS the second. `ProtectionMode.Xor` - the key allocation, the
XOR loop, the key clearing in `ReleaseHandle` - shipped entirely unexercised.

## The change

Two internal members, both reachable through the existing `InternalsVisibleTo`:

- `SensitiveData<T>.CreateWithXorProtection` - forces the fallback whatever the platform, so the XOR
  path runs on every CI leg. It threads a single `bool` through to `Allocate`; the branch conditions
  gain a `!forceXorProtection &&` and nothing else changes.
- `SensitiveData<T>.TryGetBytesAtRest` - copies the bytes as stored while protected. Returns `false`
  under the Unix protection, where the pages are `PROT_NONE` and reading them would fault rather than
  return anything.

Tests added:

- XOR round-trip across the same 0/1/15/16/17/31 lengths the other modes already use.
- XOR at-rest bytes differ from the plaintext, and the plaintext still round-trips.
- Default (platform) protection at-rest bytes differ from the plaintext - this is what actually
  proves `CryptProtectMemory` encrypted on Windows. Returns early on Linux/macOS.
- Three gaps the suite had no coverage for at all: `RevealInto` with a too-small destination (and
  that the instance stays usable afterwards), the `Create<T>(ReadOnlySpan<T>)` overload, and eight
  threads revealing concurrently.

## Verification

70/70 pass (35 tests x net10.0 + net11.0). The XOR tests genuinely take the fallback rather than
silently falling through to the platform mode: `TryGetBytesAtRest` returns `false` for the Unix
protection, so `Assert.True(data.TryGetBytesAtRest(out var atRest))` passing on macOS can only happen
if the seam actually selected XOR.

## Known remaining gap

The Unix `PROT_NONE` protection is still asserted only through the `IsProtected` flag. Observing it
directly without faulting needs a syscall probe - `write()` to `/dev/null` from the protected address
and check for `EFAULT`, or `mincore` - which means new P/Invoke in the test project. That felt like a
separate change rather than something to bundle here, so it is left undone rather than papered over.

## Note for merge ordering

This touches `Allocate`'s signature and branch conditions;
[#2348](https://github.com/meziantou/Meziantou.Framework/pull/2348) touches statements inside the
same method. Different lines, but close enough that whichever merges second may want a look.
