### PR TITLE
Serialize output targets that share the same sink

### DIFF
--- a/src/Meziantou.Framework.ProcessWrapper/OutputTarget.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/OutputTarget.cs
@@ -89,7 +89,7 @@ public abstract class OutputTarget
 
     private sealed class StringBuilderOutputTarget(StringBuilder stringBuilder) : OutputTarget
     {
-        private readonly Lock _syncObject = new();
+        private readonly Lock _syncObject = SharedSinkLock.For(stringBuilder);
         private Decoder _decoder = Encoding.UTF8.GetDecoder();
 
         public override void Write(ReadOnlySpan<byte> write)
@@ -135,7 +135,7 @@ public abstract class OutputTarget
         }
     }
 
-    private sealed class TextDelegateOutputTarget(Action<string> handler) : LineBasedTextOutputTarget
+    private sealed class TextDelegateOutputTarget(Action<string> handler) : LineBasedTextOutputTarget(handler)
     {
         protected override void HandleLine(string line)
         {
@@ -143,7 +143,7 @@ public abstract class OutputTarget
         }
     }
 
-    private sealed class TextWriterOutputTarget(TextWriter writer) : LineBasedTextOutputTarget
+    private sealed class TextWriterOutputTarget(TextWriter writer) : LineBasedTextOutputTarget(writer)
     {
         protected override void HandleLine(string line)
         {
@@ -153,7 +153,7 @@ public abstract class OutputTarget
 
     private sealed class BytesDelegateOutputTarget(Action<byte[]> handler) : OutputTarget
     {
-        private readonly Lock _syncObject = new();
+        private readonly Lock _syncObject = SharedSinkLock.For(handler);
 
         public override void Write(ReadOnlySpan<byte> write)
         {
@@ -165,7 +165,7 @@ public abstract class OutputTarget
         }
     }
 
-    private sealed class ProcessOutputCollectionOutputTarget(ProcessOutputCollection collection, ProcessOutputType outputType) : LineBasedTextOutputTarget
+    private sealed class ProcessOutputCollectionOutputTarget(ProcessOutputCollection collection, ProcessOutputType outputType) : LineBasedTextOutputTarget(collection)
     {
         protected override void HandleLine(string line)
         {
@@ -191,9 +191,9 @@ public abstract class OutputTarget
         }
     }
 
-    private abstract class LineBasedTextOutputTarget : OutputTarget
+    private abstract class LineBasedTextOutputTarget(object sink) : OutputTarget
     {
-        private readonly Lock _syncObject = new();
+        private readonly Lock _syncObject = SharedSinkLock.For(sink);
         private Decoder _decoder = Encoding.UTF8.GetDecoder();
         private readonly StringBuilder _lineBuilder = new();
         private bool _lastCharacterWasCarriageReturn;
@@ -285,6 +285,17 @@ public abstract class OutputTarget
             _lineBuilder.Clear();
             HandleLine(line);
         }
+    }
+
+    // The same sink can be attached to both standard output and standard error, and the two stream
+    // pumps run concurrently. Targets built from one sink therefore share a single lock so the sink is
+    // never mutated from two threads at once, matching what SynchronizedWriteStream and
+    // SynchronizedTextWriter already do for streams and text writers.
+    private static class SharedSinkLock
+    {
+        private static readonly ConditionalWeakTable<object, Lock> LockBySink = new();
+
+        public static Lock For(object sink) => LockBySink.GetValue(sink, static _ => new Lock());
     }
 
     [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "The wrapped stream and semaphore are shared and owned by the caller/ConditionalWeakTable.")]

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -955,6 +955,24 @@ public class ProcessWrapperTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithSharedStringBuilderOutputTarget_DoesNotLoseOutput()
+    {
+        // Both pumps append to the same StringBuilder concurrently. StringBuilder is not thread-safe,
+        // so without a shared lock this silently loses output or throws from inside Append.
+        const int Iterations = 2000;
+        const int ChunkLength = 10;
+
+        var stringBuilder = new StringBuilder();
+        await CreateInterleavedChunkCommand(Iterations, new string('o', ChunkLength), new string('e', ChunkLength))
+            .WithValidation(ProcessValidationMode.None)
+            .WithOutputStream(stringBuilder)
+            .WithErrorStream(stringBuilder)
+            .ExecuteAsync();
+
+        Assert.Equal(Iterations * ChunkLength * 2, stringBuilder.Length);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WithErrorEncoding_UsesConfiguredEncoding()
     {
         var sb = new StringBuilder();
@@ -2034,6 +2052,25 @@ public class ProcessWrapperTests
         var redirection = standardError ? " >&2" : "";
         return ProcessWrapper.Create("sh")
             .WithArguments("-c", $"printf '\\{octalValue}'{redirection}");
+    }
+
+    private static ProcessWrapper CreateInterleavedChunkCommand(int iterations, string outputChunk, string errorChunk)
+    {
+        var count = iterations.ToString(CultureInfo.InvariantCulture);
+        if (OperatingSystem.IsWindows())
+        {
+            return ProcessWrapper.Create("powershell.exe")
+                .WithArguments(
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command",
+                    $"for ($i = 0; $i -lt {count}; $i++) {{ [Console]::Out.Write('{outputChunk}'); [Console]::Error.Write('{errorChunk}') }}");
+        }
+
+        return ProcessWrapper.Create("sh")
+            .WithArguments("-c", $"i=0; while [ $i -lt {count} ]; do printf '{outputChunk}'; printf '{errorChunk}' >&2; i=$((i+1)); done");
     }
 
     private static string[] GetEchoArguments(string text)


### PR DESCRIPTION
**Stack 2 of 2 · merges into `fix/processwrapper-split-multibyte-output` · that PR must merge first.**

Both PRs rewrite `StringBuilderOutputTarget.Write` within a few lines of each other, so they cannot land independently.

## Finding

Attaching one sink to both standard output and standard error is a supported scenario — `ExecuteAsync_WithSharedBinaryOutputTarget_IsThreadSafe` already tests it for `Stream`, and `OutputTarget.ToStream` / `ToTextWriter` key a lock off the underlying sink through a `ConditionalWeakTable` to make it safe.

`StringBuilder` and the delegate targets did not. They used a per-instance lock, so `WithOutputStream(sb).WithErrorStream(sb)` created two targets with two different locks over one `StringBuilder`, and both stream pumps called `Append` concurrently.

Five runs of a child writing 30 KB to each stream:

```
[run 1] EXCEPTION ArgumentException: Destination is too short. (Parameter 'destination')
[run 2] len=55904  expected=60000  lost=4096
[run 3] len=60000  expected=60000  lost=0
[run 4] len=60000  expected=60000  lost=0
[run 5] len=59950  expected=60000  lost=50
```

Three of five were wrong — silent truncation, or an `ArgumentException` thrown from inside `StringBuilder` that surfaces as the output-stream failure. The API invites this: both methods take a `StringBuilder` by implicit conversion, and the README's "Collect output into a StringBuilder" example is one line away from the broken form.

## Change

Targets built from the same sink now share one lock, obtained from a `ConditionalWeakTable` keyed on the sink object. This covers `StringBuilder`, `Action<string>`, `Action<byte[]>`, `TextWriter` and `ProcessOutputCollection`, bringing them to the guarantee `Stream` already had.

Each target keeps its own decoder and line builder, which is correct — standard output and standard error are two byte streams and must not share decoder state.

## Verification

New test `ExecuteAsync_WithSharedStringBuilderOutputTarget_DoesNotLoseOutput` writes 2000 fixed-width chunks to each stream into one `StringBuilder` and asserts the exact final length.

Being a race, the test is a detector rather than a proof: on `main` it failed 2 of 3 runs; with the fix it passed 3 of 3, and it cannot fail once the locking is correct.

Full ProcessWrapper suite on net10.0 + net11.0: 185/185 passing.
