### PR TITLE
Remove an unreachable branch in SafeHandleValue.Value

### DIFF
--- a/src/Meziantou.Framework/SafeHandleValue.cs
+++ b/src/Meziantou.Framework/SafeHandleValue.cs
@@ -34,9 +34,6 @@ struct SafeHandleValue : IDisposable
         {
             ObjectDisposedException.ThrowIf(!HasValue, _safeHandle);
 
-            if (!HasValue)
-                throw new InvalidOperationException("Handle must have a value");
-
             return field;
         }
         private set;


### PR DESCRIPTION
The `SafeHandleValue.Value` getter guarded the same condition twice:

```csharp
ObjectDisposedException.ThrowIf(!HasValue, _safeHandle);

if (!HasValue)
    throw new InvalidOperationException("Handle must have a value");
```

`ThrowIf` already throws when `!HasValue`, so the `InvalidOperationException` was unreachable. Callers see the same `ObjectDisposedException` as before — this removes dead code, it does not change behavior.

**Where:** `src/Meziantou.Framework/SafeHandleValue.cs:35-38`

### Scope note

This file is shared via `<Compile Include>` with `Meziantou.Framework`, `Meziantou.Framework.Win32.AccessToken` and `Meziantou.Framework.Win32.ChangeJournal`, so the change reaches beyond the Jobs project.

### Verification

All four consumers build with `-p:TreatWarningsAsErrors=true`. No public API change (it is a method body), confirmed by `-p:PublicApiGeneratorVerifyNoChangeOnBuild=true` — `ref/` is untouched.
