### PR TITLE
Add a correctly spelled Subtract method

### DIFF
--- a/ref/Meziantou.Framework.ByteSize.cs
+++ b/ref/Meziantou.Framework.ByteSize.cs
@@ -41,6 +41,8 @@ namespace Meziantou.Framework
         public static Meziantou.Framework.ByteSize operator /(Meziantou.Framework.ByteSize value1, Meziantou.Framework.ByteSize value2) => throw null;
         public static implicit operator Meziantou.Framework.ByteSize(long value) => throw null;
         public Meziantou.Framework.ByteSize Add(Meziantou.Framework.ByteSize other) => throw null;
+        public Meziantou.Framework.ByteSize Subtract(Meziantou.Framework.ByteSize other) => throw null;
+        [System.Obsolete("Misspelled. Use Subtract instead. This method will be removed in the next major version.")]
         public Meziantou.Framework.ByteSize Substract(Meziantou.Framework.ByteSize other) => throw null;
         public Meziantou.Framework.ByteSize Multiply(long multiplier) => throw null;
         public Meziantou.Framework.ByteSize Divide(long divisor) => throw null;

--- a/src/Meziantou.Framework.ByteSize/ByteSize.cs
+++ b/src/Meziantou.Framework.ByteSize/ByteSize.cs
@@ -401,6 +401,9 @@ public readonly partial struct ByteSize : IEquatable<ByteSize>, IComparable, ICo
     /// <summary>Subtracts a byte size value from this instance.</summary>
     /// <param name="other">The value to subtract.</param>
     /// <returns>The result of the subtraction.</returns>
+    public ByteSize Subtract(ByteSize other) => this - other;
+
+    [Obsolete("Misspelled. Use " + nameof(Subtract) + " instead. This method will be removed in the next major version.")]
     public ByteSize Substract(ByteSize other) => this - other;
 
     /// <summary>Scales this byte size by a factor.</summary>

--- a/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
+++ b/tests/Meziantou.Framework.ByteSize.Tests/ByteSizeTests.cs
@@ -154,6 +154,12 @@ public sealed class ByteSizeTests
     }
 
     [Fact]
+    public void Subtract_SubtractsTheValue()
+    {
+        Assert.Equal(1_000L, ByteSize.FromKiloBytes(3).Subtract(ByteSize.FromKiloBytes(2)).Value);
+    }
+
+    [Fact]
     public void From_Overflow_ThrowsOverflowException()
     {
         Assert.Throws<OverflowException>(() => ByteSize.From(long.MaxValue, ByteSizeUnit.KiloByte));


### PR DESCRIPTION
**Stack 3 of 3 · merges into `fix/bytesize-checked-arithmetic` · #2646 and #2647 must merge first**

`ByteSize.Substract` is misspelled — the English word is `Subtract`. Its three siblings (`Add`, `Multiply`, `Divide`) are spelled correctly, which makes this the one member of the set that name completion cannot find. That is the whole cost of the bug: these wrapper methods are only ever discovered by typing `.` and reading the list.

## What changed

Added `Subtract`, and marked `Substract` `[Obsolete]` pointing at it, for removal in the next major version. Both delegate to `operator -`, so behaviour is identical and existing callers keep compiling with a warning telling them what to switch to.

The obsoletion message is built with `nameof(Subtract)` so it cannot drift if the method is ever renamed again.

`ref/Meziantou.Framework.ByteSize.cs` regenerated (Release + `IsOfficialBuild`).

## Why it is stacked rather than standalone

It is not logically dependent on the layers below, but it is textually dependent: `Substract` sits between `Add` and `Multiply`/`Divide`, which #2647 rewrites, and both PRs regenerate `ref/`. Landing them independently would conflict in two files. Stacking makes the order explicit instead.

## Verification

`dotnet test tests/Meziantou.Framework.ByteSize.Tests` — 302 passed (151 × net10.0/net11.0), 0 failed. Counts include both layers below.

`Subtract_SubtractsTheValue` is a straightforward guard — there was no test for `Substract` either.



---

**Rebased onto `main`** after #2587, #2591, #2598, #2609, #2631 and #2632 merged. The only conflicts were in `ByteSizeTests.cs`, where this branch and the merged PRs appended tests at the same anchors; both sides were kept. `ByteSize.cs` merged cleanly. The generated file and `ref/` were re-run after the rebase and produced no drift. All counts above are from the rebased branch.