### PR TITLE
Bound the BY* time expansion by the enumeration start instead of the moving cursor

### DIFF
--- a/src/Meziantou.Framework.Scheduling/DailyRecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/DailyRecurrenceRule.cs
@@ -15,6 +15,7 @@ internal sealed class DailyRecurrenceRule : RecurrenceRule
     protected override IEnumerable<DateTime> GetNextOccurrencesInternal(DateTime startDate)
     {
         var hasTimeFilters = !IsEmpty(ByHours) || !IsEmpty(ByMinutes) || !IsEmpty(BySeconds);
+        var current = startDate;
 
         while (true)
         {
@@ -22,7 +23,7 @@ internal sealed class DailyRecurrenceRule : RecurrenceRule
 
             if (!IsEmpty(ByMonths))
             {
-                if (!ByMonths.Contains(startDate.Month))
+                if (!ByMonths.Contains(current.Month))
                 {
                     b = false;
                 }
@@ -30,7 +31,7 @@ internal sealed class DailyRecurrenceRule : RecurrenceRule
 
             if (!IsEmpty(ByMonthDays))
             {
-                if (!ByMonthDays.Contains(startDate.Day))
+                if (!ByMonthDays.Contains(current.Day))
                 {
                     b = false;
                 }
@@ -38,7 +39,7 @@ internal sealed class DailyRecurrenceRule : RecurrenceRule
 
             if (!IsEmpty(ByWeekDays))
             {
-                if (!ByWeekDays.Contains(startDate.DayOfWeek))
+                if (!ByWeekDays.Contains(current.DayOfWeek))
                 {
                     b = false;
                 }
@@ -48,24 +49,24 @@ internal sealed class DailyRecurrenceRule : RecurrenceRule
             {
                 if (hasTimeFilters)
                 {
-                    foreach (var occurrence in ExpandByTime(startDate))
+                    foreach (var occurrence in ExpandByTime(current, startDate))
                     {
                         yield return occurrence;
                     }
                 }
                 else
                 {
-                    yield return startDate;
+                    yield return current;
                 }
             }
 
-            startDate = startDate.AddDays(Interval);
+            current = current.AddDays(Interval);
         }
 
         // ReSharper disable once FunctionNeverReturns (UNTIL & COUNT are handled by GetNextOccurrences)
     }
 
-    private IEnumerable<DateTime> ExpandByTime(DateTime date)
+    private IEnumerable<DateTime> ExpandByTime(DateTime date, DateTime lowerBound)
     {
         var hours = IsEmpty(ByHours) ? [date.Hour] : ByHours;
         var minutes = IsEmpty(ByMinutes) ? [date.Minute] : ByMinutes;
@@ -79,7 +80,7 @@ internal sealed class DailyRecurrenceRule : RecurrenceRule
                 foreach (var second in seconds)
                 {
                     var result = dateOnly.AddHours(hour).AddMinutes(minute).AddSeconds(second);
-                    if (result >= date)
+                    if (result >= lowerBound)
                     {
                         yield return result;
                     }

--- a/src/Meziantou.Framework.Scheduling/HourlyRecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/HourlyRecurrenceRule.cs
@@ -34,7 +34,7 @@ internal sealed class HourlyRecurrenceRule : RecurrenceRule
             {
                 if (hasTimeFilters)
                 {
-                    foreach (var occurrence in ExpandByTime(current))
+                    foreach (var occurrence in ExpandByTime(current, startDate))
                     {
                         yield return occurrence;
                     }
@@ -51,7 +51,7 @@ internal sealed class HourlyRecurrenceRule : RecurrenceRule
         // ReSharper disable once FunctionNeverReturns (UNTIL & COUNT are handled by GetNextOccurrences)
     }
 
-    private IEnumerable<DateTime> ExpandByTime(DateTime date)
+    private IEnumerable<DateTime> ExpandByTime(DateTime date, DateTime lowerBound)
     {
         var minutes = IsEmpty(ByMinutes) ? [date.Minute] : ByMinutes;
         var seconds = IsEmpty(BySeconds) ? [date.Second] : BySeconds;
@@ -62,7 +62,7 @@ internal sealed class HourlyRecurrenceRule : RecurrenceRule
             foreach (var second in seconds)
             {
                 var result = dateHour.AddMinutes(minute).AddSeconds(second);
-                if (result >= date)
+                if (result >= lowerBound)
                 {
                     yield return result;
                 }

--- a/src/Meziantou.Framework.Scheduling/MonthlyRecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/MonthlyRecurrenceRule.cs
@@ -18,20 +18,21 @@ internal sealed class MonthlyRecurrenceRule : RecurrenceRule
 
         if (IsEmpty(ByMonthDays) && IsEmpty(ByWeekDays))
         {
+            var current = startDate;
             while (true)
             {
                 if (hasTimeFilters)
                 {
-                    foreach (var occurrence in ExpandByTime(startDate))
+                    foreach (var occurrence in ExpandByTime(current, startDate))
                     {
                         yield return occurrence;
                     }
                 }
                 else
                 {
-                    yield return startDate;
+                    yield return current;
                 }
-                startDate = startDate.AddMonths(Interval);
+                current = current.AddMonths(Interval);
             }
         }
 
@@ -59,7 +60,7 @@ internal sealed class MonthlyRecurrenceRule : RecurrenceRule
                 {
                     if (hasTimeFilters)
                     {
-                        foreach (var occurrence in ExpandByTime(date))
+                        foreach (var occurrence in ExpandByTime(date, startDate))
                         {
                             yield return occurrence;
                         }
@@ -77,7 +78,7 @@ internal sealed class MonthlyRecurrenceRule : RecurrenceRule
         // ReSharper disable once IteratorNeverReturns
     }
 
-    private IEnumerable<DateTime> ExpandByTime(DateTime date)
+    private IEnumerable<DateTime> ExpandByTime(DateTime date, DateTime lowerBound)
     {
         var hours = IsEmpty(ByHours) ? [date.Hour] : ByHours;
         var minutes = IsEmpty(ByMinutes) ? [date.Minute] : ByMinutes;
@@ -91,7 +92,7 @@ internal sealed class MonthlyRecurrenceRule : RecurrenceRule
                 foreach (var second in seconds)
                 {
                     var result = dateOnly.AddHours(hour).AddMinutes(minute).AddSeconds(second);
-                    if (result >= date)
+                    if (result >= lowerBound)
                     {
                         yield return result;
                     }

--- a/src/Meziantou.Framework.Scheduling/WeeklyRecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/WeeklyRecurrenceRule.cs
@@ -53,7 +53,7 @@ internal sealed class WeeklyRecurrenceRule : RecurrenceRule
                     {
                         if (hasTimeFilters)
                         {
-                            foreach (var occurrence in ExpandByTime(next))
+                            foreach (var occurrence in ExpandByTime(next, startDate))
                             {
                                 yield return occurrence;
                             }
@@ -70,7 +70,7 @@ internal sealed class WeeklyRecurrenceRule : RecurrenceRule
         }
     }
 
-    private IEnumerable<DateTime> ExpandByTime(DateTime date)
+    private IEnumerable<DateTime> ExpandByTime(DateTime date, DateTime lowerBound)
     {
         var hours = IsEmpty(ByHours) ? [date.Hour] : ByHours;
         var minutes = IsEmpty(ByMinutes) ? [date.Minute] : ByMinutes;
@@ -84,7 +84,7 @@ internal sealed class WeeklyRecurrenceRule : RecurrenceRule
                 foreach (var second in seconds)
                 {
                     var result = dateOnly.AddHours(hour).AddMinutes(minute).AddSeconds(second);
-                    if (result >= date)
+                    if (result >= lowerBound)
                     {
                         yield return result;
                     }

--- a/src/Meziantou.Framework.Scheduling/YearlyRecurrenceRule.cs
+++ b/src/Meziantou.Framework.Scheduling/YearlyRecurrenceRule.cs
@@ -28,20 +28,21 @@ internal sealed class YearlyRecurrenceRule : RecurrenceRule
 
         if (IsEmpty(ByMonthDays) && IsEmpty(ByWeekDays) && IsEmpty(ByMonths) && /*IsEmpty(ByWeekNo) && */IsEmpty(ByYearDays))
         {
+            var current = startDate;
             while (true)
             {
                 if (hasTimeFilters)
                 {
-                    foreach (var occurrence in ExpandByTime(startDate))
+                    foreach (var occurrence in ExpandByTime(current, startDate))
                     {
                         yield return occurrence;
                     }
                 }
                 else
                 {
-                    yield return startDate;
+                    yield return current;
                 }
-                startDate = startDate.AddYears(Interval);
+                current = current.AddYears(Interval);
             }
         }
 
@@ -61,7 +62,7 @@ internal sealed class YearlyRecurrenceRule : RecurrenceRule
             {
                 if (hasTimeFilters)
                 {
-                    foreach (var occurrence in ExpandByTime(date))
+                    foreach (var occurrence in ExpandByTime(date, startDate))
                     {
                         yield return occurrence;
                     }
@@ -76,7 +77,7 @@ internal sealed class YearlyRecurrenceRule : RecurrenceRule
         }
     }
 
-    private IEnumerable<DateTime> ExpandByTime(DateTime date)
+    private IEnumerable<DateTime> ExpandByTime(DateTime date, DateTime lowerBound)
     {
         var hours = IsEmpty(ByHours) ? [date.Hour] : ByHours;
         var minutes = IsEmpty(ByMinutes) ? [date.Minute] : ByMinutes;
@@ -90,7 +91,7 @@ internal sealed class YearlyRecurrenceRule : RecurrenceRule
                 foreach (var second in seconds)
                 {
                     var result = dateOnly.AddHours(hour).AddMinutes(minute).AddSeconds(second);
-                    if (result >= date)
+                    if (result >= lowerBound)
                     {
                         yield return result;
                     }

--- a/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/RecurrenceRuleTests.cs
@@ -354,6 +354,84 @@ public partial class RecurrenceRuleTests
     }
 
     [Fact]
+    public void Daily_ByHourEarlierThanTheStartTimeResumesTheNextDay()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;BYHOUR=9");
+        var startDate = new DateTime(2024, 01, 01, 14, 00, 00);
+        var occurrences = rrule.GetNextOccurrences(startDate);
+
+        AssertOccurrencesStartWith(occurrences,
+            new DateTime(2024, 01, 02, 09, 00, 00),
+            new DateTime(2024, 01, 03, 09, 00, 00),
+            new DateTime(2024, 01, 04, 09, 00, 00));
+    }
+
+    [Fact]
+    public void Daily_ByHourLaterThanTheStartTimeStartsTheSameDay()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=DAILY;BYHOUR=9");
+        var startDate = new DateTime(2024, 01, 01, 08, 00, 00);
+        var occurrences = rrule.GetNextOccurrences(startDate);
+
+        AssertOccurrencesStartWith(occurrences,
+            new DateTime(2024, 01, 01, 09, 00, 00),
+            new DateTime(2024, 01, 02, 09, 00, 00),
+            new DateTime(2024, 01, 03, 09, 00, 00));
+    }
+
+    [Fact]
+    public void Weekly_ByHourEarlierThanTheStartTimeResumesTheNextWeek()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=WEEKLY;BYHOUR=9");
+        var startDate = new DateTime(2024, 01, 01, 14, 00, 00); // Monday
+        var occurrences = rrule.GetNextOccurrences(startDate);
+
+        AssertOccurrencesStartWith(occurrences,
+            new DateTime(2024, 01, 08, 09, 00, 00),
+            new DateTime(2024, 01, 15, 09, 00, 00),
+            new DateTime(2024, 01, 22, 09, 00, 00));
+    }
+
+    [Fact]
+    public void Hourly_ByMinuteEarlierThanTheStartTimeResumesTheNextHour()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=HOURLY;BYMINUTE=15");
+        var startDate = new DateTime(2024, 01, 01, 09, 30, 00);
+        var occurrences = rrule.GetNextOccurrences(startDate);
+
+        AssertOccurrencesStartWith(occurrences,
+            new DateTime(2024, 01, 01, 10, 15, 00),
+            new DateTime(2024, 01, 01, 11, 15, 00),
+            new DateTime(2024, 01, 01, 12, 15, 00));
+    }
+
+    [Fact]
+    public void Monthly_ByHourEarlierThanTheStartTimeResumesTheNextMonth()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=MONTHLY;BYHOUR=9");
+        var startDate = new DateTime(2024, 01, 15, 14, 00, 00);
+        var occurrences = rrule.GetNextOccurrences(startDate);
+
+        AssertOccurrencesStartWith(occurrences,
+            new DateTime(2024, 02, 15, 09, 00, 00),
+            new DateTime(2024, 03, 15, 09, 00, 00),
+            new DateTime(2024, 04, 15, 09, 00, 00));
+    }
+
+    [Fact]
+    public void Yearly_ByHourEarlierThanTheStartTimeResumesTheNextYear()
+    {
+        var rrule = RecurrenceRule.Parse("FREQ=YEARLY;BYHOUR=9");
+        var startDate = new DateTime(2024, 06, 15, 14, 00, 00);
+        var occurrences = rrule.GetNextOccurrences(startDate);
+
+        AssertOccurrencesStartWith(occurrences,
+            new DateTime(2025, 06, 15, 09, 00, 00),
+            new DateTime(2026, 06, 15, 09, 00, 00),
+            new DateTime(2027, 06, 15, 09, 00, 00));
+    }
+
+    [Fact]
     public void Secondly_Every5Seconds()
     {
         var rrule = RecurrenceRule.Parse("FREQ=SECONDLY;INTERVAL=5;COUNT=5");


### PR DESCRIPTION
## The bug

`ExpandByTime` filtered its expansion against the **current iteration's cursor**:

`DailyRecurrenceRule.cs:82`, `WeeklyRecurrenceRule.cs:87`, `MonthlyRecurrenceRule.cs:94`, `YearlyRecurrenceRule.cs:93`, `HourlyRecurrenceRule.cs:65`

```csharp
var result = dateOnly.AddHours(hour).AddMinutes(minute).AddSeconds(second);
if (result >= date)     // `date` is the cursor, not the enumeration start
```

The cursor keeps the original start's **time of day** at every step (`startDate.AddDays(Interval)` preserves 14:00). So a `BYHOUR` earlier than that time is discarded not only in the first period but in every later one — day 2's 09:00 is compared against day 2 at 14:00 and dropped, then day 3, and so on forever. The generator walks to `DateTime.MaxValue` and throws.

Verified against the current code:

```csharp
RecurrenceRule.Parse("FREQ=DAILY;BYHOUR=9").GetNextOccurrences(new DateTime(2024, 1, 1, 14, 0, 0))
// ArgumentOutOfRangeException: The added or subtracted value results in an un-representable DateTime
```

The same rule from `08:00` works fine and yields `09:00` daily.

## Why it matters

This is the readme's own usage pattern:

```csharp
rule.GetNextOccurrences(DateTime.Now).Take(50)
```

Whether it works depends on the wall-clock time of day the process happens to call it. A daily 09:00 reminder schedule works all morning and crashes every afternoon.

Affects `DAILY`, `WEEKLY`, `HOURLY`, `MONTHLY` and `YEARLY`.

## The change

Passes the enumeration's start date into `ExpandByTime` as an explicit `lowerBound`, so the filter stays fixed while the cursor advances. `DailyRecurrenceRule`, `MonthlyRecurrenceRule` and `YearlyRecurrenceRule` reassigned the `startDate` parameter as their cursor, so each gained a separate `current` local and the original is preserved.

`MinutelyRecurrenceRule` already compared against `startDate` (`:46`) and is unchanged — it was the one generator that had this right.

## Verification

Six new tests. The five `*EarlierThanTheStartTime*` ones were run against unfixed `src` to confirm they are genuine regression tests — all five fail there with the predicted exception:

```
total: 5, failed: 5, succeeded: 0
System.ArgumentOutOfRangeException : The added or subtracted value results in an un-representable DateTime
```

Plus `Daily_ByHourLaterThanTheStartTimeStartsTheSameDay`, pinning that a `BYHOUR` still ahead of the start time is emitted on the first day rather than skipped.

Full project suite: **268 passed, 0 failed** (262 before, 6 new).
