### PR TITLE
Replace the file in one step when writing tags and keep its permissions

### DIFF
--- a/src/Meziantou.Framework.MediaTags/MediaFile.cs
+++ b/src/Meziantou.Framework.MediaTags/MediaFile.cs
@@ -68,10 +68,12 @@ public static class MediaFile
 
         try
         {
-            var tempPath = filePath + ".tmp";
+            // Write through a symbolic link instead of replacing the link with a regular file
+            var targetPath = ResolveLinkTarget(filePath);
+            var tempPath = targetPath + ".tmp";
             try
             {
-                using (var inputStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (var inputStream = new FileStream(targetPath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 using (var outputStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write))
                 {
                     var result = WriteTagsCore(inputStream, outputStream, tags, format.Value);
@@ -81,22 +83,60 @@ public static class MediaFile
                     }
                 }
 
-                File.Delete(filePath);
-                File.Move(tempPath, filePath);
+                CopyFilePermissions(targetPath, tempPath);
+
+                // Moving with overwrite replaces the file in one step. Deleting the original first
+                // leaves no file at all if the process stops between the two operations.
+                File.Move(tempPath, targetPath, overwrite: true);
                 return MediaTagResult.Success();
             }
-            catch
+            finally
             {
-                if (File.Exists(tempPath))
-                {
-                    try { File.Delete(tempPath); } catch { /* best effort cleanup */ }
-                }
-                throw;
+                // Runs for a failed result as well as for an exception; after a successful move
+                // there is no temporary file left to remove.
+                DeleteIfExists(tempPath);
             }
         }
         catch (IOException ex)
         {
             return MediaTagResult.Failure(MediaTagError.IoError, ex.Message);
+        }
+    }
+
+    private static string ResolveLinkTarget(string filePath)
+    {
+        try
+        {
+            return File.ResolveLinkTarget(filePath, returnFinalTarget: true)?.FullName ?? filePath;
+        }
+        catch (IOException)
+        {
+            return filePath;
+        }
+    }
+
+    private static void CopyFilePermissions(string sourcePath, string destinationPath)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        // A new file gets the default permissions, which can be more permissive than the original
+        File.SetUnixFileMode(destinationPath, File.GetUnixFileMode(sourcePath));
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+            // Best effort cleanup
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best effort cleanup
         }
     }
 

