### PR TITLE
Report an unknown zone instead of Restricted for paths at MAX_PATH

### DIFF
--- a/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
+++ b/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
@@ -46,7 +46,7 @@ public static class MarkOfTheWeb
 
     /// <summary>Gets the security zone of a file using the Windows Security Manager COM API.</summary>
     /// <param name="filePath">The path to the file to query.</param>
-    /// <returns>The <see cref="UrlZone"/> of the file, or <see cref="UrlZone.Invalid"/> if the zone cannot be determined.</returns>
+    /// <returns>The <see cref="UrlZone"/> of the file, or <see cref="UrlZone.Invalid"/> if the zone cannot be determined, which includes a full path of 260 characters or more.</returns>
     [SupportedOSPlatform("windows")]
     public static UrlZone GetFileZone(string filePath)
     {
@@ -56,6 +56,8 @@ public static class MarkOfTheWeb
             return UrlZone.Invalid;
 
         filePath = Path.GetFullPath(filePath);
+        if (filePath.Length >= MaxPathLength)
+            return UrlZone.Invalid;
 
         try
         {
@@ -161,7 +163,8 @@ public static class MarkOfTheWeb
     /// Files outside of the Local Machine, Trusted, and Intranet zones are considered untrusted.
     /// </summary>
     /// <param name="filePath">The path to the file to check.</param>
-    /// <returns><see langword="true"/> if the file is from an untrusted zone (Internet or Restricted); otherwise, <see langword="false"/>.</returns>
+    /// <returns><see langword="true"/> if the file is from an untrusted zone (Internet or Restricted), or if its zone cannot be determined; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>Returns <see langword="true"/> when the full path is 260 characters or more, because the zone of such a file cannot be read.</remarks>
     [SupportedOSPlatform("windows")]
     public static bool IsUntrusted(string filePath)
     {
@@ -171,6 +174,11 @@ public static class MarkOfTheWeb
             return false;
 
         filePath = Path.GetFullPath(filePath);
+
+        // The zone cannot be read for such a path, so report the file as untrusted rather than
+        // vouching for it. Same choice as when the security manager cannot be created below.
+        if (filePath.Length >= MaxPathLength)
+            return true;
 
         var hr = PInvoke.CoInternetCreateSecurityManager(pSP: null, out var securityManager, dwReserved: 0);
         if (hr.Failed || securityManager is null)
@@ -194,4 +202,11 @@ public static class MarkOfTheWeb
             Marshal.ReleaseComObject(securityManager);
         }
     }
+
+    // MapUrlToZone stops reading the file once the path reaches MAX_PATH and answers
+    // URLZONE_UNTRUSTED, so the zone it reports for a longer path was never read from the file at
+    // all -- an unmarked local file comes back as Restricted. Neither the extended-length form nor a
+    // file URL avoids this: urlmon rejects the former outright and the latter loses the mark on
+    // names that are not pure ASCII, so the only honest answer is that the zone is unknown.
+    private const int MaxPathLength = 260;
 }

--- a/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
+++ b/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
@@ -266,4 +266,65 @@ public sealed class MarkOfTheWebTests
             File.Delete(path);
         }
     }
+
+    // MapUrlToZone answers URLZONE_UNTRUSTED for any path of MAX_PATH characters or more without
+    // reading the file, so an unmarked local file used to be reported as Restricted and untrusted.
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetFileZone_ReturnsInvalid_WhenThePathReachesMaxPath()
+    {
+        var directory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+        try
+        {
+            var path = CreateFileWithPathLength(directory, length: 260);
+
+            Assert.Equal(UrlZone.Invalid, MarkOfTheWeb.GetFileZone(path));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void IsUntrusted_ReturnsTrue_WhenThePathReachesMaxPath()
+    {
+        var directory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+        try
+        {
+            var path = CreateFileWithPathLength(directory, length: 260);
+
+            Assert.True(MarkOfTheWeb.IsUntrusted(path));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetFileZone_StillResolvesTheZone_JustBelowMaxPath()
+    {
+        var directory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+        try
+        {
+            var path = CreateFileWithPathLength(directory, length: 259);
+
+            Assert.Equal(UrlZone.LocalMachine, MarkOfTheWeb.GetFileZone(path));
+            Assert.False(MarkOfTheWeb.IsUntrusted(path));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    private static string CreateFileWithPathLength(DirectoryInfo directory, int length)
+    {
+        var name = new string('a', length - directory.FullName.Length - 1 - ".txt".Length) + ".txt";
+        var path = Path.Combine(directory.FullName, name);
+        Assert.HasCount(length, path);
+
+        File.WriteAllText(path, "");
+        return path;
+    }
 }


### PR DESCRIPTION
> **Stack 5 of 8** · merges into `fix/motw-exception-contracts` (#2524)

## The problem

`MapUrlToZone` stops reading the file once the path reaches `MAX_PATH` and answers `URLZONE_UNTRUSTED`. The zone reported for a longer path was therefore never read from the file at all. Measured, on freshly created local files:

```
len= 258 zone=Internet       (marked)
len= 259 zone=Internet       (marked)
len= 260 zone=Untrusted      <== boundary, exactly MAX_PATH
len= 261 zone=Untrusted
```

Both directions are wrong: an **unmarked** local file at 284 characters came back `Untrusted` / `IsUntrusted == true`, and a file genuinely marked `Internet` came back `Untrusted` (4) rather than `Internet` (3). .NET enables long paths on modern Windows, so callers legitimately hold such paths.

## What I tried first, and why it isn't in this PR

My review suggested normalizing the path. Both candidate forms were implemented and measured, and both are worse:

| Approach | Result |
|---|---|
| `\\?\` extended-length prefix | urlmon rejects it outright — `ArgumentException` (`E_INVALIDARG`) out of `MapUrlToZone`. `IsUntrusted` has no catch, so it crashes. |
| `file://` URL via `new Uri(path).AbsoluteUri` | Does **not** fix long paths — still `Untrusted` at 294 characters. And it regresses non-ASCII names: a marked `café.txt` that correctly reads `Internet` today reads back `LocalMachine` / `untrusted=false`. A silently *lost* mark is the worst possible direction. |

urlmon simply cannot resolve a zone for a path at or beyond `MAX_PATH`.

## What changed

`GetFileZone` returns `UrlZone.Invalid` when the full path is 260 characters or more — which is what its contract already documents for a zone it cannot determine — rather than a zone it fabricated.

`IsUntrusted` returns `true` for the same paths. That is the existing behavior, now deliberate and documented: it matches the fail-closed choice the method already makes when the security manager cannot be created. The false positive on unmarked long-path files remains, and is the honest answer while the zone is unreadable — fixing it properly would mean parsing `Zone.Identifier` directly and reimplementing the saved-file check.

## Verification

`dotnet test -p:TreatWarningsAsErrors=true` — 58/58 pass on `net10.0` and `net11.0`.

New tests pin all three sides of the boundary: `GetFileZone` returns `Invalid` at exactly 260, `IsUntrusted` returns `true` at 260, and both still resolve normally at 259.
