### PR TITLE
Document that RelativeDate equality covers the instant only

### DIFF
--- a/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
@@ -27,6 +27,9 @@ namespace Meziantou.Framework;
 /// <remarks>
 /// This type provides localized relative date/time strings for multiple languages: Dutch, English, French, German, Italian, Japanese, Korean, Portuguese, Simplified Chinese, Spanish and Turkish.
 /// The default localization can be customized by setting <see cref="LocalizationProvider.Current"/>.
+/// <para>
+/// Equality and ordering are defined over the instant alone. The time provider is display state: two instances that compare equal, and hash the same, can still render differently.
+/// </para>
 /// </remarks>
 [StructLayout(LayoutKind.Auto)]
 public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IEquatable<RelativeDate>, IFormattable
@@ -219,13 +222,18 @@ public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IE
     /// zero if they represent the same date and time;
     /// greater than zero if this instance is later than <paramref name="other"/>.
     /// </returns>
+    /// <remarks>Only the instant is compared. The time provider is display state and takes no part in the ordering.</remarks>
     public int CompareTo(RelativeDate other) => DateTime.CompareTo(other.DateTime);
 
+    /// <summary>Determines whether the specified object is a <see cref="RelativeDate"/> equal to the current instance.</summary>
+    /// <remarks>Only the instant is compared, so two equal instances built with different time providers can still produce different strings from <see cref="ToString()"/>.</remarks>
     public override bool Equals([NotNullWhen(true)] object? obj) => obj is RelativeDate date && Equals(date);
 
     /// <summary>Determines whether the specified <see cref="RelativeDate"/> is equal to the current instance.</summary>
+    /// <remarks>Only the instant is compared, so two equal instances built with different time providers can still produce different strings from <see cref="ToString()"/>.</remarks>
     public bool Equals(RelativeDate other) => DateTime == other.DateTime;
 
+    /// <summary>Returns a hash code derived from the instant, consistent with <see cref="Equals(RelativeDate)"/>.</summary>
     public override int GetHashCode() => HashCode.Combine(DateTime);
 
     /// <summary>Determines whether two <see cref="RelativeDate"/> instances are equal.</summary>

--- a/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
+++ b/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
@@ -73,6 +73,28 @@ public class RelativeDateTests
         }
     }
 
+    [Fact]
+    public void Equality_IsDefinedOverTheInstantOnly()
+    {
+        var dateTime = new DateTime(2018, 6, 15, 10, 0, 0, DateTimeKind.Utc);
+
+        var twoHoursLater = new FakeTimeProvider();
+        twoHoursLater.SetUtcNow(new DateTimeOffset(2018, 6, 15, 12, 0, 0, TimeSpan.Zero));
+        var twoYearsLater = new FakeTimeProvider();
+        twoYearsLater.SetUtcNow(new DateTimeOffset(2020, 6, 15, 12, 0, 0, TimeSpan.Zero));
+
+        var a = RelativeDate.Get(dateTime, twoHoursLater);
+        var b = RelativeDate.Get(dateTime, twoYearsLater);
+
+        Assert.Equal(a, b);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        Assert.Equal(0, a.CompareTo(b));
+
+        // The time provider is display state: it decides what an instance renders as, but takes no part in equality
+        Assert.Equal("2 hours ago", a.ToString(format: null, CultureInfo.InvariantCulture));
+        Assert.Equal("2 years ago", b.ToString(format: null, CultureInfo.InvariantCulture));
+    }
+
 #if !INVARIANT_GLOBALIZATION_MODE_ENABLED
     private static readonly string[] LocalizedCultures = ["de", "es", "fr", "it", "ja", "ko", "nl", "pt", "tr", "zh-Hans"];
 


### PR DESCRIPTION
`Equals`, `GetHashCode` and `CompareTo` use only `DateTime` (`src/Meziantou.Framework.RelativeDate/RelativeDate.cs:222-232`), while `ToString` reads the stored `TimeProvider`. Nothing says so.

Measured on `main` with two instances over the same instant, providers set to 2018 and 2020:

```
a.Equals(b)                        => True
a.GetHashCode() == b.GetHashCode() => True
a.ToString()                       => 2 hours ago
b.ToString()                       => 2 years ago
```

Two values that are equal by every comparison the type offers, and interchangeable as dictionary keys, render differently. Deduplicating a collection of `RelativeDate` therefore picks a display string arbitrarily, depending on which duplicate the container happened to keep.

## What changed

Documentation and a test — **no behavior change**.

The current semantics are defensible: the instant is the value, the provider is display state. What was missing is that this is written down anywhere. `Equals(object)` and `GetHashCode` had no doc comment at all; `CompareTo` and `Equals(RelativeDate)` had one that didn't mention the provider. The type-level `<remarks>` now states the rule once.

The cleaner design would be to not store the provider on the value at all and take it at format time instead, which would remove the discrepancy rather than document it — but that is a breaking API change, so it is not attempted here. Happy to open that separately if you'd prefer it over documenting the current behavior.

## Verification

One characterization test pinning the full set: equal, same hash code, `CompareTo` of 0, and the two different rendered strings. It passes on `main` too — that is the point, it locks in semantics that were previously implicit.

This is also part of closing a coverage gap: before this and the `IComparable` PR, every test in the project exercised `ToString` or the resource files, and the equality surface had none.

Full project suite: 94/94 across net10.0 and net11.0.
