### PR TITLE
Annotate RestartManagerProcessInfo with the Windows version it requires

### DIFF
--- a/ref/Meziantou.Framework.Win32.RestartManager.cs
+++ b/ref/Meziantou.Framework.Win32.RestartManager.cs
@@ -52,7 +52,7 @@ namespace Meziantou.Framework.Win32
         Critical = 1000
     }
 
-    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows6.0.6000")]
     public sealed class RestartManagerProcessInfo
     {
         public int ProcessId { get => throw null; }

--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManagerProcessInfo.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManagerProcessInfo.cs
@@ -4,7 +4,7 @@ using Windows.Win32.System.RestartManager;
 namespace Meziantou.Framework.Win32;
 
 /// <summary>Describes an application or service that is using a resource registered with a Restart Manager session.</summary>
-[SupportedOSPlatform("windows")]
+[SupportedOSPlatform("windows6.0.6000")]
 public sealed class RestartManagerProcessInfo
 {
     internal RestartManagerProcessInfo(RM_PROCESS_INFO processInfo)


### PR DESCRIPTION
Follow-up to a project review of `Meziantou.Framework.Win32.RestartManager`.

## Finding

`RestartManagerProcessInfo` was annotated `[SupportedOSPlatform("windows")]` (`RestartManagerProcessInfo.cs:7`) while `RestartManager` itself uses `[SupportedOSPlatform("windows6.0.6000")]` (`RestartManager.cs:37`).

`RestartManagerProcessInfo` is only reachable through `RestartManager.GetLockingProcesses()`, which is already gated at `windows6.0.6000`, so no caller could observe the looser annotation as a behaviour difference. The effect is only on diagnostics: CA1416 on downstream code reports two different platform versions for one feature.

## What changed

- `RestartManagerProcessInfo` is annotated `[SupportedOSPlatform("windows6.0.6000")]`, matching `RestartManager`.
- `ref/Meziantou.Framework.Win32.RestartManager.cs` regenerated by the build, as required by `AGENTS.md`.

No behaviour change.

## Verification

- Builds clean for `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`.
- All 12 tests pass (`net10.0`): `total: 12, failed: 0, succeeded: 12`.
- `dotnet run ./eng/update-all.cs` produced no file changes.
