### PR TITLE
Support the EB and EiB units in every parser

### DIFF
--- a/src/Meziantou.Framework.ByteSize/ByteSize.cs
+++ b/src/Meziantou.Framework.ByteSize/ByteSize.cs
@@ -380,6 +380,7 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
                 else
                 {
                     result = default;
+                    parsedLength = 0;
                     return false;
                 }
             }
@@ -404,6 +405,10 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
 
                 case 'P':
                     result = isI ? ByteSizeUnit.PebiByte : ByteSizeUnit.PetaByte;
+                    return true;
+
+                case 'E':
+                    result = isI ? ByteSizeUnit.ExbiByte : ByteSizeUnit.ExaByte;
                     return true;
             }
         }
@@ -684,6 +689,7 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
                 else
                 {
                     result = default;
+                    parsedLength = 0;
                     return false;
                 }
             }
@@ -708,6 +714,10 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
 
                 case 'P':
                     result = isI ? ByteSizeUnit.PebiByte : ByteSizeUnit.PetaByte;
+                    return true;
+
+                case 'E':
+                    result = isI ? ByteSizeUnit.ExbiByte : ByteSizeUnit.ExaByte;
                     return true;
             }
         }

--- a/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
+++ b/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
@@ -17,6 +17,11 @@ public sealed class ByteSizeTests
     [InlineData(1_510_000L, "f1", "1.5MB")]
     [InlineData(1_510_000L, "", "1.51MB")]
     [InlineData(1_510_000L, "f2", "1.51MB")]
