### PR TITLE
Reject control characters in the Mark of the Web URLs

### DIFF
--- a/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
+++ b/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
@@ -104,10 +104,13 @@ public static class MarkOfTheWeb
     /// <param name="zone">The security zone to assign to the file.</param>
     /// <param name="referrerUrl">Optional URL of the page that linked to the file.</param>
     /// <param name="hostUrl">Optional URL of the host from which the file was downloaded.</param>
+    /// <exception cref="ArgumentException"><paramref name="referrerUrl"/> or <paramref name="hostUrl"/> contains a carriage return, a line feed, or a null character.</exception>
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings")]
     public static void SetFileZone(string filePath, UrlZone zone, string? referrerUrl = null, string? hostUrl = null)
     {
         ArgumentNullException.ThrowIfNull(filePath);
+        EnsureSingleLine(referrerUrl, nameof(referrerUrl));
+        EnsureSingleLine(hostUrl, nameof(hostUrl));
 
         filePath = Path.GetFullPath(filePath);
         var adsPath = filePath + ":Zone.Identifier";
@@ -123,6 +126,15 @@ public static class MarkOfTheWeb
         {
             writer.WriteLine("HostUrl=" + hostUrl);
         }
+    }
+
+    // Zone.Identifier is an INI-shaped stream and Windows resolves a repeated key to its last occurrence.
+    // A URL containing a line break would let the caller append arbitrary entries, including a second
+    // ZoneId that silently overrides the requested zone.
+    private static void EnsureSingleLine(string? url, string parameterName)
+    {
+        if (url is not null && url.AsSpan().ContainsAny('\r', '\n', '\0'))
+            throw new ArgumentException("The URL cannot contain a carriage return, a line feed, or a null character.", parameterName);
     }
 
     /// <summary>

--- a/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
+++ b/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
@@ -50,4 +50,59 @@ public sealed class MarkOfTheWebTests
 
         File.Delete(path);
     }
+
+    [Theory, RunIf(TestOperatingSystems.Windows)]
+    [InlineData("https://example.com/\r\nZoneId=0")]
+    [InlineData("https://example.com/\nZoneId=0")]
+    [InlineData("https://example.com/\0")]
+    public void SetFileZone_ReferrerUrl_RejectsControlCharacters(string referrerUrl)
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            var exception = Assert.Throws<ArgumentException>(() => MarkOfTheWeb.SetFileZone(path, UrlZone.Internet, referrerUrl));
+            Assert.Equal("referrerUrl", exception.ParamName);
+            Assert.Null(MarkOfTheWeb.GetFileZoneContent(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Theory, RunIf(TestOperatingSystems.Windows)]
+    [InlineData("https://example.com/\r\nZoneId=0")]
+    [InlineData("https://example.com/\nZoneId=0")]
+    [InlineData("https://example.com/\0")]
+    public void SetFileZone_HostUrl_RejectsControlCharacters(string hostUrl)
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            var exception = Assert.Throws<ArgumentException>(() => MarkOfTheWeb.SetFileZone(path, UrlZone.Internet, referrerUrl: null, hostUrl));
+            Assert.Equal("hostUrl", exception.ParamName);
+            Assert.Null(MarkOfTheWeb.GetFileZoneContent(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void SetFileZone_KeepsTheRequestedZone_WhenUrlsAreProvided()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            MarkOfTheWeb.SetFileZone(path, UrlZone.Internet, referrerUrl: "https://example.com/page", hostUrl: "https://example.com/file.txt");
+
+            Assert.Equal(UrlZone.Internet, MarkOfTheWeb.GetFileZone(path));
+            Assert.True(MarkOfTheWeb.IsUntrusted(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 }


### PR DESCRIPTION
> **Stack 1 of 7** · merges into `main` · everything above depends on it

## The problem

`SetFileZone` concatenated `referrerUrl` and `hostUrl` into the `Zone.Identifier` stream with no validation ([`MarkOfTheWeb.cs:117-125`](https://github.com/meziantou/Meziantou.Framework/blob/main/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs#L117-L125)). That stream is INI-shaped, and Windows resolves a repeated key to its **last** occurrence — so a URL containing a line break let the caller append arbitrary entries, including a second `ZoneId` that overrides the requested zone:

```csharp
MarkOfTheWeb.SetFileZone(path, UrlZone.Internet, referrerUrl: "https://evil/\r\nZoneId=0");
// stream: [ZoneTransfer] / ZoneId=3 / ReferrerUrl=https://evil/ / ZoneId=0
MarkOfTheWeb.GetFileZone(path)   // => LocalMachine
MarkOfTheWeb.IsUntrusted(path)   // => false
```

A bare `\n` in `hostUrl` does the same. This is not just the library disagreeing with itself — `MapUrlToZone` is the same call Explorer, SmartScreen and Office Protected View use, so the file really is unmarked as far as Windows is concerned.

The precondition is that some part of the URL is attacker-influenced, which is the normal case: `ReferrerUrl` and `HostUrl` exist precisely to record where a file came from. A downloader using this library to mark its output could be induced to mark it as trusted instead.

## What changed

`SetFileZone` now throws `ArgumentException` when `referrerUrl` or `hostUrl` contains `\r`, `\n`, or `\0`, via a private `EnsureSingleLine` helper. The `<exception>` documentation is updated.

This is a **behavior change**: calls that previously wrote a malformed stream now throw. That is the intended outcome for a security-metadata API — silently stripping would hide caller bugs.

## Verification

`dotnet test -p:TreatWarningsAsErrors=true` — 20/20 pass on `net10.0` and `net11.0`.

New tests: both parameters rejected for `\r\n`, `\n` and `\0` (asserting `ParamName` and that no stream is written), plus a test that a legitimate referrer/host pair still produces `UrlZone.Internet`.
