### PR TITLE
Fix and harden the WMI CPU fallback

### DIFF
--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/Internals/MosCpuInfoProvider.cs
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/Internals/MosCpuInfoProvider.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using System.Management;
 
 namespace Meziantou.Framework.Diagnostics.ContextSnapshot.Internals;
@@ -22,30 +21,32 @@ internal static class MosCpuInfoProvider
         var processorsCount = 0;
         uint nominalClockSpeed = 0;
         uint maxClockSpeed = 0;
-        uint minClockSpeed = 0;
 
         try
         {
             using var mosProcessor = new ManagementObjectSearcher("SELECT * FROM Win32_Processor");
-            foreach (var moProcessor in mosProcessor.Get().Cast<ManagementObject>())
+            using var processors = mosProcessor.Get();
+            foreach (var moProcessor in processors.Cast<ManagementObject>())
             {
-                var name = moProcessor[Win32ProcessorKeyNames.Name]?.ToString();
-                if (!string.IsNullOrEmpty(name))
+                using (moProcessor)
                 {
-                    processorModelNames.Add(name);
-                    processorsCount++;
-                    physicalCoreCount += (uint)moProcessor[Win32ProcessorKeyNames.NumberOfCores];
-                    logicalCoreCount += (uint)moProcessor[Win32ProcessorKeyNames.NumberOfLogicalProcessors];
-                    maxClockSpeed = (uint)moProcessor[Win32ProcessorKeyNames.MaxClockSpeed];
+                    var name = GetString(moProcessor, Win32ProcessorKeyNames.Name);
+                    if (!string.IsNullOrEmpty(name))
+                    {
+                        processorModelNames.Add(name);
+                        processorsCount++;
+                        physicalCoreCount += GetUInt32(moProcessor, Win32ProcessorKeyNames.NumberOfCores);
+                        logicalCoreCount += GetUInt32(moProcessor, Win32ProcessorKeyNames.NumberOfLogicalProcessors);
+                        nominalClockSpeed = Math.Max(nominalClockSpeed, GetUInt32(moProcessor, Win32ProcessorKeyNames.CurrentClockSpeed));
+                        maxClockSpeed = Math.Max(maxClockSpeed, GetUInt32(moProcessor, Win32ProcessorKeyNames.MaxClockSpeed));
+                    }
                 }
             }
         }
-        catch (ManagementException)
+        catch (Exception)
         {
-            return null;
-        }
-        catch (COMException)
-        {
+            // Best-effort fallback: WMI can fail in many ways (service stopped, missing class, missing property)
+            // and none of them are actionable here.
             return null;
         }
 
@@ -54,8 +55,16 @@ internal static class MosCpuInfoProvider
             processorsCount > 0 ? processorsCount : null,
             physicalCoreCount > 0 ? (int?)physicalCoreCount : null,
             logicalCoreCount > 0 ? (int?)logicalCoreCount : null,
-            nominalClockSpeed > 0 && logicalCoreCount > 0 ? Frequency.FromMHz(nominalClockSpeed) : null,
-            minClockSpeed > 0 && logicalCoreCount > 0 ? Frequency.FromMHz(minClockSpeed) : null,
-            maxClockSpeed > 0 && logicalCoreCount > 0 ? Frequency.FromMHz(maxClockSpeed) : null);
+            nominalClockSpeed > 0 ? Frequency.FromMHz(nominalClockSpeed) : null,
+            minFrequency: null,
+            maxClockSpeed > 0 ? Frequency.FromMHz(maxClockSpeed) : null);
     }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    private static string? GetString(ManagementObject managementObject, string propertyName)
+        => managementObject[propertyName] as string;
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    private static uint GetUInt32(ManagementObject managementObject, string propertyName)
+        => managementObject[propertyName] is uint value ? value : 0;
 }

--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/Internals/Win32ProcessorKeyNames.cs
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/Internals/Win32ProcessorKeyNames.cs
@@ -6,4 +6,5 @@ internal static class Win32ProcessorKeyNames
     internal const string NumberOfCores = "NumberOfCores";
     internal const string Name = "Name";
     internal const string MaxClockSpeed = "MaxClockSpeed";
+    internal const string CurrentClockSpeed = "CurrentClockSpeed";
 }


### PR DESCRIPTION
## The finding

`Internals/MosCpuInfoProvider.cs` — four defects in one 60-line method. This is the fallback taken when `GetLogicalProcessorInformationEx` fails (`WindowsCpuInfoProvider.cs:31`), so it runs in exactly the degraded environments where these are most likely to bite.

1. **Lines 23-24, 57-58** — `nominalClockSpeed` and `minClockSpeed` are declared, never written, then tested `> 0`. So `NominalFrequency` and `MinFrequency` were *unconditionally null* on this path. The compiler doesn't flag it because they are read.
2. **Line 39** — `maxClockSpeed = …` assigns rather than maximises, so on a multi-socket box the **last** socket wins instead of the fastest.
3. **Lines 37-39** — WMI properties are unboxed with a direct `(uint)` cast. `Win32_Processor` omits `NumberOfCores` on virtualised and older guests; the cast then throws `NullReferenceException`, which is **not** among the caught `ManagementException` / `COMException` on lines 43-49, so it escapes through the `Lazy` into `AddDefault()`.
4. **Line 30** — the `ManagementObjectCollection` from `Get()` and each `ManagementObject` in it are never disposed.

## What changed

- Populate the nominal speed from `CurrentClockSpeed`; pass `minFrequency: null` explicitly instead of via a dead local.
- `Math.Max` for the peak clock.
- Read properties through pattern-matching helpers (`is uint value ? value : 0`) so a missing property yields 0 instead of throwing.
- `using` the collection and each object.
- Widen the catch to `Exception` — this is a best-effort fallback and none of the failure modes are actionable here.

One judgement call worth flagging: I also dropped the `logicalCoreCount > 0 &&` guard from the frequency conditions. A frequency does not depend on the core count parsing successfully, and that coupling only looked sensible while the speeds were always zero.

## Verification

Builds clean, 10/10 tests pass on net10.0 + net11.0. **This path is Windows-only and could not be executed** — reviewed on macOS. The changes are type-level and mechanical, but a Windows run would confirm `CurrentClockSpeed` is populated as expected.
