### PR TITLE
Stop single-character glob segments from reading past the end of a path segment

### DIFF
--- a/src/Meziantou.Framework.Globbing/Internals/PathReader.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/PathReader.cs
@@ -230,7 +230,7 @@ internal ref struct PathReader
 
     public readonly bool IsPathSeparator()
     {
-        if (!_pathSeparatorAware)
+        if (!_pathSeparatorAware || CurrentText.IsEmpty)
             return false;
 
         var c = CurrentText[0];

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterRangeIgnoreCaseInverseSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterRangeIgnoreCaseInverseSegment.cs
@@ -18,6 +18,9 @@ internal sealed class CharacterRangeIgnoreCaseInverseSegment : Segment
 
     public override bool IsMatch(ref PathReader pathReader)
     {
+        if (pathReader.IsEndOfCurrentSegment)
+            return false;
+
         var c = pathReader.CurrentText[0];
         if (CharacterRangeSegment.IsAsciiUpper(c))
         {

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterRangeIgnoreCaseSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterRangeIgnoreCaseSegment.cs
@@ -18,6 +18,9 @@ internal sealed class CharacterRangeIgnoreCaseSegment : Segment
 
     public override bool IsMatch(ref PathReader pathReader)
     {
+        if (pathReader.IsEndOfCurrentSegment)
+            return false;
+
         var c = pathReader.CurrentText[0];
         if (CharacterRangeSegment.IsAsciiUpper(c))
         {

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterRangeInverseSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterRangeInverseSegment.cs
@@ -11,6 +11,9 @@ internal sealed class CharacterRangeInverseSegment : Segment
 
     public override bool IsMatch(ref PathReader pathReader)
     {
+        if (pathReader.IsEndOfCurrentSegment)
+            return false;
+
         var result = !_range.IsInRange(pathReader.CurrentText[0]);
         if (result)
         {

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterRangeSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterRangeSegment.cs
@@ -16,6 +16,9 @@ internal sealed class CharacterRangeSegment : Segment
 
     public override bool IsMatch(ref PathReader pathReader)
     {
+        if (pathReader.IsEndOfCurrentSegment)
+            return false;
+
         var result = Range.IsInRange(pathReader.CurrentText[0]);
         if (result)
         {

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterSetInverseSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterSetInverseSegment.cs
@@ -14,6 +14,9 @@ internal sealed class CharacterSetInverseSegment : Segment
 
     public override bool IsMatch(ref PathReader pathReader)
     {
+        if (pathReader.IsEndOfCurrentSegment)
+            return false;
+
         var c = pathReader.CurrentText[0];
         var result = !_matcher.IsMatch(c);
         if (result)

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterSetSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/CharacterSetSegment.cs
@@ -17,6 +17,9 @@ internal sealed class CharacterSetSegment : Segment
 
     public override bool IsMatch(ref PathReader pathReader)
     {
+        if (pathReader.IsEndOfCurrentSegment)
+            return false;
+
         var c = pathReader.CurrentText[0];
         var result = _matcher.IsMatch(c);
         if (result)

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/MatchAnyCharacterSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/MatchAnyCharacterSegment.cs
@@ -10,7 +10,7 @@ internal sealed class MatchAnyCharacterSegment : Segment
 
     public override bool IsMatch(ref PathReader pathReader)
     {
-        if (pathReader.IsPathSeparator())
+        if (pathReader.IsEndOfCurrentSegment)
             return false;
 
         pathReader.ConsumeInSegment(1);

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/Segment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/Segment.cs
@@ -2,6 +2,12 @@ namespace Meziantou.Framework.Globbing.Internals;
 
 internal abstract class Segment
 {
+    /// <summary>
+    ///     Matches the segment against the current position of <paramref name="pathReader"/>. The reader may be
+    ///     positioned at the end of the current path segment, so implementations that consume at least one character
+    ///     must check <see cref="PathReader.IsEndOfCurrentSegment"/> before reading. The reader is only advanced when
+    ///     the segment matches.
+    /// </summary>
     public abstract bool IsMatch(ref PathReader pathReader);
 
     public virtual bool IsRecursiveMatchAll => false;

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
@@ -752,6 +752,55 @@ public class GlobTests
         AssertEnumerateFiles(directory, Glob.Parse("*.cs", GlobDialect.Posix), ["Program.cs", "src/Program.cs"]);
     }
 
+    [Theory]
+    [InlineData("*?a", "ab")]
+    [InlineData("*.md?", "readme.md")]
+    [InlineData("v*.?", "v1.")]
+    [InlineData("***[ab]", "aaac")]
+    [InlineData("*[!a]b", "ab")]
+    [InlineData("*[a-c]d", "abe")]
+    [InlineData("*?a*?b", "ab")]
+    public void SingleCharacterSubSegmentDoesNotReadPastTheEndOfTheSegment(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.False(glob.IsMatch(path));
+    }
+
+    [Theory]
+    [InlineData("*?a", "aba")]
+    [InlineData("*.md?", "readme.mdx")]
+    [InlineData("v*.?", "v1.2")]
+    [InlineData("***[ab]", "aaab")]
+    [InlineData("*[!a]b", "acb")]
+    [InlineData("*[a-c]d", "abd")]
+    [InlineData("*[ab]c", "ac")]
+    public void SingleCharacterSubSegmentStillMatchesWhenTheSegmentIsLongEnough(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.True(glob.IsMatch(path));
+    }
+
+    [Theory]
+    [InlineData("*[!a]a", "aa/a")]
+    [InlineData("*[!a]*a", "aa/a")]
+    [InlineData("*[!a-c]a", "aa/a")]
+    [InlineData("*?a", "aa/a")]
+    public void SingleCharacterSubSegmentDoesNotMatchAPathSeparator(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.False(glob.IsMatch(path));
+    }
+
+    [Fact]
+    public void EnumerateFiles_TrailingAnyCharacterAfterWildcard()
+    {
+        using var directory = TemporaryDirectory.Create();
+        directory.CreateEmptyFile("readme.md");
+        directory.CreateEmptyFile("readme.mdx");
+
+        AssertEnumerateFiles(directory, Glob.Parse("*.md?", GlobDialect.Standard), ["readme.mdx"]);
+    }
+
     private static void AssertEnumerateFiles(TemporaryDirectory directory, IGlobEvaluatable glob, string[] expectedResult)
     {
         var items = glob.EnumerateFiles(directory.FullPath)


### PR DESCRIPTION
`Glob.IsMatch` and `Glob.EnumerateFiles` throw `IndexOutOfRangeException` for ordinary patterns that put a `?` or a character class after a `*` in the same segment:

```csharp
Glob.Parse("*.md?", GlobDialect.Standard).IsMatch("readme.md")   // IndexOutOfRangeException
Glob.Parse("*?a",   GlobDialect.Standard).IsMatch("ab")          // IndexOutOfRangeException
Glob.Parse("v*.?",  GlobDialect.Standard).IsMatch("v1.")         // IndexOutOfRangeException
```

It reaches the enumeration path unchanged — a directory containing `readme.md` enumerated with `*.md?` throws out of `MoveNext`.

## Cause

`RaggedSegment.IsMatch` prechecks `CurrentSegmentLength < _minimumSegmentLength`, which correctly rejects paths too short for the pattern — but that bound is only valid on entry, not during backtracking. `MatchSingleStar` then consumes a character and immediately retries the trailing pattern without re-checking that anything is left:

```csharp
while (!pathReader.IsEndOfCurrentSegment)
{
    pathReader.ConsumeInSegment(1);   // reader may now be exhausted
    copyReader = pathReader;
    if (MatchCompleteNoStar(ref copyReader, trailingPattern))  // -> CurrentText[0] on an empty span
```

On the last iteration `CurrentText` is empty and the first trailing segment indexes into it. Seven segment types read `CurrentText[0]` (or call `PathReader.IsPathSeparator()`, which does) without checking.

The same unchecked position causes a second defect. When backtracking parks the reader exactly on a `/`, `CurrentSegmentLength` is `0` but `CurrentText[0]` is the separator, so an *inverse* class matches it (`/` is not `a`) and calls `ConsumeInSegment(1)`, driving `_currentSegmentLength` to `-1`. That either throws on the next `CurrentSegment` slice, or lets matching continue past the separator:

```csharp
Glob.Parse("*[!a]*a", ...).IsMatch("aa/a")   // ArgumentOutOfRangeException
Glob.Parse("*[!a]a",  ...).IsMatch("aa/a")   // returns true - a pattern with no '/' and no '**' matched a two-segment path
```

The parser does try to stop classes from matching separators (`GlobParser.cs`, "range contains a path separator"), but it inspects the listed characters, not the complement, so `[!a]` passes the check and then accepts `/` at match time.

## Change

Guard each single-character segment with `if (pathReader.IsEndOfCurrentSegment) return false;` before it reads. That one condition covers both failures: `IsEndOfCurrentSegment` is true when the reader is exhausted *and* when it sits on a path separator, so the classes can no longer read past the end nor consume a `/`. `MatchAnyCharacterSegment` had the weaker `IsPathSeparator()` check and now uses the same one.

`PathReader.IsPathSeparator()` also returns `false` on an empty span instead of indexing it, and the precondition is now documented on `Segment.IsMatch` — the whole defect was an undocumented contract between the segments and their callers.

No behaviour change for patterns that were already matching: the guard only fires where the old code read out of bounds or consumed a separator.

## Verification

- `dotnet test tests/Meziantou.Framework.Globbing.Tests` — 383 passed (364 before, 19 added here).
- Differential fuzz against an independent reference matcher, 3,535 generated patterns x 183 generated paths (646,905 pairs), Release build: **25,057 unhandled exceptions before this change, 0 after**. The 618 remaining wrong answers are two unrelated defects, each fixed in its own PR (trailing `**`, and multi-`*` backtracking).
- Added `SingleCharacterSubSegmentDoesNotReadPastTheEndOfTheSegment` and `SingleCharacterSubSegmentDoesNotMatchAPathSeparator`, plus `SingleCharacterSubSegmentStillMatchesWhenTheSegmentIsLongEnough` as a positive control so the theories cannot pass by rejecting everything, and an `EnumerateFiles` regression test.
- `dotnet run ./eng/update-all.cs` — no changes.
