### PR TITLE
Support ISupportExternalScope in the xUnit.net v3 logger provider

### DIFF
--- a/ref/Meziantou.Extensions.Logging.Xunit.v3.cs
+++ b/ref/Meziantou.Extensions.Logging.Xunit.v3.cs
@@ -15,6 +15,7 @@ namespace Meziantou.Extensions.Logging.Xunit.v3
         public XUnitLogger(Xunit.ITestOutputHelper? testOutputHelper, Microsoft.Extensions.Logging.LoggerExternalScopeProvider scopeProvider, string? categoryName) { }
         public XUnitLogger(Xunit.ITestOutputHelper? testOutputHelper, Microsoft.Extensions.Logging.LoggerExternalScopeProvider scopeProvider, string? categoryName, bool appendScope) { }
         public XUnitLogger(Xunit.ITestOutputHelper? testOutputHelper, Microsoft.Extensions.Logging.LoggerExternalScopeProvider scopeProvider, string? categoryName, Meziantou.Extensions.Logging.Xunit.v3.XUnitLoggerOptions? options) { }
+        public XUnitLogger(Xunit.ITestOutputHelper? testOutputHelper, Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider, string? categoryName, Meziantou.Extensions.Logging.Xunit.v3.XUnitLoggerOptions? options) { }
         public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => throw null;
         public System.IDisposable? BeginScope<TState>(TState state) => throw null;
         public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId, TState state, System.Exception? exception, System.Func<TState, System.Exception?, string> formatter) { }
@@ -38,13 +39,14 @@ namespace Meziantou.Extensions.Logging.Xunit.v3
         public bool UseUtcTimestamp { get => throw null; set { } }
     }
 
-    public sealed class XUnitLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, System.IDisposable
+    public sealed class XUnitLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, Microsoft.Extensions.Logging.ISupportExternalScope, System.IDisposable
     {
         public XUnitLoggerProvider(Xunit.ITestOutputHelper? testOutputHelper) { }
         public XUnitLoggerProvider(Xunit.ITestOutputHelper? testOutputHelper, bool appendScope) { }
         public XUnitLoggerProvider(Meziantou.Extensions.Logging.Xunit.v3.XUnitLoggerOptions? options) { }
         public XUnitLoggerProvider(Xunit.ITestOutputHelper? testOutputHelper, Meziantou.Extensions.Logging.Xunit.v3.XUnitLoggerOptions? options) { }
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName) => throw null;
+        public void SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
         public void Dispose() { }
     }
 }

--- a/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLogger.cs
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLogger.cs
@@ -24,7 +24,13 @@ public class XUnitLogger : ILogger
     private readonly ITestOutputHelper? _testOutputHelper;
     private readonly string? _categoryName;
     private readonly XUnitLoggerOptions _options;
-    private readonly LoggerExternalScopeProvider _scopeProvider;
+    private IExternalScopeProvider _scopeProvider;
+
+    internal IExternalScopeProvider ScopeProvider
+    {
+        get => Volatile.Read(ref _scopeProvider);
+        set => Volatile.Write(ref _scopeProvider, value);
+    }
 
     /// <summary>Creates a new logger instance without a test output helper.</summary>
     /// <returns>A new <see cref="ILogger"/> instance.</returns>
@@ -84,6 +90,16 @@ public class XUnitLogger : ILogger
     /// <param name="categoryName">The category name for messages produced by the logger.</param>
     /// <param name="options">The logger options.</param>
     public XUnitLogger(ITestOutputHelper? testOutputHelper, LoggerExternalScopeProvider scopeProvider, string? categoryName, XUnitLoggerOptions? options)
