### PR TITLE
Keep the months BYMONTH lists in a monthly recurrence instead of dropping them

### DIFF
--- a/src/Meziantou.Framework.Scheduling/MonthlyRecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/MonthlyRecurrenceRule.cs
@@ -41,7 +41,7 @@ internal sealed class MonthlyRecurrenceRule : RecurrenceRule
             var b = true;
             if (!IsEmpty(ByMonths))
             {
-                if (ByMonths.Contains(startOfMonth.Month))
+                if (!ByMonths.Contains(startOfMonth.Month))
                 {
                     b = false;
                 }

--- a/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
@@ -54,6 +54,33 @@ public partial class RecurrenceRuleTests
     }
 
     [Fact]
+    public void Monthly_ByMonthKeepsOnlyTheListedMonths()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=MONTHLY;BYMONTH=1;BYMONTHDAY=15");
+        var startDate = new DateTime(2024, 01, 01, 00, 00, 00);
+        var occurrences = rrule.GetNextOccurrences(startDate);
+
+        AssertOccurrencesStartWith(occurrences,
+            new DateTime(2024, 01, 15, 00, 00, 00),
+            new DateTime(2025, 01, 15, 00, 00, 00),
+            new DateTime(2026, 01, 15, 00, 00, 00));
+    }
+
+    [Fact]
+    public void Monthly_ByMonthWithSeveralMonths()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=MONTHLY;BYMONTH=3,6;BYMONTHDAY=1");
+        var startDate = new DateTime(2024, 01, 01, 00, 00, 00);
+        var occurrences = rrule.GetNextOccurrences(startDate);
+
+        AssertOccurrencesStartWith(occurrences,
+            new DateTime(2024, 03, 01, 00, 00, 00),
+            new DateTime(2024, 06, 01, 00, 00, 00),
+            new DateTime(2025, 03, 01, 00, 00, 00),
+            new DateTime(2025, 06, 01, 00, 00, 00));
+    }
+
+    [Fact]
     public void Yearly_Text01()
     {
         var rrule = RecurrenceRule.Parse("FREQ=YEARLY;UNTIL=20000131T140000Z;BYYEARDAY=1,-1;BYMONTH=1;BYDAY=TU,WE;BYMONTHDAY=2");


### PR DESCRIPTION
## The bug

`src/Meziantou.Framework.Scheduling/MonthlyRecurrenceRule.cs:44`

```csharp
if (!IsEmpty(ByMonths))
{
    if (ByMonths.Contains(startOfMonth.Month))   // missing !
    {
        b = false;
    }
}
```

The same filter in the four sibling generators has the negation — `DailyRecurrenceRule.cs:25`, `HourlyRecurrenceRule.cs:24`, `MinutelyRecurrenceRule.cs:26`, `SecondlyRecurrenceRule.cs:22` — so `FREQ=MONTHLY` is the only frequency that inverts `BYMONTH`.

Verified against the current code, `FREQ=MONTHLY;BYMONTH=1;BYMONTHDAY=15` from `2024-01-01`:

```
2024-02-15, 2024-03-15, 2024-04-15, 2024-05-15, ...
```

— every month **except** January.

## Why it matters

Silently wrong dates, no error and no crash. `Text` round-trips back to `FREQ=MONTHLY;BYMONTH=1;BYMONTHDAY=15`, so the rule looks right in logs, in storage, and in the humanized text — the only place it is wrong is the occurrences it actually yields. A quarterly or annual schedule expressed with `FREQ=MONTHLY` fires on all the wrong months.

## The change

Adds the missing `!`. Kept deliberately minimal.

## Follow-up, not in this PR

This month/monthday/weekday filter is copy-pasted across five generators, which is how one copy drifted. Extracting it to a shared helper on `RecurrenceRule` is worth doing, but it is a refactor with its own review surface and does not belong in a correctness fix.

## Verification

Two new tests in `RecurrenceRuleTests.cs` — a single-month rule and a multi-month one — both failing on `main` and passing here. Full project suite: **264 passed, 0 failed** (262 before, 2 new).
