### PR TITLE
Stop a stale DiffEngine_ variable from breaking every tool lookup

### DIFF
--- a/src/Meziantou.Framework.DiffEngine/DiffTools.cs
+++ b/src/Meziantou.Framework.DiffEngine/DiffTools.cs
@@ -211,7 +211,7 @@ public static class DiffTools
             if (definition.Tool != tool)
                 continue;
 
-            return TryResolve(definition, out resolvedTool);
+            return TryResolve(definition, throwIfEnvironmentVariableIsInvalid: true, out resolvedTool);
         }
 
         resolvedTool = null;
@@ -243,7 +243,7 @@ public static class DiffTools
         var result = new List<ResolvedTool>();
         foreach (var definition in Definitions)
         {
-            if (TryResolve(definition, out var resolvedTool))
+            if (TryResolve(definition, throwIfEnvironmentVariableIsInvalid: false, out var resolvedTool))
             {
                 result.Add(resolvedTool);
             }
@@ -252,7 +252,7 @@ public static class DiffTools
         return result;
     }
 
-    private static bool TryResolve(ToolDefinition definition, [NotNullWhen(true)] out ResolvedTool? resolvedTool)
+    private static bool TryResolve(ToolDefinition definition, bool throwIfEnvironmentVariableIsInvalid, [NotNullWhen(true)] out ResolvedTool? resolvedTool)
     {
         var platformSettings = GetPlatformSettings(definition);
         if (platformSettings is null)
@@ -261,9 +261,7 @@ public static class DiffTools
             return false;
         }
 
-        if (!TryResolveFromEnvironmentVariable(definition.Tool, platformSettings.ExecutableNames, out var exePath) &&
-            !TryResolveFromDirectories(platformSettings.SearchDirectories, platformSettings.ExecutableNames, out exePath) &&
-            !TryResolveFromPath(platformSettings.ExecutableNames, out exePath))
+        if (!TryResolveExecutable(definition.Tool, platformSettings, throwIfEnvironmentVariableIsInvalid, out var exePath))
         {
             resolvedTool = null;
             return false;
@@ -285,24 +283,29 @@ public static class DiffTools
         return null;
     }
 
-    private static bool TryResolveFromEnvironmentVariable(DiffTool tool, IReadOnlyList<string> executableNames, [NotNullWhen(true)] out string? exePath)
+    private static bool TryResolveExecutable(DiffTool tool, PlatformSettings platformSettings, bool throwIfEnvironmentVariableIsInvalid, [NotNullWhen(true)] out string? exePath)
     {
         var environmentVariable = $"DiffEngine_{tool}";
         var basePath = Environment.GetEnvironmentVariable(environmentVariable);
-        if (string.IsNullOrWhiteSpace(basePath))
+        if (!string.IsNullOrWhiteSpace(basePath))
         {
-            exePath = null;
+            var trimmedPath = Environment.ExpandEnvironmentVariables(basePath.Trim().Trim('"'));
+            if (TryResolveFile(trimmedPath, out exePath))
+                return true;
+
+            if (TryResolveFromDirectories([trimmedPath], platformSettings.ExecutableNames, out exePath))
+                return true;
+
+            if (throwIfEnvironmentVariableIsInvalid)
+                throw new InvalidOperationException($"Could not find exe defined by {environmentVariable}. Path: {basePath}");
+
+            // The variable points at an executable that is no longer there. Skip the tool rather than silently
+            // falling back to another installation of it, and let the caller keep looking at the other tools.
             return false;
         }
 
-        var trimmedPath = Environment.ExpandEnvironmentVariables(basePath.Trim().Trim('"'));
-        if (TryResolveFile(trimmedPath, out exePath))
-            return true;
-
-        if (TryResolveFromDirectories([trimmedPath], executableNames, out exePath))
-            return true;
-
-        throw new InvalidOperationException($"Could not find exe defined by {environmentVariable}. Path: {basePath}");
+        return TryResolveFromDirectories(platformSettings.SearchDirectories, platformSettings.ExecutableNames, out exePath) ||
+               TryResolveFromPath(platformSettings.ExecutableNames, out exePath);
     }
 
     private static bool TryResolveFromPath(IReadOnlyList<string> executableNames, [NotNullWhen(true)] out string? exePath)

--- a/src/Meziantou.Framework.DiffEngine/readme.md
+++ b/src/Meziantou.Framework.DiffEngine/readme.md
@@ -26,5 +26,7 @@ if (DiffTools.TryFindByName(DiffTool.VisualStudioCode, out var tool))
 
 ## Environment variables
 
