### PR TITLE
Report temporary directory and file deletion failures

### DIFF
--- a/ref/Meziantou.Framework.TemporaryDirectory.cs
+++ b/ref/Meziantou.Framework.TemporaryDirectory.cs
@@ -7,6 +7,7 @@ namespace Meziantou.Framework
     [System.Diagnostics.DebuggerDisplay("{FullPath}")]
     public sealed class TemporaryDirectory : System.IAsyncDisposable, System.IDisposable
     {
+        public System.Exception? DeleteError { get => throw null; }
         public Meziantou.Framework.FullPath FullPath { get => throw null; }
         public static Meziantou.Framework.TemporaryDirectory Create() => throw null;
         public static Meziantou.Framework.TemporaryDirectory Create(Meziantou.Framework.FullPath rootDirectory) => throw null;
@@ -28,6 +29,7 @@ namespace Meziantou.Framework
     [System.Diagnostics.DebuggerDisplay("{FullPath}")]
     public sealed class TemporaryFile : System.IAsyncDisposable, System.IDisposable
     {
+        public System.Exception? DeleteError { get => throw null; }
         public Meziantou.Framework.FullPath FullPath { get => throw null; }
         public static Meziantou.Framework.TemporaryFile Create() => throw null;
         public static Meziantou.Framework.TemporaryFile Create(string fileNameOrPath) => throw null;

--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryDirectory.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryDirectory.cs
@@ -36,6 +36,13 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
 {
     private bool _disposed;
 
+    /// <summary>Gets the exception that prevented the deletion, or <see langword="null"/> when the deletion succeeded or has not run yet.</summary>
+    /// <remarks>
+    /// Disposing never throws, so this is how a caller observes that the directory could not be deleted.
+    /// It is set when disposal completes, so it must be read after the <see langword="using"/> block.
+    /// </remarks>
+    public Exception? DeleteError { get; private set; }
+
     /// <summary>Gets the full path to the temporary directory.</summary>
     /// <value>The absolute path to the temporary directory where files and subdirectories can be created.</value>
     /// <remarks>The path remains readable after the instance is disposed, even though the directory no longer exists.</remarks>
@@ -180,7 +187,14 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
             return;
 
         _disposed = true;
-        IOUtilities.Delete(new DirectoryInfo(FullPath));
+        try
+        {
+            IOUtilities.Delete(new DirectoryInfo(FullPath));
+        }
+        catch (Exception ex)
+        {
+            DeleteError = ex;
+        }
     }
 
     /// <summary>Asynchronously deletes the temporary directory and all its contents.</summary>
@@ -192,7 +206,14 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
             return;
 
         _disposed = true;
-        await IOUtilities.DeleteAsync(new DirectoryInfo(FullPath), CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            await IOUtilities.DeleteAsync(new DirectoryInfo(FullPath), CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            DeleteError = ex;
+        }
     }
 
     /// <summary>Combines the temporary directory path with a relative path using the / operator.</summary>

--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryFile.cs
@@ -28,6 +28,13 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
     private readonly FullPath _ownedDirectory;
     private bool _disposed;
 
+    /// <summary>Gets the exception that prevented the deletion, or <see langword="null"/> when the deletion succeeded or has not run yet.</summary>
+    /// <remarks>
+    /// Disposing never throws, so this is how a caller observes that the file could not be deleted.
+    /// It is set when disposal completes, so it must be read after the <see langword="using"/> block.
+    /// </remarks>
+    public Exception? DeleteError { get; private set; }
+
     /// <summary>Gets the full path to the temporary file.</summary>
     /// <value>The absolute path to the temporary file.</value>
     public FullPath FullPath { get; }
@@ -110,13 +117,20 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
             return;
 
         _disposed = true;
-        if (_ownedDirectory.IsEmpty)
+        try
         {
-            IOUtilities.Delete(new FileInfo(FullPath));
+            if (_ownedDirectory.IsEmpty)
+            {
+                IOUtilities.Delete(new FileInfo(FullPath));
+            }
+            else
+            {
+                IOUtilities.Delete(new DirectoryInfo(_ownedDirectory));
+            }
         }
-        else
+        catch (Exception ex)
         {
-            IOUtilities.Delete(new DirectoryInfo(_ownedDirectory));
+            DeleteError = ex;
         }
     }
 
@@ -131,10 +145,20 @@ public sealed class TemporaryFile : IDisposable, IAsyncDisposable
             return ValueTask.CompletedTask;
 
         _disposed = true;
-        if (_ownedDirectory.IsEmpty)
-            return IOUtilities.DeleteAsync(new FileInfo(FullPath), CancellationToken.None);
+        return DeleteAsync();
 
-        return IOUtilities.DeleteAsync(new DirectoryInfo(_ownedDirectory), CancellationToken.None);
+        async ValueTask DeleteAsync()
+        {
+            try
+            {
+                var target = _ownedDirectory.IsEmpty ? (FileSystemInfo)new FileInfo(FullPath) : new DirectoryInfo(_ownedDirectory);
+                await IOUtilities.DeleteAsync(target, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                DeleteError = ex;
+            }
+        }
     }
 
     /// <summary>Implicitly converts a <see cref="TemporaryFile"/> to a <see cref="FullPath"/>.</summary>

--- a/src/Meziantou.Framework/IOUtilities.Delete.cs
+++ b/src/Meziantou.Framework/IOUtilities.Delete.cs
@@ -7,6 +7,9 @@ internal
 #endif
 static partial class IOUtilities
 {
+    private const int MaxAttempts = 10;
+    private static readonly TimeSpan DelayBetweenAttempts = TimeSpan.FromMilliseconds(50);
+
     /// <summary>Determines whether the specified exception is a sharing violation exception.</summary>
     /// <param name="exception">The exception. May not be null.</param>
     /// <returns>
@@ -81,23 +84,22 @@ static partial class IOUtilities
 
     private static void Retry(Action action)
     {
-        var attempt = 0;
-        while (attempt < 10)
+        for (var attempt = 0; ; attempt++)
         {
             try
             {
                 action();
                 return;
             }
-            catch (IOException ex) when (IsSharingViolation(ex))
+            // The last attempt lets the exception flow to the caller instead of reporting a deletion that did not happen.
+            catch (IOException ex) when (attempt < MaxAttempts - 1 && IsSharingViolation(ex))
             {
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException) when (attempt < MaxAttempts - 1)
             {
             }
 
-            attempt++;
-            Thread.Sleep(50);
+            Thread.Sleep(DelayBetweenAttempts);
         }
     }
 
@@ -179,23 +181,22 @@ static partial class IOUtilities
 
     private static async ValueTask RetryOnSharingViolationAsync(Action action, CancellationToken cancellationToken)
     {
-        var attempt = 0;
-        while (attempt < 10)
+        for (var attempt = 0; ; attempt++)
         {
             try
             {
                 action();
                 return;
             }
-            catch (IOException ex) when (IsSharingViolation(ex))
+            // The last attempt lets the exception flow to the caller instead of reporting a deletion that did not happen.
+            catch (IOException ex) when (attempt < MaxAttempts - 1 && IsSharingViolation(ex))
             {
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException) when (attempt < MaxAttempts - 1)
             {
             }
 
-            attempt++;
-            await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+            await Task.Delay(DelayBetweenAttempts, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
+++ b/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
@@ -262,6 +262,68 @@ public class TemporaryDirectoryTests
     }
 
     [Fact]
+    public void DeleteErrorIsNullWhenTheDirectoryIsDeleted()
+    {
+        var dir = TemporaryDirectory.Create();
+        dir.CreateTextFile("a.txt", "content");
+        dir.Dispose();
+
+        Assert.Null(dir.DeleteError);
+        Assert.False(Directory.Exists(dir.FullPath));
+    }
+
+    [Fact]
+    public void DeleteErrorReportsADirectoryThatCouldNotBeDeleted()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // relies on Unix directory permissions to make the deletion fail
+
+        using var parent = TemporaryDirectory.Create();
+        var root = parent.CreateDirectory("root");
+        var dir = TemporaryDirectory.Create(root);
+
+        // Removing the write permission on the parent prevents the directory from being unlinked.
+        File.SetUnixFileMode(root.Value, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        try
+        {
+            dir.Dispose();
+
+            Assert.NotNull(dir.DeleteError);
+            Assert.True(Directory.Exists(dir.FullPath));
+        }
+        finally
+        {
+            File.SetUnixFileMode(root.Value, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
+    [Fact]
+    public void DeleteErrorReportsAFileThatCouldNotBeDeletedAfterEveryAttempt()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // relies on Unix directory permissions to make the deletion fail
+
+        using var parent = TemporaryDirectory.Create();
+        var root = parent.CreateDirectory("root");
+        var file = TemporaryFile.Create(root / "temp.txt");
+
+        // Unlinking a file needs the write permission on its parent directory. The deletion fails with
+        // UnauthorizedAccessException, which is the exception the retry loop swallows until it runs out of attempts.
+        File.SetUnixFileMode(root.Value, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        try
+        {
+            file.Dispose();
+
+            Assert.IsType<UnauthorizedAccessException>(file.DeleteError);
+            Assert.True(File.Exists(file.FullPath));
+        }
+        finally
+        {
+            File.SetUnixFileMode(root.Value, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
+    [Fact]
     public void TemporaryFileCreateWithFullPath()
     {
         var fullPath = FullPath.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".tmp");


### PR DESCRIPTION
**Stack 4 of 4** · merges into #2607 · must merge last.

`Retry` looped ten times over sharing violations and `UnauthorizedAccessException`, and on exhaustion just fell out of the `while` and returned as if it had succeeded (`IOUtilities.Delete.cs:82-102`, and the same in `RetryOnSharingViolationAsync`). The last exception was discarded, so the caller got no return value, no exception, and no way to tell that nothing was deleted.

The sole contract of `TemporaryDirectory`/`TemporaryFile` is "automatically deleted when disposed", and it could quietly not do that. On Windows this is not exotic — a virus scanner or indexer holding a handle for more than half a second is enough. The failure mode is invisible accumulation, the hardest kind to diagnose, because the symptom (a full disk on a build agent) shows up far from the cause.

## Changes

**`IOUtilities`** — the retry guard moves into a `when` clause, so the final attempt's exception propagates naturally with its original stack trace instead of being swallowed. Attempt count and delay are unchanged (10 attempts, 50 ms apart), now named constants. The loop also no longer sleeps after the final attempt.

**`TemporaryDirectory` / `TemporaryFile`** — `Dispose`/`DisposeAsync` catch that exception and expose it as `DeleteError`:

```c#
TemporaryDirectory dir;
using (dir = TemporaryDirectory.Create()) { }
if (dir.DeleteError is not null) { /* cleanup did not happen */ }
```

Both halves are in one PR deliberately: shipping the rethrow alone would make disposal start throwing, and throwing from `Dispose` while a `using` block is already unwinding would mask the original exception. Disposal stays non-throwing.

`IOUtilities.Delete` is public API in `Meziantou.Framework` (`PUBLIC_IO_UTILITIES`), so **this is a behaviour change for that package too**: a delete that cannot complete now throws instead of returning silently. No other caller in the repo relies on the old behaviour — `TemporaryDirectory` and `TemporaryFile` are the only ones, and both are updated here.

## Verification

`DeleteErrorReportsAFileThatCouldNotBeDeletedAfterEveryAttempt` drives the exhaustion path end to end: a file whose parent directory has no write permission fails to unlink with `UnauthorizedAccessException` — the exact exception the loop swallows. Measured at 494 ms for disposal, confirming all ten attempts ran. It **fails on the parent branch** (`DeleteError` is null) and passes here.

Two further tests cover `DeleteError` being null on success, and a non-retryable `IOException` being reported.

44/44 pass (22 tests × net10.0/net11.0), `/p:TreatsWarningsAsErrors=true` clean.

`ref/Meziantou.Framework.TemporaryDirectory.cs` regenerated for the new `DeleteError` members (Release + `IsOfficialBuild`); the diff is exactly the two added properties.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
