### PR TITLE
Follow RFC 6797 for repeated directives and whitespace in the STS header

### DIFF
--- a/src/Meziantou.Framework.Http.Hsts/HstsClientHandler.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsClientHandler.cs
@@ -98,9 +98,19 @@ public sealed class HstsClientHandler : DelegatingHandler
         foreach (var part in header.Split(';'))
         {
             var directive = header[part].Trim();
-            if (directive.StartsWith("max-age=", StringComparison.OrdinalIgnoreCase))
+            if (directive.IsEmpty)
+                continue;
+
+            // The name and the value may be separated by optional whitespace around the '='
+            var separator = directive.IndexOf('=');
+            var name = separator < 0 ? directive : directive[..separator].TrimEnd();
+            var value = separator < 0 ? [] : directive[(separator + 1)..].TrimStart();
+
+            if (name.Equals("max-age", StringComparison.OrdinalIgnoreCase))
             {
-                var value = directive["max-age=".Length..].Trim();
+                // A repeated directive makes the whole header field invalid
+                if (hasMaxAge)
+                    return false;
 
                 // The directive value may be a quoted-string
                 if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
@@ -115,8 +125,11 @@ public sealed class HstsClientHandler : DelegatingHandler
                 maxAge = TimeSpan.FromSeconds(Math.Min(seconds, MaxMaxAgeInSeconds));
                 hasMaxAge = true;
             }
-            else if (directive.Equals("includeSubDomains", StringComparison.OrdinalIgnoreCase))
+            else if (separator < 0 && name.Equals("includeSubDomains", StringComparison.OrdinalIgnoreCase))
             {
+                if (includeSubdomains)
+                    return false;
+
                 includeSubdomains = true;
             }
         }

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/HstsClientHandlerTests.cs
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/HstsClientHandlerTests.cs
@@ -77,6 +77,50 @@ public sealed class HstsClientHandlerTests
         Assert.True(hsts.MustUpgradeRequest("foo.example.com"));
     }
 
+    [Theory]
+    [InlineData("max-age = 31536000")]
+    [InlineData("max-age =31536000")]
+    [InlineData("max-age= 31536000")]
+    public async Task WhitespaceAroundTheDirectiveSeparator_IsAccepted(string headerResponse)
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler(headerResponse), hsts), disposeHandler: true);
+
+        using var response = await client.GetAsync("https://example.com", XunitCancellationToken);
+        Assert.True(hsts.MustUpgradeRequest("example.com"));
+    }
+
+    [Theory]
+    [InlineData("max-age=31536000; max-age=0")]
+    [InlineData("max-age=0; max-age=31536000")]
+    [InlineData("max-age=31536000; includeSubDomains; includeSubDomains")]
+    public async Task RepeatedDirective_IsIgnored(string headerResponse)
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("example.com", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: false);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler(headerResponse), hsts), disposeHandler: true);
+
+        using var response = await client.GetAsync("https://example.com", XunitCancellationToken);
+
+        // https://datatracker.ietf.org/doc/html/rfc6797#section-6.1
+        // The whole header field is ignored, so the policy already in the collection is left alone
+        Assert.True(hsts.MustUpgradeRequest("example.com"));
+        Assert.False(hsts.MustUpgradeRequest("sub.example.com"));
+    }
+
+    [Fact]
+    public async Task IncludeSubDomainsWithAValue_IsIgnored()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        using var client = new HttpClient(new HstsClientHandler(new MockHttpMessageHandler("max-age=31536000; includeSubDomains="), hsts), disposeHandler: true);
+
+        using var response = await client.GetAsync("https://example.com", XunitCancellationToken);
+
+        // includeSubDomains is valueless; the malformed directive is skipped but the header stays usable
+        Assert.True(hsts.MustUpgradeRequest("example.com"));
+        Assert.False(hsts.MustUpgradeRequest("sub.example.com"));
+    }
+
     [Fact]
     public async Task VeryLargeMaxAge_IsClamped()
     {


### PR DESCRIPTION
Two deviations in the `Strict-Transport-Security` directive parser, both found by testing it against the grammar in [RFC 6797 §6.1](https://datatracker.ietf.org/doc/html/rfc6797#section-6.1).

## Repeated directives were applied instead of invalidating the header

The loop overwrote `maxAge` on each `max-age=` directive, so the last one won. Measured before this change:

```
max-age=31536000; max-age=0   -> policy DELETED
max-age=0; max-age=31536000   -> policy set to 31536000
```

The RFC says a header field with a repeated directive must be ignored. The first case is the one worth caring about: a malformed header that the spec says to ignore instead *removed* a policy the client already held. Both `max-age` and `includeSubDomains` now invalidate the header when repeated, so the policy already in the collection is left alone.

## Whitespace around `=` was rejected

The parser prefix-matched `"max-age="`, so the name and value had to be adjacent:

```
max-age = 31536000            -> IGNORED
```

Browsers accept optional whitespace around the `=`, so a site whose header a browser honours was not protected by this client. The directive is now split on the first `=` with the surrounding whitespace trimmed.

`includeSubDomains` is valueless, so it is still only recognised without a `=` — `includeSubDomains=` is skipped as malformed, exactly as before.

## Not changed

Everything else the parser already got right, re-confirmed by test: `MAX-AGE=100`, `max-age="100"`, `max-age=0100`, `preload; max-age=100`, `max-age=100; ;;` and leading/trailing spaces all parse; `max-age=+100`, `max-age=abc`, `max-age=`, `max-age=-1` and an out-of-range value are all ignored.

## Verification

7 new tests. `dotnet test -p:TreatWarningsAsErrors=true` → **90 passed, 0 failed** (45 × net10.0 and net11.0).
