### PR TITLE
Assert on token and SID values instead of only printing them

### DIFF
--- a/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
+++ b/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
@@ -17,7 +17,21 @@ public sealed class AccessTokenTests
     {
         using var token = AccessToken.OpenCurrentProcessToken(TokenAccessLevels.Query);
         PrintToken(token);
-        var owner = token.GetOwner();
+
+        Assert.Equal(TokenType.TokenPrimary, token.GetTokenType());
+        Assert.NotEqual(TokenElevationType.Unknown, token.GetElevationType());
+        Assert.NotNull(token.GetOwner());
+        Assert.NotNull(token.GetMandatoryIntegrityLevel());
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void EnumerateGroupsContainsTheEveryoneGroup()
+    {
+        using var token = AccessToken.OpenCurrentProcessToken(TokenAccessLevels.Query);
+        var groups = token.EnumerateGroups();
+
+        Assert.NotNull(groups);
+        Assert.Contains(groups, group => group.Sid == SecurityIdentifier.FromWellKnown(WellKnownSidType.WinWorldSid));
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
@@ -46,6 +60,22 @@ public sealed class AccessTokenTests
     public void FromWellKnownTest()
     {
         _output.WriteLine("WellKnownSID " + SecurityIdentifier.FromWellKnown(WellKnownSidType.WinLowLabelSid));
+
+        Assert.Equal("S-1-16-4096", SecurityIdentifier.FromWellKnown(WellKnownSidType.WinLowLabelSid).Sid);
+        Assert.Equal("S-1-5-32-544", SecurityIdentifier.FromWellKnown(WellKnownSidType.WinBuiltinAdministratorsSid).Sid);
+        Assert.Equal("S-1-1-0", SecurityIdentifier.FromWellKnown(WellKnownSidType.WinWorldSid).Sid);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void SecurityIdentifiersWithTheSameSidAreEqual()
+    {
+        var sid = SecurityIdentifier.FromWellKnown(WellKnownSidType.WinBuiltinAdministratorsSid);
+        var other = SecurityIdentifier.FromWellKnown(WellKnownSidType.WinBuiltinAdministratorsSid);
+
+        Assert.Equal(sid, other);
+        Assert.True(sid == other);
+        Assert.Equal(sid.GetHashCode(), other.GetHashCode());
+        Assert.NotEqual(sid, SecurityIdentifier.FromWellKnown(WellKnownSidType.WinWorldSid));
     }
 
     private void PrintToken(AccessToken? token)


### PR DESCRIPTION
## The gap

Every test in `AccessTokenTests.cs` wrote to `ITestOutputHelper` and returned. `AccessTokenTest`
even assigned `var owner = token.GetOwner();` and discarded it. The only failure any of them could
produce was an unhandled exception.

This is not a theoretical gap. It is why at least two real defects shipped:

- The trailing-null bug in privilege names was printed verbatim in the project's own **passing**
  test output (`Privilege: SeShutdownPrivilege\0`).
- The inverted `IsAdministrator` helper was exercised by `IsAdministratorTest`, which printed its
  result without checking it.

For a package whose entire job is producing correct values from the OS, output-only tests provide
close to no protection.

## The change

Assert on what is stable and machine-independent, keeping the existing `PrintToken` output for
diagnostics:

- `AccessTokenTest` — the process token is `TokenPrimary`, the elevation type resolves to something
  other than `Unknown`, and the owner and mandatory integrity level are non-null.
- `EnumerateGroupsContainsTheEveryoneGroup` (new) — every token carries `Everyone` (`S-1-1-0`).
- `FromWellKnownTest` — the well-known SIDs round-trip to their documented strings
  (`S-1-16-4096`, `S-1-5-32-544`, `S-1-1-0`).
- `SecurityIdentifiersWithTheSameSidAreEqual` (new) — covers `Equals`, `operator ==` and
  `GetHashCode`, which had no coverage at all.

## Scope

Assertions only, over behavior that is already correct on `main` — no production code changes, so
this is safe to merge in any order. Regression tests for the defects themselves travel with their
own fixes rather than landing here.

## Verification

6/6 passing on Windows 11 (arm64, net10.0). Tests remain skipped on non-Windows via the existing
`RunIf` attribute.
