### PR TITLE
Open directories in the path based overloads

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
@@ -117,10 +117,11 @@ public sealed class ChangeJournal : IDisposable
     /// <summary>Gets the change journal entry for a specific file or directory by path.</summary>
     /// <param name="path">The path to the file or directory.</param>
     /// <returns>The change journal entry for the specified file or directory.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="Win32Exception">Thrown when the operation fails.</exception>
     public static ChangeJournalEntryVersion2or3 GetEntry(string path)
     {
-        using var handle = File.OpenHandle(path);
+        using var handle = FileHandleHelper.OpenFileOrDirectory(path);
         return GetEntry(handle);
     }
 

--- a/src/Meziantou.Framework.Win32.ChangeJournal/FileIdentifier.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/FileIdentifier.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using Meziantou.Framework.Win32.Natives;
 using Microsoft.Win32.SafeHandles;
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -36,11 +37,12 @@ public readonly struct FileIdentifier : IEquatable<FileIdentifier>
     /// <summary>Gets the file identifier for the specified file or directory path.</summary>
     /// <param name="path">The path to the file or directory.</param>
     /// <returns>The file identifier for the specified file or directory.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="path"/> is <see langword="null"/>.</exception>
     /// <exception cref="Win32Exception">Thrown when the operation fails.</exception>
     [SupportedOSPlatform("windows6.0.6000")]
     public unsafe static FileIdentifier FromFile(string path)
     {
-        using var handle = File.OpenHandle(path);
+        using var handle = FileHandleHelper.OpenFileOrDirectory(path);
         return FromFile(handle);
     }
 

--- a/src/Meziantou.Framework.Win32.ChangeJournal/Natives/FileHandleHelper.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/Natives/FileHandleHelper.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.Win32.SafeHandles;
+using Windows.Win32;
+using Windows.Win32.Storage.FileSystem;
+
+namespace Meziantou.Framework.Win32.Natives;
+
+internal static class FileHandleHelper
+{
+    /// <summary>
+    ///     Opens a file or a directory so its metadata can be read. <c>FILE_FLAG_BACKUP_SEMANTICS</c> is what makes a directory
+    ///     openable, which is why <see cref="File.OpenHandle(string, FileMode, FileAccess, FileShare, FileOptions, long)"/> cannot
+    ///     be used here: it never sets that flag, so it fails on a directory with an access denied error.
+    ///     <c>FILE_READ_ATTRIBUTES</c> is all the metadata operations need, and asking for no more than that keeps the call
+    ///     working on files the caller is not allowed to read.
+    /// </summary>
+    /// <exception cref="Win32Exception">Thrown when the file or directory cannot be opened.</exception>
+    [SupportedOSPlatform("windows5.1.2600")]
+    internal static SafeFileHandle OpenFileOrDirectory(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        var handle = PInvoke.CreateFile(
+            path,
+            (uint)FILE_ACCESS_RIGHTS.FILE_READ_ATTRIBUTES,
+            FILE_SHARE_MODE.FILE_SHARE_READ | FILE_SHARE_MODE.FILE_SHARE_WRITE | FILE_SHARE_MODE.FILE_SHARE_DELETE,
+            lpSecurityAttributes: null,
+            FILE_CREATION_DISPOSITION.OPEN_EXISTING,
+            FILE_FLAGS_AND_ATTRIBUTES.FILE_FLAG_BACKUP_SEMANTICS,
+            hTemplateFile: null);
+
+        if (handle.IsInvalid)
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+
+        return handle;
+    }
+}

--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
@@ -84,6 +84,31 @@ public class ChangeJournalTests
         Assert.NotEqual(default, identifier);
     }
 
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetFileIdentifierOfADirectory()
+    {
+        var directory = CreateTemporaryDirectory();
+        Assert.NotEqual(default, FileIdentifier.FromFile(directory));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetEntryOfADirectory()
+    {
+        var directory = CreateTemporaryDirectory();
+
+        var entry = ChangeJournal.GetEntry(directory);
+
+        Assert.Equal(Path.GetFileName(directory), entry.Name);
+        Assert.True(entry.Attributes.HasFlag(FileAttributes.Directory));
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
     [Theory]
     [InlineData(0, 0ul)]                    // do not wait, return at the end of the journal
     [InlineData(-1, uint.MaxValue)]         // Timeout.InfiniteTimeSpan


### PR DESCRIPTION
Closes a Medium finding from the ChangeJournal project review.

## The defect

`ChangeJournal.GetEntry(string)` (`ChangeJournal.cs:117-125`) and `FileIdentifier.FromFile(string)` (`FileIdentifier.cs:36-45`) both document "the path to the file **or directory**", and both called `File.OpenHandle(path)`. On Windows that never sets `FILE_FLAG_BACKUP_SEMANTICS`, which is the flag that makes a directory openable, so both threw on every directory. Measured against the built assembly before the change:

```
ERR ChangeJournal.GetEntry(directory)   -> UnauthorizedAccessException: Access to the path '...\Temp' is denied.
ERR FileIdentifier.FromFile(directory)  -> UnauthorizedAccessException: Access to the path '...\Temp' is denied.
OK  ChangeJournal.GetEntry(file)        -> tmp5ad4j4.tmp
OK  FileIdentifier.FromFile(file)       -> 00000000000000000006000000024e5d
```

The `SafeFileHandle` overloads were already fine — a caller who opened the directory handle themselves got the right answer — which is what made this look like an oversight in how the handle was opened rather than a deliberate limitation.

It matters because the change journal records directory changes as first-class entries (`FileCreate` on a directory, a rename record on each parent), so resolving a directory to its `FileIdentifier` is the natural way to walk parent references back to a path. The exception was also misleading: `UnauthorizedAccessException` reads as a permissions problem and sends you looking for elevation.

## The change

A small internal `FileHandleHelper.OpenFileOrDirectory` opens through `PInvoke.CreateFile` with `FILE_FLAG_BACKUP_SEMANTICS`, and both string overloads use it. Two details worth a second of review:

- **`FILE_READ_ATTRIBUTES` only.** That is all `FSCTL_READ_FILE_USN_DATA` and `GetFileInformationByHandleEx(FileIdInfo)` need, and asking for no more keeps both overloads working on files the caller is not allowed to read. I verified empirically that the FSCTL is happy with it — the two new tests pass, and they would fail with an access denied error if it were not enough.
- **Shared rather than duplicated.** The two call sites live in different files, so the helper is a new file under `Natives/` next to `Win32DeviceControl`. It is `internal`, so no public API change and `ref/` is untouched.

## Tests

Two new ones, neither needing elevation:

- `GetFileIdentifierOfADirectory`
- `GetEntryOfADirectory` — also asserts the entry name and that `Attributes` carries `FileAttributes.Directory`, so it proves the right object came back rather than just that nothing threw.

## Verification

- `dotnet build -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test -f net10.0` — 23 total, 20 passed, 3 skipped (the elevation-gated integration tests; this machine is not elevated). Up from 21/18/3, so both new tests really ran.
- `dotnet run ./eng/update-all.cs` — no files changed.
- `ref/` unchanged.
