### PR TITLE
Bound Position and Seek to Array.MaxLength in PooledMemoryStream

### DIFF
--- a/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
+++ b/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
@@ -100,6 +100,7 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
         {
             EnsureOpen();
             ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, Array.MaxLength);
 
             _position = value;
         }
@@ -144,6 +145,8 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
     public override long Seek(long offset, SeekOrigin loc)
     {
         EnsureOpen();
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(offset, Array.MaxLength);
+
         var newPosition = loc switch
         {
             SeekOrigin.Begin => offset,
@@ -154,6 +157,8 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
 
         if (newPosition < 0)
             throw new IOException("An attempt was made to move the position before the beginning of the stream.");
+
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(newPosition, Array.MaxLength, nameof(offset));
 
         _position = newPosition;
         return newPosition;
@@ -485,8 +490,8 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
         if (source.IsEmpty)
             return;
 
-        var endPosition = _position + source.Length;
-        if (endPosition > Array.MaxLength)
+        // Subtract rather than add: _position + source.Length can overflow long for a far-out position.
+        if (_position > Array.MaxLength - source.Length)
             throw new IOException("Stream was too long.");
 
         if (_position > _length)

--- a/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
+++ b/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
@@ -125,6 +125,45 @@ public sealed class PooledMemoryStreamTests
     }
 
     [Fact]
+    public void Position_AboveArrayMaxLength_Throws()
+    {
+        using var stream = new PooledMemoryStream();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Position = (long)Array.MaxLength + 1);
+        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Position = long.MaxValue);
+        Assert.Equal(0, stream.Position);
+
+        stream.Position = Array.MaxLength;
+        Assert.Equal(Array.MaxLength, stream.Position);
+    }
+
+    [Fact]
+    public void Seek_AboveArrayMaxLength_Throws()
+    {
+        using var stream = new PooledMemoryStream();
+        stream.Write(CreateData(100));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek(long.MaxValue, SeekOrigin.Begin));
+        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek((long)Array.MaxLength + 1, SeekOrigin.Begin));
+        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Seek(Array.MaxLength, SeekOrigin.End));
+    }
+
+    [Fact]
+    public void WriteAtFarPosition_Throws_InsteadOfAllocatingForever()
+    {
+        // Regression: Position was unbounded and WriteCore guarded with "_position + count > Array.MaxLength",
+        // which overflows to a negative value near long.MaxValue. The guard passed and the write fell into an
+        // unbounded zero-fill loop that never returned.
+        using var stream = new PooledMemoryStream();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => stream.Position = long.MaxValue);
+
+        stream.Position = Array.MaxLength;
+        Assert.Throws<IOException>(() => stream.WriteByte(1));
+        Assert.Throws<IOException>(() => stream.Write(CreateData(10)));
+    }
+
+    [Fact]
     public void Overwrite_InTheMiddle()
     {
         using var stream = new PooledMemoryStream(SmallTiers());


### PR DESCRIPTION
## The bug

`Position`'s setter rejected only negatives, so a far-out position was accepted where `MemoryStream` throws:

```csharp
var s = new PooledMemoryStream();
s.Position = long.MaxValue;   // accepted (MemoryStream: ArgumentOutOfRangeException)
s.WriteByte(1);               // never returns; allocates until OOM
```

`WriteCore` guarded the length with `var endPosition = _position + source.Length; if (endPosition > Array.MaxLength) throw;`
([`PooledMemoryStream.cs:488-493`](../blob/main/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs#L488-L493)).
Near `long.MaxValue` that addition overflows to a negative value, the guard passes, and control reaches
`ExtendLengthWithZeros(_position)`, which loops renting 4 KiB blocks toward a `long.MaxValue` target. Run on a watchdog
thread it had not returned after 3 seconds and was still allocating — a process-wide hang plus unbounded allocation,
reachable from a `long` that flowed in from config or a parser without validation.

A moderate out-of-range position (`3e9`) was already handled correctly and threw `IOException`; only the
near-`long.MaxValue` range fell through. `Seek(long.MaxValue, SeekOrigin.Begin)` reached the same state.

## What changed

- `Position` setter rejects values above `Array.MaxLength`, matching `MemoryStream`'s behaviour of failing at the
  assignment rather than at the eventual write.
- `Seek` validates `offset` up front (same shape as `MemoryStream.Seek`) and re-checks the computed position, so
  `SeekOrigin.Current`/`End` can't walk past the limit either.
- `WriteCore`'s guard is now overflow-proof — it compares `_position > Array.MaxLength - source.Length` instead of
  summing — so the invariant holds even if some future path sets `_position` another way.

## Verification

Three regression tests added next to the existing `Seek_FromAllOrigins` test. All three fail on `main` and pass here:

```
failed PooledMemoryStreamTests.Position_AboveArrayMaxLength_Throws
failed PooledMemoryStreamTests.Seek_AboveArrayMaxLength_Throws
failed PooledMemoryStreamTests.WriteAtFarPosition_Throws_InsteadOfAllocatingForever
```

`WriteAtFarPosition_...` is written so it fails on the assertion rather than hanging when the fix is absent.

Full suite: **90/90 passing** (45 × net10.0/net11.0, up from 84) with `/p:TreatsWarningsAsErrors=true`.
`dotnet run ./eng/update-all.cs` produces no changes — the public API surface is unchanged.

Found by a review of `Meziantou.Framework.PooledMemoryStream` (finding F3, High).
