### PR TITLE
Narrow the catch-all in MarkOfTheWeb.GetFileZone

### DIFF
--- a/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
+++ b/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
@@ -73,9 +73,10 @@ public static class MarkOfTheWeb
                 Marshal.ReleaseComObject(securityManager);
             }
         }
-        catch
+        catch (Exception exception) when (exception is COMException or ArgumentException or PlatformNotSupportedException)
         {
-            // Ignore errors
+            // The security manager could not answer for this path. Anything else is a real failure
+            // and is left to propagate rather than being reported as an undeterminable zone.
         }
 
         return UrlZone.Invalid;


### PR DESCRIPTION
> **Stack 6 of 7** · merges into `fix/motw-fail-open` (#2543)

## The problem

`GetFileZone` wrapped its whole body in a bare `catch` ([`MarkOfTheWeb.cs:73-76`](https://github.com/meziantou/Meziantou.Framework/blob/main/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs#L73-L76)):

```csharp
catch
{
    // Ignore errors
}
```

Every failure — a urlmon rejection, a `Marshal.ReleaseComObject` `PlatformNotSupportedException` under disabled built-in COM, or a genuine bug introduced later in the method — was flattened into `UrlZone.Invalid`. A caller cannot tell "Windows could not resolve this path" from "this method is broken", and neither can whoever debugs it.

`IsUntrusted` has no such catch, so the two methods disagreed on whether a COM failure is an exception or a return value. This PR does not remove that asymmetry — `IsUntrusted` still propagates, which is the right call for a security check — it just stops `GetFileZone` from hiding everything.

## What changed

The catch filters on `COMException`, `ArgumentException` and `PlatformNotSupportedException`. Anything else propagates.

`ArgumentException` is in the list on evidence rather than speculation: urlmon returns `E_INVALIDARG` for URLs it cannot parse, and CsWin32 marshals that to `ArgumentException`. Observed directly: passing an extended-length `\\?\` path to `MapUrlToZone` produces exactly that, and it propagated straight out of `IsUntrusted`, which has no catch.

## No new tests

I could not find an input reachable through the public API that makes `MapUrlToZone` throw — the `File.Exists` guard rejects the extended-length form before it gets that far — so there is nothing honest to assert here beyond the existing suite continuing to pass. The value of the change is diagnostic: a future bug in this method now surfaces instead of being reported as an undeterminable zone. Flagging that explicitly rather than adding a test that only exercises the happy path.

## Verification

`dotnet test -p:TreatWarningsAsErrors=true` — 58/58 pass on `net10.0` and `net11.0`.
