### PR TITLE
Validate preload domain names before emitting them as C# literals

### DIFF
--- a/tools/Meziantou.Framework.Http.Hsts.Generator/Program.cs
+++ b/tools/Meziantou.Framework.Http.Hsts.Generator/Program.cs
@@ -176,7 +176,39 @@ static async Task<(List<Data> entries, string fileUrl, string commit, DateTimeOf
     if (duplicatedDomains.Count > 0)
         throw new InvalidOperationException("Duplicated domains: " + string.Join(", ", duplicatedDomains));
 
+    // The names of the small buckets are interpolated into C# string literals, so a name containing a quote
+    // or a backslash would emit source that does not compile, or worse compiles into something else. A
+    // preload entry outside the character set of a host name is data to reject, not to escape.
+    var invalidDomains = entries.Where(e => !IsValidHostName(e.Name)).Select(e => e.Name).ToList();
+    if (invalidDomains.Count > 0)
+        throw new InvalidOperationException("Invalid domain names: " + string.Join(", ", invalidDomains));
+
     return (entries, fileUrl, sha, commitDate);
+}
+
+static bool IsValidHostName(string name)
+{
+    if (name.Length is 0 or > 253 || name[0] is '.' or '-' || name[^1] is '.' or '-')
+        return false;
+
+    var previousWasDot = false;
+    foreach (var c in name)
+    {
+        if (c is '.')
+        {
+            if (previousWasDot)
+                return false;
+
+            previousWasDot = true;
+            continue;
+        }
+
+        previousWasDot = false;
+        if (!char.IsAsciiLetterOrDigit(c) && c is not ('-' or '_'))
+            return false;
+    }
+
+    return true;
 }
 
 internal sealed class Data


### PR DESCRIPTION
## The problem

Buckets with fewer than ten entries are emitted as inline `dict.TryAdd("{entry.Name}", …)` calls, with the name interpolated straight into a C# string literal (`Program.cs:43`). A name containing a quote or a backslash would produce source that does not compile — or compiles into something other than the intended literal.

The input is the Chromium preload list, so this is a supply-chain-shaped risk rather than a live bug: the current data has no such names, and today all four buckets are large enough to go through the binary resources rather than the inline path.

## The change

The generator rejects any name that is not a well-formed host name, next to the duplicate check that already runs. A preload entry outside the character set of a host name is data to reject rather than to escape.

## Verification

The generator builds clean with `-p:TreatWarningsAsErrors=true`.

**The generator was not executed** — it fetches the Chromium list from the GitHub API — so instead I decoded the four `preload_*.bin` resources currently shipped and ran every name through the new rule:

```
preload_1.bin: 51 entries
preload_2.bin: 86286 entries
preload_3.bin: 8142 entries
preload_4.bin: 149 entries

total entries: 94628
names rejected by IsValidHostName: 0
```

The per-file counts match the ones in `HstsDomainPolicyCollection.g.cs` exactly, so the next generator run will not start throwing on existing data.
