### PR TITLE
Reject sha-crypt hashes asking for more rounds than we will compute

### DIFF
--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -15,7 +15,9 @@ public sealed class HtpasswdFile
     private const int ShaCryptSaltMaxLength = 16;
     private const int ShaCryptDefaultRounds = 5000;
     private const int ShaCryptMinRounds = 1000;
-    private const int ShaCryptMaxRounds = 999_999_999;
+    // The format allows up to 999_999_999 rounds. Computing that many takes hours, so a hash asking for
+    // more rounds than we are willing to compute is rejected instead of being verified.
+    private const int ShaCryptMaxRounds = 10_000_000;
     private const string Sha1Prefix = "{SHA}";
     private readonly Dictionary<string, string> _entries;
 
@@ -230,7 +232,9 @@ public sealed class HtpasswdFile
             if (!int.TryParse(roundsText, NumberStyles.None, CultureInfo.InvariantCulture, out rounds))
                 return false;
 
-            rounds = Math.Clamp(rounds, ShaCryptMinRounds, ShaCryptMaxRounds);
+            if (rounds is < ShaCryptMinRounds or > ShaCryptMaxRounds)
+                return false;
+
             roundsCustom = true;
             remaining = remaining[(roundsSeparatorIndex + 1)..];
         }

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -95,6 +95,17 @@ public sealed class HtpasswdFileTests
         Assert.False(htpasswd.VerifyCredentials("alice", "invalid"));
     }
 
+    [Theory]
+    [InlineData("$5$rounds=999$toolongsaltstrin$Un/5jzAHMgOGZ5.mWJpuVolil07guHPvOW8mGRcvxa5")]
+    [InlineData("$5$rounds=10000001$toolongsaltstrin$Un/5jzAHMgOGZ5.mWJpuVolil07guHPvOW8mGRcvxa5")]
+    [InlineData("$5$rounds=999999999$toolongsaltstrin$Un/5jzAHMgOGZ5.mWJpuVolil07guHPvOW8mGRcvxa5")]
+    public void VerifyCredentials_ShouldRejectShaCryptRoundsOutsideTheSupportedRange(string hash)
+    {
+        var htpasswd = HtpasswdFile.Parse($"alice:{hash}");
+
+        Assert.False(htpasswd.VerifyCredentials("alice", "This is just a test"));
+    }
+
     [Fact]
     public void VerifyCredentials_String_ShouldValidateSha512CryptHash()
     {


### PR DESCRIPTION
Part of a project review of `Meziantou.Framework.Http.Htpasswd`.

## The problem

[HtpasswdFile.cs:233](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L233) clamps a `$5$`/`$6$` hash's `rounds=` value into the format's own range:

```csharp
rounds = Math.Clamp(rounds, ShaCryptMinRounds, ShaCryptMaxRounds);   // 1_000 .. 999_999_999
```

999 999 999 is a value the glibc sha-crypt spec *permits*, not one that is safe to compute. An entry reading `$5$rounds=999999999$…` makes each `VerifyCredentials` call run 999 999 999 SHA-256 compressions — on the order of hours, synchronously, with no timeout and no way to cancel. One typo adding digits, one copy-paste from a hardening blog post, and a request thread is gone.

Clamping also hides the mistake instead of reporting it. Clamping *down* is pointless besides: glibc normalises the value into the emitted string, so a stored hash carrying `rounds=100` can never compare equal to anything this code computes.

## What changed

`ShaCryptMaxRounds` drops from 999 999 999 to 10 000 000 — what we are willing to compute rather than what the format allows — and a hash outside `[1_000, 10_000_000]` is now **rejected** rather than clamped.

## Verification

`dotnet test` on both target frameworks, 26 tests green. New cases cover `rounds=999` (below the format minimum), `rounds=10000001` (above what we compute) and `rounds=999999999`, all rejected promptly. The existing `rounds=5000` round-trip tests for `$5$` and `$6$` still pass unchanged.

Note the negative tests are also their own timeout: before this change, the `rounds=10000001` case would have clamped to 999 999 999 and run for hours instead of failing.
