### PR TITLE
Resolve NuGet sources with NuGet.Configuration instead of custom logic

### DIFF
--- a/src/Meziantou.Framework.DependencyScanning.Tool/Meziantou.Framework.DependencyScanning.Tool.csproj
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Meziantou.Framework.DependencyScanning.Tool.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NuGet.Configuration" Version="7.9.0" />
     <PackageReference Include="NuGet.Protocol" Version="7.9.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.11" />
   </ItemGroup>

--- a/src/Meziantou.Framework.DependencyScanning.Tool/NuGetPackageSourceResolver.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/NuGetPackageSourceResolver.cs
@@ -1,176 +1,63 @@
-using System.Text.RegularExpressions;
-using System.Xml.Linq;
+using NuGet.Configuration;
 
 namespace Meziantou.Framework.DependencyScanning.Tool;
 
 internal static class NuGetPackageSourceResolver
 {
-    private const int NoMatch = -1;
-    private const int ExactMatch = int.MaxValue;
-
-    private static readonly StringComparer Comparer = OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+    // The search pattern is matched case-sensitively on Unix, so 'NuGet.Config' would not match '*.config'.
+    private static readonly EnumerationOptions ConfigFileEnumerationOptions = new() { MatchCasing = MatchCasing.CaseInsensitive };
 
     public static NuGetSourceResolution Resolve(FullPath dependencyFile, string packageName)
     {
-        var packageSources = new Dictionary<string, string>(Comparer);
-        var packageMappings = new Dictionary<string, List<string>>(Comparer);
+        // Only the configuration files in the repository are considered. NuGet would also load the
+        // user-wide and machine-wide files, but the tool must resolve the same sources whichever
+        // machine it runs on.
+        var configFiles = EnumerateConfigFiles(dependencyFile.Parent);
+        if (configFiles.Count is 0)
+            return new NuGetSourceResolution([], [], HasSourceMappings: false);
 
-        var configFiles = EnumerateConfigFiles(dependencyFile.Parent).Reverse();
-        foreach (var configFile in configFiles)
-        {
-            ParseConfig(configFile, packageSources, packageMappings);
-        }
+        var settings = Settings.LoadSettingsGivenConfigPaths(configFiles);
+        var sourceProvider = new PackageSourceProvider(settings);
+        var allSources = sourceProvider.LoadPackageSources().Where(source => source.IsEnabled).ToArray();
 
-        var sources = ResolveSourcesForPackage(packageName, packageSources, packageMappings);
-        return new NuGetSourceResolution([.. sources], [.. packageSources.Values], HasSourceMappings: packageMappings.Count > 0);
-    }
+        // PackageSourceMapping is NuGet's own pattern matching, so the tool queries exactly the sources
+        // a restore would. Matching a package against every source whose patterns happen to match would
+        // send an internally-mapped package name to a wildcard-mapped public feed, which is exactly what
+        // source mapping exists to prevent.
+        var mapping = PackageSourceMapping.GetPackageSourceMapping(settings);
+        if (!mapping.IsEnabled)
+            return new NuGetSourceResolution(allSources, allSources, HasSourceMappings: false);
 
-    private static IEnumerable<FullPath> EnumerateConfigFiles(FullPath directory)
-    {
-        var current = directory;
-        while (!current.IsEmpty)
-        {
-            var nugetConfig = current / "nuget.config";
-            var nuGetConfig = current / "NuGet.config";
-            var nuGetConfigUpper = current / "NuGet.Config";
-
-            if (File.Exists(nugetConfig))
-                yield return nugetConfig;
-
-            if (File.Exists(nuGetConfig) && nuGetConfig != nugetConfig)
-                yield return nuGetConfig;
-
-            if (File.Exists(nuGetConfigUpper) && nuGetConfigUpper != nugetConfig && nuGetConfigUpper != nuGetConfig)
-                yield return nuGetConfigUpper;
-
-            current = current.Parent;
-        }
-    }
-
-    private static void ParseConfig(FullPath configFile, Dictionary<string, string> packageSources, Dictionary<string, List<string>> packageMappings)
-    {
-        var document = XDocument.Load(configFile);
-        var root = document.Root;
-        if (root is null)
-            return;
-
-        var packageSourcesElement = root.Element("packageSources");
-        if (packageSourcesElement is not null)
-        {
-            ApplyClearBehavior(packageSourcesElement, packageSources);
-            foreach (var addElement in packageSourcesElement.Elements("add"))
-            {
-                var key = addElement.Attribute("key")?.Value;
-                var value = addElement.Attribute("value")?.Value;
-                if (string.IsNullOrWhiteSpace(key) || string.IsNullOrWhiteSpace(value))
-                    continue;
-
-                packageSources[key] = value;
-            }
-        }
-
-        var mappingElement = root.Element("packageSourceMapping");
-        if (mappingElement is null)
-            return;
-
-        ApplyClearBehavior(mappingElement, packageMappings);
-        foreach (var sourceElement in mappingElement.Elements("packageSource"))
-        {
-            var sourceKey = sourceElement.Attribute("key")?.Value;
-            if (string.IsNullOrWhiteSpace(sourceKey))
-                continue;
-
-            if (!packageMappings.TryGetValue(sourceKey, out var patterns))
-            {
-                patterns = [];
-                packageMappings[sourceKey] = patterns;
-            }
-
-            foreach (var packageElement in sourceElement.Elements("package"))
-            {
-                var pattern = packageElement.Attribute("pattern")?.Value;
-                if (!string.IsNullOrWhiteSpace(pattern))
-                {
-                    patterns.Add(pattern);
-                }
-            }
-        }
-    }
-
-    private static List<string> ResolveSourcesForPackage(string packageName, Dictionary<string, string> packageSources, Dictionary<string, List<string>> packageMappings)
-    {
-        if (packageMappings.Count is 0)
-            return [.. packageSources.Values];
-
-        // NuGet resolves a package to the source with the longest matching pattern, not to every source
-        // whose patterns happen to match. Querying them all would send an internally-mapped package name
-        // to a wildcard-mapped public feed, which is exactly what source mapping exists to prevent.
-        var bestScore = NoMatch;
-        var matches = new List<string>();
-        foreach (var (sourceName, patterns) in packageMappings)
-        {
-            if (!packageSources.TryGetValue(sourceName, out var sourceUrl))
-                continue;
-
-            var score = GetMatchScore(packageName, patterns);
-            if (score is NoMatch || score < bestScore)
-                continue;
-
-            if (score > bestScore)
-            {
-                bestScore = score;
-                matches.Clear();
-            }
-
-            matches.Add(sourceUrl);
-        }
-
-        if (matches.Count is 0)
-            return [];
-
-        return [.. matches.Distinct(Comparer)];
-    }
-
-    private static int GetMatchScore(string packageName, IReadOnlyCollection<string> patterns)
-    {
-        var best = NoMatch;
-        foreach (var pattern in patterns)
-        {
-            var score = GetMatchScore(packageName, pattern);
-            if (score > best)
-            {
-                best = score;
-            }
-        }
-
-        return best;
+        var mappedNames = mapping.GetConfiguredPackageSources(packageName);
+        var mappedSources = allSources.Where(source => mappedNames.Contains(source.Name, StringComparer.OrdinalIgnoreCase)).ToArray();
+        return new NuGetSourceResolution(mappedSources, allSources, HasSourceMappings: true);
     }
 
     /// <summary>
-    /// Ranks how specifically <paramref name="pattern"/> matches <paramref name="packageName"/>: an exact
-    /// pattern outranks every wildcard, and among wildcards the longest literal prefix wins.
-    /// Returns <see cref="NoMatch"/> when the pattern does not match at all.
+    /// Walks up from <paramref name="directory"/> and returns every NuGet configuration file, nearest first.
+    /// That is the order <see cref="Settings.LoadSettingsGivenConfigPaths"/> expects: the closest file wins.
     /// </summary>
-    private static int GetMatchScore(string packageName, string pattern)
+    private static List<string> EnumerateConfigFiles(FullPath directory)
     {
-        var wildcardIndex = pattern.IndexOf('*', StringComparison.Ordinal);
-        if (wildcardIndex < 0)
-            return Comparer.Equals(packageName, pattern) ? ExactMatch : NoMatch;
-
-        return GlobMatch(packageName, pattern) ? wildcardIndex : NoMatch;
-    }
-
-    private static bool GlobMatch(string text, string pattern)
-    {
-        var regexPattern = "^" + Regex.Escape(pattern).Replace("\\*", ".*", StringComparison.Ordinal) + "$";
-        return Regex.IsMatch(text, regexPattern, OperatingSystem.IsWindows() ? RegexOptions.IgnoreCase : RegexOptions.None, TimeSpan.FromSeconds(1));
-    }
-
-    private static void ApplyClearBehavior<TValue>(XElement element, Dictionary<string, TValue> data)
-    {
-        if (element.Elements("clear").Any())
+        var configFiles = new List<string>();
+        var current = directory;
+        while (!current.IsEmpty)
         {
-            data.Clear();
+            if (Directory.Exists(current))
+            {
+                // The file name is matched case-insensitively on every platform, the way NuGet does it,
+                // so 'nuget.config' and 'NuGet.Config' both work on case-sensitive file systems. Sorted
+                // because the enumeration order is undefined when a directory holds several casings.
+                var matches = Directory.EnumerateFiles(current, "*.config", ConfigFileEnumerationOptions)
+                    .Where(file => Path.GetFileName(file.AsSpan()).Equals(Settings.DefaultSettingsFileName, StringComparison.OrdinalIgnoreCase))
+                    .Order(StringComparer.Ordinal);
+
+                configFiles.AddRange(matches);
+            }
+
+            current = current.Parent;
         }
+
+        return configFiles;
     }
 }

