### PR TITLE
Reject malformed UTF-8 credentials instead of silently replacing them

### DIFF
--- a/src/Meziantou.AspNetCore.Authentication.HttpBasic/HttpBasicAuthenticationHandler.cs
+++ b/src/Meziantou.AspNetCore.Authentication.HttpBasic/HttpBasicAuthenticationHandler.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Net.Http.Headers;
 using System.Text.Encodings.Web;
+using System.Text.Unicode;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -16,6 +17,7 @@ internal sealed class HttpBasicAuthenticationHandler : AuthenticationHandler<Htt
     private static readonly AuthenticateResult MissingCredentialsResult = AuthenticateResult.Fail("Missing credentials");
     private static readonly AuthenticateResult CredentialsTooLongResult = AuthenticateResult.Fail("Credentials are too long");
     private static readonly AuthenticateResult InvalidBase64CredentialsResult = AuthenticateResult.Fail("Invalid Base64 credentials");
+    private static readonly AuthenticateResult InvalidCredentialsEncodingResult = AuthenticateResult.Fail("Credentials are not valid UTF-8");
     private static readonly AuthenticateResult InvalidCredentialsFormatResult = AuthenticateResult.Fail("Invalid credentials format");
     private static readonly AuthenticateResult InvalidUsernameOrPasswordResult = AuthenticateResult.Fail("Invalid username or password");
 
@@ -44,9 +46,10 @@ internal sealed class HttpBasicAuthenticationHandler : AuthenticationHandler<Htt
         if (headerValue.Parameter.Length > Options.MaxCredentialLength)
             return CredentialsTooLongResult;
 
-        if (!TryDecodeCredentials(headerValue.Parameter, out var credentials))
+        var decodeResult = DecodeCredentials(headerValue.Parameter, out var credentials);
+        if (decodeResult is not CredentialsDecodeResult.Success)
         {
-            return InvalidBase64CredentialsResult;
+            return decodeResult is CredentialsDecodeResult.InvalidBase64 ? InvalidBase64CredentialsResult : InvalidCredentialsEncodingResult;
         }
 
         var separatorIndex = credentials.IndexOf(':', StringComparison.Ordinal);
@@ -84,7 +87,7 @@ internal sealed class HttpBasicAuthenticationHandler : AuthenticationHandler<Htt
         return value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal);
     }
 
-    private static bool TryDecodeCredentials(string encodedCredentials, out string credentials)
+    private static CredentialsDecodeResult DecodeCredentials(string encodedCredentials, out string credentials)
     {
         byte[]? rentedBuffer = null;
 
@@ -96,11 +99,10 @@ internal sealed class HttpBasicAuthenticationHandler : AuthenticationHandler<Htt
             if (!Convert.TryFromBase64String(encodedCredentials, credentialBytes, out var bytesWritten))
             {
                 credentials = "";
-                return false;
+                return CredentialsDecodeResult.InvalidBase64;
             }
 
-            credentials = Encoding.UTF8.GetString(credentialBytes[..bytesWritten]);
-            return true;
+            return TranscodeUtf8(credentialBytes[..bytesWritten], out credentials);
         }
         finally
         {
@@ -111,8 +113,44 @@ internal sealed class HttpBasicAuthenticationHandler : AuthenticationHandler<Htt
         }
     }
 
+    private static CredentialsDecodeResult TranscodeUtf8(ReadOnlySpan<byte> credentialBytes, out string credentials)
+    {
+        char[]? rentedBuffer = null;
+
+        try
+        {
+            // A UTF-8 sequence never produces more UTF-16 code units than it has bytes.
+            var credentialChars = credentialBytes.Length <= StackallocThreshold ? stackalloc char[credentialBytes.Length] : (rentedBuffer = ArrayPool<char>.Shared.Rent(credentialBytes.Length));
+
+            // replaceInvalidSequences: false keeps malformed input from silently collapsing onto U+FFFD,
+            // which would make unrelated byte sequences decode to the same credentials.
+            if (Utf8.ToUtf16(credentialBytes, credentialChars, out _, out var charsWritten, replaceInvalidSequences: false) is not OperationStatus.Done)
+            {
+                credentials = "";
+                return CredentialsDecodeResult.InvalidEncoding;
+            }
+
+            credentials = new string(credentialChars[..charsWritten]);
+            return CredentialsDecodeResult.Success;
+        }
+        finally
+        {
+            if (rentedBuffer is not null)
+            {
+                ArrayPool<char>.Shared.Return(rentedBuffer);
+            }
+        }
+    }
+
     private static int GetMaximumDecodedLength(int encodedLength)
     {
         return (int)((encodedLength + 3L) / 4L * 3L);
+    }
+
+    private enum CredentialsDecodeResult
+    {
+        Success,
+        InvalidBase64,
+        InvalidEncoding,
     }
 }

--- a/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
+++ b/tests/Meziantou.AspNetCore.Authentication.HttpBasic.Tests/HttpBasicAuthenticationTests.cs
@@ -127,6 +127,47 @@ public sealed class HttpBasicAuthenticationTests
         });
     }
 
