### PR TITLE
Hash only the password bytes in VerifySha1 and clear the pooled buffer

### DIFF
--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -537,7 +537,7 @@ public sealed class HtpasswdFile
 
         var passwordBytes = byteCount <= 256
             ? stackalloc byte[byteCount]
-            : (rentedBytes = ArrayPool<byte>.Shared.Rent(byteCount));
+            : (rentedBytes = ArrayPool<byte>.Shared.Rent(byteCount)).AsSpan(0, byteCount);
 
         try
         {
@@ -557,7 +557,7 @@ public sealed class HtpasswdFile
         {
             if (rentedBytes is not null)
             {
-                ArrayPool<byte>.Shared.Return(rentedBytes);
+                ArrayPool<byte>.Shared.Return(rentedBytes, clearArray: true);
             }
         }
     }

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 namespace Meziantou.Framework.Http.Tests;
 
 public sealed class HtpasswdFileTests
@@ -75,6 +77,26 @@ public sealed class HtpasswdFileTests
 
         Assert.True(htpasswd.VerifyCredentials("alice", "password"));
         Assert.False(htpasswd.VerifyCredentials("alice", "invalid"));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(255)]
+    [InlineData(256)]
+    [InlineData(257)]
+    [InlineData(300)]
+    [InlineData(1024)]
+    public void VerifyCredentials_ShouldValidateSha1Hash_WhateverThePasswordLength(int length)
+    {
+        var password = new string('a', length);
+#pragma warning disable CA5350 // SHA1 is required to build the htpasswd {SHA} format
+        var hash = Convert.ToBase64String(SHA1.HashData(Encoding.UTF8.GetBytes(password)));
+#pragma warning restore CA5350
+        var htpasswd = HtpasswdFile.Parse($"alice:{{SHA}}{hash}");
+
+        Assert.True(htpasswd.VerifyCredentials("alice", password));
+        Assert.False(htpasswd.VerifyCredentials("alice", password + "b"));
     }
 
     [Fact]


### PR DESCRIPTION
Part of a project review of `Meziantou.Framework.Http.Htpasswd`.

## The problem

[HtpasswdFile.cs:538-540](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L538-L540) assigns the rented array into a `Span<byte>`:

```csharp
var passwordBytes = byteCount <= 256
    ? stackalloc byte[byteCount]
    : (rentedBytes = ArrayPool<byte>.Shared.Rent(byteCount));
```

`Rent` returns an array *at least* `byteCount` long — typically the next power of two — and the implicit `byte[]` to `Span<byte>` conversion covers the **entire** array. `Encoding.UTF8.GetBytes` fills only the prefix, so `SHA1.HashData` at [:548](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L548) digests the password *plus* whatever residue the pool holds.

Measured against `{SHA}` entries built from the correct SHA-1 of the password:

| password length | verifies |
|---|---|
| 10 | ✅ |
| 255 | ✅ |
| 256 | ✅ |
| 257 | ❌ |
| 300 | ❌ |
| 1024 | ❌ |

`{SHA}` is one of the six formats the readme advertises. Any deployment with passphrases, or with non-ASCII passwords that cross 256 bytes once UTF-8 encoded, rejects valid credentials with no error and no log line — the caller just sees `false`. It is also latently non-deterministic, since the digested bytes depend on pool residue.

The same method returns the buffer to the shared pool without clearing it ([:560](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L560)), leaving the UTF-8 bytes of the plaintext password readable by whatever rents that bucket next, and in any heap snapshot or crash dump taken afterwards. This is the one buffer in the library that holds a plaintext credential, so it is fixed here rather than in a separate PR — the two changes are three lines apart in the same `try`/`finally`, and clearing only becomes meaningful once the slice is correct.

## What changed

- Slice the rented array to `byteCount` before hashing.
- Return it with `clearArray: true`.

## Verification

`dotnet test` on both target frameworks, 34 tests green. The new `[Theory]` covers lengths 0, 1, 255, 256, 257, 300 and 1024.

Confirmed the tests are meaningful: with the slice reverted, lengths 257, 300 and 1024 fail and the rest pass.

---

Stack 1 of 3 · merges into `main` · merge before the other two layers.
