### PR TITLE
Create temporary directories and files with owner-only permissions

### DIFF
--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryDirectory.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryDirectory.cs
@@ -48,7 +48,9 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     /// <remarks>
     /// The directory is created under the system temp path in a "MezTD" subdirectory.
     /// The directory name includes a timestamp and GUID to ensure uniqueness.
+    /// On Unix, the directories are created so that only the current user can access them.
     /// </remarks>
+    /// <exception cref="UnauthorizedAccessException">The "MezTD" directory already exists and is accessible to other users.</exception>
     public static TemporaryDirectory Create()
     {
         return Create(FullPath.Combine(Path.GetTempPath(), "MezTD"));
@@ -59,10 +61,13 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     /// <returns>A new <see cref="TemporaryDirectory"/> instance.</returns>
     /// <remarks>
     /// The directory name includes a timestamp (yyyyMMdd_HHmmss) and GUID to ensure uniqueness.
+    /// On Unix, the directories are created so that only the current user can access them.
     /// </remarks>
+    /// <exception cref="UnauthorizedAccessException"><paramref name="rootDirectory"/> already exists and is accessible to other users.</exception>
     public static TemporaryDirectory Create(FullPath rootDirectory)
     {
         var folderName = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture) + "_" + Guid.NewGuid().ToString("N");
+        TemporaryPaths.EnsureRootDirectory(rootDirectory);
         var path = CreateUniqueDirectory(rootDirectory / folderName);
         return new TemporaryDirectory(path);
     }
@@ -171,7 +176,7 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     private static FullPath CreateUniqueDirectory(FullPath folderPath)
     {
         // The folder name includes a GUID, so it is unique and cannot collide with an existing directory.
-        Directory.CreateDirectory(folderPath);
+        TemporaryPaths.CreateDirectory(folderPath);
         return folderPath;
     }
 

--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
@@ -47,6 +47,7 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
     {
         var rootDirectory = FullPath.Combine(Path.GetTempPath(), "MezTF");
         var fileName = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture) + "_" + Guid.NewGuid().ToString("N") + ".tmp";
+        TemporaryPaths.EnsureRootDirectory(rootDirectory);
         return CreateInRoot(rootDirectory, fileName, ownedDirectory: default);
     }
 
@@ -66,6 +67,7 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
         if (Path.IsPathRooted(fileNameOrPath))
             return Create(FullPath.FromPath(fileNameOrPath));
 
+        TemporaryPaths.EnsureRootDirectory(FullPath.GetTempPath() / "MezTF");
         var rootDirectory = FullPath.GetTempPath() / "MezTF" / CreateUniqueFolderName();
         return CreateInRoot(rootDirectory, fileNameOrPath, ownedDirectory: rootDirectory);
     }
@@ -102,8 +104,7 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
 
     private static void CreateFile(FullPath filePath)
     {
-        filePath.CreateParentDirectory();
-        using var stream = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write);
+        TemporaryPaths.CreateFile(filePath);
     }
 
     /// <summary>Deletes the temporary file.</summary>

--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryPaths.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryPaths.cs
@@ -1,0 +1,79 @@
+namespace Meziantou.Framework;
+
+/// <summary>Creates the directories and files backing <see cref="TemporaryDirectory"/> and <see cref="TemporaryFile"/> so that other users cannot read them.</summary>
+internal static class TemporaryPaths
+{
+    private const UnixFileMode OwnerOnlyDirectoryMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+    private const UnixFileMode OwnerOnlyFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+    /// <summary>Creates the shared root directory, or validates it when it already exists.</summary>
+    /// <exception cref="UnauthorizedAccessException">The root directory already exists and is accessible to other users.</exception>
+    public static void EnsureRootDirectory(FullPath rootDirectory)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // The Windows temporary folder is already per-user.
+            Directory.CreateDirectory(rootDirectory);
+            return;
+        }
+
+        if (Directory.Exists(rootDirectory))
+        {
+            var mode = File.GetUnixFileMode(rootDirectory.Value);
+            if ((mode & ~OwnerOnlyDirectoryMode) == default)
+                return;
+
+            // The root has a well-known name, so it may predate this check, or another user may have created it
+            // first on a shared temporary folder. Only the owner of a directory can change its mode, so tightening
+            // it both repairs a root owned by this user and rejects one owned by somebody else.
+            try
+            {
+                File.SetUnixFileMode(rootDirectory.Value, OwnerOnlyDirectoryMode);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                throw new UnauthorizedAccessException($"The temporary root directory '{rootDirectory}' is owned by another user and is accessible to them (mode: {mode}). Use an explicit root directory.", ex);
+            }
+
+            return;
+        }
+
+        Directory.CreateDirectory(rootDirectory.Value, OwnerOnlyDirectoryMode);
+    }
+
+    /// <summary>Creates a directory that only the current user can access.</summary>
+    public static void CreateDirectory(FullPath path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Directory.CreateDirectory(path);
+            return;
+        }
+
+        Directory.CreateDirectory(path.Value, OwnerOnlyDirectoryMode);
+    }
+
+    /// <summary>Creates a new file that only the current user can access, along with its parent directories.</summary>
+    /// <exception cref="IOException">The file already exists.</exception>
+    public static void CreateFile(FullPath path)
+    {
+        var parent = path.Parent;
+        if (!parent.IsEmpty)
+        {
+            CreateDirectory(parent);
+        }
+
+        var options = new FileStreamOptions
+        {
+            Mode = FileMode.CreateNew,
+            Access = FileAccess.Write,
+        };
+
+        if (!OperatingSystem.IsWindows())
+        {
+            options.UnixCreateMode = OwnerOnlyFileMode;
+        }
+
+        using var stream = new FileStream(path, options);
+    }
+}

