### PR TITLE
Show invisible characters in property names, not only in values

### DIFF
--- a/src/Meziantou.Framework.HumanReadableSerializer/HumanReadableTextWriter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/HumanReadableTextWriter.cs
@@ -46,15 +46,15 @@ public sealed class HumanReadableTextWriter
         _context = WriterContext.None;
     }
 
-    private void Write(string value, bool isValue = false)
+    private void Write(string value, bool showInvisibleCharacters = false)
     {
-        Write(value.AsSpan(), isValue);
+        Write(value.AsSpan(), showInvisibleCharacters);
     }
 
-    private void Write(ReadOnlySpan<char> value, bool isValue = false)
+    private void Write(ReadOnlySpan<char> value, bool showInvisibleCharacters = false)
     {
         var first = true;
-        if (isValue && _options.ShowInvisibleCharactersInValues)
+        if (showInvisibleCharacters && _options.ShowInvisibleCharactersInValues)
         {
             foreach (var (line, eol) in StringUtils.EnumerateLines(value))
             {
@@ -75,7 +75,7 @@ public sealed class HumanReadableTextWriter
                     }
 
                     WritePendingText(indent: !line.IsEmpty);
-                    if (isValue && _options.ShowInvisibleCharactersInValues)
+                    if (showInvisibleCharacters && _options.ShowInvisibleCharactersInValues)
                     {
                         ReplaceInvisibleCharacters(_text, line);
                         ReplaceInvisibleCharacters(_text, eol);
@@ -147,7 +147,7 @@ public sealed class HumanReadableTextWriter
                 WriteNewLine();
             }
 
-            Write(value, isValue: true);
+            Write(value, showInvisibleCharacters: true);
 
             if (indent)
             {
@@ -196,7 +196,9 @@ public sealed class HumanReadableTextWriter
     /// <param name="propertyName">The name of the property.</param>
     public void WritePropertyName(string propertyName)
     {
-        Write(propertyName);
+        // Property names go through the same replacement as values: a name containing a newline
+        // would otherwise be indistinguishable from several properties.
+        Write(propertyName, showInvisibleCharacters: true);
         Write(":");
         _context = WriterContext.PropertyName;
     }

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/SerializerTests.cs
@@ -1733,6 +1733,35 @@ public sealed partial class SerializerTests : SerializerTestsBase
     }
 
     [Fact]
+    public void PropertyName_InvisibleChar()
+    {
+        AssertSerialization(new Validation
+        {
+            Subject = new Dictionary<string, int> { ["a\nb"] = 1, ["z"] = 2 },
+            Options = new HumanReadableSerializerOptions { ShowInvisibleCharactersInValues = true },
+            Expected = """
+            a␊
+            b: 1
+            z: 2
+            """,
+        });
+    }
+
+    [Fact]
+    public void PropertyName_InvisibleChar_Disabled()
+    {
+        AssertSerialization(new Validation
+        {
+            Subject = new Dictionary<string, int> { ["a\nb"] = 1, ["z"] = 2 },
+            Expected = """
+            a
+            b: 1
+            z: 2
+            """,
+        });
+    }
+
+    [Fact]
     public void String_Multiline_InObject_NoStartingWhitespace()
     {
         AssertSerialization(new Validation


### PR DESCRIPTION
## The problem

`WritePropertyName` wrote the name through the raw `Write` path, so a name containing a newline silently restructured the document. A url-encoded form body `a%0Ab%3A+9=1&z=2` — one field named `a\nb: 9` with value `1`, plus `z=2` — serialized as:

```
a
b: 9: 1
z: 2
```

which reads as three fields, one of them malformed.

`ShowInvisibleCharactersInValues` exists to make exactly this kind of ambiguity visible, but it only covered values (`Write(..., isValue: true)`). Property names had no mitigation at all — and the url-encoded, JSON and header formatters all feed it keys that come from the payload rather than from code.

## The change

`WritePropertyName` now passes through the same invisible-character replacement that values use, so turning the option on covers the whole document instead of half of it. The private `Write` parameter is renamed `isValue` → `showInvisibleCharacters`, since it no longer means "this is a value".

Per the review discussion this is deliberately scoped to the existing option — **nothing changes when `ShowInvisibleCharactersInValues` is off**, so no existing output moves. `PropertyName_InvisibleChar_Disabled` pins that, and it passes both before and after the change.

With the option on, the earlier example becomes unambiguous:

```
a␊
b: 9: 1
z: 2
```

## Note

The option is named `...InValues`, and it now also affects names. Renaming it would be a public API break, so I left it; worth a doc-comment tweak if that bothers you.

## Verification

- `PropertyName_InvisibleChar` covers the option-on behaviour, `PropertyName_InvisibleChar_Disabled` pins the unchanged default.
- Confirmed 2/6 fail without the fix (the option-on cases on both TFMs) while the option-off case stays green, then 6/6 pass with it.
- `Meziantou.Framework.HumanReadableSerializer.Tests`: 536 passed (net10.0 + net11.0), 0 failed.
- Downstream: `SnapshotTesting.Tests` 167 passed, `InlineSnapshotTesting.Tests` 131 passed.

I dropped a third test I had drafted (`...DistinguishesFromNestedProperties`) — it compared two dictionaries whose values already differed, so it passed with or without the fix and proved nothing.
