### PR TITLE
Fall back to the default folder when InitialDirectory cannot be resolved

### DIFF
--- a/Meziantou.Framework.slnx
+++ b/Meziantou.Framework.slnx
@@ -276,6 +276,7 @@
     <Project Path="tests/Meziantou.Framework.Win32.AmsiTests/Meziantou.Framework.Win32.AmsiTests.csproj" />
     <Project Path="tests/Meziantou.Framework.Win32.ChangeJournal.Tests/Meziantou.Framework.Win32.ChangeJournal.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.Win32.CredentialManager.Tests/Meziantou.Framework.Win32.CredentialManager.Tests.csproj" />
+    <Project Path="tests/Meziantou.Framework.Win32.Dialogs.Tests/Meziantou.Framework.Win32.Dialogs.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.Win32.Jobs.Tests/Meziantou.Framework.Win32.Jobs.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.Win32.Lsa.Tests/Meziantou.Framework.Win32.Lsa.Tests.csproj" />
     <Project Path="tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests.csproj" Id="32b027e9-ec12-4d92-81ba-21ee158a24ec" />

--- a/slnx/Meziantou.Framework.Win32.Dialogs.slnx
+++ b/slnx/Meziantou.Framework.Win32.Dialogs.slnx
@@ -2,4 +2,7 @@
   <Folder Name="/src/">
     <Project Path="../src/Meziantou.Framework.Win32.Dialogs/Meziantou.Framework.Win32.Dialogs.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="../tests/Meziantou.Framework.Win32.Dialogs.Tests/Meziantou.Framework.Win32.Dialogs.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/src/Meziantou.Framework.Win32.Dialogs/Meziantou.Framework.Win32.Dialogs.csproj
+++ b/src/Meziantou.Framework.Win32.Dialogs/Meziantou.Framework.Win32.Dialogs.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Meziantou.Framework.Win32.Dialogs.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.298">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Meziantou.Framework.Win32.Dialogs/Natives/NativeMethods.cs
+++ b/src/Meziantou.Framework.Win32.Dialogs/Natives/NativeMethods.cs
@@ -5,6 +5,5 @@ internal static class NativeMethods
 #pragma warning disable IDE1006 // Naming Styles
     internal const int S_OK = 0x00000000;
     internal const int ERROR_CANCELLED = unchecked((int)0x800704C7);
-    internal const int FILE_NOT_FOUND = unchecked((int)0x80070002);
 #pragma warning restore IDE1006 // Naming Styles
 }

--- a/src/Meziantou.Framework.Win32.Dialogs/OpenFolderDialog.cs
+++ b/src/Meziantou.Framework.Win32.Dialogs/OpenFolderDialog.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Runtime.Versioning;
 using Meziantou.Framework.Win32.Natives;
 using Windows.Win32;
@@ -64,6 +63,13 @@ public sealed class OpenFolderDialog
     public string? OkButtonLabel { get; set; }
 
     /// <summary>Gets or sets the initial directory to display when the dialog opens.</summary>
+    /// <remarks>
+    /// The value is resolved by the Windows shell, so it accepts a file system path as well as a
+    /// shell location such as <c>shell:Downloads</c>. A path that uses <c>/</c> as a separator is
+    /// normalized before being resolved. When the value cannot be resolved — it does not exist, it
+    /// is malformed, or it names a drive that is not currently mounted — it is ignored and the
+    /// dialog opens on the folder the shell would have chosen by default.
+    /// </remarks>
     public string? InitialDirectory { get; set; }
 
     /// <summary>Gets the path of the folder selected by the user. This property is populated after <see cref="ShowDialog()"/> returns <see cref="DialogResult.OK"/>.</summary>
@@ -78,24 +84,14 @@ public sealed class OpenFolderDialog
 
     private void Configure(IFileOpenDialog dialog)
     {
-        dialog.SetOptions(CreateOptions());
+        dialog.SetOptions(CreateOptions(ChangeCurrentDirectory));
 
         if (!string.IsNullOrEmpty(InitialDirectory))
         {
-            var result = PInvoke.SHCreateItemFromParsingName(InitialDirectory, null, out IShellItem? shellItem);
-            switch ((int)result)
+            var shellItem = TryCreateShellItem(InitialDirectory);
+            if (shellItem is not null)
             {
-                case NativeMethods.S_OK:
-                    if (shellItem is not null)
-                    {
-                        dialog.SetFolder(shellItem);
-                    }
-
-                    break;
-                case NativeMethods.FILE_NOT_FOUND:
-                    break;
-                default:
-                    throw new Win32Exception((int)result);
+                dialog.SetFolder(shellItem);
             }
         }
 
@@ -110,10 +106,49 @@ public sealed class OpenFolderDialog
         }
     }
 
