### PR TITLE
Log the request origin instead of the full request URI

### DIFF
--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/Log.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/Log.cs
@@ -4,24 +4,24 @@ namespace Meziantou.Framework.Http.ServerSideRequestForgery;
 
 internal static partial class Log
 {
-    [LoggerMessage(EventId = 1, Level = LogLevel.Warning, Message = "Rejected request to {requestUri}. Scheme '{scheme}' is not allowed.")]
-    public static partial void RejectedUnsafeScheme(ILogger logger, Uri requestUri, string scheme);
+    [LoggerMessage(EventId = 1, Level = LogLevel.Warning, Message = "Rejected request to {requestOrigin}. Scheme '{scheme}' is not allowed.")]
+    public static partial void RejectedUnsafeScheme(ILogger logger, string requestOrigin, string scheme);
 
-    [LoggerMessage(EventId = 2, Level = LogLevel.Warning, Message = "Rejected request to {requestUri}. Connect endpoint host '{endpointHost}' does not match request authority '{requestHost}'.")]
-    public static partial void RejectedHostMismatch(ILogger logger, Uri requestUri, string endpointHost, string requestHost);
+    [LoggerMessage(EventId = 2, Level = LogLevel.Warning, Message = "Rejected request to {requestOrigin}. Connect endpoint host '{endpointHost}' does not match request authority '{requestHost}'.")]
+    public static partial void RejectedHostMismatch(ILogger logger, string requestOrigin, string endpointHost, string requestHost);
 
-    [LoggerMessage(EventId = 3, Level = LogLevel.Warning, Message = "Rejected request to {requestUri}. All resolved IP addresses were unsafe.")]
-    public static partial void RejectedAllResolvedAddressesUnsafe(ILogger logger, Uri requestUri);
+    [LoggerMessage(EventId = 3, Level = LogLevel.Warning, Message = "Rejected request to {requestOrigin}. All resolved IP addresses were unsafe.")]
+    public static partial void RejectedAllResolvedAddressesUnsafe(ILogger logger, string requestOrigin);
 
-    [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "Rejected request to {requestUri}. DNS resolved both safe and unsafe IP addresses while mixed results are disallowed.")]
-    public static partial void RejectedMixedResolvedAddresses(ILogger logger, Uri requestUri);
+    [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "Rejected request to {requestOrigin}. DNS resolved both safe and unsafe IP addresses while mixed results are disallowed.")]
+    public static partial void RejectedMixedResolvedAddresses(ILogger logger, string requestOrigin);
 
-    [LoggerMessage(EventId = 5, Level = LogLevel.Warning, Message = "Rejected request to {requestUri}. Resolution strategy selected an address outside the validated safe set.")]
-    public static partial void RejectedSelectedAddressNotInSafeSet(ILogger logger, Uri requestUri);
+    [LoggerMessage(EventId = 5, Level = LogLevel.Warning, Message = "Rejected request to {requestOrigin}. Resolution strategy selected an address outside the validated safe set.")]
+    public static partial void RejectedSelectedAddressNotInSafeSet(ILogger logger, string requestOrigin);
 
-    [LoggerMessage(EventId = 6, Level = LogLevel.Warning, Message = "Rejected request to {requestUri}. Resolution strategy failed: {reason}")]
-    public static partial void RejectedResolutionStrategyFailure(ILogger logger, Uri requestUri, string reason);
+    [LoggerMessage(EventId = 6, Level = LogLevel.Warning, Message = "Rejected request to {requestOrigin}. Resolution strategy failed: {reason}")]
+    public static partial void RejectedResolutionStrategyFailure(ILogger logger, string requestOrigin, string reason);
 
-    [LoggerMessage(EventId = 7, Level = LogLevel.Warning, Message = "Rejected request to {requestUri}. The connection targets proxy '{proxyHost}', whose tunnelled destination cannot be validated.")]
-    public static partial void RejectedProxyConnection(ILogger logger, Uri requestUri, string proxyHost);
+    [LoggerMessage(EventId = 7, Level = LogLevel.Warning, Message = "Rejected request to {requestOrigin}. The connection targets proxy '{proxyHost}', whose tunnelled destination cannot be validated.")]
+    public static partial void RejectedProxyConnection(ILogger logger, string requestOrigin, string proxyHost);
 }

