### PR TITLE
Merge the rules of every group declaring the same user-agent token

### DIFF
--- a/src/Meziantou.Framework.RobotsTxt/RobotsFile.cs
+++ b/src/Meziantou.Framework.RobotsTxt/RobotsFile.cs
@@ -114,27 +114,99 @@ public sealed class RobotsFile
     /// Returns the <see cref="RobotsGroup"/> that best matches the given <paramref name="userAgent"/>.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// An exact (case-insensitive) match takes precedence over a catch-all (<c>*</c>) group.
     /// Returns <see langword="null"/> when no group matches.
+    /// </para>
+    /// <para>
+    /// When several groups declare the selected user-agent token, their rules are merged into a
+    /// single group, as required by RFC 9309 section 2.2.1. The merged group is not one of the
+    /// instances in <see cref="Groups"/>: it lists the union of the declared tokens, the rules of
+    /// every contributing group in file order, and the first <c>Crawl-delay</c> that was specified.
+    /// When exactly one group matches, that instance is returned as-is.
+    /// </para>
     /// </remarks>
     public RobotsGroup? GetGroup(string userAgent)
     {
         ArgumentNullException.ThrowIfNull(userAgent);
 
-        RobotsGroup? catchAll = null;
+        // An exact product token match wins over the catch-all, so look for one first and only
+        // fall back to '*' when no group names the agent.
+        return SelectGroup(userAgent, matchCatchAll: false) ?? SelectGroup(userAgent, matchCatchAll: true);
+    }
+
+    private RobotsGroup? SelectGroup(string userAgent, bool matchCatchAll)
+    {
+        RobotsGroup? first = null;
+        List<RobotsGroup>? matches = null;
+
         foreach (var group in Groups)
         {
-            foreach (var agent in group.UserAgents)
-            {
-                if (agent.Equals(userAgent, StringComparison.OrdinalIgnoreCase))
-                    return group;
+            if (!DeclaresToken(group, userAgent, matchCatchAll))
+                continue;
 
-                if (agent == "*")
-                    catchAll = group;
+            if (first is null)
+            {
+                first = group;
+            }
+            else
+            {
+                matches ??= [first];
+                matches.Add(group);
             }
         }
 
-        return catchAll;
+        // No duplicates: hand back the parsed instance without allocating anything.
+        if (matches is null)
+            return first;
+
+        var agents = new List<string>();
+        var rules = new List<RobotsRule>();
+        TimeSpan? crawlDelay = null;
+
+        foreach (var group in matches)
+        {
+            foreach (var agent in group.UserAgents)
+            {
+                if (!ContainsToken(agents, agent))
+                    agents.Add(agent);
+            }
+
+            foreach (var rule in group.Rules)
+            {
+                rules.Add(rule);
+            }
+
+            crawlDelay ??= group.CrawlDelay;
+        }
+
+        return new RobotsGroup(agents, rules, crawlDelay);
+    }
+
+    private static bool DeclaresToken(RobotsGroup group, string userAgent, bool matchCatchAll)
+    {
+        foreach (var agent in group.UserAgents)
+        {
+            var isMatch = matchCatchAll
+                ? agent == "*"
+                : agent.Equals(userAgent, StringComparison.OrdinalIgnoreCase);
+
+            if (isMatch)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool ContainsToken(List<string> agents, string agent)
+    {
+        foreach (var existing in agents)
+        {
+            if (existing.Equals(agent, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/Meziantou.Framework.RobotsTxt.Tests/RobotsFileTests.cs
+++ b/tests/Meziantou.Framework.RobotsTxt.Tests/RobotsFileTests.cs
@@ -232,6 +232,100 @@ public sealed class RobotsFileTests
         Assert.NotNull(robots.GetGroup("GOOGLEBOT"));
     }
 
+    [Fact]
+    public void GetGroup_WithoutDuplicates_ReturnsTheParsedGroupInstance()
+    {
+        var robots = RobotsFile.Parse("User-agent: *\nDisallow: /\n");
+
+        Assert.Same(robots.Groups[0], robots.GetGroup("Bot"));
+    }
+
+    [Fact]
+    public void GetGroup_DuplicateNamedGroups_AreMerged()
+    {
+        var robots = RobotsFile.Parse("""
+            User-agent: Googlebot
+            Disallow: /a
+
+            User-agent: Googlebot
+            Disallow: /b
+            """);
+
+        Assert.False(robots.IsAllowed("Googlebot", "/a"));
+        Assert.False(robots.IsAllowed("Googlebot", "/b"));
+    }
+
+    [Fact]
+    public void GetGroup_DuplicateCatchAllGroups_AreMerged()
+    {
+        var robots = RobotsFile.Parse("""
+            User-agent: *
+            Disallow: /x
+
+            User-agent: *
+            Disallow: /y
+            """);
+
+        Assert.False(robots.IsAllowed("Bot", "/x"));
+        Assert.False(robots.IsAllowed("Bot", "/y"));
+    }
+
+    [Fact]
+    public void GetGroup_DuplicateGroups_KeepTheFirstCrawlDelay()
+    {
+        var robots = RobotsFile.Parse("""
+            User-agent: Googlebot
+            Disallow: /a
+            Crawl-delay: 5
+
+            User-agent: Googlebot
+            Disallow: /b
+            Crawl-delay: 20
+            """);
+
+        Assert.Equal(TimeSpan.FromSeconds(5), robots.GetCrawlDelay("Googlebot"));
+    }
+
+    [Fact]
+    public void GetGroup_DuplicateGroups_UnionTheUserAgentTokens()
+    {
+        var robots = RobotsFile.Parse("""
+            User-agent: Googlebot
+            User-agent: Bingbot
+            Disallow: /a
+
+            User-agent: googlebot
+            Disallow: /b
+            """);
+
+        var group = robots.GetGroup("Googlebot");
+
+        Assert.NotNull(group);
+        Assert.Equal(["Googlebot", "Bingbot"], group.UserAgents);
+        Assert.Equal(2, group.Rules.Count);
+    }
+
+    [Fact]
+    public void GetGroup_ExactMatchWinsOverADuplicatedCatchAll()
+    {
+        var robots = RobotsFile.Parse("""
+            User-agent: *
+            Disallow: /all
+
+            User-agent: Googlebot
+            Disallow: /google
+
+            User-agent: *
+            Disallow: /everything
+            """);
+
+        Assert.True(robots.IsAllowed("Googlebot", "/all"));
+        Assert.True(robots.IsAllowed("Googlebot", "/everything"));
+        Assert.False(robots.IsAllowed("Googlebot", "/google"));
+        Assert.False(robots.IsAllowed("OtherBot", "/all"));
+        Assert.False(robots.IsAllowed("OtherBot", "/everything"));
+    }
+
     // -------------------------------------------------------------------------
     // IsAllowed
     // -------------------------------------------------------------------------


### PR DESCRIPTION
RFC 9309 §2.2.1 requires that when a group is duplicated, all of its rules are merged. `GetGroup` did neither consistently: it returned on the first exact match but *overwrote* `catchAll` on every `*` it saw, so named duplicates resolved to the first group and `*` duplicates resolved to the last. Either way, half the rules were discarded.

### Failure

`src/Meziantou.Framework.RobotsTxt/RobotsFile.cs:124-137`:

```
User-agent: Googlebot        User-agent: *
Disallow: /a                 Disallow: /x
                             
User-agent: Googlebot        User-agent: *
Disallow: /b                 Disallow: /y

/a blocked, /b NOT blocked   /x NOT blocked, /y blocked
      (first wins)                  (last wins)
```

The two cases discard opposite halves, so the behaviour is not predictable from one file to the next, and the `*` case fails **open**. Duplicated `*` blocks are common in hand-maintained and CMS-generated `robots.txt`.

### Change

`GetGroup` now selects in two passes — exact product token first, `*` only as a fallback — and merges every group that declares the selected token:

- rules of all contributing groups, in file order;
- the union of declared tokens, deduplicated case-insensitively;
- the first `Crawl-delay` specified (documented tie-break).

`Groups` keeps the raw parse result, so the merge is not observable there; the merged instance is synthesized on demand and the XML doc says so. When exactly one group matches — the overwhelmingly common case — the parsed instance is returned as-is and nothing is allocated, so `IsAllowed`'s hot path is unchanged.

No public signature changed, so `ref/` needed no regeneration.

### Verification

6 new test cases in `RobotsFileTests.cs`: duplicate named groups, duplicate catch-all groups, exact-match precedence over a duplicated catch-all, token union, the crawl-delay tie-break, and an `Assert.Same` pinning the zero-allocation single-match path. Reverting the source change turns 4 of the 6 red.

`dotnet test /p:TreatWarningsAsErrors=true` — 128 passed, 0 failed (64 × net10.0/net11.0). `dotnet run ./eng/update-all.cs` regenerated nothing.
