### PR TITLE
Bound the ID3v2 tag buffer by the bytes actually available in the stream

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2Reader.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Id3v2/Id3v2Reader.cs
@@ -24,7 +24,14 @@ internal static class Id3v2Reader
             return false;
         }
 
-        // Read tag data
+        // Read tag data. The declared size comes from the file and reaches 256 MB, so it must be checked
+        // against the bytes that are actually there before it is used as an allocation size.
+        if (stream.CanSeek && header.TagSize > stream.Length - stream.Position)
+        {
+            stream.Position = originalPosition;
+            return false;
+        }
+
         var tagData = new byte[header.TagSize];
         if (stream.ReadAtLeast(tagData, header.TagSize, throwOnEndOfStream: false) < header.TagSize)
         {

--- a/tests/Meziantou.Framework.MediaTags.Tests/Mp3Id3v2Tests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/Mp3Id3v2Tests.cs
@@ -305,4 +305,41 @@ public sealed class Mp3Id3v2Tests
         destination[2] = (byte)((value >> 7) & 0x7F);
         destination[3] = (byte)(value & 0x7F);
     }
+
+    [Fact]
+    public void ReadTags_TagSizeBeyondEndOfStream_DoesNotAllocateTheDeclaredSize()
+    {
+        // An ID3v2 header and nothing else, declaring the largest tag a synchsafe integer can express (256 MB)
+        var header = new byte[10];
+        header[0] = (byte)'I';
+        header[1] = (byte)'D';
+        header[2] = (byte)'3';
+        header[3] = 4;
+        WriteSynchsafeInteger(header.AsSpan(6, 4), 0x0FFF_FFFF);
+
+        using var stream = new MemoryStream(header);
+
+        // Read once so the measured read is not paying for JIT and first-use initialization
+        MediaFile.ReadTags(stream, MediaFormat.Mp3);
+
+        var before = GC.GetTotalAllocatedBytes(precise: true);
+        var result = MediaFile.ReadTags(stream, MediaFormat.Mp3);
+        var allocated = GC.GetTotalAllocatedBytes(precise: true) - before;
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Value.Title);
+        Assert.True(allocated < 1024 * 1024, $"Reading a {stream.Length} byte file allocated {allocated} bytes.");
+    }
+
+    [Fact]
+    public void ReadTags_TagSizeMatchingTheStream_IsStillParsed()
+    {
+        var mp3 = CreateId3v24WithTextFrame("TIT2", "Bounded Title");
+
+        using var stream = new MemoryStream(mp3);
+        var result = MediaFile.ReadTags(stream, MediaFormat.Mp3);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Bounded Title", result.Value.Title);
+    }
 }


### PR DESCRIPTION
`Id3v2Reader.TryReadTag` allocates the tag buffer straight from the size in the header, before the read that would prove those bytes exist (`Id3v2Reader.cs:28`):

```csharp
var tagData = new byte[header.TagSize];
if (stream.ReadAtLeast(tagData, header.TagSize, throwOnEndOfStream: false) < header.TagSize)
```

`TagSize` is a synchsafe integer, so it reaches `0x0FFFFFFF` — 256 MB. A 10-byte file containing nothing but `ID3 04 00 00 7F 7F 7F 7F` allocates 270,023,680 bytes, fails the read, and returns "no tags":

```
Reading a 10 byte file allocated 270023680 bytes.
```

That is a 27-million-fold amplification from four attacker-controlled bytes, and it is reachable from three formats: `.mp3`, and the `id3 ` chunks embedded in WAV and AIFF. A handful of tiny files will exhaust memory on a process that scans a directory.

## What changed

One guard before the allocation:

```csharp
if (stream.CanSeek && header.TagSize > stream.Length - stream.Position)
{
    stream.Position = originalPosition;
    return false;
}
```

The stream position is at the end of the 10-byte header at this point, so `stream.Length - stream.Position` is exactly what remains. On rejection the position is restored to where the method started, matching the other early-return paths in the method. The `CanSeek` check keeps the behaviour unchanged for non-seekable streams, which have no `Length` to compare against.

This bounds the allocation by the real file size rather than by a number the file asked for. No cap is introduced — a large ID3v2 tag backed by a large file is legitimate and still reads.

## Verification

`ReadTags_TagSizeBeyondEndOfStream_DoesNotAllocateTheDeclaredSize` fails on the current reader with the message quoted above; with the fix the same read stays under 1 MB. A second test pins that a tag whose declared size matches the stream is still parsed, so the guard does not cut into valid files.

Full suite: 252/252 on net10.0 and net11.0, built with `/p:TreatsWarningsAsErrors=true`.

Found during a review of `Meziantou.Framework.MediaTags`; part of a series of independent fixes. The same unchecked-length pattern exists in `FlacPictureBlock` and `VorbisCommentReader` and is not addressed here.
