### PR TITLE
Document the Restart Manager contracts callers have to rely on

### DIFF
--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManager.cs
@@ -17,11 +17,12 @@ namespace Meziantou.Framework.Win32;
 ///     Console.WriteLine("File is locked");
 /// }
 ///
-/// // Get processes locking a file
+/// // Get processes locking a file. The caller owns the returned Process instances.
 /// var processes = RestartManager.GetProcessesLockingFile(@"C:\path\to\file.txt");
 /// foreach (var process in processes)
 /// {
 ///     Console.WriteLine($"{process.ProcessName} (PID: {process.Id})");
+///     process.Dispose();
 /// }
 ///
 /// // Manual session management
@@ -106,6 +107,7 @@ public sealed class RestartManager : IDisposable
 
     /// <summary>Registers multiple files to be monitored by the Restart Manager session.</summary>
     /// <param name="paths">An array of full file paths to register.</param>
+    /// <remarks>The Restart Manager persists registrations to the registry, so a single session can only hold a bounded number of paths. Registering a very large set fails with a <see cref="Win32Exception"/> for ERROR_WRITE_FAULT (29) rather than a dedicated error; split such sets across several sessions.</remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="paths"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="paths"/> contains a <see langword="null"/> element.</exception>
     /// <exception cref="Win32Exception">Thrown when the registration fails.</exception>
@@ -144,7 +146,7 @@ public sealed class RestartManager : IDisposable
     }
 
     /// <summary>Gets a list of processes that are currently locking the registered resources.</summary>
-    /// <returns>A read-only list of <see cref="Process"/> instances that are locking the registered resources.</returns>
+    /// <returns>A read-only list of <see cref="Process"/> instances that are locking the registered resources. The caller owns the returned instances and should dispose them.</returns>
     /// <exception cref="Win32Exception">Thrown when the operation fails.</exception>
     public IReadOnlyList<Process> GetProcessesLockingResources()
     {
@@ -200,7 +202,7 @@ public sealed class RestartManager : IDisposable
     }
 
     /// <summary>Shuts down applications and services that are using the registered resources.</summary>
-    /// <param name="action">The shutdown options to use.</param>
+    /// <param name="action">The shutdown options to use. The Restart Manager documents this parameter as taking one or more of the defined options, so pass at least one flag.</param>
     /// <exception cref="Win32Exception">Thrown when the shutdown operation fails.</exception>
     public void Shutdown(RestartManagerShutdownType action)
     {
@@ -208,7 +210,7 @@ public sealed class RestartManager : IDisposable
     }
 
     /// <summary>Shuts down applications and services that are using the registered resources.</summary>
-    /// <param name="action">The shutdown options to use.</param>
+    /// <param name="action">The shutdown options to use. The Restart Manager documents this parameter as taking one or more of the defined options, so pass at least one flag.</param>
     /// <param name="statusCallback">An optional callback to receive progress updates during the shutdown operation. The callback is invoked by native code and must not throw; use <see cref="CancelCurrentTask"/> from another thread to stop the operation instead.</param>
     /// <exception cref="Win32Exception">Thrown when the shutdown operation fails.</exception>
     public void Shutdown(RestartManagerShutdownType action, RestartManagerWriteStatusCallback? statusCallback)
@@ -337,7 +339,7 @@ public sealed class RestartManager : IDisposable
 
     /// <summary>Gets a list of processes that are currently locking the specified file.</summary>
     /// <param name="path">The full path of the file to check.</param>
