### PR TITLE
Document what RevealInto returns

### DIFF
--- a/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
+++ b/src/Meziantou.Framework.SensitiveData/SensitiveData.cs
@@ -256,6 +256,7 @@ public sealed unsafe class SensitiveData<T> : IDisposable
     /// Copies the contents of this <see cref="SensitiveData{T}"/> instance to a destination buffer.
     /// </summary>
     /// <param name="destination">The destination buffer which should receive the contents. This buffer must be at least <see cref="GetLength"/> elements in length.</param>
+    /// <returns>The number of elements written to <paramref name="destination"/>, which is always <see cref="GetLength"/>. A larger destination is left untouched past that point.</returns>
     /// <exception cref="ArgumentException"><paramref name="destination"/>'s length is smaller than <see cref="GetLength"/>.</exception>
     /// <exception cref="ObjectDisposedException">This instance has already been disposed.</exception>
     public int RevealInto(Span<T> destination)


### PR DESCRIPTION
## The problem

`RevealInto` returns an `int`, but its documentation block had `<summary>`, `<param>` and two
`<exception>` tags and no `<returns>`. IntelliSense showed an unexplained return value, which a
caller can reasonably read as "number of elements written" in a partial-copy sense - the same number
here, but only because the copy is always complete.

## The change

Documentation only. Adds `<returns>` stating that the value is always `GetLength()`, and that a
larger destination is left untouched past that point - which is the part that was genuinely
ambiguous, since the method neither clears nor reports anything about the tail of an oversized
buffer.

## Verification

Builds clean with warnings as errors on both target frameworks. No code changes, no test changes.
