### PR TITLE
Fix npm range parsing of wildcards, prereleases and partial versions

### DIFF
--- a/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
@@ -458,6 +458,7 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         var isMaxInclusive = false;
 
         // Split by spaces for multiple constraints
+        var constraintCount = 0;
         foreach (var segment in SplitBySpace(value))
         {
             var part = segment.Trim();
@@ -470,9 +471,13 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             {
                 return false;
             }
+
+            constraintCount++;
         }
 
-        if (minVersion is null && maxVersion is null)
+        // A constraint can legitimately leave both bounds open ("x.x" matches everything), so the
+        // number of constraints read is what tells us whether anything was understood.
+        if (constraintCount == 0)
         {
             return false;
         }
@@ -488,37 +493,39 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         var leftPart = value[..hyphenIndex].Trim();
         var rightPart = value[(hyphenIndex + 3)..].Trim(); // Skip " - "
 
-        if (!TryParseNpmPartialVersion(leftPart, out var leftMajor, out var leftMinor, out var leftPatch, out _))
+        if (!TryParseNpmPartialVersion(leftPart, out var left) || left.Major is null)
         {
             return false;
         }
 
-        if (!TryParseNpmPartialVersion(rightPart, out var rightMajor, out var rightMinor, out var rightPatch, out _))
+        if (!TryParseNpmPartialVersion(rightPart, out var right) || right.Major is null)
         {
             return false;
         }
 
-        var minVersion = new SemanticVersion(leftMajor, leftMinor ?? 0, leftPatch ?? 0);
+        // LowerBound keeps any prerelease and metadata labels: "1.0.0-alpha - 2.0.0" starts at
+        // 1.0.0-alpha, not at 1.0.0.
+        var minVersion = left.LowerBound;
 
         SemanticVersion maxVersion;
         bool isMaxInclusive;
 
-        if (rightPatch.HasValue)
+        if (right.Patch is not null)
         {
             // Full version on right: <=X.Y.Z
-            maxVersion = new SemanticVersion(rightMajor, rightMinor ?? 0, rightPatch.Value);
+            maxVersion = right.LowerBound;
             isMaxInclusive = true;
         }
-        else if (rightMinor.HasValue)
+        else if (right.Minor is { } rightMinor)
         {
             // Partial minor: <X.(Y+1).0
-            maxVersion = new SemanticVersion(rightMajor, rightMinor.Value + 1, 0);
+            maxVersion = new SemanticVersion(right.Major.Value, rightMinor + 1, 0);
             isMaxInclusive = false;
         }
         else
         {
             // Only major: <(X+1).0.0
-            maxVersion = new SemanticVersion(rightMajor + 1, 0, 0);
+            maxVersion = new SemanticVersion(right.Major.Value + 1, 0, 0);
             isMaxInclusive = false;
         }
 
@@ -543,12 +550,6 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         if (part.StartsWith("^".AsSpan(), StringComparison.Ordinal))
         {
             return TryParseCaretRange(part[1..].Trim(), ref minVersion, ref maxVersion, ref isMinInclusive, ref isMaxInclusive);
-        }
-
-        // Handle X-range patterns (1.x, 1.2.x, 1.*, etc.)
-        if (IsXRange(part))
-        {
-            return TryParseXRange(part, ref minVersion, ref maxVersion, ref isMinInclusive, ref isMaxInclusive);
         }
 
         // Parse operator and version
@@ -582,6 +583,22 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         }
 
         var versionPart = part[versionStart..].Trim();