--- a/tests/Meziantou.Framework.MediaTags.Tests/MediaFileWriteTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/MediaFileWriteTests.cs
@@ -1,0 +1,97 @@
+namespace Meziantou.Framework.MediaTags.Tests;
+
+public sealed class MediaFileWriteTests
+{
+    private static string GetTestFilePath(string fileName) => Path.Combine("TestFiles", fileName);
+
+    [Fact]
+    public void WriteTags_PreservesFilePermissions()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // Unix file modes only
+
+        var tempFile = Path.GetTempFileName() + ".mp3";
+        try
+        {
+            File.Copy(GetTestFilePath("basic.mp3"), tempFile, overwrite: true);
+            File.SetUnixFileMode(tempFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+            var writeResult = MediaFile.WriteTags(tempFile, new MediaTagInfo { Title = "Title" });
+
+            Assert.True(writeResult.IsSuccess);
+            Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(tempFile));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void WriteTags_WritesThroughSymbolicLink()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // Creating a symbolic link needs elevation on Windows
+
+        var directory = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            var targetFile = Path.Combine(directory, "target.mp3");
+            var linkFile = Path.Combine(directory, "link.mp3");
+            File.Copy(GetTestFilePath("basic.mp3"), targetFile, overwrite: true);
+            File.CreateSymbolicLink(linkFile, targetFile);
+
+            var writeResult = MediaFile.WriteTags(linkFile, new MediaTagInfo { Title = "Through The Link" });
+
+            Assert.True(writeResult.IsSuccess);
+            Assert.NotNull(new FileInfo(linkFile).LinkTarget);
+            Assert.Equal("Through The Link", MediaFile.ReadTags(targetFile).Value.Title);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WriteTags_FailedWrite_DoesNotLeaveATemporaryFile()
+    {
+        var directory = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            // Detected as OGG by extension, but it holds no OGG pages, so the writer fails
+            var file = Path.Combine(directory, "not-really.ogg");
+            File.WriteAllBytes(file, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+
+            var writeResult = MediaFile.WriteTags(file, new MediaTagInfo { Title = "Title" });
+
+            Assert.False(writeResult.IsSuccess);
+            Assert.Equal([file], Directory.GetFiles(directory));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WriteTags_FailedWrite_LeavesTheOriginalFileUntouched()
+    {
+        var directory = Directory.CreateTempSubdirectory().FullName;
+        try
+        {
+            var file = Path.Combine(directory, "not-really.ogg");
+            byte[] original = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+            File.WriteAllBytes(file, original);
+
+            var writeResult = MediaFile.WriteTags(file, new MediaTagInfo { Title = "Title" });
+
+            Assert.False(writeResult.IsSuccess);
+            Assert.Equal(original, File.ReadAllBytes(file));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before the IoError PR above it.**

`MediaFile.WriteTags(string, MediaTagInfo)` replaces the file by deleting the original and moving the temporary file over it (`MediaFile.cs:71-96`). Four problems follow from that:

1. **The replacement is not atomic.** `File.Delete(filePath)` then `File.Move(tempPath, filePath)` leaves *no* file at all if the process stops between the two calls — the failure mode is losing the track, not keeping the old one.
2. **File permissions are silently widened.** The temporary file is created fresh and gets the default permissions. A `0600` MP3 comes back `0644`, so tagging a private library makes it world-readable.
3. **Symbolic links are replaced by regular files.** Writing through a link deletes the link and leaves a regular file in its place; the original target keeps the old content and the two silently diverge.
4. **Failed writes leak a `.tmp` file.** When `WriteTagsCore` returns a *failure result* rather than throwing, the early `return result;` exits the `try` without reaching the cleanup `catch`, so `<file>.tmp` is left next to the original — where the next directory scan may try to parse it.

## What changed

- `File.Move(tempPath, targetPath, overwrite: true)` replaces the delete-then-move pair. The rename is atomic on both POSIX and Windows: an interruption leaves either the old file or the new one.
- `CopyFilePermissions` applies the original's `UnixFileMode` to the temporary file before the move (no-op on Windows, where the API is not supported).
- `ResolveLinkTarget` resolves a symbolic link up front so the write goes *through* the link to its target, leaving the link intact.
- The cleanup moved from `catch { …; throw; }` to `finally`, so it also runs on the failure-result path. After a successful move there is no temporary file left, so the `finally` is a no-op then.

## Verification

Four tests in a new `MediaFileWriteTests.cs`. Three of them fail on the current implementation:

```
WriteTags_FailedWrite_DoesNotLeaveATemporaryFile
  Expected: ["…/not-really.ogg"]
  Actual:   ["…/not-really.ogg.tmp", "…/not-really.ogg"]

WriteTags_WritesThroughSymbolicLink
  Actual: <null>          // FileInfo.LinkTarget — the link is gone

WriteTags_PreservesFilePermissions
  Expected: UnixFileMode.UserRead | UnixFileMode.UserWrite
  Actual:   …GroupRead, OtherRead added
```

The fourth pins that a failed write leaves the original bytes untouched. Full suite: 256/256 on net10.0 and net11.0, built with `/p:TreatsWarningsAsErrors=true`.

A note on `AGENTS.md`: these are the first tests covering `MediaFile`'s file-path write semantics rather than any one format, and the existing `MediaFileDetectionTests` is scoped to detection, so they went in a new file rather than into a per-format test class where they would be misfiled. Happy to fold them in elsewhere if you would rather.

The two Unix-specific tests early-return on Windows; the test project does not reference `Meziantou.Xunit`, so `RunIf`/`TestOperatingSystems` are not available here and adding that reference felt out of scope for this fix.

Found during a review of `Meziantou.Framework.MediaTags`.
