### PR TITLE
Intersect npm range constraints instead of letting the last one win

### DIFF
--- a/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
@@ -420,7 +420,7 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             return result;
         }
 
-        throw new FormatException($"The value '{value}' is not a valid npm version range.");
+        throw new FormatException(GetNpmFormatErrorMessage(value));
     }
 
     /// <summary>Parses a version range in npm format.</summary>
@@ -435,7 +435,17 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             return result;
         }
 
-        throw new FormatException($"The value '{value}' is not a valid npm version range.");
+        throw new FormatException(GetNpmFormatErrorMessage(value));
+    }
+
+    private static string GetNpmFormatErrorMessage(ReadOnlySpan<char> value)
+    {
+        // A union is valid npm syntax that this type cannot represent, since it models a single
+        // interval. Saying so beats letting the caller hunt for a syntax error that is not there.
+        if (value.Contains("||".AsSpan(), StringComparison.Ordinal))
+            return $"The value '{value}' is not a valid npm version range: a union of ranges ('||') cannot be represented by a single {nameof(SemanticVersionRange)}.";
+
+        return $"The value '{value}' is not a valid npm version range.";
     }
 
     /// <summary>Attempts to parse a version range in npm format.</summary>
@@ -638,30 +648,70 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         switch (op)
         {
             case NpmOperator.Exact:
-                minVersion = version;
-                maxVersion = version;
-                isMinInclusive = true;
-                isMaxInclusive = true;
+                IntersectMin(ref minVersion, ref isMinInclusive, version, inclusive: true);
+                IntersectMax(ref maxVersion, ref isMaxInclusive, version, inclusive: true);
                 break;
             case NpmOperator.GreaterThan:
-                minVersion = version;
-                isMinInclusive = false;
+                IntersectMin(ref minVersion, ref isMinInclusive, version, inclusive: false);
                 break;
             case NpmOperator.GreaterThanOrEqual:
-                minVersion = version;
-                isMinInclusive = true;
+                IntersectMin(ref minVersion, ref isMinInclusive, version, inclusive: true);
                 break;
             case NpmOperator.LessThan:
-                maxVersion = version;
-                isMaxInclusive = false;
+                IntersectMax(ref maxVersion, ref isMaxInclusive, version, inclusive: false);
                 break;
             case NpmOperator.LessThanOrEqual:
-                maxVersion = version;
-                isMaxInclusive = true;
+                IntersectMax(ref maxVersion, ref isMaxInclusive, version, inclusive: true);
                 break;
         }
 
         return true;
+    }
+
+    // Space-separated npm constraints are ANDed together, so each one narrows the range rather
+    // than replacing it. Assigning instead would make the result depend on the order the
+    // constraints happen to be written in, and ">=1.5.0 >=1.0.0" would widen back out to >=1.0.0.
+    private static void IntersectMin(ref SemanticVersion? minVersion, ref bool isMinInclusive, SemanticVersion version, bool inclusive)
+    {
+        if (minVersion is null)
+        {
+            minVersion = version;
+            isMinInclusive = inclusive;
+            return;
+        }
+
+        var comparison = version.CompareTo(minVersion);
+        if (comparison > 0)
+        {
+            minVersion = version;
+            isMinInclusive = inclusive;
+        }
+        else if (comparison is 0)
+        {
+            // Of two equal lower bounds the exclusive one is tighter: ">1.0.0 >=1.0.0" is >1.0.0.
+            isMinInclusive &= inclusive;
+        }
+    }
+
+    private static void IntersectMax(ref SemanticVersion? maxVersion, ref bool isMaxInclusive, SemanticVersion version, bool inclusive)
+    {
+        if (maxVersion is null)
+        {
+            maxVersion = version;
+            isMaxInclusive = inclusive;
+            return;
+        }
+
+        var comparison = version.CompareTo(maxVersion);
+        if (comparison < 0)
+        {
+            maxVersion = version;
+            isMaxInclusive = inclusive;
+        }
+        else if (comparison is 0)
+        {
+            isMaxInclusive &= inclusive;
+        }
     }
 
     private enum NpmOperator
@@ -690,21 +740,13 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             return false;
         }
 
-        minVersion = partial.LowerBound;
-        isMinInclusive = true;
+        IntersectMin(ref minVersion, ref isMinInclusive, partial.LowerBound, inclusive: true);
 
