### PR TITLE
Throw when AdjustTokenPrivileges does not assign every privilege

### DIFF
--- a/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
@@ -301,6 +301,8 @@ public sealed class AccessToken : IDisposable
         using var safeHandleValue = new SafeHandleValue(_token);
         if (!PInvoke.AdjustTokenPrivileges((HANDLE)safeHandleValue.Value, DisableAllPrivileges: true, NewState: null, BufferLength: 0, PreviousState: null, &returnSize))
             throw new Win32Exception(Marshal.GetLastWin32Error());
+
+        ThrowIfNotAllPrivilegesAssigned();
     }
 
     /// <summary>Removes a privilege from this token.</summary>
@@ -341,6 +343,19 @@ public sealed class AccessToken : IDisposable
         using var safeHandleValue = new SafeHandleValue(_token);
         if (!PInvoke.AdjustTokenPrivileges((HANDLE)safeHandleValue.Value, DisableAllPrivileges: false, &tp, 0, PreviousState: null, &returnSize))
             throw new Win32Exception(Marshal.GetLastWin32Error());
+
+        ThrowIfNotAllPrivilegesAssigned();
+    }
+
+    /// <remarks>
+    /// AdjustTokenPrivileges returns a non-zero value even when it assigned none of the requested
+    /// privileges, and reports the partial failure through GetLastError instead.
+    /// </remarks>
+    private static void ThrowIfNotAllPrivilegesAssigned()
+    {
+        var error = Marshal.GetLastWin32Error();
+        if (error is not (int)WIN32_ERROR.ERROR_SUCCESS)
+            throw new Win32Exception(error);
     }
 
     /// <summary>Creates a duplicate of this token with the specified impersonation level.</summary>

--- a/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
+++ b/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
@@ -43,6 +43,18 @@ public sealed class AccessTokenTests
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void EnablePrivilegeThrowsWhenTheTokenDoesNotHoldThePrivilege()
+    {
+        const int ErrorNotAllAssigned = 1300;
+
+        // SeTcbPrivilege is not granted to standard users nor to Administrators by default
+        using var token = AccessToken.OpenCurrentProcessToken(TokenAccessLevels.Query | TokenAccessLevels.AdjustPrivileges);
+        var exception = Assert.Throws<Win32Exception>(() => token.EnablePrivilege(Privileges.SE_TCB_NAME));
+
+        Assert.Equal(ErrorNotAllAssigned, exception.NativeErrorCode);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
     public void FromWellKnownTest()
     {
         _output.WriteLine("WellKnownSID " + SecurityIdentifier.FromWellKnown(WellKnownSidType.WinLowLabelSid));


### PR DESCRIPTION
> **Stack 1 of 3** · merges into `main` · must merge before #2484 and #2485

## The defect

`AdjustTokenPrivileges` returns a **non-zero** value even when it assigned none of the requested
privileges. The documented contract is to call `GetLastError()` afterwards and treat
`ERROR_NOT_ALL_ASSIGNED` (1300) as failure. Neither call site did — `AccessToken.cs:342-343`
(`AdjustPrivilege`, backing `EnablePrivilege`/`DisablePrivilege`/`RemovePrivilege`) nor
`AccessToken.cs:302-303` (`DisableAllPrivileges`).

Reproduced against a normal, non-elevated token before the fix:

```
EnablePrivilege(SeTcbPrivilege): returned without throwing
token actually has SeTcbPrivilege afterwards: False
```

`EnablePrivilege` also documents `<exception cref="Win32Exception">The privilege could not be
enabled.</exception>`, so this was a stated guarantee that did not hold.

## Why it matters

A security-relevant silent failure. The intended usage — `EnablePrivilege(SE_DEBUG_NAME)` followed
by a privileged operation — left callers believing they held `SeDebugPrivilege`, `SeBackupPrivilege`
or `SeTcbPrivilege` when they did not; the real failure then surfaced far away as an
`ACCESS_DENIED` in unrelated code.

`RemovePrivilege` is the worse direction: code hardening a token by dropping a privilege got no
signal that the drop was a no-op.

## The change

A shared `ThrowIfNotAllPrivilegesAssigned()` helper reads the captured last-error on the success
path and throws unless it is `ERROR_SUCCESS`. Called from both `AdjustPrivilege` and
`DisableAllPrivileges`.

`GetLastError` is explicitly documented to be set to `ERROR_SUCCESS` when every privilege was
assigned, so this does not fire on the happy path — confirmed by the existing tests, which adjust
privileges the token does hold and still pass.

## Verification

Added `EnablePrivilegeThrowsWhenTheTokenDoesNotHoldThePrivilege`, asserting a `Win32Exception` with
`NativeErrorCode == 1300` when enabling `SeTcbPrivilege`. That call silently succeeded before this
change.

- Project test suite: 5/5 passing on Windows 11 (arm64, net10.0).
- `dotnet build -p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.

**Assumption worth flagging:** the test assumes the runner does not hold `SeTcbPrivilege`, which is
not granted to standard users or to Administrators by default. If a runner ever does hold it, the
test fails loudly rather than silently.
