### PR TITLE
Start a new group when a User-agent line follows a Crawl-delay

### DIFF
--- a/src/Meziantou.Framework.RobotsTxt/RobotsFile.cs
+++ b/src/Meziantou.Framework.RobotsTxt/RobotsFile.cs
@@ -191,6 +191,11 @@ public sealed class RobotsFile
         private List<RobotsRule>? _currentRules;
         private TimeSpan? _currentCrawlDelay;
 
+        // Whether the current group has moved past its User-agent lines into its body. Crawl-delay
+        // is part of the body but is not stored in _currentRules, so the count of rules alone
+        // cannot tell a continued group from a new one.
+        private bool _currentGroupHasBody;
+
         // Completed data.
         private List<RobotsGroup>? _groups;
         private List<string>? _sitemaps;
@@ -249,8 +254,9 @@ public sealed class RobotsFile
 
             if (directive.Equals("User-agent", StringComparison.OrdinalIgnoreCase))
             {
-                // A User-agent line after rules have started means a new group.
-                if (_currentRules is { Count: > 0 })
+                // Consecutive User-agent lines share one group; a User-agent line that follows the
+                // group's body starts a new one.
+                if (_currentGroupHasBody)
                     FlushGroup();
 
                 _currentAgents ??= [];
@@ -258,16 +264,22 @@ public sealed class RobotsFile
             }
             else if (directive.Equals("Allow", StringComparison.OrdinalIgnoreCase))
             {
+                _currentGroupHasBody = true;
                 _currentRules ??= [];
                 _currentRules.Add(new RobotsRule(RobotsRuleKind.Allow, value.ToString()));
             }
             else if (directive.Equals("Disallow", StringComparison.OrdinalIgnoreCase))
             {
+                _currentGroupHasBody = true;
                 _currentRules ??= [];
                 _currentRules.Add(new RobotsRule(RobotsRuleKind.Disallow, value.ToString()));
             }
             else if (directive.Equals("Crawl-delay", StringComparison.OrdinalIgnoreCase))
             {
+                // The line belongs to the group body whether or not its value parses, so grouping
+                // does not depend on the validity of the delay.
+                _currentGroupHasBody = true;
+
                 if (TryParseCrawlDelay(value, out var crawlDelay))
                 {
                     _currentCrawlDelay = crawlDelay;
@@ -316,9 +328,7 @@ public sealed class RobotsFile
         {
             if (_currentAgents is null or { Count: 0 })
             {
-                _currentAgents = null;
-                _currentRules = null;
-                _currentCrawlDelay = null;
+                ResetGroup();
                 return;
             }
 
@@ -328,9 +338,15 @@ public sealed class RobotsFile
                 (IReadOnlyList<RobotsRule>?)_currentRules ?? [],
                 _currentCrawlDelay));
 
+            ResetGroup();
+        }
+
+        private void ResetGroup()
+        {
             _currentAgents = null;
             _currentRules = null;
             _currentCrawlDelay = null;
+            _currentGroupHasBody = false;
         }
 
         private static ReadOnlySpan<char> StripComment(ReadOnlySpan<char> line)

--- a/tests/Meziantou.Framework.RobotsTxt.Tests/RobotsFileTests.cs
+++ b/tests/Meziantou.Framework.RobotsTxt.Tests/RobotsFileTests.cs
@@ -176,6 +176,86 @@ public sealed class RobotsFileTests
         Assert.Single(robots.Groups);
     }
 
