### PR TITLE
Reject unrecognized htpasswd formats unless plaintext passwords are enabled

### DIFF
--- a/ref/Meziantou.Framework.Http.Htpasswd.cs
+++ b/ref/Meziantou.Framework.Http.Htpasswd.cs
@@ -6,12 +6,17 @@ namespace Meziantou.Framework.Http
 {
     public sealed class HtpasswdFile
     {
+        public bool AllowPlaintextPasswords { get => throw null; }
         public System.Collections.Generic.ICollection<string> Usernames { get => throw null; }
         public int Count { get => throw null; }
         public static Meziantou.Framework.Http.HtpasswdFile Parse(string content) => throw null;
+        public static Meziantou.Framework.Http.HtpasswdFile Parse(string content, bool allowPlaintextPasswords) => throw null;
         public static Meziantou.Framework.Http.HtpasswdFile Parse(System.ReadOnlySpan<char> content) => throw null;
+        public static Meziantou.Framework.Http.HtpasswdFile Parse(System.ReadOnlySpan<char> content, bool allowPlaintextPasswords) => throw null;
         public static System.Threading.Tasks.Task<Meziantou.Framework.Http.HtpasswdFile> LoadAsync(string file) => throw null;
+        public static System.Threading.Tasks.Task<Meziantou.Framework.Http.HtpasswdFile> LoadAsync(string file, bool allowPlaintextPasswords) => throw null;
         public static System.Threading.Tasks.Task<Meziantou.Framework.Http.HtpasswdFile> LoadAsync(System.IO.TextReader file) => throw null;
+        public static System.Threading.Tasks.Task<Meziantou.Framework.Http.HtpasswdFile> LoadAsync(System.IO.TextReader file, bool allowPlaintextPasswords) => throw null;
         public bool VerifyCredentials(string username, string password) => throw null;
         public bool VerifyCredentials(System.ReadOnlySpan<char> username, System.ReadOnlySpan<char> password) => throw null;
     }

--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -161,7 +161,23 @@ public sealed class HtpasswdFile
         if (expectedPasswordHashSpan.StartsWith(Sha512CryptPrefix, StringComparison.Ordinal))
             return VerifyShaCrypt(password, expectedPasswordHashSpan, useSha512: true);
 
-        return password.SequenceEqual(expectedPasswordHashSpan);
+        return FixedTimeEquals(password, expectedPasswordHashSpan);
+    }
+
+    /// <summary>Compares two values in an amount of time that does not depend on where they start to differ.</summary>
+    /// <remarks>As with <see cref="System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{byte}, System.ReadOnlySpan{byte})"/>, a length difference is still observable.</remarks>
+    private static bool FixedTimeEquals(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
+    {
+        if (left.Length != right.Length)
+            return false;
+
+        var difference = 0;
+        for (var i = 0; i < left.Length; i++)
+        {
+            difference |= left[i] ^ right[i];
+        }
+
+        return difference is 0;
     }
 
     private static bool VerifyMd5Crypt(ReadOnlySpan<char> password, ReadOnlySpan<char> expectedHash, string prefix)
@@ -170,7 +186,7 @@ public sealed class HtpasswdFile
             return false;
 
         var computedHash = CreateMd5CryptHash(password, salt, prefix);
-        return expectedHash.SequenceEqual(computedHash.AsSpan());
+        return FixedTimeEquals(expectedHash, computedHash.AsSpan());
     }
 
     private static bool VerifyShaCrypt(ReadOnlySpan<char> password, ReadOnlySpan<char> expectedHash, bool useSha512)
@@ -182,7 +198,7 @@ public sealed class HtpasswdFile
             return false;
 
         var computedHash = CreateShaCryptHash(password, salt, rounds, roundsCustom, useSha512);
-        return expectedHash.SequenceEqual(computedHash.AsSpan());
+        return FixedTimeEquals(expectedHash, computedHash.AsSpan());
     }
 
     private static bool TryParseMd5CryptHash(ReadOnlySpan<char> hash, string prefix, out ReadOnlySpan<char> salt, out ReadOnlySpan<char> checksum)
@@ -551,7 +567,7 @@ public sealed class HtpasswdFile
             Span<char> base64 = stackalloc char[28];
             _ = Convert.TryToBase64Chars(hashBytes, base64, out var charsWritten);
 
-            return expectedHash.SequenceEqual(base64[..charsWritten]);
+            return FixedTimeEquals(expectedHash, base64[..charsWritten]);
         }
         finally
         {

--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
 namespace Meziantou.Framework.Http;
@@ -165,20 +166,13 @@ public sealed class HtpasswdFile
     }
 
     /// <summary>Compares two values in an amount of time that does not depend on where they start to differ.</summary>
