### PR TITLE
Reject the $2x$ revision instead of treating it as $2b$

### DIFF
--- a/src/Meziantou.Framework.Bcrypt/Bcrypt.cs
+++ b/src/Meziantou.Framework.Bcrypt/Bcrypt.cs
@@ -32,7 +32,7 @@ public static partial class Bcrypt
     /// <param name="version">The BCrypt revision to generate.</param>
     /// <returns>A BCrypt salt string.</returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="workFactor"/> is outside the supported range.</exception>
-    /// <exception cref="NotSupportedException"><paramref name="version"/> is <see cref="BcryptVersion.Revision2"/>, which cannot be generated.</exception>
+    /// <exception cref="NotSupportedException"><paramref name="version"/> is <see cref="BcryptVersion.Revision2"/> or <see cref="BcryptVersion.Revision2X"/>, neither of which can be generated.</exception>
     public static string GenerateSalt(int workFactor = DefaultWorkFactor, BcryptVersion version = BcryptVersion.Revision2B)
     {
         var minorRevision = ToMinorRevision(version);
@@ -85,6 +85,7 @@ public static partial class Bcrypt
     /// <param name="password">The plaintext password.</param>
     /// <param name="hash">The BCrypt hash string.</param>
     /// <returns><see langword="true"/> if the password matches; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="NotSupportedException"><paramref name="hash"/> uses the <c>$2x$</c> revision, which cannot be verified correctly.</exception>
     public static bool Verify(string password, string hash)
     {
         ArgumentNullException.ThrowIfNull(password);
@@ -97,6 +98,7 @@ public static partial class Bcrypt
     /// <param name="password">The plaintext password.</param>
     /// <param name="hash">The BCrypt hash string.</param>
     /// <returns><see langword="true"/> if the password matches; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="NotSupportedException"><paramref name="hash"/> uses the <c>$2x$</c> revision, which cannot be verified correctly.</exception>
     public static bool Verify(ReadOnlySpan<char> password, ReadOnlySpan<char> hash)
     {
         if (!TryParseHash(hash, out _))
@@ -238,13 +240,18 @@ public static partial class Bcrypt
         return hashInfo.WorkFactor != workFactor || hashInfo.Version != version;
     }
 
+    internal const string Revision2XNotSupportedMessage =
+        "The '$2x$' revision is not supported. It exists to reproduce the crypt_blowfish sign-extension bug, " +
+        "which this implementation does not emulate. Treating it as '$2b$' would silently mis-verify any password " +
+        "containing a byte with the high bit set. Use ParseHash to detect '$2x$' hashes and re-hash those passwords.";
+
     private static char ToMinorRevision(BcryptVersion version)
     {
         return version switch
         {
             BcryptVersion.Revision2A => 'a',
             BcryptVersion.Revision2B => 'b',
-            BcryptVersion.Revision2X => 'x',
+            BcryptVersion.Revision2X => throw new NotSupportedException(Revision2XNotSupportedMessage),
             BcryptVersion.Revision2Y => 'y',
             BcryptVersion.Revision2 => throw new NotSupportedException("Generating salts for the legacy '$2$' revision is not supported."),
             _ => throw new ArgumentOutOfRangeException(nameof(version), version, "Unsupported BCrypt version"),

--- a/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs
+++ b/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs
@@ -209,6 +209,9 @@ internal sealed class BcryptImplementation
             if (minorRevision is not ('a' or 'b' or 'x' or 'y') || salt[3] != '$')
                 throw new FormatException("Invalid salt revision");
 
+            if (minorRevision is 'x')
+                throw new NotSupportedException(Bcrypt.Revision2XNotSupportedMessage);
+
             offset = 4;
         }
 

--- a/src/Meziantou.Framework.Bcrypt/readme.md
+++ b/src/Meziantou.Framework.Bcrypt/readme.md
@@ -20,10 +20,14 @@ var shouldRehash = Bcrypt.NeedsRehash(hash, workFactor: 13, version: BcryptVersi
 
 Supported revisions are:
 
-- `2` (`$2$`, legacy parsing only)
+- `2` (`$2$`) - verified only; salts cannot be generated
 - `2a` (`$2a$`)
-- `2b` (`$2b$`)
-- `2x` (`$2x$`)
-- `2y` (`$2y$`)
+- `2b` (`$2b$`) - the default
+- `2y` (`$2y$`) - identical to `$2b$`
+
+`$2x$` is **not** supported. It exists only to reproduce the crypt_blowfish sign-extension bug, which
+this library does not emulate, so hashing or verifying a `$2x$` hash throws `NotSupportedException`
+rather than silently mis-verifying passwords that contain non-ASCII characters. `ParseHash` still
+reads `$2x$` hashes so you can find them in an existing database and re-hash those passwords.
 
 BCrypt processes passwords as UTF-8 and uses at most 72 bytes.

--- a/tests/Meziantou.Framework.Bcrypt.Tests/BcryptTests.cs
+++ b/tests/Meziantou.Framework.Bcrypt.Tests/BcryptTests.cs
@@ -48,7 +48,6 @@ public sealed class BcryptTests
     [Theory]
     [InlineData(BcryptVersion.Revision2A, "$2a$")]
     [InlineData(BcryptVersion.Revision2B, "$2b$")]
-    [InlineData(BcryptVersion.Revision2X, "$2x$")]
     [InlineData(BcryptVersion.Revision2Y, "$2y$")]
     public void HashPassword_WithRevision_GeneratesExpectedPrefix(BcryptVersion version, string expectedPrefix)
     {
@@ -94,12 +93,35 @@ public sealed class BcryptTests
     }
 
     [Theory]
-    [InlineData("a", "$2x$12$DB3BUbYa/SsEL7kCOVji0OauTkPkB5Y1OeyfxJHM7jvMrbml5sgD2")]
     [InlineData("a", "$2y$12$DB3BUbYa/SsEL7kCOVji0OauTkPkB5Y1OeyfxJHM7jvMrbml5sgD2")]
     [InlineData("a", "$2b$12$DB3BUbYa/SsEL7kCOVji0OauTkPkB5Y1OeyfxJHM7jvMrbml5sgD2")]
     public void Verify_KnownHash_WithDifferentPrefixes(string password, string hash)
     {
         Assert.True(Bcrypt.Verify(password, hash));
+    }
+
+    [Fact]
+    public void Revision2X_IsRejectedEverywhereItWouldProduceAWrongResult()
+    {
+        const string Hash2X = "$2x$12$DB3BUbYa/SsEL7kCOVji0OauTkPkB5Y1OeyfxJHM7jvMrbml5sgD2";
+        const string Salt2X = "$2x$12$DB3BUbYa/SsEL7kCOVji0Oau";
+
+        Assert.Throws<NotSupportedException>(() => Bcrypt.GenerateSalt(12, BcryptVersion.Revision2X));
+        Assert.Throws<NotSupportedException>(() => Bcrypt.HashPassword("a", workFactor: 12, BcryptVersion.Revision2X));
+        Assert.Throws<NotSupportedException>(() => Bcrypt.HashPassword("a", Salt2X));
+        Assert.Throws<NotSupportedException>(() => Bcrypt.Verify("a", Hash2X));
+        Assert.Throws<NotSupportedException>(() => Bcrypt.Verify("a".AsSpan(), Hash2X.AsSpan()));
+    }
+
+    [Fact]
+    public void Revision2X_RemainsParseableSoExistingHashesCanBeFound()
+    {
+        const string Hash2X = "$2x$12$DB3BUbYa/SsEL7kCOVji0OauTkPkB5Y1OeyfxJHM7jvMrbml5sgD2";
+
+        Assert.True(Bcrypt.TryParseHash(Hash2X, out var info));
+        Assert.Equal(BcryptVersion.Revision2X, info.Version);
+        Assert.Equal(12, info.WorkFactor);
+        Assert.True(Bcrypt.NeedsRehash(Hash2X, workFactor: 12, version: BcryptVersion.Revision2B));
     }
 
     [Fact]


### PR DESCRIPTION
Independent · merges into `main` · no ordering constraint

> ⚠️ This is a **deliberate behaviour change**: `$2x$` goes from silently working (incorrectly) to
> throwing. See "Why fail loudly" below — happy to reconsider if you'd rather keep it lenient.

## Finding

The revision character only chose whether to append a NUL terminator, so **all four revisions ran the
identical algorithm**. Verified with a fixed salt and a password containing bytes with the high bit
set (`"ÿÿabc"`, UTF-8 `C3 BF C3 BF …`):

```
$2a$06$DCq7YPn5Rq63x1Lad4cll.S9jC2spwzNI7PcmNIQy0l4k5cWnzXzW
$2b$06$DCq7YPn5Rq63x1Lad4cll.S9jC2spwzNI7PcmNIQy0l4k5cWnzXzW
$2x$06$DCq7YPn5Rq63x1Lad4cll.S9jC2spwzNI7PcmNIQy0l4k5cWnzXzW
$2y$06$DCq7YPn5Rq63x1Lad4cll.S9jC2spwzNI7PcmNIQy0l4k5cWnzXzW
```

Byte-identical digests. `$2a$` ≡ `$2b$` **is** correct — they diverge only above 255 bytes, which
bcrypt truncates away at 72 — and `$2y$` ≡ `$2b$` is correct too. `$2x$` is the one that must differ:
it exists solely to reproduce the crypt_blowfish sign-extension bug for bytes with the high bit set.

Both directions were wrong:

- **Verifying** a real `$2x$` hash migrated from a PHP database returned `false` for the correct
  password whenever it contained a non-ASCII character — a silent, unexplainable lockout for exactly
  the accounts a `$2x$` corpus exists to serve.
- **Generating** with `BcryptVersion.Revision2X` emitted a hash *labelled* `$2x$` that PHP's
  `password_verify` rejects for those same passwords. The library manufactured broken hashes.

The existing test `Verify_KnownHash_WithDifferentPrefixes` covered `$2x$` but used the password
`"a"` — pure ASCII, so it could not detect the difference.

## Why fail loudly rather than emulate

Emulating the bug is the complete fix, but it adds a second key-setup path to the crypto core with no
reference vectors available in this repo to validate it against. Silently returning `false` from
`Verify` is not an option either — that *is* the lockout bug. So `$2x$` now throws.

## Changes

- `GenerateSalt` / `HashPassword` throw `NotSupportedException` for `BcryptVersion.Revision2X`,
  matching how `BcryptVersion.Revision2` is already handled.
- `HashPassword` and `Verify` throw `NotSupportedException` for a `$2x$` salt or hash.
- **`ParseHash` / `TryParseHash` still read `$2x$` hashes** — that is how you find them in an existing
  database in order to re-hash those passwords. `NeedsRehash` correctly reports `true` for them.
- `readme.md` no longer lists `2x` as supported, notes that `2y` is identical to `2b`, and explains
  the migration path.
- `BcryptVersion.Revision2X` stays in the enum, so this is source- and binary-compatible;
  `ref/Meziantou.Framework.Bcrypt.cs` is unchanged.

## Verification

- `dotnet test -p:TreatWarningsAsErrors=true` — 104 passed, 0 failed (52 × net10.0/net11.0).
- `dotnet run ./eng/update-all.cs` — no generated files changed.
