### PR TITLE
Throw FormatException for an invalid format string

### DIFF
--- a/src/Meziantou.Framework.ByteSize/ByteSize.cs
+++ b/src/Meziantou.Framework.ByteSize/ByteSize.cs
@@ -79,13 +79,14 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
     ///     <item><c>G2</c>: Find the best unit (B, kB, MB, GB, etc.), and use F2 format for the value</item>
     ///     <item><c>Gi</c>: Find the best unit (B, kiB, MiB, GiB, etc.), and use G format for the value</item>
     ///     <item><c>Gi2</c>: Find the best unit (B, kiB, MiB, GiB, etc.), and use F2 format for the value</item>
+    ///     <item><c>F</c>, <c>F2</c>, <c>Fi</c>, <c>Fi2</c>: Synonyms of <c>G</c>, <c>G2</c>, <c>Gi</c>, <c>Gi2</c></item>
     ///     <item>
     ///         <c>B</c>, <c>kB</c>, <c>kiB</c>, <c>MB</c>, <c>MiB</c>, <c>GB</c>, <c>GiB</c>, <c>TB</c>, <c>TiB</c>, <c>PB</c>, <c>PiB</c>, <c>EB</c>, <c>EiB</c>:
     ///         Use the provided unit, and use G format for the value. If a number is provided (e.g. <c>kB3</c>), it use Fn (e.g. F3) format to convert the value to string.
     ///     </item>
     /// </list>
     /// </param>
-    /// <exception cref="ArgumentException">The provided format is not valid</exception>
+    /// <exception cref="FormatException">The provided format is not valid</exception>
     public string ToString(string? format)
     {
         return ToString(format, formatProvider: null);
@@ -99,6 +100,7 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
     ///     <item><c>G2</c>: Find the best unit (B, kB, MB, GB, etc.), and use F2 format for the value</item>
     ///     <item><c>Gi</c>: Find the best unit (B, kiB, MiB, GiB, etc.), and use G format for the value</item>
     ///     <item><c>Gi2</c>: Find the best unit (B, kiB, MiB, GiB, etc.), and use F2 format for the value</item>
+    ///     <item><c>F</c>, <c>F2</c>, <c>Fi</c>, <c>Fi2</c>: Synonyms of <c>G</c>, <c>G2</c>, <c>Gi</c>, <c>Gi2</c></item>
     ///     <item>
     ///         <c>B</c>, <c>kB</c>, <c>kiB</c>, <c>MB</c>, <c>MiB</c>, <c>GB</c>, <c>GiB</c>, <c>TB</c>, <c>TiB</c>, <c>PB</c>, <c>PiB</c>, <c>EB</c>, <c>EiB</c>:
     ///         Use the provided unit, and use G format for the value. If a number is provided (e.g. <c>kB3</c>), it use Fn (e.g. F3) format to convert the value to string.
@@ -107,7 +109,7 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
     /// </param>
     /// <param name="formatProvider"></param>
     /// <returns></returns>
-    /// <exception cref="ArgumentException">The provided format is not valid</exception>
+    /// <exception cref="FormatException">The provided format is not valid</exception>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
         if (string.IsNullOrEmpty(format))
@@ -144,7 +146,7 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
             }
             else
             {
-                throw new ArgumentException($"format '{format}' is invalid", nameof(format));
+                throw new FormatException($"format '{format}' is invalid");
             }
         }
 
@@ -152,7 +154,7 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
         if (index > 0)
         {
             if (!int.TryParse(format[index..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var number))
-                throw new ArgumentException($"format '{format}' is invalid", nameof(format));
+                throw new FormatException($"format '{format}' is invalid");
 
             numberFormat = "F" + number.ToString(CultureInfo.InvariantCulture);
         }

--- a/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
+++ b/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
@@ -67,6 +67,32 @@ public sealed class ByteSizeTests
         Assert.False(parsed);
     }
 
