### PR TITLE
Return false from NotifyFirstInstance instead of throwing when the first instance is unreachable

### DIFF
--- a/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
+++ b/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
@@ -161,15 +161,16 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
     /// <remarks>
     /// This method is only supported on Windows. The first instance must have <see cref="StartServer"/> set to <see langword="true"/> to receive notifications.
     /// The method will timeout after <see cref="ClientConnectionTimeout"/> if the first instance is not responding.
+    /// Failing to reach the first instance is reported by returning <see langword="false"/> instead of throwing.
     /// </remarks>
     public bool NotifyFirstInstance(string[] args)
     {
         ArgumentNullException.ThrowIfNull(args);
 
-        using var client = new NamedPipeClientStream(".", PipeName, PipeDirection.Out);
         try
         {
-            client.Connect((int)ClientConnectionTimeout.TotalMilliseconds);
+            using var client = new NamedPipeClientStream(".", PipeName, PipeDirection.Out);
+            client.Connect(GetConnectionTimeoutInMilliseconds());
 
             // type, process id, arg length, arg1, arg2, ...
             using var ms = new MemoryStream();
@@ -192,8 +193,28 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
         }
         catch (TimeoutException)
         {
+            // The first instance did not accept the connection in time
             return false;
         }
+        catch (IOException)
+        {
+            // The first instance stopped listening while the message was being sent
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // The pipe exists but is not accessible from this process
+            return false;
+        }
+    }
+
+    private int GetConnectionTimeoutInMilliseconds()
+    {
+        if (ClientConnectionTimeout == Timeout.InfiniteTimeSpan)
+            return Timeout.Infinite;
+
+        var milliseconds = ClientConnectionTimeout.TotalMilliseconds;
+        return milliseconds <= 0 ? 0 : (int)Math.Min(milliseconds, int.MaxValue);
     }
 
     /// <summary>

--- a/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
+++ b/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
@@ -42,6 +42,17 @@ public sealed class SingleInstanceTests
         }
     }
 
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void TestSingleInstance_NotifyFirstInstanceReturnsFalseWhenNobodyIsListening()
+    {
+        using var singleInstance = new SingleInstance(Guid.NewGuid())
+        {
+            ClientConnectionTimeout = TimeSpan.FromMilliseconds(200),
+        };
+
+        Assert.False(singleInstance.NotifyFirstInstance(["a", "b"]));
+    }
+
     [Fact]
     public void TestSingleInstance()
     {


### PR DESCRIPTION
## What

Makes `NotifyFirstInstance` honour its documented `bool` contract: the client stream is constructed inside the `try`, `IOException` and `UnauthorizedAccessException` join `TimeoutException` as "return `false`", and the timeout is converted to milliseconds without an unchecked narrowing cast.

Stack 1 of 3 · targets `main`.

## Why

The method is documented to return `true` if the notification was sent and `false` otherwise, but it only caught `TimeoutException`. Reproduced against the current code — the client connects successfully, the first instance then disposes the pipe, and the write throws straight through the caller:

```
UNCAUGHT by NotifyFirstInstance: IOException: Broken pipe
```

The trigger is ordinary: the first instance shutting down at the moment a second one starts. Both the readme and `samples/SingleInstanceConsoleAppSample/Program.cs` call this unguarded, exactly as the documented contract invites, so the second instance dies with an unhandled exception instead of exiting quietly.

Two smaller holes in the same method:

- `using var client = new NamedPipeClientStream(...)` sat *outside* the `try`, so anything it threw bypassed the `catch` entirely.
- `(int)ClientConnectionTimeout.TotalMilliseconds` is an unchecked narrowing conversion from `double`. `TimeSpan.MaxValue` overflows to an arbitrary value, and a negative `TimeSpan` other than `-1` ms produces an `ArgumentOutOfRangeException` from `Connect` that no `catch` here handled. The property is public and settable with no validation.

## Notes for the reviewer

- **The timeout is clamped, not validated in the setter.** Rejecting bad values at assignment is arguably cleaner, but it makes a public property start throwing where it never did, on a v3.0.0 package. Clamping keeps this a pure bug fix. `Timeout.InfiniteTimeSpan` is special-cased so that today's behaviour — `(int)(-1)` happening to mean `Timeout.Infinite` — is now explicit rather than accidental.
- **`UnauthorizedAccessException` is caught here although nothing raises it yet.** It becomes reachable in the next PR in this stack, which adds `PipeOptions.CurrentUserOnly` to the client and therefore starts rejecting pipes owned by someone else. Handling it here keeps that PR to a single line and avoids a window where the security fix introduces a new uncaught path.
- **I deliberately did not add an `ObjectDisposedException` guard to this method.** It needs the `_disposed` field introduced in #2389, and — worth noting — `NotifyFirstInstance` touches neither `_mutex` nor `_server`, so calling it after `Dispose()` works correctly today. The guard is a contract nicety, not a bug, and it is cleanest once both stacks have landed.
- Catching `IOException` means a genuinely broken pipe is now indistinguishable from "nobody is listening". Both mean "the message did not arrive", which is all the `bool` can express; distinguishing them would need a richer return type and an API break.

## Tests

- `TestSingleInstance_NotifyFirstInstanceReturnsFalseWhenNobodyIsListening` — no server started, 200 ms timeout, asserts `false` rather than an exception.
- **This test did not run on my machine.** It is Windows-gated (the pipe path throws `PlatformNotSupportedException` off Windows) and I am on macOS: `dotnet test` reports 6 total / 2 succeeded / 4 skipped. It runs first on the `windows-2025-vs2026` CI leg.
- Builds clean with `-p:TreatWarningsAsErrors=true`; `dotnet run ./eng/update-all.cs` produced no changes.
