### PR TITLE
Roll back applied directives when a template build fails

### DIFF
--- a/src/Meziantou.Framework.Templating/Template.cs
+++ b/src/Meziantou.Framework.Templating/Template.cs
@@ -445,88 +445,105 @@ public class Template
             if (IsBuilt)
                 return;
 
-            ApplyDirectives();
-
-            using var sw = new StringWriter();
-            using (var tw = new IndentedTextWriter(sw))
+            // A failed build must not leave the directives applied. Build can be retried directly, or
+            // after loading corrected content, and applying them twice adds duplicate usings,
+            // interfaces and references, which reports errors that hide the real diagnostic.
+            var directiveState = CaptureDirectiveState();
+            try
             {
-                foreach (var @using in Usings)
-                {
-                    tw.WriteLine("using " + @using + ";");
-                }
+                BuildCore(cancellationToken);
+            }
+            catch
+            {
+                RestoreDirectiveState(directiveState);
+                throw;
+            }
+        }
+    }
 
-                var inheritanceTypes = new List<string>();
-                if (!string.IsNullOrEmpty(BaseClassFullTypeName))
-                {
-                    inheritanceTypes.Add(BaseClassFullTypeName);
-                }
+    private void BuildCore(CancellationToken cancellationToken)
+    {
+        ApplyDirectives();
 
-                foreach (var @interface in ImplementedInterfaces)
-                {
-                    inheritanceTypes.Add(@interface);
-                }
-
-                tw.Write("public class " + ClassName);
-                if (inheritanceTypes.Count > 0)
-                {
-                    tw.Write(" : " + string.Join(", ", inheritanceTypes));
-                }
-
-                tw.WriteLine();
-                tw.WriteLine("{");
-                tw.Indent++;
-
-                tw.Write("public static void " + RunMethodName);
-                tw.Write("(");
-                tw.Write(OutputType?.FullName ?? "dynamic");
-                tw.Write(" " + OutputParameterName);
-
-                foreach (var argument in Arguments)
-                {
-                    if (argument is null)
-                        continue;
-
-                    tw.Write(", ");
-                    tw.Write(argument.Type?.FullName ?? "dynamic");
-                    tw.Write(" ");
-                    tw.Write(argument.Name);
-                }
-
-                tw.Write(")");
-                tw.WriteLine();
-                tw.WriteLine("{");
-                tw.Indent++;
-
-                foreach (var block in Blocks)
-                {
-                    if (block is ClassMemberBlock)
-                        continue;
-
-                    WriteBlock(tw, block);
-                }
-
-                tw.Indent--;
-                tw.WriteLine("}");
-
-                foreach (var block in Blocks)
-                {
-                    if (block is not ClassMemberBlock)
-                        continue;
-
-                    WriteBlock(tw, block);
-                }
-
-                tw.Indent--;
-                tw.WriteLine("}");
+        using var sw = new StringWriter();
+        using (var tw = new IndentedTextWriter(sw))
+        {
+            foreach (var @using in Usings)
+            {
+                tw.WriteLine("using " + @using + ";");
             }
 
-            var source = sw.ToString();
-            SourceCode = source;
-            Compile(source, cancellationToken);
-            if (IsBuilt)
+            var inheritanceTypes = new List<string>();
+            if (!string.IsNullOrEmpty(BaseClassFullTypeName))
             {
-                FreezeCollections();
+                inheritanceTypes.Add(BaseClassFullTypeName);
             }
+
+            foreach (var @interface in ImplementedInterfaces)
+            {
+                inheritanceTypes.Add(@interface);
+            }
+
+            tw.Write("public class " + ClassName);
+            if (inheritanceTypes.Count > 0)
+            {
+                tw.Write(" : " + string.Join(", ", inheritanceTypes));
+            }
+
+            tw.WriteLine();
+            tw.WriteLine("{");
+            tw.Indent++;
+
+            tw.Write("public static void " + RunMethodName);
+            tw.Write("(");
+            tw.Write(OutputType?.FullName ?? "dynamic");
+            tw.Write(" " + OutputParameterName);
+
+            foreach (var argument in Arguments)
+            {
+                if (argument is null)
+                    continue;
+
+                tw.Write(", ");
+                tw.Write(argument.Type?.FullName ?? "dynamic");
+                tw.Write(" ");
+                tw.Write(argument.Name);
+            }
+
+            tw.Write(")");
+            tw.WriteLine();
+            tw.WriteLine("{");
+            tw.Indent++;
+
+            foreach (var block in Blocks)
+            {
+                if (block is ClassMemberBlock)
+                    continue;
+
+                WriteBlock(tw, block);
+            }
+
+            tw.Indent--;
+            tw.WriteLine("}");
+
+            foreach (var block in Blocks)
+            {
+                if (block is not ClassMemberBlock)
+                    continue;
+
+                WriteBlock(tw, block);
+            }
+
+            tw.Indent--;
+            tw.WriteLine("}");
+        }
+
+        var source = sw.ToString();
+        SourceCode = source;
+        Compile(source, cancellationToken);
+        if (IsBuilt)
+        {
+            FreezeCollections();
         }
     }
 
@@ -564,6 +581,45 @@ public class Template
                 directive.ApplyDirective();
             }
         }
