### PR TITLE
Keep sub-millisecond ticks when serializing DateTime and DateTimeOffset

### DIFF
--- a/src/Meziantou.Framework.HumanReadableSerializer/Converters/DateTimeConverter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Converters/DateTimeConverter.cs
@@ -5,7 +5,7 @@ internal sealed class DateTimeConverter : HumanReadableConverter<DateTime>
     protected override void WriteValue(HumanReadableTextWriter writer, DateTime value, HumanReadableSerializerOptions options)
     {
         var format = "yyyy-MM-dd'T'HH:mm:ss";
-        if (value.Millisecond != 0)
+        if (value.Ticks % TimeSpan.TicksPerSecond != 0)
         {
             format += ".fffffff";
         }

--- a/src/Meziantou.Framework.HumanReadableSerializer/Converters/DateTimeOffsetConverter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Converters/DateTimeOffsetConverter.cs
@@ -5,7 +5,7 @@ internal sealed class DateTimeOffsetConverter : HumanReadableConverter<DateTimeO
     protected override void WriteValue(HumanReadableTextWriter writer, DateTimeOffset value, HumanReadableSerializerOptions options)
     {
         var format = "yyyy-MM-dd'T'HH:mm:ss";
-        if (value.Millisecond != 0)
+        if (value.Ticks % TimeSpan.TicksPerSecond != 0)
         {
             format += ".fffffff";
         }

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -1150,6 +1150,26 @@ public sealed partial class SerializerTests : SerializerTestsBase
     public void DateTimeOffset_NegativeOffset() => AssertSerialization(new DateTimeOffset(2123, 4, 5, 6, 7, 8, TimeSpan.FromHours(-5)), "2123-04-05T06:07:08-05:00");
 
     [Fact]
+    public void DateTime_Milliseconds() => AssertSerialization(new DateTime(2123, 4, 5, 6, 7, 8, 9, DateTimeKind.Utc), "2123-04-05T06:07:08.0090000Z");
+
+    [Fact]
+    public void DateTime_SubMillisecondTicks() => AssertSerialization(new DateTime(2123, 4, 5, 6, 7, 8, DateTimeKind.Utc).AddTicks(5000), "2123-04-05T06:07:08.0005000Z");
+
+    [Fact]
+    public void DateTime_SingleTick() => AssertSerialization(new DateTime(2123, 4, 5, 6, 7, 8, DateTimeKind.Utc).AddTicks(1), "2123-04-05T06:07:08.0000001Z");
+
+    [Fact]
+    public void DateTimeOffset_SubMillisecondTicks() => AssertSerialization(new DateTimeOffset(2123, 4, 5, 6, 7, 8, TimeSpan.Zero).AddTicks(5000), "2123-04-05T06:07:08.0005000+00:00");
+
+    [Fact]
+    public void DateTime_ValuesDifferingBySubMillisecondTicksAreNotSerializedIdentically()
+    {
+        var value = new DateTime(2123, 4, 5, 6, 7, 8, DateTimeKind.Utc);
+
+        Assert.NotEqual(HumanReadableSerializer.Serialize(value), HumanReadableSerializer.Serialize(value.AddTicks(1)));
+    }
+
+    [Fact]
     public void Timespan_HoursMinutesSeconds() => AssertSerialization(new TimeSpan(1, 2, 3), "01:02:03");
 
     [Fact]


### PR DESCRIPTION
## The problem

Both converters decided whether to emit the fractional part by looking at the millisecond component:

```csharp
if (value.Millisecond != 0)
    format += ".fffffff";
```

Any tick component smaller than a millisecond leaves `Millisecond == 0`, so the fraction was dropped entirely and two different values serialized to the same text:

```csharp
var d1 = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
var d2 = d1.AddTicks(5000);   // 0.5 ms

d1 == d2                      // False
Serialize(d1) == Serialize(d2) // True  ← "2024-01-01T00:00:00Z" for both
```

For a serializer whose job is that different values produce different text, this means a snapshot assertion can pass over a timestamp that actually changed. It is reachable with ordinary data: `DateTime.UtcNow` has 100ns resolution on Windows, and database round-trips and `Stopwatch`-derived timestamps routinely carry sub-millisecond ticks.

## The change

Gate on the sub-second remainder instead:

```csharp
if (value.Ticks % TimeSpan.TicksPerSecond != 0)
    format += ".fffffff";
```

## Behaviour change

Only values that previously lost precision are affected:

- Whole-second values — unchanged (no fraction, as before).
- Values with a non-zero millisecond — unchanged (they already had `Millisecond != 0`).
- Values with sub-millisecond ticks only — **now emit `.fffffff`** instead of silently truncating.

That last row will invalidate existing snapshots containing such timestamps, which is the point of the fix but is worth a release note. The pre-existing `DateTime_Utc` / `DateTimeOffset_*` tests are untouched, which is the evidence that the first two rows really are unchanged.

## Verification

- 5 new tests covering explicit milliseconds, sub-millisecond ticks, a single tick, the `DateTimeOffset` equivalent, and the round-trip property that two values one tick apart no longer collide.
- Confirmed the new tests **fail 8/8 without the fix** and pass 8/8 with it.
- `Meziantou.Framework.HumanReadableSerializer.Tests`: 542 passed (net10.0 + net11.0), 0 failed.
- Downstream, since this changes output: `SnapshotTesting.Tests` 167, `InlineSnapshotTesting.Tests` 131, `Diagnostics.ContextSnapshot.Tests` 10 — all passed.
