### PR TITLE
Default StartServer to Windows so the library works out of the box elsewhere

### DIFF
--- a/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
+++ b/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
@@ -44,9 +44,12 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
 
     /// <summary>Gets or sets a value indicating whether to start a named pipe server to receive notifications from other instances.</summary>
     /// <value>
-    /// <see langword="true"/> to start the server; otherwise, <see langword="false"/>. The default is <see langword="true"/>.
+    /// <see langword="true"/> to start the server; otherwise, <see langword="false"/>. The default is <see langword="true"/> on Windows, and <see langword="false"/> on every other operating system.
     /// </value>
-    public bool StartServer { get; set; } = true;
+    /// <remarks>
+    /// Communication between instances is only supported on Windows. Setting this property to <see langword="true"/> on another operating system makes <see cref="StartApplication"/> throw a <see cref="PlatformNotSupportedException"/>.
+    /// </remarks>
+    public bool StartServer { get; set; } = OperatingSystem.IsWindows();
 
     /// <summary>Gets or sets the timeout for connecting to the first instance when notifying it.</summary>
     /// <value>The connection timeout. The default is 3 seconds.</value>
@@ -65,6 +68,7 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
     /// <remarks>
     /// If this method returns <see langword="true"/>, the application should continue running and can receive notifications from other instances through the <see cref="NewInstance"/> event.
     /// If this method returns <see langword="false"/>, the application should call <see cref="NotifyFirstInstance"/> to notify the first instance and then exit.
