### PR TITLE
Disable DTD processing when parsing XML values

### DIFF
--- a/src/Meziantou.Framework.TdsServer/Handler/TdsQueryParameter.cs
+++ b/src/Meziantou.Framework.TdsServer/Handler/TdsQueryParameter.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using System.Xml;
 using System.Xml.Linq;
 
 namespace Meziantou.Framework.Tds.Handler;
@@ -156,11 +157,30 @@ public sealed class TdsQueryParameter
         };
     }
 
+    private static readonly XmlReaderSettings XmlReaderSettings = new()
+    {
+        DtdProcessing = DtdProcessing.Prohibit,
+        IgnoreWhitespace = true,
+        XmlResolver = null,
+    };
+
     /// <summary>Parses the value as XML when possible.</summary>
+    /// <remarks>
+    /// DTD processing is disabled. The value comes straight off the wire, and
+    /// <see cref="XDocument.Parse(string, LoadOptions)"/> would expand internal entities up to ten million
+    /// characters, so a few hundred bytes of parameter could cost megabytes of allocation.
+    /// </remarks>
+    /// <exception cref="XmlException">The value is not well-formed XML, or it declares a DTD.</exception>
     public XDocument? AsXml()
     {
         var text = AsString();
-        return text is null ? null : XDocument.Parse(text, LoadOptions.None);
+        if (text is null)
+        {
+            return null;
+        }
+
+        using var reader = XmlReader.Create(new StringReader(text), XmlReaderSettings);
+        return XDocument.Load(reader, LoadOptions.None);
     }
 
     private static JsonObject ParseJsonObject(string value)

--- a/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
+++ b/src/Meziantou.Framework.TdsServer/QueryEngine/TdsQueryEngineExecutor.cs
@@ -35,6 +35,12 @@ internal sealed class TdsQueryEngineExecutor
         public IDictionary<string, IQueryable> ResolvedQueryRoots { get; }
     }
 
+    private static readonly XmlReaderSettings XmlReaderSettings = new()
+    {
+        DtdProcessing = DtdProcessing.Prohibit,
+        XmlResolver = null,
+    };
+
     private readonly TdsQueryEngineOptions _options;
     private readonly FrozenDictionary<string, TdsQueryRoot> _queryRoots;
     private readonly FrozenDictionary<string, Delegate> _storedProcedures;
@@ -2458,13 +2464,13 @@ internal sealed class TdsQueryEngineExecutor
             return false;
         }
 
