### PR TITLE
Reject unsupported format strings in RelativeDate.ToString

### DIFF
--- a/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
+++ b/src/Meziantou.Framework.RelativeDate/RelativeDate.cs
@@ -84,9 +84,10 @@ public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IE
     public override string ToString() => ToString(format: null, formatProvider: null);
 
     /// <summary>Formats the relative date using the specified format and culture.</summary>
-    /// <param name="format">The format string (currently not used).</param>
+    /// <param name="format">The format string. Only <see langword="null"/>, an empty string and <c>"G"</c> are supported; the output does not vary between them.</param>
     /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting information, typically a <see cref="CultureInfo"/>.</param>
     /// <returns>A localized relative date string.</returns>
+    /// <exception cref="FormatException"><paramref name="format"/> is not <see langword="null"/>, empty or <c>"G"</c>.</exception>
     /// <remarks>
     /// The method returns strings like:
     /// <list type="bullet">
@@ -107,6 +108,9 @@ public readonly struct RelativeDate : IComparable, IComparable<RelativeDate>, IE
     /// </remarks>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
+        if (!string.IsNullOrEmpty(format) && !string.Equals(format, "G", StringComparison.Ordinal))
+            throw new FormatException($"The '{format}' format string is not supported");
+
         var now = TimeProvider.GetUtcNow().UtcDateTime;
 
         var delta = now - DateTime;

--- a/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
+++ b/tests/Meziantou.Framework.RelativeDate.Tests/RelativeDateTests.cs
@@ -73,6 +73,38 @@ public class RelativeDateTests
         }
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("G")]
+    public void ToString_AcceptsTheSupportedFormats(string? format)
+    {
+        Assert.Equal("2 hours ago", CreateTwoHoursAgo().ToString(format, CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [InlineData("g")]
+    [InlineData("garbage")]
+    [InlineData("R")]
+    public void ToString_Throws_ForAnUnsupportedFormat(string format)
+    {
+        Assert.Throws<FormatException>(() => CreateTwoHoursAgo().ToString(format, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void CompositeFormatting_Throws_ForAnUnsupportedFormat()
+    {
+        var date = CreateTwoHoursAgo();
+        Assert.Throws<FormatException>(() => string.Format(CultureInfo.InvariantCulture, "{0:garbage}", date));
+    }
+
+    private static RelativeDate CreateTwoHoursAgo()
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.SetUtcNow(new DateTimeOffset(2018, 6, 15, 12, 0, 0, TimeSpan.Zero));
+        return RelativeDate.Get(new DateTime(2018, 6, 15, 10, 0, 0, DateTimeKind.Utc), timeProvider);
+    }
+
 #if !INVARIANT_GLOBALIZATION_MODE_ENABLED
     private static readonly string[] LocalizedCultures = ["de", "es", "fr", "it", "ja", "ko", "nl", "pt", "tr", "zh-Hans"];
 


### PR DESCRIPTION
`RelativeDate` implements `IFormattable`, but the `format` argument is never read (`src/Meziantou.Framework.RelativeDate/RelativeDate.cs:108`).

Measured on `main`:

```
ToString("garbage", CultureInfo.InvariantCulture)      => 2 hours ago
string.Format("{0:garbage}", relativeDate)             => 2 hours ago
```

The `IFormattable` convention is to throw `FormatException` for an unrecognized format specifier. Silently ignoring it means a typo in an interpolated string produces output that looks right, so the mistake survives to production. It also forecloses adding real format specifiers later: there would be no way to tell an intentional new specifier from one that callers have been passing, and quietly having ignored, all along.

## What changed

`null`, `""` and `"G"` are accepted — none of them change the output — and anything else throws `FormatException`. The `<param>` doc, which said "currently not used", now states what is supported, and an `<exception>` tag is added.

## Behavior change

Callers currently passing an unrecognized format string get an exception instead of a value. That is the point of the change, but it is a break, so: the doc comment has always said the argument is unused, so nothing can have depended on a *specific* junk format meaning anything. Low severity finding — reasonable to defer if you would rather not break it in a patch release.

## Verification

Seven test cases added: `null` / `""` / `"G"` all still render "2 hours ago"; `"g"` / `"garbage"` / `"R"` throw; and composite formatting via `string.Format("{0:garbage}", …)` throws, which is the path a typo in an interpolated string actually takes. Four fail on `main` (the three throwing cases plus the composite one).

Note `"g"` is rejected while `"G"` is accepted — the comparison is ordinal, matching how the BCL treats format specifiers as case-sensitive for types with distinct `g`/`G` meanings. Easy to relax if you'd prefer case-insensitive.

Full project suite: 106/106 across net10.0 and net11.0.
