### PR TITLE
Name the platforms that fall back to the XOR protection

### DIFF
--- a/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
+++ b/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
@@ -177,8 +177,12 @@ public static partial class SensitiveData
 /// taken while the buffer is unprotected contains them in clear.
 /// </description></item>
 /// <item><description>
-/// Other platforms: the buffer is combined with a random key of the same length. The key lives in the same
-/// process, so this only guards against casual inspection.
+/// Every other platform, which includes Android, iOS, tvOS, Mac Catalyst, FreeBSD and WebAssembly: the buffer
+/// is combined with a random key of the same length. The key lives in the same process, so this only guards
+/// against casual inspection. Note that <c>OperatingSystem.IsLinux()</c> returns <see langword="false"/> on
+/// Android and <c>OperatingSystem.IsMacOS()</c> returns <see langword="false"/> on iOS and Mac Catalyst, so
+/// those platforms take this path rather than the <c>mmap</c> one above even though they support the syscalls
+/// it uses.
 /// </description></item>
 /// </list>
 /// <para>


### PR DESCRIPTION
## The problem

The `<remarks>` on `SensitiveData<T>` described the fallback as applying to "Other platforms", which
reads like an exotic long tail. It is not. The branch selection is
`IsWindows()` -> `IsLinux() || IsMacOS()` -> else XOR, and:

- `OperatingSystem.IsLinux()` returns `false` on Android
- `OperatingSystem.IsMacOS()` returns `false` on iOS, tvOS and Mac Catalyst

So every Apple mobile platform, every Android target, WebAssembly and the BSDs get XOR-with-an-
in-process-key - a speed bump against casual inspection - while the documentation invites a mobile
developer to assume they are in the `mprotect` bucket alongside macOS.

## The change

Documentation only. The third bullet now names the platforms that actually land there and explains
*why* they do, so the `OperatingSystem` behaviour that causes it is discoverable from the doc rather
than only from reading `Allocate`.

## Scope

This deliberately documents the current behaviour rather than changing it. Android and iOS do support
`mmap`/`mprotect`, so widening the Unix branch to cover them is arguable - but there is no CI leg for
any of those platforms in this repo, `mlock` behaves differently under the iOS sandbox, and it would
be a behaviour change merged on reading alone. That is a design call to make separately; this PR just
stops the docs from being misleading in the meantime.

## Verification

Builds clean with warnings as errors on both target frameworks. No code changes, no test changes.
