### PR TITLE
Return true from IsForever only when the rule has no end condition

### DIFF
--- a/src/Meziantou.Framework.Scheduling/RecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/RecurrenceRule.cs
@@ -63,8 +63,8 @@ public abstract class RecurrenceRule : IRecurrenceRule
     /// <summary>Limits occurrences to specific positions in the recurrence set.</summary>
     public IList<int>? BySetPositions { get; set; }
 
-    /// <summary>Gets a value indicating whether the recurrence rule has an end condition.</summary>
-    public bool IsForever => Occurrences.HasValue || EndDate.HasValue;
+    /// <summary>Gets a value indicating whether the recurrence rule never ends.</summary>
+    public bool IsForever => !Occurrences.HasValue && !EndDate.HasValue;
 
     /// <summary>Parses a recurrence rule string according to RFC 5545 format.</summary>
     /// <param name="rrule">The recurrence rule string to parse.</param>

--- a/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
@@ -17,6 +17,28 @@ public partial class RecurrenceRuleTests
             new DateTime(1997, 11, 30, 09, 00, 00));
     }
 
+    [Theory]
+    [InlineData("FREQ=DAILY")]
+    [InlineData("FREQ=WEEKLY;BYDAY=MO")]
+    [InlineData("FREQ=MONTHLY;BYMONTHDAY=-1")]
+    public void IsForever_RuleWithoutEndCondition(string rruleText)
+    {
+        var rrule = RecurrenceRule.Parse(rruleText);
+
+        Assert.True(rrule.IsForever);
+    }
+
+    [Theory]
+    [InlineData("FREQ=DAILY;COUNT=5")]
+    [InlineData("FREQ=DAILY;UNTIL=20000131T140000Z")]
+    [InlineData("FREQ=WEEKLY;BYDAY=MO;COUNT=1")]
+    public void IsForever_RuleWithEndCondition(string rruleText)
+    {
+        var rrule = RecurrenceRule.Parse(rruleText);
+
+        Assert.False(rrule.IsForever);
+    }
+
     [Fact]
     public void Daily_Text01()
     {


### PR DESCRIPTION
## The bug

`src/Meziantou.Framework.Scheduling/RecurrenceRule.cs:67`

```csharp
public bool IsForever => Occurrences.HasValue || EndDate.HasValue;
```

The property is `true` exactly when the rule **does** have an end condition — the opposite of its name. Verified against the current code:

| Rule | `IsForever` before | after |
|---|---|---|
| `FREQ=DAILY;COUNT=5` | `True` | `False` |
| `FREQ=DAILY;UNTIL=20000131T140000Z` | `True` | `False` |
| `FREQ=DAILY` | `False` | `True` |

The natural use of the property is to guard an unbounded enumeration:

```csharp
if (!rule.IsForever)
    var all = rule.GetNextOccurrences(now).ToList();
```

Inverted, that materializes an infinite sequence — an OOM in the caller.

## The change

Negates the condition and updates the XML doc, which described the implementation ("has an end condition") rather than the property name.

## Compatibility

`IsForever` is public API on a shipped package (v4.0.2), so this is a behavioural break for anyone relying on the current inverted value. Nothing in this repository consumes it — `grep -rn "IsForever" src tests` finds only the declaration and the new tests — so the blast radius is external only. Worth a release-note mention.

## Verification

Six new tests in `RecurrenceRuleTests.cs` covering both directions; they fail on `main` and pass here. Full project suite: **268 passed, 0 failed** (262 before, 6 new).
