### PR TITLE
Drop the redundant bounds check in Append(Rune)

### DIFF
--- a/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.Rune.cs
+++ b/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.Rune.cs
@@ -15,7 +15,8 @@ ref partial struct ValueStringBuilder
     {
         var pos = _pos;
         var chars = _chars;
-        if ((uint)(pos + 1) < (uint)chars.Length && (uint)pos < (uint)chars.Length)
+        // Two free characters are needed for a surrogate pair; pos < chars.Length follows from pos + 1 < chars.Length.
+        if ((uint)(pos + 1) < (uint)chars.Length)
         {
             if (rune.Value <= 0xFFFF)
             {

--- a/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
+++ b/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
@@ -111,6 +111,46 @@ public class ValueStringBuilderTests
     }
 
     [Fact]
+    public void AppendRuneSupportsBasicMultilingualPlaneRunes()
+    {
+        using var sb = new ValueStringBuilder(initialCapacity: 4);
+        sb.Append(new Rune('a'));
+        sb.Append(new Rune(0x00E9));
+        sb.Append(new Rune(0xFFFD));
+
+        Assert.Equal("a\u00E9\uFFFD", sb.AsSpan().ToString());
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void AppendRuneGrowsAtBufferBoundaries(int fillCount)
+    {
+        Span<char> initialBuffer = stackalloc char[4];
+        using var sb = new ValueStringBuilder(initialBuffer);
+        sb.Append('x', fillCount);
+
+        sb.Append(new Rune('a'));
+        sb.Append(new Rune(0x1F600));
+
+        Assert.Equal(new string('x', fillCount) + "a\U0001F600", sb.AsSpan().ToString());
+    }
+
+    [Fact]
+    public void AppendRuneFillsTheBufferExactly()
+    {
+        Span<char> initialBuffer = stackalloc char[2];
+        using var sb = new ValueStringBuilder(initialBuffer);
+
+        sb.Append(new Rune(0x1F600));
+
+        Assert.Equal("\U0001F600", sb.AsSpan().ToString());
+        Assert.Equal(2, sb.Length);
+    }
+
+    [Fact]
     public void AppendSpanFormattableUsesTryFormat()
     {
         Span<char> initialBuffer = stackalloc char[16];


### PR DESCRIPTION
## Finding

`Append(Rune)` (`src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.Rune.cs:18`) guarded its fast path with

```csharp
if ((uint)(pos + 1) < (uint)chars.Length && (uint)pos < (uint)chars.Length)
```

The second conjunct follows from the first — if `pos + 1 < chars.Length` then `pos < chars.Length` — so it never changed the outcome. One redundant comparison on a method marked `AggressiveInlining`.

## Change

Drop the redundant conjunct and note why two free characters are required (the surrogate-pair case). **Behaviour is unchanged.**

While verifying that, the suite turned out to exercise only the surrogate-pair path, so this also adds coverage for BMP runes and for appending a rune at every offset in a four-character buffer, including the case where a surrogate pair fills the buffer exactly.

## Verification

- `dotnet test` on `Meziantou.Framework.ValueStringBuilder.Tests` with `/p:TreatsWarningsAsErrors=true`, both TFMs, green (36 tests).
- The new boundary tests pass both before and after the change, which is the point: they pin the behaviour the simplification must preserve.

Independent of the other ValueStringBuilder pull requests; mergeable in any order.
