### PR TITLE
fix/contextsnapshot path separator

### DIFF
--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/ContextSnapshotBuilder.cs
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/ContextSnapshotBuilder.cs
@@ -321,7 +321,7 @@ public sealed class ContextSnapshotBuilder
             {
                 var key = (string)entry.Key;
                 if (string.Equals(key, "PATH", StringComparison.OrdinalIgnoreCase))
-                    return KeyValuePair.Create<string, object>(key, ((string)entry.Value!).Split(';').ToImmutableArray());
+                    return KeyValuePair.Create<string, object>(key, ((string)entry.Value!).Split(Path.PathSeparator).ToImmutableArray());
 
                 return KeyValuePair.Create<string, object>(key, entry.Value!);
             }

--- a/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
@@ -47,7 +47,10 @@ public sealed class SnapshotTests(ITestOutputHelper testOutputHelper)
         var variables = Assert.IsType<ImmutableSortedDictionary<string, object>>(snapshot["EnvironmentVariables.Process"]);
         var expected = Environment.GetEnvironmentVariable("PATH")!.Split(Path.PathSeparator);
 
-        Assert.Equal(expected, Assert.IsType<ImmutableArray<string>>(variables["PATH"]));
+        // Windows names the variable "Path" and the snapshot dictionary compares keys ordinally.
+        var pathKey = variables.Keys.Single(key => string.Equals(key, "PATH", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Equal(expected, Assert.IsType<ImmutableArray<string>>(variables[pathKey]));
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CA1869
 
+using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -34,6 +35,19 @@ public sealed class SnapshotTests(ITestOutputHelper testOutputHelper)
         builder.AddAppContextData();
         var snapshot = builder.BuildSnapshot();
         Assert.NotEmpty(snapshot);
+    }
+
+    [Fact]
+    public void PathEnvironmentVariableIsSplitOnThePlatformSeparator()
+    {
+        var builder = new ContextSnapshotBuilder();
+        builder.AddEnvironmentVariables(EnvironmentVariableTarget.Process);
+        var snapshot = builder.BuildSnapshot();
+
+        var variables = Assert.IsType<ImmutableSortedDictionary<string, object>>(snapshot["EnvironmentVariables.Process"]);
+        var expected = Environment.GetEnvironmentVariable("PATH")!.Split(Path.PathSeparator);
+
+        Assert.Equal(expected, Assert.IsType<ImmutableArray<string>>(variables["PATH"]));
     }
 
     [Fact]


### PR DESCRIPTION
> **Stack 1 of 2** · merges into `main` · must merge before #2403

## The finding

`ContextSnapshotBuilder.cs:324` — `((string)entry.Value!).Split(';')`. Unix uses `:`.

### Failure scenario

Verified against the JSON produced by the shipped `IsJsonSerializable` test on macOS: `"PATH"` came out as an array with **exactly one element** containing all 22 entries concatenated. The special-casing that exists precisely to make `PATH` readable does nothing on Linux or macOS — and a reader of the JSON cannot tell "one entry" from "unsplit".

Low blast radius (cosmetic, wrong shape in the output), but it is the one platform-conditional formatting decision in the builder and it was wrong on two of three platforms.

## What changed

`Split(Path.PathSeparator)`.

## Verification

New regression test `PathEnvironmentVariableIsSplitOnThePlatformSeparator` compares against `Environment.GetEnvironmentVariable("PATH")!.Split(Path.PathSeparator)`. It **fails on the previous code on any Unix host** (1 element vs 22). 12/12 tests pass on net10.0 + net11.0.

## Why this is the bottom of the stack

#2403 rewrites the same `Parse` local function, so the two would conflict as independent PRs. This one is at the bottom deliberately: it is a one-line, uncontroversial fix that should not be held hostage to the design discussion redaction will attract.
