### PR TITLE
Do not suggest FullPath for symbols used as strings

### DIFF
--- a/src/Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/FullPathContext.cs
@@ -48,6 +48,26 @@ internal sealed class FullPathContext(Compilation compilation)
         return false;
     }
 
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="operation"/> is the receiver of a <see cref="string"/>
+    /// member that <c>FullPath</c> does not expose, so that retyping the symbol to <c>FullPath</c> would not compile.
+    /// </summary>
+    public bool IsReceiverOfStringOnlyMember(IOperation operation)
+    {
+        var member = operation.Parent switch
+        {
+            IInvocationOperation invocationOperation when invocationOperation.Instance == operation => (ISymbol)invocationOperation.TargetMethod,
+            IPropertyReferenceOperation propertyReferenceOperation when propertyReferenceOperation.Instance == operation => propertyReferenceOperation.Property,
+            _ => null,
+        };
+
+        if (member?.ContainingType?.SpecialType != SpecialType.System_String)
+            return false;
+
+        // object members such as ToString or Equals exist on FullPath too and stay valid
+        return FullPathType is { } fullPathType && fullPathType.GetMembers(member.Name).IsEmpty;
+    }
+
     [MemberNotNullWhen(true, nameof(FullPathType))]
     public bool IsValid => FullPathType is not null;
 

--- a/src/Meziantou.Framework.FullPath.Analyzer/ParameterShouldBeFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/ParameterShouldBeFullPathAnalyzer.cs
@@ -41,10 +41,12 @@ public sealed class ParameterShouldBeFullPathAnalyzer : DiagnosticAnalyzer
             var candidateCache = new ConcurrentDictionary<ISymbol, bool>(SymbolEqualityComparer.Default);
             var arguments = new ConcurrentBag<ArgumentUsage>();
             var excludedMethods = new ConcurrentBag<IMethodSymbol>();
+            var excludedParameters = new ConcurrentBag<IParameterSymbol>();
 
             context.RegisterOperationAction(context => AnalyzeInvocation(context, analyzerContext, candidateCache, arguments), OperationKind.Invocation);
             context.RegisterOperationAction(context => excludedMethods.Add(((IMethodReferenceOperation)context.Operation).Method.OriginalDefinition), OperationKind.MethodReference);
-            context.RegisterCompilationEndAction(context => Report(context, arguments, excludedMethods));
+            context.RegisterOperationAction(context => AnalyzeParameterReference(context, analyzerContext, excludedParameters), OperationKind.ParameterReference);
+            context.RegisterCompilationEndAction(context => Report(context, arguments, excludedMethods, excludedParameters));
         });
     }
 
@@ -68,9 +70,33 @@ public sealed class ParameterShouldBeFullPathAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static void Report(CompilationAnalysisContext context, ConcurrentBag<ArgumentUsage> arguments, ConcurrentBag<IMethodSymbol> excludedMethods)
+    /// <summary>
+    /// Excludes a parameter whose own body usage would not survive a change of declared type.
+    /// </summary>
+    private static void AnalyzeParameterReference(OperationAnalysisContext context, FullPathContext analyzerContext, ConcurrentBag<IParameterSymbol> excludedParameters)
+    {
+        var operation = (IParameterReferenceOperation)context.Operation;
+        if (operation.Parameter.Type.SpecialType != SpecialType.System_String)
+            return;
+
+        var isWritten = operation.Parent switch
+        {
+            ISimpleAssignmentOperation assignmentOperation => assignmentOperation.Target == operation,
+            ICompoundAssignmentOperation compoundAssignmentOperation => compoundAssignmentOperation.Target == operation,
+            IIncrementOrDecrementOperation incrementOrDecrementOperation => incrementOrDecrementOperation.Target == operation,
+            _ => false,
+        };
+
+        if (isWritten || analyzerContext.IsReceiverOfStringOnlyMember(operation))
+        {
+            excludedParameters.Add(operation.Parameter.OriginalDefinition);
+        }
+    }
+
+    private static void Report(CompilationAnalysisContext context, ConcurrentBag<ArgumentUsage> arguments, ConcurrentBag<IMethodSymbol> excludedMethods, ConcurrentBag<IParameterSymbol> excludedParameters)
     {
         var excluded = new HashSet<ISymbol>(excludedMethods, SymbolEqualityComparer.Default);
+        var excludedParameterSet = new HashSet<ISymbol>(excludedParameters, SymbolEqualityComparer.Default);
 
         // For each parameter: null when never seen, true while every argument was a FullPath, false otherwise
         var states = new Dictionary<ISymbol, bool?[]>(SymbolEqualityComparer.Default);
@@ -98,6 +124,9 @@ public sealed class ParameterShouldBeFullPathAnalyzer : DiagnosticAnalyzer
                     continue;
 
                 var parameter = method.Parameters[i];
+                if (excludedParameterSet.Contains(parameter))
+                    continue;
+
                 var location = parameter.GetFirstSourceLocation();
                 if (location is null)
                     continue;

--- a/src/Meziantou.Framework.FullPath.Analyzer/VariableShouldBeFullPathAnalyzer.cs
+++ b/src/Meziantou.Framework.FullPath.Analyzer/VariableShouldBeFullPathAnalyzer.cs
@@ -77,6 +77,11 @@ public sealed class VariableShouldBeFullPathAnalyzer : DiagnosticAnalyzer
             case IArgumentOperation { Parameter.RefKind: not RefKind.None, Value: ILocalReferenceOperation argumentReference }:
                 Disqualify(candidates, argumentReference.Local);
                 break;
+
+            // Reading the variable through a string member that FullPath does not have
+            case ILocalReferenceOperation localReference when analyzerContext.IsReceiverOfStringOnlyMember(localReference):
+                Disqualify(candidates, localReference.Local);
+                break;
         }
 
         foreach (var childOperation in operation.ChildOperations)

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/ParameterShouldBeFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/ParameterShouldBeFullPathRuleTests.cs
@@ -279,4 +279,58 @@ public sealed class ParameterShouldBeFullPathRuleTests : FullPathAnalyzerTestBas
 
         await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenTheParameterIsReassigned()
