### PR TITLE
Reject empty prerelease and metadata identifiers when parsing a semantic version

### DIFF
--- a/src/Meziantou.Framework.Versioning/SemanticVersion.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersion.cs
@@ -63,17 +63,19 @@ public sealed class SemanticVersion : IFormattable, IComparable, IComparable<Sem
         if (prereleaseLabel is not null)
         {
             var index = 0;
-            PrereleaseLabels = ReadPrereleaseIdentifiers(prereleaseLabel.AsSpan(), ref index);
-            if (index != prereleaseLabel.Length)
+            if (!TryReadPrereleaseIdentifiers(prereleaseLabel.AsSpan(), ref index, out var labels) || index != prereleaseLabel.Length)
                 throw new ArgumentException("Value is not valid", nameof(prereleaseLabel));
+
+            PrereleaseLabels = labels;
         }
 
         if (metadata is not null)
         {
             var index = 0;
-            Metadata = TryReadMetadataIdentifiers(metadata.AsSpan(), ref index);
-            if (index != metadata.Length)
+            if (!TryReadMetadataIdentifiers(metadata.AsSpan(), ref index, out var labels) || index != metadata.Length)
                 throw new ArgumentException("Value is not valid", nameof(metadata));
+
+            Metadata = labels;
         }
     }
 
@@ -284,14 +286,20 @@ public sealed class SemanticVersion : IFormattable, IComparable, IComparable<Sem
         if (!TryReadNumber(versionString, ref index, out var patch))
             return false;
 
-        if (!TryReadPrerelease(versionString, ref index, out var prereleaseLabels))
+        IReadOnlyList<string>? prereleaseLabels = null;
+        if (index < versionString.Length && versionString[index] == '-')
         {
-            prereleaseLabels = null;
+            index++;
+            if (!TryReadPrereleaseIdentifiers(versionString, ref index, out prereleaseLabels))
+                return false;
         }
 
-        if (!TryReadMetadata(versionString, ref index, out var metadata))
+        IReadOnlyList<string>? metadata = null;
+        if (index < versionString.Length && versionString[index] == '+')
         {
-            metadata = null;
+            index++;
+            if (!TryReadMetadataIdentifiers(versionString, ref index, out metadata))
+                return false;
         }
 
         // Should be at the end of the string
@@ -325,76 +333,53 @@ public sealed class SemanticVersion : IFormattable, IComparable, IComparable<Sem
         return false;
     }
 
-    private static bool TryReadPrerelease(ReadOnlySpan<char> versionString, ref int index, [NotNullWhen(returnValue: true)] out IReadOnlyList<string>? labels)
-    {
-        if (index < versionString.Length && versionString[index] == '-')
-        {
-            index++;
-
-            labels = ReadPrereleaseIdentifiers(versionString, ref index);
-            return true;
-        }
-
-        labels = null;
-        return false;
-    }
-
-    private static IReadOnlyList<string> ReadPrereleaseIdentifiers(ReadOnlySpan<char> versionString, ref int index)
+    // A prerelease or metadata section is one or more dot-separated identifiers, and every one of
+    // them must be non-empty. Returns false on an empty section ("1.2.3-") or an empty identifier
+    // ("1.2.3-alpha." / "1.2.3-alpha..beta") rather than silently skipping it.
+    private static bool TryReadPrereleaseIdentifiers(ReadOnlySpan<char> versionString, ref int index, [NotNullWhen(returnValue: true)] out IReadOnlyList<string>? labels)
     {
         ReadOnlyList<string>? result = null;
         while (true)
         {
-            if (TryReadPrereleaseIdentifier(versionString, ref index, out var label))
+            if (!TryReadPrereleaseIdentifier(versionString, ref index, out var label))
             {
-                result ??= [];
-                result.Add(label);
+                labels = null;
+                return false;
             }
+
+            result ??= [];
+            result.Add(label);
 
             if (!TryReadDot(versionString, ref index))
                 break;
         }
 
-        if (result is null)
-            return EmptyArray;
-
         result.Freeze();
-        return result;
+        labels = result;
+        return true;
     }
 
-    private static bool TryReadMetadata(ReadOnlySpan<char> versionString, ref int index, [NotNullWhen(returnValue: true)] out IReadOnlyList<string>? labels)
-    {
-        if (index < versionString.Length && versionString[index] == '+')
-        {
-            index++;
-
-            labels = TryReadMetadataIdentifiers(versionString, ref index);
-            return true;
-        }
-
-        labels = null;
-        return false;
-    }
-
-    private static IReadOnlyList<string> TryReadMetadataIdentifiers(ReadOnlySpan<char> versionString, ref int index)
+    private static bool TryReadMetadataIdentifiers(ReadOnlySpan<char> versionString, ref int index, [NotNullWhen(returnValue: true)] out IReadOnlyList<string>? labels)
     {
         ReadOnlyList<string>? result = null;
         while (true)
         {
-            if (TryReadMetadataIdentifier(versionString, ref index, out var label))
+            if (!TryReadMetadataIdentifier(versionString, ref index, out var label))
             {
-                result ??= [];
-                result.Add(label);
+                labels = null;
+                return false;
             }
+
+            result ??= [];
+            result.Add(label);
 
             if (!TryReadDot(versionString, ref index))
                 break;
         }
 
-        if (result is null)
-            return EmptyArray;
-
         result.Freeze();
-        return result;
+        labels = result;
+        return true;
     }
 
     private static bool IsPrereleaseIdentifier(ReadOnlySpan<char> label)

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
@@ -34,6 +34,15 @@ public class SemanticVersionTests
     [InlineData("1.0.0-01")] // No leading 0
     [InlineData("1.0.0-beta.01")] // No leading 0
     [InlineData("1.0.0+é")] // Invalid character
