### PR TITLE
Reject AIFF chunk sizes that are negative or run past the end of the file

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Aiff/AiffReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Aiff/AiffReader.cs
@@ -34,6 +34,12 @@ internal sealed class AiffReader : IMediaTagReader
                 var chunkSize = BinaryPrimitives.ReadInt32BigEndian(chunkHeader[4..]);
                 var chunkDataStart = stream.Position;
 
+                // A chunk size is stored in a signed field, so a malformed file can declare a negative
+                // size (which would move the cursor backwards and loop forever) or a size far beyond the
+                // end of the file (which would allocate a buffer that can never be filled).
+                if (chunkSize < 0 || chunkSize > stream.Length - chunkDataStart)
+                    break;
+
                 if (chunkId is "ID3 " or "id3 ")
                 {
                     var chunkData = new byte[chunkSize];

--- a/src/Meziantou.Framework.MediaTags/Formats/Aiff/AiffWriter.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Aiff/AiffWriter.cs
@@ -29,6 +29,10 @@ internal sealed class AiffWriter : IMediaTagWriter
                 var chunkSize = BinaryPrimitives.ReadInt32BigEndian(chunkHeader[4..]);
                 var dataPos = inputStream.Position;
 
+                // See AiffReader: a negative size would move the cursor backwards and loop forever.
+                if (chunkSize < 0 || chunkSize > inputStream.Length - dataPos)
+                    break;
+
                 existingChunks.Add((chunkId, chunkSize, dataPos));
 
                 var nextPos = dataPos + chunkSize;

--- a/tests/Meziantou.Framework.MediaTags.Tests/AiffTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/AiffTests.cs
@@ -1,3 +1,6 @@
+using System.Buffers.Binary;
+using System.Text;
+
 namespace Meziantou.Framework.MediaTags.Tests;
 
 public sealed class AiffTests
@@ -90,5 +93,77 @@ public sealed class AiffTests
         using var stream = new MemoryStream([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B]);
         var result = MediaFile.ReadTags(stream, MediaFormat.Aiff);
         Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task ReadTags_NegativeChunkSize_DoesNotLoopForever()
+    {
+        // A chunk size of -8 makes the next chunk position land back on the chunk header itself
+        using var stream = new MemoryStream(CreateAiff(("SSND", -8, [1, 2, 3, 4])));
+
+        var read = Task.Run(() => MediaFile.ReadTags(stream, MediaFormat.Aiff));
+        var completed = await Task.WhenAny(read, Task.Delay(TimeSpan.FromSeconds(30))) == read;
+
+        Assert.True(completed, "ReadTags did not return; the chunk walk is stuck on the same chunk header.");
+    }
+
+    [Fact]
+    public void ReadTags_ChunkSizeBeyondEndOfFile_DoesNotAllocateTheDeclaredSize()
+    {
+        // A 1 GB NAME chunk declared by a file only a few bytes long
+        using var stream = new MemoryStream(CreateAiff(("NAME", 0x4000_0000, [1, 2, 3, 4])));
+
+        // Read once so the measured read is not paying for JIT and first-use initialization
+        MediaFile.ReadTags(stream, MediaFormat.Aiff);
+
+        var before = GC.GetTotalAllocatedBytes(precise: true);
+        var result = MediaFile.ReadTags(stream, MediaFormat.Aiff);
+        var allocated = GC.GetTotalAllocatedBytes(precise: true) - before;
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Value.Title);
+        Assert.True(allocated < 1024 * 1024, $"Reading a {stream.Length} byte file allocated {allocated} bytes.");
+    }
+
+    [Fact]
+    public async Task WriteTags_NegativeChunkSize_DoesNotLoopForever()
+    {
+        var tempFile = Path.GetTempFileName() + ".aiff";
+        try
+        {
+            File.WriteAllBytes(tempFile, CreateAiff(("SSND", -8, [1, 2, 3, 4])));
+
+            var write = Task.Run(() => MediaFile.WriteTags(tempFile, new MediaTagInfo { Title = "Title" }));
+            var completed = await Task.WhenAny(write, Task.Delay(TimeSpan.FromSeconds(30))) == write;
+
+            Assert.True(completed, "WriteTags did not return; the chunk walk is stuck on the same chunk header.");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    private static byte[] CreateAiff(params (string Id, int DeclaredSize, byte[] Data)[] chunks)
+    {
+        var body = new MemoryStream();
+        foreach (var (id, declaredSize, data) in chunks)
+        {
+            var header = new byte[8];
+            Encoding.ASCII.GetBytes(id, header);
+            BinaryPrimitives.WriteInt32BigEndian(header.AsSpan(4), declaredSize);
+            body.Write(header);
+            body.Write(data);
+        }
+
+        var result = new MemoryStream();
+        result.Write("FORM"u8);
+        var formSize = new byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(formSize, (int)body.Length + 4);
+        result.Write(formSize);
+        result.Write("AIFF"u8);
+        body.Position = 0;
+        body.CopyTo(result);
+        return result.ToArray();
     }
 }


### PR DESCRIPTION
`AiffReader` and `AiffWriter` read a chunk size out of the file into a signed `int` and use it without validating it. Two consequences, both reachable from a file of a couple of dozen bytes:

**The chunk walk can loop forever.** A chunk declaring size `-8` makes `nextPos = chunkDataStart + chunkSize` land back on the chunk header that was just read, so the loop re-reads the same 8 bytes indefinitely (`AiffReader.cs:78`, `AiffWriter.cs:34`). A 24-byte `FORM…AIFF` file with a single `SSND` chunk of size `0xFFFFFFF8` pins `MediaFile.ReadTags` at 100% CPU and never returns — no exception, and the `catch (Exception)` around it can never fire.

**The declared size is allocated before it is known to exist.** `var chunkData = new byte[chunkSize];` (`AiffReader.cs:39`, and the same shape at 48/54/60/66/72) runs before any check that the file actually holds that many bytes. A 24-byte file declaring a 1 GB `NAME` chunk allocates 1,076,875,920 bytes and then returns success — a 44-million-fold amplification from four attacker-controlled bytes.

WAV already guards its chunk sizes (`RiffChunk.ReadChunks` has `if (size < 0) break;`); AIFF was left without either check.

## What changed

One guard in each chunk-walk loop, rejecting a size that is negative or runs past the end of the stream:

```csharp
if (chunkSize < 0 || chunkSize > stream.Length - chunkDataStart)
    break;
```

Because `chunkSize` is now non-negative, the cursor advances by at least the 8-byte header on every iteration, so the loop is guaranteed to terminate. Because it is bounded by the remaining stream length, every payload allocation is bounded by the actual file size.

No cap on the payload size is introduced deliberately: an AIFF `ID3 ` chunk can legitimately carry large artwork, and capping it would silently drop tags that are read correctly today (and that `AiffWriter` would then discard on the next write).

## Verification

Three regression tests in `AiffTests.cs`. Against the unfixed parser they fail exactly as described:

```
Reading a 24 byte file allocated 1076875920 bytes
ReadTags did not return; the chunk walk is stuck on the same chunk header
WriteTags did not return; the chunk walk is stuck on the same chunk header
```

With the fix, the same read allocates under 1 MB and both walks terminate. Full suite: 254/254 on net10.0 and net11.0, built with `/p:TreatsWarningsAsErrors=true`.

Found during a review of `Meziantou.Framework.MediaTags`; part of a series of independent fixes.
