### PR TITLE
Throw from IsUntrusted when the path is not an existing file

### DIFF
--- a/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
+++ b/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
@@ -162,13 +162,16 @@ public static class MarkOfTheWeb
     /// </summary>
     /// <param name="filePath">The path to the file to check.</param>
     /// <returns><see langword="true"/> if the file is from an untrusted zone (Internet or Restricted); otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="FileNotFoundException"><paramref name="filePath"/> does not point to an existing file. A directory is not a file.</exception>
     [SupportedOSPlatform("windows")]
     public static bool IsUntrusted(string filePath)
     {
         ArgumentNullException.ThrowIfNull(filePath);
 
+        // Answering "not untrusted" for a path that was never examined would let a typo pass a gate
+        // written as: if (MarkOfTheWeb.IsUntrusted(path)) return;
         if (!File.Exists(filePath))
-            return false;
+            throw new FileNotFoundException("File not found", filePath);
 
         filePath = Path.GetFullPath(filePath);
 

--- a/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
+++ b/tests/Meziantou.Framework.Win32.MarkOfTheWeb.Tests/MarkOfTheWebTests.cs
@@ -266,4 +266,34 @@ public sealed class MarkOfTheWebTests
             File.Delete(path);
         }
     }
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void IsUntrusted_Throws_WhenTheFileDoesNotExist()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".txt");
+
+        Assert.Throws<FileNotFoundException>(() => MarkOfTheWeb.IsUntrusted(path));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void IsUntrusted_Throws_WhenThePathIsADirectory()
+    {
+        var directory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+        try
+        {
+            Assert.Throws<FileNotFoundException>(() => MarkOfTheWeb.IsUntrusted(directory.FullName));
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void GetFileZone_ReturnsInvalid_WhenTheFileDoesNotExist()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".txt");
+
+        Assert.Equal(UrlZone.Invalid, MarkOfTheWeb.GetFileZone(path));
+    }
+
 }


### PR DESCRIPTION
> **Stack 5 of 7** · merges into `fix/motw-exception-contracts` (#2524)

## The problem

`IsUntrusted` guarded with `File.Exists`, which is false for a directory and for a missing file — and then returned `false`, i.e. "not untrusted", for a path it never examined ([`MarkOfTheWeb.cs:139-140`](https://github.com/meziantou/Meziantou.Framework/blob/main/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs#L139-L140)):

```
IsUntrusted(<a directory>)   => false
IsUntrusted(<missing file>)  => false
```

The method reads as a gate:

```csharp
if (MarkOfTheWeb.IsUntrusted(path))
    return;   // a typo'd or stale path sails straight through
```

This also sat oddly next to [`:146`](https://github.com/meziantou/Meziantou.Framework/blob/main/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs#L146), where the same method deliberately returns `true` when it cannot determine the answer. The two failure paths disagreed about which way to fail.

## What changed

`IsUntrusted` throws `FileNotFoundException` when `filePath` is not an existing file. A directory is not a file, so that throws too — documented on the `<exception>` tag.

This is a **behavior change**. Callers that previously passed a missing path and got `false` now get an exception. That is the point: the old answer was indistinguishable from a genuine "this file is fine".

`GetFileZone` is deliberately left alone — returning `UrlZone.Invalid` there is consistent with its own documented contract, and a test now pins that.

## What this does not fix

There is still a TOCTOU window between the `File.Exists` probe and `MapUrlToZone`: a file deleted in that window is reported trusted rather than erroring. Closing it properly means holding a handle across both calls, which is a larger change than this one.

## Verification

`dotnet test -p:TreatWarningsAsErrors=true` — 58/58 pass on `net10.0` and `net11.0`.

New tests: `IsUntrusted` throws for a missing file and for a directory; `GetFileZone` still returns `Invalid` for a missing file.
