### PR TITLE
Compose capacity reservations from tiers instead of rounding up to one

### DIFF
--- a/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
+++ b/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
@@ -587,11 +587,11 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
 
     private void EnsureCapacityAtLeast(long target)
     {
+        // Compose the reservation out of configured tiers instead of rounding the whole thing up to the next one:
+        // GetContiguousBlockSize(70_000) is 1 MiB, so a 70 KB reservation used to allocate 15x what was asked for.
         while (_capacity < target)
         {
-            var remaining = target - _capacity;
-            var desired = Math.Max((int)Math.Min(remaining, Array.MaxLength), _options.GetBlockSize(_capacity));
-            AddSegment(_options.GetContiguousBlockSize(desired));
+            AddSegment(_options.GetReservationBlockSize(target - _capacity));
         }
     }
 

--- a/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStreamOptions.cs
+++ b/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStreamOptions.cs
@@ -102,6 +102,23 @@ public sealed class PooledMemoryStreamOptions
     }
 
     /// <summary>
+    /// Returns the block size to use when reserving <paramref name="remaining"/> more bytes of capacity: the largest
+    /// tier that fits, or the smallest tier when less than that is left. Reservations are composed of several blocks
+    /// rather than rounded up to a single larger tier, which keeps the over-allocation below the smallest tier.
+    /// </summary>
+    internal int GetReservationBlockSize(long remaining)
+    {
+        var sizes = _bufferSizes;
+        for (var i = sizes.Length - 1; i >= 0; i--)
+        {
+            if (remaining >= sizes[i])
+                return sizes[i];
+        }
+
+        return sizes[0];
+    }
+
+    /// <summary>
     /// Returns a discrete array size that is at least <paramref name="minimumSize"/> bytes. The result is one of the
     /// configured tiers, or a multiple of the largest tier when a single contiguous buffer larger than the largest
     /// tier is required (e.g. <c>GetSpan</c> with a big hint, or <c>GetBuffer</c> on a large stream).

--- a/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
+++ b/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
@@ -202,6 +202,24 @@ public sealed class PooledMemoryStreamTests
     }
 
     [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(4097)]
+    [InlineData(5000)]
+    [InlineData(70_000)]
+    [InlineData(1024 * 1024)]
+    public void Constructor_WithInitialCapacity_ComposesTiersInsteadOfRoundingUp(int initialCapacity)
+    {
+        using var stream = new PooledMemoryStream(initialCapacity);
+
+        // The reservation is built from configured tiers, so the excess stays below the smallest tier (4 KiB by
+        // default). It used to round the whole request up to the next tier: 70_000 reserved 1 MiB.
+        Assert.True(stream.Capacity >= initialCapacity);
+        Assert.True(stream.Capacity - initialCapacity < 4096);
+        Assert.Equal(0, stream.Length);
+    }
+
+    [Theory]
     [InlineData(10)]
     [InlineData(1000)]
     [InlineData(100_000)]


### PR DESCRIPTION
## The problem

`EnsureCapacityAtLeast` rounded a whole reservation up to the next *tier* instead of composing it out of the tiers it
already has. With default options (4 KiB / 64 KiB / 1 MiB):

| `new PooledMemoryStream(initialCapacity: n)` | `Capacity` before | after |
|---|---|---|
| 1 | 4 096 | 4 096 |
| 4 097 | 65 536 | 8 192 |
| 5 000 | 65 536 | 8 192 |
| 70 000 | **1 048 576** | 73 728 |
| 1 048 576 | 1 048 576 | 1 048 576 |

A caller who says "I expect about 70 KB" — exactly the caller being conscientious — got a 1 MiB array on the Large
Object Heap, 15× their request, from a library whose whole purpose is allocation discipline. The oversized array then
sat in the pool holding that memory.

The cause is `EnsureCapacityAtLeast` routing its block size through `GetContiguousBlockSize`, which exists to satisfy
callers that need **one** array (`Consolidate`, `ReserveTail`). A reservation has no such requirement — the method
already loops and appends segments.

## What changed

- New `internal PooledMemoryStreamOptions.GetReservationBlockSize(long remaining)`: the largest configured tier that
  fits in what's left, or the smallest tier when less than that remains.
- `EnsureCapacityAtLeast` uses it, so a reservation is composed of tiers.

Two properties fall out:

- **Over-allocation is now bounded by the smallest tier** (< 4 KiB by default), whatever the request. It was
  previously bounded only by the largest tier.
- **Reservations no longer mint new pool bucket sizes.** `GetContiguousBlockSize` rounds sizes above the largest tier
  to a *multiple* of it, and each distinct length opens its own bucket in the shared pool; `GetReservationBlockSize`
  only ever returns configured tiers.

No public API change — both methods are `internal`.

## Trade-off worth your call

Bounded waste costs segments. `initialCapacity: 2_000_000` now reserves 2 002 944 bytes across 24 segments where it
previously took one 2 097 152-byte array. Reads and `CopyTo` walk a longer chain.

I went with bounded waste because discrete, poolable, tier-sized blocks are the design's premise, and because the
small-request case in the table is the one users actually hit. If you'd rather keep single-array reservations for
large requests, the natural knob is to fall back to `GetContiguousBlockSize` above some threshold — say once
`remaining` exceeds the largest tier — and I'll adjust.

## Verification

`Constructor_WithInitialCapacity_ComposesTiersInsteadOfRoundingUp`, a `[Theory]` over the sizes in the table above,
asserts `Capacity >= initialCapacity` and `Capacity - initialCapacity < 4096`. It fails on `main` for the 4097 / 5000 /
70000 cases (6 failures across the two TFMs) and passes here.

Full suite: **96/96** (48 × net10.0/net11.0, up from 84) with `/p:TreatsWarningsAsErrors=true`, with
`Meziantou.Framework.Assertions.Analyzer` built first so its rules actually run.
`dotnet run ./eng/update-all.cs` produces no changes.

Found by a review of `Meziantou.Framework.PooledMemoryStream` (finding F6, Medium).