-        _ = XDocument.Parse(xmlValue.Value, LoadOptions.PreserveWhitespace);
+        _ = ParseXml(xmlValue.Value);
         return true;
     }
 
     private static void ValidateXmlAgainstSchema(string xml, XmlSchemaSet schemaSet, string? schemaCollectionName)
     {
-        var document = XDocument.Parse(xml, LoadOptions.PreserveWhitespace);
+        var document = ParseXml(xml);
         string? validationError = null;
         document.Validate(schemaSet, (_, args) =>
         {
@@ -2477,16 +2483,37 @@ internal sealed class TdsQueryEngineExecutor
         }
     }
 
+    /// <summary>Parses an XML value with DTD processing disabled.</summary>
+    /// <remarks>
+    /// <see cref="XDocument.Parse(string, LoadOptions)"/> defaults to <see cref="DtdProcessing.Parse"/> with a
+    /// ten-million-character entity budget, so a few hundred bytes of nested internal entities expand into
+    /// megabytes. XML values reach this engine from client SQL and are parsed once per row, which turns that
+    /// budget into an arbitrary amount of server CPU. External entities were never resolved, so this only
+    /// removes the expansion.
+    /// </remarks>
+    private static XDocument ParseXml(string xml)
+    {
+        try
+        {
+            using var reader = XmlReader.Create(new StringReader(xml), XmlReaderSettings);
+            return XDocument.Load(reader, LoadOptions.PreserveWhitespace);
+        }
+        catch (XmlException ex)
+        {
+            throw new TdsQueryEngineException($"The XML value could not be parsed: {ex.Message}");
+        }
+    }
+
     private static XPathNavigator CreateXmlContextNavigator(string xml)
     {
-        var document = XDocument.Parse(xml, LoadOptions.PreserveWhitespace);
+        var document = ParseXml(xml);
         return document.Root?.CreateNavigator()
             ?? throw new TdsQueryEngineException("Cannot evaluate XML query on an empty document.");
     }
 
     private static void EnsureXmlConstraint(string xml, SqlXmlDocumentConstraint documentConstraint)
     {
-        _ = XDocument.Parse(xml, LoadOptions.PreserveWhitespace);
+        _ = ParseXml(xml);
         if (documentConstraint == SqlXmlDocumentConstraint.None)
         {
             return;

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsQueryEngineTests.cs
@@ -3022,6 +3022,27 @@ public sealed class TdsQueryEngineTests
     }
 
     [Fact]
+    public async Task SqlClient_QueryEngine_XmlDataType_WithADtd_IsRejected()
+    {
+        var queryEngineOptions = CreateQueryEngineOptions();
+
+        // A few hundred bytes of nested internal entities expand into megabytes, once per row, and the query
+        // cannot be cancelled. XDocument.Parse allows that by default, so the engine has to opt out.
+        await ExecuteQueryExpectingServerError(
+            queryEngineOptions,
+            command =>
+            {
+                command.CommandText = """
+                    SELECT CAST('<?xml version="1.0"?><!DOCTYPE root [<!ENTITY a "aaaaaaaaaa"><!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">]><root>&b;</root>' AS XML) AS Bomb
+                    FROM xml_docs
+                    WHERE Id = 1
+                    """;
+            },
+            expectedErrorNumber: 50004,
+            expectedMessageContains: "could not be parsed");
+    }
+
+    [Fact]
     public async Task SqlClient_QueryEngine_XmlMethod_Query_ReturnsXmlFragment()
     {
         var queryEngineOptions = CreateQueryEngineOptions();

--- a/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
+++ b/tests/Meziantou.Framework.TdsServer.Tests/TdsServerProtocolTests.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Xml;
 using Meziantou.Framework.Tds.Handler;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
@@ -33,6 +34,36 @@ public sealed class TdsServerProtocolTests
 
         Assert.NotNull(json);
         Assert.Equal(42, json!["value"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void TdsQueryParameter_AsXml_WithADtd_Throws()
+    {
+        // The value comes straight off the wire. XDocument.Parse would expand internal entities up to ten
+        // million characters, so a handler calling AsXml on a small parameter could allocate megabytes.
+        var parameter = new TdsQueryParameter
+        {
+            Name = "@xml",
+            Value = """<?xml version="1.0"?><!DOCTYPE root [<!ENTITY a "aaaaaaaaaa"><!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">]><root>&b;</root>""",
+            Type = TdsColumnType.NVarChar,
+        };
+
+        _ = Assert.Throws<XmlException>(parameter.AsXml);
+    }
+
+    [Fact]
+    public void TdsQueryParameter_AsXml_WithoutADtd_ReturnsTheDocument()
+    {
+        var parameter = new TdsQueryParameter
+        {
+            Name = "@xml",
+            Value = """<root><item id="1">Alpha</item></root>""",
+            Type = TdsColumnType.NVarChar,
+        };
+
+        var document = parameter.AsXml();
+
+        Assert.Equal("Alpha", document?.Root?.Element("item")?.Value);
     }
 
     [Fact]


### PR DESCRIPTION
Every XML entry point used `XDocument.Parse(text, LoadOptions.PreserveWhitespace)`. .NET's `XDocument` defaults to `DtdProcessing.Parse` with `MaxCharactersFromEntities = 10_000_000`, so a document with nested internal entities expands into megabytes.

External entities are *not* resolved (`XmlResolver` is null by default), so there was **no XXE** — this is purely a CPU and allocation amplification.

### Failure scenario

XML reaches the engine from client SQL through a string literal, and `ConvertToXmlCore` parses the same string **twice**, throwing both results away — once in `TryConvertToSqlXmlValue` as a validity check, once in `EnsureXmlConstraint` — before returning the raw string. Because it compiles into the row expression, that happens per row.

Measured with a 340-character `SELECT CAST('<…nested entities…>' AS XML) AS v FROM docs`:

| rows in the query root | wall clock |
|---|---|
| 50 | 1 322 ms |
| 500 | 11 129 ms |

Linear in the row count, so a 10k-row root is roughly four minutes of CPU from one ~400-byte statement. There is no query timeout and ATTENTION does not cancel a running query, so it cannot be stopped short of killing the process.

`TdsQueryParameter.AsXml()` had the same defect on a directly client-supplied value: a 340-character RPC parameter expanded to 1 000 000 characters in 26 ms. The readme documents `parameter.AsXml()` as the way a custom query handler reads an XML parameter, so hand-written handlers inherited it.

### What changed

- New `TdsQueryEngineExecutor.ParseXml` routes all four `XDocument.Parse` call sites (`TryConvertToSqlXmlValue`, `ValidateXmlAgainstSchema`, `CreateXmlContextNavigator`, `EnsureXmlConstraint`) through an `XmlReader` with `DtdProcessing.Prohibit` and `XmlResolver = null`.
- It maps `XmlException` to `TdsQueryEngineException`, so a bad XML value returns a `50004` naming the problem instead of escaping the engine's catch as a generic `50002` plus an Error-level stack trace. `TRY_CAST` / `TRY_CONVERT` still yield `NULL` — `TryConvertToXmlCore`'s catch is unchanged.
- `TdsQueryParameter.AsXml()` uses the same settings (with `IgnoreWhitespace` to match `LoadOptions.None`) and documents that it throws `XmlException` for a DTD.

This does **not** fix the redundant double parse — that is a separate refactor, stacked on top of this PR, so the security fix can merge on its own.

### Verification

- `SqlClient_QueryEngine_XmlDataType_WithADtd_IsRejected` — confirmed it **fails** against the old `XDocument.Parse` (the query succeeds and expands the entities) and passes now.
- `TdsQueryParameter_AsXml_WithADtd_Throws` plus `TdsQueryParameter_AsXml_WithoutADtd_ReturnsTheDocument` so the happy path stays covered.
- Existing XML tests (`.query()`, `.value()`, `.exist()`, `.nodes()`, typed/untyped casts, schema collections) all still pass — no legitimate document uses a DTD.
- Full suite: 398 passed / 0 failed (199 × net10.0, 199 × net11.0). No public API change, so `ref/` is unchanged.

Found during a review of `src/Meziantou.Framework.TdsServer`.
