### PR TITLE
Cover the log level properties, Find, Contains and exception capture with tests

### DIFF
--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
@@ -226,6 +226,104 @@ public sealed partial class InMemoryLoggerTests
         Assert.Equal(new(2000, 1, 1, 0, 0, 0, TimeSpan.Zero), log.CreatedAt);
     }
 
+    [Fact]
+    public void LogLevelProperties_ReturnOnlyTheMatchingEntries()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+
+        logger.LogTrace("trace");
+        logger.LogDebug("debug");
+        logger.LogInformation("information");
+        logger.LogWarning("warning");
+        logger.LogError("error");
+        logger.LogCritical("critical");
+
+        Assert.Equal("trace", Assert.Single(logger.Logs.Traces).Message);
+        Assert.Equal("debug", Assert.Single(logger.Logs.Debugs).Message);
+        Assert.Equal("information", Assert.Single(logger.Logs.Informations).Message);
+        Assert.Equal("warning", Assert.Single(logger.Logs.Warnings).Message);
+        Assert.Equal("error", Assert.Single(logger.Logs.Errors).Message);
+        Assert.Equal("critical", Assert.Single(logger.Logs.Criticals).Message);
+    }
+
+    [Fact]
+    public void LogLevelProperties_AreEmptyWhenNothingMatches()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+
+        logger.LogInformation("information");
+
+        Assert.Empty(logger.Logs.Traces);
+        Assert.Empty(logger.Logs.Debugs);
+        Assert.Empty(logger.Logs.Warnings);
+        Assert.Empty(logger.Logs.Errors);
+        Assert.Empty(logger.Logs.Criticals);
+    }
+
+    [Fact]
+    public void Find_ReturnsTheFirstMatchingEntry()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+
+        logger.LogInformation("alpha");
+        logger.LogInformation("beta-match");
+        logger.LogInformation("gamma-match");
+
+        var found = logger.Logs.Find(log => log.Message.EndsWith("-match", StringComparison.Ordinal));
+        Assert.NotNull(found);
+        Assert.Equal("beta-match", found.Message);
+    }
+
+    [Fact]
+    public void Find_ReturnsNullWhenNothingMatches()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+
+        logger.LogInformation("first");
+
+        Assert.Null(logger.Logs.Find(log => log.Message is "missing"));
+    }
+
+    [Fact]
+    public void Contains_ReportsWhetherAnEntryMatches()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+
+        logger.LogInformation("first");
+
+        Assert.True(logger.Logs.Contains(log => log.Message is "first"));
+        Assert.False(logger.Logs.Contains(log => log.Message is "missing"));
+    }
+
+    [Fact]
+    public void Exception_IsCapturedAndRendered()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+        var exception = new InvalidOperationException("kaboom");
+
+        logger.LogError(exception, "boom");
+
+        var log = Assert.Single(logger.Logs.Errors);
+        Assert.Same(exception, log.Exception);
+        Assert.Equal("boom", log.Message);
+        Assert.Contains("kaboom", log.ToString());
+        Assert.Contains("kaboom", logger.Logs.ToString());
+    }
+
+    [Fact]
+    public void CollectionToString_RendersEveryEntryOnItsOwnLine()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+
+        logger.LogInformation("first");
+        logger.LogWarning("second");
+
+        var lines = logger.Logs.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.HasCount(4, lines);
+        Assert.StartsWith("[sample] Information: first", lines[0]);
+        Assert.StartsWith("[sample] Warning: second", lines[2]);
+    }
+
     private sealed class CustomTimeProvider : TimeProvider
     {
         public override DateTimeOffset GetUtcNow() => new(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);


### PR DESCRIPTION
Tests only — no production code changes.

A project review of this library turned up several public members with no test at all. The suite is good on what it does cover (`TimeProvider`, the deep-scope buffer policy, DI wiring, source-generated `LoggerMessage`), but these were untested:

| Member | Status before |
|---|---|
| `Traces`, `Debugs`, `Warnings`, `Errors`, `Criticals` | never called — only `Informations` was exercised |
| `InMemoryLogCollection.Find` | never called |
| `InMemoryLogCollection.Contains` | never called |
| `InMemoryLogCollection.ToString()` | never called |
| `InMemoryLogEntry.Exception` and the exception branch of `ToString()` | no test logged an exception |

`Errors` is arguably the most-used member of the package — `Assert.Empty(loggerProvider.Logs.Errors)` is the first line of the README's example — and a copy-paste error in any of the five level properties would have shipped unnoticed. For a library whose job is to make other people's tests trustworthy, that gap matters more than it would elsewhere.

### What this adds

Seven tests: one asserting each level property returns exactly its own entry, one asserting the others stay empty, `Find` returning the **first** of several matches and `null` on no match, `Contains` in both directions, an exception round-trip through `Exception`/`ToString()`, and `InMemoryLogCollection.ToString()` rendering one entry per line.

These tests all pass on `main` — they pin down existing correct behaviour rather than fixing anything, so there is no before/after to show.

### Verification

38/38 (19 tests × net10.0/net11.0) with `/p:TreatsWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` produced no further changes.

### Not included

Two coverage gaps from the same review are deliberately left out, because they belong with the fixes they guard rather than in a general coverage PR:

- reading `Logs` concurrently with writers → goes with the `InMemoryLogCollection` concurrency fix
- entry ordering across a chunk boundary → same

Found during a project review of `Meziantou.Extensions.Logging.InMemory`.
