### PR TITLE
Reject MP4 and RIFF data nested deeper than the supported limit

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Atom.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Atom.cs
@@ -4,6 +4,13 @@ namespace Meziantou.Framework.MediaTags.Formats.Mp4;
 
 internal sealed class Mp4Atom
 {
+    /// <summary>The maximum number of nested container atoms a file may contain.</summary>
+    /// <remarks>
+    /// Reading is recursive, so an unbounded nesting depth would overflow the stack, which cannot be caught.
+    /// Real files nest a handful of levels (moov/trak/mdia/minf/stbl/stsd); this limit is far above any legitimate use.
+    /// </remarks>
+    public const int MaxDepth = 32;
+
     public long Position { get; set; }
     public long Size { get; set; }
     public string Type { get; set; } = "";
@@ -15,6 +22,14 @@ internal sealed class Mp4Atom
     /// </summary>
     public static List<Mp4Atom> ReadAtoms(Stream stream, long endPosition, bool recurse = true)
     {
+        return ReadAtoms(stream, endPosition, recurse, depth: 0);
+    }
+
+    private static List<Mp4Atom> ReadAtoms(Stream stream, long endPosition, bool recurse, int depth)
+    {
+        if (depth >= MaxDepth)
+            throw new InvalidDataException($"MP4 atoms are nested too deeply. The maximum supported depth is {MaxDepth}.");
+
         var atoms = new List<Mp4Atom>();
         Span<byte> headerBuf = stackalloc byte[16]; // Reuse for both header and extended size
 
@@ -64,11 +79,11 @@ internal sealed class Mp4Atom
                         break;
 
                     stream.Seek(4, SeekOrigin.Current);
-                    atom.Children.AddRange(ReadAtoms(stream, atomEnd, recurse: true));
+                    atom.Children.AddRange(ReadAtoms(stream, atomEnd, recurse: true, depth + 1));
                 }
                 else
                 {
-                    atom.Children.AddRange(ReadAtoms(stream, atomEnd, recurse: true));
+                    atom.Children.AddRange(ReadAtoms(stream, atomEnd, recurse: true, depth + 1));
                 }
             }
             else if (dataSize > 0 && dataSize <= 10 * 1024 * 1024) // Max 10MB for single atom data

--- a/src/Meziantou.Framework.MediaTags/Formats/Wav/RiffChunk.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Wav/RiffChunk.cs
@@ -4,6 +4,13 @@ namespace Meziantou.Framework.MediaTags.Formats.Wav;
 
 internal sealed class RiffChunk
 {
+    /// <summary>The maximum number of nested LIST chunks a file may contain.</summary>
+    /// <remarks>
+    /// Reading is recursive, so an unbounded nesting depth would overflow the stack, which cannot be caught.
+    /// Real files nest a level or two; this limit is far above any legitimate use.
+    /// </remarks>
+    public const int MaxDepth = 32;
+
     public string Id { get; set; } = "";
     public int Size { get; set; }
     public long DataPosition { get; set; }
@@ -12,6 +19,14 @@ internal sealed class RiffChunk
 
     public static List<RiffChunk> ReadChunks(Stream stream, long endPosition)
     {
+        return ReadChunks(stream, endPosition, depth: 0);
+    }
+
+    private static List<RiffChunk> ReadChunks(Stream stream, long endPosition, int depth)
+    {
+        if (depth >= MaxDepth)
+            throw new InvalidDataException($"RIFF chunks are nested too deeply. The maximum supported depth is {MaxDepth}.");
+
         var chunks = new List<RiffChunk>();
         Span<byte> header = stackalloc byte[8];
         Span<byte> listType = stackalloc byte[4];
@@ -46,7 +61,7 @@ internal sealed class RiffChunk
                         break;
 
                     chunk.Id = "LIST-" + Encoding.ASCII.GetString(listType);
-                    chunk.SubChunks.AddRange(ReadChunks(stream, chunkEnd));
+                    chunk.SubChunks.AddRange(ReadChunks(stream, chunkEnd, depth + 1));
                 }
             }
             else if (size > 0 && size <= 10 * 1024 * 1024)

--- a/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
@@ -301,4 +301,33 @@ public sealed class Mp4Tests
         payload.CopyTo(atom, 8);
         return atom;
     }
