### PR TITLE
Look up usernames through an alternate span lookup

### DIFF
--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -19,10 +19,12 @@ public sealed class HtpasswdFile
     private const string Sha1Prefix = "{SHA}";
     private const int MaxPasswordLength = 1024;
     private readonly Dictionary<string, string> _entries;
+    private readonly Dictionary<string, string>.AlternateLookup<ReadOnlySpan<char>> _entriesLookup;
 
     private HtpasswdFile(Dictionary<string, string> entries)
     {
         _entries = entries;
+        _entriesLookup = entries.GetAlternateLookup<ReadOnlySpan<char>>();
     }
 
     /// <summary>Gets the list of usernames in the file.</summary>
@@ -145,7 +147,7 @@ public sealed class HtpasswdFile
         if (password.Length > MaxPasswordLength)
             return false;
 
-        if (!_entries.TryGetValue(username.ToString(), out var expectedPasswordHash))
+        if (!_entriesLookup.TryGetValue(username, out var expectedPasswordHash))
             return false;
 
         var expectedPasswordHashSpan = expectedPasswordHash.AsSpan();

--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -17,6 +17,7 @@ public sealed class HtpasswdFile
     private const int ShaCryptMinRounds = 1000;
     private const int ShaCryptMaxRounds = 999_999_999;
     private const string Sha1Prefix = "{SHA}";
+    private const int MaxPasswordLength = 1024;
     private readonly Dictionary<string, string> _entries;
 
     private HtpasswdFile(Dictionary<string, string> entries)
@@ -121,7 +122,7 @@ public sealed class HtpasswdFile
     /// Verifies a username and password against the current htpasswd entries.
     /// </summary>
     /// <param name="username">The username to verify.</param>
-    /// <param name="password">The plaintext password to verify.</param>
+    /// <param name="password">The plaintext password to verify. A password longer than 1024 characters is always rejected.</param>
     /// <returns><see langword="true"/> if the credentials are valid; otherwise, <see langword="false"/>.</returns>
     public bool VerifyCredentials(string username, string password)
     {
@@ -135,10 +136,15 @@ public sealed class HtpasswdFile
     /// Verifies a username and password against the current htpasswd entries.
     /// </summary>
     /// <param name="username">The username to verify.</param>
-    /// <param name="password">The plaintext password to verify.</param>
+    /// <param name="password">The plaintext password to verify. A password longer than 1024 characters is always rejected.</param>
     /// <returns><see langword="true"/> if the credentials are valid; otherwise, <see langword="false"/>.</returns>
     public bool VerifyCredentials(ReadOnlySpan<char> username, ReadOnlySpan<char> password)
     {
+        // The crypt algorithms hash the password once per password byte, so their cost grows quadratically
+        // with the length of an attacker-supplied value. Apache caps the password at 255 characters.
+        if (password.Length > MaxPasswordLength)
+            return false;
+
         if (!_entries.TryGetValue(username.ToString(), out var expectedPasswordHash))
             return false;
 

--- a/src/Meziantou.Framework.Http.Htpasswd/readme.md
+++ b/src/Meziantou.Framework.Http.Htpasswd/readme.md
@@ -2,6 +2,9 @@
 
 This package parses Apache htpasswd files and verifies credentials.
 
+`VerifyCredentials` rejects any password longer than 1024 characters, because the cost of the crypt algorithms
+grows quadratically with the length of the supplied password.
+
 Supported password formats:
 
 - bcrypt (`$2a$`, `$2b$`, `$2y$`)

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -125,6 +125,35 @@ public sealed class HtpasswdFileTests
     }
 
     [Fact]
+    public void VerifyCredentials_Span_ShouldLookUpAUsernameThatIsNotBackedByItsOwnString()
+    {
+        var htpasswd = HtpasswdFile.Parse("alice:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=");
+        var username = "xxaliceyy".AsSpan(2, 5);
+
+        Assert.True(htpasswd.VerifyCredentials(username, "password"));
+        Assert.False(htpasswd.VerifyCredentials(username, "invalid"));
+    }
+
+    [Fact]
+    public void VerifyCredentials_Span_ShouldNotAllocateWhileLookingUpTheUsername()
+    {
+        var htpasswd = HtpasswdFile.Parse("alice:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=");
+        var username = "xxaliceyy".AsSpan(2, 5);
+        for (var i = 0; i < 100; i++)
+        {
+            _ = htpasswd.VerifyCredentials(username, "invalid");
+        }
+
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 100; i++)
+        {
+            _ = htpasswd.VerifyCredentials(username, "invalid");
+        }
+
+        Assert.Equal(0, GC.GetAllocatedBytesForCurrentThread() - allocatedBefore);
+    }
+
+    [Fact]
     public void VerifyCredentials_Span_ShouldValidatePlaintextPassword()
     {
         var htpasswd = HtpasswdFile.Parse("alice:password");

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -69,6 +69,26 @@ public sealed class HtpasswdFileTests
     }
 
     [Fact]
+    public void VerifyCredentials_ShouldAcceptAPasswordAtTheMaximumLength()
+    {
+        var password = new string('a', 1024);
+        var hash = Bcrypt.HashPassword(password, workFactor: Bcrypt.MinWorkFactor, version: BcryptVersion.Revision2Y);
+        var htpasswd = HtpasswdFile.Parse($"alice:{hash}");
+
+        Assert.True(htpasswd.VerifyCredentials("alice", password));
+    }
+
+    [Fact]
+    public void VerifyCredentials_ShouldRejectAPasswordAboveTheMaximumLength()
+    {
+        var password = new string('a', 1025);
+        var hash = Bcrypt.HashPassword(password, workFactor: Bcrypt.MinWorkFactor, version: BcryptVersion.Revision2Y);
+        var htpasswd = HtpasswdFile.Parse($"alice:{hash}");
+
+        Assert.False(htpasswd.VerifyCredentials("alice", password));
+    }
+
+    [Fact]
     public void VerifyCredentials_String_ShouldValidateSha1Hash()
     {
         var htpasswd = HtpasswdFile.Parse("alice:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=");


### PR DESCRIPTION
Part of a project review of `Meziantou.Framework.Http.Htpasswd`.

## The problem

[HtpasswdFile.cs:142](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L142) does `_entries.TryGetValue(username.ToString(), out …)`, so the `ReadOnlySpan<char>` overload of `VerifyCredentials` materialises a string on every call — allocating exactly as much as the `string` overload it exists to avoid.

This is on the per-request authentication path, and a caller reading the username out of a header span gets no benefit from the span overload at all.

## What changed

The dictionary is wrapped once in a `Dictionary<string, string>.AlternateLookup<ReadOnlySpan<char>>` at construction (`StringComparer.Ordinal` implements `IAlternateEqualityComparer`), and the lookup goes through it. No public API change.

## Verification

`dotnet test` on both target frameworks, 28 tests green.

One new test asserts the lookup is genuinely allocation-free: after a warm-up, 100 calls through the span overload allocate 0 bytes per `GC.GetAllocatedBytesForCurrentThread()`. Confirmed meaningful — with the `ToString()` restored, that test fails. Confirmed stable across three consecutive runs on both frameworks.

A second test covers a username span that is a slice of a larger string, so it is not backed by its own string instance.

---

Stack 2 of 2 · merges into `verify/password-length-cap` · merge after layer 1.
