### PR TITLE
Document that path comparison is case-insensitive on macOS, iOS and tvOS

### DIFF
--- a/src/Meziantou.Framework.FullPath/FullPath.cs
+++ b/src/Meziantou.Framework.FullPath/FullPath.cs
@@ -14,7 +14,7 @@ namespace Meziantou.Framework;
 /// FullPath rootPath = FullPath.FromPath("demo");
 /// FullPath filePath = rootPath / "temp" / "file.txt";
 ///
-/// // Compare paths (case-sensitive on Linux, case-insensitive on Windows)
+/// // Compare paths (case-insensitive on Windows, macOS, iOS and tvOS, case-sensitive elsewhere)
 /// bool areEqual = filePath == rootPath;
 ///
 /// // Get relative path

--- a/src/Meziantou.Framework.FullPath/FullPathComparer.cs
+++ b/src/Meziantou.Framework.FullPath/FullPathComparer.cs
@@ -3,7 +3,7 @@ namespace Meziantou.Framework;
 /// <summary>Provides comparison and equality operations for <see cref="FullPath"/> values.</summary>
 public sealed class FullPathComparer : IComparer<FullPath>, IEqualityComparer<FullPath>
 {
-    /// <summary>Gets the default comparer for the current operating system (case-insensitive on Windows/macOS, case-sensitive on Linux).</summary>
+    /// <summary>Gets the default comparer for the current operating system (case-insensitive on Windows, macOS, iOS and tvOS, case-sensitive elsewhere).</summary>
     public static FullPathComparer Default { get; }
 
     /// <summary>Gets a case-sensitive comparer.</summary>

--- a/src/Meziantou.Framework.FullPath/readme.md
+++ b/src/Meziantou.Framework.FullPath/readme.md
@@ -15,7 +15,7 @@ FullPath filePath1 = rootPath / "temp" / "meziantou.txt";
 FullPath backupFilePath = filePath1 + ".bak";
 
 // Compare path
-// Comparisons are case-insensitive on Windows and case-sensitive on other operating systems by default
+// Comparisons are case-insensitive on Windows, macOS, iOS and tvOS, and case-sensitive elsewhere by default
 _ = filePath == rootPath;
 _ = filePath.Equals(rootPath, ignoreCase: false);
 


### PR DESCRIPTION
The package README states the opposite of what the comparer does on macOS.

## What is wrong

`src/Meziantou.Framework.FullPath/readme.md:18` says:

> Comparisons are case-insensitive on Windows and case-sensitive on other operating systems by default

But `FullPathComparer.IsCaseInsensitiveOperatingSystem` (`FullPathComparer.cs:52-57`) returns true for Windows **and macOS, iOS and tvOS**:

```csharp
return OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS();
```

Verified on macOS: `FullPathComparer.Default.IsCaseSensitive` is `False`, and `FullPath.FromPath("/a/File.txt") == FullPath.FromPath("/a/file.txt")` is `True`.

This is the NuGet package description page — the first and often the only documentation a consumer reads. A macOS or iOS developer following it will write a de-duplication or containment check on the assumption that `/Users/x/Secret` and `/users/x/secret` compare unequal, and get the opposite.

## Change

Documentation only, three places, all now matching `FullPathComparer.cs:52-57`:

- `readme.md:18` — the sentence above.
- `FullPathComparer.cs:6` — the XML doc on `Default` had macOS right but omitted iOS and tvOS.
- `FullPath.cs:17` — the type-level `<example>` said only "case-sensitive on Linux, case-insensitive on Windows", which was incomplete rather than wrong.

No code change.

## Verification

`dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 162 passed, 0 failed, 56 skipped.
`dotnet run ./eng/update-all.cs` produced no generated-file changes (the analyzer-rules table in the README is between the generated markers and is untouched by this edit).

## Related

`FullPathComparer` has no tests at all — `grep -c FullPathComparer` and `grep -c ignoreCase` both return 0 across the test project — so the behavior this documents is unverified in CI. That is worth its own PR; inverting the ternary at `FullPathComparer.cs:24` or `:30` would not fail a single test today.
