### PR TITLE
Resolve gitignore paths against the last matching pattern

### DIFF
--- a/src/Meziantou.Framework.Globbing/GlobCollection.cs
+++ b/src/Meziantou.Framework.Globbing/GlobCollection.cs
@@ -187,16 +187,15 @@ public sealed class GlobCollection : IReadOnlyList<IGlobEvaluatable>, IGlobEvalu
 
     private bool IsLastMatch(ReadOnlySpan<char> directory, ReadOnlySpan<char> filename, PathItemType? itemType)
     {
-        var match = false;
-        foreach (var glob in _globs)
+        // The last pattern that matches decides, so walk backwards and stop at the first hit.
+        for (var i = _globs.Length - 1; i >= 0; i--)
         {
+            var glob = _globs[i];
             if (glob.IsMatch(directory, filename, itemType))
-            {
-                match = glob.Mode is GlobMode.Include;
-            }
+                return glob.Mode is GlobMode.Include;
         }
 
-        return match;
+        return false;
     }
 
     /// <summary>Determines whether a directory should be recursed into when enumerating files.</summary>

--- a/src/Meziantou.Framework.Globbing/GlobCollection.cs
+++ b/src/Meziantou.Framework.Globbing/GlobCollection.cs
@@ -23,9 +23,19 @@ public sealed class GlobCollection : IReadOnlyList<IGlobEvaluatable>, IGlobEvalu
 {
     private readonly IGlobEvaluatable[] _globs;
 
+    // gitignore resolves a path against the last pattern that matches it, whereas a hand-built collection uses
+    // the order-independent "any exclude wins" rule. Only the gitignore factories set this.
+    private readonly bool _lastMatchWins;
+
     /// <summary>Initializes a new instance of the <see cref="GlobCollection"/> class.</summary>
     /// <param name="globs">The glob patterns to include in the collection.</param>
     public GlobCollection(params IGlobEvaluatable[] globs) => _globs = globs;
+
+    private GlobCollection(IGlobEvaluatable[] globs, bool lastMatchWins)
+    {
+        _globs = globs;
+        _lastMatchWins = lastMatchWins;
+    }
 
     /// <summary>Loads gitignore content and creates a <see cref="GlobCollection"/> from it.</summary>
     /// <param name="gitIgnoreContent">The gitignore content.</param>
@@ -37,7 +47,7 @@ public sealed class GlobCollection : IReadOnlyList<IGlobEvaluatable>, IGlobEvalu
             AddGitIgnoreLine(entry.Line, globs);
         }
 
-        return new GlobCollection([.. globs]);
+        return new GlobCollection([.. globs], lastMatchWins: true);
     }
 
     /// <summary>Loads a gitignore file asynchronously and creates a <see cref="GlobCollection"/> from it.</summary>
@@ -83,7 +93,7 @@ public sealed class GlobCollection : IReadOnlyList<IGlobEvaluatable>, IGlobEvalu
             AddGitIgnoreLine(line.AsSpan(), globs);
         }
 
-        return new GlobCollection([.. globs]);
+        return new GlobCollection([.. globs], lastMatchWins: true);
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -147,9 +157,16 @@ public sealed class GlobCollection : IReadOnlyList<IGlobEvaluatable>, IGlobEvalu
     /// <param name="directory">The directory part of the path to match.</param>
     /// <param name="filename">The filename part of the path to match.</param>
     /// <param name="itemType">The type of the path item (file or directory), or <see langword="null"/> if unknown.</param>
-    /// <returns><see langword="true"/> if the path matches any include pattern and no exclude pattern; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///     <see langword="true"/> if the path matches any include pattern and no exclude pattern; otherwise,
+    ///     <see langword="false"/>. A collection created from gitignore content resolves the path against the last
+    ///     pattern that matches it instead, as git does.
+    /// </returns>
     public bool IsMatch(ReadOnlySpan<char> directory, ReadOnlySpan<char> filename, PathItemType? itemType)
     {
+        if (_lastMatchWins)
+            return IsLastMatch(directory, filename, itemType);
+
         var match = false;
         foreach (var glob in _globs)
         {
@@ -162,6 +179,20 @@ public sealed class GlobCollection : IReadOnlyList<IGlobEvaluatable>, IGlobEvalu
                     return false;
 
                 match = true;
+            }
+        }
+
+        return match;
+    }
+
+    private bool IsLastMatch(ReadOnlySpan<char> directory, ReadOnlySpan<char> filename, PathItemType? itemType)
+    {
+        var match = false;
+        foreach (var glob in _globs)
+        {
+            if (glob.IsMatch(directory, filename, itemType))
+            {
+                match = glob.Mode is GlobMode.Include;
             }
         }
 

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobCollectionTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobCollectionTests.cs
@@ -34,4 +34,52 @@ bin/
         Assert.True(globs.IsMatch("#literal"));
         Assert.True(globs.IsMatch("!literal"));
     }
