### PR TITLE
Guard version number arithmetic against overflow and negative components

### DIFF
--- a/src/Meziantou.Framework.Versioning/SemanticVersion.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersion.cs
@@ -32,8 +32,13 @@ public sealed class SemanticVersion : IFormattable, IComparable, IComparable<Sem
     private static readonly IReadOnlyList<string> EmptyArray = Array.Empty<string>();
 
     /// <summary>Creates a new semantic version with the specified major, minor, and patch numbers.</summary>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="major"/>, <paramref name="minor"/> or <paramref name="patch"/> is negative.</exception>
     public SemanticVersion(int major, int minor, int patch)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(major);
+        ArgumentOutOfRangeException.ThrowIfNegative(minor);
+        ArgumentOutOfRangeException.ThrowIfNegative(patch);
+
         Major = major;
         Minor = minor;
         Patch = patch;

--- a/src/Meziantou.Framework.Versioning/SemanticVersionExtensions.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersionExtensions.cs
@@ -4,6 +4,7 @@ namespace Meziantou.Framework.Versioning;
 public static class SemanticVersionExtensions
 {
     /// <summary>Gets the next patch version. For prerelease versions, returns the version without the prerelease tag. For stable versions, increments the patch number.</summary>
+    /// <exception cref="OverflowException">The patch number is <see cref="int.MaxValue"/>.</exception>
     public static SemanticVersion NextPatchVersion(this SemanticVersion semanticVersion)
     {
         if (semanticVersion.IsPrerelease)
@@ -11,10 +12,11 @@ public static class SemanticVersionExtensions
             return new SemanticVersion(semanticVersion.Major, semanticVersion.Minor, semanticVersion.Patch);
         }
 
-        return new SemanticVersion(semanticVersion.Major, semanticVersion.Minor, semanticVersion.Patch + 1);
+        return new SemanticVersion(semanticVersion.Major, semanticVersion.Minor, checked(semanticVersion.Patch + 1));
     }
 
     /// <summary>Gets the next minor version. For prerelease versions, returns the version without the prerelease tag. For stable versions, increments the minor number and resets the patch number to zero.</summary>
+    /// <exception cref="OverflowException">The minor number is <see cref="int.MaxValue"/>.</exception>
     public static SemanticVersion NextMinorVersion(this SemanticVersion semanticVersion)
     {
         if (semanticVersion.IsPrerelease)
@@ -22,10 +24,11 @@ public static class SemanticVersionExtensions
             return new SemanticVersion(semanticVersion.Major, semanticVersion.Minor, 0);
         }
 
-        return new SemanticVersion(semanticVersion.Major, semanticVersion.Minor + 1, 0);
+        return new SemanticVersion(semanticVersion.Major, checked(semanticVersion.Minor + 1), 0);
     }
 
     /// <summary>Gets the next major version. For prerelease versions, returns the version without the prerelease tag. For stable versions, increments the major number and resets the minor and patch numbers to zero.</summary>
+    /// <exception cref="OverflowException">The major number is <see cref="int.MaxValue"/>.</exception>
     public static SemanticVersion NextMajorVersion(this SemanticVersion semanticVersion)
     {
         if (semanticVersion.IsPrerelease)
@@ -33,6 +36,6 @@ public static class SemanticVersionExtensions
             return new SemanticVersion(semanticVersion.Major, 0, 0);
         }
 
-        return new SemanticVersion(semanticVersion.Major + 1, 0, 0);
+        return new SemanticVersion(checked(semanticVersion.Major + 1), 0, 0);
     }
 }

--- a/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
@@ -458,6 +458,7 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         var isMaxInclusive = false;
 
         // Split by spaces for multiple constraints
+        var constraintCount = 0;
         foreach (var segment in SplitBySpace(value))
         {
             var part = segment.Trim();
@@ -470,9 +471,13 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             {
                 return false;
             }
+
+            constraintCount++;
         }
 
-        if (minVersion is null && maxVersion is null)
+        // A constraint can legitimately leave both bounds open ("x.x" matches everything), so the
+        // number of constraints read is what tells us whether anything was understood.
+        if (constraintCount == 0)
         {
             return false;
         }
@@ -488,37 +493,39 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         var leftPart = value[..hyphenIndex].Trim();
         var rightPart = value[(hyphenIndex + 3)..].Trim(); // Skip " - "
 
-        if (!TryParseNpmPartialVersion(leftPart, out var leftMajor, out var leftMinor, out var leftPatch, out _))
+        if (!TryParseNpmPartialVersion(leftPart, out var left) || left.Major is null)
         {
             return false;
         }
 
-        if (!TryParseNpmPartialVersion(rightPart, out var rightMajor, out var rightMinor, out var rightPatch, out _))
+        if (!TryParseNpmPartialVersion(rightPart, out var right) || right.Major is null)
         {
             return false;
         }
 
-        var minVersion = new SemanticVersion(leftMajor, leftMinor ?? 0, leftPatch ?? 0);
+        // LowerBound keeps any prerelease and metadata labels: "1.0.0-alpha - 2.0.0" starts at
+        // 1.0.0-alpha, not at 1.0.0.
+        var minVersion = left.LowerBound;
 
         SemanticVersion maxVersion;
         bool isMaxInclusive;
 