-        if (partial.Minor is { } minor)
-        {
-            // ~1.2.3 or ~1.2 -> <1.3.0
-            maxVersion = new SemanticVersion(partial.Major.Value, minor + 1, 0);
-        }
-        else
-        {
-            // ~1 or ~1.x -> <2.0.0
-            maxVersion = new SemanticVersion(partial.Major.Value + 1, 0, 0);
-        }
+        var upperBound = partial.Minor is { } minor
+            ? new SemanticVersion(partial.Major.Value, minor + 1, 0) // ~1.2.3 or ~1.2 -> <1.3.0
+            : new SemanticVersion(partial.Major.Value + 1, 0, 0);    // ~1 or ~1.x -> <2.0.0
 
-        isMaxInclusive = false;
+        IntersectMax(ref maxVersion, ref isMaxInclusive, upperBound, inclusive: false);
 
         return true;
     }
@@ -730,10 +772,9 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             return false;
         }
 
-        minVersion = partial.LowerBound;
-        isMinInclusive = true;
+        IntersectMin(ref minVersion, ref isMinInclusive, partial.LowerBound, inclusive: true);
 
-        maxVersion = (major, partial.Minor, partial.Patch) switch
+        var upperBound = (major, partial.Minor, partial.Patch) switch
         {
             ( > 0, _, _) => new SemanticVersion(major + 1, 0, 0),            // ^1.2.3 -> <2.0.0
             (0, > 0 and { } minor, _) => new SemanticVersion(0, minor + 1, 0), // ^0.2.3 -> <0.3.0
@@ -742,7 +783,7 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             _ => new SemanticVersion(1, 0, 0),                               // ^0 or ^0.x -> <1.0.0
         };
 
-        isMaxInclusive = false;
+        IntersectMax(ref maxVersion, ref isMaxInclusive, upperBound, inclusive: false);
 
         return true;
     }
@@ -791,28 +832,18 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         // with it.
         if (partial.Major is not { } major)
         {
-            minVersion = null;
-            maxVersion = null;
-            isMinInclusive = false;
-            isMaxInclusive = false;
+            // Every version matches, so intersecting with it leaves the range untouched. Clearing
+            // the bounds here would instead discard whatever the preceding constraints established.
             return true;
         }
 
-        minVersion = partial.LowerBound;
-        isMinInclusive = true;
+        IntersectMin(ref minVersion, ref isMinInclusive, partial.LowerBound, inclusive: true);
 
-        if (partial.Minor is { } minor)
-        {
-            // 1.2.x -> <1.3.0
-            maxVersion = new SemanticVersion(major, minor + 1, 0);
-        }
-        else
-        {
-            // 1.x -> <2.0.0
-            maxVersion = new SemanticVersion(major + 1, 0, 0);
-        }
+        var upperBound = partial.Minor is { } minor
+            ? new SemanticVersion(major, minor + 1, 0) // 1.2.x -> <1.3.0
+            : new SemanticVersion(major + 1, 0, 0);    // 1.x -> <2.0.0
 
-        isMaxInclusive = false;
+        IntersectMax(ref maxVersion, ref isMaxInclusive, upperBound, inclusive: false);
 
         return true;
     }

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
@@ -491,6 +491,49 @@ public class SemanticVersionRangeTests
     }
 
     [Theory]
