### PR TITLE
Refuse to configure SSRF over an existing ConnectCallback

### DIFF
--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
@@ -16,6 +16,12 @@ internal static class ServerSideRequestForgeryConnectPipeline
         ArgumentNullException.ThrowIfNull(options.ResolutionStrategy);
         ArgumentNullException.ThrowIfNull(dnsIpAddressResolver);
 
+        // Assigning the callback would discard the existing one, and the connection would no longer be established
+        // the way the caller configured it. Silently dropping it is worse than refusing: nothing would report that
+        // the custom transport had stopped running.
+        if (handler.ConnectCallback is not null)
+            throw new InvalidOperationException("The handler already has a ConnectCallback, which SSRF protection would replace. Remove it, or configure SSRF protection on a handler that does not define one.");
+
         handler.ConnectCallback = (context, cancellationToken) => ConnectGuardingAgainstProxyAsync(handler, context, options, dnsIpAddressResolver, cancellationToken);
     }
 

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
@@ -18,6 +18,27 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
         Assert.NotNull(handler.ConnectCallback);
     }
 
+    [Fact]
+    public void ConfigureSsrf_ThrowsWhenTheHandlerAlreadyHasAConnectCallback()
+    {
+        using var handler = new SocketsHttpHandler
+        {
+            ConnectCallback = (context, cancellationToken) => throw new InvalidOperationException("should never run"),
+        };
+
+        Assert.Throws<InvalidOperationException>(() => handler.ConfigureSsrf(new ServerSideRequestForgeryOptions(), new FakeDnsIpAddressResolver([IPAddress.Parse("203.0.113.10")])));
+    }
+
+    [Fact]
+    public void ConfigureSsrf_ThrowsWhenCalledTwiceOnTheSameHandler()
+    {
+        using var handler = new SocketsHttpHandler();
+        var resolver = new FakeDnsIpAddressResolver([IPAddress.Parse("203.0.113.10")]);
+        handler.ConfigureSsrf(new ServerSideRequestForgeryOptions(), resolver);
+
+        Assert.Throws<InvalidOperationException>(() => handler.ConfigureSsrf(new ServerSideRequestForgeryOptions(), resolver));
+    }
+
     [Theory]
     [InlineData(AddressFamily.InterNetwork)]
     [InlineData(AddressFamily.InterNetworkV6)]


### PR DESCRIPTION
`Configure` assigned `handler.ConnectCallback` unconditionally (`ServerSideRequestForgeryConnectPipeline.cs:19`), so configuring SSRF protection on a handler that already had a connect callback discarded it with no error.

### What happens

```csharp
var handler = new SocketsHttpHandler
{
    // Unix socket transport, custom TLS, a test harness…
    ConnectCallback = MyTransport.ConnectAsync,
};

handler.ConfigureSsrf(options); // MyTransport.ConnectAsync is now unreachable, silently
```

The custom transport stops running and nothing says so. Whatever it was doing — routing over a Unix socket, pinning a certificate, serving a fake in tests — quietly becomes a plain TCP connection.

Calling `ConfigureSsrf` twice on the same handler had the same shape: the second call replaced the first, which is only ever a mistake.

### Changed

`Configure` now throws `InvalidOperationException` when `handler.ConnectCallback` is already set, before touching it. `InvalidOperationException` rather than `ServerSideRequestForgeryException` — this is a handler in the wrong state at setup time, not a request rejected at connect time.

Two tests added: one for a pre-existing callback, one for a double `ConfigureSsrf` call.

### What this does not cover

The reverse direction still fails open and cannot be caught through this API:

```csharp
handler.ConfigureSsrf(options);
handler.ConnectCallback = somethingElse; // all protection gone, no error
```

That ordering is plausible in DI setups where `ConfigureHttpClient` call order is not obvious. There is no hook to detect it — `SocketsHttpHandler.ConnectCallback` is an ordinary settable property. Worth a readme line; I have left it out of this diff.

### Compatibility

This is a behaviour change. Code that relied on `ConfigureSsrf` overwriting an existing callback now throws instead. That combination was already broken — the overwritten callback was not running — so the exception surfaces an existing bug rather than creating one. Still, it turns a silent misconfiguration into a startup failure, so it is a breaking change for anyone in that state.

### Verified

`dotnet test tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests /p:TreatsWarningsAsErrors=true` — 126 passed (63 per TFM, up from 61), 0 failed, on net10.0 and net11.0. No public API change, so no `ref/` update. `dotnet run ./eng/update-all.cs` produced no further changes.

Found during a review of `src/Meziantou.Framework.Http.ServerSideRequestForgery` (finding F7 of 10).