-        if (rightPatch.HasValue)
+        if (right.Patch is not null)
         {
             // Full version on right: <=X.Y.Z
-            maxVersion = new SemanticVersion(rightMajor, rightMinor ?? 0, rightPatch.Value);
+            maxVersion = right.LowerBound;
             isMaxInclusive = true;
         }
-        else if (rightMinor.HasValue)
+        else if (right.Minor is { } rightMinor)
         {
             // Partial minor: <X.(Y+1).0
-            maxVersion = new SemanticVersion(rightMajor, rightMinor.Value + 1, 0);
+            maxVersion = new SemanticVersion(right.Major.Value, rightMinor + 1, 0);
             isMaxInclusive = false;
         }
         else
         {
             // Only major: <(X+1).0.0
-            maxVersion = new SemanticVersion(rightMajor + 1, 0, 0);
+            maxVersion = new SemanticVersion(right.Major.Value + 1, 0, 0);
             isMaxInclusive = false;
         }
 
@@ -543,12 +550,6 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         if (part.StartsWith("^".AsSpan(), StringComparison.Ordinal))
         {
             return TryParseCaretRange(part[1..].Trim(), ref minVersion, ref maxVersion, ref isMinInclusive, ref isMaxInclusive);
-        }
-
-        // Handle X-range patterns (1.x, 1.2.x, 1.*, etc.)
-        if (IsXRange(part))
-        {
-            return TryParseXRange(part, ref minVersion, ref maxVersion, ref isMinInclusive, ref isMaxInclusive);
         }
 
         // Parse operator and version
@@ -582,6 +583,22 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         }
 
         var versionPart = part[versionStart..].Trim();
+
+        // Only look for an X-range once the operator has been stripped, and only in the numeric
+        // core of the version: a prerelease or metadata label may legitimately contain an 'x'
+        // (">=1.0.0-exp"), and treating that as a wildcard rejects a perfectly valid constraint.
+        if (IsXRange(versionPart))
+        {
+            // npm only gives a wildcard a meaning of its own when it stands without a comparison
+            // operator, so ">=1.x" stays unsupported rather than being guessed at.
+            if (op is not NpmOperator.Exact)
+            {
+                return false;
+            }
+
+            return TryParseXRange(versionPart, ref minVersion, ref maxVersion, ref isMinInclusive, ref isMaxInclusive);
+        }
+
         if (!SemanticVersion.TryParse(versionPart, out var version))
         {
             return false;
@@ -637,23 +654,23 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         // ~1 := >=1.0.0 <2.0.0
         // ~0.2.3 := >=0.2.3 <0.3.0
 
-        if (!TryParseNpmPartialVersion(versionPart, out var major, out var minor, out var patch, out _))
+        if (!TryParseNpmPartialVersion(versionPart, out var partial) || partial.Major is null)
         {
             return false;
         }
 
-        minVersion = new SemanticVersion(major, minor ?? 0, patch ?? 0);
+        minVersion = partial.LowerBound;
         isMinInclusive = true;
 
-        if (minor.HasValue)
+        if (partial.Minor is { } minor)
         {
             // ~1.2.3 or ~1.2 -> <1.3.0
-            maxVersion = new SemanticVersion(major, minor.Value + 1, 0);
+            maxVersion = new SemanticVersion(partial.Major.Value, minor + 1, 0);
         }
         else
         {
-            // ~1 -> <2.0.0
-            maxVersion = new SemanticVersion(major + 1, 0, 0);
+            // ~1 or ~1.x -> <2.0.0
+            maxVersion = new SemanticVersion(partial.Major.Value + 1, 0, 0);
         }
 
         isMaxInclusive = false;
@@ -677,57 +694,48 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         // ^1.x := >=1.0.0 <2.0.0
         // ^0.x := >=0.0.0 <1.0.0
 
-        if (!TryParseNpmPartialVersion(versionPart, out var major, out var minor, out var patch, out _))
+        if (!TryParseNpmPartialVersion(versionPart, out var partial) || partial.Major is not { } major)
         {
             return false;
         }
 
-        minVersion = new SemanticVersion(major, minor ?? 0, patch ?? 0);
+        minVersion = partial.LowerBound;
         isMinInclusive = true;
 
-        if (major != 0)
+        maxVersion = (major, partial.Minor, partial.Patch) switch
         {
-            // ^1.x.x -> <2.0.0
-            maxVersion = new SemanticVersion(major + 1, 0, 0);
-        }
-        else if (minor.HasValue && minor.Value != 0)
-        {
-            // ^0.2.x -> <0.3.0
-            maxVersion = new SemanticVersion(0, minor.Value + 1, 0);
-        }
-        else if (patch.HasValue)
-        {
-            // ^0.0.3 -> <0.0.4
-            maxVersion = new SemanticVersion(0, 0, patch.Value + 1);
-        }
-        else if (minor.HasValue)
-        {
-            // ^0.0 -> <0.1.0
-            maxVersion = new SemanticVersion(0, 1, 0);
-        }
-        else
-        {
-            // ^0 -> <1.0.0
-            maxVersion = new SemanticVersion(1, 0, 0);
-        }
+            ( > 0, _, _) => new SemanticVersion(major + 1, 0, 0),            // ^1.2.3 -> <2.0.0
+            (0, > 0 and { } minor, _) => new SemanticVersion(0, minor + 1, 0), // ^0.2.3 -> <0.3.0
+            (0, _, { } patch) => new SemanticVersion(0, 0, patch + 1),       // ^0.0.3 -> <0.0.4
+            (0, not null, null) => new SemanticVersion(0, 1, 0),             // ^0.0 -> <0.1.0
+            _ => new SemanticVersion(1, 0, 0),                               // ^0 or ^0.x -> <1.0.0
+        };
 
         isMaxInclusive = false;
 
         return true;
     }
 
