### PR TITLE
Route only the documented bcrypt revisions to Bcrypt.Verify

### DIFF
--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -17,6 +17,7 @@ public sealed class HtpasswdFile
     private const int ShaCryptMinRounds = 1000;
     private const int ShaCryptMaxRounds = 999_999_999;
     private const string Sha1Prefix = "{SHA}";
+    private static readonly string[] BcryptPrefixes = ["$2a$", "$2b$", "$2y$"];
     private readonly Dictionary<string, string> _entries;
 
     private HtpasswdFile(Dictionary<string, string> entries)
@@ -143,7 +144,7 @@ public sealed class HtpasswdFile
             return false;
 
         var expectedPasswordHashSpan = expectedPasswordHash.AsSpan();
-        if (expectedPasswordHashSpan.StartsWith("$2", StringComparison.Ordinal))
+        if (IsBcryptHash(expectedPasswordHashSpan))
             return Bcrypt.Verify(password, expectedPasswordHashSpan);
 
         if (expectedPasswordHashSpan.StartsWith(Sha1Prefix, StringComparison.Ordinal))
@@ -162,6 +163,17 @@ public sealed class HtpasswdFile
             return VerifyShaCrypt(password, expectedPasswordHashSpan, useSha512: true);
 
         return password.SequenceEqual(expectedPasswordHashSpan);
+    }
+
+    private static bool IsBcryptHash(ReadOnlySpan<char> hash)
+    {
+        foreach (var prefix in BcryptPrefixes)
+        {
+            if (hash.StartsWith(prefix, StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
     }
 
     private static bool VerifyMd5Crypt(ReadOnlySpan<char> password, ReadOnlySpan<char> expectedHash, string prefix)

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -68,6 +68,29 @@ public sealed class HtpasswdFileTests
         Assert.False(htpasswd.VerifyCredentials("alice", "invalid"));
     }
 
+    [Theory]
+    [InlineData(BcryptVersion.Revision2A)]
+    [InlineData(BcryptVersion.Revision2B)]
+    [InlineData(BcryptVersion.Revision2Y)]
+    public void VerifyCredentials_ShouldValidateTheDocumentedBcryptRevisions(BcryptVersion version)
+    {
+        var hash = Bcrypt.HashPassword("password", workFactor: Bcrypt.MinWorkFactor, version: version);
+        var htpasswd = HtpasswdFile.Parse($"alice:{hash}");
+
+        Assert.True(htpasswd.VerifyCredentials("alice", "password"));
+    }
+
+    [Theory]
+    [InlineData("$2$")]
+    [InlineData("$2x$")]
+    public void VerifyCredentials_ShouldNotRouteUndocumentedBcryptRevisionsToBcrypt(string prefix)
+    {
+        var hash = Bcrypt.HashPassword("password", workFactor: Bcrypt.MinWorkFactor, version: BcryptVersion.Revision2Y);
+        var htpasswd = HtpasswdFile.Parse($"alice:{prefix}{hash[4..]}");
+
+        Assert.False(htpasswd.VerifyCredentials("alice", "password"));
+    }
+
     [Fact]
     public void VerifyCredentials_String_ShouldValidateSha1Hash()
     {


### PR DESCRIPTION
Part of a project review of `Meziantou.Framework.Http.Htpasswd`.

## The problem

[HtpasswdFile.cs:146](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L146) dispatches to bcrypt on `StartsWith("$2")`, but the readme documents only `$2a$`, `$2b$` and `$2y$`. `Meziantou.Framework.Bcrypt` accepts `$2$` and `$2x$` as well ([Bcrypt.cs:165-172](../blob/main/src/Meziantou.Framework.Bcrypt/Bcrypt.cs#L165-L172)), so both currently reach it.

That matters for `$2x$` specifically. The `x` marker exists to tag hashes produced by the 2011 crypt_blowfish sign-extension bug, but `BcryptImplementation` groups `'b'`, `'x'` and `'y'` together ([:236](../blob/main/src/Meziantou.Framework.Bcrypt/BcryptImplementation.cs#L236)) and does not reproduce the buggy algorithm. A genuine `$2x$` hash is therefore verified as if it were `$2b$`, which gives the wrong answer for any password containing a byte ≥ 0x80.

Verified: taking a `$2y$` hash and rewriting its prefix to `$2x$`, the current code returns `True` for the password — it silently accepted a format it does not actually implement.

## What changed

Only `$2a$`, `$2b$` and `$2y$` are routed to `Bcrypt.Verify`, matching what the readme claims.

## Tradeoff

A file containing `$2$` or `$2x$` entries stops authenticating. Apache's `htpasswd` emits `$2y$`, so this is close to theoretical, but it is a behaviour change. Rejecting is the safer half of the trade: the alternative is continuing to answer confidently and wrongly for high-bit passwords.

The underlying gap — `Meziantou.Framework.Bcrypt` treating `$2x$` as `$2b$` rather than implementing the sign-extension quirk — belongs to that project and is not addressed here.

## Verification

`dotnet test` on both target frameworks, 30 tests green. New tests round-trip all three documented revisions and assert `$2$` and `$2x$` are rejected. Confirmed meaningful — with the `$2` prefix check restored, the `$2x$` case fails.
