### PR TITLE
Add InMemoryLoggerProvider.Create for unambiguous null arguments

### DIFF
--- a/ref/Meziantou.Extensions.Logging.InMemory.cs
+++ b/ref/Meziantou.Extensions.Logging.InMemory.cs
@@ -72,6 +72,7 @@ namespace Meziantou.Extensions.Logging.InMemory
         public InMemoryLoggerProvider(System.TimeProvider? timeProvider, Meziantou.Extensions.Logging.InMemory.InMemoryLogCollection? logs) { }
         public InMemoryLoggerProvider(System.TimeProvider? timeProvider, Microsoft.Extensions.Logging.IExternalScopeProvider? scopeProvider) { }
         public InMemoryLoggerProvider(System.TimeProvider? timeProvider, Meziantou.Extensions.Logging.InMemory.InMemoryLogCollection? logs, Microsoft.Extensions.Logging.IExternalScopeProvider? scopeProvider) { }
+        public static Meziantou.Extensions.Logging.InMemory.InMemoryLoggerProvider Create(Meziantou.Extensions.Logging.InMemory.InMemoryLogCollection? logs = null, Microsoft.Extensions.Logging.IExternalScopeProvider? scopeProvider = null, System.TimeProvider? timeProvider = null) => throw null;
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName) => throw null;
         public Microsoft.Extensions.Logging.ILogger<T> CreateLogger<T>() => throw null;
         public void SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }

--- a/src/Meziantou.Extensions.Logging.InMemory/InMemoryLoggerProvider.cs
+++ b/src/Meziantou.Extensions.Logging.InMemory/InMemoryLoggerProvider.cs
@@ -90,6 +90,22 @@ public sealed class InMemoryLoggerProvider : ILoggerProvider, ISupportExternalSc
         _scopeProvider = new MutableExternalScopeProvider(scopeProvider ?? new LoggerExternalScopeProvider());
     }
 
+    /// <summary>Creates a new <see cref="InMemoryLoggerProvider"/>.</summary>
+    /// <param name="logs">The log collection to use, or <see langword="null"/> to create a new collection.</param>
+    /// <param name="scopeProvider">The external scope provider to use, or <see langword="null"/> to create a new instance.</param>
+    /// <param name="timeProvider">The time provider to use for timestamping log entries, or <see langword="null"/> to use the system time provider.</param>
+    /// <returns>A new instance of <see cref="InMemoryLoggerProvider"/>.</returns>
+    /// <remarks>
+    /// Prefer this over the constructors whenever an argument is <see langword="null"/>. The constructor
+    /// overloads take three independently nullable types, so a bare <see langword="null"/> cannot be
+    /// resolved to one of them and the call fails to compile. The parameter order matches
+    /// <see cref="InMemoryLogger.CreateLogger(string, InMemoryLogCollection?, IExternalScopeProvider?, TimeProvider?)"/>.
+    /// </remarks>
+    public static InMemoryLoggerProvider Create(InMemoryLogCollection? logs = null, IExternalScopeProvider? scopeProvider = null, TimeProvider? timeProvider = null)
+    {
+        return new InMemoryLoggerProvider(timeProvider, logs, scopeProvider);
+    }
+
     /// <summary>Creates a new logger instance with the specified category name.</summary>
     /// <param name="categoryName">The category name for messages produced by the logger.</param>
     /// <returns>A new instance of <see cref="ILogger"/>.</returns>

--- a/src/Meziantou.Extensions.Logging.InMemory/readme.md
+++ b/src/Meziantou.Extensions.Logging.InMemory/readme.md
@@ -16,6 +16,17 @@ Assert.Empty(loggerProvider.Logs.Errors);
 Assert.Single(loggerProvider.Logs, log => log.Message.Contains("test") && log.EventId.Id == 1);
 ```
 
+`InMemoryLoggerProvider` also has a `Create` method. Prefer it whenever an argument is `null`: the
+constructor overloads take three independently nullable types (`InMemoryLogCollection`,
+`IExternalScopeProvider`, `TimeProvider`), so a bare `null` cannot be resolved to one of them.
+
+```c#
+// Ambiguous, does not compile:
+//var provider = new InMemoryLoggerProvider(null);
+
+using var provider = InMemoryLoggerProvider.Create(scopeProvider: null, timeProvider: timeProvider);
+```
+
 If you are using a `WebApplicationFactory`:
 
 ```c#

--- a/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.InMemory.Tests/InMemoryLoggerTests.cs
@@ -216,6 +216,37 @@ public sealed partial class InMemoryLoggerTests
     }
 
     [Fact]
