### PR TITLE
Accept both the Unicode and Punycode form of a host name

### DIFF
--- a/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Runtime.InteropServices;
 using System.IO.Compression;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 
 namespace Meziantou.Framework.Http;
 
@@ -22,6 +23,18 @@ namespace Meziantou.Framework.Http;
 /// }
 /// </code>
 /// </example>
+/// <remarks>
+/// <para>
+/// Host names are IDNA-canonicalized to their Punycode form and then matched with an ordinal, case-insensitive
+/// comparison, so an internationalized domain matches whichever of its two forms is used. The preload list stores
+/// Punycode names, and <see cref="HstsClientHandler"/> looks policies up with <see cref="Uri.IdnHost"/>, which is
+/// already in that form; an ASCII host name is never converted.
+/// </para>
+/// <para>
+/// <see cref="HstsDomainPolicy.Host"/> reports the canonicalized name, which may differ from the one that was
+/// passed to <see cref="Add(string, DateTimeOffset, bool)"/>.
+/// </para>
+/// </remarks>
 public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainPolicy>
 {
     private readonly Lock _lock = new();
@@ -87,7 +100,7 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
     }
 
     /// <summary>Adds or updates an HSTS policy for the specified host with a maximum age.</summary>
-    /// <param name="host">The domain host name.</param>
+    /// <param name="host">The domain host name. An internationalized domain may be given in either its Unicode or its Punycode form.</param>
     /// <param name="maxAge">The duration for which the HSTS policy should be in effect.</param>
     /// <param name="includeSubdomains">If <see langword="true"/>, the policy applies to all subdomains of the host.</param>
     public void Add(string host, TimeSpan maxAge, bool includeSubdomains)
@@ -103,14 +116,15 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
     }
 
     /// <summary>Adds or updates an HSTS policy for the specified host with an expiration date.</summary>
-    /// <param name="host">The domain host name.</param>
+    /// <param name="host">The domain host name. An internationalized domain may be given in either its Unicode or its Punycode form.</param>
     /// <param name="expiresAt">The date and time when the HSTS policy expires.</param>
     /// <param name="includeSubdomains">If <see langword="true"/>, the policy applies to all subdomains of the host.</param>
+    /// <exception cref="ArgumentException"><paramref name="host"/> contains an empty label, or cannot be converted to its Punycode form.</exception>
     public void Add(string host, DateTimeOffset expiresAt, bool includeSubdomains)
     {
         ArgumentNullException.ThrowIfNull(host);
 
-        host = NormalizeHost(host);
+        host = NormalizeHostForStorage(host);
         if (HasEmptyLabel(host))
             throw new ArgumentException($"The host name '{host}' contains an empty label.", nameof(host));
 
@@ -143,7 +157,7 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
     }
 
     /// <summary>Removes the HSTS policy for the specified host, including a policy from the preload list.</summary>