--- a/src/Meziantou.Framework.DependencyScanning.Tool/NuGetSourceResolution.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/NuGetSourceResolution.cs
@@ -1,3 +1,5 @@
+using NuGet.Configuration;
+
 namespace Meziantou.Framework.DependencyScanning.Tool;
 
-internal sealed record NuGetSourceResolution(IReadOnlyList<string> PackageSources, IReadOnlyList<string> AllConfiguredSources, bool HasSourceMappings);
+internal sealed record NuGetSourceResolution(IReadOnlyList<PackageSource> PackageSources, IReadOnlyList<PackageSource> AllConfiguredSources, bool HasSourceMappings);

--- a/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NuGetPackageUpdater.cs
+++ b/src/Meziantou.Framework.DependencyScanning.Tool/Updaters/NuGetPackageUpdater.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -8,7 +9,7 @@ namespace Meziantou.Framework.DependencyScanning.Tool;
 
 internal sealed class NuGetPackageUpdater : PackageUpdater
 {
-    private const string NuGetOrgSource = "https://api.nuget.org/v3/index.json";
+    private static readonly PackageSource NuGetOrgSource = new("https://api.nuget.org/v3/index.json");
     public override VersioningStrategy VersioningStrategy { get; set; } = NuGetVersioningStrategy.Instance;
 
     protected override bool IsSupported(Dependency dependency) => dependency.Type is DependencyType.NuGet && dependency.Name is not null;
@@ -20,7 +21,7 @@ internal sealed class NuGetPackageUpdater : PackageUpdater
             yield break;
 
         var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(dependencyLocation), dependency.Name);
