### PR TITLE
Cover the TemporaryDirectory create methods and drop a redundant assertion loop

### DIFF
--- a/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
+++ b/tests/Meziantou.Framework.TemporaryDirectory.Tests/TemporaryDirectoryTests.cs
@@ -18,10 +18,7 @@ public class TemporaryDirectoryTests
 
             Assert.HasCount(Iterations, dirs.Select(dir => dir.FullPath).Distinct());
 
-            foreach (var dir in dirs)
-            {
-                Assert.All(dirs, dir => Assert.True(Directory.Exists(dir.FullPath)));
-            }
+            Assert.All(dirs, dir => Assert.True(Directory.Exists(dir.FullPath)));
         }
         finally
         {
@@ -77,6 +74,73 @@ public class TemporaryDirectoryTests
         await using var dir = TemporaryDirectory.Create();
         var path = dir / "subdir" / "file.txt";
         Assert.Equal(dir.GetFullPath("subdir/file.txt"), path);
+    }
+
+    [Fact]
+    public void CreateTextFileReturnsThePathAndWritesTheContent()
+    {
+        using var dir = TemporaryDirectory.Create();
+
+        var path = dir.CreateTextFile("a.txt", "content");
+
+        Assert.Equal(dir.GetFullPath("a.txt"), path);
+        Assert.Equal("content", File.ReadAllText(path));
+    }
+
+    [Fact]
+    public async Task CreateTextFileAsyncReturnsThePathAndWritesTheContent()
+    {
+        await using var dir = TemporaryDirectory.Create();
+
+        var path = await dir.CreateTextFileAsync("a.txt", "content", XunitCancellationToken);
+
+        Assert.Equal(dir.GetFullPath("a.txt"), path);
+        Assert.Equal("content", await File.ReadAllTextAsync(path, XunitCancellationToken));
+    }
+
+    [Fact]
+    public void CreateEmptyFileReturnsThePathAndCreatesAnEmptyFile()
+    {
+        using var dir = TemporaryDirectory.Create();
+
+        var path = dir.CreateEmptyFile("a.txt");
+
+        Assert.Equal(dir.GetFullPath("a.txt"), path);
+        Assert.Empty(File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void CreateDirectoryReturnsThePathAndCreatesTheDirectory()
+    {
+        using var dir = TemporaryDirectory.Create();
+
+        var path = dir.CreateDirectory("sub/nested");
+
+        Assert.Equal(dir.GetFullPath("sub/nested"), path);
+        Assert.True(Directory.Exists(path));
+    }
+
+    [Fact]
+    public void CreateFileCreatesTheParentDirectories()
+    {
+        using var dir = TemporaryDirectory.Create();
+
+        var path = dir.CreateTextFile("sub/nested/a.txt", "content");
+
+        Assert.True(File.Exists(path));
+        Assert.True(Directory.Exists(dir.GetFullPath("sub/nested")));
+    }
+
+    [Fact]
+    public void CreateUnderAnExplicitRootDirectory()
+    {
+        using var parent = TemporaryDirectory.Create();
+        var root = parent.GetFullPath("root");
+
+        using var dir = TemporaryDirectory.Create(root);
+
+        Assert.Equal(root, dir.FullPath.Parent);
+        Assert.True(Directory.Exists(dir.FullPath));
     }
 
     [Fact]


### PR DESCRIPTION
Two test-suite issues found while reviewing `src/Meziantou.Framework.TemporaryDirectory`. No production code changes.

## Missing coverage

`CreateDirectory`, `CreateTextFile`, `CreateTextFileAsync` and the `Create(FullPath rootDirectory)` overload had no tests at all, and `CreateEmptyFile` was only exercised incidentally inside `CreateInParallel`. Nothing asserted the *return value* of any create method, even though every one of them returns the path it created.

These are the paths that touch the filesystem in ways that differ across platforms, so they are the ones worth pinning. Six tests added, covering the returned path and the on-disk result for each create method, automatic parent-directory creation, and the explicit-root overload.

## `CreateInParallel` runs 160,000 assertions where 400 were intended

```c#
foreach (var dir in dirs)
{
    Assert.All(dirs, dir => Assert.True(Directory.Exists(dir.FullPath)));
}
```

The inner lambda parameter shadows the outer loop variable, which is then never used, so the complete 400-element `Assert.All` is re-run once per element — 160,000 `Directory.Exists` calls for a check the inner `Assert.All` already performs completely on its own. It passes, but it is dead work in the slowest test in the file, and the shadowing reads as intentional to the next person.

The outer `foreach` is removed; the `Assert.All` is unchanged.

## Verification

30/30 pass (15 tests × net10.0/net11.0), `/p:TreatsWarningsAsErrors=true` clean.

> Conflict note: several other PRs from the same review also append to `TemporaryDirectoryTests.cs` (#2605, #2607, #2637, #2638). Whichever merge later need a small rebase; the additions are in different regions of the file.
