### PR TITLE
Restrict the '/' rule to Path.Combine and keep side-effecting arguments

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/PathCombineWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathCombineWithFullPathAnalyzer.cs
@@ -11,7 +11,7 @@ public sealed class PathCombineWithFullPathAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathCombineWithFullPathDiagnosticId,
-        title: "Use '/' operator instead of Path.Combine or Path.Join",
+        title: "Use '/' operator instead of Path.Combine",
         messageFormat: "Use FullPath '/' operations instead of calling Path.{0}",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,
@@ -36,7 +36,9 @@ public sealed class PathCombineWithFullPathAnalyzer : DiagnosticAnalyzer
     private static void Analyze(OperationAnalysisContext context, FullPathContext analyzerContext)
     {
         var invocationOperation = (IInvocationOperation)context.Operation;
-        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" or "Join" } targetMethod)
+        // Path.Join is deliberately NOT included: it concatenates unconditionally, while the '/' operator
+        // (like Path.Combine) discards everything before a rooted segment
+        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" } targetMethod)
             return;
 
         if (!SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, analyzerContext.PathType))

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathCombineWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathCombineWithFullPathCodeFixProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Meziantou.Framework.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -79,7 +80,7 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
         out ExpressionSyntax replacementExpression)
     {
         if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is not IInvocationOperation invocationOperation ||
-            invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" or "Join" } targetMethod ||
+            invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" } targetMethod ||
             !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) ||
             invocationOperation.Arguments.Length == 0)
         {
@@ -103,6 +104,17 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
             return false;
         }
 
+        // Arguments before the FullPath are discarded by the rewrite, because Path.Combine already discards
+        // everything before a rooted segment. Dropping them is only safe when evaluating them does nothing.
+        for (var i = 0; i < fullPathIndex; i++)
+        {
+            if (!IsSideEffectFree(invocationOperation.Arguments[i].Value))
+            {
+                replacementExpression = null!;
+                return false;
+            }
+        }
+
         var startOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[fullPathIndex].Value, fullPathType);
         if (startOperation.Syntax is not ExpressionSyntax expression)
         {
@@ -124,5 +136,17 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
         }
 
         return true;
+    }
+
+    /// <summary>Reports whether evaluating the operation can be skipped without changing the program.</summary>
+    private static bool IsSideEffectFree(IOperation operation)
+    {
+        return operation.UnwrapImplicitConversions() switch
+        {
+            ILiteralOperation or INameOfOperation or IDefaultValueOperation => true,
+            ILocalReferenceOperation or IParameterReferenceOperation => true,
+            IFieldReferenceOperation { Instance: var instance } => instance is null || IsSideEffectFree(instance),
+            _ => false,
+        };
     }
 }

--- a/src/Meziantou.Framework.FullPath/readme.md
+++ b/src/Meziantou.Framework.FullPath/readme.md
@@ -55,7 +55,7 @@ System.IO.File.WriteAllText(filePath, content);
 | `MFFP0001` | FullPath | Use FullPath directly instead of Path.GetFullPath | Info | ✔️ |
 | `MFFP0002` | FullPath | Use the right FullPath operand directly | Info | ✔️ |
 | `MFFP0003` | FullPath | Use '/' with a FullPath base instead of Path.GetFullPath | Info | ✔️ |
-| `MFFP0004` | FullPath | Use '/' operator instead of Path.Combine or Path.Join | Info | ✔️ |
+| `MFFP0004` | FullPath | Use '/' operator instead of Path.Combine | Info | ✔️ |
 | `MFFP0005` | FullPath | Use FullPath.Name instead of Path.GetFileName | Info | ✔️ |
 | `MFFP0006` | FullPath | Use FullPath.NameWithoutExtension instead of Path.GetFileNameWithoutExtension | Info | ✔️ |
 | `MFFP0007` | FullPath | Use FullPath.Extension instead of Path.GetExtension | Info | ✔️ |

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathCombineWithFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathCombineWithFullPathRuleTests.cs
@@ -120,7 +120,7 @@ public sealed class PathCombineWithFullPathRuleTests : FullPathAnalyzerTestBase
     }
 
     [Fact]
