### PR TITLE
Publish FakeProcess state safely across threads

### DIFF
--- a/src/Meziantou.Framework.ProcessWrapper/FakeProcess.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/FakeProcess.cs
@@ -11,6 +11,7 @@ public sealed class FakeProcess : IProcessHandle
     private readonly Stream _inputStream;
     private readonly Stream _outputStream;
     private readonly Stream _errorStream;
+    private readonly Lock _syncObject = new();
     private readonly int _initialExitCode;
     private bool _completeOnStart = true;
     private bool _isDisposed;
@@ -90,11 +91,15 @@ public sealed class FakeProcess : IProcessHandle
     /// <param name="exitCode">Optional exit code override. If <see langword="null" />, keeps the configured code.</param>
     public void Complete(int? exitCode = null)
     {
-        if (_hasExited)
-            return;
+        lock (_syncObject)
+        {
+            if (_hasExited)
+                return;
 
-        _exitCode = exitCode ?? _initialExitCode;
-        _hasExited = true;
+            Volatile.Write(ref _exitCode, exitCode ?? _initialExitCode);
+            Volatile.Write(ref _hasExited, value: true);
+        }
+
         _waitForExitTaskSource.TrySetResult();
     }
 
@@ -117,7 +122,7 @@ public sealed class FakeProcess : IProcessHandle
 
     private bool StartCore()
     {
-        ObjectDisposedException.ThrowIf(_isDisposed, this);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _isDisposed), this);
 
         if (_completeOnStart)
         {
@@ -129,26 +134,27 @@ public sealed class FakeProcess : IProcessHandle
 
     private Task WaitForExitCoreAsync(CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_isDisposed, this);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _isDisposed), this);
         return _waitForExitTaskSource.Task.WaitAsync(cancellationToken);
     }
 
     private void KillCore()
     {
-        ObjectDisposedException.ThrowIf(_isDisposed, this);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _isDisposed), this);
 
-        if (!_hasExited)
-        {
-            Complete(_initialExitCode == 0 ? -1 : _initialExitCode);
-        }
+        Complete(_initialExitCode == 0 ? -1 : _initialExitCode);
     }
 
     private void DisposeCore()
     {
-        if (_isDisposed)
-            return;
+        lock (_syncObject)
+        {
+            if (_isDisposed)
+                return;
 
-        _isDisposed = true;
+            Volatile.Write(ref _isDisposed, value: true);
+        }
+
         _inputStream.Dispose();
         _outputStream.Dispose();
         _errorStream.Dispose();
@@ -156,8 +162,8 @@ public sealed class FakeProcess : IProcessHandle
 
     bool IProcessHandle.Start() => StartCore();
     int IProcessHandle.Id => _id;
-    bool IProcessHandle.HasExited => _hasExited;
-    int IProcessHandle.ExitCode => _exitCode;
+    bool IProcessHandle.HasExited => Volatile.Read(ref _hasExited);
+    int IProcessHandle.ExitCode => Volatile.Read(ref _exitCode);
     Stream IProcessHandle.InputStream => _inputStream;
     Stream IProcessHandle.OutputStream => _outputStream;
     Stream IProcessHandle.ErrorStream => _errorStream;


### PR DESCRIPTION
## Finding

`FakeProcess` publishes its exit state through plain fields. `Complete`, `Kill` and `Dispose` are called from test threads, while the wrapper reads `HasExited` from `ProcessWrapper.StartProcess` and `ExitCode` from `ProcessInstance.WaitForProcessExitAsync` on other threads, with no barrier on either side.

The `TaskCompletionSource` orders anything that awaits `WaitForExitAsync`, but the `HasExited` check used to decide whether to register the cancellation callback does not go through it. `Complete` and `Dispose` also each did a non-atomic check-then-act on their flag, so two concurrent calls could both pass the guard.

This is test-only infrastructure, so the practical impact is small — but flaky test infrastructure is expensive to debug precisely because nobody suspects it.

## Change

Write and read the flags with `Volatile`, and perform the two state transitions under a lock. `Kill` now delegates its guard to `Complete`, which is idempotent, instead of doing its own check-then-act.

No behaviour change is intended — this only makes the existing transitions safe to observe from another thread.

## Verification

No new test: a memory-model fix of this shape has no deterministic unit test, and adding one that passes either way would be misleading. The existing suite covers the `FakeProcess` paths.

Full ProcessWrapper suite on net10.0 + net11.0: 179/179 passing.
