### PR TITLE
Cover every Combine overload and the empty-root fallbacks

### DIFF
--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -103,6 +103,49 @@ public sealed class FullPathTests
         Assert.Equal(expected, actual);
     }
 
+    [Fact]
+    public void Combine_AllOverloadsAgree()
+    {
+        var root = FullPath.FromPath("test");
+        var expected = root / "a" / "b" / "c";
+        string[] parts = ["a", "b", "c"];
+        string[] rootedParts = ["test", "a", "b", "c"];
+
+        Assert.Equal(expected, FullPath.Combine("test", "a", "b", "c"));
+        Assert.Equal(expected, FullPath.Combine(rootedParts));
+        Assert.Equal(expected, FullPath.Combine((ReadOnlySpan<string>)rootedParts));
+        Assert.Equal(expected, FullPath.Combine(root, "a", "b", "c"));
+        Assert.Equal(expected, FullPath.Combine(root, parts));
+        Assert.Equal(expected, FullPath.Combine(root, (ReadOnlySpan<string>)parts));
+    }
+
+    [Fact]
+    public void Combine_ShorterOverloadsAgree()
+    {
+        var root = FullPath.FromPath("test");
+
+        Assert.Equal(root / "a", FullPath.Combine("test", "a"));
+        Assert.Equal(root / "a", FullPath.Combine(root, "a"));
+        Assert.Equal(root / "a" / "b", FullPath.Combine("test", "a", "b"));
+        Assert.Equal(root / "a" / "b", FullPath.Combine(root, "a", "b"));
+    }
+
+    [Fact]
+    public void Combine_EmptyRootResolvesAgainstTheCurrentDirectory()
+    {
+        // Documents current behaviour: every FullPath-rooted overload falls back to FromPath, which resolves a
+        // relative path against Environment.CurrentDirectory rather than propagating Empty or throwing.
+        var cwd = FullPath.CurrentDirectory();
+        string[] parts = ["a", "b"];
+
+        Assert.Equal(cwd / "a", FullPath.Combine(FullPath.Empty, "a"));
+        Assert.Equal(cwd / "a" / "b", FullPath.Combine(FullPath.Empty, "a", "b"));
+        Assert.Equal(cwd / "a" / "b" / "c", FullPath.Combine(FullPath.Empty, "a", "b", "c"));
+        Assert.Equal(cwd / "a" / "b", FullPath.Combine(FullPath.Empty, parts));
+        Assert.Equal(cwd / "a" / "b", FullPath.Combine(FullPath.Empty, (ReadOnlySpan<string>)parts));
+        Assert.Equal(cwd / "a", FullPath.Empty / "a");
+    }
+
     [Theory]
     [InlineData("a", "a")]
     [InlineData("a b", "a b")]


### PR DESCRIPTION
Only 3 of the 11 `Combine` overloads were exercised, and no test passed `FullPath.Empty` as the root.

## The gap

The only `FullPath.Combine` call sites in the suite were `FullPathTests.cs:94`, `:102`, `:118` and `:138`. Untested:

`Combine(string,string,string,string)`, `Combine(params string[])`, `Combine(params ReadOnlySpan<string>)`, `Combine(FullPath,string,string)`, `Combine(FullPath,params string[])`, `Combine(FullPath,string,string,string)`, and `Combine(FullPath,string)` (the one behind `operator /`).

More importantly, each `FullPath`-rooted overload has its **own** `if (rootPath.IsEmpty)` fallback (`FullPath.cs:471-513`) and not one of those seven branches was ever executed. They are the branches most likely to be wrong, since each re-derives the combine differently, and `Empty` is exactly what a default-initialised field or a `""` JSON value carries.

## Added

Three tests, next to the existing `CombinePath` tests:

- `Combine_AllOverloadsAgree` — drives six spellings of the same 3-segment combine and asserts they produce an identical result.
- `Combine_ShorterOverloadsAgree` — the 1- and 2-segment forms, string-rooted and `FullPath`-rooted.
- `Combine_EmptyRootResolvesAgainstTheCurrentDirectory` — every empty-root fallback, plus `FullPath.Empty / "a"`.

## A note on the third test

It **documents current behaviour rather than endorsing it**. `FullPath.Empty / "config.json"` returns `<cwd>/config.json`, because the empty-root fallback calls `FromPath`, which resolves a relative path against `Environment.CurrentDirectory`.

That is worth being deliberate about: every other member treats empty as either "propagate empty" (`WithName`, `WithExtension` return `Empty`) or "fail loudly" (`IsChildOf`, `MakePathRelativeTo` throw). The `Combine` family is the only one that invents a root, it is undocumented, and it is the family `MFFP0004` pushes hardest. If you decide it should propagate `Empty` or throw instead, this test is the single place that records the change — which is the point of pinning it. I have deliberately not changed the behaviour here.

## Verification

`dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 168 passed, 0 failed, 56 skipped (up from 162).
`dotnet run ./eng/update-all.cs` produced no generated-file changes.

These assertions hold both on `main` and against the `Combine` allocation change in the sibling PR "Avoid a heap array in the variadic Combine overloads" — I verified the two produce identical results before opening either.
