### PR TITLE
Redact secret-shaped environment variable values

### DIFF
--- a/ref/Meziantou.Framework.Diagnostics.ContextSnapshot.cs
+++ b/ref/Meziantou.Framework.Diagnostics.ContextSnapshot.cs
@@ -45,6 +45,7 @@ namespace Meziantou.Framework.Diagnostics.ContextSnapshot
 
     public sealed class ContextSnapshotBuilder
     {
+        public const string RedactedValue = "***";
         public Meziantou.Framework.Diagnostics.ContextSnapshot.ContextSnapshotBuilder AddValue(string key, object? value) => throw null;
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> BuildSnapshot() => throw null;
         public Meziantou.Framework.Diagnostics.ContextSnapshot.ContextSnapshotBuilder AddDefault() => throw null;
@@ -71,7 +72,9 @@ namespace Meziantou.Framework.Diagnostics.ContextSnapshot
         public Meziantou.Framework.Diagnostics.ContextSnapshot.ContextSnapshotBuilder AddRuntimeFeatures() => throw null;
         public Meziantou.Framework.Diagnostics.ContextSnapshot.ContextSnapshotBuilder AddCommonAppContext() => throw null;
         public Meziantou.Framework.Diagnostics.ContextSnapshot.ContextSnapshotBuilder AddAppContextData() => throw null;
-        public void AddEnvironmentVariables(System.EnvironmentVariableTarget target = 0) { }
+        public static bool IsSecretEnvironmentVariableName(string name) => throw null;
+        public Meziantou.Framework.Diagnostics.ContextSnapshot.ContextSnapshotBuilder AddEnvironmentVariables(System.EnvironmentVariableTarget target = 0) => throw null;
+        public Meziantou.Framework.Diagnostics.ContextSnapshot.ContextSnapshotBuilder AddEnvironmentVariables(System.EnvironmentVariableTarget target, System.Func<string, bool> shouldRedact) => throw null;
     }
 
     public sealed class CpuSnapshot

--- a/src/Meziantou.Framework.Diagnostics.ContextSnapshot/ContextSnapshotBuilder.cs
+++ b/src/Meziantou.Framework.Diagnostics.ContextSnapshot/ContextSnapshotBuilder.cs
@@ -308,18 +308,57 @@ public sealed class ContextSnapshotBuilder
         return this;
     }
 
