### PR TITLE
Mark Meziantou.Framework.FullPath as trimmable

### DIFF
--- a/src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj
+++ b/src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <IsTrimmable>false</IsTrimmable>
+    <IsTrimmable>true</IsTrimmable>
     <RootNamespace>Meziantou.Framework</RootNamespace>
     <Version>3.0.2</Version>
     <Description>FullPath makes it easier to deal with paths</Description>

--- a/tests/Trimmable/Trimmable.csproj
+++ b/tests/Trimmable/Trimmable.csproj
@@ -32,6 +32,7 @@
     <ProjectReference Include="..\..\src\Meziantou.Framework.DnsClient\Meziantou.Framework.DnsClient.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.Framework.DnsFilter\Meziantou.Framework.DnsFilter.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.Framework.FixedStringBuilder\Meziantou.Framework.FixedStringBuilder.csproj" />
+    <ProjectReference Include="..\..\src\Meziantou.Framework.FullPath\Meziantou.Framework.FullPath.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.Framework.Globbing\Meziantou.Framework.Globbing.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.Framework.Http\Meziantou.Framework.Http.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.Framework.Http.Caching\Meziantou.Framework.Http.Caching.csproj" />
@@ -95,6 +96,7 @@
     <TrimmerRootAssembly Include="Meziantou.Framework.DnsClient" />
     <TrimmerRootAssembly Include="Meziantou.Framework.DnsFilter" />
     <TrimmerRootAssembly Include="Meziantou.Framework.FixedStringBuilder" />
+    <TrimmerRootAssembly Include="Meziantou.Framework.FullPath" />
     <TrimmerRootAssembly Include="Meziantou.Framework.Globbing" />
     <TrimmerRootAssembly Include="Meziantou.Framework.Http" />
     <TrimmerRootAssembly Include="Meziantou.Framework.Http.Caching" />


### PR DESCRIPTION
`IsTrimmable` is `false` on a library that is almost entirely string manipulation, and the project trims clean today.

## Background

`src/Meziantou.Framework.FullPath/Meziantou.Framework.FullPath.csproj:5` has carried `<IsTrimmable>false</IsTrimmable>` since commit `3dd1df5d4` (2022-03-12, *"Add IsTrimmable=true to some projects"*) — this project was the **exception** in a commit that turned trimming on elsewhere. Peer libraries of the same shape (Globbing, Csv, ByteSize, CommandLine) all ship `IsTrimmable=true`.

## Why it is worth flipping

1. Under `TrimMode=partial` the assembly is rooted wholesale rather than trimmed, so a consumer that only uses `FromPath` and `/` still carries the whole 903-line `KnownFolder` static table and the CsWin32 P/Invoke plumbing.
2. More durably: with the property false the project is absent from `tests/Trimmable`, so the trimmer never runs over it. The day someone adds reflection or a `DynamicallyAccessedMembers`-hostile call here, trimmed and Native AOT consumers find out at runtime instead of in CI. This is exactly the kind of leaf dependency AOT apps take.

## Changes

- `Meziantou.Framework.FullPath.csproj` — `IsTrimmable` false → true.
- `tests/Trimmable/Trimmable.csproj` — generated by `dotnet run ./eng/update-all.cs`, which adds the project as both a `ProjectReference` and a `TrimmerRootAssembly`. This is the file that makes the trimmer actually run over the assembly.

## Verification

- **`dotnet publish tests/Trimmable -c Release`** → succeeds with **0 ILLink warnings** (`IL2xxx`/`IL3xxx`), with `PublishTrimmed=true`, `TrimMode=full`, `TrimmerSingleWarn=false` and `Meziantou.Framework.FullPath` rooted. This is the real check: the whole public surface is trimmer-visible and nothing in it is trim-unsafe.
- `dotnet build -c Release -p:IsOfficialBuild=true` → clean, **no diff in `ref/Meziantou.Framework.FullPath.cs`**, so the public API surface is unaffected.
- `dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 162 passed, 0 failed, 56 skipped.
- `dotnet run ./eng/update-all.cs` → clean (this is what produced the `Trimmable.csproj` change above).

A gotcha worth recording: set `IsTrimmable` in the csproj, **not** as a `-p:IsTrimmable=true` global property. As a global property it propagates into the `netstandard2.0` analyzer legs and fails with `NETSDK1212`.

## Correction to the original description

The first version of this PR claimed `update-all` produced no generated-file changes. That was wrong — I had not run it on this branch, and CI's `validate_generated_files` correctly caught it with `WARNING: tests/Trimmable/Trimmable.csproj was not up-to-date`. The second commit fixes that, and the trim-publish result above is a stronger verification than the compile-only check I originally reported.

## Not included

I did not add `IsAotCompatible`. It also enables the AOT analyzer and I have not verified the project under it, so it deserves its own change if you want it.
