### PR TITLE
Only take ownership of the virtualization context when the start succeeded

### DIFF
--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
@@ -17,10 +17,13 @@ internal static class NativeMethods
         return ToHResult(PInvoke.PrjMarkDirectoryAsPlaceholder(rootPathName, targetPathName, versionInfo: null, in virtualizationInstanceID));
     }
 
-    internal static unsafe HResult PrjStartVirtualizing(string virtualizationRootPath, in ProjFs.PRJ_CALLBACKS callbacks, IntPtr instanceContext, in ProjFs.PRJ_STARTVIRTUALIZING_OPTIONS options, out ProjFSSafeHandle namespaceVirtualizationContext)
+    internal static unsafe HResult PrjStartVirtualizing(string virtualizationRootPath, in ProjFs.PRJ_CALLBACKS callbacks, IntPtr instanceContext, in ProjFs.PRJ_STARTVIRTUALIZING_OPTIONS options, out ProjFSSafeHandle? namespaceVirtualizationContext)
     {
         var hr = ToHResult(PInvoke.PrjStartVirtualizing(virtualizationRootPath, in callbacks, (void*)instanceContext, options, out var context));
-        namespaceVirtualizationContext = new ProjFSSafeHandle((IntPtr)context, ownHandle: true);
+
+        // Only take ownership when the call succeeded. On failure the out parameter is not a
+        // handle the driver ever gave out, and wrapping it leaves the instance looking started.
+        namespaceVirtualizationContext = hr.IsSuccess ? new ProjFSSafeHandle((IntPtr)context, ownHandle: true) : null;
         return hr;
     }
 


### PR DESCRIPTION
## The finding

`NativeMethods.PrjStartVirtualizing` wrapped its out parameter in a `ProjFSSafeHandle(ownHandle: true)` unconditionally, before the caller could look at the HRESULT:

```csharp
var hr = ToHResult(PInvoke.PrjStartVirtualizing(..., out var context));
namespaceVirtualizationContext = new ProjFSSafeHandle((IntPtr)context, ownHandle: true);
return hr;
```

In `Start`, `out _instanceHandle` is therefore assigned *before* `hr.EnsureSuccess()` throws:

```csharp
var hr = NativeMethods.PrjStartVirtualizing(RootFolder, in _callbacks, context, in opt, out _instanceHandle);
hr.EnsureSuccess();
_instanceContextHandle = instanceContextHandle;   // never reached on failure
```

So a failed start left `_instanceHandle` non-null while `_instanceContextHandle` stayed unset — the two halves of the state disagreeing.

## Why it matters

- `Start` returns early when `_instanceHandle is not null`, so after a failed start the instance silently believes it is running and the caller can never retry.
- `Stop`/`Dispose` will call `PrjStopVirtualizing` on a handle the driver never gave out. `SafeHandleZeroOrMinusOneIsInvalid` skips the release when the value happens to be 0, but a non-zero garbage value is passed straight through.

## What changed

The handle is created only when the call succeeded, and the out parameter is `ProjFSSafeHandle?` to make that explicit. `_instanceHandle` is already nullable, so `Start` needed no change — on failure it now stays null and the instance is cleanly retryable.

## Honest scoping

**No test.** I could not induce a natural failure of `PrjStartVirtualizing` itself: every failure I could produce (missing directory, a second instance on the same root) happens earlier, in `PrjMarkDirectoryAsPlaceholder`, which throws before this code runs. Rather than assert a path I can't trigger, I'm flagging that this is a code-reading fix — which is also why the review rated it Medium and not High.

## Verification

- Builds clean with `-p:TreatWarningsAsErrors=true`.
- Full suite green on `net10.0`: 6/6 — the success path is unchanged.
