### PR TITLE
Avoid a heap array in the variadic Combine overloads

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -486,13 +486,7 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
     }
 
     /// <summary>Combines a <see cref="FullPath"/> with multiple relative paths.</summary>
-    public static FullPath Combine(FullPath rootPath, params string[] paths)
-    {
-        if (rootPath.IsEmpty)
-            return FromPath(Path.Combine(paths));
-
-        return FromPath(Path.Combine(rootPath._value, Path.Combine(paths)));
-    }
+    public static FullPath Combine(FullPath rootPath, params string[] paths) => Combine(rootPath, (ReadOnlySpan<string>)paths);
 
     /// <summary>Combines a <see cref="FullPath"/> with a span of relative paths.</summary>
     public static FullPath Combine(FullPath rootPath, params ReadOnlySpan<string> paths)
@@ -500,7 +494,17 @@ public readonly partial struct FullPath : IEquatable<FullPath>, IComparable<Full
         if (rootPath.IsEmpty)
             return FromPath(Path.Combine(paths));
 
-        return FromPath(Path.Combine([rootPath._value, .. paths]));
+        // A collection expression containing a spread has no compile-time length, so Roslyn cannot use an inline array
+        // and falls back to a heap string[] - the very allocation the span signature exists to avoid. Dispatching the
+        // common lengths to the fixed-arity Path.Combine overloads keeps them array-free.
+        return paths.Length switch
+        {
+            0 => rootPath,
+            1 => FromPath(Path.Combine(rootPath._value, paths[0])),
+            2 => FromPath(Path.Combine(rootPath._value, paths[0], paths[1])),
+            3 => FromPath(Path.Combine(rootPath._value, paths[0], paths[1], paths[2])),
+            _ => FromPath(Path.Combine([rootPath._value, .. paths])),
+        };
     }
 
     /// <summary>Combines a <see cref="FullPath"/> with three relative paths.</summary>


### PR DESCRIPTION
The two variadic `Combine(FullPath, …)` overloads each allocate more than the fixed-arity overload they generalize.

## What goes wrong

**The span overload** (`src/Meziantou.Framework.FullPath/FullPath.cs:498-504`) builds `Path.Combine([rootPath._value, .. paths])`. That collection expression contains a spread, so its length is not known at compile time, Roslyn cannot use an inline array, and it falls back to a real `string[]` on the heap — the exact allocation a `ReadOnlySpan<string>` signature exists to avoid. (Confirmed the built assembly contains no `<>y__InlineArray` type for it.)

**The `params string[]` overload** (`:489-495`) does `Path.Combine(rootPath._value, Path.Combine(paths))` — two combines, so an extra throwaway intermediate string.

## Change

Dispatch the common lengths (0-3) to the fixed-arity `Path.Combine` overloads, which compute the total length and allocate once; keep the collection expression as the fallback for 4+ segments. Route the `params string[]` overload to the span overload so both share one implementation and the double-combine goes away.

## Measurements

net11.0, Release, macOS/arm64, 500k iterations, allocations via `GC.GetAllocatedBytesForCurrentThread`. All rows produce an identical result (asserted in the harness).

| Call | Before | After |
| --- | --- | --- |
| `Combine(root, (ReadOnlySpan<string>)p3)` | 168 B | **112 B** |
| `Combine(root, p3)` (`params string[]`) | 168 B | **112 B** |
| `Combine(root, "src", "lib", "file.txt")` (fixed arity, unchanged) | 112 B | 112 B |
| `Combine(root, (ReadOnlySpan<string>)p5)` — 5 segments, hits the fallback | — | 176 B |

So both variadic overloads now match the fixed-arity cost for up to 3 segments: **a 33% allocation reduction**, and 4+ segments are unchanged.

Times moved from ~96 ns to ~78 ns for the 3-segment span case, but run-to-run variation on this machine is of the same order, so I would treat the allocation numbers as the real result and the timings as directional only. These are `Stopwatch` loops, not BenchmarkDotNet.

## Verification

`dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 162 passed, 0 failed, 56 skipped. No behavior change, so no new tests; `CombinePath_ReadOnlySpan` (`FullPathTests.cs:98-104`) covers the span overload and still passes.

`dotnet run ./eng/update-all.cs` produced no generated-file changes.

## Related, not in this PR

The larger allocation cost in this area is that a `root / "a" / "b" / "c"` chain performs N-1 independent normalizations — measured at ~2.3x the time and ~2.6x the allocations of `FullPath.Combine(root, "a", "b", "c")`, which produces an identical result. `MFFP0004`'s code fix rewrites `Path.Combine` into exactly that chain by default. Changing the code fix to emit the `Combine` overload when there is more than one trailing segment lives in the CodeFix project and is worth its own PR.
