### PR TITLE
Keep the first entry when an htpasswd file repeats a username

### DIFF
--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -90,7 +90,7 @@ public sealed class HtpasswdFile
             if (passwordHash.IsEmpty)
                 continue;
 
-            entries[username.ToString()] = passwordHash.ToString();
+            entries.TryAdd(username.ToString(), passwordHash.ToString());
         }
 
         return new HtpasswdFile(entries);

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -18,6 +18,21 @@ public sealed class HtpasswdFileTests
         Assert.Equal(["alice", "bob"], htpasswd.Usernames.OrderBy(value => value, StringComparer.Ordinal));
     }
 
+    [Fact]
+    public void Parse_DuplicateUsername_ShouldKeepTheFirstEntry()
+    {
+        var htpasswd = HtpasswdFile.Parse("""
+            alice:{SHA}4JlqN8E9RMOwYHSTnUP6N1m9MsE=
+            bob:{SHA}5en6G6MezRroT3XKqkdPOmY/BfQ=
+            alice:{SHA}NS94KaI4SwAcwSsMJhPHVkVKH2o=
+            """);
+
+        Assert.Equal(2, htpasswd.Count);
+        Assert.True(htpasswd.VerifyCredentials("alice", "first"));
+        Assert.False(htpasswd.VerifyCredentials("alice", "second"));
+        Assert.True(htpasswd.VerifyCredentials("bob", "secret"));
+    }
+
     [Theory]
     [InlineData("alice:")]
     [InlineData("alice:   ")]


### PR DESCRIPTION
Part of a project review of `Meziantou.Framework.Http.Htpasswd`.

## The problem

[HtpasswdFile.cs:87](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L87) stores entries with the dictionary indexer, so a repeated username is overwritten and the **last** entry wins. Apache's `mod_authn_file` scans the file top-down and stops at the **first** matching username.

Verified against the current code, on `alice:first\nalice:second`:

```
Count                             ->  1
VerifyCredentials("alice", "first")  ->  False
VerifyCredentials("alice", "second") ->  True
```

Duplicates happen in practice — `htpasswd` without `-D`, a merge of two files, an append-only update script. This library and Apache then disagree about which password is live for an account, which is a silent divergence in an authentication decision: an operator who appends a line believing they have rotated a password gets one answer from Apache and the opposite from this library.

## What changed

`entries[key] = value` becomes `entries.TryAdd(key, value)`, so the first entry for a username wins, matching Apache.

## Verification

`dotnet test` on both target frameworks, 30 tests green. One new test parses a file where `alice` appears twice with different `{SHA}` hashes and asserts the first one is the live password.

---

Stack 2 of 3 · merges into `parse/reject-empty-hash` · merge after layer 1, before layer 3.
