### PR TITLE
Make SingleInstance disposal safe against an in-flight connection

### DIFF
--- a/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
+++ b/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
@@ -32,8 +32,11 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
     // Upper bound on the number of arguments accepted from the pipe. The message is
     // sender-controlled, so the count is validated before allocating from it.
     private const int MaxArgumentCount = 64 * 1024;
+    private readonly Lock _lock = new();
     private NamedPipeServerStream? _server;
     private Mutex? _mutex;
+    private bool _disposed;
+    private bool _started;
 
     /// <summary>
     /// Occurs when another instance of the application attempts to start.
@@ -68,13 +71,19 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
     /// </remarks>
     public bool StartApplication()
     {
-        if (TryAcquireMutex())
-        {
-            StartNamedPipeServer();
-            return true;
-        }
+        ObjectDisposedException.ThrowIf(_disposed, this);
 
-        return false;
+        // Starting twice would acquire the re-entrant mutex again and leak the first
+        // pipe server, so a successful start is remembered and replayed.
+        if (_started)
+            return true;
+
+        if (!TryAcquireMutex())
+            return false;
+
+        _started = true;
+        StartNamedPipeServer();
+        return true;
     }
 
     private void StartNamedPipeServer()
@@ -85,15 +94,29 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
         if (!OperatingSystem.IsWindows())
             throw new PlatformNotSupportedException("The communication with the first instance is only supported on Windows");
 
-        _server = new NamedPipeServerStream(
+        var server = new NamedPipeServerStream(
                 PipeName,
                 PipeDirection.In,
                 NamedPipeServerStream.MaxAllowedServerInstances,
                 PipeTransmissionMode.Message,
                 PipeOptions.CurrentUserOnly);
+
+        lock (_lock)
+        {
+            if (_disposed)
+            {
+                // Dispose ran while this listener was being created. Publishing it would
+                // leave a live pipe server behind for the lifetime of the process.
+                server.Dispose();
+                return;
+            }
+
+            _server = server;
+        }
+
         try
         {
-            _server.BeginWaitForConnection(Listen, state: null);
+            server.BeginWaitForConnection(Listen, state: server);
         }
         catch (ObjectDisposedException)
         {
@@ -103,9 +126,7 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
 
     private void Listen(IAsyncResult ar)
     {
-        var server = _server;
-        if (server is null)
-            return;
+        var server = (NamedPipeServerStream)ar.AsyncState!;
 
         try
         {
@@ -241,7 +262,22 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
     /// </summary>
     public void Dispose()
     {
-        _mutex?.Dispose();
-        _server?.Dispose();
+        Mutex? mutex;
+        NamedPipeServerStream? server;
+
+        lock (_lock)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            mutex = _mutex;
+            server = _server;
+            _mutex = null;
+            _server = null;
+        }
+
+        mutex?.Dispose();
+        server?.Dispose();
     }
 }

--- a/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
+++ b/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
@@ -112,6 +112,32 @@ public sealed class SingleInstanceTests
         }
     }
 
+    [Fact]
+    public void TestSingleInstance_StartApplicationAfterDisposeThrows()
+    {
+        var singleInstance = new SingleInstance(Guid.NewGuid())
+        {
+            StartServer = false,
+        };
+        Assert.True(singleInstance.StartApplication());
+        singleInstance.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => _ = singleInstance.StartApplication());
+    }
+
+    [Fact]
+    public void TestSingleInstance_DisposeIsIdempotent()
+    {
+        var singleInstance = new SingleInstance(Guid.NewGuid())
+        {
+            StartServer = false,
+        };
+        Assert.True(singleInstance.StartApplication());
+
+        singleInstance.Dispose();
+        singleInstance.Dispose();
+    }
+
     private static async Task SendRawMessageAsync(string pipeName, byte[] payload)
     {
         using var client = new NamedPipeClientStream(".", pipeName, PipeDirection.Out);


### PR DESCRIPTION
## What

Gives `SingleInstance` a real lifecycle: a `_disposed` flag, the `_server` swap published under a lock, the accepted server passed through the async state instead of re-read from a field, an idempotent `StartApplication`, and `ObjectDisposedException.ThrowIf` on the public entry point.

Stack 2 of 2 · targets `fix/singleinstance-listen-crash` · must merge after #2386.

## Why

Three lifecycle defects, all in the same few lines:

- **`_server` was written from a thread pool thread with no synchronisation.** `Listen` calls `StartNamedPipeServer()`, which assigns `_server`; `Dispose` reads it from the disposing thread. Neither was volatile or locked. If a connection is accepted just as `Dispose` runs, `Dispose` can read the *old* reference and dispose that, while the newly created server stays alive and listening — a leaked handle and a live listener belonging to a disposed object, for the lifetime of the process.
- **`Dispose` never cleared the fields**, so nothing recorded that the object was finished and `StartApplication()` afterwards surfaced an `ObjectDisposedException` naming an internal type rather than `SingleInstance`. `AGENTS.md` asks for `ObjectDisposedException.ThrowIf` where applicable.
- **`StartApplication()` was not guarded against repeat calls.** The mutex is re-entrant, so a second call re-acquired it and then created a second `NamedPipeServerStream`, orphaning the first — never disposed, still registered for the pipe name. The existing `TestSingleInstance` calls it twice deliberately but with `StartServer = false`, so it never caught this.

## Notes for the reviewer

- **The `_server` race is fixed twice over, on purpose.** The lock closes the publish/dispose window, but `Listen` also no longer reads `_server` at all — it takes the accepted stream from `ar.AsyncState`, which is the stream that callback actually belongs to. Reading a mutable field to find out which connection just completed was the underlying design problem; the lock alone would have papered over it.
- **`_started` only short-circuits the success case.** A call that returned `false` still retries the mutex on the next call, which matters: the first instance may have exited in between, and that caller should be able to become the new first instance.
- **`_disposed` is read outside the lock in `StartApplication`.** That is a guard against misuse, not a synchronisation point — disposing on one thread while starting on another is already a caller bug, and the authoritative check is the one inside `StartNamedPipeServer`'s locked region, which drops a listener created during a concurrent `Dispose`.
- **I did not add a test for the race itself.** Hitting the window deterministically needs the pipe path, so it would be Windows-only, and the timing is not reliably reproducible in a test — I would rather not add a test that passes for the wrong reason. The tests below cover the disposal contract; the race fix rests on review of the ordering.
- `Lock` is used rather than a plain object, matching `Meziantou.Framework.Yaml` and `Meziantou.Framework.Threading`.

## Tests

- `TestSingleInstance_StartApplicationAfterDisposeThrows` — asserts `ObjectDisposedException` rather than the previous leak of an internal type's name.
- `TestSingleInstance_DisposeIsIdempotent` — a second `Dispose()` is a no-op.
- Both run on every platform (`StartServer = false`), and both pass locally: `dotnet test` reports 10 total / 6 succeeded / 4 skipped on net10.0 and net11.0. The 4 skipped are the Windows-only pipe tests, which will first run on the `windows-2025-vs2026` CI leg.
- Builds clean with `-p:TreatWarningsAsErrors=true`; `dotnet run ./eng/update-all.cs` produced no changes.
