### PR TITLE
Report which preload resource failed to load instead of asserting

### DIFF
--- a/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicyCollection.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Collections;
 using System.Runtime.InteropServices;
 using System.IO.Compression;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Meziantou.Framework.Http;
@@ -56,19 +55,33 @@ public sealed partial class HstsDomainPolicyCollection : IEnumerable<HstsDomainP
 
     private static void Load(ConcurrentDictionary<string, HstsDomainPolicy> dictionary, int entryCount, string resourceName)
     {
-        using var stream = typeof(HstsDomainPolicyCollection).Assembly.GetManifestResourceStream(resourceName);
-        Debug.Assert(stream is not null);
+        // The resource and the entry count come from the generated file: a mismatch means the package was
+        // built from an inconsistent tree, so say which resource is at fault instead of failing inside the
+        // decompression stream.
+        using var stream = typeof(HstsDomainPolicyCollection).Assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"The embedded resource '{resourceName}' is missing from the assembly.");
+
         using var gz = new GZipStream(stream, CompressionMode.Decompress);
         using var reader = new BinaryReader(gz);
         for (var i = 0; i < entryCount; i++)
         {
-            var name = reader.ReadString();
-            var includeSubdomains = reader.ReadBoolean();
+            string name;
+            bool includeSubdomains;
+            try
+            {
+                name = reader.ReadString();
+                includeSubdomains = reader.ReadBoolean();
 
-            // The duration in the source data is the max-age the domain must serve to qualify for the
-            // preload list, not a lifetime for the entry itself. The list is compiled into the assembly,
-            // so its entries stay valid until the package is updated.
-            _ = reader.ReadInt32();
+                // The duration in the source data is the max-age the domain must serve to qualify for the
+                // preload list, not a lifetime for the entry itself. The list is compiled into the assembly,
+                // so its entries stay valid until the package is updated.
+                _ = reader.ReadInt32();
+            }
+            catch (Exception ex) when (ex is EndOfStreamException or InvalidDataException)
+            {
+                throw new InvalidOperationException($"The embedded resource '{resourceName}' does not contain the expected {entryCount} entries; reading entry {i} failed.", ex);
+            }
+
             dictionary.TryAdd(name, new(name, DateTimeOffset.MaxValue, includeSubdomains, isPreloaded: true));
         }
     }


### PR DESCRIPTION
Diagnostics only — no behaviour change on any working build.

## The problem

`Load` guarded the embedded resource with `Debug.Assert(stream is not null)`, which is compiled out in release builds. A missing resource surfaced as `ArgumentNullException` from the `GZipStream` constructor — wrapped in a `TypeInitializationException` when it came through `HstsDomainPolicyCollection.Default` — and a resource whose content disagreed with the entry count in the generated file surfaced as `EndOfStreamException` from `BinaryReader`. Neither says which of the four resources is at fault.

This is reachable only through a build or packaging mistake, which is exactly when a useful message matters — and it is the failure mode the generator ordering fixed in the sibling exit-codes PR could have produced.

## The change

Both cases throw `InvalidOperationException` naming the resource, and the read failure also reports the entry index it stopped on. The now-unused `using System.Diagnostics;` is dropped.

## Verification

No new tests: the failure needs a deliberately broken assembly to reach, and the existing preload tests already cover the working path. `dotnet test -p:TreatWarningsAsErrors=true` → **76 passed, 0 failed** (38 × net10.0 and net11.0), unchanged from the baseline.
