### PR TITLE
Document that GetBuffer can expose pooled bytes past Length

### DIFF
--- a/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStreamOptions.cs
+++ b/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStreamOptions.cs
@@ -68,9 +68,20 @@ public sealed class PooledMemoryStreamOptions
     /// <summary>
     /// Gets or sets a value indicating whether buffers are cleared (zeroed) when returned to the pool. This is slower
     /// but ensures previously written data cannot be observed by another stream that later rents the same array.
-    /// Defaults to <see langword="false"/>. Note that <see cref="PooledMemoryStream"/> never exposes bytes that were
-    /// not explicitly written, so this option is only relevant for defense-in-depth scenarios.
+    /// Defaults to <see langword="false"/>.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The members bounded by <see cref="PooledMemoryStream.Length"/> never expose unwritten bytes.
+    /// <see cref="PooledMemoryStream.GetBuffer"/> is not bounded by it: it returns the whole underlying array, and the
+    /// bytes past <see cref="PooledMemoryStream.Length"/> can still hold data written by an unrelated stream that
+    /// rented the same array earlier. Enable this option when callers may look at that region.
+    /// </para>
+    /// <para>
+    /// The pool is process-wide and clearing happens on return, so this setting governs the data this stream hands
+    /// back to other streams. It does not clean the arrays this stream rents from them.
+    /// </para>
+    /// </remarks>
     public bool ClearOnReturn
     {
         get => _clearOnReturn;

--- a/src/Meziantou.Framework.PooledMemoryStream/readme.md
+++ b/src/Meziantou.Framework.PooledMemoryStream/readme.md
@@ -63,4 +63,5 @@ using var stream = new PooledMemoryStream(options);
 ## Notes
 
 - The byte arrays (including the array returned by `GetBuffer()` / `TryGetBuffer()`, and the spans/memory returned by the `IBufferWriter<byte>` members) are owned by the stream and are returned to the shared pool on `Dispose`. **Do not use them after the stream is disposed.**
+- `GetBuffer()` returns the whole underlying array, not just the first `Length` bytes. Because arrays come from a pool shared by every instance, the region past `Length` may still contain data written by an unrelated stream. Read only `[0, Length)`, or set `ClearOnReturn = true` so buffers are zeroed before they go back to the pool.
 - The instance is not thread-safe (like `MemoryStream`); the shared pool is.


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2595**

## The problem

The XML docs on `ClearOnReturn` told readers the option was optional in a way that isn't true:

> Note that `PooledMemoryStream` never exposes bytes that were not explicitly written, so this option is only
> relevant for defense-in-depth scenarios.

`GetBuffer()` is not bounded by `Length` — it returns the whole underlying array — and arrays come from a pool shared
by every instance. With the default `ClearOnReturn = false`, a disposed stream's array goes back to the pool with its
contents intact and the next stream to rent that size gets it as-is:

```csharp
var a = new PooledMemoryStream();
a.Write("Authorization: Bearer sk-live-TOPSECRET"u8);
a.Dispose();

var b = new PooledMemoryStream();
b.Write("x"u8);
Encoding.ASCII.GetString(b.GetBuffer(), 0, 64);
// => "xuthorization: Bearer sk-live-TOPSECRET........................."
```

That's with default options and no custom tiers. `MemoryStream.GetBuffer()` also exposes bytes past `Length`, but
those are always zeros or the same stream's own earlier data — never a different component's.

The sentence above is the one that would talk a reader out of setting `ClearOnReturn = true`, so it turns a
read-the-caveat situation into a trap.

## What changed

Documentation only — no behaviour change.

- Replaces the incorrect sentence on `ClearOnReturn` with a `<remarks>` block stating what is and isn't bounded by
  `Length`, and noting that because clearing happens on *return* to a process-wide pool, the setting governs the data
  this stream hands back rather than the arrays it rents.
- Adds a `readme.md` note under **Notes** telling callers to read only `[0, Length)`.

## Why this is split from #2595

#2595 changes the behaviour so `GetBuffer()` zeroes that region, which makes most of this text obsolete — it amends
the same doc again. This PR is separated so the accurate warning can land on its own if the behaviour change needs
more discussion: right now the shipped package documents the opposite of what it does.

## Verification

`dotnet build /p:TreatsWarningsAsErrors=true` succeeds with 0 warnings (all `cref`s resolve). Test suite unchanged at
84/84. `dotnet run ./eng/update-all.cs` produces no changes.

Found by a review of `Meziantou.Framework.PooledMemoryStream` (finding F2, High).
