### PR TITLE
Format the Byte unit from the long so the value stays exact

### DIFF
--- a/src/Meziantou.Framework.ByteSize/ByteSize.cs
+++ b/src/Meziantou.Framework.ByteSize/ByteSize.cs
@@ -64,7 +64,7 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
 
     public string ToString(ByteSizeUnit unit) => ToString(unit, formatProvider: null);
 
-    public string ToString(ByteSizeUnit unit, IFormatProvider? formatProvider) => GetValue(unit).ToString(formatProvider) + UnitToString(unit);
+    public string ToString(ByteSizeUnit unit, IFormatProvider? formatProvider) => FormatValue(unit, numberFormat: null, formatProvider) + UnitToString(unit);
 
     public string ToString(IFormatProvider? formatProvider)
     {
@@ -157,7 +157,7 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
             numberFormat = "F" + number.ToString(CultureInfo.InvariantCulture);
         }
 
-        return GetValue(unit).ToString(numberFormat, formatProvider) + UnitToString(unit);
+        return FormatValue(unit, numberFormat, formatProvider) + UnitToString(unit);
     }
 
     /// <summary>Tries to format the value into the provided span of characters.</summary>
@@ -218,11 +218,10 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
         }
 
         // Format the value
-        var value = GetValue(unit);
         var unitStr = UnitToString(unit);
 
         // Try to format the number part
-        if (!value.TryFormat(destination, out var numberCharsWritten, numberFormat, provider))
+        if (!TryFormatValue(destination, out var numberCharsWritten, unit, numberFormat, provider))
         {
             charsWritten = 0;
             return false;
@@ -292,7 +291,41 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
     /// <returns>The value in the specified unit.</returns>
     public double GetValue(ByteSizeUnit unit)
     {
-        return (double)Value / (long)unit;
+        var divisor = unit switch
+        {
+            ByteSizeUnit.Byte or ByteSizeUnit.KiloByte or ByteSizeUnit.MegaByte or ByteSizeUnit.GigaByte
+                or ByteSizeUnit.TeraByte or ByteSizeUnit.PetaByte or ByteSizeUnit.ExaByte
+                or ByteSizeUnit.KibiByte or ByteSizeUnit.MebiByte or ByteSizeUnit.GibiByte
+                or ByteSizeUnit.TebiByte or ByteSizeUnit.PebiByte or ByteSizeUnit.ExbiByte => (long)unit,
+            _ => throw new ArgumentOutOfRangeException(nameof(unit)),
+        };
+
+        return (double)Value / divisor;
+    }
+
+    // The Byte unit is formatted straight from the long so the value stays exact: going
+    // through double loses integer precision above 2^53 and lets the "G" specifier emit
+    // scientific notation, which none of this type's parsers accept. The scaled units are
+    // fractional by nature and keep using double.
+    private string FormatValue(ByteSizeUnit unit, string? numberFormat, IFormatProvider? formatProvider)
+    {
+        return unit is ByteSizeUnit.Byte
+            ? Value.ToString(numberFormat, formatProvider)
+            : GetValue(unit).ToString(numberFormat, formatProvider);
+    }
+
+    private bool TryFormatValue(Span<char> destination, out int charsWritten, ByteSizeUnit unit, ReadOnlySpan<char> numberFormat, IFormatProvider? provider)
+    {
+        return unit is ByteSizeUnit.Byte
+            ? Value.TryFormat(destination, out charsWritten, numberFormat, provider)
+            : GetValue(unit).TryFormat(destination, out charsWritten, numberFormat, provider);
+    }
+
+    private bool TryFormatValue(Span<byte> utf8Destination, out int bytesWritten, ByteSizeUnit unit, ReadOnlySpan<char> numberFormat, IFormatProvider? provider)
+    {
+        return unit is ByteSizeUnit.Byte
+            ? Value.TryFormat(utf8Destination, out bytesWritten, numberFormat, provider)
+            : GetValue(unit).TryFormat(utf8Destination, out bytesWritten, numberFormat, provider);
     }
 
     private static string UnitToString(ByteSizeUnit unit)
@@ -561,11 +594,10 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
         }
 
         // Format the value
-        var value = GetValue(unit);
         var unitStr = UnitToString(unit);
 
         // Try to format the number part as UTF-8
-        if (!value.TryFormat(utf8Destination, out var numberBytesWritten, numberFormat, provider))
+        if (!TryFormatValue(utf8Destination, out var numberBytesWritten, unit, numberFormat, provider))
         {
             bytesWritten = 0;
             return false;

--- a/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
+++ b/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
@@ -112,6 +112,42 @@ public sealed class ByteSizeTests
     }
 
     [Theory]
