### PR TITLE
Filter directory entries with the search expression from ProjFS

### DIFF
--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
@@ -481,7 +481,6 @@ public abstract class ProjectedFileSystemBase : IDisposable
 
     private HResult GetDirectoryEnumerationCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData, in Guid enumerationId, string searchExpression, IntPtr dirEntryBufferHandle)
     {
-        _ = searchExpression;
         if (!_activeEnumerations.TryGetValue(enumerationId, out var session))
         {
             return HResult.E_INVALIDARG;
@@ -495,6 +494,12 @@ public abstract class ProjectedFileSystemBase : IDisposable
         ProjectedFileSystemEntry? entry;
         while ((entry = session.GetNextEntry()) is not null)
         {
+            // ProjFS does not filter the entries the provider supplies, so an unfiltered
+            // entry here would be returned to a caller that asked for a narrower pattern.
+            // Skipped entries must not be re-enqueued: they were never offered to the buffer.
+            if (!MatchesSearchExpression(entry.Name, searchExpression))
+                continue;
+
             var info = new ProjFs.PRJ_FILE_BASIC_INFO
             {
                 FileSize = entry.Length,
@@ -510,6 +515,15 @@ public abstract class ProjectedFileSystemBase : IDisposable
         }
 
         return HResult.S_OK;
+    }
+
+    private static bool MatchesSearchExpression(string fileName, string searchExpression)
+    {
+        // ProjFS passes an empty expression when the caller did not ask for one
+        if (string.IsNullOrEmpty(searchExpression))
+            return true;
+
+        return FileNameMatch(fileName, searchExpression);
     }
 
     private HResult GetPlaceholderInfoCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData)

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/NativeDirectoryEnumerator.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/NativeDirectoryEnumerator.cs
@@ -40,11 +40,12 @@ internal sealed partial class NativeDirectoryEnumerator : IDisposable
     }
 
     /// <summary>Restarts the enumeration and reads it to completion, returning every name the driver reports.</summary>
-    public List<string> FullScan()
+    /// <param name="searchExpression">The pattern to pass to the driver, or <see langword="null"/> to enumerate everything.</param>
+    public List<string> FullScan(string? searchExpression = null)
     {
         var names = new List<string>();
         var restart = true;
-        while (Query(restart, names))
+        while (Query(restart, searchExpression, names))
         {
             restart = false;
         }
@@ -53,13 +54,28 @@ internal sealed partial class NativeDirectoryEnumerator : IDisposable
     }
 
     /// <summary>Reads one batch of entries. Returns <see langword="false"/> once the enumeration is exhausted.</summary>
-    private unsafe bool Query(bool restartScan, List<string> names)
+    private unsafe bool Query(bool restartScan, string? searchExpression, List<string> names)
     {
         var buffer = Marshal.AllocHGlobal(BufferSize);
+        var searchExpressionPtr = searchExpression is null ? IntPtr.Zero : Marshal.StringToHGlobalUni(searchExpression);
+        var unicodeStringPtr = IntPtr.Zero;
         try
         {
+            if (searchExpression is not null)
+            {
+                var unicodeString = new UNICODE_STRING
+                {
+                    Length = checked((ushort)(searchExpression.Length * sizeof(char))),
+                    MaximumLength = checked((ushort)(searchExpression.Length * sizeof(char))),
+                    Buffer = searchExpressionPtr,
+                };
+
+                unicodeStringPtr = Marshal.AllocHGlobal(Marshal.SizeOf<UNICODE_STRING>());
+                Marshal.StructureToPtr(unicodeString, unicodeStringPtr, fDeleteOld: false);
+            }
+
             var status = NtQueryDirectoryFile(_handle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, out _, buffer, BufferSize,
-                FileDirectoryInformation, returnSingleEntry: false, IntPtr.Zero, restartScan);
+                FileDirectoryInformation, returnSingleEntry: false, unicodeStringPtr, restartScan);
 
             // STATUS_NO_MORE_FILES and any other non-success status end the enumeration
             if (status != 0)
@@ -83,12 +99,29 @@ internal sealed partial class NativeDirectoryEnumerator : IDisposable
         finally
         {
             Marshal.FreeHGlobal(buffer);
+            if (unicodeStringPtr != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(unicodeStringPtr);
+            }
+
+            if (searchExpressionPtr != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(searchExpressionPtr);
+            }
         }
     }
 
     public void Dispose()
     {
         _handle.Dispose();
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct UNICODE_STRING
+    {
+        public ushort Length;
+        public ushort MaximumLength;
+        public IntPtr Buffer;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
@@ -339,4 +339,35 @@ public sealed class ProjectedFileSystemTests
             try { Directory.Delete(fullPath, recursive: true); } catch { }
         }
     }
