### PR TITLE
Apply the repository code conventions in ProcessWrapper

### DIFF
--- a/src/Meziantou.Framework.ProcessWrapper/FakeProcessFactory.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/FakeProcessFactory.cs
@@ -27,7 +27,7 @@ public sealed class FakeProcessFactory : IProcessFactory
 
         foreach (var process in processes)
         {
-            if(process == null)
+            if (process is null)
                 throw new ArgumentException("Fake processes cannot contain null values.", nameof(processes));
         }
 
@@ -47,7 +47,7 @@ public sealed class FakeProcessFactory : IProcessFactory
 
     IProcessHandle IProcessFactory.Create(ProcessStartInfo processStartInfo)
     {
-            ArgumentNullException.ThrowIfNull(processStartInfo);
+        ArgumentNullException.ThrowIfNull(processStartInfo);
 
         var process = _factory(processStartInfo);
         return process ?? throw new InvalidOperationException("Fake process factory returned null.");

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapperEnvironmentVariables.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapperEnvironmentVariables.cs
@@ -18,7 +18,7 @@ public sealed class ProcessWrapperEnvironmentVariables
     /// <summary>Sets the specified environment variable to the given value.</summary>
     public ProcessWrapperEnvironmentVariables Set(string name, string? value)
     {
-        if(value is null)
+        if (value is null)
         {
             _environment.Remove(name);
         }


### PR DESCRIPTION
## Finding

Three spots in `Meziantou.Framework.ProcessWrapper` do not follow the conventions in `AGENTS.md`:

- `FakeProcessFactory.cs` — `if(process == null)`: `AGENTS.md` requires `is null` over `== null`, and the space after `if` is missing.
- `FakeProcessFactory.cs` — a guard clause indented two levels too deep.
- `ProcessWrapperEnvironmentVariables.cs` — `if(value is null)`: missing space after `if`.

These are the only occurrences in the project, and no analyzer catches them (`dotnet build /p:TreatsWarningsAsErrors=true` is clean both before and after), so they read as accidental rather than deliberate.

## Change

Formatting and `is null` only. No behaviour change.

## Verification

Full ProcessWrapper suite on net10.0 + net11.0: 179/179 passing.
