### PR TITLE
Keep the pipe listener alive when a notification message is malformed

### DIFF
--- a/src/Meziantou.Framework.SingleInstance/Meziantou.Framework.SingleInstance.csproj
+++ b/src/Meziantou.Framework.SingleInstance/Meziantou.Framework.SingleInstance.csproj
@@ -7,4 +7,8 @@
     <Description>SingleInstance allows to ensure only one instance of an application runs. Following instances can notify the main instance before closing.</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Meziantou.Framework.SingleInstance.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
+++ b/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
@@ -28,6 +28,10 @@ namespace Meziantou.Framework;
 public sealed class SingleInstance(Guid applicationId) : IDisposable
 {
     private const byte NotifyInstanceMessageType = 1;
+
+    // Upper bound on the number of arguments accepted from the pipe. The message is
+    // sender-controlled, so the count is validated before allocating from it.
+    private const int MaxArgumentCount = 64 * 1024;
     private NamedPipeServerStream? _server;
     private Mutex? _mutex;
 
@@ -36,7 +40,7 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
     /// </summary>
     public event EventHandler<SingleInstanceEventArgs>? NewInstance;
 
-    private string PipeName { get; } = OperatingSystem.IsWindows() ? $"Local\\Pipe_{applicationId}_{GetSessionId().ToString(CultureInfo.InvariantCulture)}" : null!;
+    internal string PipeName { get; } = OperatingSystem.IsWindows() ? $"Local\\Pipe_{applicationId}_{GetSessionId().ToString(CultureInfo.InvariantCulture)}" : null!;
 
     /// <summary>Gets or sets a value indicating whether to start a named pipe server to receive notifications from other instances.</summary>
     /// <value>
@@ -106,32 +110,68 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
         try
         {
             server.EndWaitForConnection(ar);
-            StartNamedPipeServer();
-
-            using var binaryReader = new BinaryReader(server);
-            if (binaryReader.ReadByte() == NotifyInstanceMessageType)
-            {
-                var processId = binaryReader.ReadInt32();
-                var argCount = binaryReader.ReadInt32();
-                if (argCount >= 0)
-                {
-                    var args = new string[argCount];
-                    for (var i = 0; i < argCount; i++)
-                    {
-                        args[i] = binaryReader.ReadString();
-                    }
-
-                    NewInstance?.Invoke(this, new SingleInstanceEventArgs(processId, args));
-                }
-            }
         }
-        catch (ObjectDisposedException)
+        catch (Exception)
         {
+            // The server was disposed while waiting, or the connection failed. Do not re-arm:
+            // the application is either shutting down or the pipe is unusable.
+            server.Dispose();
+            return;
+        }
+
+        // Re-arm before reading, so a malformed or truncated message cannot stop the
+        // application from accepting notifications from later instances.
+        try
+        {
+            StartNamedPipeServer();
+        }
+        catch (Exception)
+        {
+            // Keep handling the current connection even if the next listener could not start.
+        }
+
+        SingleInstanceEventArgs? eventArgs;
+        try
+        {
+            eventArgs = ReadNotification(server);
+        }
+        catch (Exception)
+        {
+            // Truncated, malformed, or hostile message. This runs on a thread pool thread,
+            // so letting the exception escape would terminate the process.
+            eventArgs = null;
         }
         finally
         {
             server.Dispose();
         }
+
+        // Raised outside the catch above so an exception thrown by a subscriber is not
+        // silently swallowed as if it were a protocol error.
+        if (eventArgs is not null)
+        {
+            NewInstance?.Invoke(this, eventArgs);
+        }
+    }
+
+    private static SingleInstanceEventArgs? ReadNotification(NamedPipeServerStream server)
+    {
+        using var binaryReader = new BinaryReader(server);
+        if (binaryReader.ReadByte() != NotifyInstanceMessageType)
+            return null;
+
+        var processId = binaryReader.ReadInt32();
+        var argCount = binaryReader.ReadInt32();
+        if (argCount is < 0 or > MaxArgumentCount)
+            return null;
+
+        var args = new string[argCount];
+        for (var i = 0; i < argCount; i++)
+        {
+            args[i] = binaryReader.ReadString();
+        }
+
+        return new SingleInstanceEventArgs(processId, args);
     }
 
     private bool TryAcquireMutex()

--- a/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
+++ b/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
@@ -1,3 +1,4 @@
+using System.IO.Pipes;
 using Meziantou.Xunit;
 
 namespace Meziantou.Framework.Tests;
@@ -63,5 +64,62 @@ public sealed class SingleInstanceTests
         t.Start();
         t.Join();
         Assert.False(Volatile.Read(ref isStarted));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public async Task TestSingleInstance_MalformedMessagesDoNotStopTheServer()
