### PR TITLE
Stop the templating CLI from silently resolving mismatched code block delimiters

### DIFF
--- a/src/Meziantou.Framework.Templating.Tool/Program.cs
+++ b/src/Meziantou.Framework.Templating.Tool/Program.cs
@@ -99,16 +99,21 @@ internal static partial class Program
         }
 
         var templateContent = await File.ReadAllTextAsync(inputPath, cancellationToken).ConfigureAwait(false);
-        var (resolvedStartCodeBlockDelimiter, resolvedEndCodeBlockDelimiter) = ResolveCodeBlockDelimiters(templateContent, startCodeBlockDelimiter, endCodeBlockDelimiter);
-        if (string.IsNullOrEmpty(resolvedStartCodeBlockDelimiter))
+        if (startCodeBlockDelimiter is { Length: 0 })
         {
             await error.WriteLineAsync("The start code block delimiter cannot be empty".AsMemory(), cancellationToken);
             return 1;
         }
 
-        if (string.IsNullOrEmpty(resolvedEndCodeBlockDelimiter))
+        if (endCodeBlockDelimiter is { Length: 0 })
         {
             await error.WriteLineAsync("The end code block delimiter cannot be empty".AsMemory(), cancellationToken);
+            return 1;
+        }
+
+        if (!TryResolveCodeBlockDelimiters(templateContent, startCodeBlockDelimiter, endCodeBlockDelimiter, out var resolvedStartCodeBlockDelimiter, out var resolvedEndCodeBlockDelimiter))
+        {
+            await error.WriteLineAsync("The start and end code block delimiters must be specified together, unless the one you specify belongs to a well-known pair (<% %> or <# #>)".AsMemory(), cancellationToken);
             return 1;
         }
 
@@ -229,40 +234,60 @@ internal static partial class Program
         return inputPath.WithExtension(directiveOutputExtension);
     }
 
-    private static (string StartCodeBlockDelimiter, string EndCodeBlockDelimiter) ResolveCodeBlockDelimiters(string templateContent, string? startCodeBlockDelimiter, string? endCodeBlockDelimiter)
+    private static bool TryResolveCodeBlockDelimiters(
+        string templateContent,
+        string? startCodeBlockDelimiter,
+        string? endCodeBlockDelimiter,
+        [NotNullWhen(true)] out string? resolvedStartCodeBlockDelimiter,
+        [NotNullWhen(true)] out string? resolvedEndCodeBlockDelimiter)
     {
         if (startCodeBlockDelimiter is null && endCodeBlockDelimiter is null)
         {
-            if (templateContent.Contains(T4StartCodeBlockDelimiter, StringComparison.Ordinal))
-            {
-                return (T4StartCodeBlockDelimiter, T4EndCodeBlockDelimiter);
-            }
-
-            return (DefaultStartCodeBlockDelimiter, DefaultEndCodeBlockDelimiter);
+            (resolvedStartCodeBlockDelimiter, resolvedEndCodeBlockDelimiter) = ContainsT4CodeBlock(templateContent)
+                ? (T4StartCodeBlockDelimiter, T4EndCodeBlockDelimiter)
+                : (DefaultStartCodeBlockDelimiter, DefaultEndCodeBlockDelimiter);
+            return true;
         }
 
-        return (
-            startCodeBlockDelimiter ?? GetDefaultStartCodeBlockDelimiter(endCodeBlockDelimiter),
-            endCodeBlockDelimiter ?? GetDefaultEndCodeBlockDelimiter(startCodeBlockDelimiter));
+        resolvedStartCodeBlockDelimiter = startCodeBlockDelimiter ?? GetPairedStartCodeBlockDelimiter(endCodeBlockDelimiter);
+        resolvedEndCodeBlockDelimiter = endCodeBlockDelimiter ?? GetPairedEndCodeBlockDelimiter(startCodeBlockDelimiter);
+        return resolvedStartCodeBlockDelimiter is not null && resolvedEndCodeBlockDelimiter is not null;
     }
 
