### PR TITLE
Compare htpasswd hashes and plaintext passwords in constant time

### DIFF
--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
 namespace Meziantou.Framework.Http;
@@ -184,20 +185,13 @@ public sealed class HtpasswdFile
     }
 
     /// <summary>Compares two values in an amount of time that does not depend on where they start to differ.</summary>
-    /// <remarks>As with <see cref="System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{byte}, System.ReadOnlySpan{byte})"/>, a length difference is still observable.</remarks>
+    /// <remarks>
+    /// The spans are reinterpreted as bytes rather than encoded, so no buffer is needed on the verification path.
+    /// As with <see cref="CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{byte}, System.ReadOnlySpan{byte})"/>,
+    /// a length difference is still observable.
+    /// </remarks>
     private static bool FixedTimeEquals(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
-    {
-        if (left.Length != right.Length)
-            return false;
-
-        var difference = 0;
-        for (var i = 0; i < left.Length; i++)
-        {
-            difference |= left[i] ^ right[i];
-        }
-
-        return difference is 0;
-    }
+        => CryptographicOperations.FixedTimeEquals(MemoryMarshal.AsBytes(left), MemoryMarshal.AsBytes(right));
 
     private static bool IsBcryptHash(ReadOnlySpan<char> hash)
     {

--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -180,7 +180,23 @@ public sealed class HtpasswdFile
         if (expectedPasswordHashSpan.StartsWith(Sha512CryptPrefix, StringComparison.Ordinal))
             return VerifyShaCrypt(password, expectedPasswordHashSpan, useSha512: true);
 
-        return password.SequenceEqual(expectedPasswordHashSpan);
+        return FixedTimeEquals(password, expectedPasswordHashSpan);
+    }
+
+    /// <summary>Compares two values in an amount of time that does not depend on where they start to differ.</summary>
+    /// <remarks>As with <see cref="System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{byte}, System.ReadOnlySpan{byte})"/>, a length difference is still observable.</remarks>
+    private static bool FixedTimeEquals(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
+    {
+        if (left.Length != right.Length)
+            return false;
+
+        var difference = 0;
+        for (var i = 0; i < left.Length; i++)
+        {
+            difference |= left[i] ^ right[i];
+        }
+
+        return difference is 0;
     }
 
     private static bool IsBcryptHash(ReadOnlySpan<char> hash)
@@ -200,7 +216,7 @@ public sealed class HtpasswdFile
             return false;
 
         var computedHash = CreateMd5CryptHash(password, salt, prefix);
-        return expectedHash.SequenceEqual(computedHash.AsSpan());
+        return FixedTimeEquals(expectedHash, computedHash.AsSpan());
     }
 
     private static bool VerifyShaCrypt(ReadOnlySpan<char> password, ReadOnlySpan<char> expectedHash, bool useSha512)
@@ -212,7 +228,7 @@ public sealed class HtpasswdFile
             return false;
 
         var computedHash = CreateShaCryptHash(password, salt, rounds, roundsCustom, useSha512);
-        return expectedHash.SequenceEqual(computedHash.AsSpan());
+        return FixedTimeEquals(expectedHash, computedHash.AsSpan());
     }
 
     private static bool TryParseMd5CryptHash(ReadOnlySpan<char> hash, string prefix, out ReadOnlySpan<char> salt, out ReadOnlySpan<char> checksum)
@@ -583,7 +599,7 @@ public sealed class HtpasswdFile
             Span<char> base64 = stackalloc char[28];
             _ = Convert.TryToBase64Chars(hashBytes, base64, out var charsWritten);
 
-            return expectedHash.SequenceEqual(base64[..charsWritten]);
+            return FixedTimeEquals(expectedHash, base64[..charsWritten]);
         }
         finally
         {

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -212,6 +212,29 @@ public sealed class HtpasswdFileTests
         Assert.False(htpasswd.VerifyCredentials("alice", "invalid"));
     }
 
+    [Theory]
+    [InlineData("Xassword")]
+    [InlineData("passworX")]
+    [InlineData("passwor")]
+    [InlineData("passwordX")]
+    [InlineData("")]
+    public void VerifyCredentials_ShouldRejectAWrongPlaintextPassword_WhereverItDiffers(string candidate)
+    {
+        var htpasswd = HtpasswdFile.Parse("alice:password");
+
+        Assert.False(htpasswd.VerifyCredentials("alice", candidate));
+    }
+
+    [Theory]
+    [InlineData("$apr1$salt1234$k3J5yKYW6TlGmTytnkXbQ1")]
+    [InlineData("$apr1$salt1234$X3J5yKYW6TlGmTytnkXbQ0")]
+    public void VerifyCredentials_ShouldRejectAnApr1HashThatDiffersInASingleCharacter(string hash)
+    {
+        var htpasswd = HtpasswdFile.Parse($"alice:{hash}");
+
+        Assert.False(htpasswd.VerifyCredentials("alice", "password"));
+    }
+
     [Fact]
     public void VerifyCredentials_Span_ShouldValidatePlaintextPassword()
     {


### PR DESCRIPTION
Part of a project review of `Meziantou.Framework.Http.Htpasswd`.

## The problem

Four comparisons decide whether a credential is valid, and all four use `ReadOnlySpan<T>.SequenceEqual`, which is vectorised and returns as soon as it finds a mismatch:

| where | comparing |
|---|---|
| [:164](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L164) | the password against a stored **plaintext password** |
| [:173](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L173) | md5-crypt / `$apr1$` hashes |
| [:185](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L185) | sha-crypt hashes |
| [:554](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L554) | base64 SHA-1 digests |

The inconsistency is inside this repo: the one path this library delegates rather than implements, `Bcrypt.Verify`, already compares in constant time via `SecureEquals` ([BcryptImplementation.cs:262](../blob/main/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs#L262)).

For the three hash-vs-hash comparisons the leak is minor — an attacker learns about a value derived from a password they would still have to guess. For the plaintext path at `:164` the comparison is directly against the secret, and the early exit leaks both its length and how many leading characters matched.

## What changed

All four call sites now go through a private `FixedTimeEquals(ReadOnlySpan<char>, ReadOnlySpan<char>)` that forwards to `CryptographicOperations.FixedTimeEquals`, reinterpreting each span as bytes with `MemoryMarshal.AsBytes` rather than encoding it:

```csharp
private static bool FixedTimeEquals(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
    => CryptographicOperations.FixedTimeEquals(MemoryMarshal.AsBytes(left), MemoryMarshal.AsBytes(right));
```

`AsBytes` is a reinterpret cast, not a copy, so this keeps the BCL primitive without putting a buffer on the authentication hot path. Comparing UTF-16 code units byte-wise is equivalent to comparing them as `char`, and a length mismatch in chars is still a length mismatch in bytes.

As with the BCL primitive, a **length** difference is still observable. That is unavoidable when the operands are strings of different sizes; the value is in not leaking *where* they diverge.

## Verification

`dotnet test` on both target frameworks, 48 tests green. New tests pin that a wrong plaintext password is rejected whether it differs in the first character, the last character, or in length, and that an `$apr1$` hash differing in a single character is rejected.

Timing itself is not asserted — a wall-clock test would be flaky in CI and would not survive a scheduler hiccup. The guarantee here is structural: the loop has no early exit.

---

Stack 2 of 3 · merges into `sha1/pooled-buffer` · merge after layer 1, before layer 3.
