### PR TITLE
Format the unbounded version range as valid NuGet interval notation

### DIFF
--- a/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
@@ -151,11 +151,14 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         return new SemanticVersionRange(minVersion: null, version, isMinInclusive: false, isMaxInclusive: false);
     }
 
+    /// <summary>Formats the range using NuGet interval notation, which <see cref="TryParseNuGet(string?, out SemanticVersionRange?)"/> can read back.</summary>
     public override string ToString()
     {
         if (MinVersion is null && MaxVersion is null)
         {
-            return "*";
+            // "*" reads better but belongs to the npm grammar, and TryParseNuGet cannot parse it,
+            // which would make the unbounded range the one range ToString could not round-trip.
+            return "(, )";
         }
 
         if (MinVersion is not null && MaxVersion is not null && MinVersion.Equals(MaxVersion) && IsMinInclusive && IsMaxInclusive)

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
@@ -359,9 +359,26 @@ public class SemanticVersionRangeTests
     }
 
     [Fact]
-    public void ToString_All_ReturnsWildcard()
+    public void ToString_All_ReturnsUnboundedInterval()
     {
-        Assert.Equal("*", SemanticVersionRange.All.ToString());
+        Assert.Equal("(, )", SemanticVersionRange.All.ToString());
+    }
+
+    [Theory]
+    [InlineData("*")]
+    [InlineData("[1.0.0]")]
+    [InlineData("[1.0.0, 2.0.0]")]
+    [InlineData("[1.0.0, 2.0.0)")]
+    [InlineData("(1.0.0, 2.0.0)")]
+    [InlineData("(1.0.0, )")]
+    [InlineData("(, 2.0.0)")]
+    [InlineData("[1.0.0-alpha.1+build, 2.0.0]")]
+    public void ToString_RoundTripsThroughParseNuGet(string input)
+    {
+        var range = input is "*" ? SemanticVersionRange.All : SemanticVersionRange.ParseNuGet(input);
+
+        Assert.True(SemanticVersionRange.TryParseNuGet(range.ToString(), out var roundTripped));
+        Assert.Equal(range, roundTripped);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`SemanticVersionRange.ToString()` (`SemanticVersionRange.cs:154-172`) emits NuGet interval notation for every range **except** the unbounded one, where it emitted npm's `"*"` — which `TryParseNuGet` cannot read:

```
SemanticVersionRange.All.ToString()  =>  "*"
SemanticVersionRange.TryParseNuGet("*", out _)  =>  false
```

Every bounded form already round-trips (`(1.0.0, )`, `(, 2.0.0)`, `[1.0.0]`, `[1.0.0, 2.0.0)` all re-parse to an equal range — I checked each). `All` was the lone hole, and it's a common range: anything that persists a range as a string and reads it back — a lockfile writer, a cache key, a log line someone pastes into a test — breaks on precisely the "any version" case.

## What changed

The unbounded range now formats as `"(, )"`, which is valid NuGet interval notation and parses back to a range equal to `All`. `ToString` is documented as producing NuGet notation.

**This changes visible output.** `SemanticVersionRange.All.ToString()` returns `"(, )"` instead of `"*"`, and the existing `ToString_All_ReturnsWildcard` test is updated accordingly. `"*"` is the more readable rendering, and losing it is a real cost — but it belongs to the npm grammar, and having `ToString` emit a string its own parser rejects is the worse trade. If an npm rendering is wanted, it's better added as an explicit format specifier than as a special case buried in `ToString`.

`ParseNpm("*")` is unaffected and still returns `All`.

## Verification

`dotnet test tests/Meziantou.Framework.Versioning.Tests /p:TreatsWarningsAsErrors=true` — 326 passing (163 × 2 TFMs), up from 310.

The new `ToString_RoundTripsThroughParseNuGet` theory asserts `TryParseNuGet(range.ToString())` produces an equal range across all eight forms, including `All` and a range whose bound carries prerelease and metadata labels. That case fails against the unpatched source for `All`.

`dotnet run ./eng/update-all.cs` — no generated-file changes.
