### PR TITLE
Document that ProcessWrapper.ToString ignores the log verbosity

### DIFF
--- a/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
+++ b/src/Meziantou.Framework.ProcessWrapper/ProcessWrapper.cs
@@ -175,6 +175,12 @@ public sealed class ProcessWrapper
     public static ProcessPipeline operator |(ProcessWrapper left, ProcessWrapper right) => ProcessPipeline.Create(left, right);
 
     /// <summary>Returns the command line representation of this process configuration.</summary>
+    /// <remarks>
+    /// The executable path and the arguments are always included, regardless of the verbosity set by
+    /// <see cref="WithLogVerbosity(ProcessLogVerbosity)"/>. Use <see cref="ProcessResult.ToString()"/> or the
+    /// message of <see cref="ProcessExecutionException"/> when the rendering has to honor that verbosity, for
+    /// example to keep a secret passed as an argument out of the logs.
+    /// </remarks>
     public override string ToString()
     {
         return ProcessCommandLineFormatter.Format(_startInfo.FileName, _startInfo.ArgumentList);


### PR DESCRIPTION
## Finding

`ProcessLogVerbosity` keeps command details out of exception messages and `ProcessResult.ToString()`, but `ProcessWrapper.ToString()` calls the two-argument `ProcessCommandLineFormatter.Format` overload, which hardcodes `IncludeProcessPath | IncludeArguments`:

```
ToString() with LogVerbosity.None                => /bin/echo --token s3cr3t
ProcessResult.ToString() with LogVerbosity.None  => '(ExitCode: 0)'
```

A caller who sets `WithLogVerbosity(None)` to keep a secret out of the logs and then logs the wrapper itself — `logger.LogDebug("Running {Command}", wrapper)`, or a debugger watch — still leaks it.

## Change

Documentation only.

`ToString_QuotesFileNameAndArguments` pins the exact full command line, `ProcessLogVerbosity` is documented as applying to "log-oriented text outputs", and the README scopes it to exception messages and `ProcessResult.ToString()`. So rendering the whole command line here is deliberate, and changing it would break a pinned test. This adds a `<remarks>` saying so and pointing at the two renderings that do honor the verbosity.

## Verification

No behaviour change. Release build with `/p:PublicApiGeneratorVerifyNoChangeOnBuild=true` is clean (XML docs are not part of the API baseline).

Full ProcessWrapper suite on net10.0 + net11.0: 179/179 passing.