-    private static bool IsXRange(ReadOnlySpan<char> part)
+    private static bool IsXRange(ReadOnlySpan<char> version)
     {
-        // Check if the part contains 'x', 'X', or '*' as a version component
-        foreach (var c in part)
+        // A wildcard is a whole component of the numeric core. Scanning the raw characters instead
+        // would treat the 'x' in a label such as "1.0.0-exp" as a wildcard.
+        foreach (var component in new PartEnumerable(GetVersionCore(version)))
         {
-            if (c is 'x' or 'X' or '*')
+            if (component is "x" or "X" or "*")
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    // The numeric "major.minor.patch" part, without the prerelease or metadata labels.
+    private static ReadOnlySpan<char> GetVersionCore(ReadOnlySpan<char> version)
+    {
+        var labelIndex = version.IndexOfAny('-', '+');
+        return labelIndex < 0 ? version : version[..labelIndex];
     }
 
     private static bool TryParseXRange(
@@ -742,20 +750,16 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         // 1.* := >=1.0.0 <2.0.0
         // * := any version (handled separately)
 
-        if (!TryParseNpmPartialVersion(part, out var major, out var minor, out var patch, out var hasWildcard))
+        if (!TryParseNpmPartialVersion(part, out var partial) || !partial.HasWildcard)
         {
             return false;
         }
 
-        if (!hasWildcard)
+        // The major itself is a wildcard ("x", "x.x", "*"): every version matches. This is
+        // distinct from a literal zero major such as "0.x", which the caller must not confuse
+        // with it.
+        if (partial.Major is not { } major)
         {
-            return false;
-        }
-
-        // Full wildcard case
-        if (major == 0 && !minor.HasValue && !patch.HasValue && hasWildcard)
-        {
-            // This shouldn't happen as "*" is handled earlier, but just in case
             minVersion = null;
             maxVersion = null;
             isMinInclusive = false;
@@ -763,13 +767,13 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             return true;
         }
 
-        minVersion = new SemanticVersion(major, minor ?? 0, patch ?? 0);
+        minVersion = partial.LowerBound;
         isMinInclusive = true;
 
-        if (minor.HasValue && !patch.HasValue)
+        if (partial.Minor is { } minor)
         {
             // 1.2.x -> <1.3.0
-            maxVersion = new SemanticVersion(major, minor.Value + 1, 0);
+            maxVersion = new SemanticVersion(major, minor + 1, 0);
         }
         else
         {
@@ -782,17 +786,24 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         return true;
     }
 
-    private static bool TryParseNpmPartialVersion(
-        ReadOnlySpan<char> value,
-        out int major,
-        out int? minor,
-        out int? patch,
-        out bool hasWildcard)
+    // A version with optional trailing components, as npm range syntax allows: "1", "1.2", "1.2.3",
+    // "1.x" and "1.2.3-beta.1" are all accepted. A null component is one that was absent or was a
+    // wildcard; HasWildcard tells the two apart.
+    [StructLayout(LayoutKind.Auto)]
+    private readonly struct NpmPartialVersion(int? major, int? minor, int? patch, bool hasWildcard, SemanticVersion lowerBound)
     {
-        major = 0;
-        minor = null;
-        patch = null;
-        hasWildcard = false;
+        public int? Major { get; } = major;
+        public int? Minor { get; } = minor;
+        public int? Patch { get; } = patch;
+        public bool HasWildcard { get; } = hasWildcard;
+
+        /// <summary>The lowest version the partial version denotes, keeping any prerelease and metadata labels.</summary>
+        public SemanticVersion LowerBound { get; } = lowerBound;
+    }
+
+    private static bool TryParseNpmPartialVersion(ReadOnlySpan<char> value, out NpmPartialVersion result)
+    {
+        result = default;
 
         value = value.Trim();
         if (value.IsEmpty)
@@ -806,89 +817,79 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             value = value[1..];
         }
 
-        var parts = new PartEnumerable(value);
+        // The prerelease and metadata labels are kept aside rather than discarded, so that the
+        // lower bound of "^1.2.3-beta" is 1.2.3-beta and not 1.2.3.
+        var core = GetVersionCore(value);
+        var labels = value[core.Length..];
+
+        // The component enumerator does not yield a trailing empty component, so "1.2." has to be
+        // rejected here; an empty component anywhere else is caught in the loop below.
+        if (core.IsEmpty || core[^1] is '.')
+        {
+            return false;
+        }
+
+        int? major = null;
+        int? minor = null;
+        int? patch = null;
+        var hasWildcard = false;
         var partIndex = 0;
 
-        foreach (var part in parts)
+        foreach (var component in new PartEnumerable(core))
         {
-            if (part.IsEmpty)
+            // A version has at most three components, and every one of them must be present.
+            if (partIndex > 2 || component.IsEmpty)
             {
                 return false;
             }
 
-            var isWildcard = part is "x" or "X" or "*";
-            if (isWildcard)
+            if (component is "x" or "X" or "*")
             {
                 hasWildcard = true;
             }
-
-            switch (partIndex)
+            else if (!TryParseInt(component, out var number))
             {
-                case 0:
-                    if (isWildcard)
-                    {
-                        major = 0;
-                        hasWildcard = true;
-                    }
-                    else if (!TryParseInt(part, out major))
-                    {
-                        return false;
-                    }
-
-                    break;
-                case 1:
-                    if (isWildcard)
-                    {
-                        hasWildcard = true;
-                    }
-                    else if (TryParseInt(part, out var minorValue))
-                    {
-                        minor = minorValue;
-                    }
-                    else
-                    {
-                        return false;
-                    }
-
-                    break;
-                case 2:
-                    if (isWildcard)
-                    {
-                        hasWildcard = true;
-                    }
-                    else
-                    {
-                        // Handle prerelease/metadata suffix: "3-alpha" or "3+build"
-                        var patchPart = part;
-                        var dashIndex = patchPart.IndexOfAny(['-', '+']);
-                        if (dashIndex >= 0)
-                        {
-                            patchPart = patchPart[..dashIndex];
-                        }
-
-                        if (TryParseInt(patchPart, out var patchValue))
-                        {
-                            patch = patchValue;
-                        }
-                        else
-                        {
-                            return false;
-                        }
-                    }
-
-                    break;
+                return false;
+            }
+            else if (!hasWildcard)
+            {
+                // Everything after the first wildcard is a wildcard too: npm reads "1.x.2" as "1.x".
+                switch (partIndex)
+                {
+                    case 0:
+                        major = number;
+                        break;
+                    case 1:
+                        minor = number;
+                        break;
+                    default:
+                        patch = number;
+                        break;
+                }
             }
 
             partIndex++;
-
-            // Stop after patch version
-            if (partIndex > 2)
-            {
-                break;
-            }
         }
 
-        return partIndex >= 1;
+        if (partIndex is 0)
+        {
+            return false;
+        }
+
+        SemanticVersion lowerBound;
+        if (labels.IsEmpty)
+        {
+            lowerBound = new SemanticVersion(major ?? 0, minor ?? 0, patch ?? 0);
+        }
+        else if (patch is null || !SemanticVersion.TryParse(value, out lowerBound!))
+        {
+            // Labels only attach to a complete "major.minor.patch", and the whole thing has to be a
+            // valid semantic version. Delegating that check keeps one definition of what is valid.
+            return false;
+        }
+
+        result = new NpmPartialVersion(major, minor, patch, hasWildcard, lowerBound);
+        return true;
     }
 
     private static bool TryParseInt(ReadOnlySpan<char> value, out int result)

--- a/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
@@ -389,7 +389,7 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             return result;
         }
 
-        throw new FormatException($"The value '{value}' is not a valid npm version range.");
+        throw new FormatException(GetNpmFormatErrorMessage(value));
     }
 
     /// <summary>Parses a version range in npm format.</summary>
