### PR TITLE
Strip script, style and noscript nested in passed-through unknown elements

### DIFF
--- a/src/Meziantou.Framework.HtmlToMarkdown/HtmlToMarkdown.cs
+++ b/src/Meziantou.Framework.HtmlToMarkdown/HtmlToMarkdown.cs
@@ -492,8 +492,27 @@ public static class HtmlToMarkdown
         {
             UnknownElementHandling.Strip => "",
             UnknownElementHandling.StripKeepContent => ConvertChildNodes(element, state),
-            _ => element.OuterHtml,
+            _ => GetOuterHtmlWithoutStrippedElements(element),
         };
+    }
+
+    /// <summary>
+    /// Gets the outer HTML of an element with its script, style and noscript descendants
+    /// removed. Those elements are stripped everywhere else, so passing an unknown element
+    /// through verbatim must not reintroduce them.
+    /// </summary>
+    private static string GetOuterHtmlWithoutStrippedElements(IElement element)
+    {
+        if (element.QuerySelector(StrippedElementsSelector) is null)
+            return element.OuterHtml;
+
+        var clone = (IElement)element.Clone(deep: true);
+        foreach (var stripped in clone.QuerySelectorAll(StrippedElementsSelector).ToArray())
+        {
+            stripped.Remove();
+        }
+
+        return clone.OuterHtml;
     }
 
     // =========================================================================
@@ -939,6 +958,8 @@ public static class HtmlToMarkdown
             or "dl" or "dt" or "dd" or "figure" or "figcaption"
             or "details" or "summary";
     }
+
+    private const string StrippedElementsSelector = "script, style, noscript";
 
     private static bool IsStrippedElement(INode node)
     {

--- a/src/Meziantou.Framework.HtmlToMarkdown/readme.md
+++ b/src/Meziantou.Framework.HtmlToMarkdown/readme.md
@@ -79,10 +79,18 @@ The converter supports common Markdown-related elements, including:
 - Tables (`table`, `thead`, `tbody`, `tfoot`, `tr`, `th`, `td`) with alignment support
 - Definition lists (`dl`, `dt`, `dd`)
 
-`script`, `style`, and `noscript` elements are stripped.
+`script`, `style`, and `noscript` elements are always stripped, including when they appear
+inside an element that is passed through as raw HTML.
 
 Unknown elements are handled using `UnknownElementHandling`:
 
 - `PassThrough` (default): keep raw HTML
 - `Strip`: remove the element and its content
 - `StripKeepContent`: remove the element but keep converted child content
+
+> [!WARNING]
+> This library is a converter, not an HTML sanitizer. With `PassThrough`, an unknown element
+> is emitted as raw HTML with its attributes intact, so event handlers such as `onclick` and
+> `onerror` and URLs such as `javascript:` survive the conversion. If you convert untrusted
+> HTML and render the resulting Markdown with a renderer that allows raw HTML, run a
+> sanitizer over the input or the output, or use `Strip` or `StripKeepContent`.

--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlToMarkdownConverterTests.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/HtmlToMarkdownConverterTests.cs
@@ -3619,4 +3619,48 @@ public sealed class HtmlToMarkdownConverterTests
             ```
             """);
     }
+
+    // --- Stripped elements inside passed-through unknown elements ---
+
+    [Fact]
+    public void UnknownElement_PassThrough_StripsNestedScript()
+    {
+        AssertHtmlToMarkdown(
+            "<foo><script>alert(1)</script></foo>",
+            "<foo></foo>");
+    }
+
+    [Fact]
+    public void UnknownElement_PassThrough_StripsDeeplyNestedScript()
+    {
+        AssertHtmlToMarkdown(
+            "<custom-el><div><script>alert(1)</script></div></custom-el>",
+            "<custom-el><div></div></custom-el>");
+    }
+
+    [Theory]
+    [InlineData("style", "body{color:red}")]
+    [InlineData("noscript", "<b>no js</b>")]
+    public void UnknownElement_PassThrough_StripsNestedStyleAndNoscript(string tagName, string content)
+    {
+        AssertHtmlToMarkdown(
+            $"<foo><{tagName}>{content}</{tagName}></foo>",
+            "<foo></foo>");
+    }
+
+    [Fact]
+    public void UnknownElement_PassThrough_KeepsSurroundingContent()
+    {
+        AssertHtmlToMarkdown(
+            "<foo>before<script>alert(1)</script>after</foo>",
+            "<foo>beforeafter</foo>");
+    }
+
+    [Fact]
+    public void UnknownElement_PassThrough_WithoutStrippedElementsIsUnchanged()
+    {
+        AssertHtmlToMarkdown(
+            """<foo bar="baz">content</foo>""",
+            """<foo bar="baz">content</foo>""");
+    }
 }


### PR DESCRIPTION
## Problem

The readme states that `script`, `style` and `noscript` elements are stripped, and they are — but only when the converter descends into them through `ConvertChildNodes`. `ConvertUnknownElement` returned `element.OuterHtml` for the default `UnknownElementHandling.PassThrough`, taking the whole subtree verbatim without descending, so wrapping a `<script>` in any element the converter does not recognise skipped the check entirely:

```csharp
HtmlToMarkdown.Convert("<foo><script>alert(1)</script></foo>");
// <foo><script>alert(1)</script></foo>
```

Rendering that with Markdig — raw HTML enabled by default, as in this repository's own round-trip tests — reproduces the script tag intact in the HTML output. Any element outside the known-element switch reaches this path, including `<iframe>`, `<svg>`, `<video>`, `<object>`, `<math>` and every custom element, and the affected option is the default one.

## What changed

`ConvertUnknownElement` now routes the passthrough case through `GetOuterHtmlWithoutStrippedElements`, which removes `script`, `style` and `noscript` descendants before returning the markup. The common case is unaffected: when the subtree contains none of them — nearly always — the element's `OuterHtml` is returned directly and nothing is cloned. Only when a stripped element is actually present is the subtree cloned so the original document is left alone.

`Strip` and `StripKeepContent` were already correct and are untouched.

## The readme also needed fixing

Making the code match the documented behaviour closes the specific bypass, but the surrounding claim was still misleading, because passthrough keeps attributes. `onclick`, `onerror` and `javascript:` URLs all survive conversion and always did:

```csharp
HtmlToMarkdown.Convert("<svg onload=\"alert(1)\"></svg>");
// <svg onload="alert(1)"></svg>
```

That is defensible behaviour for a converter, but a reader who saw "script, style, and noscript elements are stripped" could reasonably infer the output is safe to render. The readme now says plainly that this is a converter and not a sanitizer, and points at `Strip`/`StripKeepContent` or an external sanitizer for untrusted input.

I did not change the default or start filtering attributes. Both would be behaviour breaks for a 2.x package and are a policy call rather than a defect — happy to do either if you would prefer.

## Verification

- Full suite green on net10.0 and net11.0: **1706 passed, 0 failed** (1694 pre-existing, unchanged, plus 12 new).
- New tests cover a directly nested `<script>`, one nested several levels down inside a `<div>`, `<style>` and `<noscript>`, content surrounding the stripped element, and an unknown element with no stripped content confirming markup and attributes still pass through byte-for-byte.
- `dotnet run ./eng/update-all.cs` run; no generated files changed.