+    {
+        var applicationId = Guid.NewGuid();
+        using var singleInstance = new SingleInstance(applicationId);
+
+        var events = new List<SingleInstanceEventArgs>();
+        var received = new TaskCompletionSource();
+        singleInstance.NewInstance += (sender, e) =>
+        {
+            lock (events)
+            {
+                events.Add(e);
+            }
+
+            received.TrySetResult();
+        };
+
+        Assert.True(singleInstance.StartApplication());
+
+        // Connects and disconnects without writing anything
+        await SendRawMessageAsync(singleInstance.PipeName, []);
+
+        // Announces far more arguments than the payload contains
+        await SendRawMessageAsync(singleInstance.PipeName, [1, .. BitConverter.GetBytes(42), .. BitConverter.GetBytes(int.MaxValue)]);
+
+        // Announces a negative argument count
+        await SendRawMessageAsync(singleInstance.PipeName, [1, .. BitConverter.GetBytes(42), .. BitConverter.GetBytes(-1)]);
+
+        // Stops in the middle of the arguments
+        await SendRawMessageAsync(singleInstance.PipeName, [1, .. BitConverter.GetBytes(42), .. BitConverter.GetBytes(2)]);
+
+        // Unknown message type
+        await SendRawMessageAsync(singleInstance.PipeName, [0xFF]);
+
+        // None of the above may take the process down or stop the server
+        Assert.True(singleInstance.NotifyFirstInstance(["still", "alive"]));
+        await received.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        lock (events)
+        {
+            var args = Assert.Single(events);
+            Assert.Equal(["still", "alive"], args.Arguments);
+        }
+    }
+
+    private static async Task SendRawMessageAsync(string pipeName, byte[] payload)
+    {
+        using var client = new NamedPipeClientStream(".", pipeName, PipeDirection.Out);
+        await client.ConnectAsync(30_000);
+        if (payload.Length > 0)
+        {
+            await client.WriteAsync(payload);
+            await client.FlushAsync();
+        }
     }
 }


### PR DESCRIPTION
## What

`SingleInstance.Listen` runs on a thread pool thread and caught only `ObjectDisposedException`. Anything else escaped the callback and terminated the process. This widens the handling, bounds the sender-controlled argument count, and re-arms the listener before the message is parsed.

## Why

The crash needs no attacker — a second instance that is killed between `Connect` and `Flush` is enough. Reproduced against the current code with a standalone program replicating the `Listen` pattern:

```
client connected, now disconnecting without writing
about to ReadByte on a client that connected then vanished
Unhandled exception. System.IO.EndOfStreamException: Unable to read beyond the end of the stream.
   at System.IO.BinaryReader.ReadByte()
   at Program.<>c__DisplayClass0_0.<<Main>$>g__Listen|0(IAsyncResult ar)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
```

The "still alive" line printed after that never appeared: the host process was gone. Three routes reached the same place:

- **Truncated message** — the notifying process dies mid-write, so `ReadByte`/`ReadInt32`/`ReadString` hits end-of-stream.
- **Hostile `argCount`** — line 115 read a caller-supplied `Int32` and line 118 allocated `new string[argCount]` from it, with only a `>= 0` guard. I measured `new string[1_000_000_000]` succeeding as an 8 GB commit and `new string[int.MaxValue]` throwing `OutOfMemoryException`.
- **Re-arming failed** — `StartNamedPipeServer()` was inside the same `try`, so an `IOException` there both killed the process and stopped all further listening.

Any process able to reach the pipe could trigger this by connecting and closing.

## Notes for the reviewer

- **`Listen` is now three separate `try` blocks rather than one.** They are not interchangeable: a failure in `EndWaitForConnection` must *not* re-arm (the instance is shutting down, and re-arming there would resurrect a listener past `Dispose`), whereas a failure while *parsing* must re-arm, or one bad message silently ends single-instance behaviour for the rest of the process lifetime. Collapsing them back into one block reintroduces one bug or the other.
- **Exceptions from `NewInstance` subscribers still propagate, deliberately.** The event is raised outside the parse `catch` so a subscriber's bug is not swallowed as if it were a protocol error, but that means a throwing handler still terminates the process — unchanged from today. Containing it silently is worse than the crash, and containing it *visibly* needs somewhere to report to. That argues for an `event EventHandler<Exception>`, which is a public API addition on a v3.0.0 package, so I kept it out of a bug fix. Happy to follow up with it.
- **`MaxArgumentCount` is 64K, which is generous rather than tight.** The Windows command line caps at 32,767 characters, so ~16K arguments is the real ceiling; 64K bounds the array at 512 KB while leaving no chance of rejecting a legitimate caller. A hostile count is now ignored rather than allocated.
- **`PipeName` became `internal`** (plus `InternalsVisibleTo`, matching the pattern in `Meziantou.Framework.DiffEngine` and others) so the tests can write raw bytes to the pipe. The alternative was duplicating the pipe-name format in the test, which would silently stop testing anything if the format changed.
- Not addressed here, tracked separately: `Listen` still writes `_server` from a thread pool thread with no synchronisation, so a connection accepted concurrently with `Dispose` can leave a live listener behind. That fix builds on this one and is the next PR in the stack.

## Tests

- `TestSingleInstance_MalformedMessagesDoNotStopTheServer` sends five bad payloads to the pipe — connect-then-close with no bytes, an `argCount` of `int.MaxValue`, a negative `argCount`, a header that stops mid-arguments, and an unknown message type — then asserts a normal notification still arrives and is the *only* event raised. Before this change the first payload alone killed the test host.
- **These tests did not run on my machine.** The pipe path is Windows-only (`RunIf(TestOperatingSystems.Windows)`) and I am on macOS: `dotnet test` reports 6 total / 2 succeeded, the other 4 skipped. They will first execute on the `windows-2025-vs2026` CI leg, so please let CI go green before trusting them.
- The cross-platform `TestSingleInstance` passes locally on net10.0 and net11.0.
- Builds clean with `-p:TreatWarningsAsErrors=true`; `dotnet run ./eng/update-all.cs` produced no changes.