-    private static string GetDefaultStartCodeBlockDelimiter(string? endCodeBlockDelimiter)
+    /// <summary>
+    /// Determines whether the template uses T4 delimiters: it must contain at least one complete
+    /// <c>&lt;# … #&gt;</c> block and no <c>&lt;%</c> at all, so that a stray <c>&lt;#</c> in the
+    /// template text cannot silently switch the delimiters.
+    /// </summary>
+    private static bool ContainsT4CodeBlock(string templateContent)
+    {
+        if (templateContent.Contains(DefaultStartCodeBlockDelimiter, StringComparison.Ordinal))
+            return false;
+
+        var startIndex = templateContent.IndexOf(T4StartCodeBlockDelimiter, StringComparison.Ordinal);
+        if (startIndex < 0)
+            return false;
+
+        return templateContent.IndexOf(T4EndCodeBlockDelimiter, startIndex + T4StartCodeBlockDelimiter.Length, StringComparison.Ordinal) >= 0;
+    }
+
+    private static string? GetPairedStartCodeBlockDelimiter(string? endCodeBlockDelimiter)
     {
         return endCodeBlockDelimiter switch
         {
             T4EndCodeBlockDelimiter => T4StartCodeBlockDelimiter,
             DefaultEndCodeBlockDelimiter => DefaultStartCodeBlockDelimiter,
-            _ => DefaultStartCodeBlockDelimiter,
+            _ => null,
         };
     }
 
-    private static string GetDefaultEndCodeBlockDelimiter(string? startCodeBlockDelimiter)
+    private static string? GetPairedEndCodeBlockDelimiter(string? startCodeBlockDelimiter)
     {
         return startCodeBlockDelimiter switch
         {
             T4StartCodeBlockDelimiter => T4EndCodeBlockDelimiter,
             DefaultStartCodeBlockDelimiter => DefaultEndCodeBlockDelimiter,
-            _ => DefaultEndCodeBlockDelimiter,
+            _ => null,
         };
     }
 

--- a/tests/Meziantou.Framework.Templating.Tool.Tests/TemplatingToolTests.cs
+++ b/tests/Meziantou.Framework.Templating.Tool.Tests/TemplatingToolTests.cs
@@ -219,4 +219,102 @@ public sealed class TemplatingToolTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(1, result);
         Assert.Contains("template.txt(2,4)", console.Error);
     }
+
+    [Fact]
+    public async Task OnlyStartDelimiterSpecified_WithUnknownValue_ReturnsError()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var inputPath = await temp.CreateTextFileAsync("template.txt", "Hello {{= \"World\" }}!", XunitCancellationToken);
+
+        var console = new ConsoleHelper(testOutputHelper);
+        var result = await Program.MainImpl(
+            [
+                "--input", inputPath.ToString(),
+                "--start-code-block-delimiter", "{{",
+            ],
+            console.ConfigureConsole);
+
+        Assert.Equal(1, result);
+        Assert.Contains("must be specified together", console.Error, ignoreCase: false);
+        Assert.Equal(string.Empty, console.Output);
+    }
+
+    [Fact]
+    public async Task OnlyStartDelimiterSpecified_WithWellKnownValue_InfersTheEndDelimiter()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var inputPath = await temp.CreateTextFileAsync("template.txt", "Hello <#= \"World\" #>!", XunitCancellationToken);
+
+        var console = new ConsoleHelper(testOutputHelper);
+        var result = await Program.MainImpl(
+            [
+                "--input", inputPath.ToString(),
+                "--start-code-block-delimiter", "<#",
+            ],
+            console.ConfigureConsole);
+
+        Assert.Equal(0, result);
+        Assert.Equal("Hello World!", console.Output);
+        Assert.Equal(string.Empty, console.Error);
+    }
+
+    [Fact]
+    public async Task OnlyEndDelimiterSpecified_WithWellKnownValue_InfersTheStartDelimiter()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var inputPath = await temp.CreateTextFileAsync("template.txt", "Hello <#= \"World\" #>!", XunitCancellationToken);
+
+        var console = new ConsoleHelper(testOutputHelper);
+        var result = await Program.MainImpl(
+            [
+                "--input", inputPath.ToString(),
+                "--end-code-block-delimiter", "#>",
+            ],
+            console.ConfigureConsole);
+
+        Assert.Equal(0, result);
+        Assert.Equal("Hello World!", console.Output);
+        Assert.Equal(string.Empty, console.Error);
+    }
+
+    [Fact]
+    public async Task T4Delimiters_AreAutoDetected()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var inputPath = await temp.CreateTextFileAsync("template.txt", "Hello <#= \"World\" #>!", XunitCancellationToken);
+
+        var console = new ConsoleHelper(testOutputHelper);
+        var result = await Program.MainImpl(["--input", inputPath.ToString()], console.ConfigureConsole);
+
+        Assert.Equal(0, result);
+        Assert.Equal("Hello World!", console.Output);
+    }
+
+    // A '<#' that is not part of a complete block, in a template that uses the default delimiters,
+    // must not switch the tool to T4 delimiters.
+    [Fact]
+    public async Task T4Delimiters_AreNotAutoDetectedFromAnIncompleteMarkerInText()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var inputPath = await temp.CreateTextFileAsync("template.txt", "C# generics: List<#> and <%= 1 + 1 %>", XunitCancellationToken);
+
+        var console = new ConsoleHelper(testOutputHelper);
+        var result = await Program.MainImpl(["--input", inputPath.ToString()], console.ConfigureConsole);
+
+        Assert.Equal(0, result);
+        Assert.Equal("C# generics: List<#> and 2", console.Output);
+    }
+
+    [Fact]
+    public async Task T4Delimiters_AreNotAutoDetectedWhenTheDefaultDelimiterIsAlsoPresent()
+    {
+        await using var temp = TemporaryDirectory.Create();
+        var inputPath = await temp.CreateTextFileAsync("template.txt", "<# is a T4 block #> and <%= 1 + 1 %>", XunitCancellationToken);
+
+        var console = new ConsoleHelper(testOutputHelper);
+        var result = await Program.MainImpl(["--input", inputPath.ToString()], console.ConfigureConsole);
+
+        Assert.Equal(0, result);
+        Assert.Equal("<# is a T4 block #> and 2", console.Output);
+    }
 }


