### PR TITLE
Drop the fake HRESULT from the PrjStopVirtualizing wrapper

### DIFF
--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/NativeMethods.cs
@@ -24,10 +24,10 @@ internal static class NativeMethods
         return hr;
     }
 
-    internal static HResult PrjStopVirtualizing(IntPtr namespaceVirtualizationContext)
+    // PrjStopVirtualizing has no return value, so there is no status to surface here
+    internal static void PrjStopVirtualizing(IntPtr namespaceVirtualizationContext)
     {
         PInvoke.PrjStopVirtualizing((ProjFs.PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT)namespaceVirtualizationContext);
-        return HResult.S_OK;
     }
 
     internal static HResult PrjFillDirEntryBuffer(string fileName, in ProjFs.PRJ_FILE_BASIC_INFO callbacks, IntPtr dirEntryBufferHandle)

--- a/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/ProjFSSafeHandle.cs
+++ b/src/Meziantou.Framework.Win32.ProjectedFileSystem/Natives/ProjFSSafeHandle.cs
@@ -19,7 +19,7 @@ internal sealed class ProjFSSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
 
     protected override bool ReleaseHandle()
     {
-        var result = NativeMethods.PrjStopVirtualizing(handle);
-        return result.IsSuccess;
+        NativeMethods.PrjStopVirtualizing(handle);
+        return true;
     }
 }


### PR DESCRIPTION
## The finding

`NativeMethods.PrjStopVirtualizing` declared an `HResult` return and hard-coded a success value:

```csharp
internal static HResult PrjStopVirtualizing(IntPtr namespaceVirtualizationContext)
{
    PInvoke.PrjStopVirtualizing((ProjFs.PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT)namespaceVirtualizationContext);
    return HResult.S_OK;
}
```

`ProjFSSafeHandle.ReleaseHandle` then tested that constant:

```csharp
var result = NativeMethods.PrjStopVirtualizing(handle);
return result.IsSuccess;   // always true
```

This is faithful to the native API — `PrjStopVirtualizing` genuinely has no return value, and the CsWin32 projection returns `void` — so it is not a bug. It is dead ceremony that reads like a checked error path, which is worse than no check at all: a reader auditing the release path sees a status being tested and assumes failures are handled.

## What changed

The wrapper returns `void`, and `ReleaseHandle` returns `true` directly with a comment noting there is no status to surface. Behaviour is identical.

## Verification

- Builds clean with `-p:TreatWarningsAsErrors=true`.
- Full suite green on `net10.0`: 6/6.
