### PR TITLE
Grow the output buffer instead of trusting ERROR_MORE_DATA

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/Natives/Win32DeviceControl.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/Natives/Win32DeviceControl.cs
@@ -9,43 +9,47 @@ namespace Meziantou.Framework.Win32.Natives;
 
 internal static class Win32DeviceControl
 {
+    /// <summary>
+    ///     Size to grow to when the caller asked for no output buffer at all but the control code turns out to want one, so that
+    ///     doubling has something to work from.
+    /// </summary>
+    private const int MinimumOutputBufferLength = 1024;
+
+    /// <summary>
+    ///     Upper bound on the output buffer, so a driver that keeps reporting ERROR_MORE_DATA cannot grow it without limit.
+    /// </summary>
+    private const int MaximumOutputBufferLength = 1024 * 1024;
+
     [SupportedOSPlatform("windows5.1.2600")]
     internal static unsafe Span<byte> ControlWithInput<TStructure>(SafeFileHandle handle, Win32ControlCode code, ref TStructure structure, int initialBufferLength) where TStructure : unmanaged
     {
-        uint returnedSize;
-        bool controlResult;
+        var structureLength = (uint)Marshal.SizeOf<TStructure>();
+        byte[] buffer = initialBufferLength is 0 ? [] : new byte[initialBufferLength];
 
-        var buffer = initialBufferLength is 0 ? Array.Empty<byte>() : new byte[initialBufferLength];
         fixed (void* structurePointer = &structure)
         {
             using var handleScope = new SafeHandleValue(handle);
-            fixed (void* bufferPointer = buffer)
+            while (true)
             {
-                controlResult = PInvoke.DeviceIoControl((HANDLE)handleScope.Value, (uint)code, structurePointer, (uint)Marshal.SizeOf(structure), bufferPointer, (uint)buffer.Length, &returnedSize, lpOverlapped: null);
-            }
+                uint returnedSize;
+                bool controlResult;
+                fixed (void* bufferPointer = buffer)
+                {
+                    controlResult = PInvoke.DeviceIoControl((HANDLE)handleScope.Value, (uint)code, structurePointer, structureLength, bufferPointer, (uint)buffer.Length, &returnedSize, lpOverlapped: null);
+                }
 
-            if (!controlResult)
-            {
+                if (controlResult)
+                    return buffer.AsSpan(0, (int)returnedSize);
+
                 var errorCode = Marshal.GetLastWin32Error();
-                if (errorCode == (int)WIN32_ERROR.ERROR_MORE_DATA)
-                {
-                    buffer = new byte[returnedSize];
-                    fixed (void* bufferPointer = buffer)
-                    {
-                        controlResult = PInvoke.DeviceIoControl((HANDLE)handleScope.Value, (uint)code, structurePointer, (uint)Marshal.SizeOf(structure), bufferPointer, (uint)buffer.Length, &returnedSize, lpOverlapped: null);
-                    }
-
-                    if (!controlResult)
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
-                }
-                else
-                {
+                if (errorCode is not (int)WIN32_ERROR.ERROR_MORE_DATA || buffer.Length >= MaximumOutputBufferLength)
                     throw new Win32Exception(errorCode);
-                }
+
+                // ERROR_MORE_DATA reports the number of bytes written, not the number required, so it is never larger than the
+                // buffer that just proved too small. Grow geometrically instead of trusting returnedSize to be large enough.
+                buffer = new byte[Math.Min(Math.Max(buffer.Length * 2, MinimumOutputBufferLength), MaximumOutputBufferLength)];
             }
         }
-
-        return buffer.AsSpan(0, (int)returnedSize);
     }
 
     [SupportedOSPlatform("windows5.1.2600")]


### PR DESCRIPTION
Closes a Medium finding from the ChangeJournal project review.

## The defect

`Win32DeviceControl.ControlWithInput` (`Win32DeviceControl.cs:27-45`) handled `ERROR_MORE_DATA` by allocating `new byte[returnedSize]` and retrying once. But [`DeviceIoControl` documents](https://learn.microsoft.com/windows/win32/api/ioapiset/nf-ioapiset-deviceiocontrol) that on `ERROR_MORE_DATA`:

> *lpBytesReturned* indicates the amount of data **received**

That is bytes *written*, not bytes *required* — so by definition it is at most the size of the buffer that just failed. The retry therefore allocated the same size or smaller and failed identically, throwing `Win32Exception(ERROR_MORE_DATA)` from the inner branch. If a driver reported zero bytes written, the retry ran with a zero-length buffer and a null `lpOutBuffer`. The recovery path could not succeed under any circumstances.

The sibling code already had this right. `ChangeJournal.GetEntry` carries the comment:

> ERROR_MORE_DATA reports the number of bytes written, not the number required, so grow geometrically instead of trusting returnedSize to be large enough.

`ControlWithInput` was simply never updated to match.

## Why it is Medium and not High

The only caller passing a non-zero buffer is the journal read (8 KiB), and a V2/V3 record cannot exceed ~588 bytes, so this is latent today. It becomes reachable with V4 records, whose length grows with `NumberOfExtents` (a `ushort`) — which is exactly what `EnableTrackModifiedRanges` turns on.

## The change

Replace the single retry with a loop that doubles the buffer and caps it, mirroring `ChangeJournal.GetEntry`. Two constants carry the bounds:

- `MinimumOutputBufferLength` (1 KiB) gives doubling something to work from when the caller passed `initialBufferLength: 0` — the `Create`/`Delete`/`TrackModifiedRanges` calls, which want no output buffer but would previously have thrown rather than grown if the driver disagreed.
- `MaximumOutputBufferLength` (1 MiB) stops a driver that keeps reporting `ERROR_MORE_DATA` from growing it without limit.

Also in the rewrite: `Marshal.SizeOf(structure)` is hoisted out of the loop, and switched to the generic `Marshal.SizeOf<TStructure>()` on the same line, since calling the boxing instance overload once per iteration would be silly. `Array.Empty<byte>()` becomes `[]`, which clears the IDE0301 that `dotnet format` reports on that line.

## Verification

This is the one change in the batch I could not write a test for: `ERROR_MORE_DATA` comes from the driver, and there is no seam to inject it without either a fake or making `Win32DeviceControl` generic over the P/Invoke. I did not think either was worth it for a static interop helper, but say the word if you would rather have it.

- `dotnet build -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test -f net10.0` — 21 total, 18 passed, 3 skipped (the elevation-gated integration tests; this machine is not elevated), unchanged from `main`. `NonAdministrator` does a real journal read through `ControlWithInput`, so the happy path is covered.
- `dotnet run ./eng/update-all.cs` — no files changed.
- `ref/` unchanged; the type is internal.
