### PR TITLE
Stop the converter from assuming char when it is not told the described type

### DIFF
--- a/src/Meziantou.Framework.SensitiveData/SensitiveDataTypeConverter.cs
+++ b/src/Meziantou.Framework.SensitiveData/SensitiveDataTypeConverter.cs
@@ -5,10 +5,12 @@ namespace Meziantou.Framework;
 [SuppressMessage("Usage", "CA1812:Avoid uninstantiated internal classes", Justification = "Instantiated dynamically")]
 internal sealed class SensitiveDataTypeConverter : TypeConverter
 {
-    private readonly Type _type;
+    private readonly Type? _type;
 
+    // Used when the converter is activated without the type it describes. There is nothing to
+    // identify the element type with, so assuming SensitiveData<char> would hand a caller asking
+    // about SensitiveData<byte> an instance of the wrong type; refuse instead.
     public SensitiveDataTypeConverter()
-        : this(typeof(SensitiveData<char>))
     {
     }
 
@@ -43,7 +45,11 @@ internal sealed class SensitiveDataTypeConverter : TypeConverter
         if (value is string str)
         {
             if (!IsSupportedType)
-                throw new NotSupportedException($"Cannot convert a string to '{_type}'. Only '{typeof(SensitiveData<char>)}' can be created from a string.");
+            {
+                throw new NotSupportedException(_type is null
+                    ? $"Cannot convert a string without knowing the type being described. Only '{typeof(SensitiveData<char>)}' can be created from a string."
+                    : $"Cannot convert a string to '{_type}'. Only '{typeof(SensitiveData<char>)}' can be created from a string.");
+            }
 
             return SensitiveData.Create(str);
         }

--- a/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
+++ b/tests/Meziantou.Framework.SensitiveData.Tests/SensitiveDataTests.cs
@@ -158,6 +158,15 @@ public sealed class SensitiveDataTests
     }
 
     [Fact]
+    public void ConverterActivatedWithoutADescribedType_RefusesToGuessTheElementType()
+    {
+        var converter = new SensitiveDataTypeConverter();
+
+        Assert.False(converter.CanConvertFrom(typeof(string)));
+        Assert.Throws<NotSupportedException>(() => converter.ConvertFromString("bar"));
+    }
+
+    [Fact]
     public void CannotConvertFromStringToNonCharElementType()
     {
         var converter = TypeDescriptor.GetConverter(typeof(SensitiveData<byte>));


### PR DESCRIPTION
## The problem

`TypeConverterAttribute` is declared on the open generic `SensitiveData<T>`, and
[#1992](https://github.com/meziantou/Meziantou.Framework/pull/1992) added the `(Type)` constructor so
the converter can tell one construction from another. But the parameterless constructor was left
hardcoding the answer:

```csharp
public SensitiveDataTypeConverter()
    : this(typeof(SensitiveData<char>))
{
}
```

Any host that activates the converter without passing the type it describes - `Activator.CreateInstance`
on the attribute's converter type is the usual way - gets a converter that claims
`CanConvertFrom(string) == true` for `SensitiveData<byte>` and returns a `SensitiveData<char>` from
`ConvertFrom`. The caller then gets an `InvalidCastException` at the assignment, rather than the
clean `NotSupportedException` that `CannotConvertFromStringToNonCharElementType` verifies for the
`TypeDescriptor` route.

This is a latent trap rather than a live bug: `TypeDescriptor` prefers the `(Type)` overload, and
that is how essentially everyone reaches this converter. The existing `CanConvertFromString` test
still passing is what confirms that path is unaffected.

## The change

The parameterless constructor leaves `_type` as `null` instead of guessing, which makes
`IsSupportedType` false, so the converter reports it cannot convert and refuses with
`NotSupportedException` if called anyway. `_type` becomes `Type?` and the `ConvertFrom` message gets
a variant for the "no described type" case, since interpolating a null type into the old message
would have produced an empty string where a type name belongs.

Refusing seemed better than removing the constructor: `TypeConverter` activation paths generally
expect a parameterless constructor to exist, and a converter that declines is easier to diagnose than
a `MissingMethodException`.

## Verification

50/50 pass (25 tests x net10.0 + net11.0). One test added, constructing the converter directly and
asserting it declines both `CanConvertFrom` and `ConvertFromString`. The two existing converter tests
are untouched and still pass, which is the evidence that the `TypeDescriptor` path still resolves the
`(Type)` constructor.
