### PR TITLE
Fix doc comment spacing and trailing whitespace in Win32.Jobs

### DIFF
--- a/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
+++ b/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
@@ -18,7 +18,7 @@ namespace Meziantou.Framework.Win32;
 ///     Flags = JobObjectLimitFlags.KillOnJobClose
 /// });
 /// job.AssignProcess(Process.GetCurrentProcess());
-/// 
+///
 /// // Start a child process that will be terminated when the job is disposed
 /// var childProcess = Process.Start("child.exe");
 /// </code>
@@ -370,6 +370,7 @@ public sealed class JobObject : IDisposable
             throw new Win32Exception(err);
         }
     }
+
     /// <summary>Sets I/O limits on a job object.</summary>
     [SupportedOSPlatform("windows10.0.10240")]
     public unsafe void SetIoLimits(JobIoRateLimits limits)

--- a/src/Meziantou.Framework.Win32.Jobs/JobObjectUILimit.cs
+++ b/src/Meziantou.Framework.Win32.Jobs/JobObjectUILimit.cs
@@ -24,7 +24,7 @@ public enum JobObjectUILimit
 
     /// <summary>Prevents processes associated with the job from creating desktops and switching desktops using the CreateDesktop and SwitchDesktop functions.</summary>
     Desktop = 0x00000040,
+
     /// <summary>Prevents processes associated with the job from calling the ExitWindows or ExitWindowsEx function.</summary>
     ExitWindows = 0x00000080,
-
 }


### PR DESCRIPTION
Formatting only, no behavior change.

`AGENTS.md` asks for a blank line before XML doc comments that follow other code, and no trailing whitespace on any line. Three spots in `Meziantou.Framework.Win32.Jobs` deviate:

- `src/Meziantou.Framework.Win32.Jobs/JobObject.cs:21` — the line is `"/// "`, with a trailing space.
- `src/Meziantou.Framework.Win32.Jobs/JobObject.cs:372` — `SetIoLimits`'s doc comment follows the previous method's closing brace with no blank line.
- `src/Meziantou.Framework.Win32.Jobs/JobObjectUILimit.cs:26` — same, between the `Desktop` and `ExitWindows` members. The enum also carried a stray blank line before its closing brace.

### Verification

Builds with `-p:TreatWarningsAsErrors=true`; `-p:PublicApiGeneratorVerifyNoChangeOnBuild=true` confirms no public API change. Test suite unchanged.

> One pre-existing test, `GetBasicAndIoAccountingInformation`, fails on this branch. It fails identically on `main` (4/4 runs) and is unrelated to this change — see the I/O accounting test PR, which fixes it.
