### PR TITLE
Forward ValueStopwatch.GetElapsedTime to Stopwatch

### DIFF
--- a/src/Meziantou.Framework.ValueStopwatch/ValueStopwatch.cs
+++ b/src/Meziantou.Framework.ValueStopwatch/ValueStopwatch.cs
@@ -18,8 +18,6 @@ namespace Meziantou.Framework;
 // https://github.com/dotnet/runtime/blob/26b6e4ea97a627ab800362b2c10f32ebecea041d/src/libraries/Common/src/Extensions/ValueStopwatch/ValueStopwatch.cs
 public readonly struct ValueStopwatch
 {
-    private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
-
     private readonly long _startTimestamp;
 
     /// <summary>Gets a value indicating whether this stopwatch instance has been initialized via <see cref="StartNew"/>.</summary>
@@ -42,12 +40,7 @@ public readonly struct ValueStopwatch
     /// <param name="startTimestamp">The starting timestamp obtained from <see cref="GetTimestamp"/>.</param>
     /// <param name="endTimestamp">The ending timestamp obtained from <see cref="GetTimestamp"/>.</param>
     /// <returns>A <see cref="TimeSpan"/> representing the elapsed time between the two timestamps.</returns>
-    public static TimeSpan GetElapsedTime(long startTimestamp, long endTimestamp)
-    {
-        var timestampDelta = endTimestamp - startTimestamp;
-        var ticks = (long)(TimestampToTicks * timestampDelta);
-        return new TimeSpan(ticks);
-    }
+    public static TimeSpan GetElapsedTime(long startTimestamp, long endTimestamp) => Stopwatch.GetElapsedTime(startTimestamp, endTimestamp);
 
     /// <summary>Gets the elapsed time since this stopwatch was started.</summary>
     /// <returns>A <see cref="TimeSpan"/> representing the elapsed time since the stopwatch was started.</returns>
@@ -59,7 +52,6 @@ public readonly struct ValueStopwatch
         if (!IsActive)
             throw new InvalidOperationException("An uninitialized, or 'default', ValueStopwatch cannot be used to get elapsed time.");
 
-        var end = Stopwatch.GetTimestamp();
-        return GetElapsedTime(_startTimestamp, end);
+        return Stopwatch.GetElapsedTime(_startTimestamp);
     }
 }

--- a/tests/Meziantou.Framework.ValueStopwatch.Tests/ValueStopwatchTest.cs
+++ b/tests/Meziantou.Framework.ValueStopwatch.Tests/ValueStopwatchTest.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace Meziantou.Framework.Tests;
 
 public class ValueStopwatchTest
@@ -19,6 +21,21 @@ public class ValueStopwatchTest
     {
         var stopwatch = default(ValueStopwatch);
         Assert.Throws<InvalidOperationException>(() => stopwatch.GetElapsedTime());
+    }
+
+    [Fact]
+    public void GetElapsedTimeFromTimestampsConvertsTicksUsingStopwatchFrequency()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(1), ValueStopwatch.GetElapsedTime(0, Stopwatch.Frequency));
+        Assert.Equal(TimeSpan.FromSeconds(0.5), ValueStopwatch.GetElapsedTime(0, Stopwatch.Frequency / 2));
+        Assert.Equal(TimeSpan.FromSeconds(2), ValueStopwatch.GetElapsedTime(Stopwatch.Frequency, Stopwatch.Frequency * 3));
+    }
+
+    [Fact]
+    public void GetElapsedTimeFromIdenticalTimestampsIsZero()
+    {
+        var timestamp = ValueStopwatch.GetTimestamp();
+        Assert.Equal(TimeSpan.Zero, ValueStopwatch.GetElapsedTime(timestamp, timestamp));
     }
 
     [Fact]


### PR DESCRIPTION
`Stopwatch.GetElapsedTime(long)` and `Stopwatch.GetElapsedTime(long, long)` have been available since .NET 7, and this project only targets `net10.0` and `net11.0`. The hand-rolled tick conversion in `ValueStopwatch` duplicated the BCL implementation — the private `TimestampToTicks` field mirrored `Stopwatch.s_tickFrequency`, and the arithmetic was identical — so this forwards to the framework instead of maintaining the same math here.

### Changes

- `GetElapsedTime(long, long)` now forwards to `Stopwatch.GetElapsedTime(startTimestamp, endTimestamp)`.
- The instance `GetElapsedTime()` now forwards to `Stopwatch.GetElapsedTime(_startTimestamp)`, which reads the end timestamp itself. The `default(ValueStopwatch)` guard is unchanged.
- The `TimestampToTicks` field is removed.

### Behavior

Unchanged. The removed code and `Stopwatch.GetElapsedTime` compute the same value:

```csharp
// removed                          // BCL
var delta = end - start;            new TimeSpan((long)((end - start) * s_tickFrequency))
var ticks = (long)(TimestampToTicks * delta);
return new TimeSpan(ticks);
```

Negative deltas still produce a negative `TimeSpan`, as before.

### Public API

No change — `ref/Meziantou.Framework.ValueStopwatch.cs` is untouched, confirmed by a `-c Release /p:IsOfficialBuild=true` build running the public API generator.

### Tests

The static `GetElapsedTime(long, long)` overload had no direct coverage, which made it the riskiest thing to refactor blind, so two tests were added to the existing `ValueStopwatchTest` that pin the conversion itself rather than the forwarding:

- `GetElapsedTimeFromTimestampsConvertsTicksUsingStopwatchFrequency` — asserts a delta of `Stopwatch.Frequency` is exactly one second (plus a half and a double).
- `GetElapsedTimeFromIdenticalTimestampsIsZero`.

Both pass against the pre-change implementation as well.

### Verification

- `dotnet test /p:TreatsWarningsAsErrors=true` — 12/12 passing (6 tests × `net10.0` and `net11.0`), up from 8.
- `dotnet build -c Release /p:IsOfficialBuild=true /p:TreatsWarningsAsErrors=true` — 0 warnings, 0 errors.
- `dotnet run ./eng/update-all.cs` — no files changed.

Only run on macOS/arm64.