### PR TITLE
Obsolete PerceivedTypeSource.Mime because Windows never reports it

### DIFF
--- a/src/Meziantou.Framework.Win32.PerceivedType/PerceivedTypeSource.cs
+++ b/src/Meziantou.Framework.Win32.PerceivedType/PerceivedTypeSource.cs
@@ -26,5 +26,6 @@ public enum PerceivedTypeSource
     ZipFolder = 0x0040,
 
     /// <summary>The perceived type was determined through MIME content types in the registry.</summary>
+    [Obsolete("PERCEIVEDFLAG has no MIME value, so AssocGetPerceivedType never reports this source.")]
     Mime = 0x0080,
 }

--- a/src/Meziantou.Framework.Win32.PerceivedType/readme.md
+++ b/src/Meziantou.Framework.Win32.PerceivedType/readme.md
@@ -68,7 +68,9 @@ The `PerceivedTypeSource` enum indicates where the perceived type information co
 - `GdiPlus` - Supported by GDI+
 - `WmSdk` - Supported by Windows Media SDK
 - `ZipFolder` - Supported by Windows compressed folders
-- `Mime` - Determined through MIME content types
+
+`Mime` is also declared, but `PERCEIVEDFLAG` has no MIME value, so Windows never reports it.
+It is obsolete and kept only so the enum stays source and binary compatible.
 
 ## Platform Support
 


### PR DESCRIPTION
**Independent — merges into `main` in any order, no relation to the #2528–#2531 stack.**

## The problem

`PerceivedTypeSource.cs:28-29` declares:

```csharp
/// <summary>The perceived type was determined through MIME content types in the registry.</summary>
Mime = 0x0080,
```

`PERCEIVEDFLAG` has no MIME value. The [`AssocGetPerceivedType` documentation](https://learn.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-assocgetperceivedtype) enumerates it as `UNDEFINED` (0x0000) through `ZIPFOLDER` (0x0040), and the official Win32 metadata declares exactly those seven members and no more:

```
PERCEIVEDFLAG_UNDEFINED      PERCEIVEDFLAG_GDIPLUS
PERCEIVEDFLAG_SOFTCODED      PERCEIVEDFLAG_WMSDK
PERCEIVEDFLAG_HARDCODED      PERCEIVEDFLAG_ZIPFOLDER
PERCEIVEDFLAG_NATIVESUPPORT
```

<sub>Source: <code>Windows.Win32.winmd</code> from <code>microsoft.windows.sdk.win32metadata</code> 70.0.11-preview, the metadata CsWin32 generates this project's bindings from.</sub>

Nothing validates the mapping on our side either: CsWin32 surfaces `pflag` as a raw `uint`, and `Perceived.cs` casts it straight to `PerceivedTypeSource`. So `AssocGetPerceivedType` cannot return `0x0080`, and a caller writing `if (source.HasFlag(PerceivedTypeSource.Mime))` has written unreachable code against published API.

## The fix

Mark the member `[Obsolete]` rather than removing it. This is a shipped `[Flags]` enum at v3.0.0 and dropping a member would be a source *and* binary breaking change for a value that costs nothing to keep. The readme entry becomes a note explaining why it's still there.

## Verification

20 tests pass on `net10.0` and `net11.0` with `-p:TreatsWarningsAsErrors=true`. Nothing in the project references `Mime`, so the obsoletion introduces no warnings.

This is an annotation and documentation change with no behaviour change, so there is nothing new to assert in the tests.

`ref/Meziantou.Framework.Win32.PerceivedType.cs` is deliberately unchanged: regenerating it with `-p:IsOfficialBuild=true` produces byte-identical API content, because the public API generator does not record `ObsoleteAttribute`.

<sub>Found during a review of `src/Meziantou.Framework.Win32.PerceivedType`.</sub>
