### PR TITLE
Delete the directory generated for a named TemporaryFile

### DIFF
--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
@@ -23,13 +23,18 @@ namespace Meziantou.Framework;
 [DebuggerDisplay("{FullPath}")]
 public sealed class TemporaryFile : IDisposable, IAsyncDisposable
 {
+    // Set when this instance created a directory for the sole purpose of holding the file.
+    // Disposing must then remove that directory, not just the file.
+    private readonly FullPath _ownedDirectory;
+
     /// <summary>Gets the full path to the temporary file.</summary>
     /// <value>The absolute path to the temporary file.</value>
     public FullPath FullPath { get; }
 
-    private TemporaryFile(FullPath fullPath)
+    private TemporaryFile(FullPath fullPath, FullPath ownedDirectory)
     {
         FullPath = fullPath;
+        _ownedDirectory = ownedDirectory;
     }
 
     /// <summary>Creates a new temporary file in the system's default temp location.</summary>
@@ -42,7 +47,7 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
     {
         var rootDirectory = FullPath.Combine(Path.GetTempPath(), "MezTF");
         var fileName = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture) + "_" + Guid.NewGuid().ToString("N") + ".tmp";
-        return CreateInRoot(rootDirectory, fileName);
+        return CreateInRoot(rootDirectory, fileName, ownedDirectory: default);
     }
 
     /// <summary>Creates a new temporary file using the specified file name or full path.</summary>
@@ -62,7 +67,7 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
             return Create(FullPath.FromPath(fileNameOrPath));
 
         var rootDirectory = FullPath.GetTempPath() / "MezTF" / CreateUniqueFolderName();
-        return CreateInRoot(rootDirectory, fileNameOrPath);
+        return CreateInRoot(rootDirectory, fileNameOrPath, ownedDirectory: rootDirectory);
     }
 
     /// <summary>Creates a new temporary file at the specified path.</summary>
@@ -80,14 +85,14 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
             throw new ArgumentException("The path is empty.", nameof(filePath));
 
         CreateFile(filePath);
-        return new TemporaryFile(filePath);
+        return new TemporaryFile(filePath, ownedDirectory: default);
     }
 
-    private static TemporaryFile CreateInRoot(FullPath rootDirectory, string relativePath)
+    private static TemporaryFile CreateInRoot(FullPath rootDirectory, string relativePath, FullPath ownedDirectory)
     {
         var fullPath = FullPath.Combine(rootDirectory, relativePath);
         CreateFile(fullPath);
-        return new TemporaryFile(fullPath);
+        return new TemporaryFile(fullPath, ownedDirectory);
     }
 
     private static string CreateUniqueFolderName()
@@ -102,16 +107,32 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
     }
 
     /// <summary>Deletes the temporary file.</summary>
+    /// <remarks>
+    /// When the instance was created from a file name, the unique directory created to hold that file is deleted as well.
+    /// </remarks>
     public void Dispose()
     {
-        IOUtilities.Delete(new FileInfo(FullPath));
+        if (_ownedDirectory.IsEmpty)
+        {
+            IOUtilities.Delete(new FileInfo(FullPath));
+        }
+        else
+        {
+            IOUtilities.Delete(new DirectoryInfo(_ownedDirectory));
+        }
     }
 
     /// <summary>Asynchronously deletes the temporary file.</summary>
     /// <returns>A task that represents the asynchronous dispose operation.</returns>
+    /// <remarks>
+    /// When the instance was created from a file name, the unique directory created to hold that file is deleted as well.
+    /// </remarks>
     public ValueTask DisposeAsync()
     {
-        return IOUtilities.DeleteAsync(new FileInfo(FullPath), CancellationToken.None);
+        if (_ownedDirectory.IsEmpty)
+            return IOUtilities.DeleteAsync(new FileInfo(FullPath), CancellationToken.None);
+
+        return IOUtilities.DeleteAsync(new DirectoryInfo(_ownedDirectory), CancellationToken.None);
     }
 
     /// <summary>Implicitly converts a <see cref="TemporaryFile"/> to a <see cref="FullPath"/>.</summary>

--- a/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
+++ b/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
@@ -117,6 +117,47 @@ public class TemporaryDirectoryTests
     }
 
     [Fact]
+    public void TemporaryFileCreateWithFileNameDeletesTheGeneratedDirectory()
+    {
+        FullPath path;
+        using (var file = TemporaryFile.Create("custom.txt"))
+        {
+            path = file.FullPath;
+            Assert.True(Directory.Exists(path.Parent));
+        }
+
+        Assert.False(File.Exists(path));
+        Assert.False(Directory.Exists(path.Parent));
+    }
+
+    [Fact]
+    public void TemporaryFileCreateWithRelativePathDeletesTheGeneratedDirectory()
+    {
+        FullPath path;
+        using (var file = TemporaryFile.Create(Path.Combine("sub", "custom.txt")))
+        {
+            path = file.FullPath;
+        }
+
+        Assert.False(File.Exists(path));
+        Assert.False(Directory.Exists(path.Parent));
+        Assert.False(Directory.Exists(path.Parent.Parent));
+    }
+
+    [Fact]
+    public void TemporaryFileCreateKeepsTheSharedRootDirectory()
+    {
+        FullPath path;
+        using (var file = TemporaryFile.Create())
+        {
+            path = file.FullPath;
+        }
+
+        Assert.False(File.Exists(path));
+        Assert.True(Directory.Exists(path.Parent));
+    }
+
+    [Fact]
     public void TemporaryFileCreateWithFullPath()
     {
         var fullPath = FullPath.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".tmp");


### PR DESCRIPTION
**Stack 1 of 3** · merges into `main` · must merge before #2606 and #2607.

`TemporaryFile.Create(string)` creates a *unique per-call directory* to hold the file (`TemporaryFile.cs:62`), but `Dispose`/`DisposeAsync` only ever deleted the `FileInfo` (`TemporaryFile.cs:99,106`). Nothing removed the directory, so every call permanently added an empty directory to the user's temp folder.

```c#
using (TemporaryFile.Create("custom.txt")) { }
// file deleted, but $TMPDIR/MezTF/20260827_041000_9e910e30.../ stays behind forever
```

`Create()` (no argument) is unaffected — it writes straight into the shared `MezTF` root and owns no directory — so the leak was specific to the overload the XML example advertises. A test suite using this in a fixture adds thousands of directories per CI run, and nothing ever prunes them.

## Changes

`TemporaryFile` now records the directory it created, if any, and disposal removes that directory instead of the file:

- `Create()` and `Create(FullPath)` own nothing and keep deleting just the file.
- `Create(string)` with a non-rooted name owns the generated directory, which also covers names with subdirectories (`"sub/custom.txt"`).

## Verification

Three tests added. The two asserting directory cleanup **fail on `main`** and pass here:

```
failed TemporaryFileCreateWithFileNameDeletesTheGeneratedDirectory
failed TemporaryFileCreateWithRelativePathDeletesTheGeneratedDirectory
```

The third pins that `Create()` must *not* delete the shared `MezTF` root. Full run: 24/24 pass (12 tests × net10.0/net11.0), `/p:TreatsWarningsAsErrors=true` clean, `dotnet run ./eng/update-all.cs` generates no changes.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
