### PR TITLE
Reject a null or empty path in AddToRecentDocuments

### DIFF
--- a/Meziantou.Framework.slnx
+++ b/Meziantou.Framework.slnx
@@ -281,6 +281,7 @@
     <Project Path="tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests.csproj" Id="32b027e9-ec12-4d92-81ba-21ee158a24ec" />
     <Project Path="tests/Meziantou.Framework.Win32.PerceivedType.Tests/Meziantou.Framework.Win32.PerceivedType.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests/Meziantou.Framework.Win32.ProjectedFileSystem.Tests.csproj" />
+    <Project Path="tests/Meziantou.Framework.Win32.RecentDocuments.Tests/Meziantou.Framework.Win32.RecentDocuments.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.Win32.RestartManager.Tests/Meziantou.Framework.Win32.RestartManager.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.WPF.Tests/Meziantou.Framework.WPF.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.Yaml.AotSmoke/Meziantou.Framework.Yaml.AotSmoke.csproj" />

--- a/slnx/Meziantou.Framework.Win32.RecentDocuments.slnx
+++ b/slnx/Meziantou.Framework.Win32.RecentDocuments.slnx
@@ -2,4 +2,7 @@
   <Folder Name="/src/">
     <Project Path="../src/Meziantou.Framework.Win32.RecentDocuments/Meziantou.Framework.Win32.RecentDocuments.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="../tests/Meziantou.Framework.Win32.RecentDocuments.Tests/Meziantou.Framework.Win32.RecentDocuments.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/src/Meziantou.Framework.Win32.RecentDocuments/RecentDocuments.cs
+++ b/src/Meziantou.Framework.Win32.RecentDocuments/RecentDocuments.cs
@@ -7,9 +7,15 @@ public static class RecentDocuments
 {
     /// <summary>Notifies the system that an item has been accessed, for the purposes of tracking those items used most recently and most frequently.</summary>
     /// <param name="path">The path to the document that has been accessed.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="path"/> is empty.</exception>
     [SupportedOSPlatform("windows5.1.2600")]
     public static unsafe void AddToRecentDocuments(string path)
     {
+        // A null pointer makes SHAddToRecentDocs clear all usage data on all items, so an unvalidated
+        // null path would silently erase the recent documents instead of adding one.
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
         fixed (char* p = path)
         {
             Windows.Win32.PInvoke.SHAddToRecentDocs((uint)Windows.Win32.UI.Shell.SHARD.SHARD_PATHW, p);

--- a/tests/Meziantou.Framework.Win32.RecentDocuments.Tests/Meziantou.Framework.Win32.RecentDocuments.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.RecentDocuments.Tests/Meziantou.Framework.Win32.RecentDocuments.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Meziantou.NET.Sdk.Test">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.RecentDocuments/Meziantou.Framework.Win32.RecentDocuments.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Meziantou.Framework.Win32.RecentDocuments.Tests/RecentDocumentsTests.cs
+++ b/tests/Meziantou.Framework.Win32.RecentDocuments.Tests/RecentDocumentsTests.cs
@@ -1,0 +1,17 @@
+namespace Meziantou.Framework.Win32.Tests;
+
+public sealed class RecentDocumentsTests
+{
+    [Fact]
+    public void AddToRecentDocuments_ThrowsWhenPathIsNull()
+    {
+        // A null path used to reach SHAddToRecentDocs as a null pointer, which clears all usage data
+        Assert.Throws<ArgumentNullException>(() => RecentDocuments.AddToRecentDocuments(null!));
+    }
+
+    [Fact]
+    public void AddToRecentDocuments_ThrowsWhenPathIsEmpty()
+    {
+        Assert.Throws<ArgumentException>(() => RecentDocuments.AddToRecentDocuments(""));
+    }
+}


### PR DESCRIPTION
## The finding

`src/Meziantou.Framework.Win32.RecentDocuments/RecentDocuments.cs:11-17`

`fixed (char* p = path)` yields a **null pointer** when `path` is null — Roslyn emits a null check in the lowered form. (`""` behaves differently: it yields a valid pointer to a zero-length, null-terminated buffer. I verified both empirically rather than assuming.)

That null pointer reached `SHAddToRecentDocs`, whose [documentation for `pv`](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shaddtorecentdocs) states: *"Set this parameter to NULL to clear all usage data on all items."* The `uFlags` value is irrelevant when `pv` is NULL.

So `AddToRecentDocuments(null)` did the exact opposite of what its name promises: instead of adding one item, it wiped the entire Recent Items list, the Recent folder shortcuts, and the Recent/Frequent entries in **every** application's Jump List. `SHAddToRecentDocs` returns `void`, so the call succeeded silently and the data was gone.

This was reachable without an obviously-wrong caller. `path` is declared non-nullable, but nullable reference types are advisory warnings, not a runtime guarantee — consumers with NRT disabled get no signal at all, and common sources of a path are themselves nullable (`Path.GetDirectoryName()` returns `string?`, as do many dialog and configuration accessors). The ordinary `AddToRecentDocuments(dialog.FileName)` shape is one null away from destroying user data.

## What changed

- `ArgumentException.ThrowIfNullOrEmpty(path)` before the pin — covers the destructive null case and the silently-no-op empty case together.
- `<exception>` tags on the XML docs.
- A new test project with regression tests for both inputs.

This follows existing house style: `Win32.AccessToken` and `Win32.ChangeJournal` already guard non-nullable parameters with `ArgumentNullException.ThrowIfNull`.

## Verification

- `dotnet test -p:TreatWarningsAsErrors=true` → **4 passed, 0 failed, 0 skipped** (2 tests × net10.0 + net11.0).
- `dotnet run ./eng/update-all.cs` was run; the regenerated `slnx` entries for the new test project are included in this PR.
- The public API surface is unchanged, so `ref/` is untouched.

The guard runs before the P/Invoke, so these tests are not Windows-only and run on every platform in CI.

**One check I deliberately skipped:** I did not confirm the tests fail without the guard. Doing that would call `SHAddToRecentDocs` with a NULL `pv` for real and destroy the Recent Items list of whichever machine ran it. The mechanism is instead established by the isolated pointer experiment and the documented NULL semantics above.

## Note on versioning

`<Version>` is left at `2.0.0`. This is a behavior change for callers that pass null today, but this repo bumps package versions in separate batch commits.