+    [Theory]
+    [InlineData("ZZZ")]
+    [InlineData("Q")]
+    [InlineData("2")]
+    public void ToString_InvalidFormat_ThrowsFormatException(string format)
+    {
+        Assert.Throws<FormatException>(() => new ByteSize(10).ToString(format, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void StringFormat_InvalidFormat_ThrowsFormatException()
+    {
+        Assert.Throws<FormatException>(() => string.Format(CultureInfo.InvariantCulture, "{0:ZZZ}", new ByteSize(10)));
+    }
+
+    [Theory]
+    [InlineData(1_500L, "G", "F")]
+    [InlineData(1_500L, "G2", "F2")]
+    [InlineData(1_024L, "Gi", "Fi")]
+    [InlineData(1_024L, "Gi2", "Fi2")]
+    public void ToString_FSpecifier_IsASynonymOfG(long value, string gFormat, string fFormat)
+    {
+        var size = new ByteSize(value);
+        Assert.Equal(size.ToString(gFormat, CultureInfo.InvariantCulture), size.ToString(fFormat, CultureInfo.InvariantCulture));
+    }
+
     [Fact]
     public void Operator_Add()
     {


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/bytesize-exact-bytes` · #2631 must merge first**

## `ArgumentException` where the platform contract says `FormatException`

`ToString(string?, IFormatProvider?)` threw `ArgumentException` for an unrecognised format specifier. Every BCL type throws `FormatException` there, and `IFormattable.ToString` documents `FormatException` as *the* exception for a bad format.

```
string.Format(CultureInfo.InvariantCulture, "{0:ZZZ}", new ByteSize(10))
-> ArgumentException: format 'ZZZ' is invalid (Parameter 'format')
```

Interpolated strings and `string.Format` are the normal way this type gets formatted. Callers who defensively wrap formatting in `catch (FormatException)` — the documented exception — did not catch this, so a bad format string in a log template escalated to an unhandled exception.

Both throw sites are converted. The `paramName` argument is dropped, since `FormatException` does not carry one. The two `<exception>` doc tags are updated to match; they previously documented `ArgumentException`, so the docs were self-consistent but both were wrong about the platform convention.

This follows the same reasoning as #2346, which kept salt errors as `FormatException` in this repo.

The two `TryFormat` overloads already returned `false` for these inputs and are untouched — only the throwing path was inconsistent.

### Compatibility

Technically a behaviour change. `FormatException` and `ArgumentException` are unrelated types, so a caller catching `ArgumentException` specifically around `ByteSize.ToString(format)` would stop catching it. That seems very unlikely to exist, and the current behaviour is the surprising one.

## Undocumented `f` / `fi` specifiers, now documented

The format parser accepts `f`, `F`, `fi` and `Fi` as synonyms for `g`, `G`, `gi` and `Gi`, and the existing test suite already relies on them (`"fi"`, `"f"`, `"f1"`, `"f2"`). Neither XML doc block mentioned them.

An accepted-and-tested specifier that no documentation mentions is either a feature nobody can find or an accident nobody can safely remove — the ambiguity is the problem. Resolved as intentional, since the tests depend on it: added a `<list>` item to both doc blocks, and a test pinning `F`/`F2`/`Fi`/`Fi2` as equivalent to `G`/`G2`/`Gi`/`Gi2` so the synonym cannot be dropped by accident.

## Verification

`dotnet test tests/Meziantou.Framework.ByteSize.Tests` — 184 passed (92 × net10.0/net11.0), 0 failed. Counts include the layer below.

Reverting only the `ByteSize.cs` change and re-running gives **8 failures**.

New coverage:
- `ToString_InvalidFormat_ThrowsFormatException` for `"ZZZ"`, `"Q"` and `"2"` (a format starting with a digit, which reaches the second throw site).
- `StringFormat_InvalidFormat_ThrowsFormatException` — the composite-formatting path callers actually use.
- `ToString_FSpecifier_IsASynonymOfG`.

The invalid formats deliberately avoid `"EB"`, which is invalid on `main` today but becomes valid via #2587; using it would make this test suite depend on merge order.
