### PR TITLE
Block NAT64 local-use, site-local and IPv4-translated IPv6 ranges

### DIFF
--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryOptions.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryOptions.cs
@@ -36,8 +36,12 @@ public sealed class ServerSideRequestForgeryOptions
         IPNetwork.Parse("::/96"),
         // IPv6 loopback address. Already covered by ::/96 above, but listed explicitly because it is the range most often looked for.
         IPNetwork.Parse("::1/128"),
+        // IPv4-translated range (RFC2765). Embeds an IPv4 address, and is not normalized by IPAddress.IsIPv4MappedToIPv6.
+        IPNetwork.Parse("::ffff:0:0:0/96"),
         // NAT64 well-known prefix (RFC6052). Embeds an IPv4 address, so it reaches IPv4 targets from an IPv6-only network.
         IPNetwork.Parse("64:ff9b::/96"),
+        // NAT64 local-use prefix (RFC8215), the standard choice when the well-known prefix is unsuitable. Also embeds an IPv4 address.
+        IPNetwork.Parse("64:ff9b:1::/48"),
         // Teredo tunneling range (RFC4380). Embeds an IPv4 address.
         IPNetwork.Parse("2001::/32"),
         // 6to4 range (RFC3056). Embeds an IPv4 address in the second and third groups.
@@ -46,6 +50,8 @@ public sealed class ServerSideRequestForgeryOptions
         IPNetwork.Parse("fc00::/7"),
         // IPv6 link-local addresses.
         IPNetwork.Parse("fe80::/10"),
+        // Deprecated IPv6 site-local addresses (RFC3879), private scope. Falls in the gap between fc00::/7 and fe80::/10.
+        IPNetwork.Parse("fec0::/10"),
         // IPv6 multicast range.
         IPNetwork.Parse("ff00::/8"),
     ];

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
@@ -317,7 +317,25 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
     [InlineData("2002:7f00:0001::")]
     [InlineData("2002:a9fe:a9fe::")]
     [InlineData("2001::1")]
+    [InlineData("64:ff9b:1::7f00:1")]
+    [InlineData("64:ff9b:1::a9fe:a9fe")]
+    [InlineData("::ffff:0:7f00:1")]
+    [InlineData("::ffff:0:a9fe:a9fe")]
     public async Task ResolveAndSelectIpAddressAsync_RejectsAddressEmbeddingUnsafeIpv4Target(string address)
+    {
+        await Assert.ThrowsAsync<ServerSideRequestForgeryException>(() => ServerSideRequestForgeryConnectPipeline.ResolveAndSelectIpAddressAsync(
+            requestUri: new Uri("https://example.com"),
+            dnsEndPoint: new DnsEndPoint("example.com", 443),
+            options: new ServerSideRequestForgeryOptions(),
+            dnsIpAddressResolver: new FakeDnsIpAddressResolver([IPAddress.Parse(address)]),
+            cancellationToken: CancellationToken.None).AsTask());
+    }
+
+    [Theory]
+    // Deprecated IPv6 site-local addresses (RFC3879) sit between fc00::/7 and fe80::/10 and are private scope.
+    [InlineData("fec0::1")]
+    [InlineData("feff::1")]
+    public async Task ResolveAndSelectIpAddressAsync_RejectsSiteLocalAddress(string address)
     {
         await Assert.ThrowsAsync<ServerSideRequestForgeryException>(() => ServerSideRequestForgeryConnectPipeline.ResolveAndSelectIpAddressAsync(
             requestUri: new Uri("https://example.com"),
@@ -333,6 +351,8 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
     [InlineData("2003::1")]
     [InlineData("192.1.0.1")]
     [InlineData("192.89.0.1")]
+    [InlineData("64:ff9b:2::1")]
+    [InlineData("2001:db8::1")]
     public async Task ResolveAndSelectIpAddressAsync_AllowsGlobalUnicastAddressNearBlockedRange(string address)
     {
         var options = new ServerSideRequestForgeryOptions


### PR DESCRIPTION
Commit 9764d91da added the IPv6 transition ranges that smuggle an IPv4 address inside an IPv6 one — `::/96`, `64:ff9b::/96`, `2001::/32`, `2002::/16`. Three neighbours in the same class were missed.

### What gets through today

Verified against the default `UnsafeIpNetworks` array in `ServerSideRequestForgeryOptions.cs:9-51`:

| Address | Blocked before | Blocked after |
|---|---|---|
| `64:ff9b:1::a9fe:a9fe` (RFC 8215 local-use NAT64 → 169.254.169.254) | no | yes |
| `64:ff9b:1::7f00:1` (RFC 8215 local-use NAT64 → 127.0.0.1) | no | yes |
| `fec0::1`, `feff::1` (RFC 3879 site-local) | no | yes |
| `::ffff:0:7f00:1` (RFC 2765 IPv4-translated) | no | yes |

The one that matters is `64:ff9b:1::/48`. On a network running NAT64 with the RFC 8215 local-use prefix — the standard choice when the well-known `64:ff9b::/96` is unsuitable — the gateway translates `64:ff9b:1::a9fe:a9fe` into a packet to `169.254.169.254`. That is the cloud metadata endpoint, reached through a filter written specifically to stop it.

`fec0::/10` falls in the gap between `fc00::/7` (which ends at `fdff::`) and `fe80::/10` (which starts at `fe80::`), so nothing covered it. `::ffff:0:0:0/96` is distinct from the IPv4-mapped `::ffff:0:0/96` and is not normalised by `IPAddress.IsIPv4MappedToIPv6`, so it never reached `NormalizeAddress`.

The last two are lower value — site-local is deprecated and IPv4-translated addresses are not routed by current stacks — but they cost one line each and belong with the rest.

### Changed

- `ServerSideRequestForgeryOptions.cs` — three entries added to `DefaultUnsafeIpNetworks`, each commented in the existing style with its RFC.
- Extended `ResolveAndSelectIpAddressAsync_RejectsAddressEmbeddingUnsafeIpv4Target` with the four new embedded-IPv4 forms.
- Added `ResolveAndSelectIpAddressAsync_RejectsSiteLocalAddress` — site-local is a private-scope range rather than an embedded IPv4 target, so it did not belong in that theory.
- Added `64:ff9b:2::1` and `2001:db8::1` to `ResolveAndSelectIpAddressAsync_AllowsGlobalUnicastAddressNearBlockedRange` to pin the new boundaries from the other side.

No public API change, so no `ref/` update.

### Note on completeness

RFC 6052 §2.2 lets a network use *any* prefix for NAT64, so prefix-based blocking is inherently incomplete — operators on such a network still need to add their own prefix to `UnsafeIpNetworks`. This closes the two standardised prefixes; it cannot close the general case. Worth a readme line, which I have kept out of this PR to leave the diff to the defaults.

### Verified

`dotnet test tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests /p:TreatsWarningsAsErrors=true` — 138 passed (69 per TFM, up from 61), 0 failed, on net10.0 and net11.0. `dotnet run ./eng/update-all.cs` produced no further changes.

Found during a review of `src/Meziantou.Framework.Http.ServerSideRequestForgery` (finding F4 of 10).