+    }
+
+    private DirectiveState CaptureDirectiveState()
+    {
+        return new DirectiveState
+        {
+            Usings = [.. Usings],
+            ImplementedInterfaces = [.. ImplementedInterfaces],
+            AssemblyReferences = [.. AssemblyReferences],
+            IncludedSourceFiles = [.. IncludedSourceFiles],
+            BaseClassFullTypeName = BaseClassFullTypeName,
+        };
+    }
+
+    private void RestoreDirectiveState(DirectiveState state)
+    {
+        Usings.Clear();
+        Usings.AddRange(state.Usings);
+
+        ImplementedInterfaces.Clear();
+        ImplementedInterfaces.AddRange(state.ImplementedInterfaces);
+
+        AssemblyReferences.Clear();
+        AssemblyReferences.AddRange(state.AssemblyReferences);
+
+        IncludedSourceFiles.Clear();
+        IncludedSourceFiles.AddRange(state.IncludedSourceFiles);
+
+        BaseClassFullTypeName = state.BaseClassFullTypeName;
+    }
+
+    /// <summary>Snapshot of everything <see cref="ApplyDirectives"/> mutates, so a failed build can be rolled back.</summary>
+    private sealed class DirectiveState
+    {
+        public required string[] Usings { get; init; }
+        public required string[] ImplementedInterfaces { get; init; }
+        public required AssemblyReference[] AssemblyReferences { get; init; }
+        public required FileReference[] IncludedSourceFiles { get; init; }
+        public required string? BaseClassFullTypeName { get; init; }
     }
 
     /// <summary>Creates a text block for text content.</summary>

--- a/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
+++ b/tests/Meziantou.Framework.Templating.Tests/TemplateTest.cs
@@ -793,4 +793,41 @@ public class TemplateTest
         Assert.Equal(new object[] { 1, 2 }.ToString(), template.Run());
     }
 
+    [Fact]
+    public void Template_FailedBuild_ProducesTheSameDiagnosticsWhenRetried()
+    {
+        var template = new Template();
+        template.Load("<%@ implements System.IDisposable %><%= Missing %>");
+
+        var first = Assert.Throws<TemplateException>(() => template.Build(CancellationToken.None));
+        var second = Assert.Throws<TemplateException>(() => template.Build(CancellationToken.None));
+
+        Assert.Equal(first.Message, second.Message);
+        Assert.DoesNotContain("CS0528", second.Message, ignoreCase: false);
+    }
+
+    [Fact]
+    public void Template_FailedBuild_RollsBackTheDirectivesItApplied()
+    {
+        var template = new Template();
+        template.Load("<%@ using System.Globalization %><%@ implements System.IDisposable %><%= Missing %>");
+
+        Assert.Throws<TemplateException>(() => template.Build(CancellationToken.None));
+
+        Assert.DoesNotContain("System.Globalization", template.Usings);
+        Assert.Empty(template.ImplementedInterfaces);
+    }
+
+    [Fact]
+    public void Template_LoadAfterFailedBuild_AppliesOnlyTheNewDirectives()
+    {
+        var template = new Template();
+        template.Load("<%@ implements System.IDisposable %><%= Missing %>");
+        Assert.Throws<TemplateException>(() => template.Build(CancellationToken.None));
+
+        template.Load("<%= \"ok\" %>");
+
+        Assert.Equal("ok", template.Run());
+        Assert.Empty(template.ImplementedInterfaces);
+    }
 }


### PR DESCRIPTION
## Finding

`Build` calls `ApplyDirectives()`, which mutates `Usings`, `ImplementedInterfaces`,
`AssemblyReferences`, `IncludedSourceFiles` and `BaseClassFullTypeName`. The collections are frozen
only when the compile **succeeds** (`Template.cs:525-528`), so a failed build leaves them mutated and
unfrozen. A second `Build()` then applies every directive a second time.

That second build is the normal editing loop — and `ThrowIfBuilt` only guards a *successful* build,
so `Load()`ing corrected content and rebuilding hits it too.

```csharp
var template = new Template();
template.Load("<%@ implements System.IDisposable %><%= Missing %>");

template.Build(CancellationToken.None);   // CS0103: The name 'Missing' does not exist
template.Build(CancellationToken.None);   // CS0528: 'IDisposable' is already listed in interface list
                                          //   ...reported *ahead of* the real error
```

The duplicate-interface error has nothing to do with what the author changed, and it is the first
thing they see.

## Change

Snapshot the directive-mutated state before applying, and restore it if the build throws. `Build`'s
body moves into a private `BuildCore` so the rollback wraps it without a large `try` block inline.

Rollback rather than a "already applied" flag on purpose: the flag would break the
`Load(corrected) → Build()` path, where the *new* content's directives do need applying.

## Verification

Three tests added, all three failing on `main`:

- retrying a failed build produces byte-identical diagnostics (and no `CS0528`),
- a failed build leaves `Usings` / `ImplementedInterfaces` as they were,
- `Load`ing corrected content after a failed build still works and doesn't carry the old directives.

`Meziantou.Framework.Templating.Tests` 120/120, `Meziantou.Framework.Templating.Html.Tests` 18/18,
`Meziantou.Framework.Templating.Tool.Tests` 22/22, on net10.0 + net11.0. Built with
`/p:TreatWarningsAsErrors=true`; `dotnet run ./eng/update-all.cs` reports no changes.
