### PR TITLE
Add a Dispose overload that clears the buffer before releasing it

### DIFF
--- a/ref/Meziantou.Framework.ValueStringBuilder.cs
+++ b/ref/Meziantou.Framework.ValueStringBuilder.cs
@@ -31,6 +31,7 @@ namespace Meziantou.Framework
         public void Append(System.ReadOnlySpan<char> value) { }
         public System.Span<char> AppendSpan(int length) => throw null;
         public void Dispose() { }
+        public void Dispose(bool clearArray) { }
         public void Append(System.Text.Rune rune) { }
         [System.Runtime.CompilerServices.InterpolatedStringHandler]
         public ref struct AppendInterpolatedStringHandler

--- a/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs
+++ b/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs
@@ -255,4 +255,28 @@ ref partial struct ValueStringBuilder
             ArrayPool<char>.Shared.Return(toReturn);
         }
     }
+
+    /// <summary>
+    /// Releases the buffer, optionally clearing the characters that were written to it first.
+    /// </summary>
+    /// <param name="clearArray">
+    /// <see langword="true" /> to zero the content before releasing the buffer, so that it is not left readable by
+    /// the next consumer to rent the array. Use it when the builder held sensitive data; it costs a clear of the
+    /// buffer, which is why <see cref="Dispose()" /> does not do it.
+    /// </param>
+    public void Dispose(bool clearArray)
+    {
+        if (clearArray)
+        {
+            // Clear through the span rather than the array so a stack-allocated initial buffer is covered too.
+            _chars.Slice(0, _pos).Clear();
+        }
+
+        var toReturn = _arrayToReturnToPool;
+        this = default;
+        if (toReturn is not null)
+        {
+            ArrayPool<char>.Shared.Return(toReturn, clearArray);
+        }
+    }
 }

--- a/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
+++ b/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
@@ -46,6 +46,43 @@ public class ValueStringBuilderTests
     }
 
     [Fact]
+    public void DisposeWithClearArrayZeroesThePooledBuffer()
+    {
+        var sb = new ValueStringBuilder(initialCapacity: 64);
+        sb.Append("hunter2-super-secret");
+
+        // RawChars aliases the rented array; nothing else rents it before the assertion below.
+        var buffer = sb.RawChars;
+        sb.Dispose(clearArray: true);
+
+        Assert.Equal(new string('\0', 20), buffer.Slice(0, 20).ToString());
+    }
+
+    [Fact]
+    public void DisposeWithClearArrayZeroesAStackAllocatedBuffer()
+    {
+        Span<char> initialBuffer = stackalloc char[32];
+        var sb = new ValueStringBuilder(initialBuffer);
+        sb.Append("hunter2-super-secret");
+
+        sb.Dispose(clearArray: true);
+
+        Assert.Equal(new string('\0', 20), initialBuffer.Slice(0, 20).ToString());
+    }
+
+    [Fact]
+    public void DisposeWithoutClearArrayLeavesTheContent()
+    {
+        Span<char> initialBuffer = stackalloc char[32];
+        var sb = new ValueStringBuilder(initialBuffer);
+        sb.Append("hunter2-super-secret");
+
+        sb.Dispose(clearArray: false);
+
+        Assert.Equal("hunter2-super-secret", initialBuffer.Slice(0, 20).ToString());
+    }
+
+    [Fact]
     public void NullTerminateWritesTerminator()
     {
         using var sb = new ValueStringBuilder(initialCapacity: 2);


### PR DESCRIPTION
## Finding

`Dispose` (`src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs:248-257`) returned the rented array to `ArrayPool<char>.Shared` without clearing it, and there was no way to ask it to.

Whatever the builder held stays readable by the next consumer to rent that array:

```csharp
var sb = new ValueStringBuilder(initialCapacity: 64);
sb.Append("hunter2-super-secret");
sb.Dispose();

var next = ArrayPool<char>.Shared.Rent(64);
// next[0..20] is "hunter2-super-secret"
```

Reading past your own written length is a bug on the reader's side, so this is low severity — but `ValueStringBuilder` is a plausible choice for assembling connection strings, tokens and query strings, and the caller had no opt-in.

## Change

Adds `Dispose(bool clearArray)`. It zeroes the written characters through the span, so a stack-allocated initial buffer is covered as well as a pooled one, and passes the flag on to `ArrayPool.Return`.

The parameterless `Dispose()` is unchanged — clearing every buffer by default would undo the point of the type.

`ref/Meziantou.Framework.ValueStringBuilder.cs` is regenerated for the new overload.

## Verification

- `dotnet test` on `Meziantou.Framework.ValueStringBuilder.Tests` with `/p:TreatsWarningsAsErrors=true`, both TFMs, green.
- Three new tests cover the pooled buffer, a stack-allocated buffer, and that `clearArray: false` still leaves the content.
- `dotnet run ./eng/update-all.cs` reports no further changes.

Independent of the other ValueStringBuilder pull requests; mergeable in any order.
