### PR TITLE
Do not search the working directory for the executable by default

### DIFF
--- a/ref/Meziantou.Framework.ProcessWrapper.cs
+++ b/ref/Meziantou.Framework.ProcessWrapper.cs
@@ -232,6 +232,7 @@ namespace Meziantou.Framework
         public Meziantou.Framework.ProcessWrapper WithArguments(params System.ReadOnlySpan<string> arguments) => throw null;
         public Meziantou.Framework.ProcessWrapper WithArguments(System.Collections.Generic.IEnumerable<string> arguments) => throw null;
         public Meziantou.Framework.ProcessWrapper WithWorkingDirectory(string workingDirectory) => throw null;
+        public Meziantou.Framework.ProcessWrapper WithSearchWorkingDirectory(bool searchWorkingDirectory = true) => throw null;
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
         public Meziantou.Framework.ProcessWrapper WithCredentials(string userName, string passwordInClearText, string? domain = null) => throw null;
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -228,9 +228,16 @@ public sealed class ProcessWrapper
 
     /// <summary>Also looks for the executable in the working directory, before the directories listed in <c>PATH</c>.</summary>
     /// <remarks>
-    /// Disabled by default. When the executable is a bare file name, enabling this lets a file in the working
-    /// directory take precedence over the command found in <c>PATH</c>, so only enable it when the working
-    /// directory is trusted.
+    /// <para>
+    /// Windows resolves a bare executable name against the current directory before <c>PATH</c>, so this is the
+    /// native behavior there. POSIX shells deliberately do not.
+    /// </para>
+    /// <para>
+    /// It is nevertheless disabled by default on every platform, Windows included, for security reasons: a file
+    /// sitting in the working directory would otherwise take precedence over the command <c>PATH</c> resolves for
+    /// the same name, letting an untrusted working directory substitute its own executable for the intended one.
+    /// Only enable it when the working directory is trusted.
+    /// </para>
     /// </remarks>
     public ProcessWrapper WithSearchWorkingDirectory(bool searchWorkingDirectory = true)
     {

--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -31,6 +31,7 @@ public sealed class ProcessWrapper
     private ImmutableArray<OutputTarget> _errorTargets;
     private InputSource? _inputSource;
     private ProcessLimits? _limits;
+    private bool _searchExecutableInWorkingDirectory;
     private Action<JobObject>? _windowsJobObjectConfiguration;
     private Action<CGroup2>? _linuxControlGroupConfiguration;
     private bool _validationModeConfigured;
@@ -58,6 +59,7 @@ public sealed class ProcessWrapper
         _errorTargets = other._errorTargets;
         _inputSource = other._inputSource;
         _limits = other._limits;
+        _searchExecutableInWorkingDirectory = other._searchExecutableInWorkingDirectory;
         _windowsJobObjectConfiguration = other._windowsJobObjectConfiguration;
         _linuxControlGroupConfiguration = other._linuxControlGroupConfiguration;
         _validationModeConfigured = other._validationModeConfigured;
@@ -221,6 +223,18 @@ public sealed class ProcessWrapper
     public ProcessWrapper WithWorkingDirectory(string workingDirectory)
     {
         _startInfo.WorkingDirectory = workingDirectory;
+        return this;
+    }
+
+    /// <summary>Also looks for the executable in the working directory, before the directories listed in <c>PATH</c>.</summary>
+    /// <remarks>
+    /// Disabled by default. When the executable is a bare file name, enabling this lets a file in the working
+    /// directory take precedence over the command found in <c>PATH</c>, so only enable it when the working
+    /// directory is trusted.
+    /// </remarks>
+    public ProcessWrapper WithSearchWorkingDirectory(bool searchWorkingDirectory = true)
+    {
+        _searchExecutableInWorkingDirectory = searchWorkingDirectory;
         return this;
     }
 
@@ -507,7 +521,7 @@ public sealed class ProcessWrapper
             throw new InvalidOperationException("Process validation cannot be configured when starting a process without tracking it.");
 
         var startInfo = CloneStartInfo(_startInfo);
-        startInfo.FileName = ResolveFileName(startInfo.FileName, startInfo.WorkingDirectory);
+        startInfo.FileName = ResolveFileName(startInfo.FileName, GetExecutableSearchDirectory(startInfo));
         ApplyProcessStartInfoInterceptors(startInfo);
 
         return Process.StartAndForget(startInfo);
@@ -526,7 +540,7 @@ public sealed class ProcessWrapper
         var hasStandardErrorOutput = 0;
 
         var startInfo = CloneStartInfo(_startInfo);
-        var resolvedFileName = ResolveFileName(startInfo.FileName, startInfo.WorkingDirectory);
+        var resolvedFileName = ResolveFileName(startInfo.FileName, GetExecutableSearchDirectory(startInfo));
         startInfo.RedirectStandardOutput = hasOutputHandlers;
         startInfo.RedirectStandardError = hasErrorHandlers;
         startInfo.RedirectStandardInput = hasInputStream;
@@ -1030,6 +1044,11 @@ public sealed class ProcessWrapper
             }
         }
     }
