### PR TITLE
Validate the CPU rate arguments before calling Win32

### DIFF
--- a/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
+++ b/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
@@ -26,6 +26,11 @@ namespace Meziantou.Framework.Win32;
 [SupportedOSPlatform("windows5.1.2600")]
 public sealed class JobObject : IDisposable
 {
+    // CPU rates are expressed as a percentage times 100, so 10,000 is 100%.
+    private const int MaxCpuRate = 10_000;
+    private const int MinCpuWeight = 1;
+    private const int MaxCpuWeight = 9;
+
     private readonly SafeFileHandle _jobHandle;
 
     private JobObject(SafeFileHandle jobHandle)
@@ -225,8 +230,12 @@ public sealed class JobObject : IDisposable
     /// can use during each scheduling interval, as the number of cycles per 10,000 cycles.
     /// For example, to let the job use 20% of the CPU, set CpuRate to 20 times 100, or 2,000.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="cpuRate"/> is not between 1 and 10,000.</exception>
     public unsafe void SetCpuRateHardCap(int cpuRate)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(cpuRate, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(cpuRate, MaxCpuRate);
+
         var restriction = new JOBOBJECT_CPU_RATE_CONTROL_INFORMATION
         {
             ControlFlags = JOB_OBJECT_CPU_RATE_CONTROL.JOB_OBJECT_CPU_RATE_CONTROL_ENABLE | JOB_OBJECT_CPU_RATE_CONTROL.JOB_OBJECT_CPU_RATE_CONTROL_HARD_CAP,
@@ -284,8 +293,12 @@ public sealed class JobObject : IDisposable
     /// Specifies the scheduling weight of the job object, which determines the share of processor time given to the job relative to other workloads on the processor.
     /// This member can be a value from 1 through 9, where 1 is the smallest share and 9 is the largest share.The default is 5, which should be used for most workloads.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="weight"/> is not between 1 and 9.</exception>
     public unsafe void SetCpuRateWeight(int weight)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(weight, MinCpuWeight);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(weight, MaxCpuWeight);
+
         var restriction = new JOBOBJECT_CPU_RATE_CONTROL_INFORMATION
         {
             ControlFlags = JOB_OBJECT_CPU_RATE_CONTROL.JOB_OBJECT_CPU_RATE_CONTROL_ENABLE | JOB_OBJECT_CPU_RATE_CONTROL.JOB_OBJECT_CPU_RATE_CONTROL_WEIGHT_BASED,
@@ -314,8 +327,15 @@ public sealed class JobObject : IDisposable
     ///
     /// After the job reaches this limit for a scheduling interval, no threads associated with the job can run until the next scheduling interval.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="minRate"/> or <paramref name="maxRate"/> is not between 1 and 10,000, or <paramref name="minRate"/> is greater than <paramref name="maxRate"/>.</exception>
     public unsafe void SetCpuRate(int minRate, int maxRate)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(minRate, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(minRate, MaxCpuRate);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxRate, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(maxRate, MaxCpuRate);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(minRate, maxRate);
+
         var restriction = new JOBOBJECT_CPU_RATE_CONTROL_INFORMATION
         {
             ControlFlags = JOB_OBJECT_CPU_RATE_CONTROL.JOB_OBJECT_CPU_RATE_CONTROL_ENABLE | JOB_OBJECT_CPU_RATE_CONTROL.JOB_OBJECT_CPU_RATE_CONTROL_MIN_MAX_RATE,

--- a/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
+++ b/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
@@ -136,6 +136,41 @@ public class JobObjectTests
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void SetCpuRate_OutOfRangeValues()
+    {
+        using var job = new JobObject();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => job.SetCpuRateHardCap(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => job.SetCpuRateHardCap(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => job.SetCpuRateHardCap(10_001));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => job.SetCpuRateWeight(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => job.SetCpuRateWeight(10));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => job.SetCpuRate(-1, 3000));
+        Assert.Throws<ArgumentOutOfRangeException>(() => job.SetCpuRate(0, 3000));
+        Assert.Throws<ArgumentOutOfRangeException>(() => job.SetCpuRate(1000, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => job.SetCpuRate(70_000, 3000));
+        Assert.Throws<ArgumentOutOfRangeException>(() => job.SetCpuRate(1000, 10_001));
+
+        // Windows rejects an inverted range, so reject it before the P/Invoke
+        Assert.Throws<ArgumentOutOfRangeException>(() => job.SetCpuRate(3000, 1000));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void SetCpuRate_BoundaryValuesAreAccepted()
+    {
+        using var job = new JobObject();
+
+        job.SetCpuRateHardCap(1);
+        job.SetCpuRateHardCap(10_000);
+        job.SetCpuRateWeight(1);
+        job.SetCpuRateWeight(9);
+        job.SetCpuRate(1, 10_000);
+        job.SetCpuRate(10_000, 10_000);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
     public void SetUILimits()
     {
         using var job = new JobObject();


### PR DESCRIPTION
**Where:** `src/Meziantou.Framework.Win32.Jobs/JobObject.cs` — `SetCpuRateHardCap`, `SetCpuRateWeight`, `SetCpuRate`

All three cast their `int` arguments without checking them, and `SetCpuRate` narrows to `ushort`, so a value above 65,535 wraps instead of saturating. Out-of-range values did fail — but as `Win32Exception: The parameter is incorrect.`, which names neither the parameter nor the valid range, even though the ranges are documented on the parameters right above the cast.

This validates up front with `ArgumentOutOfRangeException`.

### The ranges were measured, not assumed

This is the part worth reviewing. I probed Windows rather than trusting the docs, and two things did not match:

- **`minRate = 0` is rejected**, even though the documentation describes 0 as "no reservation". `SetCpuRate(0, 5000)` and `SetCpuRate(0, 10000)` both fail.
- **An inverted range is rejected**: `SetCpuRate(3000, 1000)` fails.

So `minRate <= maxRate` is a real Windows constraint, not one I invented. Accepted values:

| call | accepted |
|---|---|
| `SetCpuRateHardCap` | 1..10,000 |
| `SetCpuRateWeight` | 1..9 |
| `SetCpuRate(min, max)` | 1..10,000 each, `min <= max` |

Boundary values are covered by a test so this stays honest.

### Compatibility

Out-of-range input now throws `ArgumentOutOfRangeException` instead of `Win32Exception`. Only already-invalid input is affected — no call that previously succeeded changes behavior.

### Verification

Builds with `-p:TreatWarningsAsErrors=true`. No public API change (`PublicApiGeneratorVerifyNoChangeOnBuild` passes, `ref/` untouched). Two new tests cover the rejected and the boundary values.

> The pre-existing `GetBasicAndIoAccountingInformation` failure on this branch also fails on `main` and is unrelated — #2555 fixes it.