@@ -404,7 +404,17 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             return result;
         }
 
-        throw new FormatException($"The value '{value}' is not a valid npm version range.");
+        throw new FormatException(GetNpmFormatErrorMessage(value));
+    }
+
+    private static string GetNpmFormatErrorMessage(ReadOnlySpan<char> value)
+    {
+        // A union is valid npm syntax that this type cannot represent, since it models a single
+        // interval. Saying so beats letting the caller hunt for a syntax error that is not there.
+        if (value.Contains("||".AsSpan(), StringComparison.Ordinal))
+            return $"The value '{value}' is not a valid npm version range: a union of ranges ('||') cannot be represented by a single {nameof(SemanticVersionRange)}.";
+
+        return $"The value '{value}' is not a valid npm version range.";
     }
 
     /// <summary>Attempts to parse a version range in npm format.</summary>
@@ -607,30 +617,70 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         switch (op)
         {
             case NpmOperator.Exact:
-                minVersion = version;
-                maxVersion = version;
-                isMinInclusive = true;
-                isMaxInclusive = true;
+                IntersectMin(ref minVersion, ref isMinInclusive, version, inclusive: true);
+                IntersectMax(ref maxVersion, ref isMaxInclusive, version, inclusive: true);
                 break;
             case NpmOperator.GreaterThan:
-                minVersion = version;
-                isMinInclusive = false;
+                IntersectMin(ref minVersion, ref isMinInclusive, version, inclusive: false);
                 break;
             case NpmOperator.GreaterThanOrEqual:
-                minVersion = version;
-                isMinInclusive = true;
+                IntersectMin(ref minVersion, ref isMinInclusive, version, inclusive: true);
                 break;
             case NpmOperator.LessThan:
-                maxVersion = version;
-                isMaxInclusive = false;
+                IntersectMax(ref maxVersion, ref isMaxInclusive, version, inclusive: false);
                 break;
             case NpmOperator.LessThanOrEqual:
-                maxVersion = version;
-                isMaxInclusive = true;
+                IntersectMax(ref maxVersion, ref isMaxInclusive, version, inclusive: true);
                 break;
         }
 
         return true;
