### PR TITLE
Drop the unreachable Windows XP/Vista secret limit and correct the comment limit message

### DIFF
--- a/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
+++ b/src/Meziantou.Framework.Win32.CredentialManager/CredentialManager.cs
@@ -117,7 +117,7 @@ public static class CredentialManager
     /// <param name="persistence">The persistence option for the credential.</param>
     /// <param name="type">The type of the credential.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="applicationName"/>, <paramref name="userName"/>, or <paramref name="secret"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="secret"/> exceeds 512 bytes (on Windows XP/Vista) or 2560 bytes (on Windows 7 and later), or <paramref name="comment"/> exceeds 255 characters.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="secret"/> exceeds 2560 bytes, when <paramref name="comment"/> exceeds 255 characters, or when <paramref name="type"/> is not <see cref="CredentialType.Generic"/> or <see cref="CredentialType.DomainPassword"/>.</exception>
     public static unsafe void WriteCredential(string applicationName, string userName, string secret, string? comment, CredentialPersistence persistence, CredentialType type)
     {
         ArgumentNullException.ThrowIfNull(applicationName);
@@ -126,31 +126,22 @@ public static class CredentialManager
 
         ArgumentNullException.ThrowIfNull(secret);
 
-        // CRED_MAX_CREDENTIAL_BLOB_SIZE
-        // XP and Vista: 512;
-        // 7 and above: 5*512
+        // CRED_MAX_CREDENTIAL_BLOB_SIZE is 5*512 since Windows 7. The 512-byte limit only applied to XP and Vista,
+        // which no supported target framework can run on.
         var secretLength = secret.Length * UnicodeEncoding.CharSize;
-        if (Environment.OSVersion.Version < new Version(6, 1) /* Windows 7 */)
-        {
-            if (secretLength > 512)
-                throw new ArgumentOutOfRangeException(nameof(secret), "The secret message has exceeded 512 bytes.");
-        }
-        else
-        {
-            if (secretLength > 2560)
-                throw new ArgumentOutOfRangeException(nameof(secret), "The secret message has exceeded 2560 bytes.");
-        }
+        if (secretLength > 2560)
+            throw new ArgumentOutOfRangeException(nameof(secret), "The secret message has exceeded 2560 bytes.");
 
         if (comment is not null)
         {
-            // CRED_MAX_STRING_LENGTH 256
+            // CRED_MAX_STRING_LENGTH is 256, including the terminating null character
             if (comment.Length > 255)
-                throw new ArgumentOutOfRangeException(nameof(comment), "The comment message has exceeded 256 characters.");
+                throw new ArgumentOutOfRangeException(nameof(comment), "The comment message has exceeded 255 characters.");
         }
 
         if (type is not (CredentialType.Generic or CredentialType.DomainPassword))
         {
-            throw new ArgumentOutOfRangeException(nameof(type), "Only CredentialType.Generic and CredentialType.DomainPassword is supported");
+            throw new ArgumentOutOfRangeException(nameof(type), $"Only {nameof(CredentialType)}.{nameof(CredentialType.Generic)} and {nameof(CredentialType)}.{nameof(CredentialType.DomainPassword)} is supported");
         }
 
         fixed (char* applicationNamePtr = applicationName)

--- a/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
+++ b/tests/Meziantou.Framework.Win32.CredentialManager.Tests/CredentialManagerTests.cs
@@ -195,6 +195,24 @@ public sealed class CredentialManagerTests
         Assert.Empty(credentials);
     }
 
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void CredentialManager_LimitComment_TooLong()
+    {
+        using var context = new IsolatedContext();
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => CredentialManager.WriteCredential(context.GetCredentialName(), "John", "Doe", new string('a', 256), CredentialPersistence.Session));
+        Assert.Equal("comment", ex.ParamName);
+        Assert.StartsWith("The comment message has exceeded 255 characters.", ex.Message);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void CredentialManager_LimitSecret_TooLong()
+    {
+        using var context = new IsolatedContext();
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => CredentialManager.WriteCredential(context.GetCredentialName(), "John", new string('a', 1281), CredentialPersistence.Session));
+        Assert.Equal("secret", ex.ParamName);
+        Assert.StartsWith("The secret message has exceeded 2560 bytes.", ex.Message);
+    }
+
     private sealed class IsolatedContext : IDisposable
     {
         private readonly Mutex? _mutex;


### PR DESCRIPTION
Two small problems in `WriteCredential`'s validation block, adjacent enough that separating them would just conflict.

**The Windows 7 branch is unreachable.** The project targets `net10.0` and `net11.0`, which require Windows 10 1607 or later, so `Environment.OSVersion.Version < new Version(6, 1)` can never be true. It also allocated a `Version` on every write. This is a leftover from before b784ed51 dropped .NET Framework and the older `netstandard` TFMs.

**The comment limit message is off by one.** The check is `comment.Length > 255` — correct, since `CRED_MAX_STRING_LENGTH` is 256 *including* the terminator — but the message said "has exceeded 256 characters", so a caller passing 256 characters was told 256 was the limit.

## What changed

- Removed the dead branch; the 2560-byte check is now unconditional. The comment above it explains why 512 no longer applies.
- Comment message now says 255.
- The unsupported-type message uses `nameof` instead of hard-coded member names. The rendered text is byte-identical, so `CredentialManager_CredentialType_Invalid` still passes unchanged.
- The `ArgumentOutOfRangeException` doc no longer mentions XP/Vista and now also documents the `type` case, which it had omitted.

## Deliberately not included

The review that turned this up also flagged `[SupportedOSPlatform("windows5.1.2600")]` on the class as stale. It is imprecise, but it is not *wrong* — the APIs really are available from XP SP1 onward — and raising it would only add platform-analyzer restrictions for consumers with no functional benefit. Left alone.

## Verification

Two boundary tests added — `CredentialManager_LimitComment_TooLong` (256 characters) and `CredentialManager_LimitSecret_TooLong` (1281 characters = 2562 bytes) — asserting both `ParamName` and the corrected message. The existing `CredentialManager_LimitComment` (255 characters) and `CredentialManager_LimitSecret` (up to 1280 characters = exactly 2560 bytes) already pin the accepting side.

`dotnet test -p:TreatsWarningsAsErrors=true` — 15 tests per TFM (was 13), 30 total, 0 failed, 0 skipped.

Found during a review of `src/Meziantou.Framework.Win32.CredentialManager`.
