### PR TITLE
Delete a reparse point without deleting the content of its target

### DIFF
--- a/src/Meziantou.Framework/IOUtilities.Delete.cs
+++ b/src/Meziantou.Framework/IOUtilities.Delete.cs
@@ -43,7 +43,8 @@ static partial class IOUtilities
 
         try
         {
-            if (fileSystemInfo is DirectoryInfo directoryInfo)
+            // A reparse point is deleted as a link. Enumerating it would delete the content of its target instead.
+            if (fileSystemInfo is DirectoryInfo directoryInfo && !fileSystemInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
             {
                 foreach (var childInfo in directoryInfo.GetFileSystemInfos())
                 {
@@ -142,7 +143,8 @@ static partial class IOUtilities
 
         try
         {
-            if (fileSystemInfo is DirectoryInfo directoryInfo)
+            // A reparse point is deleted as a link. Enumerating it would delete the content of its target instead.
+            if (fileSystemInfo is DirectoryInfo directoryInfo && !fileSystemInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
             {
                 foreach (var childInfo in directoryInfo.GetFileSystemInfos())
                 {

--- a/tests/Meziantou.Framework.Tests/IOUtilitiesTests.cs
+++ b/tests/Meziantou.Framework.Tests/IOUtilitiesTests.cs
@@ -29,6 +29,47 @@ public class IOUtilitiesTests
         await IOUtilities.DeleteAsync(directoryInfo, XunitCancellationToken);
     }
 
+    [Fact]
+    public void DeleteDoesNotFollowADirectorySymbolicLink()
+    {
+        var (link, target, targetFile) = CreateDirectorySymbolicLink();
+
+        IOUtilities.Delete(new DirectoryInfo(link));
+
+        Assert.False(Directory.Exists(link));
+        Assert.True(Directory.Exists(target));
+        Assert.True(File.Exists(targetFile));
+        Directory.Delete(target, recursive: true);
+    }
+
+    [Fact]
+    public async Task DeleteAsyncDoesNotFollowADirectorySymbolicLink()
+    {
+        var (link, target, targetFile) = CreateDirectorySymbolicLink();
+
+        await IOUtilities.DeleteAsync(new DirectoryInfo(link), XunitCancellationToken);
+
+        Assert.False(Directory.Exists(link));
+        Assert.True(Directory.Exists(target));
+        Assert.True(File.Exists(targetFile));
+        Directory.Delete(target, recursive: true);
+    }
+
+    private static (string Link, string Target, string TargetFile) CreateDirectorySymbolicLink()
+    {
+        var root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var target = Path.Combine(root, "target");
+        Directory.CreateDirectory(target);
+
+        var targetFile = Path.Combine(target, "content.txt");
+        File.WriteAllText(targetFile, "content");
+
+        var link = Path.Combine(root, "link");
+        Directory.CreateSymbolicLink(link, target);
+
+        return (link, target, targetFile);
+    }
+
     // FileSystemInfo.Exists is cached, so this reproduces the window between the Exists check
     // and the enumeration of the directory content, without depending on timing.
     private static DirectoryInfo CreateDirectoryRemovedAfterTheExistsCheck()


### PR DESCRIPTION
**Stack 2 of 2** · merges into #2624 · must merge after #2624.

`Delete` already refuses to recurse into a reparse point — but only for *child* entries (`IOUtilities.Delete.cs:50`). The top-level `FileSystemInfo` was never checked, so when the path handed to `Delete` is itself a directory symlink, `GetFileSystemInfos()` enumerates straight through it and **recursively deletes the content of the link's target**. Only the link itself is then unlinked, so the target directory survives — empty.

Reproduced before the fix: a symlink pointing at a directory with one file, passed to `Delete`, left the target directory in place with 0 files.

This is the deletion half of a local privilege issue for `TemporaryDirectory`. The temp root has a fixed name (`$TMPDIR/MezTD`), which on Linux lives in world-writable `/tmp`; a local user who creates that root first owns it, and can then swap the victim's freshly created GUID directory for a symlink. Disposal follows it and deletes the content of whatever the attacker chose, with the victim's privileges.

The guard already exists and expresses exactly the right intent — it just was not applied one level up, which makes this a cheap fix regardless of the attack scenario.

## Changes

Both `Delete` and `DeleteAsync` now skip the traversal when the top-level entry is a reparse point, and fall through to deleting it as a link. `DeleteFileSystemInfo` already handles that correctly: `Directory.Delete(recursive: true)` on a symlink removes the link without following it.

## Verification

Two tests added, one per method: a directory symlink whose target holds a file is deleted, then the target and its content are asserted to still exist. Both **fail on the parent branch** and pass here, on both target frameworks:

```
failed DeleteDoesNotFollowADirectorySymbolicLink
failed DeleteAsyncDoesNotFollowADirectorySymbolicLink
```

14/14 `IOUtilities` tests pass, and the 18 `TemporaryDirectory` tests still pass. `/p:TreatsWarningsAsErrors=true` clean.

> The write half of the same issue — hardening the shared root so it cannot be pre-created and swapped — is #2606, which is independent of this stack.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
