### PR TITLE
Reject a partially filled structure in ControlWithOutput

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/Natives/Win32DeviceControl.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/Natives/Win32DeviceControl.cs
@@ -51,13 +51,20 @@ internal static class Win32DeviceControl
     [SupportedOSPlatform("windows5.1.2600")]
     internal static unsafe void ControlWithOutput<TStructure>(SafeFileHandle handle, Win32ControlCode code, ref TStructure structure) where TStructure : unmanaged
     {
+        var structureLength = (uint)Marshal.SizeOf<TStructure>();
         fixed (void* pStructure = &structure)
         {
             uint returnedSize = 0;
             using var handleScope = new SafeHandleValue(handle);
-            var controlResult = PInvoke.DeviceIoControl((HANDLE)handleScope.Value, (uint)code, lpInBuffer: null, 0u, pStructure, (uint)Marshal.SizeOf<TStructure>(), &returnedSize, lpOverlapped: null);
+            var controlResult = PInvoke.DeviceIoControl((HANDLE)handleScope.Value, (uint)code, lpInBuffer: null, 0u, pStructure, structureLength, &returnedSize, lpOverlapped: null);
             if (!controlResult)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            // A driver that does not know the whole structure fills in only the prefix it does know and reports how much it
+            // wrote. Ignoring that would hand back a structure whose newer fields are zero, which is indistinguishable from a
+            // driver that really did report zero for them.
+            if (returnedSize < structureLength)
+                throw new InvalidDataException($"The device returned {returnedSize.ToString(CultureInfo.InvariantCulture)} bytes for a {structureLength.ToString(CultureInfo.InvariantCulture)}-byte structure");
         }
     }
 }


### PR DESCRIPTION
Closes a Low finding from the ChangeJournal project review.

## The defect

`Win32DeviceControl.ControlWithOutput` (`Win32DeviceControl.cs:52-62`) passes `&returnedSize` to `DeviceIoControl` and then never reads it.

`ReadJournalDataImpl` (`ChangeJournal.cs:176-179`) always asks for a full `USN_JOURNAL_DATA_V2`. Its last three members — `Flags`, `RangeTrackChunkSize`, `RangeTrackFileSizeThreshold` — are much newer than the rest of the structure. A driver that fills in only the prefix it knows and reports a smaller `returnedSize` therefore produced a successful call and a `JournalData` reporting those fields as `0`.

That is the bad kind of wrong: `Flags == 0` means "range tracking is off", which is a perfectly plausible answer. A caller checking `Data.Flags` to decide whether to expect V4 records would quietly take the wrong branch with nothing to indicate it.

## The change

Compare `returnedSize` against the structure size and throw `InvalidDataException` when it is short — matching how the record parser already reports a structurally impossible response. A loud failure beats a plausible wrong number.

Also hoists `Marshal.SizeOf<TStructure>()` into a local, since it is now needed twice.

## Is throwing too aggressive?

I think not, and here is the reasoning so you can check it: `USN_JOURNAL_DATA_V2` is documented as Windows 8.1 / Server 2012 R2 minimum, and the package targets `net10.0`/`net11.0`, whose own floor is well above that. So on any platform that can actually load this library the driver should fill the whole structure, and a short read genuinely indicates something wrong. Confirmed on this machine: the `NonAdministrator` test opens a journal, which goes through this exact path, and passes.

If you would rather not risk it, the alternative is returning `returnedSize` and letting `ReadJournalDataImpl` decide — but `JournalData` has no way to express "these fields are unknown", so that mostly moves the problem.

## Verification

- `dotnet build -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test -f net10.0` — 21 total, 18 passed, 3 skipped (the elevation-gated integration tests; this machine is not elevated), unchanged from `main`.
- No test for the short-read branch: it needs a driver that under-fills the structure, and there is no seam to fake one behind a static interop helper.
- `ref/` unchanged; the type is internal.
