### PR TITLE
Move JobObjectUILimit into the Meziantou.Framework.Win32 namespace

### DIFF
--- a/ref/Meziantou.Framework.Win32.Jobs.cs
+++ b/ref/Meziantou.Framework.Win32.Jobs.cs
@@ -37,7 +37,7 @@ namespace Meziantou.Framework.Win32
         public void AssignProcess(System.Diagnostics.Process process) { }
         public void AssignProcess(nint processHandle) { }
         public void SetLimits(Meziantou.Framework.Win32.JobObjectLimits limits) { }
-        public void SetUIRestrictions(Meziantou.Framework.Win32.Natives.JobObjectUILimit limits) { }
+        public void SetUIRestrictions(Meziantou.Framework.Win32.JobObjectUILimit limits) { }
         public void SetCpuRateHardCap(int cpuRate) { }
         public Meziantou.Framework.Win32.JobObjectCpuHardCap GetCpuRateHardCap() => throw null;
         public void DisableCpuRateHardCap() { }
@@ -165,9 +165,7 @@ namespace Meziantou.Framework.Win32
         NoAdmin = 1,
         RestrictedToken = 2
     }
-}
-namespace Meziantou.Framework.Win32.Natives
-{
+
     [System.Flags]
     public enum JobObjectUILimit
     {

--- a/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
+++ b/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using Meziantou.Framework.Win32.Natives;
 using Microsoft.Win32.SafeHandles;
 using Windows.Win32.Foundation;
 using Windows.Win32.System.JobObjects;

--- a/src/Meziantou.Framework.Win32.Jobs/JobObjectUILimit.cs
+++ b/src/Meziantou.Framework.Win32.Jobs/JobObjectUILimit.cs
@@ -1,4 +1,4 @@
-namespace Meziantou.Framework.Win32.Natives;
+namespace Meziantou.Framework.Win32;
 
 /// <summary>Defines UI restrictions for processes in a job object.</summary>
 [Flags]

--- a/src/Meziantou.Framework.Win32.Jobs/readme.md
+++ b/src/Meziantou.Framework.Win32.Jobs/readme.md
@@ -34,7 +34,7 @@ job.SetLimits(new JobObjectLimits()
 });
 
 // Restrict UI features
-job.SetUIRestrictions(Natives.JobObjectUILimit.ReadClipboard);
+job.SetUIRestrictions(JobObjectUILimit.ReadClipboard);
 
 // Limit CPU
 job.SetCpuRateHardCap(2000); // 20% of the CPU

--- a/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
+++ b/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
@@ -139,7 +139,7 @@ public class JobObjectTests
     public void SetUILimits()
     {
         using var job = new JobObject();
-        job.SetUIRestrictions(Natives.JobObjectUILimit.ReadClipboard);
+        job.SetUIRestrictions(JobObjectUILimit.ReadClipboard);
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]


### PR DESCRIPTION
> **Breaking change** — targets a future 5.0.0, since 4.0.0 is already published.

**Where:** `src/Meziantou.Framework.Win32.Jobs/JobObjectUILimit.cs:1`

`JobObjectUILimit` was the only public type in this assembly declared in `Meziantou.Framework.Win32.Natives`; everything else lives in `Meziantou.Framework.Win32`. It is the parameter type of the public `SetUIRestrictions` method, so "Natives" also implied an implementation-detail namespace that it is not.

The cost was visible in the project's own readme and tests, both of which had to write `Natives.JobObjectUILimit.ReadClipboard` while every neighbouring call was unqualified.

### Compatibility

**BREAKING:** `JobObjectUILimit` moves to `Meziantou.Framework.Win32`. Callers that qualified the name or imported the `Natives` namespace need to update. The assembly no longer contains a `Natives` namespace at all.

I did not leave an `[Obsolete]` shim: for an enum that means keeping a second type with the same members and no way to convert between them at the API boundary, which is worse than the move.

### Verification

Builds with `-p:TreatWarningsAsErrors=true` (the now-unused `using` in `JobObject.cs` is removed). readme and tests updated. `ref/` regenerated — the diff is the `SetUIRestrictions` parameter type plus the namespace block.

> The pre-existing `GetBasicAndIoAccountingInformation` failure on this branch also fails on `main` and is unrelated — #2555 fixes it.
