### PR TITLE
Validate arguments on the public ValueStringBuilder members

### DIFF
--- a/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs
+++ b/src/Meziantou.Framework.ValueStringBuilder/ValueStringBuilder.cs
@@ -50,8 +50,8 @@ ref partial struct ValueStringBuilder
         readonly get => _pos;
         set
         {
-            Debug.Assert(value >= 0);
-            Debug.Assert(value <= _chars.Length);
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, _chars.Length);
             _pos = value;
         }
     }
@@ -67,7 +67,7 @@ ref partial struct ValueStringBuilder
     /// <param name="capacity">The minimum capacity required.</param>
     public void EnsureCapacity(int capacity)
     {
-        Debug.Assert(capacity >= 0);
+        ArgumentOutOfRangeException.ThrowIfNegative(capacity);
 
         if ((uint)capacity > (uint)_chars.Length)
         {
@@ -113,7 +113,8 @@ ref partial struct ValueStringBuilder
     {
         get
         {
-            Debug.Assert(index < _pos);
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _pos);
             return ref _chars[index];
         }
     }
@@ -168,6 +169,10 @@ ref partial struct ValueStringBuilder
     /// <param name="count">The number of times to insert it.</param>
     public void Insert(int index, char value, int count)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(index, _pos);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
         if (_pos > _chars.Length - count)
         {
             Grow(count);
@@ -190,6 +195,9 @@ ref partial struct ValueStringBuilder
         {
             return;
         }
+
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(index, _pos);
 
         var count = s.Length;
         if (_pos > _chars.Length - count)
@@ -266,6 +274,8 @@ ref partial struct ValueStringBuilder
     /// <param name="count">The number of times to append it.</param>
     public void Append(char c, int count)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
         if (_pos > _chars.Length - count)
         {
             Grow(count);
@@ -305,6 +315,8 @@ ref partial struct ValueStringBuilder
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Span<char> AppendSpan(int length)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+
         var origPos = _pos;
         if (origPos > _chars.Length - length)
         {

--- a/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
+++ b/tests/Meziantou.Framework.ValueStringBuilder.Tests/ValueStringBuilderTests.cs
@@ -361,6 +361,100 @@ public class ValueStringBuilderTests
     }
 
     [Fact]
+    public void LengthRejectsValuesOutsideTheBuffer()
+    {
+        Assert.True(ThrowsArgumentOutOfRange(() =>
+        {
+            var b = new ValueStringBuilder(initialCapacity: 16);
+            try
+            {
+                b.Length = -1;
+            }
+            finally
+            {
+                b.Dispose();
+            }
+        }));
+
+        Assert.True(ThrowsArgumentOutOfRange(() =>
+        {
+            var b = new ValueStringBuilder(initialCapacity: 16);
+            try
+            {
+                b.Length = b.Capacity + 1;
+            }
+            finally
+            {
+                b.Dispose();
+            }
+        }));
+
+        var sb = new ValueStringBuilder(initialCapacity: 16);
+        try
+        {
+            sb.Append("abc");
+            sb.Length = sb.Capacity;
+            sb.Length = 0;
+            Assert.Equal(0, sb.Length);
+        }
+        finally
+        {
+            sb.Dispose();
+        }
+    }
+
+    [Fact]
+    public void EnsureCapacityRejectsNegativeValues()
+    {
+        Assert.True(ThrowsArgumentOutOfRange(() => { using var b = new ValueStringBuilder(initialCapacity: 16); b.EnsureCapacity(-1); }));
+    }
+
+    [Fact]
+    public void IndexerRejectsPositionsOutsideTheContent()
+    {
+        Assert.True(ThrowsArgumentOutOfRange(() => { using var b = new ValueStringBuilder(initialCapacity: 16); b.Append("abc"); _ = b[-1]; }));
+        Assert.True(ThrowsArgumentOutOfRange(() => { using var b = new ValueStringBuilder(initialCapacity: 16); b.Append("abc"); _ = b[3]; }));
+
+        using var sb = new ValueStringBuilder(initialCapacity: 16);
+        sb.Append("abc");
+        Assert.Equal('c', sb[2]);
+    }
+
+    [Fact]
+    public void InsertRejectsPositionsOutsideTheContent()
+    {
+        Assert.True(ThrowsArgumentOutOfRange(() => { using var b = new ValueStringBuilder(initialCapacity: 16); b.Append("ab"); b.Insert(3, "x"); }));
+        Assert.True(ThrowsArgumentOutOfRange(() => { using var b = new ValueStringBuilder(initialCapacity: 16); b.Append("ab"); b.Insert(-1, "x"); }));
+        Assert.True(ThrowsArgumentOutOfRange(() => { using var b = new ValueStringBuilder(initialCapacity: 16); b.Append("ab"); b.Insert(3, 'x', 1); }));
+        Assert.True(ThrowsArgumentOutOfRange(() => { using var b = new ValueStringBuilder(initialCapacity: 16); b.Append("ab"); b.Insert(0, 'x', -1); }));
+
+        using var sb = new ValueStringBuilder(initialCapacity: 16);
+        sb.Append("ab");
+        sb.Insert(2, "c");
+        Assert.Equal("abc", sb.AsSpan().ToString());
+    }
+
+    [Fact]
+    public void AppendAndAppendSpanRejectNegativeCounts()
+    {
+        Assert.True(ThrowsArgumentOutOfRange(() => { using var b = new ValueStringBuilder(initialCapacity: 16); b.Append('x', -1); }));
+        Assert.True(ThrowsArgumentOutOfRange(() => { using var b = new ValueStringBuilder(initialCapacity: 16); _ = b.AppendSpan(-1); }));
+    }
+
+    private static bool ThrowsArgumentOutOfRange(Action action)
+    {
+        try
+        {
+            action();
+            return false;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return true;
+        }
+    }
+
+    [Fact]
     public void AppendInterpolatedStringAppendsContent()
     {
         using var sb = new ValueStringBuilder(initialCapacity: 2);


### PR DESCRIPTION
> **Stack 3 of 3** · merges into `fix/vsb-asspan-bounds` · #2667 and #2668 must merge first

## Finding

`Length`, `EnsureCapacity`, the indexer and both `Insert` overloads guarded their arguments with `Debug.Assert` (`ValueStringBuilder.cs:34-43`, `:47-55`, `:74-81`, `:96-126`), which compiles out of the Release build that ships to NuGet. `Insert` did not validate `index` at all.

```csharp
var sb = new ValueStringBuilder(initialCapacity: 16);
sb.Append("abc");
sb.Length = 1000;   // accepted; sb.Length is now 1000
sb.ToString();      // ArgumentOutOfRangeException, thrown from an unrelated line
```

`EnsureCapacity(-1)` and `Insert(10, "X")` on a two-character builder likewise throw from inside `Span.Slice`, naming nothing useful.

No memory-safety hole — `Span<T>`'s own bounds checks catch every case I could construct — but the diagnostics are poor, and `Debug.Assert` gives the *library author's* debug build a signal while giving the *consumer's* debug build none.

## Change

Throw `ArgumentOutOfRangeException` from the public entry points, using the `ArgumentOutOfRangeException.ThrowIf*` helpers already used elsewhere in the repository (for example `CGroup2.cs:338-339`). `Append(char, int)` and `AppendSpan(int)` get the same treatment for negative counts.

`Debug.Assert` stays on `Grow`, which is private and states an internal invariant — the file now has exactly two asserts, both there.

## Verification

- `dotnet test` with `/p:TreatsWarningsAsErrors=true`, both TFMs, green (23 tests). Five new tests cover each guarded member, including the valid cases that must keep working.
- Because `Meziantou.Framework.Globbing` source-includes `ValueStringBuilder.cs` and `Meziantou.Framework.CodeOwners` references the package, both were built and tested against this change: **904** and **38** tests respectively, all green. Neither depended on the previously unvalidated behaviour.
