### PR TITLE
Strip the terminating null character from privilege names

### DIFF
--- a/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
@@ -199,9 +199,11 @@ public sealed class AccessToken : IDisposable
         var luidNameLen = 0u;
         PInvoke.LookupPrivilegeName(lpSystemName: null, in luid, lpName: null, ref luidNameLen);
 
+        // The first call reports the buffer size including the terminating null character,
+        // whereas a successful call updates luidNameLen to the length excluding it.
         Span<char> name = new char[luidNameLen];
         if (PInvoke.LookupPrivilegeName(lpSystemName: null, in luid, name, ref luidNameLen))
-            return new string(name);
+            return new string(name[..(int)luidNameLen]);
 
         throw new Win32Exception(Marshal.GetLastWin32Error());
     }

--- a/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
+++ b/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
@@ -43,6 +43,23 @@ public sealed class AccessTokenTests
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void EnumeratePrivilegesReturnsNamesWithoutTerminatingNullCharacter()
+    {
+        using var token = AccessToken.OpenCurrentProcessToken(TokenAccessLevels.Query);
+        var privileges = token.EnumeratePrivileges();
+
+        Assert.NotNull(privileges);
+        Assert.NotEmpty(privileges);
+        foreach (var privilege in privileges)
+        {
+            Assert.DoesNotContain('\0', privilege.Name);
+        }
+
+        // SeChangeNotifyPrivilege is granted to Everyone by default, so the name must match the constant exactly
+        Assert.Contains(privileges, privilege => string.Equals(privilege.Name, Privileges.SE_CHANGE_NOTIFY_NAME, StringComparison.Ordinal));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
     public void FromWellKnownTest()
     {
         _output.WriteLine("WellKnownSID " + SecurityIdentifier.FromWellKnown(WellKnownSidType.WinLowLabelSid));


### PR DESCRIPTION
## The defect

`AccessToken.LookupPrivilegeName` (`AccessToken.cs:197-207`) sizes its buffer with a first
`LookupPrivilegeName` call, which reports the required size **including** the terminating null
character. A successful second call then updates `cchName` to the length **excluding** it — but the
method built the string from the whole span:

```csharp
Span<char> name = new char[luidNameLen];
if (PInvoke.LookupPrivilegeName(lpSystemName: null, in luid, name, ref luidNameLen))
    return new string(name);   // includes the trailing '\0'
```

So every name returned by `EnumeratePrivileges()` carried a trailing `'\0'`. Straight from the
existing test output on `main`:

```
Privilege: SeShutdownPrivilege\0 (Disabled)
Privilege: SeChangeNotifyPrivilege\0 (EnabledByDefault, Enabled)
```

`"SeShutdownPrivilege\0".Length` is 20, not 19.

## Why it matters

`EnumeratePrivileges` is the library's main read API and its output was silently wrong on every
call. Any comparison against the `Privileges` constants — the pairing the readme teaches — returned
`false` even when the privilege was present:

```csharp
// returned false on main, even though the privilege is there
token.EnumeratePrivileges().Any(p => p.Name == Privileges.SE_CHANGE_NOTIFY_NAME);
```

The same applied to dictionary lookups, `switch` on the name, `ToString()`, logging and
serialization.

## The change

Slice to the length the API reported: `new string(name[..(int)luidNameLen])`.

## Verification

Added `EnumeratePrivilegesReturnsNamesWithoutTerminatingNullCharacter`, which asserts no name
contains `'\0'` and that `SeChangeNotifyPrivilege` (granted to Everyone by default) matches its
constant ordinally.

- Test fails on `main`, passes with this change — confirmed by reverting the fix and re-running.
- Full project suite: 5/5 passing on Windows 11 (arm64, net10.0).
- `dotnet build -p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.

## Deliberately not in scope

The discarded return value of the sizing call on line 200 is also unchecked — a failure other than
`ERROR_INSUFFICIENT_BUFFER` would surface as a confusing zero-length allocation. That is a separate
robustness fix; this PR stays on the defect.
