### PR TITLE
Stop reporting an SSRF rejection when the strategy runs out after a connect failure

### DIFF
--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryConnectPipeline.cs
@@ -60,7 +60,17 @@ internal static class ServerSideRequestForgeryConnectPipeline
         return FilterSafeAddresses(requestUri, resolvedAddresses, options, logger);
     }
 
-    internal static async ValueTask<IPAddress> SelectIpAddressAsync(Uri requestUri, List<IPAddress> safeAddresses, ServerSideRequestForgeryOptions options, CancellationToken cancellationToken)
+    internal static ValueTask<IPAddress> SelectIpAddressAsync(Uri requestUri, List<IPAddress> safeAddresses, ServerSideRequestForgeryOptions options, CancellationToken cancellationToken)
+    {
+        return SelectIpAddressAsync(requestUri, safeAddresses, options, reportStrategyFailure: true, cancellationToken);
+    }
+
+    // reportStrategyFailure: whether a strategy that has no candidate left is a rejection worth reporting. It is on
+    // the first selection, where it means the policy refused every validated address. It is not once a connect has
+    // already failed: the caller then re-asks over the addresses that remain, and running out of them is an ordinary
+    // connection failure, not an SSRF rejection. Reporting it there would put a Warning and a rejected_requests
+    // increment on every unreachable host.
+    private static async ValueTask<IPAddress> SelectIpAddressAsync(Uri requestUri, List<IPAddress> safeAddresses, ServerSideRequestForgeryOptions options, bool reportStrategyFailure, CancellationToken cancellationToken)
     {
         var logger = options.Logger;
         IPAddress selectedAddress;
@@ -68,7 +78,7 @@ internal static class ServerSideRequestForgeryConnectPipeline
         {
             selectedAddress = await options.ResolutionStrategy.ResolveAsync(safeAddresses, options, cancellationToken).ConfigureAwait(false);
         }
-        catch (ServerSideRequestForgeryException ex)
+        catch (ServerSideRequestForgeryException ex) when (reportStrategyFailure)
         {
             Log.RejectedResolutionStrategyFailure(logger, FormatRequestOrigin(requestUri), ex.Message);
             ServerSideRequestForgeryMetrics.IncrementRejectedRequest("resolution_strategy_failure");
@@ -111,7 +121,7 @@ internal static class ServerSideRequestForgeryConnectPipeline
             IPAddress selectedAddress;
             try
             {
-                selectedAddress = await SelectIpAddressAsync(requestUri, remainingAddresses, options, cancellationToken).ConfigureAwait(false);
+                selectedAddress = await SelectIpAddressAsync(requestUri, remainingAddresses, options, reportStrategyFailure: lastConnectException is null, cancellationToken).ConfigureAwait(false);
             }
             catch (ServerSideRequestForgeryException) when (lastConnectException is not null)
             {

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
@@ -124,6 +124,82 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
     }
 
     [Fact]
+    public async Task ConnectCallback_DoesNotReportAnSsrfRejectionWhenTheStrategyRunsOutAfterAConnectFailure()
+    {
+        using var server = new LoopbackHttpServer();
+        using var loggerProvider = new InMemoryLoggerProvider();
+        var options = new ServerSideRequestForgeryOptions
+        {
+            ResolutionStrategy = IpAddressResolutionStrategy.Ipv6Only,
+            Logger = loggerProvider.CreateLogger("ssrf-test"),
+        };
+        options.SafeSchemes.Add(Uri.UriSchemeHttp);
+        options.SafeIpNetworks.Add(IPNetwork.Parse("::1/128"));
+        options.SafeIpNetworks.Add(IPNetwork.Parse("127.0.0.0/8"));
+
+        using var handler = new SocketsHttpHandler();
+        handler.ConfigureSsrf(options, new FakeDnsIpAddressResolver([IPAddress.IPv6Loopback, IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler);
+
+        // Both addresses passed validation. Ipv6Only picks ::1, the server listens on the IPv4 loopback only so
+        // that connect fails, and the strategy is then asked again over the IPv4 address it excludes. Running out
+        // of candidates there is an unreachable host, not an SSRF rejection.
+        var rejectedRequestCount = await CountRejectedRequestsAsync(
+            "resolution_strategy_failure",
+            () => Assert.ThrowsAsync<HttpRequestException>(() => httpClient.GetAsync(new Uri($"http://example.invalid:{server.Port}/"), TestContext.Current.CancellationToken)));
+
+        Assert.Equal(0, rejectedRequestCount);
+        Assert.Empty(loggerProvider.Logs.Warnings);
+        Assert.Equal(0, server.AcceptedConnectionCount);
+    }
+
+    private static async Task<long> CountRejectedRequestsAsync(string expectedReasonTag, Func<Task> action)
+    {
+        var context = Guid.NewGuid();
+        var rejectedRequestCount = 0L;
+        var previousContext = MeterTestContext.Value;
+        MeterTestContext.Value = context;
+        try
+        {
+            using var listener = new MeterListener();
+            listener.InstrumentPublished = (instrument, meterListener) =>
+            {
+                if (instrument.Meter.Name == ServerSideRequestForgeryMetrics.MeterName && instrument.Name == ServerSideRequestForgeryMetrics.RejectedRequestsCounterName)
+                {
+                    meterListener.EnableMeasurementEvents(instrument);
+                }
+            };
+            listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) =>
+            {
+                _ = instrument;
+                _ = state;
+                if (MeterTestContext.Value != context)
+                {
+                    return;
+                }
+
+                foreach (var tag in tags)
+                {
+                    if (string.Equals(tag.Key, ServerSideRequestForgeryMetrics.ReasonTagName, StringComparison.Ordinal) && string.Equals(tag.Value?.ToString(), expectedReasonTag, StringComparison.Ordinal))
+                    {
+                        Interlocked.Add(ref rejectedRequestCount, measurement);
+                        break;
+                    }
+                }
+            });
+            listener.Start();
+
+            await action();
+        }
+        finally
+        {
+            MeterTestContext.Value = previousContext;
+        }
+
+        return rejectedRequestCount;
+    }
+
+    [Fact]
     public async Task ConnectCallback_SurfacesRejectionAsInnerExceptionOfHttpRequestException()
     {
         var options = new ServerSideRequestForgeryOptions();


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/ssrf-log-redaction` · #2570 must merge first**

`rejected_requests.total` is the signal an operator alerts on to detect SSRF attempts. It was also incremented when a perfectly ordinary host was unreachable.

### What happens

`ConnectAsync` re-asks the resolution strategy after each failed connect, over the addresses that remain, so a fallback keeps whatever constraint the strategy expresses. When the strategy runs out of candidates it throws, and the loop deliberately swallows that — correct behaviour, the caller then gets the original connect exception. But `SelectIpAddressAsync` had already logged `RejectedResolutionStrategyFailure` at `Warning` and incremented `rejected_requests.total{reason="resolution_strategy_failure"}` before rethrowing.

Concretely, with `ResolutionStrategy = Ipv6Only` and a host resolving to both loopbacks, where only the IPv4 one is listening:

1. `Ipv6Only` picks `::1`. Both addresses passed validation.
2. The connect to `::1` fails — nothing is listening there.
3. The strategy is asked again over `[127.0.0.1]` and throws `No address found for address family 'InterNetwork6'`.
4. **A Warning is logged and the SSRF rejection counter goes up**, then the loop breaks and the caller correctly gets the connect failure.

Nothing was rejected for SSRF reasons. A server was unreachable. Any host that goes down inflates the counter and writes a log line that reads like an attack, so the alert gets tuned into uselessness or produces false security incidents.

### Changed

`SelectIpAddressAsync` gains a private `reportStrategyFailure` overload; the internal signature is unchanged and still reports. `ConnectAsync` passes `reportStrategyFailure: lastConnectException is null`, which mirrors exactly the condition the existing catch filter already uses to decide the failure is a retry rather than a rejection. The first selection still logs and counts; re-selections after a connect failure stay silent.

The `selected_address_not_validated` check is deliberately left reporting in both cases — a strategy returning an address outside the set it was handed is an integrity violation whether or not a connect failed first.

### Verified

`dotnet test tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests /p:TreatsWarningsAsErrors=true` — 128 passed (64 per TFM), 0 failed, on net10.0 and net11.0.

`ConnectCallback_DoesNotReportAnSsrfRejectionWhenTheStrategyRunsOutAfterAConnectFailure` drives the scenario above through a real `HttpClient` and a loopback server, asserting the counter stays at 0, no warning is emitted, and the server accepts no connection.

I checked the test is not vacuous: reverting the one-line change to `reportStrategyFailure: true` fails it on both target frameworks. The existing `ResolveAndSelectIpAddressAsync_IncrementsRejectedRequestsCounter` still pins the first-selection case, so the reporting path is covered from both sides.

No public API change, so no `ref/` update. `dotnet run ./eng/update-all.cs` produced no further changes.

Found during a review of `src/Meziantou.Framework.Http.ServerSideRequestForgery` (finding F3 of 10).
