### PR TITLE
Add ServerSideRequestForgeryClientHandler to reject HTTP/3 requests

### DIFF
--- a/ref/Meziantou.Framework.Http.ServerSideRequestForgery.cs
+++ b/ref/Meziantou.Framework.Http.ServerSideRequestForgery.cs
@@ -14,6 +14,13 @@ namespace Meziantou.Framework.Http.ServerSideRequestForgery
         protected internal abstract System.Threading.Tasks.ValueTask<System.Net.IPAddress> ResolveAsync(System.Collections.Generic.IReadOnlyList<System.Net.IPAddress> addresses, Meziantou.Framework.Http.ServerSideRequestForgery.ServerSideRequestForgeryOptions options, System.Threading.CancellationToken cancellationToken);
     }
 
+    public sealed class ServerSideRequestForgeryClientHandler : System.Net.Http.DelegatingHandler
+    {
+        public ServerSideRequestForgeryClientHandler(System.Net.Http.SocketsHttpHandler innerHandler, Meziantou.Framework.Http.ServerSideRequestForgery.ServerSideRequestForgeryOptions options) { }
+        protected override System.Net.Http.HttpResponseMessage Send(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) => throw null;
+        protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) => throw null;
+    }
+
     public sealed class ServerSideRequestForgeryException : System.Exception
     {
         public ServerSideRequestForgeryException(string message) { }

--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryClientHandler.cs
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/ServerSideRequestForgeryClientHandler.cs
@@ -1,0 +1,74 @@
+namespace Meziantou.Framework.Http.ServerSideRequestForgery;
+
+/// <summary>An HTTP message handler that applies SSRF protection to a <see cref="SocketsHttpHandler"/> and rejects the requests that would bypass it over HTTP/3.</summary>
+/// <remarks>
+/// <see cref="SocketHttpHandlerServerSideRequestForgeryExtensions.ConfigureSsrf(SocketsHttpHandler, ServerSideRequestForgeryOptions)"/>
+/// validates a destination from <see cref="SocketsHttpHandler.ConnectCallback"/>, which the runtime uses only for
+/// TCP connections. An HTTP/3 connection is established over QUIC and never reaches it, so a handler that allows
+/// HTTP/3 is not protected. Prefer this handler over calling <c>ConfigureSsrf</c> directly.
+/// </remarks>
+/// <example>
+/// <code>
+/// var options = new ServerSideRequestForgeryOptions();
+/// var handler = new ServerSideRequestForgeryClientHandler(new SocketsHttpHandler { UseProxy = false }, options);
+/// using var client = new HttpClient(handler, disposeHandler: true);
+/// </code>
+/// </example>
+public sealed class ServerSideRequestForgeryClientHandler : DelegatingHandler
+{
+    /// <summary>Initializes a new instance of the <see cref="ServerSideRequestForgeryClientHandler"/> class.</summary>
+    /// <param name="innerHandler">The handler that establishes the connections. SSRF protection is configured on it.</param>
+    /// <param name="options">The SSRF policy to apply.</param>
+    public ServerSideRequestForgeryClientHandler(SocketsHttpHandler innerHandler, ServerSideRequestForgeryOptions options)
+        : this(innerHandler, options, SystemDnsIpAddressResolver.Instance)
+    {
+    }
+
+    internal ServerSideRequestForgeryClientHandler(SocketsHttpHandler innerHandler, ServerSideRequestForgeryOptions options, IDnsIpAddressResolver dnsIpAddressResolver)
+        : base(ConfigureInnerHandler(innerHandler, options, dnsIpAddressResolver))
+    {
+    }
+
+    private static SocketsHttpHandler ConfigureInnerHandler(SocketsHttpHandler innerHandler, ServerSideRequestForgeryOptions options, IDnsIpAddressResolver dnsIpAddressResolver)
+    {
+        ArgumentNullException.ThrowIfNull(innerHandler);
+        ArgumentNullException.ThrowIfNull(options);
+
+        return innerHandler.ConfigureSsrf(options, dnsIpAddressResolver);
+    }
+
+    /// <summary>Sends an HTTP request, rejecting it when it would be sent over a transport this library cannot validate.</summary>
+    /// <param name="request">The HTTP request message to send.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>The HTTP response message.</returns>
+    protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        EnsureRequestCannotUseHttp3(request);
+        return base.Send(request, cancellationToken);
+    }
+
+    /// <summary>Sends an HTTP request, rejecting it when it would be sent over a transport this library cannot validate.</summary>
+    /// <param name="request">The HTTP request message to send.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>The HTTP response message.</returns>
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        EnsureRequestCannotUseHttp3(request);
+        return base.SendAsync(request, cancellationToken);
+    }
+
+    internal static void EnsureRequestCannotUseHttp3(HttpRequestMessage request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // SocketsHttpHandler attempts HTTP/3 when the request asks for version 3 or higher, and also when its policy
+        // allows a higher version over TLS - the server then only has to advertise an h3 alternative service, and
+        // Alt-Svc may name any host and port. Neither case can be caught later: the QUIC connection is opened by
+        // ConnectHelper.ConnectQuicAsync, which resolves the endpoint itself and never calls ConnectCallback.
+        // Leaving both alone is what a request must look like for the connect-time validation to see every connection.
+        if (request.Version.Major < 3 && request.VersionPolicy != HttpVersionPolicy.RequestVersionOrHigher)
+            return;
+
+        throw new ServerSideRequestForgeryException($"The request allows HTTP/3 (Version = {request.Version}, VersionPolicy = {request.VersionPolicy}). An HTTP/3 connection is established over QUIC, which does not go through SocketsHttpHandler.ConnectCallback, so its destination cannot be validated. Set the request Version to 2.0 or lower and VersionPolicy to RequestVersionOrLower; HTTP/2 is still negotiated over TLS. HttpClient.DefaultRequestVersion and HttpClient.DefaultVersionPolicy set this for every request.");
+    }
+}

