### PR TITLE
Close the ChromiumTracingEvent hierarchy

### DIFF
--- a/ref/Meziantou.Framework.ChromiumTracing.cs
+++ b/ref/Meziantou.Framework.ChromiumTracing.cs
@@ -22,7 +22,7 @@ namespace Meziantou.Framework.ChromiumTracing
         public override string Type { get => throw null; }
     }
 
-    public abstract class ChromiumTracingAsyncEvent : Meziantou.Framework.ChromiumTracing.ChromiumTracingEvent
+    public closed class ChromiumTracingAsyncEvent : Meziantou.Framework.ChromiumTracing.ChromiumTracingEvent
     {
         [System.Text.Json.Serialization.JsonPropertyName("id")]
         public int? Id { get => throw null; set { } }
@@ -68,7 +68,7 @@ namespace Meziantou.Framework.ChromiumTracing
         public override string Type { get => throw null; }
     }
 
-    public abstract class ChromiumTracingContextEvent : Meziantou.Framework.ChromiumTracing.ChromiumTracingEvent
+    public closed class ChromiumTracingContextEvent : Meziantou.Framework.ChromiumTracing.ChromiumTracingEvent
     {
     }
 
@@ -92,11 +92,11 @@ namespace Meziantou.Framework.ChromiumTracing
         public override string Type { get => throw null; }
     }
 
-    public abstract class ChromiumTracingDurationEvent : Meziantou.Framework.ChromiumTracing.ChromiumTracingEvent
+    public closed class ChromiumTracingDurationEvent : Meziantou.Framework.ChromiumTracing.ChromiumTracingEvent
     {
     }
 
-    public abstract class ChromiumTracingEvent
+    public closed class ChromiumTracingEvent
     {
         [System.Text.Json.Serialization.JsonPropertyName("ph")]
         public abstract string Type { get; }
@@ -138,7 +138,7 @@ namespace Meziantou.Framework.ChromiumTracing
         public Meziantou.Framework.ChromiumTracing.BindingPoint BindingPoint { get => throw null; set { } }
     }
 
-    public abstract class ChromiumTracingFlowEvent : Meziantou.Framework.ChromiumTracing.ChromiumTracingEvent
+    public closed class ChromiumTracingFlowEvent : Meziantou.Framework.ChromiumTracing.ChromiumTracingEvent
     {
     }
 
@@ -178,7 +178,7 @@ namespace Meziantou.Framework.ChromiumTracing
         public override string Type { get => throw null; }
     }
 
-    public abstract class ChromiumTracingMemoryDumpEvent : Meziantou.Framework.ChromiumTracing.ChromiumTracingEvent
+    public closed class ChromiumTracingMemoryDumpEvent : Meziantou.Framework.ChromiumTracing.ChromiumTracingEvent
     {
     }
 
@@ -217,7 +217,7 @@ namespace Meziantou.Framework.ChromiumTracing
         public override string Type { get => throw null; }
     }
 