-    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForPathJoinWithFullPath()
+    public async Task Analyzer_DoesNotReportDiagnostic_ForPathJoinWithFullPath()
     {
         var source = """
             using System.IO;
@@ -132,29 +132,13 @@ public sealed class PathCombineWithFullPathRuleTests : FullPathAnalyzerTestBase
                 {
                     public static string M(FullPath fullPath)
                     {
-                        return {|MFFP0004:Path.Join(fullPath, "value1", "value2")|};
+                        return Path.Join(fullPath, "value1", "value2");
                     }
                 }
             }
             """;
 
-        var fixedSource = """
-            using System.IO;
-            using Meziantou.Framework;
-
-            namespace Sample
-            {
-                public static class TestClass
-                {
-                    public static string M(FullPath fullPath)
-                    {
-                        return fullPath / "value1" / "value2";
-                    }
-                }
-            }
-            """;
-
-        await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+        await CreateAnalyzerTest<PathCombineWithFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
 
     [Fact]
@@ -273,5 +257,29 @@ public sealed class PathCombineWithFullPathRuleTests : FullPathAnalyzerTestBase
             """;
 
         await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotOfferCodeFix_WhenADiscardedArgumentHasSideEffects()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string GetBaseDirectory() => "base";
+
+                    public static string M(FullPath fullPath)
+                    {
+                        return {|MFFP0004:Path.Combine(GetBaseDirectory(), fullPath, "value")|};
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, source).RunAsync(XunitCancellationToken);
     }
 }


### PR DESCRIPTION
Two problems in MFFP0004, which rewrites `Path.Combine(fullPath, "a")` to `fullPath / "a"`.

### Path.Join was treated as Path.Combine

Both the analyzer and the fix matched `Name: "Combine" or "Join"`. `Path.Join` concatenates unconditionally; `Path.Combine` — and therefore `/` — discards everything before a rooted segment. The fix rebuilt the expression starting at the **last** FullPath argument, which is right for `Combine` and wrong for `Join`:

```csharp
Path.Join(baseDir, fullPath, "x")   // baseDir + "/" + fullPath + "/x"
fullPath / "x"                      // baseDir is gone
```

The mirror case matters more, because it can turn a contained join into an absolute-path escape:

```csharp
Path.Join(root, segment)   // root + "/" + segment, even when segment is rooted
root / segment             // just segment, when segment is rooted
```

`/` cannot express `Join` semantics at all, so `Join` is dropped from the rule rather than given a different fix. Same conclusion as #2340 for MFFP0019.

### Discarded arguments were evaluated for their side effects

Arguments before the FullPath are deleted by the rewrite. That is sound for pure operands — `Path.Combine("a", "b", fullPath)` really does equal `fullPath` for a rooted path, and that behaviour is kept. It is not sound when evaluating them does something:

```csharp
Path.Combine(GetBaseDirectory(), fullPath, "value")
fullPath / "value"     // GetBaseDirectory() never runs
```

The fix is now withheld unless every discarded argument is a literal, `nameof`, `default`, a local, a parameter, or a field. The diagnostic still reports; only the automatic rewrite steps back.

## Not addressed here

`Path.Combine(baseDir, root, "file.txt")` with `root` = `FullPath.Empty` still rewrites to `root / "file.txt"`, which resolves against the current directory instead of `baseDir`. Fixing that means either refusing the fix whenever the FullPath cannot be proven non-empty — which would also disable the deliberate `Analyzer_ReportDiagnostic_AndCodeFix_ForPathCombineWithFullPathLast` case — or changing `FullPath.Combine`'s empty-root branch. That is a design decision, so it is left alone rather than resolved unilaterally.

## Verification

The `Path.Join` test becomes a negative test, and a new test asserts no rewrite is offered when a discarded argument is a method call. Every other existing MFFP0004 test is unchanged and still green, including the FullPath-last case. Full analyzer suite green at 110 tests. Descriptor title updated and `src/Meziantou.Framework.FullPath/readme.md` regenerated via `dotnet run ./eng/update-all.cs`.

## Stack

Layer 2 of 3, targeting `fix/parenthesize-generated-syntax` (#2344). Merge #2344 first.
