### PR TITLE
Align AccessToken sources with the repository conventions

### DIFF
--- a/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
@@ -46,7 +46,7 @@ public sealed class AccessToken : IDisposable
 
     private AccessToken(SafeFileHandle token)
     {
-        _token = token ?? throw new ArgumentNullException(nameof(token));
+        _token = token;
     }
 
     /// <summary>Determines whether the token is restricted.</summary>

--- a/src/Meziantou.Framework.Win32.AccessToken/PrivilegeAttribute.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/PrivilegeAttribute.cs
@@ -7,7 +7,7 @@ namespace Meziantou.Framework.Win32;
 public enum PrivilegeAttribute : uint
 {
     /// <summary>The privilege is disabled.</summary>
-    Disabled,
+    Disabled = 0,
 
     /// <summary>The privilege is enabled.</summary>
     Enabled = TOKEN_PRIVILEGES_ATTRIBUTES.SE_PRIVILEGE_ENABLED,

--- a/src/Meziantou.Framework.Win32.AccessToken/Privileges.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/Privileges.cs
@@ -75,7 +75,7 @@ public static class Privileges
     public const string SE_MACHINE_ACCOUNT_NAME = "SeMachineAccountPrivilege";
 
     /// <summary>Required to enable volume management privileges.</summary>
-  public const string SE_MANAGE_VOLUME_NAME = "SeManageVolumePrivilege";
+    public const string SE_MANAGE_VOLUME_NAME = "SeManageVolumePrivilege";
 
     /// <summary>Required to gather profiling information for a single process.</summary>
     public const string SE_PROF_SINGLE_PROCESS_NAME = "SeProfileSingleProcessPrivilege";
@@ -114,7 +114,7 @@ public static class Privileges
     public const string SE_TCB_NAME = "SeTcbPrivilege";
 
     /// <summary>Required to adjust the time zone associated with the computer's internal clock.</summary>
-  public const string SE_TIME_ZONE_NAME = "SeTimeZonePrivilege";
+    public const string SE_TIME_ZONE_NAME = "SeTimeZonePrivilege";
 
     /// <summary>Required to access Credential Manager as a trusted caller.</summary>
     public const string SE_TRUSTED_CREDMAN_ACCESS_NAME = "SeTrustedCredManAccessPrivilege";

--- a/src/Meziantou.Framework.Win32.AccessToken/TokenEntry.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/TokenEntry.cs
@@ -5,7 +5,7 @@ public sealed class TokenEntry
 {
     internal TokenEntry(SecurityIdentifier sid)
     {
-        Sid = sid ?? throw new ArgumentNullException(nameof(sid));
+        Sid = sid;
     }
 
     /// <summary>Gets the security identifier (SID) for this entry.</summary>

--- a/src/Meziantou.Framework.Win32.AccessToken/TokenGroupEntry.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/TokenGroupEntry.cs
@@ -9,7 +9,7 @@ public sealed class TokenGroupEntry
 {
     internal TokenGroupEntry(SecurityIdentifier sid, GroupSidAttributes attributes)
     {
-        Sid = sid ?? throw new ArgumentNullException(nameof(sid));
+        Sid = sid;
         Attributes = attributes;
     }
 

--- a/src/Meziantou.Framework.Win32.AccessToken/TokenPrivilegeEntry.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/TokenPrivilegeEntry.cs
@@ -9,7 +9,7 @@ public sealed class TokenPrivilegeEntry
 {
     internal TokenPrivilegeEntry(string name, PrivilegeAttribute attributes)
     {
-        Name = name ?? throw new ArgumentNullException(nameof(name));
+        Name = name;
         Attributes = attributes;
     }
 


### PR DESCRIPTION
## What this is

Three small deviations from the conventions in `AGENTS.md` and `.editorconfig`. No behavior change
and no public API change — the generated `ref/` surface is byte-identical.

## The changes

**Indentation** — `Privileges.cs:78` and `Privileges.cs:117` (`SE_MANAGE_VOLUME_NAME` and
`SE_TIME_ZONE_NAME`) were indented with two spaces while every other constant in the file uses four.

**Redundant null checks** — `AGENTS.md` says to trust the C# null annotations and not add null
checks when the type system says a value cannot be null. Four constructors did anyway:

```csharp
_token = token ?? throw new ArgumentNullException(nameof(token));   // AccessToken
Sid    = sid   ?? throw new ArgumentNullException(nameof(sid));     // TokenEntry, TokenGroupEntry
Name   = name  ?? throw new ArgumentNullException(nameof(name));    // TokenPrivilegeEntry
```

All four are `private`/`internal` with compiler-checked call sites and non-nullable parameters, so
the guards are unreachable. The public entry points that do take user input
(`EnablePrivilege`, `OpenProcessToken`, …) keep their `ArgumentNullException.ThrowIf` guards —
those are untouched.

**Implicit enum zero** — `PrivilegeAttribute.Disabled` relied on an implicit `0` in a `[Flags]`
enum; the repo suppresses MA0099 elsewhere precisely because it wants explicit values. Now
`Disabled = 0`.

## Verification

- `dotnet build -p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.
- Project test suite: 4/4 passing on Windows 11 (arm64, net10.0).
- `ref/Meziantou.Framework.Win32.AccessToken.cs` regenerates unchanged.
