### PR TITLE
Reject NuGet ranges that cannot match any version

### DIFF
--- a/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
@@ -356,11 +356,24 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             }
         }
 
-        // An inverted range such as "[2.0.0,1.0.0]" matches nothing; reject it rather than hand
-        // back a range that silently never matches.
-        if (minVersion2 is not null && maxVersion is not null && minVersion2 > maxVersion)
+        if (minVersion2 is not null && maxVersion is not null)
         {
-            return false;
+            var comparison = minVersion2.CompareTo(maxVersion);
+
+            // An inverted range such as "[2.0.0,1.0.0]" matches nothing; reject it rather than
+            // hand back a range that silently never matches.
+            if (comparison > 0)
+            {
+                return false;
+            }
+
+            // Bounding a single version once inclusively and once exclusively contradicts itself.
+            // NuGet rejects "[1.0.0,1.0.0)" and "(1.0.0,1.0.0]" for the same reason, while
+            // accepting "(1.0.0,1.0.0)" and "[1.0.0,1.0.0]", so this matches its rule exactly.
+            if (comparison is 0 && isMinInclusive != isMaxInclusive)
+            {
+                return false;
+            }
         }
 
         result = new SemanticVersionRange(minVersion2, maxVersion, isMinInclusive, isMaxInclusive);

