### PR TITLE
Add a Clear overload that zeroes the FixedStringBuilder buffer

### DIFF
--- a/ref/Meziantou.Framework.FixedStringBuilder.cs
+++ b/ref/Meziantou.Framework.FixedStringBuilder.cs
@@ -12,6 +12,7 @@ namespace Meziantou.Framework.FixedStringBuilder
         public FixedStringBuilder16(int literalLength, int formattedCount) { }
         public FixedStringBuilder16(string value) { }
         public void Clear() { }
+        public void Clear(bool zeroBuffer) { }
         public void AppendLiteral(System.ReadOnlySpan<char> value) { }
         public void AppendFormatted(string value) { }
         public void AppendFormatted(string value, string? format) { }
@@ -48,6 +49,7 @@ namespace Meziantou.Framework.FixedStringBuilder
         public FixedStringBuilder32(int literalLength, int formattedCount) { }
         public FixedStringBuilder32(string value) { }
         public void Clear() { }
+        public void Clear(bool zeroBuffer) { }
         public void AppendLiteral(System.ReadOnlySpan<char> value) { }
         public void AppendFormatted(string value) { }
         public void AppendFormatted(string value, string? format) { }
@@ -84,6 +86,7 @@ namespace Meziantou.Framework.FixedStringBuilder
         public FixedStringBuilder64(int literalLength, int formattedCount) { }
         public FixedStringBuilder64(string value) { }
         public void Clear() { }
+        public void Clear(bool zeroBuffer) { }
         public void AppendLiteral(System.ReadOnlySpan<char> value) { }
         public void AppendFormatted(string value) { }
         public void AppendFormatted(string value, string? format) { }
@@ -120,6 +123,7 @@ namespace Meziantou.Framework.FixedStringBuilder
         public FixedStringBuilder8(int literalLength, int formattedCount) { }
         public FixedStringBuilder8(string value) { }
         public void Clear() { }
+        public void Clear(bool zeroBuffer) { }
         public void AppendLiteral(System.ReadOnlySpan<char> value) { }
         public void AppendFormatted(string value) { }
         public void AppendFormatted(string value, string? format) { }
@@ -153,6 +157,7 @@ namespace Meziantou.Framework.FixedStringBuilder
         static int MaxLength { get; }
         int Length { get; }
         void Clear();
+        void Clear(bool zeroBuffer);
         System.Span<char> GetUnsafeFullSpan();
     }
 

--- a/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder.Generator/FixedStringBuilderSourceGenerator.cs
@@ -269,6 +269,32 @@ public sealed class FixedStringBuilderSourceGenerator : IIncrementalGenerator
         AppendLine("public void Clear() => _length = 0;");
         AppendLine();
 
+        AppendLine("/// <summary>");
+        AppendLine("/// Resets this string to an empty string, optionally overwriting the underlying buffer with zeros.");
+        AppendLine("/// </summary>");
+        AppendLine("/// <param name=\"zeroBuffer\">");
+        AppendLine("/// <see langword=\"true\"/> to overwrite the whole underlying buffer with <c>\'\\0\'</c>, so the characters that were");
+        AppendLine("/// written can no longer be read; <see langword=\"false\"/> to only reset the length, as <see cref=\"Clear()\"/> does.");
+        AppendLine("/// </param>");
+        AppendLine("/// <remarks>");
+        AppendLine("/// The whole buffer is overwritten, not only the characters up to <see cref=\"Length\"/>: a previous longer");
+        AppendLine("/// value can still be present after <see cref=\"Length\"/>.");
+        AppendLine("/// </remarks>");
+        AppendLine("public void Clear(bool zeroBuffer)");
+        AppendLine("{");
+        indent++;
+        AppendLine("if (zeroBuffer)");
+        AppendLine("{");
+        indent++;
+        AppendLine("AsUnsafeFullSpan().Clear();");
+        indent--;
+        AppendLine("}");
+        AppendLine();
+        AppendLine("_length = 0;");
+        indent--;
+        AppendLine("}");
+        AppendLine();
+
         AppendLine("public void AppendLiteral(ReadOnlySpan<char> value)");
         AppendLine("{");
         indent++;

