### PR TITLE
Add the missing integrity change reason

### DIFF
--- a/ref/Meziantou.Framework.Win32.ChangeJournal.cs
+++ b/ref/Meziantou.Framework.Win32.ChangeJournal.cs
@@ -86,6 +86,7 @@ namespace Meziantou.Framework.Win32
         FileDelete = 512U,
         HardLinkChange = 65536U,
         IndexableChange = 16384U,
+        IntegrityChange = 8388608U,
         NamedDataExtend = 32U,
         NamedDataOverwrite = 16U,
         NamedDataTruncation = 64U,
@@ -96,7 +97,7 @@ namespace Meziantou.Framework.Win32
         SecurityChange = 2048U,
         StreamChange = 2097152U,
         TransactedChange = 4194304U,
-        All = 2155872119U
+        All = 2164260727U
     }
 
     public readonly struct FileIdentifier : System.IEquatable<Meziantou.Framework.Win32.FileIdentifier>

--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeReason.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeReason.cs
@@ -40,6 +40,9 @@ public enum ChangeReason : uint
     /// <summary>The file or directory's indexing state changed.</summary>
     IndexableChange = 0x00004000,
 
+    /// <summary>The file or directory's integrity status changed.</summary>
+    IntegrityChange = 0x00800000,
+
     /// <summary>A named data stream was extended.</summary>
     NamedDataExtend = 0x00000020,
 
@@ -71,5 +74,10 @@ public enum ChangeReason : uint
     TransactedChange = 0x00400000,
 
     /// <summary>All change reasons combined.</summary>
-    All = BasicInfoChange | Close | CompressionChange | DataExtend | DataOverwrite | DataTruncation | ExtendedAttributesChange | EncryptionChange | FileCreate | FileDelete | HardLinkChange | IndexableChange | NamedDataExtend | NamedDataOverwrite | NamedDataTruncation | ObjectIDChange | RenameNewName | RenameOldName | ReparsePointChange | StreamChange | SecurityChange | TransactedChange,
+    /// <remarks>
+    ///     This is passed to <c>FSCTL_READ_USN_JOURNAL</c> as its <c>ReasonMask</c>, and the change journal only returns a record
+    ///     when at least one of the requested bits is set on it. A reason missing from this list is therefore filtered out by the
+    ///     driver rather than merely losing its name, so every reason above has to be part of it.
+    /// </remarks>
+    All = BasicInfoChange | Close | CompressionChange | DataExtend | DataOverwrite | DataTruncation | ExtendedAttributesChange | EncryptionChange | FileCreate | FileDelete | HardLinkChange | IndexableChange | IntegrityChange | NamedDataExtend | NamedDataOverwrite | NamedDataTruncation | ObjectIDChange | RenameNewName | RenameOldName | ReparsePointChange | StreamChange | SecurityChange | TransactedChange,
 }

--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
@@ -125,6 +125,27 @@ public class ChangeJournalTests
     }
 
     [Fact]
+    public void ChangeReasonAllIsTheUnionOfEveryOtherReason()
+    {
+        var expected = default(ChangeReason);
+        foreach (var reason in Enum.GetValues<ChangeReason>())
+        {
+            if (reason is not ChangeReason.All)
+            {
+                expected |= reason;
+            }
+        }
+
+        Assert.Equal(expected, ChangeReason.All);
+    }
+
+    [Fact]
+    public void ChangeReasonAllMatchesTheNativeReasonMask()
+    {
+        Assert.Equal(0x80FFFF77u, (uint)ChangeReason.All);
+    }
+
+    [Fact]
     public void FileIdentifier128ToString()
     {
         FileIdentifier fileIdentifier = new FileIdentifier(new UInt128(0, 10));

--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
@@ -127,16 +127,16 @@ public class ChangeJournalTests
     [Fact]
     public void ChangeReasonAllIsTheUnionOfEveryOtherReason()
     {
-        var expected = default(ChangeReason);
+        var union = default(ChangeReason);
         foreach (var reason in Enum.GetValues<ChangeReason>())
         {
             if (reason is not ChangeReason.All)
             {
-                expected |= reason;
+                union |= reason;
             }
         }
 
-        Assert.Equal(expected, ChangeReason.All);
+        Assert.Equal(ChangeReason.All, union);
     }
 
     [Fact]


### PR DESCRIPTION
Closes a Medium finding from the ChangeJournal project review.

## The defect

`ChangeReason` (`ChangeReason.cs:5-75`) was missing `USN_REASON_INTEGRITY_CHANGE` (`0x00800000`), documented in [MS-FSCC §2.3.62.2](https://learn.microsoft.com/openspecs/windows_protocols/ms-fscc/d2a2b53e-bf78-4ef3-90c7-21b918fab304) as "A change is made in the integrity status of a file or directory".

This is not just a missing name. `ChangeReason.All` is cast straight to `ReasonMask` at `ChangeJournalEntries.cs:150`, and the change journal returns a record only when at least one of the requested bits is set on it. So `All` evaluating to `0x807FFF77` instead of `0x80FFFF77` meant a record whose only reason was an integrity change was filtered out by the driver before the library ever saw it — silently, which is the worst failure mode for a change-tracking library. A record combining it with another reason did come back, but `Reason.ToString()` rendered the unnamed bit as a number.

Integrity streams are the normal configuration on ReFS and available on NTFS.

## The change

Add the member, fold it into `All`, and add a remark on `All` explaining why membership is load-bearing rather than cosmetic.

Two tests keep it honest:

- `ChangeReasonAllIsTheUnionOfEveryOtherReason` reflects over the enum, so adding a member without updating `All` fails.
- `ChangeReasonAllMatchesTheNativeReasonMask` pins `0x80FFFF77`, so the value the driver receives cannot drift silently.

## One I deliberately left out

Modern `winioctl.h` also defines `USN_REASON_DESIRED_STORAGE_CLASS_CHANGE` (`0x01000000`). I could not confirm it from Microsoft's published documentation the way I could for `INTEGRITY_CHANGE`, so I did not add it on a guess — worth a look if you have the SDK header handy, and it would be a one-line follow-up.

I also considered defining `All` as a literal full mask so it can never drift, but the docs say unused bits are reserved and I did not want to hand the driver reserved bits. The reflection test covers the drift risk instead.

## Verification

- `dotnet build -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test -f net10.0` — 23 total, 20 passed, 3 skipped (the elevation-gated integration tests; this machine is not elevated). Up from 21/18/3.
- `ref/` regenerated from the build: a 2-line diff, `IntegrityChange = 8388608U` and `All` going from `2155872119U` to `2164260727U` (`0x80FFFF77`). Note the generator emits CRLF on Windows while the file is stored LF, so I normalised line endings to keep the diff to the two lines that actually changed.
- `dotnet run ./eng/update-all.cs` — no files changed.
