### PR TITLE
Attribute the vendored dotnet/runtime code

### DIFF
--- a/src/Meziantou.Framework.FullPath/Interop/Windows.cs
+++ b/src/Meziantou.Framework.FullPath/Interop/Windows.cs
@@ -143,6 +143,10 @@ namespace Meziantou.Framework
 }
 namespace System.IO
 {
+    // Adapted from dotnet/runtime, licensed to the .NET Foundation under one or more agreements.
+    // The .NET Foundation licenses this file to you under the MIT license.
+    // Source: https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/IO/PathInternal.Windows.cs
+    // Only the members this project needs were kept; the rest of the upstream type was dropped.
     internal static partial class PathInternal
     {
         // All paths in Win32 ultimately end up becoming a path to a File object in the Windows object manager. Passed in paths get mapped through

--- a/src/Meziantou.Framework.FullPath/Symlink.cs
+++ b/src/Meziantou.Framework.FullPath/Symlink.cs
@@ -128,6 +128,9 @@ internal static partial class Symlink
             return false;
         }
 
+        // Adapted from dotnet/runtime's reparse point reader, licensed to the .NET Foundation under one or more
+        // agreements. The .NET Foundation licenses this file to you under the MIT license.
+        // Source: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
         internal static string GetSingleSymbolicLinkTarget(string path)
         {
             using var handle =


### PR DESCRIPTION
Two regions of this project are copied from dotnet/runtime and carry no attribution or license notice.

## What is vendored

- `src/Meziantou.Framework.FullPath/Interop/Windows.cs:144-322` declares `internal static partial class PathInternal` inside `namespace System.IO`. The code, the comments and the doc-comment wording are dotnet/runtime's `Common/src/System/IO/PathInternal.Windows.cs`.
- `src/Meziantou.Framework.FullPath/Symlink.cs:131-223` (`GetSingleSymbolicLinkTarget`) is derived from runtime's reparse-point reading code, down to the *"we only care about SubstituteName"* comment and the ms-fscc documentation link.

Neither carries the `Licensed to the .NET Foundation under one or more agreements` header or a source URL. `LICENSE.txt` here is MIT `Copyright (c) Gérald Barré`; dotnet/runtime is MIT under the .NET Foundation, and MIT requires the original copyright notice to be retained in substantial portions — so the package as shipped is technically out of compliance.

The repo's own convention is the opposite: `FullPathComparer.cs:49` cites the exact upstream file **and commit** it borrowed from. These two regions are the outliers.

## Change

Documentation comments only, no code change: added the .NET Foundation MIT notice and the upstream file path to both regions, plus a note that only the needed members were kept.

## What I could not do, and why it matters more than the header

**I did not pin a commit SHA, because I do not know which revision these copies were taken from and I did not want to invent one.** That pin is the part with real ongoing value — without it there is no way to diff against upstream when the BCL fixes a path-handling bug, so this copy silently diverges. If you know the revision (or are willing to bisect it), replacing the `/blob/main/` links with `/blob/<sha>/` ones would match what `FullPathComparer.cs:49` already does and make a future sync mechanical. I also did not diff the copies against current upstream, so I cannot say how far they have already drifted.

## On the duplicate-type risk

Worth recording since declaring a type in `namespace System.IO` looks alarming: I checked and it is currently harmless. `grep -rl "class PathInternal"` and `grep -rl "namespace System.IO"` across `src/`, `tests/`, `common/`, `benchmarks/` and `tools/` show this is the only project that vendors it, and `common/AssemblyInfo.cs` declares no `InternalsVisibleTo`. So there is no `CS0433` ambiguity today, and there will not be as long as the type stays `internal` and no `InternalsVisibleTo` is added between two vendoring assemblies.

## Verification

`dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 162 passed, 0 failed, 56 skipped.
`dotnet run ./eng/update-all.cs` produced no generated-file changes.
