### PR TITLE
Do not offer the FullPath rewrite where the result is used as a string

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/PathCombineWithFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/PathCombineWithFullPathAnalyzer.cs
@@ -11,7 +11,7 @@ public sealed class PathCombineWithFullPathAnalyzer : DiagnosticAnalyzer
 {
     public static readonly DiagnosticDescriptor Descriptor = new(
         id: FullPathAnalyzerCommon.PathCombineWithFullPathDiagnosticId,
-        title: "Use '/' operator instead of Path.Combine or Path.Join",
+        title: "Use '/' operator instead of Path.Combine",
         messageFormat: "Use FullPath '/' operations instead of calling Path.{0}",
         category: "FullPath",
         defaultSeverity: DiagnosticSeverity.Info,
@@ -36,7 +36,9 @@ public sealed class PathCombineWithFullPathAnalyzer : DiagnosticAnalyzer
     private static void Analyze(OperationAnalysisContext context, FullPathContext analyzerContext)
     {
         var invocationOperation = (IInvocationOperation)context.Operation;
-        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" or "Join" } targetMethod)
+        // Path.Join is deliberately NOT included: it concatenates unconditionally, while the '/' operator
+        // (like Path.Combine) discards everything before a rooted segment
+        if (invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" } targetMethod)
             return;
 
         if (!SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, analyzerContext.PathType))

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathCombineWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathCombineWithFullPathCodeFixProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Meziantou.Framework.Roslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -79,7 +80,7 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
         out ExpressionSyntax replacementExpression)
     {
         if (semanticModel.GetOperation(expressionSyntax, cancellationToken) is not IInvocationOperation invocationOperation ||
-            invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" or "Join" } targetMethod ||
+            invocationOperation.TargetMethod is not { IsStatic: true, Name: "Combine" } targetMethod ||
             !SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) ||
             invocationOperation.Arguments.Length == 0)
         {
@@ -103,6 +104,17 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
             return false;
         }
 
+        // Arguments before the FullPath are discarded by the rewrite, because Path.Combine already discards
+        // everything before a rooted segment. Dropping them is only safe when evaluating them does nothing.
+        for (var i = 0; i < fullPathIndex; i++)
+        {
+            if (!IsSideEffectFree(invocationOperation.Arguments[i].Value))
+            {
+                replacementExpression = null!;
+                return false;
+            }
+        }
+
         var startOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[fullPathIndex].Value, fullPathType);
         if (startOperation.Syntax is not ExpressionSyntax expression)
         {
@@ -124,5 +136,17 @@ public sealed class PathCombineWithFullPathCodeFixProvider : CodeFixProvider
         }
 
         return true;
+    }
+
+    /// <summary>Reports whether evaluating the operation can be skipped without changing the program.</summary>
+    private static bool IsSideEffectFree(IOperation operation)
+    {
+        return operation.UnwrapImplicitConversions() switch
+        {
+            ILiteralOperation or INameOfOperation or IDefaultValueOperation => true,
+            ILocalReferenceOperation or IParameterReferenceOperation => true,
+            IFieldReferenceOperation { Instance: var instance } => instance is null || IsSideEffectFree(instance),
+            _ => false,
+        };
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetDirectoryNameWithFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetDirectoryNameWithFullPathCodeFixProvider.cs
@@ -83,6 +83,12 @@ public sealed class PathGetDirectoryNameWithFullPathCodeFixProvider : CodeFixPro
             SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) &&
             invocationOperation.Arguments.Length == 1)
         {
+            if (!ResultStaysCompilable(invocationOperation))
+            {
+                replacementExpression = null!;
+                return false;
+            }
+
             var fullPathOperation = FullPathAnalyzerCommon.UnwrapToFullPath(invocationOperation.Arguments[0].Value, fullPathType);
             if (SymbolEqualityComparer.Default.Equals(fullPathOperation.Type, fullPathType) &&
                 fullPathOperation.Syntax is ExpressionSyntax fullPathExpression)
@@ -97,5 +103,30 @@ public sealed class PathGetDirectoryNameWithFullPathCodeFixProvider : CodeFixPro
 
         replacementExpression = null!;
         return false;
+    }
+
+    /// <summary>
+    /// Reports whether replacing the invocation with a FullPath-typed expression leaves the surrounding code valid.
+    /// </summary>
+    /// <remarks>
+    /// FullPath converts implicitly to string, so a string-typed slot keeps compiling. A receiver position does not,
+    /// because the members being invoked belong to string, and a 'var' initializer would change the inferred type.
+    /// </remarks>
+    private static bool ResultStaysCompilable(IOperation operation)
+    {
+        var current = operation;
+        while (current.Parent is IConversionOperation { IsImplicit: true } conversionOperation)
+        {
+            current = conversionOperation;
+        }
+
+        return current.Parent switch
+        {
+            IInvocationOperation invocationOperation => invocationOperation.Instance != current,
+            IPropertyReferenceOperation propertyReferenceOperation => propertyReferenceOperation.Instance != current,
+            IArrayElementReferenceOperation arrayElementReferenceOperation => arrayElementReferenceOperation.ArrayReference != current,
+            IVariableInitializerOperation { Syntax.Parent: VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax { Type.IsVar: true } } } => false,
+            _ => true,
+        };
     }
 }

