### PR TITLE
Document which DialogResult values ShowDialog can actually return

### DIFF
--- a/src/Meziantou.Framework.Win32.Dialogs/DialogResult.cs
+++ b/src/Meziantou.Framework.Win32.Dialogs/DialogResult.cs
@@ -3,6 +3,14 @@ using System.Runtime.InteropServices;
 namespace Meziantou.Framework.Win32;
 
 /// <summary>Specifies identifiers to indicate the return value of a dialog box.</summary>
+/// <remarks>
+/// This enumeration mirrors the full set of dialog box return values for familiarity, but
+/// <see cref="OpenFolderDialog.ShowDialog()"/> only ever returns <see cref="OK"/>,
+/// <see cref="Cancel"/>, or <see cref="Abort"/>. The remaining values are never produced by
+/// this library, so a <see langword="switch"/> over them does not need arms for
+/// <see cref="None"/>, <see cref="Retry"/>, <see cref="Ignore"/>, <see cref="Yes"/>, or
+/// <see cref="No"/>.
+/// </remarks>
 [ComVisible(true)]
 public enum DialogResult
 {


### PR DESCRIPTION
`DialogResult` declares the full WinForms-style set of eight values, but `OpenFolderDialog.ShowDialog` only ever returns `OK`, `Cancel` or `Abort`, and nothing else in the package consumes the type. The other five are unreachable, so a consumer writing an exhaustive `switch` writes five dead arms with no way to tell which are real.

Adds a `<remarks>` to the enum naming the three values that actually occur. Documenting rather than trimming the enum, since removing members would be binary breaking for no functional gain.

Verified: builds clean on `net10.0` and `net11.0` with `TreatWarningsAsErrors=true`; the `ref/` API baseline is unchanged (XML docs are not part of it).

*Found by a project review of `src/Meziantou.Framework.Win32.Dialogs`.*
