### PR TITLE
Traverse the DOM with an explicit stack to avoid a stack overflow on deeply nested HTML

### DIFF
--- a/src/Meziantou.Framework.HtmlToMarkdown/HtmlToMarkdown.cs
+++ b/src/Meziantou.Framework.HtmlToMarkdown/HtmlToMarkdown.cs
@@ -26,13 +26,57 @@ public static class HtmlToMarkdown
         var parser = new HtmlParser();
         var document = parser.ParseDocument("<body>" + html + "</body>");
         var state = new ConversionState(options);
-        var result = ConvertChildNodes(document.Body!, state);
+        var body = document.Body!;
+        ConvertDescendants(body, state);
+        var result = ConvertChildNodes(body, state);
         return result.Trim('\n', '\r');
     }
 
     // =========================================================================
     // Core traversal
     // =========================================================================
+
+    /// <summary>
+    /// Converts every descendant of <paramref name="root"/> bottom-up using an explicit
+    /// stack, so that deeply nested documents cannot overflow the call stack. Every node
+    /// is converted before any of its ancestors, and the result is recorded in
+    /// <paramref name="state"/> for the ancestor to read back.
+    /// </summary>
+    private static void ConvertDescendants(INode root, ConversionState state)
+    {
+        var stack = new Stack<(INode Node, bool ChildrenConverted)>();
+        PushChildren(stack, root);
+
+        while (stack.Count > 0)
+        {
+            var (node, childrenConverted) = stack.Pop();
+            if (childrenConverted)
+            {
+                state.SetConverted(node, ConvertNode(node, state));
+                continue;
+            }
+
+            stack.Push((node, ChildrenConverted: true));
+            if (!IsOpaqueElement(node))
+                PushChildren(stack, node);
+        }
+
+        static void PushChildren(Stack<(INode Node, bool ChildrenConverted)> stack, INode parent)
+        {
+            foreach (var child in parent.ChildNodes)
+                stack.Push((child, ChildrenConverted: false));
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether an element is converted from its raw text or outer
+    /// HTML. The descendants of such an element are never read back, so the traversal does
+    /// not need to convert them.
+    /// </summary>
+    private static bool IsOpaqueElement(INode node)
+    {
+        return node is IElement el && el.LocalName is "pre" or "code" or "script" or "style" or "noscript";
+    }
 
     private static string ConvertNode(INode node, ConversionState state)
     {
@@ -79,7 +123,7 @@ public static class HtmlToMarkdown
             "code" => ConvertInlineCode(element),
             "a" => ConvertLink(element, state),
             "img" => ConvertImage(element),
-            "br" => ConvertBreak(state),
+            "br" => ConvertBreak(element, state),
             "input" => ConvertInput(element),
 
             "script" or "style" or "noscript" => "",
@@ -114,13 +158,13 @@ public static class HtmlToMarkdown
             if (IsBlockElement(child))
             {
                 FlushInlineBuffer(inlineBuf, blocks);
-                var block = ConvertNode(child, state);
+                var block = state.GetConverted(child);
                 if (!string.IsNullOrEmpty(block))
                     blocks.Add(block);
             }
             else
             {
-                inlineBuf.Append(ConvertNode(child, state));
+                inlineBuf.Append(state.GetConverted(child));
             }
         }
 
@@ -137,7 +181,7 @@ public static class HtmlToMarkdown
         var sb = new StringBuilder();
         foreach (var child in parent.ChildNodes)
         {
-            sb.Append(ConvertNode(child, state));
+            sb.Append(state.GetConverted(child));
         }
         return sb.ToString();
     }
@@ -252,7 +296,7 @@ public static class HtmlToMarkdown
                 if (inline.Length > 0)
                     parts.Add((PostProcessLineStart(inline), false));
 
-                var block = ConvertNode(child, state);
+                var block = state.GetConverted(child);
                 if (!string.IsNullOrEmpty(block))
                 {
                     var isList = child is IElement el && el.LocalName is "ul" or "ol";
@@ -261,7 +305,7 @@ public static class HtmlToMarkdown
             }
             else
             {
-                inlineBuf.Append(ConvertNode(child, state));
+                inlineBuf.Append(state.GetConverted(child));
             }
         }
 
