### PR TITLE
Stop leaking the perceived type string from AssocGetPerceivedType

### DIFF
--- a/src/Meziantou.Framework.Win32.PerceivedType/Perceived.cs
+++ b/src/Meziantou.Framework.Win32.PerceivedType/Perceived.cs
@@ -137,7 +137,7 @@ public sealed class Perceived
             if (!PerceivedTypes.TryGetValue(extension, out ptype))
             {
                 source = PerceivedTypeSource.Undefined;
-                var hr = PInvoke.AssocGetPerceivedType(extension, out var perceivedType, out var flag, out _);
+                var hr = PInvoke.AssocGetPerceivedType(extension, out var perceivedType, out var flag);
                 if (hr.Failed)
                 {
                     type = PerceivedType.Unspecified;


### PR DESCRIPTION
**Stack 1 of 4 · merges into `main` · must merge before #2529, #2530, #2531**

## The problem

`Perceived.cs:140` asked the shell for the perceived-type string and then threw the pointer away:

```csharp
var hr = PInvoke.AssocGetPerceivedType(extension, out var perceivedType, out var flag, out _);
```

CsWin32 generates two friendly overloads for `AssocGetPerceivedType`. The four-argument one pins a local and passes its address as `ppszType`; the three-argument one passes `null`. `out _` binds the **first**, so the shell allocates the string (`"text"`, `"video"`, …), writes the pointer into a discard, and nobody frees it.

The Win32 docs mark `ppszType` `[out, optional]` and note the value "can be **NULL**" precisely so callers that don't want the string can opt out.

## The fix

Drop the fourth argument so the three-argument overload binds and `ppszType` is passed as `null`. The value was never used, so nothing else changes.

## Verification

Measured directly against `SHLWAPI.dll`, 200,000 calls per configuration:

| configuration | private memory delta | per call |
|---|---|---|
| without `ppszType` | −684.0 KB | −3.50 B |
| with `ppszType`, leaked | 3048.0 KB | **15.61 B** |
| with `ppszType`, freed via `CoTaskMemFree` | 36.0 KB | 0.18 B |

That the allocation is `CoTaskMemFree`-able confirms the ownership transfer — the caller owned that string and this code never released it.

The existing 20 tests pass on `net10.0` and `net11.0` with `-p:TreatsWarningsAsErrors=true`. No test is added: the fix is a leak, and asserting on process memory in a unit test would be flaky.

## Impact

Bounded by the cache, so one leak per distinct extension a process ever queries — a few hundred bytes for a typical app. It matters mainly in combination with #2529: the same untrusted-file-name path that grows the managed cache also leaked native heap the GC cannot touch and no managed profiler attributes to this library.

<sub>Found during a review of `src/Meziantou.Framework.Win32.PerceivedType`.</sub>
