### PR TITLE
Restore the path reader between backtracking attempts in RaggedSegment

### DIFF
--- a/src/Meziantou.Framework.Globbing/Internals/Segments/RaggedSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/RaggedSegment.cs
@@ -81,8 +81,12 @@ internal sealed class RaggedSegment : Segment
                     while (!pathReader.IsEndOfCurrentSegment)
                     {
                         pathReader.ConsumeInSegment(1);
-                        if (Match(ref pathReader, remainingPatternSegments))
+                        copyReader = pathReader;
+                        if (Match(ref copyReader, remainingPatternSegments))
+                        {
+                            pathReader = copyReader;
                             return true;
+                        }
                     }
 
                     return false;

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
@@ -752,6 +752,27 @@ public class GlobTests
         AssertEnumerateFiles(directory, Glob.Parse("*.cs", GlobDialect.Posix), ["Program.cs", "src/Program.cs"]);
     }
 
+    [Theory]
+    [InlineData("*a*?b", "abbcb")]
+    [InlineData("*b*a?", "baaaa")]
+    [InlineData("*a*[a-c]", "abba")]
+    [InlineData("*a*b*c", "axxbxxc")]
+    [InlineData("*[ab]*?", "acca")]
+    public void SegmentWithSeveralWildcardsTriesEverySplitPoint(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.True(glob.IsMatch(path));
+    }
+
+    [Theory]
+    [InlineData("*a*b*c", "axxbxxd")]
+    [InlineData("*a*b*c", "axxcxxb")]
+    public void SegmentWithSeveralWildcardsStillRejectsNonMatchingPaths(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.False(glob.IsMatch(path));
+    }
+
     private static void AssertEnumerateFiles(TemporaryDirectory directory, IGlobEvaluatable glob, string[] expectedResult)
     {
         var items = glob.EnumerateFiles(directory.FullPath)


### PR DESCRIPTION
A path segment that keeps two or more `*` after parsing misses valid matches:

```csharp
Glob.Parse("*a*?b", GlobDialect.Standard).IsMatch("abbcb")  // false, should be true
Glob.Parse("*b*a?", GlobDialect.Standard).IsMatch("baaaa")  // false, should be true
```

`abbcb` does match `*a*?b`: `*` takes `""`, `a` matches, `*` takes `"bb"`, `?` takes `c`, `b` matches.

## Cause

`RaggedSegment`'s multi-star `Match` passes the reader into the recursive call **by reference** while searching for a split point:

```csharp
while (!pathReader.IsEndOfCurrentSegment)
{
    pathReader.ConsumeInSegment(1);
    if (Match(ref pathReader, remainingPatternSegments))   // <- ref, not a copy
        return true;
}
```

When that call fails it has usually already consumed characters — the sub-pattern matched partway before hitting a mismatch — and nothing rolls them back. The next iteration therefore advances from a corrupted position and skips candidate split points.

For `*a*?b` against `abbcb`: the attempt at `""` fails but leaves the reader past `b`, so the loop goes on to try `"bb"`, `"bcb"`… and never revisits the position that works.

`MatchSingleStar` gets this right using a `copyReader`, and so does the zero-width first attempt twelve lines above in the same method. The multi-star loop is the odd one out.

## Change

Copy the reader before each recursive attempt and assign back only on success, exactly as `MatchSingleStar` and the zero-width attempt already do.

Only reachable when a single segment keeps two or more `MatchAllSubSegment`s after the parser's peephole passes — `*x*` collapses to `ContainsSegment` and `*x` to `EndsWithSegment` — so it needs shapes like `*a*?b` or `*a*b*c`. That narrows the blast radius but not the wrongness: these are silent false negatives, so a build or deploy step using such a pattern quietly omits files with no error.

## Verification

- `dotnet test tests/Meziantou.Framework.Globbing.Tests` — 371 passed (364 before, 7 added here).
- Differential fuzz against an independent reference matcher, 3,535 generated patterns x 183 generated paths, Release build: **all 96 missed matches in the multi-wildcard family are fixed** — pattern shapes `*a*?`, `*a*[a-c]`, `*a*[!a]`, `*[ab]*?`, `*[ab]*[a-c]`, `*[!a]*?`, `*[!a]*[a-c]`, `*a*[ab]`, `*[ab]*[!a]`, `*[!a]*[ab]` all go to zero.
- Tests include negative cases so the theory cannot pass by matching everything.
- `dotnet run ./eng/update-all.cs` — no changes.

Note on test data: negative cases ending in `?` or a character class are *not* in this PR — on `main` they hit an unrelated `IndexOutOfRangeException` that is fixed in #2445, so they belong to that PR's test set. The two PRs touch different files and are independent.
