### PR TITLE
Read Linux CPU info from /proc and /sys instead of spawning cat and bash

### DIFF
--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/Internals/ProcCpuInfoProvider.cs
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/Internals/ProcCpuInfoProvider.cs
@@ -1,7 +1,7 @@
 namespace Meziantou.Framework.Diagnostics.ContextSnapshot.Internals;
 
 /// <summary>
-/// CPU information from output of the `cat /proc/info` command.
+/// CPU information from the <c>/proc/cpuinfo</c> and <c>/sys/devices/system/cpu</c> pseudo-files.
 /// Linux only.
 /// </summary>
 internal static class ProcCpuInfoProvider
@@ -12,25 +12,19 @@ internal static class ProcCpuInfoProvider
     {
         if (OperatingSystem.IsLinux())
         {
-            var content = ProcessHelper.RunAndReadOutput("cat", "/proc/cpuinfo") ?? "";
-            var output = GetCpuSpeed() ?? "";
-            content += output;
+            var content = ReadFile("/proc/cpuinfo") ?? "";
+            content += GetCpuFrequencies();
             return ProcCpuInfoParser.ParseOutput(content);
         }
 
         return null;
     }
 
-    private static string? GetCpuSpeed()
+    private static string? ReadFile(string path)
     {
         try
         {
-            var output = ProcessHelper.RunAndReadOutput("/bin/bash", "-c \"lscpu | grep MHz\"")?
-                .Split('\n')
-                .SelectMany(x => x.Split(':'))
-                .ToArray();
-
-            return ParseCpuFrequencies(output);
+            return File.ReadAllText(path);
         }
         catch (Exception)
         {
@@ -38,40 +32,26 @@ internal static class ProcCpuInfoProvider
         }
     }
 
-    private static string? ParseCpuFrequencies(string[]? input)
+    private static string GetCpuFrequencies()
     {
-        // Example of output we trying to parse:
-        //
-        // CPU MHz: 949.154
-        // CPU max MHz: 3200,0000
-        // CPU min MHz: 800,0000
-
-        if (input is null)
-            return null;
-
+        // cpuinfo_min_freq / cpuinfo_max_freq are expressed in kHz. They are the same values lscpu reports
+        // as "CPU min MHz" / "CPU max MHz", read directly so no shell or util-linux is required.
         var output = new StringBuilder();
-        for (var i = 0; i + 1 < input.Length; i += 2)
-        {
-            var name = input[i].Trim();
-            var value = input[i + 1].Trim();
-
-            if (string.Equals(name, "CPU min MHz", StringComparison.OrdinalIgnoreCase))
-            {
-                if (Frequency.TryParseMHz(value.Replace(',', '.'), out var minFrequency))
-                {
-                    output.Append(CultureInfo.InvariantCulture, $"\n{ProcCpuInfoKeyNames.MinFrequency}\t:{minFrequency.ToMHz()}");
-                }
-            }
-
-            if (string.Equals(name, "CPU max MHz", StringComparison.OrdinalIgnoreCase))
-            {
-                if (Frequency.TryParseMHz(value.Replace(',', '.'), out var maxFrequency))
-                {
-                    output.Append(CultureInfo.InvariantCulture, $"\n{ProcCpuInfoKeyNames.MaxFrequency}\t:{maxFrequency.ToMHz()}");
-                }
-            }
-        }
-
+        AppendFrequency(output, ProcCpuInfoKeyNames.MinFrequency, "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_min_freq");
+        AppendFrequency(output, ProcCpuInfoKeyNames.MaxFrequency, "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq");
         return output.ToString();
+
+        static void AppendFrequency(StringBuilder output, string keyName, string path)
+        {
+            var value = ReadFile(path);
+            if (value is null)
+                return;
+
+            if (!long.TryParse(value.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var kiloHertz) || kiloHertz <= 0)
+                return;
+
+            var frequency = new Frequency(kiloHertz, FrequencyUnit.KHz);
+            output.Append(CultureInfo.InvariantCulture, $"\n{keyName}\t:{frequency.ToMHz()}");
+        }
     }
 }

