### PR TITLE
Resolve the account name of a SID on first access

### DIFF
--- a/src/Meziantou.Framework.Win32.AccessToken/NativeMethods.txt
+++ b/src/Meziantou.Framework.Win32.AccessToken/NativeMethods.txt
@@ -16,3 +16,4 @@ ConvertSidToStringSid
 CreateWellKnownSid
 LookupAccountSid
 LocalFree
+GetLengthSid

--- a/src/Meziantou.Framework.Win32.AccessToken/SecurityIdentifier.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/SecurityIdentifier.cs
@@ -34,24 +34,47 @@ public sealed class SecurityIdentifier : IEquatable<SecurityIdentifier?>
     private const byte MaxSubAuthorities = 15;
     private const int MaxBinaryLength = 1 + 1 + 6 + (MaxSubAuthorities * 4); // 4 bytes for each subauth
 
-    internal SecurityIdentifier(PSID sid)
+    private readonly byte[] _sid;
+    private (string? Domain, string? Name)? _account;
+
+    internal unsafe SecurityIdentifier(PSID sid)
     {
         if (sid == default)
             throw new ArgumentNullException(nameof(sid));
 
-        LookupName(sid, out var domain, out var name);
-        Domain = domain;
-        Name = name;
+        // The SID is only valid for the lifetime of the caller's buffer, so keep a copy for the deferred lookup
+        _sid = new Span<byte>(sid.Value, (int)PInvoke.GetLengthSid(sid)).ToArray();
         Sid = ConvertSidToStringSid(sid);
     }
 
     /// <summary>Gets the domain name associated with the SID.</summary>
     /// <value>The domain name, or <see langword="null"/> if the SID could not be resolved.</value>
-    public string? Domain { get; }
+    /// <remarks>Resolved on first access, which may query the local security authority or a domain controller.</remarks>
+    /// <exception cref="Win32Exception">The account lookup failed.</exception>
+    public string? Domain => Account.Domain;
 
     /// <summary>Gets the account name associated with the SID.</summary>
     /// <value>The account name, or <see langword="null"/> if the SID could not be resolved.</value>
-    public string? Name { get; }
+    /// <remarks>Resolved on first access, which may query the local security authority or a domain controller.</remarks>
+    /// <exception cref="Win32Exception">The account lookup failed.</exception>
+    public string? Name => Account.Name;
+
+    private unsafe (string? Domain, string? Name) Account
+    {
+        get
+        {
+            if (_account is null)
+            {
+                fixed (byte* pointer = _sid)
+                {
+                    LookupName(new PSID(pointer), out var domain, out var name);
+                    _account = (domain, name);
+                }
+            }
+
+            return _account.Value;
+        }
+    }
 
     /// <summary>Gets the string representation of the SID (e.g., "S-1-5-21-...").</summary>
     public string Sid { get; }


### PR DESCRIPTION
> **Stack 3 of 3** · merges into #2488 · must merge last

## The problem

The `SecurityIdentifier` constructor called `LookupAccountSid` eagerly, which on a domain-joined
machine may contact a domain controller. `EnumerateGroups()` constructs one `SecurityIdentifier`
per group — 15 on the review machine — so a single enumeration was ~15 sequential LSA round-trips.

Callers who only want `Sid`, or who only compare SIDs, paid for all of them. That includes the
documented `group.Sid == adminSid` pattern, since equality is defined on the SID string alone.

## Why it matters

On a laptop off the corporate network or behind a slow VPN, `LookupAccountSid` can block for seconds
per unresolvable SID. `EnumerateGroups()` offers no overload that avoids this and no cancellation,
so a UI thread calling it stalls.

## The change

`Domain` and `Name` resolve on first access; `Sid` stays eager because it is a purely local
conversion. The SID pointer is only valid for the lifetime of the caller's buffer, so the
constructor copies the SID bytes (`GetLengthSid` + `Span<byte>.ToArray`) and the deferred lookup
pins that copy.

`Equals`/`GetHashCode` already depend only on `Sid`, so equality is unaffected.

## Behavioural changes worth reviewing

Two, both intentional:

1. **Exceptions move.** A `Win32Exception` from a failed lookup now surfaces on first read of
   `Name`/`Domain` rather than at construction. The XML docs on both properties were updated to say
   so. `ToString()` reads `Name`, so it can now throw where it previously could not.
2. **Immutability.** The object was fully immutable after construction; it now memoises the lookup
   on first access. Two threads racing on `Name` may both perform the lookup and one result wins —
   benign, since they compute the same value and the field assignment is atomic, but it is no longer
   strictly immutable.

## Verification

- Project test suite: 4/4 passing on Windows 11 (arm64, net10.0). Every name and domain resolves
  identically to before the change — owner, integrity level, and all 15 groups.
- `dotnet build -p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.
- Public API surface (`ref/`) regenerates unchanged: `Domain` and `Name` were already
  get-only `string?` properties.
