### PR TITLE
Wait for new records when a read timeout is set

### DIFF
--- a/samples/Meziantou.Framework.Win32.ChangeJournal.Sample/Program.cs
+++ b/samples/Meziantou.Framework.Win32.ChangeJournal.Sample/Program.cs
@@ -7,7 +7,7 @@ changeJournal.EnableTrackModifiedRanges(1, 1);
 //changeJournal.Create(ByteSize.FromMegaBytes(10).Value, ByteSize.FromMegaBytes(1).Value);
 File.Delete("D:/test.txt");
 File.WriteAllBytes("D:/test.txt", new byte[ByteSize.FromMegaBytes(10).Value]);
-var entries = changeJournal.GetEntries(ChangeReason.All, returnOnlyOnClose: false, TimeSpan.FromSeconds(10)).ToList();
+var entries = changeJournal.GetEntries(ChangeReason.All, returnOnlyOnClose: false, TimeSpan.Zero).ToList();
 var lastUsn = entries.OfType<ChangeJournalEntryVersion2or3>().LastOrDefault()?.UniqueSequenceNumber;
 
 Console.WriteLine($"Last USN: {lastUsn}");
@@ -25,7 +25,7 @@ using (var fs = new FileStream("D:/test.txt", FileMode.Open, FileAccess.Write))
     fs.SetLength(ByteSize.FromMegaBytes(200).Value);
 }
 
