### PR TITLE
Stop InMemoryLogEntry.ToString from throwing on non-serializable values

### DIFF
--- a/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogEntry.cs
+++ b/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogEntry.cs
@@ -80,15 +80,41 @@ public sealed class InMemoryLogEntry
 
         if (State is not null)
         {
-            sb.Append("\n  => ").Append(JsonSerializer.Serialize(State));
+            sb.Append("\n  => ").Append(Serialize(State));
         }
 
         foreach (var scope in Scopes)
         {
-            sb.Append("\n  => ").Append(JsonSerializer.Serialize(scope));
+            sb.Append("\n  => ").Append(Serialize(scope));
         }
 
         return sb.ToString();
+    }
+
+    // ToString is the diagnostic surface of this type: it ends up in assertion messages and in the
+    // debugger, so it must never throw. JsonSerializer rejects plenty of values that are perfectly
+    // ordinary to log (Type, delegates, reference cycles), hence the fallback to the value's own
+    // representation instead of letting the exception escape.
+    private static string Serialize(object? value)
+    {
+        if (value is null)
+            return "null";
+
+        try
+        {
+            return JsonSerializer.Serialize(value);
+        }
+        catch (Exception)
+        {
+            try
+            {
+                return value.ToString() ?? value.GetType().ToString();
+            }
+            catch (Exception)
+            {
+                return value.GetType().ToString();
+            }
+        }
     }
 
     /// <summary>Tries to retrieve the first parameter value with the specified name from the state or scopes.</summary>

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
@@ -37,6 +37,52 @@ public sealed partial class InMemoryLoggerTests
     }
 
     [Fact]
+    public void ToString_DoesNotThrow_WhenAParameterValueIsNotJsonSerializable()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+
+        logger.LogInformation("handled by {Handler}", typeof(string));
+
+        var log = logger.Logs.Informations.Single();
+        var text = log.ToString();
+        Assert.Contains("handled by System.String", text);
+        Assert.Contains("handled by System.String", logger.Logs.ToString());
+    }
+
+    [Fact]
+    public void ToString_DoesNotThrow_WhenAScopeIsNotJsonSerializable()
+    {
+        using var provider = new InMemoryLoggerProvider(new LoggerExternalScopeProvider());
+        var logger = provider.CreateLogger("my_category");
+
+        using (logger.BeginScope(new { Callback = (Action)(() => { }) }))
+        {
+            logger.LogInformation("Test");
+        }
+
+        var log = provider.Logs.Informations.Single();
+        Assert.StartsWith("[my_category] Information: Test", log.ToString());
+    }
+
+    [Fact]
+    public void ToString_DoesNotThrow_WhenTheStateContainsAReferenceCycle()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+        var node = new SelfReferencingNode();
+        node.Self = node;
+
+        logger.LogInformation("node {Node}", node);
+
+        var log = logger.Logs.Informations.Single();
+        Assert.StartsWith("[sample] Information: node ", log.ToString());
+    }
+
+    private sealed class SelfReferencingNode
+    {
+        public SelfReferencingNode? Self { get; set; }
+    }
+
+    [Fact]
     public void UsingDependencyInjection()
     {
         using var inMemoryLoggerProvider = new InMemoryLoggerProvider(NullExternalScopeProvider.Instance);


### PR DESCRIPTION
`InMemoryLogEntry.ToString()` calls `JsonSerializer.Serialize` on arbitrary user state and scopes with no error handling, so it throws for values that are entirely ordinary to log.

### The failure

| Log call | `entry.ToString()` before this change |
|---|---|
| `logger.LogInformation("handled by {Handler}", typeof(string))` | `NotSupportedException: Serialization and deserialization of 'System.RuntimeType' instances is not supported.` |
| `logger.BeginScope(new { Callback = (Action)(() => {}) })` | `NotSupportedException: … 'System.Action' instances is not supported.` |
| state object with a reference cycle | `JsonException: A possible object cycle was detected.` |

`ToString()` is the diagnostic surface of this library — it is what the README's workflow leans on, what the debugger shows, and what ends up inside assertion messages. Two bad outcomes:

1. A failing test's message is replaced by an unrelated serialization exception, hiding the actual cause.
2. Worse, an eagerly-evaluated message argument such as `Assert.True(condition, logs.ToString())` throws **even when the assertion would have passed** — a green test turns red for a reason unrelated to the code under test.

Logging a `Type` (`"Registered handler {HandlerType}"`) is a common thing to do, so this is not an exotic path.

### The change

`ToString()` now routes both state and scopes through a `Serialize` helper that falls back to the value's own `ToString()` when the serializer rejects it. The happy-path output format is unchanged, so all existing asserted strings still hold.

### Verification

Three regression tests added, each covering one row of the table above. Confirmed they fail on `main` with exactly the exceptions listed and pass with the fix. Full suite green: 30/30 (15 tests × net10.0/net11.0) with `/p:TreatsWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` produced no further changes.

### Note for review

Worth considering separately: for `FormattedLogValues` — the overwhelmingly common state type — hand-formatting the key/value pairs instead of using `JsonSerializer` would be faster, allocate less, read better in output, and sidestep the reflection-based serializer's trim/AOT unfriendliness. That would change the happy-path format and every asserted string with it, so it is deliberately **not** part of this PR.

Found during a project review of `Meziantou.Extensions.Logging.InMemory`.
