### PR TITLE
Wait on a signal instead of fixed delays in the notification test

### DIFF
--- a/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
+++ b/tests/Meziantou.Framework.SingleInstance.Tests/SingleInstanceTests.cs
@@ -7,37 +7,42 @@ public sealed class SingleInstanceTests
     [Fact, RunIf(TestOperatingSystems.Windows)]
     public async Task TestSingleInstance_NotifyFirstInstance()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-
         var applicationId = Guid.NewGuid();
         using var singleInstance = new SingleInstance(applicationId);
-        Assert.True(singleInstance.StartApplication());
-
-        // Be sure the server is ready
-        await Task.Delay(50);
 
         var events = new List<SingleInstanceEventArgs>();
+        var senders = new List<object?>();
+        var bothReceived = new TaskCompletionSource();
+
+        // Subscribed before StartApplication, so no notification can arrive unobserved
         singleInstance.NewInstance += SingleInstance_NewInstance;
+
+        Assert.True(singleInstance.StartApplication());
         Assert.True(singleInstance.NotifyFirstInstance(["a", "b", "c"]));
-        await Task.Delay(50);
         Assert.True(singleInstance.NotifyFirstInstance(["123"]));
 
-        while (!cts.Token.IsCancellationRequested && events.Count < 2)
-        {
-            await Task.Delay(50);
-        }
+        await bothReceived.Task.WaitAsync(TimeSpan.FromSeconds(30));
 
-        Assert.HasCount(2, events);
-        var orderedEvents = events.OrderBy(args => args.Arguments.Length).ToList();
-        Assert.Equal(["123"], orderedEvents[0].Arguments);
-        Assert.Equal(["a", "b", "c"], orderedEvents[1].Arguments);
+        lock (events)
+        {
+            Assert.HasCount(2, events);
+            Assert.All(senders, sender => Assert.Equal(singleInstance, sender));
+
+            var orderedEvents = events.OrderBy(args => args.Arguments.Length).ToList();
+            Assert.Equal(["123"], orderedEvents[0].Arguments);
+            Assert.Equal(["a", "b", "c"], orderedEvents[1].Arguments);
+        }
 
         void SingleInstance_NewInstance(object? sender, SingleInstanceEventArgs e)
         {
-            Assert.Equal(singleInstance, sender);
             lock (events)
             {
+                senders.Add(sender);
                 events.Add(e);
+                if (events.Count is 2)
+                {
+                    bothReceived.TrySetResult();
+                }
             }
         }
     }


### PR DESCRIPTION
## What

Replaces the fixed `Task.Delay` sequencing in `TestSingleInstance_NotifyFirstInstance` with a `TaskCompletionSource` signalled from the handler, and removes the poll loop.

## Why

The test sequenced itself with wall-clock sleeps:

- `await Task.Delay(50); // Be sure the server is ready` after `StartApplication()`
- `await Task.Delay(50)` between the two notifications
- a `while (... events.Count < 2) await Task.Delay(50)` poll loop against a 10-second `CancellationTokenSource`

That is slow on a good day and flaky under load — CI agents are exactly where a 50 ms guess stops holding. Two further problems:

- **`events.Count` was read outside the lock** that the handler uses to write it, so the loop condition raced with the handler.
- **The test subscribed *after* `StartApplication()`**, which is the notification-loss window the library's own documentation had. The `// Be sure the server is ready` delay existed to paper over it. Subscribing first removes the reason for the delay rather than tuning it.

## Notes for the reviewer

- **The first delay is not replaced by anything, on purpose.** `StartApplication()` creates the `NamedPipeServerStream` synchronously before returning, so the pipe already exists when it returns; and `NotifyFirstInstance` connects with a timeout that retries. There is nothing to wait for.
- **The delay between the two notifications is also just removed.** The second `Connect` waits for the server to re-arm on its own, within `ClientConnectionTimeout`. If this ever proves flaky on CI the answer is a longer connect timeout, not a sleep — but I would rather see it fail honestly than keep a sleep that hides which part is slow.
- **`Assert.Equal(singleInstance, sender)` moved out of the handler.** It ran on a thread pool thread, where a failed assertion would surface as a process-level crash rather than a test failure. Senders are now collected and asserted on the test thread.
- **The 30-second `WaitAsync` is a deadline, not a delay** — it costs nothing when the test passes, unlike the poll loop which cost at least 50 ms every time.
- This touches only the existing test method, so it should not conflict with the new test methods added in #2386, #2391 or #2406 — though whichever merges second may want a glance.

## Tests

- This *is* the test change. Behaviour asserted is unchanged: two notifications, matching arguments, correct sender.
- **It did not run on my machine.** The test is Windows-gated and I am on macOS: `dotnet test` reports 4 total / 2 succeeded / 2 skipped. Since the whole point is timing, the `windows-2025-vs2026` CI leg is the only meaningful verification — please let it go green.
- Builds clean with `-p:TreatWarningsAsErrors=true`.
