### PR TITLE
Fix the RelativeDate readme sample

### DIFF
--- a/src/Meziantou.Framework.RelativeDate/readme.md
+++ b/src/Meziantou.Framework.RelativeDate/readme.md
@@ -3,9 +3,10 @@
 `Meziantou.Framework.RelativeDate` allows to get a relative date similar to "5 minutes ago". It supports both local and UTC dates as well as dates with offset (DateTimeOffset). Also, culture to use can be specified explicitly. If it is not, current thread's current UI culture is used. It supports Dutch, English, French, German, Italian, Japanese, Korean, Portuguese, Simplified Chinese, Spanish and Turkish.
 
 ````c#
+using System.Globalization;
 using Meziantou.Framework;
 
 DateTime dateTime = ...;
 var relativeDate = RelativeDate.Get(dateTime).ToString();
-var relativeDate = RelativeDate.Get(dateTime).ToString(format: null, CultureInfo.Get("fr-FR"));
+var relativeDateInFrench = RelativeDate.Get(dateTime).ToString(format: null, CultureInfo.GetCultureInfo("fr-FR"));
 ````


### PR DESCRIPTION
Two defects in the sample at `src/Meziantou.Framework.RelativeDate/readme.md:9-10`:

- `CultureInfo.Get("fr-FR")` is not a method — it is `CultureInfo.GetCultureInfo`.
- `var relativeDate` is declared twice in the same scope.

This readme is the NuGet package description page, so it is the first code most consumers will copy.

## What changed

`CultureInfo.GetCultureInfo`, a distinct name for the second variable, and the `using System.Globalization;` the `CultureInfo` reference needs.

The `DateTime dateTime = ...;` placeholder is left as-is — that is deliberate shorthand for "some value", not a defect.

## Verification

Markdown only, no code change. `dotnet run ./eng/update-all.cs` reports no further changes; the root `README.md` links to this file rather than embedding the snippet, so nothing else regenerates.