+    public void Create_AcceptsNullForEveryArgument()
+    {
+        // Each of these is a compile error when written against the constructors, because a bare null
+        // cannot be resolved between InMemoryLogCollection, IExternalScopeProvider and TimeProvider
+        using var all = InMemoryLoggerProvider.Create(null, null, null);
+        using var scopeOnly = InMemoryLoggerProvider.Create(scopeProvider: null);
+        using var timeOnly = InMemoryLoggerProvider.Create(timeProvider: null);
+
+        all.CreateLogger("my_category").LogInformation("Test");
+        Assert.Equal("Test", Assert.Single(all.Logs).Message);
+    }
+
+    [Fact]
+    public void Create_UsesTheSuppliedArguments()
+    {
+        var logs = new InMemoryLogCollection();
+        using var provider = InMemoryLoggerProvider.Create(logs, NullExternalScopeProvider.Instance, new CustomTimeProvider());
+
+        var logger = provider.CreateLogger("my_category");
+        using (logger.BeginScope(new Dictionary<string, object?>(StringComparer.Ordinal) { ["Ignored"] = 1 }))
+        {
+            logger.LogInformation("Test");
+        }
+
+        Assert.Same(logs, provider.Logs);
+        var log = Assert.Single(logs);
+        Assert.Equal(new(2000, 1, 1, 0, 0, 0, TimeSpan.Zero), log.CreatedAt);
+        Assert.Empty(log.Scopes);
+    }
+
+    [Fact]
     public void WithTimeProvider()
     {
         using var provider = new InMemoryLoggerProvider(new CustomTimeProvider());


### PR DESCRIPTION
> **Stack 2 of 2** · merges into `fix/support-external-scope` · that PR must merge first.

`InMemoryLoggerProvider` has eight constructors over three optional, independently nullable parameters. The one- and two-argument groups cannot be told apart when the argument is the `null` literal, so both of these fail with **CS0121**:

```csharp
new InMemoryLoggerProvider(null);        // InMemoryLogCollection? vs IExternalScopeProvider?
new InMemoryLoggerProvider(null, null);  // (logs, scopeProvider) vs (timeProvider, logs)
```

A user who wants "default collection, explicit null scope provider" writes the natural thing and gets a compiler error whose remedy — `(InMemoryLogCollection?)null` — is not obvious.

### Why this is not the `[Obsolete]` redesign the review suggested

The review proposed collapsing the constructors into one with optional parameters and `[Obsolete]`-ing the rest. I tried that first; it does not work cleanly:

1. C# overload resolution prefers a candidate whose parameters all have a corresponding argument over one that needs defaults substituted. `new InMemoryLoggerProvider(logs)` would therefore keep binding to the **obsolete** single-argument overload, warning on correct new code — including with named arguments.
2. This repo builds with warnings as errors, so that would break its own existing tests, which use `new InMemoryLoggerProvider(NullExternalScopeProvider.Instance)` and friends.

Removing the redundant constructors outright fixes it, but that is a binary and source breaking change and a major version bump on a shipped package — your call, not something to slip into a review follow-up.

### What this does instead

Adds a static `Create` factory, mirroring `InMemoryLogger.CreateLogger` right next door:

```csharp
public static InMemoryLoggerProvider Create(
    InMemoryLogCollection? logs = null,
    IExternalScopeProvider? scopeProvider = null,
    TimeProvider? timeProvider = null)
```

`InMemoryLoggerProvider.Create(scopeProvider: null)` and `Create(null, null, null)` both compile and do the obvious thing. Purely additive: no breaking change, no obsolete warnings, nothing to update at a call site. The parameter order deliberately matches `InMemoryLogger.CreateLogger(category, logs, scopeProvider, timeProvider)`, fixing the inconsistency where `TimeProvider` came *first* in some constructors and *last* in `CreateLogger`.

**The constructors remain ambiguous for bare `null`.** This PR gives users a way around it and documents it; it does not remove it, because removing it requires the breaking change above.

### Verification

34/34 (17 tests × net10.0/net11.0) with `/p:TreatsWarningsAsErrors=true`, on top of the branch below. Two tests added — one whose very compilation is the point (`Create(null, null, null)`, plus named-argument forms), and one checking all three arguments are actually honoured. `ref/` regenerated and verified with `/p:PublicApiGeneratorVerifyNoChangeOnBuild=true`. `dotnet run ./eng/update-all.cs` produced no further changes. The package readme documents `Create` and shows the ambiguous call it replaces.

### Why this is stacked

It edits the same `InMemoryLoggerProvider` region, and the same `InMemoryLoggerProvider` block of the generated `ref/` file, as the `ISupportExternalScope` PR below.

Found during a project review of `Meziantou.Extensions.Logging.InMemory` (rated Medium).
