### PR TITLE
Remove trailing whitespace from the OpenFolderDialog doc comments

### DIFF
--- a/src/Meziantou.Framework.Win32.Dialogs/OpenFolderDialog.cs
+++ b/src/Meziantou.Framework.Win32.Dialogs/OpenFolderDialog.cs
@@ -14,7 +14,7 @@ namespace Meziantou.Framework.Win32;
 ///     InitialDirectory = @"C:\Users",
 ///     OkButtonLabel = "Select Folder"
 /// };
-/// 
+///
 /// if (dialog.ShowDialog() == DialogResult.OK)
 /// {
 ///     Console.WriteLine($"Selected folder: {dialog.SelectedPath}");
@@ -71,7 +71,7 @@ public sealed class OpenFolderDialog
 
     /// <summary>Gets or sets a value indicating whether to change the current working directory to the selected folder.</summary>
     /// <value>
-    /// <see langword="true"/> to change the current directory to the selected folder; 
+    /// <see langword="true"/> to change the current directory to the selected folder;
     /// <see langword="false"/> to preserve the current working directory. The default is <see langword="false"/>.
     /// </value>
     public bool ChangeCurrentDirectory { get; set; }


### PR DESCRIPTION
`AGENTS.md` states there should be no trailing whitespace in any lines. Two XML documentation lines in `OpenFolderDialog.cs` (17 and 74) ended with a trailing space.

Whitespace only, inside comments — no code change.

Verified: builds clean on `net10.0` and `net11.0` with `TreatWarningsAsErrors=true`.

*Found by a project review of `src/Meziantou.Framework.Win32.Dialogs`.*
