### PR TITLE
Stop parameter lookup from falling back to CLR members of key/value states

### DIFF
--- a/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogEntry.cs
+++ b/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogEntry.cs
@@ -157,12 +157,18 @@ public sealed class InMemoryLogEntry
                 }
             }
         }
-
-        var property = owner.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
-        if (property is not null)
+        else
         {
-            result = property.GetValue(owner);
-            return true;
+            // Reflection only applies to POCO and anonymous-type scopes such as BeginScope(new { UserId = 1 }).
+            // It must not run for key/value states: their own CLR members (Count, Keys, Comparer, the indexer, ...)
+            // are not log parameters, and reporting them would make a lookup succeed for a name that was never logged.
+            // Indexers are skipped as well, since GetValue would need index arguments.
+            var property = owner.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
+            if (property is not null && property.GetIndexParameters().Length is 0)
+            {
+                result = property.GetValue(owner);
+                return true;
+            }
         }
 
         result = null;

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
@@ -142,6 +142,42 @@ public sealed partial class InMemoryLoggerTests
     }
 
     [Fact]
+    public void TryGetParameterValue_DoesNotReturnClrMembersOfTheState()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+
+        logger.LogInformation("plain message");
+
+        var log = logger.Logs.Informations.Single();
+
+        // Count and the indexer belong to FormattedLogValues, not to the logged message
+        Assert.False(log.TryGetParameterValue("Count", out var count));
+        Assert.Null(count);
+        Assert.False(log.TryGetParameterValue("Item", out var item));
+        Assert.Null(item);
+        Assert.Empty(log.GetAllParameterValues("Count"));
+    }
+
+    [Fact]
+    public void TryGetParameterValue_DoesNotReturnClrMembersOfADictionaryScope()
+    {
+        using var provider = new InMemoryLoggerProvider(new LoggerExternalScopeProvider());
+        var logger = provider.CreateLogger("my_category");
+        using (logger.BeginScope(new Dictionary<string, object?>(StringComparer.Ordinal) { ["Age"] = 52 }))
+        {
+            logger.LogInformation("Test");
+        }
+
+        var log = provider.Logs.Informations.Single();
+        Assert.True(log.TryGetParameterValue("Age", out var age));
+        Assert.Equal(52, age);
+        Assert.False(log.TryGetParameterValue("Comparer", out var comparer));
+        Assert.Null(comparer);
+        Assert.False(log.TryGetParameterValue("Keys", out var keys));
+        Assert.Null(keys);
+    }
+
+    [Fact]
     public void WithScope_Parallel()
     {
         using var provider = new InMemoryLoggerProvider(new LoggerExternalScopeProvider());


### PR DESCRIPTION
`InMemoryLogEntry.TryGetValue` searches the state's key/value pairs and then, on a miss, **falls through** to `owner.GetType().GetProperty(name)`. Because `FormattedLogValues` is an `IReadOnlyList<KeyValuePair<string, object?>>`, its own CLR surface leaks into the log-parameter namespace.

### The failure

```csharp
logger.LogInformation("plain message");          // no parameters at all
var entry = logger.Logs.Informations.Single();

entry.TryGetParameterValue("Count", out var v);  // returns true, v == 1  ← FormattedLogValues.Count
entry.TryGetParameterValue("Item", out _);       // throws TargetParameterCountException
```

The false `true` is the dangerous half: `Assert.True(log.TryGetParameterValue("Count", out var c))` passes against a message that never carried that parameter, so the assertion verifies nothing. Every public member of the state type is affected — `Count`, `Keys`, `Values`, `Comparer` for a dictionary scope, and so on.

The throwing case is narrower but is a crash from a `TryXxx` method, which is a contract violation by itself: `GetProperty("Item")` resolves the indexer and `GetValue(owner)` supplies no index arguments.

The existing `TryGetParameterValue_DictionaryScope` test does assert `Assert.False(…("Unknown", …))`, but that only passes because `Dictionary<,>` happens to have no public `Unknown` property — the same assertion with `"Comparer"` or `"Keys"` fails on `main`.

### The change

The three branches become mutually exclusive: reflection now runs **only** when the owner is not a key/value collection, which is the case it exists for (POCO and anonymous-type scopes such as `BeginScope(new { UserId = 1 })`). Indexers are skipped via `GetIndexParameters().Length is 0`.

Anonymous-object scopes keep working — `WithScope` and `WithScope_LoggerMessage` still pass unchanged.

### Verification

Two regression tests added, covering the state case and the dictionary-scope case. Confirmed both fail on `main` (4 failures across net10.0/net11.0) and pass with the fix. Full suite green: 28/28 (14 tests × 2 TFMs) with `/p:TreatsWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` produced no further changes.

### Scope note

A property getter that throws would still propagate out of `TryGetParameterValue`. That is a separate, unconfirmed concern and is not addressed here; this PR fixes the two behaviours reproduced above.

Found during a project review of `Meziantou.Extensions.Logging.InMemory`.
