### PR TITLE
Reject out-of-range indexes in AnsiColor.FromIndexed

### DIFF
--- a/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
+++ b/src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs
@@ -379,6 +379,9 @@ public static class AnsiTextProcessor
     {
         public static AnsiColor FromIndexed(int value)
         {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 255);
+
             return new AnsiColor(AnsiColorKind.Indexed, Red: 0, Green: 0, Blue: 0, IndexedValue: (byte)value);
         }
 

--- a/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
+++ b/tests/Meziantou.Framework.AnsiFormatting.Tests/AnsiTextProcessorTests.cs
@@ -29,6 +29,41 @@ public class AnsiTextProcessorTests
     }
 
     [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(208)]
+    [InlineData(255)]
+    public void AnsiColor_FromIndexed_InRange(int value)
+    {
+        var color = AnsiTextProcessor.AnsiColor.FromIndexed(value);
+        Assert.Equal(AnsiTextProcessor.AnsiColorKind.Indexed, color.Kind);
+        Assert.Equal(value, color.IndexedValue);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(256)]
+    [InlineData(300)]
+    [InlineData(int.MinValue)]
+    [InlineData(int.MaxValue)]
+    public void AnsiColor_FromIndexed_OutOfRange(int value)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => AnsiTextProcessor.AnsiColor.FromIndexed(value));
+    }
+
+    [Theory]
+    [InlineData("\u001b[38;5;300mA")]
+    [InlineData("\u001b[48;5;300mA")]
+    public void ParseTextWithAnsiStyles_OutOfRangeIndexedColorDoesNotThrow(string input)
+    {
+        var parsed = AnsiTextProcessor.ParseTextWithAnsiStyles(input);
+        Assert.Equal("A", parsed.Text);
+        var run = Assert.Single(parsed.Runs);
+        Assert.Null(run.Style.Foreground);
+        Assert.Null(run.Style.Background);
+    }
+
+    [Theory]
     [InlineData("")]
     [InlineData("Hello World")]
     [InlineData("No escape sequences here")]


### PR DESCRIPTION
## Problem

`AnsiTextProcessor.AnsiColor.FromIndexed(int)` (`src/Meziantou.Framework.AnsiFormatting/AnsiTextProcessor.cs:380-383`) casts its `int` parameter to `byte` with no validation, so out-of-range values wrap silently instead of being rejected:

| Call | Result |
|---|---|
| `AnsiColor.FromIndexed(300)` | `IndexedValue = 44` |
| `AnsiColor.FromIndexed(-1)` | `IndexedValue = 255` |

Both were reproduced against the built library.

This is a public static factory on a public type (`ref/Meziantou.Framework.AnsiFormatting.cs:22`). A caller mapping a palette index gets a plausible-looking wrong colour rather than an error, and the wrongness only shows up wherever the colour is finally rendered — far from the call that produced it.

The library's own parsing path is unaffected: `ApplyExtendedColor` already range-checks with `colorIndex is >= 0 and <= 255` before calling the factory, so this only ever bit external callers.

## Change

Guard the argument with `ArgumentOutOfRangeException.ThrowIfNegative` / `ThrowIfGreaterThan`. No signature change, so the generated `ref/` API is untouched.

Changing the parameter to `byte` would have been the other option, but that is a source-breaking change for existing callers; throwing is the smaller move, and the behaviour it replaces has no defensible use.

## Verification

- New tests: `FromIndexed` accepts `0`/`1`/`208`/`255` and throws for `-1`, `256`, `300`, `int.MinValue`, `int.MaxValue`.
- New regression test that `ESC[38;5;300m` and `ESC[48;5;300m` still parse without throwing, proving the guard did not turn a tolerated bad escape sequence into an exception.
- `dotnet test tests/Meziantou.Framework.AnsiFormatting.Tests /p:TreatsWarningsAsErrors=true` → 70 passed, 0 failed (35 per TFM × net10.0 + net11.0).
- `dotnet test tests/Meziantou.AspNetCore.Components.LogViewer.Tests` (the in-repo consumer) → 24 passed, 0 failed.
- `dotnet run ./eng/update-all.cs` reports no generated-file changes; `ref/` is unchanged.

## Context

One of 8 PRs from an audit of `Meziantou.Framework.AnsiFormatting`. Independent — mergeable in any order.
