### PR TITLE
Split the OpenFolderDialog readme sample into compilable blocks

### DIFF
--- a/src/Meziantou.Framework.Win32.Dialogs/readme.md
+++ b/src/Meziantou.Framework.Win32.Dialogs/readme.md
@@ -16,18 +16,24 @@ This library provides an `OpenFolderDialog` class that uses the native Windows I
 
 ## Usage
 
+Basic usage:
+
 ````c#
 using Meziantou.Framework.Win32;
 
-// Basic usage
 var dialog = new OpenFolderDialog();
 var result = dialog.ShowDialog();
 if (result == DialogResult.OK)
 {
     Console.WriteLine($"Selected folder: {dialog.SelectedPath}");
 }
+````
 
-// Advanced usage with all options
+Advanced usage with all options:
+
+````c#
+using Meziantou.Framework.Win32;
+
 var dialog = new OpenFolderDialog
 {
     Title = "Select a folder",
@@ -41,14 +47,19 @@ if (result == DialogResult.OK)
 {
     Console.WriteLine($"Selected folder: {dialog.SelectedPath}");
 }
+````
 
-// Show dialog with owner window (WPF example)
+Show the dialog with an owner window (WPF example):
+
+````c#
+using Meziantou.Framework.Win32;
+
 var dialog = new OpenFolderDialog
 {
     Title = "Sample Open Folder dialog",
     OkButtonLabel = "Select Folder"
 };
+
 var hwnd = new System.Windows.Interop.WindowInteropHelper(this).Handle;
 var result = dialog.ShowDialog(hwnd);
 ````
-


### PR DESCRIPTION
The usage section of the package readme was a single fenced block that declared `var dialog` and `var result` three times in the same scope, so pasting it as shown produces CS0128. This is the NuGet readme, so it is the first thing a new consumer reads and the most likely thing they copy.

Split it into three blocks, one per scenario, each with the `using` it needs.

Documentation only, no code change.

*Found by a project review of `src/Meziantou.Framework.Win32.Dialogs`.*
