### PR TITLE
Make the RecentDocuments sample runnable on any machine

### DIFF
--- a/samples/Meziantou.Framework.Win32.RecentDocumentsConsole/Program.cs
+++ b/samples/Meziantou.Framework.Win32.RecentDocumentsConsole/Program.cs
@@ -3,5 +3,8 @@
 Console.WriteLine("Clearing all recent documents");
 Meziantou.Framework.Win32.RecentDocuments.ClearRecentDocuments();
 
-Console.WriteLine("Add calc to recent document");
-Meziantou.Framework.Win32.RecentDocuments.AddToRecentDocuments("C:\\Users\\mezia\\source\\repos\\FileEtw\\FileEtw.sln");
+var path = Path.Combine(Path.GetTempPath(), "Meziantou.Framework.Win32.RecentDocuments.sample.txt");
+File.WriteAllText(path, "Sample document");
+
+Console.WriteLine($"Adding '{path}' to the recent documents");
+Meziantou.Framework.Win32.RecentDocuments.AddToRecentDocuments(path);


### PR DESCRIPTION
## The finding

`samples/Meziantou.Framework.Win32.RecentDocumentsConsole/Program.cs:6-7`

The sample added `C:\Users\mezia\source\repos\FileEtw\FileEtw.sln` — a path that exists only on the author's machine. Anyone else running the sample got a no-op, so it demonstrated nothing. It also published a local Windows username and directory layout in a public repository. This was the only sample in the repo hardcoding a user-specific path.

The preceding comment said "Add calc to recent document" while the code added a solution file.

## What changed

The sample now creates a temporary file and adds that, so it does something observable on any machine. The stale comment is replaced by output that names the actual path being added.

## Verification

- `dotnet build -p:TreatWarningsAsErrors=true` → **0 warnings, 0 errors**.
- UTF-8 BOM and LF line endings preserved; no trailing whitespace.
- `dotnet run ./eng/update-all.cs` was run and produced no further changes.

I did not execute the sample: its first statement is `ClearRecentDocuments()`, which would wipe the real Recent Items list of the machine running it.