--- a/src/Meziantou.Framework.FixedStringBuilder/IFixedString.cs
+++ b/src/Meziantou.Framework.FixedStringBuilder/IFixedString.cs
@@ -26,6 +26,20 @@ public interface IFixedString : ISpanFormattable
     void Clear();
 
     /// <summary>
+    /// Resets this string to an empty string, optionally overwriting the underlying buffer with zeros.
+    /// </summary>
+    /// <param name="zeroBuffer">
+    /// <see langword="true"/> to overwrite the whole underlying buffer with <c>'\0'</c>, so the characters that
+    /// were written can no longer be read through <see cref="GetUnsafeFullSpan"/>; <see langword="false"/> to only
+    /// reset the length, as <see cref="Clear()"/> does.
+    /// </param>
+    /// <remarks>
+    /// The whole buffer is overwritten, not only the characters up to <see cref="Length"/>: a previous longer value
+    /// can still be present after <see cref="Length"/>.
+    /// </remarks>
+    void Clear(bool zeroBuffer);
+
+    /// <summary>
     /// Returns a span of all the characters up to <see cref="MaxLength"/>.
     /// </summary>
     /// <returns>A span of characters that contains the characters of this string.</returns>

--- a/src/Meziantou.Framework.FixedStringBuilder/readme.md
+++ b/src/Meziantou.Framework.FixedStringBuilder/readme.md
@@ -22,6 +22,14 @@ string str = sb.ToString();
 
 If a value does not fit in the configured capacity, operations throw `ArgumentException`.
 
+`Clear()` only resets the length: the characters stay in the underlying buffer. Use `Clear(zeroBuffer: true)` to also
+overwrite the whole buffer with `'\0'`.
+
+````csharp
+FixedStringBuilder16 sb = $"secret";
+sb.Clear(zeroBuffer: true);
+````
+
 ## Create a custom fixed-capacity type
 
 The package `Meziantou.Framework.FixedStringBuilder.Generator` includes a source generator. Declare a partial struct with `FixedStringBuilderAttribute`:

--- a/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Generator.Tests/FixedStringBuilderSourceGeneratorTests.cs
@@ -136,6 +136,60 @@ public sealed class FixedStringBuilderSourceGeneratorTests
     }
 
     [Fact]
