### PR TITLE
Compare oversized numeric prerelease identifiers by value

### DIFF
--- a/src/Meziantou.Framework.Versioning/SemanticVersionComparer.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersionComparer.cs
@@ -41,12 +41,20 @@ internal sealed class SemanticVersionComparer : IComparer<SemanticVersion>, IEqu
             var left = x.PrereleaseLabels[i];
             var right = y.PrereleaseLabels[i];
 
-            var isLeftNumber = int.TryParse(left, NumberStyles.None, CultureInfo.InvariantCulture, out var leftNumber);
-            var isRightNumber = int.TryParse(right, NumberStyles.None, CultureInfo.InvariantCulture, out var rightNumber);
+            var isLeftNumber = IsNumericIdentifier(left);
+            var isRightNumber = IsNumericIdentifier(right);
 
             if (isLeftNumber && isRightNumber)
             {
-                result = leftNumber.CompareTo(rightNumber);
+                // Numeric identifiers cannot carry a leading zero, so the one with more digits is
+                // the larger number and identifiers of equal length compare correctly as text.
+                // Comparing this way is exact for identifiers of any length, whereas parsing to a
+                // fixed-width integer is not.
+                result = left.Length.CompareTo(right.Length);
+                if (result != 0)
+                    return result;
+
+                result = StringComparer.Ordinal.Compare(left, right);
                 if (result != 0)
                     return result;
             }
@@ -71,6 +79,11 @@ internal sealed class SemanticVersionComparer : IComparer<SemanticVersion>, IEqu
             return -1;
 
         return 0;
+    }
+
+    private static bool IsNumericIdentifier(string identifier)
+    {
+        return identifier.Length > 0 && !identifier.AsSpan().ContainsAnyExceptInRange('0', '9');
     }
 
     public bool Equals(SemanticVersion? x, SemanticVersion? y)

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
@@ -109,6 +109,26 @@ public class SemanticVersionTests
     }
 
     [Theory]
+    // Numeric identifiers compare numerically, whatever their magnitude
+    [InlineData("1.0.0-2", "1.0.0-10")]
+    [InlineData("1.0.0-99999999999", "1.0.0-100000000000")]
+    [InlineData("1.0.0-2147483647", "1.0.0-2147483648")] // Straddles int.MaxValue
+    [InlineData("1.0.0-9999999999999999999999", "1.0.0-10000000000000000000000")]
+    [InlineData("1.0.0-alpha.9", "1.0.0-alpha.100000000000")]
+    // A numeric identifier always has lower precedence than an alphanumeric one
+    [InlineData("1.0.0-100000000000", "1.0.0-alpha")]
+    [InlineData("1.0.0-100000000000", "1.0.0-Alpha")]
+    public void Operator_NumericPrereleaseIdentifiers_CompareByValue(string lowerString, string greaterString)
+    {
+        var lower = SemanticVersion.Parse(lowerString);
+        var greater = SemanticVersion.Parse(greaterString);
+
+        Assert.True(lower < greater);
+        Assert.True(greater > lower);
+        Assert.NotEqual(lower, greater);
+    }
+
+    [Theory]
     [InlineData("1.2.3", "1.2.3")]
     [InlineData("1.0.0+left", "1.0.0+right")]
     [InlineData("1.0.0-alpha+left", "1.0.0-alpha+right")]


### PR DESCRIPTION
## Problem

Precedence between two prerelease identifiers was decided with `int.TryParse` (`SemanticVersionComparer.cs:44-63`). An all-digit identifier too large for `Int32` fails that parse and fell through to `StringComparer.Ordinal`, which compares digit-by-digit rather than by magnitude:

```
SemanticVersion.Parse("1.0.0-99999999999") < SemanticVersion.Parse("1.0.0-100000000000")
  =>  False        (spec: True — 99,999,999,999 < 100,000,000,000)
```

Semantic Versioning 2.0.0 puts no upper bound on a numeric identifier, so anything using a long build counter or an epoch timestamp as a prerelease identifier sorts wrongly — and a wrong sort means the wrong "latest version".

The bug is narrower than it first looks: a parseable number is defined to precede an unparseable one, and digits sort before letters ordinally, so numeric-vs-alphanumeric ordering came out right by accident. Only **two oversized numeric identifiers with different digit counts** compare wrongly.

## What changed

Numeric identifiers are now detected directly (`IsNumericIdentifier`, via `ContainsAnyExceptInRange`) rather than inferred from `int.TryParse` succeeding, and two numeric identifiers compare by digit count first, then ordinally.

That is exact for identifiers of arbitrary length and needs no big-integer type: the parser already rejects leading zeros in numeric identifiers (`1.0.0-01` does not parse), so a longer digit string is always the larger number, and equal-length digit strings compare correctly as text.

## Verification

`dotnet test tests/Meziantou.Framework.Versioning.Tests /p:TreatsWarningsAsErrors=true` — 324 passing (162 × 2 TFMs), up from 310.

Against the unpatched comparer, 4 of the 14 new cases fail (the two differing-digit-count oversized pairs, across both TFMs); the other five pass either way and are there to pin the behavior that was already correct — including the `int.MaxValue` boundary and the "numeric always sorts below alphanumeric" rule, which is the part most likely to break if someone reworks this comparison later.

`dotnet run ./eng/update-all.cs` — no generated-file changes.