+
+        // Only look for an X-range once the operator has been stripped, and only in the numeric
+        // core of the version: a prerelease or metadata label may legitimately contain an 'x'
+        // (">=1.0.0-exp"), and treating that as a wildcard rejects a perfectly valid constraint.
+        if (IsXRange(versionPart))
+        {
+            // npm only gives a wildcard a meaning of its own when it stands without a comparison
+            // operator, so ">=1.x" stays unsupported rather than being guessed at.
+            if (op is not NpmOperator.Exact)
+            {
+                return false;
+            }
+
+            return TryParseXRange(versionPart, ref minVersion, ref maxVersion, ref isMinInclusive, ref isMaxInclusive);
+        }
+
         if (!SemanticVersion.TryParse(versionPart, out var version))
         {
             return false;
@@ -637,23 +654,23 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         // ~1 := >=1.0.0 <2.0.0
         // ~0.2.3 := >=0.2.3 <0.3.0
 
-        if (!TryParseNpmPartialVersion(versionPart, out var major, out var minor, out var patch, out _))
+        if (!TryParseNpmPartialVersion(versionPart, out var partial) || partial.Major is null)
         {
             return false;
         }
 
-        minVersion = new SemanticVersion(major, minor ?? 0, patch ?? 0);
+        minVersion = partial.LowerBound;
         isMinInclusive = true;
 
-        if (minor.HasValue)
+        if (partial.Minor is { } minor)
         {
             // ~1.2.3 or ~1.2 -> <1.3.0
-            maxVersion = new SemanticVersion(major, minor.Value + 1, 0);
+            maxVersion = new SemanticVersion(partial.Major.Value, minor + 1, 0);
         }
         else
         {
-            // ~1 -> <2.0.0
-            maxVersion = new SemanticVersion(major + 1, 0, 0);
+            // ~1 or ~1.x -> <2.0.0
+            maxVersion = new SemanticVersion(partial.Major.Value + 1, 0, 0);
         }
 
         isMaxInclusive = false;
@@ -677,57 +694,48 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         // ^1.x := >=1.0.0 <2.0.0
         // ^0.x := >=0.0.0 <1.0.0
 
-        if (!TryParseNpmPartialVersion(versionPart, out var major, out var minor, out var patch, out _))
+        if (!TryParseNpmPartialVersion(versionPart, out var partial) || partial.Major is not { } major)
         {
             return false;
         }
 
-        minVersion = new SemanticVersion(major, minor ?? 0, patch ?? 0);
+        minVersion = partial.LowerBound;
         isMinInclusive = true;
 
-        if (major != 0)
+        maxVersion = (major, partial.Minor, partial.Patch) switch
         {
-            // ^1.x.x -> <2.0.0
-            maxVersion = new SemanticVersion(major + 1, 0, 0);
-        }
-        else if (minor.HasValue && minor.Value != 0)
-        {
-            // ^0.2.x -> <0.3.0
-            maxVersion = new SemanticVersion(0, minor.Value + 1, 0);
-        }
-        else if (patch.HasValue)
-        {
-            // ^0.0.3 -> <0.0.4
-            maxVersion = new SemanticVersion(0, 0, patch.Value + 1);
-        }
-        else if (minor.HasValue)
-        {
-            // ^0.0 -> <0.1.0
-            maxVersion = new SemanticVersion(0, 1, 0);
-        }
-        else
-        {
-            // ^0 -> <1.0.0
-            maxVersion = new SemanticVersion(1, 0, 0);
-        }
+            ( > 0, _, _) => new SemanticVersion(major + 1, 0, 0),            // ^1.2.3 -> <2.0.0
+            (0, > 0 and { } minor, _) => new SemanticVersion(0, minor + 1, 0), // ^0.2.3 -> <0.3.0
+            (0, _, { } patch) => new SemanticVersion(0, 0, patch + 1),       // ^0.0.3 -> <0.0.4
+            (0, not null, null) => new SemanticVersion(0, 1, 0),             // ^0.0 -> <0.1.0
+            _ => new SemanticVersion(1, 0, 0),                               // ^0 or ^0.x -> <1.0.0
+        };
 
         isMaxInclusive = false;
 
         return true;
     }
 
