### PR TITLE
Throw a serializer exception instead of a NullReferenceException for unresolvable F# unions

### DIFF
--- a/src/Meziantou.Framework.HumanReadableSerializer/Converters/FSharpDiscriminatedUnionConverter.cs
+++ b/src/Meziantou.Framework.HumanReadableSerializer/Converters/FSharpDiscriminatedUnionConverter.cs
@@ -16,8 +16,14 @@ internal sealed class FSharpDiscriminatedUnionConverter : HumanReadableConverter
         Debug.Assert(value is not null);
 
         var type = value.GetType();
-        var info = FSharpUtils.Get(type)!;
-        var unionCase = info.GetUnionCase(type, value)!;
+
+        // Both probes swallow reflection failures and return null, so they cannot be trusted
+        // to succeed here just because CanConvert did.
+        var info = FSharpUtils.Get(type)
+            ?? throw new HumanReadableSerializerException($"Cannot serialize the F# union type '{type}' as the F# reflection API is not available");
+
+        var unionCase = info.GetUnionCase(type, value)
+            ?? throw new HumanReadableSerializerException($"Cannot serialize the F# union type '{type}' as its union case cannot be determined");
 
         writer.StartObject();
         writer.WritePropertyName("Tag");


### PR DESCRIPTION
## The problem

`FSharpDiscriminatedUnionConverter.WriteValue` suppressed nullability on two probes that are explicitly designed to return `null` on failure:

```csharp
var info = FSharpUtils.Get(type)!;
var unionCase = info.GetUnionCase(type, value)!;
```

`FSharpUtils.Get` and `GetUnionCase` both wrap their reflection in `catch { }` and return `null` when anything goes wrong — a mismatched `FSharp.Core`, a trimmed assembly, a union shape without the expected `Tag` property. When that happens the next line dereferences `null` and the caller gets a bare `NullReferenceException` from inside the serializer, with nothing identifying the type or the cause.

`CanConvert` having succeeded earlier is not a guarantee: it runs at converter-resolution time, exercises a different probe (`IsUnionType`), and swallows its own failures the same way.

## The change

Both probes now produce a `HumanReadableSerializerException` naming the type, matching how `CSharpUnionConverterFactory` already handles the equivalent case for C# unions.

## Verification

- `Meziantou.Framework.HumanReadableSerializer.Tests`: 532 passed (net10.0 + net11.0), 0 failed; the 26 F# tests (`FSharp_DiscriminatedUnion_Rectangle`, `FSharp_DiscriminatedUnion_Circle`, options, collections) confirm the happy path is untouched.

No new test: reaching this branch means forcing the F# reflection probes to fail after `CanConvert` already succeeded, which needs a mocked or deliberately broken `FSharp.Core`. That is a lot of fixture for a defensive guard, so I left it uncovered rather than writing a test that exercises something other than the real path. Happy to add one if you would rather have it.