+    }
+
+    // Space-separated npm constraints are ANDed together, so each one narrows the range rather
+    // than replacing it. Assigning instead would make the result depend on the order the
+    // constraints happen to be written in, and ">=1.5.0 >=1.0.0" would widen back out to >=1.0.0.
+    private static void IntersectMin(ref SemanticVersion? minVersion, ref bool isMinInclusive, SemanticVersion version, bool inclusive)
+    {
+        if (minVersion is null)
+        {
+            minVersion = version;
+            isMinInclusive = inclusive;
+            return;
+        }
+
+        var comparison = version.CompareTo(minVersion);
+        if (comparison > 0)
+        {
+            minVersion = version;
+            isMinInclusive = inclusive;
+        }
+        else if (comparison is 0)
+        {
+            // Of two equal lower bounds the exclusive one is tighter: ">1.0.0 >=1.0.0" is >1.0.0.
+            isMinInclusive &= inclusive;
+        }
+    }
+
+    private static void IntersectMax(ref SemanticVersion? maxVersion, ref bool isMaxInclusive, SemanticVersion version, bool inclusive)
+    {
+        if (maxVersion is null)
+        {
+            maxVersion = version;
+            isMaxInclusive = inclusive;
+            return;
+        }
+
+        var comparison = version.CompareTo(maxVersion);
+        if (comparison < 0)
+        {
+            maxVersion = version;
+            isMaxInclusive = inclusive;
+        }
+        else if (comparison is 0)
+        {
+            isMaxInclusive &= inclusive;
+        }
     }
 
     private enum NpmOperator
@@ -659,21 +709,13 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             return false;
         }
 
-        minVersion = partial.LowerBound;
-        isMinInclusive = true;
+        IntersectMin(ref minVersion, ref isMinInclusive, partial.LowerBound, inclusive: true);
 
-        if (partial.Minor is { } minor)
-        {
-            // ~1.2.3 or ~1.2 -> <1.3.0
-            maxVersion = new SemanticVersion(partial.Major.Value, minor + 1, 0);
-        }
-        else
-        {
-            // ~1 or ~1.x -> <2.0.0
-            maxVersion = new SemanticVersion(partial.Major.Value + 1, 0, 0);
-        }
+        var upperBound = partial.Minor is { } minor
+            ? new SemanticVersion(partial.Major.Value, minor + 1, 0) // ~1.2.3 or ~1.2 -> <1.3.0
+            : new SemanticVersion(partial.Major.Value + 1, 0, 0);    // ~1 or ~1.x -> <2.0.0
 
-        isMaxInclusive = false;
+        IntersectMax(ref maxVersion, ref isMaxInclusive, upperBound, inclusive: false);
 
         return true;
     }
@@ -699,10 +741,9 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             return false;
         }
 
-        minVersion = partial.LowerBound;
-        isMinInclusive = true;
+        IntersectMin(ref minVersion, ref isMinInclusive, partial.LowerBound, inclusive: true);
 
-        maxVersion = (major, partial.Minor, partial.Patch) switch
+        var upperBound = (major, partial.Minor, partial.Patch) switch
         {
             ( > 0, _, _) => new SemanticVersion(major + 1, 0, 0),            // ^1.2.3 -> <2.0.0
             (0, > 0 and { } minor, _) => new SemanticVersion(0, minor + 1, 0), // ^0.2.3 -> <0.3.0
@@ -711,7 +752,7 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             _ => new SemanticVersion(1, 0, 0),                               // ^0 or ^0.x -> <1.0.0
         };
 
-        isMaxInclusive = false;
+        IntersectMax(ref maxVersion, ref isMaxInclusive, upperBound, inclusive: false);
 
         return true;
     }
@@ -760,28 +801,18 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         // with it.
         if (partial.Major is not { } major)
         {
-            minVersion = null;
-            maxVersion = null;
-            isMinInclusive = false;
-            isMaxInclusive = false;
+            // Every version matches, so intersecting with it leaves the range untouched. Clearing
+            // the bounds here would instead discard whatever the preceding constraints established.
             return true;
         }
 
-        minVersion = partial.LowerBound;
-        isMinInclusive = true;
+        IntersectMin(ref minVersion, ref isMinInclusive, partial.LowerBound, inclusive: true);
 
