### PR TITLE
Cover the USN record parser with tests

### DIFF
--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
@@ -1,4 +1,7 @@
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
 using Meziantou.Xunit;
+using Windows.Win32.System.Ioctl;
 
 namespace Meziantou.Framework.Win32.Tests;
 
@@ -136,5 +139,202 @@ public class ChangeJournalTests
     {
         FileIdentifier fileIdentifier = new FileIdentifier(10);
         Assert.Equal("000000000000000a", fileIdentifier.ToString());
+    }
+
+    [Fact]
+    public void GetBufferedEntry_ParsesAVersion2Record()
+    {
+        var buffer = CreateVersion2Record("test.txt");
+
+        var entry = Assert.IsType<ChangeJournalEntryVersion2or3>(ParseRecord(buffer));
+
+        Assert.Equal(new Version(2, 0), entry.Version);
+        Assert.Equal("test.txt", entry.Name);
+        Assert.Equal(new Usn(4096), entry.UniqueSequenceNumber);
+        Assert.Equal(ChangeReason.FileCreate, entry.Reason);
+        Assert.Equal(SourceInformation.AuxiliaryData, entry.Source);
+        Assert.Equal(7u, entry.SecurityId);
+        Assert.Equal(FileAttributes.Archive, entry.Attributes);
+        Assert.Equal(RecordTimeStamp, entry.TimeStamp);
+        Assert.Equal(new FileIdentifier(0x1122334455667788), entry.ReferenceNumber);
+    }
+
+    [Fact]
+    public void GetBufferedEntry_ParsesAVersion3Record()
+    {
+        var buffer = CreateVersion3Record("example.log");
+
+        var entry = Assert.IsType<ChangeJournalEntryVersion2or3>(ParseRecord(buffer));
+
+        Assert.Equal(new Version(3, 0), entry.Version);
+        Assert.Equal("example.log", entry.Name);
+        Assert.Equal(new Usn(8192), entry.UniqueSequenceNumber);
+        Assert.Equal(ChangeReason.RenameNewName, entry.Reason);
+        Assert.Equal(RecordTimeStamp, entry.TimeStamp);
+    }
+
+    [Fact]
+    public void GetBufferedEntry_ParsesAVersion4Record()
+    {
+        var buffer = CreateVersion4Record(extentCount: 2);
+
+        var entry = Assert.IsType<ChangeJournalEntryVersion4>(ParseRecord(buffer));
+
+        Assert.Equal(new Version(4, 0), entry.Version);
+        Assert.Equal(new Usn(16384), entry.UniqueSequenceNumber);
+        Assert.Equal(ChangeReason.DataOverwrite, entry.Reason);
+        Assert.Equal(3u, entry.RemainingExtents);
+        Assert.Equal(2, entry.Extents.Count);
+        Assert.Equal(1000, entry.Extents[0].Offset);
+        Assert.Equal(2000, entry.Extents[0].Length);
+        Assert.Equal(1001, entry.Extents[1].Offset);
+        Assert.Equal(2001, entry.Extents[1].Length);
+    }
+
+    [Fact]
+    public void GetBufferedEntry_RejectsAFileNamePastTheEndOfTheRecord()
+    {
+        var buffer = CreateVersion2Record("test.txt");
+
+        // The name is stored inside the record, so a length that runs past the record cannot be trusted.
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(56), 4096);
+
+        Assert.Throws<InvalidDataException>(() => ParseRecord(buffer));
+    }
+
+    [Fact]
+    public void GetBufferedEntry_RejectsExtentsPastTheEndOfTheRecord()
+    {
+        var buffer = CreateVersion4Record(extentCount: 2);
+
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(60), 512);
+
+        Assert.Throws<InvalidDataException>(() => ParseRecord(buffer));
+    }
+
+    [Fact]
+    public void GetBufferedEntry_RejectsAnExtentSmallerThanTheNativeStructure()
+    {
+        var buffer = CreateVersion4Record(extentCount: 2);
+
+        // An extent smaller than USN_RECORD_EXTENT would make the stride walk into the middle of the extents.
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(62), 8);
+
+        Assert.Throws<InvalidDataException>(() => ParseRecord(buffer));
+    }
+
+    [Fact]
+    public void GetBufferedEntry_RejectsAnUnsupportedRecordVersion()
+    {
+        var buffer = CreateVersion2Record("test.txt");
+
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(4), 5);
+
+        Assert.Throws<NotSupportedException>(() => ParseRecord(buffer));
+    }
+
+    private static readonly DateTime RecordTimeStamp = new(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+
+    /// <summary>
+    ///     Records are laid out inside a larger buffer, so the synthetic ones are too. Writing them into a buffer that is bigger
+    ///     than the record keeps a test that deliberately declares a bad length from reading past the array.
+    /// </summary>
+    private const int RecordBufferLength = 512;
+
+    private const int Version2FileNameOffset = 60;
+    private const int Version3FileNameOffset = 76;
+    private const int Version4ExtentsOffset = 64;
+
+    private static byte[] CreateVersion2Record(string name)
+    {
+        var buffer = new byte[RecordBufferLength];
+        var nameLength = name.Length * sizeof(char);
+
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(0), (uint)AlignRecordLength(Version2FileNameOffset + nameLength));
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(4), 2);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(6), 0);
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(8), 0x1122334455667788);
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(16), 0x8877665544332211);
+        BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(24), 4096);
+        BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(32), RecordTimeStamp.ToFileTimeUtc());
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(40), (uint)ChangeReason.FileCreate);
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(44), (uint)SourceInformation.AuxiliaryData);
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(48), 7);
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(52), (uint)FileAttributes.Archive);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(56), (ushort)nameLength);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(58), Version2FileNameOffset);
+        WriteName(buffer, Version2FileNameOffset, name);
+        return buffer;
+    }
+
+    private static byte[] CreateVersion3Record(string name)
+    {
+        var buffer = new byte[RecordBufferLength];
+        var nameLength = name.Length * sizeof(char);
+
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(0), (uint)AlignRecordLength(Version3FileNameOffset + nameLength));
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(4), 3);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(6), 0);
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(8), 0x1122334455667788);
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(24), 0x8877665544332211);
+        BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(40), 8192);
+        BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(48), RecordTimeStamp.ToFileTimeUtc());
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(56), (uint)ChangeReason.RenameNewName);
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(60), (uint)SourceInformation.SourceInfoNotSpecified);
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(64), 11);
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(68), (uint)FileAttributes.Normal);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(72), (ushort)nameLength);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(74), Version3FileNameOffset);
+        WriteName(buffer, Version3FileNameOffset, name);
+        return buffer;
+    }
+
+    private static byte[] CreateVersion4Record(int extentCount, int extentSize = 16)
+    {
+        var buffer = new byte[RecordBufferLength];
+
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(0), (uint)(Version4ExtentsOffset + (extentCount * extentSize)));
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(4), 4);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(6), 0);
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(8), 0x1122334455667788);
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(24), 0x8877665544332211);
+        BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(40), 16384);
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(48), (uint)ChangeReason.DataOverwrite);
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(52), (uint)SourceInformation.SourceInfoNotSpecified);
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(56), 3);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(60), (ushort)extentCount);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(62), (ushort)extentSize);
+
+        for (var i = 0; i < extentCount; i++)
+        {
+            var offset = Version4ExtentsOffset + (i * extentSize);
+            BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(offset), 1000 + i);
+            BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(offset + 8), 2000 + i);
+        }
+
+        return buffer;
+    }
+
+    private static void WriteName(byte[] buffer, int offset, string name)
+    {
+        MemoryMarshal.AsBytes(name.AsSpan()).CopyTo(buffer.AsSpan(offset));
+    }
+
+    // The change journal aligns records on 8 byte boundaries.
+    private static int AlignRecordLength(int length) => (length + 7) & ~7;
+
+    private static ChangeJournalEntry ParseRecord(byte[] buffer)
+    {
+        var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+        try
+        {
+            var pointer = handle.AddrOfPinnedObject();
+            var header = Marshal.PtrToStructure<USN_RECORD_COMMON_HEADER>(pointer);
+            return ChangeJournalEntries.GetBufferedEntry(pointer, header);
+        }
+        finally
+        {
+            handle.Free();
+        }
     }
 }


