### PR TITLE
Make Dispose idempotent and report use after disposal

### DIFF
--- a/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
@@ -42,11 +42,20 @@ namespace Meziantou.Framework.Win32;
 [SupportedOSPlatform("windows5.1.2600")]
 public sealed class AccessToken : IDisposable
 {
-    private SafeFileHandle _token;
+    private readonly SafeFileHandle _token;
 
     private AccessToken(SafeFileHandle token)
     {
         _token = token ?? throw new ArgumentNullException(nameof(token));
+    }
+
+    private SafeFileHandle Token
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_token.IsClosed, this);
+            return _token;
+        }
     }
 
     /// <summary>Determines whether the token is restricted.</summary>
@@ -57,7 +66,7 @@ public sealed class AccessToken : IDisposable
     /// </remarks>
     public bool IsRestricted()
     {
-        return PInvoke.IsTokenRestricted(_token);
+        return PInvoke.IsTokenRestricted(Token);
     }
 
     /// <summary>Gets the type of the token (primary or impersonation).</summary>
@@ -66,7 +75,7 @@ public sealed class AccessToken : IDisposable
     {
         TokenType result;
         uint returnedLength;
-        using var safeHandleValue = new SafeHandleValue(_token);
+        using var safeHandleValue = new SafeHandleValue(Token);
         if (!PInvoke.GetTokenInformation((HANDLE)safeHandleValue.Value, TOKEN_INFORMATION_CLASS.TokenType, &result, (uint)sizeof(TokenType), &returnedLength))
             throw new Win32Exception(Marshal.GetLastWin32Error());
 
@@ -83,7 +92,7 @@ public sealed class AccessToken : IDisposable
     {
         TokenElevationType result;
         uint returnedLength;
-        using var safeHandleValue = new SafeHandleValue(_token);
+        using var safeHandleValue = new SafeHandleValue(Token);
         if (!PInvoke.GetTokenInformation((HANDLE)safeHandleValue.Value, TOKEN_INFORMATION_CLASS.TokenElevationType, &result, (uint)sizeof(TokenElevationType), &returnedLength))
             throw new Win32Exception(Marshal.GetLastWin32Error());
 
@@ -234,7 +243,7 @@ public sealed class AccessToken : IDisposable
         where T : unmanaged
     {
         uint returnedLength;
-        using var safeHandleValue = new SafeHandleValue(_token);
+        using var safeHandleValue = new SafeHandleValue(Token);
         if (!PInvoke.GetTokenInformation((HANDLE)safeHandleValue.Value, type, TokenInformation: null, 0u, &returnedLength))
         {
             var errorCode = Marshal.GetLastWin32Error();
@@ -298,7 +307,7 @@ public sealed class AccessToken : IDisposable
     public unsafe void DisableAllPrivileges()
     {
         uint returnSize = 0;
-        using var safeHandleValue = new SafeHandleValue(_token);
+        using var safeHandleValue = new SafeHandleValue(Token);
         if (!PInvoke.AdjustTokenPrivileges((HANDLE)safeHandleValue.Value, DisableAllPrivileges: true, NewState: null, BufferLength: 0, PreviousState: null, &returnSize))
             throw new Win32Exception(Marshal.GetLastWin32Error());
 
@@ -340,7 +349,7 @@ public sealed class AccessToken : IDisposable
         };
 
         uint returnSize = 0;
-        using var safeHandleValue = new SafeHandleValue(_token);
+        using var safeHandleValue = new SafeHandleValue(Token);
         if (!PInvoke.AdjustTokenPrivileges((HANDLE)safeHandleValue.Value, DisableAllPrivileges: false, &tp, 0, PreviousState: null, &returnSize))
             throw new Win32Exception(Marshal.GetLastWin32Error());
 
@@ -364,7 +373,7 @@ public sealed class AccessToken : IDisposable
     /// <exception cref="Win32Exception">The token could not be duplicated.</exception>
     public AccessToken Duplicate(SecurityImpersonationLevel impersonationLevel)
     {
-        if (!PInvoke.DuplicateToken(_token, (SECURITY_IMPERSONATION_LEVEL)impersonationLevel, out var duplicateTokenHandle))
+        if (!PInvoke.DuplicateToken(Token, (SECURITY_IMPERSONATION_LEVEL)impersonationLevel, out var duplicateTokenHandle))
             throw new Win32Exception(Marshal.GetLastWin32Error());
 
         return new AccessToken(duplicateTokenHandle);
@@ -374,7 +383,6 @@ public sealed class AccessToken : IDisposable
     public void Dispose()
     {
         _token.Dispose();
-        _token = null!;
     }
 
     /// <summary>Opens the access token associated with the current process.</summary>

--- a/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
+++ b/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
@@ -55,6 +55,25 @@ public sealed class AccessTokenTests
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void DisposeCanBeCalledMoreThanOnce()
+    {
+        var token = AccessToken.OpenCurrentProcessToken(TokenAccessLevels.Query);
+        token.Dispose();
+        token.Dispose();
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void UsingADisposedTokenThrowsObjectDisposedException()
+    {
+        var token = AccessToken.OpenCurrentProcessToken(TokenAccessLevels.Query);
+        token.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => _ = token.IsRestricted());
+        Assert.Throws<ObjectDisposedException>(() => _ = token.GetTokenType());
+        Assert.Throws<ObjectDisposedException>(() => _ = token.GetOwner());
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
     public void FromWellKnownTest()
     {
         _output.WriteLine("WellKnownSID " + SecurityIdentifier.FromWellKnown(WellKnownSidType.WinLowLabelSid));


### PR DESCRIPTION
> **Stack 3 of 3** · merges into #2484 · must merge last

## The defect

`Dispose` set the handle field to null:

```csharp
public void Dispose()
{
    _token.Dispose();
    _token = null!;
}
```

Measured behaviour before this change:

```
double-dispose threw: System.NullReferenceException
use-after-dispose threw: System.ArgumentNullException
```

`IDisposable` requires `Dispose` to be safely callable more than once. An explicit `Dispose()`
inside a `using` block, or a `try`/`finally` that disposes on a path the `using` also covers,
crashed with a `NullReferenceException`. Any other call after disposal surfaced
`ArgumentNullException` from `SafeHandleValue`'s parameter guard, pointing a debugging consumer at
the wrong thing entirely.

## Why it matters

A `NullReferenceException` escaping a `Dispose` in a `finally` block replaces the original in-flight
exception and destroys the real diagnostic. The wrong exception type also means
`catch (ObjectDisposedException)` — the reasonable handler — never fires.

## The change

- Drop the `_token = null!` assignment; `SafeFileHandle.Dispose` is already idempotent. The field
  becomes `readonly`.
- Add a private `Token` property that calls `ObjectDisposedException.ThrowIf(_token.IsClosed, this)`
  and route every read through it, per the convention in `AGENTS.md`.

Routing through one property rather than adding a guard to each public method keeps the diff to the
seven existing `_token` reads.

## Verification

Added two tests: `DisposeCanBeCalledMoreThanOnce`, and
`UsingADisposedTokenThrowsObjectDisposedException` covering `IsRestricted`, `GetTokenType` and
`GetOwner`. Both fail on `main`.

- Project test suite: 7/7 passing on Windows 11 (arm64, net10.0).
- `dotnet build -p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.