@@ -386,7 +430,7 @@ public static class HtmlToMarkdown
         // Collapse redundant nesting: <strong><strong>x</strong></strong>
         var onlyChild = GetSingleSignificantChild(element);
         if (onlyChild is IElement childEl && childEl.LocalName is "strong" or "b")
-            return ConvertStrong(childEl, state);
+            return state.GetConverted(childEl);
 
         var content = ConvertInlineContent(element, state);
         var marker = state.Options.EmphasisMarker == EmphasisMarker.Asterisk ? "**" : "__";
@@ -397,7 +441,7 @@ public static class HtmlToMarkdown
     {
         var onlyChild = GetSingleSignificantChild(element);
         if (onlyChild is IElement childEl && childEl.LocalName is "em" or "i")
-            return ConvertEmphasis(childEl, state);
+            return state.GetConverted(childEl);
 
         var content = ConvertInlineContent(element, state);
         var marker = state.Options.EmphasisMarker == EmphasisMarker.Asterisk ? "*" : "_";
@@ -472,11 +516,25 @@ public static class HtmlToMarkdown
         return sb.ToString();
     }
 
-    private static string ConvertBreak(ConversionState state)
+    private static string ConvertBreak(IElement element, ConversionState state)
     {
-        if (state.InTableCell)
+        if (IsInTableCell(element))
             return "<br>";
         return state.Options.LineBreakStyle == LineBreakStyle.Backslash ? "\\\n" : "  \n";
+    }
+
+    /// <summary>
+    /// Determines whether an element is inside a table cell by walking its ancestors.
+    /// </summary>
+    private static bool IsInTableCell(IElement element)
+    {
+        for (var parent = element.ParentElement; parent is not null; parent = parent.ParentElement)
+        {
+            if (parent.LocalName is "td" or "th")
+                return true;
+        }
+
+        return false;
     }
 
     private static string ConvertInput(IElement element)
@@ -503,8 +561,6 @@ public static class HtmlToMarkdown
     private static List<(string Content, string? Align)> ExtractTableRow(IElement tr, ConversionState state)
     {
         var cells = new List<(string Content, string? Align)>();
-        var prevInTableCell = state.InTableCell;
-        state.InTableCell = true;
 
         foreach (var cell in tr.Children)
         {
@@ -516,7 +572,6 @@ public static class HtmlToMarkdown
             }
         }
 
-        state.InTableCell = prevInTableCell;
         return cells;
     }
 