--- a/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
+++ b/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
@@ -257,6 +257,56 @@ public class TemporaryDirectoryTests
     }
 
     [Fact]
+    public void TemporaryDirectoryIsOnlyAccessibleByTheCurrentUser()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // Unix file modes only
+
+        using var dir = TemporaryDirectory.Create();
+        Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute, File.GetUnixFileMode(dir.FullPath.Value));
+        Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute, File.GetUnixFileMode(dir.FullPath.Parent.Value));
+    }
+
+    [Fact]
+    public void TemporaryFileIsOnlyAccessibleByTheCurrentUser()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // Unix file modes only
+
+        using var file = TemporaryFile.Create();
+        Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(file.FullPath.Value));
+    }
+
+    [Fact]
+    public void CreateTightensARootDirectoryAccessibleByOtherUsers()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // Unix file modes only
+
+        using var parent = TemporaryDirectory.Create();
+        var sharedRoot = parent.GetFullPath("shared");
+        Directory.CreateDirectory(sharedRoot.Value, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+
+        using var dir = TemporaryDirectory.Create(sharedRoot);
+
+        Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute, File.GetUnixFileMode(sharedRoot.Value));
+    }
+
+    [Fact]
+    public void CreateReusesAnOwnerOnlyRootDirectory()
+    {
+        using var parent = TemporaryDirectory.Create();
+        var root = parent.GetFullPath("root");
+
+        using var first = TemporaryDirectory.Create(root);
+        using var second = TemporaryDirectory.Create(root);
+
+        Assert.NotEqual(first.FullPath, second.FullPath);
+        Assert.Equal(root, first.FullPath.Parent);
+        Assert.Equal(root, second.FullPath.Parent);
+    }
+
+    [Fact]
     public void TemporaryFileCreateWithFullPath()
     {
         var fullPath = FullPath.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".tmp");


### PR DESCRIPTION
**Stack 2 of 3** · merges into #2605 · must merge after #2605 and before #2607.

Two related weaknesses on Unix, both measured on macOS before the change:

1. **Temporary content was world-readable.** `Directory.CreateDirectory` and `new FileStream(...)` used .NET's defaults, giving `0755` directories and `0644` files. On a shared Linux host any local user could read whatever a consumer staged there — decrypted payloads, tokens, fixture data, downloaded artifacts.
2. **The root has a fixed, guessable name.** `Path.GetTempPath() / "MezTD"` (`TemporaryDirectory.cs:54`) is `/tmp/MezTD` on Linux unless `TMPDIR` is set, and it was created without checking who owns it. A local user can create it first and own it; because they own the parent they can then unlink the victim's freshly created GUID directory and swap in a symlink, redirecting the victim's writes.

## Changes

New internal `TemporaryPaths` helper used by both types:

- Directories are created `0700` and files `0600` on Unix. No-op on Windows, where `%TEMP%` is already per-user.
- The shared root is validated before use. If it exists with group/other access, the mode is **tightened in place** rather than rejected.

### On verifying ownership

The plan was to throw when the root is owned by another user, but .NET exposes no cross-platform file-owner API, and P/Invoking `stat` is not worth the `struct stat` layout risk here (it differs across platforms and architectures).

Tightening the mode turns out to be a better check than `stat` anyway: **only the owner of a directory can change its mode**, so the `chmod` succeeding *is* the ownership proof. It also repairs rather than breaks. That matters — `MezTD` already exists as `0755` on every machine that has ever used this package, so throwing would have hard-broken every existing user on upgrade. I hit exactly that locally: the first version of this change failed all 16 tests with `UnauthorizedAccessException` on my own pre-existing `MezTD`.

If the `chmod` fails with `UnauthorizedAccessException`, the root belongs to someone else and `Create` throws with a message naming the directory.

**Known residual gap:** a root pre-created by another user with mode `0700` passes validation, and creation then fails with a less specific `UnauthorizedAccessException` from `Directory.CreateDirectory`. That fails closed — no compromise — but the message is worse. Closing it properly needs real ownership lookup.

## Verification

Four tests added, covering the `0700`/`0600` modes and the tighten-in-place path. 32/32 pass (16 tests × net10.0/net11.0), `/p:TreatsWarningsAsErrors=true` clean.

Confirmed on disk — both pre-existing roots were repaired by the test run:

```
drwxr-xr-x  →  drwx------   $TMPDIR/MezTD
drwxr-xr-x  →  drwx------   $TMPDIR/MezTF
```

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
