### PR TITLE
Size the placeholder info with sizeof instead of Marshal.SizeOf

### DIFF
--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/ProjectedFileSystemBase.cs
@@ -535,10 +535,16 @@ public abstract class ProjectedFileSystemBase : IDisposable
                     new ProjFSSafeHandle(namespaceVirtualizationContext, ownHandle: false),
                     filePathName, // Use the full relative path from the callback, not just the entry name
                     in info,
-                    (uint)Marshal.SizeOf(info));
+                    PlaceholderInfoSize);
 #pragma warning restore CA2000
         return hr;
     }
+
+    // The size the driver expects is the unmanaged size of the struct that gets pinned and
+    // handed to PrjWritePlaceholderInfo, so take it with sizeof rather than Marshal.SizeOf:
+    // that boxes on every call and reports the marshaled size, which is not guaranteed to
+    // agree with the layout the span is built over.
+    private static unsafe uint PlaceholderInfoSize => (uint)sizeof(ProjFs.PRJ_PLACEHOLDER_INFO);
 
     private HResult GetFileDataCallback(in ProjFs.PRJ_CALLBACK_DATA callbackData, ulong byteOffset, uint length)
     {


### PR DESCRIPTION
## The finding

`GetPlaceholderInfoCallbackAsync` sized the placeholder buffer with `Marshal.SizeOf(info)`.

Two problems:

1. **It boxes.** `Marshal.SizeOf(object)` is the object-taking overload, so the struct is boxed on every placeholder request — one allocation per file or directory the projection reveals.
2. **It reports the wrong kind of size.** `Marshal.SizeOf` gives the *marshaled* size. That value is passed to `NativeMethods.PrjWritePlaceholderInfo`, which uses it as the length of a `ReadOnlySpan<byte>` built over the same struct after pinning it with `fixed`:

```csharp
fixed (ProjFs.PRJ_PLACEHOLDER_INFO* placeholderInfoPointer = &placeholderInfo)
{
    var placeholderInfoData = new ReadOnlySpan<byte>((byte*)placeholderInfoPointer, checked((int)placeholderInfoSize));
```

If the marshaled size ever exceeded `sizeof`, that span would read past the struct.

## What changed

The size now comes from `sizeof(ProjFs.PRJ_PLACEHOLDER_INFO)` in the existing `unsafe` context — exact, allocation-free, and guaranteed to match the layout the span is built over. It is exposed as a small `static unsafe uint` property because `GetPlaceholderInfoCallbackAsync` is `async` and cannot host the `sizeof` directly.

## Scope

This is a latent hazard, not a live bug: the two sizes agree today because every field in the generated struct is blittable. Nothing changes about what the driver receives.

## Verification

- Full suite green on `net10.0`: 6/6. Every test in the suite creates placeholders — `NestedSubdirectoryAccess` walks three levels, `DirectoryEnumerationNoDuplicates` forces placeholder creation for five entries — so a size the driver disagreed with would show up here.
- Builds clean with `-p:TreatWarningsAsErrors=true`.

I did not manage to print the two values side by side for a direct numeric comparison: the property runs inside a ProjFS callback whose exceptions are converted to HRESULTs, so a probe throw is swallowed rather than surfaced. The suite passing is the evidence I have.
