### PR TITLE
Throw FormatException for unsupported SemanticVersion format specifiers

### DIFF
--- a/src/Meziantou.Framework.Versioning/SemanticVersion.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersion.cs
@@ -142,8 +142,14 @@ public sealed class SemanticVersion : IFormattable, IComparable, IComparable<Sem
     public bool HasMetadata => Metadata != EmptyArray;
 
     /// <summary>Formats the semantic version as a string.</summary>
+    /// <param name="format">The format to use. Only the general format (<see langword="null"/>, an empty string, or <c>"G"</c>) is supported.</param>
+    /// <param name="formatProvider">Ignored. A semantic version has no culture-sensitive representation.</param>
+    /// <exception cref="FormatException"><paramref name="format"/> is not a supported format.</exception>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
+        if (!string.IsNullOrEmpty(format) && !format.Equals("G", StringComparison.OrdinalIgnoreCase))
+            throw new FormatException($"The '{format}' format specifier is not supported");
+
         var sb = new StringBuilder();
         sb.Append(Major);
         sb.Append('.');

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
@@ -139,6 +139,29 @@ public class SemanticVersionTests
         Assert.Equal(version, semanticVersion.ToString());
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("G")]
+    [InlineData("g")]
+    public void ToString_SupportedFormats_ReturnTheGeneralFormat(string? format)
+    {
+        var version = SemanticVersion.Parse("1.0.0-alpha.1+build");
+
+        Assert.Equal("1.0.0-alpha.1+build", version.ToString(format, formatProvider: null));
+    }
+
+    [Theory]
+    [InlineData("X")]
+    [InlineData("zzz")]
+    [InlineData(" ")]
+    public void ToString_UnsupportedFormat_ShouldThrowFormatException(string format)
+    {
+        var version = SemanticVersion.Parse("1.0.0");
+
+        Assert.Throws<FormatException>(() => version.ToString(format, formatProvider: null));
+    }
+
     [Fact]
     public void Constructor_WithInvalidPrerelease_ShouldThrowException()
     {


### PR DESCRIPTION
## Problem

`SemanticVersion` implements `IFormattable`, but `ToString(string? format, IFormatProvider? formatProvider)` (`SemanticVersion.cs:145-184`) never read the `format` parameter — every value produced the default rendering.

```
version.ToString("garbage", null)  =>  "1.2.3"
$"{version:zzz}"                   =>  "1.2.3"
```

The `IFormattable` contract requires an unrecognised format specifier to throw `FormatException`. Silently ignoring it means a caller who writes `$"{version:V}"` expecting some short form gets no signal that the specifier did nothing, and it forecloses adding real specifiers later without changing behavior people may have started depending on.

## What changed

`ToString` now accepts the general format only — `null`, `""`, or `"G"`/`"g"` — and throws `FormatException` for anything else. `formatProvider` stays ignored, which is correct for this type (it carries the `[CultureInsensitiveType]` annotation and has no culture-sensitive representation); that's now stated in the XML docs instead of being implicit.

No new format specifiers are introduced here — that's a separate design question, and this change is what makes it possible to add them later without a silent behavior change.

## Verification

`dotnet test tests/Meziantou.Framework.Versioning.Tests /p:TreatsWarningsAsErrors=true` — 324 passing (162 × 2 TFMs), up from 310. New theories cover the four accepted specifiers (including `"g"`, since standard specifiers are case-insensitive by convention) and three rejected ones.

`dotnet run ./eng/update-all.cs` — no generated-file changes.
