### PR TITLE
Fall back to the system TimeProvider on a default RelativeDate

### DIFF
--- a/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
@@ -31,7 +31,10 @@ namespace Meziantou.Framework;
 [StructLayout(LayoutKind.Auto)]
 public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IEquatable<RelativeDate>, IFormattable
 {
-    private TimeProvider TimeProvider { get; }
+    /// <remarks>
+    /// Null on a default instance. A struct cannot intercept its own zero-initialization, so every read must fall back to <see cref="System.TimeProvider.System"/>.
+    /// </remarks>
+    private TimeProvider? TimeProvider { get; }
     private DateTime DateTime { get; }
 
     /// <summary>Initializes a new instance of the <see cref="RelativeDate"/> struct with the specified date and time provider.</summary>
@@ -107,7 +110,8 @@ public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IE
     /// </remarks>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
-        var now = TimeProvider.GetUtcNow().UtcDateTime;
+        // TimeProvider is null on a default instance: structs cannot intercept their own zero-initialization
+        var now = (TimeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime;
 
         var delta = now - DateTime;
         var culture = formatProvider as CultureInfo;

--- a/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
+++ b/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
@@ -15,6 +15,22 @@ public class RelativeDateTests
         Assert.Throws<ArgumentException>(() => new RelativeDate(default, timeProvider).ToString());
     }
 
+    [Fact]
+    public void DefaultInstance_ToString_FallsBackToTheSystemTimeProvider()
+    {
+        // A default instance carries no TimeProvider and holds DateTime.MinValue, so it renders as a very distant past date
+        var result = default(RelativeDate).ToString(format: null, CultureInfo.InvariantCulture);
+        Assert.EndsWith(" years ago", result);
+    }
+
+    [Fact]
+    public void DefaultInstance_FromArray_ToString_FallsBackToTheSystemTimeProvider()
+    {
+        var dates = new RelativeDate[1];
+        var result = dates[0].ToString(format: null, CultureInfo.InvariantCulture);
+        Assert.EndsWith(" years ago", result);
+    }
+
     [Theory]
     [MemberData(nameof(RelativeDate_ToString_Data))]
     public void RelativeDate_ToString(string dateTimeStr, string nowStr, string expectedValueEn, string expectedValueFr)


### PR DESCRIPTION
`RelativeDate` is a `readonly struct`, so it always has a zero-initialized default that its constructors cannot intercept. `TimeProvider` is null on that default, and `ToString` dereferences it unconditionally at `src/Meziantou.Framework.RelativeDate/RelativeDate.cs:110`.

Measured on `main`:

```
default(RelativeDate).ToString()          => THROWS NullReferenceException
new RelativeDate[1] then [0].ToString()   => THROWS NullReferenceException
default.GetHashCode() / Equals / CompareTo / operators => all fine
```

Only `ToString` is affected, which is what makes it awkward to diagnose: a default instance passes every equality and ordering check and then throws at render time, with an `NRE` from inside a formatting call and no indication of the cause.

It is reachable without any misuse — `new RelativeDate[n]`, a `List<RelativeDate>` grown by capacity, an unassigned field, or a struct round-tripped through a deserializer that skips constructors.

## What changed

`ToString` now falls back to `TimeProvider.System` when the stored provider is null.

The backing property is also re-annotated from `TimeProvider` to `TimeProvider?`. It genuinely *is* null on a default instance, and the repo guidance is to trust the null annotations rather than add checks the type system says are unnecessary — so the annotation is the part that was wrong. A `<remarks>` on the property records why.

A default instance holds `DateTime.MinValue`, so it now renders as "2026 years ago" rather than throwing. That is consistent with what `RelativeDate.Get(DateTime.MinValue)` already returns, so no new special case was introduced. Throwing an explicit `InvalidOperationException` instead would also be defensible — happy to switch if you'd rather a default instance be loudly invalid.

## Verification

Two tests added covering `default(RelativeDate)` and an element read out of `new RelativeDate[1]`. Both fail with `NullReferenceException` on `main` and pass with the fix. Full project suite: 96/96 across net10.0 and net11.0.

Note: the pre-existing `DefaultDate_ToString` test covers `new RelativeDate(default, timeProvider)` — a default `DateTime`, not a default struct — which is why this case had never been exercised.
