### PR TITLE
Register the HTTP header converters only when they have something to do

### DIFF
--- a/src/Meziantou.Framework.HumanReadableSerializer/Converters/HumanReadableHttpExtensions.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Converters/HumanReadableHttpExtensions.cs
@@ -10,7 +10,7 @@ public static class HumanReadableHttpExtensions
     {
         if (httpOptions.RequestMessageOptions is { } requestOptions)
         {
-            if (requestOptions.ExcludedHeaderNames is not null || requestOptions.HeaderValueTransformer is not null)
+            if (requestOptions.ExcludedHeaderNames.Count > 0 || requestOptions.HeaderValueTransformer.Count > 0)
                 options.Converters.Add(new HttpHeadersConverter<HttpRequestHeaders>(requestOptions.ExcludedHeaderNames, requestOptions.HeaderValueTransformer));
         }
 
@@ -22,7 +22,7 @@ public static class HumanReadableHttpExtensions
                 headerFormatters = headerFormatters.Prepend(new ContentSecurityPolicyFormatter());
             }
 
-            if (responseOptions.ExcludedHeaderNames is not null || headerFormatters.Any())
+            if (responseOptions.ExcludedHeaderNames.Count > 0 || headerFormatters.Any())
             {
                 options.Converters.Add(new HttpHeadersConverter<HttpResponseHeaders>(responseOptions.ExcludedHeaderNames, headerFormatters));
             }

--- a/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HttpOptionsTests.cs
+++ b/tests/Meziantou.Framework.HumanReadableSerializer.Tests/HttpOptionsTests.cs
@@ -106,6 +106,66 @@ public sealed class HttpOptionsTests : SerializerTestsBase
     }
 
     [Fact]
+    public void RequestHeadersAreSerializedWithoutExclusionsOrTransformers()
+    {
+        using var httpContent = new HttpRequestMessage(HttpMethod.Get, "http://example.com/foo")
+        {
+            Headers =
+            {
+                { "X-Custom", "value" },
+            },
+        };
+
+        // OmitProtocolVersion is pinned so the expectation does not depend on how the
+        // protocol-version properties are filtered.
+        var httpOptions = new HumanReadableHttpOptions
+        {
+            RequestMessageOptions = new HumanReadableHttpRequestMessageOptions { OmitProtocolVersion = false },
+        };
+        var serializerOptions = new HumanReadableSerializerOptions().AddHttpConverters(httpOptions);
+
+        AssertSerialization(httpContent, serializerOptions, """
+            Method: GET
+            RequestUri: http://example.com/foo
+            Version: 1.1
+            VersionPolicy: RequestVersionOrLower
+            Headers:
+              X-Custom: value
+            Content: <null>
+            """);
+    }
+
+    [Fact]
+    public void RequestHeadersAreExcludedWhenConfigured()
+    {
+        using var httpContent = new HttpRequestMessage(HttpMethod.Get, "http://example.com/foo")
+        {
+            Headers =
+            {
+                { "X-Custom", "value" },
+                { "X-Secret", "value" },
+            },
+        };
+
+        var httpOptions = new HumanReadableHttpOptions
+        {
+            RequestMessageOptions = new HumanReadableHttpRequestMessageOptions { OmitProtocolVersion = false },
+        };
+        httpOptions.RequestMessageOptions.ExcludedHeaderNames.Add("X-Secret");
+        var serializerOptions = new HumanReadableSerializerOptions().AddHttpConverters(httpOptions);
+
+        AssertSerialization(httpContent, serializerOptions, """
+            Method: GET
+            RequestUri: http://example.com/foo
+            Version: 1.1
+            VersionPolicy: RequestVersionOrLower
+            Headers:
+              X-Custom: value
+            Content: <null>
+            """);
+    }
+
+    [Fact]
     public void RemoveExcludedHeaders()
     {
         using var httpContent = new HttpResponseMessage()


### PR DESCRIPTION
## The problem

`AddHttpConverters` guarded both header-converter registrations on null checks that can never be false:

```csharp
if (requestOptions.ExcludedHeaderNames is not null || requestOptions.HeaderValueTransformer is not null)
...
if (responseOptions.ExcludedHeaderNames is not null || headerFormatters.Any())
```

`ExcludedHeaderNames` and `HeaderValueTransformer` are get-only properties initialised to non-null collections in `HumanReadableHttpMessageOptions` with no setter, so both conditions were always `true` and the converters were always registered. The code read as conditional registration while being unconditional — the kind of thing a later reader "fixes" in the wrong direction.

## The change

Test emptiness instead, which is what the guards were evidently meant to express. When nothing is excluded and no transformer is configured, the specialised converter is no longer registered and the built-in `HttpHeadersConverter` handles the headers — it produces identical output, since `HttpHeadersConverter<T>` with no exclusions and no formatters does exactly what the built-in one does.

Note `HumanReadableHttpResponseMessageOptions` seeds `ExcludedHeaderNames` with `Date` and `Alt-Svc` in its constructor, so the response converter is still registered by default. Only the request side changes, and only when the caller configured nothing.

## No behaviour change

This is the part worth checking, so I made it testable rather than asserting it:

- `RequestHeadersAreSerializedWithoutExclusionsOrTransformers` covers the path that now skips registration.
- `RequestHeadersAreExcludedWhenConfigured` covers the path that still registers.

Both tests **pass against unmodified `main` as well as with this change** (4/4 either way), which is the evidence that the output is the same before and after.

## Verification

- `Meziantou.Framework.HumanReadableSerializer.Tests`: 536 passed (net10.0 + net11.0), 0 failed.
