### PR TITLE
Exclude the executable path from CommandLineParser.Current

### DIFF
--- a/src/Meziantou.Framework.CommandLine/CommandLineParser.cs
+++ b/src/Meziantou.Framework.CommandLine/CommandLineParser.cs
@@ -47,13 +47,16 @@ public sealed class CommandLineParser
     private readonly Dictionary<string, string> _namedArguments = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<int, string> _positionArguments = [];
 
-    /// <summary>Gets a parser for the current process's command-line arguments.</summary>
+    /// <summary>Gets a parser for the current process's command-line arguments, excluding the executable path.</summary>
+    /// <remarks>Positions match the array provided to the application entry point: position 0 is the first argument, not the path of the executable.</remarks>
     public static CommandLineParser Current { get; } = ParseCurrent();
 
     private static CommandLineParser ParseCurrent()
     {
+        // Environment.GetCommandLineArgs() starts with the executable path, unlike the array provided to the entry point.
+        var args = Environment.GetCommandLineArgs();
         var parser = new CommandLineParser();
-        parser.Parse(Environment.GetCommandLineArgs());
+        parser.Parse(args.Length > 1 ? args[1..] : []);
         return parser;
     }
 

--- a/tests/Meziantou.Framework.CommandLineTests/CommandLineParserTests.cs
+++ b/tests/Meziantou.Framework.CommandLineTests/CommandLineParserTests.cs
@@ -86,6 +86,20 @@ public class CommandLineParserTests
     }
 
     [Fact]
+    public void Current_ShouldNotIncludeTheExecutablePath()
+    {
+        var commandLineArgs = Environment.GetCommandLineArgs();
+        var expected = new CommandLineParser();
+        expected.Parse(commandLineArgs[1..]);
+
+        // Position 0 must be the first argument of the process, not the path of the executable.
+        for (var i = 0; i < commandLineArgs.Length; i++)
+        {
+            Assert.Equal(expected.GetArgument(i), CommandLineParser.Current.GetArgument(i));
+        }
+    }
+
+    [Fact]
     public void HelpRequested_01()
     {
         // Arrange


### PR DESCRIPTION
## The bug

`Environment.GetCommandLineArgs()` returns the executable path as element 0, unlike the array handed to the entry point. `ParseCurrent` passed the whole thing to `Parse`, so the executable path was treated as an ordinary argument.

`src/Meziantou.Framework.CommandLine/CommandLineParser.cs:53-58` (before this change):

```csharp
private static CommandLineParser ParseCurrent()
{
    var parser = new CommandLineParser();
    parser.Parse(Environment.GetCommandLineArgs());   // element 0 is the executable
    return parser;
}
```

Two consequences.

**Every positional index is shifted by one** relative to what the application actually sees, and nothing in the XML docs said so. `Current.GetArgument(0)` returned the program path, not the first user argument — so code that worked when tested with `new CommandLineParser()` silently returns something different after switching to `Current`.

**On Unix the path is also corrupted.** It starts with `/`, so it took the named-argument branch at line 86, had its leading `/` stripped at line 88, and was stored in that mangled form:

```
Environment.GetCommandLineArgs()[0] => [/private/tmp/.../probe.dll]
Current.GetArgument(0)              => [private/tmp/.../probe.dll]   <-- leading '/' gone
```

The remainder was also registered as a bogus named argument keyed on the whole path. A caller using `GetArgument(0)` to locate its own executable gets a relative path that will not resolve. This was Windows-safe only by accident — `C:\...` starts with neither `-` nor `/` — which made it a platform-specific bug in a package targeting `net10.0`/`net11.0` everywhere.

## What changed

`Current` now parses the arguments without the executable path, so positions match the entry point's array. The XML docs state the indexing basis explicitly, since it is the difference between two reasonable readings.

`args.Length > 1 ? args[1..] : []` guards the documented minimum of one element.

No public API signature changed, so `ref/Meziantou.Framework.CommandLine.cs` is untouched.

## Behaviour change

This is a deliberate behavioural change to `CommandLineParser.Current`: positional indices shift down by one, and the executable path is no longer returned by `GetArgument(0)` or present as a named argument. Anyone compensating for the old off-by-one will need to drop that adjustment. Instances created with `new CommandLineParser()` are unaffected. Flagging it since the package is at `4.0.0`; version bumps look like they are handled in their own commits, so this PR does not touch `<Version>`.

## Verification

- Regression test `Current_ShouldNotIncludeTheExecutablePath` added, asserting `Current` matches a parser built from `GetCommandLineArgs()[1..]`. It **fails** against the unfixed code (`Assert.Equal() assertion failed`) and passes with the fix.
- `CommandLineParserTests` with `-p:TreatsWarningsAsErrors=true`: **18/18 green**.
- `dotnet run ./eng/update-all.cs` exits 0 with no generated changes.

## CI note

A full run of this test project can go red or hang on `PromptTests.YesNo_ShouldUseParseYesValue` — a race that already exists on `main` and that this branch does not touch (zero parser-test failures in every run). #2678 fixes it. If CI here is red on a `PromptTests` failure, that is the known cause, and merging #2678 first clears it. The two PRs share no files and can merge in either order.