--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
@@ -36,14 +36,14 @@ internal static class ServerSideRequestForgeryConnectPipeline
 
         if (!IsAllowedScheme(requestUri, options))
         {
-            Log.RejectedUnsafeScheme(logger, requestUri, requestUri.Scheme);
+            Log.RejectedUnsafeScheme(logger, FormatRequestOrigin(requestUri), requestUri.Scheme);
             ServerSideRequestForgeryMetrics.IncrementRejectedRequest("unsafe_scheme");
             throw new ServerSideRequestForgeryException($"The URI scheme '{requestUri.Scheme}' is not allowed.");
         }
 
         if (!HostsMatch(dnsEndPoint.Host, requestUri.IdnHost))
         {
-            Log.RejectedHostMismatch(logger, requestUri, dnsEndPoint.Host, requestUri.IdnHost);
+            Log.RejectedHostMismatch(logger, FormatRequestOrigin(requestUri), dnsEndPoint.Host, requestUri.IdnHost);
             ServerSideRequestForgeryMetrics.IncrementRejectedRequest("host_mismatch");
             throw new ServerSideRequestForgeryException("The host resolved for the connection does not match the request URI authority.");
         }
@@ -70,14 +70,14 @@ internal static class ServerSideRequestForgeryConnectPipeline
         }
         catch (ServerSideRequestForgeryException ex)
         {
-            Log.RejectedResolutionStrategyFailure(logger, requestUri, ex.Message);
+            Log.RejectedResolutionStrategyFailure(logger, FormatRequestOrigin(requestUri), ex.Message);
             ServerSideRequestForgeryMetrics.IncrementRejectedRequest("resolution_strategy_failure");
             throw;
         }
 
         if (!safeAddresses.Exists(address => address.Equals(selectedAddress)))
         {
-            Log.RejectedSelectedAddressNotInSafeSet(logger, requestUri);
+            Log.RejectedSelectedAddressNotInSafeSet(logger, FormatRequestOrigin(requestUri));
             ServerSideRequestForgeryMetrics.IncrementRejectedRequest("selected_address_not_validated");
             throw new ServerSideRequestForgeryException("The resolution strategy selected an address that was not part of the validated safe set.");
         }
@@ -175,14 +175,14 @@ internal static class ServerSideRequestForgeryConnectPipeline
 
         if (safeAddresses.Count == 0)
         {
-            Log.RejectedAllResolvedAddressesUnsafe(logger, requestUri);
+            Log.RejectedAllResolvedAddressesUnsafe(logger, FormatRequestOrigin(requestUri));
             ServerSideRequestForgeryMetrics.IncrementRejectedRequest("all_resolved_addresses_unsafe");
             throw new ServerSideRequestForgeryException("No safe IP addresses were found after validation.");
         }
 
         if (hasUnsafeAddress && options.DisallowMixedSafeAndUnsafeIpAddresses)
         {
-            Log.RejectedMixedResolvedAddresses(logger, requestUri);
+            Log.RejectedMixedResolvedAddresses(logger, FormatRequestOrigin(requestUri));
             ServerSideRequestForgeryMetrics.IncrementRejectedRequest("mixed_addresses_disallowed");
             throw new ServerSideRequestForgeryException("The hostname resolved to a mix of safe and unsafe IP addresses.");
         }
@@ -211,7 +211,7 @@ internal static class ServerSideRequestForgeryConnectPipeline
         if (!IsConnectionToAProxy(handler, requestUri, dnsEndPoint))
             return;
 
-        Log.RejectedProxyConnection(options.Logger, requestUri, dnsEndPoint.Host);
+        Log.RejectedProxyConnection(options.Logger, FormatRequestOrigin(requestUri), dnsEndPoint.Host);
         ServerSideRequestForgeryMetrics.IncrementRejectedRequest("proxy_connection");
         throw new ServerSideRequestForgeryException("The connection targets a proxy. The request's real destination is established by the proxy and is not visible here, so it cannot be validated. Set SocketsHttpHandler.UseProxy to false, or send requests that need SSRF protection through a handler that does not use a proxy.");
     }
@@ -281,6 +281,18 @@ internal static class ServerSideRequestForgeryConnectPipeline
         }
 
         return host.TrimEnd('.');
+    }
+
+    /// <summary>Formats the destination for a log message, keeping only the parts that identify it.</summary>
+    /// <remarks>
+    /// The full <see cref="Uri"/> must never reach a log: <see cref="Uri.ToString"/> keeps the userinfo and the
+    /// query string, so a rejected request carrying basic-auth credentials, a bearer token or a signed-URL
+    /// signature would write that secret at Warning level. The origin is what identifies the destination, and it
+    /// is the only part a rejection needs.
+    /// </remarks>
+    internal static string FormatRequestOrigin(Uri requestUri)
+    {
+        return $"{requestUri.Scheme}://{requestUri.IdnHost}:{requestUri.Port}";
     }
 
     private static IPAddress NormalizeAddress(IPAddress address)

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
@@ -501,6 +501,38 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
     }
 
     [Fact]
