### PR TITLE
Reuse the ReadAsync task and validate CopyToAsync arguments synchronously

### DIFF
--- a/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
+++ b/src/Meziantou.Framework.PooledMemoryStream/PooledMemoryStream.cs
@@ -30,6 +30,10 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
     private long _capacity;
     private bool _isOpen;
 
+    // Mirrors MemoryStream: the byte[] ReadAsync overload hands back the previous task when the count matches, so a
+    // sequence of same-sized reads doesn't allocate a Task each time.
+    private Task<int>? _lastReadTask;
+
     // Cursor caching the last located segment so sequential access doesn't re-walk from segment 0 every call.
     // _cursorStart is the logical offset at which segment _cursorIndex begins (sum of Used of earlier segments).
     private int _cursorIndex;
@@ -213,7 +217,9 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
 
         try
         {
-            return Task.FromResult(Read(buffer, offset, count));
+            var read = Read(buffer, offset, count);
+            var lastTask = _lastReadTask;
+            return lastTask is not null && lastTask.Result == read ? lastTask : (_lastReadTask = Task.FromResult(read));
         }
         catch (Exception ex)
         {
@@ -333,14 +339,23 @@ public sealed class PooledMemoryStream : MemoryStream, IBufferWriter<byte>
     }
 
     /// <inheritdoc />
-    public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+    public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
     {
+        // Validate before entering the state machine so bad arguments throw synchronously, as MemoryStream does.
         ValidateCopyToArguments(destination, bufferSize);
         EnsureOpen();
-        cancellationToken.ThrowIfCancellationRequested();
-        if (_position >= _length)
-            return;
 
+        if (cancellationToken.IsCancellationRequested)
+            return Task.FromCanceled(cancellationToken);
+
+        if (_position >= _length)
+            return Task.CompletedTask;
+
+        return CopyToAsyncCore(destination, cancellationToken);
+    }
+
+    private async Task CopyToAsyncCore(Stream destination, CancellationToken cancellationToken)
+    {
         Locate(_position, out var segmentIndex, out var offset);
         var remaining = _length - _position;
         while (remaining > 0)

--- a/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
+++ b/tests/Meziantou.Framework.PooledMemoryStream.Tests/PooledMemoryStreamTests.cs
@@ -273,6 +273,36 @@ public sealed class PooledMemoryStreamTests
     }
 
     [Fact]
+    public async Task ReadAsync_ReusesTheTaskWhenTheCountRepeats()
+    {
+        using var stream = new PooledMemoryStream(SmallTiers());
+        stream.Write(CreateData(200, seed: 6));
+        stream.Position = 0;
+
+        var buffer = new byte[10];
+        var first = stream.ReadAsync(buffer, 0, buffer.Length);
+        var second = stream.ReadAsync(buffer, 0, buffer.Length);
+
+        Assert.Equal(10, await first);
+        Assert.Equal(10, await second);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void CopyToAsync_ValidatesArgumentsSynchronously()
+    {
+        using var stream = new PooledMemoryStream(SmallTiers());
+        stream.Write(CreateData(50, seed: 7));
+
+        // Block-bodied lambdas so these bind to Assert.Throws(Action): the point is that the exception is raised
+        // before any task exists, which a faulted-task assertion could not tell apart.
+        Task? task = null;
+        Assert.Throws<ArgumentNullException>(() => { task = stream.CopyToAsync(destination: null!); });
+        Assert.Throws<ArgumentOutOfRangeException>(() => { task = stream.CopyToAsync(new MemoryStream(), bufferSize: 0); });
+        Assert.Null(task);
+    }
+
+    [Fact]
     public void IBufferWriter_GetSpan_ReturnsAtLeastSizeHint_AndWritesAcrossBoundary()
     {
         using var stream = new PooledMemoryStream(SmallTiers());


### PR DESCRIPTION
## The problem

Two small `MemoryStream` parity gaps in the async members.

**1. `ReadAsync` allocates a `Task` per call.** The `byte[]` overload returned `Task.FromResult(Read(...))` every
time. `MemoryStream` caches the last returned task and reuses it when the count matches — two consecutive
same-sized reads give back the *same* `Task<int>` instance there, and two different ones here. For a library whose
reason to exist is avoiding allocation, a `Task` per async read is off-message.

(The `Memory<byte>` overload already returns a `ValueTask` and allocates nothing; it's the one most modern callers
use, which is why this is Low and not higher.)

**2. `CopyToAsync` validated its arguments asynchronously.** It was an `async` method, so `ValidateCopyToArguments`
failures came back as a faulted task instead of throwing at the call site:

```csharp
stream.CopyToAsync(null!);      // returns a faulted Task
memoryStream.CopyToAsync(null!) // throws ArgumentNullException synchronously
```

That difference bites code written as `Assert.Throws` rather than `Assert.ThrowsAsync`, and it delays a programming
error past the point where the stack trace is useful.

## What changed

- Added a `_lastReadTask` field and the same reuse check `MemoryStream` uses, so a run of same-sized reads allocates
  one task total.
- Split `CopyToAsync` into a synchronous wrapper that validates, checks `EnsureOpen`, short-circuits an already-
  cancelled token to `Task.FromCanceled`, and returns `Task.CompletedTask` when there's nothing to copy — plus a
  private `CopyToAsyncCore` holding the original loop unchanged.

No public API change; `CopyToAsyncCore` is private and the override's signature is the same.

## Verification

Two tests added next to the other async/`IBufferWriter` tests. Both fail on `main` (4 failures across the two TFMs)
and pass here:

```
ReadAsync_ReusesTheTaskWhenTheCountRepeats     Assert.Same on two consecutive reads
CopyToAsync_ValidatesArgumentsSynchronously    Assert.Throws(Action) + asserts no task was ever produced
```

The second is deliberately written with block-bodied lambdas so it binds to `Assert.Throws(Action)` rather than the
`Func<Task>` overload — a faulted-task assertion couldn't tell the two behaviours apart, which is the whole point.

Full suite: **88/88** (44 × net10.0/net11.0, up from 84) with `/p:TreatsWarningsAsErrors=true`, with
`Meziantou.Framework.Assertions.Analyzer` built first so MFAS rules actually run.
`dotnet run ./eng/update-all.cs` produces no changes.

Found by a review of `Meziantou.Framework.PooledMemoryStream` (finding F10, Low).
