### PR TITLE
Locate the query string only before the fragment

### DIFF
--- a/src/Meziantou.Framework.Uri/QueryStringUtilities.cs
+++ b/src/Meziantou.Framework.Uri/QueryStringUtilities.cs
@@ -90,20 +90,18 @@ public static class QueryStringUtilities
         ArgumentNullException.ThrowIfNull(uri);
         ArgumentNullException.ThrowIfNull(queryString);
 
-        var anchorIndex = uri.IndexOf('#', StringComparison.Ordinal);
-        var uriToBeAppended = uri;
-        var anchorText = "";
-        // If there is an anchor, then the query string must be inserted before its first occurrence.
-        if (anchorIndex != -1)
-        {
-            anchorText = uri[anchorIndex..];
-            uriToBeAppended = uri[..anchorIndex];
-        }
+        // The query string must be inserted before the first occurrence of the anchor.
+        var (beforeQuery, query, anchorText) = SplitUri(uri);
 
-        var hasQuery = uriToBeAppended.Contains('?', StringComparison.Ordinal);
+        var hasQuery = query is not null;
 
         var sb = new StringBuilder();
-        sb.Append(uriToBeAppended);
+        sb.Append(beforeQuery);
+        if (query is not null)
+        {
+            sb.Append('?').Append(query);
+        }
+
         foreach (var parameter in queryString)
         {
             if (parameter.Value is null)
@@ -147,25 +145,10 @@ public static class QueryStringUtilities
         ArgumentNullException.ThrowIfNull(uri);
         ArgumentNullException.ThrowIfNull(queryString);
 
-        var anchorIndex = uri.IndexOf('#', StringComparison.Ordinal);
-        var queryIndex = uri.IndexOf('?', StringComparison.Ordinal);
+        var (beforeQuery, _, anchorText) = SplitUri(uri);
 
         var sb = new StringBuilder();
-        if (queryIndex != -1)
-        {
-            sb.Append(uri[..queryIndex]);
-        }
-        else
-        {
-            if (anchorIndex != -1)
-            {
-                sb.Append(uri[..anchorIndex]);
-            }
-            else
-            {
-                sb.Append(uri);
-            }
-        }
+        sb.Append(beforeQuery);
 
         var hasQuery = false;
         foreach (var parameter in queryString)
@@ -182,11 +165,7 @@ public static class QueryStringUtilities
             hasQuery = true;
         }
 
-        if (anchorIndex != -1)
-        {
-            sb.Append(uri[anchorIndex..]);
-        }
-
+        sb.Append(anchorText);
         return sb.ToString();
     }
 
@@ -398,19 +377,29 @@ public static class QueryStringUtilities
 
     private static string? GetQueryString(string uri)
     {
-        var queryIndex = uri.IndexOf('?', StringComparison.Ordinal);
+        return SplitUri(uri).Query;
+    }
+
+    /// <summary>Splits the URI around its query string.</summary>
+    /// <param name="uri">The URI to split.</param>
+    /// <returns>
+    /// The part before the query, the query without its leading '?' (<see langword="null"/> when the URI has no query),
+    /// and the fragment including its leading '#' (empty when the URI has no fragment).
+    /// </returns>
+    /// <remarks>
+    /// The fragment starts at the first '#', so a '?' after that point is fragment content rather than
+    /// the query delimiter. "http://example.com/#a?b" has a fragment of "#a?b" and no query.
+    /// </remarks>
+    private static (string BeforeQuery, string? Query, string Anchor) SplitUri(string uri)
+    {
         var anchorIndex = uri.IndexOf('#', StringComparison.Ordinal);
+        var anchor = anchorIndex == -1 ? "" : uri[anchorIndex..];
+        var beforeAnchor = anchorIndex == -1 ? uri : uri[..anchorIndex];
 
+        var queryIndex = beforeAnchor.IndexOf('?', StringComparison.Ordinal);
         if (queryIndex == -1)
-        {
-            return null;
-        }
+            return (beforeAnchor, null, anchor);
 
-        if (anchorIndex == -1)
-        {
-            return uri[(queryIndex + 1)..];
-        }
-
-        return uri[(queryIndex + 1)..anchorIndex];
+        return (beforeAnchor[..queryIndex], beforeAnchor[(queryIndex + 1)..], anchor);
     }
 }

--- a/tests/Meziantou.Framework.Uri.Tests/QueryStringUtilitiesTests.cs
+++ b/tests/Meziantou.Framework.Uri.Tests/QueryStringUtilitiesTests.cs
@@ -43,4 +43,52 @@ public sealed class QueryStringUtilitiesTests
         var actual = QueryStringUtilities.RemoveQueryString(uri, "a");
         Assert.Equal("http://www.example.com/?b=2#hash", actual);
     }
