### PR TITLE
Return an empty list when no credential matches the enumeration filter

### DIFF
--- a/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
+++ b/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
@@ -205,7 +205,7 @@ public static class CredentialManager
     }
 
     /// <summary>Enumerates all credentials from the Windows Credential Manager.</summary>
-    /// <returns>A read-only list of credentials.</returns>
+    /// <returns>A read-only list of credentials, or an empty list when the credential set is empty.</returns>
     public static IReadOnlyList<Credential> EnumerateCredentials()
     {
         return EnumerateCredentials(filter: null);
@@ -213,7 +213,7 @@ public static class CredentialManager
 
     /// <summary>Enumerates credentials from the Windows Credential Manager that match the specified filter.</summary>
     /// <param name="filter">A filter string that supports wildcards. Pass <see langword="null"/> or "*" to enumerate all credentials.</param>
-    /// <returns>A read-only list of credentials matching the filter.</returns>
+    /// <returns>A read-only list of credentials matching the filter, or an empty list when no credential matches.</returns>
     public static unsafe IReadOnlyList<Credential> EnumerateCredentials(string? filter)
     {
         var count = 0u;
@@ -226,6 +226,11 @@ public static class CredentialManager
                 if (!ret)
                 {
                     var lastError = Marshal.GetLastWin32Error();
+
+                    // CredEnumerate reports an empty result set as a failure. This is not an error for the caller.
+                    if (lastError == (int)WIN32_ERROR.ERROR_NOT_FOUND)
+                        return [];
+
                     throw new Win32Exception(lastError);
                 }
 
@@ -233,7 +238,6 @@ public static class CredentialManager
                 for (uint i = 0; i < count; i++)
                 {
                     result[i] = ReadCredential(credentials[i]);
-
                 }
 
                 return result;

--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
@@ -187,6 +187,14 @@ public sealed class CredentialManagerTests
         Assert.StartsWith("Only CredentialType.Generic and CredentialType.DomainPassword is supported", ex.Message);
     }
 
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void CredentialManager_Enumerate_NoMatch_ReturnsEmpty()
+    {
+        using var context = new IsolatedContext();
+        var credentials = CredentialManager.EnumerateCredentials(context.GetCredentialName("*"));
+        Assert.Empty(credentials);
+    }
+
     private sealed class IsolatedContext : IDisposable
     {
         private readonly Mutex? _mutex;


### PR DESCRIPTION
`CredEnumerate` reports an empty result set as a *failure* — it returns `FALSE` and sets `ERROR_NOT_FOUND` (1168). `EnumerateCredentials` treated any `FALSE` as fatal, so asking for credentials that do not exist threw instead of returning nothing.

Verified against the built assembly before the change:

```
CredentialManager.EnumerateCredentials("ZZZ_NoSuchPrefix_<guid>*")
=> System.ComponentModel.Win32Exception: Element not found.
```

The parameterless overload throws the same way on a machine with an empty credential set.

This is the ordinary first-run state, not an error condition: `EnumerateCredentials("MyApp*").Count == 0` crashed on any machine where the app had not yet stored anything. The XML doc promised "a read-only list of credentials matching the filter" and documented no exception, so callers had no reason to guard.

The existing tests never reached it — `CredentialManager_Enumerate` and `CredentialManager_EnumerateCredential_FilterNull` both write credentials before enumerating.

## What changed

`ERROR_NOT_FOUND` now returns an empty list. Every other error code still throws `Win32Exception`, so genuine failures are unchanged. XML docs on both overloads now state the empty-list behavior.

Also removed a stray blank line inside the enumeration loop, since it sits in the same block.

This is an observable behavior change for anyone who wrapped the call in a `try`/`catch` to detect emptiness.

## Verification

Added `CredentialManager_Enumerate_NoMatch_ReturnsEmpty`, which enumerates a GUID-scoped filter with nothing written — it threw before this change and returns empty after.

`dotnet test -p:TreatsWarningsAsErrors=true` — 14 tests per TFM (was 13), 28 total, 0 failed, 0 skipped.

Found during a review of `src/Meziantou.Framework.Win32.CredentialManager`.
