### PR TITLE
Throw UnreachableException instead of FailFast when heap creation fails

### DIFF
--- a/src/Meziantou.Framework.SensitiveData/WindowsHeap.cs
+++ b/src/Meziantou.Framework.SensitiveData/WindowsHeap.cs
@@ -82,7 +82,6 @@ internal static partial class WindowsHeap
         if (hHeap == IntPtr.Zero)
         {
             Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
-            Environment.FailFast("Couldn't get heap information.");
         }
 
         return hHeap;

--- a/src/Meziantou.Framework.SensitiveData/WindowsHeap.cs
+++ b/src/Meziantou.Framework.SensitiveData/WindowsHeap.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Windows.Win32;
@@ -81,7 +82,11 @@ internal static partial class WindowsHeap
         var hHeap = (IntPtr.Size == 8) ? PInvoke.HeapCreate((HEAP_FLAGS)0, 0, 0) : PInvoke.GetProcessHeap();
         if (hHeap == IntPtr.Zero)
         {
+            // GetHRForLastWin32Error returns 0x80070000 | lastError, which is negative as an int even
+            // when lastError is 0, so ThrowExceptionForHR always throws. It is not annotated
+            // [DoesNotReturn], so say out loud that returning a null heap handle cannot happen.
             Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+            throw new UnreachableException();
         }
 
         return hHeap;


### PR DESCRIPTION
## The problem

```csharp
if (hHeap == IntPtr.Zero)
{
    Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
    Environment.FailFast("Couldn't get heap information.");
}
```

`Marshal.GetHRForLastWin32Error()` returns `0x80070000 | lastError`, which is negative as an `int`
even when `lastError` is `0`. So `ThrowExceptionForHR` always throws and the `FailFast` can never
run. The compiler does not flag it because `ThrowExceptionForHR` is not annotated `[DoesNotReturn]`.

It reads as a deliberate second line of defence, which makes it worse than plain dead code - someone
maintaining this has to work out whether the `FailFast` is load-bearing before touching the line
above it. Killing the process on a heap-creation failure is also a heavy response to something the
line above already turned into an exception.

## The change

Replace the `FailFast` with `throw new UnreachableException()`, per review feedback. Deleting it
outright was the first version of this PR; keeping a statement there is better, because the guard is
doing something real - it states that falling through with a null heap handle is impossible, and it
does it in the form the language has for exactly that. If `ThrowExceptionForHR`'s behaviour ever
changed, the result is a clear exception at the point of the wrong assumption rather than a null
handle propagating into `HeapAlloc`.

A comment records *why* the line below is unreachable, so the next reader does not have to re-derive
the `0x80070000 | lastError` argument.

Needs `using System.Diagnostics;` - `UnreachableException` is not in this project's global usings.

## Verification

Builds clean with warnings as errors on both target frameworks. This is a Windows-only file behind
`[SupportedOSPlatform("windows")]` and the statement is unreachable by construction, so there is no
behaviour to test - the compiler is the whole verification here.
