### PR TITLE
Subscribe to NewInstance before starting the application in the docs and sample

### DIFF
--- a/samples/SingleInstanceConsoleAppSample/Program.cs
+++ b/samples/SingleInstanceConsoleAppSample/Program.cs
@@ -2,14 +2,16 @@ using Meziantou.Framework;
 
 Console.WriteLine("Hello World!");
 using var singleInstance = new SingleInstance(new Guid("e5d38b35-b275-47f4-8aa6-bcee6361aae9"));
+
+// Subscribed before StartApplication so no notification can arrive unobserved
+singleInstance.NewInstance += SingleInstance_NewInstance;
+
 if (!singleInstance.StartApplication())
 {
     Console.WriteLine("Sending args to first app");
     singleInstance.NotifyFirstInstance(args);
     return;
 }
-
-singleInstance.NewInstance += SingleInstance_NewInstance;
 
 Console.WriteLine("Waiting for other instances");
 Console.ReadLine();

--- a/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
+++ b/src/Meziantou.Framework.SingleInstance/SingleInstance.cs
@@ -9,14 +9,18 @@ namespace Meziantou.Framework;
 /// <code>
 /// var applicationId = new Guid("dfae4e70-179f-4726-aa98-00a832315f5a");
 /// using var singleInstance = new SingleInstance(applicationId);
+///
+/// // Subscribe before calling StartApplication, otherwise a notification raised
+/// // between the server starting and the handler being attached is dropped.
+/// singleInstance.NewInstance += (sender, e) =>
+/// {
+///     // Handle notification from another instance
+///     Console.WriteLine($"New instance started with {e.Arguments.Length} arguments");
+/// };
+///
 /// if (singleInstance.StartApplication())
 /// {
 ///     // This is the first instance
-///     singleInstance.NewInstance += (sender, e) =>
-///     {
-///         // Handle notification from another instance
-///         Console.WriteLine($"New instance started with {e.Arguments.Length} arguments");
-///     };
 /// }
 /// else
 /// {

--- a/src/Meziantou.Framework.SingleInstance/readme.md
+++ b/src/Meziantou.Framework.SingleInstance/readme.md
@@ -7,21 +7,22 @@ Library to help implementing applications that must only have a single instance.
 var applicationId = new Guid("dfae4e70-179f-4726-aa98-00a832315f5a");
 
 using var singleInstance = new SingleInstance(applicationId);
+
+// Subscribe before calling StartApplication. The server starts inside StartApplication,
+// so a notification arriving before the handler is attached would be dropped.
+singleInstance.NewInstance += (sender, e) =>
+{
+    // TODO logic
+    // Can use e.Arguments to get arguments from the other instance
+};
+
 if (singleInstance.StartApplication())
 {
     // This is the first instance of the application
-
-    // Handle the case where another instance is started and use NotifyFirstInstance
-    singleInstance.NewInstance += (sender, e) =>
-    {
-        // TODO logic
-        // Can use e.Arguments to get arguments from the other instance
-    };
 }
 else
 {
-    // Notify the other instance
-    // The 
+    // Notify the first instance, then exit
     singleInstance.NotifyFirstInstance(args);
 }
 ````


### PR DESCRIPTION
## What

Reorders the documented usage so `NewInstance` is subscribed **before** `StartApplication()`, in the readme, the XML `<example>` on the type, and the console sample. Also finishes a comment in the readme that was cut off mid-sentence.

## Why

All three places showed the same order: call `StartApplication()`, then subscribe. But `StartApplication()` starts the pipe server before it returns, so between the server accepting connections and the consumer attaching a handler, `NewInstance?.Invoke` sees a `null` delegate and the message is parsed, discarded, and never reported. Nothing indicates the notification was lost.

The window is milliseconds, but the scenario that opens it is the common one — a user double-clicking two files in quick succession while the application is still starting. The second file silently fails to open, which is the exact bug this library exists to prevent. Every consumer following the documentation inherited it.

Nothing prevents the correct ordering today; the docs simply taught the lossy one. The test suite has been working around it with `await Task.Delay(50); // Be sure the server is ready`.

The readme also contained a dangling `// The ` with no text after it. That file is the NuGet package description page.

## Notes for the reviewer

- **Documentation only — no behaviour change**, and no source file outside the XML comment block is touched. I deliberately did not "fix" this in code: subscribing before starting is already possible, and queueing notifications raised before the first subscription would be a real behaviour change deserving its own discussion.
- **The sample now subscribes even in the second-instance path**, where the handler will never fire. That is the point — the ordering is correct by construction rather than by the reader noticing which branch they are in.
- A sturdier fix, if you want it later, is to accept the handler as a parameter so the ordering cannot be got wrong. That is an API addition, so not here.

## Tests

- No new tests: this changes documentation and a sample, not library behaviour.
- The sample project builds clean with `-p:TreatWarningsAsErrors=true`.
- The existing suite still passes: 4 total / 2 succeeded / 2 skipped on net10.0 and net11.0 (the skipped pair is the Windows-only pipe test).
- `dotnet run ./eng/update-all.cs` produced no changes.
