### PR TITLE
Reject a Crawl-delay that would overflow TimeSpan instead of throwing

### DIFF
--- a/src/Meziantou.Framework.RobotsTxt/RobotsFile.cs
+++ b/src/Meziantou.Framework.RobotsTxt/RobotsFile.cs
@@ -268,9 +268,9 @@ public sealed class RobotsFile
             }
             else if (directive.Equals("Crawl-delay", StringComparison.OrdinalIgnoreCase))
             {
-                if (double.TryParse(value, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var seconds) && seconds >= 0)
+                if (TryParseCrawlDelay(value, out var crawlDelay))
                 {
-                    _currentCrawlDelay = TimeSpan.FromSeconds(seconds);
+                    _currentCrawlDelay = crawlDelay;
                 }
                 else
                 {
@@ -337,6 +337,30 @@ public sealed class RobotsFile
         {
             var hash = line.IndexOf('#');
             return hash < 0 ? line : line[..hash];
+        }
+
+        // TimeSpan.MaxValue is a little over 922_337_203_685.47 seconds. Rounded down to a whole
+        // second it is still ~29_227 years, which is far beyond any meaningful crawl delay, and it
+        // keeps TimeSpan.FromSeconds safely inside Int64 ticks.
+        private const double MaxCrawlDelaySeconds = 922_337_203_685d;
+
+        private static bool TryParseCrawlDelay(ReadOnlySpan<char> value, out TimeSpan crawlDelay)
+        {
+            // NumberStyles.Float rather than NumberStyles.Any: a duration has no thousands
+            // separator, no currency symbol and no accounting parentheses, so "1,000" and "(5)"
+            // are malformed rather than 1000 seconds and -5 seconds.
+            // The upper bound also rejects NaN and infinity, which fail every comparison and would
+            // otherwise make TimeSpan.FromSeconds throw out of this deliberately lenient parser.
+            if (double.TryParse(value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var seconds)
+                && seconds >= 0
+                && seconds <= MaxCrawlDelaySeconds)
+            {
+                crawlDelay = TimeSpan.FromSeconds(seconds);
+                return true;
+            }
+
+            crawlDelay = default;
+            return false;
         }
     }
 }

--- a/tests/Meziantou.Framework.RobotsTxt.Tests/RobotsFileTests.cs
+++ b/tests/Meziantou.Framework.RobotsTxt.Tests/RobotsFileTests.cs
@@ -405,6 +405,54 @@ public sealed class RobotsFileTests
         Assert.Equal(RobotsParseErrorKind.InvalidCrawlDelay, error.Kind);
     }
 
+    [Theory]
+    [InlineData("1e300")]
+    [InlineData("1E20")]
+    [InlineData("Infinity")]
+    [InlineData("-Infinity")]
+    [InlineData("NaN")]
+    [InlineData("922337203686")]
+    public void ParseErrors_CrawlDelayOutOfRange_RecordsErrorInsteadOfThrowing(string value)
+    {
+        var robots = RobotsFile.Parse($"User-agent: *\nCrawl-delay: {value}\nDisallow: /");
+
+        var error = Assert.Single(robots.ParseErrors);
+        Assert.Equal(RobotsParseErrorKind.InvalidCrawlDelay, error.Kind);
+        Assert.Null(robots.GetCrawlDelay("Bot"));
+    }
+
+    [Fact]
+    public void Parse_CrawlDelayAtTheUpperBound_IsAccepted()
+    {
+        var robots = RobotsFile.Parse("User-agent: *\nCrawl-delay: 922337203685\nDisallow: /");
+
+        Assert.Empty(robots.ParseErrors);
+        Assert.Equal(TimeSpan.FromSeconds(922_337_203_685d), robots.GetCrawlDelay("Bot"));
+    }
+
+    [Theory]
+    [InlineData("1,000")]
+    [InlineData("(5)")]
+    [InlineData("$5")]
+    public void ParseErrors_CrawlDelayIsNotANumericLiteral_RecordsError(string value)
+    {
+        // NumberStyles.Any used to read these as durations: "1,000" became 1000 seconds.
+        var robots = RobotsFile.Parse($"User-agent: *\nCrawl-delay: {value}\nDisallow: /");
+
+        var error = Assert.Single(robots.ParseErrors);
+        Assert.Equal(RobotsParseErrorKind.InvalidCrawlDelay, error.Kind);
+    }
+
+    [Fact]
+    public async Task ParseAsync_CrawlDelayOutOfRange_DoesNotFaultTheTask()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("User-agent: *\nCrawl-delay: 1e300\nDisallow: /\n"));
+
+        var robots = await RobotsFile.ParseAsync(stream, cancellationToken: XunitCancellationToken);
+
+        Assert.Equal(RobotsParseErrorKind.InvalidCrawlDelay, Assert.Single(robots.ParseErrors).Kind);
+    }
+
     [Fact]
     public void ParseErrors_MultipleErrors_AllRecorded()
     {


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2621**

`double.TryParse` accepted values that `TimeSpan.FromSeconds` cannot represent, so a single line of a `robots.txt` fetched from an arbitrary host threw `OverflowException` out of a parser that is documented as never throwing.

### Failure

`src/Meziantou.Framework.RobotsTxt/RobotsFile.cs:269-278`:

```
Crawl-delay: 1e300     => OverflowException: TimeSpan overflowed because the duration is too long.
Crawl-delay: 1E20      => OverflowException
Crawl-delay: Infinity  => OverflowException
```

`ParseAsync(Stream)` surfaces the same thing as a faulted task. The class summary (`RobotsFile.cs:7-11`) and the readme both promise that malformed input lands in `ParseErrors` instead, so any caller written against that contract takes an unhandled exception. `1E20` is a plausible typo, not only an attack.

`NumberStyles.Any` was also too permissive for a duration: `Crawl-delay: 1,000` silently parsed as 16 minutes 40 seconds via the thousands separator, and the style allowed accounting parentheses and currency symbols too.

### Change

Extract `TryParseCrawlDelay` and:

- switch to `NumberStyles.Float`, so a thousands separator, currency symbol or accounting parentheses make the value malformed rather than a duration;
- bound the result at `922_337_203_685` seconds (`TimeSpan.MaxValue` rounded down to a whole second — still ~29,227 years) before converting. The bound also rejects `NaN` and infinity, which fail every comparison.

Out-of-range values now record `RobotsParseErrorKind.InvalidCrawlDelay` like any other bad value.

### Verification

11 new test cases in `RobotsFileTests.cs`: the overflowing and non-finite values, the non-numeric literals `NumberStyles.Any` used to accept, the exact upper bound asserted to still parse, and `ParseAsync(Stream)` asserted not to fault. Reverting the source change turns 6 of them red.

`dotnet test /p:TreatWarningsAsErrors=true` — 138 passed, 0 failed (69 × net10.0/net11.0). `dotnet run ./eng/update-all.cs` regenerated nothing.
