### PR TITLE
Stop swallowing the empty line between two LF line breaks

### DIFF
--- a/src/Meziantou.Framework.RobotsTxt/RobotsFile.cs
+++ b/src/Meziantou.Framework.RobotsTxt/RobotsFile.cs
@@ -213,9 +213,12 @@ public sealed class RobotsFile
                 else
                 {
                     line = content[..nl];
+                    var isCarriageReturn = content[nl] == '\r';
                     content = content[(nl + 1)..];
-                    // Skip the '\n' after '\r'.
-                    if (!content.IsEmpty && content[0] == '\n')
+                    // Skip the '\n' of a "\r\n" pair. Only a '\r' can be followed by a '\n'
+                    // belonging to the same line break; consuming it unconditionally would
+                    // swallow the empty line in "\n\n".
+                    if (isCarriageReturn && !content.IsEmpty && content[0] == '\n')
                         content = content[1..];
                 }
 

--- a/tests/Meziantou.Framework.RobotsTxt.Tests/RobotsFileTests.cs
+++ b/tests/Meziantou.Framework.RobotsTxt.Tests/RobotsFileTests.cs
@@ -176,6 +176,77 @@ public sealed class RobotsFileTests
         Assert.Single(robots.Groups);
     }
 
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    [InlineData("\r")]
+    public void Parse_BlankLineSeparatesGroups_ForEveryLineEnding(string newLine)
+    {
+        var content = string.Join(newLine, "User-agent: A", "Crawl-delay: 5", "", "User-agent: B", "Disallow: /");
+
+        var robots = RobotsFile.Parse(content);
+
+        Assert.Equal(2, robots.Groups.Count);
+        Assert.Equal(["A"], robots.Groups[0].UserAgents);
+        Assert.Equal(["B"], robots.Groups[1].UserAgents);
+        Assert.True(robots.IsAllowed("A", "/x"));
+        Assert.False(robots.IsAllowed("B", "/x"));
+        Assert.Null(robots.GetCrawlDelay("B"));
+    }
+
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    [InlineData("\r")]
+    public void Parse_GroupWithoutRules_IsNotMergedIntoTheNextGroup(string newLine)
+    {
+        var content = string.Join(newLine, "User-agent: A", "", "User-agent: B", "Disallow: /");
+
+        var robots = RobotsFile.Parse(content);
+
+        Assert.Equal(2, robots.Groups.Count);
+        Assert.True(robots.IsAllowed("A", "/x"));
+        Assert.False(robots.IsAllowed("B", "/x"));
+    }
+
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    [InlineData("\r")]
+    public void Parse_ConsecutiveBlankLines_DoNotShiftLineNumbers(string newLine)
+    {
+        var content = string.Join(newLine, "User-agent: *", "", "", "", "Host: example.com");
+
+        var error = Assert.Single(RobotsFile.Parse(content).ParseErrors);
+
+        Assert.Equal(5, error.LineNumber);
+    }
+
+    [Fact]
+    public async Task Parse_AgreesWithParseAsync_OnIdenticalContent()
+    {
+        const string Content = "User-agent: A\nCrawl-delay: 5\n\nUser-agent: B\nDisallow: /\n";
+        using var reader = new StringReader(Content);
+
+        var synchronous = RobotsFile.Parse(Content);
+        var asynchronous = await RobotsFile.ParseAsync(reader, XunitCancellationToken);
+
+        Assert.Equal(synchronous.Groups.Count, asynchronous.Groups.Count);
+        Assert.Equal(synchronous.IsAllowed("A", "/x"), asynchronous.IsAllowed("A", "/x"));
+        Assert.Equal(synchronous.IsAllowed("B", "/x"), asynchronous.IsAllowed("B", "/x"));
+        Assert.Equal(synchronous.GetCrawlDelay("B"), asynchronous.GetCrawlDelay("B"));
+    }
+
+    [Fact]
+    public void Parse_MixedLineEndings_ProduceTheSameGroups()
+    {
+        var robots = RobotsFile.Parse("User-agent: A\r\nDisallow: /a\n\rUser-agent: B\rDisallow: /b\r\n");
+
+        Assert.Equal(2, robots.Groups.Count);
+        Assert.Equal(["A"], robots.Groups[0].UserAgents);
+        Assert.Equal(["B"], robots.Groups[1].UserAgents);
+    }
+
     // -------------------------------------------------------------------------
     // GetGroup
     // -------------------------------------------------------------------------


### PR DESCRIPTION
`Parser.Feed` consumed a `'\n'` after any line separator, not just after a `'\r'`, so the empty line in `"A\n\nB"` was never delivered to `FeedLine`. Since a blank line terminates a group, LF-terminated `robots.txt` — the dominant format on the web — parsed into the wrong groups, silently.

### Failure

`src/Meziantou.Framework.RobotsTxt/RobotsFile.cs:213-220`. Same text, different line endings:

| Input | `Groups.Count` | `IsAllowed("A", "/x")` | `GetCrawlDelay("B")` |
|---|---|---|---|
| `User-agent: A\nCrawl-delay: 5\n\nUser-agent: B\nDisallow: /` | **1** | **false** | **00:00:05** |
| the same with `\r\n` | 2 | true | null |

A realistic file shows the impact:

```
User-agent: AhrefsBot
Disallow: /

User-agent: *
Crawl-delay: 10

User-agent: SemrushBot
Disallow: /
```

The `*` group absorbed `SemrushBot`'s `Disallow: /` and every crawler was blocked from the whole site. Rearranged, the same defect fails the other way and lets a crawler into a disallowed area. Nothing was reported in `ParseErrors` either way.

Two further consequences of the same line:

- **`Parse` and `ParseAsync` disagreed on identical content.** `ParseAsync` splits lines with `TextReader.ReadLineAsync` and was never affected, so the two entry points returned different group counts and different `IsAllowed` answers for the same string.
- **`RobotsParseError.LineNumber` drifted.** `Parse("User-agent: *\n\n\n\n\n\nHost: x")` reported line 4 for an error on line 7 — every run of consecutive LF blank lines shifted the count.

### Change

Capture whether the consumed separator was `'\r'` *before* reslicing, and only then skip a following `'\n'`. Two-character `"\r\n"` breaks still count as one; `"\n\n"` now yields the empty line between them.

This is the minimal fix: it restores consistency between LF, CRLF, CR and `ParseAsync` without changing what a blank line *means*. Whether a blank line should terminate a group at all is a separate question — RFC 9309 §2.2 permits empty lines inside a group (`group = startgroupline *(startgroupline / emptyline) *(rule / emptyline)`), which would argue for dropping the blank-line flush entirely and relying only on the "User-agent after a rule" rule. That is a deliberate behaviour change and is left out of this PR.

### Verification

11 new test cases in `RobotsFileTests.cs`, parameterized over `\n`, `\r\n` and `\r`: group separation, a group with no rules, line-number accuracy, `Parse`/`ParseAsync` equivalence, and mixed endings in one file. Reverting only the source change turns the four LF-variant cases red while the CR/CRLF variants stay green.

`dotnet test /p:TreatWarningsAsErrors=true` — 138 passed, 0 failed (69 × net10.0/net11.0). `dotnet run ./eng/update-all.cs` regenerated nothing.
