### PR TITLE
Reject null paths in RegisterFiles instead of silently ignoring them

### DIFF
--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
@@ -103,10 +103,12 @@ public sealed class RestartManager : IDisposable
     /// <summary>Registers multiple files to be monitored by the Restart Manager session.</summary>
     /// <param name="paths">An array of full file paths to register.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="paths"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="paths"/> contains a <see langword="null"/> element.</exception>
     /// <exception cref="Win32Exception">Thrown when the registration fails.</exception>
     public void RegisterFiles(string[] paths)
     {
         ArgumentNullException.ThrowIfNull(paths);
+        ThrowIfContainsNull(paths);
         ObjectDisposedException.ThrowIf(_sessionHandle.IsClosed, this);
 
         var result = PInvoke.RmRegisterResources(_sessionHandle.SessionHandle, paths, rgApplications: default, rgsServiceNames: default);
@@ -248,6 +250,15 @@ public sealed class RestartManager : IDisposable
             throw new Win32Exception((int)result, $"RmCancelCurrentTask failed ({result})");
     }
 
+    // A null entry is marshalled as a NULL pointer, which the Restart Manager accepts silently: it reports
+    // ERROR_SUCCESS and simply does not monitor that path, so the caller would be told the file is not locked.
+    private static void ThrowIfContainsNull(string[] paths)
+    {
+        var index = Array.IndexOf(paths, null);
+        if (index >= 0)
+            throw new ArgumentException($"The path at index {index} is null", nameof(paths));
+    }
+
     private static Process? TryGetProcess(RM_UNIQUE_PROCESS uniqueProcess)
     {
         Process process;
@@ -330,6 +341,7 @@ public sealed class RestartManager : IDisposable
     /// <returns>A read-only list of <see cref="Process"/> instances that are locking at least one of the files.</returns>
     /// <remarks>Prefer this method over calling <see cref="GetProcessesLockingFile(string)"/> in a loop: registering resources performs relatively expensive write operations, so registering all the files in a single session is significantly cheaper.</remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="paths"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="paths"/> contains a <see langword="null"/> element.</exception>
     /// <exception cref="Win32Exception">Thrown when the operation fails.</exception>
     public static IReadOnlyList<Process> GetProcessesLockingFiles(string[] paths)
     {

--- a/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.RestartManager.Tests/RestartManagerTests.cs
@@ -90,6 +90,37 @@ public class RestartManagerTests
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void RegisterFiles_WithNullPath_ThrowsArgumentException()
+    {
+        using var session = RestartManager.CreateSession();
+
+        var exception = Assert.Throws<ArgumentException>(() => session.RegisterFiles([@"C:\does-not-matter.txt", null!]));
+        Assert.Equal("paths", exception.ParamName);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void RegisterFiles_WithNullPath_DoesNotSilentlySkipTheRemainingPaths()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            using (File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                using var session = RestartManager.CreateSession();
+
+                Assert.Throws<ArgumentException>(() => session.RegisterFiles([path, null!]));
+
+                // Nothing was registered, so the locked file must not be reported as locked by this session.
+                Assert.False(session.IsResourcesLocked());
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
     public void JoinSession_WithUnknownKey_ReportsTheFailingFunction()
     {
         var exception = Assert.Throws<Win32Exception>(() => RestartManager.JoinSession("00000000000000000000000000000000"));


### PR DESCRIPTION
Follow-up to a project review of `Meziantou.Framework.Win32.RestartManager`.

**Stack 1 of 3 · merges into `main` · must merge before #2511 and #2512.**

## Finding

`RegisterFiles` validated the array but never its elements (`RestartManager.cs:107-115`). CsWin32's generated overload pins each string with `GCHandle.Alloc(paths[i], GCHandleType.Pinned)` and calls `AddrOfPinnedObject()`, which returns `IntPtr.Zero` for a null target — so the Restart Manager received a NULL entry in the filename array and returned `ERROR_SUCCESS`.

Verified against the real API before the fix: `RegisterFiles([lockedPath, null])` and `RegisterFiles([null, lockedPath])` both completed with **no exception** and reported exactly 1 locking process. The real path stayed monitored; the null one was silently dropped.

That makes the library give a confident wrong answer. A caller building the array from a projection that can yield null — `paths.Select(TryResolve).ToArray()`, a config-driven list, a deserialised payload — is told the file is not locked and goes on to delete or overwrite it. It also contradicted the sibling API: `RegisterFile(null)` already threw `ArgumentNullException`, so the inconsistency was not discoverable.

## What changed

- `RegisterFiles` rejects a null element with an `ArgumentException` naming the offending index, before anything is registered.
- The reason is recorded as a comment on the guard, since "the Restart Manager accepts NULL silently" is the non-obvious part.
- Documented with `<exception cref="ArgumentException">` on `RegisterFiles` and on `GetProcessesLockingFiles`, which delegates to it.

Rejecting rather than skipping is deliberate: silently registering fewer files than the caller asked for is the behaviour that caused the problem.

## Tests

- `RegisterFiles_WithNullPath_ThrowsArgumentException` — asserts the exception and `ParamName`.
- `RegisterFiles_WithNullPath_DoesNotSilentlySkipTheRemainingPaths` — locks a real file, passes `[path, null]`, and asserts the session reports nothing locked afterwards. This distinguishes old from new behaviour: before the fix the call succeeded and `IsResourcesLocked()` returned `true`.

## Verification

- Builds clean for `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`.
- Tests on this branch: `total: 14, failed: 0, succeeded: 14` — 12 before this change plus the 2 added, so both new tests ran.
