### PR TITLE
Interpret local dates in the TimeProvider time zone

### DIFF
--- a/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
@@ -36,15 +36,27 @@ public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IE
 
     /// <summary>Initializes a new instance of the <see cref="RelativeDate"/> struct with the specified date and time provider.</summary>
     /// <param name="dateTime">The date and time. Must have <see cref="DateTimeKind.Local"/> or <see cref="DateTimeKind.Utc"/>.</param>
-    /// <param name="timeProvider">The time provider to use for calculating the relative time. If <see langword="null"/>, <see cref="TimeProvider.System"/> is used.</param>
+    /// <param name="timeProvider">The time provider to use for calculating the relative time. If <see langword="null"/>, <see cref="TimeProvider.System"/> is used. A <see cref="DateTimeKind.Local"/> <paramref name="dateTime"/> is interpreted in this provider's <see cref="TimeProvider.LocalTimeZone"/>.</param>
     /// <exception cref="ArgumentException"><paramref name="dateTime"/> has <see cref="DateTimeKind.Unspecified"/>.</exception>
     public RelativeDate(DateTime dateTime, TimeProvider? timeProvider)
     {
         if (dateTime.Kind == DateTimeKind.Unspecified)
             throw new ArgumentException("Cannot determine if the argument is a local datetime or UTC datetime", nameof(dateTime));
 
-        DateTime = dateTime.ToUniversalTime();
         TimeProvider = timeProvider ?? TimeProvider.System;
+        DateTime = dateTime.Kind is DateTimeKind.Local ? ToUniversalTime(dateTime, TimeProvider.LocalTimeZone) : dateTime;
+
+        static DateTime ToUniversalTime(DateTime dateTime, TimeZoneInfo timeZone)
+        {
+            // ConvertTimeToUtc rejects a Local kind unless the zone is TimeZoneInfo.Local
+            var unspecified = DateTime.SpecifyKind(dateTime, DateTimeKind.Unspecified);
+
+            // ConvertTimeToUtc throws on a time skipped by a forward DST transition, where DateTime.ToUniversalTime returns the standard-time reading
+            if (timeZone.IsInvalidTime(unspecified))
+                return DateTime.SpecifyKind(unspecified - timeZone.BaseUtcOffset, DateTimeKind.Utc);
+
+            return TimeZoneInfo.ConvertTimeToUtc(unspecified, timeZone);
+        }
     }
 
     /// <summary>Initializes a new instance of the <see cref="RelativeDate"/> struct with the specified date and system time provider.</summary>

--- a/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
+++ b/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
@@ -74,6 +74,49 @@ public class RelativeDateTests
     }
 
 #if !INVARIANT_GLOBALIZATION_MODE_ENABLED
+    [Fact]
+    public void LocalDateTime_IsInterpretedInTheTimeProviderTimeZone()
+    {
+        var timeZone = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(new DateTimeOffset(2018, 6, 15, 12, 0, 0, TimeSpan.Zero));
+        timeProvider.SetLocalTimeZone(timeZone);
+
+        // 10:00 UTC expressed as a wall clock reading in the provider's time zone
+        var local = DateTime.SpecifyKind(TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2018, 6, 15, 10, 0, 0, DateTimeKind.Utc), timeZone), DateTimeKind.Local);
+
+        var result = RelativeDate.Get(local, timeProvider).ToString(format: null, CultureInfo.InvariantCulture);
+        Assert.Equal("2 hours ago", result);
+    }
+
+    [Fact]
+    public void LocalDateTime_SkippedByAForwardDstTransition_DoesNotThrow()
+    {
+        var timeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Paris");
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(new DateTimeOffset(2018, 3, 25, 12, 0, 0, TimeSpan.Zero));
+        timeProvider.SetLocalTimeZone(timeZone);
+
+        // 02:30 does not exist in Paris on 2018-03-25: the clock jumps from 02:00 to 03:00
+        var invalid = DateTime.SpecifyKind(new DateTime(2018, 3, 25, 2, 30, 0), DateTimeKind.Local);
+        Assert.True(timeZone.IsInvalidTime(DateTime.SpecifyKind(invalid, DateTimeKind.Unspecified)));
+
+        // Read against the standard-time offset (UTC+1), so 02:30 becomes 01:30 UTC
+        var result = RelativeDate.Get(invalid, timeProvider).ToString(format: null, CultureInfo.InvariantCulture);
+        Assert.Equal("10 hours ago", result);
+    }
+
+    [Fact]
+    public void UtcDateTime_IgnoresTheTimeProviderTimeZone()
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(new DateTimeOffset(2018, 6, 15, 12, 0, 0, TimeSpan.Zero));
+        timeProvider.SetLocalTimeZone(TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo"));
+
+        var result = RelativeDate.Get(new DateTime(2018, 6, 15, 10, 0, 0, DateTimeKind.Utc), timeProvider).ToString(format: null, CultureInfo.InvariantCulture);
+        Assert.Equal("2 hours ago", result);
+    }
+
     private static readonly string[] LocalizedCultures = ["de", "es", "fr", "it", "ja", "ko", "nl", "pt", "tr", "zh-Hans"];
 
     /// <summary>Offsets from "now" reaching every branch of <see cref="RelativeDate.ToString(string, IFormatProvider)"/>, in both directions.</summary>


