### PR TITLE
Count arrays toward MaxDepth so collection cycles throw instead of overflowing the stack

### DIFF
--- a/src/Meziantou.Framework.HumanReadableSerializer/HumanReadableTextWriter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/HumanReadableTextWriter.cs
@@ -240,6 +240,7 @@ public sealed class HumanReadableTextWriter
     /// <summary>Starts writing an array.</summary>
     public void StartArray()
     {
+        IncrementDepth();
         if (_text.Length > 0 && _context != WriterContext.ArrayItemStart)
         {
             WriteNewLine();
@@ -255,6 +256,7 @@ public sealed class HumanReadableTextWriter
     /// <summary>Ends writing an array.</summary>
     public void EndArray()
     {
+        _depth--;
         _scopes.Pop().Dispose();
     }
 

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -1752,6 +1752,43 @@ public sealed partial class SerializerTests : SerializerTestsBase
     }
 
     [Fact]
+    public void InfiniteLoop_SelfReferencingCollection()
+    {
+        var value = new List<object>();
+        value.Add(value);
+
+        Assert.Throws<HumanReadableSerializerException>(() => HumanReadableSerializer.Serialize(value));
+    }
+
+    [Fact]
+    public void InfiniteLoop_CollectionsAlternatingWithObjects()
+    {
+        var value = new Recursive2();
+        value.Items.Add(value);
+
+        Assert.Throws<HumanReadableSerializerException>(() => HumanReadableSerializer.Serialize(value));
+    }
+
+    [Fact]
+    public void NestedCollectionsWithinMaxDepthAreSerialized()
+    {
+        object value = 1;
+        for (var i = 0; i < 8; i++)
+        {
+            value = new List<object> { value };
+        }
+
+        AssertSerialization(new Validation
+        {
+            Subject = value,
+            Options = new HumanReadableSerializerOptions { MaxDepth = 8 },
+            Expected = """
+                - - - - - - - - 1
+                """,
+        });
+    }
+
+    [Fact]
     public void Attributes()
     {
         AssertSerialization(new Validation
@@ -2422,6 +2459,11 @@ public sealed partial class SerializerTests : SerializerTestsBase
     private sealed class Recursive
     {
         public Recursive Prop => this;
+    }
+
+    private sealed class Recursive2
+    {
+        public List<Recursive2> Items { get; } = [];
     }
 
     private sealed class ClassWithAttributes


### PR DESCRIPTION
## The problem

`HumanReadableTextWriter.StartObject`/`EndObject` maintain `_depth` and enforce `MaxDepth`, but `StartArray`/`EndArray` never touched it. So the recursion guard only covered object graphs:

```csharp
var value = new List<object>();
value.Add(value);
HumanReadableSerializer.Serialize(value);
```

This recursed through `EnumerableConverter<T>.WriteValueCore` → `HumanReadableSerializer.Serialize` → `EnumerableConverter<T>.WriteValueCore` until the process died with `Stack overflow.` (~14,900 frames). `StackOverflowException` cannot be caught in .NET, so a single cyclic collection takes down the whole test host with no attribution to a test.

The object-graph equivalent already behaved correctly — `InfiniteLoop` covers it and throws `HumanReadableSerializerException` — so the two paths simply disagreed.

## The change

`StartArray` now calls `IncrementDepth()` and `EndArray` decrements, mirroring `StartObject`/`EndObject`. The scopes were already balanced via `_scopes`, so the bookkeeping is symmetric.

Counting at `StartArray` rather than `StartArrayItem` keeps the depth unit as "nesting level", consistent with objects and with `System.Text.Json`.

## Behaviour change

Arrays now consume depth budget, so a graph that mixes objects and collections reaches `MaxDepth` sooner than before. That is the intended semantics — `MaxDepth` is documented as a limit on nesting — but it is worth knowing when reading the diff. `NestedCollectionsWithinMaxDepthAreSerialized` pins that a collection nested exactly to the limit still serializes.

## Verification

- 3 new tests: a self-referencing `List<object>`, a collection alternating with objects, and the within-budget case.
- `Meziantou.Framework.HumanReadableSerializer.Tests`: 538 passed (net10.0 + net11.0), 0 failed.
- Downstream consumers, since this changes serializer output limits: `SnapshotTesting.Tests` 134 passed, `InlineSnapshotTesting.Tests` 131 passed, `Diagnostics.ContextSnapshot.Tests` 10 passed.
