### PR TITLE
fix/projfs filedata truncation

### DIFF
--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/HResult.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/HResult.cs
@@ -20,6 +20,7 @@ internal readonly struct HResult : IEquatable<HResult>
     public static HResult E_FILENOTFOUND => new(unchecked((int)0x80070002));
     public static HResult E_PATHNOTFOUND => new(unchecked((int)0x80070003));
     public static HResult E_OUTOFMEMORY => new(unchecked((int)0x8007000E));
+    public static HResult ERROR_HANDLE_EOF => new(unchecked((int)0x80070026));
     public static HResult ERROR_IO_PENDING => new(unchecked((int)0x800703E5));
     public static HResult ERROR_FILE_SYSTEM_VIRTUALIZATION_INVALID_OPERATION => new(unchecked((int)0x80070181));
 #pragma warning restore IDE1006 // Naming Styles

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
@@ -624,9 +624,15 @@ public abstract class ProjectedFileSystemBase : IDisposable
                     }
                 }
 
-                var read = stream.Read(data, 0, (int)writeLength);
-                if (read == 0)
-                    break;
+                // Stream.Read may return fewer bytes than requested, so fill the whole chunk before writing it
+                var read = stream.ReadAtLeast(data.AsSpan(0, (int)writeLength), (int)writeLength, throwOnEndOfStream: false);
+                if (read < writeLength)
+                {
+                    // The stream ended before supplying the range ProjFS asked for. Returning success here
+                    // would let ProjFS zero-fill the remainder and hand the caller silently corrupt content,
+                    // so fail the read instead.
+                    return HResult.ERROR_HANDLE_EOF;
+                }
 
                 Marshal.Copy(data, 0, writeBuffer, read);
 

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
@@ -304,4 +304,31 @@ public sealed class ProjectedFileSystemTests
             try { Directory.Delete(fullPath, recursive: true); } catch { }
         }
     }
+
+    /// <summary>
+    /// Verifies that a stream ending before the declared length fails the read instead of yielding filler.
+    ///
+    /// ProjFS zero-fills whatever range the provider does not write, so returning S_OK after a short read
+    /// hands the caller a file that is half real content and half zeros, with no error anywhere. For a
+    /// provider backed by a network or a pipe, a stream ending early is an ordinary transient failure,
+    /// so it has to surface as one.
+    /// </summary>
+    [ProjectedFileSystemFact]
+    public void TruncatedStreamFailsTheReadInsteadOfZeroFilling()
+    {
+        var fullPath = Path.Combine(Path.GetTempPath(), "projFS", Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(fullPath);
+            using var vfs = new TruncatedStreamVirtualFileSystem(fullPath);
+            vfs.Start(options: null);
+
+            // The provider declares 10000 bytes but only supplies 5000
+            Assert.ThrowsAny<IOException>(() => File.ReadAllBytes(Path.Combine(fullPath, "truncated.bin")));
+        }
+        finally
+        {
+            try { Directory.Delete(fullPath, recursive: true); } catch { }
+        }
+    }
 }

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/TruncatedStreamVirtualFileSystem.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/TestFileSystems/TruncatedStreamVirtualFileSystem.cs
@@ -1,0 +1,34 @@
+namespace Meziantou.Framework.Win32.ProjectedFileSystem;
+
+/// <summary>
+/// Test VFS whose stream ends before supplying the length it declared for the entry.
+/// Stands in for a provider whose backing store is truncated mid-read (a dropped connection,
+/// a partial download), which must surface as a failed read rather than zero-filled content.
+/// </summary>
+internal sealed class TruncatedStreamVirtualFileSystem : ProjectedFileSystemBase
+{
+    private const int DeclaredSize = 10000;
+    private const int ActualSize = 5000;
+
+    public TruncatedStreamVirtualFileSystem(string rootFolder) : base(rootFolder) { }
+
+    protected override ValueTask<IEnumerable<ProjectedFileSystemEntry>> GetEntriesAsync(string path)
+    {
+        if (AreFileNamesEqual(path, ""))
+            return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([ProjectedFileSystemEntry.File("truncated.bin", DeclaredSize)]);
+
+        return ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([]);
+    }
+
+    protected override ValueTask<Stream?> OpenReadAsync(string path)
+    {
+        if (AreFileNamesEqual(path, "truncated.bin"))
+        {
+            var data = new byte[ActualSize];
+            Array.Fill(data, (byte)0xAB);
+            return ValueTask.FromResult<Stream?>(new MemoryStream(data));
+        }
+
+        return ValueTask.FromResult<Stream?>(null);
+    }
+}


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2470**

## The finding

The file data loop stopped at the first zero-length read and returned `S_OK` as though the whole requested range had been supplied:

```csharp
var read = stream.Read(data, 0, (int)writeLength);
if (read == 0)
    break;
```

ProjFS fills whatever range the provider does not write with zeros. Reproduced with a provider declaring `Length: 10000` but returning a 5000-byte stream of `0xAB`:

```
read 10000 bytes; 5000 bytes are NOT 0xAB (filler); byte[9999]=0x00
```

`File.ReadAllBytes` returned 10000 bytes and raised nothing.

Separately, `Stream.Read` is permitted to return fewer bytes than requested, so even a healthy stream could produce a short chunk — and a short chunk that is not alignment-aligned also breaks the alignment contract for the writes that follow it.

## Why it matters

A provider that mis-declares `Length` is arguably its own bug. The dangerous trigger is not: for a provider backed by HTTP, a network share, or a pipe, a stream that ends early is an ordinary transient failure. That failure was being converted into a *successful* read of partly zero-filled content, with no way for the application to detect it — and because ProjFS may then persist a hydrated placeholder, the corruption can outlive the failure that caused it.

## What changed

- The loop fills each chunk with `ReadAtLeast` rather than trusting a single `Read`.
- When the stream cannot supply the requested range, the callback returns `ERROR_HANDLE_EOF` instead of `S_OK`, so the caller's read fails loudly.
- Adds `HResult.ERROR_HANDLE_EOF` (`0x80070026`).
- Adds `TruncatedStreamVirtualFileSystem` and `TruncatedStreamFailsTheReadInsteadOfZeroFilling`, which asserts an `IOException` reaches the caller.

## Verification

- New test fails on `main` (`Assert.ThrowsAny() assertion failed` — the read silently succeeded) and passes with the fix.
- Full suite green on `net10.0`: 7/7. `LargeFileReadAtOffset` and `NonSeekableStreamFileRead` both still pass, so the chunking and offset behaviour is unchanged for well-behaved providers.

## Choice worth confirming

`ERROR_HANDLE_EOF` is my pick for "the backing store ran out early". If you would rather this surface as a different Win32 error, it is a one-line change.
