### PR TITLE
Reuse a shared read-only options instance when none is provided

### DIFF
--- a/src/Meziantou.Framework.HumanReadableSerializer/HumanReadableSerializer.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/HumanReadableSerializer.cs
@@ -12,13 +12,24 @@ namespace Meziantou.Framework.HumanReadable;
 /// </example>
 public static class HumanReadableSerializer
 {
+    // Shared so that repeated calls without explicit options reuse the converter and member
+    // caches. The instance is read-only and its caches are concurrent, so it is safe to share.
+    private static readonly HumanReadableSerializerOptions DefaultOptions = CreateDefaultOptions();
+
+    private static HumanReadableSerializerOptions CreateDefaultOptions()
+    {
+        var options = new HumanReadableSerializerOptions();
+        options.MakeReadOnly();
+        return options;
+    }
+
     /// <summary>Serializes the specified value to a human-readable string.</summary>
     /// <param name="value">The value to serialize.</param>
     /// <param name="options">Options to control the serialization behavior.</param>
     /// <returns>A human-readable string representation of the value.</returns>
     public static string Serialize(object? value, HumanReadableSerializerOptions? options = null)
     {
-        options ??= new HumanReadableSerializerOptions();
+        options ??= DefaultOptions;
         var writer = new HumanReadableTextWriter(options);
         Serialize(writer, value, value?.GetType() ?? typeof(object), options);
         return writer.ToString();
@@ -34,7 +45,7 @@ public static class HumanReadableSerializer
         if (value is not null && !type.IsAssignableFrom(value.GetType()))
             throw new ArgumentException($"The provided value cannot be assigned to type '{type.AssemblyQualifiedName}'", nameof(value));
 
-        options ??= new HumanReadableSerializerOptions();
+        options ??= DefaultOptions;
         var writer = new HumanReadableTextWriter(options);
         Serialize(writer, value, type, options);
         return writer.ToString();

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HumanReadableSerializerOptionsTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HumanReadableSerializerOptionsTests.cs
@@ -18,6 +18,36 @@ public sealed class HumanReadableSerializerOptionsTests
         Assert.Single(options.Converters);
     }
 
+    [Fact]
+    public void DefaultOptionsProduceTheSameOutputAsAnExplicitInstance()
+    {
+        var subject = new Payload();
+
+        Assert.Equal(HumanReadableSerializer.Serialize(subject, new HumanReadableSerializerOptions()), HumanReadableSerializer.Serialize(subject));
+    }
+
+    [Fact]
+    public void DefaultOptionsCanBeUsedConcurrently()
+    {
+        var subject = new Payload();
+        var expected = HumanReadableSerializer.Serialize(subject);
+
+        var results = new string[64];
+        Parallel.For(0, results.Length, i => results[i] = HumanReadableSerializer.Serialize(subject));
+
+        Assert.All(results, result => Assert.Equal(expected, result));
+    }
+
+    // Deliberately not an anonymous type: SerializerTests.Type_AnonymType asserts a
+    // Roslyn-generated anonymous type ordinal, which shifts when new shapes are added.
+    private sealed class Payload
+    {
+        public int Id { get; } = 1;
+        public string Name { get; } = "test";
+        public string[] Tags { get; } = ["a", "b"];
+        public DateTime When { get; } = new(2123, 4, 5, 6, 7, 8, DateTimeKind.Utc);
+    }
+
     private sealed class DummyConverter : HumanReadableConverter
     {
         public override bool CanConvert(Type type) => false;


### PR DESCRIPTION
## The problem

Both `Serialize` overloads did:

```csharp
options ??= new HumanReadableSerializerOptions();
```

`HumanReadableSerializerOptions` owns the `_convertersCache` and `_memberInfoCache`, so a fresh instance per call means full converter resolution plus `HumanReadableMemberInfo.Get` reflection for every type in the graph, every time. Measured on a 4-property POCO, 20,000 iterations in one process:

```
explicit shared options :   55 ms / 20000
no options argument     : 1053 ms / 20000     ← 19x
```

The in-repo consumers are unaffected — both `HumanReadableSnapshotSerializer` classes already hold a cached `Options`. The trap is for direct API users, and the library's own readme sets it: its first example is `HumanReadableSerializer.Serialize(obj)` with no options, and nothing hints that this is the slow path.

## The change

A `static readonly` default instance, made read-only up front, used whenever the caller passes `null`. After the change the two paths are equivalent:

```
explicit shared options : 55 ms / 20000
no options argument     : 61 ms / 20000
```

Sharing is safe: `MakeReadOnly` blocks all mutation (`VerifyMutable` throws), the two caches are `ConcurrentDictionary`, and the attribute lists and converter list are frozen once read-only. This is also the state any options instance already reaches — `GetConverter` calls `MakeReadOnly()` on first use — so the only change is that the instance now outlives the call.

## Tradeoff

The shared caches are process-lifetime, so types serialized through the default options stay in the cache for the life of the process. That is the same behaviour as any long-lived options instance, and it is bounded by the number of distinct types serialized, but it is a change from per-call garbage.

## Verification

- `DefaultOptionsProduceTheSameOutputAsAnExplicitInstance` pins that behaviour is unchanged.
- `DefaultOptionsCanBeUsedConcurrently` serializes from 64 parallel workers and asserts every result matches, since sharing a mutable-looking instance across threads is the risk this change introduces.
- `Meziantou.Framework.HumanReadableSerializer.Tests`: 536 passed (net10.0 + net11.0), 0 failed.
- Downstream: `SnapshotTesting.Tests` 167 passed, `InlineSnapshotTesting.Tests` 131 passed.
