### PR TITLE
Return an IoError result instead of throwing when a file cannot be accessed

### DIFF
--- a/src/Meziantou.Framework.MediaTags/MediaFile.cs
+++ b/src/Meziantou.Framework.MediaTags/MediaFile.cs
@@ -30,7 +30,7 @@ public static class MediaFile
             using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
             return ReadTagsCore(stream, format.Value);
         }
-        catch (IOException ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             return MediaTagResult<MediaTagInfo>.Failure(MediaTagError.IoError, ex.Message);
         }
@@ -97,7 +97,7 @@ public static class MediaFile
                 DeleteIfExists(tempPath);
             }
         }
-        catch (IOException ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             return MediaTagResult.Failure(MediaTagError.IoError, ex.Message);
         }
@@ -168,7 +168,7 @@ public static class MediaFile
             if (format is not null)
                 return format;
         }
-        catch (IOException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             // Fall through to extension-based detection
         }

--- a/tests/Meziantou.Framework.MediaTags.Tests/MediaFileWriteTests.cs
+++ b/tests/Meziantou.Framework.MediaTags.Tests/MediaFileWriteTests.cs
@@ -75,6 +75,73 @@ public sealed class MediaFileWriteTests
     }
 
     [Fact]
+    public void ReadTags_UnreadableFile_ReturnsIoError()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // Unix file modes only
+
+        var tempFile = Path.GetTempFileName() + ".mp3";
+        try
+        {
+            File.Copy(GetTestFilePath("basic.mp3"), tempFile, overwrite: true);
+            File.SetUnixFileMode(tempFile, UnixFileMode.None);
+
+            var result = MediaFile.ReadTags(tempFile);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(MediaTagError.IoError, result.Error);
+        }
+        finally
+        {
+            File.SetUnixFileMode(tempFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void WriteTags_UnwritableFile_ReturnsIoError()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // Unix file modes only
+
+        var tempFile = Path.GetTempFileName() + ".mp3";
+        try
+        {
+            File.Copy(GetTestFilePath("basic.mp3"), tempFile, overwrite: true);
+            File.SetUnixFileMode(tempFile, UnixFileMode.None);
+
+            var result = MediaFile.WriteTags(tempFile, new MediaTagInfo { Title = "Title" });
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(MediaTagError.IoError, result.Error);
+        }
+        finally
+        {
+            File.SetUnixFileMode(tempFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void ReadTags_DirectoryPath_ReturnsIoError()
+    {
+        var directory = Directory.CreateTempSubdirectory();
+        var directoryPath = Path.Combine(directory.FullName, "looks-like-a-file.mp3");
+        Directory.CreateDirectory(directoryPath);
+        try
+        {
+            var result = MediaFile.ReadTags(directoryPath);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal(MediaTagError.IoError, result.Error);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
     public void WriteTags_FailedWrite_LeavesTheOriginalFileUntouched()
     {
         var directory = Directory.CreateTempSubdirectory().FullName;


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/mediafile-atomic-replace` · that PR must merge first.**

The file-path entry points catch only `IOException`, so the most likely real-world failure — a file the process cannot read — throws straight out of an API whose whole point is returning `MediaTagResult` instead of throwing:

```
missing file            : returned success=False error=IoError
unreadable file         : THREW UnauthorizedAccessException
unreadable file write   : THREW UnauthorizedAccessException
directory path          : THREW UnauthorizedAccessException
```

A missing file works because `FileNotFoundException` derives from `IOException`; `UnauthorizedAccessException` does not. A caller scanning a music folder therefore still needs a `try`/`catch` around every call, and will most likely find that out in production.

## What changed

The three file-path `catch (IOException)` clauses in `MediaFile` — in `ReadTags(string)`, `WriteTags(string, …)` and `DetectFormat(string)` — now also accept `UnauthorizedAccessException`:

```csharp
catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
```

`DetectFormat` keeps falling through to extension-based detection, the other two keep returning `MediaTagError.IoError`.

Argument validation is deliberately not touched here: `WriteTags(path, null)` still comes back as `IoError` from a laundered `NullReferenceException`. That belongs with the wider "blanket `catch (Exception)` hides real defects" issue, which is a separate change.

## Verification

Three tests added to `MediaFileWriteTests.cs`, covering an unreadable file on read, an unreadable file on write, and a directory passed where a file was expected. Against the branch below this one they all fail by *throwing*:

```
System.UnauthorizedAccessException : Access to the path '…/tmpMAQzqJ.tmp.mp3' is denied.
```

With this change all three return `IsSuccess = false` and `MediaTagError.IoError`. Full suite: 262/262 on net10.0 and net11.0, built with `/p:TreatsWarningsAsErrors=true`.

Found during a review of `Meziantou.Framework.MediaTags`.
