### PR TITLE
Use CryptographicOperations.FixedTimeEquals for hash comparison

### DIFF
--- a/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs
+++ b/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 
 namespace Meziantou.Framework;
@@ -259,7 +258,7 @@ internal sealed class BcryptImplementation
     {
         var hashBytes = Utf8.GetBytes(hash);
         var computedHashBytes = Utf8.GetBytes(HashPassword(password, hash));
-        return SecureEquals(hashBytes, computedHashBytes);
+        return CryptographicOperations.FixedTimeEquals(hashBytes, computedHashBytes);
     }
 
     private static string HashBytes(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<char> extractedSalt, char minorRevision, int workFactor)
@@ -281,21 +280,6 @@ internal sealed class BcryptImplementation
         result.Append(EncodeBase64(hashed, (BfCryptCiphertext.Length * 4) - 1));
 
         return result.ToString();
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-    private static bool SecureEquals(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
-    {
-        if (left.Length != right.Length)
-            return false;
-
-        var diff = 0;
-        for (var i = 0; i < left.Length; i++)
-        {
-            diff |= left[i] ^ right[i];
-        }
-
-        return diff == 0;
     }
 
     // BCrypt uses its own Base64 variant ("./A-Za-z0-9") with no '=' padding.


### PR DESCRIPTION
Independent · merges into `main` · no ordering constraint

## Finding

`SecureEquals` reimplemented a constant-time comparison and relied on
`MethodImplOptions.NoOptimization` to keep it constant-time:

```csharp
[MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
private static bool SecureEquals(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
```

The logic is correct, but that attribute constrains the JIT, not the CPU, and nothing enforces that it
stays applied if the method is later edited. `CryptographicOperations.FixedTimeEquals` is the BCL
primitive for exactly this job — hardened and maintained for it.

To be clear about severity: this is a **hardening/maintainability** change, not a live vulnerability.
The existing implementation is not known to leak.

## Changes

- `Verify` uses `CryptographicOperations.FixedTimeEquals`.
- `SecureEquals` and the now-unused `System.Runtime.CompilerServices` using directive are removed.

Semantics are identical: `SecureEquals` returned `false` for differing lengths, which
`FixedTimeEquals` also does.

## Verification

- `dotnet test -p:TreatWarningsAsErrors=true` — 104 passed, 0 failed (52 × net10.0/net11.0).
- `dotnet run ./eng/update-all.cs` — no generated files changed.