-    /// <param name="host">The domain host name.</param>
+    /// <param name="host">The domain host name. An internationalized domain may be given in either its Unicode or its Punycode form.</param>
     /// <returns><see langword="true"/> if a policy was removed; otherwise, <see langword="false"/>.</returns>
     public bool Remove(string host)
     {
@@ -167,7 +181,7 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
 
     private bool TryGetDictionary(string host, [NotNullWhen(true)] out ConcurrentDictionary<string, HstsDomainPolicy>? dictionary, [NotNullWhen(true)] out string? key)
     {
-        key = NormalizeHost(host);
+        key = NormalizeHostForLookup(host);
         var partCount = CountSegments(key);
         var policies = _policies;
         if (partCount > policies.Length)
@@ -187,14 +201,56 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
         => host.Length == 0 || host[0] == '.' || host.Contains("..", StringComparison.Ordinal);
 
     // A fully-qualified domain name may end with a dot; it designates the same host
-    private static string NormalizeHost(string host)
+    private static string TrimTrailingDots(string host)
     {
         var trimmed = host.AsSpan().TrimEnd('.');
         return trimmed.Length == host.Length ? host : trimmed.ToString();
     }
 
+    // https://datatracker.ietf.org/doc/html/rfc6797#section-10
+    // Policies are stored under the IDNA-canonicalized host name. A name that cannot be canonicalized would be
+    // stored in a form no lookup can produce, so it is rejected rather than kept as a policy that never matches.
+    private static string NormalizeHostForStorage(string host)
+    {
+        var trimmed = TrimTrailingDots(host);
+        if (Ascii.IsValid(trimmed))
+            return trimmed;
+
+        try
+        {
+            return CreateIdnMapping().GetAscii(trimmed);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new ArgumentException($"The host name '{host}' cannot be converted to its Punycode form.", nameof(host), ex);
+        }
+    }
+
+    // The same canonicalization on the lookup side, where a name that cannot be canonicalized simply matches
+    // nothing instead of throwing.
+    private static string NormalizeHostForLookup(string host)
+    {
+        var trimmed = TrimTrailingDots(host);
+        if (Ascii.IsValid(trimmed))
+            return trimmed;
+
+        try
+        {
+            return CreateIdnMapping().GetAscii(trimmed);
+        }
+        catch (ArgumentException)
+        {
+            return trimmed;
+        }
+    }
+
+    // IdnMapping does not document its instance members as thread safe, and lookups run concurrently. The
+    // instance is tiny and only allocated for a non-ASCII name, which never happens on the HstsClientHandler
+    // path because Uri.IdnHost is already ASCII.
+    private static IdnMapping CreateIdnMapping() => new();
+
     /// <summary>Determines whether an HTTP request to the specified host should be upgraded to HTTPS based on HSTS policies.</summary>
-    /// <param name="host">The domain host name to check.</param>
+    /// <param name="host">The domain host name to check. An internationalized domain may be given in either its Unicode or its Punycode form.</param>
     /// <returns><see langword="true"/> if the request should be upgraded to HTTPS; otherwise, <see langword="false"/>.</returns>
     public bool MustUpgradeRequest(string host)
     {
@@ -203,11 +259,32 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
     }
 
     /// <summary>Determines whether an HTTP request to the specified host should be upgraded to HTTPS based on HSTS policies.</summary>
-    /// <param name="host">The domain host name to check.</param>
+    /// <param name="host">The domain host name to check. An internationalized domain may be given in either its Unicode or its Punycode form.</param>
     /// <returns><see langword="true"/> if the request should be upgraded to HTTPS; otherwise, <see langword="false"/>.</returns>
     public bool MustUpgradeRequest(ReadOnlySpan<char> host)
     {
         host = host.TrimEnd('.');
+
+        // HstsClientHandler passes Uri.IdnHost, which is already ASCII, so the request path never converts and
+        // never allocates. Only a caller passing an internationalized name in its Unicode form pays for it.
+        if (!Ascii.IsValid(host))
+        {
+            try
+            {
+                return MustUpgradeRequestCore(CreateIdnMapping().GetAscii(host.ToString()));
+            }
+            catch (ArgumentException)
+            {
+                // A name that cannot be canonicalized cannot match a policy
+                return false;
+            }
+        }
+
+        return MustUpgradeRequestCore(host);
+    }
+
+    private bool MustUpgradeRequestCore(ReadOnlySpan<char> host)
+    {
         var policies = _policies;
         var now = _timeProvider.GetUtcNow();
 

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
@@ -1,3 +1,4 @@
+using Meziantou.Xunit;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Meziantou.Framework.Http.Hsts.Tests;
@@ -176,6 +177,83 @@ public sealed class HstsDomainPolicyCollectionTests
         Assert.True(hsts.MustUpgradeRequest("xn--vt3a.jp"));
         Assert.True(hsts.MustUpgradeRequest(new Uri("http://跳.jp").IdnHost));
         Assert.True(hsts.MustUpgradeRequest(new Uri("http://sub.αβ.net").IdnHost));
+    }
+
+    [Theory]
+    [InlineData("跳.jp")]
+    [InlineData("xn--vt3a.jp")]
+    public void HstsCollection_Match_UnicodeAndPunycodeAreInterchangeable(string addedHost)
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add(addedHost, DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: false);
+
+        // https://datatracker.ietf.org/doc/html/rfc6797#section-10
+        Assert.True(hsts.MustUpgradeRequest("跳.jp"));
+        Assert.True(hsts.MustUpgradeRequest("xn--vt3a.jp"));
+    }
+
+    [Fact]
+    public void HstsCollection_Add_StoresTheCanonicalizedHost()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("跳.jp", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: false);
+
+        Assert.Equal("xn--vt3a.jp", Assert.Single(hsts).Host);
+    }
+
+    [Theory]
+    [InlineData("跳.jp")]
+    [InlineData("xn--vt3a.jp")]
+    public void HstsCollection_Remove_AcceptsEitherForm(string removedHost)
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("跳.jp", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: false);
+
+        Assert.True(hsts.Remove(removedHost));
+        Assert.Empty(hsts);
+    }
+
+    [Fact]
+    public void HstsCollection_Match_UnicodeSubdomainOfAnInternationalizedDomain()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("跳.jp", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: true);
+
+        Assert.True(hsts.MustUpgradeRequest("sub.跳.jp"));
+        Assert.True(hsts.MustUpgradeRequest("sub.xn--vt3a.jp"));
+    }
+
+    [Fact]
+    public void HstsCollection_Match_PreloadedDomainInItsUnicodeForm()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: true);
+
+        // The preload list stores Punycode names; the Unicode form of the same domain must match them
+        Assert.True(hsts.MustUpgradeRequest("跳.jp"));
+        Assert.True(hsts.MustUpgradeRequest("sub.αβ.net"));
+    }
+
+    [Fact]
+    public void HstsCollection_Match_UnconvertibleHostDoesNotThrow()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+
+        // A name that cannot be canonicalized cannot match a policy, but a lookup must not fail the request
+        Assert.False(hsts.MustUpgradeRequest("\u0080.example"));
+        Assert.False(hsts.Remove("\u0080.example"));
+    }
+
+    [Fact]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    public void HstsCollection_Add_RejectsAnUnconvertibleHost()
+    {
+        // IDNA validation follows the platform: ICU rejects a disallowed code point, while the managed
+        // fallback used in globalization-invariant mode encodes it instead. Add throws whenever the
+        // conversion fails, so only the strict mode reaches the exception.
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+
+        Assert.Throws<ArgumentException>(() => hsts.Add("\u0080.example", DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: false));
+        Assert.Empty(hsts);
     }
 
     [Fact]


