### PR TITLE
Remove the stale code analysis suppressions

### DIFF
--- a/src/Meziantou.Framework.Win32.CredentialManager/GlobalSuppressions.cs
+++ b/src/Meziantou.Framework.Win32.CredentialManager/GlobalSuppressions.cs
@@ -1,7 +1,0 @@
-// This file is used by Code Analysis to maintain SuppressMessage 
-// attributes that are applied to this project.
-// Project-level suppressions either have no target or are given 
-// a specific target and scoped to a namespace, type, member, etc.
-
-[assembly: SuppressMessage("Design", "MA0012:Do not raise reserved exception type", Justification = "<Pending>", Scope = "member", Target = "~M:Meziantou.Framework.Win32.CredentialManager.PromptForCredentialsConsole(System.String,System.String,Meziantou.Framework.Win32.CredentialSaveOption)~Meziantou.Framework.Win32.CredentialResult")]
-[assembly: SuppressMessage("Usage", "MA0015:Specify the parameter name", Justification = "<Pending>", Scope = "member", Target = "~M:Meziantou.Framework.Win32.CredentialManager.PromptForCredentialsConsole(System.String,System.String,Meziantou.Framework.Win32.CredentialSaveOption)~Meziantou.Framework.Win32.CredentialResult")]


### PR DESCRIPTION
`GlobalSuppressions.cs` held two suppressions, both targeting `PromptForCredentialsConsole`, both with `Justification = "<Pending>"`:

- **MA0012** (do not raise reserved exception type) — the method throws `Win32Exception` and `ArgumentException`, neither of which is a reserved type.
- **MA0015** (specify the parameter name) — the `ArgumentException` it throws already passes `nameof(userName)`.

Neither rule fires any more, so the file was only carrying dead metadata. Its first and third lines also had trailing whitespace, which `.editorconfig` sets `trim_trailing_whitespace = true` for.

## What changed

Deleted the file. With no suppressions left in it, the remaining boilerplate header served no purpose.

## Verification

Built with `-p:TreatsWarningsAsErrors=true` after removing it: **0 Warning(s), 0 Error(s)** on both `net10.0` and `net11.0`. If either rule still applied, the suppressed warning would have come back as an error.

`dotnet test -p:TreatsWarningsAsErrors=true` — 13 tests per TFM, 26 total, 0 failed, 0 skipped (unchanged; this is not a behavior change).

Found during a review of `src/Meziantou.Framework.Win32.CredentialManager`.
