### PR TITLE
Drop the existing ISRC chunk when writing AIFF tags

### DIFF
--- a/src/Meziantou.Framework.MediaTags/Formats/Aiff/AiffWriter.cs
+++ b/src/Meziantou.Framework.MediaTags/Formats/Aiff/AiffWriter.cs
@@ -45,7 +45,9 @@ internal sealed class AiffWriter : IMediaTagWriter
             // Copy existing chunks except ID3
             foreach (var (id, size, dataPos) in existingChunks)
             {
-                if (id is "ID3 " or "id3 " or "NAME" or "AUTH" or "ANNO" or "(c) ")
+                // Drop every chunk AiffReader can source a tag from, otherwise the stale chunk is read
+                // back in preference to the ID3 tag written below. Keep in sync with AiffReader.ReadTags.
+                if (id is "ID3 " or "id3 " or "NAME" or "AUTH" or "ANNO" or "(c) " or "ISRC")
                     continue;
 
                 // Write chunk header

--- a/tests/Meziantou.Framework.MediaTags.Tests/AiffTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/AiffTests.cs
@@ -1,3 +1,6 @@
+using System.Buffers.Binary;
+using System.Text;
+
 namespace Meziantou.Framework.MediaTags.Tests;
 
 public sealed class AiffTests
@@ -51,6 +54,58 @@ public sealed class AiffTests
         finally
         {
             File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void WriteTags_FileWithExistingIsrcChunk_WritesTheNewIsrc()
+    {
+        var tempFile = Path.GetTempFileName() + ".aiff";
+        try
+        {
+            File.WriteAllBytes(tempFile, CreateAiffWithIsrcChunk("OLDISRC00000"));
+            Assert.Equal("OLDISRC00000", MediaFile.ReadTags(tempFile).Value.Isrc);
+
+            var writeResult = MediaFile.WriteTags(tempFile, new MediaTagInfo { Title = "Title", Isrc = "NEWISRC99999" });
+            Assert.True(writeResult.IsSuccess);
+
+            var readResult = MediaFile.ReadTags(tempFile);
+            Assert.True(readResult.IsSuccess);
+            Assert.Equal("NEWISRC99999", readResult.Value.Isrc);
+            Assert.Equal("Title", readResult.Value.Title);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    private static byte[] CreateAiffWithIsrcChunk(string isrc)
+    {
+        var body = new MemoryStream();
+        WriteChunk(body, "COMM", new byte[18]);
+        WriteChunk(body, "ISRC", Encoding.ASCII.GetBytes(isrc));
+        WriteChunk(body, "SSND", new byte[16]);
+
+        var result = new MemoryStream();
+        result.Write("FORM"u8);
+        var formSize = new byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(formSize, (int)body.Length + 4);
+        result.Write(formSize);
+        result.Write("AIFF"u8);
+        body.Position = 0;
+        body.CopyTo(result);
+        return result.ToArray();
+
+        static void WriteChunk(Stream stream, string id, byte[] data)
+        {
+            var header = new byte[8];
+            Encoding.ASCII.GetBytes(id, header);
+            BinaryPrimitives.WriteInt32BigEndian(header.AsSpan(4), data.Length);
+            stream.Write(header);
+            stream.Write(data);
+            if (data.Length % 2 != 0)
+                stream.WriteByte(0);
         }
     }
 


### PR DESCRIPTION
Writing `Isrc` to an AIFF that already has an `ISRC` chunk reports success and leaves the old value in place.

`AiffWriter` skips the chunks it is about to replace when copying the input — `ID3 `, `id3 `, `NAME`, `AUTH`, `ANNO`, `(c) ` — but not `ISRC` (`AiffWriter.cs:48`). The stale chunk is therefore preserved, and the new value only lands in the ID3 tag appended at the end. On the next read, `AiffReader` walks chunks in file order with `tags.Isrc ??= …` (`AiffReader.cs:70-75`), so the preserved chunk — which comes first — wins.

```
read original ISRC: OLDISRC00000
MediaFile.WriteTags(path, new MediaTagInfo { Isrc = "NEWISRC99999" })  ->  IsSuccess = true
read back: OLDISRC00000
```

A write that reports success and does not take effect gives the caller no signal at all, which is worse than a failure. ISRC is exactly the field a distribution or mastering pipeline would be scripting.

## What changed

`ISRC` added to the writer's skip list, with a comment stating the rule the list encodes — drop every chunk the reader can source a tag from — and pointing at `AiffReader` so the two stay in sync:

```csharp
if (id is "ID3 " or "id3 " or "NAME" or "AUTH" or "ANNO" or "(c) " or "ISRC")
    continue;
```

## Verification

`WriteTags_FileWithExistingIsrcChunk_WritesTheNewIsrc` builds an AIFF carrying `COMM`, `ISRC` and `SSND` chunks, writes a new ISRC, and reads it back. Against the current writer it fails with:

```
Expected: "NEWISRC99999"
Actual:   "OLDISRC00000"
```

Full suite: 250/250 on net10.0 and net11.0, built with `/p:TreatsWarningsAsErrors=true`.

Found during a review of `Meziantou.Framework.MediaTags`; part of a series of independent fixes.
