### PR TITLE
Verify the AOT compatibility the readme advertises

### DIFF
--- a/ref/Meziantou.Framework.ChromiumTracing.cs
+++ b/ref/Meziantou.Framework.ChromiumTracing.cs
@@ -245,6 +245,7 @@ namespace Meziantou.Framework.ChromiumTracing
         public static Meziantou.Framework.ChromiumTracing.ChromiumTracingWriter CreateGzip(System.IO.Stream stream, System.Text.Json.Serialization.JsonSerializerContext? serializerContext, System.IO.Compression.CompressionLevel compressionLevel = 1) => throw null;
         public System.Threading.Tasks.ValueTask DisposeAsync() => throw null;
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "The json options are guarantee to contains the TypeResolver for events")]
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling", Justification = "The options only use source-generated resolvers, so a type that is not registered fails with NotSupportedException instead of falling back to reflection")]
         public System.Threading.Tasks.Task WriteEventAsync(Meziantou.Framework.ChromiumTracing.ChromiumTracingEvent tracingEvent, System.Threading.CancellationToken cancellationToken = null) => throw null;
     }
 }

--- a/src/Meziantou.Framework.ChromiumTracing/ChromiumTracingWriter.cs
+++ b/src/Meziantou.Framework.ChromiumTracing/ChromiumTracingWriter.cs
@@ -179,6 +179,7 @@ public sealed partial class ChromiumTracingWriter : IAsyncDisposable
     /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous write operation.</returns>
     [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "The json options are guarantee to contains the TypeResolver for events")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling", Justification = "The options only use source-generated resolvers, so a type that is not registered fails with NotSupportedException instead of falling back to reflection")]
     public async Task WriteEventAsync(ChromiumTracingEvent tracingEvent, CancellationToken cancellationToken = default)
     {
         if (tracingEvent is null)

--- a/src/Meziantou.Framework.ChromiumTracing/Meziantou.Framework.ChromiumTracing.csproj
+++ b/src/Meziantou.Framework.ChromiumTracing/Meziantou.Framework.ChromiumTracing.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
     <Version>2.0.0</Version>
     <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
     <Description>Classes to generate a tracing file that can be opened by Chromium browsers and other tools</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
Part of a review of `Meziantou.Framework.ChromiumTracing`. Independent of the other review PRs, though it touches the attribute list on `WriteEventAsync`, so it may need a trivial rebase against the writer stack in the same review.

## The problem

The readme states the package is "AOT and trimming compatible", but the project set only `IsTrimmable`, so the AOT analyzers never ran and the claim was unverified. Trimming *is* verified for real through `tests/Trimmable`.

Turning the analyzers on shows the claim was not free:

```
error IL3050: Using member 'JsonSerializer.SerializeAsync(Stream, Object, Type, JsonSerializerOptions, CancellationToken)'
which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
```

The existing `[UnconditionalSuppressMessage]` on `WriteEventAsync` covers `IL2026` for trimming only, not `IL3050` for AOT.

## What changed

Set `IsAotCompatible` and suppress `IL3050` alongside the existing trimming suppression.

The suppression holds for the same reason the trimming one does, and arguably more strongly: the options carry only source-generated resolvers, so a type that is not registered fails with `NotSupportedException` rather than silently falling back to reflection — there is no dynamic-code path to break.

`Meziantou.Framework.Yaml` and the `Http.Caching` family already set this property, so this brings the project in line with the rest of the repository.

`ref/Meziantou.Framework.ChromiumTracing.cs` is regenerated because the reference assembly includes suppression attributes.

## Verification

- `dotnet build -c Release /p:TreatsWarningsAsErrors=true` — succeeds with the AOT analyzers enabled (it fails without the suppression).
- `dotnet test -c Release /p:TreatsWarningsAsErrors=true` — 6/6 across `net10.0` and `net11.0`.
- `dotnet publish tests/Trimmable -c Release` — still clean, no trim warnings from this package.
