### PR TITLE
Stop leaking writer depth and swallowing serializer exceptions in the value formatters

### DIFF
--- a/src/Meziantou.Framework.HumanReadableSerializer/HumanReadableTextWriter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/HumanReadableTextWriter.cs
@@ -203,9 +203,12 @@ public sealed class HumanReadableTextWriter
 
     private void IncrementDepth()
     {
+        // Only increment once the limit is known to be respected. Incrementing first would leave
+        // the depth permanently inflated when a caller catches the exception and keeps writing.
+        if (_depth >= _options.MaxDepth)
+            throw new HumanReadableSerializerException($"Current depth ({_depth + 1}) is equal to or larger than the maximum allowed depth of {_options.MaxDepth}. Cannot write the next object or array");
+
         _depth++;
-        if (_depth > _options.MaxDepth)
-            throw new HumanReadableSerializerException($"Current depth ({_depth}) is equal to or larger than the maximum allowed depth of {_options.MaxDepth}. Cannot write the next object or array");
     }
 
     /// <summary>Starts writing an object.</summary>

--- a/src/Meziantou.Framework.HumanReadableSerializer/ValueFormatters/HtmlFormatter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/ValueFormatters/HtmlFormatter.cs
@@ -43,8 +43,11 @@ internal sealed class HtmlFormatter : ValueFormatter
             doc.WriteTo(stringWriter);
             writer.WriteValue(stringWriter.ToString());
         }
-        catch
+        catch (Exception ex) when (ex is not HumanReadableSerializerException)
         {
+            // The value could not be parsed or reformatted: fall back to the raw text.
+            // HumanReadableSerializerException is this library's own signal (for example
+            // MaxDepth) and must not be turned into a silent formatting fallback.
             writer.WriteValue(value);
         }
     }

--- a/src/Meziantou.Framework.HumanReadableSerializer/ValueFormatters/JsonFormatter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/ValueFormatters/JsonFormatter.cs
@@ -64,8 +64,11 @@ public sealed class JsonFormatter : ValueFormatter
 
             writer.WriteValue(JsonSerializer.Serialize(node, _options.WriteIndented ? IndentedOptions : NonIndentedOptions));
         }
-        catch
+        catch (Exception ex) when (ex is not HumanReadableSerializerException)
         {
+            // The value could not be parsed or reformatted: fall back to the raw text.
+            // HumanReadableSerializerException is this library's own signal (for example
+            // MaxDepth) and must not be turned into a silent formatting fallback.
             writer.WriteValue(value);
         }
     }

--- a/src/Meziantou.Framework.HumanReadableSerializer/ValueFormatters/XmlFormatter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/ValueFormatters/XmlFormatter.cs
@@ -66,8 +66,11 @@ public sealed class XmlFormatter : ValueFormatter
 
             writer.WriteValue(sb.ToString());
         }
-        catch
+        catch (Exception ex) when (ex is not HumanReadableSerializerException)
         {
+            // The value could not be parsed or reformatted: fall back to the raw text.
+            // HumanReadableSerializerException is this library's own signal (for example
+            // MaxDepth) and must not be turned into a silent formatting fallback.
             writer.WriteValue(value);
         }
     }

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HttpJsonSerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HttpJsonSerializerTests.cs
@@ -36,6 +36,32 @@ public sealed class HttpJsonSerializerTests : SerializerTestsBase
     }
 
     [Fact]
+    public void MaxDepthViolationIsNotSwallowedAsAFormattingFailure()
+    {
+        var options = new HumanReadableSerializerOptions { MaxDepth = 4 }
+            .AddJsonFormatter(new JsonFormatterOptions { FormatAsStandardObject = true });
+
+        using var httpContent = new StringContent("""{"a":{"b":{"c":{"d":1}}}}""", encoding: null, "application/json");
+
+        Assert.Throws<HumanReadableSerializerException>(() => HumanReadableSerializer.Serialize(httpContent, options));
+    }
+
+    [Fact]
+    public void UnparsableJsonStillFallsBackToTheRawValue()
+    {
+        var options = new HumanReadableSerializerOptions()
+            .AddJsonFormatter(new JsonFormatterOptions { FormatAsStandardObject = true });
+
+        using var httpContent = new StringContent("{not json", encoding: null, "application/json");
+
+        AssertSerialization(httpContent, options, """
+            Headers:
+              Content-Type: application/json; charset=utf-8
+            Value: {not json
+            """);
+    }
+
+    [Fact]
     public void Indented_Ordered_NullValue()
     {
         using var httpContent = new StringContent("null", encoding: null, "application/json");

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -1785,6 +1785,31 @@ public sealed partial class SerializerTests : SerializerTestsBase
     }
 
     [Fact]
