### PR TITLE
Guard TemporaryDirectory and TemporaryFile against use after dispose

### DIFF
--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryDirectory.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryDirectory.cs
@@ -48,7 +48,9 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     /// <remarks>
     /// The directory is created under the system temp path in a "MezTD" subdirectory.
     /// The directory name includes a timestamp and GUID to ensure uniqueness.
+    /// On Unix, the directories are created so that only the current user can access them.
     /// </remarks>
+    /// <exception cref="UnauthorizedAccessException">The "MezTD" directory already exists and is accessible to other users.</exception>
     public static TemporaryDirectory Create()
     {
         return Create(FullPath.Combine(Path.GetTempPath(), "MezTD"));
@@ -59,10 +61,13 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     /// <returns>A new <see cref="TemporaryDirectory"/> instance.</returns>
     /// <remarks>
     /// The directory name includes a timestamp (yyyyMMdd_HHmmss) and GUID to ensure uniqueness.
+    /// On Unix, the directories are created so that only the current user can access them.
     /// </remarks>
+    /// <exception cref="UnauthorizedAccessException"><paramref name="rootDirectory"/> already exists and is accessible to other users.</exception>
     public static TemporaryDirectory Create(FullPath rootDirectory)
     {
         var folderName = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture) + "_" + Guid.NewGuid().ToString("N");
+        TemporaryPaths.EnsureRootDirectory(rootDirectory);
         var path = CreateUniqueDirectory(rootDirectory / folderName);
         return new TemporaryDirectory(path);
     }
@@ -158,7 +163,7 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     private static FullPath CreateUniqueDirectory(FullPath folderPath)
     {
         // The folder name includes a GUID, so it is unique and cannot collide with an existing directory.
-        Directory.CreateDirectory(folderPath);
+        TemporaryPaths.CreateDirectory(folderPath);
         return folderPath;
     }
 

--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryDirectory.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryDirectory.cs
@@ -34,8 +34,11 @@ namespace Meziantou.Framework;
 [DebuggerDisplay("{FullPath}")]
 public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
 {
+    private bool _disposed;
+
     /// <summary>Gets the full path to the temporary directory.</summary>
     /// <value>The absolute path to the temporary directory where files and subdirectories can be created.</value>
+    /// <remarks>The path remains readable after the instance is disposed, even though the directory no longer exists.</remarks>
     public FullPath FullPath { get; }
 
     private TemporaryDirectory(FullPath path)
@@ -75,6 +78,7 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     /// <summary>Gets the full path for a relative path within the temporary directory.</summary>
     /// <param name="relativePath">The relative path (can include subdirectories).</param>
     /// <returns>The absolute <see cref="FullPath"/> combining the temporary directory and the relative path.</returns>
+    /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
     /// <example>
     /// <code>
     /// using var tempDir = TemporaryDirectory.Create();
@@ -83,6 +87,7 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     /// </example>
     public FullPath GetFullPath(string relativePath)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         return FullPath.Combine(FullPath, relativePath);
     }
 
@@ -168,15 +173,25 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     }
 
     /// <summary>Deletes the temporary directory and all its contents.</summary>
+    /// <remarks>Disposing an already disposed instance does nothing, so it cannot delete a directory recreated at the same path.</remarks>
     public void Dispose()
     {
+        if (_disposed)
+            return;
+
+        _disposed = true;
         IOUtilities.Delete(new DirectoryInfo(FullPath));
     }
 
     /// <summary>Asynchronously deletes the temporary directory and all its contents.</summary>
     /// <returns>A task that represents the asynchronous dispose operation.</returns>
+    /// <remarks>Disposing an already disposed instance does nothing, so it cannot delete a directory recreated at the same path.</remarks>
     public async ValueTask DisposeAsync()
     {
+        if (_disposed)
+            return;
+
+        _disposed = true;
         await IOUtilities.DeleteAsync(new DirectoryInfo(FullPath), CancellationToken.None).ConfigureAwait(false);
     }
 
@@ -227,7 +242,12 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
 
     /// <summary>Opens the temporary directory in Windows Explorer.</summary>
     /// <remarks>This method is only available on Windows platforms.</remarks>
