### PR TITLE
Bound the size of a single inbound TDS message

### DIFF
--- a/ref/Meziantou.Framework.TdsServer.cs
+++ b/ref/Meziantou.Framework.TdsServer.cs
@@ -17,7 +17,9 @@ namespace Meziantou.Framework.Tds
     {
         public const int MinimumPacketSize = 512;
         public const int MaximumPacketSize = 65535;
+        public const int DefaultMaxMessageSize = 16777216;
         public int PacketSize { get => throw null; set { } }
+        public int MaxMessageSize { get => throw null; set { } }
         public bool RequireEncryption { get => throw null; set { } }
         public string? TlsPfxPath { get => throw null; set { } }
         public string? TlsPfxPassword { get => throw null; set { } }

--- a/src/Meziantou.Framework.TdsServer/Protocol/TdsPacketReader.cs
+++ b/src/Meziantou.Framework.TdsServer/Protocol/TdsPacketReader.cs
@@ -5,9 +5,10 @@ namespace Meziantou.Framework.Tds.Protocol;
 
 internal static class TdsPacketReader
 {
-    public static async ValueTask<TdsPacket?> ReadAsync(Stream stream, CancellationToken cancellationToken)
+    public static async ValueTask<TdsPacket?> ReadAsync(Stream stream, int maxMessageSize, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(stream);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxMessageSize);
 
         TdsPacketType? messageType = null;
         byte[]? payload = null;
@@ -45,6 +46,14 @@ internal static class TdsPacketReader
                 var currentPayloadLength = packetLength - 8;
                 if (currentPayloadLength > 0)
                 {
+                    // A TDS message spans as many packets as the client wants, and the payloads accumulate into a
+                    // single buffer. Without a ceiling a client can grow that buffer until the process runs out of
+                    // memory, and it can do so before it has authenticated.
+                    if (payloadLength + currentPayloadLength > maxMessageSize)
+                    {
+                        throw new InvalidDataException($"The TDS message exceeds the maximum size of {maxMessageSize} bytes.");
+                    }
+
                     EnsurePayloadCapacity(ref payload, payloadLength + currentPayloadLength, payloadLength);
                     await stream.ReadExactlyAsync(payload.AsMemory(payloadLength, currentPayloadLength), cancellationToken).ConfigureAwait(false);
                     payloadLength += currentPayloadLength;

--- a/src/Meziantou.Framework.TdsServer/TdsConnectionProcessor.cs
+++ b/src/Meziantou.Framework.TdsServer/TdsConnectionProcessor.cs
@@ -47,7 +47,7 @@ internal sealed class TdsConnectionProcessor
         TdsPreLoginNegotiationResult? negotiationResult = null;
         try
         {
-            var preLoginPacket = await TdsPacketReader.ReadAsync(input, cancellationToken).ConfigureAwait(false);
+            var preLoginPacket = await TdsPacketReader.ReadAsync(input, _options.MaxMessageSize, cancellationToken).ConfigureAwait(false);
             if (preLoginPacket is null)
             {
                 return;
@@ -87,14 +87,14 @@ internal sealed class TdsConnectionProcessor
 
             if (negotiationResult.Value.UpgradeToTls)
             {
-                sslStream = await UpgradeToTlsAsync(transportInput, transportOutput, serverCertificate!, _options.PacketSize, cancellationToken).ConfigureAwait(false);
+                sslStream = await UpgradeToTlsAsync(transportInput, transportOutput, serverCertificate!, _options.PacketSize, _options.MaxMessageSize, cancellationToken).ConfigureAwait(false);
                 usingTls = true;
                 input = sslStream;
                 output = sslStream;
                 writer = new TdsPacketWriter(output, _options.PacketSize);
             }
 
-            var loginPacket = await TdsPacketReader.ReadAsync(input, cancellationToken).ConfigureAwait(false);
+            var loginPacket = await TdsPacketReader.ReadAsync(input, _options.MaxMessageSize, cancellationToken).ConfigureAwait(false);
             if (loginPacket is null || loginPacket.Type != TdsPacketType.Login7)
             {
                 await writer.WriteAsync(TdsPacketType.TabularResult, TdsResponseSerializer.CreateProtocolError(18456, "Missing LOGIN7 packet"), cancellationToken).ConfigureAwait(false);
@@ -144,7 +144,7 @@ internal sealed class TdsConnectionProcessor
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                var packet = await TdsPacketReader.ReadAsync(input, cancellationToken).ConfigureAwait(false);
+                var packet = await TdsPacketReader.ReadAsync(input, _options.MaxMessageSize, cancellationToken).ConfigureAwait(false);
                 if (packet is null)
                 {
                     return;
@@ -218,13 +218,13 @@ internal sealed class TdsConnectionProcessor
     }
 
     [SuppressMessage("Security", "CA5398:Do not hardcode SslProtocols", Justification = "SqlClient interoperability with TDS-over-TLS requires TLS 1.2 during PRELOGIN encryption upgrade.")]
-    private static async Task<SslStream> UpgradeToTlsAsync(Stream input, Stream output, X509Certificate2 certificate, int packetSize, CancellationToken cancellationToken)
+    private static async Task<SslStream> UpgradeToTlsAsync(Stream input, Stream output, X509Certificate2 certificate, int packetSize, int maxMessageSize, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(input);
         ArgumentNullException.ThrowIfNull(output);
         ArgumentNullException.ThrowIfNull(certificate);
 
-        var baseStream = new TdsTlsPacketStream(input, output, packetSize);
+        var baseStream = new TdsTlsPacketStream(input, output, packetSize, maxMessageSize);
         var sslStream = new SslStream(baseStream, leaveInnerStreamOpen: true);
 
         await sslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions
@@ -245,10 +245,11 @@ internal sealed class TdsConnectionProcessor
         private readonly Stream _readStream;
         private readonly Stream _writeStream;
         private readonly TdsPacketWriter _packetWriter;
+        private readonly int _maxMessageSize;
         private ReadOnlyMemory<byte> _pendingReadPayload;
         private bool _useTdsPacketMode = true;
 
-        public TdsTlsPacketStream(Stream readStream, Stream writeStream, int packetSize)
+        public TdsTlsPacketStream(Stream readStream, Stream writeStream, int packetSize, int maxMessageSize)
         {
             ArgumentNullException.ThrowIfNull(readStream);
             ArgumentNullException.ThrowIfNull(writeStream);
@@ -256,6 +257,7 @@ internal sealed class TdsConnectionProcessor
             _readStream = readStream;
             _writeStream = writeStream;
             _packetWriter = new TdsPacketWriter(writeStream, packetSize);
+            _maxMessageSize = maxMessageSize;
         }
 
         public override bool CanRead => _readStream.CanRead;
@@ -383,7 +385,7 @@ internal sealed class TdsConnectionProcessor
             {
                 while (true)
                 {
-                    var packet = await TdsPacketReader.ReadAsync(_readStream, cancellationToken).ConfigureAwait(false);
+                    var packet = await TdsPacketReader.ReadAsync(_readStream, _maxMessageSize, cancellationToken).ConfigureAwait(false);
                     if (packet is null)
                     {
                         return 0;

--- a/src/Meziantou.Framework.TdsServer/TdsServerOptions.cs
+++ b/src/Meziantou.Framework.TdsServer/TdsServerOptions.cs
@@ -12,8 +12,12 @@ public sealed class TdsServerOptions
     /// <summary>The largest packet size a TDS packet header can describe, since it stores the length in 16 bits.</summary>
     public const int MaximumPacketSize = ushort.MaxValue;
 
+    /// <summary>The default value of <see cref="MaxMessageSize"/>.</summary>
+    public const int DefaultMaxMessageSize = 16 * 1024 * 1024;
+
     private readonly Lock _tlsCertificateLock = new();
     private int _packetSize = 4096;
+    private int _maxMessageSize = DefaultMaxMessageSize;
     private X509Certificate2? _tlsCertificate;
     private bool _tlsCertificateLoaded;
 
@@ -34,6 +38,26 @@ public sealed class TdsServerOptions
             ArgumentOutOfRangeException.ThrowIfGreaterThan(value, MaximumPacketSize);
 
             _packetSize = value;
+        }
+    }
+
+    /// <summary>Gets or sets the maximum size, in bytes, of a single inbound TDS message.</summary>
+    /// <remarks>
+    /// A TDS message is made of as many packets as the client decides to send, and the server has to buffer the
+    /// whole message before it can be parsed. This limit bounds that buffer. It applies from the very first
+    /// packet of a connection, so it also bounds what an unauthenticated client can make the server allocate.
+    /// Raise it when clients legitimately send large parameters or SQL batches. Must be at least
+    /// <see cref="MaximumPacketSize"/> so that a single full packet always fits.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">The value is smaller than <see cref="MaximumPacketSize"/>.</exception>
+    public int MaxMessageSize
+    {
+        get => _maxMessageSize;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, MaximumPacketSize);
+
+            _maxMessageSize = value;
         }
     }
 

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -1594,6 +1594,91 @@ public sealed class TdsServerProtocolTests
         Assert.Equal(packetSize, options.PacketSize);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(511)]
+    [InlineData(65534)]
+    public void TdsServerOptions_MaxMessageSize_SmallerThanAPacket_Throws(int maxMessageSize)
+    {
+        var options = new TdsServerOptions();
+
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => options.MaxMessageSize = maxMessageSize);
+    }
+
+    [Theory]
+    [InlineData(65535)]
+    [InlineData(1024 * 1024)]
+    [InlineData(int.MaxValue)]
+    public void TdsServerOptions_MaxMessageSize_AtLeastAPacket_IsAccepted(int maxMessageSize)
+    {
+        var options = new TdsServerOptions
+        {
+            MaxMessageSize = maxMessageSize,
+        };
+
+        Assert.Equal(maxMessageSize, options.MaxMessageSize);
+    }
+
+    [Fact]
+    public void TdsServerOptions_MaxMessageSize_DefaultsToDefaultMaxMessageSize()
+    {
+        var options = new TdsServerOptions();
+
+        Assert.Equal(TdsServerOptions.DefaultMaxMessageSize, options.MaxMessageSize);
+    }
+
+    [Fact]
+    public async Task TdsServer_MessageLargerThanMaxMessageSize_IsRejectedBeforeAuthentication()
+    {
+        var options = new TdsServerOptions
+        {
+            MaxMessageSize = TdsServerOptions.MaximumPacketSize,
+        };
+        options.AddTcpListener(0, IPAddress.Loopback);
+
+        using var server = new TdsServer(
+            options,
+            (context, cancellationToken) => ValueTask.FromResult(TdsAuthenticationResult.Success()),
+            (context, cancellationToken) => ValueTask.FromResult(new TdsQueryResult()));
+        await server.StartAsync();
+
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, server.Ports[0], cancellationTokenSource.Token);
+        using var stream = client.GetStream();
+
+        // PRELOGIN packets that never set the end-of-message bit. The server has to buffer the whole message
+        // before it can parse anything, so without a limit this grows a single buffer without bound, and it
+        // does so on the first read of the connection: no credentials are involved.
+        var header = new byte[8];
+        header[0] = 0x12; // PRELOGIN
+        header[1] = 0x00; // not the end of the message
+        header[2] = 0xFF;
+        header[3] = 0xFF;
+        var body = new byte[TdsServerOptions.MaximumPacketSize - 8];
+
+        var connectionClosed = false;
+        try
+        {
+            for (var i = 0; i < 256 && !connectionClosed; i++)
+            {
+                await stream.WriteAsync(header, cancellationTokenSource.Token);
+                await stream.WriteAsync(body, cancellationTokenSource.Token);
+                await stream.FlushAsync(cancellationTokenSource.Token);
+            }
+
+            var buffer = new byte[1];
+            connectionClosed = await stream.ReadAsync(buffer, cancellationTokenSource.Token) == 0;
+        }
+        catch (IOException)
+        {
+            connectionClosed = true;
+        }
+
+        Assert.True(connectionClosed, "The server should close the connection instead of buffering a message larger than MaxMessageSize.");
+    }
+
     [Fact]
     public async Task SqlClient_QueryError_WithAVeryLongMessage_IsTruncatedInsteadOfOverflowingTheToken()
     {


### PR DESCRIPTION
`TdsPacketReader.ReadAsync` accumulates a multi-packet TDS message into one growing buffer and loops until it sees a packet whose status carries the `EndOfMessage` bit. Nothing bounded the accumulated length, so a client that never sets that bit grows the buffer without limit.

This is the **first** read on the connection (`TdsConnectionProcessor.cs:50`) — before PRELOGIN is parsed, before the TLS upgrade, before LOGIN7, before the authentication callback runs. No credentials are involved.

### Failure scenario

A single TCP client sending TDS headers of type `0x12` / status `0x00` / length `0xFFFF`, measured against a live `TdsServer`:

| sent | elapsed | server managed heap |
|---|---|---|
| 249 MB | 2 079 ms | 0 MB → 512 MB (working set 560 MB) |

The connection was still open at the end. Past ~1 MB `ArrayPool<byte>.Shared` stops pooling, so each doubling in `EnsurePayloadCapacity` is a fresh LOH allocation and the previous one is garbage — peak footprint is roughly 2× the bytes sent. Several concurrent connections multiply it.

The same reader is reused for post-login SQLBatch and RPC messages and inside the TLS packet stream, so an authenticated client had the same lever.

### What changed

- `TdsPacketReader.ReadAsync` takes a `maxMessageSize` and throws `InvalidDataException` once the accumulated payload would exceed it. `TdsConnectionProcessor` already closes the connection on `InvalidDataException`, so no new plumbing was needed.
- New `TdsServerOptions.MaxMessageSize`, defaulting to `DefaultMaxMessageSize` (16 MB). It must be at least `MaximumPacketSize` so a single full packet always fits.
- The limit is threaded through all four read sites, including the one inside `TdsTlsPacketStream` that feeds the TLS handshake.

The default is deliberately generous — it bounds the damage without breaking clients that send large parameters or SQL batches. Raise it if 16 MB is too small for your workload.

### Verification

- `TdsServer_MessageLargerThanMaxMessageSize_IsRejectedBeforeAuthentication` drives a raw socket, sends unterminated PRELOGIN packets, and asserts the server closes the connection. Confirmed it **fails** (30 s timeout, server happily buffering) with the new guard removed and passes with it.
- Option validation and default covered by `TdsServerOptions_MaxMessageSize_*`.
- Full suite: 410 passed / 0 failed (205 × net10.0, 205 × net11.0).
- `dotnet run ./eng/update-all.cs` produced no further changes; `ref/` regenerated for the new public API.

Found during a review of `src/Meziantou.Framework.TdsServer`.
