### PR TITLE
Read USN records without boxing them

### DIFF
--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournal.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Meziantou.Framework.Win32.Natives;
@@ -142,10 +143,10 @@ public sealed class ChangeJournal : IDisposable
                 {
                     // The record must fit in what was actually read. Without this the record could claim any length, and the
                     // file name bound inside GetBufferedEntry would be checked against a length the buffer does not have.
-                    if (returnedSize < Marshal.SizeOf<USN_RECORD_COMMON_HEADER>())
+                    if (returnedSize < sizeof(USN_RECORD_COMMON_HEADER))
                         throw new InvalidDataException($"The change journal returned {returnedSize} bytes, which is too short to hold a record header");
 
-                    var header = Marshal.PtrToStructure<USN_RECORD_COMMON_HEADER>((nint)bufferPointer);
+                    var header = Unsafe.ReadUnaligned<USN_RECORD_COMMON_HEADER>(bufferPointer);
                     if (header.RecordLength > returnedSize)
                         throw new InvalidDataException($"The change journal returned a record of length {header.RecordLength}, which does not fit in the {returnedSize} bytes that were read");
 

--- a/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
+++ b/src/Meziantou.Framework.Win32.ChangeJournal/ChangeJournalEntries.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Meziantou.Framework.Win32.Natives;
@@ -10,6 +11,12 @@ namespace Meziantou.Framework.Win32;
 [SupportedOSPlatform("windows5.1.2600")]
 internal sealed class ChangeJournalEntries : IEnumerable<ChangeJournalEntry>
 {
+    /// <summary>
+    ///     Offset of the extents inside a <see cref="USN_RECORD_V4"/>. It is a property of the layout rather than of any record,
+    ///     so it is computed once instead of once per record.
+    /// </summary>
+    private static readonly nint ExtentsOffset = Marshal.OffsetOf<USN_RECORD_V4>(nameof(USN_RECORD_V4.Extents));
+
     private readonly ChangeJournal _changeJournal;
     private readonly ReadChangeJournalOptions _options;
 
@@ -29,35 +36,35 @@ internal sealed class ChangeJournalEntries : IEnumerable<ChangeJournalEntry>
         return GetEnumerator();
     }
 
-    internal static ChangeJournalEntry GetBufferedEntry(IntPtr bufferPointer, USN_RECORD_COMMON_HEADER header)
+    internal static unsafe ChangeJournalEntry GetBufferedEntry(IntPtr bufferPointer, USN_RECORD_COMMON_HEADER header)
     {
         if (header is { MajorVersion: 2, MinorVersion: 0 })
         {
-            EnsureRecordHoldsItsStructure(header, Marshal.SizeOf<USN_RECORD_V2>());
-            var entry = Marshal.PtrToStructure<USN_RECORD_V2>(bufferPointer);
+            EnsureRecordHoldsItsStructure(header, sizeof(USN_RECORD_V2));
+            var entry = Unsafe.ReadUnaligned<USN_RECORD_V2>((void*)bufferPointer);
             return new ChangeJournalEntryVersion2or3(entry, GetFileName(bufferPointer, header, entry.FileNameOffset, entry.FileNameLength));
         }
         else if (header is { MajorVersion: 3, MinorVersion: 0 })
         {
-            EnsureRecordHoldsItsStructure(header, Marshal.SizeOf<USN_RECORD_V3>());
-            var entry = Marshal.PtrToStructure<USN_RECORD_V3>(bufferPointer);
+            EnsureRecordHoldsItsStructure(header, sizeof(USN_RECORD_V3));
+            var entry = Unsafe.ReadUnaligned<USN_RECORD_V3>((void*)bufferPointer);
             return new ChangeJournalEntryVersion2or3(entry, GetFileName(bufferPointer, header, entry.FileNameOffset, entry.FileNameLength));
         }
         else if (header is { MajorVersion: 4, MinorVersion: 0 })
         {
-            EnsureRecordHoldsItsStructure(header, Marshal.SizeOf<USN_RECORD_V4>());
-            var entry = Marshal.PtrToStructure<USN_RECORD_V4>(bufferPointer);
-            var extendOffset = Marshal.OffsetOf<USN_RECORD_V4>(nameof(USN_RECORD_V4.Extents));
+            EnsureRecordHoldsItsStructure(header, sizeof(USN_RECORD_V4));
+            var entry = Unsafe.ReadUnaligned<USN_RECORD_V4>((void*)bufferPointer);
+            var extendOffset = ExtentsOffset;
 
             // The extents are stored inside the record, so they must not extend past the record's own length.
-            if (entry.ExtentSize < Marshal.SizeOf<USN_RECORD_EXTENT>() || (long)extendOffset + ((long)entry.NumberOfExtents * entry.ExtentSize) > header.RecordLength)
+            if (entry.ExtentSize < sizeof(USN_RECORD_EXTENT) || (long)extendOffset + ((long)entry.NumberOfExtents * entry.ExtentSize) > header.RecordLength)
                 throw new InvalidDataException($"The change journal returned a record of length {header.RecordLength} holding {entry.NumberOfExtents} extents of {entry.ExtentSize} bytes at offset {extendOffset}");
 
             var extents = new ChangeJournalEntryExtent[entry.NumberOfExtents];
             for (var i = 0; i < entry.NumberOfExtents; i++)
             {
                 var extentPointer = bufferPointer + extendOffset + i * entry.ExtentSize;
-                var extent = Marshal.PtrToStructure<USN_RECORD_EXTENT>(extentPointer);
+                var extent = Unsafe.ReadUnaligned<USN_RECORD_EXTENT>((void*)extentPointer);
                 extents[i] = new ChangeJournalEntryExtent(extent);
             }
 
@@ -174,7 +181,7 @@ internal sealed class ChangeJournalEntries : IEnumerable<ChangeJournalEntry>
 
             if (entryData.Length > CurrentUSNLength) // There are more data than just data currentUSN.
             {
-                var headerLength = Marshal.SizeOf<USN_RECORD_COMMON_HEADER>();
+                var headerLength = sizeof(USN_RECORD_COMMON_HEADER);
                 fixed (byte* fixedBufferPointer = entryData)
                 {
                     var bufferPointer = (nint)fixedBufferPointer;
@@ -185,7 +192,7 @@ internal sealed class ChangeJournalEntries : IEnumerable<ChangeJournalEntry>
                     while (offset < entryData.Length)
                     {
                         var entryPointer = bufferPointer + offset;
-                        var header = Marshal.PtrToStructure<USN_RECORD_COMMON_HEADER>(entryPointer);
+                        var header = Unsafe.ReadUnaligned<USN_RECORD_COMMON_HEADER>((void*)entryPointer);
 
                         // A record must be large enough to hold its own header and must not extend past the data that
                         // was returned. Without this check, a length of 0 loops forever and an oversized length makes


### PR DESCRIPTION
**Stack 3 of 3** · merges into `fix/record-length-validation` (#2503) · merge #2502 then #2503 first.

Closes a Medium finding from the ChangeJournal project review. This one is pure performance — behaviour is identical, which is what the parser tests in #2502 and #2503 are underneath it to prove.

## The defect

`Marshal.PtrToStructure<T>` boxes for a value type. Measured on this machine over 200,000 iterations with a 64-byte record-shaped struct:

```
PtrToStructure: 56.0 bytes/call
ReadUnaligned :  0.0 bytes/call
```

The record loop paid that twice per record — once for the common header in `Read`, once for the versioned structure in `GetBufferedEntry` — plus once per extent on a V4 record. `Marshal.OffsetOf<USN_RECORD_V4>` also recomputed a fixed layout offset on every V4 record.

A full-volume enumeration is the primary use case (the readme's second example is "get all records") and a mature journal holds hundreds of thousands to millions of records, so this was the difference between the enumeration being allocation-dominated and I/O-dominated.

## The change

Every one of these structures is blittable, and USN records are documented as 64-bit aligned from the start of the buffer, so `Unsafe.ReadUnaligned<T>` is a drop-in replacement with identical semantics and no allocation. `sizeof` replaces `Marshal.SizeOf` in the same expressions, and the extents offset becomes a `static readonly` field.

`GetBufferedEntry` becomes `unsafe`; the project already compiles unsafe code in `ChangeJournal.GetEntry` and `Win32DeviceControl`.

## Measured end to end

Enumerating 200,000 records off a real journal through the public `ChangeJournal.Entries` API, same machine, same volume, only this commit differing:

| | bytes/record | total |
|---|---|---|
| before (#2503) | 329.9 | 62.9 MB |
| after | 209.8 | 40.0 MB |

120 bytes per record, ~36% of everything the enumeration allocates. The remainder is the `ChangeJournalEntry` object and the name string, which are inherent to the API shape.

## Why it is the top of the stack

It rewrites the same lines of `GetBufferedEntry` that #2503 adds guards to, so as an independent PR it would conflict. Sitting on top of the parser tests also means the "behaviour is identical" claim is checked rather than asserted: 31 tests, same results as #2503.

## Verification

- `dotnet build -p:TreatWarningsAsErrors=true` — clean.
- `dotnet test -f net10.0` — 31 total, 28 passed, 3 skipped (the elevation-gated integration tests; this machine is not elevated), identical to #2503.
- `ref/` unchanged.
