### PR TITLE
Treat a closed process stdin as end of input instead of an error

### DIFF
--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -608,15 +608,18 @@ public sealed class ProcessWrapper
                             break;
                         }
 
-                        inputStream.Write(buffer, 0, bytesRead);
+                        if (!TryWriteProcessInput(inputStream, buffer, bytesRead))
+                        {
+                            break;
+                        }
                     }
 
-                    inputStream.Flush();
+                    TryFlushProcessInput(inputStream);
                 }
                 finally
                 {
                     inputSource.NotifyProcessCompleted();
-                    inputStream.Close();
+                    TryCloseProcessInput(inputStream);
                 }
             }, cancellationToken);
         }
@@ -701,6 +704,54 @@ public sealed class ProcessWrapper
             {
                 target.NotifyProcessCompleted();
             }
+        }
+    }
+
+    // A process that stops reading its standard input closes the pipe, so the remaining writes fail.
+    // That is normal for commands such as head or grep -q, so treat it as the end of the input rather
+    // than an error, matching how ReadBufferAsync treats the same failure on the output side.
+    private static bool TryWriteProcessInput(Stream stream, byte[] buffer, int count)
+    {
+        try
+        {
+            stream.Write(buffer, 0, count);
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
+    }
+
+    private static void TryFlushProcessInput(Stream stream)
+    {
+        try
+        {
+            stream.Flush();
+        }
+        catch (IOException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    private static void TryCloseProcessInput(Stream stream)
+    {
+        try
+        {
+            stream.Close();
+        }
+        catch (IOException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
         }
     }
 

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -1105,6 +1105,18 @@ public class ProcessWrapperTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithInputStream_WhenProcessExitsWithoutReadingItsInput_ReturnsResult()
+    {
+        // The process closes its standard input immediately, so the remaining writes hit a broken pipe.
+        // That is expected for commands that stop reading early and must not fail the execution.
+        var result = await CreateExitImmediatelyCommand()
+            .WithInputStream(InputSource.FromText(new string('a', 10 * 1024 * 1024)))
+            .ExecuteAsync();
+
+        Assert.True(result.ExitCode.IsSuccess);
+    }
+
+    [Fact]
     public async Task ExecuteBufferedAsync_WithPipeOperator_PipesCommandOutput()
     {
         var processResult = await (CreateEchoCommand("hello from operator") | CreatePassthroughCommand())
@@ -1885,6 +1897,18 @@ public class ProcessWrapperTests
 
         return ProcessWrapper.Create("sh")
             .WithArguments("-c", $"echo ${variableName}");
+    }
+
+    private static ProcessWrapper CreateExitImmediatelyCommand()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return ProcessWrapper.Create("cmd.exe")
+                .WithArguments("/C", "exit /b 0");
+        }
+
+        return ProcessWrapper.Create("sh")
+            .WithArguments("-c", "exit 0");
     }
 
     private static ProcessWrapper CreateSingleByteOutputCommand(byte value, bool standardError = false)


### PR DESCRIPTION
**Stack 1 of 2 · merges into `main` · must merge before the ProcessPipe deadlock fix.**

## Finding

The input pump writes synchronously to the child's standard input. When the child exits first, the write fails with `IOException`, which is captured as the input-stream failure and rethrown from the awaiter *before* exit-code validation runs.

Reproduced with a command that reads 5 bytes and exits `0`, fed 10 MB:

```
[stdin] EXCEPTION IOException: Broken pipe
```

The process succeeded; the caller got an exception and no `ProcessResult`.

Partial stdin consumption is normal, not exceptional — `head`, `grep -q`, `jq -e`, or any child that bails early. The asymmetry is the tell: the *output* pump already swallows `IOException` as end-of-stream in `ReadBufferAsync`, with a comment citing `Process.AsyncStreamReader`, but the input pump had no equivalent, so the same underlying event was tolerated in one direction and fatal in the other.

## Change

`TryWriteProcessInput`, `TryFlushProcessInput` and `TryCloseProcessInput` treat `IOException` and `ObjectDisposedException` on the *process* stream as the end of the input and stop pumping. Failures from the `InputSource` itself still propagate — those are genuine caller errors — because only the three calls against the process stream are guarded.

## Verification

New test `ExecuteAsync_WithInputStream_WhenProcessExitsWithoutReadingItsInput_ReturnsResult` feeds 10 MB to a process that exits immediately. It fails on `main` with `IOException: Broken pipe` and passes with this change.

Full ProcessWrapper suite on net10.0 + net11.0: 181/181 passing.
