### PR TITLE
Handle a failed reparse point open and a non-progressing retry in the symlink reader

### DIFF
--- a/src/Meziantou.Framework.FullPath/Symlink.cs
+++ b/src/Meziantou.Framework.FullPath/Symlink.cs
@@ -128,7 +128,7 @@ internal static partial class Symlink
             return false;
         }
 
-        internal static string GetSingleSymbolicLinkTarget(string path)
+        internal static string? GetSingleSymbolicLinkTarget(string path)
         {
             using var handle =
                 Interop.Kernel32.CreateFile(path,
@@ -138,6 +138,12 @@ internal static partial class Symlink
                 Interop.Kernel32.FileOperations.FILE_FLAG_OPEN_REPARSE_POINT | // Open the reparse point, not its target
                 Interop.Kernel32.FileOperations.FILE_FLAG_BACKUP_SEMANTICS);   // Permit opening of directories
                                                                                // https://docs.microsoft.com/en-us/windows-hardware/drivers/ifs/fsctl-get-reparse-point
+
+            // The link can be deleted, renamed, or have its access denied between the IsSymbolicLink probe and this
+            // open. Report that as "no target" so the caller returns false, instead of letting DeviceIoControl fail
+            // with ERROR_INVALID_HANDLE and throw a Win32Exception out of a Try method.
+            if (handle.IsInvalid)
+                return null;
 
             var sizeHeader = Marshal.SizeOf<Interop.Kernel32.REPARSE_DATA_BUFFER_SYMLINK>();
             var bufferSize = sizeHeader + Interop.Kernel32.MAX_PATH;
@@ -210,7 +216,10 @@ internal static partial class Symlink
                         return target;
                     }
 
-                    if (bufferSize < buffer.Length)
+                    // The next iteration rents a buffer of at least bufferSize. If that does not exceed the buffer we
+                    // just used, ArrayPool returns the same bucket size and the call repeats identically, so the loop
+                    // would spin forever on a reparse buffer whose header declares a length it does not deliver.
+                    if (bufferSize <= buffer.Length)
                     {
                         throw new InvalidDataException($"FSCTL_GET_REPARSE_POINT did not return sufficient data ({bufferSize.ToString(CultureInfo.InvariantCulture)}) when provided buffer ({buffer.Length}).");
                     }


### PR DESCRIPTION
Two robustness defects in the Windows reparse-point reader, both in `GetSingleSymbolicLinkTarget` (`src/Meziantou.Framework.FullPath/Symlink.cs:131-223`).

## 1. A `Try*` method throws instead of returning false

`WindowsSymlink.TryGetSymLinkTarget` (`Symlink.cs:104-114`) probes with `IsSymbolicLink` (`FindFirstFileEx`) and then calls `GetSingleSymbolicLinkTarget`, which opens the link with `CreateFile` (`Symlink.cs:133-141`) and goes straight into `DeviceIoControl` (`:150`) **without checking `handle.IsInvalid`**.

If the open fails — the link was deleted or renamed between the two calls (a TOCTOU window the code creates itself by probing twice), or an ACL denies even the zero-access open — `DeviceIoControl` returns false and `Marshal.GetLastWin32Error()` yields `ERROR_INVALID_HANDLE` (6). That is none of `ERROR_SUCCESS` / `ERROR_INSUFFICIENT_BUFFER` / `ERROR_MORE_DATA`, so `:155` throws `Win32Exception`.

That propagates out of the public `FullPath.TryGetSymbolicLinkTarget` for all three resolution modes, and out of the `AllSymbolicLinks` walk mid-iteration. Callers write `if (p.TryGetSymbolicLinkTarget(out var t))` with no try/catch, so a directory walker over a live tree crashes intermittently. Only `IOException` (chain too deep) is documented as thrown.

`CanonicalPath.WindowsCanonicalPath` does check `IsInvalid` and returns false (`CanonicalPath.cs:29-33`), so the omission looks accidental rather than deliberate.

## 2. The retry loop can spin forever on a malformed reparse buffer

The loop recomputes `bufferSize` from fields inside the reparse payload (`:175`), returns when `bytesRead >= bufferSize` (`:178`), and throws when `bufferSize < buffer.Length` (`:213`).

The uncovered case is `bufferSize == buffer.Length` with `bytesRead < bufferSize`: the loop repeats, `ArrayPool.Rent(bufferSize)` hands back the same bucket size, `DeviceIoControl` returns the same bytes, and nothing changes — an infinite loop re-issuing `FSCTL_GET_REPARSE_POINT`. Reaching it needs a reparse point whose header declares a `SubstituteName` extent landing exactly on a pool bucket boundary while the returned data is shorter.

The buffer arithmetic itself is fine and is unchanged here: all four name fields are `ushort` (`Interop/Windows.cs:86-89`) so the sum cannot overflow `int`, and the slice at `:181` is bounds-checked by the `:178` guard.

## Change

- Return `null` from `GetSingleSymbolicLinkTarget` when the handle is invalid. The signature becomes `string?`; the caller already gates on `target is not null`, so `TryGetSymLinkTarget` now correctly returns false.
- Change the guard at `:213` from `<` to `<=` so the loop is strictly monotonic: a requested size that does not exceed the buffer just used is malformed data, not a reason to retry.

## Verification

`dotnet build -c Release /p:TreatsWarningsAsErrors=true` → 0 warnings (the `string?` change is nullable-clean).
`dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 162 passed, 0 failed, 56 skipped.

**No tests added.** Both paths are Windows-only and neither is reachable from a test without either racing a delete against the probe, denying an ACL, or writing a reparse point with a lying header (which needs `SeCreateSymbolicLinkPrivilege` or Developer Mode). The existing symlink suite covers the happy path and still passes. If you would rather have a test for the first one, a `FileShare`-based lock or an ACL fixture on a Windows-gated test could get there — say the word and I will add it.