--- a/src/Meziantou.Framework.FullPath.CodeFix/PathGetFullPathOnFullPathCodeFixProvider.cs
+++ b/src/Meziantou.Framework.FullPath.CodeFix/PathGetFullPathOnFullPathCodeFixProvider.cs
@@ -82,6 +82,12 @@ public sealed class PathGetFullPathOnFullPathCodeFixProvider : CodeFixProvider
             SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, pathType) &&
             invocationOperation.Arguments.Length >= 1)
         {
+            if (!ResultStaysCompilable(invocationOperation))
+            {
+                replacementExpression = null!;
+                return false;
+            }
+
             var argument = invocationOperation.Arguments[0].Value;
             if (SymbolEqualityComparer.Default.Equals(FullPathAnalyzerCommon.UnwrapToFullPath(argument, fullPathType).Type, fullPathType) &&
                 argument.Syntax is ExpressionSyntax fullPathExpression)
@@ -93,5 +99,30 @@ public sealed class PathGetFullPathOnFullPathCodeFixProvider : CodeFixProvider
 
         replacementExpression = null!;
         return false;
+    }
+
+    /// <summary>
+    /// Reports whether replacing the invocation with a FullPath-typed expression leaves the surrounding code valid.
+    /// </summary>
+    /// <remarks>
+    /// FullPath converts implicitly to string, so a string-typed slot keeps compiling. A receiver position does not,
+    /// because the members being invoked belong to string, and a 'var' initializer would change the inferred type.
+    /// </remarks>
+    private static bool ResultStaysCompilable(IOperation operation)
+    {
+        var current = operation;
+        while (current.Parent is IConversionOperation { IsImplicit: true } conversionOperation)
+        {
+            current = conversionOperation;
+        }
+
+        return current.Parent switch
+        {
+            IInvocationOperation invocationOperation => invocationOperation.Instance != current,
+            IPropertyReferenceOperation propertyReferenceOperation => propertyReferenceOperation.Instance != current,
+            IArrayElementReferenceOperation arrayElementReferenceOperation => arrayElementReferenceOperation.ArrayReference != current,
+            IVariableInitializerOperation { Syntax.Parent: VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax { Type.IsVar: true } } } => false,
+            _ => true,
+        };
     }
 }

--- a/src/Meziantou.Framework.FullPath/readme.md
+++ b/src/Meziantou.Framework.FullPath/readme.md
@@ -55,7 +55,7 @@ System.IO.File.WriteAllText(filePath, content);
 | `MFFP0001` | FullPath | Use FullPath directly instead of Path.GetFullPath | Info | ✔️ |
 | `MFFP0002` | FullPath | Use the right FullPath operand directly | Info | ✔️ |
 | `MFFP0003` | FullPath | Use '/' with a FullPath base instead of Path.GetFullPath | Info | ✔️ |
-| `MFFP0004` | FullPath | Use '/' operator instead of Path.Combine or Path.Join | Info | ✔️ |
+| `MFFP0004` | FullPath | Use '/' operator instead of Path.Combine | Info | ✔️ |
 | `MFFP0005` | FullPath | Use FullPath.Name instead of Path.GetFileName | Info | ✔️ |
 | `MFFP0006` | FullPath | Use FullPath.NameWithoutExtension instead of Path.GetFileNameWithoutExtension | Info | ✔️ |
 | `MFFP0007` | FullPath | Use FullPath.Extension instead of Path.GetExtension | Info | ✔️ |

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathCombineWithFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathCombineWithFullPathRuleTests.cs
@@ -120,7 +120,7 @@ public sealed class PathCombineWithFullPathRuleTests : FullPathAnalyzerTestBase
     }
 
     [Fact]
