### PR TITLE
Refresh the journal data after enabling range tracking

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
@@ -254,6 +254,7 @@ public sealed class ChangeJournal : IDisposable
     /// <summary>Enables range tracking for the change journal.</summary>
     /// <param name="chunkSize">The granularity of tracked ranges.</param>
     /// <param name="fileSizeThreshold">The file size threshold to start tracking ranges for files with equal or larger size.</param>
+    /// <remarks>Range tracking is reflected by <see cref="JournalData.Flags"/>, <see cref="JournalData.RangeTrackChunkSize"/> and <see cref="JournalData.RangeTrackFileSizeThreshold"/> on <see cref="Data"/>.</remarks>
     public void EnableTrackModifiedRanges(ulong chunkSize, long fileSizeThreshold)
     {
         var trackData = new USN_TRACK_MODIFIED_RANGES
@@ -263,5 +264,6 @@ public sealed class ChangeJournal : IDisposable
             FileSizeThreshold = fileSizeThreshold,
         };
         Win32DeviceControl.ControlWithInput(ChangeJournalHandle, Win32ControlCode.TrackModifiedRanges, ref trackData, initialBufferLength: 0);
+        RefreshJournalData();
     }
 }


### PR DESCRIPTION
A small consistency fix noted alongside the ChangeJournal project review.

`EnableTrackModifiedRanges` (`ChangeJournal.cs:257-266`) was the only mutating operation that did not call `RefreshJournalData` after its control code returned. `Create` and `Delete` both do.

The consequence is narrow but confusing: `Data.Flags`, `Data.RangeTrackChunkSize` and `Data.RangeTrackFileSizeThreshold` are exactly the three properties this call changes, and they kept showing the pre-call state until the caller happened to refresh by hand. So the obvious sequence

```c#
changeJournal.EnableTrackModifiedRanges(chunkSize: 10_000, fileSizeThreshold: 100_000_000);
if (changeJournal.Data.Flags.HasFlag(ChangeJournalFlags.TrackModifiedRangesEnable)) { ... }
```

read back `None`.

Adds the `RefreshJournalData()` call, plus a remark pointing at the three properties it updates.

## Verification

- `dotnet build -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test -f net10.0` — 21 total, 18 passed, 3 skipped (the elevation-gated integration tests; this machine is not elevated), unchanged from `main`.
- No test: enabling range tracking is a real, persistent change to the volume's journal, which is not something I would want a test to do to a developer machine or a CI runner.
- `ref/` unchanged; only a doc remark was added to the public surface.