### PR DESCRIPTION
**Stack 1 of 3** · merges into `main` · must merge before #2503 and #2504.

Closes a Medium finding from the ChangeJournal project review, and lays the safety net the two PRs above it need.

## Why

`ChangeJournalEntries.GetBufferedEntry` does pointer arithmetic over data the driver hands back, and the guards added to it in #2053 / #2054 had no tests at all. The 21-test suite covered the pure value types (`Usn` comparison, `FileIdentifier.ToString`, the timeout conversion) and drove real hardware behind an elevation gate, but never the parser itself.

That is backwards: the guards are the code most likely to be subtly wrong — they bound reads against attacker-shaped input — and the least likely to be exercised by an integration test against a healthy NTFS volume. The three tests that do drive real hardware are elevation-gated and marked flaky by their own comment, so a parser regression would very likely ship.

## What

`GetBufferedEntry` is `internal` and the test project already has `InternalsVisibleTo`, so it can be called directly with a hand-built buffer. Seven tests:

**Valid records** — a V2, a V3 and a V4 record, asserting the parsed name, USN, reason, source, security id, attributes, timestamp, reference number, remaining extents and extent values. These pin the field offsets, so a layout mistake shows up as a wrong value rather than as silence.

**Each guard, against the shape it exists for**

| Test | Guard |
|---|---|
| `RejectsAFileNamePastTheEndOfTheRecord` | `ChangeJournalEntries.cs:72` |
| `RejectsExtentsPastTheEndOfTheRecord` | `ChangeJournalEntries.cs:50` |
| `RejectsAnExtentSmallerThanTheNativeStructure` | `ChangeJournalEntries.cs:50` |
| `RejectsAnUnsupportedRecordVersion` | `ChangeJournalEntries.cs:65` |

Two details in the builders worth knowing:

- Records are written into a 512-byte buffer rather than an exactly-sized array, the way they arrive from the driver. A test that deliberately declares a bad length therefore exercises the guard without the test itself reading past the array.
- Record lengths are rounded to 8 bytes, matching how the change journal aligns records.

The tests need neither elevation nor a volume, so unlike most of this file they run on every leg of CI, including the Linux and macOS ones.

## Verification

- `dotnet test -f net10.0` — 28 total, 25 passed, 3 skipped (the elevation-gated integration tests; this machine is not elevated). Up from 21/18/3, so all seven new tests really ran.
- `dotnet build -p:TreatWarningsAsErrors=true` — clean. No production code changed, so `ref/` is untouched.
