### PR TITLE
Match directories with gitignore entries that have no trailing slash

### DIFF
--- a/src/Meziantou.Framework.Globbing/Internals/GlobParser.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/GlobParser.cs
@@ -306,6 +306,11 @@ internal static class GlobParser
                     segments.Add(MatchAllSegment.Instance);
                     matchLeadingDot.Add(settings.MatchLeadingDot);
                 }
+                else
+                {
+                    // A gitignore entry without a trailing '/' matches a file or a directory with that name.
+                    matchType = GlobMatchType.Any;
+                }
             }
             else
             {

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobCollectionTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobCollectionTests.cs
@@ -34,4 +34,24 @@ bin/
         Assert.True(globs.IsMatch("#literal"));
         Assert.True(globs.IsMatch("!literal"));
     }
+
+    [Fact]
+    public void GitIgnoreEntryWithoutTrailingSlashMatchesADirectory()
+    {
+        var globs = GlobCollection.ParseGitIgnore("node_modules\n".AsSpan());
+
+        Assert.True(globs.IsMatch("", "node_modules", PathItemType.Directory));
+        Assert.True(globs.IsMatch("src", "node_modules", PathItemType.Directory));
+        Assert.True(globs.IsMatch("", "node_modules", PathItemType.File));
+        Assert.True(((IGlobEvaluatable)globs).CanMatchDirectories);
+    }
+
+    [Fact]
+    public void GitIgnoreEntryWithTrailingSlashDoesNotMatchAFile()
+    {
+        var globs = GlobCollection.ParseGitIgnore("bin/\n".AsSpan());
+
+        Assert.True(globs.IsMatch("bin/test.txt"));
+        Assert.False(globs.IsMatch("", "bin", PathItemType.File));
+    }
 }


### PR DESCRIPTION
Every glob parsed with `GlobDialect.Git` carries `GlobMatchType.File`, so a gitignore entry can never match a directory:

```csharp
var globs = GlobCollection.ParseGitIgnore("node_modules\n");
globs.IsMatch("", "node_modules", PathItemType.Directory);   // false - git ignores it
((IGlobEvaluatable)globs).CanMatchDirectories;               // false
```

Because `CanMatchDirectories` is false, `GlobFileSystemEnumerator.ShouldIncludeEntry` drops every directory entry, so `EnumerateFileSystemEntries` over a gitignore collection can never report an ignored directory. A caller asking "should I skip this directory?" gets `false` and descends into `node_modules` anyway.

## Cause

In `GlobParser.TryParse`, `matchType` is initialised to `GlobMatchType.File` and the assignment to `GlobMatchType.Directory` lives in the `else` branch of `if (dialect is GlobDialect.Git)` — unreachable for Git. Nothing ever moves a Git pattern off `File`.

## Change

A gitignore entry **without** a trailing `/` matches a file or a directory of that name, which is what git does, so it now parses with `GlobMatchType.Any`.

Entries **with** a trailing `/` are left alone: they keep the existing `**/*` expansion and still match the contents of the directory.

## Scope: what this does not fix

`bin/` still does not match the directory `bin` itself — only its contents. Making it do so is not a `matchType` change: git evaluates a path as ignored when the pattern matches the path *or any of its ancestors*, which is a property of how the collection walks a path, not of a single `Glob`. Expressing "the directory `bin`, and everything under it" needs either two segment lists or ancestor-aware evaluation in `GlobCollection`.

I have deliberately left that out rather than fold a redesign into this PR. The half fixed here is well-defined and self-contained; the other half is worth its own issue if you want gitignore fidelity.

## Verification

- `dotnet test tests/Meziantou.Framework.Globbing.Tests` — 366 passed (364 before, 2 added here).
- Added `GitIgnoreEntryWithoutTrailingSlashMatchesADirectory` and `GitIgnoreEntryWithTrailingSlashDoesNotMatchAFile`, the latter pinning that the trailing-slash form stays directory-scoped.
- The existing `LoadGitIgnore_ParsesPatterns` test is unchanged and still passes.
- Verified independent of #2454: the two branches touch `GlobParser.TryParse` about seven lines apart, they merge cleanly, and the merged tree passes 377 tests.
- `dotnet run ./eng/update-all.cs` — no changes.

This changes what existing callers see: a gitignore collection now reports directories it previously stayed silent about. Worth a line in the release notes.
