### PR TITLE
Collapse the perceived type lookup onto GetOrAdd

### DIFF
--- a/src/Meziantou.Framework.Win32.PerceivedType/Perceived.cs
+++ b/src/Meziantou.Framework.Win32.PerceivedType/Perceived.cs
@@ -28,8 +28,6 @@ public sealed class Perceived
     private const int MaximumCachedExtensionLength = 24;
     private const int MaximumCacheSize = 4096;
 
-    private static object SyncObject { get; } = new object();
-
     private Perceived(string extension, PerceivedType perceivedType, PerceivedTypeSource perceivedTypeSource)
     {
         Extension = extension;
@@ -98,10 +96,7 @@ public sealed class Perceived
         ArgumentNullException.ThrowIfNull(extension);
 
         var perceived = new Perceived(extension, type, PerceivedTypeSource.HardCoded);
-        lock (SyncObject)
-        {
-            PerceivedTypes[perceived.Extension] = perceived;
-        }
+        PerceivedTypes[perceived.Extension] = perceived;
 
         return perceived;
     }
@@ -122,47 +117,26 @@ public sealed class Perceived
     /// <param name="fileName">The file name. May not be null..</param>
     /// <returns>An instance of the PerceivedType type.</returns>
     [SupportedOSPlatform("windows5.1.2600")]
-    public static unsafe Perceived GetPerceivedType(string fileName)
+    public static Perceived GetPerceivedType(string fileName)
     {
         ArgumentNullException.ThrowIfNull(fileName);
 
-        var extension = Path.GetExtension(fileName) ?? throw new ArgumentException("The extension cannot be determined from the file name", nameof(fileName));
-
-        extension = extension.ToUpperInvariant();
+        var extension = Path.GetExtension(fileName);
         if (PerceivedTypes.TryGetValue(extension, out var ptype))
             return ptype;
 
         if (!IsSupportedPlatform())
             throw new PlatformNotSupportedException("PerceivedType is only supported on Windows");
 
-        lock (SyncObject)
-        {
-            var type = PerceivedType.Unknown;
-            var source = PerceivedTypeSource.Undefined;
-            if (!PerceivedTypes.TryGetValue(extension, out ptype))
-            {
-                source = PerceivedTypeSource.Undefined;
-                var hr = PInvoke.AssocGetPerceivedType(extension, out var perceivedType, out var flag);
-                if (hr.Failed)
-                {
-                    type = PerceivedType.Unspecified;
-                    source = PerceivedTypeSource.Undefined;
-                }
-                else
-                {
-                    type = (PerceivedType)perceivedType;
-                    source = (PerceivedTypeSource)flag;
-                }
+        var hr = PInvoke.AssocGetPerceivedType(extension, out var perceivedType, out var flag);
+        var perceived = hr.Failed
+            ? new Perceived(extension, PerceivedType.Unspecified, PerceivedTypeSource.Undefined)
+            : new Perceived(extension, (PerceivedType)perceivedType, (PerceivedTypeSource)flag);
 
-                ptype = new Perceived(extension, type, source);
-                if (ShouldCache(extension, PerceivedTypes.Count))
-                {
-                    PerceivedTypes.TryAdd(extension, ptype);
-                }
-            }
+        if (!ShouldCache(extension, PerceivedTypes.Count))
+            return perceived;
 
-            return ptype;
-        }
+        return PerceivedTypes.GetOrAdd(extension, perceived);
     }
 
     /// <summary>

--- a/tests/Meziantou.Framework.Win32.PerceivedType.Tests/PerceivedTests.cs
+++ b/tests/Meziantou.Framework.Win32.PerceivedType.Tests/PerceivedTests.cs
@@ -76,4 +76,46 @@ public class PerceivedTests
 
         Assert.True(Perceived.IsExtensionCached(".png"));
     }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetPerceivedType_PreservesTheExtensionAsWritten()
