### PR TITLE
Convert the extended UNC prefix back to a UNC path in FromPath

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -441,7 +441,12 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         // '\' is a regular file name character on Unix, so a path such as @"\\?\a" is a relative file name there, not a device path
         if (OperatingSystem.IsWindows() && PathInternal.IsExtended(path))
         {
-            path = path[PathInternal.DevicePrefixLength..];
+            // The extended form of a UNC path is @"\\?\UNC\server\share". Dropping the 4-character device prefix would
+            // leave the relative @"UNC\server\share", which Path.GetFullPath would then resolve against the current
+            // directory, so restore the @"\\" prefix instead. This is the inverse of PathInternal.EnsureExtendedPrefix.
+            path = path.StartsWith(PathInternal.UncExtendedPathPrefix, StringComparison.OrdinalIgnoreCase)
+                ? string.Concat(PathInternal.UncPathPrefix, path.AsSpan(PathInternal.UncExtendedPathPrefix.Length))
+                : path[PathInternal.DevicePrefixLength..];
         }
 
         var fullPath = Path.GetFullPath(path);

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -206,6 +206,13 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    [RunIf(TestOperatingSystems.Windows)]
+    public void FromPath_ExtendedUncPrefixIsConvertedBackToAUncPath()
+    {
+        Assert.Equal(@"\\server\share\folder\file.txt", FullPath.FromPath(@"\\?\UNC\server\share\folder\file.txt").RawValue);
+    }
+
+    [Fact]
     [RunIf(TestOperatingSystems.Linux | TestOperatingSystems.MacOS)]
     public void FromPath_ExtendedPrefixIsAFileNameOnUnix()
     {
@@ -687,8 +694,22 @@ public sealed class FullPathTests
     {
         var path = FullPath.FromPath(@"C:\temp\test.txt");
         var extended = path.ToWindowsExtendedPath();
-        var doubleExtended = FullPath.FromPath(extended).ToWindowsExtendedPath();
-        Assert.Equal(extended, doubleExtended);
+
+        // FromPath removes the device prefix, so the round-trip has to give back the original path. Asserting only
+        // that ToWindowsExtendedPath is idempotent would compare two identical expressions and could never fail.
+        Assert.Equal(path, FullPath.FromPath(extended));
+        Assert.Equal(extended, FullPath.FromPath(extended).ToWindowsExtendedPath());
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Windows)]
+    public void ToWindowsExtendedPath_UNCPath_RoundTrips()
+    {
+        var path = FullPath.FromPath(@"\\server\share\folder\file.txt");
+        var extended = path.ToWindowsExtendedPath();
+
+        Assert.Equal(@"\\?\UNC\server\share\folder\file.txt", extended);
+        Assert.Equal(path, FullPath.FromPath(extended));
     }
 
     [Fact]


### PR DESCRIPTION
`FullPath.FromPath` corrupts an extended-length UNC path into a path under the process working directory.

## What goes wrong

`FromPath` removes exactly `DevicePrefixLength` (4) characters whenever `PathInternal.IsExtended(path)` is true (`src/Meziantou.Framework.FullPath/FullPath.cs:439-453`).

That is correct for a drive path — `\\?\C:\x` becomes `C:\x` — but the extended form of a UNC path is `\\?\UNC\server\share\file`. Cutting four characters leaves `UNC\server\share\file`, which is **relative**, so the `Path.GetFullPath` on the next line resolves it against `Environment.CurrentDirectory`:

| Input | After the 4-char strip | Result |
| --- | --- | --- |
| `\\?\C:\x\y` | `C:\x\y` | correct |
| `\\?\UNC\server\share\file.txt` | `UNC\server\share\file.txt` | `<cwd>\UNC\server\share\file.txt` |

This is reachable without a caller ever typing a device path, because the library produces that exact string itself:

- `ToWindowsExtendedPath()` emits `\\?\UNC\server\share\...` for UNC input — asserted by `ToWindowsExtendedPath_UNCPath` (`FullPathTests.cs:677-682`)
- `Value` emits it for any path with a reserved device-name component, and `FullPathJsonConverter.Write` serializes `Value`

So a UNC path round-tripped through this library's own extended-path helper, or through its own JSON converter, comes back pointing at a local directory. `ToWindowsExtendedPath()` is effectively one-way today.

`CanonicalPath.WindowsCanonicalPath.NormalizePath` (`CanonicalPath.cs:57-70`) already handles this prefix correctly, so the case was understood elsewhere in the same assembly.

## Why no test caught it

`ToWindowsExtendedPath_AlreadyExtended` (`FullPathTests.cs:684-692`) looks like a round-trip test but cannot fail: it feeds `extended` back through `FromPath`, which strips the prefix, so the second `ToWindowsExtendedPath()` call runs on the same `C:\temp\test.txt` as the first. It compares two identical expressions.

## Change

- In `FromPath`, detect the `\\?\UNC\` prefix first and rewrite it to `\\`, mirroring `PathInternal.EnsureExtendedPrefix`. Fall back to the existing 4-character strip otherwise.
- Rewrite `ToWindowsExtendedPath_AlreadyExtended` to assert the round-trip actually returns the original path, so it can fail.
- Add `FromPath_ExtendedUncPrefixIsConvertedBackToAUncPath` and `ToWindowsExtendedPath_UNCPath_RoundTrips`.

## Verification

`dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 162 passed, 0 failed, 60 skipped.

**The three tests that matter here are Windows-gated and were skipped locally (this was developed on macOS), so CI's Windows leg is the only real check on this PR.** Worth waiting for it before merging.

`dotnet run ./eng/update-all.cs` produced no generated-file changes.

## Not addressed here

`IsExtended` requires `path[2] == '?'`, so `\\.\` device paths still pass through `FromPath` untouched and produce a `FullPath` wrapping a raw device path (`FromPath(@"\\.\CON")`). Whether `FromPath` should accept those at all is a separate behavior decision.