+    public async Task ResolveAndSelectIpAddressAsync_DoesNotLogUserInfoOrQueryString()
+    {
+        using var loggerProvider = new InMemoryLoggerProvider();
+        var options = new ServerSideRequestForgeryOptions
+        {
+            Logger = loggerProvider.CreateLogger("ssrf-test"),
+        };
+
+        await Assert.ThrowsAsync<ServerSideRequestForgeryException>(() => ServerSideRequestForgeryConnectPipeline.ResolveAndSelectIpAddressAsync(
+            requestUri: new Uri("https://alice:s3cr3t@example.com/path?token=abcdef"),
+            dnsEndPoint: new DnsEndPoint("example.com", 443),
+            options: options,
+            dnsIpAddressResolver: new FakeDnsIpAddressResolver([IPAddress.Loopback]),
+            cancellationToken: CancellationToken.None).AsTask());
+
+        var warning = Assert.Single(loggerProvider.Logs.Warnings);
+        Assert.DoesNotContain("s3cr3t", warning.Message);
+        Assert.DoesNotContain("alice", warning.Message);
+        Assert.DoesNotContain("abcdef", warning.Message);
+        Assert.DoesNotContain("token", warning.Message);
+        Assert.Contains("https://example.com:443", warning.Message);
+    }
+
+    [Fact]
+    public void FormatRequestOrigin_KeepsOnlyTheDestination()
+    {
+        Assert.Equal("https://example.com:443", ServerSideRequestForgeryConnectPipeline.FormatRequestOrigin(new Uri("https://alice:s3cr3t@example.com/path?token=abcdef")));
+        Assert.Equal("http://example.com:8080", ServerSideRequestForgeryConnectPipeline.FormatRequestOrigin(new Uri("http://example.com:8080/")));
+        Assert.Equal("https://xn--dj-kia8a.example:443", ServerSideRequestForgeryConnectPipeline.FormatRequestOrigin(new Uri("https://déjà.example/")));
+    }
+
+    [Fact]
     public async Task ResolveAndSelectIpAddressAsync_LogsHostMismatchRejectionReason()
     {
         using var loggerProvider = new InMemoryLoggerProvider();


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2571**

Every message in `Log.cs` took the `Uri` and formatted it as `{requestUri}`, which renders through `Uri.ToString()`. That keeps the userinfo and the query string:

```csharp
new Uri("https://alice:s3cr3t@internal.example/path?token=abcdef").ToString()
// => "https://alice:s3cr3t@internal.example/path?token=abcdef"
```

So any rejected request whose URL carried basic-auth credentials, a bearer token or a signed-URL signature wrote that secret to the log at `Warning` level, and on to wherever those logs ship.

Rejections are exactly the attacker-influenced requests, so this is reachable on demand: an attacker who can steer an outbound fetch at `https://x:y@127.0.0.1/?token=…` gets it written out. A library whose job is to constrain outbound requests should not be the thing that leaks them.

### Changed

- All seven `Log` methods now take `string requestOrigin` instead of `Uri requestUri`, and the message templates say `{requestOrigin}`.
- `FormatRequestOrigin` builds `scheme://idnHost:port` — the part that identifies the destination, which is all a rejection needs. The path is dropped along with the query, since signed URLs put secrets there too.
- The seven call sites in `ServerSideRequestForgeryConnectPipeline` route through it.

The exception messages were already clean — they never embedded the URI — so they are untouched. Event IDs are unchanged.

### Behaviour change for log consumers

Log output changes shape: `https://example.com/path?x=1` now appears as `https://example.com:443`. The port is always explicit, including when it is the default. Anything parsing these messages will need updating, which seems a fair trade for not emitting credentials.

### Verified

`dotnet test tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests /p:TreatsWarningsAsErrors=true` — 126 passed (63 per TFM, up from 61), 0 failed, on net10.0 and net11.0.

Two tests added:

- `ResolveAndSelectIpAddressAsync_DoesNotLogUserInfoOrQueryString` rejects a request to `https://alice:s3cr3t@example.com/path?token=abcdef` and asserts none of `alice`, `s3cr3t`, `token` or `abcdef` appears in the emitted warning, while `https://example.com:443` does.
- `FormatRequestOrigin_KeepsOnlyTheDestination` pins the format directly, including a non-default port and an IDN host (`déjà.example` → `xn--dj-kia8a.example`).

The existing log tests assert on event IDs and reason text, so they were unaffected. No public API change, so no `ref/` update. `dotnet run ./eng/update-all.cs` produced no further changes.

Found during a review of `src/Meziantou.Framework.Http.ServerSideRequestForgery` (finding F2 of 10).
