### PR TITLE
Bound the perceived type cache so untrusted file names cannot grow it forever

### DIFF
--- a/src/Meziantou.Framework.Win32.PerceivedType/Meziantou.Framework.Win32.PerceivedType.csproj
+++ b/src/Meziantou.Framework.Win32.PerceivedType/Meziantou.Framework.Win32.PerceivedType.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Meziantou.Framework.Win32.PerceivedType.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.298">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Meziantou.Framework.Win32.PerceivedType/Perceived.cs
+++ b/src/Meziantou.Framework.Win32.PerceivedType/Perceived.cs
@@ -23,6 +23,11 @@ public sealed class Perceived
 {
     private static readonly ConcurrentDictionary<string, Perceived> PerceivedTypes = new(StringComparer.OrdinalIgnoreCase);
 
+    // The cache is keyed by a value derived from the caller's argument, and file names often come from untrusted
+    // sources. Without these limits a process that classifies arbitrary file names grows the cache forever.
+    private const int MaximumCachedExtensionLength = 24;
+    private const int MaximumCacheSize = 4096;
+
     private static object SyncObject { get; } = new object();
 
     private Perceived(string extension, PerceivedType perceivedType, PerceivedTypeSource perceivedTypeSource)
@@ -150,7 +155,10 @@ public sealed class Perceived
                 }
 
                 ptype = new Perceived(extension, type, source);
-                PerceivedTypes.TryAdd(extension, ptype);
+                if (ShouldCache(extension, PerceivedTypes.Count))
+                {
+                    PerceivedTypes.TryAdd(extension, ptype);
+                }
             }
 
             return ptype;
@@ -171,5 +179,20 @@ public sealed class Perceived
     private static bool IsSupportedPlatform()
     {
         return OperatingSystem.IsWindows();
+    }
+
+    /// <summary>Determines whether a type resolved through the operating system is worth remembering.</summary>
+    /// <remarks>
+    /// Extensions registered explicitly through <see cref="AddPerceived(string, PerceivedType)"/> are never subject
+    /// to these limits. Refusing to cache only makes a later lookup slower; it never changes the result.
+    /// </remarks>
+    internal static bool ShouldCache(string extension, int currentCount)
+    {
+        return extension.Length <= MaximumCachedExtensionLength && currentCount < MaximumCacheSize;
+    }
+
+    internal static bool IsExtensionCached(string extension)
+    {
+        return PerceivedTypes.ContainsKey(extension);
     }
 }

--- a/tests/Meziantou.Framework.Win32.PerceivedType.Tests/PerceivedTests.cs
+++ b/tests/Meziantou.Framework.Win32.PerceivedType.Tests/PerceivedTests.cs
@@ -46,4 +46,34 @@ public class PerceivedTests
         var perceived = Perceived.GetPerceivedType(".unknown_extension");
         Assert.Equal(PerceivedType.Unspecified, perceived.PerceivedType);
     }
+
+    [Theory]
+    [InlineData(".txt", 0, true)]
+    [InlineData(".appxmanifest", 4095, true)]
+    [InlineData(".txt", 4096, false)]
+    [InlineData(".txt", 5000, false)]
+    [InlineData(".this_extension_is_far_too_long", 0, false)]
+    public void ShouldCache_LimitsLengthAndCount(string extension, int currentCount, bool expected)
+    {
+        Assert.Equal(expected, Perceived.ShouldCache(extension, currentCount));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetPerceivedType_DoesNotCacheAnAbsurdlyLongExtension()
+    {
+        var extension = "." + new string('a', 512);
+
+        var perceived = Perceived.GetPerceivedType("file" + extension);
+
+        Assert.Equal(PerceivedType.Unspecified, perceived.PerceivedType);
+        Assert.False(Perceived.IsExtensionCached(extension));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetPerceivedType_CachesAnOrdinaryExtension()
+    {
+        Perceived.GetPerceivedType(".png");
+
+        Assert.True(Perceived.IsExtensionCached(".png"));
+    }
 }


### PR DESCRIPTION
**Stack 2 of 4 · merges into `fix/perceived-interop-leak` · merge #2528 first**

## The problem

`GetPerceivedType` (`Perceived.cs:126-153`) caches every extension it resolves in a `static` dictionary (`Perceived.cs:24`) with no size limit, no expiry and no eviction. The key comes straight from the caller's argument, and **failed** lookups are cached too — so misses are exactly what accumulates.

Measured against the built assembly before this change:

```
5000-char ext -> type=Unspecified Extension.Length=5001
cache entries after 100k distinct extensions: 100001
private memory growth: 22.6 MB
after full GC:         22.2 MB   (nothing is evictable)
```

`Path.GetExtension("a." + new string('x', 5000))` returns a 5001-character extension, which was accepted and cached whole.

This library's whole job is classifying files by extension, and file names routinely arrive from untrusted places — uploads, archive entries, `Content-Disposition` headers, crawled paths. Any service on that path retained roughly 230 bytes of unreclaimable memory per distinct extension it had ever seen, until the process was recycled, with no rate limit and no signal in the application's own metrics.

## The fix

Two limits, both applied only to types resolved *through the operating system*:

- `MaximumCachedExtensionLength = 24` — longer extensions are resolved but not remembered. The longest entry in `AddDefaultPerceivedTypes` is `.appxmanifest` (13), and dotfile-style names like `.editorconfig` (13) and `.gitattributes` (14) fit comfortably.
- `MaximumCacheSize = 4096` — once the dictionary reaches the ceiling, new resolutions are returned but not stored. A length cap alone does not bound anything, since there are plenty of distinct short extensions.

Neither limit can change a result: an extension past either one is simply resolved through the shell on every call instead of being remembered. Extensions registered explicitly through `AddPerceived` are never subject to either limit.

## Verification

Same repro, after the change:

```
5000-char ext -> type=Unspecified (still resolved correctly)
cache entries after 100k distinct extensions: 4096
retained managed heap: 0.64 MB
lookups still correct after cap: .txt -> Text
```

100,001 permanent entries → 4,096. Lookups stay correct after the cap is hit.

Tests: 34 pass on `net10.0` and `net11.0` (17 each, up from 10) with `-p:TreatsWarningsAsErrors=true`. New coverage:

- `ShouldCache_LimitsLengthAndCount` — the length and count limits as a pure function, five cases including the boundaries at 4095/4096.
- `GetPerceivedType_DoesNotCacheAnAbsurdlyLongExtension` — a 513-character extension still resolves, and is not cached.
- `GetPerceivedType_CachesAnOrdinaryExtension` — the normal path still caches.

`ShouldCache` and `IsExtensionCached` are `internal`, exposed to the test project via `InternalsVisibleTo` following the convention already used across this repo. No public API change, so `ref/` is untouched.

<sub>Found during a review of `src/Meziantou.Framework.Win32.PerceivedType`; the highest-severity item in it.</sub>
