### PR TITLE
Keep the audio stream when writing tags to a FLAC file with a leading ID3v2 tag

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacReader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacReader.cs
@@ -1,5 +1,3 @@
-using Meziantou.Framework.MediaTags.Formats.Id3v2;
-
 namespace Meziantou.Framework.MediaTags.Formats.Flac;
 
 internal sealed class FlacReader : IMediaTagReader
@@ -91,41 +89,10 @@ internal sealed class FlacReader : IMediaTagReader
 
     private static bool TrySeekAfterFlacMagic(Stream stream)
     {
-        if (!stream.CanSeek)
+        if (!FlacStreamLocator.TryGetStreamStart(stream, out var streamStart))
             return false;
 
-        stream.Position = 0;
-        if (TryReadFlacMagic(stream))
-            return true;
-
-        stream.Position = 0;
-        Span<byte> id3Header = stackalloc byte[3];
-        if (stream.ReadAtLeast(id3Header, id3Header.Length, throwOnEndOfStream: false) < id3Header.Length)
-            return false;
-
-        if (id3Header is not [(byte)'I', (byte)'D', (byte)'3'])
-            return false;
-
-        if (!Id3v2TagLocator.TryGetAudioDataOffsets(stream, 0, out var primaryOffset, out var secondaryOffset))
-            return false;
-
-        return TryReadFlacMagicAtOffset(stream, primaryOffset)
-            || (secondaryOffset >= 0 && TryReadFlacMagicAtOffset(stream, secondaryOffset));
-    }
-
-    private static bool TryReadFlacMagic(Stream stream)
-    {
-        Span<byte> magic = stackalloc byte[4];
-        return stream.ReadAtLeast(magic, magic.Length, throwOnEndOfStream: false) == magic.Length
-            && magic is [(byte)'f', (byte)'L', (byte)'a', (byte)'C'];
-    }
-
-    private static bool TryReadFlacMagicAtOffset(Stream stream, long offset)
-    {
-        if (offset < 0 || stream.Length < offset + 4)
-            return false;
-
-        stream.Position = offset;
-        return TryReadFlacMagic(stream);
+        stream.Position = streamStart + 4;
+        return true;
     }
 }