+    [InlineData(9_007_199_254_740_993L, "9007199254740993B")]
+    [InlineData(long.MaxValue, "9223372036854775807B")]
+    [InlineData(long.MinValue, "-9223372036854775808B")]
+    public void ToString_ByteUnit_IsExactAndRoundTrips(long value, string expected)
+    {
+        var size = new ByteSize(value);
+
+        Assert.Equal(expected, size.ToString("B", CultureInfo.InvariantCulture));
+        Assert.Equal(expected, size.ToString(ByteSizeUnit.Byte, CultureInfo.InvariantCulture));
+        Assert.Equal(size, ByteSize.Parse(expected, CultureInfo.InvariantCulture));
+
+        Span<char> chars = stackalloc char[64];
+        Assert.True(size.TryFormat(chars, out var charsWritten, "B", CultureInfo.InvariantCulture));
+        Assert.Equal(expected, chars[..charsWritten].ToString());
+
+        Span<byte> bytes = stackalloc byte[64];
+        Assert.True(size.TryFormat(bytes, out var bytesWritten, "B", CultureInfo.InvariantCulture));
+        Assert.Equal(expected, System.Text.Encoding.UTF8.GetString(bytes[..bytesWritten]));
+    }
+
+    [Fact]
+    public void ToString_ByteUnit_HonorsTheNumericPrecision()
+    {
+        Assert.Equal("10.00B", new ByteSize(10).ToString("B2", CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(3L)]
+    [InlineData(-1L)]
+    public void GetValue_UndefinedUnit_ThrowsArgumentOutOfRangeException(long unit)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = new ByteSize(10).GetValue((ByteSizeUnit)unit));
+    }
+
+    [Theory]
     [InlineData("1", 1L)]
     [InlineData("1b", 1L)]
     [InlineData("1B", 1L)]


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before #2632**

`GetValue` returns `(double)Value / (long)unit`, and every formatting path went through it — including `ByteSizeUnit.Byte`, where the divisor is `1` and no conversion is needed at all. Above 2^53 the `long` to `double` conversion loses integer precision, and the default `"G"` numeric specifier then switches to scientific notation:

```
new ByteSize(9_007_199_254_740_993).ToString("B")  -> "9007199254740992B"       // off by one byte
ByteSize.MaxValue.ToString("B")                    -> "9.223372036854776E+18B"
ByteSize.MinValue.ToString("B")                    -> "-9.223372036854776E+18B"
```

Two separate problems, both silent:

- The first line is data corruption. The caller asked for the exact byte count and got a different number, with no error and no way to detect it. The whole point of this struct is holding an exact `long` byte count, and the `B` unit is the one path where exactness is achievable and expected.
- The scientific-notation output cannot be read back. `"9.223372036854776E+18B"` strips to `"9.223372036854776E+18"`, which `long.TryParse` rejects, so `Parse` throws on this type's own output.

Sizes above 9 PB are reachable for storage-total and quota reporting, and `MaxValue` is a public property that shows up in logs and tests.

## What changed

The `Byte` unit is now formatted straight from the `long`; the scaled units, which are fractional by nature, keep using `double`. Three small private helpers cover the string and the two span paths, so all four call sites — `ToString(ByteSizeUnit, …)`, `ToString(string?, …)`, `TryFormat(Span<char>, …)` and `TryFormat(Span<byte>, …)` — pick up the fix consistently.

`long` supports the same `"G"` and `"Fn"` specifiers already in use, so precision formats keep working: `ToString("B2")` on 10 bytes is still `"10.00B"`, covered by a test.

**Second, related change:** `GetValue` now rejects undefined `ByteSizeUnit` values. `ByteSizeUnit` is a plain `enum`, so any `long` can be cast to it, and the divisor was used unvalidated:

```
new ByteSize(10).GetValue((ByteSizeUnit)0)  -> Infinity   // divide by zero, no exception
new ByteSize(10).GetValue((ByteSizeUnit)3)  -> 3.33...    // silently a 3-byte unit
```

`Infinity` propagates into the caller's arithmetic rather than failing where the mistake was made. The switch expression throws `ArgumentOutOfRangeException` instead. This is not an observable change for the format paths — they already threw the same exception type with the same parameter name a moment later, from `UnitToString` — it only closes the direct-call hole.

## Verification

`dotnet test tests/Meziantou.Framework.ByteSize.Tests` — 168 passed (84 × net10.0/net11.0), 0 failed.

Reverting only the `ByteSize.cs` change and re-running gives **12 failures**.

New coverage:
- `ToString_ByteUnit_IsExactAndRoundTrips` at 2^53+1, `long.MaxValue` and `long.MinValue`, asserting the exact text through all four formatting entry points *and* that `Parse` reads it back to the same value.
- `ToString_ByteUnit_HonorsTheNumericPrecision` guards the `Fn` path on the new `long` branch.
- `GetValue_UndefinedUnit_ThrowsArgumentOutOfRangeException` for `0`, `3` and `-1`.

`ref/Meziantou.Framework.ByteSize.cs` is unchanged — no public API change.
