### PR TITLE
Stop redirecting unread stderr and bound the wait in RunAndReadOutput

### DIFF
--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/Internals/ProcessHelper.cs
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/Internals/ProcessHelper.cs
@@ -4,6 +4,8 @@ namespace Meziantou.Framework.Diagnostics.ContextSnapshot.Internals;
 
 internal static class ProcessHelper
 {
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
     /// <summary>
     /// Run external process and return the console output.
     /// In the case of any exception, null will be returned.
@@ -18,7 +20,10 @@ internal static class ProcessHelper
             UseShellExecute = false,
             CreateNoWindow = true,
             RedirectStandardOutput = true,
-            RedirectStandardError = true,
+
+            // stderr is intentionally not redirected. Redirecting a stream nobody reads lets the
+            // child block once the pipe buffer fills, which would deadlock the WaitForExit below.
+            RedirectStandardError = false,
         };
 
         using var process = new Process { StartInfo = processStartInfo };
@@ -31,8 +36,20 @@ internal static class ProcessHelper
             return null;
         }
 
-        var output = process.StandardOutput.ReadToEnd();
-        process.WaitForExit();
-        return output;
+        try
+        {
+            var output = process.StandardOutput.ReadToEnd();
+            if (!process.WaitForExit(Timeout))
+            {
+                process.Kill(entireProcessTree: true);
+                return null;
+            }
+
+            return output;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## The finding

`Internals/ProcessHelper.cs:11-37` — the method redirects **both** stdout and stderr but only ever drains stdout, then calls `WaitForExit()` with no timeout.

If the child writes more than the OS pipe buffer to stderr, it blocks on that write, never exits, and the parent blocks in `WaitForExit()` forever.

### Failure scenario

Callers are `sysctl -a`, `cat /proc/cpuinfo`, and `/bin/bash -c "lscpu | grep MHz"`. All three sit behind `Lazy<T>` with the default `ExecutionAndPublication` mode, so the first thread that hangs also parks **every subsequent caller** of `CpuSnapshot.Get()` on the lazy's lock.

A library used to investigate a hung process should not be able to hang the process.

I measured `sysctl -a` on macOS: 0 bytes of stderr, so this does **not** reproduce there. It is a latent deadlock — `lscpu` in a restricted container emits sysfs warnings, and there is no bound at all if the child simply hangs.

## What changed

- `RedirectStandardError = false`, so stderr goes to the inherited handle and the child can never block on it. Redirecting a stream nobody reads is what created the hazard.
- Cap the wait at 5 seconds; on expiry, `Kill(entireProcessTree: true)` and return `null`, which matches the method's documented "in the case of any exception, null will be returned" contract.

## Verification

10/10 tests pass on net10.0 + net11.0. `CpuSnapshotTest` exercises `sysctl -a` through this exact method on macOS, so the change is functionally verified on that path — the processor name and core counts still come through.
