### PR TITLE
Hide the CredentialType sentinel values from completion

### DIFF
--- a/src/Meziantou.Framework.Win32.CredentialManager/CredentialType.cs
+++ b/src/Meziantou.Framework.Win32.CredentialManager/CredentialType.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Meziantou.Framework.Win32;
 
 /// <summary>Specifies the type of a credential in the Windows Credential Manager.</summary>
@@ -22,8 +24,10 @@ public enum CredentialType
     DomainExtended,
 
     /// <summary>A sentinel value indicating the maximum number of supported credential types. This is used internally by the Windows API and should not be used as an actual credential type.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     Maximum,
 
     /// <summary>A sentinel value indicating the maximum number of supported credential types including extended types. This is used internally by the Windows API and should not be used as an actual credential type.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     MaximumEx = Maximum + 1000,
 }


### PR DESCRIPTION
`CredentialType.Maximum` and `CredentialType.MaximumEx` mirror `CRED_TYPE_MAXIMUM` and `CRED_TYPE_MAXIMUM_EX`, which are array-bound sentinels in the Windows headers rather than credential types. Their XML docs already say "should not be used as an actual credential type", but they still show up in IntelliSense as ordinary, selectable values — and `ReadCredential`/`DeleteCredential` will happily pass them through to Win32, since only `WriteCredential` validates the type.

## What changed

Marked both with `[EditorBrowsable(EditorBrowsableState.Never)]`, which keeps them out of completion lists without removing them.

Removing them outright would be a breaking change for no real gain, so this is deliberately the conservative option. `ref/` is unchanged — the generator does not emit `EditorBrowsable`.

## Verification

Builds clean with `-p:TreatsWarningsAsErrors=true` on both TFMs.

`dotnet test -p:TreatsWarningsAsErrors=true` — 13 tests per TFM, 26 total, 0 failed, 0 skipped (unchanged; this is metadata only).

Found during a review of `src/Meziantou.Framework.Win32.CredentialManager`.
