### PR TITLE
Reject undefined zones in MarkOfTheWeb.SetFileZone

### DIFF
--- a/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
+++ b/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
@@ -104,11 +104,18 @@ public static class MarkOfTheWeb
     /// <param name="zone">The security zone to assign to the file.</param>
     /// <param name="referrerUrl">Optional URL of the page that linked to the file.</param>
     /// <param name="hostUrl">Optional URL of the host from which the file was downloaded.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="zone"/> is not one of <see cref="UrlZone.LocalMachine"/>, <see cref="UrlZone.Intranet"/>, <see cref="UrlZone.Trusted"/>, <see cref="UrlZone.Internet"/>, or <see cref="UrlZone.Untrusted"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="referrerUrl"/> or <paramref name="hostUrl"/> contains a carriage return, a line feed, or a null character.</exception>
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings")]
     public static void SetFileZone(string filePath, UrlZone zone, string? referrerUrl = null, string? hostUrl = null)
     {
         ArgumentNullException.ThrowIfNull(filePath);
+
+        // Windows ignores a ZoneId it cannot interpret, so writing one would report success while leaving
+        // the file effectively unmarked. UrlZone.Invalid is a "could not determine" result, not a zone.
+        if (zone is < UrlZone.LocalMachine or > UrlZone.Untrusted)
+            throw new ArgumentOutOfRangeException(nameof(zone), zone, "The zone must be a defined URL zone other than UrlZone.Invalid.");
+
         EnsureSingleLine(referrerUrl, nameof(referrerUrl));
         EnsureSingleLine(hostUrl, nameof(hostUrl));
 

--- a/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
+++ b/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
@@ -89,6 +89,66 @@ public sealed class MarkOfTheWebTests
         }
     }
 
+    [Theory, RunIf(TestOperatingSystems.Windows)]
+    [InlineData(UrlZone.Invalid)]
+    [InlineData((UrlZone)(-2))]
+    [InlineData((UrlZone)5)]
+    [InlineData((UrlZone)999)]
+    public void SetFileZone_RejectsUndefinedZones(UrlZone zone)
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => MarkOfTheWeb.SetFileZone(path, zone));
+            Assert.Equal("zone", exception.ParamName);
+            Assert.Null(MarkOfTheWeb.GetFileZoneContent(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // UrlZone.Trusted is deliberately absent: Windows resolves the Trusted Sites zone from site
+    // membership rather than from a saved-file mark, so a file marked ZoneId=2 reads back as
+    // UrlZone.LocalMachine. SetFileZone still accepts it, since the value it writes is well-formed.
+    [Theory, RunIf(TestOperatingSystems.Windows)]
+    [InlineData(UrlZone.LocalMachine)]
+    [InlineData(UrlZone.Intranet)]
+    [InlineData(UrlZone.Internet)]
+    [InlineData(UrlZone.Untrusted)]
+    public void SetFileZone_RoundTripsDefinedZones(UrlZone zone)
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            MarkOfTheWeb.SetFileZone(path, zone);
+
+            Assert.Equal(zone, MarkOfTheWeb.GetFileZone(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void SetFileZone_AcceptsTrusted_EvenThoughWindowsResolvesItToLocalMachine()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            MarkOfTheWeb.SetFileZone(path, UrlZone.Trusted);
+
+            Assert.Equal("[ZoneTransfer]\nZoneId=2\n", MarkOfTheWeb.GetFileZoneContent(path)!.ReplaceLineEndings("\n"));
+            Assert.Equal(UrlZone.LocalMachine, MarkOfTheWeb.GetFileZone(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
     [Fact, RunIf(TestOperatingSystems.Windows)]
     public void SetFileZone_KeepsTheRequestedZone_WhenUrlsAreProvided()
     {


### PR DESCRIPTION
> **Stack 2 of 7** · merges into `fix/motw-url-injection` (#2521)

## The problem

`SetFileZone` cast `zone` to `int` and wrote it verbatim, with no validation ([`MarkOfTheWeb.cs:108-116`](https://github.com/meziantou/Meziantou.Framework/blob/main/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs#L108-L116)). Windows ignores a `ZoneId` it cannot interpret, so both an out-of-range value and the `Invalid` sentinel that this same enum defines produced a call that appeared to succeed while leaving the file effectively **unmarked**:

```csharp
MarkOfTheWeb.SetFileZone(path, UrlZone.Invalid);   // writes ZoneId=-1
MarkOfTheWeb.GetFileZone(path)                     // => LocalMachine, IsUntrusted => false
MarkOfTheWeb.SetFileZone(path, (UrlZone)999);      // same outcome
```

`UrlZone.Invalid` is a public member of the enum the parameter is typed as, so passing it is a natural mistake — and round-tripping a zone from one file to another (`SetFileZone(b, GetFileZone(a))`) hits it whenever `a` couldn't be read.

## What changed

`SetFileZone` throws `ArgumentOutOfRangeException` for anything outside `LocalMachine..Untrusted`, which rejects `UrlZone.Invalid` — a "could not determine" result, not a zone.

## A behavior worth knowing about

While adding a round-trip test across every defined zone, `UrlZone.Trusted` turned out not to round-trip:

```
wrote ZoneId=0  (LocalMachine) -> GetFileZone=LocalMachine
wrote ZoneId=1  (Intranet    ) -> GetFileZone=Intranet
wrote ZoneId=2  (Trusted     ) -> GetFileZone=LocalMachine   <--
wrote ZoneId=3  (Internet    ) -> GetFileZone=Internet
wrote ZoneId=4  (Untrusted   ) -> GetFileZone=Untrusted
```

Windows resolves the Trusted Sites zone from site membership rather than from a saved-file mark, so `ZoneId=2` reads back as `LocalMachine`. `SetFileZone` still accepts it, since the value written is well-formed. This PR does not change that — it just records it in a test so it stops being a surprise. Worth deciding separately whether `Trusted` should be rejected too.

## Verification

`dotnet test -p:TreatWarningsAsErrors=true` — 38/38 pass on `net10.0` and `net11.0`.

New tests: `Invalid`, `(UrlZone)(-2)`, `(UrlZone)5` and `(UrlZone)999` all rejected with `ParamName == "zone"` and no stream written; the four zones that do round-trip verified; the `Trusted` behavior pinned explicitly.