+    /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     [System.Runtime.Versioning.SupportedOSPlatform("windows5.1.2600")]
-    public void OpenInExplorer() => FullPath.OpenInExplorer();
+    public void OpenInExplorer()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        FullPath.OpenInExplorer();
+    }
 }

--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
@@ -26,6 +26,7 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
     // Set when this instance created a directory for the sole purpose of holding the file.
     // Disposing must then remove that directory, not just the file.
     private readonly FullPath _ownedDirectory;
+    private bool _disposed;
 
     /// <summary>Gets the full path to the temporary file.</summary>
     /// <value>The absolute path to the temporary file.</value>
@@ -113,6 +114,10 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
     /// </remarks>
     public void Dispose()
     {
+        if (_disposed)
+            return;
+
+        _disposed = true;
         if (_ownedDirectory.IsEmpty)
         {
             IOUtilities.Delete(new FileInfo(FullPath));
@@ -130,6 +135,10 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
     /// </remarks>
     public ValueTask DisposeAsync()
     {
+        if (_disposed)
+            return ValueTask.CompletedTask;
+
+        _disposed = true;
         if (_ownedDirectory.IsEmpty)
             return IOUtilities.DeleteAsync(new FileInfo(FullPath), CancellationToken.None);
 

--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
@@ -23,13 +23,18 @@ namespace Meziantou.Framework;
 [DebuggerDisplay("{FullPath}")]
 public sealed class TemporaryFile : IDisposable, IAsyncDisposable
 {
+    // Set when this instance created a directory for the sole purpose of holding the file.
+    // Disposing must then remove that directory, not just the file.
+    private readonly FullPath _ownedDirectory;
+
     /// <summary>Gets the full path to the temporary file.</summary>
     /// <value>The absolute path to the temporary file.</value>
     public FullPath FullPath { get; }
 
-    private TemporaryFile(FullPath fullPath)
+    private TemporaryFile(FullPath fullPath, FullPath ownedDirectory)
     {
         FullPath = fullPath;
+        _ownedDirectory = ownedDirectory;
     }
 
     /// <summary>Creates a new temporary file in the system's default temp location.</summary>
@@ -42,7 +47,7 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
     {
         var rootDirectory = FullPath.Combine(Path.GetTempPath(), "MezTF");
         var fileName = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture) + "_" + Guid.NewGuid().ToString("N") + ".tmp";
-        return CreateInRoot(rootDirectory, fileName);
+        return CreateInRoot(rootDirectory, fileName, ownedDirectory: default);
     }
 
     /// <summary>Creates a new temporary file using the specified file name or full path.</summary>
@@ -62,7 +67,7 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
             return Create(FullPath.FromPath(fileNameOrPath));
 
         var rootDirectory = FullPath.GetTempPath() / "MezTF" / CreateUniqueFolderName();
-        return CreateInRoot(rootDirectory, fileNameOrPath);
+        return CreateInRoot(rootDirectory, fileNameOrPath, ownedDirectory: rootDirectory);
     }
 
     /// <summary>Creates a new temporary file at the specified path.</summary>
@@ -80,14 +85,14 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
             throw new ArgumentException("The path is empty.", nameof(filePath));
 
         CreateFile(filePath);
-        return new TemporaryFile(filePath);
+        return new TemporaryFile(filePath, ownedDirectory: default);
     }
 
-    private static TemporaryFile CreateInRoot(FullPath rootDirectory, string relativePath)
+    private static TemporaryFile CreateInRoot(FullPath rootDirectory, string relativePath, FullPath ownedDirectory)
     {
         var fullPath = FullPath.Combine(rootDirectory, relativePath);
         CreateFile(fullPath);
-        return new TemporaryFile(fullPath);
+        return new TemporaryFile(fullPath, ownedDirectory);
     }
 
     private static string CreateUniqueFolderName()
@@ -102,16 +107,32 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
     }
 
     /// <summary>Deletes the temporary file.</summary>
