### PR TITLE
Read and write Zone.Identifier with the encoding Windows uses

### DIFF
--- a/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
+++ b/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
@@ -25,6 +25,8 @@ namespace Meziantou.Framework.Win32;
 /// </example>
 public static class MarkOfTheWeb
 {
+    private static readonly UTF8Encoding ZoneIdentifierEncoding = new(encoderShouldEmitUTF8Identifier: false);
+
     /// <summary>Removes the Mark of the Web zone information from a file by deleting the Zone.Identifier alternate data stream.</summary>
     /// <param name="filePath">The path to the file from which to remove the zone information.</param>
     public static void RemoveFileZone(string filePath)
@@ -81,6 +83,10 @@ public static class MarkOfTheWeb
     /// <summary>Gets the raw content of the Zone.Identifier alternate data stream from a file.</summary>
     /// <param name="filePath">The path to the file to read.</param>
     /// <returns>The content of the Zone.Identifier stream, or <see langword="null"/> if the file does not have zone information.</returns>
+    /// <remarks>
+    /// Windows and web browsers write the stream as ASCII. A byte order mark, if present, takes precedence,
+    /// so streams written as UTF-16 by earlier versions of this library are still decoded correctly.
+    /// </remarks>
     public static string? GetFileZoneContent(string filePath)
     {
         ArgumentNullException.ThrowIfNull(filePath);
@@ -90,7 +96,9 @@ public static class MarkOfTheWeb
 
         try
         {
-            return File.ReadAllText(adsPath, Encoding.Unicode);
+            // File.ReadAllText honors a byte order mark when there is one and falls back to the
+            // requested encoding otherwise. UTF-8 is a superset of the ASCII that Windows writes.
+            return File.ReadAllText(adsPath, Encoding.UTF8);
         }
         catch (FileNotFoundException)
         {
@@ -121,7 +129,10 @@ public static class MarkOfTheWeb
 
         filePath = Path.GetFullPath(filePath);
         var adsPath = filePath + ":Zone.Identifier";
-        using var writer = new StreamWriter(adsPath, append: false, Encoding.Unicode);
+
+        // Windows and web browsers write the stream as ASCII. UTF-8 without a byte order mark produces
+        // the same bytes for the ASCII that URLs are normally made of, while still preserving the rest.
+        using var writer = new StreamWriter(adsPath, append: false, ZoneIdentifierEncoding);
         writer.WriteLine("[ZoneTransfer]");
         writer.WriteLine("ZoneId=" + ((int)zone).ToString(CultureInfo.InvariantCulture));
         if (referrerUrl is not null)

--- a/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
+++ b/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
@@ -51,6 +51,74 @@ public sealed class MarkOfTheWebTests
         File.Delete(path);
     }
 
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetFileZoneContent_ReadsTheAsciiStreamWrittenByWindowsAndBrowsers()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            const string Content = "[ZoneTransfer]\r\nZoneId=3\r\nHostUrl=https://example.com/file.txt\r\n";
+            File.WriteAllBytes(path + ":Zone.Identifier", Encoding.ASCII.GetBytes(Content));
+
+            Assert.Equal(Content, MarkOfTheWeb.GetFileZoneContent(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetFileZoneContent_ReadsTheUtf16StreamWrittenByEarlierVersions()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            const string Content = "[ZoneTransfer]\r\nZoneId=3\r\n";
+            File.WriteAllBytes(path + ":Zone.Identifier", [.. Encoding.Unicode.GetPreamble(), .. Encoding.Unicode.GetBytes(Content)]);
+
+            Assert.Equal(Content, MarkOfTheWeb.GetFileZoneContent(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void SetFileZone_WritesTheStreamAsAsciiWithoutAByteOrderMark()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            MarkOfTheWeb.SetFileZone(path, UrlZone.Internet, hostUrl: "https://example.com/file.txt");
+
+            var bytes = File.ReadAllBytes(path + ":Zone.Identifier");
+            Assert.All(bytes, b => b is >= 0x09 and <= 0x7F);
+            Assert.Equal("[ZoneTransfer]\nZoneId=3\nHostUrl=https://example.com/file.txt\n", Encoding.ASCII.GetString(bytes).ReplaceLineEndings("\n"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void SetFileZone_PreservesNonAsciiCharactersInUrls()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            MarkOfTheWeb.SetFileZone(path, UrlZone.Internet, hostUrl: "https://example.com/café.txt");
+
+            Assert.Contains("café.txt", MarkOfTheWeb.GetFileZoneContent(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
     [Theory, RunIf(TestOperatingSystems.Windows)]
     [InlineData("https://example.com/\r\nZoneId=0")]
     [InlineData("https://example.com/\nZoneId=0")]


### PR DESCRIPTION
> **Stack 3 of 7** · merges into `fix/motw-zone-validation` (#2522)

## The problem

`GetFileZoneContent` decoded the stream as UTF-16 ([`MarkOfTheWeb.cs:93`](https://github.com/meziantou/Meziantou.Framework/blob/main/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs#L93)), but Windows' Attachment Execution Service and every mainstream browser write it as ASCII. Checked against real downloads — all begin `5B 5A 6F 6E 65 54 72 61 6E 73 66 65 72 5D` (`[ZoneTransfer]`), not UTF-16. Decoded as UTF-16LE that yields:

```
GetFileZoneContent("ChatGPT Installer.exe") == "婛湯呥慲獮敦嵲਍潚敮摉㌽਍…"
```

A non-null, non-empty, entirely wrong string. Callers that parse it — look for `ZoneId=`, split on `=`, read `HostUrl` — find no match and conclude the file is unmarked. The method failed on 100% of files marked by anything other than this library.

It stayed invisible because `SetFileZone` wrote UTF-16 too, so the existing round-trip test was self-consistent.

## What changed

**Reads** use `File.ReadAllText(adsPath, Encoding.UTF8)`, which honors a byte order mark when there is one and falls back to the requested encoding otherwise. UTF-8 is a superset of the ASCII that Windows writes, and the BOM path means streams written as UTF-16 by v2.0.0 and earlier still decode correctly — no data migration needed.

**Writes** use `UTF8Encoding(encoderShouldEmitUTF8Identifier: false)` instead of `Encoding.Unicode`. For the ASCII that URLs are normally made of this is byte-identical to ASCII, so marks written by this library are now indistinguishable from the platform's — while a non-ASCII `HostUrl` is preserved rather than mangled to `?`, which strict ASCII would have done.

## Verification

`dotnet test -p:TreatWarningsAsErrors=true` — 46/46 pass on `net10.0` and `net11.0`.

Also confirmed end-to-end against the real downloads that reproduced the bug:

```
Claude Setup.exe
  -> [ZoneTransfer] | ZoneId=3 | ReferrerUrl=https://claude.com/ | HostUrl=https://downloads.claude.ai/…
dotnet-sdk-10.0.400-win-arm64.exe
  -> [ZoneTransfer] | ZoneId=3 | ReferrerUrl=https://dotnet.microsoft.com/ | HostUrl=https://builds.dotnet.microsoft.com/…
```

New tests: a browser-style ASCII stream reads back verbatim; a UTF-16-with-BOM stream (what earlier versions wrote) still reads back correctly; `SetFileZone` output is all ASCII bytes with no BOM; a non-ASCII `hostUrl` survives the round trip. The pre-existing `Set_Get` assertion passes unchanged.
