### PR TITLE
Report an invalid path in JSON as JsonException

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPathJsonConverter.cs
+++ b/src/Meziantou.Framework.FullPath/FullPathJsonConverter.cs
@@ -12,7 +12,17 @@ public sealed class FullPathJsonConverter : JsonConverter<FullPath>
         if (string.IsNullOrEmpty(path))
             return FullPath.Empty;
 
-        return FullPath.FromPath(path);
+        try
+        {
+            return FullPath.FromPath(path);
+        }
+        catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
+        {
+            // System.Text.Json only translates InvalidOperationException from a converter, so these would otherwise
+            // escape Deserialize and defeat a caller that catches JsonException. The path is left out of the message
+            // because it comes from the payload and may be sensitive; it is available on the inner exception.
+            throw new JsonException("The JSON value cannot be converted to a FullPath.", ex);
+        }
     }
 
     public override void Write(Utf8JsonWriter writer, FullPath value, JsonSerializerOptions options)

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -217,6 +217,14 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public void JsonDeserialize_InvalidPathThrowsJsonException()
+    {
+        var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<FullPath>("\"a\\u0000b\""));
+
+        Assert.IsAssignableTo<ArgumentException>(exception.InnerException);
+    }
+
+    [Fact]
     public void JsonSerialize_RoundTripEmpty()
     {
         var value = FullPath.Empty;


### PR DESCRIPTION
`FullPathJsonConverter.Read` lets `ArgumentException` escape `JsonSerializer.Deserialize`, so a caller that wraps deserialization in `catch (JsonException)` crashes on a single malformed string.

## What goes wrong

`src/Meziantou.Framework.FullPath/FullPathJsonConverter.cs:9-16` calls `FullPath.FromPath` unguarded, and `Path.GetFullPath` rejects some inputs:

```csharp
JsonSerializer.Deserialize<FullPath>("\"a\\u0000b\"");
// System.ArgumentException: Illegal characters in path.
```

`System.Text.Json` translates `InvalidOperationException` thrown from a converter into `JsonException`, but not `ArgumentException`, `PathTooLongException` or `NotSupportedException`. Any service deserializing user-edited or untrusted JSON containing a `FullPath` therefore gets an unhandled exception type — a trivial 500 for a web API — from one bad string.

Verified against a Release build. Note that non-string tokens are already fine: `reader.GetString()` on `123` throws `InvalidOperationException`, which `System.Text.Json` *does* wrap, so that path already surfaces as `JsonException` and needs no change.

## Change

Catch `ArgumentException`, `PathTooLongException` and `NotSupportedException` in `Read` and rethrow as `JsonException` with the original as `InnerException`.

The offending value is deliberately kept out of the message — it comes from the payload and may be sensitive — and remains available on the inner exception for debugging.

## Verification

`dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 164 passed, 0 failed, 56 skipped.

Added `JsonDeserialize_InvalidPathThrowsJsonException`, asserting both the `JsonException` and that the original `ArgumentException` is preserved as the inner exception.

`dotnet run ./eng/update-all.cs` produced no generated-file changes.

## Not addressed here

`Read` also resolves a relative string against `Environment.CurrentDirectory` — `{"path":"data/cache"}` deserializes to `<cwd>/data/cache`, so the same document means different things depending on where the process was launched. That behavior is unchanged and still undocumented; whether a relative string should be resolved or rejected is a separate decision, so I have not pinned it with a test here.
