### PR TITLE
Throw on arithmetic overflow and add scalar multiply and divide operators

### DIFF
--- a/ref/Meziantou.Framework.ByteSize.cs
+++ b/ref/Meziantou.Framework.ByteSize.cs
@@ -32,12 +32,21 @@ namespace Meziantou.Framework
         public static bool operator >(Meziantou.Framework.ByteSize value1, Meziantou.Framework.ByteSize value2) => throw null;
         public static Meziantou.Framework.ByteSize operator +(Meziantou.Framework.ByteSize value1, Meziantou.Framework.ByteSize value2) => throw null;
         public static Meziantou.Framework.ByteSize operator -(Meziantou.Framework.ByteSize value1, Meziantou.Framework.ByteSize value2) => throw null;
+        public static Meziantou.Framework.ByteSize operator *(Meziantou.Framework.ByteSize value, long multiplier) => throw null;
+        public static Meziantou.Framework.ByteSize operator *(long multiplier, Meziantou.Framework.ByteSize value) => throw null;
+        public static Meziantou.Framework.ByteSize operator /(Meziantou.Framework.ByteSize value, long divisor) => throw null;
+        [System.Obsolete("Multiplying two sizes yields bytes squared, which is not a size. Use the ByteSize * long overload to scale a size. This overload will be removed in the next major version.")]
         public static Meziantou.Framework.ByteSize operator *(Meziantou.Framework.ByteSize value1, Meziantou.Framework.ByteSize value2) => throw null;
+        [System.Obsolete("Dividing two sizes yields a dimensionless ratio, not a size. Use the ByteSize / long overload to scale a size, or divide the Value properties to get a ratio. This overload will be removed in the next major version.")]
         public static Meziantou.Framework.ByteSize operator /(Meziantou.Framework.ByteSize value1, Meziantou.Framework.ByteSize value2) => throw null;
         public static implicit operator Meziantou.Framework.ByteSize(long value) => throw null;
         public Meziantou.Framework.ByteSize Add(Meziantou.Framework.ByteSize other) => throw null;
         public Meziantou.Framework.ByteSize Substract(Meziantou.Framework.ByteSize other) => throw null;
+        public Meziantou.Framework.ByteSize Multiply(long multiplier) => throw null;
+        public Meziantou.Framework.ByteSize Divide(long divisor) => throw null;
+        [System.Obsolete("Multiplying two sizes yields bytes squared, which is not a size. Use the Multiply(long) overload to scale a size. This overload will be removed in the next major version.")]
         public Meziantou.Framework.ByteSize Multiply(Meziantou.Framework.ByteSize other) => throw null;
+        [System.Obsolete("Dividing two sizes yields a dimensionless ratio, not a size. Use the Divide(long) overload to scale a size, or divide the Value properties to get a ratio. This overload will be removed in the next major version.")]
         public Meziantou.Framework.ByteSize Divide(Meziantou.Framework.ByteSize other) => throw null;
         public static Meziantou.Framework.ByteSize Parse(string text, System.IFormatProvider? formatProvider) => throw null;
         public static bool TryParse(string text, out Meziantou.Framework.ByteSize result) => throw null;

--- a/src/Meziantou.Framework.ByteSize/ByteSize.Generated.cs
+++ b/src/Meziantou.Framework.ByteSize/ByteSize.Generated.cs
@@ -14,391 +14,391 @@ partial struct ByteSize
     /// <summary>Creates a <see cref="ByteSize"/> instance from a byte value.</summary>
     /// <param name="value">The number of bytes (1 byte).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of bytes.</returns>