--- a/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
@@ -316,7 +316,14 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
 
         if (commaIndex < 0)
         {
-            // Exact version: [1.0.0]
+            // Exact version: [1.0.0]. Both bounds have to be inclusive: "[1.0.0)", "(1.0.0]" and
+            // "(1.0.0)" describe a range no version can satisfy, so they are typos rather than
+            // ranges and are rejected instead of silently matching nothing.
+            if (!isMinInclusive || !isMaxInclusive)
+            {
+                return false;
+            }
+
             if (!SemanticVersion.TryParse(inner.Trim(), out var exactVersion))
             {
                 return false;
@@ -347,6 +354,13 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             {
                 return false;
             }
+        }
+
+        // An inverted range such as "[2.0.0,1.0.0]" matches nothing; reject it rather than hand
+        // back a range that silently never matches.
+        if (minVersion2 is not null && maxVersion is not null && minVersion2 > maxVersion)
+        {
+            return false;
         }
 
         result = new SemanticVersionRange(minVersion2, maxVersion, isMinInclusive, isMaxInclusive);

--- a/tests/Meziantou.Framework.Versioning.Tests/Meziantou.Framework.Versioning.Tests.csproj
+++ b/tests/Meziantou.Framework.Versioning.Tests/Meziantou.Framework.Versioning.Tests.csproj
@@ -5,6 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Used to cross-check that ParseNuGet agrees with the reference NuGet range parser -->
+    <PackageReference Include="NuGet.Versioning" Version="7.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../../src/Meziantou.Framework.Versioning/Meziantou.Framework.Versioning.csproj" />
   </ItemGroup>
 

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
@@ -136,6 +136,12 @@ public class SemanticVersionRangeTests
     [InlineData("[1.0.0")]
     [InlineData("1.0.0]")]
     [InlineData("[invalid]")]
+    [InlineData("[1.0.0)")] // A single version needs two inclusive bounds
+    [InlineData("(1.0.0]")]
+    [InlineData("(1.0.0)")]
+    [InlineData("[2.0.0,1.0.0]")] // Inverted bounds
+    [InlineData("(2.0.0,1.0.0)")]
+    [InlineData("[1.0.1,1.0.0]")]
     public void ParseNuGet_InvalidFormats_ThrowsFormatException(string input)
     {
         Assert.Throws<FormatException>(() => SemanticVersionRange.ParseNuGet(input));

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
@@ -142,9 +142,124 @@ public class SemanticVersionRangeTests
     [InlineData("[2.0.0,1.0.0]")] // Inverted bounds
     [InlineData("(2.0.0,1.0.0)")]
     [InlineData("[1.0.1,1.0.0]")]
+    [InlineData("[1.0.0,1.0.0)")] // One inclusive and one exclusive bound on a single version
+    [InlineData("(1.0.0,1.0.0]")]
     public void ParseNuGet_InvalidFormats_ThrowsFormatException(string input)
     {
         Assert.Throws<FormatException>(() => SemanticVersionRange.ParseNuGet(input));
+    }
+
+    // The strings below are fed to both this library and NuGet's own range parser. NuGet.Versioning
+    // is the reference implementation of this syntax, so any disagreement is either a bug here or a
+    // deliberate difference that belongs in ParseNuGet_KnownDivergencesFromNuGetVersioning.
+    public static TheoryData<string> NuGetRangeSyntax()
+    {
+        return
+        [
+            // Valid forms
+            "1.0.0",
+            "[1.0.0]",
+            "[1.0.0,)",
+            "(1.0.0,)",
+            "(,1.0.0]",
+            "(,1.0.0)",
+            "[1.0.0,2.0.0]",
+            "[1.0.0,2.0.0)",
+            "(1.0.0,2.0.0)",
+            "(1.0.0,2.0.0]",
+            "[1.0.0-alpha,2.0.0)",
+            "[1.0.0+build]",
+            "[1.0.0,1.0.0]",
+            "(1.0.0,1.0.0)",
+            // A single version cannot carry one inclusive and one exclusive bound
+            "[1.0.0)",
+            "(1.0.0]",
+            "(1.0.0)",
+            "[1.0.0,1.0.0)",
+            "(1.0.0,1.0.0]",
+            // Inverted bounds
+            "[2.0.0,1.0.0]",
+            "(2.0.0,1.0.0)",
+            "[1.0.1,1.0.0]",
+            // Malformed
+            "",
+            "[",
+            "]",
+            "[1.0.0",
+            "1.0.0]",
+            "[invalid]",
+            "[1.0.0,2.0.0",
+        ];
+    }
+
+    [Theory]
+    [MemberData(nameof(NuGetRangeSyntax))]
+    public void ParseNuGet_AcceptsTheSameStringsAsNuGetVersioning(string input)
+    {
+        var mine = SemanticVersionRange.TryParseNuGet(input, out _);
+        var reference = NuGet.Versioning.VersionRange.TryParse(input, out _);
+
+        Assert.Equal(reference, mine);
+    }
+
+    [Theory]
+    [MemberData(nameof(NuGetRangeSyntax))]
+    public void ParseNuGet_ProducesTheSameBoundsAsNuGetVersioning(string input)
+    {
+        if (!NuGet.Versioning.VersionRange.TryParse(input, out var reference))
+        {
+            return;
+        }
+
+        var range = SemanticVersionRange.ParseNuGet(input);
+
+        Assert.Equal(reference.MinVersion?.ToFullString(), range.MinVersion?.ToString());
+        Assert.Equal(reference.MaxVersion?.ToFullString(), range.MaxVersion?.ToString());
+        Assert.Equal(reference.IsMinInclusive, range.IsMinInclusive);
+        Assert.Equal(reference.IsMaxInclusive, range.IsMaxInclusive);
+    }
+
+    [Theory]
+    [MemberData(nameof(NuGetRangeSyntax))]
+    public void ParseNuGet_SatisfiesTheSameVersionsAsNuGetVersioning(string input)
+    {
+        if (!NuGet.Versioning.VersionRange.TryParse(input, out var reference))
+        {
+            return;
+        }
+
+        var range = SemanticVersionRange.ParseNuGet(input);
+        string[] versions =
+        [
+            "0.9.0", "1.0.0", "1.0.0-alpha", "1.0.0-beta.2", "1.0.0+build",
+            "1.0.1", "1.5.0", "1.9.9", "2.0.0-rc.1", "2.0.0", "2.0.1", "10.0.0",
+        ];
+
+        // Comparing the two sets of matched versions rather than asserting one version at a time
+        // means a failure names every version the two parsers disagree about.
+        var expected = versions.Where(version => reference.Satisfies(NuGet.Versioning.NuGetVersion.Parse(version))).ToArray();
+        var actual = versions.Where(version => range.Satisfies(SemanticVersion.Parse(version))).ToArray();
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    // NuGet accepts version formats that are not Semantic Versioning 2.0.0. This library parses
+    // semantic versions only, so it rejects them by design.
+    [InlineData("1.0.0.0")] // Four-part version
+    [InlineData("[1.0.0.0,)")]
+    [InlineData("[1.0,)")] // Two-part version
+    [InlineData("*")] // Floating version
+    [InlineData("1.*")]
+    // NuGet's parser wants whitespace around an omitted bound; this one does not care.
+    [InlineData("(,)")]
+    [InlineData("(,]")]
+    public void ParseNuGet_KnownDivergencesFromNuGetVersioning(string input)
+    {
+        var mine = SemanticVersionRange.TryParseNuGet(input, out _);
+        var reference = NuGet.Versioning.VersionRange.TryParse(input, out _);
+
+        Assert.NotEqual(reference, mine);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`TryParseNuGet` accepted bracket forms that NuGet's own parser rejects, and turned them into a range that matches no version at all.

When there was no comma inside the brackets (`SemanticVersionRange.cs:317-327`), the code built `new SemanticVersionRange(exact, exact, isMinInclusive, isMaxInclusive)` using whichever brackets it happened to find, without requiring both to be inclusive. It also never compared the two bounds:

```
ParseNuGet("[1.0.0)")       => [1.0.0, 1.0.0)     Satisfies("1.0.0") == false — matches nothing
ParseNuGet("(1.0.0]")       => (1.0.0, 1.0.0]
ParseNuGet("(1.0.0)")       => (1.0.0, 1.0.0)
ParseNuGet("[2.0.0,1.0.0]") => [2.0.0, 1.0.0]     also matches nothing
ParseNuGet("[1.0.0,1.0.0)") => [1.0.0, 1.0.0)     also matches nothing
```

A mismatched bracket or a transposed pair of versions in a manifest is a typo. Accepting it produces a range whose `Satisfies` returns `false` for everything, so the caller reports "no compatible version found" instead of "that range is malformed" — and the author goes looking in the wrong place.

## What changed

Three guards in `TryParseNuGet`:

- the single-version form requires both bounds inclusive, so `[1.0.0)`, `(1.0.0]` and `(1.0.0)` are rejected while `[1.0.0]` still parses;
- a lower bound strictly greater than the upper bound is rejected;
- equal bounds with mixed inclusivity are rejected, so `[1.0.0,1.0.0)` and `(1.0.0,1.0.0]` are out while `[1.0.0,1.0.0]` and `(1.0.0,1.0.0)` still parse.

That last rule looks asymmetric, and it is: it is NuGet's rule, adopted verbatim. `(1.0.0,1.0.0)` matches nothing either, but NuGet accepts it, and agreeing with the reference implementation is worth more here than internal tidiness.

`[1.0.0,]` (open upper bound) is unaffected and still parses as `>=1.0.0`.

## Cross-checking against NuGet.Versioning

The test project now references `NuGet.Versioning` (7.9.0) and runs every case in this area through **both** parsers. Three theories share one corpus of 29 range strings — valid forms, degenerate ones, and malformed ones:

- `ParseNuGet_AcceptsTheSameStringsAsNuGetVersioning` — accept/reject must match.
- `ParseNuGet_ProducesTheSameBoundsAsNuGetVersioning` — for accepted ranges, `MinVersion`, `MaxVersion`, `IsMinInclusive` and `IsMaxInclusive` must match.
- `ParseNuGet_SatisfiesTheSameVersionsAsNuGetVersioning` — each range is evaluated against 12 versions (including prereleases and build metadata) and the two sets of matches must be identical. This one is the reassuring result: `VersionRange.Satisfies` is pure interval containment, exactly like ours, with no special prerelease rule — so the two agree on every pair.

Writing these turned up a case I had got wrong. The first version of this PR deliberately kept `[1.0.0, 1.0.0)` parsing, on the reasoning that it is a well-formed interval a generator could legitimately emit. NuGet rejects it. The cross-check made that visible, and the equal-bounds guard above is the result — so the tests have already earned their keep.

A fourth theory, `ParseNuGet_KnownDivergencesFromNuGetVersioning`, pins the differences that are **intentional**, so they fail loudly if they ever change by accident:

| Input | NuGet | Here | Why |
|---|---|---|---|
| `1.0.0.0`, `[1.0.0.0,)` | accepts | rejects | Four-part versions are not Semantic Versioning 2.0.0 |
| `[1.0,)` | accepts | rejects | Two-part versions likewise |
| `*`, `1.*` | accepts | rejects | Floating versions are not implemented |
| `(,)`, `(,]` | rejects | accepts | NuGet's parser wants whitespace around an omitted bound; this one does not care |

One case is deliberately **not** in the strict-bounds theory yet: `[1.0.0,]`. NuGet reports `IsMaxInclusive == false` for an absent upper bound while this library currently reports `true`. That is fixed by #2452, which normalises the flag in the constructor; once both land, `[1.0.0,]` can be added to the corpus. It is already covered by the acceptance and `Satisfies` theories here, both of which pass, because the flag on an absent bound never affects matching.

## Verification

`dotnet test tests/Meziantou.Framework.Versioning.Tests /p:TreatsWarningsAsErrors=true` — 514 passing (257 × 2 TFMs), up from 310 on `main`. 182 of those are the cross-check theories.

I checked the cross-check is not vacuous: run against `main`'s parser it fails on 7 distinct inputs (`[1.0.0)`, `(1.0.0]`, `[2.0.0,1.0.0]`, `(2.0.0,1.0.0)`, `[1.0.1,1.0.0]`, `[1.0.0,1.0.0)`, `(1.0.0,1.0.0]`) — every case this PR fixes, and nothing else.

`dotnet run ./eng/update-all.cs` — no generated-file changes, and 7.9.0 is the current version of the package.