+    [InlineData(1_000_000_000_000_000L, "PB", "1PB")]
+    [InlineData(1_000_000_000_000_000_000L, "EB", "1EB")]
+    [InlineData(1_000_000_000_000_000_000L, "", "1EB")]
+    [InlineData(1_152_921_504_606_846_976L, "EiB", "1EiB")]
+    [InlineData(1_152_921_504_606_846_976L, "gi", "1EiB")]
     public void ToString_Test(long length, string? format, string expectedValue)
     {
         var byteSize = new ByteSize(length);
@@ -46,6 +51,11 @@ public sealed class ByteSizeTests
     [InlineData("1 KB", 1000L)]
     [InlineData("1 kiB", 1024L)]
     [InlineData("1.5 kB", 1500L)]
+    [InlineData("1PB", 1_000_000_000_000_000L)]
+    [InlineData("1EB", 1_000_000_000_000_000_000L)]
+    [InlineData("1eb", 1_000_000_000_000_000_000L)]
+    [InlineData("1 EiB", 1_152_921_504_606_846_976L)]
+    [InlineData("1PiB", 1_125_899_906_842_624L)]
     public void Parse(string str, long expectedValue)
     {
         var actual = ByteSize.Parse(str, CultureInfo.InvariantCulture);
@@ -89,6 +99,11 @@ public sealed class ByteSizeTests
     [InlineData(1_510_000L, "f1", "1.5MB")]
     [InlineData(1_510_000L, "", "1.51MB")]
     [InlineData(1_510_000L, "f2", "1.51MB")]
+    [InlineData(1_000_000_000_000_000L, "PB", "1PB")]
+    [InlineData(1_000_000_000_000_000_000L, "EB", "1EB")]
+    [InlineData(1_000_000_000_000_000_000L, "", "1EB")]
+    [InlineData(1_152_921_504_606_846_976L, "EiB", "1EiB")]
+    [InlineData(1_152_921_504_606_846_976L, "gi", "1EiB")]
     public void TryFormat_Test(long length, string? format, string expectedValue)
     {
         var byteSize = new ByteSize(length);
@@ -119,6 +134,11 @@ public sealed class ByteSizeTests
     [InlineData("1 KB", 1000L)]
     [InlineData("1 kiB", 1024L)]
     [InlineData("1.5 kB", 1500L)]
+    [InlineData("1PB", 1_000_000_000_000_000L)]
+    [InlineData("1EB", 1_000_000_000_000_000_000L)]
+    [InlineData("1eb", 1_000_000_000_000_000_000L)]
+    [InlineData("1 EiB", 1_152_921_504_606_846_976L)]
+    [InlineData("1PiB", 1_125_899_906_842_624L)]
     public void Parse_Span(string str, long expectedValue)
     {
         var actual = ByteSize.Parse(str.AsSpan(), CultureInfo.InvariantCulture);
@@ -155,6 +175,11 @@ public sealed class ByteSizeTests
     [InlineData(1_510_000L, "f1", "1.5MB")]
     [InlineData(1_510_000L, "", "1.51MB")]
     [InlineData(1_510_000L, "f2", "1.51MB")]
+    [InlineData(1_000_000_000_000_000L, "PB", "1PB")]
+    [InlineData(1_000_000_000_000_000_000L, "EB", "1EB")]
+    [InlineData(1_000_000_000_000_000_000L, "", "1EB")]
+    [InlineData(1_152_921_504_606_846_976L, "EiB", "1EiB")]
+    [InlineData(1_152_921_504_606_846_976L, "gi", "1EiB")]
     public void TryFormat_Utf8_Test(long length, string? format, string expectedValue)
     {
         var byteSize = new ByteSize(length);
@@ -185,6 +210,11 @@ public sealed class ByteSizeTests
     [InlineData("1 KB", 1000L)]
     [InlineData("1 kiB", 1024L)]
     [InlineData("1.5 kB", 1500L)]
+    [InlineData("1PB", 1_000_000_000_000_000L)]
+    [InlineData("1EB", 1_000_000_000_000_000_000L)]
+    [InlineData("1eb", 1_000_000_000_000_000_000L)]
+    [InlineData("1 EiB", 1_152_921_504_606_846_976L)]
+    [InlineData("1PiB", 1_125_899_906_842_624L)]
     public void Parse_Utf8(string str, long expectedValue)
     {
         var utf8Bytes = System.Text.Encoding.UTF8.GetBytes(str);
@@ -206,5 +236,19 @@ public sealed class ByteSizeTests
 
         var parsed = ByteSize.TryParse(utf8Bytes.AsSpan(), out var actualTry);
         Assert.False(parsed);
+    }
+
+    [Fact]
+    public void ToString_RoundTripsThroughParse_ForEveryUnit()
+    {
+        foreach (var unit in Enum.GetValues<ByteSizeUnit>())
+        {
+            var size = new ByteSize((long)unit);
+            var formatted = size.ToString(unit, CultureInfo.InvariantCulture);
+
+            Assert.Equal(size, ByteSize.Parse(formatted, CultureInfo.InvariantCulture));
+            Assert.Equal(size, ByteSize.Parse(formatted.AsSpan(), CultureInfo.InvariantCulture));
+            Assert.Equal(size, ByteSize.Parse(System.Text.Encoding.UTF8.GetBytes(formatted).AsSpan()));
+        }
     }
 }


### PR DESCRIPTION
`ByteSizeUnit` defines `ExaByte` and `ExbiByte`, the XML docs on `ToString` and `readme.md` both list `EB`/`EiB` as supported units, and `FindBestUnit`/`FindBestUnitI` actively select them — but neither unit-suffix parser recognised `E`.

`TryParseUnit` (`ByteSize.cs:387-408`) and `TryParseUtf8Unit` (`ByteSize.cs:691-712`) switch over `K`, `M`, `G`, `T`, `P` and stop. An `E` suffix fell through to the "no recognised prefix" tail, which reports `parsedLength = 1` and `ByteSizeUnit.Byte`, leaving the `E` in the numeric part where both `long.TryParse` and `double.TryParse` reject it.

So the documented units did not work:

```
ByteSize.Parse("10EB")             -> FormatException
ByteSize.Parse("10EiB")            -> FormatException
new ByteSize(10).ToString("EB")    -> ArgumentException: format 'EB' is invalid
TryFormat(dest, out _, "EB", ...)  -> false
ByteSize.Parse("1PB")              -> 1000000000000000   (only E was missing)
```

Worse, because `FindBestUnit`/`FindBestUnitI` do pick the exa units, the default `ToString()` emitted output the library could not read back — breaking the format/parse round-trip that `ISpanFormattable` + `ISpanParsable` implies, for every value at or above 1 EB:

```
new ByteSize(2_000_000_000_000_000_000).ToString()      -> "2EB"   -> Parse threw
new ByteSize(1_152_921_504_606_846_976).ToString("gi")  -> "1EiB"  -> Parse threw
```

## What changed

- `case 'E'` added to both switches, returning `ExbiByte`/`ExaByte`, matching the existing `case 'P'` shape. This fixes all four public entry points at once — `Parse`/`TryParse` (UTF-16 and UTF-8) and `ToString`/`TryFormat` (UTF-16 and UTF-8) — since they all route through these two methods.
- **Second, unrelated change in the same two methods:** the `i`-without-a-prefix failure branch (`ByteSize.cs:377-384`, `:683-688`) left `parsedLength` at `3` while returning `false`, so an input like `"iB"` reported a length longer than itself. No caller reads the length on the failure path today, so this is not observable from the public API and has no test — but `s = s[..^unitLength]` in `TryParse` would throw `ArgumentOutOfRangeException` on trimmed user input if a future change ever did. Set to `0` to match the empty-input branch a few lines above. Called out separately so it can be objected to on its own; happy to split it out.

## Verification

`dotnet test tests/Meziantou.Framework.ByteSize.Tests` — 216 passed (108 × net10.0/net11.0), 0 failed.

Reverting only the `ByteSize.cs` change and re-running gives **36 failures**, so the new cases genuinely cover the defect rather than merely passing.

New coverage:
- `EB`, `EiB`, `PB`, `PiB` and lowercase `eb` rows added to the three `Parse` theories (string, span, UTF-8) and the three format theories (`ToString`, `TryFormat`, `TryFormat` UTF-8).
- `ToString_RoundTripsThroughParse_ForEveryUnit` walks all 13 `ByteSizeUnit` values and asserts the formatted text parses back to the same value through all three parse entry points. This is the guard that would have caught the original gap, and it will catch the next unit added to the enum.

## Known gap, not addressed here

Round-tripping a *rounded* exa-scale value still misbehaves, because parsing it overflows: `ByteSize.MaxValue.ToString("gi")` is `"8EiB"`, and `8 × 2^60` exceeds `long.MaxValue`, so `Parse` now silently returns `long.MinValue` instead of throwing. That is the separate overflow defect, fixed in the `fix/bytesize-tryparse-overflow` PR. The tests here deliberately use exact unit multiples so they assert only what this change actually fixes.
