### PR TITLE
Guard the remaining ConsoleSnapshot members against throwing

### DIFF
--- a/ref/Meziantou.Framework.Diagnostics.ContextSnapshot.cs
+++ b/ref/Meziantou.Framework.Diagnostics.ContextSnapshot.cs
@@ -28,8 +28,8 @@ namespace Meziantou.Framework.Diagnostics.ContextSnapshot
         public bool IsOutputRedirected { get => throw null; }
         public bool IsErrorRedirected { get => throw null; }
         public bool IsInputRedirected { get => throw null; }
-        public Meziantou.Framework.Diagnostics.ContextSnapshot.EncodingSnapshot OutEncoding { get => throw null; }
-        public Meziantou.Framework.Diagnostics.ContextSnapshot.EncodingSnapshot InputEncoding { get => throw null; }
+        public Meziantou.Framework.Diagnostics.ContextSnapshot.EncodingSnapshot? OutEncoding { get => throw null; }
+        public Meziantou.Framework.Diagnostics.ContextSnapshot.EncodingSnapshot? InputEncoding { get => throw null; }
         public int BufferHeight { get => throw null; }
         public int BufferWidth { get => throw null; }
         public int LargestWindowHeight { get => throw null; }
@@ -38,8 +38,8 @@ namespace Meziantou.Framework.Diagnostics.ContextSnapshot
         public int WindowWidth { get => throw null; }
         public int WindowTop { get => throw null; }
         public int WindowLeft { get => throw null; }
-        public System.ConsoleColor ForegroundColor { get => throw null; }
-        public System.ConsoleColor BackgroundColor { get => throw null; }
+        public System.ConsoleColor? ForegroundColor { get => throw null; }
+        public System.ConsoleColor? BackgroundColor { get => throw null; }
         public string? Title { get => throw null; }
     }
 

--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/ConsoleSnapshot.cs
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/ConsoleSnapshot.cs
@@ -9,8 +9,8 @@ public sealed class ConsoleSnapshot
     public bool IsErrorRedirected { get; } = Console.IsErrorRedirected;
     public bool IsInputRedirected { get; } = Console.IsInputRedirected;
 
-    public EncodingSnapshot OutEncoding { get; } = new EncodingSnapshot(Console.OutputEncoding);
-    public EncodingSnapshot InputEncoding { get; } = new EncodingSnapshot(Console.InputEncoding);
+    public EncodingSnapshot? OutEncoding { get; } = Utils.SafeGet(() => new EncodingSnapshot(Console.OutputEncoding));
+    public EncodingSnapshot? InputEncoding { get; } = Utils.SafeGet(() => new EncodingSnapshot(Console.InputEncoding));
 
     public int BufferHeight { get; } = Utils.SafeGet(() => Console.BufferHeight);
     public int BufferWidth { get; } = Utils.SafeGet(() => Console.BufferWidth);
@@ -21,8 +21,32 @@ public sealed class ConsoleSnapshot
     public int WindowTop { get; } = Utils.SafeGet(() => Console.WindowTop);
     public int WindowLeft { get; } = Utils.SafeGet(() => Console.WindowLeft);
 
-    public ConsoleColor ForegroundColor { get; } = Console.ForegroundColor;
-    public ConsoleColor BackgroundColor { get; } = Console.BackgroundColor;
+    public ConsoleColor? ForegroundColor { get; } = GetColor(() => Console.ForegroundColor);
+    public ConsoleColor? BackgroundColor { get; } = GetColor(() => Console.BackgroundColor);
 
-    public string? Title { get; } = OperatingSystem.IsWindows() ? Console.Title : null;
+    public string? Title { get; } = GetTitle();
+
+    private static string? GetTitle()
+    {
+        if (!OperatingSystem.IsWindows())
+            return null;
+
+        // Console.Title throws IOException when the process has no attached console.
+        try
+        {
+            return Console.Title;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private static ConsoleColor? GetColor(Func<ConsoleColor> getColor)
+    {
+        // Console returns (ConsoleColor)(-1) when the color is unknown, which is not a defined enum value
+        // and serializes as "-1".
+        var color = Utils.SafeGet(getColor);
+        return Enum.IsDefined(color) ? color : null;
+    }
 }


### PR DESCRIPTION
## The finding

`ConsoleSnapshot.cs:12-13,24-25,27` — eight properties (lines 15-22) are wrapped in `Utils.SafeGet`; `OutputEncoding`, `InputEncoding`, `ForegroundColor`, `BackgroundColor` and `Title` are not.

### Failure scenario

On Windows, `Console.InputEncoding` and `Console.Title` throw `IOException` when the process has no attached console — a Windows Service, a GUI app, or a process whose console was detached. The exception escapes `AddConsole()` and kills the whole snapshot.

Headless Windows processes are a primary audience for a context-snapshot library, and the inconsistency inside a single 28-line file reads as an oversight rather than a decision.

Separately, in a captured run `ForegroundColor` serialized as `-1`: `Console` returns `(ConsoleColor)(-1)` when the color is unknown, which is not a defined enum value, and consumers using `JsonStringEnumConverter` get the string `"-1"`.

## What changed

- All five remaining members guarded, so a failure blanks one field instead of the document.
- `ForegroundColor` / `BackgroundColor` are now `ConsoleColor?` and report `null` for the unknown sentinel rather than `-1`.
- `Title` moved into a guarded static method — keeping it as a lambda tripped CA1416, because the `OperatingSystem.IsWindows()` check does not flow into a lambda body.

## API change

`OutEncoding` / `InputEncoding` become nullable and the two colors become `ConsoleColor?`. `ref/Meziantou.Framework.Diagnostics.ContextSnapshot.cs` regenerated accordingly (Release + `IsOfficialBuild`).

## Verification

10/10 tests pass on net10.0 + net11.0. The no-console Windows scenario was **not** reproduced — reviewed on macOS.