-    private static bool IsXRange(ReadOnlySpan<char> part)
+    private static bool IsXRange(ReadOnlySpan<char> version)
     {
-        // Check if the part contains 'x', 'X', or '*' as a version component
-        foreach (var c in part)
+        // A wildcard is a whole component of the numeric core. Scanning the raw characters instead
+        // would treat the 'x' in a label such as "1.0.0-exp" as a wildcard.
+        foreach (var component in new PartEnumerable(GetVersionCore(version)))
         {
-            if (c is 'x' or 'X' or '*')
+            if (component is "x" or "X" or "*")
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    // The numeric "major.minor.patch" part, without the prerelease or metadata labels.
+    private static ReadOnlySpan<char> GetVersionCore(ReadOnlySpan<char> version)
+    {
+        var labelIndex = version.IndexOfAny('-', '+');
+        return labelIndex < 0 ? version : version[..labelIndex];
     }
 
     private static bool TryParseXRange(
@@ -742,20 +750,16 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         // 1.* := >=1.0.0 <2.0.0
         // * := any version (handled separately)
 
-        if (!TryParseNpmPartialVersion(part, out var major, out var minor, out var patch, out var hasWildcard))
+        if (!TryParseNpmPartialVersion(part, out var partial) || !partial.HasWildcard)
         {
             return false;
         }
 
-        if (!hasWildcard)
+        // The major itself is a wildcard ("x", "x.x", "*"): every version matches. This is
+        // distinct from a literal zero major such as "0.x", which the caller must not confuse
+        // with it.
+        if (partial.Major is not { } major)
         {
-            return false;
-        }
-
-        // Full wildcard case
-        if (major == 0 && !minor.HasValue && !patch.HasValue && hasWildcard)
-        {
-            // This shouldn't happen as "*" is handled earlier, but just in case
             minVersion = null;
             maxVersion = null;
             isMinInclusive = false;
@@ -763,13 +767,13 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             return true;
         }
 
-        minVersion = new SemanticVersion(major, minor ?? 0, patch ?? 0);
+        minVersion = partial.LowerBound;
         isMinInclusive = true;
 
-        if (minor.HasValue && !patch.HasValue)
+        if (partial.Minor is { } minor)
         {
             // 1.2.x -> <1.3.0
-            maxVersion = new SemanticVersion(major, minor.Value + 1, 0);
+            maxVersion = new SemanticVersion(major, minor + 1, 0);
         }
         else
         {
@@ -782,17 +786,24 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         return true;
     }
 
-    private static bool TryParseNpmPartialVersion(
-        ReadOnlySpan<char> value,
-        out int major,
-        out int? minor,
-        out int? patch,
-        out bool hasWildcard)
+    // A version with optional trailing components, as npm range syntax allows: "1", "1.2", "1.2.3",
+    // "1.x" and "1.2.3-beta.1" are all accepted. A null component is one that was absent or was a
+    // wildcard; HasWildcard tells the two apart.
+    [StructLayout(LayoutKind.Auto)]
+    private readonly struct NpmPartialVersion(int? major, int? minor, int? patch, bool hasWildcard, SemanticVersion lowerBound)
     {
-        major = 0;
-        minor = null;
-        patch = null;
-        hasWildcard = false;
+        public int? Major { get; } = major;
+        public int? Minor { get; } = minor;
+        public int? Patch { get; } = patch;
+        public bool HasWildcard { get; } = hasWildcard;
+
+        /// <summary>The lowest version the partial version denotes, keeping any prerelease and metadata labels.</summary>
+        public SemanticVersion LowerBound { get; } = lowerBound;
+    }
+
+    private static bool TryParseNpmPartialVersion(ReadOnlySpan<char> value, out NpmPartialVersion result)
+    {
+        result = default;
 
         value = value.Trim();
         if (value.IsEmpty)
@@ -806,89 +817,79 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             value = value[1..];
         }
 
-        var parts = new PartEnumerable(value);
+        // The prerelease and metadata labels are kept aside rather than discarded, so that the
+        // lower bound of "^1.2.3-beta" is 1.2.3-beta and not 1.2.3.
+        var core = GetVersionCore(value);
+        var labels = value[core.Length..];
+
+        // The component enumerator does not yield a trailing empty component, so "1.2." has to be
+        // rejected here; an empty component anywhere else is caught in the loop below.
+        if (core.IsEmpty || core[^1] is '.')
+        {
+            return false;
+        }
+
+        int? major = null;
+        int? minor = null;
+        int? patch = null;
+        var hasWildcard = false;
         var partIndex = 0;
 
-        foreach (var part in parts)
+        foreach (var component in new PartEnumerable(core))
         {
-            if (part.IsEmpty)
+            // A version has at most three components, and every one of them must be present.
+            if (partIndex > 2 || component.IsEmpty)
             {
                 return false;
             }
 
-            var isWildcard = part is "x" or "X" or "*";
-            if (isWildcard)
+            if (component is "x" or "X" or "*")
             {
                 hasWildcard = true;
             }
-
-            switch (partIndex)
+            else if (!TryParseInt(component, out var number))
             {
-                case 0:
-                    if (isWildcard)
-                    {
-                        major = 0;
-                        hasWildcard = true;
-                    }
-                    else if (!TryParseInt(part, out major))
-                    {
-                        return false;
-                    }
-
-                    break;
-                case 1:
-                    if (isWildcard)
-                    {
-                        hasWildcard = true;
-                    }
-                    else if (TryParseInt(part, out var minorValue))
-                    {
-                        minor = minorValue;
-                    }
-                    else
-                    {
-                        return false;
-                    }
-
-                    break;
-                case 2:
-                    if (isWildcard)
-                    {
-                        hasWildcard = true;
-                    }
-                    else
-                    {
-                        // Handle prerelease/metadata suffix: "3-alpha" or "3+build"
-                        var patchPart = part;
-                        var dashIndex = patchPart.IndexOfAny(['-', '+']);
-                        if (dashIndex >= 0)
-                        {
-                            patchPart = patchPart[..dashIndex];
-                        }
-
-                        if (TryParseInt(patchPart, out var patchValue))
-                        {
-                            patch = patchValue;
-                        }
-                        else
-                        {
-                            return false;
-                        }
-                    }
-
-                    break;
+                return false;
+            }
+            else if (!hasWildcard)
+            {
+                // Everything after the first wildcard is a wildcard too: npm reads "1.x.2" as "1.x".
+                switch (partIndex)
+                {
+                    case 0:
+                        major = number;
+                        break;
+                    case 1:
+                        minor = number;
+                        break;
+                    default:
+                        patch = number;
+                        break;
+                }
             }
 
             partIndex++;
-
-            // Stop after patch version
-            if (partIndex > 2)
-            {
-                break;
-            }
         }
 
-        return partIndex >= 1;
+        if (partIndex is 0)
+        {
+            return false;
+        }
+
+        SemanticVersion lowerBound;
+        if (labels.IsEmpty)
+        {
+            lowerBound = new SemanticVersion(major ?? 0, minor ?? 0, patch ?? 0);
+        }
+        else if (patch is null || !SemanticVersion.TryParse(value, out lowerBound!))
+        {
+            // Labels only attach to a complete "major.minor.patch", and the whole thing has to be a
+            // valid semantic version. Delegating that check keeps one definition of what is valid.
+            return false;
+        }
+
+        result = new NpmPartialVersion(major, minor, patch, hasWildcard, lowerBound);
+        return true;
     }
 
     private static bool TryParseInt(ReadOnlySpan<char> value, out int result)

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
@@ -343,10 +343,75 @@ public class SemanticVersionRangeTests
     }
 
     [Theory]
+    // A prerelease or metadata label may contain 'x', 'X' or '*' without being a wildcard
+    [InlineData(">=1.0.0-exp", "[1.0.0-exp, )")]
+    [InlineData(">=1.0.0-max", "[1.0.0-max, )")]
+    [InlineData(">=1.0.0-rc.x", "[1.0.0-rc.x, )")]
+    [InlineData("<2.0.0-beta.x", "(, 2.0.0-beta.x)")]
+    [InlineData(">=1.0.0-alpha+x", "[1.0.0-alpha+x, )")]
+    [InlineData(">=1.0.0-x.7.z.92", "[1.0.0-x.7.z.92, )")]
+    // Tilde, caret and hyphen ranges keep the prerelease on their lower bound
+    [InlineData("^1.2.3-beta", "[1.2.3-beta, 2.0.0)")]
+    [InlineData("~1.2.3-beta", "[1.2.3-beta, 1.3.0)")]
+    [InlineData("^1.2.3+meta", "[1.2.3+meta, 2.0.0)")]
+    [InlineData("1.0.0-alpha - 2.0.0", "[1.0.0-alpha, 2.0.0]")]
+    [InlineData("1.0.0 - 2.0.0-rc.1", "[1.0.0, 2.0.0-rc.1]")]
+    // A literal zero major is not a wildcard major
+    [InlineData("0.x", "[0.0.0, 1.0.0)")]
+    [InlineData("0.*", "[0.0.0, 1.0.0)")]
+    [InlineData("0.X", "[0.0.0, 1.0.0)")]
+    [InlineData("0.0.x", "[0.0.0, 0.1.0)")]
+    [InlineData("^0.x", "[0.0.0, 1.0.0)")]
+    // Components after a wildcard are wildcards too: npm reads "1.x.2" as "1.x"
+    [InlineData("1.x.2", "[1.0.0, 2.0.0)")]
+    public void ParseNpm_ProducesRange(string input, string expected)
+    {
+        Assert.Equal(expected, SemanticVersionRange.ParseNpm(input).ToString());
+    }
+
+    [Theory]
+    [InlineData("x.x")]
+    [InlineData("*.*")]
+    [InlineData("x")]
+    [InlineData("*")]
+    public void ParseNpm_WildcardMajor_MatchesEveryVersion(string input)
+    {
+        Assert.Equal(SemanticVersionRange.All, SemanticVersionRange.ParseNpm(input));
+    }
+
+    [Fact]
+    public void ParseNpm_CaretWithPrerelease_IncludesThatPrerelease()
+    {
+        var range = SemanticVersionRange.ParseNpm("^1.2.3-beta");
+
+        Assert.True(range.Satisfies(SemanticVersion.Parse("1.2.3-beta")));
+        Assert.True(range.Satisfies(SemanticVersion.Parse("1.2.3")));
+        Assert.False(range.Satisfies(SemanticVersion.Parse("1.2.3-alpha")));
+    }
+
+    [Fact]
+    public void ParseNpm_ZeroMajorXRange_DoesNotMatchEveryVersion()
+    {
+        var range = SemanticVersionRange.ParseNpm("0.x");
+
+        Assert.True(range.Satisfies(SemanticVersion.Parse("0.9.9")));
+        Assert.False(range.Satisfies(SemanticVersion.Parse("5.0.0")));
+    }
+
+    [Theory]
     [InlineData("")]
     [InlineData("invalid")]
     [InlineData(">")]
     [InlineData(">=")]
+    [InlineData("~1.2.3.4")] // A version has at most three components
+    [InlineData("~1.2.3.junk")]
+    [InlineData("^1.2.3.4")]
+    [InlineData("1.2.3.4")]
+    [InlineData("~1.2.")] // Every component must be present
+    [InlineData("~1..2")]
+    [InlineData("1.2-beta")] // A label needs a complete major.minor.patch
+    [InlineData("^1.x-beta")]
+    [InlineData(">=1.x")] // A wildcard carries no meaning next to a comparison operator
     public void ParseNpm_InvalidFormats_ThrowsFormatException(string input)
     {
         Assert.Throws<FormatException>(() => SemanticVersionRange.ParseNpm(input));


### PR DESCRIPTION
**Stack 1 of 3 · merges into `main` · must merge before #2459 and #2460**

## Problem

Three separate defects in npm range parsing, all traceable to one root cause: the npm path re-derives version components with an ad-hoc partial parser (`TryParseNpmPartialVersion`) instead of reusing `SemanticVersion.TryParse`, and dispatches on a character scan (`IsXRange`) before it knows where the version actually starts. Fixing any one of them in isolation means rewriting the same method three times, so they're fixed together.

**1. A label containing `x`, `X` or `*` made the constraint unparseable.** `IsXRange` (`SemanticVersionRange.cs:719-731`) scanned every character of the whole constraint — before the operator prefix was stripped — and returned `true` on the first hit. `">=1.0.0-exp"` was therefore routed into the x-range parser, which fed `">=1"` to `TryParseInt` and failed:

```
ParseNpm(">=1.0.0-exp")        =>  FormatException
ParseNpm(">=1.0.0-max")        =>  FormatException
ParseNpm("<2.0.0-beta.x")      =>  FormatException
ParseNpm(">=1.0.0-alpha+x")    =>  FormatException
ParseNpm(">=1.0.0-x.7.z.92")   =>  FormatException   <- an example from the semver.org spec
```

`x` is not a rare letter in release labels: `exp`, `max`, `hotfix`, `fix`, `linux`, `x64`, and the `rc.x`/`preview.x` conventions all tripped it.

**2. `~`, `^` and hyphen ranges silently discarded the prerelease.** `TryParseNpmPartialVersion` truncated at the first `-`/`+` and returned only integers; every call site discarded the label as `out _`. The lower bound was rebuilt as a *release* version, and since a prerelease sorts below its release, the range excluded the very version it was written for:

```
ParseNpm("^1.2.3-beta")  =>  [1.2.3, 2.0.0)
  .Satisfies("1.2.3-beta")  =>  false        (npm: true)
```

`">=1.2.3-beta"` kept the label, because that path goes through `SemanticVersion.TryParse` — so two spellings of the same intent disagreed.

**3. A literal `0` major was indistinguishable from a wildcard major.** `TryParseNpmPartialVersion` set `major = 0` both when the major *was* a wildcard and when it was the digit `0`, so `"0.x"` took the "matches everything" branch, set both bounds to `null`, and was then rejected by `if (minVersion is null && maxVersion is null) return false`:

```
ParseNpm("0.x") / ("0.*") / ("0.X") / ("x.x")  =>  FormatException
```

`0.x` is the idiomatic constraint for the large population of packages still on a `0.y.z` line.

## What changed

`TryParseNpmPartialVersion` now returns an `NpmPartialVersion`: `int?` components where `null` means absent-or-wildcard, a `HasWildcard` flag that tells those two apart, and a `LowerBound` version that **keeps the prerelease and metadata labels**. When labels are present the whole string is handed to `SemanticVersion.TryParse`, so there is one definition of what a valid version is rather than two.

- `IsXRange` inspects only whole components of the numeric core (`GetVersionCore` strips the labels), and is consulted *after* the operator prefix is removed.
- `~`, `^`, hyphen and x-ranges build their lower bound from `LowerBound`, so the prerelease survives.
- `TryParseXRange` branches on `Major is null` rather than `major == 0`.
- `TryParseNpm` counts the constraints it understood instead of inferring failure from both bounds being null, which is what made a legitimate "matches everything" range look like a parse failure.

Two smaller leniencies in the same method are fixed along the way: a version now has at most three components and every one must be present (`~1.2.3.4`, `~1.2.3.junk`, `~1.2.` and `~1..2` are rejected — note the component enumerator does not yield a *trailing* empty component, so that case needs its own check), and components after the first wildcard are ignored as npm does, making `1.x.2` mean `1.x` rather than `>=1.0.2`.

`>=1.x` stays unsupported: a wildcard next to a comparison operator has no single sensible bound, and rejecting it preserves today's behavior rather than guessing.

## Verification

`dotnet test tests/Meziantou.Framework.Versioning.Tests /p:TreatsWarningsAsErrors=true` — 374 passing (187 × 2 TFMs), up from 310. **All 310 pre-existing tests pass unchanged**, which matters for a rewrite this size.

Every example above was re-run against the built assembly and now produces the documented npm result; the caret table in the XML docs (`^1.2.3`, `^0.2.3`, `^0.0.3`, `^0.0`, `^0`, `^0.x`) was checked case by case, as were the previously-failing inputs that should *stay* failing (`invalid`, `>`, `>=`, `>=1.x`, `||`).

`dotnet run ./eng/update-all.cs` — no generated-file changes.
