### PR TITLE
Skip htpasswd entries with an empty password hash

### DIFF
--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -87,6 +87,9 @@ public sealed class HtpasswdFile
                 continue;
 
             var passwordHash = line[(separatorIndex + 1)..].Trim();
+            if (passwordHash.IsEmpty)
+                continue;
+
             entries[username.ToString()] = passwordHash.ToString();
         }
 

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -18,6 +18,28 @@ public sealed class HtpasswdFileTests
         Assert.Equal(["alice", "bob"], htpasswd.Usernames.OrderBy(value => value, StringComparer.Ordinal));
     }
 
+    [Theory]
+    [InlineData("alice:")]
+    [InlineData("alice:   ")]
+    [InlineData("alice:\t")]
+    public void Parse_ShouldSkipEntryWithEmptyPasswordHash(string content)
+    {
+        var htpasswd = HtpasswdFile.Parse(content);
+
+        Assert.Equal(0, htpasswd.Count);
+        Assert.False(htpasswd.VerifyCredentials("alice", ""));
+    }
+
+    [Fact]
+    public void Parse_ShouldSkipEntryWithEmptyPasswordHash_AndKeepValidEntries()
+    {
+        var htpasswd = HtpasswdFile.Parse("alice:\nbob:{SHA}5en6G6MezRroT3XKqkdPOmY/BfQ=");
+
+        Assert.Equal(["bob"], htpasswd.Usernames);
+        Assert.False(htpasswd.VerifyCredentials("alice", ""));
+        Assert.True(htpasswd.VerifyCredentials("bob", "secret"));
+    }
+
     [Fact]
     public void Parse_Span_ShouldPopulateEntries()
     {


### PR DESCRIPTION
Part of a project review of `Meziantou.Framework.Http.Htpasswd`.

## The problem

`Parse` accepts any line containing a colon at index > 0 and stores the trimmed remainder as the hash, so `alice:` and `bob:   ` both become entries whose hash is `""`. `VerifyCredentials` then matches no format prefix and falls through to the plaintext comparison at [HtpasswdFile.cs:164](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L164), where `password.SequenceEqual("")` is `true` for an empty password.

Verified against the current code:

```
VerifyCredentials("alice", "")  ->  True     // entry: alice:
VerifyCredentials("bob",   "")  ->  True     // entry: bob:<spaces>
VerifyCredentials("alice", "x") ->  False
```

A line truncated by a partial write, a bad `sed`, or a hand edit therefore turns into an account anyone can log into by submitting an empty password. Failing open is the wrong direction for a credentials check, and nothing in the API surfaces that the file was malformed.

## What changed

`Parse` now skips an entry whose password field is empty after trimming, the same way it already skips lines with no colon and lines with an empty username.

## Verification

`dotnet test` on both target frameworks, 28 tests green. Four new cases cover `alice:`, `alice:<spaces>`, `alice:<tab>`, and a file mixing an empty-hash entry with a valid one.

The new tests use `{SHA}` entries rather than plaintext ones so they stay valid regardless of the plaintext-fallback change in the other stack.

---

Stack 1 of 3 · merges into `main` · merge before the other two layers.
