### PR TITLE
Describe the mechanism the Mark of the Web actually uses

### DIFF
--- a/src/Meziantou.Framework.Win32.MarkOfTheWeb/UrlZone.cs
+++ b/src/Meziantou.Framework.Win32.MarkOfTheWeb/UrlZone.cs
@@ -18,6 +18,9 @@ public enum UrlZone
     /// <summary>Internet zone - sites on the Internet that are not in other zones.</summary>
     Internet = 3,
 
-    /// <summary>Restricted Sites zone - sites that are explicitly untrusted and potentially unsafe.</summary>
+    /// <summary>
+    /// Restricted Sites zone - sites that are explicitly untrusted and potentially unsafe.
+    /// Windows names this zone "Restricted Sites"; it is the <c>URLZONE_UNTRUSTED</c> value, zone identifier 4.
+    /// </summary>
     Untrusted = 4,
 }

--- a/src/Meziantou.Framework.Win32.MarkOfTheWeb/readme.md
+++ b/src/Meziantou.Framework.Win32.MarkOfTheWeb/readme.md
@@ -1,6 +1,6 @@
 # Mark of the Web
 
-The Mark of the Web (MOTW) is a security feature in Windows that helps protect users from potentially unsafe content downloaded from the internet. It is implemented by adding a special comment to the beginning of HTML files and other web-related files, indicating that the file originated from the internet.
+The Mark of the Web (MOTW) is a security feature in Windows that helps protect users from potentially unsafe content downloaded from the internet. Windows records the security zone a file came from in an NTFS alternate data stream named `Zone.Identifier`, alongside the URLs it was downloaded from.
 When a user attempts to open a file with MOTW, Windows may display a warning message or restrict certain actions, such as running scripts or accessing certain features, to help prevent potential security risks.
 
 ## Usage


### PR DESCRIPTION
> Independent PR — merges into `main`, in any order relative to stack #2565.

Documentation only. No code changes.

## The readme described the wrong mechanism

`readme.md` opened by saying MOTW "is implemented by adding a special comment to the beginning of HTML files and other web-related files". That describes Internet Explorer's legacy `saved from url` HTML comment — a different, obsolete thing, and not what this library does. Every method in this package operates on the NTFS `Zone.Identifier` alternate data stream.

The class-level XML doc ([`MarkOfTheWeb.cs:8-11`](https://github.com/meziantou/Meziantou.Framework/blob/main/src/Meziantou.Framework.Win32.MarkOfTheWeb/MarkOfTheWeb.cs#L8-L11)) already gets this right; the readme now says the same thing, and mentions that the stream also carries the source URLs.

## `UrlZone.Untrusted` versus "Restricted"

Zone 4 is named `Untrusted` here (after the Win32 `URLZONE_UNTRUSTED` constant), but Windows presents it to users as **Restricted Sites**, and the library's own prose uses "Restricted" in places. The member's doc comment now states both names and the numeric zone identifier, so the mapping is unambiguous without a breaking rename.

## Deliberately left out

`IsUntrusted`'s `<returns>` doc also says "Internet or Restricted". Aligning that line would collide with #2543, which rewrites it — so it is better folded into that stack than fought over here.

## Verification

`dotnet test -p:TreatWarningsAsErrors=true` — 6/6 pass on `net10.0` and `net11.0`. The public API surface is unchanged, so `ref/` is untouched.
