### PR TITLE
Stop returning null from the token query methods

### DIFF
--- a/ref/Meziantou.Framework.Win32.AccessToken.cs
+++ b/ref/Meziantou.Framework.Win32.AccessToken.cs
@@ -12,11 +12,11 @@ namespace Meziantou.Framework.Win32
         public Meziantou.Framework.Win32.TokenElevationType GetElevationType() => throw null;
         public bool IsElevated() => throw null;
         public Meziantou.Framework.Win32.AccessToken? GetLinkedToken() => throw null;
-        public Meziantou.Framework.Win32.TokenEntry? GetMandatoryIntegrityLevel() => throw null;
-        public Meziantou.Framework.Win32.SecurityIdentifier? GetOwner() => throw null;
-        public System.Collections.Generic.IEnumerable<Meziantou.Framework.Win32.TokenGroupEntry>? EnumerateGroups() => throw null;
-        public System.Collections.Generic.IEnumerable<Meziantou.Framework.Win32.TokenGroupEntry>? EnumerateRestrictedSid() => throw null;
-        public System.Collections.Generic.IEnumerable<Meziantou.Framework.Win32.TokenPrivilegeEntry>? EnumeratePrivileges() => throw null;
+        public Meziantou.Framework.Win32.TokenEntry GetMandatoryIntegrityLevel() => throw null;
+        public Meziantou.Framework.Win32.SecurityIdentifier GetOwner() => throw null;
+        public System.Collections.Generic.IEnumerable<Meziantou.Framework.Win32.TokenGroupEntry> EnumerateGroups() => throw null;
+        public System.Collections.Generic.IEnumerable<Meziantou.Framework.Win32.TokenGroupEntry> EnumerateRestrictedSid() => throw null;
+        public System.Collections.Generic.IEnumerable<Meziantou.Framework.Win32.TokenPrivilegeEntry> EnumeratePrivileges() => throw null;
         public void EnablePrivilege(string privilegeName) { }
         public void DisablePrivilege(string privilegeName) { }
         public void DisableAllPrivileges() { }

--- a/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
+++ b/src/Meziantou.Framework.Win32.AccessToken/AccessToken.cs
@@ -114,9 +114,9 @@ public sealed class AccessToken : IDisposable
             });
 
     /// <summary>Gets the mandatory integrity level of the token.</summary>
-    /// <returns>A <see cref="TokenEntry"/> containing the integrity level SID, or <see langword="null"/> if not available.</returns>
+    /// <returns>A <see cref="TokenEntry"/> containing the integrity level SID.</returns>
     /// <remarks>The mandatory integrity level (e.g., Low, Medium, High, System) determines what resources the token can access.</remarks>
