### PR TITLE
Mark Meziantou.Framework.Win32.CredentialManager as trimmable

### DIFF
--- a/src/Meziantou.Framework.Win32.CredentialManager/Meziantou.Framework.Win32.CredentialManager.csproj
+++ b/src/Meziantou.Framework.Win32.CredentialManager/Meziantou.Framework.Win32.CredentialManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
-    <IsTrimmable>false</IsTrimmable>
+    <IsTrimmable>true</IsTrimmable>
     <Description>C# wrapper around CredWrite/CredRead/CredDelete/CredUIPromptForWindowsCredentials/CredUICmdLinePromptForCredentials functions to store and retrieve from Windows Credential Store</Description>
     <RootNamespace>Meziantou.Framework.Win32</RootNamespace>
     <Version>3.0.1</Version>

--- a/tests/Trimmable/Trimmable.csproj
+++ b/tests/Trimmable/Trimmable.csproj
@@ -72,6 +72,7 @@
     <ProjectReference Include="..\..\src\Meziantou.Framework.ValueStopwatch\Meziantou.Framework.ValueStopwatch.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.Framework.ValueStringBuilder\Meziantou.Framework.ValueStringBuilder.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.Framework.Versioning\Meziantou.Framework.Versioning.csproj" />
+    <ProjectReference Include="..\..\src\Meziantou.Framework.Win32.CredentialManager\Meziantou.Framework.Win32.CredentialManager.csproj" />
     <ProjectReference Include="..\..\src\Meziantou.Framework.Yaml\Meziantou.Framework.Yaml.csproj" />
   </ItemGroup>
 
@@ -136,6 +137,7 @@
     <TrimmerRootAssembly Include="Meziantou.Framework.ValueStopwatch" />
     <TrimmerRootAssembly Include="Meziantou.Framework.ValueStringBuilder" />
     <TrimmerRootAssembly Include="Meziantou.Framework.Versioning" />
+    <TrimmerRootAssembly Include="Meziantou.Framework.Win32.CredentialManager" />
     <TrimmerRootAssembly Include="Meziantou.Framework.Yaml" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
`Meziantou.Framework.Win32.CredentialManager` was the only reason this package could not be trimmed:

```xml
<IsTrimmable>false</IsTrimmable>
```

Nothing in the library justifies it. There is no reflection, no serialization and no dynamic type loading — CsWin32 emits plain `DllImport` declarations, which the trimmer handles. The setting looks like a leftover from when the package still targeted .NET Framework and older `netstandard` TFMs, before b784ed51.

Consumers who publish self-contained or trimmed applications currently pay for that with a larger output than necessary.

## What changed

- `IsTrimmable` set to `true`.
- `dotnet run ./eng/update-all.cs -- --step trimmable` enrolled the project in the trim harness, adding the `ProjectReference` and `TrimmerRootAssembly` entries to `tests/Trimmable/Trimmable.csproj`. Re-running the step afterwards reports no further changes.

Same shape as #2437, which did this for `Meziantou.Framework.FullPath`.

## Verification

```
dotnet publish tests/Trimmable/Trimmable.csproj -p:TreatsWarningsAsErrors=true
```

Exit code 0, and **no `IL2xxx` trim warnings**. That project sets `TrimMode=full` and `TrimmerSingleWarn=false`, so with warnings as errors any trim incompatibility in the newly rooted assembly would have failed the publish.

`dotnet test -p:TreatsWarningsAsErrors=true` on the package's own tests — 13 per TFM, 26 total, 0 failed, 0 skipped.

This answers an open question from a review of the project rather than a defect found in it.
