### PR TITLE
Declare EmbeddedConstant items as UpToDateCheckInput

### DIFF
--- a/src/Meziantou.Framework.EmbeddedConstantsGenerator/build/Meziantou.Framework.EmbeddedConstantsGenerator.targets
+++ b/src/Meziantou.Framework.EmbeddedConstantsGenerator/build/Meziantou.Framework.EmbeddedConstantsGenerator.targets
@@ -19,6 +19,12 @@
     <_EmbeddedConstantsGeneratedCodeDirectory>$([System.IO.Path]::GetDirectoryName('$(_EmbeddedConstantsGeneratedCodePath)'))</_EmbeddedConstantsGeneratedCodeDirectory>
   </PropertyGroup>
 
+  <!-- The Visual Studio fast up-to-date check only knows about well-known item types. Without this,
+       editing an embedded file does not invalidate the project and the build is skipped entirely. -->
+  <ItemGroup>
+    <UpToDateCheckInput Include="@(EmbeddedConstant)" />
+  </ItemGroup>
+
   <UsingTask TaskName="Meziantou.Framework.EmbeddedConstantsGenerator.GenerateEmbeddedConstantsTask"
              AssemblyFile="$(_EmbeddedConstantsTaskAssemblyPath)"
              Condition="Exists('$(_EmbeddedConstantsTaskAssemblyPath)')" />

--- a/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
+++ b/tests/Meziantou.Framework.EmbeddedConstantsGenerator.Tests/EmbeddedConstantsGeneratorTests.cs
@@ -28,6 +28,7 @@ public sealed class EmbeddedConstantsGeneratorTests(EmbeddedConstantsGeneratorPa
 
               <Target Name="CaptureEmbeddedConstantsBinlogItems" AfterTargets="GenerateEmbeddedConstants">
                 <WriteLinesToFile File="$(IntermediateOutputPath)embed-items.txt" Lines="@(EmbedInBinlog)" Overwrite="true" />
+                <WriteLinesToFile File="$(IntermediateOutputPath)uptodate-items.txt" Lines="@(UpToDateCheckInput)" Overwrite="true" />
               </Target>
             </Project>
             """);
@@ -53,6 +54,11 @@ public sealed class EmbeddedConstantsGeneratorTests(EmbeddedConstantsGeneratorPa
         var embedItemsPath = Assert.Single(Directory.GetFiles(projectDirectory / "obj", "embed-items.txt", SearchOption.AllDirectories));
         var embedItems = await File.ReadAllTextAsync(embedItemsPath, XunitCancellationToken);
         Assert.Contains(generatedFilePath, embedItems, ignoreCase: true);
+
+        // The Visual Studio fast up-to-date check skips the build unless the embedded files are declared as inputs
+        var upToDateItemsPath = Assert.Single(Directory.GetFiles(projectDirectory / "obj", "uptodate-items.txt", SearchOption.AllDirectories));
+        var upToDateItems = await File.ReadAllTextAsync(upToDateItemsPath, XunitCancellationToken);
+        Assert.Contains("hello.txt", upToDateItems);
 
         await RunDotNetCommand(projectDirectory, ["clean", "--disable-build-servers", "-nologo"], expectedExitCode: 0);
 


### PR DESCRIPTION
Editing an embedded file in Visual Studio does not trigger a rebuild, so the compiled assembly keeps the old constants.

## The finding

`build/Meziantou.Framework.EmbeddedConstantsGenerator.targets:39-43` adds the generated file to `Compile`, `FileWrites` and `EmbedInBinlog`, but nothing declares the *inputs*.

Visual Studio's fast up-to-date check decides whether to invoke MSBuild at all by looking at item types it knows about (`Compile`, `Content`, `None`, `EmbeddedResource`, `UpToDateCheckInput`, ...). `EmbeddedConstant` is a custom item type it has never heard of. So: edit `Assets/hello.txt`, press F5, and VS concludes nothing changed, skips the build, and runs the previously-compiled assembly with the stale constants.

`dotnet build` is unaffected — the target always runs, `WriteFileIfChanged` bumps the generated file's timestamp when the content changed, and `CoreCompile` then sees a newer `@(Compile)` input.

## The change

Declare the embedded files as `UpToDateCheckInput` in a top-level item group. NuGet imports `build/*.targets` at the end of the consuming project, so `@(EmbeddedConstant)` is already populated when this item group is evaluated.

## Verification

`GenerateOnBuild_TextKind_UsesDefaultNamespaceAndGeneratesStringOnly` now captures `@(UpToDateCheckInput)` alongside the existing `@(EmbedInBinlog)` capture and asserts the embedded file is in it.

Checked the assertion is not vacuous: with the targets change reverted the test fails (`Assert.Contains() assertion failed`, 5/6 passing); with it applied, 6/6 pass.
