### PR TITLE
Do not hold the ProcessPipe lock across a blocking write

### DIFF
--- a/src/Meziantou.Framework.ProcessWrapper/ProcessPipe.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessPipe.cs
@@ -8,7 +8,8 @@ public sealed class ProcessPipe
 
     private readonly Stream _inputStream;
     private readonly Stream _outputStream;
-    private readonly Lock _syncObject = new();
+    private readonly Lock _stateLock = new();
+    private readonly Lock _writerLock = new();
     private bool _isWriterDisposed;
     private bool _isReaderDisposed;
 
@@ -54,11 +55,11 @@ public sealed class ProcessPipe
     internal void DisposeReader()
     {
         var shouldDispose = false;
-        lock (_syncObject)
+        lock (_stateLock)
         {
             if (!_isReaderDisposed)
             {
-                _isReaderDisposed = true;
+                Volatile.Write(ref _isReaderDisposed, value: true);
                 shouldDispose = true;
             }
         }
@@ -71,7 +72,10 @@ public sealed class ProcessPipe
 
     internal void Write(ReadOnlySpan<byte> buffer)
     {
-        lock (_syncObject)
+        // Only serialize concurrent writers. This write blocks until the buffered data drops below
+        // the pause threshold, so it must not hold the lock guarding the disposed flags: completing
+        // the reader is what releases a paused writer, and DisposeReader needs that lock to run.
+        lock (_writerLock)
         {
             ThrowIfWriterDisposed();
             _outputStream.Write(buffer);
@@ -96,11 +100,11 @@ public sealed class ProcessPipe
     private void DisposeWriterCore()
     {
         var shouldDispose = false;
-        lock (_syncObject)
+        lock (_stateLock)
         {
             if (!_isWriterDisposed)
             {
-                _isWriterDisposed = true;
+                Volatile.Write(ref _isWriterDisposed, value: true);
                 shouldDispose = true;
             }
         }

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -1157,6 +1157,21 @@ public class ProcessWrapperTests
     }
 
     [Fact]
+    public async Task ExecuteBufferedAsync_WithPipeOperator_WhenDownstreamExitsWithoutReadingItsInput_DoesNotHang()
+    {
+        // The upstream command writes far more than the pipe's pause threshold while the downstream
+        // command exits without draining it, which used to deadlock the pipe's writer against DisposeReader.
+        var pipeline = CreateLargeOutputCommand(1024 * 1024)
+            | CreateExitImmediatelyCommand().WithValidation(ProcessValidationMode.None);
+
+        var execution = pipeline.ExecuteBufferedAsync();
+        var completed = await Task.WhenAny(execution, Task.Delay(TimeSpan.FromSeconds(30)));
+
+        Assert.Same(execution, completed);
+        await execution;
+    }
+
+    [Fact]
     public async Task ReusableConfiguration()
     {
         var baseCommand = CreateEchoBase();
@@ -1897,6 +1912,25 @@ public class ProcessWrapperTests
 
         return ProcessWrapper.Create("sh")
             .WithArguments("-c", $"echo ${variableName}");
+    }
+
+    private static ProcessWrapper CreateLargeOutputCommand(int byteCount)
+    {
+        var count = byteCount.ToString(CultureInfo.InvariantCulture);
+        if (OperatingSystem.IsWindows())
+        {
+            return ProcessWrapper.Create("powershell.exe")
+                .WithArguments(
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command",
+                    $"[Console]::Out.Write('a' * {count})");
+        }
+
+        return ProcessWrapper.Create("sh")
+            .WithArguments("-c", $"yes aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | head -c {count}");
     }
 
     private static ProcessWrapper CreateExitImmediatelyCommand()


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/processwrapper-stdin-broken-pipe` · that PR must merge first.**

The stdin fix below it is a hard prerequisite: without it this PR's regression test stops hanging but then fails with `IOException: Broken pipe`, because the downstream input pump hits that bug on the same code path.

## Finding

`ProcessPipe.Write` took `_syncObject` and then performed a *blocking* write into a `Pipe` whose `pauseWriterThreshold` is 64 KB. Once the downstream process stopped draining, the upstream output pump blocked inside the write **while holding the lock**. The downstream input pump's cleanup then called `ProcessPipe.DisposeReader()`, which needs the same lock. Completing the reader is the only thing that releases a paused writer, so it could never run.

`a | b` hung forever whenever `b` stopped reading early — `head`, `grep -q`, `head -c N`, or a process that just exits.

Reproduced end to end (`yes | head -c 100000000` piped into a command that reads 10 bytes and exits):

```
--- pipedeadlock ---
*** HUNG after 10s ***
```

And isolated to the lock itself, driving `ProcessPipe` directly:

```
bytes written before blocking: 57344 (pauseWriterThreshold = 65536)
writer thread state: Background, WaitSleepJoin
*** DisposeReader BLOCKED for 5s -> deadlock on ProcessPipe._syncObject ***
```

The hang is unrecoverable: `ExecuteAsync`'s `CancellationToken` kills the child processes but never unblocks the managed pump thread, so a timeout does not rescue it either. The blocked thread is a thread-pool thread, so repeated occurrences starve the pool.

## Change

Split the single lock in two. `_stateLock` guards the disposed flags; `_writerLock` only serializes concurrent writers. `DisposeReader` can now run while a writer is paused, which completes the `PipeReader` and releases it — the escape hatch the shared lock was removing.

## Verification

New test `ExecuteBufferedAsync_WithPipeOperator_WhenDownstreamExitsWithoutReadingItsInput_DoesNotHang` pipes 1 MB into a command that exits without reading. On `main` it times out after 30s and fails; here it completes in ~230 ms.

Full ProcessWrapper suite on net10.0 + net11.0: 183/183 passing.
