### PR TITLE
Start a fresh enumerator when ProjFS restarts a directory scan

### DIFF
--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/DirectoryEnumerationSession.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/DirectoryEnumerationSession.cs
@@ -48,7 +48,11 @@ internal sealed class DirectoryEnumerationSession : IDisposable
 
     internal void Reset()
     {
+        // Clear the field so the next GetNextEntry call creates a fresh enumerator.
+        // A disposed iterator keeps returning false from MoveNext, which would make
+        // every entry disappear after a restart scan.
         _current = null;
         _enumerator?.Dispose();
+        _enumerator = null;
     }
 }

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/NativeDirectoryEnumerator.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/NativeDirectoryEnumerator.cs
@@ -1,0 +1,110 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Meziantou.Framework.Win32.ProjectedFileSystem;
+
+/// <summary>
+/// Enumerates a directory through <c>NtQueryDirectoryFile</c> so tests can reach ProjFS behaviour that the
+/// managed <see cref="Directory"/> APIs hide: those open a fresh handle per call, so they never trigger a
+/// restart scan.
+/// </summary>
+internal sealed partial class NativeDirectoryEnumerator : IDisposable
+{
+    private const uint FileListDirectory = 0x0001;
+    private const uint FileShareAll = 0x0007;
+    private const uint OpenExisting = 3;
+    private const uint FileFlagBackupSemantics = 0x02000000;
+    private const int FileDirectoryInformation = 1;
+    private const int BufferSize = 64 * 1024;
+
+    // Offsets into FILE_DIRECTORY_INFORMATION
+    private const int NextEntryOffsetOffset = 0;
+    private const int FileNameLengthOffset = 60;
+    private const int FileNameOffset = 64;
+
+    private readonly SafeFileHandle _handle;
+
+    private NativeDirectoryEnumerator(SafeFileHandle handle)
+    {
+        _handle = handle;
+    }
+
+    public static NativeDirectoryEnumerator Open(string path)
+    {
+        var handle = CreateFileW(path, FileListDirectory, FileShareAll, IntPtr.Zero, OpenExisting, FileFlagBackupSemantics, IntPtr.Zero);
+        if (handle.IsInvalid)
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+
+        return new NativeDirectoryEnumerator(handle);
+    }
+
+    /// <summary>Restarts the enumeration and reads it to completion, returning every name the driver reports.</summary>
+    public List<string> FullScan()
+    {
+        var names = new List<string>();
+        var restart = true;
+        while (Query(restart, names))
+        {
+            restart = false;
+        }
+
+        return names;
+    }
+
+    /// <summary>Reads one batch of entries. Returns <see langword="false"/> once the enumeration is exhausted.</summary>
+    private unsafe bool Query(bool restartScan, List<string> names)
+    {
+        var buffer = Marshal.AllocHGlobal(BufferSize);
+        try
+        {
+            var status = NtQueryDirectoryFile(_handle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, out _, buffer, BufferSize,
+                FileDirectoryInformation, returnSingleEntry: false, IntPtr.Zero, restartScan);
+
+            // STATUS_NO_MORE_FILES and any other non-success status end the enumeration
+            if (status != 0)
+                return false;
+
+            var entry = (byte*)buffer;
+            while (true)
+            {
+                var nameLength = *(uint*)(entry + FileNameLengthOffset);
+                names.Add(new string((char*)(entry + FileNameOffset), 0, (int)(nameLength / sizeof(char))));
+
+                var nextEntryOffset = *(uint*)(entry + NextEntryOffsetOffset);
+                if (nextEntryOffset is 0)
+                    break;
+
+                entry += nextEntryOffset;
+            }
+
+            return true;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    public void Dispose()
+    {
+        _handle.Dispose();
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IO_STATUS_BLOCK
+    {
+        public IntPtr Status;
+        public IntPtr Information;
+    }
+
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+    private static partial SafeFileHandle CreateFileW(string fileName, uint desiredAccess, uint shareMode, IntPtr securityAttributes, uint creationDisposition, uint flagsAndAttributes, IntPtr templateFile);
+
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [LibraryImport("ntdll.dll")]
+    private static partial int NtQueryDirectoryFile(SafeFileHandle fileHandle, IntPtr @event, IntPtr apcRoutine, IntPtr apcContext,
+        out IO_STATUS_BLOCK ioStatusBlock, IntPtr fileInformation, uint length, int fileInformationClass,
+        [MarshalAs(UnmanagedType.U1)] bool returnSingleEntry, IntPtr fileName, [MarshalAs(UnmanagedType.U1)] bool restartScan);
+}

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
@@ -304,4 +304,39 @@ public sealed class ProjectedFileSystemTests
             try { Directory.Delete(fullPath, recursive: true); } catch { }
         }
     }
+
+    /// <summary>
+    /// Verifies that re-enumerating a directory on an already-open handle keeps returning the provider entries.
+    ///
+    /// ProjFS sets PRJ_CB_DATA_FLAG_ENUM_RESTART_SCAN whenever an application restarts an enumeration on a
+    /// handle it already holds (Explorer refreshing a folder, a FindFirstFile loop rescanning, an indexer).
+    /// The session must start a new enumerator in that case; reusing a disposed one silently yields no entries.
+    ///
+    /// The .NET Directory APIs open a fresh handle per call, so this has to go through NtQueryDirectoryFile
+    /// to reach the restart-scan path at all.
+    /// </summary>
+    [ProjectedFileSystemFact]
+    public void RestartScanKeepsReturningEntries()
+    {
+        var fullPath = Path.Combine(Path.GetTempPath(), "projFS", Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(fullPath);
+            using var vfs = new SampleVirtualFileSystem(fullPath);
+            vfs.Start(options: null);
+
+            using var directory = NativeDirectoryEnumerator.Open(fullPath);
+
+            // Every scan restarts the enumeration on the same handle
+            for (var scan = 1; scan <= 3; scan++)
+            {
+                var entries = directory.FullScan();
+                Assert.Equal(["a", "b", "folder"], entries.Where(name => name is not "." and not "..").Order(StringComparer.Ordinal));
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(fullPath, recursive: true); } catch { }
+        }
+    }
 }


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2467**

