### PR TITLE
Fix the number styles used to parse hexadecimal and floating-point strings

### DIFF
--- a/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
+++ b/src/Meziantou.Framework.TypeConverter/DefaultConverter.cs
@@ -67,21 +67,13 @@ public class DefaultConverter : IConverter
 
     private static bool NormalizeHexString(ref string? s)
     {
-        if (s is null)
-            return false;
-
-        switch (s)
+        if (s is ['0', 'x' or 'X', .. var rest])
         {
-            case ['x' or 'X', .. var rest]:
-                s = rest;
-                return true;
-            case ['0', 'x' or 'X', .. var rest]:
-                s = rest;
-                return true;
-
-            default:
-                return false;
+            s = rest;
+            return true;
         }
+
+        return false;
     }
 
     private static void GetBytes(decimal d, byte[] buffer)
@@ -468,12 +460,8 @@ public class DefaultConverter : IConverter
             }
         }
 
-        var styles = NumberStyles.Integer;
         var s = Convert.ToString(input, provider);
-        if (NormalizeHexString(ref s))
-        {
-            styles |= NumberStyles.AllowHexSpecifier;
-        }
+        var styles = NormalizeHexString(ref s) ? NumberStyles.HexNumber : NumberStyles.Integer;
 
         return ulong.TryParse(s, styles, provider, out value);
     }
@@ -501,12 +489,8 @@ public class DefaultConverter : IConverter
             }
         }
 
-        var styles = NumberStyles.Integer;
         var s = Convert.ToString(input, provider);
-        if (NormalizeHexString(ref s))
-        {
-            styles |= NumberStyles.AllowHexSpecifier;
-        }
+        var styles = NormalizeHexString(ref s) ? NumberStyles.HexNumber : NumberStyles.Integer;
 
         return ushort.TryParse(s, styles, provider, out value);
     }
@@ -534,14 +518,15 @@ public class DefaultConverter : IConverter
             }
         }
 
-        var styles = NumberStyles.Integer;
         var s = Convert.ToString(input, provider);
         if (NormalizeHexString(ref s))
         {
-            styles |= NumberStyles.AllowHexSpecifier;
+            // Hexadecimal notation is not supported by floating-point types
+            value = 0;
+            return false;
         }
 
-        return decimal.TryParse(s, styles, provider, out value);
+        return decimal.TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out value);
     }
 
     protected virtual bool TryConvert(object? input, IFormatProvider? provider, out float value)
@@ -567,14 +552,15 @@ public class DefaultConverter : IConverter
             }
         }
 
-        var styles = NumberStyles.Integer;
         var s = Convert.ToString(input, provider);
         if (NormalizeHexString(ref s))
         {
-            styles |= NumberStyles.AllowHexSpecifier;
+            // Hexadecimal notation is not supported by floating-point types
+            value = 0;
+            return false;
         }
 
-        return float.TryParse(s, styles, provider, out value);
+        return float.TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out value);
     }
 
     protected virtual bool TryConvert(object? input, IFormatProvider? provider, out double value)
@@ -600,14 +586,15 @@ public class DefaultConverter : IConverter
             }
         }
 
-        var styles = NumberStyles.Integer;
         var s = Convert.ToString(input, provider);
         if (NormalizeHexString(ref s))
         {
-            styles |= NumberStyles.AllowHexSpecifier;
+            // Hexadecimal notation is not supported by floating-point types
+            value = 0;
+            return false;
         }
 
-        return double.TryParse(s, styles, provider, out value);
+        return double.TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out value);
     }
 
     protected virtual bool TryConvert(object? input, IFormatProvider? provider, out char value)
@@ -687,12 +674,8 @@ public class DefaultConverter : IConverter
             }
         }
 
-        var styles = NumberStyles.Integer;
         var s = Convert.ToString(input, provider);
