### PR TITLE
Reject passwords longer than 1024 characters before hashing them

### DIFF
--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -17,6 +17,7 @@ public sealed class HtpasswdFile
     private const int ShaCryptMinRounds = 1000;
     private const int ShaCryptMaxRounds = 999_999_999;
     private const string Sha1Prefix = "{SHA}";
+    private const int MaxPasswordLength = 1024;
     private readonly Dictionary<string, string> _entries;
 
     private HtpasswdFile(Dictionary<string, string> entries)
@@ -121,7 +122,7 @@ public sealed class HtpasswdFile
     /// Verifies a username and password against the current htpasswd entries.
     /// </summary>
     /// <param name="username">The username to verify.</param>
-    /// <param name="password">The plaintext password to verify.</param>
+    /// <param name="password">The plaintext password to verify. A password longer than 1024 characters is always rejected.</param>
     /// <returns><see langword="true"/> if the credentials are valid; otherwise, <see langword="false"/>.</returns>
     public bool VerifyCredentials(string username, string password)
     {
@@ -135,10 +136,15 @@ public sealed class HtpasswdFile
     /// Verifies a username and password against the current htpasswd entries.
     /// </summary>
     /// <param name="username">The username to verify.</param>
-    /// <param name="password">The plaintext password to verify.</param>
+    /// <param name="password">The plaintext password to verify. A password longer than 1024 characters is always rejected.</param>
     /// <returns><see langword="true"/> if the credentials are valid; otherwise, <see langword="false"/>.</returns>
     public bool VerifyCredentials(ReadOnlySpan<char> username, ReadOnlySpan<char> password)
     {
+        // The crypt algorithms hash the password once per password byte, so their cost grows quadratically
+        // with the length of an attacker-supplied value. Apache caps the password at 255 characters.
+        if (password.Length > MaxPasswordLength)
+            return false;
+
         if (!_entries.TryGetValue(username.ToString(), out var expectedPasswordHash))
             return false;
 

--- a/src/Meziantou.Framework.Http.Htpasswd/readme.md
+++ b/src/Meziantou.Framework.Http.Htpasswd/readme.md
@@ -2,6 +2,9 @@
 
 This package parses Apache htpasswd files and verifies credentials.
 
+`VerifyCredentials` rejects any password longer than 1024 characters, because the cost of the crypt algorithms
+grows quadratically with the length of the supplied password.
+
 Supported password formats:
 
 - bcrypt (`$2a$`, `$2b$`, `$2y$`)

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -69,6 +69,26 @@ public sealed class HtpasswdFileTests
     }
 
     [Fact]
+    public void VerifyCredentials_ShouldAcceptAPasswordAtTheMaximumLength()
+    {
+        var password = new string('a', 1024);
+        var hash = Bcrypt.HashPassword(password, workFactor: Bcrypt.MinWorkFactor, version: BcryptVersion.Revision2Y);
+        var htpasswd = HtpasswdFile.Parse($"alice:{hash}");
+
+        Assert.True(htpasswd.VerifyCredentials("alice", password));
+    }
+
+    [Fact]
+    public void VerifyCredentials_ShouldRejectAPasswordAboveTheMaximumLength()
+    {
+        var password = new string('a', 1025);
+        var hash = Bcrypt.HashPassword(password, workFactor: Bcrypt.MinWorkFactor, version: BcryptVersion.Revision2Y);
+        var htpasswd = HtpasswdFile.Parse($"alice:{hash}");
+
+        Assert.False(htpasswd.VerifyCredentials("alice", password));
+    }
+
+    [Fact]
     public void VerifyCredentials_String_ShouldValidateSha1Hash()
     {
         var htpasswd = HtpasswdFile.Parse("alice:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=");


### PR DESCRIPTION
Part of a project review of `Meziantou.Framework.Http.Htpasswd`.

## The problem

The sha-crypt "digest P" step at [HtpasswdFile.cs:411-414](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L411-L414) appends the full password to the hasher once per password *byte*, so the work is **quadratic** in the password length — and the password is the untrusted input. The md5-crypt path at [:301-332](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L301-L332) is linear but still multiplied by 1000 rounds.

Measured on a `$5$` entry at the default 5000 rounds:

| password | wall clock |
|---|---|
| 25 KB | 269 ms |
| 50 KB | 916 ms |
| 100 KB | 3 392 ms |
| 200 KB | 13 816 ms |

Clean quadratic scaling. Extrapolating, a 1 MB password costs roughly 6 minutes of CPU on one core.

If `VerifyCredentials` sits behind HTTP Basic auth, a handful of requests carrying oversized passwords saturate the server, and the work happens *before* any authentication decision. glibc's `crypt` has the same asymptotic shape; what keeps it harmless in practice is that Apache caps the submitted password at 255 characters.

## What changed

`VerifyCredentials` rejects a password longer than 1024 characters before doing any hashing. 1024 is generous next to Apache's 255 while bounding the quadratic term to something negligible. Documented on both overloads and in the readme.

The limit is a private const rather than a parameter — no public API change, so `ref/` is untouched. If a caller ever needs it configurable that can be added without breaking anyone.

## Verification

`dotnet test` on both target frameworks, 24 tests green. Two new tests use bcrypt entries hashed from a 1024- and a 1025-character password: the first still verifies, the second is rejected even though the password is correct. (bcrypt truncates at 72 bytes, so the two hashes agree — which is what makes the pair discriminate the cap rather than the hash.)

---

Stack 1 of 2 · merges into `main` · merge before layer 2.
