### PR TITLE
Format the expiration date with the invariant culture in ToString

### DIFF
--- a/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicy.cs
+++ b/src/Meziantou.Framework.Http.Hsts/HstsDomainPolicy.cs
@@ -26,7 +26,8 @@ public sealed class HstsDomainPolicy
 
     public override string ToString()
     {
-        var result = Host + "; expires=" + ExpiresAt;
+        // The date is part of a diagnostic string that ends up in logs, so it must not depend on the culture
+        var result = Host + "; expires=" + ExpiresAt.ToString("O", CultureInfo.InvariantCulture);
         if (IncludeSubdomains)
         {
             result += "; includeSubdomains";

--- a/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
+++ b/tests/Meziantou.Framework.Http.Hsts.Tests/HstsDomainPolicyCollectionTests.cs
@@ -1,3 +1,4 @@
+using Meziantou.Xunit;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Meziantou.Framework.Http.Hsts.Tests;
@@ -222,6 +223,41 @@ public sealed class HstsDomainPolicyCollectionTests
             var partCount = Random.Shared.Next(1, 16);
             return string.Join('.', Enumerable.Range(0, partCount).Select(_ => Guid.NewGuid().ToString("N").ToLowerInvariant()));
         }
+    }
+
+    [Fact]
+    public void HstsDomainPolicy_ToString_UsesTheInvariantFormat()
+    {
+        var policy = CreatePolicyExpiringOn2030();
+
+        Assert.Equal("example.com; expires=2030-03-04T05:06:07.0000000+00:00; includeSubdomains", policy.ToString());
+    }
+
+    [Theory]
+    [InlineData("en-US")]
+    [InlineData("fr-FR")]
+    [RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]
+    public void HstsDomainPolicy_ToString_DoesNotDependOnTheCulture(string culture)
+    {
+        var policy = CreatePolicyExpiringOn2030();
+
+        var previousCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+            Assert.Equal("example.com; expires=2030-03-04T05:06:07.0000000+00:00; includeSubdomains", policy.ToString());
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
+    }
+
+    private static HstsDomainPolicy CreatePolicyExpiringOn2030()
+    {
+        var hsts = new HstsDomainPolicyCollection(includePreloadDomains: false);
+        hsts.Add("example.com", new DateTimeOffset(2030, 3, 4, 5, 6, 7, TimeSpan.Zero), includeSubdomains: true);
+        return Assert.Single(hsts);
     }
 
     [Fact]


### PR DESCRIPTION
## The problem

`HstsDomainPolicy.ToString()` concatenated `ExpiresAt`, which formats with the ambient culture. Under `fr-FR` the same policy rendered as:

```
example.com; expires=04/03/2030 05:06:07 +00:00; includeSubdomains
```

ambiguous with the invariant rendering of a different date. `ToString()` on a diagnostic type ends up in logs, where that is a small but real time sink.

No analyzer flags this — the build is warning-clean before and after.

## The change

The date uses the round-trip `"O"` format with `CultureInfo.InvariantCulture`.

## Verification

Two tests. `HstsDomainPolicy_ToString_UsesTheInvariantFormat` asserts the exact output and runs everywhere; `HstsDomainPolicy_ToString_DoesNotDependOnTheCulture` switches to `en-US` and `fr-FR` and carries `[RunIf(globalizationMode: TestGlobalizationMode.NotInvariant)]`, because `CultureInfo.GetCultureInfo` throws `CultureNotFoundException` in globalization-invariant mode.

```
normal globalization        -> total: 82, failed: 0, skipped: 0
InvariantGlobalization=true -> total: 82, failed: 0, skipped: 4
```

(41 × net10.0 and net11.0; the 4 skips are the two culture cases on each framework.)