+    [InlineData("1.2.3-")] // Prerelease section must contain at least one identifier
+    [InlineData("1.2.3-.")] // Prerelease identifiers must not be empty
+    [InlineData("1.2.3-alpha.")] // Trailing dot leaves an empty identifier
+    [InlineData("1.2.3-alpha..beta")] // Empty identifier between two dots
+    [InlineData("1.2.3+")] // Metadata section must contain at least one identifier
+    [InlineData("1.2.3+build.")] // Trailing dot leaves an empty identifier
+    [InlineData("1.2.3+a..b")] // Empty identifier between two dots
+    [InlineData("1.2.3+.-")] // Metadata identifiers must not be empty
+    [InlineData("1.2.3-alpha.+build")] // Empty prerelease identifier before the metadata section
     public void TryParse_ShouldNotParseVersion(string version)
     {
         Assert.False(SemanticVersion.TryParse(version, out _));
@@ -151,6 +160,27 @@ public class SemanticVersionTests
         Assert.Throws<ArgumentException>(() => new SemanticVersion(1, 2, 3, prereleaseLabel: [""], metadata: null));
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData(".")]
+    [InlineData("alpha.")]
+    [InlineData("alpha..beta")]
+    public void Constructor_WithInvalidPrereleaseString_ShouldThrowException(string prereleaseLabel)
+    {
+        Assert.Throws<ArgumentException>(() => new SemanticVersion(1, 2, 3, prereleaseLabel));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(".")]
+    [InlineData("build.")]
+    [InlineData("a..b")]
+    [InlineData("label./")]
+    public void Constructor_WithInvalidMetadataString_ShouldThrowException(string metadata)
+    {
+        Assert.Throws<ArgumentException>(() => new SemanticVersion(1, 2, 3, prereleaseLabel: null, metadata));
+    }
+
     [Fact]
     public void Constructor_WithEmptyMetadata_ShouldThrowException()
     {
@@ -161,12 +191,6 @@ public class SemanticVersionTests
     public void Constructor_WithInvalidMetadata_ShouldThrowException()
     {
         Assert.Throws<ArgumentException>(() => new SemanticVersion(1, 2, 3, prereleaseLabel: null, metadata: ["/"]));
-    }
-
-    [Fact]
-    public void Constructor_WithInvalidMetadataString_ShouldThrowException()
-    {
-        Assert.Throws<ArgumentException>(() => new SemanticVersion(1, 2, 3, prereleaseLabel: null, metadata: "label./"));
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`SemanticVersion.TryParse` accepts prerelease and metadata sections that Semantic Versioning 2.0.0 forbids, and silently rewrites them into a *different* version.

`ReadPrereleaseIdentifiers` (`SemanticVersion.cs:342-362`) and `TryReadMetadataIdentifiers` (`:378-398`) treated "no identifier here" as a non-event: when the identifier reader failed they simply didn't append, then carried on if a `.` followed. Nothing asserted that at least one identifier appeared after `-`/`+`, or that identifiers were non-empty. The spec requires one-or-more dot-separated non-empty identifiers in both positions.

Before this change:

```
Parse("1.2.3-")            => 1.2.3
Parse("1.2.3-.")           => 1.2.3
Parse("1.2.3-alpha.")      => 1.2.3-alpha
Parse("1.2.3-alpha..beta") => 1.2.3-alpha.beta
Parse("1.2.3+")            => 1.2.3
Parse("1.2.3+a..b")        => 1.2.3+a.b
Parse("1.2.3+.-")          => 1.2.3+-
```

So `Parse(s).ToString() != s`, and `"1.2.3-alpha."` compared equal to `"1.2.3-alpha"` even though the former is not a version at all. Callers using `TryParse` as a validator let malformed strings through, and both `SemanticVersionRange` parsers inherit the leniency because they delegate here.

The same leniency reached the public constructor: `new SemanticVersion(1, 0, 0, "")` was accepted and `new SemanticVersion(1, 0, 0, "alpha.")` was silently truncated to `alpha`, while the `IEnumerable<string>` overload correctly threw for the equivalent input. Two overloads of the same constructor disagreed on what is valid.

## What changed

`ReadPrereleaseIdentifiers`/`TryReadMetadataIdentifiers` become `TryReadPrereleaseIdentifiers`/`TryReadMetadataIdentifiers` returning `bool`: they fail on the first empty identifier and require at least one. `TryParse` now checks for the `-`/`+` marker inline and propagates failure, which makes the `TryReadPrerelease`/`TryReadMetadata` wrappers redundant — they're removed.

The string constructor overload routes through the same reader, so it now rejects `""`, `"."`, `"alpha."` and `"alpha..beta"`, matching what the `IEnumerable<string>` overload has always done.

**This is a behavioral break** for callers currently relying on the lenient parse, which is the point — but it's worth a package version bump when this batch lands.

## Verification

`dotnet test tests/Meziantou.Framework.Versioning.Tests /p:TreatsWarningsAsErrors=true` — 344 passing (172 × 2 TFMs), up from 310. New cases cover all seven malformed strings above plus the constructor overload; no existing test changed behavior. The pre-existing single-case `Constructor_WithInvalidMetadataString_ShouldThrowException` fact was folded into the new theory rather than left as a name-colliding overload.

`dotnet run ./eng/update-all.cs` — no generated-file changes.