+
+    [Fact]
+    public void RemoveQueryString_QuestionMarkInFragment_DoesNotThrow()
+    {
+        var uri = "http://www.example.com/#/search?x=1";
+        var actual = QueryStringUtilities.RemoveQueryString(uri, "x");
+        Assert.Equal("http://www.example.com/#/search?x=1", actual);
+    }
+
+    [Fact]
+    public void AddOrReplaceQueryString_QuestionMarkInFragment_AddsARealQuery()
+    {
+        var uri = "http://www.example.com/#/search?x=1";
+        var actual = QueryStringUtilities.AddOrReplaceQueryString(uri, "a", "1");
+        Assert.Equal("http://www.example.com/?a=1#/search?x=1", actual);
+    }
+
+    [Fact]
+    public void SetQueryString_QuestionMarkInFragment_DoesNotDuplicateTheFragment()
+    {
+        var uri = "http://www.example.com/#/search?x=1";
+        var actual = QueryStringUtilities.SetQueryString(uri, [KeyValuePair.Create<string, string?>("a", "1")]);
+        Assert.Equal("http://www.example.com/?a=1#/search?x=1", actual);
+    }
+
+    [Fact]
+    public void SetQueryString_QueryAndFragmentContainingAQuestionMark()
+    {
+        var uri = "http://www.example.com/?old=1#/search?x=1";
+        var actual = QueryStringUtilities.SetQueryString(uri, [KeyValuePair.Create<string, string?>("a", "1")]);
+        Assert.Equal("http://www.example.com/?a=1#/search?x=1", actual);
+    }
+
+    [Fact]
+    public void AddQueryString_QuestionMarkInFragment_AddsARealQuery()
+    {
+        var uri = "http://www.example.com/#/search?x=1";
+        var actual = QueryStringUtilities.AddQueryString(uri, "a", "1");
+        Assert.Equal("http://www.example.com/?a=1#/search?x=1", actual);
+    }
+
+    [Fact]
+    public void AddQueryString_ExistingQueryAndFragmentContainingAQuestionMark()
+    {
+        var uri = "http://www.example.com/?old=1#/search?x=1";
+        var actual = QueryStringUtilities.AddQueryString(uri, "a", "1");
+        Assert.Equal("http://www.example.com/?old=1&a=1#/search?x=1", actual);
+    }
 }


### PR DESCRIPTION
`SetQueryString` and `GetQueryString` each located the query by searching the whole URI for the first `?`, independently of where the fragment starts. When the `?` lives *inside* the fragment — routine for SPA routers, `#/search?q=1` — the two indexes cross and both functions go wrong, in different ways.

**`GetQueryString` throws.** It slices `uri[(queryIndex + 1)..anchorIndex]` with `queryIndex > anchorIndex`:

```csharp
QueryStringUtilities.RemoveQueryString("http://a/#frag?x=1", "x");
// System.ArgumentOutOfRangeException: length ('-6') must be a non-negative value. (Parameter 'length')
```

That path is reached from `RemoveQueryString` and from all four `AddOrReplaceQueryString` overloads, so a public helper taking `string uri` throws an exception type it does not document — a 500 in a request pipeline.

**`SetQueryString` corrupts the URI.** It keeps `uri[..queryIndex]` (which still contains the fragment) and then appends the fragment a second time:

```csharp
QueryStringUtilities.SetQueryString("http://a/#frag?x=1", [KeyValuePair.Create<string, string?>("a", "1")]);
// "http://a/#frag?a=1#frag?x=1"
```

No exception this time, so the broken URI propagates into redirects, links and stored records.

## What changed

One private `SplitUri` helper returns `(BeforeQuery, Query, Anchor)`. It finds the fragment first, then looks for `?` only in the part that precedes it, so a `?` after the first `#` is treated as fragment content. `AddQueryString`, `SetQueryString` and `GetQueryString` all now use it.

`AddQueryString` was already correct — it was the only one of the three that computed the anchor first. It moves onto the shared helper anyway so the three cannot drift apart again; its behaviour is unchanged, and two tests pin that down.

Both defects have the same root cause and the same fix, and splitting them would have left the helper half-converted, so they are fixed together.

## Verification

Six new cases in `QueryStringUtilitiesTests`:

- `RemoveQueryString_QuestionMarkInFragment_DoesNotThrow` and `AddOrReplaceQueryString_QuestionMarkInFragment_AddsARealQuery` — throw `ArgumentOutOfRangeException` on `main`.
- `SetQueryString_QuestionMarkInFragment_DoesNotDuplicateTheFragment` and `SetQueryString_QueryAndFragmentContainingAQuestionMark` — produce the duplicated-fragment string on `main`.
- Two `AddQueryString` cases pinning the behaviour that was already correct.

Full suite: 540 passed, 0 failed, both target frameworks, no warnings. `dotnet run ./eng/update-all.cs` produces no changes.

Found by a review of `src/Meziantou.Framework.Uri`.
