### PR TITLE
Pin the leading-dot invariant behind the recursive wildcard optimizations

### DIFF
--- a/src/Meziantou.Framework.Globbing/Internals/GlobParser.cs
+++ b/src/Meziantou.Framework.Globbing/Internals/GlobParser.cs
@@ -362,10 +362,15 @@ internal static class GlobParser
         }
     }
 
-    private static Glob CreateGlob(List<Segment> segments, List<bool> matchLeadingDot, bool exclude, bool ignoreCase, GlobMatchType matchType, bool optimizeRecursiveWildcards, bool pathSeparatorAware)
+    // canSkipLeadingDotChecks is settings.MatchLeadingDot. The rewrites below collapse a '**' and the segments that
+    // follow it into a single segment that jumps to the end of the path, which skips the per-segment
+    // CanMatchLeadingDot checks Glob.IsMatchCore would otherwise run - that is why each one records 'true' in
+    // matchLeadingDot. They are only sound when leading dots are allowed everywhere, so do not loosen this gate
+    // without giving the rewritten segments a way to reject a segment that starts with a dot.
+    private static Glob CreateGlob(List<Segment> segments, List<bool> matchLeadingDot, bool exclude, bool ignoreCase, GlobMatchType matchType, bool canSkipLeadingDotChecks, bool pathSeparatorAware)
     {
         // Optimize segments
-        if (optimizeRecursiveWildcards && segments.Count >= 3)
+        if (canSkipLeadingDotChecks && segments.Count >= 3)
         {
             for (var i = segments.Count - 3; i >= 0; i--)
             {
@@ -402,7 +407,7 @@ internal static class GlobParser
             }
         }
 
-        if (optimizeRecursiveWildcards && segments.Count >= 2)
+        if (canSkipLeadingDotChecks && segments.Count >= 2)
         {
             if (segments[^2] is RecursiveMatchAllSegment && segments[^1] is MatchAllSegment) // **/*
             {

--- a/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
+++ b/tests/Meziantou.Framework.Globbing.Tests/GlobParserTests.cs
@@ -146,6 +146,32 @@ public class GlobParserTests
             item => Assert.IsType<CharacterRangeSegment>(item));
     }
 
+    [Theory]
+    [InlineData("a/**/b")]
+    [InlineData("a/**/b/c")]
+    [InlineData("a/**/*")]
+    [InlineData("a/**/*.txt")]
+    public void RecursiveWildcardIsNotOptimizedWhenLeadingDotsMustBeExcluded(string pattern)
+    {
+        // The optimized segments jump to the end of the path and skip the per-segment leading-dot checks, so they
+        // are only sound when GlobOptions.MatchLeadingDot is set.
+        var optimized = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot)._segments;
+        var notOptimized = Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.None)._segments;
+
+        Assert.Contains(notOptimized, item => item is RecursiveMatchAllSegment);
+        Assert.DoesNotContain(optimized, item => item is RecursiveMatchAllSegment);
+    }
+
+    [Theory]
+    [InlineData("a/**/b", "a/.hidden/b")]
+    [InlineData("a/**/b/c", "a/.hidden/b/c")]
+    [InlineData("a/**/*.txt", "a/.hidden/b.txt")]
+    public void RecursiveWildcardDoesNotCrossADotSegmentWithoutMatchLeadingDot(string pattern, string path)
+    {
+        Assert.False(Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.None).IsMatch(path));
+        Assert.True(Glob.Parse(pattern, GlobDialect.Standard, GlobOptions.MatchLeadingDot).IsMatch(path));
+    }
+
     [Fact]
     public void OptimizeSingleCharSet2()
     {


### PR DESCRIPTION
No behaviour change. This pins down an invariant in `CreateGlob` that is currently correct but undocumented and easy to break.

## The trap

`GlobParser.TryParse` passes `settings.MatchLeadingDot` into a parameter named `optimizeRecursiveWildcards`:

```csharp
result = CreateGlob(segments, matchLeadingDot, exclude, settings.IgnoreCase, matchType, settings.MatchLeadingDot, settings.PathSeparatorAware);
```

That gate is load-bearing. The rewrites it controls — `PathSuffixSegment`, `MatchNonEmptyTextSegment`, `MatchAllEndsWithSegment`, `LastSegment` — collapse a `**` and the segments after it into one segment that jumps to the end of the path, which skips the per-segment `CanMatchLeadingDot` checks that `Glob.IsMatchCore` would otherwise run. That is why each rewrite records `matchLeadingDot.Add(true)`. They are sound *only* because they are disabled when leading dots must be excluded.

Nothing at the call site or in the parameter name says any of this, and those four `Add(true)` calls look exactly like the bug they would be if the gate were loosened. Extending the optimiser — or "fixing" the gate to fire more often, which is the natural thing to want — silently reintroduces dotfile leakage.

Nor would a test catch it: every case in `GlobParserTests` goes through `GetSegments`/`GetSubSegments`, which always pass `GlobOptions.MatchLeadingDot`, so the un-optimised path was not exercised at all.

## Change

- Rename the parameter to `canSkipLeadingDotChecks` and add a comment on `CreateGlob` stating the invariant and what must be true before the gate is loosened.
- Add `RecursiveWildcardIsNotOptimizedWhenLeadingDotsMustBeExcluded`, asserting the `**` survives as a `RecursiveMatchAllSegment` without `MatchLeadingDot` and is rewritten with it.
- Add `RecursiveWildcardDoesNotCrossADotSegmentWithoutMatchLeadingDot`, asserting the behaviour the gate protects — `a/**/b` must not match `a/.hidden/b` unless `MatchLeadingDot` is set.

The second test is the one that matters: it fails if the invariant is ever broken, whatever the parameter ends up being called.

## Verification

- `dotnet test tests/Meziantou.Framework.Globbing.Tests` — 371 passed (364 before, 7 added here).
- Rename only; no call site outside `TryParse`, and the argument passed is unchanged.
- `dotnet run ./eng/update-all.cs` — no changes.
