### PR TITLE
Reject host names with an empty label instead of storing them unreachably

### DIFF
--- a/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
@@ -91,6 +91,9 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
         ArgumentNullException.ThrowIfNull(host);
 
         host = NormalizeHost(host);
+        if (HasEmptyLabel(host))
+            throw new ArgumentException($"The host name '{host}' contains an empty label.", nameof(host));
+
         var partCount = CountSegments(host);
         ConcurrentDictionary<string, HstsDomainPolicy> dictionary;
         lock (_lock)
@@ -157,6 +160,11 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
         dictionary = policies[partCount - 1];
         return true;
     }
+
+    // An empty label counts as a segment, so the policy would go to a bucket the suffix walk never reads for
+    // that host and would silently never match. Such a host name is not valid anyway: Uri rejects it.
+    private static bool HasEmptyLabel(string host)
+        => host.Length == 0 || host[0] == '.' || host.Contains("..", StringComparison.Ordinal);
 
     // A fully-qualified domain name may end with a dot; it designates the same host
     private static string NormalizeHost(string host)

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
@@ -150,6 +150,36 @@ public sealed class HstsDomainPolicyCollectionTests
         Assert.True(hsts.MustUpgradeRequest("other.com."));
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData(".")]
+    [InlineData(".com")]
+    [InlineData("..com")]
+    [InlineData("a..com")]
+    [InlineData("a..b.com")]
+    public void HstsCollection_Add_RejectsAnEmptyLabel(string host)
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+
+        // Uri rejects these host names, and stored as is they would land in a bucket no lookup reads
+        Assert.Throws<ArgumentException>(() => hsts.Add(host, DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: true));
+        Assert.Empty(hsts);
+    }
+
+    [Theory]
+    [InlineData("com")]
+    [InlineData("example.com")]
+    [InlineData("example.com.")]
+    [InlineData("a.b.c.example.com")]
+    [InlineData("xn--vt3a.jp")]
+    public void HstsCollection_Add_AcceptsAWellFormedHost(string host)
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add(host, DateTimeOffset.UtcNow.AddYears(1), includeSubdomains: true);
+
+        Assert.True(hsts.MustUpgradeRequest(host));
+    }
+
     [Fact]
     public void HstsCollection_Remove()
     {


### PR DESCRIPTION
## The problem

`CountSegments` counts dots plus one, but the suffix walk in `MustUpgradeRequest` collapses consecutive dots, so the two disagreed for a host with an empty label. `Add("..com")` counted three segments and stored the policy in the three-segment bucket, while a lookup for the same host only ever consulted the one- and two-segment buckets:

```
Add("..com")  then MustUpgradeRequest("..com")  = False
Add(".com")   then MustUpgradeRequest(".com")   = False
Add("a..com") then MustUpgradeRequest("a..com") = True
```

The policy silently did nothing — the same failure shape as passing a Unicode host name.

## The change

`Add` throws `ArgumentException` for a host name with an empty label, including the empty string.

These names are not valid: `Uri` rejects every one of them, so `HstsClientHandler` can never produce one and the handler path is unaffected.

```
new Uri("http://a..com/") -> UriFormatException
new Uri("http://.com/")   -> UriFormatException
new Uri("http://..com/")  -> UriFormatException
```

`Remove` and `MustUpgradeRequest` stay lenient and keep returning `false` — reject bad input at the door, stay total on queries.

This does turn `Add("a..com")` from "silently does nothing" into "throws", which is a behaviour change for a caller passing a hand-built string. That seemed the better of the two.

## Verification

11 new test cases, split between rejected names and well-formed ones that must keep working (including the trailing-dot form and a Punycode name). `dotnet test -p:TreatWarningsAsErrors=true` → **98 passed, 0 failed** (49 × net10.0 and net11.0).
