### PR TITLE
Honor the IComparable contract for null and foreign types

### DIFF
--- a/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
@@ -204,13 +204,12 @@ public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IE
 
     private static string GetString(string name, CultureInfo? culture, int value) => string.Format(culture, LocalizationProvider.Current.GetString(name, culture), value);
 
-    int IComparable.CompareTo(object? obj)
+    int IComparable.CompareTo(object? obj) => obj switch
     {
-        if (obj is RelativeDate rd)
-            return CompareTo(rd);
-
-        return CompareTo(default);
-    }
+        null => 1,
+        RelativeDate rd => CompareTo(rd),
+        _ => throw new ArgumentException($"Object must be of type {nameof(RelativeDate)}", nameof(obj)),
+    };
 
     /// <summary>Compares this instance to another <see cref="RelativeDate"/> and returns an integer that indicates their relative order.</summary>
     /// <param name="other">The <see cref="RelativeDate"/> to compare with this instance.</param>

--- a/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
+++ b/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
@@ -73,6 +73,69 @@ public class RelativeDateTests
         }
     }
 
+    private static RelativeDate CreateDate(DateTime dateTime)
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(new DateTimeOffset(2018, 6, 15, 0, 0, 0, TimeSpan.Zero));
+        return RelativeDate.Get(dateTime, timeProvider);
+    }
+
+    [Fact]
+    public void IComparable_CompareTo_ReturnsPositive_ForNull()
+    {
+        // null sorts first, even against the smallest representable date
+        var date = (IComparable)CreateDate(new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        Assert.Equal(1, date.CompareTo(obj: null));
+    }
+
+    [Theory]
+    [InlineData(42)]
+    [InlineData("string")]
+    public void IComparable_CompareTo_Throws_ForAnotherType(object value)
+    {
+        var date = (IComparable)CreateDate(new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        Assert.Throws<ArgumentException>(() => date.CompareTo(value));
+    }
+
+    [Fact]
+    public void NonGenericSort_OrdersByDate()
+    {
+        var min = CreateDate(new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var middle = CreateDate(new DateTime(2018, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+        var max = CreateDate(new DateTime(2018, 1, 3, 0, 0, 0, DateTimeKind.Utc));
+
+        var items = new object[] { max, min, middle };
+        Array.Sort(items);
+
+        Assert.Equal(new object[] { min, middle, max }, items);
+    }
+
+    [Fact]
+    public void ComparisonOperators_AreConsistent()
+    {
+        var earlier = CreateDate(new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var later = CreateDate(new DateTime(2018, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+        var sameAsEarlier = CreateDate(new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        Assert.True(earlier < later);
+        Assert.True(earlier <= later);
+        Assert.False(earlier > later);
+        Assert.False(earlier >= later);
+        Assert.True(later > earlier);
+        Assert.True(later >= earlier);
+
+        Assert.True(earlier == sameAsEarlier);
+        Assert.False(earlier != sameAsEarlier);
+        Assert.True(earlier <= sameAsEarlier);
+        Assert.True(earlier >= sameAsEarlier);
+        Assert.Equal(0, earlier.CompareTo(sameAsEarlier));
+        Assert.Equal(earlier.GetHashCode(), sameAsEarlier.GetHashCode());
+        Assert.True(earlier.Equals((object)sameAsEarlier));
+        // Assigned first so the analyzer does not rewrite this into Assert.NotEqual, which would not exercise Equals(object)
+        var equalsAnotherType = earlier.Equals("not a relative date");
+        Assert.False(equalsAnotherType);
+    }
+
 #if !INVARIANT_GLOBALIZATION_MODE_ENABLED
     private static readonly string[] LocalizedCultures = ["de", "es", "fr", "it", "ja", "ko", "nl", "pt", "tr", "zh-Hans"];
 


### PR DESCRIPTION
`IComparable.CompareTo` at `src/Meziantou.Framework.RelativeDate/RelativeDate.cs:207` falls through to `CompareTo(default)` for anything that is not a `RelativeDate` — `null` included. That compares the instance against `DateTime.MinValue` instead of applying the interface contract.

Measured on `main`, with the instance holding `DateTime.MinValue`:

```
((IComparable)min).CompareTo(null) => 0     // contract requires a positive value
((IComparable)min).CompareTo(42)   => 0     // reports "equal to an int"
((IComparable)rd).CompareTo("str") => 1     // contract requires ArgumentException
```

`IComparable.CompareTo` is what non-generic sorting reaches for — `ArrayList.Sort`, `Array.Sort(object[])`, `IComparer` shims, older data-binding and grid sorters. Returning a comparison result instead of throwing means a heterogeneous or null-containing collection sorts into a silently wrong order rather than failing loudly. The wrongness is data-dependent — it only shows up for dates near `MinValue` — so it would not reproduce reliably.

## What changed

The documented contract, as a switch expression: `null` returns a positive value, a `RelativeDate` delegates to the strongly-typed `CompareTo`, anything else throws `ArgumentException`.

## Verification

Five tests added. Three of them (`CompareTo(null)`, `CompareTo(42)`, `CompareTo("string")`) fail on `main` and pass with the fix.

The other two — `Array.Sort` over boxed instances, and consistency across `<` `<=` `>` `>=` `==` `!=` `Equals` `GetHashCode` — pin behavior that was already correct. They are included because the comparison and equality surface of this struct had **no** test coverage at all before this change: every existing test exercises `ToString` or the resource files, which is why the contract violations above went unnoticed.

Full project suite: 102/102 across net10.0 and net11.0.
