### PR TITLE
Reject a size that does not fit in a long when parsing

### DIFF
--- a/src/Meziantou.Framework.ByteSize/ByteSize.cs
+++ b/src/Meziantou.Framework.ByteSize/ByteSize.cs
@@ -538,19 +538,48 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
 
         // Convert number
         if (long.TryParse(s, NumberStyles.Integer, provider, out var resultLong))
-        {
-            result = From(resultLong, unit);
-            return true;
-        }
+            return TryFrom(resultLong, unit, out result);
 
         if (double.TryParse(s, NumberStyles.Float, provider, out var resultDouble))
-        {
-            result = From(resultDouble, unit);
-            return true;
-        }
+            return TryFrom(resultDouble, unit, out result);
 
         result = default;
         return false;
+    }
+
+    // Text is untrusted input, so a size that does not fit in a long must be reported as a
+    // parse failure. Multiplying it out and letting it wrap would make TryParse return true
+    // with a negative value, which silently defeats any "size <= limit" check on the result.
+    private static bool TryFrom(long value, ByteSizeUnit unit, out ByteSize result)
+    {
+        var scaled = (Int128)value * (long)unit;
+        if (scaled < long.MinValue || scaled > long.MaxValue)
+        {
+            result = default;
+            return false;
+        }
+
+        result = new ByteSize((long)scaled);
+        return true;
+    }
+
+    private static bool TryFrom(double value, ByteSizeUnit unit, out ByteSize result)
+    {
+        // long.MinValue and long.MaxValue + 1 are both exactly representable as double, so
+        // this is the exact representable range of a long. Written as a negated condition so
+        // NaN - which compares false against everything - is rejected too.
+        const double MinInclusive = -9223372036854775808d;
+        const double MaxExclusive = 9223372036854775808d;
+
+        var scaled = value * (long)unit;
+        if (!(scaled >= MinInclusive && scaled < MaxExclusive))
+        {
+            result = default;
+            return false;
+        }
+
+        result = new ByteSize((long)scaled);
+        return true;
     }
 
     /// <summary>Tries to format the value as UTF-8 into the provided span of bytes.</summary>
@@ -686,16 +715,10 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
 
         // Convert number from UTF-8
         if (System.Buffers.Text.Utf8Parser.TryParse(utf8Text, out long resultLong, out var bytesConsumed) && bytesConsumed == utf8Text.Length)
-        {
-            result = From(resultLong, unit);
-            return true;
-        }
+            return TryFrom(resultLong, unit, out result);
 
         if (System.Buffers.Text.Utf8Parser.TryParse(utf8Text, out double resultDouble, out bytesConsumed) && bytesConsumed == utf8Text.Length)
-        {
-            result = From(resultDouble, unit);
-            return true;
-        }
+            return TryFrom(resultDouble, unit, out result);
 
         result = default;
         return false;

--- a/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
+++ b/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
@@ -356,4 +356,32 @@ public sealed class ByteSizeTests
             Assert.Equal(size, ByteSize.Parse(System.Text.Encoding.UTF8.GetBytes(formatted).AsSpan()));
         }
     }
