### PR TITLE
Stop the pathname canonicalization from inserting a separator before every literal

### DIFF
--- a/src/Meziantou.Framework.Uri/UrlPattern/Internal/PatternParser.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/Internal/PatternParser.cs
@@ -9,7 +9,7 @@ namespace Meziantou.Framework.UrlPatternInternal;
 internal sealed class PatternParser
 {
     private readonly List<Token> _tokenList;
-    private readonly Func<string, string> _encodingCallback;
+    private readonly Func<string, string>? _encodingCallback;
     private readonly string _segmentWildcardRegexp;
     private readonly PatternOptions _options;
     private readonly List<Part> _partList;
@@ -25,7 +25,7 @@ internal sealed class PatternParser
     /// </remarks>
     private const string FullWildcardRegexpValue = ".*";
 
-    public PatternParser(List<Token> tokenList, Func<string, string> encodingCallback, PatternOptions options)
+    public PatternParser(List<Token> tokenList, Func<string, string>? encodingCallback, PatternOptions options)
     {
         _tokenList = tokenList;
         _encodingCallback = encodingCallback;
@@ -36,6 +36,9 @@ internal sealed class PatternParser
         _index = 0;
         _nextNumericName = 0;
     }
+
+    /// <summary>Runs the encoding callback, or returns the value unchanged when the component needs no encoding.</summary>
+    private string Encode(string value) => _encodingCallback is null ? value : _encodingCallback(value);
 
     /// <summary>Parses the token list into a part list.</summary>
     /// <remarks>
@@ -217,7 +220,7 @@ internal sealed class PatternParser
         if (_pendingFixedValue.Length == 0)
             return;
 
-        var encodedValue = _encodingCallback(_pendingFixedValue.ToString());
+        var encodedValue = Encode(_pendingFixedValue.ToString());
         _pendingFixedValue.Clear();
         var part = new Part(PartType.FixedText, encodedValue, PartModifier.None);
         _partList.Add(part);
@@ -240,7 +243,7 @@ internal sealed class PatternParser
 
             if (!string.IsNullOrEmpty(prefix))
             {
-                var encodedValue = _encodingCallback(prefix);
+                var encodedValue = Encode(prefix);
                 var part = new Part(PartType.FixedText, encodedValue, modifier);
                 _partList.Add(part);
             }
@@ -291,8 +294,8 @@ internal sealed class PatternParser
             throw new UrlPatternException($"Duplicate name '{name}'");
         }
 
-        var encodedPrefix = _encodingCallback(prefix);
-        var encodedSuffix = _encodingCallback(suffix);
+        var encodedPrefix = Encode(prefix);
+        var encodedSuffix = Encode(suffix);
         var newPart = new Part(type, regexpValue, modifier, name, encodedPrefix, encodedSuffix);
         _partList.Add(newPart);
     }

--- a/src/Meziantou.Framework.Uri/UrlPattern/Internal/UrlPatternComponent.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/Internal/UrlPatternComponent.cs
@@ -31,10 +31,13 @@ internal sealed class UrlPatternComponent
     public bool HasRegexpGroups { get; }
 
     /// <summary>Compiles a component from an input pattern string.</summary>
+    /// <param name="input">The pattern string of the component.</param>
+    /// <param name="encodingCallback">Canonicalizes each fixed-text part of the pattern, or <see langword="null"/> when the component needs no canonicalization.</param>
+    /// <param name="options">The options controlling the delimiter, the prefix and the case sensitivity.</param>
     /// <remarks>
     /// <see href="https://urlpattern.spec.whatwg.org/#compile-a-component">WHATWG URL Pattern Spec - Compile a component</see>
     /// </remarks>
