### PR TITLE
Resolve the culture once for resources and counts

### DIFF
--- a/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
@@ -85,7 +85,7 @@ public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IE
 
     /// <summary>Formats the relative date using the specified format and culture.</summary>
     /// <param name="format">The format string (currently not used).</param>
-    /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting information, typically a <see cref="CultureInfo"/>.</param>
+    /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting information, typically a <see cref="CultureInfo"/>. A provider that returns a <see cref="CultureInfo"/> from <see cref="IFormatProvider.GetFormat(Type)"/> is also honored. When <see langword="null"/>, <see cref="CultureInfo.CurrentUICulture"/> is used.</param>
     /// <returns>A localized relative date string.</returns>
     /// <remarks>
     /// The method returns strings like:
@@ -110,7 +110,7 @@ public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IE
         var now = TimeProvider.GetUtcNow().UtcDateTime;
 
         var delta = now - DateTime;
-        var culture = formatProvider as CultureInfo;
+        var culture = GetCulture(formatProvider);
 
         if (delta < TimeSpan.Zero)
         {
@@ -200,9 +200,22 @@ public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IE
         }
     }
 
-    private static string GetString(string name, CultureInfo? culture) => LocalizationProvider.Current.GetString(name, culture);
+    private static CultureInfo GetCulture(IFormatProvider? formatProvider)
+    {
+        if (formatProvider is CultureInfo culture)
+            return culture;
 
-    private static string GetString(string name, CultureInfo? culture, int value) => string.Format(culture, LocalizationProvider.Current.GetString(name, culture), value);
+        // A provider wrapping a culture can surrender it, which "as CultureInfo" alone would miss
+        if (formatProvider?.GetFormat(typeof(CultureInfo)) is CultureInfo providedCulture)
+            return providedCulture;
+
+        // Resources are looked up by UI culture, so the same culture must format the count
+        return CultureInfo.CurrentUICulture;
+    }
+
+    private static string GetString(string name, CultureInfo culture) => LocalizationProvider.Current.GetString(name, culture);
+
+    private static string GetString(string name, CultureInfo culture, int value) => string.Format(culture, LocalizationProvider.Current.GetString(name, culture), value);
 
     int IComparable.CompareTo(object? obj)
     {

--- a/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
+++ b/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
@@ -151,6 +151,74 @@ public class RelativeDateTests
         }
     }
 
+    [Fact]
+    public void FormatProvider_ExposingACultureFromGetFormat_IsHonored()
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(new DateTimeOffset(2018, 6, 15, 12, 0, 0, TimeSpan.Zero));
+        var date = RelativeDate.Get(new DateTime(2018, 6, 14, 6, 0, 0, DateTimeKind.Utc), timeProvider);
+
+        Assert.Equal("hier", date.ToString(format: null, new CultureFormatProvider(CultureInfo.GetCultureInfo("fr"))));
+    }
+
+    // Ambient culture is restored in a finally block, but a leak would be observed by anything running beside this test
+    [Fact(DisableParallelization = true)]
+    public void NoFormatProvider_UsesTheCurrentUICulture()
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(new DateTimeOffset(2018, 6, 15, 12, 0, 0, TimeSpan.Zero));
+        var date = RelativeDate.Get(new DateTime(2018, 6, 14, 6, 0, 0, DateTimeKind.Utc), timeProvider);
+
+        var previousCulture = CultureInfo.CurrentCulture;
+        var previousUICulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr");
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+            Assert.Equal("hier", date.ToString());
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+            CultureInfo.CurrentUICulture = previousUICulture;
+        }
+    }
+
+    // Swaps both LocalizationProvider.Current and the ambient culture, so it must not run beside any other test
+    [Fact(DisableParallelization = true)]
+    public void NoFormatProvider_PassesTheResolvedCultureToTheProvider()
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(new DateTimeOffset(2018, 6, 15, 12, 0, 0, TimeSpan.Zero));
+        var date = RelativeDate.Get(new DateTime(2018, 6, 14, 6, 0, 0, DateTimeKind.Utc), timeProvider);
+
+        var previousProvider = LocalizationProvider.Current;
+        var previousUICulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            LocalizationProvider.Current = new CultureEchoLocalizationProvider();
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr");
+
+            // Without resolution the provider receives null and has to guess the culture itself
+            Assert.Equal("fr", date.ToString());
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previousUICulture;
+            LocalizationProvider.Current = previousProvider;
+        }
+    }
+
+    private sealed class CultureFormatProvider(CultureInfo culture) : IFormatProvider
+    {
+        public object? GetFormat(Type? formatType) => formatType == typeof(CultureInfo) ? culture : null;
+    }
+
+    private sealed class CultureEchoLocalizationProvider : ILocalizationProvider
+    {
+        public string GetString(string name, CultureInfo? culture) => culture?.Name ?? "<null>";
+    }
+
     private static string GetDigits(string value) => string.Concat(value.Where(char.IsAsciiDigit));
 #endif
 }