+
+    [Theory]
+    [InlineData("99999999999PB")]
+    [InlineData("10000EB")]
+    [InlineData("9223372036854775808B")]
+    [InlineData("-99999999999999999999B")]
+    [InlineData("1e30MB")]
+    [InlineData("NaN")]
+    [InlineData("Infinity")]
+    [InlineData("-Infinity")]
+    public void TryParse_ValueDoesNotFitInLong_ReturnsFalse(string str)
+    {
+        Assert.False(ByteSize.TryParse(str, CultureInfo.InvariantCulture, out _));
+        Assert.False(ByteSize.TryParse(str.AsSpan(), CultureInfo.InvariantCulture, out _));
+        Assert.False(ByteSize.TryParse(System.Text.Encoding.UTF8.GetBytes(str).AsSpan(), out _));
+
+        Assert.Throws<FormatException>(() => ByteSize.Parse(str, CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [InlineData("9223372036854775807B", long.MaxValue)]
+    [InlineData("-9223372036854775808B", long.MinValue)]
+    [InlineData("9223PB", 9_223_000_000_000_000_000L)]
+    public void TryParse_ValueAtTheEdgeOfLong_StillSucceeds(string str, long expected)
+    {
+        Assert.True(ByteSize.TryParse(str, CultureInfo.InvariantCulture, out var result));
+        Assert.Equal(expected, result.Value);
+    }
 }


### PR DESCRIPTION
**Stack 1 of 3 · merges into `main` · must merge before #2647 and #2648**

`TryParse` multiplied the parsed number by the unit in an unchecked context and reported success regardless of the result. The multiplication wraps, so the method returned `true` with a **negative** size:

```
ByteSize.TryParse("99999999999PB", …, out var s)   -> true, s.Value == -2538764290115403776
ByteSize.TryParse("9223372036854775808B", …)       -> true, wrapped
ByteSize.TryParse("NaN", …)                        -> true, 0 bytes
ByteSize.TryParse("Infinity", …)                   -> true, long.MaxValue
```

This is the security-relevant half of the overflow problem. A size limit written the obvious way accepts an absurd input, because the parsed value is negative and therefore under any positive limit:

```csharp
if (ByteSize.TryParse(contentLength, out var size) && size <= maxUpload)
    Accept(); // reached for "99999999999PB"
```

`ByteSize` is exactly the type someone reaches for when validating a `Content-Length`, a quota, or a config value, and the input is untrusted text by definition. A `TryParse` that returns `true` with a wrong answer cannot be defended against at the call site — the caller has no way to know.

## What changed

Two private `TryFrom` helpers now do the scaling and report failure instead of wrapping. Both `TryParse` paths (UTF-16 and UTF-8) route through them.

- **Integer path** — scales through `Int128` and rejects anything outside `long`'s range. `Int128` makes the check obviously correct at a glance, versus the usual divide-back trick.
- **Floating-point path** — range-checks against `long.MinValue` and `long.MaxValue + 1`, both of which are exactly representable as `double`, so the bound is exact rather than off by a rounding step. Written as a negated condition so `NaN` — which compares `false` against everything — is rejected by the same expression.

`Parse` inherits the fix, since it is defined in terms of `TryParse`: these inputs now throw `FormatException` rather than returning a wrong value.

No public API change; `ref/` is untouched.

## Verification

`dotnet test tests/Meziantou.Framework.ByteSize.Tests` — 292 passed (146 × net10.0/net11.0), 0 failed.

Reverting only the `ByteSize.cs` change and re-running gives **16 failures**.

New coverage:
- `TryParse_ValueDoesNotFitInLong_ReturnsFalse` across all three parse entry points plus `Parse`, covering integer overflow (`"99999999999PB"`), exactly `long.MaxValue + 1`, a large exponent (`"1e30MB"`), and `NaN`/`±Infinity`.
- `TryParse_ValueAtTheEdgeOfLong_StillSucceeds` pins the boundary from the other side — `long.MaxValue`, `long.MinValue` and `"9223PB"` must keep parsing. Without this the fix could silently over-reject.

## Note on what is *not* fixed here

`ByteSize.FromGigaBytes(10_000_000_000L)` and `ByteSize.MaxValue + 1` still wrap silently. Those are the direct construction and arithmetic paths, fixed in #2647 on top of this. This PR is deliberately limited to the parse path so the security-relevant fix does not have to wait on a breaking behaviour change.

One inherent limit worth knowing about: the parser falls back to `double` when `long.TryParse` fails, so a value one past `long.MinValue` rounds to exactly `long.MinValue` and is still accepted. Distinguishing those needs the `double` fallback to go away, which is a separate design change.



---

**Rebased onto `main`** after #2587, #2591, #2598, #2609, #2631 and #2632 merged. The only conflicts were in `ByteSizeTests.cs`, where this branch and the merged PRs appended tests at the same anchors; both sides were kept. `ByteSize.cs` merged cleanly. The generated file and `ref/` were re-run after the rebase and produced no drift. All counts above are from the rebased branch.

One test case got stronger as a result: `"10000EB"` previously failed to parse for the unrelated reason that `EB` was unsupported. Now that #2587 has merged it reaches the unit multiplication and genuinely exercises the overflow guard, which is why the revert check went from 14 failures to 16.