### PR TITLE
Normalize paths returned by the With* methods

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -268,7 +268,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         if (IsEmpty)
             return Empty;
 
-        return new FullPath(Path.ChangeExtension(_value, extension));
+        return FromPath(Path.ChangeExtension(_value, extension));
     }
 
     /// <summary>Returns a new path with the specified file extension, optionally replacing all trailing extensions.</summary>
@@ -311,12 +311,12 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         }
 
         if (string.IsNullOrEmpty(extension))
-            return new FullPath(current);
+            return FromPath(current);
 
         if (!extension.StartsWith('.', StringComparison.Ordinal))
             extension = "." + extension;
 
-        return new FullPath(current + extension);
+        return FromPath(current + extension);
     }
 
     /// <summary>Returns a new path with the specified name, keeping the same parent directory.</summary>
@@ -328,11 +328,9 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         if (IsEmpty)
             return Empty;
 
-        var parent = Path.GetDirectoryName(_value);
-        if (parent is null)
-            return new FullPath(name);
-
-        return new FullPath(Path.Combine(parent, name));
+        // A null directory name means the path is already a root (such as "/" or @"C:\"), which is its own parent here
+        var parent = Path.GetDirectoryName(_value) ?? _value;
+        return FromPath(Path.Combine(parent, name));
     }
 
     /// <summary>Returns a new path with the specified name, keeping the same parent directory but without changing the extension.</summary>
@@ -344,13 +342,11 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         if (IsEmpty)
             return Empty;
 
-        var parent = Path.GetDirectoryName(_value);
+        // A null directory name means the path is already a root (such as "/" or @"C:\"), which is its own parent here
+        var parent = Path.GetDirectoryName(_value) ?? _value;
         var extension = Path.GetExtension(_value);
         var newName = nameWithoutExtension + extension;