### PR DESCRIPTION
Closes two related findings about how `ToString(string?, IFormatProvider?)` picks its culture at `src/Meziantou.Framework.RelativeDate/RelativeDate.cs:113`.

**A non-`CultureInfo` provider is silently discarded.** `formatProvider as CultureInfo` yields `null` for anything that is not literally a `CultureInfo`, and the caller gets the current culture with no indication the argument was ignored:

```
formatProvider = CultureInfo.GetCultureInfo("fr")  => il y a 2 heures
formatProvider = a custom IFormatProvider wrapping fr => 2 hours ago
```

**Resource lookup and number formatting disagree.** With no culture supplied, `ResourceManager.GetString(name, null)` resolves against `CurrentUICulture`, but the `null` culture then handed to `string.Format` makes it use `CurrentCulture`:

```
UICulture=fr, CurrentCulture=en-US => il y a 2 heures   (text follows UICulture)
```

## What changed

One resolution step, `GetCulture`, used for both the resource lookup and the count formatting: a `CultureInfo` directly, else a `CultureInfo` offered by the provider's `GetFormat(typeof(CultureInfo))`, else `CurrentUICulture`. The private `GetString` helpers now take a non-nullable `CultureInfo`, since after this the culture is always resolved.

### Scope, honestly

The `GetFormat` probe helps **custom** providers that choose to expose their culture. It does **not** rescue `CultureInfo.GetCultureInfo("fr").DateTimeFormat` — verified that `DateTimeFormatInfo.GetFormat(typeof(CultureInfo))` returns `null`, as does `CultureInfo.GetFormat(typeof(CultureInfo))`. There is no supported way to recover a `CultureInfo` from a `DateTimeFormatInfo`, so passing one still falls back to the current culture. That case is now documented on the parameter rather than fixed.

The `CurrentUICulture`/`CurrentCulture` unification is a consistency fix, not an observable one today: the only formatted argument is a plain `int`, which renders identically in essentially every culture. It matters the moment a resource gains a group separator or a decimal. Flagging that so the change is not mistaken for a visible bug fix.

## Verification

Three tests added:

- a custom `IFormatProvider` exposing `fr` via `GetFormat` now yields "hier" — **fails on `main`**
- a stub `ILocalizationProvider` that echoes the culture it was handed now receives `fr` instead of `null` — **fails on `main`**, and is the direct evidence that resolution happens before the lookup
- `CurrentUICulture=fr` with `CurrentCulture=en-US` and no provider yields "hier" — passes on `main` too, pinning behavior the readme already claims

The two tests that touch ambient culture or the process-wide `LocalizationProvider.Current` are marked `[Fact(DisableParallelization = true)]`; xunit v3 runs tests within a class in parallel, so without it a swap is observed by whatever runs beside them.

Full project suite: 98/98 across net10.0 and net11.0.
