### PR TITLE
Implement ISupportExternalScope on InMemoryLoggerProvider

### DIFF
--- a/ref/Meziantou.Extensions.Logging.InMemory.cs
+++ b/ref/Meziantou.Extensions.Logging.InMemory.cs
@@ -62,7 +62,7 @@ namespace Meziantou.Extensions.Logging.InMemory
         public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
     }
 
-    public sealed class InMemoryLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, System.IDisposable
+    public sealed class InMemoryLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, Microsoft.Extensions.Logging.ISupportExternalScope, System.IDisposable
     {
         public Meziantou.Extensions.Logging.InMemory.InMemoryLogCollection Logs { get => throw null; }
         public InMemoryLoggerProvider(Meziantou.Extensions.Logging.InMemory.InMemoryLogCollection? logs) { }
@@ -74,6 +74,7 @@ namespace Meziantou.Extensions.Logging.InMemory
         public InMemoryLoggerProvider(System.TimeProvider? timeProvider, Meziantou.Extensions.Logging.InMemory.InMemoryLogCollection? logs, Microsoft.Extensions.Logging.IExternalScopeProvider? scopeProvider) { }
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName) => throw null;
         public Microsoft.Extensions.Logging.ILogger<T> CreateLogger<T>() => throw null;
+        public void SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
         public void Dispose() { }
     }
 }

--- a/src/Meziantou.Extensions.Logging.InMemory/InMemoryLoggerProvider.cs
+++ b/src/Meziantou.Extensions.Logging.InMemory/InMemoryLoggerProvider.cs
@@ -18,9 +18,9 @@ namespace Meziantou.Extensions.Logging.InMemory;
 /// var logs = provider.Logs.Informations;
 /// </code>
 /// </example>
