### PR TITLE
Fix the readme and XML examples so they compile and match actual output

### DIFF
--- a/src/Meziantou.Framework.ByteSize/ByteSize.cs
+++ b/src/Meziantou.Framework.ByteSize/ByteSize.cs
@@ -8,10 +8,11 @@ namespace Meziantou.Framework;
 /// // Create an instance
 /// var size = new ByteSize(1024);
 /// var size2 = ByteSize.FromKiloBytes(10);
-/// var size3 = ByteSize.Parse("10MB");
+/// var size3 = ByteSize.Parse("10MB", CultureInfo.InvariantCulture);
 ///
 /// // Format with automatic unit selection
-/// Console.WriteLine(size.ToString()); // "1kiB"
+/// Console.WriteLine(size.ToString()); // "1.024kB" - decimal units
+/// Console.WriteLine(size.ToString("gi")); // "1kiB" - binary units
 ///
 /// // Format with specific unit
 /// Console.WriteLine(size.ToString("MB")); // "0.001024MB"

--- a/src/Meziantou.Framework.ByteSize/readme.md
+++ b/src/Meziantou.Framework.ByteSize/readme.md
@@ -5,20 +5,20 @@
 ````c#
 // Create an instance of ByteSize
 var size = new ByteSize(10); // 10 bytes
-_ = ByteSize.FromKiloByte(10);
+_ = ByteSize.FromKiloBytes(10);
 _ = ByteSize.From(10, ByteSizeUnit.GigaByte);
-_ = ByteSize.Parse("10MB");
-var parsed = ByteSize.TryParse("10MB", out var size);
-var parsed = ByteSize.TryParse("10MB", CultureInfo.InvariantCulture, out var size);
+_ = ByteSize.Parse("10MB", CultureInfo.InvariantCulture);
+_ = ByteSize.TryParse("10MB", out var parsedSize);
+_ = ByteSize.TryParse("10MB", CultureInfo.InvariantCulture, out var parsedSizeInvariant);
 
 // Formatting
 size.ToString(); // Automatically find the best unit
 size.ToString("MB"); // Display the value in megabytes
-                     // Supports B, kB, kiB, MB, MiB, GB, GiB, TB, TiB, EB, EiB
+                     // Supports B, kB, kiB, MB, MiB, GB, GiB, TB, TiB, PB, PiB, EB, EiB
 
 // Comparisons
-ByteSize a;
-ByteSize b;
+var a = ByteSize.FromKiloBytes(1);
+var b = ByteSize.FromMegaBytes(1);
 _ = a == b;
 _ = a != b;
 _ = a < b;


### PR DESCRIPTION
Documentation-only. No behaviour change, no public API change.

## The readme sample did not compile

`src/Meziantou.Framework.ByteSize/readme.md` is packed into the NuGet package, so it is the first thing a consumer copy-pastes. Compiling it verbatim against the library produces six errors:

```
error CS0117: 'ByteSize' does not contain a definition for 'FromKiloByte'
error CS1503: Argument 1: cannot convert from 'string' to 'System.ReadOnlySpan<byte>'
error CS0128: A local variable or function named 'parsed' is already defined in this scope
error CS0128: A local variable or function named 'size' is already defined in this scope
error CS0165: Use of unassigned local variable 'a'
error CS0165: Use of unassigned local variable 'b'
```

Four distinct problems:

- **`FromKiloByte` does not exist.** Every generated factory is plural — `FromKiloBytes`. There is no singular form on any of the thirteen units.
- **`ByteSize.Parse("10MB")` does not exist.** The overloads are `Parse(string, IFormatProvider?)`, `Parse(ReadOnlySpan<char>, IFormatProvider?)` and `Parse(ReadOnlySpan<byte>)`. A one-argument string call binds to the UTF-8 overload and fails to convert.
- **Redeclared locals.** `var parsed` and `out var size` each appear twice, and `size` also collides with the `var size` three lines above.
- **Unassigned locals.** `ByteSize a; ByteSize b;` are then compared; definite-assignment rejects that for structs too.

Also added the `PB` and `PiB` units to the supported-format list, which work today but were missing.

## The XML `<example>` stated an output the code does not produce

The `<example>` on the type (`ByteSize.cs:9-14`) is what IntelliSense shows on `ByteSize` itself, so it sets the reader's mental model of default unit selection. It claimed:

```csharp
Console.WriteLine(size.ToString()); // "1kiB"    // size = new ByteSize(1024)
```

The parameterless `ToString()` routes to `FindBestUnit` (decimal), not `FindBestUnitI`, so the actual output is `"1.024kB"`. `"1kiB"` requires `ToString("gi")`. Rather than just correcting the comment I kept both lines, since the contrast is the thing worth teaching:

```csharp
Console.WriteLine(size.ToString());     // "1.024kB" - decimal units
Console.WriteLine(size.ToString("gi")); // "1kiB" - binary units
```

The same block also had the non-existent `ByteSize.Parse("10MB")`; corrected to the two-argument overload.

The two other claims in that block were checked and are correct, so they are untouched: `ToString("MB")` on 1024 really is `"0.001024MB"`, and `1kB + 2kB` really is `"3kB"`.

## Verification

Both samples were extracted into a scratch project and compiled against the library. The originals produce the six errors above; the corrected versions build clean with no errors and no warnings. Output claims were checked by running them:

```
ToString()      = "1.024kB"
ToString("gi")  = "1kiB"
ToString("MB")  = "0.001024MB"
1kB+2kB         = "3kB"
```

`dotnet test tests/Meziantou.Framework.ByteSize.Tests` — 154 passed, 0 failed (unchanged; this PR adds no tests since it changes no behaviour).

## Note

The supported-unit list still names `EB` and `EiB`. Those do not currently work — that is a separate defect, fixed in #2587. This PR deliberately leaves that line alone rather than removing and re-adding it.