--- a/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
@@ -62,6 +62,39 @@ public sealed class SnapshotTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public void ProcCpuInfoParserReadsAppendedFrequencies()
+    {
+        // /proc/cpuinfo blocks are separated by a blank line and the file ends with one. The frequencies
+        // are appended as an extra section, which must not be mistaken for another logical core.
+        var content = "processor\t: 0\nphysical id\t: 0\ncpu cores\t: 2\nmodel name\t: Intel(R) Core(TM) i7 CPU @ 3.20GHz\n\n"
+                    + "processor\t: 1\nphysical id\t: 0\ncpu cores\t: 2\nmodel name\t: Intel(R) Core(TM) i7 CPU @ 3.20GHz\n\n"
+                    + "\nmin freq\t:800\nmax freq\t:3200";
+
+        var cpuInfo = ProcCpuInfoParser.ParseOutput(content);
+
+        Assert.Equal("Intel(R) Core(TM) i7 CPU @ 3.20GHz", cpuInfo.ProcessorName);
+        Assert.Equal(1, cpuInfo.PhysicalProcessorCount);
+        Assert.Equal(2, cpuInfo.PhysicalCoreCount);
+        Assert.Equal(2, cpuInfo.LogicalCoreCount);
+        Assert.Equal(Frequency.FromMHz(800), cpuInfo.MinFrequency);
+        Assert.Equal(Frequency.FromMHz(3200), cpuInfo.MaxFrequency);
+    }
+
+    [Fact]
+    public void ProcCpuInfoParserReadsFrequenciesConvertedFromKiloHertz()
+    {
+        // cpuinfo_min_freq / cpuinfo_max_freq are in kHz; the provider converts them to the MHz form the parser expects.
+        var minFrequency = new Frequency(800000, FrequencyUnit.KHz);
+        var maxFrequency = new Frequency(3200000, FrequencyUnit.KHz);
+        var content = $"model name\t: CPU\n\n\nmin freq\t:{minFrequency.ToMHz()}\nmax freq\t:{maxFrequency.ToMHz()}";
+
+        var cpuInfo = ProcCpuInfoParser.ParseOutput(content);
+
+        Assert.Equal(Frequency.FromMHz(800), cpuInfo.MinFrequency);
+        Assert.Equal(Frequency.FromMHz(3200), cpuInfo.MaxFrequency);
+    }
+
+    [Fact]
     public unsafe void CountProcessorsWalksVariableSizedEntries()
     {
         var buffer = new List<byte>();


### PR DESCRIPTION
## The finding

`Internals/ProcCpuInfoProvider.cs:15,28` — `cat /proc/cpuinfo` is spawned as a child process to read a file the runtime can read directly, and CPU frequency goes through `/bin/bash -c "lscpu | grep MHz"` — three processes and a shell.

### Failure scenario

On distroless, Alpine (`/bin/bash` absent, only `/bin/sh`), or any image without `util-linux`, both silently return `null` and the frequency fields come back empty. Container images are the common deployment target for this kind of diagnostics, and this is exactly where it degrades.

It also makes the library visible to process-spawn auditing and breaks under seccomp profiles that deny `fork`/`exec` — awkward for a diagnostics package to need whitelisting for.

## What changed

- `File.ReadAllText("/proc/cpuinfo")` instead of spawning `cat`.
- Frequencies read from `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_{min,max}_freq` (kHz), which is where `lscpu` gets its numbers, instead of shelling out.

The appended text keeps the exact `\n{key}\t:{MHz}` shape `ProcCpuInfoParser` already expected, so the parse path is unchanged.

As a side effect this removes the Linux exposure to the unread-stderr deadlock, though that is fixed independently in #2395.

## Verification

Two new tests in `SnapshotTests.cs` pin the contract this change has to preserve, and they run on every platform:

- `ProcCpuInfoParserReadsAppendedFrequencies` — a realistic two-core `/proc/cpuinfo` plus the appended frequency section, asserting the section is not miscounted as another logical core.
- `ProcCpuInfoParserReadsFrequenciesConvertedFromKiloHertz` — pins the kHz→MHz conversion; a wrong unit fails it.

14/14 pass on net10.0 + net11.0. **The Linux runtime path itself was not executed** (reviewed on macOS) — the parser contract is covered by tests, the file reads are not.