-public sealed class InMemoryLoggerProvider : ILoggerProvider
+public sealed class InMemoryLoggerProvider : ILoggerProvider, ISupportExternalScope
 {
-    private readonly IExternalScopeProvider _scopeProvider;
+    private readonly MutableExternalScopeProvider _scopeProvider;
     private readonly TimeProvider _timeProvider;
 
     /// <summary>Gets the collection of log entries captured by all loggers created by this provider.</summary>
@@ -52,7 +52,7 @@ public sealed class InMemoryLoggerProvider : ILoggerProvider
     public InMemoryLoggerProvider(InMemoryLogCollection? logs, IExternalScopeProvider? scopeProvider)
     {
         Logs = logs ?? [];
-        _scopeProvider = scopeProvider ?? new LoggerExternalScopeProvider();
+        _scopeProvider = new MutableExternalScopeProvider(scopeProvider ?? new LoggerExternalScopeProvider());
         _timeProvider = TimeProvider.System;
     }
 
@@ -87,7 +87,7 @@ public sealed class InMemoryLoggerProvider : ILoggerProvider
     {
         _timeProvider = timeProvider ?? TimeProvider.System;
         Logs = logs ?? [];
-        _scopeProvider = scopeProvider ?? new LoggerExternalScopeProvider();
+        _scopeProvider = new MutableExternalScopeProvider(scopeProvider ?? new LoggerExternalScopeProvider());
     }
 
     /// <summary>Creates a new logger instance with the specified category name.</summary>
@@ -104,6 +104,18 @@ public sealed class InMemoryLoggerProvider : ILoggerProvider
     public ILogger<T> CreateLogger<T>()
     {
         return new InMemoryLogger<T>(Logs, _scopeProvider, _timeProvider);
+    }
+
+    /// <summary>Sets the external scope provider supplied by the logger factory.</summary>
+    /// <param name="scopeProvider">The scope provider the factory uses to track scopes.</param>
+    /// <remarks>
+    /// Implementing <see cref="ISupportExternalScope"/> is what makes the factory route its scopes
+    /// through this provider, including the ones it synthesises from the current activity when
+    /// <c>LoggerFactoryOptions.ActivityTrackingOptions</c> is set.
+    /// </remarks>
+    public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+    {
+        _scopeProvider.Current = scopeProvider;
     }
 
     public void Dispose()

--- a/src/Meziantou.Extensions.Logging.InMemory/MutableExternalScopeProvider.cs
+++ b/src/Meziantou.Extensions.Logging.InMemory/MutableExternalScopeProvider.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Logging;
+
+namespace Meziantou.Extensions.Logging.InMemory;
+
+// ILoggerFactory hands a provider its own scope provider through ISupportExternalScope, but only
+// once the provider is registered. Loggers therefore hold this indirection instead of a specific
+// IExternalScopeProvider, so a logger created before that hand-off still observes the factory's
+// scopes afterwards.
+internal sealed class MutableExternalScopeProvider : IExternalScopeProvider
+{
+    private IExternalScopeProvider _current;
+
+    public MutableExternalScopeProvider(IExternalScopeProvider current)
+    {
+        _current = current;
+    }
+
+    public IExternalScopeProvider Current
+    {
+        get => Volatile.Read(ref _current);
+        set => Volatile.Write(ref _current, value);
+    }
+
+    public void ForEachScope<TState>(Action<object?, TState> callback, TState state) => Current.ForEachScope(callback, state);
+
+    public IDisposable Push(object? state) => Current.Push(state);
+}

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/HostTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/HostTests.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CA1848 // Use the LoggerMessage delegates
+using System.Diagnostics;
 using Meziantou.Extensions.Logging.Xunit.v3;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -31,5 +32,78 @@ public sealed class HostTests
         logger.LogInformation("Test");
 
         Assert.Single(provider.Logs);
+    }
+
+    [Fact]
+    public void ScopeIsCapturedExactlyOnce()
+    {
+        using var provider = new InMemoryLoggerProvider();
+        var host = new HostBuilder()
+            .ConfigureLogging(builder => builder.Services.AddSingleton<ILoggerProvider>(provider))
+            .Build();
+
+        var logger = host.Services.GetRequiredService<ILogger<HostTests>>();
+        using (logger.BeginScope(new Dictionary<string, object?>(StringComparer.Ordinal) { ["UserId"] = 42 }))
+        {
+            logger.LogInformation("Test");
+        }
+
+        var log = Assert.Single(provider.Logs);
+        var scope = Assert.Single(log.Scopes);
+        Assert.Equal(42, Assert.IsType<Dictionary<string, object?>>(scope)["UserId"]);
+    }
+
+    [Fact]
+    public void ActivityTrackingScopesAreCaptured()
+    {
+        using var provider = new InMemoryLoggerProvider();
+        var host = new HostBuilder()
+            .ConfigureLogging(builder =>
+            {
+                builder.Services.AddSingleton<ILoggerProvider>(provider);
+                builder.Configure(options => options.ActivityTrackingOptions = ActivityTrackingOptions.TraceId | ActivityTrackingOptions.SpanId);
+            })
+            .Build();
+
+        using var activitySource = new ActivitySource("Meziantou.Extensions.Logging.InMemory.Tests");
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source == activitySource,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var logger = host.Services.GetRequiredService<ILogger<HostTests>>();
+        using var activity = activitySource.StartActivity("operation");
+        Assert.NotNull(activity);
+
+        logger.LogInformation("Test");
+
+        var log = Assert.Single(provider.Logs);
+        Assert.True(log.TryGetParameterValue("TraceId", out var traceId));
+        Assert.Equal(activity.TraceId.ToString(), traceId?.ToString());
+        Assert.True(log.TryGetParameterValue("SpanId", out var spanId));
+        Assert.Equal(activity.SpanId.ToString(), spanId?.ToString());
+    }
+
+    [Fact]
+    public void ScopesAreNotCapturedWhenTheFactoryDisablesThem()
+    {
+        using var provider = new InMemoryLoggerProvider();
+        var host = new HostBuilder()
+            .ConfigureLogging(builder =>
+            {
+                builder.Services.AddSingleton<ILoggerProvider>(provider);
+                builder.Services.Configure<LoggerFilterOptions>(options => options.CaptureScopes = false);
+            })
+            .Build();
+
+        var logger = host.Services.GetRequiredService<ILogger<HostTests>>();
+        using (logger.BeginScope(new Dictionary<string, object?>(StringComparer.Ordinal) { ["UserId"] = 42 }))
+        {
+            logger.LogInformation("Test");
+        }
+
+        Assert.Empty(Assert.Single(provider.Logs).Scopes);
     }
 }