+    [Fact]
+    public void Parse_UserAgentAfterCrawlDelay_StartsANewGroup()
+    {
+        var robots = RobotsFile.Parse("""
+            User-agent: A
+            Crawl-delay: 5
+            User-agent: B
+            Disallow: /
+            """);
+
+        Assert.Equal(2, robots.Groups.Count);
+        Assert.Equal(["A"], robots.Groups[0].UserAgents);
+        Assert.Equal(["B"], robots.Groups[1].UserAgents);
+        Assert.Equal(TimeSpan.FromSeconds(5), robots.GetCrawlDelay("A"));
+        Assert.Null(robots.GetCrawlDelay("B"));
+        Assert.True(robots.IsAllowed("A", "/anything"));
+        Assert.False(robots.IsAllowed("B", "/anything"));
+    }
+
+    [Fact]
+    public void Parse_UserAgentAfterInvalidCrawlDelay_StartsANewGroup()
+    {
+        // Grouping is structural: it must not depend on whether the delay value parses.
+        var robots = RobotsFile.Parse("""
+            User-agent: A
+            Crawl-delay: notanumber
+            User-agent: B
+            Disallow: /
+            """);
+
+        Assert.Equal(2, robots.Groups.Count);
+        Assert.True(robots.IsAllowed("A", "/anything"));
+        Assert.False(robots.IsAllowed("B", "/anything"));
+    }
+
+    [Fact]
+    public void Parse_ConsecutiveUserAgents_StillShareOneGroup()
+    {
+        var robots = RobotsFile.Parse("""
+            User-agent: A
+            User-agent: B
+            Crawl-delay: 5
+            Disallow: /
+            """);
+
+        var group = Assert.Single(robots.Groups);
+        Assert.Equal(["A", "B"], group.UserAgents);
+        Assert.Equal(TimeSpan.FromSeconds(5), group.CrawlDelay);
+    }
+
+    [Fact]
+    public void Parse_SitemapInsideAGroup_DoesNotStartANewGroup()
+    {
+        // Sitemap is a file-level record, not part of a group body.
+        var robots = RobotsFile.Parse("""
+            User-agent: A
+            Sitemap: https://example.com/sitemap.xml
+            User-agent: B
+            Disallow: /
+            """);
+
+        var group = Assert.Single(robots.Groups);
+        Assert.Equal(["A", "B"], group.UserAgents);
+        Assert.Equal(["https://example.com/sitemap.xml"], robots.Sitemaps);
+    }
+
+    [Fact]
+    public void Parse_UnknownDirectiveBetweenUserAgents_DoesNotStartANewGroup()
+    {
+        var robots = RobotsFile.Parse("""
+            User-agent: A
+            Host: example.com
+            User-agent: B
+            Disallow: /
+            """);
+
+        var group = Assert.Single(robots.Groups);
+        Assert.Equal(["A", "B"], group.UserAgents);
+    }
+
     // -------------------------------------------------------------------------
     // GetGroup
     // -------------------------------------------------------------------------


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/robotstxt-crawl-delay-overflow` · merge #2620 first**

A `User-agent` line only started a new group when `_currentRules` was non-empty. `Crawl-delay` is stored in `_currentCrawlDelay`, not in `_currentRules`, so a group whose body was just a crawl delay never terminated and silently absorbed the next group.

### Failure

`src/Meziantou.Framework.RobotsTxt/RobotsFile.cs:250-258`. With no blank line:

```
User-agent: A
Crawl-delay: 5
User-agent: B
Disallow: /
```

parsed as **one** group containing both agents. Bot `A` inherited `Disallow: /` (fails closed — a bot that was allowed everywhere is blocked from the whole site) and bot `B` inherited a crawl delay that was never meant for it.

This is independent of the blank-line defect in #2617 and survives fixing it, because it needs no blank line to trigger.

### Change

Replace the `_currentRules.Count` test with an explicit `_currentGroupHasBody` flag, set by `Allow`, `Disallow` and `Crawl-delay`. Consecutive `User-agent` lines still share one group; a `User-agent` line after any body directive starts a new one.

Two deliberate choices, both covered by tests:

- The flag is set for a `Crawl-delay` line **whether or not its value parses**. Grouping is structural, so it should not depend on the validity of a delay.
- `Sitemap` does not set it. It is a file-level record, not part of a group body, so it must not split a group.

`FlushGroup`'s duplicated reset is extracted into `ResetGroup` so the new field cannot be forgotten on one of the two paths.

### Verification

5 new test cases in `RobotsFileTests.cs`: `User-agent` after a valid and after an invalid `Crawl-delay`, consecutive `User-agent` lines still sharing a group, and `Sitemap` / unknown directives asserted *not* to split one. With layer #2620 applied but this layer's source change reverted, 2 of them fail.

`dotnet test /p:TreatWarningsAsErrors=true` on this branch (layer #2620 applied) — 148 passed, 0 failed (74 × net10.0/net11.0). `dotnet run ./eng/update-all.cs` regenerated nothing.