+
+    /// <summary>
+    /// Verifies that the provider filters its entries with the search expression ProjFS passes down.
+    ///
+    /// ProjFS applies the expression to the entries it owns (".", "..", on-disk placeholders) but leaves the
+    /// provider responsible for its own, which is what PrjFileNameMatch exists for. Without that filtering a
+    /// caller asking for "*.txt" is handed every entry in the directory.
+    ///
+    /// Directory.GetFiles re-filters client-side, so it hides the bug; the raw enumeration does not.
+    /// </summary>
+    [ProjectedFileSystemFact]
+    public void SearchExpressionFiltersProviderEntries()
+    {
+        var fullPath = Path.Combine(Path.GetTempPath(), "projFS", Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(fullPath);
+            using var vfs = new UnsortedEntriesVirtualFileSystem(fullPath);
+            vfs.Start(options: null);
+
+            using var directory = NativeDirectoryEnumerator.Open(fullPath);
+
+            // "banana" is a directory with no extension, so it must not come back
+            var matches = directory.FullScan("*.txt").Order(StringComparer.Ordinal);
+            Assert.Equal(["apple.txt", "mango.txt", "yellow.txt", "zebra.txt"], matches);
+        }
+        finally
+        {
+            try { Directory.Delete(fullPath, recursive: true); } catch { }
+        }
+    }
 }


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/projfs-restart-scan` (#2466) · merge #2466 first**

## The finding

`GetDirectoryEnumerationCallback` discarded its `searchExpression` parameter (`_ = searchExpression;`) and pushed every provider entry into the buffer.

ProjFS applies the expression to the entries *it* owns — `.`, `..`, on-disk placeholders — but leaves the provider responsible for its own. That is what the exported `PrjFileNameMatch` is for; the wrapper already surfaced it as `FileNameMatch` and never called it.

Reproduced with `NtQueryDirectoryFile` and the pattern `*.txt` against a provider exposing `alpha.txt`, `beta.dat`, `gamma.txt`:

```
PATTERN *.txt => alpha.txt,beta.dat,gamma.txt
```

`.` and `..` *were* filtered out, which confirms nothing downstream re-filters the provider's entries.

## Why it matters

Any application enumerating with a wildcard gets entries that do not match what it asked for, and will typically act on them: `cmd /c dir *.txt`, `FindFirstFileEx` consumers, most native tools. `Directory.GetFiles(path, pattern)` happens to re-filter client-side, which is why this never surfaced in the managed tests. It also means the buffer is filled with entries that are then discarded, so large directories do redundant work.

## What changed

- `GetDirectoryEnumerationCallback` now skips entries that fail `MatchesSearchExpression` before calling `PrjFillDirEntryBuffer`. Skipping happens *before* the fill, so a filtered-out entry never consumes a re-enqueue slot when the buffer fills.
- `MatchesSearchExpression` treats a null/empty expression as "match all" — ProjFS passes an empty string when the caller did not supply a pattern.
- Extends `NativeDirectoryEnumerator` (added in #2466) to pass a `UNICODE_STRING` search expression to `NtQueryDirectoryFile`.
- Adds `SearchExpressionFiltersProviderEntries`, reusing `UnsortedEntriesVirtualFileSystem` — it already has four `.txt` files plus a `banana` directory, so `*.txt` must exclude the directory.

## Verification

- New test fails without the filter (`Assert.Equal() ... Lengths differ`) and passes with it.
- Full suite green on `net10.0` with both layers applied: 8/8.

## Note

The related `PRJ_CB_DATA_FLAG_ENUM_RETURN_SINGLE_ENTRY` flag is still not honored — it lives in the same loop, but ProjFS tolerates ignoring it and I saw no failure from it, so it is deliberately left out of this PR rather than bundled in.
