### PR TITLE
Apply OmitProtocolVersion to the request message instead of the response message

### DIFF
--- a/src/Meziantou.Framework.HumanReadableSerializer/Converters/HumanReadableHttpExtensions.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Converters/HumanReadableHttpExtensions.cs
@@ -54,7 +54,8 @@ public static class HumanReadableHttpExtensions
 
         if (requestOptions is not null && requestOptions.OmitProtocolVersion)
         {
-            options.AddAttribute(typeof(HttpResponseMessage), nameof(HttpResponseMessage.Version), new HumanReadableIgnoreAttribute { Condition = HumanReadableIgnoreCondition.Always });
+            options.AddAttribute(typeof(HttpRequestMessage), nameof(HttpRequestMessage.Version), new HumanReadableIgnoreAttribute { Condition = HumanReadableIgnoreCondition.WhenWritingDefault });
+            options.AddAttribute(typeof(HttpRequestMessage), nameof(HttpRequestMessage.VersionPolicy), new HumanReadableIgnoreAttribute { Condition = HumanReadableIgnoreCondition.WhenWritingDefault });
         }
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HttpOptionsTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HttpOptionsTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Meziantou.Framework.HumanReadable.Converters;
 
 namespace Meziantou.Framework.HumanReadable.Tests;
@@ -8,6 +9,13 @@ public sealed class HttpOptionsTests : SerializerTestsBase
     {
         var serializerOptions = new HumanReadableSerializerOptions()
             .AddHttpConverters(new HumanReadableHttpOptions { ResponseMessageOptions = options });
+
+        AssertSerialization(value, serializerOptions, expected);
+    }
+
+    private static void AssertSerialization(object value, HumanReadableHttpOptions options, string expected)
+    {
+        var serializerOptions = new HumanReadableSerializerOptions().AddHttpConverters(options);
 
         AssertSerialization(value, serializerOptions, expected);
     }
@@ -34,11 +42,101 @@ public sealed class HttpOptionsTests : SerializerTestsBase
             RequestMessage:
               Method: GET
               RequestUri: http://example.com/foo