+
+    [Fact]
+    public void GitIgnoreResolvesAPathAgainstTheLastMatchingPattern()
+    {
+        var globs = GlobCollection.ParseGitIgnore("""
+*.log
+!important.log
+important.log
+""".AsSpan());
+
+        Assert.True(globs.IsMatch("important.log"));
+        Assert.True(globs.IsMatch("trace.log"));
+    }
+
+    [Fact]
+    public void GitIgnoreNegationAfterAMatchReIncludesThePath()
+    {
+        var globs = GlobCollection.ParseGitIgnore("""
+*.log
+!important.log
+""".AsSpan());
+
+        Assert.False(globs.IsMatch("important.log"));
+        Assert.True(globs.IsMatch("trace.log"));
+    }
+
+    [Fact]
+    public void GitIgnoreOrderMatters()
+    {
+        var globs = GlobCollection.ParseGitIgnore("""
+!important.log
+*.log
+""".AsSpan());
+
+        Assert.True(globs.IsMatch("important.log"));
+    }
+
+    [Fact]
+    public void HandBuiltCollectionKeepsAnyExcludeWins()
+    {
+        GlobCollection globs = [
+            Glob.Parse("!important.log", GlobDialect.Standard),
+            Glob.Parse("*.log", GlobDialect.Standard),
+        ];
+
+        Assert.False(globs.IsMatch("important.log"));
+        Assert.True(globs.IsMatch("trace.log"));
+    }
 }


### PR DESCRIPTION
> **Stack 1 of 2** · merges into `main` · **#2462 targets this branch and must merge after it**

git resolves a path against the **last** pattern that matches it. `GlobCollection.IsMatch` instead returns `false` as soon as any exclude matches, whatever the order:

```csharp
// .gitignore:  *.log / !important.log / important.log
GlobCollection.ParseGitIgnore(content).IsMatch("important.log");   // false - git ignores it
```

Re-including then re-excluding is a normal gitignore idiom (`!*.log` followed by `debug.log`), and the disagreement with git is silent.

The existing `LoadGitIgnore_ParsesPatterns` test only exercises the ordering where the two rules happen to agree, which is why this was not caught.

## Change

Collections built by `ParseGitIgnore` / `LoadGitIgnoreAsync` now use last-match-wins. Hand-built collections are **unchanged** and keep "any exclude wins".

That split is deliberate. "Any exclude wins" is order-independent, which is a good property for a general-purpose include/exclude collection and is what existing callers of the public constructor rely on. git's rule is the contract only where the method name promises git, so it is scoped to those two factories via a private constructor flag rather than changed globally.

## Scope: what this does not fix

git also refuses to let a negation re-include a file whose *parent directory* is excluded — `!bin/keep.txt` has no effect if `bin/` is ignored, because git never descends into `bin`. That rule needs ancestor-aware evaluation and is not implemented here; this PR is only about the ordering of matches on a single path.

## Verification

- `dotnet test tests/Meziantou.Framework.Globbing.Tests` — 368 passed (364 before, 4 added here).
- `GitIgnoreResolvesAPathAgainstTheLastMatchingPattern` covers the re-ignore case, `GitIgnoreNegationAfterAMatchReIncludesThePath` covers the plain negation, and `GitIgnoreOrderMatters` pins that the two orderings now differ.
- `HandBuiltCollectionKeepsAnyExcludeWins` pins the unchanged behaviour of the public constructor, so the split cannot be collapsed by accident.
- `dotnet run ./eng/update-all.cs` — no changes.
