### PR TITLE
Report which CPU rate control policy a job is using

### DIFF
--- a/ref/Meziantou.Framework.Win32.Jobs.cs
+++ b/ref/Meziantou.Framework.Win32.Jobs.cs
@@ -100,10 +100,32 @@ namespace Meziantou.Framework.Win32
         public bool Equals(Meziantou.Framework.Win32.JobObjectBasicAndIoAccountingInformation? other) => throw null;
     }
 
-    public struct JobObjectCpuHardCap
+    public readonly struct JobObjectCpuHardCap : System.IEquatable<Meziantou.Framework.Win32.JobObjectCpuHardCap>
     {
-        public bool Enabled { readonly get => throw null; set { } }
-        public int Rate { readonly get => throw null; set { } }
+        public bool Enabled { get => throw null; init { } }
+        public Meziantou.Framework.Win32.JobObjectCpuRateControlMode Mode { get => throw null; init { } }
+        public int Rate { get => throw null; init { } }
+        public int Weight { get => throw null; init { } }
+        public int MinRate { get => throw null; init { } }
+        public int MaxRate { get => throw null; init { } }
+        #nullable disable
+        public override string ToString() => throw null;
+        #nullable restore
+        public static bool operator !=(Meziantou.Framework.Win32.JobObjectCpuHardCap left, Meziantou.Framework.Win32.JobObjectCpuHardCap right) => throw null;
+        public static bool operator ==(Meziantou.Framework.Win32.JobObjectCpuHardCap left, Meziantou.Framework.Win32.JobObjectCpuHardCap right) => throw null;
+        public override int GetHashCode() => throw null;
+        #nullable disable
+        public override bool Equals(object obj) => throw null;
+        #nullable restore
+        public bool Equals(Meziantou.Framework.Win32.JobObjectCpuHardCap other) => throw null;
+    }
+
+    public enum JobObjectCpuRateControlMode
+    {
+        Disabled = 0,
+        HardCap = 1,
+        Weight = 2,
+        MinMaxRate = 3
     }
 
     public sealed class JobObjectIoCounters : System.IEquatable<Meziantou.Framework.Win32.JobObjectIoCounters>

--- a/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
+++ b/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
@@ -244,8 +244,13 @@ public sealed class JobObject : IDisposable
         }
     }
 
-    /// <summary>Get the job's CPU rate limit enabled status and value.</summary>
-    /// <returns>Bool indicating if CPU rate control is enabled and the job's CPU rate limit.</returns>
+    /// <summary>Get the job's CPU rate control policy and the values that belong to it.</summary>
+    /// <returns>
+    /// A <see cref="JobObjectCpuHardCap"/> describing the active policy. Windows stores the rate, the
+    /// weight and the min/max pair in a union, so only the members matching
+    /// <see cref="JobObjectCpuHardCap.Mode"/> carry a meaningful value.
+    /// </returns>
+    /// <exception cref="Win32Exception">The operation failed.</exception>
     public unsafe JobObjectCpuHardCap GetCpuRateHardCap()
     {
         var restriction = new JOBOBJECT_CPU_RATE_CONTROL_INFORMATION();
@@ -257,12 +262,40 @@ public sealed class JobObject : IDisposable
             throw new Win32Exception(err);
         }
 
-        var cpuRateEnabled = restriction.ControlFlags.HasFlag(JOB_OBJECT_CPU_RATE_CONTROL.JOB_OBJECT_CPU_RATE_CONTROL_ENABLE);
-
-        return new JobObjectCpuHardCap
+        var mode = restriction.ControlFlags switch
         {
-            Enabled = cpuRateEnabled,
-            Rate = (int)restriction.Anonymous.CpuRate,
+            var flags when !flags.HasFlag(JOB_OBJECT_CPU_RATE_CONTROL.JOB_OBJECT_CPU_RATE_CONTROL_ENABLE) => JobObjectCpuRateControlMode.Disabled,
+            var flags when flags.HasFlag(JOB_OBJECT_CPU_RATE_CONTROL.JOB_OBJECT_CPU_RATE_CONTROL_WEIGHT_BASED) => JobObjectCpuRateControlMode.Weight,
+            var flags when flags.HasFlag(JOB_OBJECT_CPU_RATE_CONTROL.JOB_OBJECT_CPU_RATE_CONTROL_MIN_MAX_RATE) => JobObjectCpuRateControlMode.MinMaxRate,
+            _ => JobObjectCpuRateControlMode.HardCap,
+        };
+
+        return mode switch
+        {
+            JobObjectCpuRateControlMode.Weight => new JobObjectCpuHardCap
+            {
+                Enabled = true,
+                Mode = mode,
+                Weight = (int)restriction.Anonymous.Weight,
+            },
+            JobObjectCpuRateControlMode.MinMaxRate => new JobObjectCpuHardCap
+            {
+                Enabled = true,
+                Mode = mode,
+                MinRate = restriction.Anonymous.Anonymous.MinRate,
+                MaxRate = restriction.Anonymous.Anonymous.MaxRate,
+            },
+            JobObjectCpuRateControlMode.HardCap => new JobObjectCpuHardCap
+            {
+                Enabled = true,
+                Mode = mode,
+                Rate = (int)restriction.Anonymous.CpuRate,
+            },
+            _ => new JobObjectCpuHardCap
+            {
+                Enabled = false,
+                Mode = JobObjectCpuRateControlMode.Disabled,
+            },
         };
     }
 

