### PR TITLE
Saturate instead of throwing when max-age would overflow the expiration date

### DIFF
--- a/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
@@ -79,7 +79,14 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
     /// <param name="includeSubdomains">If <see langword="true"/>, the policy applies to all subdomains of the host.</param>
     public void Add(string host, TimeSpan maxAge, bool includeSubdomains)
     {
-        Add(host, _timeProvider.GetUtcNow().Add(maxAge), includeSubdomains);
+        // A max-age that would push the expiration date out of range saturates instead of throwing
+        var now = _timeProvider.GetUtcNow();
+        var expiresAt =
+            maxAge >= DateTimeOffset.MaxValue - now ? DateTimeOffset.MaxValue :
+            maxAge <= DateTimeOffset.MinValue - now ? DateTimeOffset.MinValue :
+            now.Add(maxAge);
+
+        Add(host, expiresAt, includeSubdomains);
     }
 
     /// <summary>Adds or updates an HSTS policy for the specified host with an expiration date.</summary>

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
@@ -13,6 +13,38 @@ public sealed class HstsDomainPolicyCollectionTests
     }
 
     [Fact]
+    public void HstsCollection_Add_VeryLargeMaxAge_Saturates()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("example.com", TimeSpan.MaxValue, includeSubdomains: false);
+
+        Assert.Equal(DateTimeOffset.MaxValue, Assert.Single(hsts).ExpiresAt);
+        Assert.True(hsts.MustUpgradeRequest("example.com"));
+    }
+
+    [Fact]
+    public void HstsCollection_Add_MaxAgeBeyondTheRepresentableRange_Saturates()
+    {
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.MaxValue.AddYears(-1));
+        var hsts = new HstsDomainPolicyCollection(timeProvider, includePreloadDomains: false);
+
+        // The handler clamps max-age to 100 years before it gets here, but the collection is public
+        hsts.Add("example.com", TimeSpan.FromDays(365 * 100), includeSubdomains: false);
+
+        Assert.Equal(DateTimeOffset.MaxValue, Assert.Single(hsts).ExpiresAt);
+    }
+
+    [Fact]
+    public void HstsCollection_Add_VeryNegativeMaxAge_Saturates()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("example.com", TimeSpan.MinValue, includeSubdomains: false);
+
+        Assert.Equal(DateTimeOffset.MinValue, Assert.Single(hsts).ExpiresAt);
+        Assert.False(hsts.MustUpgradeRequest("example.com"));
+    }
+
+    [Fact]
     public void HstsCollection_Match_IncludeSubdomain_True()
     {
         var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);


### PR DESCRIPTION
## The problem

`Add(string host, TimeSpan maxAge, bool includeSubdomains)` computed `_timeProvider.GetUtcNow().Add(maxAge)` with no guard, so a large `TimeSpan` threw `ArgumentOutOfRangeException` from a public method that documents no exception:

```
Add("example.com", TimeSpan.MaxValue, false) -> THREW ArgumentOutOfRangeException
```

`HstsClientHandler` clamps `max-age` to 100 years (`MaxMaxAgeInSeconds`) before it gets here, so the handler never hit this. But the collection is public API, and the guard belonged on the side that does the arithmetic rather than in one of its callers.

## The change

The expiration date saturates at `DateTimeOffset.MaxValue` and `DateTimeOffset.MinValue`, which also makes the method total. The clamp in the handler is left in place as belt and braces.

## Verification

3 new tests: `TimeSpan.MaxValue`, a large `max-age` against a `TimeProvider` set near `DateTimeOffset.MaxValue`, and `TimeSpan.MinValue`. `dotnet test -p:TreatWarningsAsErrors=true` → **82 passed, 0 failed** (41 × net10.0 and net11.0).
