### PR TITLE
Return null from GetNextOccurrence when the rule has no next occurrence

### DIFF
--- a/src/Meziantou.Framework.Scheduling/RecurrenceRuleExtensions.cs
+++ b/src/Meziantou.Framework.Scheduling/RecurrenceRuleExtensions.cs
@@ -8,6 +8,10 @@ public static class RecurrenceRuleExtensions
     public static DateTime? GetNextOccurrence(this IRecurrenceRule recurrenceRule, DateTime startDate)
     {
         ArgumentNullException.ThrowIfNull(recurrenceRule);
-        return recurrenceRule.GetNextOccurrences(startDate).FirstOrDefault();
+
+        foreach (var occurrence in recurrenceRule.GetNextOccurrences(startDate))
+            return occurrence;
+
+        return null;
     }
 }

--- a/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
@@ -36,6 +36,33 @@ public partial class RecurrenceRuleTests
     }
 
     [Fact]
+    public void GetNextOccurrence_ReturnsTheFirstOccurrence()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY");
+        var startDate = new DateTime(2024, 01, 01, 09, 00, 00);
+
+        Assert.Equal(startDate, rrule.GetNextOccurrence(startDate));
+    }
+
+    [Fact]
+    public void GetNextOccurrence_ReturnsNullWhenTheRuleIsExhausted()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;COUNT=0");
+        var startDate = new DateTime(2024, 01, 01, 09, 00, 00);
+
+        Assert.Null(rrule.GetNextOccurrence(startDate));
+    }
+
+    [Fact]
+    public void GetNextOccurrence_ReturnsNullWhenTheEndDateHasPassed()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;UNTIL=20230101T000000Z");
+        var startDate = new DateTime(2024, 01, 01, 09, 00, 00);
+
+        Assert.Null(rrule.GetNextOccurrence(startDate));
+    }
+
+    [Fact]
     public void Weekly_Text01()
     {
         var rrule = RecurrenceRule.Parse("FREQ=WEEKLY;UNTIL=20000131T140000Z;BYMONTH=1;BYDAY=TU,WE");


### PR DESCRIPTION
## The bug

`src/Meziantou.Framework.Scheduling/RecurrenceRuleExtensions.cs:11`

```csharp
return recurrenceRule.GetNextOccurrences(startDate).FirstOrDefault();
```

This binds to `Enumerable.FirstOrDefault<DateTime>`, whose default is `default(DateTime)` — a non-null value, then widened to `DateTime?`. The `null` documented on line 7 is unreachable.

Verified against the current code:

```csharp
RecurrenceRule.Parse("FREQ=DAILY;COUNT=0").GetNextOccurrence(new DateTime(2024, 1, 1))
// returns 0001-01-01T00:00:00, not null
```

The `if (next is null)` check every caller writes never fires, so an exhausted schedule reads as "next run: year 1" — and whatever the caller does with that (persist it, compare it, sleep until it) is wrong. Returning a nullable is the entire point of this method's signature.

## The change

Enumerates directly and returns `null` when the sequence is empty. Also avoids the LINQ delegate/enumerator allocation, which matters given this is the per-tick call in a scheduler loop.

## Verification

Three new tests in `RecurrenceRuleTests.cs`: the normal case, an exhausted rule (`COUNT=0`), and a rule whose `UNTIL` is already in the past. The two null cases fail on `main` and pass here. Full project suite: **265 passed, 0 failed** (262 before, 3 new).
