### PR TITLE
Free the buffer allocated by ConvertSidToStringSid

### DIFF
--- a/src/Meziantou.Framework.Win32.AccessToken/NativeMethods.txt
+++ b/src/Meziantou.Framework.Win32.AccessToken/NativeMethods.txt
@@ -15,3 +15,4 @@ TOKEN_ELEVATION
 ConvertSidToStringSid
 CreateWellKnownSid
 LookupAccountSid
+LocalFree

--- a/src/Meziantou.Framework.Win32.AccessToken/SecurityIdentifier.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/SecurityIdentifier.cs
@@ -103,10 +103,18 @@ public sealed class SecurityIdentifier : IEquatable<SecurityIdentifier?>
     private static unsafe string ConvertSidToStringSid(PSID sid)
     {
         PWSTR result = default;
-        if (PInvoke.ConvertSidToStringSid(sid, &result))
-            return result.ToString();
+        if (!PInvoke.ConvertSidToStringSid(sid, &result))
+            throw new Win32Exception(Marshal.GetLastWin32Error());
 
-        throw new Win32Exception(Marshal.GetLastWin32Error());
+        try
+        {
+            return result.ToString();
+        }
+        finally
+        {
+            // ConvertSidToStringSid allocates the buffer with LocalAlloc
+            PInvoke.LocalFree((HLOCAL)result.Value);
+        }
     }
 
     private static unsafe void LookupName(PSID sid, out string? domain, out string? name)


### PR DESCRIPTION
> **Stack 1 of 3** · merges into `main` · must merge before #2488 and #2489

## The defect

`ConvertSidToStringSid` allocates its output string with `LocalAlloc`; the caller must release it
with `LocalFree`. `SecurityIdentifier.ConvertSidToStringSid` (`SecurityIdentifier.cs:103-110`)
marshalled the buffer into a managed string and dropped the pointer.

An A/B measurement over 200,000 conversions of the same SID — two identical loops, one calling
`LocalFree` and one not:

```
200k conversions WITH LocalFree   : private delta =  4,812,800 bytes
200k conversions WITHOUT LocalFree: private delta = 18,841,600 bytes
per-call leak ~ 94 bytes
```

Managed memory stayed flat throughout, so this was invisible to GC diagnostics and to
`GC.GetTotalMemory`.

## Why it matters

The leak is in the constructor, so it fired for every SID the library produced — roughly 15 per
`EnumerateGroups()` call on a typical token, plus one each for `GetOwner`,
`GetMandatoryIntegrityLevel` and `FromWellKnown`. A long-running service inspecting tokens on a
timer leaked unboundedly in the native heap, where it is hard to attribute.

Notably `FromWellKnown` already freed its own buffer correctly, which is what made the
inconsistency easy to miss.

## The change

Invert the success check and free the buffer in a `finally`. `LocalFree` added to
`NativeMethods.txt`.

## Verification

- The A/B measurement above, run directly against the Win32 API, is the decisive evidence.
- End-to-end through the public API (200k `FromWellKnown` calls, private bytes vs. baseline): before
  this change the process stayed +4–7 MB above baseline throughout; after, it returns to −0.9 MB.
  This measurement is noisier than the raw A/B because `FromWellKnown` also allocates managed
  strings — directional corroboration, not the primary evidence.
- Project test suite: 4/4 passing on Windows 11 (arm64, net10.0).
- `dotnet build -p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.
