### PR TITLE
Remove an always-true condition in ConsumeToLastSegment

### DIFF
--- a/src/Meziantou.Framework.Globbing/Internals/PathReader.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/PathReader.cs
@@ -142,11 +142,9 @@ internal ref struct PathReader
         }
         else
         {
+            // When the text holds no separator, index is -1 and the slice starts at 0, which keeps the whole text.
             var index = CurrentText.LastIndexOfAny(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            if (index >= -1)
-            {
-                CurrentText = CurrentText[(index + 1)..];
-            }
+            CurrentText = CurrentText[(index + 1)..];
         }
 
         _currentSegmentLength = CurrentText.Length;

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobTests.cs
@@ -752,6 +752,28 @@ public class GlobTests
         AssertEnumerateFiles(directory, Glob.Parse("*.cs", GlobDialect.Posix), ["Program.cs", "src/Program.cs"]);
     }
 
+    [Theory]
+    [InlineData("**/b.txt", "b.txt")]
+    [InlineData("**/b.txt", "a/b.txt")]
+    [InlineData("**/b.txt", "a/nested/b.txt")]
+    [InlineData("a/**/b.txt", "a/b.txt")]
+    [InlineData("a/**/b.txt", "a/nested/b.txt")]
+    public void RecursiveWildcardFollowedByASingleSegmentMatchesAtEveryDepth(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.True(glob.IsMatch(path));
+    }
+
+    [Theory]
+    [InlineData("**/b.txt", "c.txt")]
+    [InlineData("**/b.txt", "a/c.txt")]
+    [InlineData("a/**/b.txt", "c/b.txt")]
+    public void RecursiveWildcardFollowedByASingleSegmentStillRejectsOtherPaths(string pattern, string path)
+    {
+        var glob = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot);
+        Assert.False(glob.IsMatch(path));
+    }
+
     private static void AssertEnumerateFiles(TemporaryDirectory directory, IGlobEvaluatable glob, string[] expectedResult)
     {
         var items = glob.EnumerateFiles(directory.FullPath)


### PR DESCRIPTION
`PathReader.ConsumeToLastSegment` guards a slice with a condition that is always true:

```csharp
var index = CurrentText.LastIndexOfAny(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
if (index >= -1)          // LastIndexOfAny never returns less than -1
{
    CurrentText = CurrentText[(index + 1)..];
}
```

`>= 0` was surely meant. As written there is no runtime effect — when `index` is `-1` the slice is `CurrentText[0..]`, a no-op — so this is not a bug report, just a line that reads as a deliberate boundary condition and is not one.

## Change

Drop the condition and slice unconditionally, with a comment explaining why `-1` is fine. That is provably equivalent to both the current code and the intended `>= 0`, and it removes the dead branch rather than leaving a reader to work out whether it is load-bearing.

It matters mainly because the branch would quietly become a real bug the moment the body gained a second statement.

## Verification

- `dotnet test tests/Meziantou.Framework.Globbing.Tests` — 372 passed (364 before, 8 added here).
- `ConsumeToLastSegment` is reached through `LastSegment`, the optimised form of `**` followed by one segment. The added tests exercise it both with a separator present (`a/nested/b.txt`, the `index >= 0` path) and without (`b.txt`, the `index == -1` path this line is about), plus negative cases.
- `dotnet run ./eng/update-all.cs` — no changes.
