### PR TITLE
Document TemporaryFile in the package readme and API docs

### DIFF
--- a/src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj
+++ b/src/Meziantou.Framework.TemporaryDirectory/Meziantou.Framework.TemporaryDirectory.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Meziantou.Framework</RootNamespace>
     <Version>3.0.3</Version>
     <IsTrimmable>true</IsTrimmable>
-    <Description>TemporaryDirectory allows to create a disposable directory to store temporary files</Description>
+    <Description>TemporaryDirectory and TemporaryFile allow to create a disposable directory or file to store temporary data</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
@@ -51,6 +51,8 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
     /// <remarks>
     /// If <paramref name="fileNameOrPath"/> is not rooted, it is created under the system temp path in a "MezTF" subdirectory.
     /// </remarks>
+    /// <exception cref="ArgumentException"><paramref name="fileNameOrPath"/> is <see langword="null"/>, empty, or contains only white-space characters.</exception>
+    /// <exception cref="IOException">The file already exists.</exception>
     public static TemporaryFile Create(string fileNameOrPath)
     {
         if (string.IsNullOrWhiteSpace(fileNameOrPath))
@@ -66,6 +68,12 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
     /// <summary>Creates a new temporary file at the specified path.</summary>
     /// <param name="filePath">The full path where the temporary file will be created.</param>
     /// <returns>A new <see cref="TemporaryFile"/> instance.</returns>
+    /// <remarks>
+    /// The file must not already exist. An existing file is never adopted, so disposing the returned instance
+    /// cannot delete data that it did not create.
+    /// </remarks>
+    /// <exception cref="ArgumentException"><paramref name="filePath"/> is empty.</exception>
+    /// <exception cref="IOException">The file already exists.</exception>
     public static TemporaryFile Create(FullPath filePath)
     {
         if (filePath.IsEmpty)

--- a/src/Meziantou.Framework.TemporaryDirectory/readme.md
+++ b/src/Meziantou.Framework.TemporaryDirectory/readme.md
@@ -1,9 +1,27 @@
 # Meziantou.Framework.TemporaryDirectory
 
+## TemporaryDirectory
+
 Create a unique empty folder that is deleted at the end of the scope.
 
 ````c#
 using var temporaryDirectory = TemporaryDirectory.Create();
 temporaryDirectory.CreateEmptyFile("test/demo.txt");
 File.WriteAllText(temporaryDirectory.GetFullPath("foo.txt"), "bar");
+````
+
+## TemporaryFile
+
+Create a unique file that is deleted at the end of the scope.
+
+````c#
+// Generated name under the system temp folder
+using var temporaryFile = TemporaryFile.Create();
+File.WriteAllText(temporaryFile.FullPath, "content");
+
+// Choose the file name; a unique parent folder is created for it
+using var namedFile = TemporaryFile.Create("custom.txt");
+
+// Choose the full path. The file must not already exist.
+using var atPath = TemporaryFile.Create(FullPath.Combine(Path.GetTempPath(), "custom.txt"));
 ````


### PR DESCRIPTION
`TemporaryFile` is a fully public, documented type shipped in `Meziantou.Framework.TemporaryDirectory`, but neither the package readme nor the NuGet `<Description>` mentions it, so the only way to find it is to already know it exists.

Three exceptions the type throws deliberately were also undocumented, while the implicit operators in the same file document theirs carefully:

- `Create(string)` throws `ArgumentException` for null/empty/whitespace (`TemporaryFile.cs:56-57`)
- `Create(FullPath)` throws `ArgumentException` for an empty path (`TemporaryFile.cs:71-72`)
- both throw `IOException` when the file already exists, because `CreateFile` uses `FileMode.CreateNew` (`TemporaryFile.cs:93`)

That last one is a genuine safety property — `TemporaryFile` never adopts a file it did not create, so disposing it cannot delete pre-existing data. Undocumented, it reads to a caller as an unexpected failure rather than a guarantee, so the remarks now state it.

## Changes

- `readme.md`: split into `TemporaryDirectory` and `TemporaryFile` sections, with examples for all three `Create` overloads.
- `.csproj`: `<Description>` now names both types.
- `TemporaryFile.cs`: `<exception>` tags on both `Create` overloads, plus remarks on `Create(FullPath)` explaining the must-not-exist contract.

No code changes — documentation and package metadata only.

## Verification

- `dotnet build /p:TreatsWarningsAsErrors=true` — clean, 0 warnings.
- `dotnet test` — 18/18 pass (9 tests × net10.0/net11.0).
- `dotnet run ./eng/update-all.cs` — no further changes generated.

Found during a review of `src/Meziantou.Framework.TemporaryDirectory`.
