### PR TITLE
Assert job I/O counters against I/O the test actually performs

### DIFF
--- a/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
+++ b/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
@@ -169,9 +169,30 @@ public class JobObjectTests
     {
         using var job = new JobObject();
         job.AssignProcess(Process.GetCurrentProcess());
-        var info = job.GetBasicAndIoAccountingInformation();
-        Assert.NotEqual(TimeSpan.Zero, info.BasicInfo.TotalUserTime);
-        Assert.NotEqual((ulong)0, info.IoInfo.ReadOperationCount);
+
+        // A job only accounts for I/O performed after a process joins it, so the counters are
+        // still zero right after AssignProcess. Perform I/O and assert the counters moved,
+        // instead of depending on whatever the runtime happens to do in the meantime.
+        var before = job.GetBasicAndIoAccountingInformation();
+
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(path, new byte[64 * 1024]);
+            _ = File.ReadAllBytes(path);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+
+        var after = job.GetBasicAndIoAccountingInformation();
+
+        Assert.NotEqual(TimeSpan.Zero, after.BasicInfo.TotalUserTime);
+        Assert.True(after.IoInfo.ReadOperationCount > before.IoInfo.ReadOperationCount, "The job should have accounted for the read operations");
+        Assert.True(after.IoInfo.WriteOperationCount > before.IoInfo.WriteOperationCount, "The job should have accounted for the write operations");
+        Assert.True(after.IoInfo.ReadTransferCount >= before.IoInfo.ReadTransferCount + (64 * 1024), "The job should have accounted for the bytes read");
+        Assert.True(after.IoInfo.WriteTransferCount >= before.IoInfo.WriteTransferCount + (64 * 1024), "The job should have accounted for the bytes written");
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]


### PR DESCRIPTION
Fixes the one failing test in this project.

**Where:** `tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs:167-175`

`GetBasicAndIoAccountingInformation` asserted `info.IoInfo.ReadOperationCount != 0` immediately after `AssignProcess`. A job only accounts for I/O performed *after* a process joins it, and no reads happen in the few microseconds between the two calls, so the assertion did not test what it intended.

### The failure

It fails **10 consecutive runs** on Windows 11 / .NET 10, and identically on `main`. It passes when run right after a build, which is why it can look green in CI — it depends on whatever incidental I/O the test host happens to do between the two calls. That makes it a latent flake on every platform, not an ARM64-specific failure.

### The library is fine

Worth stating explicitly, because the obvious reading is that the counters are broken. They are not. After assigning the process and then reading a 512 KB file 20 times, the same call reports `ReadOperationCount=20` and `ReadTransferCount=10485760` — exactly 20 × 512 KB. The marshalling and the counters are correct; only the assertion was unsound.

### The change

Take a baseline right after `AssignProcess`, write and read back a 64 KB temp file, then assert the counters moved and that the byte counts grew by at least the file size.

### Verification

6/6 runs of the test pass where it previously failed 10/10; the full suite is 14/14 green across 3 consecutive runs.
