### PR TITLE
Verify the pipe server owner when notifying the first instance

### DIFF
--- a/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
+++ b/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
@@ -209,7 +209,7 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
 
         try
         {
-            using var client = new NamedPipeClientStream(".", PipeName, PipeDirection.Out);
+            using var client = new NamedPipeClientStream(".", PipeName, PipeDirection.Out, PipeOptions.CurrentUserOnly);
             client.Connect(GetConnectionTimeoutInMilliseconds());
 
             // type, process id, arg length, arg1, arg2, ...


### PR DESCRIPTION
## What

Adds `PipeOptions.CurrentUserOnly` to the `NamedPipeClientStream` in `NotifyFirstInstance`, so the client verifies who owns the pipe before sending anything to it. One line.

Stack 2 of 3 · targets `fix/singleinstance-notify-error-handling` · must merge after #2391.

## Why

The server is created with `PipeOptions.CurrentUserOnly`, but the client used the three-argument overload, which the [documentation](https://learn.microsoft.com/dotnet/api/system.io.pipes.namedpipeclientstream.-ctor) confirms defaults to `PipeOptions.None`.

`CurrentUserOnly` is a two-sided check. On the server it restricts who may connect; on the **client** it verifies that the server is owned by the same user, and on Windows at the same elevation level. Without it, the client connects to whoever happens to own that pipe name.

The name is fully predictable: `Local\Pipe_{applicationId}_{sessionId}`. The GUID is a compile-time constant in the consuming application and the session id is trivially readable. Note that `Local\` here is literal text in the pipe name, not a namespace prefix — it confers no isolation, and the pipe lives in the machine-wide `\\.\pipe\` namespace. So a process that creates that pipe *before* the real application starts receives, verbatim, the `args` array of every later instance.

The sharpest version is elevation: a non-elevated squatter harvests the command line of an elevated instance, which `CurrentUserOnly` on the client would have refused. Command lines routinely carry material worth stealing — file paths that disclose a user's directory layout, and for any application registered as a URI protocol handler, the full callback URI including OAuth codes or session tokens.

## Notes for the reviewer

- **This changes no behaviour in the legitimate case** — same user, same elevation, connection proceeds exactly as before. It only starts refusing connections that should never have been made.
- **Mismatched-owner connections now surface as `UnauthorizedAccessException` from `Connect`.** #2391, immediately below this in the stack, is what catches it and returns `false`; that is why this sits on top of it rather than going straight to `main`. Merging this one alone would introduce a new uncaught exception path.
- **The mutex is still unprotected.** `Local\Mutex{guid}` (`SingleInstance.cs:141`) is equally predictable and has no ACL, so a squatter holding it permanently makes the real application believe another instance is always running. That is a denial of service rather than disclosure, it needs a different fix, and I did not want to widen a one-line security fix — flagging it rather than fixing it here.

## Tests

- No new test: proving the rejection needs a pipe owned by a *different* user, which a unit test cannot arrange. What matters for regression is that the same-user round trip still works, and `TestSingleInstance_NotifyFirstInstance` already covers exactly that.
- **The relevant tests are Windows-only and did not run on my machine** (macOS): `dotnet test` reports 6 total / 2 succeeded / 4 skipped. Since this changes the pipe handshake, please treat the `windows-2025-vs2026` CI leg as the real check that the legitimate path still connects.
- Builds clean with `-p:TreatWarningsAsErrors=true`.
