### PR TITLE
Stop rendering 90-119 minutes as "1 hours ago"

### DIFF
--- a/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
@@ -95,8 +95,8 @@ public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IE
     /// <item><description>"X seconds ago" / "in X seconds" - for &lt;1 minute</description></item>
     /// <item><description>"a minute ago" / "in a minute" - for 1-2 minutes</description></item>
     /// <item><description>"X minutes ago" / "in X minutes" - for &lt;45 minutes</description></item>
-    /// <item><description>"an hour ago" / "in an hour" - for 45-90 minutes</description></item>
-    /// <item><description>"X hours ago" / "in X hours" - for &lt;24 hours</description></item>
+    /// <item><description>"an hour ago" / "in an hour" - for 45-120 minutes</description></item>
+    /// <item><description>"X hours ago" / "in X hours" - for 2-24 hours</description></item>
     /// <item><description>"yesterday" / "tomorrow" - for 24-48 hours</description></item>
     /// <item><description>"X days ago" / "in X days" - for &lt;30 days</description></item>
     /// <item><description>"one month ago" / "in one month" - for 30-60 days</description></item>
@@ -128,7 +128,7 @@ public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IE
             if (delta < TimeSpan.FromMinutes(45))
                 return GetString("InManyMinutes", culture, delta.Minutes);
 
-            if (delta < TimeSpan.FromMinutes(90))
+            if (delta < TimeSpan.FromMinutes(120))
                 return GetString("InAnHour", culture);
 
             if (delta < TimeSpan.FromHours(24))
@@ -172,7 +172,7 @@ public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IE
         if (delta < TimeSpan.FromMinutes(45))
             return GetString("ManyMinutesAgo", culture, delta.Minutes);
 
-        if (delta < TimeSpan.FromMinutes(90))
+        if (delta < TimeSpan.FromMinutes(120))
             return GetString("AnHourAgo", culture);
 
         if (delta < TimeSpan.FromHours(24))

--- a/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
+++ b/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
@@ -50,6 +50,8 @@ public class RelativeDateTests
             yield return new object[] { "2018/01/01 00:00:00Z", "2018/01/01 00:01:00Z", "a minute ago", "il y a une minute" };
             yield return new object[] { "2018/01/01 00:00:00Z", "2018/01/01 00:10:00Z", "10 minutes ago", "il y a 10 minutes" };
             yield return new object[] { "2018/01/01 00:00:00Z", "2018/01/01 01:00:00Z", "an hour ago", "il y a une heure" };
+            yield return new object[] { "2018/01/01 00:00:00Z", "2018/01/01 01:30:00Z", "an hour ago", "il y a une heure" };
+            yield return new object[] { "2018/01/01 00:00:00Z", "2018/01/01 01:59:00Z", "an hour ago", "il y a une heure" };
             yield return new object[] { "2018/01/01 00:00:00Z", "2018/01/01 02:00:00Z", "2 hours ago", "il y a 2 heures" };
             yield return new object[] { "2018/01/01 00:00:00Z", "2018/01/02 00:00:00Z", "yesterday", "hier" };
             yield return new object[] { "2018/01/01 00:00:00Z", "2018/01/03 00:00:00Z", "2 days ago", "il y a 2 jours" };
@@ -62,6 +64,8 @@ public class RelativeDateTests
             yield return new object[] { "2018/01/01 00:00:25Z", "2018/01/01 00:00:00Z", "in 25 seconds", "dans 25 secondes" };
             yield return new object[] { "2018/01/01 00:10:00Z", "2018/01/01 00:00:00Z", "in 10 minutes", "dans 10 minutes" };
             yield return new object[] { "2018/01/01 01:00:00Z", "2018/01/01 00:00:00Z", "in an hour", "dans une heure" };
+            yield return new object[] { "2018/01/01 01:30:00Z", "2018/01/01 00:00:00Z", "in an hour", "dans une heure" };
+            yield return new object[] { "2018/01/01 01:59:00Z", "2018/01/01 00:00:00Z", "in an hour", "dans une heure" };
             yield return new object[] { "2018/01/01 00:01:00Z", "2018/01/01 00:00:00Z", "in a minute", "dans une minute" };
             yield return new object[] { "2018/01/01 02:00:00Z", "2018/01/01 00:00:00Z", "in 2 hours", "dans 2 heures" };
             yield return new object[] { "2018/01/02 00:00:00Z", "2018/01/01 00:00:00Z", "tomorrow", "demain" };


### PR DESCRIPTION
`RelativeDate.ToString` ends its singular "an hour" bucket at 90 minutes, but the next bucket truncates with `delta.Hours` — so anything 90–119 minutes away formats the **plural** resource with the value `1`.

Measured on `main`, at `src/Meziantou.Framework.RelativeDate/RelativeDate.cs:131` (future) and `:175` (past):

```
-89 minutes  => an hour ago         -90 minutes  => 1 hours ago
-119 minutes => 1 hours ago         -120 minutes => 2 hours ago
+90 minutes  => in 1 hours
```

The broken grammar reaches six of the eleven supported languages. At −90 minutes: `de` → "vor 1 Stunden", `es` → "hace 1 horas", `fr` → "il y a 1 heures", `it` → "1 ore fa", `pt` → "há 1 horas", plus English. `nl` ("1 uur geleden") and `tr` ("1 saat önce") escape only because their singular and plural forms coincide; `ja`, `ko` and `zh-Hans` are unaffected.

It went unnoticed because `AllBranchOffsets` in the test suite steps from `FromMinutes(-60)` straight to `FromHours(-2)`, right over the gap.

## What changed

The singular bucket now runs to 120 minutes, so the plural hours bucket starts at `delta.Hours == 2`. This is the minimal fix — no other output changes. The tradeoff is that "an hour ago" now covers up to 1h59m.

The alternative, rounding `TotalHours`, would also fix it and is what most relative-time formatters do, but it changes output for every timestamp with a ≥30 minute remainder (2h30 → "3 hours ago"). Not taken, since this is a shipped v4 package.

The `<remarks>` bucket list on `ToString` is updated to match the new boundaries.

## Verification

Four rows added to `RelativeDate_ToString_Data` covering 90 and 119 minutes in both directions. Reverting only the source change makes exactly those 4 rows fail; with the fix the full project suite is 100/100 across net10.0 and net11.0.