+    [Fact]
+    public async Task MalformedUtf8Credentials_AreRejected()
+    {
+        await using var application = await TestApplication.CreateAsync(options =>
+        {
+            options.ValidateCredentials = (_, username, password) => ValidateCredentials("victim", "\uFFFD\uFFFD\uFFFD", username, password);
+        });
+
+        byte[] credentials = [.. "victim:"u8, 0xFF, 0xFE, 0xC0];
+        await application.SendRawAndAssert("/", credentials, response =>
+        {
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        });
+    }
+
+    [Fact]
+    public async Task MalformedUtf8Credentials_DoNotCollideOnReplacementCharacter()
+    {
+        await using var application = await TestApplication.CreateAsync(options =>
+        {
+            options.ValidateCredentials = (_, username, password) => ValidateCredentials("victim", "\uFFFD\uFFFD\uFFFD", username, password);
+        });
+
+        byte[] credentials = [.. "victim:"u8, 0x80, 0x81, 0x82];
+        await application.SendRawAndAssert("/", credentials, response =>
+        {
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        });
+    }
+
+    [Fact]
+    public async Task NonAsciiUtf8Credentials_AreAccepted()
+    {
+        await using var application = await TestApplication.CreateAsync("\u00DCn\u00EFc\u00F8de", "p\u00E4ssw\u00F6rd");
+        await application.SendAndAssert("/", "\u00DCn\u00EFc\u00F8de", "p\u00E4ssw\u00F6rd", async response =>
+        {
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("\u00DCn\u00EFc\u00F8de", await response.Content.ReadAsStringAsync(XunitCancellationToken));
+        });
+    }
+
     private static IdentityUser CreateIdentityUser(string id, string username, string password)
     {
         var user = new IdentityUser
@@ -249,6 +290,15 @@ public sealed class HttpBasicAuthenticationTests
             {
                 request.Headers.Authorization = CreateAuthorizationHeader(username, password);
             }
+
+            using var response = await Client.SendAsync(request);
+            assert(response);
+        }
+
+        public async Task SendRawAndAssert(string url, byte[] credentials, Action<HttpResponseMessage> assert)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.TryAddWithoutValidation("Authorization", HttpBasicAuthenticationDefaults.AuthenticationScheme + " " + Convert.ToBase64String(credentials));
 
             using var response = await Client.SendAsync(request);
             assert(response);


### PR DESCRIPTION
## Finding

`HttpBasicAuthenticationHandler.cs:102` decoded credentials with `Encoding.UTF8.GetString`, which uses the default replacement fallback. Every invalid byte became U+FFFD instead of raising an error, so the decode was lossy and many-to-one: unlimited distinct byte sequences collapsed onto the same credential string.

Against a validator whose stored password is the three-character string `"���"`, two unrelated payloads both authenticated:

```
Authorization: Basic <base64 of "victim:" + FF FE C0>  => 200  AUTHENTICATED as victim
Authorization: Basic <base64 of "victim:" + 80 81 82>  => 200  AUTHENTICATED as victim
```

Neither payload is the stored password. The set of byte strings that authenticate as `victim` was unbounded. The same lossiness applied to usernames, so `alice\xFF` and `alice\x80` were the same user to the lookup.

This is an authentication bypass gated on a precondition — some account's stored password or username must contain U+FFFD. That is uncommon but reachable, and independently of the bypass, an auth handler should reject input it cannot parse rather than guess at it.

## What changed

- `TryDecodeCredentials` becomes `DecodeCredentials`, returning a `CredentialsDecodeResult` so a Base64 failure and an encoding failure are reported separately instead of both surfacing as "Invalid Base64 credentials".
- Transcoding now goes through `Utf8.ToUtf16(..., replaceInvalidSequences: false)`, which reports `OperationStatus.InvalidData` rather than substituting U+FFFD. This is allocation-free and non-throwing, so attacker-controlled input does not raise exceptions on the hot path.
- The existing stackalloc/`ArrayPool` strategy is mirrored for the `char` buffer, reusing `StackallocThreshold`. A UTF-8 sequence never produces more UTF-16 code units than it has bytes, so the byte count is a safe upper bound.
- New failure result: `Credentials are not valid UTF-8`.

Behaviour change worth noting: clients sending non-UTF-8 credentials (legacy ISO-8859-1 Basic auth, which predates RFC 7617's `charset` parameter) are now rejected. The handler already advertises `charset="UTF-8"`, so rejecting is the consistent choice.

## Verification

Three tests added to `HttpBasicAuthenticationTests.cs`. Confirmed the two bypass tests **fail against the unfixed handler** and pass with the fix:

```
### new tests against UNFIXED handler ###
failed  MalformedUtf8Credentials_AreRejected
failed  MalformedUtf8Credentials_DoNotCollideOnReplacementCharacter
  total: 11  failed: 2  succeeded: 9
```

`NonAsciiUtf8Credentials_AreAccepted` guards the regression in the other direction — valid non-ASCII credentials still work.

Full suite green on both target frameworks with `/p:TreatsWarningsAsErrors=true`: **22 passed** (11 x net10.0/net11.0). `dotnet run ./eng/update-all.cs` reports no changes. No public API change, so `ref/` is untouched.
