### PR TITLE
Throw ArgumentException from CompareTo when the object is not a ByteSize

### DIFF
--- a/src/Meziantou.Framework.ByteSize/ByteSize.cs
+++ b/src/Meziantou.Framework.ByteSize/ByteSize.cs
@@ -56,8 +56,10 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
         if (obj is null)
             return 1;
 
-        var fileLength = (ByteSize)obj;
-        return CompareTo(fileLength);
+        if (obj is not ByteSize byteSize)
+            throw new ArgumentException($"Object must be of type {nameof(ByteSize)}", nameof(obj));
+
+        return CompareTo(byteSize);
     }
 
     public override string ToString() => ToString(format: null, formatProvider: null);

--- a/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
+++ b/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
@@ -74,6 +74,27 @@ public sealed class ByteSizeTests
         Assert.Equal(3000L, result);
     }
 
+    [Fact]
+    public void CompareTo_Object_Null_ReturnsGreaterThan()
+    {
+        Assert.Equal(1, ((IComparable)new ByteSize(1)).CompareTo(obj: null));
+    }
+
+    [Fact]
+    public void CompareTo_Object_ByteSize_ComparesValues()
+    {
+        Assert.True(((IComparable)new ByteSize(1)).CompareTo(new ByteSize(2)) < 0);
+        Assert.True(((IComparable)new ByteSize(2)).CompareTo(new ByteSize(1)) > 0);
+        Assert.Equal(0, ((IComparable)new ByteSize(1)).CompareTo(new ByteSize(1)));
+    }
+
+    [Fact]
+    public void CompareTo_Object_OtherType_ThrowsArgumentException()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => ((IComparable)new ByteSize(1)).CompareTo("not a byte size"));
+        Assert.Equal("obj", exception.ParamName);
+    }
+
     [Theory]
     [InlineData(10L, null, "10B")]
     [InlineData(10L, "", "10B")]


### PR DESCRIPTION
`IComparable.CompareTo` is specified to throw `ArgumentException` when the argument is not of the same type. `ByteSize.CompareTo(object?)` (`ByteSize.cs:54-61`) instead reached an unguarded cast:

```csharp
var fileLength = (ByteSize)obj;
```

which throws `InvalidCastException`:

```
((IComparable)new ByteSize(1)).CompareTo("str")
-> InvalidCastException: Unable to cast object of type 'System.String' to type 'Meziantou.Framework.ByteSize'.
```

The non-generic comparison path is reached precisely by type-agnostic infrastructure — `Array.Sort`, `Comparer<object>.Default`, `SortedList`, `DataView` — which catches `ArgumentException` to turn a mixed-type collection into a useful diagnostic. An `InvalidCastException` escapes those handlers as an unexpected fault, so a sort over a list that accidentally contains a `string` alongside `ByteSize` values fails with a confusing error instead of the framework's normal one.

## What changed

Replaced the cast with a pattern-match and an explicit `ArgumentException` carrying the `obj` parameter name. The `null` branch is untouched — returning `1` for `null` is already correct per the interface contract.

## Verification

`dotnet test tests/Meziantou.Framework.ByteSize.Tests` — 160 passed (80 × net10.0/net11.0), 0 failed.

Reverting only the `ByteSize.cs` change and re-running gives **2 failures**, confirming the new test covers the defect.

New coverage — three facts pinning the full `CompareTo(object?)` contract, none of which existed before:
- `CompareTo_Object_Null_ReturnsGreaterThan`
- `CompareTo_Object_ByteSize_ComparesValues` (less-than, greater-than and equal)
- `CompareTo_Object_OtherType_ThrowsArgumentException`, which also asserts `ParamName` is `obj`
