### PR TITLE
Throw PlatformNotSupportedException from ToWindowsExtendedPath on non-Windows

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -756,9 +756,15 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
     /// <para>UNC paths are converted to <c>\\?\UNC\server\share</c> format.</para>
     /// <para>If the path already uses a device path syntax (<c>\\?\</c>, <c>\\.\</c>, or <c>\??\</c>), it is returned as-is.</para>
     /// </remarks>
+    /// <exception cref="PlatformNotSupportedException">The current operating system is not Windows.</exception>
     [SupportedOSPlatform("windows")]
     public string ToWindowsExtendedPath()
     {
+        // EnsureExtendedPrefix treats any '/'-rooted path as partially qualified and returns it unchanged, so without
+        // this check the method would silently hand back something that is not an extended path.
+        if (!OperatingSystem.IsWindows())
+            throw new PlatformNotSupportedException("Extended-length paths are only supported on Windows.");
+
         if (IsEmpty)
             return "";
 

--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -664,6 +664,15 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    [RunIf(TestOperatingSystems.Linux | TestOperatingSystems.MacOS)]
+    public void ToWindowsExtendedPath_ThrowsOnNonWindows()
+    {
+        var path = FullPath.FromPath("test") / "a" / "b.txt";
+
+        Assert.Throws<PlatformNotSupportedException>(path.ToWindowsExtendedPath);
+    }
+
+    [Fact]
     [RunIf(TestOperatingSystems.Windows)]
     public void ToWindowsExtendedPath_RegularPath()
     {


### PR DESCRIPTION
`ToWindowsExtendedPath()` returns the path unchanged on non-Windows instead of failing.

## What goes wrong

The method carries `[SupportedOSPlatform("windows")]` but has no runtime check (`src/Meziantou.Framework.FullPath/FullPath.cs:752-766`). It calls `PathInternal.EnsureExtendedPrefix`, whose first branch is `IsPartiallyQualified` (`Interop/Windows.cs:236-237`), and that treats any `/`-rooted Unix path as partially qualified and returns it verbatim.

Verified on macOS:

```csharp
FullPath.FromPath("/tmp/a/b/c.txt").ToWindowsExtendedPath()  // "/tmp/a/b/c.txt"
```

No exception, and the result is not an extended path.

Compare the two sibling platform-gated members: `OpenInExplorer` is annotated the same way but still throws `PlatformNotSupportedException` on an unsupported OS (`FullPath.cs:748`), and `GetKnownFolderPath` fails at the P/Invoke. `ToWindowsExtendedPath` is the only one that silently returns a wrong answer.

CA1416 catches honest call sites, but anything that suppresses it, reflects, or runs on a plain non-OS-specific TFM gets a method named `ToWindowsExtendedPath` returning something that is not one — and a caller using it to get past `MAX_PATH` on a cross-platform code path will believe it worked.

## Change

Throw `PlatformNotSupportedException` when `!OperatingSystem.IsWindows()`, matching `OpenInExplorer`'s own defensive branch, and document it with an `<exception>` tag.

## Verification

`dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 164 passed, 0 failed, 56 skipped.

Added `ToWindowsExtendedPath_ThrowsOnNonWindows`, gated to Linux/macOS, which runs and passes here. All five pre-existing `ToWindowsExtendedPath` tests are already `[RunIf(TestOperatingSystems.Windows)]`, so none of them is affected by the new throw — I checked each one before making the change.

`dotnet run ./eng/update-all.cs` produced no generated-file changes.

## Behavior change

This is technically breaking for anyone calling it on Linux or macOS today, but the value they get back is meaningless, so the failure is strictly more useful than the current silent pass-through.