+              Content: <null>
+            """);
+    }
+
+    [Fact]
+    public void RequestMessage_Full_KeepsNonDefaultProtocolVersion()
+    {
+        using var httpContent = new HttpResponseMessage()
+        {
+            Headers =
+            {
+                Date = DateTimeOffset.UtcNow,
+            },
+            Content = new StringContent("test"),
+            RequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.com/foo")
+            {
+                Version = HttpVersion.Version20,
+                VersionPolicy = HttpVersionPolicy.RequestVersionExact,
+            },
+        };
+
+        AssertSerialization(httpContent, new HumanReadableHttpResponseMessageOptions { RequestMessageFormat = HttpRequestMessageFormat.Full }, """
+            StatusCode: 200 (OK)
+            Content:
+              Headers:
+                Content-Type: text/plain; charset=utf-8
+              Value: test
+            RequestMessage:
+              Method: GET
+              RequestUri: http://example.com/foo
+              Version: 2.0
+              VersionPolicy: RequestVersionExact
+              Content: <null>
+            """);
+    }
+
+    [Fact]
+    public void RequestMessage_Full_ProtocolVersionIsKeptWhenNotOmitted()
+    {
+        using var httpContent = new HttpResponseMessage()
+        {
+            Headers =
+            {
+                Date = DateTimeOffset.UtcNow,
+            },
+            Content = new StringContent("test"),
+            RequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.com/foo"),
+        };
+
+        var options = new HumanReadableHttpOptions
+        {
+            RequestMessageOptions = new HumanReadableHttpRequestMessageOptions { OmitProtocolVersion = false },
+            ResponseMessageOptions = new HumanReadableHttpResponseMessageOptions { RequestMessageFormat = HttpRequestMessageFormat.Full },
+        };
+
+        AssertSerialization(httpContent, options, """
+            StatusCode: 200 (OK)
+            Content:
+              Headers:
+                Content-Type: text/plain; charset=utf-8
+              Value: test
+            RequestMessage:
+              Method: GET
+              RequestUri: http://example.com/foo
               Version: 1.1
               VersionPolicy: RequestVersionOrLower
               Content: <null>
             """);
     }
+
+    [Fact]
+    public void ResponseMessage_ProtocolVersionIsNotHiddenByTheRequestOptions()
+    {
+        using var httpContent = new HttpResponseMessage()
+        {
+            Version = HttpVersion.Version20,
+            Content = new StringContent("test"),
+        };
+
+        var options = new HumanReadableHttpOptions
+        {
+            RequestMessageOptions = new HumanReadableHttpRequestMessageOptions { OmitProtocolVersion = true },
+            ResponseMessageOptions = new HumanReadableHttpResponseMessageOptions { OmitProtocolVersion = false },
+        };
+
+        AssertSerialization(httpContent, options, """
+            StatusCode: 200 (OK)
+            Version: 2.0
+            Content:
+              Headers:
+                Content-Type: text/plain; charset=utf-8
+              Value: test
+            """);
+    }
+
     [Fact]
     public void RequestMessage_Uri()
     {


### PR DESCRIPTION
## The problem

`ConfigureHttpRequestMessage` configured `typeof(HttpResponseMessage)`:

```csharp
if (requestOptions is not null && requestOptions.OmitProtocolVersion)
{
    options.AddAttribute(typeof(HttpResponseMessage), nameof(HttpResponseMessage.Version), ...Always);
}
```

`HumanReadableHttpMessageOptions.OmitProtocolVersion` documents that it suppresses `HttpResponseMessage.Version`, `HttpRequestMessage.Version` and `HttpRequestMessage.VersionPolicy`. Because of the wrong type, it did neither of the things it promised:

**The response option could not be turned off.** `RequestMessageOptions.OmitProtocolVersion` defaults to `true`, so that line always ran and registered `IgnoreCondition.Always` on the *response* `Version`. `HumanReadableMemberInfo.Get` drops any member with an `Always` condition outright, so setting `ResponseMessageOptions.OmitProtocolVersion = false` had no effect — an `HttpResponseMessage { Version = 2.0 }` serialized with no `Version` line at all. The only workaround was to also flip the unrelated request option.

**The request option did nothing.** `HttpRequestMessage.Version` and `VersionPolicy` were always serialized, despite `OmitProtocolVersion` being `true` by default. Line 48 already registers `HumanReadableDefaultValueAttribute(HttpVersion.Version11)` on the request `Version` — inert without an accompanying `WhenWritingDefault` ignore, which is what makes the original intent clear.

## The change

The block now targets `HttpRequestMessage` and covers both `Version` and `VersionPolicy`, using `WhenWritingDefault` to match how `ConfigureHttpResponseMessage` already handles the response side. Removing the stray line leaves the response governed solely by `ResponseMessageOptions.OmitProtocolVersion`, as intended.

`WhenWritingDefault` rather than `Always` is deliberate: a request explicitly set to HTTP/2 is information worth keeping in a snapshot, and it makes the existing `DefaultValueAttribute(Version11)` meaningful.

## Behaviour change

Two visible output changes, both matching the documented contract:

- `HttpRequestMessage` with the default `1.1` / `RequestVersionOrLower` no longer emits `Version:` / `VersionPolicy:` when `OmitProtocolVersion` is on (the default). `RequestMessage_Full`'s expectation is updated accordingly.
- `HttpResponseMessage.Version` now appears when `ResponseMessageOptions.OmitProtocolVersion = false`.

Anyone relying on the accidental response-side suppression will see a new `Version:` line, so this is worth a release note.

## Verification

- `RequestMessage_Full` updated to show the two omitted lines.
- 3 new tests: non-default request version is kept, request version is kept when the option is off, and response version is no longer hidden by the request option.
- `Meziantou.Framework.HumanReadableSerializer.Tests`: 538 passed (net10.0 + net11.0), 0 failed.
- Downstream: `SnapshotTesting.Tests` 167 passed, `InlineSnapshotTesting.Tests` 131 passed.