-        IReadOnlyList<string> sources;
+        IReadOnlyList<PackageSource> sources;
         if (resolution.PackageSources.Count > 0)
         {
             sources = resolution.PackageSources;
@@ -81,10 +82,13 @@ internal sealed class NuGetPackageUpdater : PackageUpdater
         }
     }
 
-    private static async IAsyncEnumerable<PackageVersion> GetVersionsFromSourceWithMetadataAsync(string sourceUrl, string packageName, [EnumeratorCancellation] CancellationToken cancellationToken)
+    private static async IAsyncEnumerable<PackageVersion> GetVersionsFromSourceWithMetadataAsync(PackageSource source, string packageName, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         using var cache = new SourceCacheContext { NoCache = true };
-        var repository = Repository.Factory.GetCoreV3(sourceUrl);
+
+        // The PackageSource overload carries the credentials, client certificates and protocol settings
+        // declared in the configuration file, so authenticated private feeds work.
+        var repository = Repository.Factory.GetCoreV3(source);
         var metadataResource = await repository.GetResourceAsync<PackageMetadataResource>(cancellationToken).ConfigureAwait(false);
 
         if (metadataResource is null)

--- a/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
+++ b/tests/Meziantou.Framework.DependencyScanning.Tool.Tests/FunctionalTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Meziantou.Framework;
+using NuGet.Configuration;
 using NuGet.Versioning;
 
 namespace Meziantou.Framework.DependencyScanning.Tool.Tests;
@@ -12,6 +13,8 @@ public sealed class FunctionalTests
     {
         _testOutputHelper = testOutputHelper;
     }
+
+    private static string[] Urls(IReadOnlyList<PackageSource> sources) => [.. sources.Select(source => source.Source)];
 
     [Fact]
     public async Task UpdateNuGetPackage()
@@ -332,8 +335,8 @@ public sealed class FunctionalTests
 
         var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Package.Id");
 
-        Assert.Equal(["https://feed1/v3/index.json"], resolution.PackageSources);
-        Assert.Equal(["https://feed1/v3/index.json"], resolution.AllConfiguredSources);
+        Assert.Equal(["https://feed1/v3/index.json"], Urls(resolution.PackageSources));
+        Assert.Equal(["https://feed1/v3/index.json"], Urls(resolution.AllConfiguredSources));
         Assert.False(resolution.HasSourceMappings);
     }
 
