### PR TITLE
Dispose the current Process after snapshotting it

### DIFF
--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/CurrentProcessSnapshot.cs
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/CurrentProcessSnapshot.cs
@@ -7,8 +7,15 @@ namespace Meziantou.Framework.Diagnostics.ContextSnapshot;
 public sealed class CurrentProcessSnapshot : ProcessSnapshot
 {
     internal CurrentProcessSnapshot()
-        : base(Process.GetCurrentProcess())
+        : this(Process.GetCurrentProcess())
     {
+    }
+
+    private CurrentProcessSnapshot(Process process)
+        : base(process)
+    {
+        // The Process is owned by this constructor, so it is disposed once every property has been read.
+        process.Dispose();
     }
 
     public string CommandLine { get; } = Environment.CommandLine;

--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/ProcessSnapshot.cs
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/ProcessSnapshot.cs
@@ -13,7 +13,7 @@ public class ProcessSnapshot
         StartTime = process.StartTime;
 
         MainModule = process.MainModule is null ? null : new ProcessModuleSnapshot(process.MainModule);
-        Modules = process.Modules.Cast<ProcessModule>().Select(module => new ProcessModuleSnapshot(module)).ToImmutableArray();
+        Modules = GetModules(process);
 
         UserProcessorTime = process.UserProcessorTime;
         TotalProcessorTime = process.TotalProcessorTime;
@@ -53,4 +53,19 @@ public class ProcessSnapshot
     public long PeakVirtualMemorySize64 { get; }
     public long PeakPagedMemorySize64 { get; }
     public ProcessPriorityClass PriorityClass { get; }
+
+    private static ImmutableArray<ProcessModuleSnapshot> GetModules(Process process)
+    {
+        var modules = process.Modules;
+        var result = ImmutableArray.CreateBuilder<ProcessModuleSnapshot>(initialCapacity: modules.Count);
+        foreach (ProcessModule module in modules)
+        {
+            using (module)
+            {
+                result.Add(new ProcessModuleSnapshot(module));
+            }
+        }
+
+        return result.ToImmutable();
+    }
 }

--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/ProcessSnapshot.cs
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/ProcessSnapshot.cs
@@ -13,7 +13,7 @@ public class ProcessSnapshot
         StartTime = process.StartTime;
 
         MainModule = process.MainModule is null ? null : new ProcessModuleSnapshot(process.MainModule);
-        Modules = GetModules(process);
+        Modules = process.Modules.Cast<ProcessModule>().Select(module => new ProcessModuleSnapshot(module)).ToImmutableArray();
 
         UserProcessorTime = process.UserProcessorTime;
         TotalProcessorTime = process.TotalProcessorTime;
@@ -53,19 +53,4 @@ public class ProcessSnapshot
     public long PeakVirtualMemorySize64 { get; }
     public long PeakPagedMemorySize64 { get; }
     public ProcessPriorityClass PriorityClass { get; }
-
-    private static ImmutableArray<ProcessModuleSnapshot> GetModules(Process process)
-    {
-        var modules = process.Modules;
-        var result = ImmutableArray.CreateBuilder<ProcessModuleSnapshot>(initialCapacity: modules.Count);
-        foreach (ProcessModule module in modules)
-        {
-            using (module)
-            {
-                result.Add(new ProcessModuleSnapshot(module));
-            }
-        }
-
-        return result.ToImmutable();
-    }
 }


### PR DESCRIPTION
## The finding

`CurrentProcessSnapshot.cs:9-12` — the base constructor receives `Process.GetCurrentProcess()` and reads ~18 properties from it, but nothing disposes the `Process`.

### Failure scenario

`Process` holds a `SafeProcessHandle` until finalisation. Small and bounded per call, but this is a library — a host that snapshots on every unhandled exception accumulates handles between collections. It also breaks the convention the rest of this repo follows, where every other `IDisposable` is in a `using`.

## What changed

`CurrentProcessSnapshot` now chains through a private constructor that disposes the `Process` after the base constructor has read every property.

Ownership stays where it belongs: `ProcessSnapshot(Process)` still does **not** dispose a `Process` it did not create — only `CurrentProcessSnapshot`, which creates one, disposes it. Confirmed no other caller constructs a `ProcessSnapshot`.

Field-initialiser ordering is safe here: with `this(…)` chaining, the derived initialisers run inside the private constructor before `base(…)`, and none of them touch `process`.

## Review feedback

The first revision also disposed each `ProcessModule` from `process.Modules`. That was wrong and has been reverted: on .NET Core `ProcessModule` owns no unmanaged handle — `ProcessManager` closes the module handles before returning the collection — so `Component.Dispose` is a no-op there. `ProcessSnapshot.cs` is now byte-identical to `main`.

## Verification

10/10 tests pass on net10.0 + net11.0, including `IsJsonSerializable`, which builds a full `CurrentProcessSnapshot` and serializes it — so the disposal does not race the property reads. Handle-count behaviour is Windows-specific and was not measured.