--- a/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacStreamLocator.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacStreamLocator.cs
@@ -1,0 +1,61 @@
+using Meziantou.Framework.MediaTags.Formats.Id3v2;
+
+namespace Meziantou.Framework.MediaTags.Formats.Flac;
+
+/// <summary>
+/// Locates the start of the FLAC stream in a file, which is not always the start of the file:
+/// some taggers prepend an ID3v2 tag to a FLAC file.
+/// </summary>
+internal static class FlacStreamLocator
+{
+    /// <summary>
+    /// Finds the offset of the "fLaC" signature. The reader and the writer must agree on this offset,
+    /// otherwise the writer parses the ID3v2 tag as metadata blocks and destroys the audio.
+    /// </summary>
+    public static bool TryGetStreamStart(Stream stream, out long offset)
+    {
+        offset = 0;
+
+        if (!stream.CanSeek)
+            return false;
+
+        if (HasFlacMagicAt(stream, 0))
+            return true;
+
+        stream.Position = 0;
+        Span<byte> id3Header = stackalloc byte[3];
+        if (stream.ReadAtLeast(id3Header, id3Header.Length, throwOnEndOfStream: false) < id3Header.Length)
+            return false;
+
+        if (id3Header is not [(byte)'I', (byte)'D', (byte)'3'])
+            return false;
+
+        if (!Id3v2TagLocator.TryGetAudioDataOffsets(stream, 0, out var primaryOffset, out var secondaryOffset))
+            return false;
+
+        if (HasFlacMagicAt(stream, primaryOffset))
+        {
+            offset = primaryOffset;
+            return true;
+        }
+
+        if (secondaryOffset >= 0 && HasFlacMagicAt(stream, secondaryOffset))
+        {
+            offset = secondaryOffset;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasFlacMagicAt(Stream stream, long offset)
+    {
+        if (offset < 0 || stream.Length < offset + 4)
+            return false;
+
+        stream.Position = offset;
+        Span<byte> magic = stackalloc byte[4];
+        return stream.ReadAtLeast(magic, magic.Length, throwOnEndOfStream: false) == magic.Length
+            && magic is [(byte)'f', (byte)'L', (byte)'a', (byte)'C'];
+    }
+}

--- a/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacWriter.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Flac/FlacWriter.cs
@@ -8,6 +8,16 @@ internal sealed class FlacWriter : IMediaTagWriter
         {
             inputStream.Position = 0;
 
+            // The FLAC signature is not always at the start of the file: some taggers prepend an ID3v2
+            // tag, and FlacReader reads those files. Writing from offset 0 regardless would copy the tag
+            // header in place of the signature and parse the tag as metadata blocks, destroying the audio.
+            if (!FlacStreamLocator.TryGetStreamStart(inputStream, out var streamStart))
+                return MediaTagResult.Failure(MediaTagError.CorruptFile, "Not a FLAC file.");
+
+            // Copy anything preceding the signature verbatim
+            inputStream.Position = 0;
+            CopyBytes(inputStream, outputStream, streamStart);
+
             // Copy "fLaC" magic
             Span<byte> magic = stackalloc byte[4];
             if (inputStream.ReadAtLeast(magic, 4, throwOnEndOfStream: false) < 4)
@@ -17,7 +27,7 @@ internal sealed class FlacWriter : IMediaTagWriter
 
             // Read all existing metadata blocks (preserve non-tag blocks)
             var preservedBlocks = new List<FlacMetadataBlock>();
-            long audioDataStart = 4;
+            var audioDataStart = streamStart + 4;
             Span<byte> blockHeader = stackalloc byte[4];
 
             while (true)
@@ -89,6 +99,23 @@ internal sealed class FlacWriter : IMediaTagWriter
         catch (Exception ex)
         {
             return MediaTagResult.Failure(MediaTagError.IoError, ex.Message);
+        }
+    }
+
+    private static void CopyBytes(Stream source, Stream destination, long count)
+    {
+        if (count <= 0)
+            return;
+
+        var buffer = new byte[(int)Math.Min(count, 8192)];
+        while (count > 0)
+        {
+            var read = source.Read(buffer, 0, (int)Math.Min(count, buffer.Length));
+            if (read == 0)
+                break;
+
+            destination.Write(buffer, 0, read);
+            count -= read;
         }
     }
 

--- a/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/FlacTests.cs
@@ -254,4 +254,78 @@ public sealed class FlacTests
         Assert.False(result.IsSuccess);
         Assert.Equal(MediaTagError.UnsupportedFormat, result.Error);
     }
+
+    [Fact]
+    public void WriteTags_FileWithLeadingId3Tag_KeepsTheAudioStream()
+    {
+        var tempFile = Path.GetTempFileName() + ".flac";
+        try
+        {
+            var original = File.ReadAllBytes(GetTestFilePath("basic.flac"));
+            File.WriteAllBytes(tempFile, [.. CreateId3v2Tag(paddingSize: 100), .. original]);
+
+            Assert.Equal(MediaFormat.Flac, MediaFile.DetectFormat(tempFile));
+
+            var writeResult = MediaFile.WriteTags(tempFile, new MediaTagInfo { Title = "New Title" });
+            Assert.True(writeResult.IsSuccess);
+
+            var written = File.ReadAllBytes(tempFile);
+
+            // The ID3v2 tag is preserved and the FLAC signature still follows it
+            const int TagLength = 110;
+            Assert.Equal("ID3"u8.ToArray(), written.AsSpan(0, 3).ToArray());
+            Assert.Equal("fLaC"u8.ToArray(), written.AsSpan(TagLength, 4).ToArray());
+
+            // The audio frames are byte-for-byte what they were
+            var originalAudio = original.AsSpan(FindAudioStart(original, streamStart: 0)).ToArray();
+            var writtenAudio = written.AsSpan(FindAudioStart(written, streamStart: TagLength)).ToArray();
+            Assert.Equal(originalAudio, writtenAudio);
+
+            var readResult = MediaFile.ReadTags(tempFile);
+            Assert.True(readResult.IsSuccess);
+            Assert.Equal("New Title", readResult.Value.Title);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void WriteTags_NotAFlacFile_ReturnsError()
+    {
+        using var input = new MemoryStream([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
+        using var output = new MemoryStream();
+
+        var result = MediaFile.WriteTags(input, output, new MediaTagInfo { Title = "Title" }, MediaFormat.Flac);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(MediaTagError.CorruptFile, result.Error);
+        Assert.Equal(0, output.Length);
+    }
+
+    private static byte[] CreateId3v2Tag(int paddingSize)
+    {
+        var tag = new byte[10 + paddingSize];
+        tag[0] = (byte)'I';
+        tag[1] = (byte)'D';
+        tag[2] = (byte)'3';
+        tag[3] = 4;
+        tag[9] = (byte)paddingSize; // Synchsafe size, small enough to fit in the last byte
+        return tag;
+    }
+
+    private static int FindAudioStart(byte[] flac, int streamStart)
+    {
+        // Walk the metadata blocks from just after the "fLaC" signature to the first audio frame
+        var offset = streamStart + 4;
+        while (true)
+        {
+            var isLast = (flac[offset] & 0x80) != 0;
+            var blockSize = (flac[offset + 1] << 16) | (flac[offset + 2] << 8) | flac[offset + 3];
+            offset += 4 + blockSize;
+            if (isLast)
+                return offset;
+        }
+    }
 }


### PR DESCRIPTION
`FlacWriter` reads the first four bytes of the input and copies them to the output **without checking they are `fLaC`** (`FlacWriter.cs:12-16`), then parses whatever follows as metadata blocks.

Some taggers prepend an ID3v2 tag to a FLAC file. The reader handles those files deliberately — `FlacReader.TrySeekAfterFlacMagic` locates the signature behind the tag (added by #1381 and #1383) and `DetectFormat` reports `Flac` for them — so they reach this writer, which then writes the ID3v2 header in place of the signature and treats the tag body as metadata blocks.

The result is silent, unrecoverable data loss: `MediaFile.WriteTags` returns `IsSuccess = true`, and because it deletes the original and moves the temp file over it, the audio is gone by the time anyone looks. Prepending a 110-byte ID3v2 tag to `basic.flac` and writing a title gives an output that starts `49 44 33 04` instead of `fLaC`, and ffmpeg reports:

```
[flac] invalid sync code
[flac] invalid frame header
[flac] decode_frame() failed
```

The same missing check meant that writing FLAC tags to any non-FLAC input reported success and produced garbage.

The root cause is that the reader and the writer each decided independently where the FLAC stream starts, and only the reader knew about the ID3v2 case.

## What changed

Extracted that decision into one place, `FlacStreamLocator.TryGetStreamStart`, and pointed both the reader and the writer at it. `FlacReader` keeps its exact previous behaviour (its two private helpers are replaced by the shared call). `FlacWriter` now:

- fails with `CorruptFile` when no `fLaC` signature is found, instead of writing whatever bytes were there,
- copies anything preceding the signature verbatim, so the leading ID3v2 tag survives the write and the file stays exactly as identifiable as it was,
- starts its metadata-block walk — and its `audioDataStart` — at the signature rather than at offset 4.

Preserving the leading tag rather than stripping it is the conservative choice: the reader ignores it today, so dropping it would discard bytes the caller never asked to lose.

## Verification

Two regression tests in `FlacTests.cs`. Against the unfixed writer they fail with `Assert.Equal() assertion failed: Item at index 0 differs` (the audio frames) and `Assert.False() assertion failed` (the non-FLAC input reporting success).

With the fix, the audio frames after the write are byte-for-byte identical to the original, and ffmpeg — which refused the old output — decodes the new one with no errors and reads the tag back:

```
$ ffmpeg -v error -i id3.flac -f null -      # no output
$ ffprobe -v error -show_entries format=format_name,duration -show_entries format_tags=title id3.flac
format_name=flac
duration=1.000000
TAG:TITLE=New Title
```

Full suite: 252/252 on net10.0 and net11.0, built with `/p:TreatsWarningsAsErrors=true`.

Found during a review of `Meziantou.Framework.MediaTags`; part of a series of independent fixes.
