### PR TITLE
Fix the inverted IsAdministrator sample

### DIFF
--- a/src/Meziantou.Framework.Win32.AccessToken/readme.md
+++ b/src/Meziantou.Framework.Win32.AccessToken/readme.md
@@ -99,7 +99,10 @@ bool IsAdministrator()
     using var token = AccessToken.OpenCurrentProcessToken(TokenAccessLevels.Query);
 
     // Check if current token has admin rights
-    if (!IsAdministrator(token) && token.GetElevationType() == TokenElevationType.Limited)
+    if (IsAdministrator(token))
+        return true;
+
+    if (token.GetElevationType() == TokenElevationType.Limited)
     {
         // If limited, check the linked token (elevated token)
         using var linkedToken = token.GetLinkedToken();

--- a/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
+++ b/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
@@ -43,6 +43,21 @@ public sealed class AccessTokenTests
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void IsAdministratorReturnsTrueWhenTheCurrentTokenHasTheAdministratorsGroupEnabled()
+    {
+        using var token = AccessToken.OpenCurrentProcessToken(TokenAccessLevels.Query);
+        var adminSid = SecurityIdentifier.FromWellKnown(WellKnownSidType.WinBuiltinAdministratorsSid);
+        var hasEnabledAdministratorsGroup = (token.EnumerateGroups() ?? [])
+            .Any(group => group.Attributes.HasFlag(GroupSidAttributes.SE_GROUP_ENABLED) && group.Sid == adminSid);
+
+        // Only meaningful when the test process is elevated; on a UAC-filtered token the group is deny-only
+        if (hasEnabledAdministratorsGroup)
+        {
+            Assert.True(IsAdministrator());
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
     public void FromWellKnownTest()
     {
         _output.WriteLine("WellKnownSID " + SecurityIdentifier.FromWellKnown(WellKnownSidType.WinLowLabelSid));
@@ -81,7 +96,10 @@ public sealed class AccessTokenTests
         if (token is null)
             return false;
 
-        if (!IsAdministrator(token) && token.GetElevationType() == TokenElevationType.Limited)
+        if (IsAdministrator(token))
+            return true;
+
+        if (token.GetElevationType() == TokenElevationType.Limited)
         {
             using var linkedToken = token.GetLinkedToken();
             return IsAdministrator(linkedToken);


### PR DESCRIPTION
## The defect

The `IsAdministrator` recipe in `readme.md` — the package's documented way to check for
administrator rights — has inverted control flow. The `if` body is the only path that can return
`true`, and it is guarded by `!IsAdministrator(token)`, so the result of the local check is
discarded rather than returned:

```csharp
if (!IsAdministrator(token) && token.GetElevationType() == TokenElevationType.Limited)
{
    using var linkedToken = token.GetLinkedToken();
    return IsAdministrator(linkedToken);
}

return false;
```

Walking the three cases:

| Case | `IsAdministrator(token)` | Result | |
|---|---|---|---|
| Elevated administrator | `true` | falls through to `return false` | **wrong** |
| UAC-filtered administrator | `false` (group is `SE_GROUP_USE_FOR_DENY_ONLY`) | checks linked token → `true` | correct |
| Standard user | `false` | `false` | correct |

The function returns `true` in exactly the case where the process is *not* currently running as an
administrator, and `false` when it is.

## Why it matters

This is a security check, and it ships in the NuGet package readme, so it is the version consumers
copy. An application gating administrative UI or an installer step on it misbehaves for precisely
the users who have the rights. The same inverted helper was also duplicated in
`AccessTokenTests.cs`.

## The change

Return the local check's result directly, then fall through to the linked-token lookup only when the
token is UAC-filtered. Applied to both the readme and the test helper.

## Verification

Added `IsAdministratorReturnsTrueWhenTheCurrentTokenHasTheAdministratorsGroupEnabled`: if the
current token carries an enabled `BUILTIN\Administrators` group, `IsAdministrator()` must be `true`
— which is exactly what the old code got wrong.

**Being precise about coverage:** the assertion is conditional, and my review machine runs a
UAC-filtered token, so it was vacuous locally. It should bite on the Windows CI runners, which run
elevated. The logic fix itself is verified by inspection of the three cases above, not by a test I
was able to execute on the failing path.

- Full project suite: 5/5 passing on Windows 11 (arm64, net10.0).
- `dotnet run ./eng/update-all.cs`: no files changed (this readme is not generated).