+    {
+        var perceived = Perceived.GetPerceivedType("report.CasingSample");
+
+        Assert.Equal(".CasingSample", perceived.Extension);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetPerceivedType_IsCaseInsensitiveAndReturnsTheSameInstance()
+    {
+        var first = Perceived.GetPerceivedType("a.InstanceSample");
+        var second = Perceived.GetPerceivedType("b.INSTANCESAMPLE");
+
+        Assert.Same(first, second);
+    }
+
+    [Theory, RunIf(TestOperatingSystems.Windows)]
+    [InlineData("readme")]
+    [InlineData("")]
+    public void GetPerceivedType_ReturnsUnspecifiedWhenThereIsNoExtension(string fileName)
+    {
+        var perceived = Perceived.GetPerceivedType(fileName);
+
+        Assert.Equal(PerceivedType.Unspecified, perceived.PerceivedType);
+        Assert.Empty(perceived.Extension);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetPerceivedType_AcceptsAFullPath()
+    {
+        var perceived = Perceived.GetPerceivedType(@"C:\dir.d\sub\file.txt");
+
+        Assert.Equal(PerceivedType.Text, perceived.PerceivedType);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetPerceivedType_Null_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => Perceived.GetPerceivedType(fileName: null!));
+    }
 }


### PR DESCRIPTION
**Stack 3 of 4 · merges into `fix/perceived-bound-cache` · merge #2528 and #2529 first**

## The problem

The cache-miss path in `GetPerceivedType` carried several things that did nothing, which is what made the two real bugs below it (#2528, #2529) easy to miss:

- **`Perceived.cs:124` — validation that cannot run.** `Path.GetExtension(fileName) ?? throw new ArgumentException(...)` never throws. `Path.GetExtension(string?)` is annotated `[return: NotNullIfNotNull(nameof(path))]` (verified by reflection) and `fileName` is already non-null past `ArgumentNullException.ThrowIfNull`, so it returns `""` — never `null` — for a name with no extension. `AGENTS.md` asks us to trust the null annotations rather than re-check them.
- **`Perceived.cs:135-139` — dead assignments.** `type` and `source` were initialised to values every path overwrote before reading, and `source` was assigned `Undefined` twice in a row. (`PERCEIVED_TYPE_UNKNOWN` is also documented as "never returned by `AssocGetPerceivedType`".)
- **`Perceived.cs:120` — an unnecessary `unsafe`.** The CsWin32 friendly overload exposes no pointers; the modifier only forced `AllowUnsafeBlocks` on the assembly.
- **`Perceived.cs:26,133-157` — a lock that duplicated `ConcurrentDictionary`.** Every write already happened under `SyncObject`, so the concurrent collection bought nothing the lock didn't already provide — and the lock was held across the P/Invoke, serialising concurrent first-time lookups of *different* extensions behind one shell call.

## The fix

The whole miss path is a `GetOrAdd`. That drops the lock, the `SyncObject`, the dead initialisers, the `unsafe`, and the unreachable `??` — 48 lines out, and `GetOrAdd` still hands every caller the same instance per extension, so nothing observable about identity changes.

## The one behaviour change

`ToUpperInvariant()` also goes. `Extension` now reports what the caller wrote rather than a shouty version of it:

```
before: GetPerceivedType(".txt").Extension == ".TXT"
after:  GetPerceivedType(".txt").Extension == ".txt"
```

This matches `AddPerceived`, which has always stored the extension exactly as given — so the two paths previously disagreed and `ToString()` showed it. Lookups stay case-insensitive because the dictionary uses `StringComparer.OrdinalIgnoreCase`, and the uppercasing was doing no work for matching; it only allocated.

**If you'd rather keep the uppercasing, this one line can be dropped without touching the rest of the layer** — it's independent of the `GetOrAdd` rewrite.

## Verification

46 tests pass on `net10.0` and `net11.0` (23 each, up from 17) with `-p:TreatsWarningsAsErrors=true`. New coverage, all of it previously absent:

- `GetPerceivedType_PreservesTheExtensionAsWritten` — the casing change above.
- `GetPerceivedType_IsCaseInsensitiveAndReturnsTheSameInstance` — `.InstanceSample` and `.INSTANCESAMPLE` resolve to the *same instance*, pinning the `GetOrAdd` contract.
- `GetPerceivedType_ReturnsUnspecifiedWhenThereIsNoExtension` — `"readme"` and `""` return `Unspecified` with an empty `Extension`, documenting what actually happens where the dead `ArgumentException` used to suggest otherwise.
- `GetPerceivedType_AcceptsAFullPath` — the parameter is called `fileName`, but every existing test passed a naked extension; this pins `C:\dir.d\sub\file.txt`.
- `GetPerceivedType_Null_Throws`.

No public API change (`unsafe` is not part of the signature metadata), so `ref/` is untouched.

<sub>Found during a review of `src/Meziantou.Framework.Win32.PerceivedType`.</sub>