@@ -379,8 +382,8 @@ public sealed class FunctionalTests
 
         var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Package.Id");
 
-        Assert.Equal(["https://child/v3/index.json"], resolution.PackageSources);
-        Assert.Equal(["https://child/v3/index.json"], resolution.AllConfiguredSources);
+        Assert.Equal(["https://child/v3/index.json"], Urls(resolution.PackageSources));
+        Assert.Equal(["https://child/v3/index.json"], Urls(resolution.AllConfiguredSources));
     }
 
     [Fact]
@@ -413,8 +416,8 @@ public sealed class FunctionalTests
 
         var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Package.Id");
 
-        Assert.Equal(["https://feed3/v3/index.json"], resolution.PackageSources);
-        Assert.Equal(["https://feed3/v3/index.json"], resolution.AllConfiguredSources);
+        Assert.Equal(["https://feed3/v3/index.json"], Urls(resolution.PackageSources));
+        Assert.Equal(["https://feed3/v3/index.json"], Urls(resolution.AllConfiguredSources));
     }
 
     [Fact]
@@ -443,7 +446,7 @@ public sealed class FunctionalTests
 
         var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Contoso.Library");
 
-        Assert.Equal(["https://private/v3/index.json"], resolution.PackageSources);
+        Assert.Equal(["https://private/v3/index.json"], Urls(resolution.PackageSources));
         Assert.True(resolution.HasSourceMappings);
     }
 
@@ -475,8 +478,8 @@ public sealed class FunctionalTests
         var newtonsoft = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Newtonsoft.Json");
 
         // 'Contoso.*' is more specific than '*', so the public feed must not be queried for it
-        Assert.Equal(["https://private/v3/index.json"], contoso.PackageSources);
-        Assert.Equal(["https://api.nuget.org/v3/index.json"], newtonsoft.PackageSources);
+        Assert.Equal(["https://private/v3/index.json"], Urls(contoso.PackageSources));
+        Assert.Equal(["https://api.nuget.org/v3/index.json"], Urls(newtonsoft.PackageSources));
     }
 
     [Fact]
@@ -506,8 +509,8 @@ public sealed class FunctionalTests
         var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Contoso.Library");
         var other = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Contoso.Other");
 
-        Assert.Equal(["https://exact/v3/index.json"], resolution.PackageSources);
-        Assert.Equal(["https://prefix/v3/index.json"], other.PackageSources);
+        Assert.Equal(["https://exact/v3/index.json"], Urls(resolution.PackageSources));
+        Assert.Equal(["https://prefix/v3/index.json"], Urls(other.PackageSources));
     }
 
     [Fact]
@@ -537,8 +540,8 @@ public sealed class FunctionalTests
         var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Contoso.Library");
 
         Assert.Equal(2, resolution.PackageSources.Count);
-        Assert.Contains("https://first/v3/index.json", resolution.PackageSources);
-        Assert.Contains("https://second/v3/index.json", resolution.PackageSources);
+        Assert.Contains("https://first/v3/index.json", Urls(resolution.PackageSources));
+        Assert.Contains("https://second/v3/index.json", Urls(resolution.PackageSources));
     }
 
     [Fact]
