### PR TITLE
Normalize a BYSECOND leap second to 59 so it produces occurrences instead of throwing

### DIFF
--- a/src/Meziantou.Framework.Scheduling/RecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/RecurrenceRule.cs
@@ -15,7 +15,7 @@ namespace Meziantou.Framework.Scheduling;
 /// <item><description>COUNT - Maximum number of occurrences</description></item>
 /// <item><description>UNTIL - End date for the recurrence</description></item>
 /// <item><description>WKST - The day on which the workweek starts</description></item>
-/// <item><description>BYSECOND - Limits occurrences to specific seconds (0-60)</description></item>
+/// <item><description>BYSECOND - Limits occurrences to specific seconds (0-60; 60 denotes a leap second and is normalized to 59)</description></item>
 /// <item><description>BYMINUTE - Limits occurrences to specific minutes (0-59)</description></item>
 /// <item><description>BYHOUR - Limits occurrences to specific hours (0-23)</description></item>
 /// <item><description>BYDAY - Limits occurrences to specific days of the week</description></item>
@@ -45,7 +45,8 @@ public abstract class RecurrenceRule : IRecurrenceRule
     /// <summary>The first day of the week for the recurrence rule.</summary>
     public DayOfWeek WeekStart { get; set; } = DefaultFirstDayOfWeek;
 
-    /// <summary>Limits occurrences to specific seconds (0-60, where 60 represents leap seconds).</summary>
+    /// <summary>Limits occurrences to specific seconds (0-59). A parsed BYSECOND value of 60 denotes a
+    /// leap second, which <see cref="DateTime"/> cannot represent, and is normalized to 59.</summary>
     public IList<int>? BySeconds { get; set; }
 
     /// <summary>Limits occurrences to specific minutes (0-59).</summary>
@@ -381,15 +382,21 @@ public abstract class RecurrenceRule : IRecurrenceRule
             return null;
 
         var seconds = SplitToInt32List(str);
-        foreach (var second in seconds)
+        for (var i = 0; i < seconds.Count; i++)
         {
-            if (second is >= 0 and <= 60)
-                continue;
+            var second = seconds[i];
+            if (second is < 0 or > 60)
+                throw new FormatException($"Second '{second.ToString(CultureInfo.InvariantCulture)}' is invalid. Must be between 0 and 60.");
 
-            throw new FormatException($"Second '{second.ToString(CultureInfo.InvariantCulture)}' is invalid. Must be between 0 and 60.");
+            // RFC 5545 allows 60 to denote a leap second. DateTime cannot represent one, so it
+            // is normalized to the last representable second of the minute.
+            if (second is 60)
+                seconds[i] = 59;
         }
 
-        return seconds;
+        // Normalizing may have produced a duplicate (BYSECOND=59,60), which would yield the
+        // same occurrence twice.
+        return seconds.Distinct().ToList();
     }
 
     private static List<int>? ParseByMinutes(Dictionary<string, string> values)

--- a/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
@@ -96,11 +96,44 @@ public partial class RecurrenceRuleTests
     }
 
     [Fact]
-    public void BySecond_LeapSecond_Allowed()
+    public void BySecond_LeapSecond_IsNormalizedToTheLastSecondOfTheMinute()
     {
         var rrule = RecurrenceRule.Parse("FREQ=DAILY;BYSECOND=60");
         var text = rrule.Text;
-        Assert.Equal("FREQ=DAILY;BYSECOND=60", text);
+        Assert.Equal("FREQ=DAILY;BYSECOND=59", text);
+    }
+
+    [Fact]
+    public void BySecond_LeapSecond_IsDeduplicatedAgainstTheLastSecond()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;BYSECOND=59,60");
+        var text = rrule.Text;
+        Assert.Equal("FREQ=DAILY;BYSECOND=59", text);
+    }
+
+    [Fact]
+    public void Minutely_LeapSecond_ProducesOccurrences()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=MINUTELY;COUNT=3;BYSECOND=60");
+        var startDate = new DateTime(2024, 01, 01, 09, 00, 00);
+        var occurrences = rrule.GetNextOccurrences(startDate);
+
+        AssertOccurrences(occurrences,
+            new DateTime(2024, 01, 01, 09, 00, 59),
+            new DateTime(2024, 01, 01, 09, 01, 59),
+            new DateTime(2024, 01, 01, 09, 02, 59));
+    }
+
+    [Fact]
+    public void Daily_LeapSecond_ProducesOccurrences()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;COUNT=2;BYSECOND=60");
+        var startDate = new DateTime(2024, 01, 01, 09, 00, 00);
+        var occurrences = rrule.GetNextOccurrences(startDate);
+
+        AssertOccurrences(occurrences,
+            new DateTime(2024, 01, 01, 09, 00, 59),
+            new DateTime(2024, 01, 02, 09, 00, 59));
     }
 
     [Fact]


### PR DESCRIPTION
## The bug

The parser deliberately accepts `0..60` for `BYSECOND` (`RecurrenceRule.cs:386`), because RFC 5545 §3.3.10 allows `60` to denote a leap second — and `RecurrenceRule.cs:18` advertises exactly that. But `DateTime` has no representation for a leap second, so the generators disagreed on what to do with it:

| Frequency | Code | Behaviour before |
|---|---|---|
| `MINUTELY` | `new DateTime(y, m, d, h, min, 60)` (`MinutelyRecurrenceRule.cs:45`) | **throws** `ArgumentOutOfRangeException: Hour, Minute, and Second parameters describe an un-representable DateTime` |
| `DAILY`, `WEEKLY`, `MONTHLY`, `YEARLY` | `AddSeconds(60)` (`DailyRecurrenceRule.cs:81` + siblings) | silently rolls into the **next minute** — one `BYMINUTE` may not have selected |

So this threw, on documented-as-supported input:

```csharp
RecurrenceRule.Parse("FREQ=MINUTELY;BYSECOND=60").GetNextOccurrences(new DateTime(2024, 1, 1))
```

and it threw from inside the iterator on the first `MoveNext`, far from the `Parse` call a caller would think to guard.

## The change

Normalizes `60` to `59` **once, at parse time**, instead of clamping at each of the five points of use — one normalization point, and it keeps this independent of the other generator fixes. Values outside `0..60` are still rejected, so `BYSECOND=61` and `BYSECOND=-1` behave as before.

Normalization can collide with an explicit `59` (`BYSECOND=59,60`), so the list is deduplicated — otherwise the same occurrence would be yielded twice.

Rejecting `60` outright was the alternative, but RFC 5545 explicitly permits it, so normalizing keeps the parser spec-conformant.

## ⚠️ One existing test changed

`BySecond_LeapSecond_Allowed` asserted that `Text` round-tripped `BYSECOND=60` unchanged. That is no longer true — it now normalizes to `BYSECOND=59` — so the test is updated and renamed to assert the normalization.

Worth noting *why* that test did not catch the crash: it only covered `Parse` and `Text`, and never evaluated an occurrence. The replacements do evaluate occurrences, for both `MINUTELY` and `DAILY`.

This is a visible behaviour change for anyone persisting the `Text` output of a rule authored with `BYSECOND=60`.

## Verification

Four tests replace the one: the normalization, the dedup case, and occurrence generation for `MINUTELY` (previously threw) and `DAILY` (previously rolled to `09:01:00` instead of `09:00:59`). Full project suite: **265 passed, 0 failed** (262 before).
