### PR TITLE
Support the common BCL types as trace event argument values

### DIFF
--- a/src/Meziantou.Framework.ChromiumTracing/ChromiumTracingWriter.cs
+++ b/src/Meziantou.Framework.ChromiumTracing/ChromiumTracingWriter.cs
@@ -231,7 +231,27 @@ public sealed partial class ChromiumTracingWriter : IAsyncDisposable
     [JsonSerializable(typeof(ChromiumTracingObjectCreatedEvent))]
     [JsonSerializable(typeof(ChromiumTracingObjectDestroyedEvent))]
     [JsonSerializable(typeof(ChromiumTracingObjectSnapshotEvent))]
+    // Values in ChromiumTracingEvent.Arguments are resolved by their runtime type. Without these,
+    // only the types that happen to appear on the event properties can be used as argument values.
+    [JsonSerializable(typeof(bool))]
+    [JsonSerializable(typeof(byte))]
+    [JsonSerializable(typeof(char))]
+    [JsonSerializable(typeof(DateTime))]
+    [JsonSerializable(typeof(DateTimeOffset))]
+    [JsonSerializable(typeof(decimal))]
+    [JsonSerializable(typeof(double))]
+    [JsonSerializable(typeof(float))]
+    [JsonSerializable(typeof(Guid))]
+    [JsonSerializable(typeof(int))]
     [JsonSerializable(typeof(long))]
+    [JsonSerializable(typeof(sbyte))]
+    [JsonSerializable(typeof(short))]
+    [JsonSerializable(typeof(string))]
+    [JsonSerializable(typeof(TimeSpan))]
+    [JsonSerializable(typeof(uint))]
+    [JsonSerializable(typeof(ulong))]
+    [JsonSerializable(typeof(ushort))]
+    [JsonSerializable(typeof(Uri))]
     private sealed partial class SourceGenerationContext : JsonSerializerContext
     {
     }

--- a/tests/Meziantou.Framework.ChromiumTracing.Tests/WriterTests.cs
+++ b/tests/Meziantou.Framework.ChromiumTracing.Tests/WriterTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Meziantou.Framework.ChromiumTracing.Tests;
@@ -75,6 +76,48 @@ public sealed partial class WriterTests
                 ["payload"] = new CustomPayload(42),
             },
         });
+    }
+
+    public static TheoryData<object> SupportedArgumentValues() => new()
+    {
+        "text",
+        (bool)true,
+        (byte)1,
+        (sbyte)1,
+        (char)'c',
+        (short)1,
+        (ushort)1,
+        (int)1,
+        (uint)1,
+        (long)1,
+        (ulong)1,
+        (float)1.5f,
+        (double)1.5,
+        (decimal)1.5m,
+        Guid.Empty,
+        new DateTime(2024, 5, 6, 7, 8, 9, DateTimeKind.Utc),
+        new DateTimeOffset(2024, 5, 6, 7, 8, 9, TimeSpan.Zero),
+        TimeSpan.FromSeconds(1),
+        new Uri("https://example.com"),
+    };
+
+    [Theory]
+    [MemberData(nameof(SupportedArgumentValues))]
+    public async Task ArgumentValuesOfCommonTypesCanBeSerialized(object value)
+    {
+        using var stream = new MemoryStream();
+        await using (var writer = ChromiumTracingWriter.Create(stream, streamOwned: false))
+        {
+            await writer.WriteEventAsync(new ChromiumTracingInstantEvent
+            {
+                Name = "Sample",
+                Arguments = new Dictionary<string, object?>(StringComparer.Ordinal) { ["value"] = value },
+            });
+        }
+
+        using var document = JsonDocument.Parse(stream.ToArray());
+        Assert.Equal(1, document.RootElement.GetArrayLength());
+        Assert.True(document.RootElement[0].GetProperty("args").TryGetProperty("value", out _));
     }
 
     private sealed record CustomPayload(int Value);


### PR DESCRIPTION
Part of a review of `Meziantou.Framework.ChromiumTracing`. Independent of the other review PRs.

## The problem

`ChromiumTracingEvent.Arguments` is `IReadOnlyDictionary<string, object?>`, so each value is resolved by its runtime type against the source-generated context. That context declared only the event types plus `long`, so which types worked was an accident of which ones appear on the event properties — `int` worked only because `ProcessId` is `int?`, `string` only because `Name` is a string. Everything else threw at serialization time:

| worked | threw `NotSupportedException` |
|---|---|
| `string`, `int`, `long`, `string[]`, `Dictionary<string,object?>`, `null` | `double`, `float`, `decimal`, `bool`, `short`, `byte`, `uint`, `char`, `Guid`, `DateTime`, `int[]`, enums |

```
JsonTypeInfo metadata for type 'System.Double' was not provided by TypeInfoResolver
of type 'ChromiumTracingWriter+SourceGenerationContext' ... Path: $.Arguments.
```

`double` is the natural value for a counter series (CPU load, ratios, rates) and `bool` for a flag — mainstream uses of `args`, not edge cases. The existing `[JsonSerializable(typeof(long))]` line reads like this was already hit once and patched for a single type.

## What changed

Declare the common BCL value types explicitly on `SourceGenerationContext`.

Enums and arrays of value types still need a caller-supplied `JsonSerializerContext`, which the existing constructor and factory overloads already accept — a generic fix is not possible for those, since each enum is a distinct type.

## Verification

`dotnet test -c Release /p:TreatsWarningsAsErrors=true` — 44/44 across `net10.0` and `net11.0`.

Added a `[Theory]` walking 19 value types and asserting each produces a parsable document with the argument present.