-    /// <returns>A read-only list of <see cref="Process"/> instances that are locking the file.</returns>
+    /// <returns>A read-only list of <see cref="Process"/> instances that are locking the file. The caller owns the returned instances and should dispose them.</returns>
     /// <exception cref="Win32Exception">Thrown when the operation fails.</exception>
     public static IReadOnlyList<Process> GetProcessesLockingFile(string path)
     {
@@ -348,8 +350,8 @@ public sealed class RestartManager : IDisposable
 
     /// <summary>Gets a list of processes that are currently locking any of the specified files.</summary>
     /// <param name="paths">An array of full file paths to check.</param>
-    /// <returns>A read-only list of <see cref="Process"/> instances that are locking at least one of the files.</returns>
-    /// <remarks>Prefer this method over calling <see cref="GetProcessesLockingFile(string)"/> in a loop: registering resources performs relatively expensive write operations, so registering all the files in a single session is significantly cheaper.</remarks>
+    /// <returns>A read-only list of <see cref="Process"/> instances that are locking at least one of the files. The caller owns the returned instances and should dispose them.</returns>
+    /// <remarks>Prefer this method over calling <see cref="GetProcessesLockingFile(string)"/> in a loop: registering resources performs relatively expensive write operations, so registering all the files in a single session is significantly cheaper, though a session can only hold a bounded number of paths - see <see cref="RegisterFiles(string[])"/>.</remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="paths"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="paths"/> contains a <see langword="null"/> element.</exception>
     /// <exception cref="Win32Exception">Thrown when the operation fails.</exception>

--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManagerProcessInfo.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManagerProcessInfo.cs
@@ -22,7 +22,7 @@ public sealed class RestartManagerProcessInfo
     /// <summary>Gets the identifier of the process.</summary>
     public int ProcessId { get; }
 
-    /// <summary>Gets the time at which the process started. Windows recycles process identifiers, so only the combination of <see cref="ProcessId"/> and <see cref="StartTime"/> identifies a process.</summary>
+    /// <summary>Gets the time at which the process started, expressed in local time (<see cref="DateTimeKind.Local"/>). Windows recycles process identifiers, so only the combination of <see cref="ProcessId"/> and <see cref="StartTime"/> identifies a process.</summary>
     public DateTime StartTime { get; }
 
     /// <summary>Gets the friendly name of the application.</summary>

--- a/src/Meziantou.Framework.Win32.RestartManager/RestartManagerShutdownType.cs
+++ b/src/Meziantou.Framework.Win32.RestartManager/RestartManagerShutdownType.cs
@@ -1,6 +1,7 @@
 namespace Meziantou.Framework.Win32;
 
 /// <summary>Configures the shut down of applications.</summary>
+/// <remarks>The Restart Manager documents its shutdown flags as taking one or more of these options, so pass at least one when calling <see cref="RestartManager.Shutdown(RestartManagerShutdownType)"/>.</remarks>
 [Flags]
 public enum RestartManagerShutdownType
 {

--- a/src/Meziantou.Framework.Win32.RestartManager/readme.md
+++ b/src/Meziantou.Framework.Win32.RestartManager/readme.md
@@ -24,6 +24,8 @@ if (RestartManager.IsFileLocked(path))
 
 Get a list of all processes that have locks on a specific file:
 
+The caller owns the returned `Process` instances and should dispose them.
+
 ```csharp
 using Meziantou.Framework.Win32;
 
@@ -33,6 +35,7 @@ var processes = RestartManager.GetProcessesLockingFile(path);
 foreach (var process in processes)
 {
     Console.WriteLine($"Process {process.ProcessName} (PID: {process.Id}) is locking the file");
+    process.Dispose();
 }
 ```
 
@@ -40,6 +43,9 @@ foreach (var process in processes)
 
 Registering resources performs relatively expensive write operations, so checking many files with one
 session is significantly cheaper than calling `GetProcessesLockingFile` in a loop:
+
+Registrations are persisted to the registry, so one session can only hold a bounded number of paths. A very
+large set fails with `ERROR_WRITE_FAULT` (29) and should be split across several sessions.
 
 ```csharp
 using Meziantou.Framework.Win32;
@@ -53,6 +59,7 @@ var processes = RestartManager.GetProcessesLockingFiles(
 foreach (var process in processes)
 {
     Console.WriteLine($"Process {process.ProcessName} (PID: {process.Id}) is locking at least one of the files");
+    process.Dispose();
 }
 ```
 
@@ -78,6 +85,7 @@ if (session.IsResourcesLocked())
     foreach (var process in processes)
     {
         Console.WriteLine($"Locked by: {process.ProcessName}");
+        process.Dispose();
     }
 }
 ```


### PR DESCRIPTION
Follow-up to a project review of `Meziantou.Framework.Win32.RestartManager`.

**Stack 3 of 3 · merges into `fix/safehandle-addref` (#2511) · must merge last.**

Documentation only — no behaviour change, no public API change, so `ref/` is unchanged. Four review findings, grouped because they edit the same doc blocks and would conflict as separate PRs.

## 1. `RegisterFiles` has an undocumented ceiling

The XML docs and readme both steer callers toward one big batch ("registering all the files in a single session is significantly cheaper"), with no mention that it is bounded. Measured on a dev machine with ~70-character paths:

| paths | result |
|---|---|
| 10 000 | OK (14 ms) |
| 25 000 | OK (13 ms) |
| 50 000 | OK (28 ms) |
| 100 000 | `Win32Exception (29): RmRegisterResources failed (ERROR_WRITE_FAULT)` |
| 400 000 | same |

The Restart Manager persists registrations to the registry, so the ceiling depends on path length and machine state rather than being a fixed count. A caller following the documented advice hits a failure whose message — "an operation was unable to read or write to the registry" — gives no hint that the batch was simply too large. Now called out on `RegisterFiles`, on `GetProcessesLockingFiles`, and in the readme.

## 2. Returned `Process` instances have no documented owner

`GetProcessesLockingResources`, `GetProcessesLockingFile` and `GetProcessesLockingFiles` all return `IReadOnlyList<Process>`, and nothing said the caller owns them — the readme and `<example>` snippets both modelled the non-disposing pattern.

Measured, the practical cost is small: 300 undisposed `GetProcessesLockingFile` calls moved the process handle count by 29, and disposing all 300 reclaimed nothing, because `Process.GetProcessById` plus a `StartTime` read does not retain an OS handle. The exposure only appears for callers who then touch `Handle`, `MainModule` or `WaitForExit`. Documented rather than changed, since the return type is fixed for v4; the examples now dispose.

## 3. `StartTime` is local time and did not say so

`RestartManagerProcessInfo.StartTime` goes through `DateTime.FromFileTime`, which converts to local time. Confirmed on a live run: `start=2026-08-29T14:04:48.4599296-07:00 kind=Local`. The doc mentioned only the PID-recycling pairing, so a caller comparing against a UTC timestamp got a silent offset error. Now states the kind explicitly.

Exposing `DateTimeOffset` would be cleaner but is a breaking change on a shipped v4 package, so documenting is the proportionate fix. The internal use in `HasDifferentStartTime` is unaffected — it round-trips through `ToFileTime` and compares file times.

## 4. `RestartManagerShutdownType` has no zero member

The enum defines only `ForceShutdown = 0x1` and `ShutdownOnlyRegistered = 0x10`, so `default` is unnameable (the CA1008 pattern). `RmShutdown`'s documentation describes `lActionFlags` as "one or more" of the two options and never blesses `0`, so rather than adding `None = 0` and asserting a contract Windows does not document, this documents that at least one flag is expected — on both `Shutdown` overloads and on the enum.

## Verification

- Builds clean for `net10.0` and `net11.0` with `/p:TreatWarningsAsErrors=true`, so every new `cref` resolves.
- Tests on this branch: `total: 15, failed: 0, succeeded: 15` — unchanged from #2511, as expected for a docs-only change.
