### PR TITLE
Zero the bytes past Length before GetBuffer hands out a pooled array

### DIFF
--- a/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
+++ b/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
@@ -651,7 +651,7 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
             return Array.Empty<byte>();
 
         if (_segments.Count == 1)
-            return _segments[0].Array;
+            return ClearTail(_segments[0].Array);
 
         var size = _options.GetContiguousBlockSize((int)_length);
         var array = PooledBufferPool.Shared.Rent(size);
@@ -664,6 +664,15 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
         _segments.Add(new Segment(array) { Used = (int)_length });
         _capacity = array.Length;
         ResetCursor();
+        return ClearTail(array);
+    }
+
+    // GetBuffer/TryGetBuffer hand out the whole array, not just [0, Length). Arrays come from a pool shared by every
+    // instance, so the region past Length would otherwise expose whatever its previous tenant wrote.
+    private byte[] ClearTail(byte[] array)
+    {
+        var length = (int)_length;
+        Array.Clear(array, length, array.Length - length);
         return array;
     }
 

--- a/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStreamOptions.cs
+++ b/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStreamOptions.cs
@@ -72,10 +72,11 @@ public sealed class PooledMemoryStreamOptions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The members bounded by <see cref="PooledMemoryStream.Length"/> never expose unwritten bytes.
-    /// <see cref="PooledMemoryStream.GetBuffer"/> is not bounded by it: it returns the whole underlying array, and the
-    /// bytes past <see cref="PooledMemoryStream.Length"/> can still hold data written by an unrelated stream that
-    /// rented the same array earlier. Enable this option when callers may look at that region.
+    /// The members bounded by <see cref="PooledMemoryStream.Length"/> never expose unwritten bytes, and
+    /// <see cref="PooledMemoryStream.GetBuffer"/> zeroes the region past <see cref="PooledMemoryStream.Length"/>
+    /// before handing the array out, so it cannot surface data left by an unrelated stream either. The one region
+    /// that stays uninitialized is the span returned by the <see cref="System.Buffers.IBufferWriter{T}"/> members,
+    /// which is the usual contract for a buffer writer.
     /// </para>
     /// <para>
     /// The pool is process-wide and clearing happens on return, so this setting governs the data this stream hands

--- a/src/Meziantou.Framework.PooledMemoryStream/readme.md
+++ b/src/Meziantou.Framework.PooledMemoryStream/readme.md
@@ -63,5 +63,5 @@ using var stream = new PooledMemoryStream(options);
 ## Notes
 
 - The byte arrays (including the array returned by `GetBuffer()` / `TryGetBuffer()`, and the spans/memory returned by the `IBufferWriter<byte>` members) are owned by the stream and are returned to the shared pool on `Dispose`. **Do not use them after the stream is disposed.**
-- `GetBuffer()` returns the whole underlying array, not just the first `Length` bytes. Because arrays come from a pool shared by every instance, the region past `Length` may still contain data written by an unrelated stream. Read only `[0, Length)`, or set `ClearOnReturn = true` so buffers are zeroed before they go back to the pool.
+- `GetBuffer()` returns the whole underlying array, not just the first `Length` bytes. Only `[0, Length)` is meaningful; the rest is zeroed before the array is handed out, so it never exposes data written by another stream. The spans returned by the `IBufferWriter<byte>` members are uninitialized, as usual for a buffer writer.
 - The instance is not thread-safe (like `MemoryStream`); the shared pool is.

--- a/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
+++ b/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
@@ -227,6 +227,47 @@ public sealed class PooledMemoryStreamTests
     }
 
     [Fact]