--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/readme.md
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/readme.md
@@ -18,11 +18,14 @@ options.SafeSchemes.Add("wss");
 options.UnsafeIpNetworks.Add(IPNetwork.Parse("203.0.113.0/24"));
 options.SafeIpNetworks.Add(IPNetwork.Parse("198.51.100.10/32"));
 
-var handler = new SocketsHttpHandler();
-handler.ConfigureSsrf(options);
+var handler = new ServerSideRequestForgeryClientHandler(new SocketsHttpHandler { UseProxy = false }, options);
 
 using var httpClient = new HttpClient(handler, disposeHandler: true);
 ```
+
+`ServerSideRequestForgeryClientHandler` configures the inner `SocketsHttpHandler` and rejects the requests that
+would bypass it over HTTP/3. `SocketsHttpHandler.ConfigureSsrf(options)` applies the connection validation on its
+own, but leaves the HTTP/3 gap below open, so prefer the handler.
 
 ## Behavior
 
@@ -32,6 +35,7 @@ using var httpClient = new HttpClient(handler, disposeHandler: true);
 - Optionally rejects mixed safe/unsafe DNS responses.
 - Uses `IpAddressResolutionStrategy` to select the final address (`Ipv4Only`, `Ipv6Only`, `PreferIpv4`, `Random`, `RoundRobin`).
 - Rejects connections that target an HTTP proxy.
+- Rejects requests that would be sent over HTTP/3, whose QUIC connection cannot be validated.
 
 ## Proxies
 
@@ -51,3 +55,30 @@ handler.ConfigureSsrf(options);
 ```
 
 Requests the proxy is configured to bypass are connected to directly and are validated normally.