+    /// Ensuring a single instance is supported on every operating system; only the communication between instances is Windows-only.
     /// </remarks>
     public bool StartApplication()
     {
@@ -199,13 +203,16 @@ public sealed class SingleInstance(Guid applicationId) : IDisposable
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="args"/> is <see langword="null"/>.</exception>
     /// <remarks>
-    /// This method is only supported on Windows. The first instance must have <see cref="StartServer"/> set to <see langword="true"/> to receive notifications.
+    /// This method is only supported on Windows and returns <see langword="false"/> on every other operating system. The first instance must have <see cref="StartServer"/> set to <see langword="true"/> to receive notifications.
     /// The method will timeout after <see cref="ClientConnectionTimeout"/> if the first instance is not responding.
     /// Failing to reach the first instance is reported by returning <see langword="false"/> instead of throwing.
     /// </remarks>
     public bool NotifyFirstInstance(string[] args)
     {
         ArgumentNullException.ThrowIfNull(args);
+
+        if (!OperatingSystem.IsWindows())
+            return false;
 
         try
         {

--- a/src/Meziantou.Framework.SingleInstance/readme.md
+++ b/src/Meziantou.Framework.SingleInstance/readme.md
@@ -2,6 +2,8 @@
 
 Library to help implementing applications that must only have a single instance.
 
+Ensuring a single instance is supported on every operating system. Notifying the first instance uses a named pipe and is only supported on Windows: elsewhere `StartServer` defaults to `false` and `NotifyFirstInstance` returns `false`.
+
 ````c#
 // Generate a unique Guid for the application
 var applicationId = new Guid("dfae4e70-179f-4726-aa98-00a832315f5a");

--- a/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
+++ b/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
@@ -54,6 +54,27 @@ public sealed class SingleInstanceTests
         Assert.False(singleInstance.NotifyFirstInstance(["a", "b"]));
     }
 
+    [Fact, RunIf(TestOperatingSystems.Linux | TestOperatingSystems.MacOS)]
+    public void TestSingleInstance_DefaultConfigurationDoesNotThrowOnNonWindows()
+    {
+        using var singleInstance = new SingleInstance(Guid.NewGuid());
+
+        Assert.False(singleInstance.StartServer);
+        Assert.True(singleInstance.StartApplication());
+        Assert.False(singleInstance.NotifyFirstInstance(["a", "b"]));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Linux | TestOperatingSystems.MacOS)]
+    public void TestSingleInstance_StartServerExplicitlyEnabledThrowsOnNonWindows()
+    {
+        using var singleInstance = new SingleInstance(Guid.NewGuid())
+        {
+            StartServer = true,
+        };
+
+        Assert.Throws<PlatformNotSupportedException>(() => _ = singleInstance.StartApplication());
+    }
+
     [Fact]
     public void TestSingleInstance()
     {


### PR DESCRIPTION
## What

`StartServer` now defaults to `OperatingSystem.IsWindows()` instead of `true`, and `NotifyFirstInstance` returns `false` off Windows instead of failing on a `null` pipe name. Documented on both members and in the readme.

Stack 3 of 3 · targets `fix/singleinstance-client-currentuseronly` · must merge after #2394.

## Why

The package targets `net10.0;net11.0` — platform-neutral — but `StartServer` defaulted to `true`, so the first call in the readme sample threw on Linux and macOS:

`StartApplication()` → `TryAcquireMutex()` succeeds → `StartNamedPipeServer()` → `throw new PlatformNotSupportedException`.

There is no `[SupportedOSPlatform("windows")]` anywhere in the project, so the analyzer that exists precisely to catch this stayed silent, and nothing in the package description or readme mentioned Windows.

Working around it made things worse rather than better. `PipeName` is initialised to `null!` off Windows, so a consumer who set `StartServer = false` and then called `NotifyFirstInstance` got:

```
ArgumentNullException: Value cannot be null. (Parameter 'pipeName')
```

raised from the `NamedPipeClientStream` constructor — with no path back to "this feature is Windows-only".

The test suite had already been quietly working around all of this: the only test that ran off Windows had to set `StartServer = false`, and the notification test is gated behind `RunIf(TestOperatingSystems.Windows)`.

## Notes for the reviewer

- **This is the "degrade gracefully" option, not the "declare it Windows-only" option.** The alternative was `[SupportedOSPlatform("windows")]` plus `$(LatestTargetFrameworksWindows)`, which is more honest about the pipe feature but is a breaking packaging change for anyone using mutex-only mode on Linux or macOS. This keeps mutual exclusion — which genuinely works everywhere — available out of the box. Say the word if you'd rather have the annotation.
- **`StartNamedPipeServer` still throws when `StartServer` is explicitly set to `true` off Windows**, and needed no edit: the default now short-circuits at `if (!StartServer) return;` before reaching the throw. An explicit opt-in deserves a loud error rather than silence, so that path is kept and now covered by a test.
- **`NotifyFirstInstance` returns `false` rather than throwing `PlatformNotSupportedException`.** `false` already means "the message did not arrive", which is exactly what happened, and it lets a second instance on Linux exit cleanly instead of crashing. The consequence worth being explicit about: on Linux the first instance never learns that a second one started. That is degraded behaviour, and it is now documented rather than discovered.
- **`PipeName` is still `null!` off Windows.** Nothing dereferences it any more — `StartServer` is `false` and `NotifyFirstInstance` returns early — so cleaning it up would be churn in a file three PRs deep in a stack. Worth a follow-up.
- Longer term this need not be Windows-only at all: .NET backs `NamedPipeServerStream` with Unix domain sockets on Linux and macOS, so the feature could be made genuinely cross-platform. That is a bigger change than a default value.

## Tests

- `TestSingleInstance_DefaultConfigurationDoesNotThrowOnNonWindows` — the documented usage now works off Windows: `StartServer` is `false`, `StartApplication()` returns `true`, `NotifyFirstInstance` returns `false`. Before this change the second line threw.
- `TestSingleInstance_StartServerExplicitlyEnabledThrowsOnNonWindows` — an explicit `StartServer = true` still throws `PlatformNotSupportedException`.
- **These two ran locally and passed** — unlike the rest of this stack, they are gated to Linux/macOS, so my machine is the right place for them. `dotnet test` reports 10 total / 6 succeeded / 4 skipped on net10.0 and net11.0; the 4 skipped are the Windows-only pipe tests.
- Builds clean with `-p:TreatWarningsAsErrors=true`; `dotnet run ./eng/update-all.cs` produced no changes.