-    /// <summary>Adds environment variables for the specified target scope.</summary>
-    public void AddEnvironmentVariables(EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
+    /// <summary>The value substituted for environment variables whose name looks like it holds a secret.</summary>
+    public const string RedactedValue = "***";
+
+    private static readonly string[] SecretNameFragments = ["TOKEN", "SECRET", "PASSWORD", "PASSWD", "PWD", "APIKEY", "API_KEY", "ACCESS_KEY", "PRIVATE_KEY", "CREDENTIAL", "SESSION"];
+
+    /// <summary>
+    /// Determines whether the value of an environment variable is replaced by <see cref="RedactedValue"/>.
+    /// Defaults to a name-based match on fragments such as <c>TOKEN</c>, <c>SECRET</c> and <c>PASSWORD</c>.
+    /// </summary>
+    /// <remarks>
+    /// Name-based redaction is best-effort. It cannot recognise a secret stored under an unremarkable name,
+    /// so it reduces accidental disclosure rather than guaranteeing a snapshot is safe to publish.
+    /// </remarks>
+    public static bool IsSecretEnvironmentVariableName(string name)
     {
-        AddValue("EnvironmentVariables." + target, GetEnvironmentVariables(target));
-
-        static ImmutableSortedDictionary<string, object> GetEnvironmentVariables(EnvironmentVariableTarget target)
+        foreach (var fragment in SecretNameFragments)
         {
-            return Environment.GetEnvironmentVariables(target).Cast<DictionaryEntry>().Select(item => Parse(item)).ToImmutableSortedDictionary();
+            if (name.Contains(fragment, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
 
-            static KeyValuePair<string, object> Parse(DictionaryEntry entry)
+        return false;
+    }
+
+    /// <summary>Adds environment variables for the specified target scope, redacting values whose name looks like a secret.</summary>
+    public ContextSnapshotBuilder AddEnvironmentVariables(EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
+        => AddEnvironmentVariables(target, IsSecretEnvironmentVariableName);
+
+    /// <summary>Adds environment variables for the specified target scope.</summary>
+    /// <param name="target">The scope to read the variables from.</param>
+    /// <param name="shouldRedact">
+    /// Called with each variable name. When it returns <see langword="true"/> the value is replaced by
+    /// <see cref="RedactedValue"/>. Pass <c>_ => false</c> to capture every value verbatim.
+    /// </param>
+    public ContextSnapshotBuilder AddEnvironmentVariables(EnvironmentVariableTarget target, Func<string, bool> shouldRedact)
+    {
+        ArgumentNullException.ThrowIfNull(shouldRedact);
+
+        AddValue("EnvironmentVariables." + target, GetEnvironmentVariables(target, shouldRedact));
+        return this;
+
+        static ImmutableSortedDictionary<string, object> GetEnvironmentVariables(EnvironmentVariableTarget target, Func<string, bool> shouldRedact)
+        {
+            return Environment.GetEnvironmentVariables(target).Cast<DictionaryEntry>().Select(item => Parse(item, shouldRedact)).ToImmutableSortedDictionary();
+
+            static KeyValuePair<string, object> Parse(DictionaryEntry entry, Func<string, bool> shouldRedact)
             {
                 var key = (string)entry.Key;
+                if (shouldRedact(key))
+                    return KeyValuePair.Create<string, object>(key, RedactedValue);
+
                 if (string.Equals(key, "PATH", StringComparison.OrdinalIgnoreCase))
                     return KeyValuePair.Create<string, object>(key, ((string)entry.Value!).Split(Path.PathSeparator).ToImmutableArray());
 

--- a/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
+++ b/tests/Meziantou.Framework.Diagnostics.ContextSnapshot.Tests/SnapshotTests.cs
@@ -54,6 +54,45 @@ public sealed class SnapshotTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public void SecretShapedEnvironmentVariablesAreRedactedByDefault()
+    {
+        Environment.SetEnvironmentVariable("CONTEXTSNAPSHOT_TEST_API_TOKEN", "super-secret");
+        Environment.SetEnvironmentVariable("CONTEXTSNAPSHOT_TEST_PLAIN", "visible");
+        try
+        {
+            var builder = new ContextSnapshotBuilder();
+            builder.AddEnvironmentVariables(EnvironmentVariableTarget.Process);
+            var variables = Assert.IsType<ImmutableSortedDictionary<string, object>>(builder.BuildSnapshot()["EnvironmentVariables.Process"]);
+
+            Assert.Equal(ContextSnapshotBuilder.RedactedValue, variables["CONTEXTSNAPSHOT_TEST_API_TOKEN"]);
+            Assert.Equal("visible", variables["CONTEXTSNAPSHOT_TEST_PLAIN"]);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CONTEXTSNAPSHOT_TEST_API_TOKEN", value: null);
+            Environment.SetEnvironmentVariable("CONTEXTSNAPSHOT_TEST_PLAIN", value: null);
+        }
+    }
+
+    [Fact]
+    public void EnvironmentVariableRedactionCanBeOverridden()
+    {
+        Environment.SetEnvironmentVariable("CONTEXTSNAPSHOT_TEST_API_TOKEN", "super-secret");
+        try
+        {
+            var builder = new ContextSnapshotBuilder();
+            builder.AddEnvironmentVariables(EnvironmentVariableTarget.Process, _ => false);
+            var variables = Assert.IsType<ImmutableSortedDictionary<string, object>>(builder.BuildSnapshot()["EnvironmentVariables.Process"]);
+
+            Assert.Equal("super-secret", variables["CONTEXTSNAPSHOT_TEST_API_TOKEN"]);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CONTEXTSNAPSHOT_TEST_API_TOKEN", value: null);
+        }
+    }
+
+    [Fact]
     public void SpecialFolderShouldContainsAllValues()
     {
         var snapshot = new SpecialFolderSnapshot();


### PR DESCRIPTION
> **Stack 2 of 2** · merges into `fix/contextsnapshot-path-separator` (#2402) · merge #2402 first

## The finding

`ContextSnapshotBuilder.cs:38-40` and `:312-329` — `AddDefault()` calls `AddEnvironmentVariables` for `Process`, `User` and `Machine` and stores every name/value pair unmodified. There is no redaction hook, no denylist, and no way to get the other 20 sections of `AddDefault()` without also getting the variables.

### Failure scenario

I ran the shipped `IsJsonSerializable` test and dumped the result: 72 process variables, including a live **`CLAUDE_CODE_MESSAGING_TOKEN`**, plus `CLAUDE_CODE_OAUTH_SCOPES` and `SSH_AUTH_SOCK`. On CI the same call captures `NUGET_AUTH_TOKEN`, `GITHUB_TOKEN`, `AZURE_CLIENT_SECRET`, connection strings — whatever the job injected.

The readme's only example is "you can serialize the context" and the package description is "ease investigation", so the expected flow is snapshot → JSON → issue tracker / log sink / support ticket. **A user following the documented happy path publishes live credentials.**

## What changed

Values whose name contains `TOKEN`, `SECRET`, `PASSWORD`, `PASSWD`, `PWD`, `APIKEY`, `API_KEY`, `ACCESS_KEY`, `PRIVATE_KEY`, `CREDENTIAL` or `SESSION` are replaced by `ContextSnapshotBuilder.RedactedValue` (`"***"`).

A new overload `AddEnvironmentVariables(EnvironmentVariableTarget, Func<string, bool> shouldRedact)` lets callers widen or disable it; `_ => false` restores the previous behaviour exactly. `IsSecretEnvironmentVariableName` is public so callers can compose with the default.

The variables **stay in `AddDefault()`** — nothing silently disappears for existing consumers.

Name-based redaction is documented in the XML docs as best-effort: it cannot recognise a secret stored under an unremarkable name, so it reduces accidental disclosure rather than guaranteeing a snapshot is safe to publish. Worth deciding whether that is the right bar.

## API change, and one thing to call out

Adding the overload makes `AddEnvironmentVariables` return `ContextSnapshotBuilder` instead of `void`. That was not the goal of this PR — but two overloads with different return types would be worse, and it happens to fix the one method that broke the fluent chain the readme advertises. Source- and binary-compatible for existing callers. `ref/` regenerated (Release + `IsOfficialBuild`).

## Verification

Two new tests: `SecretShapedEnvironmentVariablesAreRedactedByDefault` and `EnvironmentVariableRedactionCanBeOverridden`, both setting and restoring real process variables. 16/16 tests pass on net10.0 + net11.0.
