### PR TITLE
Cache the proxy probe lookups per proxy instance

### DIFF
--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 
 namespace Meziantou.Framework.Http.ServerSideRequestForgery;
@@ -8,6 +9,12 @@ internal static class ServerSideRequestForgeryConnectPipeline
 {
     // Reserved TLD (RFC2606): never a real destination, so a proxy returned for it is the handler's proxy address.
     private static readonly Uri[] ProxyProbeUris = [new("https://ssrf-proxy-probe.invalid/"), new("http://ssrf-proxy-probe.invalid/")];
+
+    // Short enough that a proxy reconfiguration takes effect promptly, long enough to cover a burst of connections.
+    // The window is not attacker-controlled: it bounds how long a change the application makes takes to be observed.
+    internal const long ProxyProbeCacheDurationMs = 1000;
+
+    private static readonly ConditionalWeakTable<IWebProxy, ProxyProbeCache> ProxyProbeCaches = [];
 
     internal static void Configure(SocketsHttpHandler handler, ServerSideRequestForgeryOptions options, IDnsIpAddressResolver dnsIpAddressResolver)
     {
@@ -231,13 +238,53 @@ internal static class ServerSideRequestForgeryConnectPipeline
         if (ProxyAddressMatchesEndPoint(proxy, requestUri, dnsEndPoint, unknownMeansProxied: true))
             return true;
 
-        foreach (var probeUri in ProxyProbeUris)
+        foreach (var probeAddress in GetProbeProxyAddresses(proxy))
         {
-            if (ProxyAddressMatchesEndPoint(proxy, probeUri, dnsEndPoint, unknownMeansProxied: false))
+            if (probeAddress is not null && MatchesEndPoint(probeAddress, dnsEndPoint))
                 return true;
         }
 
         return false;
+    }
+
+    // The probe destinations are constant, so the answer depends only on the proxy, not on the request. Resolving
+    // them per connection is what costs: a PAC-backed proxy evaluates the script for every lookup, and WinHTTP
+    // caches by URL, so the reserved probe destinations are a permanent cache miss while the real request URI is
+    // not. Caching them per proxy instance for a short window collapses that cost across a burst of connections.
+    private static Uri?[] GetProbeProxyAddresses(IWebProxy proxy)
+    {
+        var cache = ProxyProbeCaches.GetOrCreateValue(proxy);
+        var cachedAddresses = cache.TryGet();
+        if (cachedAddresses is not null)
+            return cachedAddresses;
+
+        var addresses = new Uri?[ProxyProbeUris.Length];
+        for (var i = 0; i < ProxyProbeUris.Length; i++)
+        {
+            addresses[i] = TryGetProxyAddress(proxy, ProxyProbeUris[i]);
+        }
+
+        cache.Set(addresses);
+        return addresses;
+    }
+
+    /// <summary>Resolves the proxy address for a probe destination, or <see langword="null"/> when the proxy does not apply to it.</summary>
+    private static Uri? TryGetProxyAddress(IWebProxy proxy, Uri destination)
+    {
+        Uri? proxyUri;
+        try
+        {
+            proxyUri = proxy.GetProxy(destination);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A probe destination the proxy dislikes tells us nothing and must not fail an ordinary request.
+            return null;
+        }
+
+        // IWebProxy reports "no proxy for this destination" either by returning null (HttpClient.DefaultProxy)
+        // or by returning the destination itself (WebProxy when the address is bypassed).
+        return proxyUri == destination ? null : proxyUri;
     }
 
     private static bool ProxyAddressMatchesEndPoint(IWebProxy proxy, Uri destination, DnsEndPoint dnsEndPoint, bool unknownMeansProxied)
@@ -250,7 +297,7 @@ internal static class ServerSideRequestForgeryConnectPipeline
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // A proxy that cannot answer for the real request is treated as one that applies, so the connection
-            // fails closed. A probe destination it dislikes tells us nothing and must not fail an ordinary request.
+            // fails closed.
             return unknownMeansProxied;
         }
 
@@ -259,8 +306,34 @@ internal static class ServerSideRequestForgeryConnectPipeline
         if (proxyUri is null || proxyUri == destination)
             return false;
 
