### PR TITLE
Normalize the inclusive flag of an absent version range bound

### DIFF
--- a/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
@@ -37,8 +37,12 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
     {
         MinVersion = minVersion;
         MaxVersion = maxVersion;
-        IsMinInclusive = isMinInclusive;
-        IsMaxInclusive = isMaxInclusive;
+
+        // A bound that is not there cannot be inclusive or exclusive. Normalising the flag keeps
+        // ranges that accept exactly the same versions equal to one another and hashing alike,
+        // e.g. NuGet's "[,]" and "(,)" both describing All.
+        IsMinInclusive = minVersion is not null && isMinInclusive;
+        IsMaxInclusive = maxVersion is not null && isMaxInclusive;
     }
 
     /// <summary>Gets the minimum version bound, or null if there is no lower bound.</summary>

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
@@ -393,6 +393,31 @@ public class SemanticVersionRangeTests
         Assert.Equal(range1.GetHashCode(), range2.GetHashCode());
     }
 
+    [Theory]
+    [InlineData("(,)")]
+    [InlineData("[,]")]
+    [InlineData("[,)")]
+    [InlineData("(,]")]
+    public void UnboundedRanges_AreEqualToAll(string input)
+    {
+        var range = SemanticVersionRange.ParseNuGet(input);
+
+        Assert.Equal(SemanticVersionRange.All, range);
+        Assert.Equal(SemanticVersionRange.All.GetHashCode(), range.GetHashCode());
+        Assert.False(range.IsMinInclusive);
+        Assert.False(range.IsMaxInclusive);
+    }
+
+    [Fact]
+    public void MissingUpperBound_IsNotInclusive()
+    {
+        var range = SemanticVersionRange.ParseNuGet("[1.0.0,]");
+
+        Assert.Equal(SemanticVersionRange.GreaterThanOrEqual(SemanticVersion.Parse("1.0.0")), range);
+        Assert.True(range.IsMinInclusive);
+        Assert.False(range.IsMaxInclusive);
+    }
+
     [Fact]
     public void Equality_DifferentRange_AreNotEqual()
     {


### PR DESCRIPTION
## Problem

`SemanticVersionRange` stored the inclusive/exclusive flag for a bound even when that bound was `null`, so ranges that accept exactly the same set of versions could compare unequal and hash differently:

```
SemanticVersionRange.ParseNuGet("[,]").Equals(SemanticVersionRange.All)  =>  false
```

Both match every version — `Satisfies` only consults `IsMinInclusive` inside `if (MinVersion is not null)`, so the flag is dead weight on an absent bound — but `Equals` (`SemanticVersionRange.cs:179-195`) compares all four fields, and `GetHashCode` combines all four. Anything using a range as a dictionary key or in a set treats the two as distinct.

The same applied to `[1.0.0,]`, which carried `IsMaxInclusive == true` with no upper bound at all, and consequently formatted as `"[1.0.0, ]"`.

## What changed

The constructor normalises each flag to `false` when its bound is `null`. Doing it at construction rather than inside `Equals` means the invariant holds for every consumer — equality, hashing, `ToString`, and anyone reading the properties directly.

Behavior notes:

- `Satisfies` is unchanged for every input, since it already ignored the flag on an absent bound.
- `ParseNuGet("[1.0.0,]").ToString()` now returns `"[1.0.0, )"` rather than `"[1.0.0, ]"`, and the range is equal to `GreaterThanOrEqual(1.0.0)` as it should be.
- The `All`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan` and `LessThanOrEqual` factories already passed `false` for their absent bound, so none of them changes.

## Verification

`dotnet test tests/Meziantou.Framework.Versioning.Tests /p:TreatsWarningsAsErrors=true` — 320 passing (160 × 2 TFMs), up from 310.

New tests assert that all four unbounded NuGet spellings (`(,)`, `[,]`, `[,)`, `(,]`) are equal to `All` *and* hash equal, and that `[1.0.0,]` normalises to `GreaterThanOrEqual`. I checked the existing `ParseNuGet_ValidData` cases first — none of them constructs a null bound with an inclusive flag set, so no existing expectation shifts.

`dotnet run ./eng/update-all.cs` — no generated-file changes.
