### PR TITLE
Document the public ValueStringBuilder API

### DIFF
--- a/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.AppendSpanFormattable.cs
+++ b/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.AppendSpanFormattable.cs
@@ -8,6 +8,13 @@ internal
 #endif
 ref partial struct ValueStringBuilder
 {
+    /// <summary>
+    /// Appends <paramref name="value" /> by formatting it straight into the buffer, falling back to
+    /// <see cref="IFormattable.ToString(string, IFormatProvider)" /> when it does not fit.
+    /// </summary>
+    /// <param name="value">The value to append.</param>
+    /// <param name="format">The format to use, or <see langword="null" /> for the default format.</param>
+    /// <param name="provider">The provider to use, or <see langword="null" /> for the current culture.</param>
     public void AppendSpanFormattable<T>(T value, string? format = null, IFormatProvider? provider = null) where T : ISpanFormattable
     {
         if (value.TryFormat(_chars.Slice(_pos), out var charsWritten, format, provider))

--- a/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.Rune.cs
+++ b/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.Rune.cs
@@ -10,6 +10,10 @@ internal
 #endif
 ref partial struct ValueStringBuilder
 {
+    /// <summary>
+    /// Appends a Unicode scalar value, encoded as one character or as a surrogate pair.
+    /// </summary>
+    /// <param name="rune">The scalar value to append.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Append(Rune rune)
     {

--- a/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs
+++ b/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs
@@ -17,6 +17,11 @@ ref partial struct ValueStringBuilder
     private Span<char> _chars;
     private int _pos;
 
+    /// <summary>
+    /// Initializes a builder that writes into <paramref name="initialBuffer" /> and only rents from
+    /// <see cref="ArrayPool{T}" /> once the content outgrows it.
+    /// </summary>
+    /// <param name="initialBuffer">The buffer to write into, typically stack-allocated.</param>
     public ValueStringBuilder(Span<char> initialBuffer)
     {
         _arrayToReturnToPool = null;
@@ -24,6 +29,11 @@ ref partial struct ValueStringBuilder
         _pos = 0;
     }
 
+    /// <summary>
+    /// Initializes a builder backed by a buffer of at least <paramref name="initialCapacity" /> characters
+    /// rented from <see cref="ArrayPool{T}" />.
+    /// </summary>
+    /// <param name="initialCapacity">The minimum number of characters the buffer must hold.</param>
     public ValueStringBuilder(int initialCapacity)
     {
         _arrayToReturnToPool = ArrayPool<char>.Shared.Rent(initialCapacity);
@@ -31,6 +41,10 @@ ref partial struct ValueStringBuilder
         _pos = 0;
     }
 
+    /// <summary>
+    /// Gets or sets the number of characters written so far. Setting it truncates the content, or exposes
+    /// characters already present in the buffer when it is increased.
+    /// </summary>
     public int Length
     {
         readonly get => _pos;
@@ -42,8 +56,15 @@ ref partial struct ValueStringBuilder
         }
     }
 
+    /// <summary>
+    /// Gets the number of characters the current buffer can hold before it has to grow.
+    /// </summary>
     public readonly int Capacity => _chars.Length;
 
+    /// <summary>
+    /// Grows the buffer so that it can hold at least <paramref name="capacity" /> characters.
+    /// </summary>
+    /// <param name="capacity">The minimum capacity required.</param>
     public void EnsureCapacity(int capacity)
     {
         Debug.Assert(capacity >= 0);
@@ -54,11 +75,19 @@ ref partial struct ValueStringBuilder
         }
     }
 
+    /// <summary>
+    /// Resets <see cref="Length" /> to 0, keeping the current buffer. The characters are not erased and stay
+    /// readable through <see cref="RawChars" />.
+    /// </summary>
     public void Clear()
     {
         _pos = 0;
     }
 
+    /// <summary>
+    /// Writes a null character after the content, growing the buffer if needed, without changing
+    /// <see cref="Length" />.
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void NullTerminate()
     {
@@ -66,11 +95,20 @@ ref partial struct ValueStringBuilder
         _chars[_pos] = '\0';
     }
 
+    /// <summary>
+    /// Returns a reference to the first character of the buffer, so the builder can be used with a
+    /// <see langword="fixed" /> statement. The result is not null-terminated unless
+    /// <see cref="NullTerminate" /> was called.
+    /// </summary>
     public ref char GetPinnableReference()
     {
         return ref MemoryMarshal.GetReference(_chars);
     }
 
+    /// <summary>
+    /// Gets a reference to the character at <paramref name="index" />, which can be used to overwrite it.
+    /// </summary>
+    /// <param name="index">The position of the character, which must be less than <see cref="Length" />.</param>
     public ref char this[int index]
     {
         get
@@ -87,12 +125,39 @@ ref partial struct ValueStringBuilder
         return s;
     }
 
+    /// <summary>
+    /// Gets the whole buffer, including the part past <see cref="Length" />.
+    /// </summary>
+    /// <remarks>
+    /// Everything beyond <see cref="Length" /> is uninitialized pooled memory and may hold data left by a
+    /// previous user of the array. Use <see cref="AsSpan()" /> to read only what was written.
+    /// </remarks>
     public readonly Span<char> RawChars => _chars;
 
+    /// <summary>
+    /// Returns the characters written so far, without disposing the builder.
+    /// </summary>
     public readonly ReadOnlySpan<char> AsSpan() => _chars.Slice(0, _pos);
+
+    /// <summary>
+    /// Returns the characters written so far from <paramref name="start" /> onwards.
+    /// </summary>
+    /// <param name="start">The position to start at.</param>
     public readonly ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
+
+    /// <summary>
+    /// Returns <paramref name="length" /> characters starting at <paramref name="start" />.
+    /// </summary>
+    /// <param name="start">The position to start at.</param>
+    /// <param name="length">The number of characters to return.</param>
     public readonly ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
 
+    /// <summary>
+    /// Inserts <paramref name="value" /> <paramref name="count" /> times at <paramref name="index" />.
+    /// </summary>
+    /// <param name="index">The position to insert at.</param>
+    /// <param name="value">The character to insert.</param>
+    /// <param name="count">The number of times to insert it.</param>
     public void Insert(int index, char value, int count)
     {
         if (_pos > _chars.Length - count)
@@ -106,6 +171,11 @@ ref partial struct ValueStringBuilder
         _pos += count;
     }
 
+    /// <summary>
+    /// Inserts <paramref name="s" /> at <paramref name="index" />. A <see langword="null" /> string is ignored.
+    /// </summary>
+    /// <param name="index">The position to insert at.</param>
+    /// <param name="s">The string to insert.</param>
     public void Insert(int index, string? s)
     {
         if (s is null)
@@ -125,6 +195,10 @@ ref partial struct ValueStringBuilder
         _pos += count;
     }
 
+    /// <summary>
+    /// Appends a single character.
+    /// </summary>
+    /// <param name="c">The character to append.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Append(char c)
     {
@@ -141,6 +215,10 @@ ref partial struct ValueStringBuilder
         }
     }
 
+    /// <summary>
+    /// Appends a string. A <see langword="null" /> string is ignored.
+    /// </summary>
+    /// <param name="s">The string to append.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Append(string? s)
     {
@@ -173,6 +251,11 @@ ref partial struct ValueStringBuilder
         _pos += s.Length;
     }
 
+    /// <summary>
+    /// Appends <paramref name="c" /> <paramref name="count" /> times.
+    /// </summary>
+    /// <param name="c">The character to append.</param>
+    /// <param name="count">The number of times to append it.</param>
     public void Append(char c, int count)
     {
         if (_pos > _chars.Length - count)
@@ -189,6 +272,10 @@ ref partial struct ValueStringBuilder
         _pos += count;
     }
 
+    /// <summary>
+    /// Appends the characters of <paramref name="value" />.
+    /// </summary>
+    /// <param name="value">The characters to append.</param>
     public void Append(ReadOnlySpan<char> value)
     {
         var pos = _pos;
@@ -201,6 +288,12 @@ ref partial struct ValueStringBuilder
         _pos += value.Length;
     }
 
+    /// <summary>
+    /// Reserves <paramref name="length" /> characters at the end of the content and returns them so the caller
+    /// can write into the buffer directly. <see cref="Length" /> is advanced immediately, so the reserved
+    /// characters are part of the content whether or not they are written to.
+    /// </summary>
+    /// <param name="length">The number of characters to reserve.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Span<char> AppendSpan(int length)
     {
@@ -245,6 +338,11 @@ ref partial struct ValueStringBuilder
         }
     }
 