-        if (partial.Minor is { } minor)
-        {
-            // 1.2.x -> <1.3.0
-            maxVersion = new SemanticVersion(major, minor + 1, 0);
-        }
-        else
-        {
-            // 1.x -> <2.0.0
-            maxVersion = new SemanticVersion(major + 1, 0, 0);
-        }
+        var upperBound = partial.Minor is { } minor
+            ? new SemanticVersion(major, minor + 1, 0) // 1.2.x -> <1.3.0
+            : new SemanticVersion(major + 1, 0, 0);    // 1.x -> <2.0.0
 
-        isMaxInclusive = false;
+        IntersectMax(ref maxVersion, ref isMaxInclusive, upperBound, inclusive: false);
 
         return true;
     }

--- a/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
+++ b/src/Meziantou.Framework.Versioning/SemanticVersionRange.cs
@@ -529,12 +529,22 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         else if (right.Minor is { } rightMinor)
         {
             // Partial minor: <X.(Y+1).0
+            if (rightMinor is int.MaxValue)
+            {
+                return false;
+            }
+
             maxVersion = new SemanticVersion(right.Major.Value, rightMinor + 1, 0);
             isMaxInclusive = false;
         }
         else
         {
             // Only major: <(X+1).0.0
+            if (right.Major.Value is int.MaxValue)
+            {
+                return false;
+            }
+
             maxVersion = new SemanticVersion(right.Major.Value + 1, 0, 0);
             isMaxInclusive = false;
         }
@@ -709,6 +719,14 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             return false;
         }
 
+        // Every upper bound below is a component plus one, so a component sitting at int.MaxValue
+        // would wrap into a negative version. Reject the range instead of building a nonsensical
+        // one; such versions are pathological and the alternative is a range matching nothing.
+        if (partial.Major is int.MaxValue || partial.Minor is int.MaxValue || partial.Patch is int.MaxValue)
+        {
+            return false;
+        }
+
         IntersectMin(ref minVersion, ref isMinInclusive, partial.LowerBound, inclusive: true);
 
         var upperBound = partial.Minor is { } minor
@@ -737,6 +755,14 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
         // ^0.x := >=0.0.0 <1.0.0
 
         if (!TryParseNpmPartialVersion(versionPart, out var partial) || partial.Major is not { } major)
+        {
+            return false;
+        }
+
+        // Every upper bound below is a component plus one, so a component sitting at int.MaxValue
+        // would wrap into a negative version. Reject the range instead of building a nonsensical
+        // one; such versions are pathological and the alternative is a range matching nothing.
+        if (partial.Major is int.MaxValue || partial.Minor is int.MaxValue || partial.Patch is int.MaxValue)
         {
             return false;
         }
@@ -804,6 +830,14 @@ public sealed class SemanticVersionRange : IEquatable<SemanticVersionRange>
             // Every version matches, so intersecting with it leaves the range untouched. Clearing
             // the bounds here would instead discard whatever the preceding constraints established.
             return true;
+        }
+
+        // Every upper bound below is a component plus one, so a component sitting at int.MaxValue
+        // would wrap into a negative version. Reject the range instead of building a nonsensical
+        // one; such versions are pathological and the alternative is a range matching nothing.
+        if (partial.Major is int.MaxValue || partial.Minor is int.MaxValue || partial.Patch is int.MaxValue)
+        {
+            return false;
         }
 
         IntersectMin(ref minVersion, ref isMinInclusive, partial.LowerBound, inclusive: true);

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
@@ -343,10 +343,75 @@ public class SemanticVersionRangeTests
     }
 
     [Theory]