--- a/src/Meziantou.Framework.Win32.Jobs/JobObjectCpuHardCap.cs
+++ b/src/Meziantou.Framework.Win32.Jobs/JobObjectCpuHardCap.cs
@@ -1,14 +1,28 @@
-using System.Runtime.InteropServices;
-
 namespace Meziantou.Framework.Win32;
 
-/// <summary>Represents the CPU rate hard cap settings for a job object.</summary>
-[StructLayout(LayoutKind.Sequential)]
-public struct JobObjectCpuHardCap
+/// <summary>Represents the CPU rate control settings of a job object.</summary>
+/// <remarks>
+/// Only the members that belong to <see cref="Mode"/> carry a meaningful value; the others are zero.
+/// Check <see cref="Mode"/> before reading <see cref="Rate"/>, <see cref="Weight"/>,
+/// <see cref="MinRate"/> or <see cref="MaxRate"/>.
+/// </remarks>
+public readonly record struct JobObjectCpuHardCap
 {
-    /// <summary>Whether the CPU hard cap is enabled for this job.</summary>
-    public bool Enabled { get; set; }
+    /// <summary>Gets a value indicating whether CPU rate control is enabled for the job.</summary>
+    public bool Enabled { get; init; }
 
-    /// <summary>The value of the CPU hard cap.</summary>
-    public int Rate { get; set; }
+    /// <summary>Gets the CPU rate control policy the job is using.</summary>
+    public JobObjectCpuRateControlMode Mode { get; init; }
+
+    /// <summary>Gets the portion of processor cycles the job may use, as a percentage times 100. Meaningful when <see cref="Mode"/> is <see cref="JobObjectCpuRateControlMode.HardCap"/>.</summary>
+    public int Rate { get; init; }
+
+    /// <summary>Gets the scheduling weight of the job, from 1 to 9. Meaningful when <see cref="Mode"/> is <see cref="JobObjectCpuRateControlMode.Weight"/>.</summary>
+    public int Weight { get; init; }
+
+    /// <summary>Gets the minimum portion of processor cycles reserved for the job, as a percentage times 100. Meaningful when <see cref="Mode"/> is <see cref="JobObjectCpuRateControlMode.MinMaxRate"/>.</summary>
+    public int MinRate { get; init; }
+
+    /// <summary>Gets the maximum portion of processor cycles the job may use, as a percentage times 100. Meaningful when <see cref="Mode"/> is <see cref="JobObjectCpuRateControlMode.MinMaxRate"/>.</summary>
+    public int MaxRate { get; init; }
 }

--- a/src/Meziantou.Framework.Win32.Jobs/JobObjectCpuRateControlMode.cs
+++ b/src/Meziantou.Framework.Win32.Jobs/JobObjectCpuRateControlMode.cs
@@ -1,0 +1,22 @@
+namespace Meziantou.Framework.Win32;
+
+/// <summary>Identifies which CPU rate control policy is active for a job object.</summary>
+/// <remarks>
+/// The policy determines which member of <see cref="JobObjectCpuHardCap"/> carries a meaningful value.
+/// Windows stores those values in a union, so reading the wrong one yields an unrelated number rather
+/// than an error.
+/// </remarks>
+public enum JobObjectCpuRateControlMode
+{
+    /// <summary>CPU rate control is not enabled for the job.</summary>
+    Disabled,
+
+    /// <summary>The job is capped at a fixed portion of processor cycles, reported by <see cref="JobObjectCpuHardCap.Rate"/>.</summary>
+    HardCap,
+
+    /// <summary>The job's share of processor time is derived from its weight relative to other jobs, reported by <see cref="JobObjectCpuHardCap.Weight"/>.</summary>
+    Weight,
+
+    /// <summary>The job is confined to a range of processor cycles, reported by <see cref="JobObjectCpuHardCap.MinRate"/> and <see cref="JobObjectCpuHardCap.MaxRate"/>.</summary>
+    MinMaxRate,
+}

