### PR TITLE
Document that glob matching backtracks on untrusted patterns

### DIFF
--- a/src/Meziantou.Framework.Globbing/Glob.cs
+++ b/src/Meziantou.Framework.Globbing/Glob.cs
@@ -54,6 +54,12 @@ namespace Meziantou.Framework.Globbing;
 ///         </item>
 ///     </list>
 ///     <para>If the pattern ends with a <c>/</c>, only directories are matched. Otherwise, only files are matched.</para>
+///     <para>
+///         Matching backtracks, so the cost of a single <see cref="IsMatch(ReadOnlySpan{char}, ReadOnlySpan{char}, PathItemType?)"/>
+///         call grows exponentially with the number of <c>*</c> wildcards in one path segment. Ordinary patterns and
+///         file names are unaffected, but a pattern coming from an untrusted source can be made expensive on purpose.
+///         Bound the length and the wildcard count of such patterns before parsing them.
+///     </para>
 /// </summary>
 /// <example>
 /// Parse a glob pattern and check if a path matches:


### PR DESCRIPTION
Documentation only.

Matching backtracks without memoisation, in `RaggedSegment` for `*` within a segment and in `Glob.IsMatchCore` for `**` across segments. The cost of one `IsMatch` call grows exponentially with the number of `*` in a single path segment. Measured on a Release build, matching `(*a)xk + b` against `'a'x4k`:

| `*` count | path length | time |
|---|---|---|
| 12 | 48 | 1.3 ms |
| 14 | 56 | 5.2 ms |
| 16 | 64 | 23.6 ms |
| 18 | 72 | 99.0 ms |

Roughly 4x per two extra wildcards. The `**` path behaves similarly — `(**/*a*/)xk` against a 24-deep tree goes 7 ms at k=5 to 105 ms at k=8 — though it plateaus rather than growing without bound.

## Why documentation rather than a fix

Real path segments are short and real patterns have few wildcards, so this is not reachable by accident. It only matters when patterns come from an untrusted source, where it is a straightforward denial-of-service primitive.

Memoising the matcher would defend against it, but at the cost of allocating on every match to guard a case that almost never occurs — a bad trade for a library whose whole design is allocation-free matching through a `ref struct` reader. The honest fix is to say who owns the risk. The current docs are silent, which reads as a guarantee that is not there.

## Change

A `<para>` on the `Glob` XML docs stating that matching backtracks, that cost grows exponentially with the wildcard count in one segment, and that callers accepting untrusted patterns should bound pattern length and wildcard count before parsing.

## Verification

- `dotnet build` with `-p:TreatWarningsAsErrors=true` — clean, XML doc reference resolves.
- `dotnet test tests/Meziantou.Framework.Globbing.Tests` — 364 passed, unchanged.
- `dotnet run ./eng/update-all.cs` — no changes.