@@ -564,7 +567,7 @@ public sealed class FunctionalTests
         var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Newtonsoft.Json");
 
         Assert.Empty(resolution.PackageSources);
-        Assert.Equal(["https://private/v3/index.json"], resolution.AllConfiguredSources);
+        Assert.Equal(["https://private/v3/index.json"], Urls(resolution.AllConfiguredSources));
         Assert.True(resolution.HasSourceMappings);
     }
 
@@ -636,7 +639,116 @@ public sealed class FunctionalTests
         var newtonsoftResolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Newtonsoft.Json");
 
         Assert.Empty(contosoResolution.PackageSources);
-        Assert.Equal(["https://api.nuget.org/v3/index.json"], newtonsoftResolution.PackageSources);
+        Assert.Equal(["https://api.nuget.org/v3/index.json"], Urls(newtonsoftResolution.PackageSources));
+    }
+
+    [Fact]
+    public async Task NuGetPackageSourceResolver_PackageSourceMapping_PackageIdIsCaseInsensitive()
+    {
+        await using var tempDir = TemporaryDirectory.Create();
+        var projectFile = tempDir.CreateEmptyFile("a.csproj");
+        await File.WriteAllTextAsync(projectFile, "<Project />", XunitCancellationToken);
+        await File.WriteAllTextAsync(tempDir.CreateEmptyFile("nuget.config"), """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+                <add key="private" value="https://private/v3/index.json" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="nuget">
+                  <package pattern="*" />
+                </packageSource>
+                <packageSource key="private">
+                  <package pattern="Contoso.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """, XunitCancellationToken);
+
+        var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "CONTOSO.library");
+
+        // Package ids are case-insensitive on every platform, so the public feed must not be queried
+        Assert.Equal(["https://private/v3/index.json"], Urls(resolution.PackageSources));
+    }
+
+    [Fact]
+    public async Task NuGetPackageSourceResolver_PackageSourceMapping_OnlyThePrefixBeforeTheWildcardMatters()
+    {
+        await using var tempDir = TemporaryDirectory.Create();
+        var projectFile = tempDir.CreateEmptyFile("a.csproj");
+        await File.WriteAllTextAsync(projectFile, "<Project />", XunitCancellationToken);
+        await File.WriteAllTextAsync(tempDir.CreateEmptyFile("nuget.config"), """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+                <add key="private" value="https://private/v3/index.json" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="nuget">
+                  <package pattern="*" />
+                </packageSource>
+                <packageSource key="private">
+                  <package pattern="Contoso.*.Extensions" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """, XunitCancellationToken);
+
+        var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Contoso.Library");
+
+        // NuGet ignores everything after the first '*', so 'Contoso.*.Extensions' behaves like 'Contoso.*'
+        Assert.Equal(["https://private/v3/index.json"], Urls(resolution.PackageSources));
+    }
+
+    [Fact]
+    public async Task NuGetPackageSourceResolver_DisabledPackageSourceIsIgnored()
+    {
+        await using var tempDir = TemporaryDirectory.Create();
+        var projectFile = tempDir.CreateEmptyFile("a.csproj");
+        await File.WriteAllTextAsync(projectFile, "<Project />", XunitCancellationToken);
+        await File.WriteAllTextAsync(tempDir.CreateEmptyFile("nuget.config"), """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <add key="enabled" value="https://enabled/v3/index.json" />
+                <add key="disabled" value="https://disabled/v3/index.json" />
+              </packageSources>
+              <disabledPackageSources>
+                <add key="disabled" value="true" />
+              </disabledPackageSources>
+            </configuration>
+            """, XunitCancellationToken);
+
+        var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Package.Id");
+
+        Assert.Equal(["https://enabled/v3/index.json"], Urls(resolution.PackageSources));
+        Assert.Equal(["https://enabled/v3/index.json"], Urls(resolution.AllConfiguredSources));
+    }
+
+    [Fact]
+    public async Task NuGetPackageSourceResolver_RelativeSourceIsResolvedAgainstTheConfigFile()
+    {
+        await using var tempDir = TemporaryDirectory.Create();
+        var srcDirectory = tempDir.GetFullPath("src");
+        Directory.CreateDirectory(srcDirectory);
+
+        var projectFile = srcDirectory / "a.csproj";
+        await File.WriteAllTextAsync(projectFile, "<Project />", XunitCancellationToken);
+        await File.WriteAllTextAsync(tempDir.CreateEmptyFile("nuget.config"), """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <add key="local" value="./packages" />
+              </packageSources>
+            </configuration>
+            """, XunitCancellationToken);
+
+        var resolution = NuGetPackageSourceResolver.Resolve(FullPath.FromPath(projectFile), "Package.Id");
+
+        var source = Assert.Single(resolution.PackageSources);
+        Assert.Equal(tempDir.GetFullPath("packages"), FullPath.FromPath(source.Source));
     }
 
     [Fact]


