### PR TITLE
Drop the unused skip reason from the round-tripping test filter

### DIFF
--- a/tests/Meziantou.Framework.HtmlToMarkdown.Tests/MarkdownRoundTrippingTests.cs
+++ b/tests/Meziantou.Framework.HtmlToMarkdown.Tests/MarkdownRoundTrippingTests.cs
@@ -38,7 +38,7 @@ public sealed class MarkdownRoundTrippingTests
         foreach (var testCase in AllCases.Value)
         {
             // Some tests may not round-trip due to extension-specific parsing behaviors
-            if (!ShouldSkip(testCase, out _))
+            if (!ShouldSkip(testCase))
             {
                 data.Add(testCase);
             }
@@ -67,24 +67,14 @@ public sealed class MarkdownRoundTrippingTests
         HtmlNormalizer.AssertEquivalent(testCase.Html, roundTrippedHtml);
     }
 
-    private static bool ShouldSkip(MarkdigTestCase testCase, out string reason)
+    private static bool ShouldSkip(MarkdigTestCase testCase)
     {
         // CommonMark.md contains the full CommonMark spec. We test those separately
         // in CommonMarkSpecTests. Skip the duplicate here to avoid 600+ duplicate tests.
         if (testCase.FileName == "CommonMark.md")
-        {
-            reason = "CommonMark spec is tested separately in CommonMarkSpecTests";
             return true;
-        }
 
-        if (SkippedExamples.TryGetValue((testCase.FileName, testCase.Example), out var skippedReason))
-        {
-            reason = skippedReason;
-            return true;
-        }
-
-        reason = "";
-        return false;
+        return SkippedExamples.ContainsKey((testCase.FileName, testCase.Example));
     }
 
     private static readonly Dictionary<(string FileName, int Example), string> SkippedExamples = new()


### PR DESCRIPTION
## Problem

`ShouldSkip` in `MarkdownRoundTrippingTests` took an `out string reason`, and its only caller discarded it with `out _`. Every branch built a reason string that nothing ever read.

## What changed

The `out` parameter is removed and the body reduces to the two conditions that actually decide the result, with the second becoming a plain `ContainsKey`. The explanatory comment about `CommonMark.md` being covered by `CommonMarkSpecTests` is kept — that was the useful part of the discarded string, and it belongs in a comment rather than in an unread variable.

The skip reasons in the `SkippedExamples` dictionary are untouched: those are read by a human looking at the table, which is where they earn their keep.

## Verification

- Full suite green on net10.0 and net11.0: **1694 passed, 0 failed** — the same set of tests runs, since the filter's behaviour is unchanged.
- `dotnet run ./eng/update-all.cs` run; no generated files changed.
