### PR TITLE
Compute the grown capacity without overflowing int

### DIFF
--- a/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs
+++ b/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs
@@ -229,8 +229,12 @@ ref partial struct ValueStringBuilder
 
         const uint ArrayMaxLength = 0x7FFFFFC7;
 
+        // Add as uint and clamp: _pos + additionalCapacityBeyondPos overflows int for a builder close to the
+        // maximum array length, and the negative result used to reach Rent as an out-of-range argument.
+        var requiredCapacity = Math.Min((uint)_pos + (uint)additionalCapacityBeyondPos, ArrayMaxLength);
+
         var newCapacity = (int)Math.Max(
-            (uint)(_pos + additionalCapacityBeyondPos),
+            requiredCapacity,
             Math.Min((uint)_chars.Length * 2, ArrayMaxLength));
 
         var poolArray = ArrayPool<char>.Shared.Rent(newCapacity);


### PR DESCRIPTION
## Finding

`Grow` (`src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs:232-234`) computed

```csharp
var newCapacity = (int)Math.Max(
    (uint)(_pos + additionalCapacityBeyondPos),
    Math.Min((uint)_chars.Length * 2, ArrayMaxLength));
```

The sum is evaluated as `int` before the widening cast, so a builder close to the maximum array length wraps to a negative value. The `(int)` cast of the result can then be negative too, and `ArrayPool.Rent` fails with an `ArgumentOutOfRangeException` naming an argument the caller never supplied.

Inherited verbatim from the runtime's internal implementation, which has the same shape.

## Change

Add as `uint` and clamp to the maximum array length, so `Rent` always receives a valid size and an allocation that genuinely cannot be satisfied fails as one.

## Verification

- `dotnet test` on `Meziantou.Framework.ValueStringBuilder.Tests` with `/p:TreatsWarningsAsErrors=true`, both TFMs, green.
- **Not covered by a new test.** Reaching the overflow needs a builder of roughly `int.MaxValue` characters, which the suite cannot allocate. The change is by inspection of the arithmetic; the existing growth tests confirm no regression on ordinary sizes.

Independent of the other ValueStringBuilder pull requests; mergeable in any order.
