### PR TITLE
Redact CSP nonces in Content-Security-Policy-Report-Only too

### DIFF
--- a/src/Meziantou.Framework.HumanReadableSerializer/Converters/ContentSecurityPolicyFormatter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Converters/ContentSecurityPolicyFormatter.cs
@@ -6,7 +6,9 @@ internal sealed partial class ContentSecurityPolicyFormatter : HttpHeaderValueFo
 {
     public override string FormatHeaderValue(string headerName, string headerValue)
     {
-        if (string.Equals(headerName, "Content-Security-Policy", StringComparison.OrdinalIgnoreCase))
+        // Covers Content-Security-Policy and Content-Security-Policy-Report-Only, which carries
+        // nonces with the same syntax.
+        if (headerName.StartsWith("Content-Security-Policy", StringComparison.OrdinalIgnoreCase))
             headerValue = ContentSecurityPolicyNonceRegex.Replace(headerValue, "[redacted]");
 
         return headerValue;

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HttpOptionsTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HttpOptionsTests.cs
@@ -154,4 +154,52 @@ public sealed class HttpOptionsTests : SerializerTestsBase
               Value: test
             """);
     }
+
+    [Fact]
+    public void Redact_CSP_Nonce_ReportOnly()
+    {
+        using var httpContent = new HttpResponseMessage()
+        {
+            Headers =
+            {
+                Date = DateTimeOffset.UtcNow,
+            },
+            Content = new StringContent("test"),
+        };
+        httpContent.Headers.Add("Content-Security-Policy-Report-Only", "script-src 'nonce-QOlYr5k1Ls3VoNjVQLK5DWFc';");
+
+        AssertSerialization(httpContent, new HumanReadableHttpResponseMessageOptions { RedactContentSecurityPolicyNonce = true }, """
+            StatusCode: 200 (OK)
+            Headers:
+              Content-Security-Policy-Report-Only: script-src 'nonce-[redacted]';
+            Content:
+              Headers:
+                Content-Type: text/plain; charset=utf-8
+              Value: test
+            """);
+    }
+
+    [Fact]
+    public void Redact_CSP_Nonce_LeavesOtherHeadersAlone()
+    {
+        using var httpContent = new HttpResponseMessage()
+        {
+            Headers =
+            {
+                Date = DateTimeOffset.UtcNow,
+            },
+            Content = new StringContent("test"),
+        };
+        httpContent.Headers.Add("X-Custom", "script-src 'nonce-QOlYr5k1Ls3VoNjVQLK5DWFc';");
+
+        AssertSerialization(httpContent, new HumanReadableHttpResponseMessageOptions { RedactContentSecurityPolicyNonce = true }, """
+            StatusCode: 200 (OK)
+            Headers:
+              X-Custom: script-src 'nonce-QOlYr5k1Ls3VoNjVQLK5DWFc';
+            Content:
+              Headers:
+                Content-Type: text/plain; charset=utf-8
+              Value: test
+            """);
+    }
 }


### PR DESCRIPTION
## The problem

`ContentSecurityPolicyFormatter` matched the header name exactly:

```csharp
if (string.Equals(headerName, "Content-Security-Policy", StringComparison.OrdinalIgnoreCase))
```

so with `RedactContentSecurityPolicyNonce = true` a response carrying both headers serialized as:

```
Content-Security-Policy: script-src 'nonce-[redacted]'
Content-Security-Policy-Report-Only: script-src 'nonce-SECRET2'
```

`-Report-Only` is the standard header for staged CSP rollouts and carries nonces with identical syntax. The whole point of the option is to keep per-request nonces out of snapshot files that get committed — otherwise every run produces a diff and the nonce values accumulate in git history. A team that turns the option on reasonably believes they are covered.

## The change

Match with `StartsWith(..., OrdinalIgnoreCase)`, which covers both headers and any future `Content-Security-Policy-*` variant. The regex is untouched.

## Verification

- `Redact_CSP_Nonce_ReportOnly` covers the new case.
- `Redact_CSP_Nonce_LeavesOtherHeadersAlone` pins that an unrelated header carrying `nonce-` text is still left alone, so `StartsWith` did not widen the match too far.
- Confirmed 2/6 fail without the fix (the `-Report-Only` case on both TFMs) and 6/6 pass with it; the pre-existing `Redact_CSP_Nonce` stays green throughout.
- `Meziantou.Framework.HumanReadableSerializer.Tests`: 536 passed (net10.0 + net11.0), 0 failed.

## Note, not fixed here

The redaction is syntactic: the regex `(?<=nonce-).*?(?=')` requires a closing single quote, so an unquoted nonce is not redacted. That matches how CSP is written in practice, so I left it alone. Separately, `HumanReadableHttpRequestMessageOptions` has no `RedactContentSecurityPolicyNonce` at all — request-side CSP headers are never redacted. Happy to open that as its own change if you want it.
