### PR TITLE
Drop expired HSTS policies when a lookup walks past them

### DIFF
--- a/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
@@ -196,6 +196,9 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
             {
                 if (hsts.ExpiresAt < now)
                 {
+                    // The policy is dead, so drop it instead of keeping every host the process has ever seen.
+                    // The compare-and-remove leaves a policy added concurrently for the same host in place.
+                    dictionary.TryRemove(new KeyValuePair<string, HstsDomainPolicy>(hsts.Host, hsts));
                     continue;
                 }
 

--- a/src/Meziantou.Framework.Http.Hsts/readme.md
+++ b/src/Meziantou.Framework.Http.Hsts/readme.md
@@ -10,6 +10,6 @@ using var client = new HttpClient(new HstsClientHandler(new SocketsHttpHandler()
 using var response = await client.GetAsync("http://github.com");
 ```
 
-The handler reads the `Strict-Transport-Security` header of HTTPS responses and adds the host to the collection, so later requests to that host are upgraded. A `max-age=0` header removes the policy, unless the host comes from the preload list. Policies learned this way are kept in memory only, and are not removed when they expire; use `Remove` to drop the ones you no longer need.
+The handler reads the `Strict-Transport-Security` header of HTTPS responses and adds the host to the collection, so later requests to that host are upgraded. A `max-age=0` header removes the policy, unless the host comes from the preload list. Policies learned this way are kept in memory only, and an expired one is dropped the next time a request looks up its host; use `Remove` to drop a policy before it expires.
 
 The `HstsClientHandler` constructor that takes no collection uses `HstsDomainPolicyCollection.Default`, a shared instance for the whole process. Every handler using it observes the policies learned by the others. Create a dedicated `HstsDomainPolicyCollection` to isolate a client from the rest of the application.

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
@@ -81,6 +81,60 @@ public sealed class HstsDomainPolicyCollectionTests
     }
 
     [Fact]
+    public void HstsCollection_ExpiredPolicy_IsDroppedOnLookup()
+    {
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.Parse("2024-01-01T00:00:00Z", CultureInfo.InvariantCulture));
+        var hsts = new HstsDomainPolicyCollection(timeProvider, includePreloadDomains: false);
+        hsts.Add("example.com", TimeSpan.FromDays(30), includeSubdomains: true);
+
+        timeProvider.Advance(TimeSpan.FromDays(31));
+        Assert.False(hsts.MustUpgradeRequest("example.com"));
+
+        // Otherwise a process that talks to many hosts keeps every policy it has ever learned
+        Assert.Empty(hsts);
+    }
+
+    [Fact]
+    public void HstsCollection_ExpiredPolicy_IsDroppedWithoutHidingAMoreSpecificOne()
+    {
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.Parse("2024-01-01T00:00:00Z", CultureInfo.InvariantCulture));
+        var hsts = new HstsDomainPolicyCollection(timeProvider, includePreloadDomains: false);
+        hsts.Add("example.com", TimeSpan.FromDays(30), includeSubdomains: true);
+        hsts.Add("foo.example.com", TimeSpan.FromDays(90), includeSubdomains: true);
+
+        timeProvider.Advance(TimeSpan.FromDays(31));
+
+        Assert.True(hsts.MustUpgradeRequest("foo.example.com"));
+        Assert.Equal("foo.example.com", Assert.Single(hsts).Host);
+    }
+
+    [Fact]
+    public void HstsCollection_RenewedPolicy_IsNotDroppedByAConcurrentLookup()
+    {
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.Parse("2024-01-01T00:00:00Z", CultureInfo.InvariantCulture));
+        var hsts = new HstsDomainPolicyCollection(timeProvider, includePreloadDomains: false);
+        hsts.Add("example.com", TimeSpan.FromDays(30), includeSubdomains: true);
+
+        timeProvider.Advance(TimeSpan.FromDays(31));
+        hsts.Add("example.com", TimeSpan.FromDays(30), includeSubdomains: true);
+
+        Assert.True(hsts.MustUpgradeRequest("example.com"));
+        Assert.Single(hsts);
+    }
+
+    [Fact]
+    public void HstsCollection_PreloadedPolicy_IsNotDroppedOnLookup()
+    {
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.Parse("2024-01-01T00:00:00Z", CultureInfo.InvariantCulture));
+        var hsts = new HstsDomainPolicyCollection(timeProvider, includePreloadDomains: true);
+
+        timeProvider.Advance(TimeSpan.FromDays(365 * 100));
+
+        Assert.True(hsts.MustUpgradeRequest("github.com"));
+        Assert.Contains(hsts, policy => policy.Host == "github.com");
+    }
+
+    [Fact]
     public void HstsCollection_Match_PreloadedInternationalizedDomain()
     {
         var hsts = new HstsDomainPolicyCollection(includePreloadDomains: true);


### PR DESCRIPTION
## The problem

A policy learned from a `Strict-Transport-Security` header was never removed once it expired. `MustUpgradeRequest` skipped it with `continue` and moved on; only an explicit `Remove` could free it.

The growth is driven by remote responses. A long-lived process that fetches arbitrary URLs — a crawler, a link-preview service, a webhook fetcher — accumulated one permanent entry per distinct HSTS host it had ever touched. With the parameterless constructor those land in the shared `HstsDomainPolicyCollection.Default`, so the growth was not scoped to the component that caused it.

Measured:

```
200,000 expired learned policies: 35,469,120 bytes (177 bytes/entry)
still enumerable: 200,000 entries
MustUpgradeRequest(host0.example.com) = False (expired, yet retained)
```

The readme documented the no-expiry behaviour, which is why this was rated Medium rather than High — but "documented" is thin cover for growth an attacker can drive.

## The change

An expired policy is removed when a lookup walks past it, which bounds the collection by live policies instead of by every host ever seen. The removal is a compare-and-remove on the exact entry (`TryRemove(KeyValuePair<,>)`, the same primitive `RemoveLearnedPolicy` already uses), so a policy added concurrently for the same host survives. Preloaded entries have `ExpiresAt == DateTimeOffset.MaxValue`, never reach the branch, and are never dropped.

**This makes `MustUpgradeRequest` mutating**, which is worth a moment's thought before merging: a lookup can now change what `GetEnumerator` returns. The alternative — a background sweep or a size cap — needs an eviction policy that is a real design decision, whereas this one only ever drops entries that are already dead.

The readme sentence that promised the old behaviour is updated.

## Verification

4 new tests: an expired entry disappears on lookup, an expired parent is dropped without hiding a live child, a renewed policy survives the lookup that would have evicted the old one, and a preloaded entry is untouched after 100 years. `dotnet test -p:TreatWarningsAsErrors=true` → **84 passed, 0 failed** (42 × net10.0 and net11.0).
