### PR TITLE
Reject a zero or negative BufferSize instead of silently truncating reads

### DIFF
--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
@@ -61,8 +61,19 @@ public abstract class ProjectedFileSystemBase : IDisposable
     /// <summary>Gets the root folder path where the virtual file system is mounted.</summary>
     public string RootFolder { get; }
 
+    private int _bufferSize = 4096; // 4kB
+
     /// <summary>Gets or sets the buffer size used for reading file data. Default is 4096 bytes.</summary>
-    protected int BufferSize { get; set; } = 4096; // 4kB
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the value is zero or negative.</exception>
+    protected int BufferSize
+    {
+        get => _bufferSize;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+            _bufferSize = value;
+        }
+    }
 
     /// <summary>Initializes a new instance of the <see cref="ProjectedFileSystemBase"/> class.</summary>
     /// <param name="rootFolder">The root folder path where the virtual file system will be mounted.</param>

--- a/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
+++ b/tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/ProjectedFileSystemTests.cs
@@ -304,4 +304,30 @@ public sealed class ProjectedFileSystemTests
             try { Directory.Delete(fullPath, recursive: true); } catch { }
         }
     }
+
+    [Fact]
+    public void BufferSizeRejectsZeroAndNegativeValues()
+    {
+        // The constructor only resolves the path, so this needs no ProjFS instance
+        using var vfs = new BufferSizeVirtualFileSystem(Path.GetTempPath());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => vfs.SetBufferSize(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => vfs.SetBufferSize(-1));
+
+        vfs.SetBufferSize(8192);
+        Assert.Equal(8192, vfs.GetBufferSize());
+    }
+
+    private sealed class BufferSizeVirtualFileSystem : ProjectedFileSystemBase
+    {
+        public BufferSizeVirtualFileSystem(string rootFolder) : base(rootFolder) { }
+
+        public void SetBufferSize(int value) => BufferSize = value;
+        public int GetBufferSize() => BufferSize;
+
+        protected override ValueTask<IEnumerable<ProjectedFileSystemEntry>> GetEntriesAsync(string path)
+            => ValueTask.FromResult<IEnumerable<ProjectedFileSystemEntry>>([]);
+
+        protected override ValueTask<Stream?> OpenReadAsync(string path) => ValueTask.FromResult<Stream?>(null);
+    }
 }


### PR DESCRIPTION
## The finding

`BufferSize` was a `protected` settable `int` with no validation:

```csharp
protected int BufferSize { get; set; } = 4096; // 4kB
```

It reaches the file data callback through a `uint` cast (`var maxBufferSize = (uint)BufferSize;`), so two bad values fail in different and equally quiet ways:

- **`0`** → `bufferSize` is zero, the read loop exits on its first iteration, and the callback returns `S_OK` having written nothing. ProjFS zero-fills the entire range, so the caller gets a file of zeros and no error.
- **negative** → the cast produces a very large `uint`, `Math.Min(length, maxBufferSize)` collapses to `length`, and the chunking is bypassed entirely — along with the write-alignment handling that only runs when the read is chunked.

Neither is a configuration anyone wants, and neither announces itself.

## What changed

`BufferSize` gets an explicit backing field and a setter that calls `ArgumentOutOfRangeException.ThrowIfNegativeOrZero`, so a bad value fails at the point of the mistake instead of surfacing later as empty file content.

## Verification

- New `BufferSizeRejectsZeroAndNegativeValues` covers `0`, `-1`, and a valid round-trip. It is a plain `[Fact]`, not a `[ProjectedFileSystemFact]` — the constructor only resolves the root path, so it needs no ProjFS instance and runs even where the optional Windows feature is absent.
- Full suite green on `net10.0`: 7/7.
