### PR TITLE
Check a record against the structure it is parsed as

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
@@ -140,7 +140,15 @@ public sealed class ChangeJournal : IDisposable
             {
                 if (PInvoke.DeviceIoControl((HANDLE)handleScope.Value, PInvoke.FSCTL_READ_FILE_USN_DATA, lpInBuffer: null, 0, bufferPointer, (uint)buffer.Length, &returnedSize, lpOverlapped: null))
                 {
+                    // The record must fit in what was actually read. Without this the record could claim any length, and the
+                    // file name bound inside GetBufferedEntry would be checked against a length the buffer does not have.
+                    if (returnedSize < Marshal.SizeOf<USN_RECORD_COMMON_HEADER>())
+                        throw new InvalidDataException($"The change journal returned {returnedSize} bytes, which is too short to hold a record header");
+
                     var header = Marshal.PtrToStructure<USN_RECORD_COMMON_HEADER>((nint)bufferPointer);
+                    if (header.RecordLength > returnedSize)
+                        throw new InvalidDataException($"The change journal returned a record of length {header.RecordLength}, which does not fit in the {returnedSize} bytes that were read");
+
                     return (ChangeJournalEntryVersion2or3)ChangeJournalEntries.GetBufferedEntry((nint)bufferPointer, header);
                 }
             }

--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
@@ -33,16 +33,19 @@ internal sealed class ChangeJournalEntries : IEnumerable<ChangeJournalEntry>
     {
         if (header is { MajorVersion: 2, MinorVersion: 0 })
         {
+            EnsureRecordHoldsItsStructure(header, Marshal.SizeOf<USN_RECORD_V2>());
             var entry = Marshal.PtrToStructure<USN_RECORD_V2>(bufferPointer);
             return new ChangeJournalEntryVersion2or3(entry, GetFileName(bufferPointer, header, entry.FileNameOffset, entry.FileNameLength));
         }
         else if (header is { MajorVersion: 3, MinorVersion: 0 })
         {
+            EnsureRecordHoldsItsStructure(header, Marshal.SizeOf<USN_RECORD_V3>());
             var entry = Marshal.PtrToStructure<USN_RECORD_V3>(bufferPointer);
             return new ChangeJournalEntryVersion2or3(entry, GetFileName(bufferPointer, header, entry.FileNameOffset, entry.FileNameLength));
         }
         else if (header is { MajorVersion: 4, MinorVersion: 0 })
         {
+            EnsureRecordHoldsItsStructure(header, Marshal.SizeOf<USN_RECORD_V4>());
             var entry = Marshal.PtrToStructure<USN_RECORD_V4>(bufferPointer);
             var extendOffset = Marshal.OffsetOf<USN_RECORD_V4>(nameof(USN_RECORD_V4.Extents));
 
@@ -64,6 +67,14 @@ internal sealed class ChangeJournalEntries : IEnumerable<ChangeJournalEntry>
         {
             throw new NotSupportedException($"Record version {header.MajorVersion}.{header.MinorVersion} is not supported");
         }
+    }
+
+    private static void EnsureRecordHoldsItsStructure(USN_RECORD_COMMON_HEADER header, int structureLength)
+    {
+        // The versioned structure is read out of the record, so the record has to be at least that long. The record has already
+        // been checked to fit in the buffer it came from, so this is what keeps that read inside the record as well.
+        if (header.RecordLength < structureLength)
+            throw new InvalidDataException($"The change journal returned a version {header.MajorVersion}.{header.MinorVersion} record of length {header.RecordLength}, which is smaller than the {structureLength}-byte structure it declares");
     }
 
     private static string GetFileName(IntPtr bufferPointer, USN_RECORD_COMMON_HEADER header, ushort fileNameOffset, ushort fileNameLength)

--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
@@ -243,7 +243,7 @@ public class ChangeJournalTests
         // The name and extent guards would reject these records too, but only after the structure has been read out of them.
         // Matching the message is what proves the length was rejected first.
         var exception = Assert.Throws<InvalidDataException>(() => ParseRecord(buffer));
-        Assert.True(exception.Message.Contains("smaller than the", StringComparison.Ordinal), exception.Message);
+        Assert.Contains("smaller than the", exception.Message);
     }
 
     [Fact]