+    /// <remarks>
+    /// When the instance was created from a file name, the unique directory created to hold that file is deleted as well.
+    /// </remarks>
     public void Dispose()
     {
-        IOUtilities.Delete(new FileInfo(FullPath));
+        if (_ownedDirectory.IsEmpty)
+        {
+            IOUtilities.Delete(new FileInfo(FullPath));
+        }
+        else
+        {
+            IOUtilities.Delete(new DirectoryInfo(_ownedDirectory));
+        }
     }
 
     /// <summary>Asynchronously deletes the temporary file.</summary>
     /// <returns>A task that represents the asynchronous dispose operation.</returns>
+    /// <remarks>
+    /// When the instance was created from a file name, the unique directory created to hold that file is deleted as well.
+    /// </remarks>
     public ValueTask DisposeAsync()
     {
-        return IOUtilities.DeleteAsync(new FileInfo(FullPath), CancellationToken.None);
+        if (_ownedDirectory.IsEmpty)
+            return IOUtilities.DeleteAsync(new FileInfo(FullPath), CancellationToken.None);
+
+        return IOUtilities.DeleteAsync(new DirectoryInfo(_ownedDirectory), CancellationToken.None);
     }
 
     /// <summary>Implicitly converts a <see cref="TemporaryFile"/> to a <see cref="FullPath"/>.</summary>

--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
@@ -47,6 +47,7 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
     {
         var rootDirectory = FullPath.Combine(Path.GetTempPath(), "MezTF");
         var fileName = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture) + "_" + Guid.NewGuid().ToString("N") + ".tmp";
+        TemporaryPaths.EnsureRootDirectory(rootDirectory);
         return CreateInRoot(rootDirectory, fileName, ownedDirectory: default);
     }
 
@@ -66,6 +67,7 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
         if (Path.IsPathRooted(fileNameOrPath))
             return Create(FullPath.FromPath(fileNameOrPath));
 
+        TemporaryPaths.EnsureRootDirectory(FullPath.GetTempPath() / "MezTF");
         var rootDirectory = FullPath.GetTempPath() / "MezTF" / CreateUniqueFolderName();
         return CreateInRoot(rootDirectory, fileNameOrPath, ownedDirectory: rootDirectory);
     }
@@ -102,8 +104,7 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
 
     private static void CreateFile(FullPath filePath)
     {
-        filePath.CreateParentDirectory();
-        using var stream = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write);
+        TemporaryPaths.CreateFile(filePath);
     }
 
     /// <summary>Deletes the temporary file.</summary>

--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryPaths.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryPaths.cs
@@ -1,0 +1,79 @@
+namespace Meziantou.Framework;
+
+/// <summary>Creates the directories and files backing <see cref="TemporaryDirectory"/> and <see cref="TemporaryFile"/> so that other users cannot read them.</summary>
+internal static class TemporaryPaths
+{
+    private const UnixFileMode OwnerOnlyDirectoryMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+    private const UnixFileMode OwnerOnlyFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+    /// <summary>Creates the shared root directory, or validates it when it already exists.</summary>
+    /// <exception cref="UnauthorizedAccessException">The root directory already exists and is accessible to other users.</exception>
+    public static void EnsureRootDirectory(FullPath rootDirectory)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // The Windows temporary folder is already per-user.
+            Directory.CreateDirectory(rootDirectory);
+            return;
+        }
+
+        if (Directory.Exists(rootDirectory))
+        {
+            var mode = File.GetUnixFileMode(rootDirectory.Value);
+            if ((mode & ~OwnerOnlyDirectoryMode) == default)
+                return;
+
+            // The root has a well-known name, so it may predate this check, or another user may have created it
+            // first on a shared temporary folder. Only the owner of a directory can change its mode, so tightening
+            // it both repairs a root owned by this user and rejects one owned by somebody else.
+            try
+            {
+                File.SetUnixFileMode(rootDirectory.Value, OwnerOnlyDirectoryMode);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                throw new UnauthorizedAccessException($"The temporary root directory '{rootDirectory}' is owned by another user and is accessible to them (mode: {mode}). Use an explicit root directory.", ex);
+            }
+
+            return;
+        }
+
+        Directory.CreateDirectory(rootDirectory.Value, OwnerOnlyDirectoryMode);
+    }
+
+    /// <summary>Creates a directory that only the current user can access.</summary>
+    public static void CreateDirectory(FullPath path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Directory.CreateDirectory(path);
+            return;
+        }
+
+        Directory.CreateDirectory(path.Value, OwnerOnlyDirectoryMode);
+    }
+
+    /// <summary>Creates a new file that only the current user can access, along with its parent directories.</summary>
+    /// <exception cref="IOException">The file already exists.</exception>
+    public static void CreateFile(FullPath path)
+    {
+        var parent = path.Parent;
+        if (!parent.IsEmpty)
+        {
+            CreateDirectory(parent);
+        }
+
+        var options = new FileStreamOptions
+        {
+            Mode = FileMode.CreateNew,
+            Access = FileAccess.Write,
+        };
+
+        if (!OperatingSystem.IsWindows())
+        {
+            options.UnixCreateMode = OwnerOnlyFileMode;
+        }
+
+        using var stream = new FileStream(path, options);
+    }
+}