-    public abstract class ChromiumTracingObjectEvent : Meziantou.Framework.ChromiumTracing.ChromiumTracingEvent
+    public closed class ChromiumTracingObjectEvent : Meziantou.Framework.ChromiumTracing.ChromiumTracingEvent
     {
         [System.Text.Json.Serialization.JsonPropertyName("id")]
         public string? Id { get => throw null; set { } }

--- a/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingAsyncEvent.cs
+++ b/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingAsyncEvent.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 namespace Meziantou.Framework.ChromiumTracing;
 
 /// <summary>Base class for asynchronous events that track operations across multiple threads.</summary>
-public abstract class ChromiumTracingAsyncEvent : ChromiumTracingEvent
+public closed class ChromiumTracingAsyncEvent : ChromiumTracingEvent
 {
     /// <summary>Gets or sets the unique identifier for the asynchronous operation.</summary>
     [JsonPropertyName("id")]

--- a/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingContextEvent.cs
+++ b/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingContextEvent.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.Framework.ChromiumTracing;
 
 /// <summary>Base class for context events that track nested scopes.</summary>
-public abstract class ChromiumTracingContextEvent : ChromiumTracingEvent
+public closed class ChromiumTracingContextEvent : ChromiumTracingEvent
 {
 }

--- a/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingDurationEvent.cs
+++ b/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingDurationEvent.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.Framework.ChromiumTracing;
 
 /// <summary>Base class for duration events that track the beginning and end of operations as separate events.</summary>
-public abstract class ChromiumTracingDurationEvent : ChromiumTracingEvent
+public closed class ChromiumTracingDurationEvent : ChromiumTracingEvent
 {
 }

--- a/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingEvent.cs
+++ b/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingEvent.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 namespace Meziantou.Framework.ChromiumTracing;
 
 /// <summary>Base class for all Chromium trace events.</summary>
-public abstract class ChromiumTracingEvent
+public closed class ChromiumTracingEvent
 {
     /// <summary>Gets the event type identifier (phase) used in the trace format.</summary>
     // Note: overriden members should also set the attribute (https://github.com/dotnet/runtime/issues/50078)

--- a/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingFlowEvent.cs
+++ b/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingFlowEvent.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.Framework.ChromiumTracing;
 
 /// <summary>Base class for flow events that visualize the flow of control or data between events.</summary>
-public abstract class ChromiumTracingFlowEvent : ChromiumTracingEvent
+public closed class ChromiumTracingFlowEvent : ChromiumTracingEvent
 {
 }

--- a/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingMemoryDumpEvent.cs
+++ b/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingMemoryDumpEvent.cs
@@ -1,6 +1,6 @@
 namespace Meziantou.Framework.ChromiumTracing;
 
 /// <summary>Base class for memory dump events.</summary>
-public abstract class ChromiumTracingMemoryDumpEvent : ChromiumTracingEvent
+public closed class ChromiumTracingMemoryDumpEvent : ChromiumTracingEvent
 {
 }

--- a/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingObjectEvent.cs
+++ b/src/Meziantou.Framework.ChromiumTracing/Events/ChromiumTracingObjectEvent.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 namespace Meziantou.Framework.ChromiumTracing;
 
 /// <summary>Base class for object lifecycle events.</summary>
-public abstract class ChromiumTracingObjectEvent : ChromiumTracingEvent
+public closed class ChromiumTracingObjectEvent : ChromiumTracingEvent
 {
     /// <summary>Gets or sets the unique identifier for the object.</summary>
     [JsonPropertyName("id")]


### PR DESCRIPTION
Makes `ChromiumTracingEvent` a C# 15 `closed` class so the trace-event hierarchy can no longer be extended from outside `Meziantou.Framework.ChromiumTracing`.

## What changed

- `ChromiumTracingEvent` is now `public closed class` instead of `public abstract class`. The `abstract` keyword had to be dropped: a closed type is always implicitly abstract, and combining the two is CS9384.
- The six intermediate abstract classes are closed as well: `ChromiumTracingAsyncEvent`, `ChromiumTracingContextEvent`, `ChromiumTracingDurationEvent`, `ChromiumTracingFlowEvent`, `ChromiumTracingMemoryDumpEvent`, `ChromiumTracingObjectEvent`.
- `ref/Meziantou.Framework.ChromiumTracing.cs` regenerated by the build.

The 30 concrete leaf event classes were already `sealed`, so they needed no change.

## Why the intermediates too

The compiler enforces `closed` only against the **direct** base type. With just the root closed, an external assembly still compiled this without any error:

```csharp
public sealed class ViaIntermediate : ChromiumTracingAsyncEvent { public override string Type => "y"; }
```

So closing only `ChromiumTracingEvent` would have left six public bypasses and provided no real guarantee. With all seven closed, both direct and via-intermediate external derivation fail with CS9382. I verified this by building a throwaway project that references the built assembly, before and after.

## Reviewer notes

- **This is a breaking change** for consumers outside the assembly that derived their own event types. `Type` is `public abstract`, so external derivation was genuinely possible before this change. May warrant a release-note mention.
- If you'd rather keep the change to `ChromiumTracingEvent` alone and accept the bypasses, the six intermediate commits are trivial to revert — but the `closed` modifier wouldn't buy much in that case.

## Verification

- `dotnet build` clean with `/p:TreatWarningsAsErrors=true`
- Tests pass: 6/6 across net10.0 and net11.0
- `dotnet run ./eng/update-all.cs` produced no further changes