+
+    [Fact]
+    public void ReadTags_DeeplyNestedAtoms_ReturnsErrorInsteadOfOverflowingTheStack()
+    {
+        // An atom size of 0 means "extends to the end of the file", so every 8 bytes adds a nesting level
+        var file = new MemoryStream();
+        file.Write(CreateAtom("ftyp", new byte[8]));
+        for (var i = 0; i < 100_000; i++)
+        {
+            file.Write([0, 0, 0, 0]);
+            file.Write("moov"u8);
+        }
+
+        using var stream = new MemoryStream(file.ToArray());
+        var result = MediaFile.ReadTags(stream, MediaFormat.Mp4);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(MediaTagError.CorruptFile, result.Error);
+    }
+
+    [Fact]
+    public void ReadTags_NestingUpToTheSupportedDepth_IsStillParsed()
+    {
+        // moov > udta > meta > ilst > ©nam > data is the deepest path a real file uses
+        var result = MediaFile.ReadTags(GetTestFilePath("all_fields.m4a"));
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("All Fields Title", result.Value.Title);
+    }
 }

--- a/tests/Meziantou.Framework.MediaTags.Tests/WavTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/WavTests.cs
@@ -109,4 +109,28 @@ public sealed class WavTests
         Assert.True(result.IsSuccess);
         Assert.Null(result.Value.Title);
     }
+
+    [Fact]
+    public void ReadTags_DeeplyNestedListChunks_ReturnsErrorInsteadOfOverflowingTheStack()
+    {
+        // Each LIST chunk declares the rest of the file as its payload, so every 12 bytes adds a nesting level
+        const int Levels = 100_000;
+        var file = new MemoryStream();
+        file.Write("RIFF"u8);
+        file.Write([0, 0, 0, 0]);
+        file.Write("WAVE"u8);
+        for (var i = 0; i < Levels; i++)
+        {
+            file.Write("LIST"u8);
+            var size = (Levels - i - 1) * 12 + 4;
+            file.Write([(byte)size, (byte)(size >> 8), (byte)(size >> 16), (byte)(size >> 24)]);
+            file.Write("INFO"u8);
+        }
+
+        using var stream = new MemoryStream(file.ToArray());
+        var result = MediaFile.ReadTags(stream, MediaFormat.Wav);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(MediaTagError.CorruptFile, result.Error);
+    }
 }


### PR DESCRIPTION
`Mp4Atom.ReadAtoms` and `RiffChunk.ReadChunks` recurse into container atoms / `LIST` chunks with no depth limit, so nesting depth is bounded only by the file size.

For MP4 the cheapest attack is an atom size of `0`, which `Mp4Atom.cs:39-43` treats as "extends to end of file": every 8 bytes of input buys one stack frame. A 1.6 MB `.m4a` made of `ftyp` followed by repetitions of `00 00 00 00 "moov"` terminates the process:

```
Stack overflow.
Repeated 30727 times:
   at Meziantou.Framework.MediaTags.Formats.Mp4.Mp4Atom.ReadAtoms(System.IO.Stream, Int64, Boolean)
```

RIFF has the same shape at `RiffChunk.cs:49`, at 12 bytes per level, via nested `LIST` chunks.

`StackOverflowException` cannot be caught in .NET, so the `catch (Exception)` in `Mp4Reader`/`WavReader` never runs and the whole process dies — any service that reads audio it did not produce has an unauthenticated remote kill switch.

## What changed

The same depth-limit shape `BencodeDecoder` already uses in this repo (`MaxDepth = 64`, `EnsureDepth`): a `MaxDepth` constant with the rationale in a doc comment, a private recursive overload carrying `depth`, and a throw when the limit is reached.

```csharp
private static List<Mp4Atom> ReadAtoms(Stream stream, long endPosition, bool recurse, int depth)
{
    if (depth >= MaxDepth)
        throw new InvalidDataException($"MP4 atoms are nested too deeply. The maximum supported depth is {MaxDepth}.");
```

The limit is 32 for both. The deepest path a real MP4 uses is `moov/trak/mdia/minf/stbl/stsd` and `moov/udta/meta/ilst/©nam/data` — six levels; RIFF files nest one or two. The existing catch-all in each reader turns the throw into `MediaTagError.CorruptFile`, so the public behaviour is a failed result instead of a dead process.

## Verification

Two regression tests, one per format, each building a 100 000-level file. Against the unfixed parsers both kill the test host, independently confirmed by fixing one parser at a time:

```
Stack overflow. Repeated 6570 times:
   at Meziantou.Framework.MediaTags.Formats.Mp4.Mp4Atom.ReadAtoms(System.IO.Stream, Int64, Boolean)

Stack overflow. Repeated 6159 times:
   at Meziantou.Framework.MediaTags.Formats.Wav.RiffChunk.ReadChunks(System.IO.Stream, Int64)
```

With the fix both return `CorruptFile`. A third test pins that `all_fields.m4a` — whose real nesting reaches the `ilst` leaves — still parses, so the limit does not cut into legitimate depth. Full suite: 254/254 on net10.0 and net11.0, built with `/p:TreatsWarningsAsErrors=true`.

Found during a review of `Meziantou.Framework.MediaTags`; part of a series of independent fixes.
