### PR TITLE
Publish log chunks only once they hold an entry

### DIFF
--- a/src/Meziantou.Extensions.Logging.InMemory/Chunk.cs
+++ b/src/Meziantou.Extensions.Logging.InMemory/Chunk.cs
@@ -2,12 +2,33 @@ namespace Meziantou.Extensions.Logging.InMemory;
 
 internal sealed class Chunk<T>
 {
+    private int _count;
+    private Chunk<T>? _next;
+
     public Chunk(int capacity)
     {
-        Items = GC.AllocateUninitializedArray<T>(capacity);
+        Items = new T[capacity];
     }
 
-    public T[] Items { get; set; }
-    public int Count { get; set; }
-    public Chunk<T>? Next { get; set; }
+    public T[] Items { get; }
+
+    /// <summary>Gets or sets the number of entries written to <see cref="Items"/>.</summary>
+    /// <remarks>
+    /// Written under the collection's lock but read without it, so both accessors are volatile.
+    /// The release on the write publishes the preceding <see cref="Items"/> store to any reader
+    /// that acquires the new count.
+    /// </remarks>
+    public int Count
+    {
+        get => Volatile.Read(ref _count);
+        set => Volatile.Write(ref _count, value);
+    }
+
+    /// <summary>Gets or sets the next chunk of the collection.</summary>
+    /// <remarks>Volatile for the same reason as <see cref="Count"/>: it publishes a populated chunk.</remarks>
+    public Chunk<T>? Next
+    {
+        get => Volatile.Read(ref _next);
+        set => Volatile.Write(ref _next, value);
+    }
 }

--- a/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogCollection.cs
+++ b/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogCollection.cs
@@ -25,31 +25,48 @@ public sealed class InMemoryLogCollection : IEnumerable<InMemoryLogEntry>
     private Chunk<InMemoryLogEntry>? _firstChunk;
     private Chunk<InMemoryLogEntry>? _lastChunk;
 