### PR DESCRIPTION
> **Stack 1 of 2** · merges into `main` · must merge before the constructor PR stacked on top of it.

`InMemoryLoggerProvider` declares only `ILoggerProvider`. `LoggerFactory` calls `SetScopeProvider` **only** on providers that implement `ISupportExternalScope`, and that factory-owned scope provider is what synthesises the `ActivityTrackingOptions` scopes — TraceId, SpanId, ParentId, Baggage, Tags. This provider kept its own private `LoggerExternalScopeProvider` instead, so it only ever saw scopes pushed through `ILogger.BeginScope`.

### The failure

Against a `HostBuilder` configured with `ActivityTrackingOptions.TraceId | SpanId`, inside a live `Activity`:

```
Activity.Current = a0bdd46ee0cdc69761e86d1e1ca524f0
scopes captured = 1
  - String: manual scope
TraceId findable = False
provider implements ISupportExternalScope = False
```

Manual `BeginScope` was captured correctly; the TraceId/SpanId scope that `ConsoleLoggerProvider` shows was absent. This is the one place the library's observable behaviour diverged from every in-box provider, and it diverged **silently** — an empty result rather than an error. Anyone writing a test that asserts a log line carries the right correlation id — a common reason to reach for this package with `WebApplicationFactory`, which the README explicitly promotes — could not, and was not told why.

### The change

`InMemoryLoggerProvider` implements `ISupportExternalScope`. Loggers hold a small `MutableExternalScopeProvider` indirection rather than a specific `IExternalScopeProvider`, so a logger created *before* the factory hands over its provider still observes the factory's scopes afterwards — the factory calls `SetScopeProvider` at registration time, but `provider.CreateLogger(...)` can legitimately be called before that.

### Behaviour change to be aware of

This is not purely additive. Under a host, scopes now flow through the factory's provider, so **activity-tracking scopes start appearing in `log.Scopes`** where previously only manual scopes did. An existing consumer asserting `Assert.Single(log.Scopes)` while activity tracking is enabled would go red on upgrade. That seems clearly like the correct behaviour — it is what every other provider does — but it is a real change and worth a deliberate nod before merging.

### Verification

30/30 (15 tests × net10.0/net11.0) with `/p:TreatsWarningsAsErrors=true`. `dotnet run ./eng/update-all.cs` produced no further changes. `ref/` regenerated; verified with `/p:PublicApiGeneratorVerifyNoChangeOnBuild=true`, the same check CI runs.

Three tests added to `HostTests`:

- `ActivityTrackingScopesAreCaptured` — confirmed failing on `main` on both TFMs, passing with the fix.
- `ScopeIsCapturedExactlyOnce` — the risk when adopting `ISupportExternalScope` is double-counting, since `Logger.BeginScope` could push a scope both through the factory's provider and through the provider's own logger. It does not: the factory adds a single shared `ScopeLogger` for providers that support external scope. This test pins that down.

### Correction to the finding that prompted this

The review also claimed the provider ignored `LoggerFilterOptions.CaptureScopes = false`. **That was wrong** — I wrote a test for it and it passes on `main` too. With `CaptureScopes = false` the factory's scope-logger list is empty, so `BeginScope` never reaches the provider at all. `ScopesAreNotCapturedWhenTheFactoryDisablesThem` is kept anyway as a guard, but it is not fixing anything.

Found during a project review of `Meziantou.Extensions.Logging.InMemory` (rated Medium).