+    // Space-separated constraints are ANDed, so the order they are written in cannot matter
+    [InlineData(">=1.0.0 >=1.5.0", ">=1.5.0 >=1.0.0")]
+    [InlineData("<1.5.0 <2.0.0", "<2.0.0 <1.5.0")]
+    [InlineData(">1.0.0 >=1.0.0", ">=1.0.0 >1.0.0")]
+    [InlineData("<2.0.0 <=2.0.0", "<=2.0.0 <2.0.0")]
+    [InlineData(">=1.5.0 ^1.0.0", "^1.0.0 >=1.5.0")]
+    [InlineData(">=1.2.0 1.x", "1.x >=1.2.0")]
+    [InlineData(">=2.0.0 x.x", "x.x >=2.0.0")]
+    public void ParseNpm_ConstraintOrder_DoesNotChangeTheRange(string one, string other)
+    {
+        Assert.Equal(SemanticVersionRange.ParseNpm(one), SemanticVersionRange.ParseNpm(other));
+    }
+
+    [Theory]
+    [InlineData(">=1.5.0 >=1.0.0", "[1.5.0, )")] // The tighter lower bound wins
+    [InlineData("<1.5.0 <2.0.0", "(, 1.5.0)")] // The tighter upper bound wins
+    [InlineData(">1.0.0 >=1.0.0", "(1.0.0, )")] // Equal bounds keep the exclusive one
+    [InlineData("<2.0.0 <=2.0.0", "(, 2.0.0)")]
+    [InlineData(">=2.0.0 x.x", "[2.0.0, )")] // A match-everything constraint narrows nothing
+    [InlineData(">=1.0.0 <2.0.0", "[1.0.0, 2.0.0)")]
+    public void ParseNpm_MultipleConstraints_AreIntersected(string input, string expected)
+    {
+        Assert.Equal(expected, SemanticVersionRange.ParseNpm(input).ToString());
+    }
+
+    [Fact]
+    public void ParseNpm_LooserConstraintLast_DoesNotWidenTheRange()
+    {
+        var range = SemanticVersionRange.ParseNpm(">=1.5.0 >=1.0.0");
+
+        Assert.False(range.Satisfies(SemanticVersion.Parse("1.2.0")));
+        Assert.True(range.Satisfies(SemanticVersion.Parse("1.5.0")));
+    }
+
+    [Fact]
+    public void ParseNpm_Union_ReportsThatUnionsAreUnsupported()
+    {
+        var exception = Assert.Throws<FormatException>(() => SemanticVersionRange.ParseNpm("^1.0.0 || ^2.0.0"));
+
+        Assert.Contains("||", exception.Message);
+    }
+
+    [Theory]
     [InlineData("x.x")]
     [InlineData("*.*")]
     [InlineData("x")]


### PR DESCRIPTION
**Stack 2 of 3 · merges into `fix/npm-partial-version` (#2458) · must merge after #2458 and before #2460**

## Problem

Space-separated npm constraints are ANDed together, but each one **overwrote** the accumulated bound instead of narrowing it (`SemanticVersionRange.cs:592-611`, plus the direct `minVersion = …` assignments in the tilde, caret and x-range helpers). When the constraints happened to be written loosest-first the result was accidentally right; in the other order it was wrong and **wider** than asked for:

```
ParseNpm(">=1.0.0 >=1.5.0")  =>  [1.5.0, )     correct, by ordering luck
ParseNpm(">=1.5.0 >=1.0.0")  =>  [1.0.0, )     WRONG — Satisfies("1.2.0") == true, npm says false
ParseNpm("<1.5.0 <2.0.0")    =>  (, 2.0.0)     WRONG — Satisfies("1.8.0") == true, npm says false
ParseNpm(">1.0.0 >=1.0.0")   =>  [1.0.0, )     WRONG — the exclusive bound is silently lost
```

An over-wide range in a resolver admits versions the manifest author excluded. The failure mode is "installs an incompatible package", and it is silent.

Separately, `||` (npm's union operator) failed with a generic "not a valid npm version range" message, which reads as a syntax error when in fact the syntax is fine and the type simply cannot represent it.

## What changed

Two helpers, `IntersectMin` and `IntersectMax`, replace every direct bound assignment — in the operator `switch` and in the tilde, caret and x-range helpers alike, so a constraint narrows the range wherever it comes from. When two bounds are equal the **exclusive** one wins, since `>1.0.0` ∩ `>=1.0.0` is `>1.0.0`.

The "matches everything" x-range (`x.x`) now returns without touching the bounds. Previously it cleared them, so `">=2.0.0 x.x"` discarded the `>=2.0.0` it had already read — intersecting with "everything" must be a no-op.

One deliberate behavior change worth calling out: `"1.0.0 <2.0.0"` now yields `[1.0.0]` rather than `[1.0.0, 2.0.0)`. An exact constraint pins both bounds, and intersecting that with `<2.0.0` leaves the exact version. That is the correct reading of an AND.

`||` still isn't supported — representing a union needs a different shape than a single interval — but `ParseNpm` now says so explicitly instead of implying the input is malformed.

## Verification

`dotnet test tests/Meziantou.Framework.Versioning.Tests /p:TreatsWarningsAsErrors=true` — 404 passing (202 × 2 TFMs), up from 374 on #2458. Verified with the layer below applied, as a stack requires.

The core new test asserts the property that was violated: for seven constraint pairs, writing them in either order produces an **equal** range. The four wrong outputs above were each re-run and now give the intersected result.

`dotnet run ./eng/update-all.cs` — no generated-file changes.