+    {
+        var source = """
+            using System.IO;
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static void M(FullPath value)
+                    {
+                        Process(value);
+                    }
+
+                    private static void Process(string path)
+                    {
+                        path = Path.GetFullPath(path);
+                        System.Console.WriteLine(path);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenTheParameterIsUsedAsAString()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static void M(FullPath value)
+                    {
+                        Process(value);
+                    }
+
+                    private static void Process(string path)
+                    {
+                        System.Console.WriteLine(path.Length);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<ParameterShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
 }

--- a/tests/Meziantou.Framework.FullPath.Analyzer.Tests/VariableShouldBeFullPathRuleTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Analyzer.Tests/VariableShouldBeFullPathRuleTests.cs
@@ -168,4 +168,48 @@ public sealed class VariableShouldBeFullPathRuleTests : FullPathAnalyzerTestBase
 
         await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
     }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenTheVariableIsUsedAsAString()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static int M(FullPath fullPath)
+                    {
+                        string path = fullPath;
+                        return path.Length;
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
+
+    [Fact]
+    public async Task Analyzer_DoesNotReportDiagnostic_WhenTheVariableIsSliced()
+    {
+        var source = """
+            using Meziantou.Framework;
+
+            namespace Sample
+            {
+                public static class TestClass
+                {
+                    public static string M(FullPath fullPath)
+                    {
+                        string path = fullPath;
+                        return path.Substring(1);
+                    }
+                }
+            }
+            """;
+
+        await CreateAnalyzerTest<VariableShouldBeFullPathAnalyzerType>(source).RunAsync(XunitCancellationToken);
+    }
 }


### PR DESCRIPTION
MFFP0013 ("declare the variable as FullPath") and MFFP0014 ("declare the parameter as FullPath") judged a symbol purely by what was *written* to it, never by how it was *read*. Both therefore proposed changes that do not compile.

```csharp
// MFFP0014 — reported on 'path', but retyping it makes the assignment CS0029
private static void Process(string path)
{
    path = Path.GetFullPath(path);
    Console.WriteLine(path);
}

// MFFP0014 — reported on 'path'; FullPath has no Length
private static void Process(string path) => Console.WriteLine(path.Length);

// MFFP0013 — reported on 'path'; FullPath has no Length or Substring
string path = fullPath;
return path.Length;
```

`ParameterShouldBeFullPathAnalyzer` registered only `Invocation` and `MethodReference`, so it never looked inside the callee at all — every negative test in its suite varies the *call site*, and every callee body in that file is empty. Normalizing a path parameter in place is a very common shape, and MFFP0014 is the flagship rule of the set.

The asymmetry was visible in the code: `VariableShouldBeFullPathAnalyzer` already disqualified locals on compound assignment and `ref`/`out` use; the parameter analyzer had neither guard, and neither analyzer inspected reads.

## What changed

- `FullPathContext.IsReceiverOfStringOnlyMember` — shared check for "this symbol is the receiver of a `System.String` member that `FullPath` does not expose". Members present on both (`ToString`, `Equals`, `GetHashCode`) stay valid, so they do not disqualify.
- `VariableShouldBeFullPathAnalyzer` disqualifies a local read through such a member, alongside its existing write-based disqualifications.
- `ParameterShouldBeFullPathAnalyzer` registers a `ParameterReference` action and excludes a parameter that is assigned, incremented, or read through such a member. Exclusions are collected per compilation and applied in the existing compilation-end report.

## Verification

Four negative tests added — parameter reassigned, parameter read via `.Length`, local read via `.Length`, local read via `.Substring`. All four fail on `main` and pass with the fix. All 105 pre-existing tests are unchanged and still green, so the rules still fire on everything they fired on before. Full analyzer suite green at 109 tests.

## Known limitation

Extension methods invoked in reduced form (`path.AsSpan()`) are not detected, because the receiver is an argument rather than `Instance`. That is a narrowing of this fix, not a regression — those cases behave as they do today.