@@ -1044,12 +1099,17 @@ public static class HtmlToMarkdown
 
     private sealed class ConversionState
     {
+        private readonly Dictionary<INode, string> _converted = [];
+
         public HtmlToMarkdownOptions Options { get; }
-        public bool InTableCell { get; set; }
 
         public ConversionState(HtmlToMarkdownOptions options)
         {
             Options = options;
         }
+
+        public void SetConverted(INode node, string markdown) => _converted[node] = markdown;
+
+        public string GetConverted(INode node) => _converted.TryGetValue(node, out var markdown) ? markdown : "";
     }
 }

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlToMarkdownConverterTests.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlToMarkdownConverterTests.cs
@@ -3619,4 +3619,31 @@ public sealed class HtmlToMarkdownConverterTests
             ```
             """);
     }
+
+    // --- Deeply nested documents (must not overflow the call stack) ---
+
+    // The recursive traversal this replaced overflowed the stack at a nesting depth of
+    // about 10,000. The depth here stays well past that while keeping the test cheap:
+    // the cost of these cases is dominated by AngleSharp's own parsing of deep documents.
+    private const int NestingDepthBeyondStackLimit = 20_000;
+
+    [Fact]
+    public void DeeplyNestedElements_DoesNotOverflowTheStack()
+    {
+        var html = string.Concat(Enumerable.Repeat("<div>", NestingDepthBeyondStackLimit))
+            + "text"
+            + string.Concat(Enumerable.Repeat("</div>", NestingDepthBeyondStackLimit));
+
+        AssertHtmlToMarkdown(html, "text");
+    }
+
+    [Fact]
+    public void DeeplyNestedEmphasis_DoesNotOverflowTheStack()
+    {
+        var html = string.Concat(Enumerable.Repeat("<b>", NestingDepthBeyondStackLimit))
+            + "text"
+            + string.Concat(Enumerable.Repeat("</b>", NestingDepthBeyondStackLimit));
+
+        AssertHtmlToMarkdown(html, "**text**");
+    }
 }


### PR DESCRIPTION
## Problem

`HtmlToMarkdown.Convert` walked the DOM recursively: `ConvertNode` → `ConvertChildNodes` → `ConvertNode`, one call frame per level of nesting, with no bound. Deeply nested HTML overflowed the call stack:

```csharp
var html = string.Concat(Enumerable.Repeat("<div>", 50_000)) + "x" + string.Concat(Enumerable.Repeat("</div>", 50_000));
HtmlToMarkdown.Convert(html);
```

```
Stack overflow.
Repeated 10452 times:
   at Meziantou.Framework.HtmlToMarkdown.ConvertElement(IElement, ConversionState)
   at Meziantou.Framework.HtmlToMarkdown.ConvertNode(INode, ConversionState)
   at Meziantou.Framework.HtmlToMarkdown.ConvertChildNodes(INode, ConversionState)
```

The cliff is around 10,400 levels on a default 1 MB stack — roughly a 60 KB input. `StackOverflowException` cannot be caught in .NET, so the runtime kills the process; a `try`/`catch` around `Convert` does not help. For a library whose input is HTML the caller did not author, that turns one request into a denial of service. `ConvertStrong`/`ConvertEmphasis` recursed separately for redundant nesting (`<b><b><b>…`), giving a second route to the same crash.

## What changed

The traversal is now iterative. `ConvertDescendants` walks the document with an explicit `Stack<>` in post-order, so every node is converted before any of its ancestors and its Markdown is recorded in `ConversionState`. `ConvertChildNodes`, `ConvertInlineContent` and `ConvertListItemContent` read those recorded results back instead of recursing, and the emphasis-collapse paths read the already-converted child rather than calling themselves.

Two supporting changes fall out of converting bottom-up:

- **`ConvertBreak` determines table-cell context from ancestors.** `ConversionState.InTableCell` was set by `ExtractTableRow` *while* descending, which no longer works when a `<br>` is converted before its enclosing cell is reached. It now walks `ParentElement` to find a `td`/`th`. This removes the last piece of mutable traversal state.
- **`IsOpaqueElement` skips descending into `pre`, `code`, `script`, `style` and `noscript`.** Those are converted from `TextContent` or produce `""`, so their descendants are never read back and converting them was wasted work.

No public API changed — everything here is private — so `ref/` is unchanged.

## Verification

- Full suite green on net10.0 and net11.0: **1698 passed, 0 failed** (1694 pre-existing, all passing unchanged, plus 4 new).
- Two regression tests at 20,000 levels of nesting, covering the container path (`<div>`) and the emphasis-collapse path (`<b>`). Both crashed the test process before this change.
- `dotnet run ./eng/update-all.cs` run; no generated files changed.

The depth in the tests is 20,000 rather than something larger because the cost of these cases is dominated by AngleSharp's own parsing, which is itself superlinear in nesting depth (~0.5 s at 5,000 levels, ~22 s at 40,000). That is worth knowing as a remaining limit: this change removes the crash, but a sufficiently deep document is still expensive to *parse* before this library sees it, and that bound lives in AngleSharp rather than here. The suite goes from 1.8 s to 4.5 s.

## Not addressed here

Conversion time is still superlinear in nesting depth for constructs that prefix their content (`PrefixLines` re-splits and re-prefixes the accumulated string at every level, so nested blockquotes and lists re-copy their content once per level). That is a separate finding and a separate change to how output is assembled; this PR deliberately keeps the output byte-identical.