+
+## HTTP/3
+
+Validation runs from `SocketsHttpHandler.ConnectCallback`, which the runtime uses only for TCP connections. An
+HTTP/3 connection is established over QUIC by `ConnectHelper.ConnectQuicAsync`, which resolves the endpoint itself
+and never calls the callback, so **an HTTP/3 request is not validated at all**. Setting a `ConnectCallback` does not
+disable HTTP/3: `HttpConnectionPool` clears it for plaintext HTTP and for every proxy kind, but not for a direct
+HTTPS connection, and HTTP/3 is enabled by default on Windows, Linux and macOS.
+
+Two requests reach QUIC:
+
+- one that asks for it — `Version` 3.0 with a policy other than `RequestVersionOrLower`;
+- one that merely allows an upgrade — `VersionPolicy = RequestVersionOrHigher` over TLS. The server then only has
+  to answer with an `Alt-Svc: h3="..."` header, which may name **any** host and port, and the next request to that
+  authority goes to it over QUIC. The first, validated connection buys nothing.
+
+`ServerSideRequestForgeryClientHandler` rejects both with a `ServerSideRequestForgeryException`, the same way a
+proxied request is rejected, rather than appear to protect a request it cannot see. A request is accepted when its
+`Version` is below 3.0 *and* its `VersionPolicy` is not `RequestVersionOrHigher`; HTTP/2 is still negotiated over
+TLS under those settings.
+
+The check is on the version alone and not on the scheme, because `SocketsHttpHandler` follows redirects below this
+handler: a plaintext request that redirects to HTTPS would otherwise slip through.
+
+If you call `ConfigureSsrf` directly instead of using the handler, HTTP/3 must be ruled out some other way — the
+`DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3SUPPORT=0` environment variable, the matching `AppContext` switch,
+or `HttpClient.DefaultRequestVersion` and `HttpClient.DefaultVersionPolicy` on every client.

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/FakeDnsIpAddressResolver.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/FakeDnsIpAddressResolver.cs
@@ -1,0 +1,13 @@
+using System.Net;
+
+namespace Meziantou.Framework.Http.ServerSideRequestForgery.Tests;
+
+internal sealed class FakeDnsIpAddressResolver(IReadOnlyList<IPAddress> addresses) : IDnsIpAddressResolver
+{
+    public ValueTask<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken cancellationToken)
+    {
+        _ = host;
+        _ = cancellationToken;
+        return ValueTask.FromResult(addresses);
+    }
+}

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/LoopbackHttpServer.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/LoopbackHttpServer.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace Meziantou.Framework.Http.ServerSideRequestForgery.Tests;
+
+internal sealed class LoopbackHttpServer : IDisposable
+{
+    private const string Response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok";
+
+    private readonly TcpListener _listener;
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private int _acceptedConnectionCount;
+
+    public LoopbackHttpServer()
+    {
+        _listener = new TcpListener(IPAddress.Loopback, port: 0);
+        _listener.Start();
+        Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        _ = Task.Run(() => AcceptLoopAsync(_cancellationTokenSource.Token));
+    }
+
+    public int Port { get; }
+
+    public int AcceptedConnectionCount => Volatile.Read(ref _acceptedConnectionCount);
+
+    private async Task AcceptLoopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                using var client = await _listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+                Interlocked.Increment(ref _acceptedConnectionCount);
+
+                using var stream = client.GetStream();
+                await ReadRequestHeadersAsync(stream, cancellationToken).ConfigureAwait(false);
+                await stream.WriteAsync(Encoding.ASCII.GetBytes(Response), cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (SocketException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    private static async Task ReadRequestHeadersAsync(NetworkStream stream, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[4096];
+        var count = 0;
+        while (count < buffer.Length)
+        {
+            var read = await stream.ReadAsync(buffer.AsMemory(count), cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+                break;
+
+            count += read;
+            if (Encoding.ASCII.GetString(buffer, 0, count).Contains("\r\n\r\n", StringComparison.Ordinal))
+                break;
+        }
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+        _listener.Dispose();
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryClientHandlerTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryClientHandlerTests.cs
@@ -1,0 +1,131 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Meziantou.Framework.Http.ServerSideRequestForgery.Tests;
+
+public sealed class ServerSideRequestForgeryClientHandlerTests
+{
+    [Theory]
+    [InlineData("3.0", HttpVersionPolicy.RequestVersionOrLower)]
+    [InlineData("3.0", HttpVersionPolicy.RequestVersionExact)]
+    [InlineData("3.0", HttpVersionPolicy.RequestVersionOrHigher)]
+    [InlineData("1.1", HttpVersionPolicy.RequestVersionOrHigher)]
+    [InlineData("2.0", HttpVersionPolicy.RequestVersionOrHigher)]
+    public void EnsureRequestCannotUseHttp3_RejectsRequestThatAllowsHttp3(string version, HttpVersionPolicy versionPolicy)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/")
+        {
+            Version = Version.Parse(version),
+            VersionPolicy = versionPolicy,
+        };
+
+        Assert.Throws<ServerSideRequestForgeryException>(() => ServerSideRequestForgeryClientHandler.EnsureRequestCannotUseHttp3(request));
+    }
+
+    [Theory]
+    [InlineData("1.0", HttpVersionPolicy.RequestVersionOrLower)]
+    [InlineData("1.1", HttpVersionPolicy.RequestVersionOrLower)]
+    [InlineData("1.1", HttpVersionPolicy.RequestVersionExact)]
+    [InlineData("2.0", HttpVersionPolicy.RequestVersionOrLower)]
+    [InlineData("2.0", HttpVersionPolicy.RequestVersionExact)]
+    public void EnsureRequestCannotUseHttp3_AllowsRequestThatCannotReachHttp3(string version, HttpVersionPolicy versionPolicy)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/")
+        {
+            Version = Version.Parse(version),
+            VersionPolicy = versionPolicy,
+        };
+
+        ServerSideRequestForgeryClientHandler.EnsureRequestCannotUseHttp3(request);
+    }
+
+    [Fact]
+    public async Task SendAsync_RejectsAnHttp3RequestWithoutConnecting()
+    {
+        using var server = new LoopbackHttpServer();
+        var options = new ServerSideRequestForgeryOptions();
+        options.SafeSchemes.Add(Uri.UriSchemeHttp);
+        options.SafeIpNetworks.Add(IPNetwork.Parse("127.0.0.0/8"));
+
+        using var innerHandler = new SocketsHttpHandler();
+        using var handler = new ServerSideRequestForgeryClientHandler(innerHandler, options, new FakeDnsIpAddressResolver([IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Get, new Uri($"http://example.invalid:{server.Port}/"))
+        {
+            Version = HttpVersion.Version30,
+            VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher,
+        };
+
+        await Assert.ThrowsAsync<ServerSideRequestForgeryException>(() => httpClient.SendAsync(request, TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, server.AcceptedConnectionCount);
+    }
+
+    [Fact]
+    public async Task SendAsync_RejectsARequestThatOnlyAllowsAnUpgrade()
+    {
+        using var server = new LoopbackHttpServer();
+        var options = new ServerSideRequestForgeryOptions();
+        options.SafeSchemes.Add(Uri.UriSchemeHttp);
+        options.SafeIpNetworks.Add(IPNetwork.Parse("127.0.0.0/8"));
+
+        using var innerHandler = new SocketsHttpHandler();
+        using var handler = new ServerSideRequestForgeryClientHandler(innerHandler, options, new FakeDnsIpAddressResolver([IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler)
+        {
+            // The Alt-Svc route needs no explicit HTTP/3 request: this policy alone is enough for the pool to
+            // switch to QUIC once the server advertises an h3 alternative service.
+            DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher,
+        };
+
+        await Assert.ThrowsAsync<ServerSideRequestForgeryException>(() => httpClient.GetAsync(new Uri($"http://example.invalid:{server.Port}/"), TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, server.AcceptedConnectionCount);
+    }
+
+    [Fact]
+    public async Task SendAsync_SendsARequestThatCannotUseHttp3()
+    {
+        using var server = new LoopbackHttpServer();
+        var options = new ServerSideRequestForgeryOptions();
+        options.SafeSchemes.Add(Uri.UriSchemeHttp);
+        options.SafeIpNetworks.Add(IPNetwork.Parse("127.0.0.0/8"));
+
+        using var innerHandler = new SocketsHttpHandler();
+        using var handler = new ServerSideRequestForgeryClientHandler(innerHandler, options, new FakeDnsIpAddressResolver([IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler);
+
+        using var response = await httpClient.GetAsync(new Uri($"http://example.invalid:{server.Port}/"), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, server.AcceptedConnectionCount);
+    }
+
+    [Fact]
+    public async Task SendAsync_StillAppliesTheSsrfPolicyOfTheInnerHandler()
+    {
+        var options = new ServerSideRequestForgeryOptions();
+        options.SafeSchemes.Add(Uri.UriSchemeHttp);
+
+        using var innerHandler = new SocketsHttpHandler();
+        using var handler = new ServerSideRequestForgeryClientHandler(innerHandler, options, new FakeDnsIpAddressResolver([IPAddress.Loopback]));
+        using var httpClient = new HttpClient(handler);
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => httpClient.GetAsync(new Uri("http://example.invalid/"), TestContext.Current.CancellationToken));
+
+        Assert.IsType<ServerSideRequestForgeryException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void Constructor_ThrowsWhenTheInnerHandlerIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ServerSideRequestForgeryClientHandler(innerHandler: null!, new ServerSideRequestForgeryOptions()));
+    }
+
+    [Fact]
+    public void Constructor_ThrowsWhenTheOptionsAreNull()
+    {
+        using var innerHandler = new SocketsHttpHandler();
+        Assert.Throws<ArgumentNullException>(() => new ServerSideRequestForgeryClientHandler(innerHandler, options: null!));
+    }
+}

--- a/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
+++ b/tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests/ServerSideRequestForgeryConnectPipelineTests.cs
@@ -665,16 +665,6 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
         }
     }
 
-    private sealed class FakeDnsIpAddressResolver(IReadOnlyList<IPAddress> addresses) : IDnsIpAddressResolver
-    {
-        public ValueTask<IReadOnlyList<IPAddress>> ResolveAsync(string host, CancellationToken cancellationToken)
-        {
-            _ = host;
-            _ = cancellationToken;
-            return ValueTask.FromResult(addresses);
-        }
-    }
-
     private sealed class FirstAddressStrategy : IpAddressResolutionStrategy
     {
         protected internal override ValueTask<IPAddress> ResolveAsync(IReadOnlyList<IPAddress> addresses, ServerSideRequestForgeryOptions options, CancellationToken cancellationToken)
@@ -735,75 +725,6 @@ public sealed class ServerSideRequestForgeryConnectPipelineTests
             _ = cancellationToken;
             LastSeenOptions = options;
             return ValueTask.FromResult(addresses[0]);
-        }
-    }
-
-    private sealed class LoopbackHttpServer : IDisposable
-    {
-        private const string Response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok";
-
-        private readonly TcpListener _listener;
-        private readonly CancellationTokenSource _cancellationTokenSource = new();
-        private int _acceptedConnectionCount;
-
-        public LoopbackHttpServer()
-        {
-            _listener = new TcpListener(IPAddress.Loopback, port: 0);
-            _listener.Start();
-            Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
-            _ = Task.Run(() => AcceptLoopAsync(_cancellationTokenSource.Token));
-        }
-
-        public int Port { get; }
-
-        public int AcceptedConnectionCount => Volatile.Read(ref _acceptedConnectionCount);
-
-        private async Task AcceptLoopAsync(CancellationToken cancellationToken)
-        {
-            try
-            {
-                while (!cancellationToken.IsCancellationRequested)
-                {
-                    using var client = await _listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
-                    Interlocked.Increment(ref _acceptedConnectionCount);
-
-                    using var stream = client.GetStream();
-                    await ReadRequestHeadersAsync(stream, cancellationToken).ConfigureAwait(false);
-                    await stream.WriteAsync(Encoding.ASCII.GetBytes(Response), cancellationToken).ConfigureAwait(false);
-                }
-            }
-            catch (OperationCanceledException)
-            {
-            }
-            catch (SocketException)
-            {
-            }
-            catch (ObjectDisposedException)
-            {
-            }
-        }
-
-        private static async Task ReadRequestHeadersAsync(NetworkStream stream, CancellationToken cancellationToken)
-        {
-            var buffer = new byte[4096];
-            var count = 0;
-            while (count < buffer.Length)
-            {
-                var read = await stream.ReadAsync(buffer.AsMemory(count), cancellationToken).ConfigureAwait(false);
-                if (read == 0)
-                    break;
-
-                count += read;
-                if (Encoding.ASCII.GetString(buffer, 0, count).Contains("\r\n\r\n", StringComparison.Ordinal))
-                    break;
-            }
-        }
-
-        public void Dispose()
-        {
-            _cancellationTokenSource.Cancel();
-            _listener.Dispose();
-            _cancellationTokenSource.Dispose();
         }
     }
 }


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2574**

`ConfigureSsrf` installs a `SocketsHttpHandler.ConnectCallback`, and the runtime uses that callback **only for TCP connections**. An HTTP/3 connection is opened by `ConnectHelper.ConnectQuicAsync`, which passes the `DnsEndPoint` straight to `QuicConnection.ConnectAsync` — MsQuic resolves the hostname itself and the callback is never consulted. So a handler that allows HTTP/3 is not protected, and nothing says so.

Setting a `ConnectCallback` does not disable HTTP/3. In the `HttpConnectionPool` constructor, `_http3Enabled` is cleared for `HttpConnectionKind.Http` and for every proxy and tunnel kind, but **not** for `HttpConnectionKind.Https`; `GlobalHttpSettings.SocketsHttpHandler.AllowHttp3` defaults to `true` on Windows, Linux and macOS, and `HttpConnectionSettings` then defaults `_maxHttpVersion` to 3.0.

### The two routes in

Both start from an attacker-supplied URL — the situation this library exists for.

**Asked for.** The application sets `Version = HttpVersion.Version30` (or `HttpClient.DefaultRequestVersion`) with a policy other than `RequestVersionOrLower`. `TryGetHttp3Authority` falls back to the origin authority and the very first connection is QUIC.

**Merely allowed.** The application sets `VersionPolicy = RequestVersionOrHigher` — how gRPC and most "prefer HTTP/2" setups are configured, and chosen for reasons that have nothing to do with HTTP/3. Request 1 goes over TCP and is validated correctly. The response carries `Alt-Svc: h3="169.254.169.254:443"`. `ProcessAltSvc` accepts an arbitrary alternate host (`new HttpAuthority(value.Host ?? _originAuthority.IdnHost, value.Port)`) and stores it; request 2 to the same authority opens a QUIC connection to that address with no validation. The first, validated connection buys nothing.

The Alt-Svc route still completes a TLS 1.3 handshake for the *origin's* hostname, so straightforward response exfiltration needs a certificate the attacker can satisfy. That narrows the impact; it does not remove it. The UDP connection to the internal address is made either way, which is enough for reachability probing and for any internal endpoint whose certificate does validate.

### Changed

`SocketsHttpHandler` exposes no public max-version knob, so this cannot be closed from the handler alone. Added `ServerSideRequestForgeryClientHandler : DelegatingHandler`, following the `HstsClientHandler` shape in `Meziantou.Framework.Http.Hsts`:

```csharp
var handler = new ServerSideRequestForgeryClientHandler(new SocketsHttpHandler { UseProxy = false }, options);
using var client = new HttpClient(handler, disposeHandler: true);
```

It configures the inner handler for you, and rejects a request whose `Version` is 3.0 or higher, or whose `VersionPolicy` is `RequestVersionOrHigher`, with a `ServerSideRequestForgeryException` naming the fix. That is the exact negation of the runtime's own guard, so a request that passes cannot reach the HTTP/3 path. `Send` and `SendAsync` are both overridden, so the synchronous path is covered too.

Rejecting rather than silently downgrading is the same call this library already makes for proxies: refuse, rather than appear to protect a request it cannot see.

**The check deliberately ignores the scheme.** Only HTTPS can reach HTTP/3 via the policy route, so gating on `requestUri.Scheme` looks tempting — but `SocketsHttpHandler` runs its `RedirectHandler` *below* this handler, so a plaintext request that redirects to HTTPS would slip through unexamined. The version and policy are the only things this handler can see for the whole redirect chain.

Additive: `ConfigureSsrf` is unchanged and still works for callers who rule out HTTP/3 another way. `ref/` regenerated.

### Compatibility

Applications that set `VersionPolicy = RequestVersionOrHigher` and adopt this handler will start getting exceptions. Those are exactly the applications that are unprotected today, so the exception reports an existing hole rather than creating one — but it is a hard failure, and the message says what to change (`Version` ≤ 2.0 with `RequestVersionOrLower`; HTTP/2 is still negotiated over TLS).

### Verified

`dotnet test tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests /p:TreatsWarningsAsErrors=true` — 154 passed (77 per TFM, up from 61), 0 failed, on net10.0 and net11.0.

`ServerSideRequestForgeryClientHandlerTests` covers the accept/reject matrix over five version-and-policy combinations each way, that an HTTP/3 request is rejected *before* any connection is attempted (`AcceptedConnectionCount == 0`), that `DefaultVersionPolicy = RequestVersionOrHigher` alone is enough to be rejected, that an ordinary request still reaches the server, and that the inner handler's SSRF policy still applies through the wrapper.

`FakeDnsIpAddressResolver` and `LoopbackHttpServer` moved out of `ServerSideRequestForgeryConnectPipelineTests` into their own files so both test classes can use them — no behaviour change, and the analyzer requires one type per file.

The bypass was confirmed by reading `dotnet/runtime` (`HttpConnectionPool.cs`, `HttpConnectionPool.Http3.cs`, `ConnectHelper.cs`, `HttpConnectionSettings.cs`, `GlobalHttpSettings.cs`) rather than inferred. It was **not** reproduced against a live HTTP/3 server — the tests pin the handler's decision, not the runtime's behaviour beyond it.

Found during a review of `src/Meziantou.Framework.Http.ServerSideRequestForgery` (finding F1 of 10, the highest-severity one).
