### PR TITLE
Compute contiguous block sizes in long so they cannot overflow to a bogus length

### DIFF
--- a/src/Meziantou.Framework.PooledMemoryStream/Meziantou.Framework.PooledMemoryStream.csproj
+++ b/src/Meziantou.Framework.PooledMemoryStream/Meziantou.Framework.PooledMemoryStream.csproj
@@ -7,4 +7,8 @@
     <Description>A pooled, recyclable MemoryStream backed by a shared pool of fixed-size byte arrays, implementing IBufferWriter&lt;byte&gt;.</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Meziantou.Framework.PooledMemoryStream.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
+++ b/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
@@ -111,7 +111,10 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
         get
         {
             EnsureOpen();
-            return (int)_capacity;
+
+            // _capacity is a long and can exceed int.MaxValue by up to one block on a stream near Array.MaxLength.
+            // Clamp rather than wrap to a negative value; a getter that throws would be worse.
+            return _capacity > int.MaxValue ? int.MaxValue : (int)_capacity;
         }
         set
         {

--- a/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStreamOptions.cs
+++ b/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStreamOptions.cs
@@ -116,9 +116,18 @@ public sealed class PooledMemoryStreamOptions
         }
 
         // Larger than the largest tier: round up to a multiple of it so the size stays discrete and poolable.
+        // Computed in long: "minimumSize + largest - 1" overflows int once minimumSize approaches Array.MaxLength,
+        // which made 'multiples' negative or zero and handed a bogus length to Rent. The 'checked' on the multiply
+        // never caught it, because the addition had already wrapped.
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(minimumSize, Array.MaxLength);
+
         var largest = sizes[^1];
-        var multiples = (minimumSize + largest - 1) / largest;
-        return checked(multiples * largest);
+        var multiples = ((long)minimumSize + largest - 1) / largest;
+        var size = multiples * largest;
+
+        // A rounded-up size can pass Array.MaxLength even when minimumSize itself fits. Clamp instead of failing:
+        // an Array.MaxLength array still satisfies the request.
+        return size > Array.MaxLength ? Array.MaxLength : (int)size;
     }
 
     private void ThrowIfFrozen()

--- a/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
+++ b/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
@@ -413,6 +413,44 @@ public sealed class PooledMemoryStreamTests
         Assert.Throws<ArgumentOutOfRangeException>(() => options.BufferSizes = [.. sizes]);
     }
 
+    [Theory]
+    // Just past the point where "minimumSize + largest - 1" wraps int: used to return int.MinValue.
+    [InlineData(2_146_435_073)]
+    // Array.MaxLength itself: used to return -2146435072.
+    [InlineData(2_147_483_591)]
+    public void GetContiguousBlockSize_NearArrayMaxLength_StaysPositiveAndAtLeastTheRequest(int minimumSize)
+    {
+        var options = new PooledMemoryStreamOptions { BufferSizes = [4096, 65536, 1024 * 1024] };
+
+        var size = options.GetContiguousBlockSize(minimumSize);
+
+        Assert.True(size >= minimumSize);
+        Assert.True(size <= Array.MaxLength);
+    }
+
+    [Fact]
+    public void GetContiguousBlockSize_AboveArrayMaxLength_Throws()
+    {
+        var options = new PooledMemoryStreamOptions { BufferSizes = [4096, 65536, 1024 * 1024] };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.GetContiguousBlockSize(int.MaxValue));
+    }
+
+    [Theory]
+    [InlineData(1_000_000_000)]
+    [InlineData(2_000_000_000)]
+    public void GetContiguousBlockSize_WithAHugeSingleTier_DoesNotReturnZero(int tier)
+    {
+        // The overflow path only runs when minimumSize exceeds the largest tier, so reaching it needs a tier above
+        // ~1 GiB. Exercised through the options object so the test costs no allocation.
+        var options = new PooledMemoryStreamOptions { BufferSizes = [tier] };
+
+        var size = options.GetContiguousBlockSize(tier + 1);
+
+        Assert.True(size >= tier + 1);
+        Assert.True(size <= Array.MaxLength);
+    }
+
     [Fact]
     public void Options_Default_IsFrozen()
     {


### PR DESCRIPTION
## The problem

`GetContiguousBlockSize` rounds a request above the largest tier up to a multiple of that tier:

```csharp
var multiples = (minimumSize + largest - 1) / largest;
return checked(multiples * largest);
```

`minimumSize + largest - 1` is `int` arithmetic and wraps before the `checked` multiply ever runs, so the `checked`
keyword catches nothing — the addition has already overflowed. With the default 4 KiB / 64 KiB / 1 MiB tiers:

| `GetContiguousBlockSize(n)` | returned |
|---|---|
| `2_146_435_073` | `-2147483648` |
| `2_147_483_591` (`Array.MaxLength`) | `-2146435072` |

The negative flows into `PooledBufferPool.Rent` as `new byte[negative]`, surfacing as `OverflowException` from
`new PooledMemoryStream(initialCapacity: 2_146_435_073)` or `((IBufferWriter<byte>)stream).GetSpan(2_146_435_073)`.

With a large configured tier the wrap lands on **zero** rather than a negative, which is worse: `AddSegment(0)` rents
a zero-length array and `GetSpan` silently returns an *empty* span for a multi-gigabyte request, violating the
`IBufferWriter<byte>` contract instead of throwing.

Separately, `Capacity`'s getter did an unchecked `(int)_capacity`. Capacity is a `long` and is rounded up past
`Length`, so a stream near `Array.MaxLength` could report a negative capacity.

## What changed

- `GetContiguousBlockSize` computes the rounding in `long`, rejects `minimumSize` above `Array.MaxLength` with
  `ArgumentOutOfRangeException`, and clamps a rounded-up result to `Array.MaxLength` rather than failing — an
  `Array.MaxLength` array still satisfies the request.
- `Capacity`'s getter clamps to `int.MaxValue` instead of wrapping negative. Clamping loses at most one block's worth
  of accuracy on a stream that is already at the 2 GiB limit; a property getter that throws would be worse.

## Note on the test setup

This PR adds `<InternalsVisibleTo Include="Meziantou.Framework.PooledMemoryStream.Tests" />` (the pattern ~49 other
projects in this repo already use) so the arithmetic can be tested directly.

That isn't gold-plating: the overflow path only runs when `minimumSize` exceeds the largest tier, which — as the
arithmetic works out — requires a tier above ~1 GiB. **Every end-to-end repro therefore costs a >1 GB allocation**,
which doesn't belong in CI. Testing `GetContiguousBlockSize` directly covers the defect for free. Happy to drop the
`InternalsVisibleTo` and the tests with it if you'd rather not widen the seam for a Low-severity fix.

## Verification

Five test cases added next to the other options tests. Four fail on `main` (8 failures across the two TFMs) and pass
here; the `1_000_000_000` tier case is a control that doesn't overflow either way.

Full suite: **94/94** (47 × net10.0/net11.0, up from 84) with `/p:TreatsWarningsAsErrors=true`.
`dotnet run ./eng/update-all.cs` produces no changes — `ref/` is unaffected, since `InternalsVisibleTo` doesn't alter
the public API surface.

Found by a review of `Meziantou.Framework.PooledMemoryStream` (finding F9, Low).
