### PR TITLE
Remove a stray space after a cast in JournalData

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/JournalData.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/JournalData.cs
@@ -24,7 +24,7 @@ public sealed class JournalData
         AllocationDelta = nativeData.AllocationDelta;
         MinSupportedMajorVersion = nativeData.MinSupportedMajorVersion;
         MaxSupportedMajorVersion = nativeData.MaxSupportedMajorVersion;
-        Flags = (ChangeJournalFlags) nativeData.Flags;
+        Flags = (ChangeJournalFlags)nativeData.Flags;
         RangeTrackChunkSize = nativeData.RangeTrackChunkSize;
         RangeTrackFileSizeThreshold = nativeData.RangeTrackFileSizeThreshold;
     }


### PR DESCRIPTION
`dotnet format --verify-no-changes` reported one violation in this project:

```
JournalData.cs(27,37): error WHITESPACE: Fix whitespace formatting. Delete 1 characters.
```

`(ChangeJournalFlags) nativeData.Flags` had a space after the cast. Removed; the project now verifies clean.

## Scope note

The same run also reports `CHARSET` on every file, but that is repo-wide — the identical run against `Meziantou.Framework.Win32.Amsi` reports it too — so it is a tool default (the file encoding has no BOM) rather than anything about this project. I have not touched it.

Two `MA0076` infos (culture-sensitive `ToString` in an interpolated string) sit inside the `InvalidDataException` messages in `ChangeJournalEntries`, which other PRs in this batch are editing. I left those out to avoid a pointless conflict.

## Verification

`dotnet build -p:TreatWarningsAsErrors=true` — clean. `dotnet format --verify-no-changes` — no WHITESPACE violations remain.