+    // A prerelease or metadata label may contain 'x', 'X' or '*' without being a wildcard
+    [InlineData(">=1.0.0-exp", "[1.0.0-exp, )")]
+    [InlineData(">=1.0.0-max", "[1.0.0-max, )")]
+    [InlineData(">=1.0.0-rc.x", "[1.0.0-rc.x, )")]
+    [InlineData("<2.0.0-beta.x", "(, 2.0.0-beta.x)")]
+    [InlineData(">=1.0.0-alpha+x", "[1.0.0-alpha+x, )")]
+    [InlineData(">=1.0.0-x.7.z.92", "[1.0.0-x.7.z.92, )")]
+    // Tilde, caret and hyphen ranges keep the prerelease on their lower bound
+    [InlineData("^1.2.3-beta", "[1.2.3-beta, 2.0.0)")]
+    [InlineData("~1.2.3-beta", "[1.2.3-beta, 1.3.0)")]
+    [InlineData("^1.2.3+meta", "[1.2.3+meta, 2.0.0)")]
+    [InlineData("1.0.0-alpha - 2.0.0", "[1.0.0-alpha, 2.0.0]")]
+    [InlineData("1.0.0 - 2.0.0-rc.1", "[1.0.0, 2.0.0-rc.1]")]
+    // A literal zero major is not a wildcard major
+    [InlineData("0.x", "[0.0.0, 1.0.0)")]
+    [InlineData("0.*", "[0.0.0, 1.0.0)")]
+    [InlineData("0.X", "[0.0.0, 1.0.0)")]
+    [InlineData("0.0.x", "[0.0.0, 0.1.0)")]
+    [InlineData("^0.x", "[0.0.0, 1.0.0)")]
+    // Components after a wildcard are wildcards too: npm reads "1.x.2" as "1.x"
+    [InlineData("1.x.2", "[1.0.0, 2.0.0)")]
+    public void ParseNpm_ProducesRange(string input, string expected)
+    {
+        Assert.Equal(expected, SemanticVersionRange.ParseNpm(input).ToString());
+    }
+
+    [Theory]
+    [InlineData("x.x")]
+    [InlineData("*.*")]
+    [InlineData("x")]
+    [InlineData("*")]
+    public void ParseNpm_WildcardMajor_MatchesEveryVersion(string input)
+    {
+        Assert.Equal(SemanticVersionRange.All, SemanticVersionRange.ParseNpm(input));
+    }
+
+    [Fact]
+    public void ParseNpm_CaretWithPrerelease_IncludesThatPrerelease()
+    {
+        var range = SemanticVersionRange.ParseNpm("^1.2.3-beta");
+
+        Assert.True(range.Satisfies(SemanticVersion.Parse("1.2.3-beta")));
+        Assert.True(range.Satisfies(SemanticVersion.Parse("1.2.3")));
+        Assert.False(range.Satisfies(SemanticVersion.Parse("1.2.3-alpha")));
+    }
+
+    [Fact]
+    public void ParseNpm_ZeroMajorXRange_DoesNotMatchEveryVersion()
+    {
+        var range = SemanticVersionRange.ParseNpm("0.x");
+
+        Assert.True(range.Satisfies(SemanticVersion.Parse("0.9.9")));
+        Assert.False(range.Satisfies(SemanticVersion.Parse("5.0.0")));
+    }
+
+    [Theory]
     [InlineData("")]
     [InlineData("invalid")]
     [InlineData(">")]
     [InlineData(">=")]
+    [InlineData("~1.2.3.4")] // A version has at most three components
+    [InlineData("~1.2.3.junk")]
+    [InlineData("^1.2.3.4")]
+    [InlineData("1.2.3.4")]
+    [InlineData("~1.2.")] // Every component must be present
+    [InlineData("~1..2")]
+    [InlineData("1.2-beta")] // A label needs a complete major.minor.patch
+    [InlineData("^1.x-beta")]
+    [InlineData(">=1.x")] // A wildcard carries no meaning next to a comparison operator
     public void ParseNpm_InvalidFormats_ThrowsFormatException(string input)
     {
         Assert.Throws<FormatException>(() => SemanticVersionRange.ParseNpm(input));

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
@@ -455,6 +455,12 @@ public class SemanticVersionRangeTests
     [InlineData("1.2-beta")] // A label needs a complete major.minor.patch
     [InlineData("^1.x-beta")]
     [InlineData(">=1.x")] // A wildcard carries no meaning next to a comparison operator
+    // An upper bound of "component + 1" would overflow into a negative version
+    [InlineData("^2147483647.0.0")]
+    [InlineData("~2147483647.0.0")]
+    [InlineData("2147483647.x")]
+    [InlineData("^0.0.2147483647")]
+    [InlineData("1.0.0 - 2147483647")]
     public void ParseNpm_InvalidFormats_ThrowsFormatException(string input)
     {
         Assert.Throws<FormatException>(() => SemanticVersionRange.ParseNpm(input));

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionRangeTests.cs
@@ -370,6 +370,49 @@ public class SemanticVersionRangeTests
     }
 
     [Theory]
+    // Space-separated constraints are ANDed, so the order they are written in cannot matter
+    [InlineData(">=1.0.0 >=1.5.0", ">=1.5.0 >=1.0.0")]
+    [InlineData("<1.5.0 <2.0.0", "<2.0.0 <1.5.0")]
+    [InlineData(">1.0.0 >=1.0.0", ">=1.0.0 >1.0.0")]
+    [InlineData("<2.0.0 <=2.0.0", "<=2.0.0 <2.0.0")]
+    [InlineData(">=1.5.0 ^1.0.0", "^1.0.0 >=1.5.0")]
+    [InlineData(">=1.2.0 1.x", "1.x >=1.2.0")]
+    [InlineData(">=2.0.0 x.x", "x.x >=2.0.0")]
+    public void ParseNpm_ConstraintOrder_DoesNotChangeTheRange(string one, string other)
+    {
+        Assert.Equal(SemanticVersionRange.ParseNpm(one), SemanticVersionRange.ParseNpm(other));
+    }
+
+    [Theory]
+    [InlineData(">=1.5.0 >=1.0.0", "[1.5.0, )")] // The tighter lower bound wins
+    [InlineData("<1.5.0 <2.0.0", "(, 1.5.0)")] // The tighter upper bound wins
+    [InlineData(">1.0.0 >=1.0.0", "(1.0.0, )")] // Equal bounds keep the exclusive one
+    [InlineData("<2.0.0 <=2.0.0", "(, 2.0.0)")]
+    [InlineData(">=2.0.0 x.x", "[2.0.0, )")] // A match-everything constraint narrows nothing
+    [InlineData(">=1.0.0 <2.0.0", "[1.0.0, 2.0.0)")]
+    public void ParseNpm_MultipleConstraints_AreIntersected(string input, string expected)
+    {
+        Assert.Equal(expected, SemanticVersionRange.ParseNpm(input).ToString());
+    }
+
+    [Fact]
+    public void ParseNpm_LooserConstraintLast_DoesNotWidenTheRange()
+    {
+        var range = SemanticVersionRange.ParseNpm(">=1.5.0 >=1.0.0");
+
+        Assert.False(range.Satisfies(SemanticVersion.Parse("1.2.0")));
+        Assert.True(range.Satisfies(SemanticVersion.Parse("1.5.0")));
+    }
+
+    [Fact]
+    public void ParseNpm_Union_ReportsThatUnionsAreUnsupported()
+    {
+        var exception = Assert.Throws<FormatException>(() => SemanticVersionRange.ParseNpm("^1.0.0 || ^2.0.0"));
+
+        Assert.Contains("||", exception.Message);
+    }
+
+    [Theory]
     [InlineData("x.x")]
     [InlineData("*.*")]
     [InlineData("x")]

--- a/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
+++ b/tests/Meziantou.Framework.Versioning.Tests/SemanticVersionTests.cs
@@ -169,6 +169,26 @@ public class SemanticVersionTests
         Assert.Throws<ArgumentException>(() => new SemanticVersion(1, 2, 3, prereleaseLabel: null, metadata: "label./"));
     }
 
