### PR TITLE
Create temporary files with owner-only permissions on Unix

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -386,6 +386,21 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         prefix ??= string.Empty;
         suffix ??= string.Empty;
 
+        var options = new FileStreamOptions
+        {
+            Mode = FileMode.CreateNew,
+            Access = FileAccess.ReadWrite,
+            Share = FileShare.None,
+        };
+
+        if (!OperatingSystem.IsWindows())
+        {
+            // FileStream would otherwise create the file with 0666 & ~umask, which leaves it readable by every local
+            // user when the temporary folder is shared (Path.GetTempPath is /tmp on most Linux systems).
+            // Path.GetTempFileName uses mkstemp and creates with 0600, so match that.
+            options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        }
+
         IOException? lastException = null;
         for (var attempt = 0; attempt < 10; attempt++)
         {
@@ -393,7 +408,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
 
             try
             {
-                using var stream = File.Open(filePath.Value, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
+                using var stream = File.Open(filePath.Value, options);
                 return filePath;
             }
             catch (IOException ex)

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -492,6 +492,21 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    [RunIf(TestOperatingSystems.Linux | TestOperatingSystems.MacOS)]
+    public void CreateTempFile_IsOnlyAccessibleByTheCurrentUser()
+    {
+        var path = FullPath.CreateTempFile(prefix: null);
+        try
+        {
+            Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(path.Value));
+        }
+        finally
+        {
+            File.Delete(path.Value);
+        }
+    }
+
+    [Fact]
     public void CreateTempFile_WithFolderPrefixSuffix()
     {
         using var tempDirectory = TemporaryDirectory.Create();


### PR DESCRIPTION
`FullPath.CreateTempFile` creates temporary files with mode `0644` on Unix, so any local user can read them.

## What goes wrong

`src/Meziantou.Framework.FullPath/FullPath.cs:376-406` creates the file with `File.Open(path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None)`. On Unix `FileStream` creates with `0666 & ~umask`, which under the usual `umask 022` is `0644`.

Measured in one process on macOS:

| Call | Resulting mode |
| --- | --- |
| `FullPath.CreateTempFile()` | `OtherRead, GroupRead, UserWrite, UserRead` (0644) |
| `Path.GetTempFileName()` | `UserWrite, UserRead` (0600) |

`Path.GetTempFileName` uses `mkstemp`, which creates with `0600`. Since `CreateTempFile` (and the `[EditorBrowsable(Never)]` alias `GetTempFileName`, `FullPath.cs:359-360`) replaced that call, callers of the old API silently lost the restrictive mode.

The default destination is `Path.GetTempPath()` (`FullPath.cs:379-384`), which on most Linux systems is the shared, world-readable, world-writable `/tmp`. So whatever the consuming application writes into its temp file — credentials, tokens, decrypted payloads — is readable by every other local user or co-tenant for the file's whole lifetime. macOS is largely spared by its per-user `TMPDIR` and Windows by ACL inheritance.

## What is *not* wrong

Worth stating since it narrows the fix: the names are `Guid.NewGuid()` so they are unpredictable, and `FileMode.CreateNew` maps to `O_CREAT|O_EXCL`, which fails on an existing symlink. There is no name-guessing or symlink-planting race here — only the permissions are wrong.

## Change

Build a `FileStreamOptions` once outside the retry loop and set `UnixCreateMode` to `UserRead | UserWrite`.

The setter is annotated `[UnsupportedOSPlatform("windows")]`, so it is guarded with `!OperatingSystem.IsWindows()` rather than set unconditionally.

## Verification

`dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 164 passed, 0 failed, 56 skipped.

Added `CreateTempFile_IsOnlyAccessibleByTheCurrentUser`, gated to Linux/macOS, asserting `File.GetUnixFileMode` is exactly `UserRead | UserWrite`. It runs and passes on this machine; on `main` it returns `0644` and fails.

`dotnet run ./eng/update-all.cs` produced no generated-file changes.

## Possible follow-up

If a caller ever legitimately needs a group-readable temp file in a shared spool directory, this would need an opt-out — an optional `UnixFileMode` parameter defaulting to `0600`. Not added here, since nothing in the repo needs it and it widens the API.