-    public TokenEntry? GetMandatoryIntegrityLevel()
+    public TokenEntry GetMandatoryIntegrityLevel()
     {
         return GetTokenInformation<TOKEN_MANDATORY_LABEL, TokenEntry>(
             TOKEN_INFORMATION_CLASS.TokenIntegrityLevel,
@@ -124,8 +124,8 @@ public sealed class AccessToken : IDisposable
     }
 
     /// <summary>Gets the owner security identifier (SID) of the token.</summary>
-    /// <returns>The <see cref="SecurityIdentifier"/> of the token owner, or <see langword="null"/> if not available.</returns>
-    public SecurityIdentifier? GetOwner()
+    /// <returns>The <see cref="SecurityIdentifier"/> of the token owner.</returns>
+    public SecurityIdentifier GetOwner()
     {
         return GetTokenInformation<TOKEN_OWNER, SecurityIdentifier>(
             TOKEN_INFORMATION_CLASS.TokenOwner,
@@ -133,21 +133,21 @@ public sealed class AccessToken : IDisposable
     }
 
     /// <summary>Enumerates all groups (security identifiers) associated with the token.</summary>
-    /// <returns>A collection of <see cref="TokenGroupEntry"/> objects representing the groups, or <see langword="null"/> if not available.</returns>
-    public IEnumerable<TokenGroupEntry>? EnumerateGroups()
+    /// <returns>A collection of <see cref="TokenGroupEntry"/> objects representing the groups.</returns>
+    public IEnumerable<TokenGroupEntry> EnumerateGroups()
     {
         return EnumerateGroups(TOKEN_INFORMATION_CLASS.TokenGroups);
     }
 
     /// <summary>Enumerates the restricted SIDs in the token.</summary>
-    /// <returns>A collection of <see cref="TokenGroupEntry"/> objects representing the restricted SIDs, or <see langword="null"/> if not available.</returns>
+    /// <returns>A collection of <see cref="TokenGroupEntry"/> objects representing the restricted SIDs.</returns>
     /// <remarks>Restricted SIDs are used to limit the token's access to resources beyond the standard access checks.</remarks>
-    public IEnumerable<TokenGroupEntry>? EnumerateRestrictedSid()
+    public IEnumerable<TokenGroupEntry> EnumerateRestrictedSid()
     {
         return EnumerateGroups(TOKEN_INFORMATION_CLASS.TokenRestrictedSids);
     }
 
-    private IReadOnlyList<TokenGroupEntry>? EnumerateGroups(TOKEN_INFORMATION_CLASS informationClass)
+    private IReadOnlyList<TokenGroupEntry> EnumerateGroups(TOKEN_INFORMATION_CLASS informationClass)
     {
         return GetTokenInformation<TOKEN_GROUPS, IReadOnlyList<TokenGroupEntry>>(
             informationClass,
@@ -166,8 +166,8 @@ public sealed class AccessToken : IDisposable
     }
 
     /// <summary>Enumerates all privileges held by the token.</summary>
-    /// <returns>A collection of <see cref="TokenPrivilegeEntry"/> objects representing the privileges, or <see langword="null"/> if not available.</returns>
-    public IEnumerable<TokenPrivilegeEntry>? EnumeratePrivileges()
+    /// <returns>A collection of <see cref="TokenPrivilegeEntry"/> objects representing the privileges.</returns>
+    public IEnumerable<TokenPrivilegeEntry> EnumeratePrivileges()
     {
         return GetTokenInformation<TOKEN_PRIVILEGES, IReadOnlyList<TokenPrivilegeEntry>>(
             TOKEN_INFORMATION_CLASS.TokenPrivileges,
@@ -216,13 +216,13 @@ public sealed class AccessToken : IDisposable
         static T Identity(T arg) => arg;
     }
 
-    private TResult? GetTokenInformation<T, TResult>(TOKEN_INFORMATION_CLASS type, Func<T, TResult> func)
+    private TResult GetTokenInformation<T, TResult>(TOKEN_INFORMATION_CLASS type, Func<T, TResult> func)
         where T : unmanaged
     {
         return GetTokenInformation<T, TResult>(type, (_, arg) => func(arg));
     }
 
-    private unsafe TResult? GetTokenInformation<T, TResult>(TOKEN_INFORMATION_CLASS type, Func<IntPtr, T, TResult> func)
+    private unsafe TResult GetTokenInformation<T, TResult>(TOKEN_INFORMATION_CLASS type, Func<IntPtr, T, TResult> func)
         where T : unmanaged
     {
         uint returnedLength;
@@ -260,7 +260,8 @@ public sealed class AccessToken : IDisposable
             }
         }
 
-        return default;
+        // The sizing call above asks for zero bytes, so it only succeeds if the information class carries no data
+        throw new InvalidOperationException(FormattableString.Invariant($"GetTokenInformation({type}) returned no data"));
     }
 
     /// <summary>Enables a privilege for this token.</summary>

--- a/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
+++ b/tests/Meziantou.Framework.Win32.AccessToken.Tests/AccessTokenTests.cs
@@ -59,17 +59,17 @@ public sealed class AccessTokenTests
         _output.WriteLine("IsElevatedToken: " + token.IsElevated());
         _output.WriteLine("IsRestricted: " + token.IsRestricted());
         _output.WriteLine("MandatoryIntegrityLevel: " + token.GetMandatoryIntegrityLevel()?.Sid);
-        foreach (var group in token.EnumerateGroups() ?? [])
+        foreach (var group in token.EnumerateGroups())
         {
             _output.WriteLine($"Group: {group.Sid} ({group.Attributes})");
         }
 
-        foreach (var group in token.EnumerateRestrictedSid() ?? [])
+        foreach (var group in token.EnumerateRestrictedSid())
         {
             _output.WriteLine($"Restricted Group: {group.Sid} ({group.Attributes})");
         }
 
-        foreach (var privilege in token.EnumeratePrivileges() ?? [])
+        foreach (var privilege in token.EnumeratePrivileges())
         {
             _output.WriteLine($"Privilege: {privilege.Name} ({privilege.Attributes})");
         }
@@ -95,7 +95,7 @@ public sealed class AccessTokenTests
                 return false;
 
             var adminSid = SecurityIdentifier.FromWellKnown(WellKnownSidType.WinBuiltinAdministratorsSid);
-            foreach (var group in accessToken.EnumerateGroups() ?? [])
+            foreach (var group in accessToken.EnumerateGroups())
             {
                 if (group.Attributes.HasFlag(GroupSidAttributes.SE_GROUP_ENABLED) && group.Sid == adminSid)
                     return true;


### PR DESCRIPTION
> **Stack 2 of 2** · merges into #2491 · must merge last

## The problem

`GetTokenInformation` (`AccessToken.cs:271`) returned `default` on exactly one path: when the sizing
call — which asks for **zero bytes** — *succeeds*. No information class used by this library does
that, so the path is unreachable in practice.

That unreachable `default` made the generic return `TResult?`, which propagated to five public
methods:

```csharp
public SecurityIdentifier? GetOwner()
public TokenEntry? GetMandatoryIntegrityLevel()
public IEnumerable<TokenGroupEntry>? EnumerateGroups()
public IEnumerable<TokenGroupEntry>? EnumerateRestrictedSid()
public IEnumerable<TokenPrivilegeEntry>? EnumeratePrivileges()
```

So every caller wrote `?? []` for a state that cannot occur — the project's own tests and readme do
it four times. It also trains consumers to null-check, when the real failure mode is a thrown
`Win32Exception`.

## The change

- Treat an unexpected success of the sizing call as an error and throw `InvalidOperationException`
  naming the information class, instead of silently returning `default`.
- Drop the `?` from the five public return types and from the XML `<returns>` docs.
- Remove the now-redundant `?? []` from the tests.

`GetLinkedToken()` stays nullable — it genuinely returns `null` when the token has no linked token,
which is a real, reachable state.

## Compatibility

Source-compatible for consumers who were already null-checking: `?? []` and `?.` against a
non-nullable reference still compile. Consumers with warnings-as-errors may see the null checks
flagged as redundant.

`ref/Meziantou.Framework.Win32.AccessToken.cs` is regenerated; the diff is exactly these five
signatures.

## Verification

- Project test suite: 4/4 passing on Windows 11 (arm64, net10.0).
- `dotnet build -p:TreatsWarningsAsErrors=true`: 0 warnings, 0 errors.

## Worth a maintainer decision

This changes the public API shape, so it is the one PR in this batch I would not merge without your
sign-off on the direction. If you would rather keep the nullable signatures for compatibility, the
`return default` → `throw` half still stands on its own.
