### PR TITLE
Format interpolated string holes with ISpanFormattable instead of ToString

### DIFF
--- a/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.AppendInterpolatedStringHandler.cs
+++ b/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.AppendInterpolatedStringHandler.cs
@@ -82,28 +82,7 @@ ref partial struct ValueStringBuilder
 
         public void AppendLiteral(string value) => _valueStringBuilder.Append(value);
 
-        public void AppendFormatted<T>(T value)
-        {
-            if (_hasCustomFormatter)
-            {
-                AppendCustomFormatter(value, format: null);
-                return;
-            }
-
-            if (value is null)
-            {
-                return;
-            }
-
-            if (value is IFormattable formattable)
-            {
-                _valueStringBuilder.Append(formattable.ToString(format: null, _provider));
-            }
-            else
-            {
-                _valueStringBuilder.Append(value.ToString());
-            }
-        }
+        public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
         public void AppendFormatted<T>(T value, string? format)
         {
@@ -113,18 +92,27 @@ ref partial struct ValueStringBuilder
                 return;
             }
 
-            if (value is null)
+            if (value is IFormattable)
             {
-                return;
-            }
+                // ISpanFormattable formats straight into the buffer. IFormattable.ToString allocates a
+                // string for every hole, so it is only the fallback for types that cannot do better.
+                if (value is ISpanFormattable)
+                {
+                    int charsWritten;
+                    while (!((ISpanFormattable)value).TryFormat(_valueStringBuilder._chars[_valueStringBuilder._pos..], out charsWritten, format, _provider))
+                    {
+                        _valueStringBuilder.EnsureCapacity(_valueStringBuilder.Capacity + 1);
+                    }
 
-            if (value is IFormattable formattable)
-            {
-                _valueStringBuilder.Append(formattable.ToString(format, _provider));
+                    _valueStringBuilder._pos += charsWritten;
+                    return;
+                }
+
+                _valueStringBuilder.Append(((IFormattable)value).ToString(format, _provider));
             }
             else
             {
-                _valueStringBuilder.Append(value.ToString());
+                _valueStringBuilder.Append(value?.ToString());
             }
         }
 
@@ -132,14 +120,42 @@ ref partial struct ValueStringBuilder
 
         public void AppendFormatted<T>(T value, int alignment, string? format)
         {
-            if (alignment is 0)
+            var startingPos = _valueStringBuilder.Length;
+            AppendFormatted(value, format);
+
+            if (alignment is not 0)
             {
-                AppendFormatted(value, format);
+                // Formatting first and padding afterwards avoids materialising the value as a string
+                // just to measure it.
+                AppendOrInsertAlignmentIfNeeded(startingPos, alignment);
+            }
+        }
+
+        private void AppendOrInsertAlignmentIfNeeded(int startingPos, int alignment)
+        {
+            var charsWritten = _valueStringBuilder.Length - startingPos;
+
+            var leftAlign = false;
+            if (alignment < 0)
+            {
+                leftAlign = true;
+                alignment = -alignment;
+            }
+
+            var paddingRequired = alignment - charsWritten;
+            if (paddingRequired <= 0)
+            {
                 return;
             }
 
-            var formatted = FormatToString(value, format);
-            AppendFormatted(formatted.AsSpan(), alignment);
+            if (leftAlign)
+            {
+                _valueStringBuilder.Append(' ', paddingRequired);
+            }
+            else
+            {
+                _valueStringBuilder.Insert(startingPos, ' ', paddingRequired);
+            }
         }
 
         public void AppendFormatted(ReadOnlySpan<char> value) => _valueStringBuilder.Append(value);
@@ -206,26 +222,6 @@ ref partial struct ValueStringBuilder
             {
                 _valueStringBuilder.Append(formatter.Format(format, value, _provider));
             }
-        }
-
-        private string FormatToString<T>(T value, string? format)
-        {
-            if (_hasCustomFormatter && _provider?.GetFormat(typeof(ICustomFormatter)) is ICustomFormatter formatter)
-            {
-                return formatter.Format(format, value, _provider) ?? string.Empty;
-            }
-
-            if (value is null)
-            {
-                return string.Empty;
-            }
-
-            if (value is IFormattable formattable)
-            {
-                return formattable.ToString(format, _provider) ?? string.Empty;
-            }
-
-            return value.ToString() ?? string.Empty;
         }
     }
 }

--- a/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
+++ b/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
@@ -200,6 +200,79 @@ public class ValueStringBuilderTests
     private static string ThrowingHole() => throw new InvalidOperationException("boom");
 
     [Fact]