+        return MatchesEndPoint(proxyUri, dnsEndPoint);
+    }
+
+    private static bool MatchesEndPoint(Uri proxyUri, DnsEndPoint dnsEndPoint)
+    {
         return proxyUri.Port == dnsEndPoint.Port
             && string.Equals(NormalizeHost(proxyUri.IdnHost), NormalizeHost(dnsEndPoint.Host), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class ProxyProbeCache
+    {
+        private Uri?[]? _addresses;
+        private long _expiresAt;
+
+        public Uri?[]? TryGet()
+        {
+            var addresses = Volatile.Read(ref _addresses);
+            if (addresses is null || Environment.TickCount64 >= Volatile.Read(ref _expiresAt))
+                return null;
+
+            return addresses;
+        }
+
+        public void Set(Uri?[] addresses)
+        {
+            Volatile.Write(ref _expiresAt, Environment.TickCount64 + ProxyProbeCacheDurationMs);
+            Volatile.Write(ref _addresses, addresses);
+        }
     }
 
     private static bool IsAllowedScheme(Uri requestUri, ServerSideRequestForgeryOptions options)

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
@@ -248,6 +248,105 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
             options);
     }
 
+    [Fact]
+    public void EnsureConnectionIsNotToAProxy_ProbesTheProxyOnceForABurstOfConnections()
+    {
+        var options = new ServerSideRequestForgeryOptions();
+        var proxy = new CountingWebProxy(new Uri("http://proxy.invalid:8080"));
+        using var handler = new SocketsHttpHandler { UseProxy = true, Proxy = proxy };
+
+        for (var i = 0; i < 5; i++)
+        {
+            ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
+                handler,
+                new Uri("https://example.com/"),
+                new DnsEndPoint("example.com", 443),
+                options);
+        }
+
+        // The two reserved probe destinations are resolved once and reused; only the real request URI is asked every time.
+        Assert.Equal(2, proxy.ProbeQueryCount);
+        Assert.Equal(5, proxy.RequestQueryCount);
+    }
+
+    [Fact]
+    public void EnsureConnectionIsNotToAProxy_StillDetectsTheProxyOnACachedProbeResult()
+    {
+        var options = new ServerSideRequestForgeryOptions();
+        var proxy = new CountingWebProxy(new Uri("http://proxy.invalid:8080"));
+        using var handler = new SocketsHttpHandler { UseProxy = true, Proxy = proxy };
+
+        // Populate the cache with a connection that is not to the proxy.
+        ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
+            handler,
+            new Uri("https://example.com/"),
+            new DnsEndPoint("example.com", 443),
+            options);
+
+        // A later connection that does target the proxy must still be rejected off the cached probe result.
+        var exception = Assert.Throws<ServerSideRequestForgeryException>(() => ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
+            handler,
+            new Uri("https://example.com/"),
+            new DnsEndPoint("proxy.invalid", 8080),
+            options));
+
+        Assert.Contains("targets a proxy", exception.Message);
+        Assert.Equal(2, proxy.ProbeQueryCount);
+    }
+
+    [Fact]
+    public void EnsureConnectionIsNotToAProxy_DoesNotShareProbeResultsBetweenProxies()
+    {
+        var options = new ServerSideRequestForgeryOptions();
+        var first = new CountingWebProxy(new Uri("http://proxy-one.invalid:8080"));
+        var second = new CountingWebProxy(new Uri("http://proxy-two.invalid:9090"));
+
+        using var handler = new SocketsHttpHandler { UseProxy = true, Proxy = first };
+        ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
+            handler,
+            new Uri("https://example.com/"),
+            new DnsEndPoint("example.com", 443),
+            options);
+
+        handler.Proxy = second;
+        Assert.Throws<ServerSideRequestForgeryException>(() => ServerSideRequestForgeryConnectPipeline.EnsureConnectionIsNotToAProxy(
+            handler,
+            new Uri("https://example.com/"),
+            new DnsEndPoint("proxy-two.invalid", 9090),
+            options));
+
+        Assert.Equal(2, first.ProbeQueryCount);
+        Assert.Equal(2, second.ProbeQueryCount);
+    }
+
+    private sealed class CountingWebProxy(Uri proxyUri) : IWebProxy
+    {
+        private int _probeQueryCount;
+        private int _requestQueryCount;
+
+        public ICredentials? Credentials { get; set; }
+
+        public int ProbeQueryCount => _probeQueryCount;
+
+        public int RequestQueryCount => _requestQueryCount;
+
+        public Uri? GetProxy(Uri destination)
+        {
+            if (destination.Host.EndsWith(".invalid", StringComparison.OrdinalIgnoreCase))
+            {
+                Interlocked.Increment(ref _probeQueryCount);
+                return proxyUri;
+            }
+
+            // Mirrors the case the probes exist for: the proxy reports nothing for the real destination, so its
+            // own address is only visible through a destination that is certainly not it.
+            Interlocked.Increment(ref _requestQueryCount);
+            return null;
+        }
+
+        public bool IsBypassed(Uri host) => false;
+    }
+
     private static ServerSideRequestForgeryOptions CreateProxyTestOptions()
     {
         var options = new ServerSideRequestForgeryOptions();


### PR DESCRIPTION
`IsConnectionToAProxy` ran up to three `IWebProxy.GetProxy` lookups on every new connection (`ServerSideRequestForgeryConnectPipeline.cs:219-241`): once for the real request URI, then once for each of the two reserved probe destinations. In the common non-proxied case none matches, so all three run every time — synchronously, on the connect path, before any async work starts.

### Why the probes are the expensive ones

The probe destinations (`https://ssrf-proxy-probe.invalid/`, `http://ssrf-proxy-probe.invalid/`) are constant, so the answer depends only on the proxy instance — not on the request. But when `HttpClient.DefaultProxy` is the Windows system proxy backed by a PAC script, each lookup can execute the script, and WinHTTP's result cache is keyed by URL. The real request URI is likely already in that cache; the two reserved destinations are a **permanent cache miss**, so they re-evaluate the PAC on every single connection. PAC evaluation can itself perform network I/O, and the call blocks the calling thread rather than yielding — on a thread-pool-constrained app under load that converts into starvation.

### Changed

The two probe results are now resolved once per proxy instance and reused for a short window:

- `ConditionalWeakTable<IWebProxy, ProxyProbeCache>` keyed on the proxy instance, so a different proxy object never reuses another's answer and neither keeps the other alive.
- 1 second TTL (`ProxyProbeCacheDurationMs`).
- The real request URI is still resolved on every connection, uncached — it varies per request and it is the cheap one.
- `ProxyAddressMatchesEndPoint`'s tail is extracted into `MatchesEndPoint` and shared with the cached path, so the host/port comparison stays in one place.

The comment at `:221-222` — read the proxy live so a late `handler.Proxy` assignment or a `HttpClient.DefaultProxy` change is still seen — is preserved: the proxy is still read per connection, and swapping the instance swaps the cache with it.

### The tradeoff, stated plainly

This caches part of a security decision, so it deserves scrutiny. What the window costs: for up to one second after the application changes its proxy configuration *on the same `IWebProxy` instance* (e.g. mutating `WebProxy.Address`, or a system proxy setting change picked up by `HttpWindowsProxy`), connections may still be evaluated against the previous answer.

That window is **not attacker-controlled**. An attacker who supplies a URL cannot induce a proxy reconfiguration, so there is no way to steer a request into the stale window. It bounds how quickly a change *the application makes* is observed, which is a correctness property, not an attack surface. Replacing the proxy instance — the usual way this changes — is picked up immediately.

If you would rather not cache here at all, the alternative is to leave the three lookups and accept the PAC cost; I could not find a way to reduce the count without caching, because the ambiguity the probes resolve (`GetProxy` returning the destination itself is indistinguishable from "bypassed") is exactly what makes the real request URI insufficient on its own.

### Verified

`dotnet test tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests /p:TreatsWarningsAsErrors=true` — 128 passed (64 per TFM, up from 61), 0 failed, on net10.0 and net11.0.

Three tests added, using a counting `IWebProxy` that returns nothing for the real destination and its own address for the probes — the ambiguous shape the probes exist to resolve:

- a burst of 5 connections probes twice, not ten times, while the real URI is still asked five times;
- a proxied endpoint is still rejected off a *cached* probe result;
- two proxy instances do not share a cache.

No public API change, so no `ref/` update. `dotnet run ./eng/update-all.cs` produced no further changes.

Found during a review of `src/Meziantou.Framework.Http.ServerSideRequestForgery` (finding F5 of 10).
