### PR TITLE
Apply a JobObjectLimits limit only when its value is set

### DIFF
--- a/ref/Meziantou.Framework.Win32.Jobs.cs
+++ b/ref/Meziantou.Framework.Win32.Jobs.cs
@@ -135,16 +135,16 @@ namespace Meziantou.Framework.Win32
     public sealed class JobObjectLimits
     {
         public Meziantou.Framework.Win32.JobObjectLimitFlags Flags { get => throw null; set { } }
-        public long PerProcessUserTimeLimit { get => throw null; set { } }
-        public long PerJobUserTimeLimit { get => throw null; set { } }
-        public nuint MinimumWorkingSetSize { get => throw null; set { } }
-        public nuint MaximumWorkingSetSize { get => throw null; set { } }
-        public uint ActiveProcessLimit { get => throw null; set { } }
-        public nuint Affinity { get => throw null; set { } }
-        public uint PriorityClass { get => throw null; set { } }
-        public uint SchedulingClass { get => throw null; set { } }
-        public nuint ProcessMemoryLimit { get => throw null; set { } }
-        public nuint JobMemoryLimit { get => throw null; set { } }
+        public long? PerProcessUserTimeLimit { get => throw null; set { } }
+        public long? PerJobUserTimeLimit { get => throw null; set { } }
+        public nuint? MinimumWorkingSetSize { get => throw null; set { } }
+        public nuint? MaximumWorkingSetSize { get => throw null; set { } }
+        public uint? ActiveProcessLimit { get => throw null; set { } }
+        public nuint? Affinity { get => throw null; set { } }
+        public uint? PriorityClass { get => throw null; set { } }
+        public uint? SchedulingClass { get => throw null; set { } }
+        public nuint? ProcessMemoryLimit { get => throw null; set { } }
+        public nuint? JobMemoryLimit { get => throw null; set { } }
     }
 
     public sealed class JobObjectMemoryAccountingInformation : System.IEquatable<Meziantou.Framework.Win32.JobObjectMemoryAccountingInformation>

--- a/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
+++ b/src/Meziantou.Framework.Win32.Jobs/JobObject.cs
@@ -175,18 +175,18 @@ public sealed class JobObject : IDisposable
         {
             BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
             {
-                ActiveProcessLimit = limits.ActiveProcessLimit,
-                Affinity = limits.Affinity,
-                MaximumWorkingSetSize = limits.MaximumWorkingSetSize,
-                MinimumWorkingSetSize = limits.MinimumWorkingSetSize,
-                PerJobUserTimeLimit = limits.PerJobUserTimeLimit,
-                PerProcessUserTimeLimit = limits.PerProcessUserTimeLimit,
-                PriorityClass = limits.PriorityClass,
-                SchedulingClass = limits.SchedulingClass,
-                LimitFlags = limits.InternalFlags,
+                ActiveProcessLimit = limits.ActiveProcessLimit.GetValueOrDefault(),
+                Affinity = limits.Affinity.GetValueOrDefault(),
+                MaximumWorkingSetSize = limits.MaximumWorkingSetSize.GetValueOrDefault(),
+                MinimumWorkingSetSize = limits.MinimumWorkingSetSize.GetValueOrDefault(),
+                PerJobUserTimeLimit = limits.PerJobUserTimeLimit.GetValueOrDefault(),
+                PerProcessUserTimeLimit = limits.PerProcessUserTimeLimit.GetValueOrDefault(),
+                PriorityClass = limits.PriorityClass.GetValueOrDefault(),
+                SchedulingClass = limits.SchedulingClass.GetValueOrDefault(),
+                LimitFlags = limits.ComputeLimitFlags(),
             },
-            ProcessMemoryLimit = limits.ProcessMemoryLimit,
-            JobMemoryLimit = limits.JobMemoryLimit,
+            ProcessMemoryLimit = limits.ProcessMemoryLimit.GetValueOrDefault(),
+            JobMemoryLimit = limits.JobMemoryLimit.GetValueOrDefault(),
         };
 
         using var handleScope = new SafeHandleValue(_jobHandle);

