### PR TITLE
Retry LookupAccountSid with the sizes it reports

### DIFF
--- a/src/Meziantou.Framework.Win32.AccessToken/SecurityIdentifier.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/SecurityIdentifier.cs
@@ -122,26 +122,31 @@ public sealed class SecurityIdentifier : IEquatable<SecurityIdentifier?>
         var userNameLen = 256u;
         var domainNameLen = 256u;
 
-        fixed (char* userName = new char[userNameLen])
-        fixed (char* domainName = new char[domainNameLen])
+        // LookupAccountSid reports the required sizes when a buffer is too small, so retry once with them
+        for (var attempt = 0; ; attempt++)
         {
-            SID_NAME_USE sidType;
-            if (PInvoke.LookupAccountSid(lpSystemName: null, sid, userName, &userNameLen, domainName, &domainNameLen, &sidType) != 0)
+            fixed (char* userName = new char[userNameLen])
+            fixed (char* domainName = new char[domainNameLen])
             {
-                name = new string(userName, 0, (int)userNameLen);
-                domain = new string(domainName, 0, (int)domainNameLen);
-                return;
-            }
+                SID_NAME_USE sidType;
+                if (PInvoke.LookupAccountSid(lpSystemName: null, sid, userName, &userNameLen, domainName, &domainNameLen, &sidType) != 0)
+                {
+                    name = new string(userName, 0, (int)userNameLen);
+                    domain = new string(domainName, 0, (int)domainNameLen);
+                    return;
+                }
 
-            var error = Marshal.GetLastWin32Error();
-            if (error == (int)WIN32_ERROR.ERROR_NONE_MAPPED)
-            {
-                domain = default;
-                name = default;
-                return;
-            }
+                var error = Marshal.GetLastWin32Error();
+                if (error == (int)WIN32_ERROR.ERROR_NONE_MAPPED)
+                {
+                    domain = default;
+                    name = default;
+                    return;
+                }
 
-            throw new Win32Exception(error);
+                if (error != (int)WIN32_ERROR.ERROR_INSUFFICIENT_BUFFER || attempt > 0)
+                    throw new Win32Exception(error);
+            }
         }
     }
 


### PR DESCRIPTION
> **Stack 2 of 3** · merges into #2487 · must merge after #2487, before #2489

## The defect

`LookupName` (`SecurityIdentifier.cs:114-121`) hard-codes the name and domain buffers to 256
characters. When either is too small, `LookupAccountSid` fails with `ERROR_INSUFFICIENT_BUFFER` and
writes the required sizes back through `cchName`/`cchReferencedDomainName` — but that error fell
through to `throw new Win32Exception(error)` instead of being retried.

## Why it matters

Low severity: 256 covers `UNLEN`, so this is rare in practice. But the API is explicitly designed
around a size-then-read retry, and the failure mode is disproportionate — one unusually-named
principal turns an entire `EnumerateGroups()` call into an exception rather than degrading for the
single entry.

## The change

Wrap the lookup in a loop that retries exactly once with the sizes the API reported. Every other
outcome is unchanged: `ERROR_NONE_MAPPED` still yields `null` name and domain, and any other error —
including a second `ERROR_INSUFFICIENT_BUFFER` — still throws.

This mirrors the size-then-read pattern already used by `AccessToken.GetTokenInformation`.

## Verification

- Project test suite: 4/4 passing on Windows 11 (arm64, net10.0). Account names still resolve
  identically (`DESKTOP-…\mezia`, `BUILTIN\Administrators`, `NT AUTHORITY\…`).
- `dotnet build -p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.

**Coverage caveat:** the retry path itself is not covered by a test — I could not produce a
principal whose name exceeds 256 characters on the review machine. The change is structured so the
non-retry paths are provably unchanged.