### PR DESCRIPTION
## What

`Meziantou.Framework.DependencyScanning.Tool` parsed `nuget.config` by hand with `XDocument` and matched package source mapping patterns with a regex-based glob. This replaces both with the `NuGet.Configuration` library, so source resolution stays aligned with real NuGet behavior by construction rather than by us re-implementing it.

`Settings.LoadSettingsGivenConfigPaths` now handles parsing, file precedence and `<clear/>`, and `PackageSourceMapping.GetPackageSourceMapping` does the pattern matching using NuGet's own search tree. The only logic left in `NuGetPackageSourceResolver` is the walk up the directory tree that collects the config files — the file drops from 176 to 60 lines.

`NuGet.Configuration` was already present transitively via `NuGet.Protocol`; it is now referenced explicitly at the same version (7.9.0).

## Why

The hand-rolled logic diverged from what a restore actually does, in ways that were verified against `NuGet.Configuration` 7.9.0. Each of the following is fixed here and covered by a new test:

- **Package ids are now matched case-insensitively on every platform.** The comparer used to be OS-dependent, so on Linux and macOS `CONTOSO.Library` missed a `Contoso.*` mapping and fell through to the wildcard-mapped public feed — exactly the leak source mapping exists to prevent.
- **Wildcards use NuGet's real semantics.** NuGet walks a trie and stops at the first `*`, so `Contoso.*.Extensions` behaves like `Contoso.*`. The old regex glob (`^Contoso\..*\.Extensions$`) did not match `Contoso.Library` and fell through to the public feed.
- **`<disabledPackageSources>` is honored.** It was ignored entirely, so disabled feeds were still queried.
- **Relative source paths resolve against their config file** instead of being passed through raw as `./packages`.

Additionally, `Directory.EnumerateFiles(dir, "*.config")` matches its search pattern case-*sensitively* on Unix, so `NuGet.Config` would not have been discovered on Linux CI even though it works on a case-insensitive macOS filesystem. The enumeration now passes `MatchCasing.CaseInsensitive`.

## Notes for reviewers

**`NuGetSourceResolution` now carries `PackageSource` objects rather than source URL strings.** That lets `NuGetPackageUpdater` call the `Repository.Factory.GetCoreV3(PackageSource)` overload, which carries credentials, client certificates and protocol settings from the configuration file — so authenticated private feeds work.

**One deliberate deviation from real NuGet:** resolution stays scoped to the repository rather than using `Settings.LoadDefaultSettings`, which would also read `~/.nuget/NuGet/NuGet.Config` and machine-wide configs. Rationale:

- It preserves today's behavior — no surprise where a developer's personal feed silently starts being queried for every repo.
- The tests assert exact source lists; user-wide config would make them depend on whoever's machine runs them. NuGet only exposes `loadUserWideSettings: false` internally, and the env-var lever (`DOTNET_CLI_HOME`) also relocates the global packages folder, which would defeat the package cache in the `dotnet restore` tests.

The trade-off is that feed credentials usually live in the user-wide config, so the `GetCoreV3(PackageSource)` win currently only applies to credentials declared in-repo. Happy to rework the test isolation and switch to `LoadDefaultSettings` if you'd prefer full alignment there.

## Testing

- 196 tests pass across `net10.0` and `net11.0` (34 resolver tests, 17 per TFM — 13 pre-existing plus 4 new).
- `dotnet build -c Release /p:TreatsWarningsAsErrors=true` is clean, with the in-repo analyzers loaded.
- `dotnet run ./eng/update-all.cs` exits 0 with no generated-file changes.