### PR TITLE
Match Apache and stop trimming htpasswd usernames and passwords

### DIFF
--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -82,11 +82,11 @@ public sealed class HtpasswdFile
             if (separatorIndex <= 0)
                 continue;
 
-            var username = line[..separatorIndex].Trim();
+            var username = line[..separatorIndex];
             if (username.IsEmpty)
                 continue;
 
-            var passwordHash = line[(separatorIndex + 1)..].Trim();
+            var passwordHash = line[(separatorIndex + 1)..];
             if (passwordHash.IsEmpty)
                 continue;
 

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -19,6 +19,24 @@ public sealed class HtpasswdFileTests
     }
 
     [Fact]
+    public void Parse_ShouldNotTrimThePasswordField()
+    {
+        var htpasswd = HtpasswdFile.Parse("alice: {SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=");
+
+        Assert.False(htpasswd.VerifyCredentials("alice", "password"));
+    }
+
+    [Fact]
+    public void Parse_ShouldNotTrimTheUsername()
+    {
+        var htpasswd = HtpasswdFile.Parse("  bob :{SHA}N/omUzCtg+qoee+x4ttjgIls9jk=");
+
+        Assert.Equal(["bob "], htpasswd.Usernames);
+        Assert.True(htpasswd.VerifyCredentials("bob ", "pwd"));
+        Assert.False(htpasswd.VerifyCredentials("bob", "pwd"));
+    }
+
+    [Fact]
     public void Parse_DuplicateUsername_ShouldKeepTheFirstEntry()
     {
         var htpasswd = HtpasswdFile.Parse("""


### PR DESCRIPTION
Part of a project review of `Meziantou.Framework.Http.Htpasswd`.

## The problem

`Parse` trims the username at [HtpasswdFile.cs:82](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L82) and the password field at [:86](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L86), on top of the line-level `Trim()` at [:74](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L74). Apache does the line-level trim (`ap_cfg_getline`) but not the field-level one — `ap_getword(&rpw, ':')` returns the field verbatim.

Verified against the current code:

```
Parse("alice: secret")  ->  VerifyCredentials("alice", "secret")   == True   // leading space silently dropped
Parse("  bob :pwd")     ->  Usernames == ["bob"]                             // trailing space silently dropped
```

The library therefore cannot represent a plaintext password with a leading space at all, and it silently rewrites credential data on the way in. `Trim()` also uses `char.IsWhiteSpace`, so it strips NBSP and other Unicode spaces.

## What changed

Dropped the two field-level `Trim()` calls. The line-level trim stays, which is what Apache does and what keeps comment and blank-line handling working.

## Tradeoff

A file written as `alice : password` now yields the username `alice ` rather than `alice`, so it stops matching. That is Apache's behaviour, and real `htpasswd` never emits spaces around the separator, but it is a behaviour change worth knowing about.

## Verification

`dotnet test` on both target frameworks, 34 tests green. Two new tests pin that the password field is not trimmed (`alice: {SHA}...` no longer verifies, because the leading space breaks the prefix) and that the username keeps its trailing space.

---

Stack 3 of 3 · merges into `parse/duplicate-username-first-wins` · merge last in this stack.
