### PR TITLE
Add tests for FullPathComparer and the ignoreCase overloads

### DIFF
--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -199,6 +199,83 @@ public sealed class FullPathTests
     }
 
     [Fact]
+    public void FullPathComparer_CaseSensitive()
+    {
+        var lower = FullPath.FromPath("test") / "a.txt";
+        var upper = FullPath.FromPath("test") / "A.TXT";
+
+        Assert.True(FullPathComparer.CaseSensitive.IsCaseSensitive);
+        Assert.False(FullPathComparer.CaseSensitive.Equals(lower, upper));
+        Assert.NotEqual(0, FullPathComparer.CaseSensitive.Compare(lower, upper));
+    }
+
+    [Fact]
+    public void FullPathComparer_CaseInsensitive()
+    {
+        var lower = FullPath.FromPath("test") / "a.txt";
+        var upper = FullPath.FromPath("test") / "A.TXT";
+
+        Assert.False(FullPathComparer.CaseInsensitive.IsCaseSensitive);
+        Assert.True(FullPathComparer.CaseInsensitive.Equals(lower, upper));
+        Assert.Equal(0, FullPathComparer.CaseInsensitive.Compare(lower, upper));
+        Assert.Equal(FullPathComparer.CaseInsensitive.GetHashCode(lower), FullPathComparer.CaseInsensitive.GetHashCode(upper));
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Windows | TestOperatingSystems.MacOS)]
+    public void FullPathComparer_DefaultIgnoresCaseOnWindowsAndMacOS()
+    {
+        // Compared through the comparer rather than Assert.Equal: FullPath converts implicitly to string, so
+        // Assert.Equal would bind to the string overload and compare ordinally instead of using FullPath equality.
+        Assert.False(FullPathComparer.Default.IsCaseSensitive);
+        Assert.True(FullPathComparer.Default.Equals(FullPath.FromPath("test") / "a.txt", FullPath.FromPath("test") / "A.TXT"));
+        Assert.True((FullPath.FromPath("test") / "a.txt") == (FullPath.FromPath("test") / "A.TXT"));
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Linux)]
+    public void FullPathComparer_DefaultIsCaseSensitiveOnLinux()
+    {
+        Assert.True(FullPathComparer.Default.IsCaseSensitive);
+        Assert.False(FullPathComparer.Default.Equals(FullPath.FromPath("test") / "a.txt", FullPath.FromPath("test") / "A.TXT"));
+        Assert.False((FullPath.FromPath("test") / "a.txt") == (FullPath.FromPath("test") / "A.TXT"));
+    }
+
+    [Fact]
+    public void FullPathComparer_Compare()
+    {
+        var a = FullPath.FromPath("test") / "a.txt";
+        var b = FullPath.FromPath("test") / "b.txt";
+
+        Assert.True(FullPathComparer.CaseSensitive.Compare(a, b) < 0);
+        Assert.True(FullPathComparer.CaseSensitive.Compare(b, a) > 0);
+        Assert.Equal(0, FullPathComparer.CaseSensitive.Compare(a, a));
+    }
+
+    [Fact]
+    public void FullPathComparer_Empty()
+    {
+        Assert.Equal(0, FullPathComparer.Default.GetHashCode(FullPath.Empty));
+        Assert.Equal(0, FullPathComparer.CaseSensitive.GetHashCode(FullPath.Empty));
+        Assert.Equal(0, FullPathComparer.CaseInsensitive.GetHashCode(FullPath.Empty));
+        Assert.True(FullPathComparer.Default.Equals(FullPath.Empty, FullPath.Empty));
+        Assert.False(FullPathComparer.Default.Equals(FullPath.Empty, FullPath.FromPath("test")));
+    }
+
+    [Fact]
+    public void EqualsAndCompareTo_IgnoreCase()
+    {
+        var lower = FullPath.FromPath("test") / "a.txt";
+        var upper = FullPath.FromPath("test") / "A.TXT";
+
+        Assert.True(lower.Equals(upper, ignoreCase: true));
+        Assert.False(lower.Equals(upper, ignoreCase: false));
+        Assert.Equal(lower.GetHashCode(ignoreCase: true), upper.GetHashCode(ignoreCase: true));
+        Assert.Equal(0, lower.CompareTo(upper, ignoreCase: true));
+        Assert.NotEqual(0, lower.CompareTo(upper, ignoreCase: false));
+    }
+
+    [Fact]
     [RunIf(TestOperatingSystems.Windows)]
     public void FromPath_ExtendedPrefixIsRemovedOnWindows()
     {


### PR DESCRIPTION
`FullPathComparer` and every `ignoreCase` overload had no tests at all.

## The gap

`grep -c FullPathComparer` and `grep -c ignoreCase` both returned **0** across the test project. That left untested:

- the entire public surface of `FullPathComparer`: `Default`, `CaseSensitive`, `CaseInsensitive`, `IsCaseSensitive`, `Compare`, `Equals`, `GetHashCode`
- `FullPath.Equals(FullPath, bool)` (`FullPath.cs:192`), `CompareTo(FullPath, bool)` (`:175`), `GetHashCode(bool)` (`:197`)

Inverting the ternary in `GetComparer` (`FullPathComparer.cs:24`) or in the constructor (`:30`) would not fail a single test today. A silent case-sensitivity inversion is a security-relevant class of bug for path containment checks, and an `Equals`/`GetHashCode` disagreement corrupts hash containers — neither had any coverage.

## Added

Seven tests in `FullPathTests.cs`, next to the existing equality tests:

- `FullPathComparer_CaseSensitive` / `FullPathComparer_CaseInsensitive` — each comparer's `IsCaseSensitive`, `Equals`, `Compare`, and `GetHashCode` agreement
- `FullPathComparer_DefaultIgnoresCaseOnWindowsAndMacOS` / `FullPathComparer_DefaultIsCaseSensitiveOnLinux` — the **concrete** per-OS outcome rather than a self-referential check
- `FullPathComparer_Compare` — ordering and sign symmetry
- `FullPathComparer_Empty` — `GetHashCode(Empty)` is 0 for all three comparers, and `Equals` handles empty
- `EqualsAndCompareTo_IgnoreCase` — all three `ignoreCase` overloads

## Something worth knowing that came out of writing these

My first version used `Assert.Equal(pathA, pathB)` and **failed on macOS**, where the two should compare equal. The reason is that `FullPath` has an implicit conversion to `string`, so `Assert.Equal(FullPath, FullPath)` binds to `Meziantou.Framework.Assertions.Assert.Equal(string, string)` and compares **ordinally** — it never uses `FullPath` equality at all.

The new tests therefore assert through `FullPathComparer.Default.Equals(...)` and the `==` operator explicitly, with a comment saying why.

This has a wider implication worth a look: the existing `Assert.Equal(FullPath, FullPath)` calls throughout this file are all string comparisons, not `FullPath` comparisons. They pass because the values happen to be string-identical, but they are not testing the equality semantics they appear to test — and `MFFP0015` ("Compare FullPath values instead of their string representation") exists precisely for this shape of mistake. Auditing those is out of scope here but may be worth its own pass.

## Verification

`dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 174 passed, 0 failed, 58 skipped (up from 162 passed).
`dotnet run ./eng/update-all.cs` produced no generated-file changes.