--- a/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
+++ b/tests/Meziantou.Framework.Win32.ChangeJournal.Tests/ChangeJournalTests.cs
@@ -223,6 +223,29 @@ public class ChangeJournalTests
         Assert.Throws<InvalidDataException>(() => ParseRecord(buffer));
     }
 
+    [Theory]
+    [InlineData(2, 40)]     // USN_RECORD_V2 is 64 bytes
+    [InlineData(3, 70)]     // USN_RECORD_V3 is 80 bytes
+    [InlineData(4, 40)]     // USN_RECORD_V4 is 80 bytes
+    public void GetBufferedEntry_RejectsARecordSmallerThanTheStructureItDeclares(int majorVersion, int recordLength)
+    {
+        var buffer = majorVersion switch
+        {
+            2 => CreateVersion2Record("test.txt"),
+            3 => CreateVersion3Record("example.log"),
+            _ => CreateVersion4Record(extentCount: 0),
+        };
+
+        // A record only long enough for the common header still gets marshalled as its full versioned structure, which reads
+        // past the record unless the length is checked against that structure.
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(0), (uint)recordLength);
+
+        // The name and extent guards would reject these records too, but only after the structure has been read out of them.
+        // Matching the message is what proves the length was rejected first.
+        var exception = Assert.Throws<InvalidDataException>(() => ParseRecord(buffer));
+        Assert.True(exception.Message.Contains("smaller than the", StringComparison.Ordinal), exception.Message);
+    }
+
     [Fact]
     public void GetBufferedEntry_RejectsAnUnsupportedRecordVersion()
     {


### PR DESCRIPTION
**Stack 2 of 3** · merges into `fix/parser-guard-tests` (#2502) · merge #2502 first; #2504 sits on top.

Closes a Medium finding from the ChangeJournal project review.

## The defect

Two halves of the same gap.

**In `Read`** (`ChangeJournalEntries.cs:182`): a record was required to be at least `sizeof(USN_RECORD_COMMON_HEADER)` — 8 bytes — and to fit in the returned data. `GetBufferedEntry` then marshalled it as `USN_RECORD_V2`, `USN_RECORD_V3` or `USN_RECORD_V4`, which read **64, 80 and 80** bytes respectively (measured). A record declaring `RecordLength = 8` with `MajorVersion = 3` passed validation and was then read as 80 bytes — up to 72 past its own end, and past the end of the managed array when it sat at the tail of the buffer. For a V4 record the extent bounds check at line 50 runs *after* the 80-byte read that produced the `NumberOfExtents` it checks.

**In `GetEntry`** (`ChangeJournal.cs:141`): `header.RecordLength` was never compared against `returnedSize` or the buffer length at all. So a record could declare any length, and `GetFileName`'s bound at line 72 was checked against a length the buffer did not have — a record claiming `RecordLength = 60000` with a 59 KB file name inside a 588-byte buffer passed, and `Marshal.PtrToStringUni` read well past the array.

This is an out-of-bounds *read*, and it needs the kernel or a filesystem filter driver to return a malformed record, so it is a robustness gap rather than something an unprivileged caller triggers. But the surrounding code was written specifically to survive a driver that lies, and this is the field it forgot.

## The change

`EnsureRecordHoldsItsStructure` checks the record length against the versioned structure before marshalling it. Putting it in `GetBufferedEntry` rather than in `Read` covers both callers at once. `GetEntry` additionally checks that the record fits in the bytes `DeviceIoControl` actually returned, and that enough bytes came back to hold a header in the first place.

## Tests

`GetBufferedEntry_RejectsARecordSmallerThanTheStructureItDeclares`, a theory over V2/V3/V4.

The name and extent guards would reject these same records too — but only *after* the structure has already been read out of them, which is the bug. So the test matches the exception message to prove the length was rejected first. Verified with teeth: commenting out the three `EnsureRecordHoldsItsStructure` calls fails all three cases, and restoring them passes.

## Verification

- `dotnet build -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test -f net10.0` — 31 total, 28 passed, 3 skipped (the elevation-gated integration tests; this machine is not elevated). Up from 28/25/3 on #2502.
- `ref/` unchanged.
