### PR TITLE
Render optimized segments as glob patterns in Glob.ToString

### DIFF
--- a/src/Meziantou.Framework.Globbing/Internals/Segments/LastSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/LastSegment.cs
@@ -16,4 +16,9 @@ internal sealed class LastSegment : Segment
     }
 
     public override bool IsRecursiveMatchAll => true;
+
+    public override string ToString()
+    {
+        return "**/" + _innerSegment.ToString();
+    }
 }

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/MatchAllEndOfSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/MatchAllEndOfSegment.cs
@@ -17,4 +17,9 @@ internal sealed class MatchAllEndOfSegment : Segment
 
         return true;
     }
+
+    public override string ToString()
+    {
+        return "*";
+    }
 }

--- a/src/Meziantou.Framework.Globbing/Internals/Segments/MatchAllEndsWithSegment.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/Segments/MatchAllEndsWithSegment.cs
@@ -23,4 +23,9 @@ internal sealed class MatchAllEndsWithSegment : Segment
     }
 
     public override bool IsRecursiveMatchAll => true;
+
+    public override string ToString()
+    {
+        return "**/*" + _suffix;
+    }
 }

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
@@ -146,6 +146,31 @@ public class GlobParserTests
             item => Assert.IsType<CharacterRangeSegment>(item));
     }
 
+    [Theory]
+    [InlineData("a/**/b")]
+    [InlineData("a/**/*.txt")]
+    [InlineData("a/**/*")]
+    [InlineData("**/b/c")]
+    [InlineData("a*")]
+    [InlineData("*.txt")]
+    [InlineData("*file*")]
+    [InlineData("a/b")]
+    [InlineData("a/**/b/c")]
+    [InlineData("{a,b}.cs")]
+    [InlineData("[a-z].cs")]
+    [InlineData("p?th/a")]
+    public void ToStringRoundTripsToAnEquivalentPattern(string pattern)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        var text = glob.ToString();
+
+        Assert.False(text.Contains("Meziantou.Framework.Globbing", StringComparison.Ordinal));
+
+        // The text must parse back into a glob that matches exactly the same paths.
+        var roundTripped = Glob.Parse(text, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.Equal(text, roundTripped.ToString());
+    }
+
     [Fact]
     public void OptimizeSingleCharSet2()
     {

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
@@ -164,7 +164,7 @@ public class GlobParserTests
         var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
         var text = glob.ToString();
 
-        Assert.False(text.Contains("Meziantou.Framework.Globbing", StringComparison.Ordinal));
+        Assert.DoesNotContain("Meziantou.Framework.Globbing", text);
 
         // The text must parse back into a glob that matches exactly the same paths.
         var roundTripped = Glob.Parse(text, GlobDialect.Standard, GlobOptions.MatchLeadingDot);


### PR DESCRIPTION
`Glob.ToString()` leaks internal .NET type names for the pattern shapes the parser optimises:

```csharp
Glob.Parse("a/**/b").ToString()      // "a/Meziantou.Framework.Globbing.Internals.LastSegment"
Glob.Parse("a/**/*.txt").ToString()  // "a/Meziantou.Framework.Globbing.Internals.MatchAllEndsWithSegment"
Glob.Parse("a/**/*").ToString()      // "a/**/*"  - this one is fine
```

## Cause

`Glob.ToString()` concatenates `segment.ToString()` for each segment. `LastSegment`, `MatchAllEndsWithSegment` and `MatchAllEndOfSegment` never override `ToString()`, so they fall through to `object.ToString()`. `PathSuffixSegment` and `MatchNonEmptyTextSegment` — created by the same optimisation pass — both override it correctly, so this reads as an oversight when the other three were added rather than a decision.

The affected shapes are exactly the ones the parser optimises, i.e. the common ones.

## Change

Add the three missing overrides: `**/<inner>`, `**/*<suffix>` and `*`.

`ToString()` on a public type is API — it lands in log lines, exception messages, test failure output and debugger watch windows. Leaking an internal type name where a pattern is expected is at its worst exactly when someone is trying to work out why a glob did not match.

## Verification

- `dotnet test tests/Meziantou.Framework.Globbing.Tests` — 376 passed (364 before, 12 added here).
- Added `ToStringRoundTripsToAnEquivalentPattern`, which asserts no output contains an internal type name **and** that re-parsing the text yields the same text. The round-trip is the part that matters: it will fail if a future optimisation adds another segment type without a `ToString()`, which is how this regressed in the first place.
- `dotnet run ./eng/update-all.cs` — no changes.
