### PR TITLE
Correct the documented sample output and the .class classification

### DIFF
--- a/src/Meziantou.Framework.Win32.PerceivedType/Perceived.cs
+++ b/src/Meziantou.Framework.Win32.PerceivedType/Perceived.cs
@@ -10,7 +10,7 @@ namespace Meziantou.Framework.Win32;
 /// // Get perceived type for a file
 /// var perceived = Perceived.GetPerceivedType(".txt");
 /// Console.WriteLine(perceived.PerceivedType); // Output: Text
-/// Console.WriteLine(perceived.PerceivedTypeSource); // Output: SoftCoded or HardCoded
+/// Console.WriteLine(perceived.PerceivedTypeSource); // Output: SoftCoded, NativeSupport
 ///
 /// // Add custom perceived types
 /// Perceived.AddPerceived(".myext", PerceivedType.Text);
@@ -44,7 +44,7 @@ public sealed class Perceived
         AddPerceived(".ashx", PerceivedType.Text);
         AddPerceived(".asmx", PerceivedType.Text);
         AddPerceived(".bat", PerceivedType.Text);
-        AddPerceived(".class", PerceivedType.Text);
+        AddPerceived(".class", PerceivedType.Application);
         AddPerceived(".cmd", PerceivedType.Text);
         AddPerceived(".cs", PerceivedType.Text);
         AddPerceived(".cshtml", PerceivedType.Text);
@@ -114,7 +114,7 @@ public sealed class Perceived
     public PerceivedTypeSource PerceivedTypeSource { get; }
 
     /// <summary>Gets a file's perceived type based on its extension.</summary>
-    /// <param name="fileName">The file name. May not be null..</param>
+    /// <param name="fileName">The file name. May not be null.</param>
     /// <returns>An instance of the PerceivedType type.</returns>
     [SupportedOSPlatform("windows5.1.2600")]
     public static Perceived GetPerceivedType(string fileName)

--- a/src/Meziantou.Framework.Win32.PerceivedType/readme.md
+++ b/src/Meziantou.Framework.Win32.PerceivedType/readme.md
@@ -14,7 +14,7 @@ using Meziantou.Framework.Win32;
 // Get perceived type for a file extension
 var perceived = Perceived.GetPerceivedType(".txt");
 Console.WriteLine(perceived.PerceivedType); // Text
-Console.WriteLine(perceived.PerceivedTypeSource); // SoftCoded or HardCoded
+Console.WriteLine(perceived.PerceivedTypeSource); // SoftCoded, NativeSupport
 
 // Works with various file types
 var image = Perceived.GetPerceivedType(".jpg");
@@ -41,7 +41,10 @@ Perceived.AddDefaultPerceivedTypes();
 
 ### Perceived Types
 
-The library supports the following perceived types:
+The library supports the following perceived types. Which extension maps to which type is
+decided by Windows and by the file associations registered on the machine, so the examples
+below are illustrative rather than guaranteed: an extension with no registered handler
+reports `Unspecified`.
 
 - `Text` - Text files (.txt, .cs, .html, .xml, etc.)
 - `Image` - Image files (.jpg, .png, .gif, etc.)

--- a/tests/Meziantou.Framework.Win32.PerceivedType.Tests/PerceivedTests.cs
+++ b/tests/Meziantou.Framework.Win32.PerceivedType.Tests/PerceivedTests.cs
@@ -118,4 +118,12 @@ public class PerceivedTests
     {
         Assert.Throws<ArgumentNullException>(() => Perceived.GetPerceivedType(fileName: null!));
     }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void AddDefaultPerceivedTypes_TreatsCompiledJavaClassesAsApplications()
+    {
+        Perceived.AddDefaultPerceivedTypes();
+
+        Assert.Equal(PerceivedType.Application, Perceived.GetPerceivedType("Program.class").PerceivedType);
+    }
 }


### PR DESCRIPTION
**Stack 4 of 4 · merges into `fix/perceived-simplify-lookup` · merge #2528, #2529 and #2530 first**

Four things the documentation and defaults claimed that the code doesn't produce.

## Sample output that can't happen

`readme.md:17` and the class-level `<example>` at `Perceived.cs:13` both claim `.txt` reports:

```
// SoftCoded or HardCoded
```

`PerceivedTypeSource` is a `[Flags]` enum and prints *combinations*. On a stock Windows 11 machine `.txt` actually reports:

```
SoftCoded, NativeSupport
```

The "or" is the first thing a reader meets in both the readme and IntelliSense, and it teaches the wrong mental model of the type. Corrected to the real value.

## Per-extension promises that depend on the machine

`readme.md:52` lists `Document` as covering `.pdf`. Perceived types are resolved from the associations registered on the machine — on a box with no PDF handler, `.pdf` returns `Unspecified` (verified). The lists are now introduced as illustrative, with a note that an extension with no registered handler reports `Unspecified`.

## `.class` classified as text

`Perceived.cs:44` mapped `.class` to `PerceivedType.Text`. Java `.class` files are compiled bytecode, and the same list already classifies `.dll` and `.exe` as `Application`. Changed to `Application`.

This is the only behaviour change in the layer, and it only affects callers who opt in by calling `AddDefaultPerceivedTypes()`.

## Typo

`Perceived.cs:117` — `The file name. May not be null..` had a stray second period.

## Verification

48 tests pass on `net10.0` and `net11.0` (24 each) with `-p:TreatsWarningsAsErrors=true`. `AddDefaultPerceivedTypes_TreatsCompiledJavaClassesAsApplications` covers the `.class` change; the rest is documentation.

<sub>Found during a review of `src/Meziantou.Framework.Win32.PerceivedType`.</sub>
