### PR TITLE
Keep a localization provider's value from breaking formatting

### DIFF
--- a/src/Meziantou.Framework.RelativeDate/ILocalizationProvider.cs
+++ b/src/Meziantou.Framework.RelativeDate/ILocalizationProvider.cs
@@ -10,6 +10,9 @@ public interface ILocalizationProvider
     /// <summary>Gets a localized string for the specified resource name and culture.</summary>
     /// <param name="name">The name of the resource string (e.g., "Now", "OneSecondAgo", "InManyDays").</param>
     /// <param name="culture">The culture for which to retrieve the localized string. If <see langword="null"/>, the current culture is used.</param>
-    /// <returns>The localized string, or an empty string if the resource is not found.</returns>
+    /// <returns>The localized string, or an empty string if the resource is not found, in which case the neutral culture is queried instead.</returns>
+    /// <remarks>
+    /// A string for a resource that reports a count must contain the <c>{0}</c> placeholder. It is substituted literally rather than treated as a composite format string, so braces need no escaping.
+    /// </remarks>
     string GetString(string name, CultureInfo? culture);
 }

--- a/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
@@ -200,9 +200,22 @@ public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IE
         }
     }
 
-    private static string GetString(string name, CultureInfo? culture) => LocalizationProvider.Current.GetString(name, culture);
+    private static string GetString(string name, CultureInfo? culture)
+    {
+        var value = LocalizationProvider.Current.GetString(name, culture);
 
-    private static string GetString(string name, CultureInfo? culture, int value) => string.Format(culture, LocalizationProvider.Current.GetString(name, culture), value);
+        // An empty value means the provider has no string for that culture: rendering nothing at all is never useful, so ask for the neutral one
+        if (string.IsNullOrEmpty(value))
+            return LocalizationProvider.Current.GetString(name, CultureInfo.InvariantCulture);
+
+        return value;
+    }
+
+    private static string GetString(string name, CultureInfo? culture, int value)
+    {
+        // The placeholder is substituted instead of going through string.Format, so a brace in a provider's value cannot throw FormatException
+        return GetString(name, culture).Replace("{0}", value.ToString(culture), StringComparison.Ordinal);
+    }
 
     int IComparable.CompareTo(object? obj)
     {

--- a/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
+++ b/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
@@ -73,6 +73,54 @@ public class RelativeDateTests
         }
     }
 
+    // Swapping LocalizationProvider.Current is process-wide, so this test must not run beside any other
+    [Fact(DisableParallelization = true)]
+    public void CustomProvider_ValueContainingABrace_DoesNotThrow()
+    {
+        var result = FormatWithProvider(new StubLocalizationProvider("{oops} {0}"), TimeSpan.FromHours(-2));
+        Assert.Equal("{oops} 2", result);
+    }
+
+    // Swapping LocalizationProvider.Current is process-wide, so this test must not run beside any other
+    [Fact(DisableParallelization = true)]
+    public void CustomProvider_EmptyValue_FallsBackToTheNeutralCulture()
+    {
+        var provider = new StubLocalizationProvider(value: "", neutralValue: "{0} hours ago");
+        Assert.Equal("2 hours ago", FormatWithProvider(provider, TimeSpan.FromHours(-2)));
+    }
+
+    // Swapping LocalizationProvider.Current is process-wide, so this test must not run beside any other
+    [Fact(DisableParallelization = true)]
+    public void CustomProvider_EmptyValue_FallsBackToTheNeutralCulture_WithoutACount()
+    {
+        var provider = new StubLocalizationProvider(value: "", neutralValue: "yesterday");
+        Assert.Equal("yesterday", FormatWithProvider(provider, TimeSpan.FromHours(-30)));
+    }
+
+    private static string FormatWithProvider(ILocalizationProvider provider, TimeSpan offset)
+    {
+        var now = new DateTimeOffset(2018, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(now);
+
+        var previous = LocalizationProvider.Current;
+        try
+        {
+            LocalizationProvider.Current = provider;
+            return RelativeDate.Get(now + offset, timeProvider).ToString(format: null, CultureInfo.GetCultureInfo("fr"));
+        }
+        finally
+        {
+            LocalizationProvider.Current = previous;
+        }
+    }
+
+    private sealed class StubLocalizationProvider(string value, string? neutralValue = null) : ILocalizationProvider
+    {
+        public string GetString(string name, CultureInfo? culture)
+            => culture is not null && culture.Equals(CultureInfo.InvariantCulture) ? neutralValue ?? "" : value;
+    }
+
 #if !INVARIANT_GLOBALIZATION_MODE_ENABLED
     private static readonly string[] LocalizedCultures = ["de", "es", "fr", "it", "ja", "ko", "nl", "pt", "tr", "zh-Hans"];
 


### PR DESCRIPTION
`ILocalizationProvider` is a public extension point, but its return value is passed straight to `string.Format` as the **format string** at `src/Meziantou.Framework.RelativeDate/RelativeDate.cs:205`, and `ILocalizationProvider.GetString` explicitly sanctions returning `""` for a missing resource.

Measured on `main` with two trivial providers:

```
provider returns ""        => (empty string)
provider returns "{oops}"  => THROWS FormatException: ... Failure to parse near offset 1
```

Two bad outcomes from ordinary implementations:

- A provider backed by an incomplete translation database returns `""`, and the caller renders a blank timestamp with no error anywhere. The built-in provider has the same behavior by design, so a trimmed or missing resource set would blank out silently rather than fail.
- Any translation containing a literal brace — plausible for a hand-edited or user-supplied string table — turns a formatting call into a `FormatException` from deep inside the library.

Both are reachable only through the public extension point, which is why neither was covered.

## What changed

- The count is now substituted with an ordinal `Replace("{0}", …)` instead of `string.Format`. Every built-in resource uses exactly one `{0}`, so output is unchanged, but a stray brace can no longer throw.
- An empty value now falls back to the neutral culture rather than rendering nothing. No change for the built-in provider — `ResourceManager` already falls back — this only helps providers that do per-culture-only lookup.
- `ILocalizationProvider.GetString` documents both: what an empty return means, and that the value is substituted rather than treated as a composite format string, so braces need no escaping.

## Verification

Three tests added, all three failing on `main` (one with `FormatException`, two with an empty result).

They are marked `[Fact(DisableParallelization = true)]`. `LocalizationProvider.Current` is process-wide, and xunit v3 runs tests within a class in parallel — without it, a test that swaps the provider is observed by whatever runs beside it. That reproduced as ~10 unrelated failures with `resultEn == ""` before the attribute was added. Suite run three times to confirm it is stable: 98/98 across net10.0 and net11.0 each time.

Worth noting the underlying design point: `LocalizationProvider.Current` being a mutable static is what forces that opt-out. A per-call provider overload would remove the constraint, but that is an API change and out of scope here.