+    public void AppendInterpolatedStringUsesTryFormatInsteadOfToString()
+    {
+        using var sb = new ValueStringBuilder(initialCapacity: 64);
+        var value = new TestSpanFormattable("abc", returnFromTryFormat: true);
+
+        sb.Append(CultureInfo.InvariantCulture, $"{value}");
+
+        Assert.Equal(1, value.TryFormatCount);
+        Assert.Equal(0, value.ToStringCount);
+        Assert.Equal("abc", sb.AsSpan().ToString());
+    }
+
+    [Fact]
+    public void AppendInterpolatedStringGrowsAndRetriesWhenTryFormatDoesNotFit()
+    {
+        using var sb = new ValueStringBuilder(initialCapacity: 1);
+        var value = new TestSpanFormattable(new string('a', 400), returnFromTryFormat: true);
+
+        sb.Append(CultureInfo.InvariantCulture, $"{value}");
+
+        Assert.True(value.TryFormatCount > 1);
+        Assert.Equal(0, value.ToStringCount);
+        Assert.Equal(new string('a', 400), sb.AsSpan().ToString());
+    }
+
+    [Fact]
+    public void AppendInterpolatedStringFallsBackToToStringForNonSpanFormattableValues()
+    {
+        using var sb = new ValueStringBuilder(initialCapacity: 64);
+        var value = new FormattableOnly("xyz");
+
+        sb.Append(CultureInfo.InvariantCulture, $"{value}");
+
+        Assert.Equal(1, value.ToStringCount);
+        Assert.Equal("xyz", sb.AsSpan().ToString());
+    }
+
+    [Fact]
+    public void AppendInterpolatedStringFormatsSpanFormattableValuesInPlace()
+    {
+        using var sb = new ValueStringBuilder(initialCapacity: 2);
+
+        sb.Append(CultureInfo.InvariantCulture, $"{42}|{2.5}|{DateTime.UnixEpoch:yyyy-MM-dd}|{Guid.Empty}");
+
+        Assert.Equal("42|2.5|1970-01-01|00000000-0000-0000-0000-000000000000", sb.AsSpan().ToString());
+    }
+
+    [Fact]
+    public void AppendInterpolatedStringPadsSpanFormattableValuesWithoutAllocating()
+    {
+        using var sb = new ValueStringBuilder(initialCapacity: 64);
+
+        sb.Append(CultureInfo.InvariantCulture, $"|{12,6}|{34,-6}|{5,2}|{123456,3}|");
+
+        Assert.Equal("|    12|34    | 5|123456|", sb.AsSpan().ToString());
+    }
+
+    [Fact]
+    public void AppendInterpolatedStringSupportsNonSpanFormattableValues()
+    {
+        using var sb = new ValueStringBuilder(initialCapacity: 8);
+
+        sb.Append(CultureInfo.InvariantCulture, $"{new NotSpanFormattable(),8}|{new NotSpanFormattable(),-8}|");
+
+        Assert.Equal("    text|text    |", sb.AsSpan().ToString());
+    }
+
+    private sealed class NotSpanFormattable
+    {
+        public override string ToString() => "text";
+    }
+
+    [Fact]
     public void AppendRuneSupportsSurrogatePairs()
     {
         using var sb = new ValueStringBuilder(initialCapacity: 4);
@@ -233,6 +306,21 @@ public class ValueStringBuilderTests
         Assert.Equal(1, value.TryFormatCount);
         Assert.Equal(1, value.ToStringCount);
         Assert.Equal("fallback", sb.ToString());
+    }
+
+    private sealed class FormattableOnly : IFormattable
+    {
+        private readonly string _value;
+
+        public FormattableOnly(string value) => _value = value;
+
+        public int ToStringCount { get; private set; }
+
+        public string ToString(string? format, IFormatProvider? formatProvider)
+        {
+            ToStringCount++;
+            return _value;
+        }
     }
 
     private sealed class TestSpanFormattable : ISpanFormattable


### PR DESCRIPTION
> **Stack 2 of 2** · merges into `fix/vsb-handler-buffer-ownership` · #2664 must merge first

## Finding

Both `AppendFormatted<T>` overloads (`ValueStringBuilder.AppendInterpolatedStringHandler.cs:61-105`) tested `value is IFormattable` and called `formattable.ToString(format, _provider)`. `ISpanFormattable.TryFormat` was never consulted, even though `AppendSpanFormattable` sits next door in the same type.

Alignment was worse: `AppendFormatted<T>(T, int, string?)` went through `FormatToString` (`:182-200`), which materialised the value as a string purely to measure its length for padding.

`System.Text.StringBuilder`'s own interpolated-string handler *does* use `ISpanFormattable`, so a caller who moved to `ValueStringBuilder` for performance and kept using `$"..."` got strictly more allocation than the type they left.

## Change

Try `ISpanFormattable.TryFormat` into the free space first, growing and retrying when it does not fit, and fall back to `IFormattable.ToString` only for types that cannot do better. Alignment now formats in place and inserts the padding afterwards, so `FormatToString` is gone.

## Measured effect

Release build, `GC.GetAllocatedBytesForCurrentThread`, warm, per call:

| | before | after |
|---|---|---|
| `$"a={i} b={d} c={guid} d={date:O}"` | 312 B | **128 B** |
| `$"{i}"` | 24 B | 24 B |
| `$"{someString}"` | 0 B | 0 B |

**A correction to the review that prompted this.** That report quoted "240 B → 0 B". The 0 came from `AppendSpanFormattable`, which is a *constrained* generic (`where T : ISpanFormattable`) and so compiles to a devirtualized call. An interpolated-string handler receives an unconstrained `T`, and the `((ISpanFormattable)value)` cast costs one JIT box per value-type hole that C# cannot avoid. `DefaultInterpolatedStringHandler` pays the same cost — measured here at 32 B for a `Guid` hole.

So what this removes is the per-hole **string** allocation, which is deterministic and scales with the formatted length. The remaining box does not.

## Verification

- `dotnet test` with `/p:TreatsWarningsAsErrors=true`, both TFMs, green (23 tests).
- Two new tests fail against #2664 alone: one asserts `TryFormat` is used and `ToString` is not, the other that a value too large for the buffer causes a grow-and-retry rather than a `ToString` fallback. A third covers the `IFormattable`-only fallback.
- Deliberately **not** asserting a byte count in the suite: the remaining allocation is a JIT box whose elimination varies by type, runtime and configuration, so such a test would be brittle. The behavioural assertion (`TryFormat` called, `ToString` not) is what actually pins the fix.
- Existing alignment and custom-formatter tests pass unchanged, confirming the rewritten padding path is equivalent.
