### PR TITLE
Match the rest of the path when a pattern ends with the recursive wildcard

### DIFF
--- a/src/Meziantou.Framework.Globbing/Glob.cs
+++ b/src/Meziantou.Framework.Globbing/Glob.cs
@@ -208,8 +208,23 @@ public sealed class Glob : IGlobEvaluatable
             if (patternSegment is RecursiveMatchAllSegment)
             {
                 var remainingPatternSegments = patternSegments[(i + 1)..];
-                if (remainingPatternSegments.IsEmpty) // Last segment
-                    return false; // Match only files
+                if (remainingPatternSegments.IsEmpty)
+                {
+                    // A trailing '**' matches the rest of the path. It must consume at least one segment, so 'a/**'
+                    // matches the content of 'a' but not 'a' itself.
+                    if (pathReader.IsEndOfPath)
+                        return false;
+
+                    while (!pathReader.IsEndOfPath)
+                    {
+                        if (!CanMatchLeadingDot(pathReader, matchLeadingDot[i]))
+                            return false;
+
+                        pathReader.ConsumeSegment();
+                    }
+
+                    return true;
+                }
 
                 var remainingAnchors = anchors[(i + 1)..];
                 var remainingMatchLeadingDot = matchLeadingDot[(i + 1)..];

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
@@ -801,6 +801,59 @@ public class GlobTests
         AssertEnumerateFiles(directory, Glob.Parse("*.md?", GlobDialect.Standard), ["readme.mdx"]);
     }
 
+    [Theory]
+    [InlineData("**", "a.txt")]
+    [InlineData("**", "src/a.txt")]
+    [InlineData("src/**", "src/a.txt")]
+    [InlineData("src/**", "src/nested/a.txt")]
+    [InlineData("src/**/**", "src/nested/a.txt")]
+    public void TrailingRecursiveWildcardMatchesTheRestOfThePath(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.True(glob.IsMatch(path));
+    }
+
+    [Theory]
+    [InlineData("src/**", "src")]
+    [InlineData("src/**", "other/a.txt")]
+    [InlineData("src/**", "srcx/a.txt")]
+    public void TrailingRecursiveWildcardRequiresAtLeastOneSegment(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.False(glob.IsMatch(path));
+    }
+
+    [Theory]
+    [InlineData("src/**", "src/.hidden")]
+    [InlineData("src/**", "src/.hidden/a.txt")]
+    [InlineData("**", ".hidden")]
+    public void TrailingRecursiveWildcardHonorsLeadingDot(string pattern, string path)
+    {
+        Assert.False(Glob.Parse(pattern, GlobDialect.Standard).IsMatch(path));
+        Assert.True(Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot).IsMatch(path));
+    }
+
+    [Theory]
+    [InlineData(GlobDialect.Git)]
+    [InlineData(GlobDialect.MSBuild)]
+    public void TrailingRecursiveWildcardMatchesTheRestOfThePathInEveryDialect(GlobDialect dialect)
+    {
+        var glob = Glob.Parse("src/**", dialect, GlobOptions.MatchLeadingDot);
+        Assert.True(glob.IsMatch("src/a.txt"));
+        Assert.True(glob.IsMatch("src/nested/a.txt"));
+    }
+
+    [Fact]
+    public void EnumerateFiles_TrailingRecursiveWildcard()
+    {
+        using var directory = TemporaryDirectory.Create();
+        directory.CreateEmptyFile("src/a.txt");
+        directory.CreateEmptyFile("src/nested/b.txt");
+        directory.CreateEmptyFile("other/c.txt");
+
+        AssertEnumerateFiles(directory, Glob.Parse("src/**", GlobDialect.Standard), ["src/a.txt", "src/nested/b.txt"]);
+    }
+
     private static void AssertEnumerateFiles(TemporaryDirectory directory, IGlobEvaluatable glob, string[] expectedResult)
     {
         var items = glob.EnumerateFiles(directory.FullPath)


### PR DESCRIPTION
A pattern whose last segment is `**` matches nothing at all, in every dialect that supports the recursive wildcard:

```csharp
Glob.Parse("src/**", GlobDialect.Standard).IsMatch("src/a.txt")    // false
Glob.Parse("src/**", GlobDialect.Standard).IsMatch("src/x/a.txt")  // false
Glob.Parse("**",     GlobDialect.Standard).IsMatch("a.txt")        // false
Glob.Parse("foo/**", GlobDialect.Git).IsMatch("foo/a.txt")         // false
```

`IsPartialMatch` still returns `true` for those directories, so `EnumerateFiles("src/**")` walks the whole tree and then rejects every entry — slow *and* empty.

## Cause

`Glob.IsMatchCore` bails out as soon as a `RecursiveMatchAllSegment` has nothing after it:

```csharp
var remainingPatternSegments = patternSegments[(i + 1)..];
if (remainingPatternSegments.IsEmpty) // Last segment
    return false; // Match only files
```

The comment says "match only files", but the effect is "match nothing" — there is no path for which this returns `true`.

## Change

A trailing `**` now consumes the rest of the path, requiring at least one segment, so `src/**` matches the content of `src` but not `src` itself — the same rule git (`foo/**`) and MSBuild use. Every consumed segment goes through the existing `CanMatchLeadingDot` check, so `src/**` still does not reach `src/.hidden/a.txt` unless `GlobOptions.MatchLeadingDot` is set.

This is deliberately not done as a parser rewrite to `MatchNonEmptyTextSegment`: that segment skips the per-segment leading-dot checks and is only sound when `MatchLeadingDot` is on, which is why `CreateGlob` gates the existing `**` optimisations behind it. Handling it in the matcher keeps both modes correct.

Directory matching is unchanged: `src/**` still carries `GlobMatchType.File`, so directory entries are rejected before reaching this code.

## Verification

- `dotnet test tests/Meziantou.Framework.Globbing.Tests` — 378 passed (364 before, 14 added here).
- Differential fuzz against an independent reference matcher, 3,535 generated patterns x 183 generated paths, Release build: the trailing-`**` family of wrong answers — 522 pairs across the 7 pattern shapes `**`, `*/**`, `?/**`, `[a-c]/**`, `a/**`, `[ab]/**`, `[!a]/**` — **goes to 0**. Remaining fuzz failures on this branch belong to two unrelated defects, each fixed in its own PR.
- Tests cover all three dialects, the "must consume at least one segment" rule, the leading-dot interaction in both modes, and an `EnumerateFiles` case.
- `dotnet run ./eng/update-all.cs` — no changes.

One thing worth a second opinion: whether `src/**` should *also* match the directory `src` itself. I kept it not matching, to agree with git and MSBuild.
