### PR TITLE
Reject glob patterns that normalize away to no segment

### DIFF
--- a/src/Meziantou.Framework.Globbing/Internals/GlobParser.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/GlobParser.cs
@@ -315,6 +315,14 @@ internal static class GlobParser
                 }
             }
 
+            // '.' and '..' normalization can remove every segment (".", "./", "a/.."). Such a pattern cannot match
+            // anything, and a Glob without any segment is not usable, so reject it instead of returning it.
+            if (segments.Count == 0)
+            {
+                errorMessage = "the pattern does not contain any segment";
+                return false;
+            }
+
             errorMessage = null;
             result = CreateGlob(segments, matchLeadingDot, exclude, settings.IgnoreCase, matchType, settings.MatchLeadingDot, settings.PathSeparatorAware);
             return true;

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
@@ -28,9 +28,34 @@ public class GlobParserTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
+    [InlineData(".")]
+    [InlineData("./")]
+    [InlineData("./.")]
+    [InlineData("a/..")]
+    [InlineData("a/../")]
     public void InvalidPatterns(string? content)
     {
         Assert.Throws<ArgumentException>(() => Glob.Parse(content!, GlobDialect.Standard));
+    }
+
+    [Theory]
+    [InlineData(".")]
+    [InlineData("./")]
+    [InlineData("a/..")]
+    public void PatternsWithoutAnySegmentAreRejected(string pattern)
+    {
+        Assert.False(Glob.TryParse(pattern, GlobDialect.Standard, GlobOptions.None, out var result));
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("a/./b")]
+    [InlineData("a/b/../c")]
+    [InlineData("./a")]
+    public void PatternsThatStillHaveSegmentsAfterNormalizationAreAccepted(string pattern)
+    {
+        Assert.True(Glob.TryParse(pattern, GlobDialect.Standard, GlobOptions.None, out var result));
+        Assert.NotNull(result);
     }
 
     [Fact]


### PR DESCRIPTION
`.` parses successfully and then throws on first use:

```csharp
var glob = Glob.Parse(".", GlobDialect.Standard);   // succeeds
glob.EnumerateFiles(directory);                     // IndexOutOfRangeException
```

Same for `./`, `./.`, `a/..` and `a/../`.

## Cause

`.` normalizes away to nothing and `..` pops the previous segment, with no floor on the segment list. All of these produce a `Glob` whose `_segments` is empty, and `TryParse` reports success. The first read of `IGlobEvaluatable.TraverseDirectories` then indexes into it:

```csharp
bool IGlobEvaluatable.TraverseDirectories => !_pathSeparatorAware || _segments.Length > 1 || ShouldRecurse(_segments[0]);
```

`IsMatch` does not throw — the segment loop simply never runs, so it returns `false` for everything — which is why the failure only shows up on the enumeration path, far from `Parse`.

## Change

Reject a pattern that has no segment left after normalization, with the error `the pattern does not contain any segment`. This matches how the parser already handles the empty pattern and the `..` underflow (`the pattern cannot start with '..'`) a few lines above, and it means `TryParse` returning `true` once again guarantees a usable `Glob`.

Patterns that still have segments after normalization are unaffected: `a/./b`, `a/b/../c` and `./a` all keep parsing, and there is a test pinning that down so the check cannot creep.

Git-dialect patterns are almost never affected — a gitignore entry with no `/` gets a leading `**` segment, so it cannot normalize to empty. Only a pattern containing `/` that cancels itself out (`a/..`) is rejected.

`Glob.Parse(".")` now throws `ArgumentException` where it previously returned an object that threw later. That is a behaviour change, but the previous object had no valid use.

## Verification

- `dotnet test tests/Meziantou.Framework.Globbing.Tests` — 375 passed (364 before, 11 added here).
- Extended the existing `InvalidPatterns` theory and added `PatternsWithoutAnySegmentAreRejected` plus `PatternsThatStillHaveSegmentsAfterNormalizationAreAccepted`.
- Verified independent of #2455: the two branches touch `GlobParser.TryParse` about seven lines apart, they merge cleanly, and the merged tree passes 377 tests.
- `dotnet run ./eng/update-all.cs` — no changes.
