### PR TITLE
Add Count and Clear to InMemoryLogCollection

### DIFF
--- a/ref/Meziantou.Extensions.Logging.InMemory.cs
+++ b/ref/Meziantou.Extensions.Logging.InMemory.cs
@@ -16,12 +16,14 @@ namespace Meziantou.Extensions.Logging.InMemory
 
     public sealed class InMemoryLogCollection : System.Collections.Generic.IEnumerable<Meziantou.Extensions.Logging.InMemory.InMemoryLogEntry>, System.Collections.IEnumerable
     {
+        public int Count { get => throw null; }
         public System.Collections.Generic.IEnumerable<Meziantou.Extensions.Logging.InMemory.InMemoryLogEntry> Debugs { get => throw null; }
         public System.Collections.Generic.IEnumerable<Meziantou.Extensions.Logging.InMemory.InMemoryLogEntry> Traces { get => throw null; }
         public System.Collections.Generic.IEnumerable<Meziantou.Extensions.Logging.InMemory.InMemoryLogEntry> Informations { get => throw null; }
         public System.Collections.Generic.IEnumerable<Meziantou.Extensions.Logging.InMemory.InMemoryLogEntry> Warnings { get => throw null; }
         public System.Collections.Generic.IEnumerable<Meziantou.Extensions.Logging.InMemory.InMemoryLogEntry> Errors { get => throw null; }
         public System.Collections.Generic.IEnumerable<Meziantou.Extensions.Logging.InMemory.InMemoryLogEntry> Criticals { get => throw null; }
+        public void Clear() { }
         public override string ToString() => throw null;
         public Enumerator GetEnumerator() => throw null;
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw null;

--- a/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogCollection.cs
+++ b/src/Meziantou.Extensions.Logging.InMemory/InMemoryLogCollection.cs
@@ -24,6 +24,14 @@ public sealed class InMemoryLogCollection : IEnumerable<InMemoryLogEntry>
     private readonly Lock _lock = new();
     private Chunk<InMemoryLogEntry>? _firstChunk;
     private Chunk<InMemoryLogEntry>? _lastChunk;
+    private int _count;
+
+    /// <summary>Gets the number of log entries in the collection.</summary>
+    /// <remarks>
+    /// The count is incremented only after the entry is reachable, so a concurrent reader never sees
+    /// a count that promises more entries than an enumeration would yield.
+    /// </remarks>
+    public int Count => Volatile.Read(ref _count);
 
     // Readers walk the chunks without taking the lock, so the head is published with a release
     // and read with an acquire, exactly like Chunk.Count and Chunk.Next.
@@ -41,6 +49,7 @@ public sealed class InMemoryLogCollection : IEnumerable<InMemoryLogEntry>
                 firstChunk.Count = 1;
                 _lastChunk = firstChunk;
                 Volatile.Write(ref _firstChunk, firstChunk);
+                Volatile.Write(ref _count, _count + 1);
                 return;
             }
 
@@ -55,11 +64,27 @@ public sealed class InMemoryLogCollection : IEnumerable<InMemoryLogEntry>
                 newChunk.Count = 1;
                 _lastChunk = newChunk;
                 lastChunk.Next = newChunk;
+                Volatile.Write(ref _count, _count + 1);
                 return;
             }
 
             lastChunk.Items[lastChunk.Count] = entry;
             lastChunk.Count++;
+            Volatile.Write(ref _count, _count + 1);
+        }
+    }
+
+    /// <summary>Removes all log entries from the collection.</summary>
+    /// <remarks>
+    /// An enumeration already in progress keeps walking the entries it started on; it is not invalidated.
+    /// </remarks>
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _lastChunk = null;
+            Volatile.Write(ref _count, 0);
+            Volatile.Write(ref _firstChunk, null);
         }
     }
 

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
@@ -314,6 +314,56 @@ public sealed partial class InMemoryLoggerTests
     }
 
     [Fact]
+    public void Count_TracksTheNumberOfEntries()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+        Assert.Equal(0, logger.Logs.Count);
+
+        logger.LogInformation("first");
+        Assert.Equal(1, logger.Logs.Count);
+
+        // Past the first chunk boundary
+        for (var i = 0; i < 50; i++)
+        {
+            logger.LogInformation("Entry {Index}", i);
+        }
+
+        Assert.Equal(51, logger.Logs.Count);
+        Assert.HasCount(51, logger.Logs);
+    }
+
+    [Fact]
+    public void Clear_RemovesEveryEntry()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+        for (var i = 0; i < 50; i++)
+        {
+            logger.LogInformation("Entry {Index}", i);
+        }
+
+        logger.Logs.Clear();
+
+        Assert.Equal(0, logger.Logs.Count);
+        Assert.Empty(logger.Logs);
+        Assert.Empty(logger.Logs.Informations);
+        Assert.Null(logger.Logs.Find(_ => true));
+        Assert.Empty(logger.Logs.ToString());
+    }
+
+    [Fact]
+    public void Clear_LeavesTheCollectionUsable()
+    {
+        var logger = InMemoryLogger.CreateLogger("sample");
+        logger.LogInformation("before");
+
+        logger.Logs.Clear();
+        logger.LogInformation("after");
+
+        Assert.Equal(1, logger.Logs.Count);
+        Assert.Equal("after", Assert.Single(logger.Logs).Message);
+    }
+
+    [Fact]
     public void WithTimeProvider()
     {
         using var provider = new InMemoryLoggerProvider(new CustomTimeProvider());


### PR DESCRIPTION
> **Stack 2 of 2** · merges into `fix/collection-concurrent-reads` · that PR must merge first.

`InMemoryLogCollection` exposes no `Count` and no `Clear`. Counting an assertion's worth of entries means `logs.Count()`, which walks the whole chunk chain through LINQ, and a collection shared across a test fixture accumulates with no way to reset it between cases.

### The change

- **`Count`** — maintained under the existing lock in `Add`, so reading it is O(1) instead of an O(n) LINQ walk.
- **`Clear()`** — drops the chunk chain and resets the count.

### Why this is stacked rather than independent

`Count` is incremented inside `Add`, and `Clear` has to reset the same head/tail fields — both are the exact code the concurrency PR below rewrites. Landing them independently would conflict. They also share the same `InMemoryLogCollection` block of the generated `ref/` file.

Ordering detail worth a look during review: the increment happens **after** the entry is reachable, not before. Under a concurrent reader that means `Count` may briefly under-report, never over-report — a count that promised an entry an enumeration could not yet yield would be the worse failure. `Clear` leaves an in-progress enumeration walking the entries it started on rather than invalidating it; that is documented on the method.

### Deliberately not included

The review that produced this also noted that entries are retained forever, and that every entry pins its `State` and whole scope stack — a concern for a long-running integration fixture. I did **not** add a max-entry cap or ring-buffer mode: retaining everything is the right default for a test library, and that is worth adding only if someone actually reports it.

### Verification

34/34 (17 tests × net10.0/net11.0) with `/p:TreatsWarningsAsErrors=true`, on top of the branch below. Three tests added: `Count` across a chunk boundary, `Clear` emptying every accessor (`Count`, enumeration, `Informations`, `Find`, `ToString`), and the collection staying usable after a `Clear`.

`ref/Meziantou.Extensions.Logging.InMemory.cs` regenerated — the diff is exactly the two new members. Verified with `/p:PublicApiGeneratorVerifyNoChangeOnBuild=true`, the same check CI runs. `dotnet run ./eng/update-all.cs` produced no further changes.

Found during a project review of `Meziantou.Extensions.Logging.InMemory` (rated Low).
