### PR TITLE
Split gitignore content on CR and LF only

### DIFF
--- a/src/Meziantou.Framework.Globbing/GlobCollection.cs
+++ b/src/Meziantou.Framework.Globbing/GlobCollection.cs
@@ -42,7 +42,9 @@ public sealed class GlobCollection : IReadOnlyList<IGlobEvaluatable>, IGlobEvalu
     public static GlobCollection ParseGitIgnore(ReadOnlySpan<char> gitIgnoreContent)
     {
         var globs = new List<IGlobEvaluatable>();
-        foreach (var entry in new StringExtensions.LineSplitEnumerator(gitIgnoreContent))
+        // Split on CR/LF/CRLF only, like git and like TextReader.ReadLine in the LoadGitIgnoreAsync overloads. The
+        // default Unicode mode also breaks on U+0085, U+2028 and U+2029, which are legal characters in a file name.
+        foreach (var entry in new StringExtensions.LineSplitEnumerator(gitIgnoreContent, LineBreakMode.Standard))
         {
             AddGitIgnoreLine(entry.Line, globs);
         }

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobCollectionTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobCollectionTests.cs
@@ -82,4 +82,33 @@ important.log
         Assert.False(globs.IsMatch("important.log"));
         Assert.True(globs.IsMatch("trace.log"));
     }
+
+    [Theory]
+    [InlineData("\u0085")]
+    [InlineData("\u2028")]
+    [InlineData("\u2029")]
+    public async Task ParseGitIgnoreAndLoadGitIgnoreAgreeOnLineBreaks(string character)
+    {
+        var content = "a" + character + "b.txt";
+
+        var parsed = GlobCollection.ParseGitIgnore(content.AsSpan());
+        var loaded = await GlobCollection.LoadGitIgnoreAsync(new StringReader(content));
+
+        Assert.Equal(loaded.Count, parsed.Count);
+        Assert.Equal(1, parsed.Count);
+        Assert.True(parsed.IsMatch(content));
+        Assert.True(loaded.IsMatch(content));
+    }
+
+    [Fact]
+    public async Task ParseGitIgnoreAndLoadGitIgnoreAgreeOnCarriageReturns()
+    {
+        var content = "*.log\r\n!important.log\r\n";
+
+        var parsed = GlobCollection.ParseGitIgnore(content.AsSpan());
+        var loaded = await GlobCollection.LoadGitIgnoreAsync(new StringReader(content));
+
+        Assert.Equal(loaded.Count, parsed.Count);
+        Assert.Equal(2, parsed.Count);
+    }
 }


### PR DESCRIPTION
> **Stack 2 of 2** · merges into `fix/globbing-gitignore-last-match-wins` (#2457) · **must merge after #2457**

`ParseGitIgnore` and `LoadGitIgnoreAsync` split the same content into different lines:

- `ParseGitIgnore` uses `StringExtensions.LineSplitEnumerator`, whose default `LineBreakMode.Unicode` breaks on `\r`, `\n`, U+0085, U+2028 and U+2029.
- `LoadGitIgnoreAsync` uses `TextReader.ReadLineAsync`, which breaks only on `\r`, `\n` and `\r\n`.

git itself breaks on `\n`. So a `.gitignore` containing a file name with U+2028 — a legal character on every mainstream filesystem — parses into two patterns through the sync API and one through the async API. Same file, same operation, different collection.

## Change

Pass `LineBreakMode.Standard` so both paths agree, and agree with git.

Obscure, and unlikely to be hit in practice. It is worth fixing because the two overloads document themselves as doing the same thing, and a sync/async divergence in the same operation is the kind of defect that costs an afternoon when it does surface.

## Verification

- `dotnet test tests/Meziantou.Framework.Globbing.Tests` — 372 passed (368 on the base branch, 4 added here).
- `ParseGitIgnoreAndLoadGitIgnoreAgreeOnLineBreaks` asserts the two APIs produce the same pattern count for U+0085, U+2028 and U+2029, and that the pattern still matches the file name containing them.
- `ParseGitIgnoreAndLoadGitIgnoreAgreeOnCarriageReturns` pins that CRLF handling is unchanged.
- `dotnet run ./eng/update-all.cs` — no changes.

## Why this is stacked

This targets #2457 rather than `main` because both PRs add tests at the same point in `GlobCollectionTests.cs` and both edit `ParseGitIgnore`; they conflict textually (verified with `git merge-tree`). The changes themselves are unrelated — this is a mechanical conflict, not a semantic dependency. Merge #2457 first and this one applies cleanly.
