### PR TITLE
Return a positive value from SemanticVersion.CompareTo(object) for null

### DIFF
--- a/src/Meziantou.Framework.Versioning/SemanticVersion.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersion.cs
@@ -207,14 +207,16 @@ public sealed class SemanticVersion : IFormattable, IComparable, IComparable<Sem
     }
 
     /// <summary>Compares the current version to a specified object and returns an integer that indicates their relative position in the sort order.</summary>
+    /// <returns>A positive value if <paramref name="obj"/> is <see langword="null"/>, as every instance is greater than <see langword="null"/>; otherwise the result of comparing the two versions.</returns>
+    /// <exception cref="ArgumentException"><paramref name="obj"/> is neither <see langword="null"/> nor a <see cref="SemanticVersion"/>.</exception>
     public int CompareTo(object? obj)
     {
-        if (obj is SemanticVersion semver)
+        return obj switch
         {
-            return CompareTo(semver);
-        }
-
-        throw new ArgumentException("Argument must be an instance of " + nameof(SemanticVersion), nameof(obj));
+            null => 1,
+            SemanticVersion semver => CompareTo(semver),
+            _ => throw new ArgumentException("Argument must be an instance of " + nameof(SemanticVersion), nameof(obj)),
+        };
     }
 
     /// <summary>Compares the current version to a specified semantic version and returns an integer that indicates their relative position in the sort order.</summary>

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
@@ -55,6 +55,22 @@ public class SemanticVersionTests
     }
 
     [Fact]
+    public void CompareTo_Object_Null_ReturnsPositive()
+    {
+        var version = SemanticVersion.Parse("1.0.0");
+
+        Assert.True(version.CompareTo(obj: null) > 0);
+    }
+
+    [Fact]
+    public void CompareTo_Object_UnrelatedType_ShouldThrowException()
+    {
+        var version = SemanticVersion.Parse("1.0.0");
+
+        Assert.Throws<ArgumentException>(() => version.CompareTo(obj: "1.0.0"));
+    }
+
+    [Fact]
     public void PropertiesAreSet()
     {
         var version = SemanticVersion.Parse("1.2.3-beta.1+label");


### PR DESCRIPTION
## Problem

`SemanticVersion.CompareTo(object?)` (`SemanticVersion.cs:210-218`) threw on `null`:

```csharp
new SemanticVersion(1, 0, 0).CompareTo((object?)null)  =>  ArgumentException
```

`obj is SemanticVersion` is `false` for `null`, so the method fell through to the "argument must be an instance of SemanticVersion" throw. The `IComparable` contract specifies that any instance compares greater than `null`, i.e. return a positive value.

The generic `CompareTo(SemanticVersion?)` overload (`:221`) already handled `null` correctly via `SemanticVersionComparer`, so the two overloads disagreed with each other.

## What changed

`CompareTo(object?)` returns `1` for `null`, still delegates for a `SemanticVersion`, and still throws `ArgumentException` for an unrelated type. Rewritten as a switch expression to match the codebase's style guidance, and the null and throw behaviors are now documented on the method.

## Verification

`dotnet test tests/Meziantou.Framework.Versioning.Tests /p:TreatsWarningsAsErrors=true` — 314 passing (157 × 2 TFMs), up from 310.

I confirmed the new `CompareTo_Object_Null_ReturnsPositive` test fails against the unpatched source, so it's a real regression guard. Worth noting for anyone tempted to add one: an `Array.Sort` test over an `object?[]` containing `null` does **not** exercise this path — the BCL comparer null-checks before dispatching to `IComparable`, so such a test passes either way. I wrote one, found it was vacuous, and dropped it. The direct call is what actually pins the contract.

`dotnet run ./eng/update-all.cs` — no generated-file changes.
