### PR TITLE
Size the token information buffer from the value being read

### DIFF
--- a/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
@@ -67,7 +67,7 @@ public sealed class AccessToken : IDisposable
         TokenType result;
         uint returnedLength;
         using var safeHandleValue = new SafeHandleValue(_token);
-        if (!PInvoke.GetTokenInformation((HANDLE)safeHandleValue.Value, TOKEN_INFORMATION_CLASS.TokenType, &result, (uint)IntPtr.Size, &returnedLength))
+        if (!PInvoke.GetTokenInformation((HANDLE)safeHandleValue.Value, TOKEN_INFORMATION_CLASS.TokenType, &result, (uint)sizeof(TokenType), &returnedLength))
             throw new Win32Exception(Marshal.GetLastWin32Error());
 
         return result;
@@ -84,7 +84,7 @@ public sealed class AccessToken : IDisposable
         TokenElevationType result;
         uint returnedLength;
         using var safeHandleValue = new SafeHandleValue(_token);
-        if (!PInvoke.GetTokenInformation((HANDLE)safeHandleValue.Value, TOKEN_INFORMATION_CLASS.TokenElevationType, &result, (uint)IntPtr.Size, &returnedLength))
+        if (!PInvoke.GetTokenInformation((HANDLE)safeHandleValue.Value, TOKEN_INFORMATION_CLASS.TokenElevationType, &result, (uint)sizeof(TokenElevationType), &returnedLength))
             throw new Win32Exception(Marshal.GetLastWin32Error());
 
         return result;


### PR DESCRIPTION
> **Stack 2 of 3** · merges into #2483 · must merge after #2483, before #2485

## The defect

`GetTokenType` and `GetElevationType` pass `(uint)IntPtr.Size` as `TokenInformationLength` while
`&result` points at a 4-byte enum on the stack:

```
IntPtr.Size passed as buffer length = 8
sizeof(TokenType)                   = 4
```

On x64/arm64 that tells the kernel an 8-byte buffer is available where only 4 bytes exist.

## Why it matters

**Nothing overflows today** — both information classes write exactly 4 bytes, which is why the
existing tests pass and why this is easy to miss. It is reported and fixed as a latent problem, not
a live defect: a copy-paste of the pattern to an information class with a larger payload, or a
future Windows revision widening either value, would write past the local. On 32-bit the value is
correct only by coincidence.

## The change

Size the buffer from the value being read: `(uint)sizeof(TokenType)` and
`(uint)sizeof(TokenElevationType)`. Both methods are already `unsafe`.

## Verification

- Project test suite: 5/5 passing on Windows 11 (arm64, net10.0); `GetTokenType()` and
  `GetElevationType()` return the same values as before (`TokenPrimary`, `Limited`).
- `dotnet build -p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.

## Note for review

An alternative is to route both methods through the existing `GetTokenInformation<T>` helper, which
sizes the buffer from the API itself and would delete the duplication. That is a larger refactor of
two working methods, so this PR makes the minimal correct change instead — happy to take the other
route if you prefer it.
