### PR TITLE
Escape iCalendar values and separate content lines with CRLF

### DIFF
--- a/src/Meziantou.Framework.Scheduling/InternetCalendar.cs
+++ b/src/Meziantou.Framework.Scheduling/InternetCalendar.cs
@@ -15,6 +15,10 @@ namespace Meziantou.Framework.Scheduling;
 /// </example>
 public sealed class InternetCalendar
 {
+    /// <summary>iCalendar requires CRLF between content lines (RFC 5545 section 3.1), which
+    /// <see cref="TextWriter.WriteLine()"/> does not guarantee: it emits <see cref="Environment.NewLine"/>.</summary>
+    private const string CrLf = "\r\n";
+
     /// <summary>Gets additional custom properties for the calendar.</summary>
     public IDictionary<string, string> AdditionalProperties { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -65,64 +69,124 @@ public sealed class InternetCalendar
         END:VCALENDAR
         */
 
-        writer.WriteLine("BEGIN:VCALENDAR");
+        WriteLine(writer, "BEGIN:VCALENDAR");
         if (!string.IsNullOrEmpty(Version))
-            writer.WriteLine("VERSION:" + Version);
+            WriteTextProperty(writer, "VERSION", Version);
 
-        foreach (var additionalProperty in AdditionalProperties)
-        {
-            if (string.IsNullOrEmpty(additionalProperty.Key))
-                continue;
-
-            writer.Write(additionalProperty.Key);
-            writer.Write(":");
-            writer.WriteLine(additionalProperty.Value);
-        }
+        WriteAdditionalProperties(writer, AdditionalProperties);
 
         foreach (var @event in Events)
         {
-            writer.WriteLine("BEGIN:VEVENT");
+            WriteLine(writer, "BEGIN:VEVENT");
             if (!string.IsNullOrEmpty(@event.Id))
-                writer.WriteLine("UID:" + @event.Id);
+                WriteTextProperty(writer, "UID", @event.Id);
 
-            writer.WriteLine("STATUS:" + Utilities.StatusToString(@event.Status));
+            WriteLine(writer, "STATUS:" + Utilities.StatusToString(@event.Status));
             if ((@event.Organizer?.Address) is not null)
-                writer.WriteLine("ORGANIZER:" + @event.Organizer.Address);
+                WriteLine(writer, "ORGANIZER:" + @event.Organizer.Address);
 
             foreach (var attendee in @event.Attendees)
             {
                 if (attendee is null)
                     continue;
 
-                writer.WriteLine("ATTENDEE:" + attendee.Address);
+                WriteLine(writer, "ATTENDEE:" + attendee.Address);
             }
 
-            writer.WriteLine("CREATED:" + Utilities.DateTimeToString(@event.Created));
-            writer.WriteLine("LAST-MODIFIED:" + Utilities.DateTimeToString(@event.LastModified));
-            writer.WriteLine("DTSTAMP:" + Utilities.DateTimeToString(@event.DateTimeStamp));
-            writer.WriteLine("DTSTART:" + Utilities.DateTimeToString(@event.Start));
-            writer.WriteLine("DTEND:" + Utilities.DateTimeToString(@event.End));
+            WriteLine(writer, "CREATED:" + Utilities.DateTimeToString(@event.Created));
+            WriteLine(writer, "LAST-MODIFIED:" + Utilities.DateTimeToString(@event.LastModified));
+            WriteLine(writer, "DTSTAMP:" + Utilities.DateTimeToString(@event.DateTimeStamp));
+            WriteLine(writer, "DTSTART:" + Utilities.DateTimeToString(@event.Start));
+            WriteLine(writer, "DTEND:" + Utilities.DateTimeToString(@event.End));
             if (@event.RecurrenceRule is not null)
-                writer.WriteLine("RRULE:" + @event.RecurrenceRule.Text);
+                WriteLine(writer, "RRULE:" + @event.RecurrenceRule.Text);
 
             if (!string.IsNullOrEmpty(@event.Summary))
-                writer.WriteLine("SUMMARY:" + @event.Summary);
+                WriteTextProperty(writer, "SUMMARY", @event.Summary);
 
-            foreach (var additionalProperty in @event.AdditionalProperties)
-            {
-                if (string.IsNullOrEmpty(additionalProperty.Key))
-                    continue;
+            WriteAdditionalProperties(writer, @event.AdditionalProperties);
 
-                writer.Write(additionalProperty.Key);
-                writer.Write(":");
-                writer.WriteLine(additionalProperty.Value);
-            }
-
-            writer.WriteLine("DESCRIPTION:\\n");
-            writer.WriteLine("END:VEVENT");
+            WriteLine(writer, "DESCRIPTION:\\n");
+            WriteLine(writer, "END:VEVENT");
         }
 
-        writer.WriteLine("END:VCALENDAR");
+        WriteLine(writer, "END:VCALENDAR");
+    }
+
+    private static void WriteAdditionalProperties(TextWriter writer, IDictionary<string, string> properties)
+    {
+        foreach (var additionalProperty in properties)
+        {
+            // A name outside the iCalendar grammar cannot be written as a content line, and a
+            // name carrying a line break would start an attacker-chosen property.
+            if (!IsValidPropertyName(additionalProperty.Key))
+                continue;
+
+            // RFC 5545 section 3.8.8.2: the default value type of a non-standard property is TEXT.
+            WriteTextProperty(writer, additionalProperty.Key, additionalProperty.Value);
+        }
+    }
+
+    /// <summary>Writes a content line whose value is escaped as an iCalendar TEXT value.</summary>
+    private static void WriteTextProperty(TextWriter writer, string name, string? value)
+    {
+        writer.Write(name);
+        writer.Write(':');
+        WriteEscaped(writer, value);
+        writer.Write(CrLf);
+    }
+
+    /// <summary>Writes a content line whose value is already in its final form.</summary>
+    private static void WriteLine(TextWriter writer, string line)
+    {
+        writer.Write(line);
+        writer.Write(CrLf);
+    }
+
+    /// <summary>Escapes an iCalendar TEXT value per RFC 5545 section 3.3.11.</summary>
+    private static void WriteEscaped(TextWriter writer, string? value)
+    {
+        if (value is null)
+            return;
+
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\':
+                    writer.Write("\\\\");
+                    break;
+                case ';':
+                    writer.Write("\\;");
+                    break;
+                case ',':
+                    writer.Write("\\,");
+                    break;
+                case '\r':
+                    break;
+                case '\n':
+                    writer.Write("\\n");
+                    break;
+                default:
+                    writer.Write(c);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>An iCalendar property name is ALPHA / DIGIT / "-" (RFC 5545 section 3.1).</summary>
+    private static bool IsValidPropertyName(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return false;
+
+        foreach (var c in name)
+        {
+            if (!char.IsAsciiLetterOrDigit(c) && c is not '-')
+                return false;
+        }
+
+        return true;
     }
 
     /// <summary>Converts the calendar to an iCalendar format string.</summary>

--- a/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
@@ -1,0 +1,131 @@
+namespace Meziantou.Framework.Scheduling.Tests;
+
+public sealed class InternetCalendarTests
+{
+    // A value that contains an escaped "\nBEGIN:VEVENT" still holds those characters, so the
+    // injection has to be judged on the content lines rather than on a substring search.
+    private static int CountContentLines(string ics, string line)
+    {
+        var count = 0;
+        foreach (var contentLine in ics.Split("\r\n", StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (string.Equals(contentLine, line, StringComparison.Ordinal))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static InternetCalendar CreateCalendarWithEvent(Event @event)
+    {
+        var calendar = new InternetCalendar();
+        calendar.Events.Add(@event);
+        return calendar;
+    }
+
+    private static Event CreateEvent()
+    {
+        return new Event
+        {
+            Start = new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Utc),
+            End = new DateTime(2024, 01, 02, 09, 00, 00, DateTimeKind.Utc),
+        };
+    }
+
+    [Fact]
+    public void ToIcs_SeparatesContentLinesWithCrLf()
+    {
+        var calendar = CreateCalendarWithEvent(CreateEvent());
+
+        var ics = calendar.ToIcs();
+
+        Assert.StartsWith("BEGIN:VCALENDAR\r\nVERSION:2.0\r\n", ics);
+        Assert.EndsWith("END:VCALENDAR\r\n", ics);
+        Assert.DoesNotContain("\n\r", ics);
+    }
+
+    [Fact]
+    public void ToIcs_ANewLineInTheSummaryDoesNotInjectAProperty()
+    {
+        var @event = CreateEvent();
+        @event.Summary = "Hi\r\nATTENDEE:MAILTO:evil@example.com\r\nX-EVIL:1";
+        var calendar = CreateCalendarWithEvent(@event);
+
+        var ics = calendar.ToIcs();
+
+        Assert.Contains("SUMMARY:Hi\\nATTENDEE:MAILTO:evil@example.com\\nX-EVIL:1\r\n", ics);
+        Assert.DoesNotContain("\r\nATTENDEE:", ics);
+        Assert.DoesNotContain("\r\nX-EVIL:", ics);
+    }
+
+    [Fact]
+    public void ToIcs_EscapesTheStructuralCharactersOfATextValue()
+    {
+        var @event = CreateEvent();
+        @event.Summary = @"Lunch; with Bob, Jr \ friends";
+        var calendar = CreateCalendarWithEvent(@event);
+
+        var ics = calendar.ToIcs();
+
+        Assert.Contains(@"SUMMARY:Lunch\; with Bob\, Jr \\ friends" + "\r\n", ics);
+    }
+
+    [Fact]
+    public void ToIcs_EscapesTheEventIdentifier()
+    {
+        var @event = CreateEvent();
+        @event.Id = "uid\r\nBEGIN:VEVENT";
+        var calendar = CreateCalendarWithEvent(@event);
+
+        var ics = calendar.ToIcs();
+
+        Assert.Contains("UID:uid\\nBEGIN:VEVENT\r\n", ics);
+        var beginEventCount = CountContentLines(ics, "BEGIN:VEVENT");
+        Assert.Equal(1, beginEventCount);
+    }
+
+    [Fact]
+    public void ToIcs_ANewLineInAnAdditionalPropertyDoesNotCloseTheCalendar()
+    {
+        var calendar = new InternetCalendar();
+        calendar.AdditionalProperties["X-A"] = "v\r\nEND:VCALENDAR\r\nBEGIN:VCALENDAR";
+
+        var ics = calendar.ToIcs();
+
+        Assert.Contains("X-A:v\\nEND:VCALENDAR\\nBEGIN:VCALENDAR\r\n", ics);
+        var beginCalendarCount = CountContentLines(ics, "BEGIN:VCALENDAR");
+        var endCalendarCount = CountContentLines(ics, "END:VCALENDAR");
+        Assert.Equal(1, beginCalendarCount);
+        Assert.Equal(1, endCalendarCount);
+    }
+
+    [Theory]
+    [InlineData("X-A\r\nEND:VCALENDAR")]
+    [InlineData("X-A:INJECTED")]
+    [InlineData("X A")]
+    [InlineData("")]
+    public void ToIcs_SkipsAnAdditionalPropertyWhoseNameIsNotAValidPropertyName(string name)
+    {
+        var calendar = new InternetCalendar();
+        calendar.AdditionalProperties[name] = "value";
+
+        var ics = calendar.ToIcs();
+
+        Assert.DoesNotContain("value", ics);
+    }
+
+    [Theory]
+    [InlineData("X-MICROSOFT-CDO-BUSYSTATUS")]
+    [InlineData("X-CUSTOM-1")]
+    public void ToIcs_KeepsAnAdditionalPropertyWhoseNameIsValid(string name)
+    {
+        var calendar = new InternetCalendar();
+        calendar.AdditionalProperties[name] = "OOF";
+
+        var ics = calendar.ToIcs();
+
+        Assert.Contains(name + ":OOF\r\n", ics);
+    }
+}


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2412**

## The bug

`src/Meziantou.Framework.Scheduling/InternetCalendar.cs:68-125` concatenated every caller-supplied value straight into the output — no escaping, no name validation.

Verified against the current code:

```csharp
Summary = "Hi\r\nATTENDEE:MAILTO:evil@example.com\r\nX-EVIL:1"
```

produced

```
SUMMARY:Hi
ATTENDEE:MAILTO:evil@example.com
X-EVIL:1
```

— three content lines where one was intended. `AdditionalProperties["X-A"] = "v\r\nEND:VCALENDAR\r\nBEGIN:VCALENDAR"` likewise closed the calendar and opened a forged one.

Any application that builds an `.ics` from user-supplied event titles, identifiers or custom properties — the obvious use for this class — let an attacker add attendees, organizers, extra `VEVENT`s, or a `VALARM` to the file recipients import. It is the calendar equivalent of HTTP header injection.

The far more common case was benign input: RFC 5545 §3.3.11 requires `\`, `;`, `,` and newlines to be escaped inside a TEXT value, so a summary containing a comma was already being mis-parsed by conforming readers.

## The change

- **Escapes TEXT values** — `VERSION`, `UID`, `SUMMARY`, and the additional properties (whose default value type is TEXT per §3.8.8.2). Same escaping rules and same shape as `AppendVCardEscaped` in `QRCodePayload.cs:272`, which #2302 introduced for the vCard/iCalendar payload writer.
- **Validates property names** against the §3.1 grammar (`ALPHA / DIGIT / "-"`), skipping anything else — a name carrying a line break starts an attacker-chosen property just as a value can. `X-MICROSOFT-CDO-BUSYSTATUS` and friends still pass.
- **Separates content lines with an explicit CRLF.** §3.1 requires it, but `WriteLine` emits `Environment.NewLine`, so the output was LF-only on Linux and macOS.

`ORGANIZER` and `ATTENDEE` are CAL-ADDRESS values, not TEXT, so they are not escaped — they come from `Uri.ToString()`, which cannot contain a line break.

## Known gap, deliberately not closed here

**Line folding at 75 octets (§3.1) is still not implemented**, matching the vCard payload writer, which #2302 also left unfolded. Worth doing, but it needs UTF-8 octet counting and surrogate-pair handling, and it does not belong in a security fix.

## Verification

New `InternetCalendarTests.cs` — this class previously had **zero** tests, which is why the injection went unnoticed. 11 tests covering the injection vectors, the escaping of `; , \`, name validation, and CRLF separation.

Run against unfixed `src` to confirm they are genuine regression tests: **10 of 11 fail** there (the 11th is the "valid name is kept" case, which already worked).

Full project suite: **273 passed, 0 failed** (262 before, 11 new).