--- a/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
+++ b/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
@@ -124,15 +124,49 @@ public class JobObjectTests
 
         cap = job.GetCpuRateHardCap();
         Assert.False(cap.Enabled);
+        Assert.Equal(JobObjectCpuRateControlMode.Disabled, cap.Mode);
 
         job.SetCpuRateHardCap(7654);
         cap = job.GetCpuRateHardCap();
         Assert.True(cap.Enabled);
+        Assert.Equal(JobObjectCpuRateControlMode.HardCap, cap.Mode);
         Assert.Equal(7654, cap.Rate);
 
         job.DisableCpuRateHardCap();
         cap = job.GetCpuRateHardCap();
         Assert.False(cap.Enabled);
+        Assert.Equal(JobObjectCpuRateControlMode.Disabled, cap.Mode);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void CpuRateWeight_IsReportedAsWeight()
+    {
+        using var job = new JobObject();
+        job.SetCpuRateWeight(5);
+
+        var cap = job.GetCpuRateHardCap();
+        Assert.True(cap.Enabled);
+        Assert.Equal(JobObjectCpuRateControlMode.Weight, cap.Mode);
+        Assert.Equal(5, cap.Weight);
+
+        // The weight lives in the same union as the hard cap rate, so Rate must not report it
+        Assert.Equal(0, cap.Rate);
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void CpuRateMinMax_IsReportedAsRange()
+    {
+        using var job = new JobObject();
+        job.SetCpuRate(minRate: 1000, maxRate: 3000);
+
+        var cap = job.GetCpuRateHardCap();
+        Assert.True(cap.Enabled);
+        Assert.Equal(JobObjectCpuRateControlMode.MinMaxRate, cap.Mode);
+        Assert.Equal(1000, cap.MinRate);
+        Assert.Equal(3000, cap.MaxRate);
+
+        // Reading CpuRate here used to yield 196609000: MaxRate and MinRate reinterpreted as one uint
+        Assert.Equal(0, cap.Rate);
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]


### PR DESCRIPTION
> **Breaking change** — targets a future 5.0.0, since 4.0.0 is already published.

**Where:** `src/Meziantou.Framework.Win32.Jobs/JobObject.cs:249-267`

`JOBOBJECT_CPU_RATE_CONTROL_INFORMATION` overlays `CpuRate`, `Weight` and the `{MinRate, MaxRate}` pair in a **union**, and `ControlFlags` says which one is live. `GetCpuRateHardCap` checked `ControlFlags` only for the `ENABLE` bit and then always read `CpuRate`.

### The failure

A job configured through this class's own API reports nonsense:

| configured with | `GetCpuRateHardCap()` returned |
|---|---|
| `SetCpuRate(1000, 3000)` (10%–30%) | `Enabled=True, Rate=196609000` |
| `SetCpuRateWeight(5)` | `Enabled=True, Rate=5` |

`196609000` is `0x0BB803E8` — `MaxRate=3000` in the high half, `MinRate=1000` in the low half, reinterpreted as one `uint`.

The first row is obviously garbage. The second is the dangerous one: `5` is a plausible rate that a caller would log, display or branch on, and nothing in the returned value said the job was in weight mode.

### The change

Read `ControlFlags` for the policy, expose it as a new `Mode` property, and populate only the members that belong to that policy. The class offers four ways to configure CPU control and had one reader that understood one of them; now the reader reports which one is in effect.

Also folded in, because this reshapes the type anyway: `JobObjectCpuHardCap` becomes a `readonly record struct` with `init` accessors, matching every other result type in the project (`JobObjectIoCounters`, `JobObjectBasicAccountingInformation`, …). It drops `[StructLayout(LayoutKind.Sequential)]`, which suggested an interop contract that never existed — the type is never marshalled — and would have been a trap given `bool` blits as a 4-byte `BOOL`. Its properties previously had public setters, so `job.GetCpuRateHardCap().Rate = 5` compiled and silently mutated a temporary.

### Follow-up left out on purpose

With `Mode` added, the names `GetCpuRateHardCap` and `JobObjectCpuHardCap` no longer describe something that covers every policy. Renaming both would be the honest next step, but it is a separate decision from fixing the defect, so I left it.

### Compatibility

**BREAKING:** `JobObjectCpuHardCap` is now a `readonly record struct` with init-only properties. `Rate` reports `0` unless `Mode` is `HardCap`, where it previously returned whatever the union happened to hold.

### Verification

The existing `CpuHardRateCap` test only covered the hard-cap path — which is exactly why this went unnoticed. Weight and min/max modes now have tests that assert both the mode and that `Rate` stays `0`. Suite is 16/16 green.
