### PR TITLE
Bound the whole AllSymbolicLinks walk instead of consecutive links

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -668,12 +668,16 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
                     string? resultPath = null;
                     var current = this;
                     var hasSymLink = false;
-                    var componentDepth = 0;
+
+                    // Counts every link resolved by this walk, not just consecutive ones. Resetting it per component
+                    // would let two links that reference each other through a directory alternate forever, because
+                    // each resolution is separated by a component that is not itself a link.
+                    var resolvedLinkCount = 0;
                     while (!current.IsEmpty)
                     {
                         if (Symlink.TryGetSymLinkTarget(current._value, out path))
                         {
-                            if (++componentDepth > MaxSymbolicLinkDepth)
+                            if (++resolvedLinkCount > MaxSymbolicLinkDepth)
                                 throw CreateTooManyLevelsOfSymbolicLinksException();
 
                             current = FromPath(path);
@@ -692,7 +696,6 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
                             }
 
                             current = current.Parent;
-                            componentDepth = 0;
                         }
                     }
 

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -392,6 +392,20 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public async Task ResolveSymlink_CycleThroughADirectoryLink()
+    {
+        // The links reference each other through a directory component, so the walk alternates between resolving a
+        // link and consuming a component that is not one
+        await using var temp = TemporaryDirectory.Create();
+        var a = temp.GetFullPath("a");
+        var b = temp.GetFullPath("b");
+        CreateSymlink(a, Path.Combine("b", "c"), isDirectory: true);
+        CreateSymlink(b, "a", isDirectory: true);
+
+        Assert.Throws<IOException>(() => { a.TryGetSymbolicLinkTarget(SymbolicLinkResolutionMode.AllSymbolicLinks, out _); });
+    }
+
+    [Fact]
     public async Task ResolveSymlink_ResolveAllSymbolicLinks()
     {
         await using var temp = TemporaryDirectory.Create();


### PR DESCRIPTION
`TryGetSymbolicLinkTarget(SymbolicLinkResolutionMode.AllSymbolicLinks, …)` does not terminate on a symlink cycle whose links reference each other through a directory component.

## What goes wrong

The walk in `src/Meziantou.Framework.FullPath/FullPath.cs:667-705` uses `componentDepth` as its only cycle guard, and resets it to `0` every time it consumes a component that is not a link (`FullPath.cs:695`).

With `$base/a -> $base/b/c` and `$base/b -> $base/a`:

1. `$base/a` is a link → resolve to `$base/b/c`, depth 1
2. `$base/b/c` is not a link → append `c`, step to `$base/b`, **depth reset to 0**
3. `$base/b` is a link → resolve to `$base/a`, depth 1
4. …repeat forever

`++componentDepth > MaxSymbolicLinkDepth` therefore never fires. The loop pins a core and `resultPath` grows by one component per iteration via `Path.Combine(name, resultPath)` until `OutOfMemoryException`.

Reproduced against a Release build with a watchdog: the call had not returned after 8 seconds, with `resultPath` growing steadily.

The `FinalTarget` branch a few lines above (`FullPath.cs:648-657`) gets this right with a single monotonic counter, which is what the `AllSymbolicLinks` guard was clearly meant to be.

`ResolveSymlink_Cycle` (`FullPathTests.cs:377`) only covers a direct `a -> b -> a` cycle, where no non-link component is ever consumed and the counter is never reset — so it passes today and hides this.

## Change

Count every link resolved by the walk rather than only consecutive ones: drop the per-component reset and rename the variable to `resolvedLinkCount` to make the intent explicit. The bound stays `MaxSymbolicLinkDepth` (40), matching `MAXSYMLINKS` and the `FinalTarget` branch.

A path legitimately containing more than 40 symlinked components now throws `IOException` instead of resolving. That matches what the kernel itself does with `ELOOP`, and matches the sibling branch.

## Verification

`dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 164 passed, 0 failed, 56 skipped (Windows-gated).

Added `ResolveSymlink_CycleThroughADirectoryLink` next to the existing cycle test. Note that on `main` this test does not *fail*, it **hangs** — so it is a regression test in the sense that a revert stalls CI rather than reporting red.

`dotnet run ./eng/update-all.cs` produced no generated-file changes.