--- a/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
+++ b/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
@@ -158,6 +158,56 @@ public class TemporaryDirectoryTests
     }
 
     [Fact]
+    public void TemporaryDirectoryIsOnlyAccessibleByTheCurrentUser()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // Unix file modes only
+
+        using var dir = TemporaryDirectory.Create();
+        Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute, File.GetUnixFileMode(dir.FullPath.Value));
+        Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute, File.GetUnixFileMode(dir.FullPath.Parent.Value));
+    }
+
+    [Fact]
+    public void TemporaryFileIsOnlyAccessibleByTheCurrentUser()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // Unix file modes only
+
+        using var file = TemporaryFile.Create();
+        Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(file.FullPath.Value));
+    }
+
+    [Fact]
+    public void CreateTightensARootDirectoryAccessibleByOtherUsers()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // Unix file modes only
+
+        using var parent = TemporaryDirectory.Create();
+        var sharedRoot = parent.GetFullPath("shared");
+        Directory.CreateDirectory(sharedRoot.Value, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+
+        using var dir = TemporaryDirectory.Create(sharedRoot);
+
+        Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute, File.GetUnixFileMode(sharedRoot.Value));
+    }
+
+    [Fact]
+    public void CreateReusesAnOwnerOnlyRootDirectory()
+    {
+        using var parent = TemporaryDirectory.Create();
+        var root = parent.GetFullPath("root");
+
+        using var first = TemporaryDirectory.Create(root);
+        using var second = TemporaryDirectory.Create(root);
+
+        Assert.NotEqual(first.FullPath, second.FullPath);
+        Assert.Equal(root, first.FullPath.Parent);
+        Assert.Equal(root, second.FullPath.Parent);
+    }
+
+    [Fact]
     public void TemporaryFileCreateWithFullPath()
     {
         var fullPath = FullPath.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".tmp");

--- a/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
+++ b/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
@@ -208,6 +208,60 @@ public class TemporaryDirectoryTests
     }
 
     [Fact]
