### PR TITLE
Cover TryFindFirstAncestor and pin IsChildOf case sensitivity per OS

### DIFF
--- a/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
+++ b/tests/Meziantou.Framework.FullPath.Tests/FullPathTests.cs
@@ -165,12 +165,23 @@ public sealed class FullPathTests
     }
 
     [Fact]
-    public void IsChildOf_UsesTheSameCaseSensitivityAsTheDefaultComparer()
+    [RunIf(TestOperatingSystems.Windows | TestOperatingSystems.MacOS)]
+    public void IsChildOf_IgnoresCaseOnWindowsAndMacOS()
     {
         var rootPath = FullPath.FromPath("test");
         var childPath = FullPath.FromPath("TEST") / "a.txt";
 
-        Assert.Equal(childPath.Parent == rootPath, childPath.IsChildOf(rootPath));
+        Assert.True(childPath.IsChildOf(rootPath));
+    }
+
+    [Fact]
+    [RunIf(TestOperatingSystems.Linux)]
+    public void IsChildOf_IsCaseSensitiveOnLinux()
+    {
+        var rootPath = FullPath.FromPath("test");
+        var childPath = FullPath.FromPath("TEST") / "a.txt";
+
+        Assert.False(childPath.IsChildOf(rootPath));
     }
 
     [Theory]
@@ -578,6 +589,32 @@ public sealed class FullPathTests
 
         Assert.True(subDir.TryFindFirstAncestorOrSelf(p => File.Exists(p / fileName), out var result));
         Assert.Equal(tempDir.FullPath, result);
+    }
+
+    [Fact]
+    public async Task TryFindFirstAncestor_ExcludesSelf()
+    {
+        await using var tempDir = TemporaryDirectory.Create();
+        var fileName = Guid.NewGuid().ToString("N");
+        tempDir.CreateEmptyFile(fileName);
+        var subDir = tempDir.CreateDirectory("a");
+
+        // The predicate matches the starting directory itself, which is the only thing that distinguishes the two
+        Assert.True(tempDir.FullPath.TryFindFirstAncestorOrSelf(p => File.Exists(p / fileName), out var withSelf));
+        Assert.Equal(tempDir.FullPath, withSelf);
+        Assert.False(tempDir.FullPath.TryFindFirstAncestor(p => File.Exists(p / fileName), out _));
+
+        Assert.True(subDir.TryFindFirstAncestor(p => File.Exists(p / fileName), out var fromChild));
+        Assert.Equal(tempDir.FullPath, fromChild);
+    }
+
+    [Fact]
+    public async Task TryFindFirstAncestor_NoMatch()
+    {
+        await using var tempDir = TemporaryDirectory.Create();
+
+        Assert.False(tempDir.FullPath.TryFindFirstAncestor(p => false, out var result));
+        Assert.True(result.IsEmpty);
     }
 
     [Fact]


### PR DESCRIPTION
Two related gaps in ancestor-walk and containment coverage.

## 1. `TryFindFirstAncestor` had no tests at all

`grep -n 'TryFindFirstAncestor('` returned **0** hits — all six textual matches in the suite were `TryFindFirstAncestorOrSelf`.

The two methods differ only in the `Parent.` prefix on `FullPath.cs:617`, and that exclude-self semantics is the entire reason the method exists ("find the nearest *enclosing* X, not X itself"). Dropping the `Parent.` would silently change results for every self-exclusion lookup, and nothing would notice.

Added `TryFindFirstAncestor_ExcludesSelf`, which puts the predicate's match on the starting directory itself — the only condition that distinguishes the two methods — and asserts they disagree, plus `TryFindFirstAncestor_NoMatch` for the false/`Empty` path.

## 2. The `IsChildOf` case-sensitivity test could not fail

`IsChildOf_UsesTheSameCaseSensitivityAsTheDefaultComparer` (`FullPathTests.cs:167-174`) asserted:

```csharp
Assert.Equal(childPath.Parent == rootPath, childPath.IsChildOf(rootPath));
```

Both sides read `FullPathComparer.Default` — `operator ==` goes to `Default.Equals`, and `IsChildOf` reads `Default.IsCaseSensitive` (`FullPath.cs:230`). If `Default` flipped on any OS, **both sides flip together and the assertion still holds**. It could only fail if `IsChildOf` used a different comparer, and it never stated what the answer should be on any platform.

This was the only test guarding the case-sensitivity of a containment check — the classic place a path-traversal check goes wrong.

Replaced with two tests that assert the concrete outcome: `IsChildOf_IgnoresCaseOnWindowsAndMacOS` and `IsChildOf_IsCaseSensitiveOnLinux`. Between them every CI platform is covered, and each now pins a real answer rather than an internal consistency property.

## Verification

`dotnet test -c Debug /p:TreatsWarningsAsErrors=true` → 166 passed, 0 failed, 58 skipped (up from 162 passed).

The two replacement `IsChildOf` tests are OS-gated, so on this macOS machine the Windows/macOS one runs and the Linux one is skipped; CI covers the other side. No test was disabled or commented out — the tautological one is replaced by strictly stronger assertions.

`dotnet run ./eng/update-all.cs` produced no generated-file changes.
