### PR TITLE
Throw when TerminateJobObject fails

### DIFF
--- a/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
+++ b/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
@@ -145,6 +145,7 @@ public sealed class JobObject : IDisposable
     public void Dispose() => _jobHandle.Dispose();
 
     /// <summary>Terminates all processes currently associated with the job. If the job is nested, this function terminates all processes currently associated with the job and all of its child jobs in the hierarchy.</summary>
+    /// <exception cref="Win32Exception">The processes could not be terminated.</exception>
     public void Terminate()
     {
         Terminate(1);
@@ -152,9 +153,14 @@ public sealed class JobObject : IDisposable
 
     /// <summary>Terminates all processes currently associated with the job. If the job is nested, this function terminates all processes currently associated with the job and all of its child jobs in the hierarchy.</summary>
     /// <param name="exitCode">The exit code to be used by all processes and threads in the job object.</param>
+    /// <exception cref="Win32Exception">The processes could not be terminated. This happens when the handle does not have the <see cref="JobObjectAccessRights.Terminate"/> access right.</exception>
     public void Terminate(int exitCode)
     {
-        Windows.Win32.PInvoke.TerminateJobObject(_jobHandle, unchecked((uint)exitCode));
+        if (!Windows.Win32.PInvoke.TerminateJobObject(_jobHandle, unchecked((uint)exitCode)))
+        {
+            var err = Marshal.GetLastWin32Error();
+            throw new Win32Exception(err);
+        }
     }
 
     /// <summary>Assigns a process to an existing job object.</summary>

--- a/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
+++ b/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
@@ -112,6 +112,16 @@ public class JobObjectTests
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void Terminate_WithoutTerminateAccessRight()
+    {
+        var objectName = Guid.NewGuid().ToString("N");
+        using var job = new JobObject(objectName);
+        using var queryOnly = JobObject.Open(JobObjectAccessRights.Query, inherited: false, objectName);
+
+        Assert.Throws<Win32Exception>(queryOnly.Terminate);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
     public void CreateAndOpenJobObject()
     {
         var objectName = Guid.NewGuid().ToString("N");


### PR DESCRIPTION
> **Breaking change** — targets a future 5.0.0, since 4.0.0 is already published.

**Where:** `src/Meziantou.Framework.Win32.Jobs/JobObject.cs:132-135`

`Terminate` discarded the `BOOL` returned by `TerminateJobObject`, so a failed termination was indistinguishable from a successful one.

### The failure

Open a job with `JobObjectAccessRights.Query` — no `JOB_OBJECT_TERMINATE` right — and call `Terminate()`. It returns normally. Every process in the job keeps running.

This is the library's kill switch, and the readme presents it as the way to guarantee child processes die when the parent exits, so a silent no-op is at its worst here. It was also the only method on the type that did not throw `Win32Exception` on failure — every other call site in the class already does.

### The change

Check the result and throw `Win32Exception`, matching the rest of the type.

### Compatibility

**BREAKING:** `Terminate()` and `Terminate(int)` now throw `Win32Exception` when the underlying call fails. Callers who relied on the silent no-op — most likely without knowing — will start seeing the error. If a non-throwing path is wanted, a `TryTerminate()` returning `bool` would be the natural addition; I left that out as it is a new API rather than a fix to this defect.

### Verification

New test `Terminate_WithoutTerminateAccessRight` asserts the throw; the existing `ShouldKillProcessOnTerminate` and `KillOnJobClose_ShouldKillProcessOnClose` still pass. No public API signature change.

> The pre-existing `GetBasicAndIoAccountingInformation` failure on this branch also fails on `main` and is unrelated — #2555 fixes it.