+    public async Task ClearCanZeroTheBuffer()
+    {
+        const string Source = """
+            namespace Meziantou.Framework.FixedStringBuilder
+            {
+                public interface IFixedString
+                {
+                    global::System.Span<char> GetUnsafeFullSpan();
+                }
+
+                public interface IFixedString<T> : IFixedString where T : IFixedString<T>
+                {
+                    void Clear();
+                    void Clear(bool zeroBuffer);
+                    static abstract implicit operator T(string value);
+                }
+            }
+
+            [FixedStringBuilderAttribute(4)]
+            public partial struct FixedStringBuilder4
+            {
+            }
+
+            public static class Harness
+            {
+                public static string ClearAndGetBuffer(bool zeroBuffer)
+                {
+                    FixedStringBuilder4 value = "abcd";
+                    value.Clear(zeroBuffer);
+                    return new string(((Meziantou.Framework.FixedStringBuilder.IFixedString)value).GetUnsafeFullSpan());
+                }
+            }
+            """;
+
+        var (runResult, compilation) = await GenerateAsync(Source);
+        Assert.Empty(runResult.Diagnostics);
+
+        var generatedCode = string.Join('\n', runResult.Results[0].GeneratedSources.Select(static source => source.SourceText.ToString()));
+        Assert.Contains("public void Clear(bool zeroBuffer)", generatedCode);
+        Assert.Contains("AsUnsafeFullSpan().Clear();", generatedCode);
+
+        using var peStream = new MemoryStream();
+        var emitResult = compilation.Emit(peStream);
+        var diagnostics = string.Join('\n', emitResult.Diagnostics);
+        Assert.True(emitResult.Success, diagnostics);
+
+        var assembly = Assembly.Load(peStream.ToArray());
+        var method = assembly.GetType("Harness")?.GetMethod("ClearAndGetBuffer", BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(method);
+        Assert.Equal("abcd", (string?)method!.Invoke(null, [false]));
+        Assert.Equal("\0\0\0\0", (string?)method!.Invoke(null, [true]));
+    }
+
+    [Fact]
     public async Task AnalyzerReportsMissingValue()
     {
         const string Source = """

--- a/tests/Meziantou.Framework.FixedStringBuilder.Tests/FixedStringBuilderTests.cs
+++ b/tests/Meziantou.Framework.FixedStringBuilder.Tests/FixedStringBuilderTests.cs
@@ -154,6 +154,55 @@ public sealed class FixedStringBuilderTests
     }
 
     [Fact]
+    public void ClearWithZeroBufferErasesTheBuffer()
+    {
+        FixedStringBuilder8 value = "abcdefgh";
+        value.Clear(zeroBuffer: true);
+
+        Assert.Equal(0, value.Length);
+        Assert.Equal("", value.ToString(null, null));
+
+        var fullSpan = ((IFixedString)value).GetUnsafeFullSpan();
+        Assert.Equal(new string('\0', 8), fullSpan.ToString());
+    }
+
+    [Fact]
+    public void ClearWithZeroBufferErasesTheCharactersAfterTheCurrentLength()
+    {
+        FixedStringBuilder8 value = "abcdefgh";
+        value.Clear();
+        value.AppendLiteral("ab");
+        value.Clear(zeroBuffer: true);
+
+        var fullSpan = ((IFixedString)value).GetUnsafeFullSpan();
+        Assert.Equal(new string('\0', 8), fullSpan.ToString());
+    }
+
+    [Fact]
+    public void ClearWithoutZeroBufferKeepsTheBuffer()
+    {
+        FixedStringBuilder8 value = "abcdefgh";
+        value.Clear(zeroBuffer: false);
+
+        Assert.Equal(0, value.Length);
+
+        var fullSpan = ((IFixedString)value).GetUnsafeFullSpan();
+        Assert.Equal("abcdefgh", fullSpan.ToString());
+    }
+
+    [Fact]
+    public void ClearWithZeroBufferCanBeCalledThroughTheInterface()
+    {
+        FixedStringBuilder8 value = "abcdefgh";
+        Clear(ref value);
+
+        Assert.Equal(0, value.Length);
+        Assert.Equal(new string('\0', 8), ((IFixedString)value).GetUnsafeFullSpan().ToString());
+
+        static void Clear<T>(ref T value) where T : IFixedString => value.Clear(zeroBuffer: true);
+    }
+
+    [Fact]
     public void InterpolatedHoleSupportsASpan()
     {
         ReadOnlySpan<char> span = "World".AsSpan();


### PR DESCRIPTION
## What

Adds `Clear(bool zeroBuffer)` to the generated fixed string types and to `IFixedString`.

```csharp
FixedStringBuilder16 sb = $"secret";
sb.Clear(zeroBuffer: true); // length reset AND buffer overwritten with '\0'
```

## Why

`Clear()` only resets the length. The characters that were written stay in the underlying buffer and remain readable through `GetUnsafeFullSpan()` — documented behavior, but there was no way to actually erase a value that should not linger.

## Notes for the reviewer

- **The whole buffer is zeroed, not just `0..Length`.** Otherwise a longer previous value would survive a plain `Clear()` followed by a shorter append. Covered by `ClearWithZeroBufferErasesTheCharactersAfterTheCurrentLength`.
- **`IFixedString` gains a member**, which is source-breaking for anyone implementing the interface by hand. That seemed acceptable for this package; easy to drop from the interface and keep the overload on the generated structs only if preferred.
- **The parameter name is up for debate.** `zeroBuffer` says exactly what happens and matches `CryptographicOperations.ZeroMemory`. The closest BCL precedent for this kind of flag is `ArrayPool<T>.Return(array, clearArray: true)`, but `Clear(clearBuffer: true)` stutters. `eraseBuffer` is a third option. Renaming is a one-word change across the generator, the interface, the tests and `ref/`.
- `ref/Meziantou.Framework.FixedStringBuilder.cs` regenerated; readme updated; `dotnet run ./eng/update-all.cs` produced no further changes.

## Tests

- 4 new tests in `FixedStringBuilderTests`: erases the buffer, erases past the current length, `zeroBuffer: false` keeps the buffer, and the overload is reachable through a `where T : IFixedString` constraint.
- 1 new generator test that compiles and executes generated code for both values.
- The existing `MutatingMembersAreNotReadOnly` test already covers the new overload (it filters by method name).

Both test projects pass on net10.0 and net11.0 (96 + 40 tests).