### PR DESCRIPTION
The constructor at `src/Meziantou.Framework.RelativeDate/RelativeDate.cs:46` calls `dateTime.ToUniversalTime()`, which always uses the ambient `TimeZoneInfo.Local` and never the supplied provider's zone — even though `TimeProvider` exists specifically to abstract that away.

Measured on `main` with a `FakeTimeProvider` whose `LocalTimeZone` is `Asia/Tokyo`, on a machine in `America/Nipigon`, passing a `Local`-kind date meaning "two hours ago in the provider's zone":

```
machine TimeZoneInfo.Local = America/Nipigon, provider.LocalTimeZone = Asia/Tokyo
result   => in 11 hours
expected => 2 hours ago
```

This silently defeats the point of injecting a `TimeProvider`: a consumer writing a deterministic test with `FakeTimeProvider` and a `Local` timestamp gets a result that depends on the machine's `TZ` — the classic "passes locally, fails in CI" shape. UTC and `DateTimeOffset` inputs are unaffected, which is why the existing suite (all UTC) never saw it.

## What changed

A `Local`-kind `dateTime` is now converted against `TimeProvider.LocalTimeZone`. A `Utc`-kind one is stored as-is (`ToUniversalTime()` was already a no-op for it). `TimeProvider` is assigned before `DateTime` so the zone is available.

Two details worth flagging, both found while testing rather than assumed:

- `TimeZoneInfo.ConvertTimeToUtc` **rejects** a `DateTimeKind.Local` input unless the target zone is `TimeZoneInfo.Local`, so the kind is cleared to `Unspecified` first.
- `TimeZoneInfo.ConvertTimeToUtc` **throws `ArgumentException`** for a wall-clock reading skipped by a forward DST transition (`2018-03-25 02:30` in `Europe/Paris`), where `DateTime.ToUniversalTime()` silently converts. A naive swap would therefore have turned a working call into a crash. Invalid times are now read against the zone's standard offset via an `IsInvalidTime` guard.

Ambiguous times (the repeated hour at a backward transition) need no guard — `ConvertTimeToUtc` already resolves them to standard time, matching `ToUniversalTime`.

## Behavior change

For callers passing **both** a custom `TimeProvider` **and** a `Local`-kind `DateTime`, the resulting instant changes. When the provider is `TimeProvider.System` — the overwhelmingly common case — `LocalTimeZone` *is* `TimeZoneInfo.Local`, so nothing changes. Calling out explicitly since this is a shipped v4 package.

## Verification

Three tests added: the Tokyo-provider case, the Paris DST-gap case, and a `Utc`-kind case pinning that the provider's zone is ignored there. The first two fail on `main`; the DST one fails with `ArgumentException` against the naive fix.

Full project suite passes under `TZ=UTC`, `Asia/Tokyo`, `Europe/Paris` and `America/Los_Angeles` (49/49 each on net10.0), confirming the new tests are machine-independent. 98/98 across net10.0 and net11.0.
