### PR TITLE
Free the GUID buffer PowerGetActiveScheme allocates

### DIFF
--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/NativeMethods.txt
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/NativeMethods.txt
@@ -2,3 +2,4 @@ GetLogicalProcessorInformationEx
 PowerReadFriendlyName
 PowerGetActiveScheme
 WscGetSecurityProviderHealth
+LocalFree

--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/PowerManagementSnapshot.cs
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/PowerManagementSnapshot.cs
@@ -23,7 +23,16 @@ public sealed class PowerManagementSnapshot
         if (result != Windows.Win32.Foundation.WIN32_ERROR.ERROR_SUCCESS || guid is null)
             return null;
 
-        var currentPlan = *guid;
+        Guid currentPlan;
+        try
+        {
+            currentPlan = *guid;
+        }
+        finally
+        {
+            // PowerGetActiveScheme allocates the returned GUID with LocalAlloc; the caller must free it.
+            Windows.Win32.PInvoke.LocalFree((Windows.Win32.Foundation.HLOCAL)guid);
+        }
 
         uint buffSize = 0;
         result = Windows.Win32.PInvoke.PowerReadFriendlyName(RootPowerKey: null, currentPlan, SubGroupOfPowerSettingsGuid: null, PowerSettingGuid: null, Buffer: null, ref buffSize);


### PR DESCRIPTION
## The finding

`PowerManagementSnapshot.cs:22-26` — `PowerGetActiveScheme` allocates the returned `GUID*` with `LocalAlloc` and [documents](https://learn.microsoft.com/en-us/windows/win32/api/powrprof/nf-powrprof-powergetactivescheme) that the caller must free it with `LocalFree`. The code dereferences `*guid` into `currentPlan` and returns without freeing.

### Failure scenario

16 bytes of process heap per `AddDefault()` call, never reclaimed — trivial for a one-shot snapshot, real for a host that snapshots periodically, and an outright API-contract violation either way.

## What changed

- Copy the GUID, then free the buffer in a `finally`.
- `LocalFree` added to `NativeMethods.txt` so CsWin32 generates it.

## Verification

Builds clean on net10.0 + net11.0 — which does confirm the generated `LocalFree` signature and the `Guid*` → `HLOCAL` cast compile. 10/10 tests pass. **The Windows runtime path was not executed** (reviewed on macOS); the function is guarded by `OperatingSystem.IsWindowsVersionAtLeast` and returns early elsewhere.
