### PR TITLE
Write iCalendar date-times in a form RFC 5545 defines

### DIFF
--- a/src/Meziantou.Framework.Scheduling/InternetCalendar.cs
+++ b/src/Meziantou.Framework.Scheduling/InternetCalendar.cs
@@ -19,6 +19,9 @@ public sealed class InternetCalendar
     /// <see cref="TextWriter.WriteLine()"/> does not guarantee: it emits <see cref="Environment.NewLine"/>.</summary>
     private const string CrLf = "\r\n";
 
+    /// <summary>The product identifier written as PRODID, in the FPI form suggested by RFC 5545 section 3.7.3.</summary>
+    private const string ProductIdentifier = "-//Meziantou//Meziantou.Framework.Scheduling//EN";
+
     /// <summary>Gets additional custom properties for the calendar.</summary>
     public IDictionary<string, string> AdditionalProperties { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -72,6 +75,9 @@ public sealed class InternetCalendar
         WriteLine(writer, "BEGIN:VCALENDAR");
         if (!string.IsNullOrEmpty(Version))
             WriteTextProperty(writer, "VERSION", Version);
+
+        // PRODID is REQUIRED in a VCALENDAR (RFC 5545 section 3.6).
+        WriteLine(writer, "PRODID:" + ProductIdentifier);
 
         WriteAdditionalProperties(writer, AdditionalProperties);
 

--- a/src/Meziantou.Framework.Scheduling/Utilities.cs
+++ b/src/Meziantou.Framework.Scheduling/Utilities.cs
@@ -2,7 +2,7 @@ namespace Meziantou.Framework.Scheduling;
 
 internal static class Utilities
 {
-    public const string DateTimeFormat = "yyyyMMddTHHmmsszzz";
+    public const string FloatingDateTimeFormat = "yyyyMMddTHHmmss";
     public const string UtcDateTimeFormat = "yyyyMMddTHHmmssZ";
 
     public static DateTime ParseDateTime(string str)
@@ -54,14 +54,21 @@ internal static class Utilities
         };
     }
 
+    /// <summary>Formats a date-time using one of the forms defined in RFC 5545 section 3.3.5.</summary>
     public static string DateTimeToString(DateTime dt)
     {
-        if (dt.Kind is DateTimeKind.Utc)
+        return dt.Kind switch
         {
-            return dt.ToString(UtcDateTimeFormat, CultureInfo.InvariantCulture);
-        }
+            // Form 2: a date-time in UTC.
+            DateTimeKind.Utc => dt.ToString(UtcDateTimeFormat, CultureInfo.InvariantCulture),
 
-        return dt.ToString(DateTimeFormat, CultureInfo.InvariantCulture);
+            // A local time is only meaningful to a reader that also knows the offset, and the
+            // output carries no TZID parameter to convey it, so it is written as UTC.
+            DateTimeKind.Local => dt.ToUniversalTime().ToString(UtcDateTimeFormat, CultureInfo.InvariantCulture),
+
+            // Form 1: a floating date-time, interpreted in the reader's own time zone.
+            _ => dt.ToString(FloatingDateTimeFormat, CultureInfo.InvariantCulture),
+        };
     }
 
     public static string StatusToString(EventStatus status)

--- a/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
@@ -18,6 +18,20 @@ public sealed class InternetCalendarTests
         return count;
     }
 
+    private static string GetContentLine(string ics, string name)
+    {
+        foreach (var contentLine in ics.Split("\r\n", StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (contentLine.StartsWith(name + ":", StringComparison.Ordinal))
+            {
+                return contentLine;
+            }
+        }
+
+        Assert.Fail($"No '{name}' content line in:\n{ics}");
+        return null!;
+    }
+
     private static InternetCalendar CreateCalendarWithEvent(Event @event)
     {
         var calendar = new InternetCalendar();
@@ -127,5 +141,85 @@ public sealed class InternetCalendarTests
         var ics = calendar.ToIcs();
 
         Assert.Contains(name + ":OOF\r\n", ics);
+    }
+
+    [Fact]
+    public void ToIcs_WritesTheRequiredProductIdentifier()
+    {
+        var calendar = CreateCalendarWithEvent(CreateEvent());
+
+        var ics = calendar.ToIcs();
+
+        Assert.Contains("PRODID:-//Meziantou//Meziantou.Framework.Scheduling//EN\r\n", ics);
+    }
+
+    [Fact]
+    public void ToIcs_WritesAUtcDateTimeWithTheZSuffix()
+    {
+        var @event = new Event
+        {
+            Start = new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Utc),
+            End = new DateTime(2024, 01, 02, 09, 00, 00, DateTimeKind.Utc),
+        };
+        var calendar = CreateCalendarWithEvent(@event);
+
+        var ics = calendar.ToIcs();
+
+        Assert.Equal("DTSTART:20240102T080000Z", GetContentLine(ics, "DTSTART"));
+        Assert.Equal("DTEND:20240102T090000Z", GetContentLine(ics, "DTEND"));
+    }
+
+    [Fact]
+    public void ToIcs_WritesAnUnspecifiedDateTimeAsAFloatingDateTime()
+    {
+        var @event = new Event
+        {
+            Start = new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Unspecified),
+            End = new DateTime(2024, 01, 02, 09, 00, 00, DateTimeKind.Unspecified),
+        };
+        var calendar = CreateCalendarWithEvent(@event);
+
+        var ics = calendar.ToIcs();
+
+        Assert.Equal("DTSTART:20240102T080000", GetContentLine(ics, "DTSTART"));
+        Assert.Equal("DTEND:20240102T090000", GetContentLine(ics, "DTEND"));
+    }
+
+    [Fact]
+    public void ToIcs_WritesALocalDateTimeAsUtc()
+    {
+        var start = new DateTime(2024, 01, 02, 08, 00, 00, DateTimeKind.Local);
+        var @event = new Event
+        {
+            Start = start,
+            End = start.AddHours(1),
+        };
+        var calendar = CreateCalendarWithEvent(@event);
+
+        var ics = calendar.ToIcs();
+
+        Assert.Equal("DTSTART:" + start.ToUniversalTime().ToString("yyyyMMddTHHmmss", CultureInfo.InvariantCulture) + "Z", GetContentLine(ics, "DTSTART"));
+    }
+
+    [Theory]
+    [InlineData(DateTimeKind.Utc)]
+    [InlineData(DateTimeKind.Local)]
+    [InlineData(DateTimeKind.Unspecified)]
+    public void ToIcs_NeverWritesADateTimeWithAUtcOffset(DateTimeKind kind)
+    {
+        var @event = new Event
+        {
+            Start = new DateTime(2024, 01, 02, 08, 00, 00, kind),
+            End = new DateTime(2024, 01, 02, 09, 00, 00, kind),
+        };
+        var calendar = CreateCalendarWithEvent(@event);
+
+        var ics = calendar.ToIcs();
+
+        foreach (var name in new[] { "DTSTART", "DTEND", "CREATED", "LAST-MODIFIED", "DTSTAMP" })
+        {
+            var value = GetContentLine(ics, name)[(name.Length + 1)..];
+            Assert.Matches(@"^\d{8}T\d{6}Z?$", value);
+        }
     }
 }