-        if (parent is null)
-            return new FullPath(newName);
-
-        return new FullPath(Path.Combine(parent, newName));
+        return FromPath(Path.Combine(parent, newName));
     }
 
     /// <summary>Gets the path of the system's temporary folder.</summary>

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -49,6 +49,105 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public void ChangeName_NormalizesTheResultingPath()
+    {
+        var root = FullPath.FromPath("test");
+        var path = root / "a" / "b.txt";
+
+        var newPath = path.WithName("../c.txt");
+
+        Assert.Equal(root / "c.txt", newPath);
+        Assert.Equal(FullPath.FromPath(newPath.RawValue), newPath);
+    }
+
+    [Fact]
+    public void ChangeName_EscapingTheRootIsNotReportedAsAChild()
+    {
+        var root = FullPath.FromPath("test");
+        var path = root / "a" / "b.txt";
+
+        var newPath = path.WithName("../../../../etc/passwd");
+
+        Assert.False(newPath.IsChildOf(root));
+        Assert.Equal(FullPath.FromPath(newPath.RawValue), newPath);
+    }
+
+    [Fact]
+    public void ChangeName_RootDirectory()
+    {
+        var root = GetRootDirectory();
+
+        var newPath = root.WithName("temp");
+
+        Assert.Equal(root / "temp", newPath);
+    }
+
+    [Fact]
+    public void ChangeName_EmbeddedNullCharacterIsRejected()
+    {
+        var path = FullPath.FromPath("test") / "a" / "b.txt";
+
+        Assert.Throws<ArgumentException>(() => path.WithName("a\0b"));
+    }
+
+    [Fact]
+    public void ChangeNameWithoutExtension_NormalizesTheResultingPath()
+    {
+        var root = FullPath.FromPath("test");
+        var path = root / "a" / "b.txt";
+
+        var newPath = path.WithNameWithoutExtension("../c");
+
+        Assert.Equal(root / "c.txt", newPath);
+    }
+
+    [Fact]
+    public void ChangeNameWithoutExtension_RootDirectory()
+    {
+        var root = GetRootDirectory();
+
+        var newPath = root.WithNameWithoutExtension("temp");
+
+        Assert.Equal(root / "temp", newPath);
+    }
+
+    [Fact]
+    public void ChangeExtension_NormalizesTheResultingPath()
+    {
+        var root = FullPath.FromPath("test");
+        var path = root / "a" / "b.txt";
+
+        var newPath = path.WithExtension("/../../c");
+
+        Assert.Equal(FullPath.FromPath(newPath.RawValue), newPath);
+        Assert.False(newPath.IsChildOf(root / "a"));
+    }
+
+    [Fact]
+    public void ChangeExtension_DotFileKeepsNoTrailingSeparator()
+    {
+        var parent = FullPath.FromPath("test") / "a";
+        var path = parent / ".gitignore";
+
+        var newPath = path.WithExtension(null);
+
+        Assert.Equal(parent, newPath);
+        Assert.Equal(parent.RawValue, newPath.RawValue);
+    }
+
+    [Fact]
+    public void ChangeMultipleExtensions_DotFileKeepsNoTrailingSeparator()
+    {
+        var parent = FullPath.FromPath("test") / "a";
+        var path = parent / ".gitignore";
+
+        var newPath = path.WithExtension(null, replaceAllTrailingExtensions: true);
+
+        Assert.Equal(parent, newPath);
+        Assert.Equal(parent.RawValue, newPath.RawValue);
+    }
+
+    [Fact]
     public void ChangeMultipleExtensions()
     {
         var path = FullPath.FromPath("test") / "a" / "b.tar.gz";


### PR DESCRIPTION
`WithName`, `WithNameWithoutExtension` and both `WithExtension` overloads build their result with `Path.Combine` / `Path.ChangeExtension` and hand it straight to the private `FullPath` constructor, bypassing the `Path.GetFullPath` + `TrimEndingDirectorySeparator` normalization that every other entry point goes through (`src/Meziantou.Framework.FullPath/FullPath.cs:326-354`, `:266-272`, `:287-320`).

The constructor only checks the invariant with `Debug.Assert` (`FullPath.cs:29-37`), so a Debug consumer gets a process abort and a Release consumer — which is what ships on NuGet — gets a `FullPath` whose `_value` is not normalized.

## What goes wrong

Because `FullPathComparer` is an ordinal string comparison that assumes the invariant, a denormalized value breaks everything built on it:

| Call on `/root/sub/file.txt` | Stored value | Consequence |
| --- | --- | --- |
| `WithName("../../etc/passwd")` | `/root/sub/../../etc/passwd` | `IsChildOf(FromPath("/root"))` returns **true**, but the path resolves to `/etc/passwd` |
| `WithNameWithoutExtension("../../../etc/shadow")` | `/root/sub/../../../etc/shadow.txt` | same |
| `WithExtension("/../../../etc/passwd")` | `/srv/app/data/user./../../../etc/passwd` | same |
| `WithName("b\0c")` | `/a/b\0c` | embeds a NUL that `Path.GetFullPath` rejects; the library's own UTF-8 P/Invokes truncate there |
| `FromPath("/").WithName("tmp")` | `tmp` | `Path.GetDirectoryName("/")` is null, so the result is **relative** — `IsPathFullyQualified` is false |
| `FromPath("/repo/.gitignore").WithExtension(null)` | `/repo/` | trailing separator: `!= FromPath("/repo")`, misses dictionary lookups, `Name` is `""` |

The last row is the common one — `Path.GetExtension(".gitignore")` returns the whole name, so `Path.ChangeExtension` leaves the parent directory *with* its separator.

`MakePathRelativeTo` already normalizes (via `Path.GetRelativePath`), so today the two containment-shaped APIs disagree on the same value.

## Change

- Route all five methods through `FromPath` instead of the private constructor. This restores normalization, the trailing-separator trim, and `Path.GetFullPath`'s rejection of embedded NULs.
- When `Path.GetDirectoryName` returns null the path is already a root (`/`, `C:\`), so use the path itself as the parent rather than dropping it.

No public signature changes.

## Verification

`dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 180 passed, 0 failed, 56 skipped (Windows-gated). 9 regression tests added next to the existing `ChangeName` tests, covering traversal, root paths, embedded NUL, and dot-files for each affected method.

`dotnet run ./eng/update-all.cs` produced no generated-file changes.

## Note for review

The Windows-only tests (reserved device names, `\\?\`) are skipped on the macOS machine this was developed on, so **CI's Windows leg is the real check** on this one. The relevant question is whether `Path.GetFullPath` alters a fully-qualified reserved-device path such as `C:\temp\CON.txt` — the existing `ReservedDeviceNameTests` already exercise `FromPath` on those inputs and pass, so this should be the same class of input, but it is worth a look at the Windows results before merging.

## Not addressed here

`FromPath("/.gitignore").WithExtension(null)` still returns `/`, because normalizing `/` cannot recover the file name. Treating a leading-dot file as extensionless is a behavior change and is left as a separate decision.