--- a/src/Meziantou.Framework.Win32.Jobs/JobObjectLimits.cs
+++ b/src/Meziantou.Framework.Win32.Jobs/JobObjectLimits.cs
@@ -3,6 +3,10 @@ using Windows.Win32.System.JobObjects;
 namespace Meziantou.Framework.Win32;
 
 /// <summary>Defines a job object limits.</summary>
+/// <remarks>
+/// A limit applies only when its property is set to a non-<see langword="null"/> value. Leave a property
+/// <see langword="null"/> - the default - to leave that limit alone.
+/// </remarks>
 /// <example>
 /// <code>
 /// var limits = new JobObjectLimits
@@ -16,138 +20,83 @@ namespace Meziantou.Framework.Win32;
 /// </example>
 public sealed class JobObjectLimits
 {
-    internal JOB_OBJECT_LIMIT InternalFlags { get; set; }
-
     /// <summary>Defines options for a job object.</summary>
     /// <value>The options for a job object.</value>
-    public JobObjectLimitFlags Flags
-    {
-        get;
-        set
-        {
-            field = value;
-            InternalFlags |= (JOB_OBJECT_LIMIT)field;
-        }
-    }
+    public JobObjectLimitFlags Flags { get; set; }
 
     /// <summary>Gets or sets the per-process user-mode execution time limit, in 100-nanosecond ticks.</summary>
-    /// <value>The per-process user-mode execution time limit, in 100-nanosecond ticks.</value>
-    public long PerProcessUserTimeLimit
-    {
-        get;
-        set
-        {
-            field = value;
-            InternalFlags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_PROCESS_TIME;
-        }
-    }
+    /// <value>The per-process user-mode execution time limit, in 100-nanosecond ticks, or <see langword="null"/> to apply no limit.</value>
+    public long? PerProcessUserTimeLimit { get; set; }
 
     /// <summary>Gets or sets the per-job user-mode execution time limit, in 100-nanosecond ticks.</summary>
-    /// <value>The per-job user-mode execution time limit, in 100-nanosecond ticks.</value>
-    public long PerJobUserTimeLimit
-    {
-        get;
-        set
-        {
-            field = value;
-            InternalFlags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_JOB_TIME;
-        }
-    }
+    /// <value>The per-job user-mode execution time limit, in 100-nanosecond ticks, or <see langword="null"/> to apply no limit.</value>
+    public long? PerJobUserTimeLimit { get; set; }
 
     /// <summary>Gets or sets the minimum working set size for each process associated with the job.</summary>
-    /// <value>The minimum working set size for each process associated with the job.</value>
-    public nuint MinimumWorkingSetSize
-    {
-        get;
-        set
-        {
-            field = value;
-            InternalFlags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_WORKINGSET;
-        }
-    }
+    /// <value>The minimum working set size for each process associated with the job, or <see langword="null"/> to apply no limit.</value>
+    /// <remarks>Windows applies the working set limit only when both <see cref="MinimumWorkingSetSize"/> and <see cref="MaximumWorkingSetSize"/> are set.</remarks>
+    public nuint? MinimumWorkingSetSize { get; set; }
 
     /// <summary>Gets or sets the maximum working set size for each process associated with the job.</summary>
-    /// <value>The maximum working set size for each process associated with the job.</value>
-    public nuint MaximumWorkingSetSize
-    {
-        get;
-        set
-        {
-            field = value;
-            InternalFlags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_WORKINGSET;
-        }
-    }
+    /// <value>The maximum working set size for each process associated with the job, or <see langword="null"/> to apply no limit.</value>
+    /// <remarks>Windows applies the working set limit only when both <see cref="MinimumWorkingSetSize"/> and <see cref="MaximumWorkingSetSize"/> are set.</remarks>
+    public nuint? MaximumWorkingSetSize { get; set; }
 
     /// <summary>Gets or sets the active process limit for the job.</summary>
-    /// <value>The active process limit for the job.</value>
-    public uint ActiveProcessLimit
-    {
-        get;
-        set
-        {
-            field = value;
-            InternalFlags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_ACTIVE_PROCESS;
-        }
-    }
+    /// <value>The active process limit for the job, or <see langword="null"/> to apply no limit. A value of <c>0</c> is an explicit limit of zero processes, which makes the job reject every process.</value>
+    public uint? ActiveProcessLimit { get; set; }
 
     /// <summary>Gets or sets the processor affinity for all processes associated with the job.</summary>
-    /// <value>The processor affinity for all processes associated with the job.</value>
-    public nuint Affinity
-    {
-        get;
-        set
-        {
-            field = value;
-            InternalFlags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_AFFINITY;
-        }
-    }
+    /// <value>The processor affinity for all processes associated with the job, or <see langword="null"/> to apply no limit.</value>
+    public nuint? Affinity { get; set; }
 
     /// <summary>Gets or sets priority class for all processes associated with the job.</summary>
-    /// <value>The priority class for all processes associated with the job.</value>
-    public uint PriorityClass
-    {
-        get;
-        set
-        {
-            field = value;
-            InternalFlags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_PRIORITY_CLASS;
-        }
-    }
+    /// <value>The priority class for all processes associated with the job, or <see langword="null"/> to apply no limit.</value>
+    public uint? PriorityClass { get; set; }
 
-    /// <summary>Gets or sets scheduling  class for all processes associated with the job.</summary>
-    /// <value>The scheduling  class for all processes associated with the job.</value>
-    public uint SchedulingClass
-    {
-        get;
-        set
-        {
-            field = value;
-            InternalFlags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_SCHEDULING_CLASS;
-        }
-    }
+    /// <summary>Gets or sets scheduling class for all processes associated with the job.</summary>
+    /// <value>The scheduling class for all processes associated with the job, or <see langword="null"/> to apply no limit.</value>
+    public uint? SchedulingClass { get; set; }
 
     /// <summary>Gets or sets the limit for the virtual memory that can be committed by a process.</summary>
-    /// <value>The limit for the virtual memory that can be committed by a process.</value>
-    public nuint ProcessMemoryLimit
-    {
-        get;
-        set
-        {
-
-            field = value;
-            InternalFlags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_PROCESS_MEMORY;
-        }
-    }
+    /// <value>The limit for the virtual memory that can be committed by a process, or <see langword="null"/> to apply no limit.</value>
+    public nuint? ProcessMemoryLimit { get; set; }
 
     /// <summary>Gets or sets limit for the virtual memory that can be committed for the job.</summary>
-    /// <value>The limit for the virtual memory that can be committed for the job.</value>
-    public nuint JobMemoryLimit
+    /// <value>The limit for the virtual memory that can be committed for the job, or <see langword="null"/> to apply no limit.</value>
+    public nuint? JobMemoryLimit { get; set; }
+
+    internal JOB_OBJECT_LIMIT ComputeLimitFlags()
     {
-        get;
-        set
-        {
-            field = value;
-            InternalFlags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_JOB_MEMORY;
-        }
+        var flags = (JOB_OBJECT_LIMIT)Flags;
+
+        if (PerProcessUserTimeLimit.HasValue)
+            flags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_PROCESS_TIME;
+
+        if (PerJobUserTimeLimit.HasValue)
+            flags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_JOB_TIME;
+
+        if (MinimumWorkingSetSize.HasValue || MaximumWorkingSetSize.HasValue)
+            flags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_WORKINGSET;
+
+        if (ActiveProcessLimit.HasValue)
+            flags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_ACTIVE_PROCESS;
+
+        if (Affinity.HasValue)
+            flags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_AFFINITY;
+
+        if (PriorityClass.HasValue)
+            flags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_PRIORITY_CLASS;
+
+        if (SchedulingClass.HasValue)
+            flags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_SCHEDULING_CLASS;
+
+        if (ProcessMemoryLimit.HasValue)
+            flags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_PROCESS_MEMORY;
+
+        if (JobMemoryLimit.HasValue)
+            flags |= JOB_OBJECT_LIMIT.JOB_OBJECT_LIMIT_JOB_MEMORY;
+
+        return flags;
     }
 }