-    public static UrlPatternComponent Compile(string input, Func<string, string> encodingCallback, PatternOptions options)
+    public static UrlPatternComponent Compile(string input, Func<string, string>? encodingCallback, PatternOptions options)
     {
         var tokenizer = new Tokenizer(input, TokenizePolicy.Strict);
         var tokenList = tokenizer.Tokenize();

--- a/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
@@ -769,15 +769,10 @@ public sealed class UrlPattern
 
     private static string CanonicalizePathname(string value)
     {
-        if (string.IsNullOrEmpty(value))
-            return value;
-
-        // Ensure starts with /
-        if (!value.StartsWith('/', StringComparison.Ordinal))
-        {
-            value = "/" + value;
-        }
-
+        // The callback runs on every fixed-text part of the pattern, not once on the whole pathname,
+        // so it must not add a leading "/": that would insert a separator in front of any literal
+        // that follows a group, turning "/books/:id.json" into "/books/:id/.json".
+        // The spec avoids the same trap by prefixing "/-" before parsing and stripping it afterwards.
         return value;
     }
 

--- a/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
+++ b/src/Meziantou.Framework.Uri/UrlPattern/UrlPattern.cs
@@ -266,15 +266,14 @@ public sealed class UrlPattern
         var compileOptions = PatternOptions.Default.WithIgnoreCase(ignoreCase);
         var pathCompileOptions = PatternOptions.Pathname.WithIgnoreCase(ignoreCase);
 
-        UrlPatternComponent pathnameComponent;
-        if (ProtocolMatchesSpecialScheme(protocolComponent))
-        {
-            pathnameComponent = UrlPatternComponent.Compile(processedInit.Pathname, CanonicalizePathname, pathCompileOptions);
-        }
-        else
-        {
-            pathnameComponent = UrlPatternComponent.Compile(processedInit.Pathname, CanonicalizeOpaquePathname, compileOptions);
-        }
+        // The spec canonicalizes a pathname by percent-encoding it, which this implementation does not do,
+        // so the pathname is matched as written and needs no encoding callback. It must not gain a leading
+        // "/" here: the callback runs on every fixed-text part, so that would insert a separator in front of
+        // any literal following a group, turning "/books/:id.json" into "/books/:id/.json". The spec avoids
+        // the same trap by prefixing "/-" before parsing and stripping it afterwards. Only the compile
+        // options differ between an opaque path and a special-scheme path.
+        var pathnameOptions = ProtocolMatchesSpecialScheme(protocolComponent) ? pathCompileOptions : compileOptions;
+        var pathnameComponent = UrlPatternComponent.Compile(processedInit.Pathname, encodingCallback: null, pathnameOptions);
 
         var searchComponent = UrlPatternComponent.Compile(processedInit.Search, CanonicalizeSearch, compileOptions);
         var hashComponent = UrlPatternComponent.Compile(processedInit.Hash, CanonicalizeHash, compileOptions);
@@ -764,20 +763,6 @@ public sealed class UrlPattern
             }
         }
 
-        return value;
-    }
-
-    private static string CanonicalizePathname(string value)
-    {
-        // The callback runs on every fixed-text part of the pattern, not once on the whole pathname,
-        // so it must not add a leading "/": that would insert a separator in front of any literal
-        // that follows a group, turning "/books/:id.json" into "/books/:id/.json".
-        // The spec avoids the same trap by prefixing "/-" before parsing and stripping it afterwards.
-        return value;
-    }
-
-    private static string CanonicalizeOpaquePathname(string value)
-    {
         return value;
     }
 

--- a/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
+++ b/tests/Meziantou.Framework.Uri.Tests/UrlPatternTests.cs
@@ -1215,4 +1215,50 @@ public sealed class UrlPatternTests
         Assert.NotNull(result);
         Assert.Equal("css/styles/main.css", result.Pathname.Groups["path"]);
     }
