### PR TITLE
Close the volume handle when Open fails to construct

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
@@ -86,7 +86,19 @@ public sealed class ChangeJournal : IDisposable
         if (handle.IsInvalid)
             throw new Win32Exception(Marshal.GetLastWin32Error());
 
-        return new ChangeJournal(handle, unprivileged);
+        try
+        {
+            return new ChangeJournal(handle, unprivileged);
+        }
+        catch
+        {
+            // The constructor queries the journal, which fails on a volume that has no change journal support and while a
+            // deletion started by Delete(waitForCompletion: false) is still running. Ownership of the handle only passes to
+            // the caller once there is an instance to dispose, so it has to be closed here instead of waiting for the
+            // finalizer to reclaim an open volume handle.
+            handle.Dispose();
+            throw;
+        }
     }
 
     /// <summary>Gets change journal entries with the specified filter criteria.</summary>


### PR DESCRIPTION
Closes a Low finding from the ChangeJournal project review.

## The defect

`ChangeJournal.Open` (`ChangeJournal.cs:77-89`) creates the volume handle, checks `IsInvalid`, then passes it to the constructor — which immediately calls `ReadJournalDataImpl`. That method catches only `ERROR_JOURNAL_NOT_ACTIVE` (`ChangeJournal.cs:181`), so any other `Win32Exception` propagates out of the constructor and the `handle` local is left referenced by nothing.

The clearest way in is one the library already documents itself. `Delete`'s remarks say:

> While the deletion is in progress, any attempt to create, modify, delete, or query the change journal fails with `ERROR_JOURNAL_DELETE_IN_PROGRESS`.

So `Delete(waitForCompletion: false)` followed by `Open` throws from the constructor and leaks. A volume whose filesystem does not implement the FSCTL at all does the same.

## The change

Wrap the construction in `try`/`catch`, dispose the handle, rethrow. Ownership only passes to the caller once there is an instance for them to dispose.

## Why Low

`SafeFileHandle` has a finalizer, so this is non-deterministic cleanup of an open volume handle rather than an unbounded leak. It bites in a retry loop, where the finalizer may not keep up.

## A related thing I did not do here

`JournalData.IsActive` exists so callers can ask whether a volume has a journal instead of catching. Today it only covers one of the two ways the answer is no — a volume with no journal support at all still throws a raw `Win32Exception` from `Open`. Widening `IsActive` to cover that is a behaviour change to a public property, so it did not belong in a leak fix. Happy to open it separately if you want it.

## Verification

- `dotnet build -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test -f net10.0` — 21 total, 18 passed, 3 skipped (the elevation-gated integration tests; this machine is not elevated), unchanged from `main`.
- No test: reaching the failure needs a volume without journal support or a real deletion in flight, and neither is something I would want a unit test to arrange.
- `ref/` unchanged.
