### PR TITLE
Let LoadAsync observe a CancellationToken and open the file asynchronously

### DIFF
--- a/ref/Meziantou.Framework.Http.Htpasswd.cs
+++ b/ref/Meziantou.Framework.Http.Htpasswd.cs
@@ -11,7 +11,9 @@ namespace Meziantou.Framework.Http
         public static Meziantou.Framework.Http.HtpasswdFile Parse(string content) => throw null;
         public static Meziantou.Framework.Http.HtpasswdFile Parse(System.ReadOnlySpan<char> content) => throw null;
         public static System.Threading.Tasks.Task<Meziantou.Framework.Http.HtpasswdFile> LoadAsync(string file) => throw null;
+        public static System.Threading.Tasks.Task<Meziantou.Framework.Http.HtpasswdFile> LoadAsync(string file, System.Threading.CancellationToken cancellationToken) => throw null;
         public static System.Threading.Tasks.Task<Meziantou.Framework.Http.HtpasswdFile> LoadAsync(System.IO.TextReader file) => throw null;
+        public static System.Threading.Tasks.Task<Meziantou.Framework.Http.HtpasswdFile> LoadAsync(System.IO.TextReader file, System.Threading.CancellationToken cancellationToken) => throw null;
         public bool VerifyCredentials(string username, string password) => throw null;
         public bool VerifyCredentials(System.ReadOnlySpan<char> username, System.ReadOnlySpan<char> password) => throw null;
     }

--- a/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
+++ b/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs
@@ -95,13 +95,21 @@ public sealed class HtpasswdFile
     /// </summary>
     /// <param name="file">The path of the htpasswd file.</param>
     /// <returns>A parsed <see cref="HtpasswdFile"/> instance.</returns>
-    public static async Task<HtpasswdFile> LoadAsync(string file)
+    public static Task<HtpasswdFile> LoadAsync(string file) => LoadAsync(file, CancellationToken.None);
+
+    /// <summary>
+    /// Loads and parses an htpasswd file from disk.
+    /// </summary>
+    /// <param name="file">The path of the htpasswd file.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A parsed <see cref="HtpasswdFile"/> instance.</returns>
+    public static async Task<HtpasswdFile> LoadAsync(string file, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(file);
 
-        await using var stream = File.OpenRead(file);
+        await using var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
         using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
-        return await LoadAsync(reader).ConfigureAwait(false);
+        return await LoadAsync(reader, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -109,11 +117,19 @@ public sealed class HtpasswdFile
     /// </summary>
     /// <param name="file">The reader containing the htpasswd content.</param>
     /// <returns>A parsed <see cref="HtpasswdFile"/> instance.</returns>
-    public static async Task<HtpasswdFile> LoadAsync(TextReader file)
+    public static Task<HtpasswdFile> LoadAsync(TextReader file) => LoadAsync(file, CancellationToken.None);
+
+    /// <summary>
+    /// Loads and parses an htpasswd file from a <see cref="TextReader"/>.
+    /// </summary>
+    /// <param name="file">The reader containing the htpasswd content.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A parsed <see cref="HtpasswdFile"/> instance.</returns>
+    public static async Task<HtpasswdFile> LoadAsync(TextReader file, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(file);
 
-        var content = await file.ReadToEndAsync().ConfigureAwait(false);
+        var content = await file.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
         return Parse(content);
     }
 

--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -59,6 +59,35 @@ public sealed class HtpasswdFileTests
     }
 
     [Fact]
+    public async Task LoadAsync_TextReader_ShouldObserveTheCancellationToken()
+    {
+        using var reader = new StringReader("alice:password");
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => HtpasswdFile.LoadAsync(reader, cts.Token));
+    }
+
+    [Fact]
+    public async Task LoadAsync_String_ShouldObserveTheCancellationToken()
+    {
+        var filePath = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(filePath, "alice:password");
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => HtpasswdFile.LoadAsync(filePath, cts.Token));
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
     public void VerifyCredentials_String_ShouldValidateBcryptHash()
     {
         var hash = Bcrypt.HashPassword("password", workFactor: Bcrypt.MinWorkFactor, version: BcryptVersion.Revision2Y);


### PR DESCRIPTION
Part of a project review of `Meziantou.Framework.Http.Htpasswd`.

## The problem

Neither `LoadAsync` overload accepts a `CancellationToken` ([HtpasswdFile.cs:98-118](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L98-L118)), so `ReadToEndAsync()` cannot be cancelled, and `File.OpenRead` at [:102](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L102) opens the handle synchronously without `FileOptions.Asynchronous`.

Minor for a small local file. It matters mostly because this is a public async API on a package targeting modern .NET, and adding the parameter later is awkward — a defaulted parameter on the existing methods would change their signatures and break already-compiled callers.

## What changed

- New `LoadAsync(string, CancellationToken)` and `LoadAsync(TextReader, CancellationToken)` overloads; the existing two forward with `CancellationToken.None`, so compiled callers keep binding to the same signatures.
- `File.OpenRead` becomes a `FileStream` with `useAsync: true`.
- `ref/Meziantou.Framework.Http.Htpasswd.cs` regenerated (+2 lines).

## Merge order

This and `verify/plaintext-opt-in` both restructure the `LoadAsync` overload set and both regenerate `ref/`, so whichever merges second needs a rebase — re-run `dotnet build` on the project to regenerate `ref/` rather than resolving that file by hand. Every other pair among the review PRs merges clean.

## Verification

`dotnet test` on both target frameworks, 24 tests green. Two new tests pass an already-cancelled token to each overload and assert `OperationCanceledException`.