+    public void UsingADisposedTemporaryDirectoryThrows()
+    {
+        var dir = TemporaryDirectory.Create();
+        dir.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => dir.GetFullPath("a.txt"));
+        Assert.Throws<ObjectDisposedException>(() => dir.CreateTextFile("a.txt", "content"));
+        Assert.Throws<ObjectDisposedException>(() => dir.CreateEmptyFile("a.txt"));
+        Assert.Throws<ObjectDisposedException>(() => dir.CreateDirectory("sub"));
+        Assert.Throws<ObjectDisposedException>(() => dir / "a.txt");
+        Assert.False(Directory.Exists(dir.FullPath));
+    }
+
+    [Fact]
+    public void DisposingATemporaryDirectoryTwiceKeepsARecreatedDirectory()
+    {
+        var dir = TemporaryDirectory.Create();
+        var path = dir.FullPath;
+        dir.Dispose();
+
+        Directory.CreateDirectory(path.Value);
+        try
+        {
+            File.WriteAllText(path / "unrelated.txt", "content");
+            dir.Dispose();
+
+            Assert.True(File.Exists(path / "unrelated.txt"));
+        }
+        finally
+        {
+            Directory.Delete(path.Value, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DisposingATemporaryFileTwiceKeepsARecreatedFile()
+    {
+        var file = TemporaryFile.Create();
+        var path = file.FullPath;
+        file.Dispose();
+
+        File.WriteAllText(path.Value, "content");
+        try
+        {
+            file.Dispose();
+            Assert.True(File.Exists(path));
+        }
+        finally
+        {
+            File.Delete(path.Value);
+        }
+    }
+
+    [Fact]
     public void TemporaryFileCreateWithFullPath()
     {
         var fullPath = FullPath.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".tmp");

--- a/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
+++ b/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
@@ -117,6 +117,47 @@ public class TemporaryDirectoryTests
     }
 
     [Fact]
+    public void TemporaryFileCreateWithFileNameDeletesTheGeneratedDirectory()
+    {
+        FullPath path;
+        using (var file = TemporaryFile.Create("custom.txt"))
+        {
+            path = file.FullPath;
+            Assert.True(Directory.Exists(path.Parent));
+        }
+
+        Assert.False(File.Exists(path));
+        Assert.False(Directory.Exists(path.Parent));
+    }
+
+    [Fact]
+    public void TemporaryFileCreateWithRelativePathDeletesTheGeneratedDirectory()
+    {
+        FullPath path;
+        using (var file = TemporaryFile.Create(Path.Combine("sub", "custom.txt")))
+        {
+            path = file.FullPath;
+        }
+
+        Assert.False(File.Exists(path));
+        Assert.False(Directory.Exists(path.Parent));
+        Assert.False(Directory.Exists(path.Parent.Parent));
+    }
+
+    [Fact]
+    public void TemporaryFileCreateKeepsTheSharedRootDirectory()
+    {
+        FullPath path;
+        using (var file = TemporaryFile.Create())
+        {
+            path = file.FullPath;
+        }
+
+        Assert.False(File.Exists(path));
+        Assert.True(Directory.Exists(path.Parent));
+    }
+
+    [Fact]
     public void TemporaryFileCreateWithFullPath()
     {
         var fullPath = FullPath.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".tmp");


### PR DESCRIPTION
**Stack 3 of 3** · merges into #2606 · must merge last.

`Dispose()` set no state, so a disposed instance stayed fully usable and both directions were silent:

```c#
var dir = TemporaryDirectory.Create();
dir.Dispose();
dir.CreateTextFile("zombie.txt", "still here");  // recreates the whole tree — now leaked, no owner
```

Symmetrically, a second `Dispose()` deleted whatever currently sat at that path. Verified by recreating the directory with an unrelated file after disposal and calling `Dispose()` again — the file was deleted.

GUID paths make an accidental collision very unlikely, so this is API hygiene rather than a practical data-loss risk, but it is what turns a stray `Dispose()` in a `finally` into a mystery. `AGENTS.md` also calls for `ObjectDisposedException.ThrowIf` where applicable.

## Changes

- `TemporaryDirectory`: `ObjectDisposedException.ThrowIf` on `GetFullPath` and `OpenInExplorer`. Guarding `GetFullPath` covers `CreateEmptyFile`, `CreateTextFile`, `CreateTextFileAsync`, `CreateDirectory` and `operator /`, since they all funnel through it.
- Both types: `Dispose`/`DisposeAsync` are now no-ops after the first call, so they cannot delete data recreated at the same path.
- `FullPath` deliberately stays readable after disposal — reading the path to assert on it is the common pattern in tests, and returning it is harmless.

This is technically breaking for anyone writing to a disposed instance, which is already a bug.

## Verification

Three tests added: the throwing members, and the double-dispose behaviour for both types. 38/38 pass (19 tests × net10.0/net11.0), `/p:TreatsWarningsAsErrors=true` clean.

No public API surface change, so `ref/` needs no regeneration.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
