### PR TITLE
Cover the $1$ md5-crypt format and malformed md5-crypt hashes

### DIFF
--- a/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
+++ b/tests/Meziantou.Framework.Http.Htpasswd.Tests/HtpasswdFileTests.cs
@@ -87,6 +87,29 @@ public sealed class HtpasswdFileTests
     }
 
     [Fact]
+    public void VerifyCredentials_String_ShouldValidateMd5CryptHash()
+    {
+        var htpasswd = HtpasswdFile.Parse("alice:$1$salt1234$HJCsv4hSeVLHo3hVyl4nh0");
+
+        Assert.True(htpasswd.VerifyCredentials("alice", "password"));
+        Assert.False(htpasswd.VerifyCredentials("alice", "invalid"));
+    }
+
+    [Theory]
+    [InlineData("alice:$1$salt1234$HJCsv4hSeVLHo3hVyl4nh1")]
+    [InlineData("alice:$1$salt1235$HJCsv4hSeVLHo3hVyl4nh0")]
+    [InlineData("alice:$1$salt1234$")]
+    [InlineData("alice:$1$salt1234")]
+    [InlineData("alice:$1$toolongsalt$HJCsv4hSeVLHo3hVyl4nh0")]
+    [InlineData("alice:$1$salt1234$HJCsv4hSeVLHo3hVyl4n!0")]
+    public void VerifyCredentials_ShouldRejectAMalformedOrWrongMd5CryptHash(string entry)
+    {
+        var htpasswd = HtpasswdFile.Parse(entry);
+
+        Assert.False(htpasswd.VerifyCredentials("alice", "password"));
+    }
+
+    [Fact]
     public void VerifyCredentials_String_ShouldValidateSha256CryptHash()
     {
         var htpasswd = HtpasswdFile.Parse("alice:$5$rounds=5000$toolongsaltstrin$Un/5jzAHMgOGZ5.mWJpuVolil07guHPvOW8mGRcvxa5");


### PR DESCRIPTION
Part of a project review of `Meziantou.Framework.Http.Htpasswd`.

## The problem

`$1$` md5-crypt is implemented at [HtpasswdFile.cs:155-156](../blob/main/src/Meziantou.Framework.Http.Htpasswd/HtpasswdFile.cs#L155-L156) and shares `CreateMd5CryptHash` with `$apr1$`, but **no test exercises it** — the existing suite covers bcrypt, `{SHA}`, `$apr1$`, `$5$`, `$6$` and plaintext, and stops there. An entire supported format could regress silently.

The suite is also happy-path only: one success and one wrong-password case per format, and no coverage of malformed hashes, which is what a corrupted or hand-edited file actually produces.

Tests only — no production change. This is the residual of the review's coverage finding; the per-behaviour tests for each fix ride in their own PRs.

## What changed

- A `$1$` round-trip against a hash generated by `openssl passwd -1 -salt salt1234 password`, verifying the right password and rejecting a wrong one.
- Six malformed/wrong `$1$` cases: a checksum off by one character, a salt off by one character, an empty checksum, a missing checksum separator, an over-long salt, and a checksum containing a character outside the hash64 alphabet.

## Verification

`dotnet test` on both target frameworks, 34 tests green. All six negative cases already behave correctly against `main` — they pin existing behaviour rather than fixing anything.
