### PR TITLE
Select the display unit from the magnitude so negative sizes scale

### DIFF
--- a/src/Meziantou.Framework.ByteSize/ByteSize.cs
+++ b/src/Meziantou.Framework.ByteSize/ByteSize.cs
@@ -241,24 +241,30 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
         return true;
     }
 
+    // The unit is chosen from the magnitude so negative sizes scale like positive ones.
+    // Negating long.MinValue overflows, but the unchecked wrap-around reinterpreted as
+    // ulong is exactly its magnitude (2^63), so no value needs a special case.
+    private ulong Magnitude => Value < 0 ? unchecked((ulong)(-Value)) : (ulong)Value;
+
     private ByteSizeUnit FindBestUnit()
     {
-        if (Value >= (long)ByteSizeUnit.ExaByte)
+        var magnitude = Magnitude;
+        if (magnitude >= (ulong)ByteSizeUnit.ExaByte)
             return ByteSizeUnit.ExaByte;
 
-        if (Value >= (long)ByteSizeUnit.PetaByte)
+        if (magnitude >= (ulong)ByteSizeUnit.PetaByte)
             return ByteSizeUnit.PetaByte;
 
-        else if (Value >= (long)ByteSizeUnit.TeraByte)
+        if (magnitude >= (ulong)ByteSizeUnit.TeraByte)
             return ByteSizeUnit.TeraByte;
 
-        else if (Value >= (long)ByteSizeUnit.GigaByte)
+        if (magnitude >= (ulong)ByteSizeUnit.GigaByte)
             return ByteSizeUnit.GigaByte;
 
-        else if (Value >= (long)ByteSizeUnit.MegaByte)
+        if (magnitude >= (ulong)ByteSizeUnit.MegaByte)
             return ByteSizeUnit.MegaByte;
 
-        else if (Value >= (long)ByteSizeUnit.KiloByte)
+        if (magnitude >= (ulong)ByteSizeUnit.KiloByte)
             return ByteSizeUnit.KiloByte;
 
         return ByteSizeUnit.Byte;
@@ -266,22 +272,23 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
 
     private ByteSizeUnit FindBestUnitI()
     {
-        if (Value >= (long)ByteSizeUnit.ExbiByte)
+        var magnitude = Magnitude;
+        if (magnitude >= (ulong)ByteSizeUnit.ExbiByte)
             return ByteSizeUnit.ExbiByte;
 
-        if (Value >= (long)ByteSizeUnit.PebiByte)
+        if (magnitude >= (ulong)ByteSizeUnit.PebiByte)
             return ByteSizeUnit.PebiByte;
 
-        if (Value >= (long)ByteSizeUnit.TebiByte)
+        if (magnitude >= (ulong)ByteSizeUnit.TebiByte)
             return ByteSizeUnit.TebiByte;
 
-        if (Value >= (long)ByteSizeUnit.GibiByte)
+        if (magnitude >= (ulong)ByteSizeUnit.GibiByte)
             return ByteSizeUnit.GibiByte;
 
-        if (Value >= (long)ByteSizeUnit.MebiByte)
+        if (magnitude >= (ulong)ByteSizeUnit.MebiByte)
             return ByteSizeUnit.MebiByte;
 
-        if (Value >= (long)ByteSizeUnit.KibiByte)
+        if (magnitude >= (ulong)ByteSizeUnit.KibiByte)
             return ByteSizeUnit.KibiByte;
 
         return ByteSizeUnit.Byte;

--- a/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
+++ b/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
@@ -39,6 +39,28 @@ public sealed class ByteSizeTests
     }
 
     [Theory]
+    [InlineData(-10L, "", "-10B")]
+    [InlineData(-1_500L, "", "-1.5kB")]
+    [InlineData(-1_500_000_000L, "", "-1.5GB")]
+    [InlineData(-1_024L, "gi", "-1kiB")]
+    [InlineData(-1_073_741_824L, "gi", "-1GiB")]
+    [InlineData(long.MinValue, "gi", "-8EiB")]
+    public void ToString_NegativeValue_UsesScaledUnit(long length, string format, string expectedValue)
+    {
+        Assert.Equal(expectedValue, new ByteSize(length).ToString(format, CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [InlineData(1_500L, "", "1.5kB")]
+    [InlineData(1_500_000_000L, "", "1.5GB")]
+    [InlineData(1_073_741_824L, "gi", "1GiB")]
+    public void ToString_NegativeValue_MatchesPositiveApartFromTheSign(long length, string format, string expectedValue)
+    {
+        Assert.Equal(expectedValue, new ByteSize(length).ToString(format, CultureInfo.InvariantCulture));
+        Assert.Equal("-" + expectedValue, new ByteSize(-length).ToString(format, CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
     [InlineData("1", 1L)]
     [InlineData("1b", 1L)]
     [InlineData("1B", 1L)]


### PR DESCRIPTION
`FindBestUnit` and `FindBestUnitI` (`ByteSize.cs:244-288`) selected the display unit with `Value >= (long)unit`. A negative `Value` fails every one of those comparisons, so it fell through to `ByteSizeUnit.Byte` and was rendered as a raw byte count:

```
new ByteSize(-1_500_000_000).ToString()  -> "-1500000000B"            (expected "-1.5GB")
new ByteSize(-1_024).ToString("gi")      -> "-1024B"                  (expected "-1kiB")
ByteSize.MinValue.ToString()             -> "-9.223372036854776E+18B"
ByteSize.MinValue.ToString("gi")         -> "-9.223372036854776E+18B" ("gi" made no difference)
```

Negative sizes are a first-class concept in this type: `MinValue` is public and `operator -` is the documented way to compute a delta. "Space freed" and "size change" are the obvious uses, and both rendered as an unreadable raw byte count while the positive value beside them rendered as `1.5GB`.

## What changed

Both selectors now compare the **magnitude** rather than the signed value, via a new private `Magnitude` property. The sign then flows through the numeric format on its own, so no other code changes.

`long.MinValue` is the case worth looking at: `Math.Abs(long.MinValue)` throws, so it is normally a special case. Here it does not need one — negating it wraps back to itself, and that bit pattern reinterpreted as `ulong` is exactly `2^63`, its true magnitude. The unchecked negation is therefore correct for every input including `MinValue`, and there is a comment on the property saying so, since the code otherwise reads like an overflow bug.

The comparisons move to `ulong` so `MinValue`'s `2^63` magnitude — which does not fit in a `long` — compares correctly against the unit constants.

Also normalised the `else if` / `if` mix in `FindBestUnit` to plain `if`, matching `FindBestUnitI`. Every branch returns, so this is not a behaviour change.

## Verification

`dotnet test tests/Meziantou.Framework.ByteSize.Tests` — 172 passed (86 × net10.0/net11.0), 0 failed.

Reverting only the `ByteSize.cs` change and re-running gives **16 failures**, confirming the new tests cover the defect.

New coverage:
- `ToString_NegativeValue_UsesScaledUnit` — negative values across `B`, `kB`, `GB`, `kiB`, `GiB`, plus `long.MinValue` formatting as `-8EiB`, which exercises the wrap-around path directly.
- `ToString_NegativeValue_MatchesPositiveApartFromTheSign` — asserts the negative rendering is the positive rendering with a `-` in front, which is the property that was actually broken.