+    [Theory]
+    [InlineData(-1, 0, 0)]
+    [InlineData(0, -1, 0)]
+    [InlineData(0, 0, -1)]
+    [InlineData(int.MinValue, int.MinValue, int.MinValue)]
+    public void Constructor_WithNegativeComponent_ShouldThrowException(int major, int minor, int patch)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SemanticVersion(major, minor, patch));
+    }
+
+    [Fact]
+    public void NextVersion_AtMaxValue_ShouldThrowOverflowException()
+    {
+        var version = new SemanticVersion(int.MaxValue, int.MaxValue, int.MaxValue);
+
+        Assert.Throws<OverflowException>(() => version.NextMajorVersion());
+        Assert.Throws<OverflowException>(() => version.NextMinorVersion());
+        Assert.Throws<OverflowException>(() => version.NextPatchVersion());
+    }
+
     [Fact]
     public void NextPatchVersion_ShouldRemovePrereleaseTag()
     {


### PR DESCRIPTION
**Stack 3 of 3 · merges into `fix/npm-intersect-constraints` (#2459) · must merge last**

## Problem

Every "next version" computation was a bare `+ 1` on an `int` with no overflow check, and the public constructors accepted negative components without validation:

```
new SemanticVersion(int.MaxValue, int.MaxValue, int.MaxValue).NextMajorVersion()
  =>  -2147483648.0.0
                                                             .NextPatchVersion()
  =>  2147483647.2147483647.-2147483648
ParseNpm("^2147483647.0.0")   =>  [2147483647.0.0, -2147483648.0.0)    inverted; matches nothing
new SemanticVersion(-1, -2, -3).ToString()   =>  "-1.-2.-3"
```

All four are strings `SemanticVersion.TryParse` refuses — a `SemanticVersion` that cannot round-trip through its own parser. The likelihood is low, but the failure is total and silent, and the negative-constructor case needs no extreme input at all, just a caller passing an unvalidated `int`.

## What changed

- The public `SemanticVersion(int, int, int)` constructor rejects negative components with `ArgumentOutOfRangeException.ThrowIfNegative`. The other public constructors chain through it. The private parser constructor is untouched — the parser cannot produce a negative component, and it stays on the allocation-free path.
- `NextMajorVersion`, `NextMinorVersion` and `NextPatchVersion` use `checked`, so overflow raises `OverflowException` rather than wrapping.
- The range helpers guard their increments and **return `false`** instead of throwing. This is the important detail: `TryParseNpm` must not throw, and without a guard the now-validating constructor would have turned a pathological input into an escaping `ArgumentOutOfRangeException` — trading a silent wrong answer for a crash.

The guard in the tilde, caret and x-range helpers is a single check covering all three components rather than one per increment site. That is very slightly over-strict — `^1.2147483647.0` is rejected even though only the major is incremented there — which is a deliberate trade of a pathological edge case for a parser that stays readable. The hyphen range, where the right-hand side often needs no increment at all, guards only the branches that actually increment, so `1.0.0 - 2147483647.0.0` keeps working.

`>=2147483647.0.0` is unaffected: it goes through `SemanticVersion.TryParse` and never increments.

## Verification

`dotnet test tests/Meziantou.Framework.Versioning.Tests /p:TreatsWarningsAsErrors=true` — 424 passing (212 × 2 TFMs), up from 404 on #2459. Verified with both layers below applied.

Beyond the unit tests I re-ran every pathological input through `TryParseNpm` to confirm **none of them throws** — they return `false` — while the boundary-minus-one cases (`^2147483646.0.0`, `1.0.0 - 2147483646`) still parse normally.

`dotnet run ./eng/update-all.cs` — no generated-file changes, which also confirms the public API surface in `ref/` is unchanged by all three layers.