+    public void MaxDepthViolationDoesNotConsumeDepthBudget()
+    {
+        var options = new HumanReadableSerializerOptions { MaxDepth = 1 };
+        var writer = new HumanReadableTextWriter(options);
+
+        writer.StartObject();
+        writer.WritePropertyName("a");
+        Assert.Throws<HumanReadableSerializerException>(writer.StartObject);
+        writer.WriteValue("1");
+        writer.EndObject();
+
+        // The failed StartObject must not have left the depth inflated, so an unrelated
+        // object written afterwards is still within the budget.
+        writer.StartObject();
+        writer.WritePropertyName("b");
+        writer.WriteValue("2");
+        writer.EndObject();
+
+        Assert.Equal("""
+            a: 1
+              b: 2
+            """, writer.ToString(), ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
     public void IgnoreNullValues_Never()
     {
         AssertSerialization(new Validation


### PR DESCRIPTION
## The problem

`IncrementDepth` incremented `_depth` *before* checking the limit:

```csharp
_depth++;
if (_depth > _options.MaxDepth)
    throw new HumanReadableSerializerException(...);
```

The matching `EndObject` never runs on that path, so the throw permanently inflated the depth counter. On its own that was invisible, because the exception aborted serialization — but the value formatters catch everything:

```csharp
catch
{
    writer.WriteValue(value);   // fall back to raw text
}
```

so the writer kept going with a corrupted counter. Reproduced with `MaxDepth = 4` and `AddJsonFormatter(new JsonFormatterOptions { FormatAsStandardObject = true })`, serializing an object whose first property holds JSON nested past the limit and whose second property is an ordinary three-level object:

- shallow JSON body → the second property serializes fine;
- deep JSON body → the **identical** second property throws `Current depth (5) ... maximum allowed depth of 4`.

The reported depth is one the visible output never reaches, which makes it a miserable thing to debug.

The catch-all is a second problem in its own right. While reproducing this I hit `JsonSerializer.Deserialize<JsonNode>` throwing `InvalidOperationException: Reflection-based serialization has been disabled for this application` — swallowed, with the formatter silently degrading to raw passthrough and no signal at all. Any trimmed or AOT-published consumer gets that degradation permanently and invisibly.

## The change

1. `IncrementDepth` checks first and increments only on success, so a caught exception can no longer leave the writer inconsistent. The message is unchanged (it still reports the depth that was refused).
2. The three formatters now use `catch (Exception ex) when (ex is not HumanReadableSerializerException)`. Parse and reformat failures still fall back to the raw value exactly as before; the library's own control-flow signal propagates.

I kept the catch broad rather than narrowing it to `JsonException`/`XmlException`. These formatters are deliberately best-effort over arbitrary payloads, and enumerating what `HtmlDocument` can throw is its own risk. Excluding `HumanReadableSerializerException` is the smallest change that fixes the real problem.

## Behaviour change

A `MaxDepth` violation raised *inside* a formatted value now surfaces instead of silently falling back to raw text. Someone with deeply nested JSON in a body and a low `MaxDepth` will see an exception where they previously got a raw blob. That is the intended reading of `MaxDepth` — and the silent fallback was worse for snapshot stability, since the same payload rendered as structured output or as a raw blob depending on its depth — but it is a behaviour change, so flagging it explicitly.

## Verification

- `MaxDepthViolationDoesNotConsumeDepthBudget` drives `HumanReadableTextWriter` directly and pins that a refused `StartObject` leaves the budget intact.
- `MaxDepthViolationIsNotSwallowedAsAFormattingFailure` covers the end-to-end formatter path.
- `UnparsableJsonStillFallsBackToTheRawValue` pins that the raw-text fallback for genuinely malformed input is unaffected — it passes both before and after, which is the point.
- Confirmed the two depth tests **fail without the fix** (4/6 red across both TFMs) while the two fallback tests stay green, then all 6 pass with it.
- `Meziantou.Framework.HumanReadableSerializer.Tests`: 538 passed (net10.0 + net11.0), 0 failed.
- Downstream: `SnapshotTesting.Tests` 167 passed, `InlineSnapshotTesting.Tests` 131 passed.
