### PR TITLE
Reject paths that resolve outside the temporary directory

### DIFF
--- a/src/Meziantou.Framework.TemporaryDirectory/TemporaryDirectory.cs
+++ b/src/Meziantou.Framework.TemporaryDirectory/TemporaryDirectory.cs
@@ -70,6 +70,8 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     /// <summary>Gets the full path for a relative path within the temporary directory.</summary>
     /// <param name="relativePath">The relative path (can include subdirectories).</param>
     /// <returns>The absolute <see cref="FullPath"/> combining the temporary directory and the relative path.</returns>
+    /// <remarks>The resulting path must stay inside the temporary directory, so it cannot be escaped using "..".</remarks>
+    /// <exception cref="ArgumentException"><paramref name="relativePath"/> is rooted, or resolves to a path outside the temporary directory.</exception>
     /// <example>
     /// <code>
     /// using var tempDir = TemporaryDirectory.Create();
@@ -78,13 +80,21 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     /// </example>
     public FullPath GetFullPath(string relativePath)
     {
-        return FullPath.Combine(FullPath, relativePath);
+        var path = FullPath.Combine(FullPath, relativePath);
+
+        // Path.Combine returns relativePath as-is when it is rooted, and GetFullPath resolves any "..",
+        // so both ways out of the directory are caught here.
+        if (path != FullPath && !path.IsChildOf(FullPath))
+            throw new ArgumentException($"The path '{relativePath}' resolves to '{path}', which is outside the temporary directory '{FullPath}'.", nameof(relativePath));
+
+        return path;
     }
 
     /// <summary>Creates an empty file at the specified relative path.</summary>
     /// <param name="relativePath">The relative path for the file (can include subdirectories).</param>
     /// <returns>The absolute <see cref="FullPath"/> of the created file.</returns>
     /// <remarks>If the parent directories don't exist, they will be created automatically.</remarks>
+    /// <exception cref="ArgumentException"><paramref name="relativePath"/> resolves to a path outside the temporary directory.</exception>
     /// <example>
     /// <code>
     /// using var tempDir = TemporaryDirectory.Create();
@@ -104,6 +114,7 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     /// <param name="content">The text content to write to the file.</param>
     /// <returns>The absolute <see cref="FullPath"/> of the created file.</returns>
     /// <remarks>If the parent directories don't exist, they will be created automatically.</remarks>
+    /// <exception cref="ArgumentException"><paramref name="relativePath"/> resolves to a path outside the temporary directory.</exception>
     /// <example>
     /// <code>
     /// using var tempDir = TemporaryDirectory.Create();
@@ -124,6 +135,7 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation, containing the absolute <see cref="FullPath"/> of the created file.</returns>
     /// <remarks>If the parent directories don't exist, they will be created automatically.</remarks>
+    /// <exception cref="ArgumentException"><paramref name="relativePath"/> resolves to a path outside the temporary directory.</exception>
     /// <example>
     /// <code>
     /// await using var tempDir = TemporaryDirectory.Create();
@@ -142,6 +154,7 @@ public sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
     /// <param name="relativePath">The relative path for the directory (can include subdirectories).</param>
     /// <returns>The absolute <see cref="FullPath"/> of the created directory.</returns>
     /// <remarks>If parent directories don't exist, they will be created automatically.</remarks>
+    /// <exception cref="ArgumentException"><paramref name="relativePath"/> resolves to a path outside the temporary directory.</exception>
     /// <example>
     /// <code>
     /// using var tempDir = TemporaryDirectory.Create();

--- a/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
+++ b/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
@@ -79,6 +79,41 @@ public class TemporaryDirectoryTests
         Assert.Equal(dir.GetFullPath("subdir/file.txt"), path);
     }
 
