### PR TITLE
fix/projfs stop state cleanup

### DIFF
--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
@@ -216,9 +216,18 @@ public abstract class ProjectedFileSystemBase : IDisposable
         if (_instanceHandle is null)
             return;
 
-        _callbacks = default;
+        // Stop virtualizing before dropping the callback table: the driver can still be
+        // invoking those delegates until PrjStopVirtualizing returns.
         _instanceHandle.Dispose();
         _instanceHandle = null;
+        _callbacks = default;
+
+        foreach (var enumeration in _activeEnumerations.Values)
+        {
+            enumeration.Dispose();
+        }
+
+        _activeEnumerations.Clear();
 
         if (_instanceContextHandle.IsAllocated)
         {
@@ -473,8 +482,11 @@ public abstract class ProjectedFileSystemBase : IDisposable
     private HResult EndDirectoryEnumerationCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData, in Guid enumerationId)
     {
         _ = callbackData;
-        if (_activeEnumerations.TryRemove(enumerationId, out _))
+        if (_activeEnumerations.TryRemove(enumerationId, out var session))
+        {
+            session.Dispose();
             return HResult.S_OK;
+        }
 
         return HResult.E_INVALIDARG;
     }


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2474**

## The finding

Three related lifetime problems around stopping an instance.

**Sessions are never disposed.** `EndDirectoryEnumerationCallback` discarded the removed value with `out _`:

```csharp
if (_activeEnumerations.TryRemove(enumerationId, out _))
```

`DirectoryEnumerationSession` implements `IDisposable`, so for a provider whose `GetEntriesAsync` returns a lazy sequence over a file handle or a database cursor, that resource stayed open.

**The dictionary is never cleared.** `Stop()` left `_activeEnumerations` populated, so sessions from a stopped instance were retained for the object's lifetime. Each holds a sorted sequence of every entry in a directory, so over large directories that is real memory rather than just dictionary slots.

**The callback table was dropped too early.** `Stop()` set `_callbacks = default` *before* `_instanceHandle.Dispose()` ran `PrjStopVirtualizing`, so for that window the driver held function pointers the managed side no longer referenced. `PRJ_CALLBACKS` holds managed delegate types, not function pointers — confirmed in the generated `Windows.Win32.PRJ_CALLBACKS.g.cs`.

In practice that last one is currently safe: all eight callbacks are `static`, and Roslyn caches static method-group conversions in a static field that lives as long as the assembly. But the safety rests on a compiler optimization rather than on the code's own structure, which is not something to leave load-bearing.

## What changed

- `EndDirectoryEnumerationCallback` disposes the session it removes.
- `Stop()` disposes and clears any sessions still registered.
- `Stop()` now stops virtualizing first, then drops the callback table.

## Not covered here

The third leak in this finding — a `StartDirectoryEnumerationCallbackAsync` whose async work completes *after* the command was cancelled will insert a session that never receives a matching `EndDirectoryEnumeration` — is **not** fixed. It needs `CancelCommandCallback` (currently a `static` no-op) to become instance-based and track cancelled command ids, which brings its own eviction question. That is a design change rather than a leak plug, so it is left for a separate PR rather than bundled in here.

## Verification

- Full suite green on `net10.0`: 6/6.
- No new test: session disposal and dictionary contents are not observable from the public surface (no `InternalsVisibleTo`), and a start/stop/restart test is not possible because `PrjMarkDirectoryAsPlaceholder` fails with `ERROR_REPARSE_POINT_ENCOUNTERED` on an already-placeholdered root. Flagging that rather than adding a test that would not actually assert the fix.