-    /// <remarks>As with <see cref="System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{byte}, System.ReadOnlySpan{byte})"/>, a length difference is still observable.</remarks>
+    /// <remarks>
+    /// The spans are reinterpreted as bytes rather than encoded, so no buffer is needed on the verification path.
+    /// As with <see cref="CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{byte}, System.ReadOnlySpan{byte})"/>,
+    /// a length difference is still observable.
+    /// </remarks>
     private static bool FixedTimeEquals(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
-    {
-        if (left.Length != right.Length)
-            return false;
-
-        var difference = 0;
-        for (var i = 0; i < left.Length; i++)
-        {
-            difference |= left[i] ^ right[i];
-        }
-
-        return difference is 0;
-    }
+        => CryptographicOperations.FixedTimeEquals(MemoryMarshal.AsBytes(left), MemoryMarshal.AsBytes(right));
 
     private static bool VerifyMd5Crypt(ReadOnlySpan<char> password, ReadOnlySpan<char> expectedHash, string prefix)
     {

--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -537,7 +537,7 @@ public sealed class HtpasswdFile
 
         var passwordBytes = byteCount <= 256
             ? stackalloc byte[byteCount]
-            : (rentedBytes = ArrayPool<byte>.Shared.Rent(byteCount));
+            : (rentedBytes = ArrayPool<byte>.Shared.Rent(byteCount)).AsSpan(0, byteCount);
 
         try
         {
@@ -557,7 +557,7 @@ public sealed class HtpasswdFile
         {
             if (rentedBytes is not null)
             {
-                ArrayPool<byte>.Shared.Return(rentedBytes);
+                ArrayPool<byte>.Shared.Return(rentedBytes, clearArray: true);
             }
         }
     }

--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -19,11 +19,16 @@ public sealed class HtpasswdFile
     private const int ShaCryptMaxRounds = 999_999_999;
     private const string Sha1Prefix = "{SHA}";
     private readonly Dictionary<string, string> _entries;
+    private readonly bool _allowPlaintextPasswords;
 
-    private HtpasswdFile(Dictionary<string, string> entries)
+    private HtpasswdFile(Dictionary<string, string> entries, bool allowPlaintextPasswords)
     {
         _entries = entries;
+        _allowPlaintextPasswords = allowPlaintextPasswords;
     }
+
+    /// <summary>Gets a value indicating whether entries whose format is not recognized are compared as plaintext passwords.</summary>
+    public bool AllowPlaintextPasswords => _allowPlaintextPasswords;
 
     /// <summary>Gets the list of usernames in the file.</summary>
     public ICollection<string> Usernames => _entries.Keys;
@@ -31,13 +36,23 @@ public sealed class HtpasswdFile
     /// <summary>Gets the number of entries in the file.</summary>
     public int Count => _entries.Count;
 
-    /// <summary>Parses the content of an htpasswd file.</summary>
+    /// <summary>Parses the content of an htpasswd file. Entries whose format is not recognized are rejected.</summary>
     /// <param name="content">The text content of the htpasswd file.</param>
     /// <returns>A parsed <see cref="HtpasswdFile"/> instance.</returns>
-    public static HtpasswdFile Parse(string content)
+    public static HtpasswdFile Parse(string content) => Parse(content, allowPlaintextPasswords: false);
+
+    /// <summary>Parses the content of an htpasswd file.</summary>
+    /// <param name="content">The text content of the htpasswd file.</param>
+    /// <param name="allowPlaintextPasswords">
+    /// <see langword="true"/> to compare an entry whose format is not recognized against the password as plaintext;
+    /// <see langword="false"/> to reject it. Enabling this also accepts hashes the library does not implement, such as
+    /// traditional DES crypt, as plaintext passwords.
+    /// </param>
+    /// <returns>A parsed <see cref="HtpasswdFile"/> instance.</returns>
+    public static HtpasswdFile Parse(string content, bool allowPlaintextPasswords)
     {
         ArgumentNullException.ThrowIfNull(content);
-        return Parse(content.AsSpan());
+        return Parse(content.AsSpan(), allowPlaintextPasswords);
     }
 
     /// <summary>
@@ -45,7 +60,18 @@ public sealed class HtpasswdFile
     /// </summary>
     /// <param name="content">The text content of the htpasswd file.</param>
     /// <returns>A parsed <see cref="HtpasswdFile"/> instance.</returns>
-    public static HtpasswdFile Parse(ReadOnlySpan<char> content)
+    public static HtpasswdFile Parse(ReadOnlySpan<char> content) => Parse(content, allowPlaintextPasswords: false);
+
+    /// <summary>
+    /// Parses the content of an htpasswd file.
+    /// </summary>
+    /// <param name="content">The text content of the htpasswd file.</param>
+    /// <param name="allowPlaintextPasswords">
+    /// <see langword="true"/> to compare an entry whose format is not recognized against the password as plaintext;
+    /// <see langword="false"/> to reject it.
+    /// </param>
+    /// <returns>A parsed <see cref="HtpasswdFile"/> instance.</returns>
+    public static HtpasswdFile Parse(ReadOnlySpan<char> content, bool allowPlaintextPasswords)
     {
         var entries = new Dictionary<string, string>(StringComparer.Ordinal);
 
@@ -88,7 +114,7 @@ public sealed class HtpasswdFile
             entries[username.ToString()] = passwordHash.ToString();
         }
 
-        return new HtpasswdFile(entries);
+        return new HtpasswdFile(entries, allowPlaintextPasswords);
     }
 
     /// <summary>
@@ -96,13 +122,24 @@ public sealed class HtpasswdFile
     /// </summary>
     /// <param name="file">The path of the htpasswd file.</param>
     /// <returns>A parsed <see cref="HtpasswdFile"/> instance.</returns>
-    public static async Task<HtpasswdFile> LoadAsync(string file)
+    public static Task<HtpasswdFile> LoadAsync(string file) => LoadAsync(file, allowPlaintextPasswords: false);
+
+    /// <summary>
+    /// Loads and parses an htpasswd file from disk.
+    /// </summary>
+    /// <param name="file">The path of the htpasswd file.</param>
+    /// <param name="allowPlaintextPasswords">
+    /// <see langword="true"/> to compare an entry whose format is not recognized against the password as plaintext;
+    /// <see langword="false"/> to reject it.
+    /// </param>
+    /// <returns>A parsed <see cref="HtpasswdFile"/> instance.</returns>
+    public static async Task<HtpasswdFile> LoadAsync(string file, bool allowPlaintextPasswords)
     {
         ArgumentNullException.ThrowIfNull(file);
 
         await using var stream = File.OpenRead(file);
         using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
-        return await LoadAsync(reader).ConfigureAwait(false);
+        return await LoadAsync(reader, allowPlaintextPasswords).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -110,12 +147,23 @@ public sealed class HtpasswdFile
     /// </summary>
     /// <param name="file">The reader containing the htpasswd content.</param>
     /// <returns>A parsed <see cref="HtpasswdFile"/> instance.</returns>
-    public static async Task<HtpasswdFile> LoadAsync(TextReader file)
+    public static Task<HtpasswdFile> LoadAsync(TextReader file) => LoadAsync(file, allowPlaintextPasswords: false);
+
+    /// <summary>
+    /// Loads and parses an htpasswd file from a <see cref="TextReader"/>.
+    /// </summary>
+    /// <param name="file">The reader containing the htpasswd content.</param>
+    /// <param name="allowPlaintextPasswords">
+    /// <see langword="true"/> to compare an entry whose format is not recognized against the password as plaintext;
+    /// <see langword="false"/> to reject it.
+    /// </param>
+    /// <returns>A parsed <see cref="HtpasswdFile"/> instance.</returns>
+    public static async Task<HtpasswdFile> LoadAsync(TextReader file, bool allowPlaintextPasswords)
     {
         ArgumentNullException.ThrowIfNull(file);
 
         var content = await file.ReadToEndAsync().ConfigureAwait(false);
-        return Parse(content);
+        return Parse(content, allowPlaintextPasswords);
     }
 
     /// <summary>
@@ -161,6 +209,9 @@ public sealed class HtpasswdFile
 
         if (expectedPasswordHashSpan.StartsWith(Sha512CryptPrefix, StringComparison.Ordinal))
             return VerifyShaCrypt(password, expectedPasswordHashSpan, useSha512: true);
+
+        if (!_allowPlaintextPasswords)
+            return false;
 
         return FixedTimeEquals(password, expectedPasswordHashSpan);
     }

--- a/src/Meziantou.Framework.Http.Htpasswd/readme.md
+++ b/src/Meziantou.Framework.Http.Htpasswd/readme.md
@@ -9,7 +9,7 @@ Supported password formats:
 - SHA-256 crypt (`$5$`)
 - SHA-512 crypt (`$6$`)
 - SHA-1 (`{SHA}`)
-- plaintext
+- plaintext (opt-in, see [Plaintext passwords](#plaintext-passwords))
 
 ```csharp
 var htpasswd = HtpasswdFile.Parse("""
@@ -20,3 +20,16 @@ var htpasswd = HtpasswdFile.Parse("""
 var isAliceValid = htpasswd.VerifyCredentials("alice", "password");
 var isBobValid = htpasswd.VerifyCredentials("bob", "password");
 ```
+
+## Plaintext passwords
+
+An entry whose format is not recognized is rejected. Pass `allowPlaintextPasswords: true` to compare it against the
+supplied password as plaintext instead:
+
+```csharp
+var htpasswd = HtpasswdFile.Parse("alice:password", allowPlaintextPasswords: true);
+```
+
+Enabling this also makes hashes the library does not implement, such as traditional DES crypt (`htpasswd -d`), match
+when the stored hash itself is supplied as the password. Leave it disabled unless the file really does contain
+plaintext passwords.

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 namespace Meziantou.Framework.Http.Tests;
 
 public sealed class HtpasswdFileTests
@@ -75,6 +77,26 @@ public sealed class HtpasswdFileTests
 
         Assert.True(htpasswd.VerifyCredentials("alice", "password"));
         Assert.False(htpasswd.VerifyCredentials("alice", "invalid"));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(255)]
+    [InlineData(256)]
+    [InlineData(257)]
+    [InlineData(300)]
+    [InlineData(1024)]
+    public void VerifyCredentials_ShouldValidateSha1Hash_WhateverThePasswordLength(int length)
+    {
+        var password = new string('a', length);
+#pragma warning disable CA5350 // SHA1 is required to build the htpasswd {SHA} format
+        var hash = Convert.ToBase64String(SHA1.HashData(Encoding.UTF8.GetBytes(password)));
+#pragma warning restore CA5350
+        var htpasswd = HtpasswdFile.Parse($"alice:{{SHA}}{hash}");
+
+        Assert.True(htpasswd.VerifyCredentials("alice", password));
+        Assert.False(htpasswd.VerifyCredentials("alice", password + "b"));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -40,7 +40,7 @@ public sealed class HtpasswdFileTests
         {
             File.WriteAllText(filePath, "alice:password");
 
-            var htpasswd = await HtpasswdFile.LoadAsync(filePath);
+            var htpasswd = await HtpasswdFile.LoadAsync(filePath, allowPlaintextPasswords: true);
 
             Assert.True(htpasswd.VerifyCredentials("alice", "password"));
         }
@@ -55,7 +55,7 @@ public sealed class HtpasswdFileTests
     {
         using var reader = new StringReader("alice:password");
 
-        var htpasswd = await HtpasswdFile.LoadAsync(reader);
+        var htpasswd = await HtpasswdFile.LoadAsync(reader, allowPlaintextPasswords: true);
 
         Assert.True(htpasswd.VerifyCredentials("alice", "password"));
     }
@@ -134,7 +134,7 @@ public sealed class HtpasswdFileTests
     [InlineData("")]
     public void VerifyCredentials_ShouldRejectAWrongPlaintextPassword_WhereverItDiffers(string candidate)
     {
-        var htpasswd = HtpasswdFile.Parse("alice:password");
+        var htpasswd = HtpasswdFile.Parse("alice:password", allowPlaintextPasswords: true);
 
         Assert.False(htpasswd.VerifyCredentials("alice", candidate));
     }
@@ -149,10 +149,38 @@ public sealed class HtpasswdFileTests
         Assert.False(htpasswd.VerifyCredentials("alice", "password"));
     }
 
+    [Theory]
+    [InlineData("password")]
+    [InlineData("abJnggxhB/yWI")]
+    public void VerifyCredentials_ShouldRejectAnUnrecognizedFormatByDefault(string candidate)
+    {
+        var htpasswd = HtpasswdFile.Parse("alice:abJnggxhB/yWI");
+
+        Assert.False(htpasswd.AllowPlaintextPasswords);
+        Assert.False(htpasswd.VerifyCredentials("alice", candidate));
+    }
+
+    [Fact]
+    public void VerifyCredentials_ShouldStillValidateHashedEntries_WhenPlaintextIsDisabled()
+    {
+        var htpasswd = HtpasswdFile.Parse("alice:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=");
+
+        Assert.True(htpasswd.VerifyCredentials("alice", "password"));
+    }
+
+    [Fact]
+    public void VerifyCredentials_ShouldCompareAnUnrecognizedFormatAsPlaintext_WhenEnabled()
+    {
+        var htpasswd = HtpasswdFile.Parse("alice:abJnggxhB/yWI", allowPlaintextPasswords: true);
+
+        Assert.True(htpasswd.AllowPlaintextPasswords);
+        Assert.True(htpasswd.VerifyCredentials("alice", "abJnggxhB/yWI"));
+    }
+
     [Fact]
     public void VerifyCredentials_Span_ShouldValidatePlaintextPassword()
     {
-        var htpasswd = HtpasswdFile.Parse("alice:password");
+        var htpasswd = HtpasswdFile.Parse("alice:password", allowPlaintextPasswords: true);
 
         Assert.True(htpasswd.VerifyCredentials("alice".AsSpan(), "password".AsSpan()));
         Assert.False(htpasswd.VerifyCredentials("alice".AsSpan(), "invalid".AsSpan()));

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -126,6 +126,29 @@ public sealed class HtpasswdFileTests
         Assert.False(htpasswd.VerifyCredentials("alice", "invalid"));
     }
 
+    [Theory]
+    [InlineData("Xassword")]
+    [InlineData("passworX")]
+    [InlineData("passwor")]
+    [InlineData("passwordX")]
+    [InlineData("")]
+    public void VerifyCredentials_ShouldRejectAWrongPlaintextPassword_WhereverItDiffers(string candidate)
+    {
+        var htpasswd = HtpasswdFile.Parse("alice:password");
+
+        Assert.False(htpasswd.VerifyCredentials("alice", candidate));
+    }
+
+    [Theory]
+    [InlineData("$apr1$salt1234$k3J5yKYW6TlGmTytnkXbQ1")]
+    [InlineData("$apr1$salt1234$X3J5yKYW6TlGmTytnkXbQ0")]
+    public void VerifyCredentials_ShouldRejectAnApr1HashThatDiffersInASingleCharacter(string hash)
+    {
+        var htpasswd = HtpasswdFile.Parse($"alice:{hash}");
+
+        Assert.False(htpasswd.VerifyCredentials("alice", "password"));
+    }
+
     [Fact]
     public void VerifyCredentials_Span_ShouldValidatePlaintextPassword()
     {


### PR DESCRIPTION
Part of a project review of `Meziantou.Framework.Http.Htpasswd`.

## The problem

After the six prefix checks, [HtpasswdFile.cs:164](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L164) falls back to comparing the supplied password against the stored value as plaintext. Traditional DES crypt — what `htpasswd -d` produces and what pre-2.4 files are full of — has no prefix, so it lands there.

Verified against the current code, on the entry `alice:abJnggxhB/yWI`:

```
VerifyCredentials("alice", "password")        ->  False    // the real owner is locked out
VerifyCredentials("alice", "abJnggxhB/yWI")   ->  True     // the hash itself is a valid password
```

The same applies to `{SSHA}`, `$argon2*$`, `$y$` (yescrypt), and to any hash whose prefix is corrupted: `alice:$apr1` (missing the trailing `$`) becomes the literal plaintext password `$apr1`.

An htpasswd file is normally readable by the web server user and is often checked into configuration management; the hash is not guarded the way a password is. Turning it into an accepted password collapses that distinction.

## What changed

Plaintext comparison is now **opt-in**. An entry whose format is not recognised is rejected unless the file was parsed with `allowPlaintextPasswords: true`:

```csharp
var htpasswd = HtpasswdFile.Parse(content);                                // unrecognised -> false
var htpasswd = HtpasswdFile.Parse(content, allowPlaintextPasswords: true); // previous behaviour
```

Added as overloads rather than defaulted parameters on the existing methods, so existing compiled callers keep binding to the same signatures. `AllowPlaintextPasswords` is exposed on the instance. `ref/Meziantou.Framework.Http.Htpasswd.cs` is regenerated in this commit.

## ⚠️ This is a behaviour break

A file that genuinely holds plaintext passwords stops authenticating until the caller passes the flag. That is the intent — the previous default was unsafe — but it warrants a major version bump, and `<Version>` is deliberately left alone here since a bot owns those bumps.

## Merge order

**Merge this last.** It rewrites `:164`, so it conflicts with anything else that touches the tail of `VerifyCredentials` or the `LoadAsync` overload set. Merging all thirteen review PRs in sequence, this one and `loadasync/cancellation-token` need a small rebase; every other pair merges clean.

Any plaintext-based test added by the sibling PRs will need `allowPlaintextPasswords: true` after this lands. The four such tests that exist today are updated in this commit; the new tests in the other PRs were deliberately written against `{SHA}` and bcrypt entries so they are unaffected.

## Verification

`dotnet test` on both target frameworks, 56 tests green. New tests cover a DES-crypt entry rejected by default (both for the real password and for the hash-as-password), hashed entries still verifying with plaintext disabled, and the opt-in path accepting the plaintext comparison.

---

Stack 3 of 3 · merges into `verify/constant-time-compare` · merge last in this stack, and last overall.