+    // Readers walk the chunks without taking the lock, so the head is published with a release
+    // and read with an acquire, exactly like Chunk.Count and Chunk.Next.
+    private Chunk<InMemoryLogEntry>? FirstChunk => Volatile.Read(ref _firstChunk);
+
     internal void Add(InMemoryLogEntry entry)
     {
         lock (_lock)
         {
-            if (_lastChunk is null)
+            var lastChunk = _lastChunk;
+            if (lastChunk is null)
             {
-                _firstChunk = _lastChunk = new Chunk<InMemoryLogEntry>(16);
-            }
-            else if (_lastChunk.Count == _lastChunk.Items.Length)
-            {
-                var newCapacity = Math.Min(MaxChunkSize, _lastChunk.Count * 2);
-                var newChunk = new Chunk<InMemoryLogEntry>(newCapacity);
-                _lastChunk.Next = newChunk;
-                _lastChunk = newChunk;
+                var firstChunk = new Chunk<InMemoryLogEntry>(16);
+                firstChunk.Items[0] = entry;
+                firstChunk.Count = 1;
+                _lastChunk = firstChunk;
+                Volatile.Write(ref _firstChunk, firstChunk);
+                return;
             }
 
-            _lastChunk.Items[_lastChunk.Count] = entry;
-            _lastChunk.Count++;
+            if (lastChunk.Count == lastChunk.Items.Length)
+            {
+                var newCapacity = Math.Min(MaxChunkSize, lastChunk.Count * 2);
+                var newChunk = new Chunk<InMemoryLogEntry>(newCapacity);
+
+                // Populate the chunk before linking it, so a reader that observes the new Next
+                // never sees a chunk whose first entry has not been written yet.
+                newChunk.Items[0] = entry;
+                newChunk.Count = 1;
+                _lastChunk = newChunk;
+                lastChunk.Next = newChunk;
+                return;
+            }
+
+            lastChunk.Items[lastChunk.Count] = entry;
+            lastChunk.Count++;
         }
     }
 
     public override string ToString()
     {
         var sb = new StringBuilder();
-        var chunk = _firstChunk;
+        var chunk = FirstChunk;
         while (chunk is not null)
         {
             for (var i = 0; i < chunk.Count; i++)
@@ -98,7 +115,7 @@ public sealed class InMemoryLogCollection : IEnumerable<InMemoryLogEntry>
     /// <returns>The first log entry that matches the predicate, or <see langword="null"/> if no match is found.</returns>
     public InMemoryLogEntry? Find(Func<InMemoryLogEntry, bool> predicate)
     {
-        var chunk = _firstChunk;
+        var chunk = FirstChunk;
         while (chunk is not null)
         {
             for (var i = 0; i < chunk.Count; i++)
@@ -116,7 +133,7 @@ public sealed class InMemoryLogCollection : IEnumerable<InMemoryLogEntry>
 
     private IEnumerable<InMemoryLogEntry> GetByLogLevel(LogLevel logLevel)
     {
-        var chunk = _firstChunk;
+        var chunk = FirstChunk;
         while (chunk is not null)
         {
             for (var i = 0; i < chunk.Count; i++)
@@ -138,7 +155,7 @@ public sealed class InMemoryLogCollection : IEnumerable<InMemoryLogEntry>
 
         public Enumerator(InMemoryLogCollection collection)
         {
-            _chunk = collection._firstChunk;
+            _chunk = collection.FirstChunk;
         }
 
         public readonly InMemoryLogEntry Current
@@ -154,18 +171,20 @@ public sealed class InMemoryLogCollection : IEnumerable<InMemoryLogEntry>
 
         public bool MoveNext()
         {
-            if (_chunk is null)
-                return false;
-
-            _index++;
-            if (_index >= _chunk.Count)
+            // A chunk is only ever linked once it holds an entry, but the loop tolerates an empty
+            // one anyway: returning true for a chunk whose Count is still 0 would hand out a
+            // default(InMemoryLogEntry) as if it were a real entry.
+            while (_chunk is not null)
             {
+                _index++;
+                if (_index < _chunk.Count)
+                    return true;
+
                 _chunk = _chunk.Next;
-                _index = 0;
-                return _chunk is not null;
+                _index = -1;
             }
 
-            return true;
+            return false;
         }
 
         public readonly void Dispose()

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
@@ -216,6 +216,58 @@ public sealed partial class InMemoryLoggerTests
     }
 
     [Fact]
+    public void EntriesKeepTheirOrderAcrossChunkBoundaries()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+
+        // Chunks hold 16, then 32, then 64 entries, so this spans three of them
+        for (var i = 0; i < 100; i++)
+        {
+            logger.LogInformation("Entry {Index}", i);
+        }
+
+        Assert.HasCount(100, logger.Logs);
+        Assert.Equal(Enumerable.Range(0, 100).Cast<object?>(), logger.Logs.Select(log =>
+        {
+            Assert.True(log.TryGetParameterValue("Index", out var index));
+            return index;
+        }));
+    }
+
+    [Fact]
+    public async Task CanEnumerateWhileAnotherThreadLogs()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+        var writer = Task.Run(() =>
+        {
+            for (var i = 0; i < 200_000; i++)
+            {
+                logger.LogInformation("Test");
+            }
+        });
+
+        // A smoke test: the window this guards is a few instructions wide, so it does not reliably
+        // reproduce on its own. It does catch a reader walking the chunks being broken outright.
+        var missing = 0;
+        do
+        {
+            foreach (var log in logger.Logs)
+            {
+                if (log is null)
+                {
+                    missing++;
+                }
+            }
+        }
+        while (!writer.IsCompleted);
+
+        await writer;
+
+        Assert.Equal(0, missing);
+        Assert.HasCount(200_000, logger.Logs);
+    }
+
+    [Fact]
     public void WithTimeProvider()
     {
         using var provider = new InMemoryLoggerProvider(new CustomTimeProvider());


### PR DESCRIPTION
> **Stack 1 of 2** · merges into `main` · must merge before the `Count`/`Clear` PR stacked on top of it.

`InMemoryLogCollection` documents itself as *"a thread-safe collection of log entries"*. `Add` does take a lock, but **every read path walks the chunks with no lock, no `volatile` and no barrier** — `ToString`, `Find`, `GetByLogLevel` (which backs `Errors`, `Warnings`, …) and `Enumerator.MoveNext`.

### The failure

Two windows let a reader observe a `null` where the type says non-null:

1. **A chunk is published before it is filled.** `Add` linked the new chunk (`_lastChunk.Next = newChunk`) *before* writing its first item and incrementing `Count`. A concurrent `MoveNext` that advanced into that chunk hit `return _chunk is not null` — which returned `true` without checking `_chunk.Count > 0` — and `Current` then read `Items[0]`, still zeroed.
2. **`Count` becomes visible before `Items[Count]`.** Both were ordinary writes; a reader with no acquire may observe the incremented count before the element store, particularly on arm64.

Window 1 reproduces deterministically. Reflectively linking an empty chunk to mimic the mid-`Add` state makes a 16-entry collection yield a `null` at position 17. A concurrent stress harness (one thread logging, one enumerating) also hit a real `null` directly:

```
enumeration: nullEntries=1 exceptions=0 readerPasses=92095863
```

The symptom for a user is a `NullReferenceException` from inside a `foreach` over `Logs`, or from their own predicate in `Find`, at a rate low enough to look like an unrelated flaky test. The natural way to use this library is exactly the failing pattern: assert on `provider.Logs` while background work is still logging — a `WebApplicationFactory` request in flight, a hosted service, a `Parallel.For`.

### The change

- **`Add` populates a chunk before linking it**, so a reader that observes a new `Next` always sees a chunk with at least one entry.
- **`Chunk.Count` and `Chunk.Next` become volatile.** The release on the write publishes the preceding `Items` store to any reader that acquires the new value; `_firstChunk` is published and read the same way through a `FirstChunk` property.
- **`MoveNext` skips empty chunks** instead of assuming a linked chunk is non-empty. Defence in depth — unreachable once `Add` fills before publishing — but the alternative is handing out a `default(InMemoryLogEntry)` as though it were real.
- **`Chunk` drops `GC.AllocateUninitializedArray`** for a plain `new T[capacity]`. For a reference-type `T` the runtime zeroes the array regardless, so it bought nothing; it was also the reason the symptom was a benign `null` rather than genuine garbage. `Items` becomes get-only while nearby.

### Verification

Full suite green: 28/28 (14 tests × net10.0/net11.0) with `/p:TreatsWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` produced no further changes.

Two tests added. `EntriesKeepTheirOrderAcrossChunkBoundaries` deterministically covers the 16→32→64 growth path that nothing exercised before — `LogManyMessages` only ever asserted a count, never that entry *n* survived the transitions in order.

**Being straight about the second one:** `CanEnumerateWhileAnotherThreadLogs` is a smoke test, not a regression test. I checked, and it still passes against the unfixed code on three consecutive runs — the window is a few instructions wide, and the earlier stress harness needed ~92M reader passes to hit it once. It is worth keeping because nothing else exercises concurrent read/write at all and it would catch a reader being broken outright, but it does **not** prove this fix. The evidence for the fix is the deterministic empty-chunk repro and the memory-ordering argument above. I chose not to add a reflection-based white-box test for the `MoveNext` guard, since that state is unreachable once `Add` fills before publishing.

### Follow-up worth considering

If lock-free reads are not worth the reasoning cost for a test library, taking `_lock` in the readers and snapshotting would be simpler and unconditionally correct, at the cost of blocking loggers during enumeration. Either way, the XML doc should eventually state precisely what "thread-safe" guarantees here — this PR makes concurrent read/write actually safe but does not reword the doc.

Found during a project review of `Meziantou.Extensions.Logging.InMemory` (rated High).
