### PR TITLE
Reject an INTERVAL below 1 instead of looping forever on it

### DIFF
--- a/src/Meziantou.Framework.Scheduling/RecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/RecurrenceRule.cs
@@ -37,10 +37,32 @@ public abstract class RecurrenceRule : IRecurrenceRule
     public DateTime? EndDate { get; set; }
 
     /// <summary>The number of occurrences before the recurrence ends.</summary>
-    public int? Occurrences { get; set; }
+    /// <exception cref="ArgumentOutOfRangeException">The value is negative.</exception>
+    public int? Occurrences
+    {
+        get => field;
+        set
+        {
+            if (value.HasValue)
+            {
+                ArgumentOutOfRangeException.ThrowIfNegative(value.Value);
+            }
 
-    /// <summary>The interval between occurrences.</summary>
-    public int Interval { get; set; } = 1;
+            field = value;
+        }
+    }
+
+    /// <summary>The interval between occurrences. Must be greater than or equal to 1.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">The value is less than 1.</exception>
+    public int Interval
+    {
+        get => field;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            field = value;
+        }
+    } = 1;
 
     /// <summary>The first day of the week for the recurrence rule.</summary>
     public DayOfWeek WeekStart { get; set; } = DefaultFirstDayOfWeek;
@@ -218,8 +240,22 @@ public abstract class RecurrenceRule : IRecurrenceRule
 
             // Set general properties
             // Set Interval
-            recurrenceRule.Interval = values.GetValue("INTERVAL", 1);
-            recurrenceRule.Occurrences = values.GetValue("COUNT", null);
+            var interval = values.GetValue("INTERVAL", 1);
+            if (interval < 1)
+            {
+                error = $"INTERVAL value '{interval.ToString(CultureInfo.InvariantCulture)}' is invalid. Must be greater than or equal to 1.";
+                return false;
+            }
+
+            var occurrences = values.GetValue("COUNT", null);
+            if (occurrences < 0)
+            {
+                error = $"COUNT value '{occurrences.Value.ToString(CultureInfo.InvariantCulture)}' is invalid. Must be greater than or equal to 0.";
+                return false;
+            }
+
+            recurrenceRule.Interval = interval;
+            recurrenceRule.Occurrences = occurrences;
             if (values.TryGetNonEmptyValue("UNTIL", out var until))
             {
                 recurrenceRule.EndDate = Utilities.ParseDateTime(until);

--- a/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
@@ -145,6 +145,60 @@ public partial class RecurrenceRuleTests
             new DateTime(2021, 1, 1, 9, 0, 30));
     }
 
+    [Theory]
+    [InlineData("FREQ=DAILY;INTERVAL=0")]
+    [InlineData("FREQ=DAILY;INTERVAL=-1")]
+    [InlineData("FREQ=WEEKLY;INTERVAL=0;BYDAY=MO")]
+    [InlineData("FREQ=MONTHLY;INTERVAL=-2")]
+    public void Parse_RejectsAnIntervalBelowOne(string rruleText)
+    {
+        Assert.False(RecurrenceRule.TryParse(rruleText, out _, out var error));
+        Assert.NotNull(error);
+        Assert.Contains("INTERVAL", error);
+        Assert.Throws<FormatException>(() => RecurrenceRule.Parse(rruleText));
+    }
+
+    [Theory]
+    [InlineData("FREQ=DAILY;COUNT=-1")]
+    [InlineData("FREQ=DAILY;COUNT=-5")]
+    public void Parse_RejectsANegativeCount(string rruleText)
+    {
+        Assert.False(RecurrenceRule.TryParse(rruleText, out _, out var error));
+        Assert.NotNull(error);
+        Assert.Contains("COUNT", error);
+    }
+
+    [Theory]
+    [InlineData("FREQ=DAILY;INTERVAL=1")]
+    [InlineData("FREQ=DAILY;INTERVAL=2")]
+    [InlineData("FREQ=DAILY;COUNT=0")]
+    [InlineData("FREQ=DAILY;COUNT=1")]
+    public void Parse_AcceptsValidIntervalAndCount(string rruleText)
+    {
+        Assert.True(RecurrenceRule.TryParse(rruleText, out _, out _));
+    }
+
+    [Fact]
+    public void Interval_SetterRejectsValuesBelowOne()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => rrule.Interval = 0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => rrule.Interval = -1);
+        Assert.Equal(1, rrule.Interval);
+    }
+
+    [Fact]
+    public void Occurrences_SetterRejectsNegativeValues()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => rrule.Occurrences = -1);
+
+        rrule.Occurrences = null;
+        Assert.Null(rrule.Occurrences);
+    }
+
     [Fact]
     public void ByMinute_Daily_ParseAndSerialize()
     {


### PR DESCRIPTION
## The bug

`src/Meziantou.Framework.Scheduling/RecurrenceRule.cs:221` took `INTERVAL` straight from the string with no validation, and `:43` exposed a public settable `int` with none either:

```csharp
recurrenceRule.Interval = values.GetValue("INTERVAL", 1);
```

RFC 5545 §3.3.10 requires `INTERVAL` to be a positive integer. Every generator advances its cursor with `AddDays(Interval)` / `AddHours(Interval)` / … (`DailyRecurrenceRule.cs:62`, `WeeklyRecurrenceRule.cs:69`, `HourlyRecurrenceRule.cs:48`, `MinutelyRecurrenceRule.cs:58`, `SecondlyRecurrenceRule.cs:42`, `MonthlyRecurrenceRule.cs:34`/`:74`, `YearlyRecurrenceRule.cs:44`/`:75`), so a zero interval never advances and `while (true)` becomes an infinite loop.

Verified against the current code:

| Rule | Behaviour before |
|---|---|
| `FREQ=DAILY;INTERVAL=0;BYDAY=MO` from a Tuesday | **never yields, never returns** — 100% CPU, no cancellation path |
| `FREQ=DAILY;INTERVAL=0` | yields `2024-01-01` repeatedly, forever |
| `FREQ=DAILY;INTERVAL=-1` from `2024-01-10` | `2024-01-10, 2024-01-09, 2024-01-08` — backwards, descending |
| `FREQ=DAILY;COUNT=-5` | exactly one occurrence (`count >= Occurrences.Value` is `1 >= -5`) |

The first row is the serious one: a single malformed rule string — from a form, an imported feed, a config file — burns a thread with no way for the caller to defend itself, because `Take(1)` never gets its first element. While confirming this I had it pin a test host for a full 10-minute hang-dump window.

## The change

- Validates `INTERVAL >= 1` and `COUNT >= 0` during parsing, reported through the existing `error` out parameter (so `TryParse` returns `false` and `Parse` throws `FormatException`, per the established contract).
- Guards both property setters with `ArgumentOutOfRangeException`, so a hand-built rule cannot reach the same state without parsing.

`COUNT=0` stays valid — it means "no occurrences" and is handled explicitly at `RecurrenceRule.cs:736`.

## Verification

12 new tests in `RecurrenceRuleTests.cs`: rejected intervals (`0`, `-1`, `-2`) across three frequencies, negative counts, the accepted values including `COUNT=0`, and both setter guards. The `INTERVAL=0` cases previously hung the runner rather than failing. Full project suite: **274 passed, 0 failed** (262 before, 12 new).

`ref/Meziantou.Framework.Scheduling.cs` is unchanged — converting the auto-properties to full properties does not alter the public signature.
