### PR TITLE
Ignore a UTF-8 BOM at the start of a robots.txt file

### DIFF
--- a/src/Meziantou.Framework.RobotsTxt/RobotsFile.cs
+++ b/src/Meziantou.Framework.RobotsTxt/RobotsFile.cs
@@ -227,8 +227,18 @@ public sealed class RobotsFile
         {
             _lineNumber++;
 
+            var line = rawLine.AsSpan();
+
+            // A UTF-8 BOM that was decoded rather than consumed shows up as U+FEFF at the very
+            // start of the file. It is a format character, not whitespace, so Trim() leaves it
+            // glued to the first directive and the whole file parses as unknown directives.
+            // Only the first character of the first line can be a BOM; U+FEFF anywhere else is
+            // a zero-width no-break space and is left alone.
+            if (_lineNumber == 1 && !line.IsEmpty && line[0] == '\uFEFF')
+                line = line[1..];
+
             // Strip inline comments and trim whitespace.
-            var trimmed = StripComment(rawLine.AsSpan()).Trim();
+            var trimmed = StripComment(line).Trim();
 
             if (trimmed.IsEmpty)
             {

--- a/tests/Meziantou.Framework.RobotsTxt.Tests/RobotsFileTests.cs
+++ b/tests/Meziantou.Framework.RobotsTxt.Tests/RobotsFileTests.cs
@@ -176,6 +176,29 @@ public sealed class RobotsFileTests
         Assert.Single(robots.Groups);
     }
 
+    [Fact]
+    public void Parse_LeadingByteOrderMark_IsIgnored()
+    {
+        var robots = RobotsFile.Parse("\uFEFFUser-agent: *\nDisallow: /\n");
+
+        var group = Assert.Single(robots.Groups);
+        Assert.Equal(["*"], group.UserAgents);
+        Assert.Empty(robots.ParseErrors);
+        Assert.False(robots.IsAllowed("Bot", "/anything"));
+    }
+
+    [Fact]
+    public void Parse_ByteOrderMarkOnALaterLine_IsNotStripped()
+    {
+        // Only the very first character of the file can be a BOM. Elsewhere U+FEFF is a
+        // zero-width no-break space and must not be silently removed from a directive.
+        var robots = RobotsFile.Parse("User-agent: *\n\uFEFFDisallow: /\n");
+
+        var error = Assert.Single(robots.ParseErrors);
+        Assert.Equal(RobotsParseErrorKind.UnknownDirective, error.Kind);
+        Assert.Equal(2, error.LineNumber);
+    }
+
     // -------------------------------------------------------------------------
     // GetGroup
     // -------------------------------------------------------------------------
@@ -505,6 +528,33 @@ public sealed class RobotsFileTests
         var robots = await RobotsFile.ParseAsync(stream, cancellationToken: XunitCancellationToken);
 
         Assert.Single(robots.Groups);
+        Assert.False(robots.IsAllowed("Bot", "/anything"));
+    }
+
+    [Fact]
+    public async Task ParseAsync_Utf8StreamWithByteOrderMark_IsIgnored()
+    {
+        using var stream = new MemoryStream();
+        stream.Write(Encoding.UTF8.GetPreamble());
+        stream.Write(Encoding.UTF8.GetBytes("User-agent: *\nDisallow: /\n"));
+        stream.Position = 0;
+
+        var robots = await RobotsFile.ParseAsync(stream, cancellationToken: XunitCancellationToken);
+
+        Assert.Single(robots.Groups);
+        Assert.Empty(robots.ParseErrors);
+        Assert.False(robots.IsAllowed("Bot", "/anything"));
+    }
+
+    [Fact]
+    public async Task ParseAsync_TextReaderWithByteOrderMark_IsIgnored()
+    {
+        using var reader = new StringReader("\uFEFFUser-agent: *\nDisallow: /\n");
+
+        var robots = await RobotsFile.ParseAsync(reader, XunitCancellationToken);
+
+        Assert.Single(robots.Groups);
+        Assert.Empty(robots.ParseErrors);
         Assert.False(robots.IsAllowed("Bot", "/anything"));
     }
 


### PR DESCRIPTION
`U+FEFF` is a format character, not whitespace, so `Trim()` left a decoded UTF-8 BOM glued to the first directive. `"\uFEFFUser-agent"` matched nothing, no group was ever opened, and every subsequent `Allow`/`Disallow` was dropped.

### Failure

`src/Meziantou.Framework.RobotsTxt/RobotsFile.cs:231`. With `"\uFEFFUser-agent: *\nDisallow: /\n"`:

```
Groups.Count            == 0
IsAllowed("Bot", "/x")  == true      // the file said Disallow: /
```

It fails **open** and silently — a site that blocks all crawling gets crawled, and the only trace is a single `UnknownDirective` entry in `ParseErrors`. BOM-prefixed `robots.txt` is common enough that Google's parser strips it explicitly.

Only the `string` and `ReadOnlySpan<char>` entry points were affected: `ParseAsync(Stream)` passes `detectEncodingFromByteOrderMarks: true` and `StreamReader` already consumed the BOM. So a caller doing `Encoding.UTF8.GetString(bytes)` then `Parse(...)` hit this while a caller using the stream overload did not.

### Change

Strip a single leading `U+FEFF` in `Parser.FeedLine` when `_lineNumber == 1`. Putting it in the parser rather than in `Parse` covers every entry point uniformly, including `ParseAsync(TextReader)` over already-decoded text.

The strip is deliberately narrow: only the very first character of the file can be a BOM. Elsewhere `U+FEFF` is a zero-width no-break space and is left alone, so it still surfaces as a parse error rather than being silently removed from a directive.

### Verification

4 new test cases in `RobotsFileTests.cs`: BOM via `Parse`, via `ParseAsync(TextReader)`, via `ParseAsync(Stream)` with a real UTF-8 preamble, and a `U+FEFF` on line 2 asserting it is *not* stripped. Reverting the source change turns the first two red; the stream case passes either way (documenting that `StreamReader` already handled it) and the line-2 case pins the boundary.

`dotnet test /p:TreatWarningsAsErrors=true` — 124 passed, 0 failed (62 × net10.0/net11.0). `dotnet run ./eng/update-all.cs` regenerated nothing.
