### PR TITLE
Reject a null session key in JoinSession

### DIFF
--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
@@ -75,9 +75,12 @@ public sealed class RestartManager : IDisposable
     /// <summary>Joins an existing Restart Manager session using the specified session key.</summary>
     /// <param name="sessionKey">The session key of an existing Restart Manager session.</param>
     /// <returns>A <see cref="RestartManager"/> instance representing the joined session.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sessionKey"/> is <see langword="null"/>.</exception>
     /// <exception cref="Win32Exception">Thrown when joining the session fails.</exception>
     public static RestartManager JoinSession(string sessionKey)
     {
+        ArgumentNullException.ThrowIfNull(sessionKey);
+
         var result = PInvoke.RmJoinSession(out var handle, sessionKey);
         if (result != WIN32_ERROR.ERROR_SUCCESS)
             throw new Win32Exception((int)result, $"RmJoinSession failed ({result})");

--- a/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
@@ -97,6 +97,12 @@ public class RestartManagerTests
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void JoinSession_WithNullKey_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => RestartManager.JoinSession(sessionKey: null!));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
     public void GetProcessesLockingFiles()
     {
         var unlockedPath = Path.GetTempFileName();


### PR DESCRIPTION
Follow-up to a project review of `Meziantou.Framework.Win32.RestartManager`.

## Finding

`RestartManager.JoinSession` passed `sessionKey` straight to `RmJoinSession` with no null check (`RestartManager.cs:79-86`). A null key became a NULL `PCWSTR`, Restart Manager rejected it, and the caller got:

```
System.ComponentModel.Win32Exception: RmJoinSession failed (...)
```

That points the caller at Windows instead of at their own null argument. The sibling entry points already guard: `RegisterFile` and `RegisterFiles` both call `ArgumentNullException.ThrowIfNull`, so the inconsistency was not discoverable from the API surface.

Diagnosability only — the caller got an exception either way, just an unhelpful one.

## What changed

- `JoinSession` calls `ArgumentNullException.ThrowIfNull(sessionKey)`, matching `RegisterFile`/`RegisterFiles`.
- Documented with an `<exception cref="ArgumentNullException">` tag, as the sibling overloads are.
- Added `JoinSession_WithNullKey_ThrowsArgumentNullException`, next to the existing `JoinSession_WithUnknownKey_ReportsTheFailingFunction`.

No public API change, so `ref/` is unchanged.

## Verification

- Builds clean for `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`.
- Tests pass on this branch: `total: 13, failed: 0, succeeded: 13` — 12 before this change plus the new one, so the added test did run.