-    public async Task Analyzer_ReportDiagnostic_AndCodeFix_ForPathJoinWithFullPath()
+    public async Task Analyzer_DoesNotReportDiagnostic_ForPathJoinWithFullPath()
     {
         var source = """
             using System.IO;
@@ -132,29 +132,13 @@ public sealed class PathCombineWithFullPathRuleTests : FullPathAnalyzerTestBase
                 {
                     public static string M(FullPath fullPath)
                     {
-                        return {|MFFP0004:Path.Join(fullPath, "value1", "value2")|};
+                        return Path.Join(fullPath, "value1", "value2");
                     }
                 }
             }
             """;
 
-        var fixedSource = """
-            using System.IO;
-            using Meziantou.Framework;
-
-            namespace Sample
-            {
-                public static class TestClass
-                {
-                    public static string M(FullPath fullPath)
-                    {
-                        return fullPath / "value1" / "value2";
-                    }
-                }
-            }
-            """;
-
-        await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+        await CreateAnalyzerTest<PathCombineWithFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
 
     [Fact]
@@ -273,5 +257,29 @@ public sealed class PathCombineWithFullPathRuleTests : FullPathAnalyzerTestBase
             """;
 
         await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, fixedSource).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotOfferCodeFix_WhenADiscardedArgumentHasSideEffects()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string GetBaseDirectory() => "base";
+
+                    public static string M(FullPath fullPath)
+                    {
+                        return {|MFFP0004:Path.Combine(GetBaseDirectory(), fullPath, "value")|};
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathCombineWithFullPathAnalyzerType, PathCombineWithFullPathCodeFixProviderType>(source, source).RunAsync(XunitCancellationToken);
     }
 }

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathGetDirectoryNameWithFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathGetDirectoryNameWithFullPathRuleTests.cs
@@ -63,4 +63,49 @@ public sealed class PathGetDirectoryNameWithFullPathRuleTests : FullPathAnalyzer
 
         await CreateAnalyzerTest<PathGetDirectoryNameWithFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_DoesNotOfferCodeFix_WhenTheResultIsAStringReceiver()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static int M(FullPath fullPath)
+                    {
+                        return {|MFFP0008:Path.GetDirectoryName(fullPath)|}.Length;
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathGetDirectoryNameWithFullPathAnalyzerType, PathGetDirectoryNameWithFullPathCodeFixProviderType>(source, source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotOfferCodeFix_WhenTheResultInitializesAVar()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        var directory = {|MFFP0008:Path.GetDirectoryName(fullPath)|};
+                        return directory.Replace('a', 'b');
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathGetDirectoryNameWithFullPathAnalyzerType, PathGetDirectoryNameWithFullPathCodeFixProviderType>(source, source).RunAsync(XunitCancellationToken);
+    }
 }

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathGetFullPathOnFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/PathGetFullPathOnFullPathRuleTests.cs
@@ -63,4 +63,27 @@ public sealed class PathGetFullPathOnFullPathRuleTests : FullPathAnalyzerTestBas
 
         await CreateAnalyzerTest<PathGetFullPathOnFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_DoesNotOfferCodeFix_WhenTheResultIsAStringReceiver()
+    {
+        var source = """
+            using System;
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static bool M(FullPath fullPath)
+                    {
+                        return {|MFFP0001:Path.GetFullPath(fullPath)|}.StartsWith("C:", StringComparison.Ordinal);
+                    }
+                }
+            }
+            """;
+
+        await CreateCodeFixTest<PathGetFullPathOnFullPathAnalyzerType, PathGetFullPathOnFullPathCodeFixProviderType>(source, source).RunAsync(XunitCancellationToken);
+    }
 }


### PR DESCRIPTION
MFFP0008 rewrites `Path.GetDirectoryName(fullPath)` to `fullPath.Parent`, and MFFP0001 rewrites `Path.GetFullPath(fullPath)` to `fullPath`. Both change the expression's static type from `string` to `FullPath`. The implicit `FullPath`→`string` conversion covers a slot whose type is already known to be `string`, but not a receiver and not a `var` initializer:

```csharp
Path.GetDirectoryName(fullPath).Length                          → fullPath.Parent.Length          // CS1061
Path.GetFullPath(fullPath).StartsWith("C:", StringComparison.Ordinal)
                                                                → fullPath.StartsWith(…)          // CS1061

var directory = Path.GetDirectoryName(fullPath);                → var directory = fullPath.Parent;
directory.Replace('a', 'b');                                    // directory is now a FullPath      // CS1061
```

Neither analyzer looks at how the result is consumed, so Fix-All over a file that treats these results as strings left a document that did not compile.

## What changed

Both providers now check the invocation's parent operation and withhold the fix when the result is a receiver (member access, indexer) or initializes a `var`. Everywhere else — a `string` return, a `string` variable, an argument — the fix is offered exactly as before.

The diagnostic still reports in the withheld cases; only the automatic rewrite steps back, since the user may want to restructure.

Note this affects only these two rules. The `GetFileName`/`GetExtension`/`NameWithoutExtension` family is unaffected: those members return `string`, so their rewrites do not change the type.

## Verification

Three tests added asserting the source is left unchanged: `.Length` on the directory name, `.StartsWith` on the full path, and a `var` initializer followed by a string-only call. All three fail on the parent branch and pass here. All existing tests unchanged and green; full analyzer suite green at 113 tests.

## Stack

Layer 3 of 3, targeting `fix/pathcombine-join-and-dropped-args` (#2356). Merge order: #2344 → #2356 → this.

It depends on #2344 only (both edit `TryGetReplacementExpression` in `PathGetDirectoryNameWithFullPathCodeFixProvider`), not on #2356 — the stack is linearized because a GitHub stack cannot express that shape.