-    private FOS CreateOptions()
+    /// <summary>Resolves a path or shell location to a shell item, or <see langword="null"/> when the shell cannot parse it.</summary>
+    internal static IShellItem? TryCreateShellItem(string path)
+    {
+        if (TryParse(path, out var shellItem))
+        {
+            return shellItem;
+        }
+
+        // The shell parser only accepts the canonical Windows form. "C:/Users" names an existing
+        // directory as far as .NET is concerned but the shell rejects it, so retry once normalized.
+        if (TryGetFullPath(path, out var fullPath) && !string.Equals(fullPath, path, StringComparison.Ordinal) && TryParse(fullPath, out shellItem))
+        {
+            return shellItem;
+        }
+
+        return null;
+
+        static bool TryParse(string value, [NotNullWhen(true)] out IShellItem? item)
+        {
+            var hr = PInvoke.SHCreateItemFromParsingName(value, null, out IShellItem? result);
+            item = (int)hr == NativeMethods.S_OK ? result : null;
+            return item is not null;
+        }
+
+        static bool TryGetFullPath(string value, [NotNullWhen(true)] out string? fullPath)
+        {
+            try
+            {
+                fullPath = Path.GetFullPath(value);
+                return true;
+            }
+            catch (Exception exception) when (exception is ArgumentException or NotSupportedException or PathTooLongException)
+            {
+                fullPath = null;
+                return false;
+            }
+        }
+    }
+
+    internal static FOS CreateOptions(bool changeCurrentDirectory)
     {
         var result = FOS.FOS_FORCEFILESYSTEM | FOS.FOS_PICKFOLDERS;
-        if (!ChangeCurrentDirectory)
+        if (!changeCurrentDirectory)
         {
             result |= FOS.FOS_NOCHANGEDIR;
         }

--- a/tests/Meziantou.Framework.Win32.Dialogs.Tests/Meziantou.Framework.Win32.Dialogs.Tests.csproj
+++ b/tests/Meziantou.Framework.Win32.Dialogs.Tests/Meziantou.Framework.Win32.Dialogs.Tests.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Meziantou.NET.Sdk.Test">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- All the tests are skipped on non-Windows operating systems -->
+    <MinimumExpectedTests>0</MinimumExpectedTests>
+    <RootNamespace>Meziantou.Framework.Win32.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Meziantou.Framework.Win32.Dialogs/Meziantou.Framework.Win32.Dialogs.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Meziantou.Framework.Win32.Dialogs.Tests/OpenFolderDialogTests.cs
+++ b/tests/Meziantou.Framework.Win32.Dialogs.Tests/OpenFolderDialogTests.cs
@@ -1,0 +1,84 @@
+using Meziantou.Framework.Win32.Natives;
+using Meziantou.Xunit;
+
+namespace Meziantou.Framework.Win32.Tests;
+
+public class OpenFolderDialogTests
+{
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void CreateOptions_PreservesCurrentDirectoryByDefault()
+    {
+        var options = OpenFolderDialog.CreateOptions(changeCurrentDirectory: false);
+
+        Assert.Equal(FOS.FOS_FORCEFILESYSTEM | FOS.FOS_PICKFOLDERS | FOS.FOS_NOCHANGEDIR, options);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void CreateOptions_AllowsChangingCurrentDirectory()
+    {
+        var options = OpenFolderDialog.CreateOptions(changeCurrentDirectory: true);
+
+        Assert.Equal(FOS.FOS_FORCEFILESYSTEM | FOS.FOS_PICKFOLDERS, options);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void TryCreateShellItem_ResolvesAnExistingDirectory()
+    {
+        var directory = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+
+        var item = OpenFolderDialog.TryCreateShellItem(directory);
+
+        Assert.NotNull(item);
+        Assert.Equal(directory, GetFileSystemPath(item), ignoreCase: true);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void TryCreateShellItem_ResolvesADirectoryWrittenWithForwardSlashes()
+    {
+        // The shell parser rejects "C:/Windows" with E_INVALIDARG even though Directory.Exists
+        // returns true for it, so the value has to be normalized before it is resolved.
+        var directory = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        var forwardSlashes = directory.Replace('\\', '/');
+
+        var item = OpenFolderDialog.TryCreateShellItem(forwardSlashes);
+
+        Assert.NotNull(item);
+        Assert.Equal(directory, GetFileSystemPath(item), ignoreCase: true);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void TryCreateShellItem_ReturnsNullForADriveThatIsNotMounted()
+    {
+        var mounted = DriveInfo.GetDrives().Select(drive => char.ToUpperInvariant(drive.Name[0])).ToHashSet();
+        var letter = "ZYXWVU".FirstOrDefault(candidate => !mounted.Contains(candidate));
+        global::Xunit.Assert.SkipWhen(letter is '\0', "Every candidate drive letter is in use on this machine");
+
+        Assert.Null(OpenFolderDialog.TryCreateShellItem($@"{letter}:\some\folder"));
+    }
+
+    [Theory, RunIf(TestOperatingSystems.Windows)]
+    [InlineData(@"C:\this-directory-does-not-exist")]
+    [InlineData(@"C:\this-directory\does-not\exist")]
+    [InlineData(@"C:\invalid|character")]
+    [InlineData("   ")]
+    public void TryCreateShellItem_ReturnsNullForAnUnresolvableValue(string path)
+    {
+        Assert.Null(OpenFolderDialog.TryCreateShellItem(path));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void TryCreateShellItem_ResolvesAShellLocation()
+    {
+        // "This PC" is not a file system path, so it only resolves because the value goes through
+        // the shell namespace parser rather than a path parser.
+        var item = OpenFolderDialog.TryCreateShellItem("::{20D04FE0-3AEA-1069-A2D8-08002B30309D}");
+
+        Assert.NotNull(item);
+    }
+
+    private static string GetFileSystemPath(IShellItem item)
+    {
+        item.GetDisplayName(SIGDN.SIGDN_FILESYSPATH, out var path);
+        return path;
+    }
+}


### PR DESCRIPTION
**Stack 1 of 3 · merges into `main` · must merge before #2539 and #2540.**

`Configure` only handled `S_OK` and `ERROR_FILE_NOT_FOUND` from `SHCreateItemFromParsingName` and threw a `Win32Exception` for everything else, so `ShowDialog` threw before the dialog appeared for values that are perfectly valid to .NET. Measured against the real API:

| `InitialDirectory` | HRESULT | Before |
|---|---|---|
| `C:\Windows` | `0x00000000` | works |
| `C:\nonexistent\deeper\still` | `0x80070002` | falls back — handled |
| `C:/Windows` (forward slashes) | `0x80070057` | **throws** |
| `Z:\somewhere` (drive not mounted) | `0x8007000F` | **throws** |
| `\no-such-host\share` | `0x80070057` | **throws** |
| `"   "` | `0x80070057` | **throws** |

The forward-slash case cannot be defended against by validating first: `Directory.Exists("C:/Windows")` returns `true` and `Path.GetFullPath("C:/Windows")` returns `C:\Windows`, so the path is valid by every .NET measure and `ShowDialog()` still throws.

Both throwing cases are the normal lifecycle of restoring a remembered folder — a saved path that used forward slashes, or one on a USB stick or mapped drive that is not connected this session. A missing folder was already treated as recoverable, so a missing drive should be too.

### What changed

`TryCreateShellItem` resolves the value, retrying once with a normalized path so the forward-slash form works, and returns `null` for anything the shell cannot parse so the dialog opens on the shell default. The `Win32Exception` was also being constructed from an HRESULT where a Win32 error code was expected, leaving `NativeErrorCode` meaningless (`-2147024881` instead of `15`); that path is gone entirely.

Also adds `tests/Meziantou.Framework.Win32.Dialogs.Tests`, which the library did not have — 112 of the 135 projects under `src/` have a matching test project and this was one of the 23 without.

### Verification

- 10 tests, passing on `net10.0` and `net11.0`; build clean with `TreatWarningsAsErrors=true`.
- Mutation-checked the fix: disabling the normalization retry fails exactly `TryCreateShellItem_ResolvesADirectoryWrittenWithForwardSlashes` and nothing else, so the test is a real regression test.
- The tests drive the live shell (`SHCreateItemFromParsingName`) without displaying any dialog.

*Found by a project review of `src/Meziantou.Framework.Win32.Dialogs`.*
