### PR TITLE
Read the Strict-Transport-Security header when RequestMessage is unset

### DIFF
--- a/src/Meziantou.Framework.Http.Hsts/HstsClientHandler.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsClientHandler.cs
@@ -96,7 +96,7 @@ public sealed class HstsClientHandler : DelegatingHandler
             UpgradeRequest(request);
 
             var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
-            ProcessStrictTransportSecurityHeader(response);
+            ProcessStrictTransportSecurityHeader(request, response);
 
             if (remainingRedirections <= 0)
                 return response;
@@ -130,13 +130,15 @@ public sealed class HstsClientHandler : DelegatingHandler
         }
     }
 
-    private void ProcessStrictTransportSecurityHeader(HttpResponseMessage response)
+    private void ProcessStrictTransportSecurityHeader(HttpRequestMessage request, HttpResponseMessage response)
     {
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
         // Note: The Strict-Transport-Security header is ignored by the browser when your site has only been accessed using HTTP.
         // Once your site is accessed over HTTPS with no certificate errors, the browser knows your site is HTTPS-capable and
         // will honor the Strict-Transport-Security header.
-        var responseUri = response.RequestMessage?.RequestUri;
+        // The response URI is the one the request ended on; an inner handler that does not set RequestMessage
+        // leaves the request itself as the best available source
+        var responseUri = response.RequestMessage?.RequestUri ?? request.RequestUri;
         if (responseUri?.Scheme == Uri.UriSchemeHttps && !IsIPAddress(responseUri) && response.Headers.TryGetValues("Strict-Transport-Security", out var headers))
         {
             // https://datatracker.ietf.org/doc/html/rfc6797#section-8.1

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/HstsClientHandlerTests.cs
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/HstsClientHandlerTests.cs
@@ -170,6 +170,40 @@ public sealed class HstsClientHandlerTests
     }
 
     [Fact]
+    public async Task Header_IsReadWhenTheInnerHandlerDoesNotSetRequestMessage()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        using var client = new HttpClient(new HstsClientHandler(new NoRequestMessageHttpMessageHandler("max-age=31536000"), hsts), disposeHandler: true);
+
+        using var response = await client.GetAsync("https://example.com", XunitCancellationToken);
+
+        // A handler that builds its own response, such as a cache or a test double, may leave RequestMessage unset
+        Assert.Null(response.RequestMessage);
+        Assert.True(hsts.MustUpgradeRequest("example.com"));
+    }
+
+    [Fact]
+    public async Task Header_IsIgnoredForIPAddress_WhenTheInnerHandlerDoesNotSetRequestMessage()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        using var client = new HttpClient(new HstsClientHandler(new NoRequestMessageHttpMessageHandler("max-age=31536000"), hsts), disposeHandler: true);
+
+        using var response = await client.GetAsync("https://127.0.0.1", XunitCancellationToken);
+
+        Assert.False(hsts.MustUpgradeRequest("127.0.0.1"));
+    }
+
+    private sealed class NoRequestMessageHttpMessageHandler(string header) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Headers.TryAddWithoutValidation("Strict-Transport-Security", header);
+            return Task.FromResult(response);
+        }
+    }
+
+    [Fact]
     public async Task Redirect_ToHstsHost_IsUpgraded()
     {
         var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);


### PR DESCRIPTION
**Stacked on top of https://github.com/meziantou/Meziantou.Framework/pull/2423 — merges into `fix/hsts-follow-redirects`, and must merge after it.** It touches the same block of `SendAsync` that PR rewrites, which is the only reason it is stacked rather than independent.

## The problem

The response URI was read from `response.RequestMessage?.RequestUri` alone (`HstsClientHandler.cs:63`). An inner handler that builds its own response — a cache, a retry handler, a test double — may leave `RequestMessage` null, and the `Strict-Transport-Security` header was then dropped with no signal.

Confirmed with a handler returning a well-formed `max-age=31536000` and no `RequestMessage`:

```
learned = False (header silently dropped)
```

It fails silently and only in composed pipelines, so it presents as "HSTS just doesn't work here" with nothing to grep for.

## The change

Fall back to the request URI, which is the same host in that case. The response URI stays preferred, because it reflects the host the request actually ended on after a redirect.

## Verification

2 new tests, including one confirming the IP-address rule still applies on the fallback path. `dotnet test -p:TreatWarningsAsErrors=true` → **108 passed, 0 failed**.