+        : this(testOutputHelper, (IExternalScopeProvider)scopeProvider, categoryName, options)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="XUnitLogger"/> class.</summary>
+    /// <param name="testOutputHelper">The xUnit.net test output helper.</param>
+    /// <param name="scopeProvider">The scope provider.</param>
+    /// <param name="categoryName">The category name for messages produced by the logger.</param>
+    /// <param name="options">The logger options.</param>
+    public XUnitLogger(ITestOutputHelper? testOutputHelper, IExternalScopeProvider scopeProvider, string? categoryName, XUnitLoggerOptions? options)
     {
         _testOutputHelper = testOutputHelper;
         _scopeProvider = scopeProvider;
@@ -95,7 +111,7 @@ public class XUnitLogger : ILogger
     public bool IsEnabled(LogLevel logLevel) => logLevel is not LogLevel.None;
 
     /// <inheritdoc/>
-    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => _scopeProvider.Push(state);
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => ScopeProvider.Push(state);
 
     /// <inheritdoc/>
     [SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs")]
@@ -135,7 +151,7 @@ public class XUnitLogger : ILogger
         // Append scopes
         if (_options.IncludeScopes)
         {
-            _scopeProvider.ForEachScope((scope, state) =>
+            ScopeProvider.ForEachScope((scope, state) =>
             {
                 state.Append("\n => ");
                 state.Append(scope);

--- a/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLoggerProvider.cs
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLoggerProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -20,11 +21,15 @@ namespace Meziantou.Extensions.Logging.Xunit.v3;
 ///     .Build();
 /// </code>
 /// </example>
-public sealed class XUnitLoggerProvider : ILoggerProvider
+public sealed class XUnitLoggerProvider : ILoggerProvider, ISupportExternalScope
 {
     private readonly ITestOutputHelper? _testOutputHelper;
     private readonly XUnitLoggerOptions _options;
-    private readonly LoggerExternalScopeProvider _scopeProvider = new();
+    private readonly ConcurrentDictionary<string, XUnitLogger> _loggers = new(StringComparer.Ordinal);
+
+    private IExternalScopeProvider _scopeProvider = new LoggerExternalScopeProvider();
+
+    private IExternalScopeProvider ScopeProvider => Volatile.Read(ref _scopeProvider);
 
     /// <summary>Initializes a new instance of the <see cref="XUnitLoggerProvider"/> class.</summary>
     public XUnitLoggerProvider()
@@ -66,7 +71,18 @@ public sealed class XUnitLoggerProvider : ILoggerProvider
     /// <inheritdoc/>
     public ILogger CreateLogger(string categoryName)
     {
-        return new XUnitLogger(_testOutputHelper, _scopeProvider, categoryName, _options);
+        return _loggers.GetOrAdd(categoryName, static (name, state) => new XUnitLogger(state._testOutputHelper, state.ScopeProvider, name, state._options), this);
+    }
+
+    /// <inheritdoc/>
+    public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+    {
+        Volatile.Write(ref _scopeProvider, scopeProvider);
+
+        foreach (var logger in _loggers)
+        {
+            logger.Value.ScopeProvider = scopeProvider;
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLogger`1.cs
+++ b/src/Meziantou.Extensions.Logging.Xunit.v3/XUnitLogger`1.cs
@@ -7,12 +7,12 @@ namespace Meziantou.Extensions.Logging.Xunit.v3;
 
 internal sealed class XUnitLogger<T> : XUnitLogger, ILogger<T>
 {
-    public XUnitLogger(ITestOutputHelper? testOutputHelper, LoggerExternalScopeProvider scopeProvider)
+    public XUnitLogger(ITestOutputHelper? testOutputHelper, IExternalScopeProvider scopeProvider)
         : this(testOutputHelper, scopeProvider, options: null)
     {
     }
 
-    public XUnitLogger(ITestOutputHelper? testOutputHelper, LoggerExternalScopeProvider scopeProvider, XUnitLoggerOptions? options)
+    public XUnitLogger(ITestOutputHelper? testOutputHelper, IExternalScopeProvider scopeProvider, XUnitLoggerOptions? options)
         : base(testOutputHelper, scopeProvider, GetCategoryName(), options)
     {
     }

--- a/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/XunitLoggerTests.cs
+++ b/tests/Meziantou.Extensions.Logging.Xunit.v3.Tests/XunitLoggerTests.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CA1848 // Use the LoggerMessage delegates
 #pragma warning disable IDE1006 // Naming Styles
+using System.Diagnostics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
@@ -44,5 +45,47 @@ public sealed class XunitLoggerTests
         logger.LogInformation("Test {Sample}", "value");
 
         // Nothing to assert, it will throw an exception if something goes wrong
+    }
+
+    [Fact]
+    public void SetScopeProviderUpdatesExistingAndNewLoggers()
+    {
+        var output = new InMemoryTestOutputHelper();
+        using var provider = new XUnitLoggerProvider(output, new XUnitLoggerOptions { IncludeScopes = true });
+        var loggerCreatedBeforeSet = provider.CreateLogger("before");
+
+        var scopeProvider = new LoggerExternalScopeProvider();
+        ((ISupportExternalScope)provider).SetScopeProvider(scopeProvider);
+
+        var loggerCreatedAfterSet = provider.CreateLogger("after");
+
+        using (scopeProvider.Push("external scope"))
+        {
+            loggerCreatedBeforeSet.LogInformation("Test");
+            loggerCreatedAfterSet.LogInformation("Test");
+        }
+
+        Assert.Equal(2, output.Logs.Count());
+        Assert.All(output.Logs, log => Assert.Contains("=> external scope", log, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void LoggerFactorySetsTheScopeProvider()
+    {
+        var output = new InMemoryTestOutputHelper();
+        using var provider = new XUnitLoggerProvider(output, new XUnitLoggerOptions { IncludeScopes = true });
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.Configure(options => options.ActivityTrackingOptions = ActivityTrackingOptions.TraceId);
+            builder.AddProvider(provider);
+        });
+
+        using var activity = new Activity("Test");
+        activity.Start();
+
+        var logger = loggerFactory.CreateLogger("category");
+        logger.LogInformation("Test");
+
+        Assert.Contains(activity.TraceId.ToHexString(), output.Output, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## What

`XUnitLoggerProvider` now implements `ISupportExternalScope`, so `LoggerFactory` can hand it the scope provider it shares across all providers.

## Why

Without it, the provider only ever saw scopes pushed through its own `LoggerExternalScopeProvider`. Two things were missing as a result:

- Scopes opened on loggers belonging to *other* providers never reached the xUnit.net output.
- `LoggerFactoryOptions.ActivityTrackingOptions` (TraceId / SpanId / ParentId) produced nothing, since those scopes are synthesized by the factory's scope provider.

Both now work, and this matches how `ConsoleLoggerProvider` and this repo's own `FileLoggerProvider` behave.

## How

- `XUnitLoggerProvider` implements `ISupportExternalScope`. It caches loggers per category in a `ConcurrentDictionary`, so `SetScopeProvider` can update loggers that were already created, not just future ones — the same pattern as `ConsoleLoggerProvider`.
- `XUnitLogger` stores an `IExternalScopeProvider` instead of the concrete `LoggerExternalScopeProvider`, exposed internally through a `Volatile` read/write property.
- The default stays a `LoggerExternalScopeProvider`, so behavior is unchanged when nothing calls `SetScopeProvider`.

## Notes for reviewers

- **Public API:** one constructor overload added, `XUnitLogger(ITestOutputHelper?, IExternalScopeProvider, string?, XUnitLoggerOptions?)`. The three existing `LoggerExternalScopeProvider` constructors are kept for binary compatibility and delegate to it. This is not source-breaking: for a `null` literal argument, overload resolution still prefers the more derived `LoggerExternalScopeProvider` overload. `ref/Meziantou.Extensions.Logging.Xunit.v3.cs` is regenerated accordingly.
- **Behavior change:** `CreateLogger` returns a cached instance per category rather than a fresh one each call. `LoggerFactory` already calls it once per category, and caching is required for `SetScopeProvider` to reach existing loggers.
- `SetScopeProvider` does not null-check its argument, since the interface declares the parameter non-nullable (per `AGENTS.md`).
- `<Version>` is deliberately left alone; version bumps land in separate bot PRs.

## Tests

Two tests added to the existing `XunitLoggerTests`:

- `SetScopeProviderUpdatesExistingAndNewLoggers` — loggers created both before and after the `SetScopeProvider` call read from the new provider.
- `LoggerFactorySetsTheScopeProvider` — with `ActivityTrackingOptions.TraceId`, the active activity's trace ID reaches the output. This can only pass via the external scope provider, since `XUnitLogger` never produces a trace ID itself.

Build is clean with `/p:TreatsWarningsAsErrors=true` and all 8 tests pass (4 tests × net10.0/net11.0). `dotnet run ./eng/update-all.cs` reported no further changes.