### PR TITLE
Align the async delete path with the synchronous one

### DIFF
--- a/src/Meziantou.Framework/IOUtilities.Delete.cs
+++ b/src/Meziantou.Framework/IOUtilities.Delete.cs
@@ -140,32 +140,33 @@ static partial class IOUtilities
         if (!fileSystemInfo.Exists)
             return;
 
-        if (fileSystemInfo is DirectoryInfo directoryInfo)
-        {
-            foreach (var childInfo in directoryInfo.GetFileSystemInfos())
-            {
-                if (childInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
-                {
-                    try
-                    {
-                        await RetryOnSharingViolationAsync(() => childInfo.Delete(), cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (FileNotFoundException)
-                    {
-                    }
-                    catch (DirectoryNotFoundException)
-                    {
-                    }
-                }
-                else
-                {
-                    await DeleteAsync(childInfo, cancellationToken).ConfigureAwait(false);
-                }
-            }
-        }
-
         try
         {
+            if (fileSystemInfo is DirectoryInfo directoryInfo)
+            {
+                foreach (var childInfo in directoryInfo.GetFileSystemInfos())
+                {
+                    if (childInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
+                    {
+                        try
+                        {
+                            await RetryOnSharingViolationAsync(() => RemoveReadOnlyAttribute(childInfo), cancellationToken).ConfigureAwait(false);
+                            await RetryOnSharingViolationAsync(() => childInfo.Delete(), cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (FileNotFoundException)
+                        {
+                        }
+                        catch (DirectoryNotFoundException)
+                        {
+                        }
+                    }
+                    else
+                    {
+                        await DeleteAsync(childInfo, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            }
+
             await RetryOnSharingViolationAsync(() => RemoveReadOnlyAttribute(fileSystemInfo), cancellationToken).ConfigureAwait(false);
             await RetryOnSharingViolationAsync(() => DeleteFileSystemInfo(fileSystemInfo), cancellationToken).ConfigureAwait(false);
         }

--- a/tests/Meziantou.Framework.Tests/IOUtilitiesTests.cs
+++ b/tests/Meziantou.Framework.Tests/IOUtilitiesTests.cs
@@ -12,4 +12,34 @@ public class IOUtilitiesTests
         var result = IOUtilities.ToValidFileName(fileName);
         Assert.Equal(expectedResult, result);
     }
+
+    [Fact]
+    public void DeleteIgnoresADirectoryRemovedAfterTheExistsCheck()
+    {
+        var directoryInfo = CreateDirectoryRemovedAfterTheExistsCheck();
+
+        IOUtilities.Delete(directoryInfo);
+    }
+
+    [Fact]
+    public async Task DeleteAsyncIgnoresADirectoryRemovedAfterTheExistsCheck()
+    {
+        var directoryInfo = CreateDirectoryRemovedAfterTheExistsCheck();
+
+        await IOUtilities.DeleteAsync(directoryInfo, XunitCancellationToken);
+    }
+
+    // FileSystemInfo.Exists is cached, so this reproduces the window between the Exists check
+    // and the enumeration of the directory content, without depending on timing.
+    private static DirectoryInfo CreateDirectoryRemovedAfterTheExistsCheck()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+
+        var directoryInfo = new DirectoryInfo(path);
+        Assert.True(directoryInfo.Exists);
+        Directory.Delete(path);
+
+        return directoryInfo;
+    }
 }


### PR DESCRIPTION
**Stack 1 of 2** · merges into `main` · must merge before #2625.

`Delete` and `DeleteAsync` are near line-for-line copies of the same algorithm, and the async copy had drifted in two independent places.

**1. The traversal is not protected by the same `try`.** The sync path wraps everything — including `GetFileSystemInfos()` — in a `try` with `catch (DirectoryNotFoundException)` (`IOUtilities.Delete.cs:44,77`). The async path's catch covered only the final delete calls, leaving the enumeration unprotected. If the directory disappears between the `Exists` check and the enumeration, `DeleteAsync` throws where `Delete` returns silently:

```
IOUtilities.Delete(di)       → returns normally
IOUtilities.DeleteAsync(di)  → DirectoryNotFoundException
```

Because the two are documented as equivalent, `await using` and `using` are treated as interchangeable by consumers. A temp cleaner or a CI cleanup step removing the tree turns a silent no-op into an exception thrown *during stack unwinding*, masking whatever failure the test was actually reporting.

**2. Reparse-point children skip the read-only reset.** The sync path calls `RemoveReadOnlyAttribute` before deleting a reparse-point child; the async path went straight to the delete. A read-only junction that the sync path removes fails to delete on the async path, where the failure is then swallowed by the retry loop. Windows-only and narrow, but it is the second confirmed drift in the same pair of methods.

## Changes

`DeleteAsync` now mirrors `Delete` exactly: the traversal moves inside the existing `try`, and the missing `RemoveReadOnlyAttribute` call is restored.

## Verification

Two tests added, one per method, using the fact that `FileSystemInfo.Exists` is cached to reproduce the race deterministically rather than by timing. The async one **fails on `main`** and passes here; the sync one passes both ways, which is the point:

```
failed DeleteAsyncIgnoresADirectoryRemovedAfterTheExistsCheck
       System.IO.DirectoryNotFoundException : Could not find a part of the path '...'
```

10/10 `IOUtilities` tests pass, and the 18 `TemporaryDirectory` tests that link this file still pass. `/p:TreatsWarningsAsErrors=true` clean.

> Note: this file is compiled into `Meziantou.Framework` with `PUBLIC_IO_UTILITIES`, so `IOUtilities.Delete` is public API there, not only an internal helper for `Meziantou.Framework.TemporaryDirectory`.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
