### PR TITLE
Document network precedence, pre-populated defaults and how rejections surface

### DIFF
--- a/src/Meziantou.Framework.Http.ServerSideRequestForgery/readme.md
+++ b/src/Meziantou.Framework.Http.ServerSideRequestForgery/readme.md
@@ -31,11 +31,43 @@ own, but leaves the HTTP/3 gap below open, so prefer the handler.
 
 - Validates request scheme against `SafeSchemes`.
 - Resolves DNS on every connection attempt to avoid TOCTOU vulnerabilities.
-- Validates each resolved address against `UnsafeIpNetworks` and `SafeIpNetworks`.
+- Validates each resolved address against `UnsafeIpNetworks`, unless `SafeIpNetworks` already matches it.
 - Optionally rejects mixed safe/unsafe DNS responses.
 - Uses `IpAddressResolutionStrategy` to select the final address (`Ipv4Only`, `Ipv6Only`, `PreferIpv4`, `Random`, `RoundRobin`).
 - Rejects connections that target an HTTP proxy.
 - Rejects requests that would be sent over HTTP/3, whose QUIC connection cannot be validated.
+
+## Configuration
+
+The collections start populated, and the example above adds to those defaults rather than replacing them:
+
+- `SafeSchemes` already contains `https` and `wss`.
+- `UnsafeIpNetworks` already contains the loopback, private, link-local, carrier-grade NAT, multicast and reserved
+  ranges, plus the IPv6 transition ranges that embed an IPv4 address.
+- `SafeIpNetworks` starts empty.
+
+Call `Clear()` first to define a set from scratch:
+
+```csharp
+options.SafeSchemes.Clear();
+options.SafeSchemes.Add("https");
+```
+
+`SafeIpNetworks` takes precedence: an address it matches is allowed even when `UnsafeIpNetworks` also matches it.
+That is how you reach a specific internal host without dropping the range it sits in — and why a broad entry there
+silently re-opens whatever part of the deny list it covers.
+
+## Errors
+
+A rejected request surfaces as an `HttpRequestException` with a `ServerSideRequestForgeryException` as its
+`InnerException`, because the runtime wraps anything thrown from `ConnectCallback`. Catch it accordingly:
+
+```csharp
+catch (HttpRequestException ex) when (ex.InnerException is ServerSideRequestForgeryException ssrf)
+```
+
+The HTTP/3 rejection is thrown before the request reaches the inner handler, so that one arrives as a
+`ServerSideRequestForgeryException` directly.
 
 ## Proxies
 


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/ssrf-http3-handler` · #2573 must merge first**

Three things a caller needs to know were not written down anywhere.

### `SafeIpNetworks` takes precedence

`IsSafeAddress` checks `SafeIpNetworks` first and returns `true` on a match, before `UnsafeIpNetworks` is consulted at all. The readme listed both without saying which wins, so a broad entry in `SafeIpNetworks` silently re-opens whatever part of the default deny list it covers. Now stated, along with why the precedence is useful — reaching one internal host without dropping the range it sits in.

### The collections start populated

The usage example only ever calls `.Add(...)`, which reads as though it defines the set from scratch. In fact `SafeSchemes` already contains `https` and `wss`, and `UnsafeIpNetworks` already contains twenty ranges. Additive is the right default — a user adding one unsafe range should not lose the other twenty — it just needs saying, with `Clear()` shown for the replace case.

### Rejections arrive wrapped

The runtime wraps anything thrown from `ConnectCallback`, so a rejection surfaces as `HttpRequestException` with `ServerSideRequestForgeryException` as its `InnerException`. `ConnectCallback_SurfacesRejectionAsInnerExceptionOfHttpRequestException` pins this, but the readme never mentioned it, so the obvious `catch (ServerSideRequestForgeryException)` never fires. Added, with the `when` clause that does work — and noting that the HTTP/3 rejection from #2573 is thrown above the inner handler and so arrives unwrapped.

### Changed

Documentation only — two new sections and one corrected bullet in `readme.md`. No code, no API change.

Depends on #2573 only because both edit the readme's usage section; there is no code dependency.

### Verified

`dotnet test tests/Meziantou.Framework.Http.ServerSideRequestForgery.Tests /p:TreatsWarningsAsErrors=true` — 154 passed, 0 failed, on net10.0 and net11.0. `dotnet run ./eng/update-all.cs` produced no further changes.

Found during a review of `src/Meziantou.Framework.Http.ServerSideRequestForgery` (finding F9 of 10).