-    public static ByteSize FromBytes(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.Byte);
+    public static ByteSize FromBytes(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.Byte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a byte value.</summary>
     /// <param name="value">The number of bytes (1 byte).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of bytes.</returns>
-    public static ByteSize FromBytes(short value) => new ByteSize((long)value * (long)ByteSizeUnit.Byte);
+    public static ByteSize FromBytes(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.Byte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a byte value.</summary>
     /// <param name="value">The number of bytes (1 byte).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of bytes.</returns>
-    public static ByteSize FromBytes(int value) => new ByteSize((long)value * (long)ByteSizeUnit.Byte);
+    public static ByteSize FromBytes(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.Byte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a byte value.</summary>
     /// <param name="value">The number of bytes (1 byte).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of bytes.</returns>
-    public static ByteSize FromBytes(long value) => new ByteSize((long)value * (long)ByteSizeUnit.Byte);
+    public static ByteSize FromBytes(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.Byte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a byte value.</summary>
     /// <param name="value">The number of bytes (1 byte).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of bytes.</returns>
-    public static ByteSize FromBytes(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.Byte));
+    public static ByteSize FromBytes(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.Byte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a byte value.</summary>
     /// <param name="value">The number of bytes (1 byte).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of bytes.</returns>
-    public static ByteSize FromBytes(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.Byte));
+    public static ByteSize FromBytes(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.Byte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a kilobyte value.</summary>
     /// <param name="value">The number of kilobytes (1,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of kilobytes.</returns>
-    public static ByteSize FromKiloBytes(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.KiloByte);
+    public static ByteSize FromKiloBytes(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.KiloByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a kilobyte value.</summary>
     /// <param name="value">The number of kilobytes (1,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of kilobytes.</returns>
-    public static ByteSize FromKiloBytes(short value) => new ByteSize((long)value * (long)ByteSizeUnit.KiloByte);
+    public static ByteSize FromKiloBytes(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.KiloByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a kilobyte value.</summary>
     /// <param name="value">The number of kilobytes (1,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of kilobytes.</returns>
-    public static ByteSize FromKiloBytes(int value) => new ByteSize((long)value * (long)ByteSizeUnit.KiloByte);
+    public static ByteSize FromKiloBytes(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.KiloByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a kilobyte value.</summary>
     /// <param name="value">The number of kilobytes (1,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of kilobytes.</returns>
-    public static ByteSize FromKiloBytes(long value) => new ByteSize((long)value * (long)ByteSizeUnit.KiloByte);
+    public static ByteSize FromKiloBytes(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.KiloByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a kilobyte value.</summary>
     /// <param name="value">The number of kilobytes (1,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of kilobytes.</returns>
-    public static ByteSize FromKiloBytes(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.KiloByte));
+    public static ByteSize FromKiloBytes(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.KiloByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a kilobyte value.</summary>
     /// <param name="value">The number of kilobytes (1,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of kilobytes.</returns>
-    public static ByteSize FromKiloBytes(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.KiloByte));
+    public static ByteSize FromKiloBytes(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.KiloByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a megabyte value.</summary>
     /// <param name="value">The number of megabytes (1,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of megabytes.</returns>
-    public static ByteSize FromMegaBytes(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.MegaByte);
+    public static ByteSize FromMegaBytes(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.MegaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a megabyte value.</summary>
     /// <param name="value">The number of megabytes (1,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of megabytes.</returns>
-    public static ByteSize FromMegaBytes(short value) => new ByteSize((long)value * (long)ByteSizeUnit.MegaByte);
+    public static ByteSize FromMegaBytes(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.MegaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a megabyte value.</summary>
     /// <param name="value">The number of megabytes (1,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of megabytes.</returns>
-    public static ByteSize FromMegaBytes(int value) => new ByteSize((long)value * (long)ByteSizeUnit.MegaByte);
+    public static ByteSize FromMegaBytes(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.MegaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a megabyte value.</summary>
     /// <param name="value">The number of megabytes (1,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of megabytes.</returns>
-    public static ByteSize FromMegaBytes(long value) => new ByteSize((long)value * (long)ByteSizeUnit.MegaByte);
+    public static ByteSize FromMegaBytes(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.MegaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a megabyte value.</summary>
     /// <param name="value">The number of megabytes (1,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of megabytes.</returns>
-    public static ByteSize FromMegaBytes(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.MegaByte));
+    public static ByteSize FromMegaBytes(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.MegaByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a megabyte value.</summary>
     /// <param name="value">The number of megabytes (1,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of megabytes.</returns>
-    public static ByteSize FromMegaBytes(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.MegaByte));
+    public static ByteSize FromMegaBytes(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.MegaByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a gigabyte value.</summary>
     /// <param name="value">The number of gigabytes (1,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of gigabytes.</returns>
-    public static ByteSize FromGigaBytes(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.GigaByte);
+    public static ByteSize FromGigaBytes(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.GigaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a gigabyte value.</summary>
     /// <param name="value">The number of gigabytes (1,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of gigabytes.</returns>
-    public static ByteSize FromGigaBytes(short value) => new ByteSize((long)value * (long)ByteSizeUnit.GigaByte);
+    public static ByteSize FromGigaBytes(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.GigaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a gigabyte value.</summary>
     /// <param name="value">The number of gigabytes (1,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of gigabytes.</returns>
-    public static ByteSize FromGigaBytes(int value) => new ByteSize((long)value * (long)ByteSizeUnit.GigaByte);
+    public static ByteSize FromGigaBytes(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.GigaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a gigabyte value.</summary>
     /// <param name="value">The number of gigabytes (1,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of gigabytes.</returns>
-    public static ByteSize FromGigaBytes(long value) => new ByteSize((long)value * (long)ByteSizeUnit.GigaByte);
+    public static ByteSize FromGigaBytes(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.GigaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a gigabyte value.</summary>
     /// <param name="value">The number of gigabytes (1,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of gigabytes.</returns>
-    public static ByteSize FromGigaBytes(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.GigaByte));
+    public static ByteSize FromGigaBytes(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.GigaByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a gigabyte value.</summary>
     /// <param name="value">The number of gigabytes (1,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of gigabytes.</returns>
-    public static ByteSize FromGigaBytes(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.GigaByte));
+    public static ByteSize FromGigaBytes(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.GigaByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a terabyte value.</summary>
     /// <param name="value">The number of terabytes (1,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of terabytes.</returns>
-    public static ByteSize FromTeraBytes(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.TeraByte);
+    public static ByteSize FromTeraBytes(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.TeraByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a terabyte value.</summary>
     /// <param name="value">The number of terabytes (1,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of terabytes.</returns>
-    public static ByteSize FromTeraBytes(short value) => new ByteSize((long)value * (long)ByteSizeUnit.TeraByte);
+    public static ByteSize FromTeraBytes(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.TeraByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a terabyte value.</summary>
     /// <param name="value">The number of terabytes (1,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of terabytes.</returns>
-    public static ByteSize FromTeraBytes(int value) => new ByteSize((long)value * (long)ByteSizeUnit.TeraByte);
+    public static ByteSize FromTeraBytes(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.TeraByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a terabyte value.</summary>
     /// <param name="value">The number of terabytes (1,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of terabytes.</returns>
-    public static ByteSize FromTeraBytes(long value) => new ByteSize((long)value * (long)ByteSizeUnit.TeraByte);
+    public static ByteSize FromTeraBytes(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.TeraByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a terabyte value.</summary>
     /// <param name="value">The number of terabytes (1,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of terabytes.</returns>
-    public static ByteSize FromTeraBytes(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.TeraByte));
+    public static ByteSize FromTeraBytes(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.TeraByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a terabyte value.</summary>
     /// <param name="value">The number of terabytes (1,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of terabytes.</returns>
-    public static ByteSize FromTeraBytes(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.TeraByte));
+    public static ByteSize FromTeraBytes(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.TeraByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a petabyte value.</summary>
     /// <param name="value">The number of petabytes (1,000,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of petabytes.</returns>
-    public static ByteSize FromPetaBytes(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.PetaByte);
+    public static ByteSize FromPetaBytes(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.PetaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a petabyte value.</summary>
     /// <param name="value">The number of petabytes (1,000,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of petabytes.</returns>
-    public static ByteSize FromPetaBytes(short value) => new ByteSize((long)value * (long)ByteSizeUnit.PetaByte);
+    public static ByteSize FromPetaBytes(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.PetaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a petabyte value.</summary>
     /// <param name="value">The number of petabytes (1,000,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of petabytes.</returns>
-    public static ByteSize FromPetaBytes(int value) => new ByteSize((long)value * (long)ByteSizeUnit.PetaByte);
+    public static ByteSize FromPetaBytes(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.PetaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a petabyte value.</summary>
     /// <param name="value">The number of petabytes (1,000,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of petabytes.</returns>
-    public static ByteSize FromPetaBytes(long value) => new ByteSize((long)value * (long)ByteSizeUnit.PetaByte);
+    public static ByteSize FromPetaBytes(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.PetaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a petabyte value.</summary>
     /// <param name="value">The number of petabytes (1,000,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of petabytes.</returns>
-    public static ByteSize FromPetaBytes(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.PetaByte));
+    public static ByteSize FromPetaBytes(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.PetaByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a petabyte value.</summary>
     /// <param name="value">The number of petabytes (1,000,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of petabytes.</returns>
-    public static ByteSize FromPetaBytes(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.PetaByte));
+    public static ByteSize FromPetaBytes(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.PetaByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a exabyte value.</summary>
     /// <param name="value">The number of exabytes (1,000,000,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of exabytes.</returns>
-    public static ByteSize FromExaBytes(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.ExaByte);
+    public static ByteSize FromExaBytes(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.ExaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a exabyte value.</summary>
     /// <param name="value">The number of exabytes (1,000,000,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of exabytes.</returns>
-    public static ByteSize FromExaBytes(short value) => new ByteSize((long)value * (long)ByteSizeUnit.ExaByte);
+    public static ByteSize FromExaBytes(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.ExaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a exabyte value.</summary>
     /// <param name="value">The number of exabytes (1,000,000,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of exabytes.</returns>
-    public static ByteSize FromExaBytes(int value) => new ByteSize((long)value * (long)ByteSizeUnit.ExaByte);
+    public static ByteSize FromExaBytes(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.ExaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a exabyte value.</summary>
     /// <param name="value">The number of exabytes (1,000,000,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of exabytes.</returns>
-    public static ByteSize FromExaBytes(long value) => new ByteSize((long)value * (long)ByteSizeUnit.ExaByte);
+    public static ByteSize FromExaBytes(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.ExaByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a exabyte value.</summary>
     /// <param name="value">The number of exabytes (1,000,000,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of exabytes.</returns>
-    public static ByteSize FromExaBytes(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.ExaByte));
+    public static ByteSize FromExaBytes(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.ExaByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a exabyte value.</summary>
     /// <param name="value">The number of exabytes (1,000,000,000,000,000,000 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of exabytes.</returns>
-    public static ByteSize FromExaBytes(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.ExaByte));
+    public static ByteSize FromExaBytes(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.ExaByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a kibibyte value.</summary>
     /// <param name="value">The number of kibibytes (1,024 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of kibibytes.</returns>
-    public static ByteSize FromKibiBytes(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.KibiByte);
+    public static ByteSize FromKibiBytes(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.KibiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a kibibyte value.</summary>
     /// <param name="value">The number of kibibytes (1,024 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of kibibytes.</returns>
-    public static ByteSize FromKibiBytes(short value) => new ByteSize((long)value * (long)ByteSizeUnit.KibiByte);
+    public static ByteSize FromKibiBytes(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.KibiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a kibibyte value.</summary>
     /// <param name="value">The number of kibibytes (1,024 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of kibibytes.</returns>
-    public static ByteSize FromKibiBytes(int value) => new ByteSize((long)value * (long)ByteSizeUnit.KibiByte);
+    public static ByteSize FromKibiBytes(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.KibiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a kibibyte value.</summary>
     /// <param name="value">The number of kibibytes (1,024 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of kibibytes.</returns>
-    public static ByteSize FromKibiBytes(long value) => new ByteSize((long)value * (long)ByteSizeUnit.KibiByte);
+    public static ByteSize FromKibiBytes(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.KibiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a kibibyte value.</summary>
     /// <param name="value">The number of kibibytes (1,024 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of kibibytes.</returns>
-    public static ByteSize FromKibiBytes(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.KibiByte));
+    public static ByteSize FromKibiBytes(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.KibiByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a kibibyte value.</summary>
     /// <param name="value">The number of kibibytes (1,024 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of kibibytes.</returns>
-    public static ByteSize FromKibiBytes(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.KibiByte));
+    public static ByteSize FromKibiBytes(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.KibiByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a mebibyte value.</summary>
     /// <param name="value">The number of mebibytes (1,048,576 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of mebibytes.</returns>
-    public static ByteSize FromMebiBytes(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.MebiByte);
+    public static ByteSize FromMebiBytes(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.MebiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a mebibyte value.</summary>
     /// <param name="value">The number of mebibytes (1,048,576 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of mebibytes.</returns>
-    public static ByteSize FromMebiBytes(short value) => new ByteSize((long)value * (long)ByteSizeUnit.MebiByte);
+    public static ByteSize FromMebiBytes(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.MebiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a mebibyte value.</summary>
     /// <param name="value">The number of mebibytes (1,048,576 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of mebibytes.</returns>
-    public static ByteSize FromMebiBytes(int value) => new ByteSize((long)value * (long)ByteSizeUnit.MebiByte);
+    public static ByteSize FromMebiBytes(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.MebiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a mebibyte value.</summary>
     /// <param name="value">The number of mebibytes (1,048,576 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of mebibytes.</returns>
-    public static ByteSize FromMebiBytes(long value) => new ByteSize((long)value * (long)ByteSizeUnit.MebiByte);
+    public static ByteSize FromMebiBytes(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.MebiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a mebibyte value.</summary>
     /// <param name="value">The number of mebibytes (1,048,576 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of mebibytes.</returns>
-    public static ByteSize FromMebiBytes(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.MebiByte));
+    public static ByteSize FromMebiBytes(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.MebiByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a mebibyte value.</summary>
     /// <param name="value">The number of mebibytes (1,048,576 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of mebibytes.</returns>
-    public static ByteSize FromMebiBytes(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.MebiByte));
+    public static ByteSize FromMebiBytes(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.MebiByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a gibibyte value.</summary>
     /// <param name="value">The number of gibibytes (1,073,741,824 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of gibibytes.</returns>
-    public static ByteSize FromGibiBytes(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.GibiByte);
+    public static ByteSize FromGibiBytes(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.GibiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a gibibyte value.</summary>
     /// <param name="value">The number of gibibytes (1,073,741,824 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of gibibytes.</returns>
-    public static ByteSize FromGibiBytes(short value) => new ByteSize((long)value * (long)ByteSizeUnit.GibiByte);
+    public static ByteSize FromGibiBytes(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.GibiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a gibibyte value.</summary>
     /// <param name="value">The number of gibibytes (1,073,741,824 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of gibibytes.</returns>
-    public static ByteSize FromGibiBytes(int value) => new ByteSize((long)value * (long)ByteSizeUnit.GibiByte);
+    public static ByteSize FromGibiBytes(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.GibiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a gibibyte value.</summary>
     /// <param name="value">The number of gibibytes (1,073,741,824 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of gibibytes.</returns>
-    public static ByteSize FromGibiBytes(long value) => new ByteSize((long)value * (long)ByteSizeUnit.GibiByte);
+    public static ByteSize FromGibiBytes(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.GibiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a gibibyte value.</summary>
     /// <param name="value">The number of gibibytes (1,073,741,824 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of gibibytes.</returns>
-    public static ByteSize FromGibiBytes(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.GibiByte));
+    public static ByteSize FromGibiBytes(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.GibiByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a gibibyte value.</summary>
     /// <param name="value">The number of gibibytes (1,073,741,824 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of gibibytes.</returns>
-    public static ByteSize FromGibiBytes(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.GibiByte));
+    public static ByteSize FromGibiBytes(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.GibiByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a tebibyte value.</summary>
     /// <param name="value">The number of tebibytes (1,099,511,627,776 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of tebibytes.</returns>
-    public static ByteSize FromTebiBytes(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.TebiByte);
+    public static ByteSize FromTebiBytes(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.TebiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a tebibyte value.</summary>
     /// <param name="value">The number of tebibytes (1,099,511,627,776 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of tebibytes.</returns>
-    public static ByteSize FromTebiBytes(short value) => new ByteSize((long)value * (long)ByteSizeUnit.TebiByte);
+    public static ByteSize FromTebiBytes(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.TebiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a tebibyte value.</summary>
     /// <param name="value">The number of tebibytes (1,099,511,627,776 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of tebibytes.</returns>
-    public static ByteSize FromTebiBytes(int value) => new ByteSize((long)value * (long)ByteSizeUnit.TebiByte);
+    public static ByteSize FromTebiBytes(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.TebiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a tebibyte value.</summary>
     /// <param name="value">The number of tebibytes (1,099,511,627,776 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of tebibytes.</returns>
-    public static ByteSize FromTebiBytes(long value) => new ByteSize((long)value * (long)ByteSizeUnit.TebiByte);
+    public static ByteSize FromTebiBytes(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.TebiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a tebibyte value.</summary>
     /// <param name="value">The number of tebibytes (1,099,511,627,776 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of tebibytes.</returns>
-    public static ByteSize FromTebiBytes(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.TebiByte));
+    public static ByteSize FromTebiBytes(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.TebiByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a tebibyte value.</summary>
     /// <param name="value">The number of tebibytes (1,099,511,627,776 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of tebibytes.</returns>
-    public static ByteSize FromTebiBytes(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.TebiByte));
+    public static ByteSize FromTebiBytes(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.TebiByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a pebibyte value.</summary>
     /// <param name="value">The number of pebibytes (1,125,899,906,842,624 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of pebibytes.</returns>
-    public static ByteSize FromPebiBytes(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.PebiByte);
+    public static ByteSize FromPebiBytes(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.PebiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a pebibyte value.</summary>
     /// <param name="value">The number of pebibytes (1,125,899,906,842,624 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of pebibytes.</returns>
-    public static ByteSize FromPebiBytes(short value) => new ByteSize((long)value * (long)ByteSizeUnit.PebiByte);
+    public static ByteSize FromPebiBytes(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.PebiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a pebibyte value.</summary>
     /// <param name="value">The number of pebibytes (1,125,899,906,842,624 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of pebibytes.</returns>
-    public static ByteSize FromPebiBytes(int value) => new ByteSize((long)value * (long)ByteSizeUnit.PebiByte);
+    public static ByteSize FromPebiBytes(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.PebiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a pebibyte value.</summary>
     /// <param name="value">The number of pebibytes (1,125,899,906,842,624 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of pebibytes.</returns>
-    public static ByteSize FromPebiBytes(long value) => new ByteSize((long)value * (long)ByteSizeUnit.PebiByte);
+    public static ByteSize FromPebiBytes(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.PebiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a pebibyte value.</summary>
     /// <param name="value">The number of pebibytes (1,125,899,906,842,624 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of pebibytes.</returns>
-    public static ByteSize FromPebiBytes(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.PebiByte));
+    public static ByteSize FromPebiBytes(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.PebiByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a pebibyte value.</summary>
     /// <param name="value">The number of pebibytes (1,125,899,906,842,624 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of pebibytes.</returns>
-    public static ByteSize FromPebiBytes(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.PebiByte));
+    public static ByteSize FromPebiBytes(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.PebiByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a exbibyte value.</summary>
     /// <param name="value">The number of exbibytes (1,152,921,504,606,846,976 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of exbibytes.</returns>
-    public static ByteSize FromExbiBytes(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.ExbiByte);
+    public static ByteSize FromExbiBytes(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.ExbiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a exbibyte value.</summary>
     /// <param name="value">The number of exbibytes (1,152,921,504,606,846,976 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of exbibytes.</returns>
-    public static ByteSize FromExbiBytes(short value) => new ByteSize((long)value * (long)ByteSizeUnit.ExbiByte);
+    public static ByteSize FromExbiBytes(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.ExbiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a exbibyte value.</summary>
     /// <param name="value">The number of exbibytes (1,152,921,504,606,846,976 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of exbibytes.</returns>
-    public static ByteSize FromExbiBytes(int value) => new ByteSize((long)value * (long)ByteSizeUnit.ExbiByte);
+    public static ByteSize FromExbiBytes(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.ExbiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a exbibyte value.</summary>
     /// <param name="value">The number of exbibytes (1,152,921,504,606,846,976 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of exbibytes.</returns>
-    public static ByteSize FromExbiBytes(long value) => new ByteSize((long)value * (long)ByteSizeUnit.ExbiByte);
+    public static ByteSize FromExbiBytes(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.ExbiByte));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a exbibyte value.</summary>
     /// <param name="value">The number of exbibytes (1,152,921,504,606,846,976 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of exbibytes.</returns>
-    public static ByteSize FromExbiBytes(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.ExbiByte));
+    public static ByteSize FromExbiBytes(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.ExbiByte)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a exbibyte value.</summary>
     /// <param name="value">The number of exbibytes (1,152,921,504,606,846,976 bytes).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of exbibytes.</returns>
-    public static ByteSize FromExbiBytes(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.ExbiByte));
+    public static ByteSize FromExbiBytes(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.ExbiByte)));
 
 }

--- a/src/Meziantou.Framework.ByteSize/ByteSize.Generated.tt
+++ b/src/Meziantou.Framework.ByteSize/ByteSize.Generated.tt
@@ -34,32 +34,32 @@ partial struct ByteSize
     /// <summary>Creates a <see cref="ByteSize"/> instance from a <#= unit.Description #> value.</summary>
     /// <param name="value">The number of <#= unit.Description #>s (<#= unit.NumericValue #>).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of <#= unit.Description #>s.</returns>
-    public static ByteSize From<#= unit.Name #>s(byte value) => new ByteSize((long)value * (long)ByteSizeUnit.<#= unit.Name #>);
+    public static ByteSize From<#= unit.Name #>s(byte value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.<#= unit.Name #>));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a <#= unit.Description #> value.</summary>
     /// <param name="value">The number of <#= unit.Description #>s (<#= unit.NumericValue #>).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of <#= unit.Description #>s.</returns>
-    public static ByteSize From<#= unit.Name #>s(short value) => new ByteSize((long)value * (long)ByteSizeUnit.<#= unit.Name #>);
+    public static ByteSize From<#= unit.Name #>s(short value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.<#= unit.Name #>));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a <#= unit.Description #> value.</summary>
     /// <param name="value">The number of <#= unit.Description #>s (<#= unit.NumericValue #>).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of <#= unit.Description #>s.</returns>
-    public static ByteSize From<#= unit.Name #>s(int value) => new ByteSize((long)value * (long)ByteSizeUnit.<#= unit.Name #>);
+    public static ByteSize From<#= unit.Name #>s(int value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.<#= unit.Name #>));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a <#= unit.Description #> value.</summary>
     /// <param name="value">The number of <#= unit.Description #>s (<#= unit.NumericValue #>).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of <#= unit.Description #>s.</returns>
-    public static ByteSize From<#= unit.Name #>s(long value) => new ByteSize((long)value * (long)ByteSizeUnit.<#= unit.Name #>);
+    public static ByteSize From<#= unit.Name #>s(long value) => new ByteSize(checked((long)value * (long)ByteSizeUnit.<#= unit.Name #>));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a <#= unit.Description #> value.</summary>
     /// <param name="value">The number of <#= unit.Description #>s (<#= unit.NumericValue #>).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of <#= unit.Description #>s.</returns>
-    public static ByteSize From<#= unit.Name #>s(float value) => new ByteSize((long)(value * (long)ByteSizeUnit.<#= unit.Name #>));
+    public static ByteSize From<#= unit.Name #>s(float value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.<#= unit.Name #>)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a <#= unit.Description #> value.</summary>
     /// <param name="value">The number of <#= unit.Description #>s (<#= unit.NumericValue #>).</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified number of <#= unit.Description #>s.</returns>
-    public static ByteSize From<#= unit.Name #>s(double value) => new ByteSize((long)(value * (long)ByteSizeUnit.<#= unit.Name #>));
+    public static ByteSize From<#= unit.Name #>s(double value) => new ByteSize(checked((long)(value * (long)ByteSizeUnit.<#= unit.Name #>)));
 
 <# } #>
 }

--- a/src/Meziantou.Framework.ByteSize/ByteSize.cs
+++ b/src/Meziantou.Framework.ByteSize/ByteSize.cs
@@ -373,9 +373,22 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
 
     public static bool operator >(ByteSize value1, ByteSize value2) => value1.CompareTo(value2) > 0;
 
-    public static ByteSize operator +(ByteSize value1, ByteSize value2) => new(value1.Value + value2.Value);
-    public static ByteSize operator -(ByteSize value1, ByteSize value2) => new(value1.Value - value2.Value);
-    public static ByteSize operator *(ByteSize value1, ByteSize value2) => new(value1.Value * value2.Value);
+    public static ByteSize operator +(ByteSize value1, ByteSize value2) => new(checked(value1.Value + value2.Value));
+    public static ByteSize operator -(ByteSize value1, ByteSize value2) => new(checked(value1.Value - value2.Value));
+
+    /// <summary>Scales a byte size by a factor.</summary>
+    public static ByteSize operator *(ByteSize value, long multiplier) => new(checked(value.Value * multiplier));
+
+    /// <summary>Scales a byte size by a factor.</summary>
+    public static ByteSize operator *(long multiplier, ByteSize value) => new(checked(multiplier * value.Value));
+
+    /// <summary>Divides a byte size by a factor.</summary>
+    public static ByteSize operator /(ByteSize value, long divisor) => new(value.Value / divisor);
+
+    [Obsolete("Multiplying two sizes yields bytes squared, which is not a size. Use the ByteSize * long overload to scale a size. This overload will be removed in the next major version.")]
+    public static ByteSize operator *(ByteSize value1, ByteSize value2) => new(checked(value1.Value * value2.Value));
+
+    [Obsolete("Dividing two sizes yields a dimensionless ratio, not a size. Use the ByteSize / long overload to scale a size, or divide the Value properties to get a ratio. This overload will be removed in the next major version.")]
     public static ByteSize operator /(ByteSize value1, ByteSize value2) => new(value1.Value / value2.Value);
 
     public static implicit operator ByteSize(long value) => new(value);
@@ -390,15 +403,24 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
     /// <returns>The result of the subtraction.</returns>
     public ByteSize Substract(ByteSize other) => this - other;
 
-    /// <summary>Multiplies two byte size values.</summary>
-    /// <param name="other">The value to multiply by.</param>
-    /// <returns>The product of the two byte sizes.</returns>
-    public ByteSize Multiply(ByteSize other) => this * other;
+    /// <summary>Scales this byte size by a factor.</summary>
+    /// <param name="multiplier">The factor to scale by.</param>
+    /// <returns>The scaled byte size.</returns>
+    public ByteSize Multiply(long multiplier) => this * multiplier;
 
-    /// <summary>Divides this byte size by another.</summary>
-    /// <param name="other">The value to divide by.</param>
-    /// <returns>The result of the division.</returns>
-    public ByteSize Divide(ByteSize other) => this / other;
+    /// <summary>Divides this byte size by a factor.</summary>
+    /// <param name="divisor">The factor to divide by.</param>
+    /// <returns>The divided byte size.</returns>
+    public ByteSize Divide(long divisor) => this / divisor;
+
+    // Computed inline rather than delegating to the obsolete operators, so this file does not
+    // need to suppress its own obsoletion warnings.
+
+    [Obsolete("Multiplying two sizes yields bytes squared, which is not a size. Use the Multiply(long) overload to scale a size. This overload will be removed in the next major version.")]
+    public ByteSize Multiply(ByteSize other) => new(checked(Value * other.Value));
+
+    [Obsolete("Dividing two sizes yields a dimensionless ratio, not a size. Use the Divide(long) overload to scale a size, or divide the Value properties to get a ratio. This overload will be removed in the next major version.")]
+    public ByteSize Divide(ByteSize other) => new(Value / other.Value);
 
     private static bool TryParseUnit(ReadOnlySpan<char> unit, out ByteSizeUnit result, out int parsedLength)
     {
@@ -798,37 +820,37 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
     /// <param name="value">The numeric value.</param>
     /// <param name="unit">The unit of the value.</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified value and unit.</returns>
-    public static ByteSize From(byte value, ByteSizeUnit unit) => new(value * (long)unit);
+    public static ByteSize From(byte value, ByteSizeUnit unit) => new(checked(value * (long)unit));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a value and unit.</summary>
     /// <param name="value">The numeric value.</param>
     /// <param name="unit">The unit of the value.</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified value and unit.</returns>
-    public static ByteSize From(short value, ByteSizeUnit unit) => new(value * (long)unit);
+    public static ByteSize From(short value, ByteSizeUnit unit) => new(checked(value * (long)unit));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a value and unit.</summary>
     /// <param name="value">The numeric value.</param>
     /// <param name="unit">The unit of the value.</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified value and unit.</returns>
-    public static ByteSize From(int value, ByteSizeUnit unit) => new(value * (long)unit);
+    public static ByteSize From(int value, ByteSizeUnit unit) => new(checked(value * (long)unit));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a value and unit.</summary>
     /// <param name="value">The numeric value.</param>
     /// <param name="unit">The unit of the value.</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified value and unit.</returns>
-    public static ByteSize From(long value, ByteSizeUnit unit) => new(value * (long)unit);
+    public static ByteSize From(long value, ByteSizeUnit unit) => new(checked(value * (long)unit));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a value and unit.</summary>
     /// <param name="value">The numeric value.</param>
     /// <param name="unit">The unit of the value.</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified value and unit.</returns>
-    public static ByteSize From(float value, ByteSizeUnit unit) => new((long)(value * (long)unit));
+    public static ByteSize From(float value, ByteSizeUnit unit) => new(checked((long)(value * (long)unit)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a value and unit.</summary>
     /// <param name="value">The numeric value.</param>
     /// <param name="unit">The unit of the value.</param>
     /// <returns>A <see cref="ByteSize"/> instance representing the specified value and unit.</returns>
-    public static ByteSize From(double value, ByteSizeUnit unit) => new((long)(value * (long)unit));
+    public static ByteSize From(double value, ByteSizeUnit unit) => new(checked((long)(value * (long)unit)));
 
     /// <summary>Creates a <see cref="ByteSize"/> instance from a file's length.</summary>
     /// <param name="fileInfo">The file information.</param>

--- a/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
+++ b/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
@@ -153,6 +153,42 @@ public sealed class ByteSizeTests
         Assert.Equal("obj", exception.ParamName);
     }
 
+    [Fact]
+    public void From_Overflow_ThrowsOverflowException()
+    {
+        Assert.Throws<OverflowException>(() => ByteSize.From(long.MaxValue, ByteSizeUnit.KiloByte));
+        Assert.Throws<OverflowException>(() => ByteSize.FromGigaBytes(10_000_000_000L));
+        Assert.Throws<OverflowException>(() => ByteSize.FromExaBytes(10));
+        Assert.Throws<OverflowException>(() => ByteSize.From(1e30, ByteSizeUnit.MegaByte));
+        Assert.Throws<OverflowException>(() => ByteSize.FromKiloBytes(double.NaN));
+        Assert.Throws<OverflowException>(() => ByteSize.FromKiloBytes(double.PositiveInfinity));
+    }
+
+    [Fact]
+    public void From_AtTheEdgeOfLong_DoesNotThrow()
+    {
+        Assert.Equal(long.MaxValue, ByteSize.From(long.MaxValue, ByteSizeUnit.Byte).Value);
+        Assert.Equal(9_223_000_000_000_000_000L, ByteSize.FromPetaBytes(9_223L).Value);
+    }
+
+    [Fact]
+    public void Operator_Overflow_ThrowsOverflowException()
+    {
+        Assert.Throws<OverflowException>(() => ByteSize.MaxValue + new ByteSize(1));
+        Assert.Throws<OverflowException>(() => ByteSize.MinValue - new ByteSize(1));
+        Assert.Throws<OverflowException>(() => ByteSize.MaxValue * 2);
+    }
+
+    [Fact]
+    public void Operator_ScalesByAFactor()
+    {
+        Assert.Equal(3_000L, (ByteSize.FromKiloBytes(1) * 3).Value);
+        Assert.Equal(3_000L, (3 * ByteSize.FromKiloBytes(1)).Value);
+        Assert.Equal(500L, (ByteSize.FromKiloBytes(1) / 2).Value);
+        Assert.Equal(3_000L, ByteSize.FromKiloBytes(1).Multiply(3).Value);
+        Assert.Equal(500L, ByteSize.FromKiloBytes(1).Divide(2).Value);
+    }
+
     [Theory]
     [InlineData(10L, null, "10B")]
     [InlineData(10L, "", "10B")]


### PR DESCRIPTION
**Stack 2 of 3 · merges into `fix/bytesize-tryparse-overflow` · #2646 must merge first, then this before #2648**

Two related defects on the arithmetic surface. They are in one PR because they collide on the same operator declarations — `*` and `/` cannot be made overflow-safe and re-shaped independently.

## 1. Construction and arithmetic wrapped silently

Every multiplication was unchecked, so oversized values became negative with no diagnostic:

```
ByteSize.FromGigaBytes(10_000_000_000L).Value        ->  -8446744073709551616
ByteSize.From(long.MaxValue, ByteSizeUnit.KiloByte)  ->  -1000
ByteSize.FromExaBytes(10).Value                      ->  -8446744073709551616
(ByteSize.MaxValue + new ByteSize(1)).Value          ->  -9223372036854775808
ByteSize.FromKiloBytes(double.NaN).Value             ->  0
```

Accumulating sizes across a large file set could silently go negative, and a wrong-by-2^64 answer is worse than an exception.

The `From` overloads, the 78 generated `From<Unit>s` factories and the `+`, `-`, `*` operators are now `checked`. Floating-point overloads are covered by the same mechanism: in a checked context an out-of-range or `NaN` float-to-integer conversion throws `OverflowException` too, so `FromKiloBytes(double.NaN)` no longer silently yields `0`.

The generated factories come from `ByteSize.Generated.tt`; the template was edited and `dotnet run ./eng/update-all.cs` regenerated all 78.

**This is a breaking behaviour change.** Code that relied on wraparound now throws `OverflowException`. That seems clearly preferable to a silently negative size, but it is a real change and the reason this is separated from #2646.

## 2. `*` and `/` on two sizes were dimensionally meaningless

`ByteSize * ByteSize` returned a `ByteSize`, so:

```
ByteSize.FromKiloBytes(1) * ByteSize.FromKiloBytes(1)  ->  1MB
```

Bytes times bytes is bytes squared, and 1 kB squared is certainly not 1 MB. Dividing two sizes has the mirror problem: the meaningful result is a dimensionless ratio, not a size. Both type-check, so the compiler cannot help and the result is a plausible-looking number.

Added the operators that are actually meaningful, all overflow-checked:

```csharp
ByteSize operator *(ByteSize value, long multiplier)
ByteSize operator *(long multiplier, ByteSize value)
ByteSize operator /(ByteSize value, long divisor)
ByteSize Multiply(long multiplier)
ByteSize Divide(long divisor)
```

and marked the two-size operators and `Multiply(ByteSize)`/`Divide(ByteSize)` `[Obsolete]` with a message naming the replacement, for removal in the next major version.

Existing scalar call sites are unaffected in both binding and result. `size * 3` previously went through `implicit operator ByteSize(long)` and the two-size operator; it now binds to the `long` overload, because a standard conversion beats a user-defined one. The computed value is identical — the degenerate scalar case happened to coincide — so this is a silent, correct migration rather than a break.

`ByteSize / ByteSize` returning `double`, which is the genuinely useful ratio operator, cannot be added yet: return type does not participate in overload resolution, so it can only exist once the obsolete overload is removed.

The obsolete members compute their result inline instead of delegating to the obsolete operators, so the file does not have to suppress its own obsoletion warnings.

`ref/Meziantou.Framework.ByteSize.cs` regenerated (Release + `IsOfficialBuild`) — it records the three new operators, the two new methods, and the four `[Obsolete]` attributes.

## Verification

`dotnet test tests/Meziantou.Framework.ByteSize.Tests` — 300 passed (150 × net10.0/net11.0), 0 failed. Counts include the layer below.

Reverting only `src/` and `ref/` and re-running gives **4 failures** (`From_Overflow_ThrowsOverflowException` and `Operator_Overflow_ThrowsOverflowException` on both TFMs).

New coverage:
- `From_Overflow_ThrowsOverflowException` — the `From(long, unit)` path, two generated factories, a huge `double`, `NaN` and `+Infinity`.
- `From_AtTheEdgeOfLong_DoesNotThrow` — the boundary from the other side, so the guard cannot over-reject.
- `Operator_Overflow_ThrowsOverflowException` — `+`, `-`, and scalar `*`.
- `Operator_ScalesByAFactor` — both `*` orderings, `/`, and the two new methods.



---

**Rebased onto `main`** after #2587, #2591, #2598, #2609, #2631 and #2632 merged. The only conflicts were in `ByteSizeTests.cs`, where this branch and the merged PRs appended tests at the same anchors; both sides were kept. `ByteSize.cs` merged cleanly. The generated file and `ref/` were re-run after the rebase and produced no drift. All counts above are from the rebased branch.