### PR TITLE
Drain HttpContent off the ambient synchronization context to avoid a deadlock

### DIFF
--- a/src/Meziantou.Framework.HumanReadableSerializer/Converters/HttpContentConverter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Converters/HttpContentConverter.cs
@@ -40,7 +40,7 @@ internal sealed class HttpContentConverter : HumanReadableConverter<HttpContent>
         {
             if (CanReadAsString(value))
             {
-                var str = value.ReadAsStringAsync().Result;
+                var str = ReadSynchronously(value.ReadAsStringAsync);
 
                 var mediaType = value.Headers.ContentType?.MediaType;
                 if (mediaType is not null)
@@ -54,12 +54,25 @@ internal sealed class HttpContentConverter : HumanReadableConverter<HttpContent>
             }
             else
             {
-                var bytes = value.ReadAsByteArrayAsync().Result;
+                var bytes = ReadSynchronously(value.ReadAsByteArrayAsync);
                 options.GetConverter(typeof(byte[])).WriteValue(writer, bytes, typeof(byte[]), options);
             }
         }
 
         writer.EndObject();
+    }
+
+    // The serializer is synchronous, so the content has to be drained on the calling thread.
+    // Task.Run detaches the read from the ambient SynchronizationContext: without it, content
+    // whose continuations post back to a single-threaded context (a UI thread, or a custom
+    // Stream in a test fixture) deadlocks against the thread blocked here.
+    // ConfigureAwait(false) is not enough, as it only applies to the awaits owned by this method.
+    private static T ReadSynchronously<T>(Func<Task<T>> read)
+    {
+        if (SynchronizationContext.Current is null)
+            return read().GetAwaiter().GetResult();
+
+        return Task.Run(read).GetAwaiter().GetResult();
     }
 
     private static bool CanReadAsString(HttpContent content)

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -1490,6 +1490,112 @@ public sealed partial class SerializerTests : SerializerTestsBase
     }
 
     [Fact]
+    public void HttpContent_DoesNotDeadlockUnderSingleThreadedSynchronizationContext()
+    {
+        using var completed = new ManualResetEventSlim();
+        string? result = null;
+
+        var thread = new Thread(() =>
+        {
+            var context = new SingleThreadedSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(context);
+            context.Post(_ =>
+            {
+                try
+                {
+                    using var message = new StreamContent(new ContextCapturingStream());
+                    message.Headers.TryAddWithoutValidation("Content-Type", "text/plain");
+                    result = HumanReadableSerializer.Serialize(message);
+                }
+                finally
+                {
+                    completed.Set();
+                    context.Complete();
+                }
+            }, state: null);
+
+            context.RunLoop();
+        })
+        {
+            IsBackground = true,
+        };
+
+        thread.Start();
+
+        Assert.True(completed.Wait(TimeSpan.FromSeconds(30)), "Serializing the content deadlocked");
+        Assert.Equal("""
+            Headers:
+              Content-Type: text/plain
+            Value: xxx
+            """, result, ignoreLineEndingDifferences: true);
+    }
+
+    // Continuations are posted back to the captured context, which is what deadlocks a
+    // caller that blocks on the read. A hand-written stream in a test fixture behaves this way.
+    private sealed class ContextCapturingStream : Stream
+    {
+        private int _remaining = 3;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            if (_remaining-- <= 0)
+                return 0;
+
+            buffer.Span[0] = (byte)'x';
+            return 1;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class SingleThreadedSynchronizationContext : SynchronizationContext
+    {
+        private readonly BlockingCollection<(SendOrPostCallback Callback, object? State)> _queue = [];
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            try
+            {
+                _queue.Add((d, state));
+            }
+            catch (InvalidOperationException)
+            {
+                // The queue is completed, the loop has already stopped
+            }
+        }
+
+        public void Complete() => _queue.CompleteAdding();
+
+        public void RunLoop()
+        {
+            foreach (var (callback, state) in _queue.GetConsumingEnumerable())
+            {
+                callback(state);
+            }
+        }
+    }
+
+    [Fact]
     public void HttpContent_ByteArrayContent_WithHeaders()
     {
         using var message = new ByteArrayContent([1, 2, 3, 4, 5, 6, 7, 8, 9])


### PR DESCRIPTION
## The problem

`HttpContentConverter` drained the content with `.Result`:

```csharp
var str = value.ReadAsStringAsync().Result;
...
var bytes = value.ReadAsByteArrayAsync().Result;
```

Under a single-threaded `SynchronizationContext` — a UI thread, or any host with a message pump — this deadlocks whenever the content's read continuations post back to that context. The one thread is parked inside `.Result` and can never run the continuation that would complete the task. Serializing an `HttpResponseMessage` for a snapshot simply hangs.

Content that is already buffered completes synchronously, which is why this has not bitten more often: it needs an `HttpContent` that actually yields.

## Why not `ConfigureAwait(false)`

That was my first instinct and it does **not** work. I measured all three variants against a `StreamContent` whose `ReadAsync` awaits without `ConfigureAwait(false)` (i.e. a hand-written stream in a test fixture — exactly the shape this library gets pointed at):

| approach | result |
|---|---|
| `.Result` | **deadlock** |
| `.ConfigureAwait(false).GetAwaiter().GetResult()` | **deadlock** |
| `Task.Run(...).GetAwaiter().GetResult()` | completes |

`ConfigureAwait(false)` only governs the awaits owned by the calling method. It does nothing about continuations captured *inside* the content's own read path, which is where the capture actually happens.

## The change

A small `ReadSynchronously` helper. When there is no ambient context it awaits directly, exactly as before, so the common path adds nothing. When a context is present it hops to the thread pool via `Task.Run`, which runs the read with no ambient context so nothing can post back to the blocked thread.

This does not make the serializer asynchronous — the writer API is synchronous by design and the calling thread still blocks. It converts a permanent hang into progress. Under severe thread-pool starvation a blocking wait can still stall; the real fix for that would be an async serialization path, which is a much larger change.

## Scope

`AsyncEnumerableConverterFactory` and `AsyncEnumerableKeyValuePairConverterFactory` bridge with `ToBlockingEnumerable()`, which has the same shape. Fixing those properly means buffering the sequence rather than streaming it, so I left them out of this PR rather than changing collection semantics along the way.

## Verification

- New test `HttpContent_DoesNotDeadlockUnderSingleThreadedSynchronizationContext` drives serialization on a real single-threaded pump and asserts completion within 30s. I confirmed it **fails on both TFMs without the fix** (`Serializing the content deadlocked`) and passes with it, so it is a real regression test rather than one that merely happens to be green.
- `Meziantou.Framework.HumanReadableSerializer.Tests`: 534 passed (net10.0 + net11.0), 0 failed.
- Downstream: `SnapshotTesting.Tests` 167 passed, `InlineSnapshotTesting.Tests` 131 passed.
