### PR TITLE
Return false from IsEnabled for LogLevel.None

### DIFF
--- a/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogger.cs
+++ b/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogger.cs
@@ -71,7 +71,7 @@ public class InMemoryLogger : IInMemoryLogger
         return _scopeProvider.Push(state);
     }
 
-    public bool IsEnabled(LogLevel logLevel) => true;
+    public bool IsEnabled(LogLevel logLevel) => logLevel is not LogLevel.None;
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
@@ -22,6 +22,28 @@ public sealed partial class InMemoryLoggerTests
         Assert.Equal("[sample] Information: Test\n  => [{\"Key\":\"{OriginalFormat}\",\"Value\":\"Test\"}]", log.ToString());
     }
 
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    public void IsEnabled_ReturnsTrueForEveryLevelThatCanBeLogged(LogLevel logLevel)
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+
+        Assert.True(logger.IsEnabled(logLevel));
+    }
+
+    [Fact]
+    public void IsEnabled_ReturnsFalseForNone()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+
+        Assert.False(logger.IsEnabled(LogLevel.None));
+    }
+
     [Fact]
     public void CreateTypedLogger()
     {


### PR DESCRIPTION
`InMemoryLogger.IsEnabled` returns `true` unconditionally, including for `LogLevel.None`.

`LogLevel.None` is documented as *"Not used for writing log messages. Specifies that a logging category should not write any messages."* Every in-box logger returns `false` for it; this one returns `true`.

### Why it matters

Capturing everything is the correct and intended behaviour for a test logger, so the impact is limited — but code under test that branches on `IsEnabled` takes a **different path here than it does in production**, which is exactly the divergence a test double should not introduce:

```csharp
if (_logger.IsEnabled(level))   // false in production for None, true under InMemoryLogger
{
    _logger.Log(level, BuildExpensivePayload());
}
```

### The change

```csharp
public bool IsEnabled(LogLevel logLevel) => logLevel is not LogLevel.None;
```

### Deliberately not changed

`Log(LogLevel.None, …)` still records an entry. Dropping it would change what the logger captures, and a caller may well be relying on this logger capturing everything handed to it — that is the whole point of the type. The remaining inconsistency (`IsEnabled` says no, `Log` still records) is the conservative choice; say the word if you would rather `Log` filtered too and I will follow up.

### Verification

A theory covering the six loggable levels plus a test for `None`. Confirmed `IsEnabled_ReturnsFalseForNone` fails on `main` on both TFMs and passes with the fix. Full suite green: 38/38 (19 tests × net10.0/net11.0) with `/p:TreatsWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` produced no further changes.

Found during a project review of `Meziantou.Extensions.Logging.InMemory` (rated Low).
