### PR TITLE
Stop redirecting git's stderr when reading merge tool configuration

### DIFF
--- a/src/Meziantou.Framework.SnapshotTesting/common/MergeTools/GitTool.cs
+++ b/src/Meziantou.Framework.SnapshotTesting/common/MergeTools/GitTool.cs
@@ -46,7 +46,6 @@ internal abstract class GitTool : MergeTool
         var psi = new ProcessStartInfo(gitPath)
         {
             Arguments = "config --get --null " + key,
-            RedirectStandardError = true,
             RedirectStandardOutput = true,
             WorkingDirectory = workingDirectory,
             CreateNoWindow = true,
@@ -57,11 +56,10 @@ internal abstract class GitTool : MergeTool
         if (process is null)
             return null;
 
-        // Both pipes must be drained while git is still running. Waiting for exit first deadlocks as soon as
-        // git writes more than a pipe buffer to either stream - stderr carries warnings such as the
-        // safe.directory ownership diagnostics, which is not something this call can rule out.
+        // The pipe must be drained while git is still running. Waiting for exit first deadlocks as soon as git
+        // writes more than a pipe buffer. Only stdout is redirected: stderr carries warnings such as the
+        // safe.directory ownership diagnostics that nothing here reads, so it is left inherited.
         var standardOutput = process.StandardOutput.ReadToEndAsync();
-        var standardError = process.StandardError.ReadToEndAsync();
 
         // This runs on the failure path of every failing snapshot assertion, so a git that never returns must
         // not take the test run down with it.
@@ -71,8 +69,8 @@ internal abstract class GitTool : MergeTool
             return null;
         }
 
-        // WaitForExit(int) returns as soon as the process ends, without waiting for the redirected streams.
-        if (!Task.WaitAll([standardOutput, standardError], GitConfigurationTimeoutInMilliseconds))
+        // WaitForExit(int) returns as soon as the process ends, without waiting for the redirected stream.
+        if (!standardOutput.Wait(GitConfigurationTimeoutInMilliseconds))
             return null;
 
         if (process.ExitCode != 0)


### PR DESCRIPTION
## What changed

`GitTool.GetGitConfiguration` no longer sets `RedirectStandardError`.

The stderr content was read into a `Task<string>` that was never used — it existed only to keep the pipe drained, and redirecting the stream was the sole reason draining it was necessary. Removing the redirection removes both the read and that class of deadlock hazard.

Follow-on cleanup: `Task.WaitAll([standardOutput, standardError], timeout)` becomes `standardOutput.Wait(timeout)`.

## Why

Dead work on the failure path of every failing snapshot assertion, and one fewer pipe to reason about.

## For reviewers

- **Behavior change:** git's stderr is now inherited by the test host rather than swallowed, so diagnostics such as the `safe.directory` ownership warning will print into the test run's console output. That only happens on a misconfigured repository, and surfacing it is arguably an improvement over discarding it silently.
- The drain-before-`WaitForExit` ordering still matters for stdout and is unchanged; the timeout and kill path are untouched.
- The file lives under `common/` and is linked into both `Meziantou.Framework.SnapshotTesting` and `Meziantou.Framework.InlineSnapshotTesting`, so both packages pick this up.

## Verification

- Both projects build clean with `/p:TreatWarningsAsErrors=true`.
- `Meziantou.Framework.SnapshotTesting.Tests` passes in full: 334 tests across net10.0 and net11.0, 0 failed, 0 skipped — including `GitTool_GetGitConfiguration_ReadsTheValueWithoutDeadlocking`.
- `dotnet run ./eng/update-all.cs` produced no file changes.