### PR TITLE
Document that ToString disposes the ValueStringBuilder

### DIFF
--- a/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs
+++ b/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs
@@ -80,6 +80,14 @@ ref partial struct ValueStringBuilder
         }
     }
 
+    /// <summary>
+    /// Returns the characters written so far and disposes this instance, returning the rented buffer to the pool.
+    /// </summary>
+    /// <remarks>
+    /// This method is destructive. After it returns, the builder is reset to its default state: <see cref="Length"/>
+    /// and <see cref="Capacity"/> are 0, a second call returns an empty string, and appending starts a new buffer.
+    /// Use <see cref="AsSpan()"/> to read the content without disposing the builder.
+    /// </remarks>
     public override string ToString()
     {
         var s = _chars.Slice(0, _pos).ToString();

--- a/src/Meziantou.Framework.ValueStringBuilder/readme.md
+++ b/src/Meziantou.Framework.ValueStringBuilder/readme.md
@@ -4,7 +4,7 @@
 
 ````c#
 Span<char> initialBuffer = stackalloc char[64];
-var sb = new ValueStringBuilder(initialBuffer);
+using var sb = new ValueStringBuilder(initialBuffer);
 
 sb.Append("Hello");
 sb.Append(' ');
@@ -12,3 +12,36 @@ sb.Append("World");
 
 string text = sb.ToString();
 ````
+
+## Disposing the builder
+
+The builder rents its buffer from `ArrayPool<char>.Shared` as soon as it outgrows the initial span, so it must be
+disposed to return that buffer. Declaring it with `using` is the simplest way to guarantee it.
+
+`ToString()` is destructive: it returns the content **and** disposes the builder. After calling it, the builder is
+reset to its default state, so a second call returns an empty string and appending starts a new buffer.
+
+````c#
+using var sb = new ValueStringBuilder(stackalloc char[64]);
+sb.Append("Hello");
+
+_ = sb.ToString(); // "Hello", and the builder is now disposed
+_ = sb.ToString(); // ""
+````
+
+Use `AsSpan()` when you need to read the content without disposing the builder:
+
+````c#
+using var sb = new ValueStringBuilder(stackalloc char[64]);
+sb.Append("Hello");
+
+ReadOnlySpan<char> content = sb.AsSpan(); // "Hello", the builder is still usable
+sb.Append(" World");
+````
+
+Disposing twice is safe, so combining `using` with a final `ToString()` is fine.
+
+## Reading past the content
+
+`RawChars` exposes the whole buffer, not just the part that has been written. Everything beyond `Length` is
+uninitialized pooled memory and may contain data left by a previous user of the array.

--- a/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
+++ b/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
@@ -57,6 +57,41 @@ public class ValueStringBuilderTests
     }
 
     [Fact]
+    public void ToStringDisposesTheBuilder()
+    {
+        using var sb = new ValueStringBuilder(initialCapacity: 16);
+        sb.Append("hello");
+
+        Assert.Equal("hello", sb.ToString());
+        Assert.Equal("", sb.ToString());
+        Assert.Equal(0, sb.Length);
+        Assert.Equal(0, sb.Capacity);
+    }
+
+    [Fact]
+    public void AsSpanDoesNotDisposeTheBuilder()
+    {
+        using var sb = new ValueStringBuilder(initialCapacity: 16);
+        sb.Append("hello");
+
+        Assert.Equal("hello", sb.AsSpan().ToString());
+
+        sb.Append(" world");
+        Assert.Equal("hello world", sb.AsSpan().ToString());
+    }
+
+    [Fact]
+    public void DisposeIsIdempotentAfterToString()
+    {
+        var sb = new ValueStringBuilder(initialCapacity: 16);
+        sb.Append("hello");
+
+        Assert.Equal("hello", sb.ToString());
+        sb.Dispose();
+        sb.Dispose();
+    }
+
+    [Fact]
     public void AppendInterpolatedStringAppendsContent()
     {
         using var sb = new ValueStringBuilder(initialCapacity: 2);


### PR DESCRIPTION
> **Stack 1 of 3** · merges into `main` · must merge before #2668 and #2669

## Finding

`ToString()` (`ValueStringBuilder.cs:83-88`) returns the string **and** calls `Dispose()`, which returns the array to the pool and resets the builder:

```
first  ToString(): 'hello'
second ToString(): ''  Length=0 Capacity=0
after Append("world"): 'world'      // the first 'hello' is gone
```

Nothing said so. The project had zero `///` comments, and `readme.md` ended its only example on `string text = sb.ToString();` without mentioning it.

This is inherited from the runtime's internal implementation, where it is safe precisely because the type is `internal` and every call site is in-tree. As public API the failure mode is an empty or truncated string rather than an exception, and routine tooling trips it — a debugger evaluating `sb` in a watch window destroys the builder mid-session.

## Change

**Documentation only**, by explicit choice: the behaviour is deliberate and changing it would break existing v3 consumers silently.

- XML documentation on `ToString`, stating it is destructive and pointing at `AsSpan()` for a non-destructive read.
- A `readme.md` section covering the disposal contract, the `using` pattern, the `ToString`-disposes behaviour with a worked example, and the fact that `RawChars` exposes uninitialized memory past `Length`.

No API change, so no `ref/` regeneration.

## Verification

- `dotnet test` with `/p:TreatsWarningsAsErrors=true`, both TFMs, green (15 tests).
- Three new tests pin the documented contract, none of which existed before: `ToString` disposes and a second call returns empty; `AsSpan` does not dispose and the builder stays usable; `Dispose` after `ToString` is a safe no-op. Every previous test consumed the builder exactly once, so a regression here would not have been caught.
