### PR TITLE
Throw instead of looping forever when the prompt input is closed

### DIFF
--- a/src/Meziantou.Framework.CommandLine/Prompt.cs
+++ b/src/Meziantou.Framework.CommandLine/Prompt.cs
@@ -5,8 +5,9 @@ public static class Prompt
 {
     /// <summary>Prompts the user with a yes/no question using standard Y/N labels.</summary>
     /// <param name="question">The question to display to the user.</param>
-    /// <param name="defaultValue">The default value to use if the user presses Enter without typing a response. If <see langword="null"/>, the user must provide an explicit answer.</param>
+    /// <param name="defaultValue">The default value to use if the user presses Enter without typing a response, or if the standard input is closed. If <see langword="null"/>, the user must provide an explicit answer.</param>
     /// <returns><see langword="true"/> if the user answered yes; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="EndOfStreamException">The standard input is closed and <paramref name="defaultValue"/> is <see langword="null"/>.</exception>
     public static bool YesNo(string question, bool? defaultValue)
     {
         if (defaultValue.HasValue)
@@ -30,15 +31,25 @@ public static class Prompt
     /// <param name="question">The question to display to the user.</param>
     /// <param name="yesValue">The text representing a yes response (case-insensitive).</param>
     /// <param name="noValue">The text representing a no response (case-insensitive).</param>
-    /// <param name="defaultValue">The default value to use if the user presses Enter without typing a response. If <see langword="null"/>, the user must provide an explicit answer.</param>
+    /// <param name="defaultValue">The default value to use if the user presses Enter without typing a response, or if the standard input is closed. If <see langword="null"/>, the user must provide an explicit answer.</param>
     /// <returns><see langword="true"/> if the user answered yes; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="EndOfStreamException">The standard input is closed and <paramref name="defaultValue"/> is <see langword="null"/>.</exception>
     public static bool YesNo(string question, string yesValue, string noValue, bool? defaultValue)
     {
         while (true)
         {
             Console.Write($"{question} [{yesValue}/{noValue}] ");
             var result = Console.ReadLine();
-            if (string.IsNullOrEmpty(result))
+            if (result is null)
+            {
+                // The input is closed, so asking again would loop forever without ever reading a different answer.
+                if (defaultValue.HasValue)
+                    return defaultValue.Value;
+
+                throw new EndOfStreamException("Cannot read the answer because the standard input is closed and no default value is provided");
+            }
+
+            if (result.Length == 0)
             {
                 if (defaultValue.HasValue)
                     return defaultValue.Value;

--- a/tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj
+++ b/tests/Meziantou.Framework.CommandLineTests/Meziantou.Framework.CommandLineTests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(LatestTargetFrameworks)</TargetFrameworks>
+    <!-- PromptTests redirects the process-wide Console, so its tests must not run in parallel with each other. -->
+    <XunitParallelizationMode>Collections</XunitParallelizationMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Meziantou.Framework.CommandLineTests/PromptTests.cs
+++ b/tests/Meziantou.Framework.CommandLineTests/PromptTests.cs
@@ -55,6 +55,28 @@ public class PromptTests
         Assert.True(output.LastIndexOf("test?", StringComparison.Ordinal) >= 0);
     }
 
+    [Fact]
+    public void YesNo_ShouldThrowWhenInputIsClosedAndNoDefaultValue()
+    {
+        Assert.Throws<EndOfStreamException>(() => UsingConsole("", () => Prompt.YesNo("test?", defaultValue: null)));
+    }
+
+    [Fact]
+    public void YesNo_ShouldThrowWhenInputIsClosedAfterAnInvalidValue()
+    {
+        Assert.Throws<EndOfStreamException>(() => UsingConsole("maybe\r\n", () => Prompt.YesNo("test?", "Yes", "No", defaultValue: null)));
+    }
+
+    [Fact]
+    public void YesNo_ShouldUseDefaultValueWhenInputIsClosed()
+    {
+        UsingConsole("", () =>
+        {
+            var result = Prompt.YesNo("test?", defaultValue: true);
+            Assert.True(result);
+        });
+    }
+
     private static string UsingConsole(string input, Action action)
     {
         var initialInStream = Console.In;


### PR DESCRIPTION
## The bug

`Console.ReadLine()` returns `null` when standard input is closed — a CI step, a container without a TTY, or `< /dev/null`. `string.IsNullOrEmpty` folded that into the same branch as "the user pressed Enter", so with `defaultValue: null` the loop reached `continue` without consuming anything. The next iteration behaved identically, forever.

`src/Meziantou.Framework.CommandLine/Prompt.cs:40-47` (before this change):

```csharp
var result = Console.ReadLine();
if (string.IsNullOrEmpty(result))
{
    if (defaultValue.HasValue)
        return defaultValue.Value;

    continue;   // <-- EOF lands here and spins
}
```

Measured by pointing `Console.SetIn` at an exhausted reader and calling `Prompt.YesNo("Are you sure?", defaultValue: null)`:

```
Thread still alive after 3s : True
Prompt re-printed           : 44,675,277 times in 3.0s
=> 14,826,288 spins/sec (busy loop, 100% CPU)
```

No exception, no timeout, no cancellation — the caller cannot detect or recover from it, and the prompt is written to stdout tens of millions of times per second.

## What changed

EOF is now distinguished from an empty line. It returns `defaultValue` when there is one, and otherwise throws `EndOfStreamException`. The `defaultValue.HasValue` path was already safe and behaves as before.

No public API signature changed, so `ref/Meziantou.Framework.CommandLine.cs` is untouched.

## This was already breaking the test suite

While verifying, `PromptTests` turned out to hang on `main` — **2 of 3 runs**, reproducibly, on `net10.0` alone.

The cause is a second one. `Meziantou.NET.Sdk.Test` generates `[assembly: Xunit.v3.Parallelization(Mode = ParallelMode.All)]`, which parallelizes individual test *methods*. So the existing `[Collection("PromptTests")]` never serialized anything, and the tests raced on the process-wide `Console` that `UsingConsole` swaps in and out. Each test passes alone (3/3); they only hang together.

This PR sets `<XunitParallelizationMode>Collections</XunitParallelizationMode>` on the test project — the SDK's supported knob — which restores exactly the serialization the `[Collection]` attribute was already asking for. Other test classes still run in parallel.

It is in this PR rather than a separate one because without it the new regression tests below are themselves flaky.

## Verification

- Three regression tests added. Against the unfixed `Prompt.cs` (with the parallelization fix in place) they **hang** — the infinite loop reproduced in the suite. With the fix they pass.
- `PromptTests` run 10 consecutive times: **10/10 green, 8 tests each, no hangs**. On `main` the same loop hangs.
- Full project, both target frameworks, `-p:TreatsWarningsAsErrors=true`: **88 total, 0 failed, 60 succeeded, 28 skipped** (the skips are the Windows-only `WindowsCmdArgument_Test` cases; this ran on macOS).
- `dotnet run ./eng/update-all.cs` exits 0 with no generated changes.