-        if (NormalizeHexString(ref s))
-        {
-            styles |= NumberStyles.AllowHexSpecifier;
-        }
+        var styles = NormalizeHexString(ref s) ? NumberStyles.HexNumber : NumberStyles.Integer;
 
         return uint.TryParse(s, styles, provider, out value);
     }
@@ -720,12 +703,8 @@ public class DefaultConverter : IConverter
             }
         }
 
-        var styles = NumberStyles.Integer;
         var s = Convert.ToString(input, provider);
-        if (NormalizeHexString(ref s))
-        {
-            styles |= NumberStyles.AllowHexSpecifier;
-        }
+        var styles = NormalizeHexString(ref s) ? NumberStyles.HexNumber : NumberStyles.Integer;
 
         return byte.TryParse(s, styles, provider, out value);
     }
@@ -753,12 +732,8 @@ public class DefaultConverter : IConverter
             }
         }
 
-        var styles = NumberStyles.Integer;
         var s = Convert.ToString(input, provider);
-        if (NormalizeHexString(ref s))
-        {
-            styles |= NumberStyles.AllowHexSpecifier;
-        }
+        var styles = NormalizeHexString(ref s) ? NumberStyles.HexNumber : NumberStyles.Integer;
 
         return sbyte.TryParse(s, styles, provider, out value);
     }
@@ -798,12 +773,8 @@ public class DefaultConverter : IConverter
             }
         }
 
-        var styles = NumberStyles.Integer;
         var s = Convert.ToString(input, provider);
-        if (NormalizeHexString(ref s))
-        {
-            styles |= NumberStyles.AllowHexSpecifier;
-        }
+        var styles = NormalizeHexString(ref s) ? NumberStyles.HexNumber : NumberStyles.Integer;
 
         return short.TryParse(s, styles, provider, out value);
     }
@@ -843,12 +814,8 @@ public class DefaultConverter : IConverter
             }
         }
 
-        var styles = NumberStyles.Integer;
         var s = Convert.ToString(input, provider);
-        if (NormalizeHexString(ref s))
-        {
-            styles |= NumberStyles.AllowHexSpecifier;
-        }
+        var styles = NormalizeHexString(ref s) ? NumberStyles.HexNumber : NumberStyles.Integer;
 
         return int.TryParse(s, styles, provider, out value);
     }
@@ -888,12 +855,8 @@ public class DefaultConverter : IConverter
             }
         }
 
-        var styles = NumberStyles.Integer;
         var s = Convert.ToString(input, provider);
-        if (NormalizeHexString(ref s))
-        {
-            styles |= NumberStyles.AllowHexSpecifier;
-        }
+        var styles = NormalizeHexString(ref s) ? NumberStyles.HexNumber : NumberStyles.Integer;
 
         return long.TryParse(s, styles, provider, out value);
     }

--- a/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_StringTo.cs
+++ b/tests/Meziantou.Framework.TypeConverter.Tests/DefaultConverterTests_StringTo.cs
@@ -325,4 +325,115 @@ public class DefaultConverterTests_StringTo
         Assert.True(converted);
         Assert.False(value);
     }