### PR DESCRIPTION
Replaces the documentation-only version of this PR, following the question about security and RFC compliance on the original.

## The problem

`HstsClientHandler` looks policies up with `Uri.IdnHost` and the preload list stores internationalized names as Punycode, but the collection compared host names ordinally and converted nothing. A name passed in its Unicode form created a policy that no request could ever match:

```
Add("跳.jp") -> MustUpgradeRequest("跳.jp")      = True
Add("跳.jp") -> MustUpgradeRequest("xn--vt3a.jp") = False  <- what the handler asks
preloaded    -> MustUpgradeRequest("跳.jp")      = False
```

No exception, no log. For a security control, an operator believing a policy is active when it is not is the wrong default — a doc comment only helps the people who read it.

## RFC position

[RFC 6797 §10](https://datatracker.ietf.org/doc/html/rfc6797#section-10) ("Domain Name IDNA-Canonicalization") requires host names to be IDNA-canonicalized, and the matching in §8.2 presumes that has already happened. The RFC does not say which component canonicalizes: the handler already did its half, and the collection now does the same for names it is given directly.

## The change

- `Add` and `Remove` canonicalize unconditionally — off the request path, so the cost is irrelevant.
- `MustUpgradeRequest` converts only when the name is not ASCII. `Uri.IdnHost` is always ASCII, so **the handler path never converts**.
- `Add` throws `ArgumentException` when a name cannot be converted, rather than storing a policy that could never match. A lookup with such a name returns `false` instead of throwing.
- `HstsDomainPolicy.Host` now reports the canonicalized name, which may differ from the one passed to `Add`. Documented on the type.

Canonicalization uses `IdnMapping`, which agrees with `Uri.IdnHost` on the Punycode output for every IDN tested (`跳.jp`, `sub.αβ.net`, `ß.de`, `faß.de`, `😀.com`). The two differ on case — `ABC.COM` stays uppercase under `IdnMapping`, lowercases under `Uri` — which is harmless **only** because the dictionary comparer is `OrdinalIgnoreCase`; there is a comment saying so, since changing that comparer would silently break IDN matching.

A fresh `IdnMapping` is allocated per conversion: its instance members are not documented as thread safe and lookups run concurrently. It is only allocated for a non-ASCII name, which never happens on the handler path.

## Cost

The hot path is unchanged and still allocates nothing:

```
1M ASCII hits    : 79 ms
1M ASCII misses  : 108 ms
100k Unicode hits: 31 ms   (~310 ns, the path that pays)
allocation for 100k ASCII lookups: 0 bytes
```

The `Ascii.IsValid` guard measures ~1.2 ns/call.

## One platform-dependent behavior

IDNA *validation* strictness follows the platform, and this is worth knowing about:

| input | ICU | globalization-invariant |
|---|---|---|
| `跳.jp` | `xn--vt3a.jp` | `xn--vt3a.jp` |
| empty label | throws | throws |
| `U+0080`, ZWJ | **throws** | **encodes anyway** |

Both modes agree on valid names, so matching is unaffected. Only whether `Add` *rejects* a malformed name differs, and such a name still round-trips consistently within a process because `Add` and `MustUpgradeRequest` call the same function. The one test that depends on this carries `[RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]`.

## Verification

9 new tests: both forms interchangeable in both directions, canonical storage, `Remove` by either form, Unicode subdomains, preloaded domains matched by their Unicode form, and the unconvertible-name paths.

```
normal globalization        -> total: 144, failed: 0, skipped: 0
InvariantGlobalization=true -> total: 144, failed: 0, skipped: 2
```

Rebased onto current `main`, which now contains #2430; the empty-label check and the canonicalization both run in `Add`, canonicalization first.