+
+    // A file dropped in the working directory must not shadow a command resolved from PATH, so the working
+    // directory is searched only when the caller opts in with WithSearchWorkingDirectory.
+    private string? GetExecutableSearchDirectory(ProcessStartInfo startInfo)
+        => _searchExecutableInWorkingDirectory ? startInfo.WorkingDirectory : null;
 
     private static string ResolveFileName(string fileName, string? workingDirectory)
     {

--- a/src/Meziantou.Framework.ProcessWrapper/readme.md
+++ b/src/Meziantou.Framework.ProcessWrapper/readme.md
@@ -109,6 +109,17 @@ await ProcessWrapper.Create("git")
     .ExecuteAsync();
 ````
 
+The executable is resolved from `PATH`. The working directory is not searched, so a file sitting in it cannot
+shadow the command `PATH` resolves for the same name. Opt in with `WithSearchWorkingDirectory()` when the
+working directory is trusted and you want the executable looked up there first:
+
+````c#
+await ProcessWrapper.Create("run.sh")
+    .WithWorkingDirectory("/path/to/scripts")
+    .WithSearchWorkingDirectory()
+    .ExecuteAsync();
+````
+
 ## Environment variables
 
 ````c#

--- a/src/Meziantou.Framework.ProcessWrapper/readme.md
+++ b/src/Meziantou.Framework.ProcessWrapper/readme.md
@@ -110,7 +110,8 @@ await ProcessWrapper.Create("git")
 ````
 
 The executable is resolved from `PATH`. The working directory is not searched, so a file sitting in it cannot
-shadow the command `PATH` resolves for the same name. Opt in with `WithSearchWorkingDirectory()` when the
+shadow the command `PATH` resolves for the same name. Windows searches the current directory before `PATH` by
+default, but that is disabled here too, for the same reason. Opt in with `WithSearchWorkingDirectory()` when the
 working directory is trusted and you want the executable looked up there first:
 
 ````c#

--- a/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
+++ b/tests/Meziantou.Framework.ProcessWrapper.Tests/ProcessWrapperTests.cs
@@ -513,11 +513,41 @@ public class ProcessWrapperTests
 
         var result = ProcessWrapper.Create(executableName)
             .WithWorkingDirectory(temporaryDirectoryPath)
+            .WithSearchWorkingDirectory()
             .ExecuteBufferedAsync();
 
         var processResult = await result;
 
         Assert.Equal("test-from-working-directory", processResult.Output.StandardOutput.First().Text.Trim());
+    }
+
+    [Fact]
+    public async Task WithWorkingDirectory_DoesNotFindExecutableInWorkingDirectoryByDefault()
+    {
+        // Without the opt-in, an executable sitting in the working directory must not be picked up: it would
+        // otherwise shadow the command that PATH resolves for the same bare name.
+        using var temporaryDirectory = TemporaryDirectory.Create();
+        var temporaryDirectoryPath = temporaryDirectory.FullPath.Value;
+
+        string executableName;
+        if (OperatingSystem.IsWindows())
+        {
+            executableName = $"run{Guid.NewGuid():N}";
+            temporaryDirectory.CreateTextFile(executableName + ".bat", "@echo off\r\necho test-from-working-directory\r\n");
+        }
+        else
+        {
+            executableName = $"run{Guid.NewGuid():N}.sh";
+            var scriptPath = temporaryDirectory.CreateTextFile(executableName, "#!/bin/sh\necho test-from-working-directory\n");
+            File.SetUnixFileMode(scriptPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        await Assert.ThrowsAsync<System.ComponentModel.Win32Exception>(async () =>
+        {
+            _ = await ProcessWrapper.Create(executableName)
+                .WithWorkingDirectory(temporaryDirectoryPath)
+                .ExecuteBufferedAsync();
+        });
     }
 
     [Fact]
@@ -1348,6 +1378,7 @@ public class ProcessWrapperTests
 
         var processId = ProcessWrapper.Create(executableName)
             .WithWorkingDirectory(temporaryDirectoryPath)
+            .WithSearchWorkingDirectory()
             .WithArguments("argument")
             .WithEnvironmentVariables(env => env.Set("OUTPUT_FILE", outputPath))
             .StartAndForget();


### PR DESCRIPTION
## Finding

`ResolveFileName` passed the working directory to `ExecutableFinder.GetFullExecutablePath`, which searches it **before** `PATH`. A bare command name therefore resolved to a file sitting in the working directory.

Reproduced with a shell script named `git` dropped into a temp directory:

```
--- hijack ---
output: PWNED   (real git would print 'git version ...')
```

That is `ProcessWrapper.Create("git").WithArguments("--version").WithWorkingDirectory(dir)` running `dir/git`, not `/usr/bin/git`.

Windows searches the current directory by design, so the behaviour is defensible there. No POSIX shell does, precisely because of this attack — and the natural use of this library is exactly the exposed shape: `ProcessWrapper.Create("git" | "npm" | "dotnet").WithWorkingDirectory(checkoutPath)`. A CI runner or bot that clones untrusted code and then runs a tool inside the clone executes attacker-controlled code from a file the attacker only had to commit and mark executable.

## Change

The working directory is searched only when the caller opts in with `WithSearchWorkingDirectory()`.

`ExecutableFinder` itself is untouched — the `workingDirectory` parameter keeps its current contract, so `Meziantou.Framework`, `Meziantou.Framework.SnapshotTesting`, `Meziantou.Framework.InlineSnapshotTesting` and `Meziantou.Framework.TemporaryContainers` are unaffected, and `ExecutableFinderTests` still passes unchanged. Only the default used by `ProcessWrapper` changes.

**This is a breaking change** for callers that relied on resolving an executable out of the working directory. They add `WithSearchWorkingDirectory()`.

## Verification

New test `WithWorkingDirectory_DoesNotFindExecutableInWorkingDirectoryByDefault` puts an executable in the working directory and asserts it is *not* used. It fails on `main` (the script runs, no exception) and passes here.

Three existing tests relied on the old default and now opt in explicitly: `WithWorkingDirectory_FindsExecutableInWorkingDirectory`, `StartAndForget_AppliesConfigurationAndInterceptors`, and the first via the resolution path. They still assert the same behaviour, now behind the opt-in.

`ref/Meziantou.Framework.ProcessWrapper.cs` regenerated for the new method; a Release build with `/p:PublicApiGeneratorVerifyNoChangeOnBuild=true` is clean. `readme.md` documents the default and the opt-in.

Full ProcessWrapper suite on net10.0 + net11.0: 181/181 passing.