+
+    [Theory]
+    [InlineData("0x1F", 31)]
+    [InlineData("0X1F", 31)]
+    [InlineData("0x0", 0)]
+    [InlineData("0xff", 255)]
+    public void TryConvert_HexStringToInt32(string text, int expected)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var converted = converter.TryChangeType(text, cultureInfo, out int value);
+        Assert.True(converted);
+        Assert.Equal(expected, value);
+    }
+
+    [Theory]
+    [InlineData("0x1F", 31L)]
+    [InlineData("0xFFFFFFFFFF", 1099511627775L)]
+    public void TryConvert_HexStringToInt64(string text, long expected)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var converted = converter.TryChangeType(text, cultureInfo, out long value);
+        Assert.True(converted);
+        Assert.Equal(expected, value);
+    }
+
+    [Theory]
+    [InlineData("0x0A")]
+    [InlineData("0x7F")]
+    public void TryConvert_HexStringToByte(string text)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var converted = converter.TryChangeType(text, cultureInfo, out byte value);
+        Assert.True(converted);
+        Assert.Equal(Convert.ToByte(text[2..], fromBase: 16), value);
+    }
+
+    // A string starting with 'x' or '0x' used to combine NumberStyles.AllowHexSpecifier with
+    // NumberStyles.Integer, which the BCL rejects with an ArgumentException.
+    [Theory]
+    [InlineData("xyz")]
+    [InlineData("X-Men")]
+    [InlineData("x")]
+    [InlineData("0x")]
+    [InlineData("0xZZ")]
+    public void TryConvert_StringStartingWithX_DoesNotThrow(string text)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+
+        Assert.False(converter.TryChangeType(text, cultureInfo, out int _));
+        Assert.False(converter.TryChangeType(text, cultureInfo, out long _));
+        Assert.False(converter.TryChangeType(text, cultureInfo, out short _));
+        Assert.False(converter.TryChangeType(text, cultureInfo, out byte _));
+        Assert.False(converter.TryChangeType(text, cultureInfo, out sbyte _));
+        Assert.False(converter.TryChangeType(text, cultureInfo, out uint _));
+        Assert.False(converter.TryChangeType(text, cultureInfo, out ulong _));
+        Assert.False(converter.TryChangeType(text, cultureInfo, out ushort _));
+        Assert.False(converter.TryChangeType(text, cultureInfo, out float _));
+        Assert.False(converter.TryChangeType(text, cultureInfo, out double _));
+        Assert.False(converter.TryChangeType(text, cultureInfo, out decimal _));
+        Assert.False(converter.TryChangeType(text, cultureInfo, out int? _));
+    }
+
+    // Hexadecimal notation is not supported by the floating-point types
+    [Fact]
+    public void TryConvert_HexStringToDouble_ReturnsFalse()
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var converted = converter.TryChangeType("0x1F", cultureInfo, out double _);
+        Assert.False(converted);
+    }
+
+    // A word starting with 'x' is no longer treated as a hexadecimal literal
+    [Fact]
+    public void TryConvert_StringWithoutHexPrefix_IsNotParsedAsHexadecimal()
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        Assert.False(converter.TryChangeType("xA", cultureInfo, out byte _));
+    }
+
+    // These used to reach the TypeDescriptor fallback because NumberStyles.Integer
+    // rejects the decimal separator, the thousands separator and the exponent
+    [Theory]
+    [InlineData("1.5e3", 1500d)]
+    [InlineData("42.24", 42.24d)]
+    [InlineData("-0.5", -0.5d)]
+    public void TryConvert_StringToDouble_SupportsFloatingPointNotation(string text, double expected)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var converted = converter.TryChangeType(text, cultureInfo, out double value);
+        Assert.True(converted);
+        Assert.Equal(expected, value);
+    }
+
+    [Theory]
+    [InlineData("42.24")]
+    [InlineData("1,234.56")]
+    public void TryConvert_StringToDecimal_SupportsSeparators(string text)
+    {
+        var converter = new DefaultConverter();
+        var cultureInfo = CultureInfo.InvariantCulture;
+        var converted = converter.TryChangeType(text, cultureInfo, out decimal value);
+        Assert.True(converted);
+        Assert.Equal(decimal.Parse(text, NumberStyles.Float | NumberStyles.AllowThousands, cultureInfo), value);
+    }
 }


### PR DESCRIPTION
`ConvertUtilities.TryChangeType("xyz", out int value)` throws `ArgumentException`.

## The bug

`NormalizeHexString` strips a leading `x`/`X`/`0x`/`0X` and returns `true`, and each of the 11 numeric overloads then does `styles |= NumberStyles.AllowHexSpecifier` on a `styles` that is already `NumberStyles.Integer`. The BCL rejects both resulting combinations before parsing anything — for the integer types because `AllowLeadingSign` may not accompany `AllowHexSpecifier`, and for `decimal`/`float`/`double` because hexadecimal parsing is not supported at all:

```
ConvertUtilities.TryChangeType("0x1F", inv, out int v)   → ArgumentException: With the AllowHexSpecifier or AllowBinarySpecifier bit set …
ConvertUtilities.TryChangeType("xyz",  inv, out int v)   → ArgumentException (same)
ConvertUtilities.TryChangeType("Xml",  inv, out float v) → ArgumentException: The number styles AllowHexSpecifier and AllowBinarySpecifier are not supported on floating point data types.
ConvertUtilities.TryChangeType("xyz",  inv, out int? v)  → ArgumentException
new Dictionary<string, object> { ["k"] = "xyz" }.GetValueOrDefault("k", 0) → ArgumentException
```

The trigger was not limited to real hexadecimal literals: the first pattern in `NormalizeHexString` was `['x' or 'X', .. var rest]`, so a bare word like `"xyz"`, `"X-Men"` or a product code like `"XA-1"` was enough. This is the failure mode a `TryXxx` API exists to prevent — callers wrap `TryChangeType` around config values, query strings and CSV cells precisely so they do not need a `try`/`catch`, and `DictionaryExtensions.GetValueOrDefault`, whose contract is "return `defaultValue` if conversion fails", threw instead.

The path has existed since the initial commit and had no test coverage: no test converted a hex-prefixed string to a number (the only `"0x…"` tests target `byte[]`).

## What changed

**`NormalizeHexString` now requires the `0x`/`0X` prefix** (`DefaultConverter.cs:68`). The bare-`x` form is dropped, so `"xyz"` and `"X-Men"` are no longer read as hexadecimal. This is a behaviour change: `"xA"` → `byte` previously *intended* to yield `10` (it actually threw), and now returns `false`.

**Integer types** (`byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`) select the style set instead of OR-ing into it:

```csharp
var s = Convert.ToString(input, provider);
var styles = NormalizeHexString(ref s) ? NumberStyles.HexNumber : NumberStyles.Integer;
```

**Floating-point types** (`decimal`, `float`, `double`) reject the hexadecimal form — .NET does not support it on these types in any style combination — and otherwise parse with `NumberStyles.Float | NumberStyles.AllowThousands`, which is what `decimal.Parse(string, IFormatProvider)` uses by default.

That second half also fixes a separate latent problem: these three overloads previously passed `NumberStyles.Integer`, which allows no decimal separator, no thousands separator and no exponent, so `decimal.TryParse("42.24", NumberStyles.Integer, invariant, out _)` returned `false` and the intended fast path never fired. The existing `TryConvert_StringToDecimal` test passed only because the failure fell through ~750 lines later to the `TypeDescriptor` fallback, where `DecimalConverter` parsed it correctly. Both findings are fixed together because they are the same lines.

## Verification

`dotnet test tests/Meziantou.Framework.TypeConverter.Tests /p:TreatWarningsAsErrors=true` — **156 passed, 0 failed** (was 116; 20 new cases per target framework, net10.0 and net11.0).

New tests cover: hexadecimal parsing to `int`/`long`/`byte`; that every numeric target (including `int?`, `float`, `double`, `decimal`) returns `false` rather than throwing for `"xyz"`, `"X-Men"`, `"x"`, `"0x"` and `"0xZZ"`; that hexadecimal to `double` returns `false`; that `"xA"` is no longer parsed as hexadecimal; and that the direct floating-point path now handles `"1.5e3"`, `"42.24"`, `"-0.5"` and `"1,234.56"` so the `TypeDescriptor` fallback can no longer mask a regression.

`dotnet run ./eng/update-all.cs` reports no generated-file changes, and `ref/` is untouched — no public API surface change.

## Note for review

Dropping the bare-`x` prefix is the one judgment call here. It is what widened the crash from "hex literals" to "any word starting with x", and the form is undocumented, but it is a behaviour change for anyone who relied on it. Happy to restore it and fix only the invalid style combination if you would rather keep that surface.

Found by a project review of `Meziantou.Framework.TypeConverter`.