+
+    [Theory]
+    [InlineData("/books/:id.json", "/books/:id.json")]
+    [InlineData("/assets/*.png", "/assets/*.png")]
+    [InlineData("/:name-suffix", "/:name-suffix")]
+    [InlineData("/file-:name-v:version.txt", "/file-:name-v:version.txt")]
+    [InlineData("/{:name}text", "/{:name}text")]
+    public void Create_LiteralFollowingAGroup_KeepsThePathnameUnchanged(string pathname, string expected)
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = pathname });
+
+        Assert.Equal(expected, pattern.Pathname);
+    }
+
+    [Theory]
+    [InlineData("/books/:id.json", "https://example.com/books/123.json")]
+    [InlineData("/assets/*.png", "https://example.com/assets/logo.png")]
+    [InlineData("/:name-suffix", "https://example.com/value-suffix")]
+    [InlineData("/file-:name-v:version.txt", "https://example.com/file-report-v2.txt")]
+    public void IsMatch_LiteralFollowingAGroup_ShouldMatch(string pathname, string url)
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = pathname });
+
+        Assert.True(pattern.IsMatch(url));
+    }
+
+    [Fact]
+    public void Match_ExtensionAfterAGroup_ShouldCaptureWithoutTheExtension()
+    {
+        var pattern = UrlPattern.Create(new UrlPatternInit { Pathname = "/books/:id.json" });
+
+        var result = pattern.Match("https://example.com/books/123.json");
+
+        Assert.NotNull(result);
+        Assert.Equal("123", result.Pathname.Groups["id"]);
+        Assert.False(pattern.IsMatch("https://example.com/books/123/.json"));
+    }
+
+    [Fact]
+    public void Create_FromPatternString_LiteralFollowingAGroupIsPreserved()
+    {
+        var pattern = UrlPattern.Create("https://example.com/books/:id.json");
+
+        Assert.Equal("/books/:id.json", pattern.Pathname);
+        Assert.True(pattern.IsMatch("https://example.com/books/123.json"));
+    }
 }


### PR DESCRIPTION
`CanonicalizePathname` is the encoding callback that `PatternParser` runs on **every** fixed-text part of a parsed pattern — plus each part's prefix and suffix — not once on the whole pathname. It prepended `/` to any value that did not already start with one, so any literal that follows a group acquired a separator:

| pattern | compiled `Pathname` (before) | `IsMatch` (before) |
|---|---|---|
| `/books/:id.json` | `/books/:id/.json` | `https://e.com/books/123.json` → **false** |
| `/assets/*.png` | `/assets/*/.png` | `https://e.com/assets/logo.png` → **false** |
| `/:name-suffix` | `/:name/-suffix` | `https://e.com/value-suffix` → **false** |
| `/file-:name-v:version.txt` | `/file-:name/-v:version/.txt` | `https://e.com/file-report-v2.txt` → **false** |

Callers got a silent `false` from `IsMatch` — no exception, no diagnostic — so a route table or allow-list built on an extension pattern quietly matched nothing. The `Pathname` getter reported the mangled pattern back, so the one value that would have revealed the problem was itself wrong.

Patterns whose parts all begin with `/` (`/a/:x/b`) were unaffected, which is why this went unnoticed.

## What changed

`CanonicalizePathname` is now the identity. The spec's [canonicalize a pathname](https://urlpattern.spec.whatwg.org/#canonicalize-a-pathname) does percent-encoding only — it deliberately prefixes `"/-"` before running the URL parser and strips those two code points back off afterwards, precisely so that a value which does not start with `/` round-trips unchanged. This implementation does no percent-encoding, so the faithful callback is a no-op.

The one behaviour this drops is an undocumented convenience: `new UrlPatternInit { Pathname = "books" }` previously became `/books`. It now stays `books`, which is what the spec and every browser implementation do. No existing test relied on it.

## Verification

- 11 new theory/fact cases in `UrlPatternTests` covering an extension after a group, a wildcard with an extension, a literal suffix, several groups with literals between them, and the constructor-string path. Each of them fails on `main`.
- `Match_ExtensionAfterAGroup_ShouldCaptureWithoutTheExtension` also asserts the group captures `123` (not `123.json`) and that the previously-matching `/books/123/.json` no longer matches.
- Full suite: 550 passed, 0 failed, both target frameworks, no warnings.
- `dotnet run ./eng/update-all.cs` produces no changes.

Found by a review of `src/Meziantou.Framework.Uri`.
