### PR TITLE
Read file data asynchronously instead of blocking a thread-pool thread

### DIFF
--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
@@ -575,7 +575,7 @@ public abstract class ProjectedFileSystemBase : IDisposable
                 while (bytesToSkip > 0)
                 {
                     var toRead = (int)Math.Min(bytesToSkip, skipBuffer.Length);
-                    var skipped = stream.Read(skipBuffer, 0, toRead);
+                    var skipped = await stream.ReadAsync(skipBuffer.AsMemory(0, toRead)).ConfigureAwait(false);
                     if (skipped == 0)
                         break;
                     bytesToSkip -= skipped;
@@ -625,7 +625,7 @@ public abstract class ProjectedFileSystemBase : IDisposable
                 }
 
                 // Stream.Read may return fewer bytes than requested, so fill the whole chunk before writing it
-                var read = stream.ReadAtLeast(data.AsSpan(0, (int)writeLength), (int)writeLength, throwOnEndOfStream: false);
+                var read = await stream.ReadAtLeastAsync(data.AsMemory(0, (int)writeLength), (int)writeLength, throwOnEndOfStream: false).ConfigureAwait(false);
                 if (read < writeLength)
                 {
                     // The stream ended before supplying the range ProjFS asked for. Returning success here


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/projfs-filedata-truncation` (#2469) · merge #2469 first**

## The finding

`GetFileDataCallbackAsync` is an `async` method whose entire body performed synchronous `Stream.Read` calls — in the non-seekable skip loop and in the main read loop. By the time those run, the callback has already returned `ERROR_IO_PENDING` to ProjFS, so the blocking happens on a thread-pool thread.

## Why it matters

The reason `OpenReadAsync` hands back a `Stream` is to let providers back files with network or database sources, and those streams block on `Read`. ProjFS issues file data callbacks concurrently for concurrent readers, so a provider fetching over the network holds one blocked pool thread per in-flight read. Under a burst — a build tool or an antivirus scan walking the projection — that starves the pool, and the symptom is the whole projection hanging rather than merely being slow.

## What changed

- Skip loop: `stream.Read(...)` → `await stream.ReadAsync(...)`.
- Read loop: `stream.ReadAtLeast(...)` → `await stream.ReadAtLeastAsync(...)`.

Both keep `ConfigureAwait(false)`, matching the rest of the file. No signature changes — the method was already `async`.

Deliberately left alone: the `stream.Seek` call on the seekable path (synchronous but in-memory), and `using` vs `await using` for the stream itself, which is a separate question about disposal.

## Verification

- Full suite green on `net10.0` with both layers applied: 7/7, including `NonSeekableStreamFileRead` which exercises the skip loop and `LargeFileReadAtOffset` which exercises multi-chunk reads.
