### PR TITLE
Write the meta handler box so other tools can read MP4 tags

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Writer.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Mp4/Mp4Writer.cs
@@ -99,10 +99,23 @@ internal sealed class Mp4Writer : IMediaTagWriter
 
     private static byte[] BuildMetaAtomData(byte[] content)
     {
-        // meta atom has 4 bytes version/flags before children
-        var result = new byte[4 + content.Length];
-        content.CopyTo(result, 4);
+        // meta atom has 4 bytes version/flags, then a handler box, then the children. The handler box
+        // declares the metadata as iTunes-style: readers such as iTunes and ffmpeg use it to recognise
+        // the ilst box, and without it they report the file as having no tags at all.
+        var handlerAtom = BuildHandlerAtom();
+        var result = new byte[4 + handlerAtom.Length + content.Length];
+        handlerAtom.CopyTo(result, 4);
+        content.CopyTo(result, 4 + handlerAtom.Length);
         return result;
+    }
+
+    private static byte[] BuildHandlerAtom()
+    {
+        // hdlr payload: version/flags(4) + predefined(4) + handler type(4) + reserved(12) + empty name(1)
+        var data = new byte[25];
+        Encoding.Latin1.GetBytes("mdir", data.AsSpan(8, 4));
+        Encoding.Latin1.GetBytes("appl", data.AsSpan(12, 4));
+        return BuildAtom("hdlr", data);
     }
 
     private static byte[] BuildIlstData(MediaTagInfo tags)

--- a/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Mp4Tests.cs
@@ -301,4 +301,49 @@ public sealed class Mp4Tests
         payload.CopyTo(atom, 8);
         return atom;
     }
+
+    [Fact]
+    public void WriteTags_WritesTheMetaHandlerBox()
+    {
+        var tempFile = Path.GetTempFileName() + ".m4a";
+        try
+        {
+            File.Copy(GetTestFilePath("basic.m4a"), tempFile, overwrite: true);
+
+            var writeResult = MediaFile.WriteTags(tempFile, new MediaTagInfo { Title = "Handler Title" });
+            Assert.True(writeResult.IsSuccess);
+
+            var written = File.ReadAllBytes(tempFile);
+            var meta = IndexOfAtomType(written, "meta");
+            Assert.True(meta >= 0, "No meta atom in the written file.");
+
+            // meta payload: version/flags(4), then the handler box, then ilst
+            var handler = meta + 8;
+            Assert.Equal(33u, BinaryPrimitives.ReadUInt32BigEndian(written.AsSpan(handler, 4)));
+            Assert.Equal("hdlr", Encoding.Latin1.GetString(written, handler + 4, 4));
+            Assert.Equal("mdir", Encoding.Latin1.GetString(written, handler + 16, 4));
+            Assert.Equal("ilst", Encoding.Latin1.GetString(written, handler + 33 + 4, 4));
+
+            // The tags are still readable through the library itself
+            var readResult = MediaFile.ReadTags(tempFile);
+            Assert.True(readResult.IsSuccess);
+            Assert.Equal("Handler Title", readResult.Value.Title);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    private static int IndexOfAtomType(byte[] data, string atomType)
+    {
+        var needle = Encoding.Latin1.GetBytes(atomType);
+        for (var i = 4; i + 4 <= data.Length; i++)
+        {
+            if (data.AsSpan(i, 4).SequenceEqual(needle))
+                return i;
+        }
+
+        return -1;
+    }
 }


### PR DESCRIPTION
`Mp4Writer` rebuilds `moov.udta.meta` with only the 4-byte version/flags followed by `ilst` (`Mp4Writer.cs:100-105`). A `meta` box is supposed to carry an `hdlr` box declaring the metadata handler (`mdir`/`appl`) before `ilst`; ffmpeg and iTunes both write it and both use it to recognise the box.

`Mp4Reader` never looks for `hdlr`, so the library round-trips its own output happily and every existing test passes — while nothing else can see the tags.

Before this change, on `TestFiles/basic.m4a`:

```
$ ffprobe -show_entries format_tags=title,artist,album basic.m4a     # original, written by ffmpeg
TAG:title=Test Title
TAG:artist=Test Artist
TAG:album=Test Album

$ # ... MediaFile.WriteTags(path, tags) ...
$ ffprobe -show_entries format_tags=title,artist,album basic.m4a     # after
[FORMAT]
[/FORMAT]
```

The tags are in the file — `MediaFile.ReadTags` returns them — but every other tool reports the file as untagged. For a tagging library that is the primary use case failing silently on one of the seven supported formats, and a user only finds out when their player shows nothing.

## What changed

`BuildMetaAtomData` now emits the handler box between the version/flags and the children:

```
size(4)=33 | 'hdlr' | version/flags(4) | predefined(4) | 'mdir' | 'appl' + reserved(8) | name(1)=0
```

That is the same 33-byte box ffmpeg writes. Nothing else about the write path changes.

This was isolated before writing the fix: taking a file the library had already written and inserting exactly this box (bumping the three parent sizes) made `ffprobe` print the tags again, which identified the missing box as the sole cause.

## Verification

`WriteTags_WritesTheMetaHandlerBox` asserts the structure of the written `meta` box — a 33-byte `hdlr` with handler type `mdir`, followed by `ilst` — and that the library still reads its own tags back. It fails on the current writer, where `ilst` sits where `hdlr` should be.

Checked against ffmpeg as an external oracle: after the fix, `ffprobe` reads back all three tags written by the library, and `ffmpeg -f null -` decodes the file with no errors. Full suite: 250/250 on net10.0 and net11.0, built with `/p:TreatsWarningsAsErrors=true`.

Two related MP4 write issues are **not** in this PR and still open: chunk offsets (`stco`/`co64`) are not patched when `moov` changes size, which corrupts faststart files; and rebuilding `udta` discards any children other than `meta`.

Found during a review of `Meziantou.Framework.MediaTags`; part of a series of independent fixes.
