### PR TITLE
Handle the nullable result in the CredentialManager readme sample

### DIFF
--- a/src/Meziantou.Framework.Win32.CredentialManager/readme.md
+++ b/src/Meziantou.Framework.Win32.CredentialManager/readme.md
@@ -9,12 +9,17 @@ CredentialManager.WriteCredential(
     comment: "Test",
     persistence: CredentialPersistence.LocalMachine);
 
-// Get a credential from the credential manager
+// Get a credential from the credential manager.
+// ReadCredential returns null when no such credential exists.
 var cred = CredentialManager.ReadCredential(applicationName: "CredentialManagerTests");
-Console.WriteLine(cred.UserName);
-Console.WriteLine(cred.Password);
+if (cred is not null)
+{
+    Console.WriteLine(cred.UserName);
+    Console.WriteLine(cred.Password);
+}
 
-// Delete a credential from the credential manager
+// Delete a credential from the credential manager.
+// DeleteCredential throws Win32Exception when no such credential exists.
 CredentialManager.DeleteCredential(applicationName: "CredentialManagerTests");
 ````
 


### PR DESCRIPTION
The package readme's sample dereferenced the result of `ReadCredential` directly:

```c#
var cred = CredentialManager.ReadCredential(applicationName: "CredentialManagerTests");
Console.WriteLine(cred.UserName);
```

`ReadCredential` returns `Credential?`, so copying this into any nullable-enabled project — the default for the TFMs this package targets — produces a `CS8602` warning, and an error where warnings are errors. It also happens to be the first thing a new user copies.

The sample also called `DeleteCredential` without mentioning that it throws `Win32Exception` when the credential does not exist.

## What changed

Readme only, no code. The sample now null-checks the read result, and both behaviors are called out in comments so the sample teaches the actual contract.

## Verification

Documentation change; nothing to build or test. Confirmed this file is not regenerated — `eng/update-all.cs`'s `readme` step builds the root `README.md` from csproj metadata and does not consume per-package readmes.

Found during a review of `src/Meziantou.Framework.Win32.CredentialManager`.
