### PR TITLE
Stop the interpolated string handler from sharing the builder's pooled buffer

### DIFF
--- a/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.AppendInterpolatedStringHandler.cs
+++ b/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.AppendInterpolatedStringHandler.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Meziantou.Framework;
@@ -12,27 +13,49 @@ ref partial struct ValueStringBuilder
 {
     public void Append([InterpolatedStringHandlerArgument("")] ref AppendInterpolatedStringHandler handler)
     {
-        this = handler._valueStringBuilder;
+        AppendAndDispose(ref handler);
     }
 
     public void Append(IFormatProvider? provider, [InterpolatedStringHandlerArgument("", nameof(provider))] ref AppendInterpolatedStringHandler handler)
     {
         _ = provider;
 
-        this = handler._valueStringBuilder;
+        AppendAndDispose(ref handler);
+    }
+
+    private void AppendAndDispose(ref AppendInterpolatedStringHandler handler)
+    {
+        try
+        {
+            Append(handler._valueStringBuilder.AsSpan());
+        }
+        finally
+        {
+            handler._valueStringBuilder.Dispose();
+        }
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [InterpolatedStringHandler]
+    [SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "The handler is only created by the compiler for an interpolated string argument, and the Append overload it is passed to always disposes the buffer.")]
     public ref struct AppendInterpolatedStringHandler
     {
+        // Matches the heuristic used by DefaultInterpolatedStringHandler: assume ~11 characters per hole.
+        private const int GuessedLengthPerHole = 11;
+        private const int MinimumLength = 16;
+
         internal ValueStringBuilder _valueStringBuilder;
         private readonly IFormatProvider? _provider;
         private readonly bool _hasCustomFormatter;
 
         public AppendInterpolatedStringHandler(int literalLength, int formattedCount, ValueStringBuilder valueStringBuilder)
         {
-            _valueStringBuilder = valueStringBuilder;
+            // The handler must not share the buffer of the builder it appends to. It receives a copy of that
+            // builder, so growing it here would return the caller's pooled array while the caller still points
+            // at it, and an exception thrown between two holes would leave the copy - and the appended text -
+            // unreachable. Building into a private buffer keeps the caller's builder untouched until Append runs.
+            _ = valueStringBuilder;
+            _valueStringBuilder = new ValueStringBuilder(GetInitialCapacity(literalLength, formattedCount));
             _provider = null;
             _hasCustomFormatter = false;
         }
@@ -45,7 +68,8 @@ ref partial struct ValueStringBuilder
 
         public AppendInterpolatedStringHandler(int literalLength, int formattedCount, ValueStringBuilder valueStringBuilder, IFormatProvider? provider)
         {
-            _valueStringBuilder = valueStringBuilder;
+            _ = valueStringBuilder;
+            _valueStringBuilder = new ValueStringBuilder(GetInitialCapacity(literalLength, formattedCount));
             _provider = provider;
             _hasCustomFormatter = provider?.GetFormat(typeof(ICustomFormatter)) is ICustomFormatter;
         }
@@ -169,6 +193,11 @@ ref partial struct ValueStringBuilder
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => AppendFormatted<string?>(value, alignment, format);
 
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => AppendFormatted<object?>(value, alignment, format);
+
+        private static int GetInitialCapacity(int literalLength, int formattedCount)
+        {
+            return Math.Max(MinimumLength, literalLength + (formattedCount * GuessedLengthPerHole));
+        }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void AppendCustomFormatter<T>(T value, string? format)

--- a/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
+++ b/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
@@ -1,3 +1,6 @@
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
 namespace Meziantou.Framework.Tests;
 
 public class ValueStringBuilderTests
@@ -100,6 +103,101 @@ public class ValueStringBuilderTests
 
         Assert.Equal("A=<12>, B=<34>", sb.ToString());
     }
+
+    [Fact]
+    public void AppendInterpolatedStringDoesNotShareItsBufferWithTheBuilderWhenAHoleThrows()
+    {
+        using var sb = new ValueStringBuilder(initialCapacity: 32);
+        try
+        {
+            // The literal forces the handler to grow before the throwing hole is evaluated.
+            sb.Append($"{new string('x', 200)}{ThrowingHole()}");
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        var rented = ArrayPool<char>.Shared.Rent(32);
+        try
+        {
+            Assert.False(Unsafe.AreSame(ref sb.GetPinnableReference(), ref rented[0]));
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(rented);
+        }
+
+        sb.Append("still usable");
+        Assert.Equal("still usable", sb.ToString());
+    }
+
+    [Fact]
+    public void AppendInterpolatedStringReturnsTheBufferOnlyOnceWhenAHoleThrows()
+    {
+        var sb = new ValueStringBuilder(initialCapacity: 32);
+        try
+        {
+            sb.Append($"{new string('x', 200)}{ThrowingHole()}");
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        sb.Dispose();
+
+        var first = ArrayPool<char>.Shared.Rent(32);
+        var second = ArrayPool<char>.Shared.Rent(32);
+        try
+        {
+            Assert.NotSame(first, second);
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(first);
+            ArrayPool<char>.Shared.Return(second);
+        }
+    }
+
+    [Fact]
+    public void AppendInterpolatedStringLeavesTheBuilderUntouchedWhenAHoleThrows()
+    {
+        using var sb = new ValueStringBuilder(initialCapacity: 32);
+        sb.Append("before");
+
+        try
+        {
+            sb.Append($"{new string('x', 200)}{ThrowingHole()}");
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        Assert.Equal("before", sb.AsSpan().ToString());
+    }
+
+    [Fact]
+    public void AppendInterpolatedStringGrowsTheBuilderWhenTheResultIsLarger()
+    {
+        using var sb = new ValueStringBuilder(initialCapacity: 2);
+        var value = new string('a', 500);
+
+        sb.Append(CultureInfo.InvariantCulture, $"{value}|{value}");
+
+        Assert.Equal(value + "|" + value, sb.AsSpan().ToString());
+    }
+
+    [Fact]
+    public void AppendInterpolatedStringWorksWithAStackAllocatedBuffer()
+    {
+        Span<char> initialBuffer = stackalloc char[4];
+        using var sb = new ValueStringBuilder(initialBuffer);
+
+        sb.Append(CultureInfo.InvariantCulture, $"{new string('z', 50)}");
+
+        Assert.Equal(new string('z', 50), sb.AsSpan().ToString());
+    }
+
+    private static string ThrowingHole() => throw new InvalidOperationException("boom");
 
     [Fact]
     public void AppendRuneSupportsSurrogatePairs()


### PR DESCRIPTION
> **Stack 1 of 2** · merges into `main` · must merge before #2665

## Finding

`AppendInterpolatedStringHandler` takes the builder **by value** (`ValueStringBuilder.AppendInterpolatedStringHandler.cs:33-57`) and writes the state back only after every hole has been evaluated (`:13-23`).

Two things follow:

- when the handler's copy grows, `Grow` returns the *caller's* rented array to `ArrayPool<char>.Shared` (`ValueStringBuilder.cs:240-245`) while the caller's `_chars` still spans it;
- if any expression inside the interpolation throws, `Append(ref handler)` never runs, so the copy-back never happens and the caller is left permanently aliasing a pooled array.

Reproduced on a Release build:

```csharp
var sb = new ValueStringBuilder(initialCapacity: 32);
try { sb.Append($"{new string('x', 200)}{Thrower()}"); }   // literal grows the copy, then throws
catch (InvalidOperationException) { }

var victim = ArrayPool<char>.Shared.Rent(32);   // another component rents the array sb still owns
// victim aliases sb's live buffer : True
victim.AsSpan(0, 5).Fill('A');
sb.Append("HELLO");
// victim's first 5 characters are now "HELLO", not "AAAAA"

sb.Dispose();                                   // returns the array a SECOND time
var a = ArrayPool<char>.Shared.Rent(32);
// a is the same char[] that `victim` still holds : True
```

An exception is not strictly required — `sb.Append($"[{sb.ToString()}]")` produces the same aliasing, because `ToString` disposes.

`ArrayPool<char>.Shared` is process-wide, so the corrupted array goes to whatever unrelated code rents next, on any thread, with no exception and nothing in a stack trace pointing back here.

## Change

The handler no longer shares the caller's buffer. It builds into a private `ValueStringBuilder` sized from `literalLength + formattedCount * 11`, and `Append` copies that in once and disposes it in a `finally`.

A `ref ValueStringBuilder` field would be the obvious fix and is not available: `ref` fields cannot refer to a ref struct (CS9050, confirmed by compiling it).

This also fixes the separate finding that the handler ignored `literalLength`/`formattedCount` entirely and never pre-sized — which is what made it grow, and therefore made this bug fire, far more often than necessary.

**Tradeoff:** one extra copy of the interpolated segment per `Append`, and a pool rent/return for the handler's own buffer. The pre-sizing means that is normally a single rent with no growth, where the old code could grow several times.

The public API is unchanged, so `ref/` needs no regeneration. `CA1001` is suppressed on the handler with a justification: it now owns a disposable field, but it is only ever constructed by the compiler and the `Append` overload it is passed to always disposes it.

## Verification

- `dotnet test` with `/p:TreatsWarningsAsErrors=true`, both TFMs, green (17 tests).
- Two of the five new tests fail against the unfixed code — the aliasing check and the double-return check — which is the regression proof. The other three pin behaviour that must not change (builder untouched after a throwing hole, growth from a small builder, stack-allocated buffers).
- `dotnet build` of the library leaves `ref/` unchanged; `dotnet run ./eng/update-all.cs` reports no changes.
