### PR TITLE
Throw NotSupportedException from the SensitiveData converter's ConvertTo

### DIFF
--- a/src/Meziantou.Framework.SensitiveData/SensitiveDataTypeConverter.cs
+++ b/src/Meziantou.Framework.SensitiveData/SensitiveDataTypeConverter.cs
@@ -35,7 +35,11 @@ internal sealed class SensitiveDataTypeConverter : TypeConverter
 
     public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
     {
-        throw new InvalidOperationException();
+        // Converting away from SensitiveData is never supported: the whole point of the type is that
+        // its contents do not leak into a string. NotSupportedException is what TypeConverter
+        // documents for a conversion it cannot perform, and what callers that probe a converter
+        // defensively catch.
+        throw new NotSupportedException($"Cannot convert '{typeof(SensitiveData<char>)}' to '{destinationType}'. Revealing the contents has to be explicit.");
     }
 
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)

--- a/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
+++ b/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
@@ -154,7 +154,8 @@ public sealed class SensitiveDataTests
     public void TypeConverterToStringDoesNotRevealValue()
     {
         using var data = SensitiveData.Create("foo");
-        Assert.Throws<InvalidOperationException>(() => TypeDescriptor.GetConverter(typeof(SensitiveData<char>)).ConvertToString(data));
+        var exception = Assert.Throws<NotSupportedException>(() => TypeDescriptor.GetConverter(typeof(SensitiveData<char>)).ConvertToString(data));
+        Assert.DoesNotContain("foo", exception.Message, ignoreCase: true);
     }
 
     [Fact]


### PR DESCRIPTION
## The problem

`SensitiveDataTypeConverter.ConvertTo` threw `InvalidOperationException`:

```csharp
public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
{
    throw new InvalidOperationException();
}
```

`TypeConverter.ConvertTo` is documented to throw `NotSupportedException` when the conversion cannot
be performed, and `CanConvertTo` here already returns `false`. Framework code that probes a converter
defensively - designers, some binding and diagnostics paths - catches `NotSupportedException` and
falls back to another strategy. It does not catch `InvalidOperationException`, so a caller that would
have degraded gracefully instead sees a hard failure propagate.

The sibling `ConvertFrom` path in the same file already gets this right, throwing
`NotSupportedException` for an unsupported element type.

## The change

Throw `NotSupportedException`, with a message naming the destination type. The refusal itself is
deliberate and stays - it is what makes `TypeDescriptor.GetConverter(...).ConvertToString(secret)`
safe - only the exception type changes.

The exception message is built from `typeof(SensitiveData<char>)` and `destinationType`, never from
`value`, so it cannot leak the contents. The test asserts that.

## Verification

48/48 pass (24 tests x net10.0 + net11.0). `TypeConverterToStringDoesNotRevealValue` is updated to
expect `NotSupportedException` and now also asserts the message does not contain the secret.

## Compatibility

Breaking for anyone catching `InvalidOperationException` from this specific call. Given the type is
2.0.0 and this is the documented-correct exception for the contract, it seemed worth fixing rather
than preserving - but it is a behaviour change, so flagging it explicitly.