-- `DiffEngine_<ToolName>`: override executable detection for one tool (file path or directory)
+- `DiffEngine_<ToolName>`: override executable detection for one tool (file path or directory).
+  When the variable is set but the executable cannot be found, `TryFindByName` throws so the typo is not
+  silently ignored, while `TryFindByExtension` skips that tool and keeps looking at the others.
 - `DiffEngine_TargetOnLeft=true`: invert generated argument order

--- a/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
+++ b/tests/Meziantou.Framework.DiffEngine.Tests/DiffToolsTests.cs
@@ -27,6 +27,29 @@ public sealed class DiffToolsTests
     }
 
     [Fact]
+    public void TryFindByName_ThrowsWhenEnvironmentVariableCannotBeResolved()
+    {
+        using var temp = TemporaryDirectory.Create();
+        using var scope = new EnvironmentVariableScope("DiffEngine_VisualStudioCode", Path.Combine(temp.FullPath, "missing"));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => DiffTools.TryFindByName(DiffTool.VisualStudioCode, out _));
+        Assert.Contains("DiffEngine_VisualStudioCode", exception.Message);
+    }
+
+    [Fact]
+    public void TryFindByExtension_SkipsToolWhoseEnvironmentVariableCannotBeResolved()
+    {
+        using var temp = TemporaryDirectory.Create();
+        _ = temp.CreateTextFile(GetVisualStudioCodeExecutableName(), "");
+        using var vscodeScope = new EnvironmentVariableScope("DiffEngine_VisualStudioCode", temp.FullPath);
+        using var vimScope = new EnvironmentVariableScope("DiffEngine_Vim", Path.Combine(temp.FullPath, "missing"));
+
+        Assert.True(DiffTools.TryFindByExtension(".bin", out var tool));
+        Assert.NotNull(tool);
+        Assert.Equal(DiffTool.VisualStudioCode, tool.Tool);
+    }
+
+    [Fact]
     public void TryFindByExtension_ReturnsBinaryTool()
     {
         using var temp = TemporaryDirectory.Create();


### PR DESCRIPTION
`DiffTools.TryFindByExtension` throws `InvalidOperationException` when **any** tool — not
just the one being looked for — has a `DiffEngine_<Tool>` variable pointing at an
executable that is no longer there.

`TryResolveFromEnvironmentVariable` threw instead of returning `false`, and
`ResolveAvailableTools` runs `TryResolve` over all 25 definitions, so one stale
variable aborted the whole scan:

```c#
Environment.SetEnvironmentVariable("DiffEngine_Vim", "/does/not/exist/vim");
DiffTools.TryFindByExtension(".txt", out var tool);
// InvalidOperationException: Could not find exe defined by DiffEngine_Vim. Path: /does/not/exist/vim
```

VS Code and Rider were both installed and resolvable at that moment. The caller asked
for a `.txt` tool and got an exception about Vim.

This matters because `AutoDiffEngineTool.Start` calls it in both snapshot-testing
packages and nothing up to `MergeTool.Launch` catches. A developer who uninstalled a
tool months ago but left the variable in their shell profile sees their snapshot
mismatch replaced by an unrelated `InvalidOperationException` — the assertion message
they actually needed is gone.

## What changed

`TryResolveFromEnvironmentVariable` and the fallback chain collapse into a single
`TryResolveExecutable`, which takes `throwIfEnvironmentVariableIsInvalid`:

- `TryFindByName` passes `true` — you named a tool explicitly, so a typo in its
  variable is still reported loudly. Behavior unchanged.
- `TryFindByExtension` passes `false` — that tool is skipped and the scan continues.

A tool with an unusable override is *skipped* rather than falling through to the
search directories and `PATH`, so an explicit override stays authoritative: you don't
silently get a different installation of the tool than the one you pointed at.

Merging the two methods also removes the awkward split where the environment variable
was probed in one place and the directory/`PATH` fallback in another.

## Verification

`dotnet test /p:TreatsWarningsAsErrors=true` — 12 of 14 pass on net10.0 and net11.0.
Two new tests cover both directions (throws by name, skips by extension).

The two failures are `TryFindByExtension_ReturnsTextTool`, which is **pre-existing on
this branch and unrelated** — it depends on which diff tools the developer has
installed and fails on any machine with Rider, WinMerge or TortoiseGit. It is fixed
separately in the sibling PR "Stop TryFindByExtension_ReturnsTextTool depending on the
developer's installed tools". CI images are bare, so this branch is green there.