+    [Theory]
+    [InlineData("../escape.txt")]
+    [InlineData("sub/../../escape.txt")]
+    [InlineData("..")]
+    public void GetFullPathRejectsPathsOutsideTheDirectory(string relativePath)
+    {
+        using var dir = TemporaryDirectory.Create();
+
+        Assert.Throws<ArgumentException>(() => dir.GetFullPath(relativePath));
+        Assert.Throws<ArgumentException>(() => dir.CreateTextFile(relativePath, "content"));
+        Assert.Throws<ArgumentException>(() => dir.CreateEmptyFile(relativePath));
+        Assert.Throws<ArgumentException>(() => dir.CreateDirectory(relativePath));
+        Assert.Throws<ArgumentException>(() => dir / relativePath);
+    }
+
+    [Fact]
+    public void GetFullPathRejectsARootedPath()
+    {
+        using var dir = TemporaryDirectory.Create();
+        var rooted = FullPath.Combine(Path.GetTempPath(), "escape.txt");
+
+        Assert.Throws<ArgumentException>(() => dir.GetFullPath(rooted.Value));
+    }
+
+    [Fact]
+    public void GetFullPathAllowsPathsInsideTheDirectory()
+    {
+        using var dir = TemporaryDirectory.Create();
+
+        Assert.Equal(dir.FullPath / "a.txt", dir.GetFullPath("a.txt"));
+        Assert.Equal(dir.FullPath / "sub" / "a.txt", dir.GetFullPath("sub/a.txt"));
+        Assert.Equal(dir.FullPath / "a.txt", dir.GetFullPath("sub/../a.txt"));
+        Assert.Equal(dir.FullPath, dir.GetFullPath(""));
+    }
+
     [Fact]
     public void TemporaryFileDisposedDeletesFile()
     {


### PR DESCRIPTION
`GetFullPath` is `FullPath.Combine(FullPath, relativePath)` (`TemporaryDirectory.cs:79-82`), which neither rejects rooted paths nor checks containment — so both ways out of the directory worked:

```c#
using var tempDir = TemporaryDirectory.Create();
tempDir.GetFullPath("../escape.txt");            // → $TMPDIR/MezTD/escape.txt   (sibling)
tempDir.GetFullPath("/tmp/abs.txt");             // → /tmp/abs.txt               (Path.Combine drops the root entirely)
tempDir.CreateTextFile("../escaped.txt", "x");   // actually writes there, and survives disposal
```

Meanwhile the XML docs say "relative path **within** the temporary directory", so consumers reasonably read the type as a sandbox. It was not one, and every create method funnels through `GetFullPath`, so all of them inherited the gap.

The realistic damage is in consumer code that feeds it names it did not author — `tempDir.CreateTextFile(entry.FullName, …)` while extracting an archive is a textbook zip-slip. Escaped files also defeat cleanup, since disposal only covers the temp directory itself.

## Changes

`GetFullPath` now verifies the combined path is the temporary directory or a child of it, and throws `ArgumentException` otherwise. This uses the existing `FullPath.IsChildOf`, which already handles separator boundaries and per-OS case sensitivity, so `../MezTD-evil` is not mistaken for a child of `../MezTD`.

Because `Path.Combine` returns a rooted second argument as-is and `Path.GetFullPath` resolves `..`, one check at the end covers both escape routes. `GetFullPath("")` still returns the directory itself, and paths that traverse and come back (`"sub/../a.txt"`) are still allowed — only the resolved destination matters.

`CreateEmptyFile`, `CreateTextFile`, `CreateTextFileAsync`, `CreateDirectory` and `operator /` all inherit the check, and their docs now list the exception.

## Breaking change

`..` currently works, so anything deliberately relying on it will now throw. I grepped the repo for `..` passed to these members and found nothing outside `FullPath`'s own tests, so no in-repo caller is affected.

## Verification

Five tests added, covering `..`, a path that traverses out and back, a bare `..`, a rooted path, and the still-allowed cases — each asserted across `GetFullPath`, all three create methods and `operator /`.

- `Meziantou.Framework.TemporaryDirectory.Tests`: 28/28 pass (14 tests × net10.0/net11.0).
- `Meziantou.Framework.FullPath.Tests` as a smoke test for a heavy consumer: 216 passed, 0 failed.
- `/p:TreatsWarningsAsErrors=true` clean. No public API change, so `ref/` is untouched.

> Conflict note: #2607 also edits `GetFullPath` (to add the disposed guard). Whichever merges second needs a small rebase.