--- a/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
+++ b/tests/Meziantou.Framework.Win32.Jobs.Tests/JobObjectTests.cs
@@ -62,6 +62,56 @@ public class JobObjectTests
     }
 
     [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void Flags_AreReplacedNotAccumulated()
+    {
+        var limits = new JobObjectLimits { Flags = JobObjectLimitFlags.KillOnJobClose };
+        limits.Flags = JobObjectLimitFlags.SilentBreakawayOk;
+
+        Assert.Equal(JobObjectLimitFlags.SilentBreakawayOk, limits.Flags);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "ping",
+            Arguments = "127.0.0.1 -n 100",
+            UseShellExecute = true,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(psi);
+        Assert.NotNull(process);
+        Assert.False(process.WaitForExit(500)); // Ensure process is started
+
+        using (var job = new JobObject())
+        {
+            job.SetLimits(limits);
+            job.AssignProcess(process);
+        }
+
+        // KillOnJobClose was replaced before SetLimits, so closing the job must leave the process alive
+        Assert.False(process.WaitForExit(1000));
+        process.Kill();
+        process.WaitForExit();
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void ActiveProcessLimit_UnsetAppliesNoLimit()
+    {
+        using var job = new JobObject();
+        job.SetLimits(new JobObjectLimits { Flags = JobObjectLimitFlags.SilentBreakawayOk });
+
+        job.AssignProcess(Process.GetCurrentProcess());
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
+    public void ActiveProcessLimit_ZeroIsAnExplicitLimit()
+    {
+        using var job = new JobObject();
+        job.SetLimits(new JobObjectLimits { ActiveProcessLimit = 0 });
+
+        Assert.Throws<Win32Exception>(() => job.AssignProcess(Process.GetCurrentProcess()));
+    }
+
+    [Fact, RunIf(TestOperatingSystems.Windows)]
     public void CreateAndOpenJobObject()
     {
         var objectName = Guid.NewGuid().ToString("N");


### PR DESCRIPTION
> **Breaking change** — targets a future 5.0.0, since 4.0.0 is already published.

**Where:** `src/Meziantou.Framework.Win32.Jobs/JobObjectLimits.cs` — all eleven setters

Every setter did `InternalFlags |= <its flag>` and never cleared, so a limit could be switched on but never off. Two distinct failures followed from that one root cause.

### Scenario A — a revoked flag is still sent

```csharp
var l = new JobObjectLimits { JobMemoryLimit = 100 * 1024 * 1024 };
l.Flags = JobObjectLimitFlags.KillOnJobClose;
l.Flags = JobObjectLimitFlags.SilentBreakawayOk;   // caller changes their mind
```

The getter reports `SilentBreakawayOk`. Win32 receives `SilentBreakawayOk | KillOnJobClose`, so **every process in the job is still killed when the last handle closes**. Short of allocating a fresh `JobObjectLimits`, the caller cannot take that flag back — and the object's observable state disagrees with what it sends to the kernel, which makes it impossible to reason about locally.

### Scenario B — `0` is not a neutral value

`new JobObjectLimits { ActiveProcessLimit = 0 }` set `JOB_OBJECT_LIMIT_ACTIVE_PROCESS` with a limit of zero. Win32 accepted it, and the next `AssignProcess` failed with `Not enough quota is available to process this command` — so a caller who wrote `0` meaning "no limit" got a job that can never hold a process, diagnosed at an unrelated call site.

### The change

Make the limit values nullable and derive `LimitFlags` in one pass at `SetLimits` time from which ones are non-null. "Unset" becomes expressible and is the default; `Flags` assigns rather than accumulates; an explicit `0` now means a real limit of zero, which is at least honest.

This is the "nullable fields" direction rather than the narrower "make it reversible" one — it fixes both scenarios instead of just the first.

### Compatibility

**BREAKING:** the value properties are now `uint?` / `nuint?` / `long?`. *Assigning* them is unchanged, so most construction sites compile as-is; code that reads them back gets a nullable. Setting a value no longer keeps earlier `Flags` assignments alive.

### Verification

`Flags_AreReplacedNotAccumulated` is a behavioral regression test, not just a getter check: it assigns `KillOnJobClose`, replaces it, assigns a live process, closes the job, and asserts the process is **still running**. On the old code that process would be killed. Plus tests for unset-means-no-limit and explicit-zero. Suite is 17/17 green.
