### PR TITLE
Tolerate a missing directory in RemoveFileZone and GetFileZoneContent

### DIFF
--- a/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
+++ b/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
@@ -29,6 +29,7 @@ public static class MarkOfTheWeb
 
     /// <summary>Removes the Mark of the Web zone information from a file by deleting the Zone.Identifier alternate data stream.</summary>
     /// <param name="filePath">The path to the file from which to remove the zone information.</param>
+    /// <remarks>Does nothing when the file carries no zone information, or when the file or its directory does not exist.</remarks>
     public static void RemoveFileZone(string filePath)
     {
         ArgumentNullException.ThrowIfNull(filePath);
@@ -38,7 +39,7 @@ public static class MarkOfTheWeb
         {
             File.Delete(adsPath);
         }
-        catch (FileNotFoundException)
+        catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException)
         {
         }
     }
@@ -82,7 +83,7 @@ public static class MarkOfTheWeb
 
     /// <summary>Gets the raw content of the Zone.Identifier alternate data stream from a file.</summary>
     /// <param name="filePath">The path to the file to read.</param>
-    /// <returns>The content of the Zone.Identifier stream, or <see langword="null"/> if the file does not have zone information.</returns>
+    /// <returns>The content of the Zone.Identifier stream, or <see langword="null"/> if the file does not have zone information, or if the file or its directory does not exist.</returns>
     /// <remarks>
     /// Windows and web browsers write the stream as ASCII. A byte order mark, if present, takes precedence,
     /// so streams written as UTF-16 by earlier versions of this library are still decoded correctly.
@@ -100,7 +101,7 @@ public static class MarkOfTheWeb
             // requested encoding otherwise. UTF-8 is a superset of the ASCII that Windows writes.
             return File.ReadAllText(adsPath, Encoding.UTF8);
         }
-        catch (FileNotFoundException)
+        catch (Exception exception) when (exception is FileNotFoundException or DirectoryNotFoundException)
         {
         }
 

--- a/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
+++ b/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
@@ -52,6 +52,39 @@ public sealed class MarkOfTheWebTests
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void RemoveFileZone_DoesNothing_WhenTheFileHasNoZoneInformation()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            MarkOfTheWeb.RemoveFileZone(path);
+
+            Assert.Null(MarkOfTheWeb.GetFileZoneContent(path));
+            Assert.True(File.Exists(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void RemoveFileZone_DoesNothing_WhenTheDirectoryDoesNotExist()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "missing.txt");
+
+        MarkOfTheWeb.RemoveFileZone(path);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetFileZoneContent_ReturnsNull_WhenTheDirectoryDoesNotExist()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "missing.txt");
+
+        Assert.Null(MarkOfTheWeb.GetFileZoneContent(path));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
     public void GetFileZoneContent_ReadsTheAsciiStreamWrittenByWindowsAndBrowsers()
     {
         var path = Path.GetTempFileName();


### PR DESCRIPTION
> **Stack 4 of 7** · merges into `fix/motw-ads-encoding` (#2523)

## The problem

`RemoveFileZone` ([`MarkOfTheWeb.cs:39-41`](https://github.com/meziantou/Meziantou.Framework/blob/main/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs#L39-L41)) and `GetFileZoneContent` ([`:95-97`](https://github.com/meziantou/Meziantou.Framework/blob/main/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs#L95-L97)) both caught `FileNotFoundException` only. A path whose *directory* does not exist throws `DirectoryNotFoundException`, which escaped:

```
RemoveFileZone("<dir>/nope/x.txt")        -> DirectoryNotFoundException
GetFileZoneContent("<dir>/nope/x.txt")    -> DirectoryNotFoundException
```

`GetFileZoneContent` is documented to return `null` when there is no zone information; `RemoveFileZone` documents no failure mode at all. Both promises were broken on a plausible input.

(A missing file inside an *existing* directory was already handled — `File.Delete` swallows that itself, which makes the original `FileNotFoundException` catch close to dead code for `RemoveFileZone`.)

## What changed

Both `catch` clauses now filter on `FileNotFoundException or DirectoryNotFoundException`. The XML documentation on each method states the tolerated cases explicitly.

The filter stays narrow on purpose — a locked stream still throws `IOException`, and an unwritable file still throws `UnauthorizedAccessException`, so genuine failures are not swallowed.

## Verification

`dotnet test -p:TreatWarningsAsErrors=true` — 52/52 pass on `net10.0` and `net11.0`.

New tests: `RemoveFileZone` on a file with no zone information is a no-op that leaves the file intact; `RemoveFileZone` and `GetFileZoneContent` on a path under a non-existent directory no longer throw.
