### PR TITLE
Keep the caller's ambient activity when starting a process

### DIFF
--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -627,8 +627,16 @@ public sealed class ProcessWrapper
             registration = cancellationToken.Register(static state => ProcessInstance.KillProcess((IProcessHandle)state!, entireProcessTree: true), processHandle);
         }
 
+        // StartActivity makes the new activity ambient on this thread, but it is stopped later from the
+        // completion task. Activity.Stop only restores Activity.Current where it runs, so the caller
+        // would keep a stopped activity as its ambient one and parent everything it does next to it.
+        var previousActivity = Activity.Current;
         var activity = ProcessWrapperTelemetry.ActivitySource.StartActivity("process.execute");
-        activity?.SetTag("process.executable.path", resolvedFileName);
+        if (activity is not null)
+        {
+            activity.SetTag("process.executable.path", resolvedFileName);
+            Activity.Current = previousActivity;
+        }
 
         return factory(processHandle, inputStreamTask, Task.WhenAll(outputStreamTask, errorStreamTask), registration, processLimiter, () => Volatile.Read(ref hasStandardErrorOutput) != 0, activity, processFileName, arguments, _logVerbosity, cancellationToken);
     }

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -152,6 +152,32 @@ public class ProcessWrapperTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_DoesNotChangeTheAmbientActivityOfTheCaller()
+    {
+        var activityTask = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var listener = CreateProcessWrapperActivityListener(activity => activityTask.TrySetResult(activity));
+        ActivitySource.AddActivityListener(listener);
+
+        using var ambientSource = new ActivitySource("Meziantou.Framework.ProcessWrapper.Tests.Ambient");
+        using var ambientListener = new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == "Meziantou.Framework.ProcessWrapper.Tests.Ambient",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(ambientListener);
+
+        using var ambientActivity = ambientSource.StartActivity("ambient");
+        Assert.NotNull(ambientActivity);
+
+        await CreateEchoCommand("test").ExecuteAsync();
+
+        // The process activity is emitted, but it must not replace the caller's ambient activity.
+        var processActivity = await activityTask.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal("process.execute", processActivity.OperationName);
+        Assert.Same(ambientActivity, Activity.Current);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WithOutputStream_Action()
     {
         var lines = new List<string>();


### PR DESCRIPTION
## Finding

`ProcessWrapper.StartProcess` starts the `process.execute` activity on the calling thread, but the activity is stopped from the completion task in `ProcessInstance.WaitForProcessExitAsync`. `Activity.Stop()` restores `Activity.Current` only when it runs on a context where `Current` points at that activity, which is not the case here — so the caller's ambient activity is never restored.

Observed with an `ActivityListener` attached:

```
before:                                  <null>
after ExecuteAsync (same sync context):  process.execute
after await:                             process.execute   stopped=00:00:00.0535190
```

Everything the caller does after `ExecuteAsync` is then parented to a *stopped* span, and because it rides the execution context it leaks across `await` boundaries. In an OpenTelemetry pipeline this produces mis-nested traces and orphaned spans.

## Change

Capture `Activity.Current` before `StartActivity` and restore it immediately afterwards. The activity still records the caller's activity as its parent — `StartActivity` resolves the parent when it creates the activity, before the restore.

## Verification

New test `ExecuteAsync_DoesNotChangeTheAmbientActivityOfTheCaller` establishes an ambient activity, runs a process, and asserts `Activity.Current` is unchanged. It fails on `main` and passes with this change.

Full ProcessWrapper suite on net10.0 + net11.0: 181/181 passing.
