### PR TITLE
Write the {{# }} expression value without treating it as format arguments

### DIFF
--- a/src/Meziantou.Framework.Templating.Html/HtmlEmailCodeBlock.cs
+++ b/src/Meziantou.Framework.Templating.Html/HtmlEmailCodeBlock.cs
@@ -70,7 +70,7 @@ public class HtmlEmailCodeBlock : CodeBlock
 
         if (text.StartsWith('#', StringComparison.Ordinal))
         {
-            return Template.OutputParameterName + ".Write(\"{0}\", " + text[1..].TrimStart() + ");";
+            return Template.OutputParameterName + ".Write(" + text[1..].TrimStart() + ");";
         }
 
         return base.BuildCode();

--- a/tests/Meziantou.Framework.Templating.Html.Tests/EmailTemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Html.Tests/EmailTemplateTest.cs
@@ -118,4 +118,30 @@ public class EmailTemplateTest
         Assert.Equal("42", metadata.Title);
     }
 
+    [Fact]
+    public void EmailTemplate_ExpressionBlock_WritesArrayValueWithoutTreatingItAsFormatArguments()
+    {
+        var template = new HtmlEmailTemplate();
+        template.Load("{{# new object[] { 1, 2 } }}");
+
+        Assert.Equal(new object[] { 1, 2 }.ToString(), template.Run(out _));
+    }
+
+    [Fact]
+    public void EmailTemplate_ExpressionBlock_WritesEmptyArrayValueWithoutThrowing()
+    {
+        var template = new HtmlEmailTemplate();
+        template.Load("{{# System.Array.Empty<object>() }}");
+
+        Assert.Equal(System.Array.Empty<object>().ToString(), template.Run(out _));
+    }
+
+    [Fact]
+    public void EmailTemplate_HtmlEncode_EncodesArrayValueWithoutTreatingItAsFormatArguments()
+    {
+        var template = new HtmlEmailTemplate();
+        template.Load("{{#html new object[] { 1, 2 } }}");
+
+        Assert.Equal(new object[] { 1, 2 }.ToString(), template.Run(out _));
+    }
 }


### PR DESCRIPTION
## Finding

`HtmlEmailCodeBlock.BuildCode()` emitted a two-argument call for the generic `#` prefix:

```csharp
// src/Meziantou.Framework.Templating.Html/HtmlEmailCodeBlock.cs:73
return Template.OutputParameterName + ".Write(\"{0}\", " + text[1..].TrimStart() + ");";
```

Because `__output__` is `dynamic`, the runtime binder resolves that against
`Output.Write(string format, params object?[] args)` in **normal** form whenever the expression's
runtime type is `object[]` — the value becomes the argument array instead of a single argument.

```
{{# new object[] { 1, 2 } }}          → "1"                (expected "System.Object[]")
{{# System.Array.Empty<object>() }}   → FormatException     (wrapped in TargetInvocationException)
```

The core library fixed exactly this in 039f8688a *"Write template output without going through
string.Format"* and has a regression test for it
(`Template_ExpressionBlock_WritesArrayValueWithoutTreatingItAsFormatArguments`).
`Meziantou.Framework.Templating.Html` was never updated.

Scope note: only the plain `{{# }}` path is affected. `{{#html }}`, `{{#attr }}` and `{{#url }}`
call the single-value `WriteXxxEncode` overloads, which bind at compile time in expanded form and
were always correct — the third test added here pins that down.

## Change

One line: emit a single-argument `Write(<expr>)`, matching what `CodeBlock.BuildCode()` already
does for expression blocks in the core package.

## Verification

Three tests added to `EmailTemplateTest`, mirroring the core's regression test. All three fail on
`main` (two with the wrong value / a `FormatException`, and the `#html` one passing as the control)
and pass with the fix.

`Meziantou.Framework.Templating.Html.Tests` 24/24, `Meziantou.Framework.Templating.Tests` 114/114,
`Meziantou.Framework.Templating.Tool.Tests` 22/22, all on net10.0 + net11.0. Built with
`/p:TreatWarningsAsErrors=true`; `dotnet run ./eng/update-all.cs` reports no changes.

## Adjacent, not fixed here

The `WriteHtmlEncode` / `WriteHtmlAttributeEncode` / `WriteUrlEncode` format overloads use
`string.Format(provider: null, …)`, so they format with the **current culture** — a template's
numbers and dates change with the server locale. Separate concern, tracked separately.