### PR DESCRIPTION
## Findings

Two defects in the CLI's delimiter resolution, both of which make the tool write a corrupted file
and **exit 0**. That matters more than usual here: this is a code-generation tool, so the damage is
noticed downstream when the generated file fails to compile — or worse, compiles into something wrong.

### 1. T4 auto-detection fires on any `<#` in the file

`Program.cs:236` tested `templateContent.Contains("<#")` against the whole file, with no regard for
whether the occurrence was a real block start:

```
input:  C# generics: List<#> and <%= 1 + 1 %>
output: C# generics: List> and <%= 1 + 1 %>       (exit 0)
```

The tool switched to `<# … #>`, executed `List<#>`'s interior as an empty code block, and passed the
real `<%= 1 + 1 %>` through as literal text. Any `<%`-style template that merely *mentions* `<#` —
in prose, a code sample, or a C# generic — was affected, with no flags involved.

### 2. One delimiter specified without the other pairs with the wrong partner

`GetDefaultEndCodeBlockDelimiter` fell through its `switch` to `%>` for *any* unrecognised value,
so `--start-code-block-delimiter "{{"` produced the pair `{{ … %>`:

```
input:  Hello {{= "World" }}!
output: Hello = "World" }}!                        (exit 0)
```

The `{{` is consumed as a block start, no `%>` is ever found, and the unterminated-block fallback
drops the delimiter and emits the code as literal text.

## Change

- **Auto-detection now requires evidence.** `ContainsT4CodeBlock` demands at least one *complete*
  `<# … #>` block **and** no `<%` anywhere in the file. A stray or incomplete marker no longer
  flips the delimiters.
- **`_ =>` arms return `null` instead of the default delimiter.** `ResolveCodeBlockDelimiters`
  becomes `TryResolveCodeBlockDelimiters`; when only one delimiter is given and it isn't half of a
  well-known pair, the tool now reports an error and returns 1 rather than guessing.

Inferring the partner for the two *known* pairs is deliberate and preserved — `--start-code-block-delimiter "<#"`
still gives you `#>`. The empty-delimiter checks moved ahead of resolution so they keep reporting
"cannot be empty" rather than the new pairing error.

## Verification

Six tests added. Three fail on `main` — one per defect above, plus the `<#`-and-`<%`-together case —
and three are guards confirming the intentional behaviour still works (inference from either half of
a known pair, and genuine T4 auto-detection).

`Meziantou.Framework.Templating.Tool.Tests` 34/34, `Meziantou.Framework.Templating.Tests` 114/114,
`Meziantou.Framework.Templating.Html.Tests` 18/18, on net10.0 + net11.0. Built with
`/p:TreatWarningsAsErrors=true`; `dotnet run ./eng/update-all.cs` reports no changes (the `--help`
output is unchanged — no options were added or renamed).

## Considered and left out

Echoing the chosen delimiter pair to stderr would make the decision visible, but it would break the
several existing tests that assert stderr is empty, and it belongs in its own change.