-entries = changeJournal.GetEntries(lastUsn!.Value, ChangeReason.All, returnOnlyOnClose: false, TimeSpan.FromSeconds(10)).ToList();
+entries = changeJournal.GetEntries(lastUsn!.Value, ChangeReason.All, returnOnlyOnClose: false, TimeSpan.Zero).ToList();
 Console.WriteLine($"Entries: {entries.Count}");
 foreach (var entry in entries)
 {

--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
@@ -92,8 +92,13 @@ public sealed class ChangeJournal : IDisposable
     /// <summary>Gets change journal entries with the specified filter criteria.</summary>
     /// <param name="reasonFilter">A filter that specifies which types of changes to include.</param>
     /// <param name="returnOnlyOnClose">If <see langword="true"/>, returns only entries with the Close reason flag set.</param>
-    /// <param name="timeout">The time to wait for new entries before returning.</param>
+    /// <param name="timeout">The time to wait for new entries once the end of the journal is reached. Use <see cref="TimeSpan.Zero"/> to stop there instead of waiting.</param>
     /// <returns>A collection of change journal entries matching the filter criteria.</returns>
+    /// <remarks>
+    /// A non-zero <paramref name="timeout"/> makes the enumeration wait for a matching entry rather than end, so it never completes on
+    /// its own. The wait happens inside a synchronous call to the driver and cannot be cancelled, which means a thread enumerating with
+    /// a non-zero timeout stays blocked until an entry matches the filter.
+    /// </remarks>
     public IEnumerable<ChangeJournalEntry> GetEntries(ChangeReason reasonFilter, bool returnOnlyOnClose, TimeSpan timeout)
     {
         return new ChangeJournalEntries(this, new ReadChangeJournalOptions(initialUSN: null, reasonFilter, returnOnlyOnClose, timeout, _unprivileged));
@@ -103,8 +108,13 @@ public sealed class ChangeJournal : IDisposable
     /// <param name="currentUSN">The USN to start reading from.</param>
     /// <param name="reasonFilter">A filter that specifies which types of changes to include.</param>
     /// <param name="returnOnlyOnClose">If <see langword="true"/>, returns only entries with the Close reason flag set.</param>
-    /// <param name="timeout">The time to wait for new entries before returning.</param>
+    /// <param name="timeout">The time to wait for new entries once the end of the journal is reached. Use <see cref="TimeSpan.Zero"/> to stop there instead of waiting.</param>
     /// <returns>A collection of change journal entries matching the filter criteria.</returns>
+    /// <remarks>
+    /// A non-zero <paramref name="timeout"/> makes the enumeration wait for a matching entry rather than end, so it never completes on
+    /// its own. The wait happens inside a synchronous call to the driver and cannot be cancelled, which means a thread enumerating with
+    /// a non-zero timeout stays blocked until an entry matches the filter.
+    /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="currentUSN"/> is outside the valid range.</exception>
     public IEnumerable<ChangeJournalEntry> GetEntries(Usn currentUSN, ChangeReason reasonFilter, bool returnOnlyOnClose, TimeSpan timeout)
     {

--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
@@ -150,6 +150,7 @@ internal sealed class ChangeJournalEntries : IEnumerable<ChangeJournalEntry>
                 ReasonMask = (uint)Options.ReasonFilter,
                 ReturnOnlyOnClose = Options.ReturnOnlyOnClose ? 1u : 0u,
                 Timeout = Options.TimeoutInSeconds,
+                BytesToWaitFor = Options.BytesToWaitFor,
                 UsnJournalID = ChangeJournal.Data.ID,
                 MinMajorVersion = Options.MinimumMajorVersion,
                 MaxMajorVersion = Options.MaximumMajorVersion,

--- a/src/Meziantou.Framework.Win32.ChangeJournal/ReadChangeJournalOptions.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ReadChangeJournalOptions.cs
@@ -28,4 +28,12 @@ internal sealed class ReadChangeJournalOptions(Usn? initialUSN, ChangeReason rea
         { Ticks: < 0 } => InfiniteTimeoutInSeconds,
         var value => (ulong)Math.Max(1, Math.Ceiling(value.TotalSeconds)),
     };
+
+    /// <summary>
+    /// Gets the value passed to <c>FSCTL_READ_USN_JOURNAL</c> as <c>BytesToWaitFor</c>, which is the amount of new data the
+    /// read waits for once it reaches the end of the journal. The control code ignores <see cref="TimeoutInSeconds"/> entirely
+    /// while this is <c>0</c>, so a read that is meant to wait has to ask for at least one byte. Asking for a single byte
+    /// makes the read return as soon as anything is appended rather than after a fixed amount of new data.
+    /// </summary>
+    public ulong BytesToWaitFor => TimeoutInSeconds is 0 ? 0ul : 1ul;
 }

--- a/src/Meziantou.Framework.Win32.ChangeJournal/readme.md
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/readme.md
@@ -35,9 +35,13 @@ foreach (var change in changeJournal.GetEntries(entry.UniqueSequenceNumber, Chan
 
 ## Monitor changes as they happen
 
-Pass a non-zero timeout to wait for new records instead of stopping at the end of the journal.
-`Timeout.InfiniteTimeSpan` waits indefinitely, so the loop below never completes on its own.
-The underlying control code counts in whole seconds, so a sub-second timeout is rounded up to one second.
+Pass a non-zero timeout to wait for new records instead of stopping at the end of the journal, so the loop below
+never completes on its own. The timeout is how long the driver waits before it looks for new records again, not a
+deadline: the read stays outstanding until a record matches the filter, whatever the timeout is. The underlying
+control code counts in whole seconds, so a sub-second timeout is rounded up to one second.
+
+The wait happens inside a synchronous call to the driver and cannot be cancelled, so only use a non-zero timeout on
+a thread that can afford to block until a change happens.
 
 ```c#
 foreach (var change in changeJournal.GetEntries(ChangeReason.All, returnOnlyOnClose: false, Timeout.InfiniteTimeSpan))

--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
@@ -71,7 +71,10 @@ public class ChangeJournalTests
             var file = Path.GetTempFileName();
             var drive = Path.GetPathRoot(file) ?? throw new InvalidOperationException("Cannot determine drive root");
             using var changeJournal = ChangeJournal.Open(new DriveInfo(drive), unprivileged: true);
-            var entries = changeJournal.GetEntries(ChangeReason.FileCreate, returnOnlyOnClose: false, TimeSpan.FromSeconds(10)).ToList();
+
+            // TimeSpan.Zero stops at the end of the journal. Any other value keeps the read waiting for a new record,
+            // so enumerating to the end would never return.
+            var entries = changeJournal.GetEntries(ChangeReason.FileCreate, returnOnlyOnClose: false, TimeSpan.Zero).ToList();
             Assert.NotEmpty(entries);
         });
     }
@@ -97,6 +100,19 @@ public class ChangeJournalTests
     {
         var options = new ReadChangeJournalOptions(initialUSN: null, ChangeReason.All, returnOnlyOnClose: false, TimeSpan.FromMilliseconds(milliseconds), unprivileged: false);
         Assert.Equal(expected, options.TimeoutInSeconds);
+    }
+
+    [Theory]
+    [InlineData(0, 0ul)]                    // do not wait, so the control code must not be asked for new data
+    [InlineData(-1, 1ul)]                   // Timeout.InfiniteTimeSpan
+    [InlineData(500, 1ul)]
+    [InlineData(30_000, 1ul)]
+    public void ReadOptions_AsksForNewDataOnlyWhenTheReadIsMeantToWait(int milliseconds, ulong expected)
+    {
+        // FSCTL_READ_USN_JOURNAL ignores its timeout while BytesToWaitFor is 0, so a read that is meant to wait has to
+        // ask for at least one byte of new data.
+        var options = new ReadChangeJournalOptions(initialUSN: null, ChangeReason.All, returnOnlyOnClose: false, TimeSpan.FromMilliseconds(milliseconds), unprivileged: false);
+        Assert.Equal(expected, options.BytesToWaitFor);
     }
 
     [Theory]


### PR DESCRIPTION
Closes the High finding from the ChangeJournal project review.

## The defect

`ChangeJournalEntries.Read` (`ChangeJournalEntries.cs:147-156`) builds a `READ_USN_JOURNAL_DATA_V1`, assigns `Timeout`, and leaves `BytesToWaitFor` at its default of `0`. The [structure documentation](https://learn.microsoft.com/windows/win32/api/winioctl/ns-winioctl-read_usn_journal_data_v1) is explicit:

> If **BytesToWaitFor** is zero, then **Timeout** is ignored. In this case, the FSCTL_READ_USN_JOURNAL operation always returns successfully when the end of the change journal file is encountered.

So the `timeout` argument on both `GetEntries` overloads did nothing. `readme.md` documents a "Monitor changes as they happen" loop with `Timeout.InfiniteTimeSpan` that "never completes on its own" — in practice that `foreach` fell straight through.

Measured before the change, against a live journal, starting at `Data.NextUSN` so nothing could match yet:

```
GetEntries(nextUsn, ChangeReason.All, false, TimeSpan.FromSeconds(20))
  -> 0 entries in 0.00s
```

## The change

`ReadChangeJournalOptions` gains `BytesToWaitFor`, which is `1` whenever `TimeoutInSeconds` is non-zero and `0` otherwise, and `Read` passes it through. One byte means "return as soon as anything is appended" rather than after a fixed amount of new data. `TimeSpan.Zero` keeps the existing read-to-the-end-and-stop behaviour untouched.

Measured after, with a `ChangeReason.ObjectIDChange` filter that effectively never matches:

```
GetEntries(nextUsn, ChangeReason.ObjectIDChange, false, TimeSpan.FromSeconds(2))
  -> still waiting after 8s
```

## Behaviour change worth a close look

This makes a previously non-blocking call block, so it needs your judgement on two points:

1. **A non-zero timeout is not a deadline.** The docs say that after the timeout elapses the driver looks for new records and, if there are none, *repeats the timeout period* — the read "remains outstanding until at least one record is returned or I/O is canceled". So `TimeSpan.FromSeconds(10)` does not return after ten seconds with nothing; it waits until a record matches. That is now documented on both `GetEntries` overloads and in the readme, but it is a sharp edge.

2. **The wait cannot be cancelled.** It is a synchronous `DeviceIoControl`. Disposing the instance does not help — `SafeHandleValue` holds a `DangerousAddRef` for the duration, so `SafeFileHandle.Dispose` will not close the handle until the call returns. A `CancellationToken` overload (or an overlapped handle) would be the fix, and I would rather leave that as a follow-up than smuggle it into this PR.

Two callers passed a non-zero timeout and then enumerated to the end, which would now hang, so they move to `TimeSpan.Zero` — which is what they actually meant:

- `ChangeJournalTests.NonAdministrator` — it tests unprivileged access, not the timeout.
- `samples/.../Program.cs` — both `GetEntries(...).ToList()` calls.

## Verification

- `dotnet build -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test -f net10.0` — 25 total, 22 passed, 3 skipped (the elevation-gated integration tests; this machine is not elevated). Up from 21/18/3: the four new cases are the `BytesToWaitFor` theory.
- `dotnet run ./eng/update-all.cs` — no files changed. It reports "one or more steps reported errors", but it does that on a clean checkout of `main` too (an MSBuild server timeout in this environment), so it is not from this change.
- `ref/` is unchanged; nothing public was added.