--- a/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
@@ -29,7 +29,7 @@ public sealed class InternetCalendarTests
         }
 
         Assert.Fail($"No '{name}' content line in:\n{ics}");
-        return null!;
+        throw new UnreachableException();
     }
 
     private static InternetCalendar CreateCalendarWithEvent(Event @event)

--- a/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
+++ b/tests/Meziantou.Framework.Scheduling.Tests/InternetCalendarTests.cs
@@ -29,7 +29,7 @@ public sealed class InternetCalendarTests
         }
 
         Assert.Fail($"No '{name}' content line in:\n{ics}");
-        throw new UnreachableException();
+        throw new System.Diagnostics.UnreachableException();
     }
 
     private static InternetCalendar CreateCalendarWithEvent(Event @event)


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/scheduling-ics-escape` · merge #2411 first**

## The bug

`src/Meziantou.Framework.Scheduling/Utilities.cs:57-65`

```csharp
public const string DateTimeFormat = "yyyyMMddTHHmmsszzz";   // note the offset

public static string DateTimeToString(DateTime dt)
{
    if (dt.Kind is DateTimeKind.Utc)
        return dt.ToString(UtcDateTimeFormat, CultureInfo.InvariantCulture);

    return dt.ToString(DateTimeFormat, CultureInfo.InvariantCulture);
}
```

For any `DateTime` whose `Kind` is not `Utc` — including `Unspecified`, which is what `new DateTime(2024, 1, 2, 8, 0, 0)` and `default(DateTime)` produce — the format appends a UTC offset. Verified output:

```
DTSTART:20240102T080000-05:00
CREATED:00010101T000000-05:17
```

RFC 5545 §3.3.5 defines exactly three DATE-TIME forms: floating local time (no suffix), UTC (`Z` suffix), and local time with a `TZID` parameter. **An inline offset is none of them**, so conforming parsers reject or misread the line. It also leaked the generating machine's time zone into the file, and for `default(DateTime)` produced historical LMT offsets like `-05:17`.

## The change

| `Kind` | Before | After |
|---|---|---|
| `Utc` | `20240102T080000Z` | unchanged |
| `Unspecified` | `20240102T080000-05:00` | `20240102T080000` (floating, form 1) |
| `Local` | `20240102T080000-05:00` | converted to UTC, `…Z` (form 2) |

Also writes **`PRODID`**, which §3.6 requires in a `VCALENDAR` and which was never emitted.

## Side benefit

`Utilities.DateTimeToString` also formats `UNTIL` in the RRULE `Text` output (`DailyRecurrenceRule.cs:108` and siblings). A rule whose `EndDate` was not `Utc` therefore emitted `UNTIL=20240101T000000+01:00`, which is not valid RRULE syntax either. That is fixed by the same change. Rules parsed from a string are unaffected — `Utilities.ParseDateTime` already returns `Kind == Utc`, so every existing `Text` round-trip test still passes untouched.

## Follow-up, not in this PR

`Event.Created` / `LastModified` / `DateTimeStamp` default to `default(DateTime)`, so an event that does not set them still serialises `00010101T000000`. Valid now, but meaningless. `DTSTAMP` is REQUIRED by §3.6.1 so it cannot simply be omitted; giving those properties a sensible default deserves its own change.

## Verification

7 new tests: `PRODID` presence, each of the three `Kind` values, and a theory asserting that no `DTSTART`/`DTEND`/`CREATED`/`LAST-MODIFIED`/`DTSTAMP` value ever matches an offset form (`^\d{8}T\d{6}Z?$`).

Full project suite: **280 passed, 0 failed** (262 before, 18 new across the stack).