+    /// <summary>
+    /// Releases the buffer back to <see cref="ArrayPool{T}" /> and resets the builder. Calling it more than
+    /// once is safe.
+    /// </summary>
+    /// <remarks>The content is not erased; it stays readable by the next consumer to rent the array.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Dispose()
     {


### PR DESCRIPTION
## Finding

The package shipped without a single XML documentation comment — `grep -c '///'` returned `0` for all four source files.

Consumers got no IntelliSense for a type whose correct use depends on several non-obvious rules:

- the buffer must be released, or a pooled array leaks;
- `RawChars` deliberately exposes memory past `Length`, which holds whatever the previous renter of that array left there;
- `AppendSpan` advances `Length` before anything has been written into the span it returns;
- `Clear` resets `Length` without erasing anything;
- `GetPinnableReference` does not null-terminate.

## Change

Documents the public surface of `ValueStringBuilder`, `AppendSpanFormattable` and `Append(Rune)`, with the ownership and buffer-tail caveats stated on the members they apply to.

No behaviour changes, and no build configuration changes — this does not turn on `GenerateDocumentationFile`, which is a repository-wide decision rather than a per-package one.

`ToString` is deliberately left alone: it is documented by the separate "Document that ToString disposes the ValueStringBuilder" pull request, which owns that contract.

## Verification

- `dotnet build` and `dotnet test` on the package and its tests with `/p:TreatsWarningsAsErrors=true`, both TFMs, green.
- `ref/` is unchanged, as expected for a comment-only change.

**Merge this one last.** It touches every member of `ValueStringBuilder.cs`, so it conflicts with any other pull request that changes that file, and it will need a rebase once the others land. Nothing in it depends on them.