+    public void GetBuffer_DoesNotExposeBytesLeftByAnotherStream()
+    {
+        // Unique tier size so this test owns its pool bucket and deterministically rents the same array back.
+        var options = new PooledMemoryStreamOptions { BufferSizes = [4111] };
+
+        using (var first = new PooledMemoryStream(options))
+        {
+            first.Write(CreateData(4111, seed: 77));
+        }
+
+        using var second = new PooledMemoryStream(options);
+        var data = CreateData(10, seed: 1);
+        second.Write(data);
+
+        var buffer = second.GetBuffer();
+        Assert.Equal(data, buffer.AsSpan(0, data.Length).ToArray());
+        Assert.Equal(new byte[buffer.Length - data.Length], buffer.AsSpan(data.Length).ToArray());
+    }
+
+    [Fact]
+    public void GetBuffer_AfterConsolidatingSegments_DoesNotExposeBytesLeftByAnotherStream()
+    {
+        // Both streams consolidate into the same 4139-byte bucket, so the second one rents the first one's array.
+        var options = new PooledMemoryStreamOptions { BufferSizes = [16, 4139] };
+
+        using (var first = new PooledMemoryStream(options))
+        {
+            first.Write(CreateData(300, seed: 55));
+            first.GetBuffer();
+        }
+
+        using var second = new PooledMemoryStream(options);
+        var data = CreateData(20, seed: 2);
+        second.Write(data);
+
+        var buffer = second.GetBuffer();
+        Assert.Equal(data, buffer.AsSpan(0, data.Length).ToArray());
+        Assert.Equal(new byte[buffer.Length - data.Length], buffer.AsSpan(data.Length).ToArray());
+    }
+
+    [Fact]
     public void CopyTo_FromCurrentPosition()
     {
         var data = CreateData(1000, seed: 6);


### PR DESCRIPTION
**Stack 2 of 2 · targets `fix/clearonreturn-doc` · must merge after #2594**

## The problem

Described in full in #2594: `GetBuffer()` / `TryGetBuffer()` return the whole underlying pooled array, so the bytes
past `Length` are whatever the array's previous tenant wrote — reproducibly, with default options, another stream's
`Authorization: Bearer …` header.

#2594 documents that. This PR removes it.

## What changed

`Consolidate()` now zeroes `[Length, array.Length)` before handing the array out, on both paths
([`PooledMemoryStream.cs`](../blob/main/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs)):

- the single-segment fast path, which returns the segment's array directly;
- the multi-segment path, which rents a fresh array from the pool and copies into it.

Both go through one small `ClearTail` helper. Callers who correctly read only `[0, Length)` see no difference; callers
who pass the whole array onward — `socket.Send(stream.GetBuffer())`, hashing `GetBuffer()`, wrapping it in a
`ReadOnlySpan<byte>` — no longer leak.

The `ClearOnReturn` doc from #2594 and the readme note are narrowed accordingly: the only region that stays
uninitialized is the span returned by the `IBufferWriter<byte>` members, which is the normal contract for a buffer
writer (`ArrayBufferWriter<T>` behaves the same).

## Cost

One `Array.Clear` over `Capacity - Length` bytes per `GetBuffer()` / `TryGetBuffer()` call. Repeated calls re-clear an
already-zero tail; that seemed better than carrying a flag for it, since `GetBuffer()` isn't a hot-loop API. Say the
word if you'd rather trade the simplicity for the bookkeeping.

This does **not** make `ClearOnReturn` redundant — it still scrubs buffers on the way back to the pool, which matters
for anything that reads pooled memory outside this type.

## Verification

Two regression tests added next to `ToArray_GetBuffer_TryGetBuffer_WriteTo`, one per `Consolidate` path, each using a
unique tier size so it deterministically rents the previous stream's array back:

```
GetBuffer_DoesNotExposeBytesLeftByAnotherStream                        (single-segment path)
GetBuffer_AfterConsolidatingSegments_DoesNotExposeBytesLeftByAnotherStream  (rent-and-copy path)
```

Both fail without the `Consolidate` change (4 failures across the two TFMs) and pass with it.

Full suite: **88/88** (44 × net10.0/net11.0, up from 84) with `/p:TreatsWarningsAsErrors=true`.
`dotnet run ./eng/update-all.cs` produces no changes — the public API surface is unchanged (`ClearTail` is private).

Found by a review of `Meziantou.Framework.PooledMemoryStream` (finding F2, High).
