### PR TITLE
Share the group enumeration between the two token group classes

### DIFF
--- a/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
@@ -136,20 +136,7 @@ public sealed class AccessToken : IDisposable
     /// <returns>A collection of <see cref="TokenGroupEntry"/> objects representing the groups, or <see langword="null"/> if not available.</returns>
     public IEnumerable<TokenGroupEntry>? EnumerateGroups()
     {
-        return GetTokenInformation<TOKEN_GROUPS, IReadOnlyList<TokenGroupEntry>>(
-            TOKEN_INFORMATION_CLASS.TokenGroups,
-            (handle, groups) =>
-            {
-                var list = new TokenGroupEntry[groups.GroupCount];
-                var index = 0;
-                foreach (var group in ReadArray<TOKEN_GROUPS, SID_AND_ATTRIBUTES>(handle, nameof(TOKEN_GROUPS.Groups), groups.GroupCount))
-                {
-                    list[index] = new TokenGroupEntry(new SecurityIdentifier(group.Sid), (GroupSidAttributes)group.Attributes);
-                    index++;
-                }
-
-                return list;
-            });
+        return EnumerateGroups(TOKEN_INFORMATION_CLASS.TokenGroups);
     }
 
     /// <summary>Enumerates the restricted SIDs in the token.</summary>
@@ -157,8 +144,13 @@ public sealed class AccessToken : IDisposable
     /// <remarks>Restricted SIDs are used to limit the token's access to resources beyond the standard access checks.</remarks>
     public IEnumerable<TokenGroupEntry>? EnumerateRestrictedSid()
     {
+        return EnumerateGroups(TOKEN_INFORMATION_CLASS.TokenRestrictedSids);
+    }
+
+    private IReadOnlyList<TokenGroupEntry>? EnumerateGroups(TOKEN_INFORMATION_CLASS informationClass)
+    {
         return GetTokenInformation<TOKEN_GROUPS, IReadOnlyList<TokenGroupEntry>>(
-            TOKEN_INFORMATION_CLASS.TokenRestrictedSids,
+            informationClass,
             (handle, groups) =>
             {
                 var list = new TokenGroupEntry[groups.GroupCount];


### PR DESCRIPTION
> **Stack 1 of 2** · merges into `main` · must merge before #2492

## What this is

`EnumerateGroups` (`AccessToken.cs:137-153`) and `EnumerateRestrictedSid` (`AccessToken.cs:158-174`)
held sixteen byte-identical lines, differing only in whether they read
`TOKEN_INFORMATION_CLASS.TokenGroups` or `TokenRestrictedSids`.

## Why bother

Low impact on its own, but this is the classic shape where a fix lands in one copy and not the
other — and there *is* pending work here: both are call sites for the `SecurityIdentifier`
constructor being changed in #2487 and #2489. The next PR in this stack also rewrites both
signatures.

## The change

A private `EnumerateGroups(TOKEN_INFORMATION_CLASS)` overload holds the body; the two public methods
become one-line delegations. No behavior change.

## Verification

- Project test suite: 4/4 passing on Windows 11 (arm64, net10.0); group enumeration returns the
  same 15 groups with the same attribute flags.
- `dotnet build -p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.
- `ref/Meziantou.Framework.Win32.AccessToken.cs` regenerates unchanged — the public surface is
  untouched.
