### PR TITLE
Mark the whole MarkOfTheWeb class as Windows-only

### DIFF
--- a/ref/Meziantou.Framework.Win32.MarkOfTheWeb.cs
+++ b/ref/Meziantou.Framework.Win32.MarkOfTheWeb.cs
@@ -4,14 +4,13 @@
 
 namespace Meziantou.Framework.Win32
 {
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
     public static class MarkOfTheWeb
     {
         public static void RemoveFileZone(string filePath) { }
-        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
         public static Meziantou.Framework.Win32.UrlZone GetFileZone(string filePath) => throw null;
         public static string? GetFileZoneContent(string filePath) => throw null;
         public static void SetFileZone(string filePath, Meziantou.Framework.Win32.UrlZone zone, string? referrerUrl = null, string? hostUrl = null) { }
-        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
         public static bool IsUntrusted(string filePath) => throw null;
     }
 

--- a/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
+++ b/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs
@@ -23,6 +23,7 @@ namespace Meziantou.Framework.Win32;
 /// MarkOfTheWeb.RemoveFileZone(path);
 /// </code>
 /// </example>
+[SupportedOSPlatform("windows")]
 public static class MarkOfTheWeb
 {
     private static readonly UTF8Encoding ZoneIdentifierEncoding = new(encoderShouldEmitUTF8Identifier: false);
@@ -47,7 +48,6 @@ public static class MarkOfTheWeb
     /// <summary>Gets the security zone of a file using the Windows Security Manager COM API.</summary>
     /// <param name="filePath">The path to the file to query.</param>
     /// <returns>The <see cref="UrlZone"/> of the file, or <see cref="UrlZone.Invalid"/> if the zone cannot be determined.</returns>
-    [SupportedOSPlatform("windows")]
     public static UrlZone GetFileZone(string filePath)
     {
         ArgumentNullException.ThrowIfNull(filePath);
@@ -164,7 +164,6 @@ public static class MarkOfTheWeb
     /// <param name="filePath">The path to the file to check.</param>
     /// <returns><see langword="true"/> if the file is from an untrusted zone (Internet or Restricted); otherwise, <see langword="false"/>.</returns>
     /// <exception cref="FileNotFoundException"><paramref name="filePath"/> does not point to an existing file. A directory is not a file.</exception>
-    [SupportedOSPlatform("windows")]
     public static bool IsUntrusted(string filePath)
     {
         ArgumentNullException.ThrowIfNull(filePath);


### PR DESCRIPTION
> **Stack 7 of 7** · merges into `fix/motw-catch-narrowing` (#2544)

## The problem

`RemoveFileZone`, `GetFileZoneContent` and `SetFileZone` carried no `[SupportedOSPlatform]`, and the package's target frameworks are platform-neutral (`net10.0;net11.0`). So the package installs and compiles cleanly on Linux and macOS with no signal whatsoever.

Alternate data streams don't exist outside NTFS, and `:` is a legal filename character on POSIX — so `SetFileZone("/tmp/x.txt", UrlZone.Internet)` creates a **sibling regular file** named `x.txt:Zone.Identifier` and returns as if it had worked. `GetFileZoneContent` then reads that sibling back, so even a round-trip test would pass while nothing is actually marked. The caller gets a silent no-op plus a stray file in their output directory.

`GetFileZone` and `IsUntrusted` were already annotated, so this was a gap covering exactly the three methods that don't touch CsWin32.

## What changed

The attribute moves to the class:

```diff
+[SupportedOSPlatform("windows")]
 public static class MarkOfTheWeb
```

and the two method-level attributes are removed as redundant. This matches `CredentialManager`, which is also a platform-neutral TFM carrying a class-level `[SupportedOSPlatform("windows5.1.2600")]`.

**Deliberately not changing the TFMs.** Making these `net10.0-windows` would be the stronger enforcement, but all twelve `Meziantou.Framework.Win32.*` projects use the neutral `$(LatestTargetFrameworks)`, so neutral-TFM-plus-annotation is the established convention here — and switching would break consumers referencing the package from a neutral TFM.

## Verification

`dotnet build -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors. `dotnet test` — 58/58 pass on `net10.0` and `net11.0`.

Confirmed the annotation actually does its job, with a throwaway neutral-TFM (`net10.0`) consumer referencing the built assembly:

```
Consumer.cs(4,47): warning CA1416: This call site is reachable on all platforms.
  'MarkOfTheWeb.SetFileZone(string, UrlZone, string?, string?)' is only supported on: 'windows'.
Consumer.cs(5,49): warning CA1416: This call site is reachable on all platforms.
  'MarkOfTheWeb.RemoveFileZone(string)' is only supported on: 'windows'.
```

Neither warning existed before this change. Note that CA1416 does not fire in this repo's own test project — something in `Meziantou.NET.Sdk.Test` appears to suppress it — so the check had to be done outside the solution.

## Note on `ref/`

`ref/Meziantou.Framework.Win32.MarkOfTheWeb.cs` is regenerated, and the diff is only the API change. The generator writes CRLF on Windows while all 111 committed `ref/*.cs` files are LF and `.gitattributes` (`* -text`) disables normalization, so I converted the output back to LF to keep the diff readable. That mismatch is pre-existing and affects any Windows contributor who builds — worth a separate look.
