### PR TITLE
Document the $1$ md5-crypt format in the htpasswd readme

### DIFF
--- a/src/Meziantou.Framework.Http.Htpasswd/readme.md
+++ b/src/Meziantou.Framework.Http.Htpasswd/readme.md
@@ -6,10 +6,14 @@ Supported password formats:
 
 - bcrypt (`$2a$`, `$2b$`, `$2y$`)
 - Apache MD5 (`$apr1$`)
+- MD5 crypt (`$1$`)
 - SHA-256 crypt (`$5$`)
 - SHA-512 crypt (`$6$`)
 - SHA-1 (`{SHA}`)
 - plaintext
+
+`{SHA}` and plaintext entries are unsalted, so they are only there to read existing files. Use bcrypt for
+new ones.
 
 ```csharp
 var htpasswd = HtpasswdFile.Parse("""


### PR DESCRIPTION
Part of a project review of `Meziantou.Framework.Http.Htpasswd`.

## The problem

The readme's supported-formats list omits **`$1$` md5-crypt**, which [HtpasswdFile.cs:155-156](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L155-L156) implements and which `openssl passwd -1` and older `htpasswd` builds produce. A reader checking whether this library can read their file gets the wrong answer.

The list also gives `{SHA}` and plaintext equal billing with bcrypt, with nothing saying they are unsalted. For a security-adjacent package the readme is where someone decides whether the library is safe for their file, so that reads as an endorsement it should not be.

## What changed

- Added `- MD5 crypt (`$1$`)` to the list.
- Added one line noting `{SHA}` and plaintext are unsalted and exist to read existing files, not to write new ones.

Documentation only — no code change. `dotnet run ./eng/update-all.cs` reports nothing further to sync.
