### PR TITLE
Expose whether the constructor created the job object

### DIFF
--- a/ref/Meziantou.Framework.Win32.Jobs.cs
+++ b/ref/Meziantou.Framework.Win32.Jobs.cs
@@ -27,6 +27,7 @@ namespace Meziantou.Framework.Win32
     [System.Runtime.Versioning.SupportedOSPlatform("windows5.1.2600")]
     public sealed class JobObject : System.IDisposable
     {
+        public bool CreatedNew { get => throw null; }
         public JobObject(string? name) { }
         public JobObject(string? name, bool inheritHandle) { }
         public static Meziantou.Framework.Win32.JobObject Open(Meziantou.Framework.Win32.JobObjectAccessRights desiredAccess, bool inherited, string name) => throw null;

--- a/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
+++ b/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
@@ -31,7 +31,24 @@ public sealed class JobObject : IDisposable
     private JobObject(SafeFileHandle jobHandle)
     {
         _jobHandle = jobHandle;
+        CreatedNew = false;
     }
+
+    /// <summary>
+    /// Gets a value indicating whether this instance created the underlying job object.
+    /// </summary>
+    /// <value>
+    /// <see langword="true"/> when the constructor created a new job object;
+    /// <see langword="false"/> when a job object with the requested name already existed and this
+    /// instance attached to it, or when the instance was returned by <see cref="Open"/> or <see cref="TryOpen"/>.
+    /// </value>
+    /// <remarks>
+    /// Job objects share a namespace with events, semaphores, mutexes, waitable timers and file-mapping
+    /// objects, and <c>CreateJobObject</c> returns a handle to the existing object rather than failing when
+    /// the name is taken. Check this property when the caller needs an isolated job: attaching to a job
+    /// created elsewhere means inheriting its limits, its process set and its lifetime.
+    /// </remarks>
+    public bool CreatedNew { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="JobObject"/> class. The associated job object will have no name.
@@ -55,6 +72,10 @@ public sealed class JobObject : IDisposable
     /// </summary>
     /// <param name="name">The job object name. May be null.</param>
     /// <param name="inheritHandle">A Boolean value that specifies whether the returned handle is inherited when a new process is created. If this member is <see langword="true" />, the new process inherits the handle.</param>
+    /// <remarks>
+    /// When <paramref name="name"/> matches a job object that already exists, this attaches to that job
+    /// object instead of creating a new one. Inspect <see cref="CreatedNew"/> to tell the two apart.
+    /// </remarks>
     public unsafe JobObject(string? name, bool inheritHandle)
     {
         var atts = new Windows.Win32.Security.SECURITY_ATTRIBUTES
@@ -65,12 +86,14 @@ public sealed class JobObject : IDisposable
         };
 
         _jobHandle = Windows.Win32.PInvoke.CreateJobObject(atts, name);
+        var lastError = Marshal.GetLastWin32Error();
         if (_jobHandle.IsInvalid)
         {
             _jobHandle.Dispose();
-            var lastError = Marshal.GetLastWin32Error();
             throw new Win32Exception(lastError);
         }
+
+        CreatedNew = lastError != (int)WIN32_ERROR.ERROR_ALREADY_EXISTS;
     }
 
     /// <summary>Opens an existing job object.</summary>

--- a/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
+++ b/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
@@ -73,6 +73,31 @@ public class JobObjectTests
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void CreatedNew_DistinguishesCreateFromAttach()
+    {
+        using (var unnamed = new JobObject())
+        {
+            Assert.True(unnamed.CreatedNew);
+        }
+
+        var objectName = Guid.NewGuid().ToString("N");
+        using var first = new JobObject(objectName);
+        Assert.True(first.CreatedNew);
+
+        using var second = new JobObject(objectName);
+        Assert.False(second.CreatedNew);
+
+        using var opened = JobObject.Open(JobObjectAccessRights.Query, inherited: false, objectName);
+        Assert.False(opened.CreatedNew);
+
+        Assert.True(JobObject.TryOpen(JobObjectAccessRights.Query, inherited: false, objectName, out var tryOpened));
+        using (tryOpened)
+        {
+            Assert.False(tryOpened.CreatedNew);
+        }
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
     public void InvalidName_TooLong()
     {
         var objectName = "Local\\" + new string('a', 40000);


### PR DESCRIPTION
**Where:** `src/Meziantou.Framework.Win32.Jobs/JobObject.cs:58-74`

`CreateJobObject` returns a handle to an *existing* job object, with `GetLastError` set to `ERROR_ALREADY_EXISTS`, when the requested name is already taken. The constructor only tested the handle for validity, so creating a job and attaching to someone else's were indistinguishable: constructing two `JobObject` instances with the same name succeeds twice, with no signal.

### Why it matters

A caller who wanted an isolated job can silently join one created elsewhere, inheriting its limits, its process set, and — if that job carries `KillOnJobClose` — its lifetime. Job objects share a namespace with events, semaphores, mutexes, waitable timers and file-mapping objects, so where the name is predictable and the namespace shared (`Global\`), another process can pre-create the object and shape the sandbox the caller believed it had established.

The existing tests already work around this: `TryOpen` takes a cross-process mutex specifically because parallel test hosts collide on a fixed job name.

### The change

Capture the last error immediately after `CreateJobObject` and expose it as `CreatedNew`, mirroring `Mutex`, `Semaphore` and `EventWaitHandle` in the BCL, which callers will already recognise. `Open` and `TryOpen` report `false`.

Additive only — nothing that compiled before changes meaning. A stricter `createNew: true` overload that throws on collision would be the natural follow-up if you want to force the issue, but that is a new API rather than a fix.

### Verification

`CreatedNew_DistinguishesCreateFromAttach` covers all four paths: unnamed ctor, first named ctor, second named ctor, and both `Open`/`TryOpen`. `ref/` regenerated — the diff is the single new member.