## The finding

`DirectoryEnumerationSession.Reset()` disposed `_enumerator` but left the field set. `GetNextEntry()` then evaluates `_enumerator ??= Entries.GetEnumerator()`, sees a non-null (disposed) LINQ iterator, and calls `MoveNext()` on it — which returns `false` forever, because a compiler-generated iterator's `Dispose` moves it to the finished state.

ProjFS sets `PRJ_CB_DATA_FLAG_ENUM_RESTART_SCAN` whenever an application restarts an enumeration on a directory handle it already holds. Every provider entry disappeared from that point on.

Reproduced against a provider exposing three files, using `NtQueryDirectoryFile(RestartScan: true)`:

```
FULL-SCAN#1 => .,..,alpha.txt,beta.dat,gamma.txt
FULL-SCAN#2 => .,..
FULL-SCAN#3 => .,..
```

## Why it matters

Hitting <kbd>F5</kbd> in Explorer, any native `FindFirstFile`/`FindNextFile` loop that rescans, and most indexers and backup tools re-enumerate on a held handle. For all of them the projection appears to be an empty folder — files that were visible a moment ago vanish. It affects every consumer, needs no unusual input, and a derived class cannot work around it.

## What changed

- `DirectoryEnumerationSession.Reset()` now clears `_enumerator` after disposing it, so the next `GetNextEntry()` builds a fresh one.

  This also makes the existing guard in `Reenqueue()` correct: after a reset nothing has been dequeued, so `_enumerator is null` and it throws `InvalidOperationException` as documented, instead of silently reading `.Current` off a disposed iterator.

- Adds `NativeDirectoryEnumerator`, a test helper that enumerates through `NtQueryDirectoryFile`. This is needed because the managed `Directory` APIs open a fresh handle per call and so never reach the restart-scan path — which is exactly why the existing suite did not catch this.

- Adds `RestartScanKeepsReturningEntries`, which scans the same handle three times and asserts all entries come back each time.

## Verification

- New test fails on `main` (`Assert.Equal() ... Lengths differ`) and passes with the fix.
- Full suite green on `net10.0`: 7/7.
- `dotnet run ./eng/update-all.cs` produced no file changes.

> `net11.0` was not exercised locally — no x64 `Microsoft.NETCore.App` 11.0.0-preview.7 runtime on this machine. The source is shared, so CI covers it.
